### PR TITLE
fix(lazy-deps): byte-compile lazily installed backends at install time (#100461)

### DIFF
--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -483,3 +483,98 @@ class TestInstallSpecs:
         result = ld.install_specs(["honcho-ai==2.2.0"])
         assert result.ok is False
         assert "disk on fire" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Post-install bytecode warm (#100461)
+# ---------------------------------------------------------------------------
+
+
+class TestWarmInstalledBytecode:
+    """A pip/uv install leaves ``.py`` sources with no ``__pycache__``.
+
+    Whoever imports next pays the whole compile, and for a lazily installed
+    backend that is the foreground of a user request. These tests pin that
+    the installer pays it instead.
+    """
+
+    @staticmethod
+    def _package(tmp_path):
+        pkg = tmp_path / "zzzfakepkg"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("VALUE = 1\n", encoding="utf-8")
+        (pkg / "mod.py").write_text("def f():\n    return 2\n", encoding="utf-8")
+        return pkg
+
+    def test_compiles_the_installed_package(self, tmp_path, monkeypatch):
+        pkg = self._package(tmp_path)
+        monkeypatch.setattr(ld, "_installed_dist_roots", lambda spec, target: {pkg})
+
+        assert not list(pkg.rglob("*.pyc"))
+        ld._warm_installed_bytecode(("zzzfake==1.0",), None)
+        assert len(list(pkg.rglob("*.pyc"))) == 2
+
+    def test_honors_dont_write_bytecode(self, tmp_path, monkeypatch):
+        pkg = self._package(tmp_path)
+        monkeypatch.setattr(ld, "_installed_dist_roots", lambda spec, target: {pkg})
+        monkeypatch.setattr(ld.sys, "dont_write_bytecode", True)
+
+        ld._warm_installed_bytecode(("zzzfake==1.0",), None)
+        assert not list(pkg.rglob("*.pyc"))
+
+    def test_compile_failure_never_propagates(self, tmp_path, monkeypatch):
+        # An unwritable tree (read-only mount, --target on a sealed image)
+        # must not turn a successful install into a failed one.
+        def boom(spec, target):
+            raise OSError("read-only file system")
+        monkeypatch.setattr(ld, "_installed_dist_roots", boom)
+
+        ld._warm_installed_bytecode(("zzzfake==1.0",), None)  # no exception
+
+    def test_dist_roots_resolve_from_metadata_not_the_spec_name(self):
+        # The import name is read off the distribution's own file list, so
+        # specs whose package name differs from their module name still warm.
+        roots = ld._installed_dist_roots("pytest>=8", None)
+        assert roots, "pytest is a test dependency and must resolve"
+        assert all(r.is_dir() for r in roots)
+        assert any(list(r.glob("*.py")) for r in roots)
+
+    def test_unknown_distribution_resolves_to_nothing(self):
+        assert ld._installed_dist_roots("zzz-not-installed==9.9", None) == set()
+
+
+class TestInstallWarmsBytecode:
+    """The warm runs on install success, and only on success."""
+
+    @staticmethod
+    def _install(monkeypatch, returncode):
+        calls = []
+        monkeypatch.setattr(ld, "_lazy_install_target", lambda: None)
+        monkeypatch.setattr(ld.shutil, "which", lambda name: "uv" if name == "uv" else None)
+        monkeypatch.setattr(
+            "hermes_cli.managed_uv.resolve_uv", lambda *a, **kw: "uv", raising=False
+        )
+
+        class _Completed:
+            def __init__(self):
+                self.returncode = returncode
+                self.stdout = "out"
+                self.stderr = "err"
+
+        monkeypatch.setattr(ld.subprocess, "run", lambda *a, **kw: _Completed())
+        monkeypatch.setattr(
+            ld, "_warm_installed_bytecode",
+            lambda specs, target: calls.append((specs, target)),
+        )
+        result = ld._venv_pip_install(("zzzfake==1.0",))
+        return result, calls
+
+    def test_success_warms_once_with_the_installed_specs(self, monkeypatch):
+        result, calls = self._install(monkeypatch, 0)
+        assert result.success is True
+        assert calls == [(("zzzfake==1.0",), None)]
+
+    def test_failed_install_does_not_warm(self, monkeypatch):
+        result, calls = self._install(monkeypatch, 1)
+        assert result.success is False
+        assert calls == []

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -699,6 +699,80 @@ def _core_constraints_file() -> Optional[Path]:
         return None
 
 
+def _installed_dist_roots(spec: str, target: Optional[Path]) -> set[Path]:
+    """Return the package directories a freshly installed *spec* owns.
+
+    Resolved from the distribution's own file list rather than guessing the
+    import name from the spec — ``python-telegram-bot`` ships ``telegram``,
+    ``firecrawl-anydoc`` ships ``anydoc``, and several specs ship more than
+    one top-level package.
+    """
+    name = _pkg_name_from_spec(spec)
+    try:
+        import importlib.metadata as _md
+
+        if target is not None:
+            dists = list(_md.distributions(name=name, path=[str(target)]))
+            dist = dists[0] if dists else None
+        else:
+            dist = _md.distribution(name)
+    except Exception:
+        return set()
+    if dist is None:
+        return set()
+
+    roots: set[Path] = set()
+    try:
+        for entry in dist.files or ():
+            parts = entry.parts
+            if not parts or parts[0].startswith(".") or parts[0] == "__pycache__":
+                continue
+            root = Path(dist.locate_file(parts[0]))
+            if root.is_dir():
+                roots.add(root)
+    except Exception:
+        return set()
+    return roots
+
+
+def _warm_installed_bytecode(specs: tuple[str, ...], target: Optional[Path]) -> None:
+    """Byte-compile what we just installed, so no user request has to.
+
+    A pip/uv install writes ``.py`` sources and no ``__pycache__`` — and an
+    install of the *same* version still deletes the cache the old copy had.
+    Whoever imports the package next pays the whole compile: for
+    ``anthropic==0.87.0`` (541 modules) on cpython-3.12.13 that measured
+    2.2-2.7s cold against 0.7-1.0s warm, and 10.5s cold under concurrent
+    load.  That bill lands wherever the first import happens, and
+    for a lazily-installed backend that is the foreground of a user request
+    (#100461) — with nothing printed while it runs, so it reads as a hang.
+    Worse, N per-profile daemons cold-starting together each pay it in full
+    before any of them has written the cache.
+
+    Paying it here instead is strictly better: the caller is already waiting
+    on an installer and can see why.  Best-effort — a compile failure never
+    invalidates an install that succeeded.
+    """
+    if sys.dont_write_bytecode:
+        return
+    try:
+        import compileall
+    except Exception:  # pragma: no cover — stdlib, but never break an install
+        return
+
+    for spec in specs:
+        try:
+            roots = _installed_dist_roots(spec, target)
+        except Exception as exc:
+            logger.debug("Bytecode warm skipped for %s: %s", spec, exc)
+            continue
+        for root in roots:
+            try:
+                compileall.compile_dir(str(root), quiet=2, force=False, workers=1)
+            except Exception as exc:
+                logger.debug("Bytecode warm skipped for %s: %s", root, exc)
+
+
 def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _InstallResult:
     """Install ``specs`` using the uv → pip → ensurepip ladder.
 
@@ -765,6 +839,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                 if r.returncode == 0:
                     if target is not None:
                         _activate_target_on_syspath(target)
+                    _warm_installed_bytecode(specs, target)
                     return _InstallResult(True, r.stdout or "", r.stderr or "")
                 logger.debug("uv pip install failed: %s", r.stderr)
                 # A resolver failure is authoritative. Falling through to pip
@@ -810,8 +885,10 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                 stdin=subprocess.DEVNULL,
                 creationflags=windows_hide_flags(),
             )
-            if r.returncode == 0 and target is not None:
-                _activate_target_on_syspath(target)
+            if r.returncode == 0:
+                if target is not None:
+                    _activate_target_on_syspath(target)
+                _warm_installed_bytecode(specs, target)
             return _InstallResult(r.returncode == 0, r.stdout or "", r.stderr or "")
         except subprocess.TimeoutExpired as e:
             return _InstallResult(False, "", f"pip install timed out: {e}")


### PR DESCRIPTION
## Summary

`hermes` never byte-compiles a lazily installed backend. A pip/uv install writes `.py` sources and no `__pycache__`, and reinstalling the *same* version still deletes the cache the previous copy had — so the entire compile is paid by whoever imports the package next. For a lazy backend that is the foreground of a user request, with nothing printed while it runs.

This compiles the freshly installed distributions inside `_venv_pip_install`, on the success path of both the uv and pip tiers.

## Root cause (measured, not inferred)

I could not reproduce anything the issue's accepted theory predicts, so I measured every claim against real artifacts (`anthropic==0.87.0`, `cpython-3.12.13`):

| Claim under test | Result |
|---|---|
| `import anthropic` crashes on 3.12.13 | **No.** Cold import succeeds, 4.1s |
| Concurrent cold-start breaks it | **No.** 10 concurrent cold processes: all rc=0, 4.39s wall, zero errors |
| `typing` recursion exhausts the stack | **No.** The import needs ~142 frames of headroom (limit 1000) |
| cpython ≥3.12.14 fixes the typing bug | **Cannot.** `Lib/typing.py` is **byte-identical** across the two patches (md5 `bfee20a1927a5370393de42ae8873706`), and so is `Lib/functools.py`. 3.12.14 is a security release (`tarfile`, `zipfile`, `http.client`, `csv`, …) |

The traceback's line numbers *do* match 3.12.13's `typing.py` exactly — 395 is `_caches[func](*args, **kwds)` inside `_tp_cache.inner`, 1088 is `params = tuple(_type_convert(p) for p in params)`. And the frame chain is **linear**, not the repeated-frame shape a `RecursionError` produces. That is an interrupt landing on the hottest frame of a slow import, not a crash.

So the import is not broken — it is **slow, silent, and in the foreground**, and the reporter ran it under `-Q -q`:

```
reinstall anthropic==0.87.0 (same version)   ->  __pycache__ = 0 files
first import after that                      ->  10.51s
next import                                  ->   1.07s
```

Every install path leaves the backend uncompiled: first lazy use, a pin bump, and `restore_features()` after a managed-runtime rebuild — which is exactly how an upgrade lands a user on a fresh venv with `cpython-3.12.13` and an SDK that has to recompile 541 modules on the next dispatch. Same SDK version before and after, which is what the issue reports. N per-profile daemons starting together each pay it in full, because none of them has written the cache yet.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A["🩸 Lazy Install / Runtime Rebuild"] -->|"writes .py, no __pycache__"| B["🔥 Uncompiled Backend"]
    B --> C{"Who Pays The Compile?"}
    C -->|"before: nobody did"| D["⚔️ First User Request"]
    D --> E["🕯️ 541 Modules Recompiled, Silent"]
    E --> F["💀 Reads As A Hang -> Ctrl+C"]
    C -->|"after: this PR"| G["🛡️ Installer Compiles Now"]
    G --> H["✅ First Request Imports Warm"]
```

## Result

Paired A/B, first import after an install:

| | main | this PR |
|---|---|---|
| trial 1 | 2.73s | **1.01s** |
| trial 2 | 2.24s | **0.69s** |

Under concurrent load the cold side measured 10.5s.

## Not duplicating

- #100505 / #100595 (both closed) added a process-local `threading.Lock` to `_get_anthropic_sdk`. Refuted by maintainer review and not revisited here.
- #84766 (open, @Manantra) owns cross-process locking of `lazy_deps.ensure()`. Untouched — this PR adds no locking, and the two changes compose.
- #30157 (open) owns import-failure diagnostics in `_get_anthropic_sdk`. Untouched.
- No `compileall` exists anywhere in the repo today; #75125 and #60242 *cleared* stale bytecode, they never warmed it.

## Scope note

This removes the silent multi-second foreground stall that produces the reported symptom. It does not claim to explain a hard crash on the reporter's Linux host — I could not reproduce one, and no Linux engine was available here. If a genuine non-interrupt exception exists, its final line is still missing from the report.

## Test plan

- `tests/tools/test_lazy_deps.py` — new `TestWarmInstalledBytecode` (compiles the installed package; honors `sys.dont_write_bytecode`; a compile failure never propagates; roots resolve from distribution metadata, not the spec name) and `TestInstallWarmsBytecode` (warm runs once on success with the installed specs; never on a failed install).
- `pytest tests/tools/test_lazy_deps.py` → **68 passed**.
- `pytest tests/tools/test_lazy_deps.py tests/tools/test_lazy_deps_durable_target.py tests/tools/test_lazy_deps_managed.py` → 86 passed, 1 skipped, 1 failed: `TestAbiStamp::test_readonly_target_reports_error`, which fails identically on clean `main` (Windows `chmod` cannot make a directory read-only).
- `ruff check` clean, `git diff --check` clean.

Fixes #100461

 
