### PR TITLE
fix(bootstrap): don't pass release tags as branch

### DIFF
--- a/apps/desktop/electron/bootstrap-runner.test.ts
+++ b/apps/desktop/electron/bootstrap-runner.test.ts
@@ -131,6 +131,66 @@ test('fallback install stamps use an unpinned branch ref', () => {
   )
 })
 
+test('tag build stamp does not pass the tag as --branch (refType=tag)', () => {
+  const stamp = { commit: 'a'.repeat(40), branch: 'v1.0.0', refType: 'tag' }
+
+  assert.equal(isPinnedCommit(stamp.commit), true)
+  // Commit pin must still be passed
+  assert.deepEqual(buildPinArgs(stamp), ['-Commit', stamp.commit])
+  assert.deepEqual(
+    buildPosixPinArgs({
+      installStamp: stamp,
+      activeRoot: '/tmp/hermes-agent',
+      hermesHome: '/tmp/hermes'
+    }),
+    ['--dir', '/tmp/hermes-agent', '--hermes-home', '/tmp/hermes', '--commit', stamp.commit]
+  )
+})
+
+test('branch build stamp passes --branch (refType=branch)', () => {
+  const stamp = { commit: 'a'.repeat(40), branch: 'release/1.2', refType: 'branch' }
+
+  assert.equal(isPinnedCommit(stamp.commit), true)
+  assert.deepEqual(buildPinArgs(stamp), ['-Commit', stamp.commit, '-Branch', 'release/1.2'])
+  assert.deepEqual(
+    buildPosixPinArgs({
+      installStamp: stamp,
+      activeRoot: '/tmp/hermes-agent',
+      hermesHome: '/tmp/hermes'
+    }),
+    ['--dir', '/tmp/hermes-agent', '--hermes-home', '/tmp/hermes', '--branch', 'release/1.2', '--commit', stamp.commit]
+  )
+})
+
+test('legacy stamp without refType passes branch for backward compatibility', () => {
+  const stamp = { commit: 'a'.repeat(40), branch: 'main' }
+
+  assert.equal(isPinnedCommit(stamp.commit), true)
+  assert.deepEqual(buildPinArgs(stamp), ['-Commit', stamp.commit, '-Branch', 'main'])
+  assert.deepEqual(
+    buildPosixPinArgs({
+      installStamp: stamp,
+      activeRoot: '/tmp/hermes-agent',
+      hermesHome: '/tmp/hermes'
+    }),
+    ['--dir', '/tmp/hermes-agent', '--hermes-home', '/tmp/hermes', '--branch', 'main', '--commit', stamp.commit]
+  )
+})
+
+test('fallback stamp without refType passes branch', () => {
+  const stamp = { commit: ZERO_COMMIT, branch: 'main' }
+
+  assert.deepEqual(buildPinArgs(stamp), ['-Branch', 'main'])
+  assert.deepEqual(
+    buildPosixPinArgs({
+      installStamp: stamp,
+      activeRoot: '/tmp/hermes',
+      hermesHome: '/tmp/home'
+    }),
+    ['--dir', '/tmp/hermes', '--hermes-home', '/tmp/home', '--branch', 'main']
+  )
+})
+
 test('resolveMarkerPinnedCommit prefers real HEAD over fallback stamp zeros', () => {
   const realHead = 'c'.repeat(40)
   assert.equal(

--- a/apps/desktop/electron/bootstrap-runner.ts
+++ b/apps/desktop/electron/bootstrap-runner.ts
@@ -662,6 +662,32 @@ function spawnBash(scriptPath, args, { emit, stageName, abortSignal, hermesHome 
 // a repair/update path and must not let an old packaged app detach the checkout
 // back to the commit baked into that app. All-zero fallback stamps are never
 // passed as -Commit/--commit — only the branch is used (#50823 / #50864 review).
+//
+// refType (from install-stamp.json) controls whether we pass the branch to the
+// installer. GitHub Actions sets GITHUB_REF_TYPE=branch|tag. For tag builds we
+// must NOT pass the tag name as --branch, because `git clone --branch <tag>`
+// clones only the tag and leaves the checkout detached with no origin/main.
+// The --commit pin handles the exact release commit.
+function shouldPassBranch(installStamp) {
+  if (!installStamp) {
+    return false
+  }
+  // Explicit refType from GitHub Actions CI: only pass branch for branch builds.
+  if (installStamp.refType === 'branch') {
+    return true
+  }
+  if (installStamp.refType === 'tag') {
+    return false
+  }
+  // Legacy stamps / local builds / fallback: preserve existing behavior.
+  return !!installStamp.branch
+}
+
+// Build the installer branch/pin args from the install stamp. The commit pin
+// is fresh-install only: once a managed checkout already exists, bootstrap is
+// a repair/update path and must not let an old packaged app detach the checkout
+// back to the commit baked into that app. All-zero fallback stamps are never
+// passed as -Commit/--commit — only the branch is used (#50823 / #50864 review).
 function buildPinArgs(installStamp, { pinCommit = true } = {}) {
   const args = []
 
@@ -669,7 +695,7 @@ function buildPinArgs(installStamp, { pinCommit = true } = {}) {
     args.push('-Commit', installStamp.commit)
   }
 
-  if (installStamp && installStamp.branch) {
+  if (shouldPassBranch(installStamp)) {
     args.push('-Branch', installStamp.branch)
   }
 
@@ -679,7 +705,7 @@ function buildPinArgs(installStamp, { pinCommit = true } = {}) {
 function buildPosixPinArgs({ installStamp, activeRoot, hermesHome, pinCommit = true }) {
   const args = ['--dir', activeRoot, '--hermes-home', hermesHome]
 
-  if (installStamp && installStamp.branch) {
+  if (shouldPassBranch(installStamp)) {
     args.push('--branch', installStamp.branch)
   }
 

--- a/apps/desktop/scripts/write-build-stamp.mjs
+++ b/apps/desktop/scripts/write-build-stamp.mjs
@@ -55,9 +55,11 @@ export function fromCI(env = process.env) {
   const sha = env.GITHUB_SHA
   if (!sha) return null
   const branch = env.GITHUB_REF_NAME || env.GITHUB_HEAD_REF || null
+  const refType = env.GITHUB_REF_TYPE || null
   return {
     commit: sha,
     branch: branch,
+    refType: refType,
     dirty: false, // CI builds from a checkout-of-ref by definition
     source: "ci"
   }
@@ -153,6 +155,7 @@ function main() {
     schemaVersion: STAMP_SCHEMA_VERSION,
     commit: stamp.commit,
     branch: stamp.branch,
+    refType: stamp.refType,
     builtAt: new Date().toISOString(),
     dirty: stamp.dirty,
     source: stamp.source

--- a/apps/desktop/scripts/write-build-stamp.test.mjs
+++ b/apps/desktop/scripts/write-build-stamp.test.mjs
@@ -14,7 +14,7 @@ import {
 test('fromCI reads GITHUB_SHA / GITHUB_REF_NAME', () => {
   assert.deepEqual(
     fromCI({ GITHUB_SHA: 'a'.repeat(40), GITHUB_REF_NAME: 'release' }),
-    { commit: 'a'.repeat(40), branch: 'release', dirty: false, source: 'ci' }
+    { commit: 'a'.repeat(40), branch: 'release', refType: null, dirty: false, source: 'ci' }
   )
   assert.equal(fromCI({}), null)
 })

--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -741,6 +741,7 @@ cd "$INSTALL_ROOT" || {
   FINAL_CODE=3 FINAL_MSG="Update aborted: cannot enter the install root ($INSTALL_ROOT). Nothing was changed."
   log "$FINAL_MSG"; exit 3
 }
+
 export PYTHONUNBUFFERED=1
 # --keep-stash: never re-apply local source edits after the update (they stay
 # parked in git stash). Probe --help first: older installed backends don't


### PR DESCRIPTION
## Overview

Fixes desktop bootstrap failures for tag-based releases.

### Root cause

Release builds can have a Git tag (for example, `v1.0.0`) as `GITHUB_REF_NAME`. The desktop build stamp previously stored this value as `branch`, and the bootstrap passed it to the installer as `--branch`.

The installer then performed a single-branch clone of the tag. Because the ref was a tag rather than a branch, the resulting checkout was detached and did not contain `origin/main`.

When the desktop updater later ran:

`hermes update --branch main`

the update command could not create or switch to `main` because `origin/main` did not exist.

### Fix

Use the authoritative GitHub `GITHUB_REF_TYPE` when generating and consuming the build stamp:

* Branch builds continue passing `--branch`.
* Tag builds no longer pass the tag name as `--branch`.
* The installer uses its normal `main` branch while `--commit` continues to pin the exact release commit.
* Legacy stamps without `refType` retain the previous behavior for backwards compatibility.

This keeps the release pinned to the exact build commit while ensuring the checkout retains the `origin/main` reference required for future updates.

### Testing

* 15 `bootstrap-runner` tests pass.
* 6 `write-build-stamp` tests pass.
* Total: **21/21 desktop tests passing**.
