### PR TITLE
fix(mcp): a zero ttl_ms silently disables lazy MCP startup

### DIFF
--- a/tests/tools/test_mcp_schema_cache_ttl.py
+++ b/tests/tools/test_mcp_schema_cache_ttl.py
@@ -18,6 +18,22 @@ def test_entry_without_ttl_never_expires():
     assert sc.get_cached_entry("srv", "fp") is not None
 
 
+def test_zero_ttl_never_expires(monkeypatch):
+    # The mcp SDK declares ListToolsResult.ttl_ms with a default of 0, so a
+    # server that never sends ttlMs is read as 0 rather than None. Treating
+    # that as "already stale" makes the entry a permanent miss the moment it
+    # is written, which silently turns `lazy: true` into an eager spawn.
+    sc.write_cache_entry("srv", "fp", tools=[{"name": "t"}], ttl_ms=0)
+    real_time = time.time
+    monkeypatch.setattr(sc.time, "time", lambda: real_time() + 86_400.0)
+    assert sc.get_cached_entry("srv", "fp") is not None
+
+
+def test_negative_ttl_never_expires():
+    sc.write_cache_entry("srv", "fp", tools=[{"name": "t"}], ttl_ms=-1)
+    assert sc.get_cached_entry("srv", "fp") is not None
+
+
 def test_entry_within_ttl_served():
     sc.write_cache_entry("srv", "fp", tools=[{"name": "t"}], ttl_ms=60_000)
     entry = sc.get_cached_entry("srv", "fp")

--- a/tools/mcp_schema_cache.py
+++ b/tools/mcp_schema_cache.py
@@ -71,7 +71,8 @@ def get_cached_entry(server_name: str, fingerprint: str) -> Optional[dict]:
     freshness hint. When the live discovery path recorded one, an entry
     older than its TTL is treated as a miss so the next startup re-probes
     the server instead of serving a stale manifest forever. Entries without
-    a recorded TTL (pre-2026 servers) keep the old never-expires behavior.
+    a positive recorded TTL (pre-2026 servers, and any server that leaves
+    ``ttlMs`` unset -- the SDK default is 0) keep the never-expires behavior.
     ``cacheScope`` is irrelevant here: this cache is per-user local disk,
     which satisfies even ``private``.
     """
@@ -83,7 +84,18 @@ def get_cached_entry(server_name: str, fingerprint: str) -> Optional[dict]:
         return None
     ttl_ms = entry.get("ttl_ms")
     written_at = entry.get("written_at")
-    if isinstance(ttl_ms, (int, float)) and isinstance(written_at, (int, float)):
+    # A non-positive TTL means "no freshness hint", not "already stale". The
+    # mcp SDK declares ``ListToolsResult.ttl_ms`` with a default of 0, and
+    # pydantic defaults are indistinguishable from an explicit 0 over
+    # attribute access -- so every server that does not send ``ttlMs`` lands
+    # here as 0. Expiring on that makes the entry a permanent miss the instant
+    # it is written, which silently degrades ``lazy: true`` servers into eager
+    # spawns forever (the cache lookup in register_mcp_servers never hits).
+    if (
+        isinstance(ttl_ms, (int, float))
+        and ttl_ms > 0
+        and isinstance(written_at, (int, float))
+    ):
         if (time.time() - written_at) * 1000.0 >= float(ttl_ms):
             return None
     return entry


### PR DESCRIPTION
## Problem

`lazy: true` (#56832) is supposed to let an MCP server register its tools from the on-disk schema cache and defer the spawn until first use. In practice the cache lookup **never hits**, so every lazy server falls through to the eager connect and the feature is a silent no-op.

The mcp SDK declares `ListToolsResult.ttl_ms` with a **default of 0**:

```python
>>> mcp.types.ListToolsResult.model_fields["ttl_ms"]
FieldInfo(default=0, alias='ttlMs', annotation=<class 'int'>)
```

A pydantic default is indistinguishable from an explicit `0` over attribute access — the same hazard `mcp_field` already documents for the 1.x → 2.x rename. So a server that never sends SEP-2549 `ttlMs` still yields `ttl_ms == 0`, `write_cache_entry` records `ttl_ms: 0` plus `written_at`, and the expiry check

```python
if (time.time() - written_at) * 1000.0 >= float(ttl_ms):
    return None
```

is true **the instant the entry is written**. Every subsequent lookup misses, the lazy branch in `register_mcp_servers` `continue`s past every server, and the eager connect runs as if `lazy` were never set.

`get_cached_entry`'s docstring already states the intended rule —

> Entries without a recorded TTL (pre-2026 servers) keep the old never-expires behavior.

— but a defaulted `0` never reaches that branch.

## Observed

A 5-server deployment with `lazy: true` on all five. Every entry recorded `ttl_ms: 0`, every lookup missed, and all five spawned eagerly **in both the gateway and the dashboard** (the dashboard loads the same MCP config), for ~28 subprocesses and ~540 MB of duplicate footprint on a 3.4 GB host.

With the patch, the same deployment logs:

```
MCP server 'officecli' (lazy): registered 1 tool(s) from schema cache
MCP server 'tikhub-douyin' (lazy): registered 293 tool(s) from schema cache
...
MCP: registered 368 lazy tool(s) from schema cache (no processes spawned)
```

0 MCP subprocesses at startup, adapters up in 6s instead of 45s, and first use wakes exactly the one server that was called while the other four stay dormant.

## Fix

Treat a non-positive TTL as "no freshness hint" rather than "already stale". Positive TTLs expire exactly as before.

## Verification

Added two cases to `test_mcp_schema_cache_ttl.py`; existing TTL behaviour is unchanged:

| case | expected |
|---|---|
| `ttl_ms=0`, read 24h later | **hit** (the fix — SDK default means "no hint") |
| `ttl_ms=-1` | **hit** (defensive) |
| no `ttl_ms` recorded | hit (pre-existing) |
| `ttl_ms=1000` read after 2s | miss (no regression) |
| fingerprint mismatch | miss (no regression) |
