### PR TITLE
fix(cli): allowlist Alacritty for extended Shift+Enter key reporting

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4400,11 +4400,13 @@ def _terminal_supports_extended_enter_keys(env: Optional[Mapping[str, str]] = No
     term = (env.get("TERM") or "").strip().lower()
     if env.get("WT_SESSION"):
         return True
-    if term_program in {"iTerm.app", "WezTerm", "ghostty", "vscode"}:
+    if term_program in {"iTerm.app", "WezTerm", "ghostty", "vscode", "alacritty"}:
         return True
     if env.get("KITTY_WINDOW_ID") or "kitty" in term:
         return True
     if term == "xterm-ghostty":
+        return True
+    if "alacritty" in term or env.get("ALACRITTY_WINDOW_ID") or env.get("ALACRITTY_SOCKET"):
         return True
     if term.startswith("tmux") or term_program.lower() == "tmux":
         return True

--- a/tests/cli/test_ctrl_enter_newline.py
+++ b/tests/cli/test_ctrl_enter_newline.py
@@ -153,6 +153,44 @@ def test_unknown_terminal_does_not_enable_extended_enter_keys():
     assert cli_mod._terminal_supports_extended_enter_keys({"TERM_PROGRAM": "unknown"}) is False
 
 
+def test_alacritty_term_program_is_allowlisted_for_extended_enter_keys():
+    """Alacritty implements the Kitty keyboard protocol unconditionally
+    (`kitty_keyboard: true` in its own config derivation) but Hermes must
+    still ask it to enable extended key reporting to receive distinct
+    Shift+Enter sequences."""
+    import cli as cli_mod
+
+    assert cli_mod._terminal_supports_extended_enter_keys({"TERM_PROGRAM": "alacritty"}) is True
+
+
+def test_alacritty_term_var_is_allowlisted_for_extended_enter_keys():
+    """Alacritty does not set TERM_PROGRAM by default — only TERM=alacritty
+    and the ALACRITTY_WINDOW_ID / ALACRITTY_SOCKET env vars it exports."""
+    import cli as cli_mod
+
+    assert cli_mod._terminal_supports_extended_enter_keys({"TERM": "alacritty"}) is True
+    assert (
+        cli_mod._terminal_supports_extended_enter_keys(
+            {"TERM": "xterm-256color", "ALACRITTY_WINDOW_ID": "94212259512240"}
+        )
+        is True
+    )
+    assert (
+        cli_mod._terminal_supports_extended_enter_keys(
+            {"TERM": "xterm-256color", "ALACRITTY_SOCKET": "/run/user/1000/Alacritty-wayland-1.sock"}
+        )
+        is True
+    )
+
+
+def test_alacritty_is_not_treated_as_ghostty():
+    """Alacritty must get the full dual-protocol push, not the Ghostty-only
+    modifyOtherKeys exception."""
+    import cli as cli_mod
+
+    assert cli_mod._is_ghostty_terminal({"TERM": "alacritty", "ALACRITTY_WINDOW_ID": "1"}) is False
+
+
 # ---------------------------------------------------------------------------
 # Ghostty: must push ONLY modifyOtherKeys, not the Kitty keyboard protocol —
 # see cli._is_ghostty_terminal for the full rationale (#87630).

--- a/ui-tui/packages/hermes-ink/src/ink/terminal.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/terminal.test.ts
@@ -93,7 +93,7 @@ describe('skipKittyKeyboardProtocol', () => {
     }
   })
 
-  it.each(['iTerm.app', 'kitty', 'WezTerm', 'tmux', 'windows-terminal', 'vscode'])(
+  it.each(['iTerm.app', 'kitty', 'WezTerm', 'tmux', 'windows-terminal', 'vscode', 'alacritty'])(
     'keeps the dual push for %s',
     async terminal => {
       const { env } = await import('../utils/env.js')
@@ -108,4 +108,19 @@ describe('skipKittyKeyboardProtocol', () => {
       }
     }
   )
+})
+
+describe('supportsExtendedKeys — alacritty (Kitty keyboard protocol is always-on in Alacritty itself)', () => {
+  it('reports support for alacritty', async () => {
+    const { env } = await import('../utils/env.js')
+    const { supportsExtendedKeys } = await import('./terminal.js')
+    const saved = env.terminal
+
+    try {
+      env.terminal = 'alacritty'
+      expect(supportsExtendedKeys()).toBe(true)
+    } finally {
+      env.terminal = saved
+    }
+  })
 })

--- a/ui-tui/packages/hermes-ink/src/ink/terminal.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/terminal.ts
@@ -318,7 +318,7 @@ export function parseOscColor(data: string): string | undefined {
 // in xterm.js-based terminals like VS Code). tmux is allowlisted because it
 // accepts modifyOtherKeys and doesn't forward the kitty sequence to the outer
 // terminal.
-const EXTENDED_KEYS_TERMINALS = ['iTerm.app', 'kitty', 'WezTerm', 'ghostty', 'tmux', 'windows-terminal', 'vscode']
+const EXTENDED_KEYS_TERMINALS = ['iTerm.app', 'kitty', 'WezTerm', 'ghostty', 'tmux', 'windows-terminal', 'vscode', 'alacritty']
 
 /** True if this terminal correctly handles extended key reporting
  *  (Kitty keyboard protocol + xterm modifyOtherKeys). */

--- a/ui-tui/packages/hermes-ink/src/utils/env.ts
+++ b/ui-tui/packages/hermes-ink/src/utils/env.ts
@@ -33,6 +33,10 @@ function detectTerminal(): TerminalName {
     return 'windows-terminal'
   }
 
+  if (process.env.TERM?.includes('alacritty') || process.env.ALACRITTY_WINDOW_ID) {
+    return 'alacritty'
+  }
+
   return process.env.TERM ?? null
 }
 


### PR DESCRIPTION
## Summary

Alacritty implements the Kitty keyboard protocol unconditionally — `kitty_keyboard: true` is hardcoded in Alacritty's own config derivation (`alacritty/src/config/ui_config.rs`), no opt-in needed on the terminal side, and has been since v0.13. But Hermes only pushes the extended-key-reporting request (`CSI >1u` + `CSI >4;2m`) to an allowlist of terminals, and Alacritty was missing from it in both the classic CLI (`cli.py`) and the Ink TUI (`env.ts` / `terminal.ts`).

As a result, Shift+Enter in Alacritty was indistinguishable from plain Enter and always submitted the message instead of inserting a newline — even though the terminal is fully capable of reporting it distinctly once asked.

The docs (`Shift+Enter compatibility` table) already list Alacritty as "Supported once the Kitty protocol is enabled in settings" — but there is no such setting in Alacritty; the gap was entirely on Hermes's side never asking.

## Changes

- `cli.py`: `_terminal_supports_extended_enter_keys` now recognizes Alacritty via `TERM_PROGRAM=alacritty`, `TERM=alacritty`, or the `ALACRITTY_WINDOW_ID` / `ALACRITTY_SOCKET` env vars Alacritty exports. Alacritty does not need the Ghostty-only modifyOtherKeys exception, so it gets the full dual-protocol push.
- `ui-tui/packages/hermes-ink/src/utils/env.ts`: `detectTerminal()` now returns `'alacritty'` for the same signals.
- `ui-tui/packages/hermes-ink/src/ink/terminal.ts`: added `'alacritty'` to `EXTENDED_KEYS_TERMINALS`.
- Added tests in `tests/cli/test_ctrl_enter_newline.py` and `ui-tui/packages/hermes-ink/src/ink/terminal.test.ts`.

## Test Plan

- `uv run pytest tests/cli/test_ctrl_enter_newline.py` — 18 passed, 1 pre-existing skip (unrelated).
- `npx vitest run packages/hermes-ink/src/ink/terminal.test.ts` — 17 passed (15 existing + 2 new).
- Full `npx vitest run` in `ui-tui/`: 1731 passed, 3 pre-existing skips, 1 pre-existing unrelated flake (`virtualHistoryOffsetCache.test.ts`, scroll-timing test unrelated to terminal detection).
- Manually verified `_terminal_supports_extended_enter_keys()` returns `True` against a real Alacritty 0.17.0 session's actual env vars (`TERM=alacritty`, `ALACRITTY_WINDOW_ID`, `ALACRITTY_SOCKET`).