### PR TITLE
ci: reject unparseable workflow files from outside ci.yaml (root cause of #100748)

### DIFF
--- a/.github/workflows/workflow-syntax.yml
+++ b/.github/workflows/workflow-syntax.yml
@@ -1,0 +1,54 @@
+name: Workflow syntax
+
+# The one check that cannot live inside ci.yaml.
+#
+# `24f5a60` ("fix: re-disable e2e") left a `${{` unclosed on ci.yaml:126 and
+# every CI run in the repository failed at parse time (#100748). The pull
+# request that shipped it was green: GitHub does not create a run for a
+# workflow file it cannot parse, so the `CI` check did not go red — it
+# stopped existing, and there was nothing pending for a required-check gate
+# to block on. Only the *other* pull requests, which inherit the broken file
+# from main, ever see the failure.
+#
+# Thirty-one of the thirty-two workflow files are `workflow_call` targets
+# that ci.yaml invokes, so none of them run when ci.yaml is unparseable and
+# none of them can police it. This workflow therefore owns its trigger, the
+# same reason docker.yml and nix.yml own theirs.
+#
+# It runs on every pull request rather than behind a `paths:` filter so it
+# can be a required status check without the skipped-and-stuck-pending trap.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: workflow-syntax-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  check-workflow-syntax:
+    name: Workflow files parse
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
+        with:
+          # Pinned: unpinned setup-uv fetches a 'latest' manifest from
+          # raw.githubusercontent.com every job; transient fetch failures
+          # fail the job (2026-07-28 incident). Keep in sync with tests.yml.
+          version: "0.9.28"
+
+      - name: Reject unparseable workflow files
+        # --no-project: this guard must not depend on the project resolving.
+        # The pyyaml pin matches the one in pyproject.toml.
+        run: |
+          uv run --no-project --with 'pyyaml==6.0.3' \
+            python scripts/ci/check_workflow_expressions.py

--- a/scripts/ci/check_workflow_expressions.py
+++ b/scripts/ci/check_workflow_expressions.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Reject workflow files GitHub cannot parse.
+
+A syntax break in ``.github/workflows/ci.yaml`` is invisible to the pull
+request that introduces it.  When GitHub cannot parse a workflow file it
+never creates a run for it, so the ``CI`` check does not turn red — it simply
+stops existing, and a required-check gate has nothing to block on.  Every
+*other* pull request then inherits the broken file from ``main`` and fails at
+parse time.  That is exactly how ``24f5a60`` ("fix: re-disable e2e") shipped
+an unclosed ``${{`` and took the whole repository's CI down (#100748).
+
+Thirty-one of the thirty-two workflow files are ``workflow_call`` targets that
+``ci.yaml`` invokes, so none of them can police it.  This check therefore runs
+from a workflow that owns its own trigger and survives ``ci.yaml`` being
+unparseable.
+
+Two failure classes are covered, both of which produce the same silence:
+
+* the file is not valid YAML;
+* a ``${{`` expression is never closed by a ``}}`` inside its own YAML scalar,
+  which is the unit GitHub's expression parser works on.  Scoping to the
+  scalar — rather than to the line or the whole file — is what makes a legal
+  multi-line expression in a folded scalar pass while ``'true' })}`` fails.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator
+
+import yaml
+
+_WORKFLOW_SUFFIXES = (".yml", ".yaml")
+_OPEN = "${{"
+_CLOSE = "}}"
+
+
+@dataclass(frozen=True)
+class Problem:
+    """One rejected workflow file location."""
+
+    path: Path
+    line: int
+    message: str
+
+
+def iter_workflow_files(root: Path) -> list[Path]:
+    """Return the workflow files under ``root``, sorted by path."""
+    workflows = root / ".github" / "workflows"
+    if not workflows.is_dir():
+        return []
+    return sorted(
+        path
+        for path in workflows.iterdir()
+        if path.is_file() and path.suffix in _WORKFLOW_SUFFIXES
+    )
+
+
+def _iter_scalars(node: yaml.Node | None) -> Iterator[yaml.ScalarNode]:
+    if isinstance(node, yaml.ScalarNode):
+        yield node
+    elif isinstance(node, yaml.SequenceNode):
+        for child in node.value:
+            yield from _iter_scalars(child)
+    elif isinstance(node, yaml.MappingNode):
+        for key, value in node.value:
+            yield from _iter_scalars(key)
+            yield from _iter_scalars(value)
+
+
+def check_source(path: Path, text: str) -> list[Problem]:
+    """Return every parse problem in one workflow file's source."""
+    try:
+        root_node = yaml.compose(text)
+    except yaml.YAMLError as exc:
+        mark = getattr(exc, "problem_mark", None)
+        line = mark.line + 1 if mark is not None else 1
+        reason = getattr(exc, "problem", None) or str(exc).splitlines()[0]
+        return [Problem(path, line, f"not valid YAML: {reason}")]
+
+    problems: list[Problem] = []
+    for scalar in _iter_scalars(root_node):
+        value = scalar.value
+        cursor = 0
+        while True:
+            start = value.find(_OPEN, cursor)
+            if start < 0:
+                break
+            end = value.find(_CLOSE, start + len(_OPEN))
+            if end < 0:
+                line = scalar.start_mark.line + 1 + value.count("\n", 0, start)
+                problems.append(
+                    Problem(
+                        path,
+                        line,
+                        "the expression is not closed: an unescaped ${{ "
+                        "sequence was found, but the closing }} sequence was "
+                        "not found",
+                    )
+                )
+                break
+            cursor = end + len(_CLOSE)
+    return problems
+
+
+def check_workflows(root: Path) -> list[Problem]:
+    """Return every parse problem across the checkout's workflow files."""
+    root = root.resolve()
+    if not root.is_dir():
+        raise ValueError(f"repository root is not a directory: {root}")
+
+    problems: list[Problem] = []
+    for path in iter_workflow_files(root):
+        problems.extend(
+            check_source(path.relative_to(root), path.read_text(encoding="utf-8"))
+        )
+    return problems
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Reject workflow files GitHub cannot parse."
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path.cwd(),
+        help="repository root to inspect (default: current directory)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        problems = check_workflows(args.root)
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    if not problems:
+        count = len(iter_workflow_files(args.root.resolve()))
+        print(f"All {count} workflow files parse.")
+        return 0
+
+    for problem in problems:
+        posix = problem.path.as_posix()
+        print(
+            f"::error file={posix},line={problem.line}::{problem.message}",
+            file=sys.stdout,
+        )
+        print(f"  {posix}:{problem.line}: {problem.message}")
+    print(
+        "GitHub creates no run at all for an unparseable workflow, so this "
+        "would not have shown up as a failing check on this pull request."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_check_workflow_expressions.py
+++ b/tests/scripts/test_check_workflow_expressions.py
@@ -1,0 +1,134 @@
+"""Behavioral tests for the workflow-parse CI guard."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "ci" / "check_workflow_expressions.py"
+
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "ci"))
+
+from check_workflow_expressions import (  # noqa: E402
+    check_source,
+    check_workflows,
+)
+
+# The exact guard `24f5a60` ("fix: re-disable e2e") shipped. The trailing
+# `})}` is one brace short, which left the `${{` open and took every CI run
+# in the repository down at parse time (#100748).
+BROKEN_GUARD = """\
+name: CI
+on:
+  pull_request:
+jobs:
+  e2e-desktop:
+    needs: detect
+    if: ${{ false && (needs.detect.outputs.python_prod == 'true' || needs.detect.outputs.frontend == 'true' })}
+    uses: ./.github/workflows/e2e-desktop.yml
+"""
+
+FIXED_GUARD = BROKEN_GUARD.replace("'true' })}", "'true') }}")
+
+
+def _write_workflow(root: Path, name: str, text: str) -> None:
+    workflows = root / ".github" / "workflows"
+    workflows.mkdir(parents=True, exist_ok=True)
+    (workflows / name).write_text(text, encoding="utf-8")
+
+
+def _run(root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--root", str(root)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_unclosed_expression_is_reported_at_its_own_line():
+    problems = check_source(Path("ci.yaml"), BROKEN_GUARD)
+
+    assert len(problems) == 1
+    # GitHub reports "(Line: 126, Col: 9)" for this scalar in the real file;
+    # here the same guard sits on line 7 of the fixture.
+    assert problems[0].line == 7
+    assert "the expression is not closed" in problems[0].message
+
+
+def test_closing_the_expression_makes_the_file_pass():
+    assert check_source(Path("ci.yaml"), FIXED_GUARD) == []
+
+
+def test_multi_line_expression_in_a_folded_scalar_is_not_flagged():
+    # Legal GitHub syntax: the expression spans lines inside one YAML scalar.
+    # A line-by-line scan would reject this, which is why the check is scoped
+    # to the scalar the expression actually lives in.
+    source = """\
+name: CI
+on:
+  push:
+jobs:
+  build:
+    if: >-
+      ${{ github.event_name == 'push'
+          && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+"""
+
+    assert check_source(Path("ci.yaml"), source) == []
+
+
+def test_escaped_braces_inside_format_are_not_flagged():
+    source = """\
+name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${{ format('{{0}} done', github.sha) }}"
+"""
+
+    assert check_source(Path("ci.yaml"), source) == []
+
+
+def test_invalid_yaml_is_reported():
+    problems = check_source(Path("ci.yaml"), "name: CI\non:\n  push:\n   - [unclosed\n")
+
+    assert len(problems) == 1
+    assert "not valid YAML" in problems[0].message
+
+
+def test_directory_without_workflows_is_clean(tmp_path):
+    assert check_workflows(tmp_path) == []
+
+
+def test_cli_rejects_a_broken_workflow(tmp_path):
+    _write_workflow(tmp_path, "ci.yaml", BROKEN_GUARD)
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 1
+    assert "::error file=.github/workflows/ci.yaml,line=7::" in result.stdout
+
+
+def test_cli_accepts_a_fixed_workflow(tmp_path):
+    _write_workflow(tmp_path, "ci.yaml", FIXED_GUARD)
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 0
+    assert "workflow files parse" in result.stdout
+
+
+def test_every_workflow_in_this_repository_parses():
+    problems = check_workflows(REPO_ROOT)
+
+    assert problems == [], "\n".join(
+        f"{problem.path.as_posix()}:{problem.line}: {problem.message}"
+        for problem in problems
+    )


### PR DESCRIPTION
## What does this PR do?

**This PR deliberately does not contain the one-line brace fix.** That fix is already owned by #100752, #100754 and #100757 — one of them should land immediately to bring CI back. This PR addresses the separate, unowned question: *why did a syntax break in `ci.yaml` reach `main` in the first place, and why was the pull request that shipped it green?*

### Root cause

GitHub **does not create a run at all** for a workflow file it cannot parse. It does not produce a failing check — it produces no check.

On #100720, the PR that shipped `24f5a60`, the head SHA `887d666` got these runs:

```
2026-09-01T22:08:55Z  success   Docker Build, Test, and Publish   sha=887d666
2026-09-01T22:08:55Z  success   Nix flake check                   sha=887d666
2026-08-26T07:19:47Z  success   CI                                sha=ddadc0e   <- previous SHA, same branch
```

`CI` is absent on `887d666` and present on the branch's previous SHA. Nothing was red and nothing was pending, so a required-status-check gate had nothing to block on. Only *other* pull requests, which inherit the broken file from `main`, ever see `Invalid workflow file`.

The second half is structural: **31 of the 32 workflow files are `workflow_call` targets that `ci.yaml` invokes.** `lint.yml`, `tests.yml`, `tests-os.yml`, `case-collision-check.yml`, `profile-artifact-check.yml` — every existing guard in the repo is downstream of the file that broke. No check the repository owns could have caught this, because all of them were unreachable at exactly the moment they were needed.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A["Unclosed expression on ci.yaml:126"] -->|GitHub parser| B{"Is ci.yaml parseable?"}
    B -->|No| C["No run created - CI check absent, not red"]
    C --> D["Required-check gate sees nothing pending"]
    D --> E["Merged to main"]
    E --> F["Every downstream PR fails at parse time"]

    B -.->|Unreachable once broken| G["31 workflow_call guards<br/>lint / tests / tests-os / case-collision"]

    E -.->|This PR| H["workflow-syntax.yml - owns its own trigger"]
    H --> I["check_workflow_expressions.py<br/>YAML validity + per-scalar expression balance"]
    I --> J["Break is red on the PR that introduces it"]

    style C fill:#3a0a1e,stroke:#ff007f
    style G fill:#1a1a2e,stroke:#ff007f
    style J fill:#062a2e,stroke:#00f0ff
```

## Related Issue

Refs #100748 (root cause / prevention; the line fix itself is #100752 / #100754 / #100757)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`scripts/ci/check_workflow_expressions.py`** (new) — rejects the two failure classes that produce the same silence: a workflow file that is not valid YAML, and an opening expression sequence never closed **inside its own YAML scalar**.

  The scalar is the right unit, and it is load-bearing in both directions:
  - A **whole-file** scan does not find this bug at all. The unclosed sequence on line 126 happily matches the closing braces of a later expression 40 lines down, so the file looks balanced (32 open, 32 close). Verified against the current checkout.
  - A **per-line** scan finds it, but would reject a legal multi-line expression in a folded scalar (`if: >-` spanning two lines), which GitHub accepts. Covered by a test.

  Escaped braces inside `format()` are also not flagged.

- **`.github/workflows/workflow-syntax.yml`** (new) — owns its own `pull_request` / `push: main` trigger, for the same reason `docker.yml` and `nix.yml` own theirs: it must still run when `ci.yaml` cannot be parsed. Runs unconditionally rather than behind a `paths:` filter so it can be made a required status check without the skipped-and-stuck-pending trap. Pinned `actions/checkout` + `astral-sh/setup-uv` SHAs match the rest of the repo; `uv run --no-project` so the guard does not depend on the project resolving.

- **`tests/scripts/test_check_workflow_expressions.py`** (new) — 9 tests following the `test_check_profile_archive_boundary.py` pattern: the exact `24f5a60` guard line, the closed form, folded multi-line expressions, `format()` escapes, invalid YAML, the CLI in both directions, and a sweep over the repository's real workflow files.

## How to Test

1. **The guard reproduces GitHub's own report on the current `main`:**

   ```
   $ python scripts/ci/check_workflow_expressions.py
   ::error file=.github/workflows/ci.yaml,line=126::the expression is not closed: an unescaped ${{ sequence was found, but the closing }} sequence was not found
   ```

   Observed result: exit 1, file and line identical to GitHub's `(Line: 126, Col: 9)`.

2. **It goes green the moment the brace is closed.** In a throwaway copy of the checkout, apply the closing fix from #100752 / #100754 / #100757:

   ```
   $ python scripts/ci/check_workflow_expressions.py --root <copy>
   All 33 workflow files parse.
   ```

   Observed result: exit 0.

3. **No false positives on the existing 32 files.** Every other workflow — 497 expressions across `docker.yml`, `supply-chain-audit.yml`, `review-labels.yml`, and the rest — passes unchanged.

4. `python -m pytest tests/scripts/ -q` → **38 passed, 1 failed**. The single failure is `test_every_workflow_in_this_repository_parses`, which is the guard correctly catching the live break on `main`. **It turns green as soon as #100752 / #100754 / #100757 lands** — this PR is intentionally stacked behind whichever of those the maintainers pick, and does not duplicate it.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — #100752, #100754 and #100757 all own the one-line fix, which is why it is **not** in this PR; no open PR adds workflow-syntax validation
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — `tests/scripts/` is 38 passed / 1 failed, the failure being the new guard catching the live `main` break described above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (Python 3.14), plus `ruff check` and `scripts/check-windows-footguns.py --all` clean

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; the rationale lives in the script and workflow headers
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; adds a guard, changes no existing lane
- [x] I've considered cross-platform impact (Windows, macOS) — the script is stdlib + `pyyaml` (already pinned at `6.0.3` in `pyproject.toml`), `Path`-based, and reads with an explicit encoding; the workflow runs on `ubuntu-latest`
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Run inventory for #100720's head SHA, showing `CI` never ran:

```
$ gh api "repos/NousResearch/hermes-agent/actions/runs?branch=ethernet8023-patch-1"
2026-09-01T22:08:55Z  success    Docker Build, Test, and Publish   sha=887d666
2026-09-01T22:08:55Z  success    Nix flake check                   sha=887d666
2026-08-26T07:19:47Z  success    CI                                sha=ddadc0e
```

Current state of the repository, for contrast — every recent `ci.yaml` run, on every branch:

```
$ gh run list --workflow=ci.yaml --limit 6
failure  pull_request  feat/bot-mode-group-chat-messaging-20260829
failure  pull_request  upstream/claude-sdk-parity
failure  pull_request  fix/transport-thinking-fallback
failure  pull_request  feat/stream-perf-upstream
failure  pull_request  fix/82874-mcp-shutdown-executor
failure  pull_request  pr-b-session
```

Those runs are named `.github/workflows/ci.yaml` rather than `CI` — GitHub could not read the `name:` field, which is the signature of a workflow file that failed to parse.


Fixes 100748