### PR TITLE
fix(mcp): respawn and retry once when a stdio child died

### DIFF
--- a/tests/tools/test_mcp_stdio_fastfail_reconnect.py
+++ b/tests/tools/test_mcp_stdio_fastfail_reconnect.py
@@ -1,16 +1,23 @@
-"""Regression tests for stdio fast-fail reconnect signaling (#95626 salvage).
+"""Regression tests for dead stdio subprocess recovery (#95626 salvage).
 
 The #81995 fast-fail gate detects a dead stdio subprocess but the transport
 failure never cleared ``server.session``, so the transport-down reconnect path
 (which only fires when the session is gone/not-ready) never ran. The call
 failed fast — correctly — but nothing asked the server task to respawn the
-subprocess, so every subsequent call kept failing until the idle keepalive
-probe eventually noticed. Both fast-fail sites must signal a reconnect:
+subprocess (#95626 added the reconnect signal).
 
-- pre-call gate (children already dead when the call arrives): return a clean
-  "reconnecting" tool error and set ``_reconnect_event``;
-- mid-call watcher race (children die while the RPC is in flight): raise the
-  fast-fail TimeoutError and set ``_reconnect_event``.
+Signalling alone still lost the call: a gateway restart kills every MCP stdio
+child, and the first call from a surviving agent session (or a cron run
+spanning the restart) failed in 0.00s while the subprocess was respawned
+seconds later. Both fast-fail sites now respawn AND retry once:
+
+- pre-call gate (children already dead when the call arrives);
+- mid-call watcher race (children die while the RPC is in flight).
+
+Both must recover transparently, and both must stop after ONE retry so a
+server that keeps dying parks via run()'s rapid-drop budget instead of
+hot-cycling respawns forever. The error text must never claim a timeout —
+that wording is what misdirected the original investigation.
 """
 
 import asyncio
@@ -23,10 +30,26 @@ import pytest
 pytest.importorskip("mcp")
 
 
+def _success_result():
+    result = MagicMock()
+    result.is_error = False
+    block = MagicMock()
+    block.text = "ok"
+    result.content = [block]
+    result.structured_content = None
+    result.meta = None
+    return result
+
+
 def _install_stub_server(mcp_tool_module, name: str, call_tool_impl,
-                         *, children_dead):
+                         *, children_dead, on_reconnect=None):
     """Fake MCP server with real-bool stdio liveness and a countable
-    reconnect event (mirrors tests/tools/test_mcp_circuit_breaker.py)."""
+    reconnect event (mirrors tests/tools/test_mcp_circuit_breaker.py).
+
+    ``on_reconnect`` runs on the MCP loop thread when the reconnect event is
+    set — the hook tests use to simulate the server task respawning the
+    subprocess and publishing a fresh session.
+    """
     server = MagicMock()
     server.name = name
     session = MagicMock()
@@ -42,6 +65,8 @@ def _install_stub_server(mcp_tool_module, name: str, call_tool_impl,
 
         def set(self):
             self.set_calls += 1
+            if on_reconnect is not None:
+                on_reconnect(server)
 
     server._reconnect_event = _ReconnectAdapter()
     server._ready = ready_flag
@@ -64,63 +89,171 @@ def _cleanup(mcp_tool_module, name: str) -> None:
         mcp_tool_module._server_breaker_opened_at.pop(name, None)
 
 
-def test_precall_dead_children_signal_reconnect(monkeypatch, tmp_path):
-    """Dead-at-call-time subprocess → clean reconnecting error + reconnect
-    signal, instead of a bare fast-fail that leaves the server dead."""
+def test_precall_dead_children_respawn_and_retry(monkeypatch, tmp_path):
+    """Dead-at-call-time subprocess (the gateway-restart case): respawn,
+    retry once, and hand the model a normal result — no error at all."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     from tools import mcp_tool
     from tools.mcp_tool import _make_tool_handler
 
     called = {"n": 0}
+    alive = {"v": False}
 
     async def _call_tool(*a, **kw):
         called["n"] += 1
-        return MagicMock(is_error=False, content=[])
+        return _success_result()
+
+    def _respawn(server):
+        # What the server task does after a gateway restart: fresh child,
+        # fresh session object, _ready re-armed.
+        alive["v"] = True
+        new_session = MagicMock()
+        new_session.call_tool = _call_tool
+        server.session = new_session
+        server._ready.set()
 
     server = _install_stub_server(
-        mcp_tool, "srv-dead", _call_tool, children_dead=lambda: True
+        mcp_tool, "srv-dead", _call_tool,
+        children_dead=lambda: not alive["v"],
+        on_reconnect=_respawn,
     )
     mcp_tool._ensure_mcp_loop()
     try:
         handler = _make_tool_handler("srv-dead", "tool1", 10.0)
-        result = handler({})
-        parsed = json.loads(result)
-        assert "error" in parsed, parsed
-        assert "reconnect" in parsed["error"].lower(), parsed
+        parsed = json.loads(handler({}))
+        assert "error" not in parsed, parsed
+        assert parsed["result"] == "ok", parsed
         assert server._reconnect_event.set_calls == 1
-        assert called["n"] == 0, "RPC must not be attempted on a dead transport"
-        # The error payload flows through the handler's JSON parse, which
-        # bumps the breaker exactly once (no double-bump at the gate).
-        assert mcp_tool._server_error_counts.get("srv-dead", 0) == 1
+        assert called["n"] == 1, "exactly one RPC — the retry after respawn"
+        assert mcp_tool._server_error_counts.get("srv-dead", 0) == 0
     finally:
         _cleanup(mcp_tool, "srv-dead")
 
 
-def test_midcall_child_exit_signals_reconnect(monkeypatch, tmp_path):
-    """Subprocess dies while the RPC is in flight → fast-fail error AND a
-    reconnect signal so the next call lands on a respawned transport."""
+def test_midcall_child_exit_respawn_and_retry(monkeypatch, tmp_path):
+    """Subprocess dies while the RPC is in flight → respawn and retry once,
+    so the caller still gets its result."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     from tools import mcp_tool
     from tools.mcp_tool import _make_tool_handler
 
+    alive = {"v": True}
+
     async def _hanging_call(*a, **kw):
         await asyncio.sleep(30)
 
-    server = _install_stub_server(
-        mcp_tool, "srv-midcall", _hanging_call, children_dead=lambda: False
-    )
+    async def _good_call(*a, **kw):
+        return _success_result()
 
     async def _watch_children():
-        return  # children die immediately → watcher resolves first
+        # Resolves immediately while the child is dead; never while alive.
+        while alive["v"]:
+            await asyncio.sleep(0.05)
 
+    def _respawn(server):
+        alive["v"] = True
+        new_session = MagicMock()
+        new_session.call_tool = _good_call
+        server.session = new_session
+        server._ready.set()
+
+    server = _install_stub_server(
+        mcp_tool, "srv-midcall", _hanging_call,
+        children_dead=lambda: not alive["v"],
+        on_reconnect=_respawn,
+    )
     server._watch_stdio_children = _watch_children
     mcp_tool._ensure_mcp_loop()
     try:
         handler = _make_tool_handler("srv-midcall", "tool1", 10.0)
-        result = handler({})
-        parsed = json.loads(result)
-        assert "error" in parsed, parsed
-        assert "exited mid-call" in parsed["error"], parsed
+        # The child dies once the RPC is in flight.
+        alive["v"] = False
+        parsed = json.loads(handler({}))
+        assert "error" not in parsed, parsed
+        assert parsed["result"] == "ok", parsed
         assert server._reconnect_event.set_calls == 1
     finally:
         _cleanup(mcp_tool, "srv-midcall")
+
+
+def test_dead_child_never_returning_is_not_reported_as_a_timeout(
+    monkeypatch, tmp_path,
+):
+    """No fresh session inside the respawn window → a clean error that says
+    the subprocess exited, never that something timed out (the
+    old "failing the call fast instead of waiting 300s" wording sent the
+    investigation into a healthy remote backend)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    monkeypatch.setattr(mcp_tool, "_STDIO_RESPAWN_WAIT_SEC", 1.0)
+    called = {"n": 0}
+
+    async def _call_tool(*a, **kw):
+        called["n"] += 1
+        return _success_result()
+
+    server = _install_stub_server(
+        mcp_tool, "srv-gone", _call_tool, children_dead=lambda: True,
+    )
+    mcp_tool._ensure_mcp_loop()
+    try:
+        handler = _make_tool_handler("srv-gone", "tool1", 300.0)
+        parsed = json.loads(handler({}))
+        assert "error" in parsed, parsed
+        message = parsed["error"]
+        assert "exited" in message, message
+        for forbidden in ("TimeoutError", "300s", "timed out"):
+            assert forbidden not in message, message
+        assert server._reconnect_event.set_calls == 1
+        assert called["n"] == 0, "RPC must not be attempted on a dead transport"
+        assert mcp_tool._server_error_counts.get("srv-gone", 0) == 1
+    finally:
+        _cleanup(mcp_tool, "srv-gone")
+
+
+def test_child_dying_again_after_respawn_does_not_hot_cycle(
+    monkeypatch, tmp_path,
+):
+    """A server whose child dies immediately after every respawn gets ONE
+    retry per call, not an endless respawn loop — run()'s rapid-drop budget
+    is what parks it, and this path must not fight that."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    monkeypatch.setattr(mcp_tool, "_STDIO_RESPAWN_WAIT_SEC", 1.0)
+    called = {"n": 0}
+
+    async def _call_tool(*a, **kw):
+        called["n"] += 1
+        return _success_result()
+
+    def _respawn_then_die(server):
+        # Fresh session object (so the readiness wait succeeds) whose child
+        # is already dead again by the time the retry dispatches.
+        new_session = MagicMock()
+        new_session.call_tool = _call_tool
+        server.session = new_session
+        server._ready.set()
+
+    server = _install_stub_server(
+        mcp_tool, "srv-flap", _call_tool,
+        children_dead=lambda: True,
+        on_reconnect=_respawn_then_die,
+    )
+    mcp_tool._ensure_mcp_loop()
+    try:
+        handler = _make_tool_handler("srv-flap", "tool1", 10.0)
+        parsed = json.loads(handler({}))
+        assert "error" in parsed, parsed
+        assert "exited again" in parsed["error"], parsed
+        assert "do NOT retry" in parsed["error"], parsed
+        assert server._reconnect_event.set_calls == 1, (
+            "one respawn request per tool call — never a retry loop"
+        )
+        assert called["n"] == 0
+        assert mcp_tool._server_error_counts.get("srv-flap", 0) == 1
+    finally:
+        _cleanup(mcp_tool, "srv-flap")

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -588,6 +588,13 @@ _MAX_BACKOFF_SECONDS = 60
 # can ever reach the circuit-breaker half-open probe or _signal_reconnect.
 _PARKED_RETRY_INTERVAL = 300     # seconds between parked self-probes
 _RECYCLED_RECONNECT_TIMEOUT = 15.0
+# How long a tool call waits for a respawned stdio child after its subprocess
+# was found dead — a gateway restart kills every MCP stdio child,
+# and the next call from a still-live session would otherwise fail for no real
+# reason). Bounded: when the wait elapses the call reports the dead transport
+# instead of looping, so a genuinely broken server still parks via the
+# rapid-drop budget in run() rather than hot-cycling respawns.
+_STDIO_RESPAWN_WAIT_SEC = 15.0
 # Jitter applied to reconnect backoff sleeps. Without it, every server that
 # lost the same backend retries in lockstep (thundering herd) and log lines
 # from N servers land in synchronized bursts.
@@ -5234,6 +5241,123 @@ def _handle_session_expired_and_retry(
     return None
 
 
+class _StdioChildExited(RuntimeError):
+    """A server's stdio subprocess was gone when (or while) a call ran.
+
+    Deliberately NOT a TimeoutError: nothing timed out — the child was
+    already dead, usually because a gateway restart killed every MCP stdio
+    subprocess out from under a still-live agent session. The old wording
+    ("failing the call fast instead of waiting 300s") sent an investigation
+    into the remote server for an afternoon; the server was healthy.
+
+    Handled by :func:`_handle_stdio_child_exited_and_retry`, which respawns
+    and retries the call once before any error reaches the model.
+    """
+
+
+def _handle_stdio_child_exited_and_retry(
+    server_name: str,
+    exc: Exception,
+    retry_call,
+    op_description: str,
+):
+    """Respawn a dead stdio child and retry the call once.
+
+    A gateway restart kills every MCP stdio subprocess. An agent session that
+    outlives the restart still holds the dead child, so its next tool call
+    used to fail in 0.00s — before anything reached the network — while the
+    subprocess was respawned seconds later. Cron runs spanning a restart lost
+    tool calls this way, silently.
+
+    Why retrying here cannot hot-cycle respawns: this function never spawns
+    anything. It sets ``_reconnect_event`` (one signal, same as before) and
+    waits for the server task to publish a fresh session. Spawn frequency
+    stays governed entirely by ``run()``'s rapid-drop budget, which parks a
+    transport that keeps dropping without proving healthy (#62212). The retry
+    is single-shot: a child that dies again immediately reports and stops,
+    so a genuinely broken server converges on the park instead of looping.
+
+    Returns:
+        A JSON string when this was a dead-stdio failure (retry result, or a
+        clean error), or ``None`` when ``exc`` is something else and the
+        caller should use its generic error path.
+    """
+    if not isinstance(exc, _StdioChildExited):
+        return None
+
+    with _lock:
+        srv = _servers.get(server_name)
+
+    reconnected = False
+    if srv is not None and hasattr(srv, "_reconnect_event"):
+        logger.info(
+            "MCP server '%s': %s found the stdio subprocess dead (%s); "
+            "respawning and retrying once.",
+            server_name, op_description, exc,
+        )
+        loop = _mcp_loop
+        if loop is not None and loop.is_running():
+            reconnected = _signal_reconnect_and_wait(
+                server_name,
+                srv,
+                op_description=op_description,
+                timeout=_STDIO_RESPAWN_WAIT_SEC,
+            )
+        else:
+            # No MCP loop to wait on (non-async adapters, tests) — still ask
+            # for the respawn so the next call lands on a live transport.
+            _signal_reconnect(srv)
+
+    if reconnected:
+        try:
+            result = retry_call()
+        except _StdioChildExited as retry_exc:
+            # Respawned and died again straight away: this is a broken
+            # server, not a restart artifact. Stop here — run()'s budget
+            # takes it to the park.
+            logger.warning(
+                "MCP server '%s': %s stdio subprocess exited again right "
+                "after respawn (%s); not retrying further.",
+                server_name, op_description, retry_exc,
+            )
+            _bump_server_error(server_name)
+            return tool_error(
+                f"MCP server '{server_name}' respawned its stdio subprocess "
+                f"and it exited again immediately. The server is not "
+                f"starting cleanly — do NOT retry this tool; ask the user to "
+                f"check the server's command and its stderr log."
+            )
+        except Exception as retry_exc:
+            logger.warning(
+                "MCP %s/%s retry after stdio respawn failed: %s",
+                server_name, op_description, retry_exc,
+            )
+            _bump_server_error(server_name)
+            return tool_error(_sanitize_error(
+                f"MCP call failed after respawning the stdio subprocess for "
+                f"'{server_name}': {type(retry_exc).__name__}: "
+                f"{_exc_str(retry_exc)}"
+            ))
+        try:
+            parsed = json.loads(result)
+            if "error" not in parsed:
+                _reset_server_error(server_name)
+            else:
+                _bump_server_error(server_name)
+        except (json.JSONDecodeError, TypeError):
+            _reset_server_error(server_name)
+        return result
+
+    _bump_server_error(server_name)
+    return tool_error(
+        f"MCP server '{server_name}' stdio subprocess had exited (this is "
+        f"not a timeout — the call never reached the server). A respawn was "
+        f"requested but no fresh session came back within "
+        f"{_STDIO_RESPAWN_WAIT_SEC:.0f}s. Wait a few seconds before retrying; "
+        f"if it keeps failing the server is not starting and needs the user."
+    )
+
+
 # Exact raw server names whose ``supports_parallel_tool_calls`` config is True.
 # Raw identity matters: distinct names such as ``foo-bar`` and ``foo_bar`` both
 # sanitize to ``foo_bar`` but must not share policy.
@@ -6166,21 +6290,13 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                         and _stdio_dead_result
                     ):
                         # Dead children but stale server.session, so the
-                        # transport-down path above never fired — signal the
-                        # server task to respawn and return a clean
-                        # reconnecting error. No explicit _bump_server_error:
-                        # the error return flows through the handler's JSON
-                        # parse, which already bumps once.
-                        if _signal_reconnect(server):
-                            return tool_error(
-                                f"MCP server '{server_name}' stdio subprocess is "
-                                f"dead and reconnect was requested. Do NOT retry "
-                                f"immediately — give it a few seconds to respawn."
-                            )
-                        raise TimeoutError(
-                            f"MCP stdio subprocess for '{server_name}' has "
-                            f"exited; failing the call fast instead of "
-                            f"waiting {float(tool_timeout):.0f}s"
+                        # transport-down path above never fired. Hand this to
+                        # the handler's respawn-and-retry path —
+                        # it is not a timeout, and a gateway restart that
+                        # killed the child must not cost the caller a call.
+                        raise _StdioChildExited(
+                            f"MCP stdio subprocess for '{server_name}' had "
+                            f"already exited when the call was dispatched"
                         )
                     _call_coro = server.session.call_tool(tool_name, arguments=args)
                     _watch_children = getattr(server, "_watch_stdio_children", None)
@@ -6216,16 +6332,13 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                                 # Same stale-session problem as the pre-call
                                 # gate above: the subprocess died mid-call but
                                 # nothing clears server.session, so without a
-                                # reconnect signal the server would stay dead
-                                # until the idle keepalive probe notices.
-                                _signal_reconnect(server)
-                                raise TimeoutError(
-                                    f"MCP stdio subprocess for '{server_name}' "
-                                    f"exited mid-call; failing the call fast "
-                                    f"instead of waiting "
-                                    f"{float(tool_timeout):.0f}s; reconnect "
-                                    f"requested — give it a few seconds to "
-                                    f"respawn before retrying"
+                                # reconnect the server would stay dead until
+                                # the idle keepalive probe notices. The
+                                # handler's respawn-and-retry path owns the
+                                # reconnect signal.
+                                raise _StdioChildExited(
+                                    f"MCP stdio subprocess for "
+                                    f"'{server_name}' exited mid-call"
                                 )
                             result = await rpc_task
                         finally:
@@ -6385,6 +6498,16 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
         except InterruptedError:
             return _interrupted_call_result()
         except Exception as exc:
+            # Dead stdio child: respawn and retry once before any
+            # error reaches the model — a gateway restart kills every MCP
+            # subprocess, and the call it lands on is not really a failure.
+            recovered = _handle_stdio_child_exited_and_retry(
+                server_name, exc, _call_once,
+                f"tools/call {tool_name}",
+            )
+            if recovered is not None:
+                return recovered
+
             # Auth-specific recovery path: consult the manager, signal
             # reconnect if viable, retry once. Returns None to fall
             # through for non-auth exceptions.


### PR DESCRIPTION
## What does this PR do?

A gateway restart kills every MCP stdio subprocess. An agent session that outlives the restart still holds a handle to the dead child, so its next tool call fails in **0.00s** — before anything reaches the network — while the subprocess is respawned seconds later. Cron runs spanning a restart lose tool calls silently.

The `#81995` / `#95626` machinery already detects the dead child and signals a reconnect. It just never waits for it, so the caller eats the failure. This PR makes both fast-fail sites respawn **and retry once** before any error reaches the model.

**Why this cannot hot-cycle respawns** (the concern the comments around `_mark_session_proven` / the park ladder guard): the new handler never spawns anything. It sets `_reconnect_event` — one signal per tool call, exactly as before — and waits for the server task to publish a fresh session. Spawn frequency stays governed entirely by `run()`'s rapid-drop budget (`#62212`), which parks a transport that keeps dropping without proving healthy. The retry is single-shot: a child that dies again immediately reports and stops.

Secondary fix: the error text no longer claims a timeout. `"failing the call fast instead of waiting 300s"` describes a healthy remote backend as a timing problem — that wording sent an afternoon of investigation into the wrong system before the client was suspected.

## Related Issue

No existing issue — found while diagnosing a "this MCP tool times out" report that turned out to be client-side. I searched open and closed PRs/issues for `stdio subprocess`, `stdio respawn`, and `mcp stdio`; the nearest neighbours are all orthogonal (#98770 parks pre-handshake crashers, #98088/#98810 fix watcher-coroutine creation, #95583 fixed the inverted liveness check this builds on). Happy to open an issue first if you'd prefer that order.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py`
  - New `_StdioChildExited(RuntimeError)` — deliberately **not** a `TimeoutError`, because nothing timed out.
  - New `_handle_stdio_child_exited_and_retry()` — respawns, waits up to `_STDIO_RESPAWN_WAIT_SEC` (15s) for a fresh session, retries once. Mirrors the existing `_handle_auth_error_and_retry` / `_handle_session_expired_and_retry` shape and is wired into the same `except` chain in `_make_tool_handler`.
  - Pre-call gate and mid-call watcher race now raise `_StdioChildExited` instead of returning a "reconnect requested" error / raising `TimeoutError`.
- `tests/tools/test_mcp_stdio_fastfail_reconnect.py` — updated to the new contract, plus two new cases: the never-comes-back error (asserting the text contains no `TimeoutError` / `300s` / `timed out`) and the no-hot-cycle case.

## How to Test

Automated:

```bash
scripts/run_tests.sh tests/tools/test_mcp_stdio_fastfail_reconnect.py tests/tools/test_mcp_stdio_children_dead.py
```

Manual, with a real subprocess — this is the actual failure, and it does not reproduce against mocks:

1. Register any stdio MCP server and make one successful tool call.
2. `kill -9` the PID in `server._stdio_child_pids` (this is what the restart does to a surviving session's child).
3. Call the same tool again.

Before: fails in `0.00s` with `MCP server '<name>' stdio subprocess is dead and reconnect was requested`.
After: succeeds. Measured `0.51s` on a local echo server, `3.26s` against a real HTTP-backed one, with the respawn visible between the two backend audit entries.

No-hot-cycle check, a server whose child exits on every tool call:

```
distinct child PIDs spawned across 8 calls: 6
reconnect budget used: 6/5   parked=True   tools_registered=0
```

At most one respawn per call, then the rapid-drop budget parks it and deregisters its tools.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (single commit, 2 files)
- [x] I've run `pytest tests/ -q` (via `scripts/run_tests.sh`) — **full suite, and it is clean relative to `main`.**

  | run | result |
  |---|---|
  | this branch | **82 failed / 37 files** |
  | clean `a9c783f219` worktree | **82 failed / 37 files** |

  The two failure lists are **identical, file for file and count for count** — no regressions from this change. Those 82 are pre-existing environmental failures on my machine, not upstream being broken: missing optional deps (`daytona`, `modal`, `hindsight`, voice/transcription), the `hermes_cli` update-flow tests, and macOS-specific `man` / `sort` / tmpdir behaviour in `test_execution_flag_detection.py`.

  Two notes for anyone reproducing this:
  - Run the suite from a checkout that does **not** contain a nested git worktree. `tests/test_managed_runtime_resolution.py` scans the repo tree, so a worktree under `.claude/worktrees/` gets audited as a second copy of the codebase and adds phantom failures (this cost me a 5-failure false positive before I compared properly).
  - `tests/tools/test_mcp_tool_issue_948.py` appears in both lists and passes **4/4 in isolation** — a `-j 32` flake, present with and without this patch.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings on both new symbols) — the rest N/A
- [x] `cli-config.yaml.example` — N/A (no new config keys; `_STDIO_RESPAWN_WAIT_SEC` is a module constant alongside `_RECYCLED_RECONNECT_TIMEOUT`)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture or workflow change)
- [x] Cross-platform: the liveness probe is the existing `psutil.pid_exists` path (already Windows-safe per `#85125`); this PR adds no new process handling. Tested on macOS only — a Windows/Linux confirmation would be welcome.
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

Before, from the report that started this — note the `0.00s`, and the respawn arriving **after** the failure:

```
15:18:02  ERROR tools.mcp_tool: MCP tool <server>/<tool> call failed:
          MCP stdio subprocess for '<server>' has exited; failing the call fast
          instead of waiting 300s
15:18:02  WARNING agent.tool_executor: Tool mcp__<server>__<tool> returned error (0.00s)
15:18:05  ===== starting MCP server '<server>' =====
```

That message names a timeout and a 300s wait for a call that never left the process, which is what made the remote service look guilty.
