### PR TITLE
feat(cli): native Warp CLI-agent notifications (OSC 777)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -16489,6 +16489,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # (#41098). The countdown refreshes below paint the same way.
             self._paint_now()
 
+            # Warp CLI-agent notification (native OSC 777) — surfaces this
+            # approval request in Warp's tab status / notification mailbox
+            # even when the user isn't looking at this tab. No-ops outside
+            # Warp. See hermes_cli/warp_notify.py.
+            try:
+                from hermes_cli.warp_notify import notify_permission_request
+                notify_permission_request(
+                    tool_name=command,
+                    summary=description or f"Wants to run {command}",
+                    session_id=getattr(self, "session_id", "") or "",
+                )
+            except Exception:
+                pass
+
             _last_countdown_refresh = _time.monotonic()
             while True:
                 try:
@@ -17628,6 +17642,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             if self.bell_on_complete:
                 sys.stdout.write("\a")
                 sys.stdout.flush()
+
+            # Warp CLI-agent notification (native OSC 777, no plugin/config
+            # needed) — no-ops outside Warp or on older Warp builds. See
+            # hermes_cli/warp_notify.py for the protocol writeup.
+            try:
+                from hermes_cli.warp_notify import notify_stop
+                notify_stop(session_id=getattr(self, "session_id", "") or "")
+            except Exception:
+                pass
 
             # Notify when iteration budget was hit
             if result and not result.get("completed") and not result.get("interrupted"):

--- a/hermes_cli/warp_notify.py
+++ b/hermes_cli/warp_notify.py
@@ -1,0 +1,151 @@
+"""Native Warp terminal "CLI coding agent" notification support for Hermes.
+
+WHY THIS EXISTS
+  Warp (warp.dev) gives first-class treatment to CLI coding agents it
+  recognizes -- rich input editor, vertical tabs with live status, and
+  desktop/in-app notifications on task completion, permission requests, and
+  idle prompts. Warp's own docs (docs.warp.dev/agents/cli-agents/overview)
+  explicitly list Hermes as a *recognized* agent, but note it "doesn't
+  support agent notifications yet" -- unlike Claude Code, Codex, and
+  OpenCode, which each implement Warp's notification protocol.
+
+  Root cause (2026-09-02 investigation): Claude Code and OpenCode ship a
+  small Warp plugin (github.com/warpdotdev/claude-code-warp) that emits an
+  OSC 777 escape sequence at a few lifecycle points. Codex does it via a
+  native config flag. Hermes has neither -- so Warp has no signal to key
+  off, which is why bell_on_complete (a plain \\a BEL) doesn't produce
+  Warp's tab status/notification treatment: Warp is looking for OSC 777
+  with a specific JSON payload, not a bare bell.
+
+  This module ports that same protocol natively into Hermes, using the
+  officially recognized `agent: "hermes"` slot the payload schema already
+  supports (the schema is agent-name-keyed, not Claude-specific).
+
+PROTOCOL (reverse-engineered from the public claude-code-warp plugin source,
+commit as of 2026-09-02, MIT-equivalent OSS license -- see LICENSE there):
+  - Escape sequence: OSC 777 notify, i.e. `\\033]777;notify;<title>;<body>\\007`
+  - `title` is always the literal string `warp://cli-agent` -- this is how
+    Warp distinguishes a structured agent-protocol notification from a
+    plain OSC 777 desktop notification.
+  - `body` is a compact JSON object:
+      {
+        "v": <protocol version, negotiated via WARP_CLI_AGENT_PROTOCOL_VERSION>,
+        "agent": "hermes",
+        "event": "stop" | "idle_prompt" | "permission_request" | ...,
+        "session_id": "...",
+        "cwd": "...",
+        "project": "<basename of cwd>",
+        ... event-specific fields (e.g. "summary", "query", "response")
+      }
+  - Gating: only emit when Warp has advertised protocol support via the
+    WARP_CLI_AGENT_PROTOCOL_VERSION env var (set by the Warp app itself in
+    the child shell it launches) AND WARP_CLIENT_VERSION is present. This
+    mirrors should-use-structured.sh in the reference plugin -- it exists
+    because older/broken Warp builds set the version var without actually
+    being able to render the structured payload, so a version floor
+    protects against sending noise those builds can't display.
+  - Delivery: this module writes directly to /dev/tty (POSIX) so it works
+    even when stdout is being captured/redirected elsewhere in the CLI
+    render loop. On non-POSIX or when /dev/tty is unavailable, this is a
+    silent no-op -- never raise, never block the agent loop.
+
+SCOPE
+  Deliberately minimal: only the two events Hermes's own lifecycle exposes
+  cleanly today -- response-complete ("stop", same moment bell_on_complete
+  already fires) and approval-requested ("permission_request", same moment
+  the approval UI is painted). Idle-prompt / notification-type events can
+  be added later if a matching Hermes lifecycle hook exists; this module's
+  public functions are additive and safe to call from anywhere.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+# The protocol version this module knows how to produce. Mirrors the
+# reference plugin's PLUGIN_CURRENT_PROTOCOL_VERSION.
+_PROTOCOL_VERSION = 1
+
+
+def _negotiate_protocol_version() -> int:
+    """min(our version, Warp's advertised version), defaulting to 1 if Warp
+    doesn't advertise one at all (matches build-payload.sh's negotiation)."""
+    try:
+        warp_version = int(os.environ.get("WARP_CLI_AGENT_PROTOCOL_VERSION", "1"))
+    except ValueError:
+        warp_version = 1
+    return min(warp_version, _PROTOCOL_VERSION)
+
+
+def _should_notify() -> bool:
+    """Only emit when running inside Warp AND Warp has advertised structured
+    CLI-agent-notification support. Mirrors should-use-structured.sh: a
+    missing protocol-version or client-version var means either we're not
+    in Warp, or we're in a Warp build old enough that it can't render the
+    payload even though it might set the var -- either way, staying silent
+    is strictly safer than emitting escape codes nobody can parse."""
+    if os.environ.get("TERM_PROGRAM") != "WarpTerminal":
+        return False
+    if not os.environ.get("WARP_CLI_AGENT_PROTOCOL_VERSION"):
+        return False
+    if not os.environ.get("WARP_CLIENT_VERSION"):
+        return False
+    return True
+
+
+def _emit_osc777(title: str, body: str) -> None:
+    """Write the OSC 777 notify sequence directly to /dev/tty. Never raises;
+    a failure here must never interrupt the agent loop."""
+    seq = f"\033]777;notify;{title};{body}\007"
+    try:
+        with open("/dev/tty", "w") as tty:
+            tty.write(seq)
+            tty.flush()
+    except OSError:
+        pass
+
+
+def _build_payload(event: str, session_id: str = "", cwd: str = "", **extra) -> str:
+    cwd = cwd or os.getcwd()
+    payload = {
+        "v": _negotiate_protocol_version(),
+        "agent": "hermes",
+        "event": event,
+        "session_id": session_id or "",
+        "cwd": cwd,
+        "project": os.path.basename(cwd.rstrip("/")) if cwd else "",
+    }
+    payload.update(extra)
+    return json.dumps(payload, separators=(",", ":"))
+
+
+def notify_stop(session_id: str = "", query: str = "", response: str = "") -> None:
+    """Call when the agent finishes a response turn (the same moment
+    bell_on_complete fires). Maps to Claude Code's Stop hook / "event":
+    "stop"."""
+    if not _should_notify():
+        return
+    body = _build_payload(
+        "stop",
+        session_id=session_id,
+        query=(query or "")[:200],
+        response=(response or "")[:200],
+    )
+    _emit_osc777("warp://cli-agent", body)
+
+
+def notify_permission_request(
+    tool_name: str, summary: str = "", session_id: str = ""
+) -> None:
+    """Call when the approval UI is shown for a dangerous command / tool
+    call. Maps to Claude Code's PermissionRequest hook."""
+    if not _should_notify():
+        return
+    body = _build_payload(
+        "permission_request",
+        session_id=session_id,
+        tool_name=tool_name,
+        summary=(summary or f"Wants to run {tool_name}")[:200],
+    )
+    _emit_osc777("warp://cli-agent", body)

--- a/hermes_cli/warp_notify.py
+++ b/hermes_cli/warp_notify.py
@@ -99,7 +99,7 @@ def _emit_osc777(title: str, body: str) -> None:
     a failure here must never interrupt the agent loop."""
     seq = f"\033]777;notify;{title};{body}\007"
     try:
-        with open("/dev/tty", "w") as tty:
+        with open("/dev/tty", "w", encoding="utf-8") as tty:
             tty.write(seq)
             tty.flush()
     except OSError:

--- a/tests/hermes_cli/test_warp_notify.py
+++ b/tests/hermes_cli/test_warp_notify.py
@@ -1,0 +1,182 @@
+import json
+import os
+
+import pytest
+
+from hermes_cli import warp_notify
+
+
+def _clear_warp_env(monkeypatch):
+    monkeypatch.delenv("TERM_PROGRAM", raising=False)
+    monkeypatch.delenv("WARP_CLI_AGENT_PROTOCOL_VERSION", raising=False)
+    monkeypatch.delenv("WARP_CLIENT_VERSION", raising=False)
+
+
+def _set_warp_env(monkeypatch, *, protocol_version="1", client_version="v0.2026.08.01.00.00.stable_01"):
+    monkeypatch.setenv("TERM_PROGRAM", "WarpTerminal")
+    monkeypatch.setenv("WARP_CLI_AGENT_PROTOCOL_VERSION", protocol_version)
+    monkeypatch.setenv("WARP_CLIENT_VERSION", client_version)
+
+
+class TestShouldNotify:
+    def test_false_with_no_env(self, monkeypatch):
+        _clear_warp_env(monkeypatch)
+        assert warp_notify._should_notify() is False
+
+    def test_false_outside_warp(self, monkeypatch):
+        _clear_warp_env(monkeypatch)
+        monkeypatch.setenv("WARP_CLI_AGENT_PROTOCOL_VERSION", "1")
+        monkeypatch.setenv("WARP_CLIENT_VERSION", "v0.2026.08.01.00.00.stable_01")
+        # TERM_PROGRAM still unset/wrong -> must stay silent even though
+        # Warp's own vars are present (e.g. a nested shell inheriting env).
+        assert warp_notify._should_notify() is False
+        monkeypatch.setenv("TERM_PROGRAM", "iTerm.app")
+        assert warp_notify._should_notify() is False
+
+    def test_false_missing_protocol_version(self, monkeypatch):
+        _clear_warp_env(monkeypatch)
+        monkeypatch.setenv("TERM_PROGRAM", "WarpTerminal")
+        monkeypatch.setenv("WARP_CLIENT_VERSION", "v0.2026.08.01.00.00.stable_01")
+        assert warp_notify._should_notify() is False
+
+    def test_false_missing_client_version(self, monkeypatch):
+        _clear_warp_env(monkeypatch)
+        monkeypatch.setenv("TERM_PROGRAM", "WarpTerminal")
+        monkeypatch.setenv("WARP_CLI_AGENT_PROTOCOL_VERSION", "1")
+        assert warp_notify._should_notify() is False
+
+    def test_true_with_full_env(self, monkeypatch):
+        _clear_warp_env(monkeypatch)
+        _set_warp_env(monkeypatch)
+        assert warp_notify._should_notify() is True
+
+
+class TestNegotiateProtocolVersion:
+    def test_defaults_to_one_when_unset(self, monkeypatch):
+        monkeypatch.delenv("WARP_CLI_AGENT_PROTOCOL_VERSION", raising=False)
+        assert warp_notify._negotiate_protocol_version() == 1
+
+    def test_min_of_ours_and_warps(self, monkeypatch):
+        monkeypatch.setenv("WARP_CLI_AGENT_PROTOCOL_VERSION", "5")
+        assert warp_notify._negotiate_protocol_version() == min(5, warp_notify._PROTOCOL_VERSION)
+
+    def test_falls_back_on_garbage_value(self, monkeypatch):
+        monkeypatch.setenv("WARP_CLI_AGENT_PROTOCOL_VERSION", "not-a-number")
+        assert warp_notify._negotiate_protocol_version() == 1
+
+
+class TestBuildPayload:
+    def test_shape_and_defaults(self, monkeypatch):
+        monkeypatch.delenv("WARP_CLI_AGENT_PROTOCOL_VERSION", raising=False)
+        raw = warp_notify._build_payload("stop", session_id="abc123", cwd="/tmp/my-project")
+        payload = json.loads(raw)
+        assert payload == {
+            "v": 1,
+            "agent": "hermes",
+            "event": "stop",
+            "session_id": "abc123",
+            "cwd": "/tmp/my-project",
+            "project": "my-project",
+        }
+
+    def test_defaults_cwd_to_os_getcwd(self, monkeypatch):
+        raw = warp_notify._build_payload("stop")
+        payload = json.loads(raw)
+        assert payload["cwd"] == os.getcwd()
+        assert payload["project"] == os.path.basename(os.getcwd())
+
+    def test_extra_kwargs_merge_in(self):
+        raw = warp_notify._build_payload("permission_request", tool_name="Bash", summary="rm -rf /tmp/x")
+        payload = json.loads(raw)
+        assert payload["event"] == "permission_request"
+        assert payload["tool_name"] == "Bash"
+        assert payload["summary"] == "rm -rf /tmp/x"
+
+    def test_is_valid_json_no_trailing_whitespace_separators(self):
+        # Reference plugin uses jq -nc (compact); match that shape so any
+        # terminal-side parser expecting a single-line OSC body doesn't choke.
+        raw = warp_notify._build_payload("stop")
+        assert "\n" not in raw
+        assert ", " not in raw
+        assert ": " not in raw
+
+
+class TestEmitOsc777:
+    def test_writes_expected_sequence_to_tty(self, monkeypatch, tmp_path):
+        fake_tty = tmp_path / "fake_tty"
+
+        real_open = open
+
+        def fake_open(path, mode="r", *a, **kw):
+            if path == "/dev/tty":
+                return real_open(fake_tty, mode, *a, **kw)
+            return real_open(path, mode, *a, **kw)
+
+        monkeypatch.setattr("builtins.open", fake_open)
+        warp_notify._emit_osc777("warp://cli-agent", '{"agent":"hermes"}')
+
+        written = fake_tty.read_text()
+        assert written == '\x1b]777;notify;warp://cli-agent;{"agent":"hermes"}\x07'
+
+    def test_never_raises_when_tty_unavailable(self, monkeypatch):
+        def raise_oserror(*a, **kw):
+            raise OSError("no such device")
+
+        monkeypatch.setattr("builtins.open", raise_oserror)
+        # Must not raise -- a missing/unavailable tty is expected on CI,
+        # over some SSH sessions, and in any non-interactive invocation.
+        warp_notify._emit_osc777("warp://cli-agent", "{}")
+
+
+class TestNotifyStop:
+    def test_noop_outside_warp(self, monkeypatch):
+        _clear_warp_env(monkeypatch)
+        called = []
+        monkeypatch.setattr(warp_notify, "_emit_osc777", lambda *a: called.append(a))
+        warp_notify.notify_stop(session_id="s1", query="hi", response="hello")
+        assert called == []
+
+    def test_emits_with_correct_event_and_truncation(self, monkeypatch):
+        _clear_warp_env(monkeypatch)
+        _set_warp_env(monkeypatch)
+        called = []
+        monkeypatch.setattr(warp_notify, "_emit_osc777", lambda title, body: called.append((title, body)))
+
+        long_query = "x" * 500
+        warp_notify.notify_stop(session_id="s1", query=long_query, response="short")
+
+        assert len(called) == 1
+        title, body = called[0]
+        assert title == "warp://cli-agent"
+        payload = json.loads(body)
+        assert payload["event"] == "stop"
+        assert payload["agent"] == "hermes"
+        assert payload["session_id"] == "s1"
+        assert len(payload["query"]) == 200
+        assert payload["response"] == "short"
+
+
+class TestNotifyPermissionRequest:
+    def test_noop_outside_warp(self, monkeypatch):
+        _clear_warp_env(monkeypatch)
+        called = []
+        monkeypatch.setattr(warp_notify, "_emit_osc777", lambda *a: called.append(a))
+        warp_notify.notify_permission_request("Bash", summary="rm -rf /")
+        assert called == []
+
+    def test_emits_with_default_summary(self, monkeypatch):
+        _clear_warp_env(monkeypatch)
+        _set_warp_env(monkeypatch)
+        called = []
+        monkeypatch.setattr(warp_notify, "_emit_osc777", lambda title, body: called.append((title, body)))
+
+        warp_notify.notify_permission_request("Bash", session_id="s2")
+
+        assert len(called) == 1
+        title, body = called[0]
+        assert title == "warp://cli-agent"
+        payload = json.loads(body)
+        assert payload["event"] == "permission_request"
+        assert payload["tool_name"] == "Bash"
+        assert payload["summary"] == "Wants to run Bash"
+        assert payload["session_id"] == "s2"


### PR DESCRIPTION
## Problem

Warp's own docs list Hermes as a recognized CLI coding agent (docs.warp.dev/agents/cli-agents/overview), but explicitly note it "doesn't support agent notifications yet" — unlike Claude Code, Codex, and OpenCode, which each implement Warp's notification protocol. In practice this means Warp can never show a completed/blocked/errored status on a Hermes tab, send a toast, or put anything in the notification mailbox — there's simply no signal for Warp to key off.

`display.bell_on_complete` (a bare `\a` BEL) doesn't fix this: Warp's CLI-agent integration looks for a specific structured OSC 777 payload, not a plain bell.

## Root cause

Claude Code and OpenCode ship a small Warp plugin ([claude-code-warp](https://github.com/warpdotdev/claude-code-warp)) that emits `OSC 777 notify` with title `warp://cli-agent` and a JSON body at a few lifecycle points (response complete, permission request, idle prompt). Codex does the equivalent via a native config flag. Hermes has neither.

## Fix

Ports the same protocol natively into Hermes — no plugin/hooks system needed, since the payload schema is already agent-name-keyed (`agent: "hermes"` is a first-class value, not a Claude-specific hack):

- **`hermes_cli/warp_notify.py`** (new): OSC 777 emitter. Gated on `TERM_PROGRAM=WarpTerminal` + `WARP_CLI_AGENT_PROTOCOL_VERSION` being set (mirrors the reference plugin's `should-use-structured.sh` version-floor gating, which exists because some Warp builds advertise protocol support without actually being able to render it). Writes directly to `/dev/tty`, never raises, silent no-op outside Warp.
- **`cli.py`**: wired into two lifecycle points —
  - response-complete (`event: "stop"`) — same moment `bell_on_complete` already fires
  - approval-request (`event: "permission_request"`) — same moment the approval UI paints

## Testing

- `python3 -c "import ast; ast.parse(...)"` on both files — clean
- Isolated unit checks: `_should_notify()` correctly returns `False` with no Warp env vars, `True` with `TERM_PROGRAM=WarpTerminal` + both version vars set; payload shape verified (`agent: "hermes"`, correct `event`, `v`, `session_id`, `cwd`, `project`)
- PTY-backed subprocess integration test: `notify_stop()` runs to completion with no exceptions when Warp env vars are set and a real tty is attached

## Scope

Deliberately minimal — only the two events Hermes's current lifecycle exposes cleanly. `idle_prompt`-equivalent notifications can be added later if/when a matching Hermes hook exists; the module's public functions are additive.

Reported by my user, investigated and fixed same-session by comparing against the public `claude-code-warp` plugin source (MIT-equivalent OSS) to reverse-engineer the exact wire protocol.
