### PR TITLE
docs: codify the 2,000-line file ceiling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,14 @@ conservative at the waist.
   concern — as long as it integrates with the existing setup/config UX
   (`hermes tools`, `hermes setup`, auto-install) rather than bolting on a raw
   env var.
+- **Enforce a 2,000-physical-line ceiling for hand-maintained source and test
+  files.** New files must remain at or below 2,000 lines, and files already
+  below the ceiling must not cross it. A legacy file already above 2,000 lines
+  is inherited debt, not permission to grow: changes may not increase its
+  physical line count, and substantive new responsibility belongs in a focused
+  module. The ceiling is not a target—split earlier when responsibilities
+  diverge—and a bounded change does not require refactoring unrelated legacy
+  god-files.
 - **Refactor god-files into clean modules.** Extracting a multi-thousand-line
   cluster out of `cli.py` / `run_agent.py` / `gateway/run.py` into a focused
   mixin or module is wanted work, even when the diff is huge and mechanical


### PR DESCRIPTION
## What does this PR do?

This PR codifies the repository's existing 2,000-physical-line ceiling in the root `AGENTS.md`, immediately beside the recently added instruction to refactor god-files into clean modules.

The current guidance establishes the direction but omits the numerical threshold. That ambiguity surfaced in [#99999](https://github.com/NousResearch/hermes-agent/pull/99999#issuecomment-5502394616), where a contributor reasonably asked where the 2,000-line requirement was documented.

This is not a new standard. The threshold has already been applied as an explicit maintainer merge condition: [“every touched file under the hard 2,000-physical-line ceiling”](https://github.com/NousResearch/hermes-agent/issues/97681#issuecomment-5472640342). The qualitative `AGENTS.md` instruction was added in [`6b33052`](https://github.com/NousResearch/hermes-agent/commit/6b330522e1fb8950a6552e421d1fa9df4793b33f), but the number itself was not included.

The 2,000-line boundary is intentionally an operational ceiling, not a claim that one round number is a mathematically unique optimum. Its value is that it is concrete, reviewable, and consistently enforceable while keeping the legacy remediation surface finite and manageable.

## Related Issue

- Documentation gap surfaced in [#99999](https://github.com/NousResearch/hermes-agent/pull/99999#issuecomment-5502394616)
- Existing maintainer enforcement in [#97681](https://github.com/NousResearch/hermes-agent/issues/97681#issuecomment-5472640342)
- Qualitative god-file guidance introduced by [`6b33052`](https://github.com/NousResearch/hermes-agent/commit/6b330522e1fb8950a6552e421d1fa9df4793b33f)

No standalone issue is closed by this documentation-only reconciliation.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add an explicit 2,000-physical-line ceiling for hand-maintained source and test files.
- Require new and currently under-ceiling files to remain at or below the ceiling.
- Treat an inherited over-ceiling file as debt, not permission for further growth.
- Route substantive new responsibility into focused modules instead of enlarging a legacy god-file.
- Clarify that the ceiling is not a target and does not turn a bounded change into a repository-wide refactor of unrelated legacy files.

## How to Test

1. Compare base [`1802911`](https://github.com/NousResearch/hermes-agent/commit/180291162ff4df0d42b5dc4fecd08005cf7cebf9) with head [`fe2ff23`](https://github.com/andrexibiza/hermes-agent/commit/fe2ff238c335c1fa1d56486d9d1ef1b6d3c8e208).
2. Verify the exact diff is limited to `AGENTS.md`: 8 additions, 0 deletions, no unrelated paths.
3. Verify the resulting `AGENTS.md` is 1,792 physical lines and therefore remains below the rule it documents.
4. Read the new rule beside the existing god-file-refactor guidance and confirm all four cases are explicit: new files, under-ceiling files, inherited over-ceiling files, and unrelated legacy debt.

No runtime test applies because this change modifies repository instructions only.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit message follows [Conventional Commits](https://www.conventionalcommits.org/) (`docs:`)
- [x] I searched open and merged PRs and issues for an existing documentation fix
- [x] My PR contains only the requested `AGENTS.md` clarification
- [x] Test suite: N/A — documentation-only change with no executable behavior
- [x] New tests: N/A — no runtime behavior changed
- [x] Platform testing: N/A — platform-independent repository guidance

### Documentation & Housekeeping

- [x] Relevant documentation is the change itself (`AGENTS.md`)
- [x] `cli-config.yaml.example`: N/A — no configuration changed
- [x] `AGENTS.md` is updated because this change defines a repository workflow invariant
- [x] Cross-platform impact considered: the physical-line rule is platform-independent
- [x] Tool descriptions/schemas: N/A — no tool behavior changed

## Screenshots / Logs

Exact-object verification:

```text
base:    180291162ff4df0d42b5dc4fecd08005cf7cebf9
head:    fe2ff238c335c1fa1d56486d9d1ef1b6d3c8e208
commits: 1
paths:   AGENTS.md
stats:   +8 / -0
lines:   1,792
```

Hosted checks on that exact head:

- [Nix flake check #78201](https://github.com/NousResearch/hermes-agent/actions/runs/33579274964): **success**. The affected-area detector passed; the Nix build job was correctly skipped for the `AGENTS.md`-only diff.
- [Docker Build, Test, and Publish #34272](https://github.com/NousResearch/hermes-agent/actions/runs/33579274997): **success**. The affected-area detector passed; build, publish, and merge jobs were correctly skipped for the documentation-only diff.

Both attached check suites are complete and successful for `fe2ff238c335c1fa1d56486d9d1ef1b6d3c8e208`.
