### PR TITLE
fix: improve _validate_llm_response error preview

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6299,8 +6299,22 @@ def _validate_llm_response(response: Any, task: str = None) -> Any:
         recovered = _recover_aux_response_message(response)
         if recovered is not None:
             return recovered
-        response_type = type(response).__name__
-        response_preview = str(response)[:120]
+        # Build a useful preview instead of raw str()[:120] that shows mostly None fields
+        try:
+            response_type = type(response).__name__
+            _id = getattr(response, 'id', None)
+            _model = getattr(response, 'model', None)
+            _choices = getattr(response, 'choices', None)
+            preview_parts = []
+            if _id:
+                preview_parts.append(f"id={_id!r}")
+            if _model:
+                preview_parts.append(f"model={_model!r}")
+            if _choices is None:
+                preview_parts.append("choices=None")
+            response_preview = f"{response_type}({', '.join(preview_parts)})"
+        except Exception:
+            response_preview = repr(response)[:200]
         raise RuntimeError(
             f"Auxiliary {task or 'call'}: LLM returned invalid response "
             f"(type={response_type}): {response_preview!r}. "


### PR DESCRIPTION
## What changed and why

Fixes #100419.

Previously `str(response)[:120]` showed mostly `None` fields from pydantic models, leaving no room for what actually matters. The truncation was mid-token and the `f"{...!r}"` re-quote left an unmatched quote.

## Changes

- **agent/auxiliary_client.py**: Build a concise preview with `id`, `model`, and `choices` status instead of raw `str()[:120]`.

## How to test

1. Trigger an auxiliary LLM call that returns a malformed response
2. Check the error message shows useful fields instead of `None` padding

## Platforms tested

- [x] Windows (native)
- [ ] macOS (needs manual verification)
- [ ] Linux (needs manual verification)

## Related

Closes #100419