### PR TITLE
TUI: pasting into a slash command no longer hands the skill a truncation placeholder

### DIFF
--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -1072,6 +1072,43 @@ describe('createSlashHandler', () => {
     expect(ctx.transcript.sys).toHaveBeenCalledWith('no active session — nothing to rollback')
   })
 
+  // A pasted PR thread / diff / log reaches a skill command as its argument.
+  // parseSlashCommand used to split the whole line on `\s+` and rejoin with a
+  // single space, so every line break was gone before the skill ran — and the
+  // fallback command.dispatch carried that flattened text.
+  it('carries a multi-line argument to the backend without flattening it', async () => {
+    patchUiState({ sid: 'sid-abc' })
+
+    const arg = 'line one\nline two\n\n  indented tail'
+
+    const ctx = buildCtx({
+      gateway: {
+        gw: {
+          getLogTail: vi.fn(() => ''),
+          kill: vi.fn(),
+          request: vi.fn((method: string) =>
+            method === 'slash.exec' ? Promise.reject(new Error('skill command')) : Promise.resolve({})
+          )
+        },
+        rpc: vi.fn(() => Promise.resolve({}))
+      }
+    })
+
+    createSlashHandler(ctx)(`/pr-triage ${arg}`)
+
+    expect(ctx.gateway.gw.request).toHaveBeenCalledWith('slash.exec', {
+      command: `pr-triage ${arg}`,
+      session_id: 'sid-abc'
+    })
+    await vi.waitFor(() => {
+      expect(ctx.gateway.gw.request).toHaveBeenCalledWith('command.dispatch', {
+        arg,
+        name: 'pr-triage',
+        session_id: 'sid-abc'
+      })
+    })
+  })
+
   it('/title <name> uses session.title RPC and bypasses slash.exec', async () => {
     patchUiState({ sid: 'sid-abc' })
     const rpc = vi.fn(() => Promise.resolve({ pending: false, title: 'my title' }))

--- a/ui-tui/src/__tests__/queueSubmission.test.ts
+++ b/ui-tui/src/__tests__/queueSubmission.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import type { ComposerToken } from '../app/interfaces.js'
-import { expandPasteTokens, queueItemFromSlash } from '../app/useSubmission.js'
+import { expandPasteTokens, prepareSlashSubmission, queueItemFromSlash } from '../app/useSubmission.js'
 import { imageToken } from '../domain/attachments.js'
 
 describe('/queue collapsed paste submission', () => {
@@ -27,5 +27,32 @@ describe('/queue collapsed paste submission', () => {
     const image: ComposerToken = { kind: 'image', index: 1, label: imageToken(1), path: '/tmp/image.png' }
 
     expect(expandPasteTokens([paste, image])(`${paste.label} and ${image.label}`)).toBe(`one\ntwo and ${image.label}`)
+  })
+})
+
+describe('prepareSlashSubmission', () => {
+  const label = '[[ Done — verified.. [412 lines] .. already on it. ]]'
+  const text = 'Done — verified through the real resolver\nline two\nline three'
+  const tokens: ComposerToken[] = [{ kind: 'paste', label, text }]
+
+  // The reported bug: `/pr-triage <paste>` dispatched the LABEL, so the skill
+  // received "[412 lines]" as its argument and the agent reported the paste as
+  // truncated. The command has to carry the full text; only the transcript
+  // stays collapsed.
+  it('dispatches the full paste while the transcript keeps the collapsed label', () => {
+    expect(prepareSlashSubmission(`/pr-triage ${label}`, tokens)).toEqual({
+      command: `/pr-triage ${text}`,
+      display: `/pr-triage ${label}`
+    })
+  })
+
+  it('leaves image tokens as labels — the gateway already holds the file', () => {
+    const image: ComposerToken = { kind: 'image', index: 1, label: imageToken(1), path: '/tmp/shot.png' }
+
+    expect(prepareSlashSubmission(`/pr-triage ${image.label}`, [image]).command).toBe(`/pr-triage ${image.label}`)
+  })
+
+  it('is a no-op on a token-free command', () => {
+    expect(prepareSlashSubmission('/model opus', [])).toEqual({ command: '/model opus', display: '/model opus' })
   })
 })

--- a/ui-tui/src/__tests__/slashParity.test.ts
+++ b/ui-tui/src/__tests__/slashParity.test.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 
 import { findSlashCommand, SLASH_COMMANDS } from '../app/slash/registry.js'
+import { parseSlashCommand } from '../domain/slash.js'
 
 type CommandRoute = 'fallback' | 'local' | 'native'
 
@@ -120,5 +121,31 @@ describe('slash parity matrix', () => {
     const cmd = findSlashCommand('q')
     expect(cmd, '/q must resolve to a command').toBeDefined()
     expect(cmd!.name).toBe('queue')
+  })
+})
+
+describe('parseSlashCommand argument fidelity', () => {
+  it('keeps a multi-line argument byte-for-byte', () => {
+    const arg = 'first line\nsecond line\n\n  indented tail'
+
+    expect(parseSlashCommand(`/pr-triage ${arg}`)).toEqual({
+      arg,
+      cmd: `/pr-triage ${arg}`,
+      name: 'pr-triage'
+    })
+  })
+
+  it('preserves runs of spaces inside the argument', () => {
+    expect(parseSlashCommand('/goal ship   it').arg).toBe('ship   it')
+  })
+
+  it('still splits the command name off a single separator', () => {
+    expect(parseSlashCommand('/cron add daily')).toEqual({
+      arg: 'add daily',
+      cmd: '/cron add daily',
+      name: 'cron'
+    })
+    expect(parseSlashCommand('/exit')).toEqual({ arg: '', cmd: '/exit', name: 'exit' })
+    expect(parseSlashCommand('/exit ')).toEqual({ arg: '', cmd: '/exit ', name: 'exit' })
   })
 })

--- a/ui-tui/src/app/useSubmission.ts
+++ b/ui-tui/src/app/useSubmission.ts
@@ -40,6 +40,24 @@ export const prepareSubmission = (display: string, tokens: ComposerToken[]) => (
   text: expandTokens(tokens)(display)
 })
 
+/**
+ * Split a slash submission into the two things it has to be at once.
+ *
+ * A slash command's argument is ordinary user text, so a collapsed paste in it
+ * must resolve BEFORE the command runs — otherwise `/pr-triage [[ … [412 lines]
+ * … ]]` hands the skill the label and the agent faithfully reports that the
+ * paste is truncated. The transcript still shows the compact form, because a
+ * 412-line paste inlined into the scrollback is exactly what collapsing it was
+ * for.
+ *
+ * Image tokens stay as labels: the gateway already holds those files in
+ * `attached_images` and splices them in at submit.
+ */
+export const prepareSlashSubmission = (display: string, tokens: ComposerToken[]) => ({
+  command: expandPasteTokens(tokens)(display),
+  display
+})
+
 export const shouldInterpolateSubmission = (display: string) => hasInterpolation(display)
 
 export function useSubmission(opts: UseSubmissionOptions) {
@@ -245,22 +263,23 @@ export function useSubmission(opts: UseSubmissionOptions) {
       const submissionTokens = [...composerRefs.tokensRef.current]
       const submission = prepareSubmission(full, submissionTokens)
       const toHistory = submission.text
-      const queuePayload = expandPasteTokens(submissionTokens)(full)
 
       if (looksLikeSlashCommand(full)) {
-        appendMessage({ kind: 'slash', role: 'system', text: full })
+        const slash = prepareSlashSubmission(full, submissionTokens)
+
+        appendMessage({ kind: 'slash', role: 'system', text: slash.display })
         composerActions.pushHistory(toHistory)
 
         const parsed = parseSlashCommand(full)
 
         const queued =
-          parsed.name === 'queue' || parsed.name === 'q' ? queueItemFromSlash(full, queuePayload) : undefined
+          parsed.name === 'queue' || parsed.name === 'q' ? queueItemFromSlash(slash.display, slash.command) : undefined
 
         if (queued) {
           composerActions.enqueue(queued.text, queued.display)
           sys(`queued: "${queued.display.slice(0, 50)}${queued.display.length > 50 ? '…' : ''}"`)
         } else {
-          slashRef.current(full)
+          slashRef.current(slash.command)
         }
 
         composerActions.clearIn()

--- a/ui-tui/src/domain/slash.ts
+++ b/ui-tui/src/domain/slash.ts
@@ -47,10 +47,17 @@ export const inlineSlashTrigger = (text: string): { query: string; start: number
   return { query, start: text.length - query.length - 1 }
 }
 
-export const parseSlashCommand = (cmd: string) => {
-  const [name = '', ...rest] = cmd.slice(1).split(/\s+/)
+// Only the separator between the command name and its argument is whitespace
+// the parser owns. Everything after it is the user's text and survives
+// verbatim: splitting the whole line on `\s+` and rejoining with a space
+// flattened every pasted diff, log, or PR thread into one run-on line before
+// the command ever saw it.
+const SLASH_PARTS_RE = /^(\S*)\s*([\s\S]*)$/
 
-  return { arg: rest.join(' '), cmd, name: name.toLowerCase() }
+export const parseSlashCommand = (cmd: string) => {
+  const [, name = '', arg = ''] = SLASH_PARTS_RE.exec(cmd.slice(1)) ?? []
+
+  return { arg, cmd, name: name.toLowerCase() }
 }
 
 /**


### PR DESCRIPTION
Pasting into a slash command in the TUI corrupted the argument twice over, so `/pr-triage <pasted PR thread>` reached the skill as a truncation placeholder squashed onto one line — and the agent, reading exactly what it was handed, replied "it's truncated."

## What was wrong

| | before | after |
|---|---|---|
| `/pr-triage [[ Done.. [412 lines] .. on it. ]]` | skill receives `[[ Done.. [412 lines] .. on it. ]]` | skill receives all 412 lines |
| `/pr-triage line one\nline two` | `line one line two` | `line one\nline two` |

**The collapsed paste never expanded.** `dispatchSubmission` computed the expansion and then only used it for `/queue`; every other command got `slashRef.current(full)` — the raw `[[ … ]]` label. So the argument the skill saw literally *was* a "[412 lines]" placeholder.

**`parseSlashCommand` flattened the argument.** It split the whole line on `\s+` and rejoined with a single space, so pasted diffs, logs, and threads lost every line break before the command ran, and the `command.dispatch` fallback carried the flattened text to the backend.

Both were verified against the real modules on `main` before any change.

## The fix

`parseSlashCommand` now splits only the separator between the command name and its argument (`/^(\S*)\s*([\s\S]*)$/`); everything after it is the user's text and survives verbatim. Every consumer already re-splits the arg it receives, so `/cron add`, `/model x --global`, and friends are unchanged.

`prepareSlashSubmission` names the split the slash branch actually needed: the transcript keeps the compact label (collapsing a 412-line paste in the scrollback is the point), the dispatch carries the full text. Image tokens stay as labels — the gateway already holds those files in `attached_images`.

## Tests

4 new behavioral tests, each mutation-verified: reverting either fix turns them red, restoring it turns them green. Full `ui-tui` suite: 1733 passed, 4 failed — the same 4 (`syntax.test.ts`, `createGatewayEventHandler.test.ts`) fail identically on clean `main`. 0 added failures.
