### PR TITLE
fix(computer_use): no-overlay policy for user-registered cua-driver MCP servers + interrupt teardown

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2354,6 +2354,39 @@ def cleanup_task_resources(agent, task_id: str) -> None:
             if agent.verbose_logging:
                 logger.warning("Failed to cleanup %s for task %s: %s", label, task_id, e)
 
+    # An interrupted turn must end the computer-use session (#81220):
+    # the cua-driver cursor overlay on Linux/X11 is a fullscreen
+    # InputOutput override-redirect window, and leaving the backend alive
+    # after a wedged turn left the overlay mapped over the whole virtual
+    # desktop — swallowing every click outside Hermes until a manual
+    # ``set_agent_cursor_enabled(false)``. Backends are cached under the
+    # tool ``session_id`` (== agent.session_id; see agent/tool_executor.py
+    # dispatch kwargs), NOT the per-turn task_id, so the release must be
+    # keyed the same way or it pops a key that never exists. Gated on the
+    # interrupt flag so normal turns keep the cached
+    # one-backend-per-session behavior (no respawn / re-handshake
+    # mid-conversation). Best-effort, like the VM and browser steps
+    # above: a dead driver socket must not break the rest of the cleanup
+    # chain. The lazy import keeps the narrow core footprint for sessions
+    # that never touch computer use.
+    if not getattr(agent, "_interrupt_requested", False):
+        return
+    session_id = str(getattr(agent, "session_id", "") or "")
+    if not session_id:
+        return
+    try:
+        from tools.computer_use import release_computer_use_session
+
+        release_computer_use_session(session_id)
+    except Exception as e:
+        if agent.verbose_logging:
+            logger.warning(
+                "Failed to release computer-use session for session %s "
+                "after interrupt: %s",
+                getattr(agent, "session_id", None),
+                e,
+            )
+
 
 def _build_partial_stream_stub(role, full_content, full_reasoning, model_name, usage_obj, *,
     dropped_tool_names=None):

--- a/tests/agent/test_cleanup_releases_computer_use_on_interrupt.py
+++ b/tests/agent/test_cleanup_releases_computer_use_on_interrupt.py
@@ -1,0 +1,130 @@
+"""Regression tests for #81220 — interrupted turns release computer use.
+
+An interrupted turn used to leave the session-owned computer-use backend
+(and any mapped cua-driver cursor overlay) alive until agent ``close()`` or
+process exit. On Linux/X11 the overlay is a fullscreen InputOutput
+override-redirect window, so a wedged turn left the desktop unusable until
+a manual ``set_agent_cursor_enabled(false)`` — the reporter's exact
+symptom. The fix: ``cleanup_task_resources`` releases the computer-use
+backend **only when the turn was interrupted**; normal completion keeps
+the cached one-backend-per-session behavior (no respawn cost
+mid-conversation).
+
+Keying contract under test: backends are cached under the tool
+``session_id`` (``agent.session_id`` — see ``agent/tool_executor.py``
+dispatch kwargs), NOT the per-turn ``task_id``. The release must use the
+same key or it pops a cache entry that never exists.
+"""
+
+from unittest.mock import patch
+
+import agent.chat_completion_helpers as helpers
+from agent.chat_completion_helpers import cleanup_task_resources
+
+
+class _StubBudget:
+    used = 0
+    max_total = 100
+    remaining = 100
+
+
+class _StubAgent:
+    """Minimal agent surface that ``cleanup_task_resources`` reads from."""
+
+    def __init__(self, session_id: str | None = "sess-42"):
+        self.session_id = session_id
+        self.verbose_logging = False
+        self.cleaned_vm = []
+        self.cleaned_browser = []
+        self._interrupt_requested = False
+
+    def cleanup_vm(self, task_id):
+        self.cleaned_vm.append(task_id)
+
+    def cleanup_browser(self, task_id):
+        self.cleaned_browser.append(task_id)
+
+
+def _cleanup(monkeypatch, agent, *, interrupted, task_id="turn-uuid-1"):
+    monkeypatch.setattr(helpers, "is_persistent_env", lambda tid: False)
+    monkeypatch.setattr(helpers, "_ra", lambda: agent)
+    agent._interrupt_requested = interrupted
+    cleanup_task_resources(agent, task_id)
+
+
+class TestInterruptedTurnReleasesComputerUse:
+    def test_interrupted_turn_releases_backend(self, monkeypatch):
+        """An interrupted turn must end the cua-driver session so the
+        overlay cannot outlive the turn (#81220). Patched at the real
+        seam — the ``tools.computer_use`` free function the production
+        code imports at call time — and asserting the SESSION key, not
+        the per-turn task id."""
+        agent = _StubAgent(session_id="sess-42")
+        with patch(
+            "tools.computer_use.release_computer_use_session"
+        ) as mock_release:
+            _cleanup(monkeypatch, agent, interrupted=True, task_id="turn-uuid-1")
+        mock_release.assert_called_once_with("sess-42")
+
+    def test_interrupted_release_pops_real_backend_cache(self, monkeypatch):
+        """Cross-seam proof against the real cache: a backend registered
+        under the agent's session_id is gone after an interrupted turn,
+        and a backend under any other key survives untouched."""
+        import tools.computer_use.tool as cu_tool
+
+        class _FakeBackend:
+            def __init__(self):
+                self.stopped = False
+
+            def stop(self):
+                self.stopped = True
+
+        agent = _StubAgent(session_id="sess-42")
+        mine = _FakeBackend()
+        other = _FakeBackend()
+        cu_tool._backends["sess-42"] = mine
+        cu_tool._backends["sess-99"] = other
+        try:
+            _cleanup(monkeypatch, agent, interrupted=True, task_id="turn-uuid-1")
+            assert "sess-42" not in cu_tool._backends, (
+                "interrupted turn must pop the session-keyed backend"
+            )
+            assert cu_tool._backends.get("sess-99") is other, (
+                "other sessions' backends must be untouched"
+            )
+            assert mine.stopped and not other.stopped, (
+                "exactly the session backend was stopped"
+            )
+        finally:
+            cu_tool._backends.pop("sess-99", None)
+            cu_tool._backends.pop("sess-42", None)
+
+    def test_normal_completion_keeps_cached_backend(self, monkeypatch):
+        """Normal completion must NOT release: the one-backend-per-session
+        cache is load-bearing (no respawn, no re-handshake mid-chat)."""
+        agent = _StubAgent(session_id="sess-42")
+        with patch(
+            "tools.computer_use.release_computer_use_session"
+        ) as mock_release:
+            _cleanup(monkeypatch, agent, interrupted=False)
+        mock_release.assert_not_called()
+
+    def test_interrupted_turn_without_session_id_skips_release(self, monkeypatch):
+        """An incomplete agent stub must not target the empty cache key."""
+        agent = _StubAgent(session_id=None)
+        with patch(
+            "tools.computer_use.release_computer_use_session"
+        ) as mock_release:
+            _cleanup(monkeypatch, agent, interrupted=True)
+        mock_release.assert_not_called()
+
+    def test_release_failure_never_raises(self, monkeypatch):
+        """Teardown is best-effort: a dead driver socket must not break the
+        rest of the cleanup chain (same contract as VM/browser steps)."""
+        agent = _StubAgent(session_id="sess-42")
+        with patch(
+            "tools.computer_use.release_computer_use_session",
+            side_effect=RuntimeError("driver socket gone"),
+        ):
+            _cleanup(monkeypatch, agent, interrupted=True)
+        assert agent.cleaned_vm == ["turn-uuid-1"]  # the other steps still ran

--- a/tests/computer_use/test_cua_mcp_overlay_policy.py
+++ b/tests/computer_use/test_cua_mcp_overlay_policy.py
@@ -1,0 +1,316 @@
+"""Regression tests for #81220 — overlay policy on user-registered MCP.
+
+A user-registered ``mcp_servers.cua-driver`` entry (``args: [mcp]``) used to
+spawn cua-driver verbatim: the args bypassed the ``--no-overlay`` policy the
+embedded cua-backend already applies at ``_resolve_mcp_invocation``, so the
+cursor overlay (a fullscreen InputOutput override-redirect X11 window) could
+map across the whole virtual desktop and swallow every click outside Hermes
+until a manual ``set_agent_cursor_enabled(false)``.
+
+These assert the behavior contract of the MCP-launch normalization —
+policy-derived flag injection, deduplication of an explicit flag, explicit
+opt-in preservation, byte-identical passthrough for unrelated commands, and
+the older-driver support-probe invariant — not snapshots of config.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from tools.computer_use import cua_backend_driver
+
+
+@pytest.fixture(autouse=True)
+def _reset_probe_cache():
+    cua_backend_driver._cua_driver_supports_no_overlay.cache_clear()
+    yield
+    cua_backend_driver._cua_driver_supports_no_overlay.cache_clear()
+
+
+class TestLooksLikeCuaDriverCommand:
+    """The detector recognizes every *class* of cua-driver invocation."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "cua-driver",                       # bare name
+            "/usr/local/bin/cua-driver",        # absolute POSIX path
+            "./cua-driver",                     # relative path
+            "C:\\Program Files\\cua\\cua-driver.exe",  # Windows path + .exe
+        ],
+    )
+    def test_recognizes_cua_driver_binaries(self, command):
+        assert cua_backend_driver.looks_like_cua_driver_command(command) is True
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "",                          # empty
+            None,                        # absent
+            "npx",                       # unrelated launcher
+            "mcp-remote",                # unrelated server
+            "my-cua-driver-wrapper",     # lookalike — must NOT match
+            "driver-cua",                # reordered lookalike
+        ],
+    )
+    def test_rejects_non_cua_driver_commands(self, command):
+        assert cua_backend_driver.looks_like_cua_driver_command(command) is False
+
+
+class TestNormalizeUserCuaDriverArgs:
+    """Overlay policy applied to a user-configured MCP launch."""
+
+    def test_appends_flag_when_policy_true(self):
+        """The #81220 repro: policy resolves True (Linux/X11 auto-detect),
+        driver supports the flag — the user's ``args: [mcp]`` must gain
+        ``--no-overlay``."""
+        with patch.object(cua_backend_driver._cb(), "_cua_no_overlay", return_value=True), \
+             patch.object(
+                 cua_backend_driver, "_cua_driver_supports_no_overlay",
+                 return_value=True,
+             ):
+            result = cua_backend_driver.normalize_user_cua_driver_args(
+                "/usr/local/bin/cua-driver", ["mcp"],
+            )
+        assert result == ["mcp", "--no-overlay"]
+
+    @pytest.mark.parametrize(
+        "flag", ["--no-overlay", "--no-overlay=true", "--no-overlay=false"]
+    )
+    def test_deduplicates_explicit_flag(self, flag):
+        """A user who already supplied ``--no-overlay`` keeps one token —
+        duplicate flags are noise at best and a driver-side error at worst."""
+        with patch.object(cua_backend_driver._cb(), "_cua_no_overlay", return_value=True), \
+             patch.object(
+                 cua_backend_driver, "_cua_driver_supports_no_overlay",
+                 return_value=True,
+             ):
+            result = cua_backend_driver.normalize_user_cua_driver_args(
+                "cua-driver", ["mcp", flag],
+            )
+        assert result == ["mcp", flag]
+
+    def test_explicit_optin_false_preserves_overlay(self):
+        """``computer_use.no_overlay: false`` is the documented opt-in to
+        keep the cursor visualization — normalization must not fight it."""
+        with patch.object(cua_backend_driver._cb(), "_cua_no_overlay", return_value=False), \
+             patch.object(
+                 cua_backend_driver, "_cua_driver_supports_no_overlay",
+                 return_value=True,
+             ):
+            result = cua_backend_driver.normalize_user_cua_driver_args(
+                "cua-driver", ["mcp"],
+            )
+        assert result == ["mcp"]
+
+    def test_unrelated_command_is_byte_identical(self):
+        """Non-cua-driver servers must pass through untouched — this is what
+        keeps the change class-level instead of touching every MCP spawn."""
+        args = ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+        with patch.object(cua_backend_driver._cb(), "_cua_no_overlay", return_value=True), \
+             patch.object(
+                 cua_backend_driver, "_cua_driver_supports_no_overlay",
+                 return_value=True,
+             ):
+            result = cua_backend_driver.normalize_user_cua_driver_args(
+                "npx", list(args),
+            )
+        assert result == args
+
+    def test_older_driver_falls_back_without_flag(self):
+        """Older drivers reject unknown flags; when the installed binary
+        doesn't recognise ``--no-overlay`` the launch must proceed without
+        it (the embedded-backend probe invariant)."""
+        with patch.object(cua_backend_driver._cb(), "_cua_no_overlay", return_value=True), \
+             patch.object(
+                 cua_backend_driver, "_cua_driver_supports_no_overlay",
+                 return_value=False,
+             ):
+            result = cua_backend_driver.normalize_user_cua_driver_args(
+                "cua-driver", ["mcp"],
+            )
+        assert result == ["mcp"]
+
+    def test_does_not_mutate_caller_list(self):
+        original = ["mcp"]
+        with patch.object(cua_backend_driver._cb(), "_cua_no_overlay", return_value=True), \
+             patch.object(
+                 cua_backend_driver, "_cua_driver_supports_no_overlay",
+                 return_value=True,
+             ):
+            cua_backend_driver.normalize_user_cua_driver_args("cua-driver", original)
+        assert original == ["mcp"]
+
+    def test_probe_runs_against_user_resolved_binary(self):
+        """The support probe must run against the user's binary, not the
+        embedded default — a relocated driver with a different feature set
+        is the exact case the embedded path guards."""
+        with patch.object(cua_backend_driver._cb(), "_cua_no_overlay", return_value=True), \
+             patch.object(
+                 cua_backend_driver, "_cua_driver_supports_no_overlay",
+                 return_value=True,
+             ) as mock_supports:
+            cua_backend_driver.normalize_user_cua_driver_args(
+                "/opt/vendor/bin/cua-driver", ["mcp"],
+            )
+        mock_supports.assert_called_once_with("/opt/vendor/bin/cua-driver")
+
+
+class TestSupportProbePerBinary:
+    """The ``--help`` probe caches per resolved binary (maxsize=8), not
+    process-wide — a relocated driver must be probed on its own."""
+
+    def test_probe_cached_per_binary(self):
+        completed = SimpleNamespace(stdout="--no-overlay", stderr="", returncode=0)
+        # ``_cb()._run_driver`` is the facade seam the driver module calls.
+        with patch.object(
+                cua_backend_driver._cb(), "_run_driver",
+                return_value=completed,
+             ) as mock_run:
+            assert cua_backend_driver._cua_driver_supports_no_overlay("/opt/a/cua-driver")
+            assert cua_backend_driver._cua_driver_supports_no_overlay("/opt/b/cua-driver")
+            assert cua_backend_driver._cua_driver_supports_no_overlay("/opt/a/cua-driver")
+        assert mock_run.call_count == 2
+
+
+class TestMcpStdioHookAppliesPolicy:
+    """One integration proof through the real ``_run_stdio``: normalization
+    lands AFTER command resolution and BEFORE the OSV preflight / watchdog
+    wrap, so the policy rides the real user launch line.
+
+    The transport is faked at the two SDK seams (``stdio_client`` /
+    ``ClientSession``): the fake session raises on ``__aenter__``, so the
+    coroutine unwinds through the real ``finally`` right after the spawn
+    seam — deterministically, with no subprocess and no network.
+    """
+
+    @pytest.fixture
+    def server_task(self):
+        pytest.importorskip("mcp")
+        import tools.mcp_tool as mcp_tool_mod
+        from tools.mcp_tool import MCPServerTask
+
+        # Bind the lazy SDK symbols (stdio_client et al. are PEP 562
+        # lazy attrs) so the monkeypatches below target real module state.
+        assert mcp_tool_mod._ensure_mcp_sdk() is True
+
+        task = MCPServerTask.__new__(MCPServerTask)
+        task.name = "cua-driver"
+        task._sampling = None
+        task._elicitation = None
+        return task
+
+    @staticmethod
+    def _capture_spawn(monkeypatch):
+        """Drive ``_run_stdio`` to the spawn seam with every external
+        effect stubbed; return the dict the fake transport fills."""
+        captured = {}
+
+        class _FakeStdioCM:
+            async def __aenter__(self):
+                return (None, None)
+
+            async def __aexit__(self, *exc):
+                return False
+
+        def _fake_stdio_client(server_params, errlog=None):
+            captured["command"] = server_params.command
+            captured["args"] = list(server_params.args)
+            return _FakeStdioCM()
+
+        class _ExplodingSession:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                raise RuntimeError("stop at spawn seam")
+
+            async def __aexit__(self, *exc):
+                return False
+
+        async def _fake_preflight(server_name, command, args):
+            # Post-split, the preflight lives on the origin facade; bypass
+            # the OSV network hop but keep command/args untouched so the
+            # captured spawn reflects exactly what normalization produced.
+            return command, args
+
+        # Post-split seams: origin facade keeps SDK symbols + preflight;
+        # the config/lifecycle helpers live in their own modules now.
+        monkeypatch.setattr(
+            "tools.mcp_tool_config._resolve_stdio_command",
+            lambda command, env: (command, env),
+        )
+        monkeypatch.setattr("tools.mcp_tool_config._build_safe_env", lambda user_env: {})
+        monkeypatch.setattr(
+            "tools.mcp_tool._preflight_stdio_command",
+            _fake_preflight,
+        )
+        monkeypatch.setattr(
+            "tools.mcp_tool_lifecycle._kill_orphaned_mcp_children", lambda: None
+        )
+        monkeypatch.setattr("tools.mcp_tool_lifecycle._snapshot_child_pids", lambda: set())
+        monkeypatch.setattr(
+            "tools.mcp_tool_config._write_stderr_log_header", lambda name: None
+        )
+        monkeypatch.setattr("tools.mcp_tool_config._get_mcp_stderr_log", lambda: None)
+        # Direct import in the transport module — patch the transport's binding,
+        # not the lifecycle origin.
+        monkeypatch.setattr(
+            "tools.mcp_tool_transport._filter_mcp_children", lambda pids: set()
+        )
+        monkeypatch.setattr(
+            "tools.osv_check.check_package_for_malware", lambda *a, **k: None
+        )
+        monkeypatch.setattr("tools.mcp_tool.ClientSession", _ExplodingSession)
+        monkeypatch.setattr("tools.mcp_tool.stdio_client", _fake_stdio_client)
+        return captured
+
+    @staticmethod
+    def _drive(server_task, config):
+        import asyncio
+
+        async def _run():
+            # The exploding fake session intentionally aborts the coroutine
+            # at the spawn seam; any exception type is acceptable so long as
+            # the args were captured first.
+            try:
+                await server_task._run_stdio(config)
+            except Exception:
+                pass
+
+        asyncio.run(_run())
+
+    def test_user_cua_driver_entry_receives_flag_before_spawn(
+        self, server_task, monkeypatch
+    ):
+        """End-to-end through the real ``_run_stdio``: a user-registered
+        ``cua-driver`` entry with ``args: [mcp]`` gets ``--no-overlay``
+        appended to the launch args (Linux/X11 auto-detect path)."""
+        captured = self._capture_spawn(monkeypatch)
+        with patch.object(cua_backend_driver._cb(), "_cua_no_overlay", return_value=True), \
+             patch.object(
+                 cua_backend_driver, "_cua_driver_supports_no_overlay", return_value=True
+             ):
+            self._drive(server_task, {"command": "cua-driver", "args": ["mcp"]})
+        assert captured["args"] == ["mcp", "--no-overlay"], (
+            "user-configured cua-driver MCP must receive --no-overlay so "
+            "#81220 cannot reproduce via mcp_servers"
+        )
+
+    def test_unrelated_entry_untouched_through_run_stdio(
+        self, server_task, monkeypatch
+    ):
+        """A filesystem MCP server's args must reach the spawn untouched."""
+        captured = self._capture_spawn(monkeypatch)
+        with patch.object(cua_backend_driver._cb(), "_cua_no_overlay", return_value=True), \
+             patch.object(
+                 cua_backend_driver, "_cua_driver_supports_no_overlay", return_value=True
+             ):
+            self._drive(server_task, {
+                "command": "npx",
+                "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+            })
+        assert captured["args"] == [
+            "-y", "@modelcontextprotocol/server-filesystem", "/tmp",
+        ]

--- a/tools/computer_use/cua_backend_driver.py
+++ b/tools/computer_use/cua_backend_driver.py
@@ -12,7 +12,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import PureWindowsPath
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 logger = logging.getLogger("tools.computer_use.cua_backend")
 
@@ -110,13 +110,70 @@ def cua_driver_install_hint() -> str:
 
 def _mcp_args_with_overlay_flag(args: List[str], driver_cmd: str = _CUA_DRIVER_DEFAULT_CMD) -> List[str]:
     """Return *args* with ``--no-overlay`` appended when configured and supported."""
+    if any(arg == "--no-overlay" or arg.startswith("--no-overlay=") for arg in args):
+        # The user asked for it explicitly — never duplicate the flag.
+        return list(args)
     on = _cb()._cua_no_overlay() and _cua_driver_supports_no_overlay(driver_cmd)
     return [*args, "--no-overlay"] if on else list(args)
 
-@functools.lru_cache(maxsize=1)
+# Binaries whose *user-configured* MCP launch (``mcp_servers.<name>``) must
+# receive the same overlay policy the embedded cua-backend applies to its own
+# spawn. Kept in sync with what ``resolve_cua_driver_cmd`` accepts so an
+# upstream binary rename stays covered on both paths.
+_CUA_DRIVER_MCP_BINARIES: Tuple[str, ...] = (
+    _CUA_DRIVER_DEFAULT_CMD,
+    "cua-driver-rs",
+    "cua_driver",
+)
+
+
+def looks_like_cua_driver_command(command: Optional[str]) -> bool:
+    """True when *command* is a known cua-driver binary (any path form).
+
+    Used by the stdio MCP launch path to apply the same ``--no-overlay``
+    policy to *user-registered* ``mcp_servers.<name>`` entries that wrap
+    cua-driver (``args: [mcp]``). Without this check such an entry spawns
+    the user's args verbatim, bypassing ``_resolve_mcp_invocation`` and
+    leaving the fullscreen X11 cursor overlay mapped across the virtual
+    desktop — an InputOutput override-redirect window that can swallow
+    every click outside Hermes until a manual recovery call (#81220).
+    Deliberately narrow (exact basename match, not a substring) so an
+    unrelated server named e.g. ``my-cua-driver-wrapper`` is untouched.
+    """
+    if not command:
+        return False
+    base = os.path.basename(command.strip().replace("\\", "/")).lower()
+    if not base:
+        return False
+    # ``cua-driver.exe`` on Windows is the same binary.
+    if base.endswith(".exe"):
+        base = base[:-4]
+    return base in _CUA_DRIVER_MCP_BINARIES
+
+
+def normalize_user_cua_driver_args(
+    command: Optional[str],
+    args: Sequence[str],
+) -> List[str]:
+    """Apply the cua-driver overlay policy to a user-configured MCP launch.
+
+    Returns *args* unchanged (a fresh list, never the caller's object) when
+    *command* is not a known cua-driver binary, when the overlay policy is
+    off, or when the user already passed ``--no-overlay``. Otherwise appends
+    ``--no-overlay`` so the overlay cannot reach the X11 desktop class
+    (#81220). The support probe runs against the user's resolved binary —
+    an older driver must never be handed a flag it rejects.
+    """
+    if not looks_like_cua_driver_command(command):
+        return list(args)
+    return _mcp_args_with_overlay_flag(
+        list(args), driver_cmd=(command or _CUA_DRIVER_DEFAULT_CMD),
+    )
+
+@functools.lru_cache(maxsize=8)
 def _cua_driver_supports_no_overlay(driver_cmd: str) -> bool:
-    """True if ``<driver> --help`` mentions ``--no-overlay`` (probed once); older drivers reject unknown flags, which
-    would crash the MCP spawn."""
+    """True if ``<driver> --help`` mentions ``--no-overlay`` (probed once per binary); older drivers reject unknown
+    flags, which would crash the MCP spawn."""
     try:
         proc = _cb()._run_driver(driver_cmd, "--help", timeout=3.0)
         return "--no-overlay" in (proc.stdout or "") + (proc.stderr or "")

--- a/tools/mcp_tool_transport.py
+++ b/tools/mcp_tool_transport.py
@@ -214,8 +214,28 @@ class MCPServerTransportMixin:
         if not command:
             raise ValueError(f"MCP server '{self.name}' has no 'command' in config")
         command, safe_env = _config._resolve_stdio_command(command, _config._build_safe_env(config.get("env")))
+        # Apply the cua-driver overlay policy to *user-registered* MCP
+        # launches (#81220). A ``mcp_servers.cua-driver`` entry with
+        # ``args: [mcp]`` otherwise spawns verbatim, bypassing the
+        # normalization the embedded cua-backend performs at
+        # ``_resolve_mcp_invocation`` — so on Linux/X11 the fullscreen
+        # cursor-overlay window (an InputOutput override-redirect surface)
+        # can map across the whole virtual desktop and swallow every click
+        # outside Hermes until a manual recovery call. The helper is a
+        # strict no-op for any non-cua-driver command; it honours an
+        # explicit ``computer_use.no_overlay: false`` opt-in and never
+        # duplicates a user-supplied ``--no-overlay``. Runs BEFORE the OSV
+        # preflight and the watchdog wrap so both see the real launch line.
+        try:
+            from tools.computer_use.cua_backend_driver import normalize_user_cua_driver_args
+
+            config_args = normalize_user_cua_driver_args(command, config.get("args", []))
+        except ImportError:
+            # cua_backend is an optional module surface; without it there is
+            # no overlay policy to apply and the launch proceeds as before.
+            config_args = config.get("args", [])
         # OSV malware preflight, then the cached-npx swap (ordering enforced there).
-        command, args = await _core._preflight_stdio_command(self.name, command, config.get("args", []))
+        command, args = await _core._preflight_stdio_command(self.name, command, config_args)
         server_params = _core.StdioServerParameters(
             command=command, args=args, env=safe_env or None, cwd=config.get("cwd"),
             # Windows pipes can split non-UTF-8 bytes at chunk boundaries; substitute, don't raise.


### PR DESCRIPTION
## Summary
Issue #81220: a cua-driver cursor overlay left mapped after a wedged turn swallows every click on Linux/X11. Two remaining unclaimed segments (embedded-daemon protection already landed via #95284/#95291; withdrawn #81277 covered this territory but was never reworked):

- **Overlay policy for user-registered `mcp_servers` entries.** `MCPServerTask` stdio launches now pass `--no-overlay` when the resolved command is cua-driver and `computer_use.no_overlay` policy says so — the same `_mcp_args_with_overlay_flag` policy the embedded backend already uses. Exact basename matching (`cua-driver`, `cua-driver.exe`, backslash-normalized); non-cua servers get an unchanged args copy; an explicit `--no-overlay` is never duplicated; `computer_use.no_overlay: false` stays an honored opt-out; older drivers without the flag are left alone via the existing fallback.
- **Deterministic teardown on interrupted turns.** `cleanup_task_resources` now calls `release_computer_use_session(agent.session_id)` when `agent._interrupt_requested` is set, ending the driver session (and its overlay) instead of leaving it mapped until process exit. Keyed on `session_id` — the same key the backend cache uses (see `agent/tool_executor.py` dispatch kwargs) — NOT the per-turn task_id. Normal completion keeps the cached one-backend-per-session behavior (no respawn/re-handshake mid-conversation). Best-effort with lazy import, same contract as the VM/browser cleanup steps.

## Test plan
- [x] `tests/computer_use/test_cua_mcp_overlay_policy.py` — policy classes + one `_run_stdio` integration proof at the spawn seam (SDK fakes only).
- [x] `tests/agent/test_cleanup_releases_computer_use_on_interrupt.py` — interrupted release (session key asserted), **cross-seam proof against the real `_backends` cache** (session backend popped+stopped, other session untouched), normal-completion no-release, release-failure-never-raises.
- [x] Sibling suites green: test_mcp_tool.py, turn-finalizer cleanup-guard + interrupt-alternation (126 passed).
- [x] Independent review (2 rounds): round 2 caught a real keying defect (task_id vs session_id) — fixed in this head; final round passed source-level, executed runs green.
- [x] Isolated Xvfb smoke on `:77` (never the real display): `cua-driver serve --stdio --no-overlay` spawned with **0 overlay-like windows**, clean teardown on SIGINT/SIGTERM.

Closes #81220