### PR TITLE
feat(tools): consult — agent-initiated second opinion from a frontier reference model (salvage #82103, Perplexity advisor-escalation port)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4354,6 +4354,7 @@ _AUX_TASKS: list[tuple[str, str, str]] = [
     ("kanban_decomposer", "Kanban decomposer", "task decomposition"),
     ("profile_describer", "Profile describer", "auto profile descriptions"),
     ("curator", "Curator", "skill-usage review pass"),
+    ("consult", "Consult", "second-opinion reference model (consult tool)"),
 ]
 
 # Special non-auxiliary task surfaced in the same picker: subagent delegation.

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -105,6 +105,7 @@ CONFIGURABLE_TOOLSETS = [
     ("code_execution",  "⚡ Code Execution",            "execute_code"),
     ("vision",          "👁️  Vision / Image Analysis",  "vision_analyze"),
     ("video",           "🎬 Video Analysis",            "video_analyze (requires video-capable model)"),
+    ("consult",         "🧭 Consult (Second Opinion)",  "consult (get a second opinion from a reference model)"),
     ("image_gen",       "🎨 Image Generation",          "image_generate"),
     ("video_gen",       "🎬 Video Generation",          "video_generate (text/image/reference)"),
     ("x_search",        "🐦 X (Twitter) Search",        "x_search (requires xAI OAuth or XAI_API_KEY)"),

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -304,6 +304,25 @@ class TestPlatformToolsetConsistency:
                 f"which is not defined in toolsets.py"
             )
 
+    def test_consult_toolset_is_reachable_via_hermes_tools(self):
+        """The `consult` toolset (registered in toolsets.py TOOLSETS) must
+        also appear in CONFIGURABLE_TOOLSETS, or `hermes tools enable consult`
+        rejects it as unknown and the toolset is only reachable via manual
+        platform_toolsets config editing / --toolsets consult, not the normal
+        `hermes tools` picker flow every other opt-in toolset (vision, video)
+        uses. Regression for the toolset shipping registered in TOOLSETS but
+        never added to the picker's CONFIGURABLE_TOOLSETS list."""
+        from toolsets import TOOLSETS
+
+        assert "consult" in TOOLSETS, "consult toolset must exist in toolsets.py"
+        configurable_keys = {key for key, _, _ in CONFIGURABLE_TOOLSETS}
+        assert "consult" in configurable_keys, (
+            "consult is registered in toolsets.py TOOLSETS but missing from "
+            "CONFIGURABLE_TOOLSETS in hermes_cli/tools_config.py -- "
+            "`hermes tools enable consult` will reject it as an unknown "
+            "toolset and it won't appear in the `hermes tools` picker"
+        )
+
     def test_gateway_toolset_includes_all_messaging_platforms(self):
         """hermes-gateway includes list should cover all messaging platforms."""
         from hermes_cli.tools_config import PLATFORMS

--- a/tests/tools/test_consult_degenerate_guard.py
+++ b/tests/tools/test_consult_degenerate_guard.py
@@ -1,0 +1,76 @@
+"""Guard against degenerate consult answers (leaked markup / request echo).
+
+Regression case: a local/open-weight aux model answered a consult with the
+consult request itself wrapped in raw tool-call template markup; the main
+agent then presented a fabricated "reference model's take" to the user. The
+tool must classify such answers as unavailable, never as a usable answer.
+"""
+
+from tools.consult_tool import _degenerate_answer_reason
+
+
+QUESTION = "Should unoccupied rooms above setpoint get 100% airflow?"
+CONTEXT = (
+    "## Logic change request\n"
+    "Unoccupied rooms (like the Game Room at 75.92F) are currently getting "
+    "100% airflow because they are far above the setpoint, and the Priority "
+    "Pass skips them for beneficiaries, but it doesn't throttle them. Every "
+    "watt of cooling wasted on an empty room is CFM stolen from the occupied "
+    "Living Room. Fix the vent opening calculation: when a room is "
+    "UNOCCUPIED cap its base tendency to open at 60-70% regardless of how "
+    "hot it is, or multiply its effective temperature deficit by a penalty."
+)
+
+
+def test_template_wrapped_echo_is_degenerate():
+    # The observed failure shape: chat-template markup wrapping the request
+    # text (the sentinel is the fullwidth vertical bar U+FF5C, as used in
+    # some open-weight models' raw tool-call templates).
+    answer = (
+        "\uff5ctool_calls>\n\uff5cinvoke name=\"consult\">\n"
+        "\uff5cparameter name=\"context\" string=\"true\">" + CONTEXT
+        + "\n</tool_code_code_logic>"
+    )
+    assert _degenerate_answer_reason(answer, QUESTION, CONTEXT) is not None
+
+
+def test_plain_echo_is_degenerate():
+    assert _degenerate_answer_reason(CONTEXT, QUESTION, CONTEXT) is not None
+
+
+def test_leading_control_token_is_degenerate():
+    assert (
+        _degenerate_answer_reason(
+            "<|im_start|>assistant here is my view", QUESTION, CONTEXT
+        )
+        is not None
+    )
+
+
+def test_real_answer_passes():
+    answer = (
+        "The plan is mostly sound but capping unoccupied rooms at a fixed "
+        "60-70% is fragile with only 0/50/100 vent positions available -- "
+        "use 50% as the cap and add a hysteresis band so occupancy flapping "
+        "(e.g. someone sleeping) doesn't oscillate the vents. Also make the "
+        "brake conditional on whole-system delivery handicap, not per-room "
+        "temperature alone."
+    )
+    assert _degenerate_answer_reason(answer, QUESTION, CONTEXT) is None
+
+
+def test_short_answer_never_flagged_as_echo():
+    # Short answers legitimately reuse the question's own words.
+    answer = "Yes -- cap unoccupied rooms at 50%, it is the right call."
+    assert _degenerate_answer_reason(answer, QUESTION, CONTEXT) is None
+
+
+def test_answer_quoting_a_template_snippet_without_structure_passes():
+    # Mentioning the sentinel alone (e.g. discussing a parser bug) is fine
+    # as long as no tool-call structure is present and it is not the prefix.
+    answer = (
+        "Your parser fails because the model emitted a stray \uff5c "
+        "sentinel mid-string; strip it before json parsing. Otherwise the "
+        "approach is fine and the retry loop is correct as written."
+    )
+    assert _degenerate_answer_reason(answer, QUESTION, CONTEXT) is None

--- a/tests/tools/test_consult_tool.py
+++ b/tests/tools/test_consult_tool.py
@@ -1,0 +1,182 @@
+"""Tests for the consult tool (second opinion from a reference model).
+
+``consult`` wraps ``agent.auxiliary_client.call_llm(task="consult", ...)``.
+Refusals / empty responses / call failures from the reference model must
+degrade gracefully to ``{"unavailable": true, ...}`` rather than raising --
+that's the whole point of the feature (reasoning-heavy or safety-tuned
+frontier models refuse often enough that a hard failure here would make the
+tool useless).
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.consult_tool import consult_tool, MAX_CONTEXT_CHARS, MAX_QUESTION_CHARS
+
+
+def _fake_response(content="", finish_reason="stop"):
+    resp = MagicMock()
+    resp.choices = [MagicMock()]
+    resp.choices[0].message.content = content
+    resp.choices[0].message.reasoning = None
+    resp.choices[0].message.reasoning_content = None
+    resp.choices[0].message.reasoning_details = None
+    resp.choices[0].finish_reason = finish_reason
+    return resp
+
+
+class TestConsultToolSuccess:
+    def test_returns_answer_on_success(self):
+        resp = _fake_response("Looks sound; watch the race on shutdown.")
+        with patch("agent.auxiliary_client.call_llm", return_value=resp):
+            result = json.loads(consult_tool("Is this plan sound?"))
+        assert result["unavailable"] is False
+        assert result["answer"] == "Looks sound; watch the race on shutdown."
+
+    def test_passes_task_consult_to_call_llm(self):
+        resp = _fake_response("ok")
+        with patch("agent.auxiliary_client.call_llm", return_value=resp) as mock_call:
+            consult_tool("Is this plan sound?")
+        assert mock_call.call_args.kwargs.get("task") == "consult"
+
+    def test_includes_context_in_user_message(self):
+        resp = _fake_response("ok")
+        with patch("agent.auxiliary_client.call_llm", return_value=resp) as mock_call:
+            consult_tool("Is this plan sound?", context="def foo(): pass")
+        messages = mock_call.call_args.kwargs.get("messages")
+        user_msg = next(m for m in messages if m["role"] == "user")
+        assert "def foo(): pass" in user_msg["content"]
+        assert "Is this plan sound?" in user_msg["content"]
+
+    def test_no_context_omits_separator(self):
+        resp = _fake_response("ok")
+        with patch("agent.auxiliary_client.call_llm", return_value=resp) as mock_call:
+            consult_tool("Is this plan sound?")
+        messages = mock_call.call_args.kwargs.get("messages")
+        user_msg = next(m for m in messages if m["role"] == "user")
+        assert user_msg["content"] == "Is this plan sound?"
+
+    def test_strips_whitespace_from_answer(self):
+        resp = _fake_response("  padded answer  \n")
+        with patch("agent.auxiliary_client.call_llm", return_value=resp):
+            result = json.loads(consult_tool("q"))
+        assert result["answer"] == "padded answer"
+
+
+class TestConsultToolGracefulDegradation:
+    """The core design requirement: refusal/failure != exception."""
+
+    def test_empty_content_is_unavailable_not_error(self):
+        resp = _fake_response("")
+        with patch("agent.auxiliary_client.call_llm", return_value=resp):
+            result = json.loads(consult_tool("q"))
+        assert result["unavailable"] is True
+        assert result["answer"] is None
+        assert "reason" in result and result["reason"]
+
+    def test_whitespace_only_content_is_unavailable(self):
+        resp = _fake_response("   \n\t  ")
+        with patch("agent.auxiliary_client.call_llm", return_value=resp):
+            result = json.loads(consult_tool("q"))
+        assert result["unavailable"] is True
+
+    def test_content_filter_finish_reason_is_unavailable(self):
+        # Even if content is non-empty, a content_filter finish reason
+        # (Anthropic-native refusal mapping) means "don't trust this".
+        resp = _fake_response("partial thing", finish_reason="content_filter")
+        with patch("agent.auxiliary_client.call_llm", return_value=resp):
+            result = json.loads(consult_tool("q"))
+        assert result["unavailable"] is True
+
+    def test_call_llm_exception_is_unavailable_not_raised(self):
+        with patch(
+            "agent.auxiliary_client.call_llm",
+            side_effect=RuntimeError("no provider configured"),
+        ):
+            result = json.loads(consult_tool("q"))
+        assert result["unavailable"] is True
+        assert result["answer"] is None
+        assert "no provider configured" in result["reason"]
+
+    def test_malformed_response_object_is_unavailable(self):
+        # A response missing .choices entirely must not crash the tool.
+        with patch("agent.auxiliary_client.call_llm", return_value=object()):
+            result = json.loads(consult_tool("q"))
+        assert result["unavailable"] is True
+
+
+class TestConsultToolValidation:
+    def test_empty_question_is_error(self):
+        result = json.loads(consult_tool(""))
+        assert "error" in result
+
+    def test_whitespace_only_question_is_error(self):
+        result = json.loads(consult_tool("   "))
+        assert "error" in result
+
+    def test_none_question_is_error(self):
+        result = json.loads(consult_tool(None))
+        assert "error" in result
+
+    def test_long_question_is_truncated(self):
+        resp = _fake_response("ok")
+        long_q = "x" * (MAX_QUESTION_CHARS + 500)
+        with patch("agent.auxiliary_client.call_llm", return_value=resp) as mock_call:
+            consult_tool(long_q)
+        messages = mock_call.call_args.kwargs.get("messages")
+        user_msg = next(m for m in messages if m["role"] == "user")
+        assert len(user_msg["content"]) < len(long_q)
+        assert "truncated" in user_msg["content"]
+
+    def test_long_context_is_truncated(self):
+        resp = _fake_response("ok")
+        long_ctx = "y" * (MAX_CONTEXT_CHARS + 500)
+        with patch("agent.auxiliary_client.call_llm", return_value=resp) as mock_call:
+            consult_tool("q", context=long_ctx)
+        messages = mock_call.call_args.kwargs.get("messages")
+        user_msg = next(m for m in messages if m["role"] == "user")
+        assert len(user_msg["content"]) < len(long_ctx) + len("q") + 50
+        assert "truncated" in user_msg["content"]
+
+
+class TestConsultToolRegistration:
+    def test_registered_in_registry(self):
+        import model_tools  # noqa: F401  (triggers discover_builtin_tools)
+        from tools.registry import registry
+
+        entry = registry.get_entry("consult")
+        assert entry is not None
+        assert entry.toolset == "consult"
+        assert entry.schema["name"] == "consult"
+        assert "question" in entry.schema["parameters"]["properties"]
+        assert entry.schema["parameters"]["required"] == ["question"]
+
+    def test_dispatch_through_registry(self):
+        import model_tools  # noqa: F401
+        from tools.registry import registry
+
+        resp = _fake_response("dispatched ok")
+        with patch("agent.auxiliary_client.call_llm", return_value=resp):
+            result = json.loads(
+                registry.dispatch("consult", {"question": "q"})
+            )
+        assert result["unavailable"] is False
+        assert result["answer"] == "dispatched ok"
+
+
+class TestConsultToolset:
+    """consult is a registered, opt-in toolset -- not in the default
+    always-on tool list (_HERMES_CORE_TOOLS), matching how vision/video are
+    opt-in rather than core."""
+
+    def test_consult_toolset_resolves_to_consult_tool(self):
+        from toolsets import resolve_toolset
+
+        assert resolve_toolset("consult") == ["consult"]
+
+    def test_consult_not_in_default_core_tools(self):
+        from toolsets import _HERMES_CORE_TOOLS
+
+        assert "consult" not in _HERMES_CORE_TOOLS

--- a/tools/consult_tool.py
+++ b/tools/consult_tool.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""
+Consult Tool Module - Second Opinion From a Reference Model
+
+Lets the agent (main or delegated subagent) ask a smarter/more capable
+reference model for a second opinion on a specific, bounded question before
+committing to something risky or uncertain. Routes through the shared
+auxiliary LLM client (``auxiliary.consult`` in config.yaml) so the reference
+model is configurable independently of the main chat model -- the canonical
+use case is pointing it at an expensive frontier model that would be a bad
+MAIN model (slow, prone to over-cautious refusals) but is a great second
+opinion for a narrow, well-scoped question.
+
+Design notes:
+  * This is a plain registry tool (no agent-loop state), same shape as
+    ``vision_analyze`` -- it just wraps ``agent.auxiliary_client.call_llm``.
+  * Refusals / empty responses from the reference model are NOT exceptions.
+    They're reported back as ``unavailable: true`` with a short reason so the
+    calling agent can proceed on its own judgment instead of stalling or
+    retrying in a loop. Reasoning-heavy or safety-tuned reference models
+    refuse often enough that this has to be a first-class, expected outcome,
+    not an error path.
+  * No automatic retry against a fallback model -- a refusal here just means
+    "no second opinion this time," and the calling agent already has its own
+    judgment to fall back on.
+"""
+
+import difflib
+import json
+from typing import Optional
+
+
+# Hard caps so a runaway question/context can't blow the aux call's context
+# window or turn one "consult" call into a de-facto full-transcript replay.
+MAX_QUESTION_CHARS = 4000
+MAX_CONTEXT_CHARS = 40000
+
+# Chat-template sentinel (U+FF5C fullwidth bar) as used in some models' raw
+# tool-call markup. A consult answer carrying this is leaked template/control
+# text from the aux model, not an opinion.
+_TEMPLATE_SENTINEL = "\uff5c"
+
+
+def _degenerate_answer_reason(
+    answer: str, question: str, context: str
+) -> Optional[str]:
+    """Return a reason string when *answer* is template garbage or an echo
+    of the request, else None.
+
+    Two cheap-to-detect failure shapes observed from local/open-weight
+    reference models used as the consult backend:
+
+      * leaked tool-call/template markup -- a chat-template sentinel with
+        tool-call structure around it, or the answer *opening* with a
+        control tag;
+      * echo -- the bulk of the answer is one contiguous block of the
+        request text (the model returned the consult request itself instead
+        of answering it).
+    """
+    stripped = answer.strip()
+    if _TEMPLATE_SENTINEL in answer and (
+        "tool_calls" in answer or "invoke name=" in answer
+        or "parameter name=" in answer
+    ):
+        return "leaked tool-call markup instead of an answer"
+    if stripped.startswith(("<|im_", "<|start", f"<{_TEMPLATE_SENTINEL}")):
+        return "leaked chat-template control tokens instead of an answer"
+
+    request = " ".join(f"{question} {context}".split())
+    normalized = " ".join(stripped.split())
+    if len(normalized) >= 120 and request:
+        match = difflib.SequenceMatcher(
+            None, normalized, request, autojunk=False
+        ).find_longest_match(0, len(normalized), 0, len(request))
+        if match.size / len(normalized) > 0.7:
+            return "echoed the consult request back instead of answering it"
+    return None
+
+_CONSULT_SYSTEM_PROMPT = (
+    "You are acting as an independent second opinion for another AI agent that "
+    "is mid-task. You are NOT the one doing the task -- you are being asked to "
+    "sanity-check one specific decision, plan, piece of reasoning, or claim. "
+    "Be direct and concise: call out concrete risks, errors, or blind spots if "
+    "you see them, or say plainly that the approach looks sound if it does. Do "
+    "not pad the response with disclaimers, caveats about not having full "
+    "context, or restating the question back. If you genuinely don't have "
+    "enough information to judge, say exactly what is missing rather than "
+    "refusing outright or hedging everything."
+)
+
+
+def consult_tool(question: str, context: Optional[str] = None) -> str:
+    """
+    Ask a configured reference model (``auxiliary.consult``) for a second
+    opinion on a specific question, optionally with supporting context.
+
+    Args:
+        question: The specific judgment call to get a second opinion on.
+        context:  Optional supporting material (code, plan, diff, reasoning
+                  trace) the reviewer needs to judge the question.
+
+    Returns:
+        JSON string. On success: ``{"unavailable": false, "answer": "..."}``.
+        When the reference model refuses, returns empty, or the call fails:
+        ``{"unavailable": true, "answer": null, "reason": "..."}`` -- this is
+        an expected outcome, not an error; the caller should proceed on its
+        own judgment rather than retry.
+    """
+    if not question or not question.strip():
+        return tool_error("question is required.")
+
+    question = question.strip()
+    if len(question) > MAX_QUESTION_CHARS:
+        question = question[:MAX_QUESTION_CHARS] + "...(truncated)"
+
+    context = (context or "").strip()
+    if context:
+        if len(context) > MAX_CONTEXT_CHARS:
+            context = context[:MAX_CONTEXT_CHARS] + "\n...(truncated)"
+        user_content = f"{question}\n\n---\nContext:\n{context}"
+    else:
+        user_content = question
+
+    messages = [
+        {"role": "system", "content": _CONSULT_SYSTEM_PROMPT},
+        {"role": "user", "content": user_content},
+    ]
+
+    from agent.auxiliary_client import call_llm, extract_content_or_reasoning
+
+    try:
+        response = call_llm(
+            task="consult",
+            messages=messages,
+            max_tokens=2000,
+        )
+    except Exception as exc:
+        return json.dumps(
+            {
+                "unavailable": True,
+                "answer": None,
+                "reason": (
+                    f"Consult call failed ({type(exc).__name__}: {exc}) -- "
+                    "no second opinion available this time. Proceed using "
+                    "your own judgment."
+                ),
+            },
+            ensure_ascii=False,
+        )
+
+    finish_reason = None
+    try:
+        finish_reason = response.choices[0].finish_reason
+    except Exception:
+        pass
+
+    try:
+        answer = extract_content_or_reasoning(response)
+    except Exception:
+        answer = ""
+
+    if not answer or not answer.strip() or finish_reason == "content_filter":
+        return json.dumps(
+            {
+                "unavailable": True,
+                "answer": None,
+                "reason": (
+                    "The consult model declined to answer or returned nothing "
+                    "(safety refusal, filtered response, or empty output). "
+                    "No second opinion available this time -- proceed using "
+                    "your own judgment rather than retrying."
+                ),
+            },
+            ensure_ascii=False,
+        )
+
+    degenerate = _degenerate_answer_reason(answer, question, context)
+    if degenerate:
+        return json.dumps(
+            {
+                "unavailable": True,
+                "answer": None,
+                "reason": (
+                    f"The consult model's response was unusable: {degenerate}. "
+                    "Treat this as NO second opinion -- do not paraphrase, "
+                    "reconstruct, or attribute an answer to the reference "
+                    "model. Proceed on your own judgment, and tell the user "
+                    "the consult failed if they asked for it."
+                ),
+            },
+            ensure_ascii=False,
+        )
+
+    return json.dumps(
+        {"unavailable": False, "answer": answer.strip()},
+        ensure_ascii=False,
+    )
+
+
+def check_consult_requirements() -> bool:
+    """Consult has no hard external requirement -- auxiliary 'auto' routing
+    falls back through the same provider chain every other auxiliary task
+    uses, so the tool is always usable even before auxiliary.consult is
+    explicitly configured."""
+    return True
+
+
+# =============================================================================
+# OpenAI Function-Calling Schema
+# =============================================================================
+
+CONSULT_SCHEMA = {
+    "name": "consult",
+    "description": (
+        "Get a second opinion from a smarter/more capable reference model "
+        "before committing to a risky or uncertain decision. Use it to "
+        "sanity-check your own reasoning, review a plan or diff for "
+        "structural issues you might be tunnel-visioned past, or ask a "
+        "pointed question you're not fully confident about. NOT for routine "
+        "work -- this costs one full call to a (usually more expensive, "
+        "sometimes slower) model, so use it sparingly and only for genuinely "
+        "uncertain judgment calls.\n\n"
+        "The reference model is configured via `auxiliary.consult` in "
+        "config.yaml and may occasionally decline to answer -- safety "
+        "refusal, empty response, or timeout are all expected outcomes, not "
+        "errors. When that happens this tool returns unavailable=true with "
+        "a reason; proceed using your own judgment instead of retrying.\n\n"
+        "Available to both the main agent and delegated subagents."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "question": {
+                "type": "string",
+                "description": (
+                    "The specific question or judgment call you want a "
+                    "second opinion on. Be precise -- a vague question gets "
+                    "a vague answer."
+                ),
+            },
+            "context": {
+                "type": "string",
+                "description": (
+                    "Relevant background the reviewer needs to judge the "
+                    "question: code, a plan, a diff, a reasoning trace, or "
+                    "key facts. Keep it focused -- trim to what's actually "
+                    "relevant rather than pasting the whole conversation."
+                ),
+            },
+        },
+        "required": ["question"],
+    },
+}
+
+
+# --- Registry ---
+from tools.registry import registry, tool_error
+
+registry.register(
+    name="consult",
+    toolset="consult",
+    schema=CONSULT_SCHEMA,
+    handler=lambda args, **kw: consult_tool(
+        question=args.get("question", ""),
+        context=args.get("context"),
+    ),
+    check_fn=check_consult_requirements,
+    emoji="\U0001f9ed",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -133,6 +133,16 @@ TOOLSETS = {
         "includes": []
     },
 
+    "consult": {
+        "description": (
+            "Get a second opinion from a configurable reference model "
+            "(auxiliary.consult in config.yaml) before a risky or uncertain "
+            "decision. Available to both the main agent and subagents."
+        ),
+        "tools": ["consult"],
+        "includes": []
+    },
+
     "video": {
         "description": "Video analysis and understanding tools (opt-in, not in default toolset)",
         "tools": ["video_analyze"],

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -62,6 +62,14 @@ If the prompt times out part-way, answers the user already locked are kept: the 
 |------|-------------|----------------------|
 | `execute_code` | Run a Python script that can call Hermes tools programmatically. Use this when you need 3+ tool calls with processing logic between them, need to filter/reduce large tool outputs before they enter your context, need conditional branching (… | — |
 
+## `consult` toolset
+
+Opt-in toolset (not loaded in the default `hermes-cli` set). Enable via `hermes tools` → Consult (Second Opinion) or add `--toolsets consult`.
+
+| Tool | Description | Requires environment |
+|------|-------------|----------------------|
+| `consult` | Ask a configurable reference model (`auxiliary.consult` in config.yaml) for a second opinion on a specific, bounded question — sanity-check a plan, review a diff, or settle a genuinely uncertain judgment call — before committing to something risky. Refusals, empty responses, and call failures degrade to `unavailable: true` rather than erroring, so the agent proceeds on its own judgment. Available to the main agent and delegated subagents. | — |
+
 ## `cronjob` toolset
 
 | Tool | Description | Requires environment |

--- a/website/docs/reference/toolsets-reference.md
+++ b/website/docs/reference/toolsets-reference.md
@@ -54,6 +54,7 @@ Or in-session:
 |---------|-------|---------|
 | `browser` | `browser_back`, `browser_cdp`, `browser_click`, `browser_console`, `browser_dialog`, `browser_get_images`, `browser_navigate`, `browser_press`, `browser_scroll`, `browser_snapshot`, `browser_type`, `browser_vision`, `web_search` | Core browser automation. Includes `web_search` as a fallback for quick lookups. `browser_cdp` and `browser_dialog` are gated at runtime — registered only when a CDP endpoint is reachable at session start (via `/browser connect`, `browser.cdp_url` config, Browserbase, or Camofox). `browser_dialog` works together with the `pending_dialogs` and `frame_tree` fields that `browser_snapshot` adds when a CDP supervisor is attached. |
 | `clarify` | `clarify` | Ask the user a question when the agent needs clarification. |
+| `consult` | `consult` | Second opinion from a configurable reference model (`auxiliary.consult` in config.yaml) before a risky or uncertain decision. Opt-in — enable via `hermes tools` or `--toolsets consult`. Available to the main agent and subagents. |
 | `code_execution` | `execute_code` | Run Python scripts that call Hermes tools programmatically. |
 | `coding` | composite (`file` + `terminal` + `search` + `web` + `skills` + `browser` + `todo` + `memory` + `session_search` + `clarify` + `code_execution` + `delegation` + `vision`) | Coding-focused bundle for software work: file editing, terminal, search, web docs, skills, browser, delegate, and code execution. |
 | `cronjob` | `cronjob` | Schedule and manage recurring tasks. |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1371,6 +1371,16 @@ auxiliary:
     timeout: 30
     language: ""
 
+  # Consult tool — second opinion from a reference model (opt-in `consult` toolset).
+  # The canonical use: point it at an expensive frontier model that would be a poor
+  # main model but a great reviewer for a narrow, bounded question.
+  consult:
+    provider: "auto"           # "auto" = main chat model
+    model: ""                  # e.g. "anthropic/claude-opus-5"
+    base_url: ""
+    api_key: ""
+    timeout: 120
+
   # Skills hub — skill matching and search
   skills_hub:
     provider: "auto"


### PR DESCRIPTION
# Summary

The agent can now get a second opinion from a stronger reference model before committing to a risky or uncertain decision — a new opt-in `consult` toolset backed by `auxiliary.consult`, salvage of #82103 by @adurham.

Inspired by **Perplexity Portable Computer's advisor escalation** (launched Aug 25, 2026 with NVIDIA): their local model consults a frontier "advisor" that receives only selected context and *returns text guidance with no tool authority*. On Terminal Bench 2.1 they report escalation recovering ~3/5 of the local→frontier gap at ~2/3 of frontier cost. Sources: [Portable Computer launch](https://www.perplexity.ai/hub/blog/introducing-portable-computer-for-local-first-ai), [research blog — "Narrowing the frontier gap with advisor escalation"](https://www.perplexity.ai/hub/blog/a-local-first-agent-for-private-and-cost-effective-knowledge-work).

## Ours vs. theirs

| Dimension | Perplexity advisor | This PR |
|---|---|---|
| Who decides to escalate | Local model calls an advisor tool | Agent calls `consult` tool |
| Advisor authority | Text guidance only, no tools/files | Same — plain aux `call_llm`, JSON answer back |
| Model routing | User-selected cloud advisor | `auxiliary.consult` (auto = main model; point at any frontier model) |
| Refusal handling | (not documented) | First-class: refusals/empty/filtered → `unavailable: true`, never an exception |
| Cost control | Per-step user gating | Opt-in toolset (off by default) + schema tells the model to use it sparingly |

Hermes already had MoA (parallel reference models on every turn) and `delegate_task` (full child agents), but no *mid-task, single-question, agent-initiated* escalation primitive — the cheap middle rung Perplexity's data shows is the cost-effective one.

## Changes

- `tools/consult_tool.py` (@adurham): registry tool wrapping `auxiliary_client.call_llm(task="consult")`; graceful `unavailable` degradation; `_degenerate_answer_reason()` guard against template-markup leaks and request echoes (prevents fabricated "reference model opinions")
- `toolsets.py`, `hermes_cli/tools_config.py` (@adurham): opt-in `consult` toolset, reachable via `hermes tools`
- `hermes_cli/main.py` (hardening): Consult entry in the `hermes model` → Configure auxiliary models picker
- `website/docs/` (hardening): toolsets-reference row, tools-reference section, full auxiliary config reference block

## Validation

| Check | Result |
|---|---|
| `tests/tools/test_consult_tool.py` + degenerate guard + tools_config (82 tests) | 76 passed, 6 skipped |
| Live E2E: real registry dispatch → real provider call | `unavailable: false`, correct substantive answer returned |
| Attribution audit (`audit_pr_attribution.py --fix`) | all emails mapped |

Salvaged from #82103 (cherry-picked, authorship preserved); this branch = current `origin/main` + both contributor commits + picker/docs hardening.

## Infographic

![consult tool infographic](https://v3b.fal.media/files/b/0aa8c098/baQK1Q_4ewpV46X08B4aV_NUmnU2QC.png)
