### PR TITLE
fix(kanban): persist guardrail halt handoff

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -113,6 +113,61 @@ def _record_kanban_budget_exhausted(
         )
 
 
+def _record_kanban_guardrail_halt(kanban_task: str, decision, logger: logging.Logger) -> None:
+    """End the current Kanban run as a durable blocked handoff after a hard tool guardrail halt.
+
+    A guardrail halt intentionally stops unsafe repetition, but a worker that
+    exits without a board transition is indistinguishable from a crash to the
+    dispatcher.  Pin the update to this worker run so a stale subprocess can
+    never block a later retry.
+    """
+    raw_run_id = (os.environ.get("HERMES_KANBAN_RUN_ID") or "").strip()
+    try:
+        expected_run_id = int(raw_run_id)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Kanban guardrail halt for task %s has no valid run id; leaving task state unchanged",
+            kanban_task,
+        )
+        return
+
+    tool_name = str(getattr(decision, "tool_name", "") or "a tool")
+    code = str(getattr(decision, "code", "") or "guardrail_halt")
+    count = getattr(decision, "count", 0)
+    try:
+        count = int(count)
+    except (TypeError, ValueError):
+        count = 0
+    reason = (
+        f"Tool guardrail halted {tool_name} ({code}) after {count} "
+        "repeated non-progressing calls."
+    )
+
+    try:
+        from hermes_cli import kanban_db as _kb
+
+        _conn = _kb.connect()
+        try:
+            _kb.block_task(
+                _conn,
+                kanban_task,
+                reason=reason,
+                kind="transient",
+                expected_run_id=expected_run_id,
+            )
+        finally:
+            try:
+                _conn.close()
+            except Exception:
+                pass
+    except Exception:
+        logger.warning(
+            "Failed to record guardrail halt for Kanban task %s",
+            kanban_task,
+            exc_info=True,
+        )
+
+
 def _drop_verification_continuation_scaffolding(messages) -> None:
     """Remove verification-continuation nudge messages from *messages* in place.
 
@@ -231,11 +286,18 @@ def finalize_turn(
                 _kanban_task, api_call_count, agent.max_iterations, logger,
             )
 
+    if str(_turn_exit_reason) == "guardrail_halt":
+        _kanban_task = os.environ.get("HERMES_KANBAN_TASK")
+        _guardrail = getattr(agent, "_tool_guardrail_halt_decision", None)
+        if _kanban_task and _guardrail is not None:
+            _record_kanban_guardrail_halt(_kanban_task, _guardrail, logger)
+
     # Determine if conversation completed successfully
     normal_text_response = str(_turn_exit_reason).startswith("text_response(")
     completed = (
         final_response is not None
         and not failed
+        and str(_turn_exit_reason) != "guardrail_halt"
         and (
             api_call_count < agent.max_iterations
             or normal_text_response

--- a/tests/agent/test_turn_finalizer_iteration_limit_exit.py
+++ b/tests/agent/test_turn_finalizer_iteration_limit_exit.py
@@ -1,11 +1,13 @@
 """Regression tests for iteration-limit exit normalization (#61631)."""
 
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 
 from agent.turn_finalizer import finalize_turn
+from hermes_cli import kanban_db as kb
 
 
 class _LimitAgent:
@@ -163,6 +165,79 @@ def test_pending_response_does_not_mask_later_terminal_exit(
     assert result["turn_exit_reason"] == exit_reason
     assert result["completed"] is False
     assert agent._handle_max_iterations_called is False
+
+
+
+def test_guardrail_halt_blocks_active_kanban_worker(monkeypatch, tmp_path):
+    """A guardrail halt writes a real blocked terminal transition, not a crash."""
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="guardrail", assignee="builder")
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None and claimed.current_run_id is not None
+        run_id = claimed.current_run_id
+    finally:
+        conn.close()
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+    agent = _LimitAgent(max_iterations=60, budget_remaining=56)
+    agent._tool_guardrail_halt_decision = MagicMock(
+        tool_name="terminal", code="repeated_exact_failure_block", count=5
+    )
+    agent._tool_guardrail_halt_decision.to_metadata.return_value = {}
+
+    result = _finalize(
+        agent,
+        final_response="guardrail halted",
+        exit_reason="guardrail_halt",
+        api_call_count=4,
+    )
+
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, task_id)
+        events = kb.list_events(conn, task_id)
+    finally:
+        conn.close()
+    assert task is not None
+    assert task.status == "blocked"
+    assert task.block_kind == "transient"
+    assert events[-1].kind == "blocked"
+    assert events[-1].payload["reason"] == (
+        "Tool guardrail halted terminal "
+        "(repeated_exact_failure_block) after 5 repeated non-progressing calls."
+    )
+    assert result["turn_exit_reason"] == "guardrail_halt"
+    assert result["completed"] is False
+
+
+def test_guardrail_halt_without_run_id_cannot_block_a_later_worker(monkeypatch):
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-guardrail")
+    monkeypatch.delenv("HERMES_KANBAN_RUN_ID", raising=False)
+    block = MagicMock(name="block_task")
+    monkeypatch.setattr("hermes_cli.kanban_db.block_task", block)
+    agent = _LimitAgent(max_iterations=60, budget_remaining=56)
+    agent._tool_guardrail_halt_decision = MagicMock(
+        tool_name="terminal", code="repeated_exact_failure_block", count=5
+    )
+    agent._tool_guardrail_halt_decision.to_metadata.return_value = {}
+
+    _finalize(
+        agent,
+        final_response="guardrail halted",
+        exit_reason="guardrail_halt",
+        api_call_count=4,
+    )
+
+    block.assert_not_called()
 
 
 def test_pending_response_records_kanban_timeout(monkeypatch):


### PR DESCRIPTION
When the tool-loop guardrail hard-stops a Kanban worker, persist a transient Kanban block event before the worker exits.

This preserves the actual terminal reason, prevents the dispatcher from classifying the clean guardrail exit as a crash, and lets the normal blocked-card recovery path handle it.

The update is compare-and-set safe: a stale worker cannot block a later run.

Tests:
- tests/agent/test_turn_finalizer_iteration_limit_exit.py
- tests/run_agent/test_tool_call_guardrail_runtime.py
- tests/agent/test_kanban_stop.py
