### PR TITLE
fix(desktop): re-arm client wake-word capture across gateway reconnects

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -82,7 +82,7 @@ import {
   setMessages
 } from '@/store/session'
 import { clearSessionTodos, setSessionTodos, todosForHydration } from '@/store/todos'
-import { armWakeWord, stopClientCapture } from '@/store/wake-word'
+import { armWakeWord, clearWakeWordConnectionState, stopClientCapture } from '@/store/wake-word'
 import { isAuxiliaryWindow, isBrowserWindow, isHudWindow } from '@/store/windows'
 import { useSkinCommand } from '@/themes/use-skin-command'
 
@@ -228,6 +228,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   const messagingSessions = useStore($messagingSessions)
   const sessions = useStore($sessions)
   const activeConnectionId = useStore($activeConnectionId)
+  const connection = useStore($connection)
   const activeGatewayProfile = useStore($activeGatewayProfile)
   const profileScope = useStore($profileScope)
   const boot = useStore($desktopBoot)
@@ -804,12 +805,19 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   })
 
   useEffect(() => {
-    if (gatewayState === 'open') {
-      // Status-then-arm, syncing $wakeWord so the composer toggle reflects the
-      // same listener this auto-arm claims.
-      void armWakeWord(requestGateway)
+    if (gatewayState !== 'open') {
+      clearWakeWordConnectionState()
+
+      return
     }
-  }, [gatewayState, requestGateway])
+
+    // Re-run when main recycles a local backend: the registry connection id can
+    // stay `local` while the ephemeral port/base URL changes, so gatewayState
+    // alone does not give React a new dependency. The request must be issued on
+    // the newly-open socket or the old wake lease is gone forever.
+
+    void armWakeWord(requestGateway)
+  }, [activeConnectionId, activeGatewayProfile, connection?.baseUrl, gatewayState, requestGateway])
 
   const activeIsMessaging =
     !!selectedStoredSessionId &&
@@ -1085,7 +1093,6 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   // (preview's monitor/devtools cluster, …) arrive as registry contributions.
   const leftTitlebarTools = useTitlebarToolContributions('left')
   const rightTitlebarTools = useTitlebarToolContributions('right')
-  const connection = useStore($connection)
   const controlsPos = titlebarControlsPosition(connection?.windowButtonPosition, Boolean(connection?.isFullscreen))
   // Windows/WSLg reserve native min/max/close on the right (AppShell parity:
   // prefer the live WCO measurement, fall back to the static reservation).

--- a/apps/desktop/src/store/wake-word.test.ts
+++ b/apps/desktop/src/store/wake-word.test.ts
@@ -6,6 +6,7 @@ import {
   applyWakeStatus,
   applyWakeStopResult,
   armWakeWord,
+  clearWakeWordConnectionState,
   resetWakeWordState,
   resumeWakeAfterVoice,
   toggleWakeWord,
@@ -243,6 +244,23 @@ describe('applyWakeStopResult', () => {
     const state = $wakeWord.get()
     expect(state.listening).toBe(false)
     expect(state.notice).toBe('another surface owns the listener')
+  })
+})
+
+describe('clearWakeWordConnectionState', () => {
+  it('clears the live lease state without losing backend configuration', () => {
+    applyWakeStatus({ available: true, enabled: true, listening: true, phrase: 'hey alia' })
+
+    clearWakeWordConnectionState()
+
+    expect($wakeWord.get()).toMatchObject({
+      available: true,
+      enabled: true,
+      listening: false,
+      notice: '',
+      pending: false,
+      phrase: 'hey alia'
+    })
   })
 })
 

--- a/apps/desktop/src/store/wake-word.ts
+++ b/apps/desktop/src/store/wake-word.ts
@@ -401,6 +401,19 @@ export async function resumeWakeAfterVoice(request: WakeRequester = gatewayReque
   }
 }
 
+/** The transport lease is gone; keep config truth but clear the live listener UI. */
+export function clearWakeWordConnectionState(): void {
+  const current = $wakeWord.get()
+
+  stopClientCapture()
+  $wakeWord.set({
+    ...current,
+    listening: false,
+    notice: '',
+    pending: false
+  })
+}
+
 /** Test-only reset. */
 export function resetWakeWordState(): void {
   stopClientCapture()

--- a/tests/tools/test_wake_word.py
+++ b/tests/tools/test_wake_word.py
@@ -523,6 +523,61 @@ def test_detector_opens_configured_input_device_and_reports_backend(monkeypatch)
         det.stop()
 
 
+def test_macos_local_capture_uses_callback_queue(monkeypatch):
+    """Core Audio must use callback capture; blocking ``read()`` can hang forever."""
+    np = pytest.importorskip("numpy")
+    opened = []
+    processed = []
+
+    class _CallbackStream:
+        def __init__(self, **kwargs):
+            opened.append(kwargs)
+            self.closed = False
+
+        def start(self):
+            callback = opened[-1]["callback"]
+            callback(np.full((4, 1), 500, dtype=np.int16), 4, None, None)
+
+        def read(self, _n):
+            raise AssertionError("macOS capture must not use blocking read()")
+
+        def stop(self):
+            pass
+
+        def close(self):
+            self.closed = True
+
+    fake_sd = types.SimpleNamespace(
+        InputStream=lambda **kwargs: _CallbackStream(**kwargs),
+        query_devices=lambda selector, kind: {
+            "name": "Yeti Stereo Microphone",
+            "hostapi": 0,
+            "max_input_channels": 2,
+            "default_samplerate": 16000.0,
+        },
+        query_hostapis=lambda index: {"name": "Core Audio"},
+    )
+    monkeypatch.setattr(ww.sys, "platform", "darwin")
+    monkeypatch.setattr(ww, "_import_audio", lambda: (fake_sd, np))
+
+    class _RecordingEngine(_FakeEngine):
+        def process(self, frame):
+            processed.append(frame)
+            return False
+
+    det = ww.WakeWordDetector(_RecordingEngine(fire=False), lambda: None, input_device="Yeti Stereo Microphone")
+    det.start()
+    try:
+        deadline = time.monotonic() + 2.0
+        while not processed and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert processed
+        assert callable(opened[0]["callback"])
+        assert len(processed[0]) == 4
+    finally:
+        det.stop()
+
+
 @pytest.mark.windows_only
 def test_windows_silent_hint_names_selected_device():
     hint = ww.silent_audio_hint(
@@ -710,9 +765,9 @@ def test_resolve_capture_mode_auto_and_prefer_client(monkeypatch):
     assert ww.resolve_capture_mode({"capture": "auto"}, force_local=True) == "local"
     monkeypatch.setattr(ww, "_local_input_device_ready", lambda: True)
     assert ww.resolve_capture_mode({"capture": "auto"}) == "local"
-    # A working backend mic wins under auto even for a preferring surface, so
-    # local desktops keep PortAudio + wake_word.input_device selection.
-    assert ww.resolve_capture_mode({"capture": "auto"}, prefer_client=True) == "local"
+    # A GUI-preferring surface deliberately uses client capture under auto;
+    # enumeration alone is not proof that opening the backend stream works.
+    assert ww.resolve_capture_mode({"capture": "auto"}, prefer_client=True) == "client"
     # Explicit client still forces streaming (backend mic exists but is wrong).
     assert ww.resolve_capture_mode({"capture": "client"}, prefer_client=True) == "client"
 

--- a/tools/wake_word.py
+++ b/tools/wake_word.py
@@ -269,14 +269,15 @@ def resolve_capture_mode(
         return "client"
     if raw == "local":
         return "local"
-    # auto: a working backend input always wins so local desktops keep
-    # PortAudio and the configured ``input_device`` selection. Client capture
-    # is the fallback for a preferring surface (desktop remote) on a backend
-    # with no usable mic — the headless VPS/Cloud case.
-    if _local_input_device_ready():
-        return "local"
+    # auto: a preferring surface owns the microphone capture decision. This is
+    # intentional: device enumeration can succeed while opening the stream
+    # hangs (Core Audio/HAL, permissions, or a stale device). The Desktop can
+    # capture PCM through getUserMedia and keep the detector on the selected
+    # backend, so do not let a false-positive local probe defeat that path.
     if prefer_client:
         return "client"
+    if _local_input_device_ready():
+        return "local"
     # No local mic and no client preference (CLI/TUI): stay local so status
     # reports the real requirement instead of advertising a capture path
     # nothing will feed.
@@ -1030,6 +1031,30 @@ class WakeWordDetector:
         t = self._thread
         return t is not None and t.is_alive()
 
+    def _queue_audio_chunk(self, chunk) -> None:
+        """Enqueue capture data without blocking the audio callback."""
+        try:
+            self._audio_q.put_nowait(chunk)
+        except Exception:
+            # Drop oldest on overflow so we stay real-time.
+            try:
+                self._audio_q.get_nowait()
+            except Exception:
+                pass
+            try:
+                self._audio_q.put_nowait(chunk)
+            except Exception:
+                pass
+
+    def _on_local_audio(self, indata, _frames, _time_info, status) -> None:
+        if status:
+            logger.debug("wake word: capture status: %s", status)
+
+        try:
+            self._queue_audio_chunk(indata.copy())
+        except Exception:
+            self._queue_audio_chunk(indata)
+
     def feed(self, pcm_int16) -> None:
         """Enqueue one int16 mono frame (or raw bytes) for client capture.
 
@@ -1060,17 +1085,9 @@ class WakeWordDetector:
                 pad[: chunk.shape[0]] = chunk
                 chunk = pad
             try:
-                self._audio_q.put_nowait(chunk)
+                self._queue_audio_chunk(chunk)
             except Exception:
-                # Drop oldest on overflow so we stay real-time
-                try:
-                    self._audio_q.get_nowait()
-                except Exception:
-                    pass
-                try:
-                    self._audio_q.put_nowait(chunk)
-                except Exception:
-                    pass
+                pass
 
     def start(self) -> None:
         """Open the mic (or client feeder) and begin listening. Idempotent."""
@@ -1127,6 +1144,7 @@ class WakeWordDetector:
         frame_length = self.engine.frame_length
         capture_frame_length = frame_length
         capture_rate = SAMPLE_RATE
+        local_callback_capture = False
         np = None
         stream = None
 
@@ -1165,14 +1183,18 @@ class WakeWordDetector:
                 capture_rate,
                 SAMPLE_RATE,
             )
+            local_callback_capture = sys.platform == "darwin"
             try:
-                stream = sd.InputStream(
-                    device=self.input_device,
-                    samplerate=capture_rate,
-                    channels=1,
-                    dtype="int16",
-                    blocksize=capture_frame_length,
-                )
+                stream_kwargs = {
+                    "device": self.input_device,
+                    "samplerate": capture_rate,
+                    "channels": 1,
+                    "dtype": "int16",
+                    "blocksize": capture_frame_length,
+                }
+                if local_callback_capture:
+                    stream_kwargs["callback"] = self._on_local_audio
+                stream = sd.InputStream(**stream_kwargs)
                 stream.start()
             except Exception as e:
                 logger.error("wake word: failed to open microphone: %s", e)
@@ -1198,16 +1220,15 @@ class WakeWordDetector:
         try:
             while not self._stop.is_set():
                 try:
-                    if self.external_audio:
+                    if self.external_audio or local_callback_capture:
                         try:
-                            frame = self._audio_q.get(timeout=0.25)
+                            data = self._audio_q.get(timeout=0.25)
                         except Exception:
-                            # No client frames yet — count as silence for status.
+                            # No callback/client frames yet — count as silence for status.
                             self._silent_frames += 1
                             if self._silent_frames == silent_alert_frames:
                                 self.audio_silent = True
                             continue
-                        data = frame
                     else:
                         data, _overflow = stream.read(capture_frame_length)
                 except Exception as e:


### PR DESCRIPTION
## Summary

Make remote desktop wake-word capture reliable across gateway reconnects.

- Prefer client audio capture when the detector is instructed to use the client stream.
- Use the sounddevice callback path on macOS so Core Audio capture does not block the detector loop.
- Clear the connection-scoped wake lease when the gateway closes and re-arm against the current connection.
- Keep multi-profile phrase enrollment and cooldown behavior unchanged.

## Validation

- `uv run pytest tests/tools/test_wake_word.py -q --tb=short` — 27 passed, 3 skipped
- `npm exec -- vitest run --project ui src/store/wake-word.test.ts` — 23 passed
- `npm exec -- tsc -p tsconfig.json --noEmit` — passed
- `npm exec -- tsc -p tsconfig.electron.json --noEmit` — passed
- `npm exec -- eslint src/app/contrib/wiring.tsx src/store/wake-word.ts src/store/wake-word.test.ts` — passed
- `uvx ruff check tools/wake_word.py tests/tools/test_wake_word.py` — passed
