### PR TITLE
fix(mattermost): accept (path, is_voice) media tuples in standalone send

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -1090,7 +1090,13 @@ async def _standalone_send(
             # 1. Upload media (if any) and collect file_ids.
             file_ids: List[str] = []
             for media in media_files:
-                file_path = media.get("path") if isinstance(media, dict) else media
+                if isinstance(media, dict):
+                    file_path = media.get("path")
+                elif isinstance(media, (tuple, list)) and media:
+                    # extract_media() yields (path, is_voice) tuples
+                    file_path = media[0]
+                else:
+                    file_path = media
                 if not file_path or not os.path.exists(file_path):
                     continue
                 form = aiohttp.FormData()

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -594,3 +594,98 @@ async def test_mattermost_top_level_channel_post_is_thread_root():
     assert msg_event.message_id == "top_post_123"
 
 
+# ---------------------------------------------------------------------------
+# Standalone send (out-of-process cron delivery) — media descriptor shapes
+# ---------------------------------------------------------------------------
+
+class TestMattermostStandaloneSendMedia:
+    """``_standalone_send`` must accept the media shape the caller actually sends.
+
+    ``tools/send_message_tool`` builds ``media_files`` with
+    ``BasePlatformAdapter.extract_media()``, which returns ``(path, is_voice)``
+    tuples (see ``gateway/platforms/base.py``), and forwards them unchanged to
+    the platform's ``standalone_sender_fn``.
+    """
+
+    @staticmethod
+    def _fake_session(responses):
+        """Build an aiohttp.ClientSession stand-in returning `responses` in order."""
+        calls = []
+
+        def _make_resp(spec):
+            resp = AsyncMock()
+            resp.status = spec["status"]
+            resp.json = AsyncMock(return_value=spec.get("json", {}))
+            resp.text = AsyncMock(return_value=spec.get("text", ""))
+            resp.__aenter__ = AsyncMock(return_value=resp)
+            resp.__aexit__ = AsyncMock(return_value=False)
+            return resp
+
+        prepared = [_make_resp(spec) for spec in responses]
+
+        session = MagicMock()
+
+        def _post(url, **kwargs):
+            calls.append((url, kwargs))
+            return prepared[min(len(calls) - 1, len(prepared) - 1)]
+
+        session.post = MagicMock(side_effect=_post)
+        session.__aenter__ = AsyncMock(return_value=session)
+        session.__aexit__ = AsyncMock(return_value=False)
+        return session, calls
+
+    @pytest.mark.asyncio
+    async def test_tuple_media_descriptor_is_uploaded(self, tmp_path):
+        """A ``(path, is_voice)`` tuple uploads the file and attaches its id."""
+        from plugins.platforms.mattermost.adapter import _standalone_send
+
+        media = tmp_path / "report.pdf"
+        media.write_bytes(b"%PDF-1.4 test")
+
+        pconfig = MagicMock()
+        pconfig.token = "tok"
+        pconfig.extra = {"url": "https://mm.example.com"}
+
+        session, calls = self._fake_session([
+            {"status": 201, "json": {"file_infos": [{"id": "file_1"}]}},
+            {"status": 201, "json": {"id": "post_1"}},
+        ])
+
+        with patch("aiohttp.ClientSession", return_value=session):
+            result = await _standalone_send(
+                pconfig,
+                "chan_1",
+                "here is the report",
+                media_files=[(str(media), False)],
+            )
+
+        assert result.get("error") is None
+        assert result["success"] is True
+        assert result["message_id"] == "post_1"
+        # The upload happened, and the post carries the returned file id.
+        assert calls[0][0].endswith("/api/v4/files")
+        assert calls[1][1]["json"]["file_ids"] == ["file_1"]
+
+    @pytest.mark.asyncio
+    async def test_dict_and_plain_path_descriptors_still_work(self, tmp_path):
+        """Dict and bare-string descriptors keep working."""
+        from plugins.platforms.mattermost.adapter import _standalone_send
+
+        media = tmp_path / "photo.png"
+        media.write_bytes(b"\x89PNG")
+
+        pconfig = MagicMock()
+        pconfig.token = "tok"
+        pconfig.extra = {"url": "https://mm.example.com"}
+
+        for descriptor in ({"path": str(media)}, str(media)):
+            session, calls = self._fake_session([
+                {"status": 201, "json": {"file_infos": [{"id": "file_2"}]}},
+                {"status": 201, "json": {"id": "post_2"}},
+            ])
+            with patch("aiohttp.ClientSession", return_value=session):
+                result = await _standalone_send(
+                    pconfig, "chan_1", "hi", media_files=[descriptor]
+                )
+            assert result["success"] is True, descriptor
+            assert calls[1][1]["json"]["file_ids"] == ["file_2"], descriptor


### PR DESCRIPTION
## Symptom

Out-of-process delivery of media to Mattermost (cron jobs, anything routed
through `tools/send_message_tool` while the gateway runner is not in-process)
fails outright with:

```
Mattermost send failed: stat: path should be string, bytes, os.PathLike or integer, not tuple
```

The text never lands either — the exception happens before the `POST /posts`,
so the whole send returns an error dict. In-gateway sends are unaffected, which
is why this only shows up for cron delivery.

## Root cause

`tools/send_message_tool.py` builds the media list with
`BasePlatformAdapter.extract_media()`:

```python
# gateway/platforms/base.py
def extract_media(content: str) -> Tuple[List[Tuple[str, bool]], str]:
```

so every descriptor is a `(path, is_voice)` tuple, and it is forwarded
unchanged to the plugin's `standalone_sender_fn`:

```python
result = await entry.standalone_sender_fn(
    pconfig, chat_id, chunk, thread_id=thread_id,
    media_files=media_files, force_document=force_document,
)
```

Slack's standalone sender unpacks that contract:

```python
for media_path, _is_voice in media_files:
```

Mattermost's did not — it treated any non-dict descriptor as the path itself:

```python
file_path = media.get("path") if isinstance(media, dict) else media
...
if not file_path or not os.path.exists(file_path):
```

`os.path.exists()` raises `TypeError` on a tuple (it is not caught by
`genericpath.exists`, which only swallows `OSError`/`ValueError`), and the
adapter's broad `except Exception` converts it into the error string above.

## Fix

Resolve tuple/list descriptors to their path element, keeping the existing
dict and bare-string shapes working.

## Tests

`tests/gateway/test_mattermost.py::TestMattermostStandaloneSendMedia`

- `test_tuple_media_descriptor_is_uploaded` — the real caller shape; asserts the
  file is uploaded and its id is attached to the post.
- `test_dict_and_plain_path_descriptors_still_work` — no regression for the two
  shapes that already worked.

Verified RED on unpatched `main` (the tuple test fails with the exact
production error above) and GREEN with the fix; the full
`tests/gateway/test_mattermost.py` + `test_mattermost_plugin_setup.py` suite
passes (26 passed).
