### PR TITLE
fix(kanban): safely reclassify blocked cards

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -676,6 +676,20 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         ),
     )
 
+    p_reclassify = sub.add_parser(
+        "reclassify-block",
+        help="Correct only the blocker kind on an already-blocked task",
+    )
+    p_reclassify.add_argument("task_id")
+    p_reclassify.add_argument(
+        "--kind", required=True, choices=sorted(kb.VALID_BLOCK_KINDS),
+        help="Correct blocker classifier; lifecycle state is preserved.",
+    )
+    p_reclassify.add_argument(
+        "--note", default=None,
+        help="Optional audit note recorded with the classifier correction.",
+    )
+
     p_schedule = sub.add_parser("schedule", help="Park one or more tasks in Scheduled (waiting on time, not human input)")
     p_schedule.add_argument("task_id")
     p_schedule.add_argument("reason", nargs="*", help="Reason/timing note (also appended as a comment)")
@@ -1166,6 +1180,7 @@ def kanban_command(args: argparse.Namespace) -> int:
             "complete": _cmd_complete,
             "edit":     _cmd_edit,
             "block":    _cmd_block,
+            "reclassify-block": _cmd_reclassify_block,
             "schedule": _cmd_schedule,
             "unblock":  _cmd_unblock,
             "request-review": _cmd_request_review,
@@ -2469,6 +2484,32 @@ def _cmd_block(args: argparse.Namespace) -> int:
                 else:
                     print(f"Blocked {tid}{suffix}")
     return 0 if not failed else 1
+
+
+def _cmd_reclassify_block(args: argparse.Namespace) -> int:
+    tid = args.task_id
+    scoped_task = os.environ.get("HERMES_KANBAN_TASK")
+    if scoped_task and scoped_task != tid:
+        print(
+            f"cannot reclassify {tid}: task-scoped worker may only mutate {scoped_task}",
+            file=sys.stderr,
+        )
+        return 1
+    with kb.connect_closing() as conn:
+        if not kb.reclassify_blocked_task(
+            conn,
+            tid,
+            kind=args.kind,
+            actor=_profile_author(),
+            note=args.note,
+        ):
+            print(
+                f"cannot reclassify {tid} (unknown id or task is not blocked)",
+                file=sys.stderr,
+            )
+            return 1
+    print(f"Reclassified {tid}: {args.kind}")
+    return 0
 
 
 def _cmd_schedule(args: argparse.Namespace) -> int:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6482,6 +6482,46 @@ def block_task(
     return True
 
 
+def reclassify_blocked_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    kind: str,
+    actor: str,
+    note: Optional[str] = None,
+) -> bool:
+    """Correct only the classifier on an already-blocked task.
+
+    This deliberately bypasses ``unblock_task`` and ``block_task``: status,
+    claims, runs, dependency state, recurrence memory, and notification hooks
+    remain untouched while an operator corrects a stored classifier.
+    """
+    if kind not in VALID_BLOCK_KINDS:
+        raise ValueError(f"block kind must be one of {sorted(VALID_BLOCK_KINDS)}")
+    if not actor or not actor.strip():
+        raise ValueError("actor is required")
+    clean_note = note.strip() if note and note.strip() else None
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT status, block_kind FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+        if row is None or row["status"] != "blocked":
+            return False
+        old_kind = row["block_kind"]
+        conn.execute(
+            "UPDATE tasks SET block_kind = ? WHERE id = ? AND status = 'blocked'",
+            (kind, task_id),
+        )
+        payload = {"old_kind": old_kind, "new_kind": kind, "actor": actor.strip()}
+        if clean_note:
+            payload["note"] = clean_note
+        _append_event(conn, task_id, "block_reclassified", payload)
+        comment = f"BLOCK CLASSIFIER: {old_kind or 'untyped'} → {kind}"
+        if clean_note:
+            comment += f" — {clean_note}"
+        add_comment(conn, task_id, actor.strip(), comment)
+    return True
+
 
 def redact_review_value(value: Any) -> Any:
     """Redact secrets at the domain boundary for durable review handoffs."""

--- a/tests/hermes_cli/test_kanban_block_reclassification.py
+++ b/tests/hermes_cli/test_kanban_block_reclassification.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban as cli
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def board(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    return home
+
+
+def _blocked(conn, kind: str = "needs_input") -> str:
+    tid = kb.create_task(conn, title="blocked", assignee="worker")
+    with kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+    assert kb.claim_task(conn, tid, claimer="worker")
+    assert kb.block_task(conn, tid, reason="original reason", kind=kind)
+    return tid
+
+
+@pytest.mark.parametrize(
+    ("old_kind", "new_kind"),
+    [
+        ("needs_input", "dependency"),
+        ("dependency", "transient"),
+        ("transient", "capability"),
+        ("capability", "needs_input"),
+    ],
+)
+def test_reclassify_changes_only_kind_and_appends_audit(
+    board: Path,
+    old_kind: str,
+    new_kind: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lifecycle_calls: list[tuple[object, ...]] = []
+    monkeypatch.setattr(
+        kb,
+        "_fire_kanban_lifecycle_hook",
+        lambda *args, **kwargs: lifecycle_calls.append(args),
+    )
+    with kb.connect_closing() as conn:
+        tid = _blocked(conn)
+        lifecycle_calls.clear()
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET block_kind=?, block_recurrences=7 WHERE id=?",
+                (old_kind, tid),
+            )
+        before = dict(conn.execute("SELECT * FROM tasks WHERE id=?", (tid,)).fetchone())
+        runs_before = [dict(row) for row in conn.execute(
+            "SELECT * FROM task_runs WHERE task_id=? ORDER BY id", (tid,)
+        )]
+        assert kb.reclassify_blocked_task(
+            conn, tid, kind=new_kind, actor="operator", note="classifier fix"
+        )
+        after = dict(conn.execute("SELECT * FROM tasks WHERE id=?", (tid,)).fetchone())
+        runs_after = [dict(row) for row in conn.execute(
+            "SELECT * FROM task_runs WHERE task_id=? ORDER BY id", (tid,)
+        )]
+        assert after.pop("block_kind") == new_kind
+        assert before.pop("block_kind") == old_kind
+        assert after == before
+        assert runs_after == runs_before
+        event = [e for e in kb.list_events(conn, tid) if e.kind == "block_reclassified"][-1]
+        assert event.payload == {
+            "old_kind": old_kind,
+            "new_kind": new_kind,
+            "actor": "operator",
+            "note": "classifier fix",
+        }
+        assert "BLOCK CLASSIFIER" in kb.list_comments(conn, tid)[-1].body
+        assert lifecycle_calls == []
+
+
+def test_reclassify_is_blocked_only(board: Path) -> None:
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="ready", assignee="worker")
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+        assert not kb.reclassify_blocked_task(
+            conn, tid, kind="capability", actor="operator"
+        )
+        assert kb.get_task(conn, tid).status == "ready"
+
+
+def test_existing_block_operation_still_refuses_already_blocked(board: Path) -> None:
+    with kb.connect_closing() as conn:
+        tid = _blocked(conn)
+        assert not kb.block_task(
+            conn, tid, reason="must still refuse", kind="capability"
+        )
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "blocked"
+        assert task.block_kind == "needs_input"
+
+
+def test_reclassify_survives_copied_wal_board(board: Path, tmp_path: Path) -> None:
+    with kb.connect_closing() as conn:
+        tid = _blocked(conn)
+        conn.execute("PRAGMA wal_checkpoint(FULL)")
+    copied = tmp_path / "copied.db"
+    shutil.copy2(kb.kanban_db_path(), copied)
+    conn = kb.connect(copied)
+    try:
+        assert kb.reclassify_blocked_task(
+            conn, tid, kind="transient", actor="operator"
+        )
+        assert kb.get_task(conn, tid).block_kind == "transient"
+    finally:
+        conn.close()
+
+
+def _parse(argv: list[str]) -> argparse.Namespace:
+    root = argparse.ArgumentParser()
+    sub = root.add_subparsers(dest="command")
+    cli.build_parser(sub)
+    return root.parse_args(["kanban", *argv])
+
+
+def test_cli_reclassify_enforces_worker_scope_and_serializes(
+    board: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    with kb.connect_closing() as conn:
+        own = _blocked(conn)
+        other = _blocked(conn)
+    monkeypatch.setenv("HERMES_KANBAN_TASK", own)
+    assert cli.kanban_command(
+        _parse(["reclassify-block", other, "--kind", "capability"])
+    ) == 1
+    assert "may only mutate" in capsys.readouterr().err
+    assert cli.kanban_command(
+        _parse(["reclassify-block", own, "--kind", "capability", "--note", "fix"])
+    ) == 0
+    assert f"Reclassified {own}: capability" in capsys.readouterr().out
+    monkeypatch.delenv("HERMES_KANBAN_TASK")
+    assert cli.kanban_command(
+        _parse(["reclassify-block", other, "--kind", "transient"])
+    ) == 0
+    with kb.connect_closing() as conn:
+        assert kb.get_task(conn, own).block_kind == "capability"
+        assert kb.get_task(conn, other).block_kind == "transient"


### PR DESCRIPTION
## Summary
- add a transactional `reclassify_blocked_task` lifecycle operation that changes only `block_kind` on already-blocked cards
- add `hermes kanban reclassify-block <task> --kind ... [--note ...]` with task-scoped worker authorization and operator/supervisor authority
- record a dedicated audit event and comment without lifecycle notifications, dispatch, recurrence, run, status, dependency, or claim changes

## Verification
- RED: new regression file on `origin/main`: 7 failed, 1 passed
- GREEN: focused classifier/lifecycle suite: 29 passed
- broader Kanban suite: 319 passed, 1 environment-only failure because the shared test venv lacks optional `acp`
- Ruff: passed
- `git diff --check`: passed

Independent exact-head review is required before merge/install.