### PR TITLE
feat(plugins): add private Git marketplaces

### DIFF
--- a/apps/desktop/src/app/settings/plugin-install-modal.tsx
+++ b/apps/desktop/src/app/settings/plugin-install-modal.tsx
@@ -22,6 +22,7 @@ import { ExternalLink } from '@/lib/external-link'
 import { AlertTriangle } from '@/lib/icons'
 import { resolvePluginSourceLinks } from '@/lib/plugin-source-urls'
 import { installAgentPlugin, loadAgentPlugins } from '@/store/agent-plugins'
+import { requestGatewayForAgent } from '@/store/gateway'
 import { notify } from '@/store/notifications'
 import {
   $pluginInstallRequest,
@@ -47,6 +48,14 @@ export function PluginInstallModal() {
   const connection = useStore($connection)
   const activeProfile = useStore($activeGatewayProfile)
   const profileScope = useStore($profileScope)
+  const agentRequest = useMemo(
+    () =>
+      request?.scopeKey
+        ? async <T,>(method: string, params: Record<string, unknown> = {}) =>
+            requestGatewayForAgent<T>(request.connectionId ?? null, request.profile ?? 'default', method, params)
+        : requestGateway,
+    [request?.connectionId, request?.profile, request?.scopeKey, requestGateway]
+  )
 
   const [phase, setPhase] = useState<ProbePhase>('idle')
   const [probe, setProbe] = useState<ProbeResult | null>(null)
@@ -57,8 +66,10 @@ export function PluginInstallModal() {
   const [installing, setInstalling] = useState(false)
   const [installError, setInstallError] = useState<string | null>(null)
   const probeToken = useRef(0)
+  const installToken = useRef(0)
 
   const resetState = useCallback(() => {
+    installToken.current += 1
     setPhase('idle')
     setProbe(null)
     setInstallAgent(true)
@@ -150,8 +161,10 @@ export function PluginInstallModal() {
 
   const profileLabel = request?.profile || activeProfile || profileScope || 'default'
 
-  const agentTargetHint =
-    connection?.mode === 'remote' ? m.agentTargetRemote(profileLabel) : m.agentTargetLocal(profileLabel)
+  const targetIsRemote = request?.scopeKey
+    ? request.connectionId !== null && request.connectionId !== 'local'
+    : connection?.mode === 'remote'
+  const agentTargetHint = targetIsRemote ? m.agentTargetRemote(profileLabel) : m.agentTargetLocal(profileLabel)
 
   const sourceLinks = useMemo(() => (request ? resolvePluginSourceLinks(request.repo) : null), [request])
 
@@ -177,6 +190,9 @@ export function PluginInstallModal() {
 
     setInstalling(true)
     setInstallError(null)
+    const token = ++installToken.current
+    const payload = request
+    const isCurrent = () => token === installToken.current && $pluginInstallRequest.get() === payload
 
     const errors: string[] = []
     const successes: string[] = []
@@ -184,13 +200,17 @@ export function PluginInstallModal() {
 
     try {
       if (installAgent && probe.agent) {
-        const result = await installAgentPlugin(requestGateway, {
+        const result = await installAgentPlugin(agentRequest, {
           identifier: request.repo,
           force: forceReinstall,
           enable: enableAgent,
           catalogName: request.catalogName,
           profile: request.profile
         })
+
+        if (!isCurrent()) {
+          return
+        }
 
         if (result.ok) {
           successes.push(m.agentSuccess(result.pluginName ?? request.repo))
@@ -227,16 +247,26 @@ export function PluginInstallModal() {
         } else {
           const result = await installFn({ identifier: request.repo, force: forceReinstall })
 
+          if (!isCurrent()) {
+            return
+          }
+
           if (result.ok) {
             successes.push(m.desktopSuccess(result.pluginName ?? request.repo))
             await discoverRuntimePlugins()
+            if (!isCurrent()) {
+              return
+            }
           } else {
             errors.push(result.error || m.desktopFailed)
           }
         }
       }
 
-      await loadAgentPlugins(requestGateway)
+      await loadAgentPlugins(agentRequest, request.profile, request.scopeKey)
+      if (!isCurrent()) {
+        return
+      }
 
       if (errors.length === 0) {
         for (const message of successes) {
@@ -268,7 +298,9 @@ export function PluginInstallModal() {
 
       setInstallError(errors.join('\n'))
     } finally {
-      setInstalling(false)
+      if (token === installToken.current) {
+        setInstalling(false)
+      }
     }
   }
 
@@ -311,9 +343,7 @@ export function PluginInstallModal() {
                 <div className="font-medium text-foreground">
                   {request.catalogName ? m.reviewedHeading : m.securityHeading}
                 </div>
-                <p className="text-(--ui-text-secondary)">
-                  {request.catalogName ? m.reviewedIntro : m.securityIntro}
-                </p>
+                <p className="text-(--ui-text-secondary)">{request.catalogName ? m.reviewedIntro : m.securityIntro}</p>
               </div>
 
               {sourceLinks && (

--- a/apps/desktop/src/app/settings/plugin-install-modal.tsx
+++ b/apps/desktop/src/app/settings/plugin-install-modal.tsx
@@ -48,6 +48,7 @@ export function PluginInstallModal() {
   const connection = useStore($connection)
   const activeProfile = useStore($activeGatewayProfile)
   const profileScope = useStore($profileScope)
+
   const agentRequest = useMemo(
     () =>
       request?.scopeKey
@@ -164,6 +165,7 @@ export function PluginInstallModal() {
   const targetIsRemote = request?.scopeKey
     ? request.connectionId !== null && request.connectionId !== 'local'
     : connection?.mode === 'remote'
+
   const agentTargetHint = targetIsRemote ? m.agentTargetRemote(profileLabel) : m.agentTargetLocal(profileLabel)
 
   const sourceLinks = useMemo(() => (request ? resolvePluginSourceLinks(request.repo) : null), [request])
@@ -254,6 +256,7 @@ export function PluginInstallModal() {
           if (result.ok) {
             successes.push(m.desktopSuccess(result.pluginName ?? request.repo))
             await discoverRuntimePlugins()
+
             if (!isCurrent()) {
               return
             }
@@ -264,6 +267,7 @@ export function PluginInstallModal() {
       }
 
       await loadAgentPlugins(agentRequest, request.profile, request.scopeKey)
+
       if (!isCurrent()) {
         return
       }

--- a/apps/desktop/src/app/skills/plugins-tab.test.tsx
+++ b/apps/desktop/src/app/skills/plugins-tab.test.tsx
@@ -1,28 +1,39 @@
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { $agentPlugins, $agentPluginsStatus } from '@/store/agent-plugins'
+import { $agentPluginScope, $agentPlugins, $agentPluginsStatus } from '@/store/agent-plugins'
 import { $pluginInstallRequest, closePluginInstallRequest } from '@/store/plugin-install-request'
+import { $connection } from '@/store/session'
 
 import { PluginsTab } from './plugins-tab'
 
 const requestGateway = vi.fn(async () => ({ plugins: [] }))
+const { activeGatewayConnectionId, requestGatewayForAgent } = vi.hoisted(() => ({
+  activeGatewayConnectionId: vi.fn<() => null | string>(() => null),
+  requestGatewayForAgent: vi.fn(async () => ({ marketplaces: [], plugins: [] }))
+}))
 
 vi.mock('@/app/gateway/hooks/use-gateway-request', () => ({
   useGatewayRequest: () => ({ requestGateway })
 }))
+vi.mock('@/store/gateway', () => ({ activeGatewayConnectionId, requestGatewayForAgent }))
 
 describe('PluginsTab', () => {
   beforeEach(() => {
     $agentPlugins.set([])
+    $agentPluginScope.set('local::default')
     $agentPluginsStatus.set('ready')
     closePluginInstallRequest()
     requestGateway.mockClear()
+    requestGatewayForAgent.mockClear()
+    activeGatewayConnectionId.mockReturnValue(null)
+    $connection.set(null)
   })
 
   afterEach(cleanup)
 
   it('lists the scoped profile agent plugins with toggles', () => {
+    $agentPluginScope.set('local::workbot')
     $agentPlugins.set([
       {
         description: 'A test plugin',
@@ -67,6 +78,57 @@ describe('PluginsTab', () => {
     )
   })
 
+  it('routes an explicitly selected connection to its owning backend', async () => {
+    render(<PluginsTab profile={{ connectionId: 'remote-a', profile: 'workbot' }} />)
+
+    await waitFor(() =>
+      expect(requestGatewayForAgent).toHaveBeenCalledWith(
+        'remote-a',
+        'workbot',
+        'plugins.manage',
+        expect.objectContaining({ action: 'list', profile: 'workbot' })
+      )
+    )
+    expect(requestGateway).not.toHaveBeenCalled()
+  })
+
+  it('invalidates same-profile rows when the ambient backend changes', async () => {
+    $connection.set({ connectionId: 'remote-a', mode: 'remote', profile: 'same' } as never)
+    $agentPluginScope.set('remote-a::same')
+    $agentPlugins.set([
+      {
+        description: '',
+        key: 'from-a',
+        name: 'from-a',
+        source: 'git',
+        status: 'enabled',
+        version: ''
+      }
+    ])
+    render(<PluginsTab profile="same" />)
+    expect(screen.getByText('from-a')).toBeTruthy()
+
+    act(() => $connection.set({ connectionId: 'remote-b', mode: 'remote', profile: 'same' } as never))
+
+    await waitFor(() => expect(screen.queryByText('from-a')).toBeNull())
+    await waitFor(() => expect($agentPluginScope.get()).toBe('remote-b::same'))
+  })
+
+  it('isolates an explicit local profile from the ambient remote backend', async () => {
+    activeGatewayConnectionId.mockReturnValue('remote-a')
+    render(<PluginsTab profile={{ connectionId: 'local', profile: 'same' }} />)
+
+    await waitFor(() =>
+      expect(requestGatewayForAgent).toHaveBeenCalledWith(
+        'local',
+        'same',
+        'plugins.manage',
+        expect.objectContaining({ action: 'list', profile: 'same' })
+      )
+    )
+    expect($agentPluginScope.get()).toBe('local::same')
+  })
+
   it('opens the dual-target install modal from a catalog pick message', async () => {
     render(<PluginsTab profile="workbot" />)
 
@@ -89,10 +151,36 @@ describe('PluginsTab', () => {
 
       expect(request).not.toBeNull()
       expect(request?.catalogName).toBe('weather-plugin')
+      expect(request?.connectionId).toBeNull()
       expect(request?.repo).toBe('https://github.com/example/weather-plugin')
       expect(request?.profile).toBe('workbot')
+      expect(request?.scopeKey).toBe('local::workbot')
       expect(request?.sha).toBe('a'.repeat(40))
     })
+  })
+
+  it('captures the selected backend and cancels confirmation when that scope changes', async () => {
+    const { rerender } = render(<PluginsTab profile={{ connectionId: 'remote-a', profile: 'workbot' }} />)
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: {
+          name: 'weather-plugin',
+          repo: 'https://github.com/example/weather-plugin',
+          type: 'hermes-plugin-pick'
+        },
+        origin: 'https://hermes-agent.nousresearch.com'
+      })
+    )
+
+    await waitFor(() => {
+      expect($pluginInstallRequest.get()?.connectionId).toBe('remote-a')
+      expect($pluginInstallRequest.get()?.scopeKey).toBe('remote-a::workbot')
+    })
+
+    rerender(<PluginsTab profile={{ connectionId: 'remote-b', profile: 'workbot' }} />)
+
+    await waitFor(() => expect($pluginInstallRequest.get()).toBeNull())
   })
 
   it('ignores pick messages from foreign origins', () => {
@@ -161,10 +249,7 @@ describe('PluginsTab', () => {
 
     toggle.click()
 
-    expect(requestGateway).not.toHaveBeenCalledWith(
-      'plugins.manage',
-      expect.objectContaining({ action: 'toggle' })
-    )
+    expect(requestGateway).not.toHaveBeenCalledWith('plugins.manage', expect.objectContaining({ action: 'toggle' }))
   })
 
   it('appends the subdir fragment for multi-plugin repos', async () => {
@@ -183,9 +268,7 @@ describe('PluginsTab', () => {
     )
 
     await waitFor(() => {
-      expect($pluginInstallRequest.get()?.repo).toBe(
-        'https://github.com/example/plugins-monorepo#nested-plugin'
-      )
+      expect($pluginInstallRequest.get()?.repo).toBe('https://github.com/example/plugins-monorepo#nested-plugin')
     })
   })
 })
@@ -193,9 +276,13 @@ describe('PluginsTab', () => {
 describe('PluginsTab catalog UX', () => {
   beforeEach(() => {
     $agentPlugins.set([])
+    $agentPluginScope.set('local::default')
     $agentPluginsStatus.set('ready')
     closePluginInstallRequest()
     requestGateway.mockClear()
+    requestGatewayForAgent.mockClear()
+    activeGatewayConnectionId.mockReturnValue(null)
+    $connection.set(null)
   })
 
   afterEach(cleanup)
@@ -222,7 +309,30 @@ describe('PluginsTab catalog UX', () => {
     expect(screen.getByRole('button', { name: `Update to ${'b'.repeat(8)}` })).toBeTruthy()
   })
 
+  it('shows the private marketplace subtree target on its Update chip', () => {
+    $agentPlugins.set([
+      {
+        current_tree_sha: 'c'.repeat(40),
+        description: '',
+        key: 'demo-private',
+        marketplace_id: 'private-source',
+        marketplace_name: 'Private Market',
+        marketplace_plugin_name: 'demo-private',
+        name: 'demo-private',
+        source: 'git',
+        status: 'enabled',
+        update_available: true,
+        version: '1.0.0'
+      }
+    ])
+
+    render(<PluginsTab profile={null} />)
+
+    expect(screen.getByRole('button', { name: `Update to ${'c'.repeat(8)}` })).toBeTruthy()
+  })
+
   it('re-pins through plugins.manage update when the chip is clicked', async () => {
+    $agentPluginScope.set('local::workbot')
     $agentPlugins.set([
       {
         catalog_name: 'demo-weather',
@@ -247,7 +357,7 @@ describe('PluginsTab catalog UX', () => {
     await waitFor(() =>
       expect(requestGateway).toHaveBeenCalledWith(
         'plugins.manage',
-        expect.objectContaining({ action: 'update', name: 'demo-weather', profile: 'workbot' })
+        expect.objectContaining({ action: 'update', key: 'demo-weather', profile: 'workbot' })
       )
     )
   })

--- a/apps/desktop/src/app/skills/plugins-tab.test.tsx
+++ b/apps/desktop/src/app/skills/plugins-tab.test.tsx
@@ -1,13 +1,14 @@
 import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { $agentPluginScope, $agentPlugins, $agentPluginsStatus } from '@/store/agent-plugins'
+import { $agentPlugins, $agentPluginScope, $agentPluginsStatus } from '@/store/agent-plugins'
 import { $pluginInstallRequest, closePluginInstallRequest } from '@/store/plugin-install-request'
 import { $connection } from '@/store/session'
 
 import { PluginsTab } from './plugins-tab'
 
 const requestGateway = vi.fn(async () => ({ plugins: [] }))
+
 const { activeGatewayConnectionId, requestGatewayForAgent } = vi.hoisted(() => ({
   activeGatewayConnectionId: vi.fn<() => null | string>(() => null),
   requestGatewayForAgent: vi.fn(async () => ({ marketplaces: [], plugins: [] }))

--- a/apps/desktop/src/app/skills/plugins-tab.tsx
+++ b/apps/desktop/src/app/skills/plugins-tab.tsx
@@ -1,5 +1,5 @@
 import { useStore } from '@nanostores/react'
-import { memo, useEffect, useMemo, useState } from 'react'
+import { memo, useEffect, useMemo } from 'react'
 
 import { useGatewayRequest } from '@/app/gateway/hooks/use-gateway-request'
 import { Button } from '@/components/ui/button'
@@ -8,23 +8,32 @@ import { Tip } from '@/components/ui/tooltip'
 import type { ProfileScope } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { Loader2, Package } from '@/lib/icons'
-import { cn } from '@/lib/utils'
+
 import {
   $agentPluginBusy,
+  $agentPluginScope,
   $agentPlugins,
   $agentPluginsError,
   $agentPluginsStatus,
   type AgentPluginRow,
+  type GatewayRequest,
   isDesktopRelevantPlugin,
   loadAgentPlugins,
   toggleAgentPlugin,
   updateAgentPlugin
 } from '@/store/agent-plugins'
+import { activeGatewayConnectionId, requestGatewayForAgent } from '@/store/gateway'
 import { notify } from '@/store/notifications'
-import { $paneHeightOverride, setPaneHeightOverride } from '@/store/panes'
-import { openPluginInstallRequest } from '@/store/plugin-install-request'
+
+import {
+  $pluginInstallRequest,
+  closePluginInstallRequest,
+  openPluginInstallRequest
+} from '@/store/plugin-install-request'
+import { $connection } from '@/store/session'
 
 import { PanelEmpty } from '../overlays/panel'
+import { PrivateMarketplaces } from './private-marketplaces'
 
 // The REAL Plugin Catalog page (docs site) embedded as a one-click picker —
 // the same pattern as the Skills tab's EmbeddedHubPicker. `?embed=picker`
@@ -36,10 +45,6 @@ import { PanelEmpty } from '../overlays/panel'
 // packages install both halves in one flow.
 const CATALOG_ORIGIN = 'https://hermes-agent.nousresearch.com'
 const CATALOG_PICKER_URL = `${CATALOG_ORIGIN}/docs/plugins?embed=picker`
-
-const CATALOG_PANE_ID = 'capabilities-plugin-catalog'
-const CATALOG_DEFAULT_PX = 380
-const CATALOG_COLLAPSED_PX = 4
 
 interface PluginPickMessage {
   installCmd?: string
@@ -91,15 +96,33 @@ function PluginRow({
           {row.catalog_name && (
             <Tip label={t.skills.plugins.catalogProvenance(row.installed_sha?.slice(0, 8) ?? '')}>
               <span className="rounded border border-(--ui-stroke-tertiary) px-1 text-[0.65rem] text-(--ui-text-tertiary)">
-                {row.catalog_tier === 'official'
-                  ? t.skills.plugins.tierOfficial
-                  : t.skills.plugins.tierCommunity}
+                {row.catalog_tier === 'official' ? t.skills.plugins.tierOfficial : t.skills.plugins.tierCommunity}
+              </span>
+            </Tip>
+          )}
+          {row.marketplace_id && (
+            <Tip
+              label={t.skills.plugins.marketplaceProvenance(
+                row.marketplace_name ?? row.marketplace_id,
+                row.installed_repo_sha?.slice(0, 8) ?? ''
+              )}
+            >
+              <span className="rounded border border-(--ui-stroke-tertiary) px-1 text-[0.65rem] text-(--ui-text-tertiary)">
+                {row.marketplace_name ?? row.marketplace_id}
               </span>
             </Tip>
           )}
           {row.update_available && onUpdate && (
-            <Button className="h-5 px-1.5 text-[0.65rem]" disabled={busy} onClick={onUpdate} size="xs" variant="outline">
-              {t.skills.plugins.updateToPin(row.catalog_sha?.slice(0, 8) ?? '')}
+            <Button
+              className="h-5 px-1.5 text-[0.65rem]"
+              disabled={busy}
+              onClick={onUpdate}
+              size="xs"
+              variant="outline"
+            >
+              {t.skills.plugins.updateToPin(
+                (row.catalog_sha ?? row.current_tree_sha ?? row.current_repo_sha ?? '').slice(0, 8)
+              )}
             </Button>
           )}
         </div>
@@ -137,31 +160,48 @@ export const PluginsTab = memo(function PluginsTab({ profile }: { profile: Profi
   const status = useStore($agentPluginsStatus)
   const error = useStore($agentPluginsError)
   const busyKey = useStore($agentPluginBusy)
+  const agentScope = useStore($agentPluginScope)
+  const activeConnection = useStore($connection)
 
   const scope = profileParam(profile)
-
-  useEffect(() => {
-    void loadAgentPlugins(requestGateway, scope)
-  }, [requestGateway, scope])
-
-  const visible = useMemo(() => rows.filter(isDesktopRelevantPlugin), [rows])
-
-  // Catalog picker viewport (persisted height, collapse toggle) — same pane
-  // store contract as EmbeddedHubPicker.
-  const heightOverride = useStore($paneHeightOverride(CATALOG_PANE_ID))
-  const height = heightOverride ?? CATALOG_DEFAULT_PX
-  const open = height > CATALOG_COLLAPSED_PX
-  const [pickerMounted, setPickerMounted] = useState(open)
-
-  if (open && !pickerMounted) {
-    setPickerMounted(true)
-  }
-
-  useEffect(() => {
-    if (!open) {
-      return undefined
+  const explicitScope = Boolean(profile && typeof profile === 'object')
+  const ambientConnectionId =
+    String(activeConnection?.connectionId || (activeConnection?.mode === 'local' ? 'local' : '')).trim() ||
+    activeGatewayConnectionId()
+  const connectionId = explicitScope
+    ? ((profile as { connectionId?: null | string }).connectionId ?? null)
+    : ambientConnectionId
+  const scopeKey = `${connectionId ?? 'local'}::${scope ?? 'default'}`
+  const request = useMemo<GatewayRequest>(() => {
+    if (!explicitScope) {
+      return requestGateway
     }
 
+    return async <T,>(method: string, params: Record<string, unknown> = {}) =>
+      requestGatewayForAgent<T>(connectionId, scope ?? 'default', method, params)
+  }, [connectionId, explicitScope, requestGateway, scope])
+
+  useEffect(() => {
+    void loadAgentPlugins(request, scope, scopeKey)
+  }, [request, scope, scopeKey])
+
+  useEffect(
+    () => () => {
+      if ($pluginInstallRequest.get()?.scopeKey === scopeKey) {
+        closePluginInstallRequest()
+      }
+    },
+    [scopeKey]
+  )
+
+  const visible = useMemo(
+    () => (agentScope === scopeKey ? rows.filter(isDesktopRelevantPlugin) : []),
+    [agentScope, rows, scopeKey]
+  )
+  const visibleStatus = agentScope === scopeKey ? status : 'loading'
+  const visibleError = agentScope === scopeKey ? error : null
+
+  useEffect(() => {
     const onMessage = (event: MessageEvent) => {
       if (event.origin !== CATALOG_ORIGIN) {
         return
@@ -176,9 +216,7 @@ export const PluginsTab = memo(function PluginsTab({ profile }: { profile: Profi
       // Already installed at (or past) this pin in the scoped profile →
       // tell the user instead of re-running the install ceremony. Rows with
       // update_available keep their explicit Update chip in the list above.
-      const existing = $agentPlugins
-        .get()
-        .find(row => row.catalog_name === data.name || row.name === data.name)
+      const existing = $agentPlugins.get().find(row => row.catalog_name === data.name || row.name === data.name)
 
       if (existing && !existing.update_available) {
         notify({ kind: 'success', message: t.skills.plugins.alreadyInstalled(String(data.name)) })
@@ -191,8 +229,10 @@ export const PluginsTab = memo(function PluginsTab({ profile }: { profile: Profi
       // into the scoped profile, and offers the desktop half locally.
       openPluginInstallRequest({
         catalogName: String(data.name),
+        connectionId,
         profile: scope,
         repo: data.subdir ? `${String(data.repo)}#${String(data.subdir)}` : String(data.repo),
+        scopeKey,
         sha: data.sha ? String(data.sha) : undefined
       })
     }
@@ -200,23 +240,23 @@ export const PluginsTab = memo(function PluginsTab({ profile }: { profile: Profi
     window.addEventListener('message', onMessage)
 
     return () => window.removeEventListener('message', onMessage)
-  }, [open, scope, t])
+  }, [connectionId, scope, scopeKey, t])
 
   return (
     <div className="flex h-full min-h-0 flex-col">
       <div className="min-h-32 flex-1 overflow-y-auto">
-        {status === 'error' ? (
+        {visibleStatus === 'error' ? (
           <PanelEmpty
             action={
-              <Button onClick={() => void loadAgentPlugins(requestGateway, scope)} size="sm">
+              <Button onClick={() => void loadAgentPlugins(request, scope, scopeKey)} size="sm">
                 {t.skills.refresh}
               </Button>
             }
-            description={error ?? undefined}
+            description={visibleError ?? undefined}
             icon="error"
             title={p.loadFailed}
           />
-        ) : visible.length === 0 && status === 'ready' ? (
+        ) : visible.length === 0 && visibleStatus === 'ready' ? (
           <PanelEmpty description={p.emptyHint} icon="package" title={p.empty} />
         ) : (
           <div className="flex flex-col">
@@ -229,12 +269,12 @@ export const PluginsTab = memo(function PluginsTab({ profile }: { profile: Profi
                     return
                   }
 
-                  void toggleAgentPlugin(requestGateway, row.key, enable, p.toggleFailed(row.name), scope)
+                  void toggleAgentPlugin(request, row.key, enable, p.toggleFailed(row.name), scope, scopeKey)
                 }}
                 onUpdate={
-                  row.update_available
+                  row.update_available && row.key
                     ? () => {
-                        void updateAgentPlugin(requestGateway, row.name, p.updateFailed(row.name), scope).then(
+                        void updateAgentPlugin(request, row.key!, p.updateFailed(row.name), scope, scopeKey).then(
                           applied => {
                             if (applied) {
                               notify({ kind: 'success', message: p.updated(row.name) })
@@ -251,22 +291,15 @@ export const PluginsTab = memo(function PluginsTab({ profile }: { profile: Profi
         )}
       </div>
 
-      <section
-        className={cn('relative flex min-h-9 flex-col overflow-hidden border-t border-(--ui-stroke-secondary)')}
-      >
-        <div className="flex shrink-0 items-center justify-between px-3 py-1.5">
-          <span className="text-[0.7rem] font-medium text-(--ui-text-tertiary)">{p.catalogTitle}</span>
-          <Button onClick={() => setPaneHeightOverride(CATALOG_PANE_ID, open ? 0 : undefined)} size="xs" variant="text">
-            {open ? p.catalogHide : p.catalogBrowse}
-          </Button>
-        </div>
-        {pickerMounted && (
-          <div className={cn('flex min-h-0 flex-col gap-1 px-3 pb-2', !open && 'hidden')}>
+      <PrivateMarketplaces
+        installed={visible}
+        officialCatalog={
+          <div className="flex min-h-0 flex-col gap-1 px-3 pb-2">
             <div
               style={{
                 border: '1px solid var(--ui-stroke-secondary)',
                 borderRadius: 8,
-                flex: `0 1 ${height}px`,
+                height: 280,
                 maxWidth: '100%',
                 minHeight: 0,
                 minWidth: 320,
@@ -291,8 +324,11 @@ export const PluginsTab = memo(function PluginsTab({ profile }: { profile: Profi
             </div>
             <p className="shrink-0 px-1 text-[0.65rem] leading-4 text-(--ui-text-quaternary)">{p.catalogHint}</p>
           </div>
-        )}
-      </section>
+        }
+        profile={scope}
+        request={request}
+        scopeKey={scopeKey}
+      />
     </div>
   )
 })

--- a/apps/desktop/src/app/skills/plugins-tab.tsx
+++ b/apps/desktop/src/app/skills/plugins-tab.tsx
@@ -8,11 +8,10 @@ import { Tip } from '@/components/ui/tooltip'
 import type { ProfileScope } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { Loader2, Package } from '@/lib/icons'
-
 import {
   $agentPluginBusy,
-  $agentPluginScope,
   $agentPlugins,
+  $agentPluginScope,
   $agentPluginsError,
   $agentPluginsStatus,
   type AgentPluginRow,
@@ -24,7 +23,6 @@ import {
 } from '@/store/agent-plugins'
 import { activeGatewayConnectionId, requestGatewayForAgent } from '@/store/gateway'
 import { notify } from '@/store/notifications'
-
 import {
   $pluginInstallRequest,
   closePluginInstallRequest,
@@ -33,6 +31,7 @@ import {
 import { $connection } from '@/store/session'
 
 import { PanelEmpty } from '../overlays/panel'
+
 import { PrivateMarketplaces } from './private-marketplaces'
 
 // The REAL Plugin Catalog page (docs site) embedded as a one-click picker —
@@ -165,13 +164,17 @@ export const PluginsTab = memo(function PluginsTab({ profile }: { profile: Profi
 
   const scope = profileParam(profile)
   const explicitScope = Boolean(profile && typeof profile === 'object')
+
   const ambientConnectionId =
     String(activeConnection?.connectionId || (activeConnection?.mode === 'local' ? 'local' : '')).trim() ||
     activeGatewayConnectionId()
+
   const connectionId = explicitScope
     ? ((profile as { connectionId?: null | string }).connectionId ?? null)
     : ambientConnectionId
+
   const scopeKey = `${connectionId ?? 'local'}::${scope ?? 'default'}`
+
   const request = useMemo<GatewayRequest>(() => {
     if (!explicitScope) {
       return requestGateway
@@ -198,6 +201,7 @@ export const PluginsTab = memo(function PluginsTab({ profile }: { profile: Profi
     () => (agentScope === scopeKey ? rows.filter(isDesktopRelevantPlugin) : []),
     [agentScope, rows, scopeKey]
   )
+
   const visibleStatus = agentScope === scopeKey ? status : 'loading'
   const visibleError = agentScope === scopeKey ? error : null
 

--- a/apps/desktop/src/app/skills/private-marketplaces.test.tsx
+++ b/apps/desktop/src/app/skills/private-marketplaces.test.tsx
@@ -4,8 +4,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { $agentPlugins, type GatewayRequest } from '@/store/agent-plugins'
 import {
   $pluginMarketplaceBusy,
-  $pluginMarketplaceScope,
   $pluginMarketplaces,
+  $pluginMarketplaceScope,
   $pluginMarketplacesStatus,
   type PluginMarketplace
 } from '@/store/plugin-marketplaces'
@@ -29,26 +29,29 @@ const marketplace: PluginMarketplace = {
   id: 'market-1',
   name: 'Private Market',
   available: true,
-  stale: false,
-  url: 'https://github.com/example/private-marketplace'
+  stale: false
 }
 
 const requestMock = vi.fn(async (_method: string, params?: Record<string, unknown>) => {
   if (params?.action === 'marketplaces') {
     return { marketplaces: [marketplace] }
   }
+
   if (params?.action === 'marketplace_add') {
     return { marketplace, ok: true }
   }
+
   if (params?.action === 'update') {
     return { ok: true, unchanged: false }
   }
+
   if (params?.action === 'install') {
     return { ok: true, plugin_name: 'private-plugin' }
   }
 
   return { marketplaces: [marketplace], plugins: [] }
 })
+
 const request = requestMock as unknown as GatewayRequest
 
 describe('PrivateMarketplaces', () => {
@@ -66,8 +69,8 @@ describe('PrivateMarketplaces', () => {
   it('installs through the selected backend without exposing clone coordinates', async () => {
     render(
       <PrivateMarketplaces
-        officialCatalog={<div>Official Catalog</div>}
         installed={[]}
+        officialCatalog={<div>Official Catalog</div>}
         profile="workbot"
         request={request}
         scopeKey="workbot"
@@ -112,8 +115,8 @@ describe('PrivateMarketplaces', () => {
 
     render(
       <PrivateMarketplaces
-        officialCatalog={<div>Official Catalog</div>}
         installed={installed}
+        officialCatalog={<div>Official Catalog</div>}
         profile={null}
         request={request}
         scopeKey="default"
@@ -135,8 +138,8 @@ describe('PrivateMarketplaces', () => {
   it('closes an install confirmation when the profile changes', async () => {
     const view = render(
       <PrivateMarketplaces
-        officialCatalog={<div>Official Catalog</div>}
         installed={[]}
+        officialCatalog={<div>Official Catalog</div>}
         profile="first"
         request={request}
         scopeKey="one::first"
@@ -150,8 +153,8 @@ describe('PrivateMarketplaces', () => {
 
     view.rerender(
       <PrivateMarketplaces
-        officialCatalog={<div>Official Catalog</div>}
         installed={[]}
+        officialCatalog={<div>Official Catalog</div>}
         profile="second"
         request={request}
         scopeKey="two::second"
@@ -162,17 +165,21 @@ describe('PrivateMarketplaces', () => {
 
   it('does not publish an install continuation after the backend changes', async () => {
     let resolveInstall: ((value: unknown) => void) | undefined
+
     const delayedRequestMock = vi.fn(async (_method: string, params?: Record<string, unknown>) => {
       if (params?.action === 'install') {
         return await new Promise(resolve => (resolveInstall = resolve))
       }
+
       return { marketplaces: [marketplace], plugins: [] }
     })
+
     const delayedRequest = delayedRequestMock as unknown as GatewayRequest
+
     const view = render(
       <PrivateMarketplaces
-        officialCatalog={<div>Official Catalog</div>}
         installed={[]}
+        officialCatalog={<div>Official Catalog</div>}
         profile="same"
         request={delayedRequest}
         scopeKey="one::same"
@@ -188,8 +195,8 @@ describe('PrivateMarketplaces', () => {
 
     view.rerender(
       <PrivateMarketplaces
-        officialCatalog={<div>Official Catalog</div>}
         installed={[]}
+        officialCatalog={<div>Official Catalog</div>}
         profile="same"
         request={delayedRequest}
         scopeKey="two::same"
@@ -204,8 +211,8 @@ describe('PrivateMarketplaces', () => {
   it('adds a marketplace URL through the profile-scoped backend', async () => {
     render(
       <PrivateMarketplaces
-        officialCatalog={<div>Official Catalog</div>}
         installed={[]}
+        officialCatalog={<div>Official Catalog</div>}
         profile="workbot"
         request={request}
         scopeKey="workbot"
@@ -238,6 +245,7 @@ describe('PrivateMarketplaces', () => {
       name: 'Automation Lab',
       entries: [{ ...marketplace.entries[0], display_name: 'Automation Plugin', name: 'automation-plugin' }]
     }
+
     const tabsRequest = vi.fn(async () => ({
       marketplaces: [marketplace, second],
       plugins: []

--- a/apps/desktop/src/app/skills/private-marketplaces.test.tsx
+++ b/apps/desktop/src/app/skills/private-marketplaces.test.tsx
@@ -1,0 +1,265 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $agentPlugins, type GatewayRequest } from '@/store/agent-plugins'
+import {
+  $pluginMarketplaceBusy,
+  $pluginMarketplaceScope,
+  $pluginMarketplaces,
+  $pluginMarketplacesStatus,
+  type PluginMarketplace
+} from '@/store/plugin-marketplaces'
+
+import { PrivateMarketplaces } from './private-marketplaces'
+
+const marketplace: PluginMarketplace = {
+  entries: [
+    {
+      compatible: true,
+      description: 'A private plugin.',
+      display_name: 'Private Plugin',
+      incompatibility_reason: '',
+      maintainer: 'Example',
+      name: 'private-plugin',
+      source_id: 'market-1',
+      source_name: 'Private Market',
+      version: '1.2.0'
+    }
+  ],
+  id: 'market-1',
+  name: 'Private Market',
+  available: true,
+  stale: false,
+  url: 'https://github.com/example/private-marketplace'
+}
+
+const requestMock = vi.fn(async (_method: string, params?: Record<string, unknown>) => {
+  if (params?.action === 'marketplaces') {
+    return { marketplaces: [marketplace] }
+  }
+  if (params?.action === 'marketplace_add') {
+    return { marketplace, ok: true }
+  }
+  if (params?.action === 'update') {
+    return { ok: true, unchanged: false }
+  }
+  if (params?.action === 'install') {
+    return { ok: true, plugin_name: 'private-plugin' }
+  }
+
+  return { marketplaces: [marketplace], plugins: [] }
+})
+const request = requestMock as unknown as GatewayRequest
+
+describe('PrivateMarketplaces', () => {
+  beforeEach(() => {
+    requestMock.mockClear()
+    $pluginMarketplaces.set([])
+    $pluginMarketplaceScope.set(null)
+    $pluginMarketplacesStatus.set('idle')
+    $pluginMarketplaceBusy.set(null)
+    $agentPlugins.set([])
+  })
+
+  afterEach(cleanup)
+
+  it('installs through the selected backend without exposing clone coordinates', async () => {
+    render(
+      <PrivateMarketplaces
+        officialCatalog={<div>Official Catalog</div>}
+        installed={[]}
+        profile="workbot"
+        request={request}
+        scopeKey="workbot"
+      />
+    )
+
+    ;(await screen.findByRole('tab', { name: 'Private Market' })).click()
+    expect(await screen.findByText('Private Plugin')).toBeTruthy()
+    screen.getByRole('button', { name: 'Install' }).click()
+    expect(await screen.findByText('Install Private Plugin?')).toBeTruthy()
+    screen.getAllByRole('button', { name: 'Install' }).at(-1)?.click()
+
+    await waitFor(() => {
+      expect(requestMock).toHaveBeenCalledWith(
+        'plugins.manage',
+        expect.objectContaining({
+          action: 'install',
+          identifier: '',
+          marketplace_id: 'market-1',
+          marketplace_plugin_name: 'private-plugin',
+          profile: 'workbot'
+        })
+      )
+    })
+  })
+
+  it('shows Update when the installed plugin subtree changed', async () => {
+    const installed = [
+      {
+        description: '',
+        key: 'private-plugin',
+        marketplace_id: 'market-1',
+        marketplace_name: 'Private Market',
+        marketplace_plugin_name: 'private-plugin',
+        name: 'private-plugin',
+        source: 'git',
+        status: 'enabled' as const,
+        update_available: true,
+        version: '1.1.0'
+      }
+    ]
+
+    render(
+      <PrivateMarketplaces
+        officialCatalog={<div>Official Catalog</div>}
+        installed={installed}
+        profile={null}
+        request={request}
+        scopeKey="default"
+      />
+    )
+
+    ;(await screen.findByRole('tab', { name: 'Private Market' })).click()
+    const update = await screen.findByRole('button', { name: 'Update' })
+    update.click()
+
+    await waitFor(() =>
+      expect(requestMock).toHaveBeenCalledWith(
+        'plugins.manage',
+        expect.objectContaining({ action: 'update', key: 'private-plugin' })
+      )
+    )
+  })
+
+  it('closes an install confirmation when the profile changes', async () => {
+    const view = render(
+      <PrivateMarketplaces
+        officialCatalog={<div>Official Catalog</div>}
+        installed={[]}
+        profile="first"
+        request={request}
+        scopeKey="one::first"
+      />
+    )
+
+    ;(await screen.findByRole('tab', { name: 'Private Market' })).click()
+    await screen.findByText('Private Plugin')
+    screen.getByRole('button', { name: 'Install' }).click()
+    expect(await screen.findByText('Install Private Plugin?')).toBeTruthy()
+
+    view.rerender(
+      <PrivateMarketplaces
+        officialCatalog={<div>Official Catalog</div>}
+        installed={[]}
+        profile="second"
+        request={request}
+        scopeKey="two::second"
+      />
+    )
+    await waitFor(() => expect(screen.queryByText('Install Private Plugin?')).toBeNull())
+  })
+
+  it('does not publish an install continuation after the backend changes', async () => {
+    let resolveInstall: ((value: unknown) => void) | undefined
+    const delayedRequestMock = vi.fn(async (_method: string, params?: Record<string, unknown>) => {
+      if (params?.action === 'install') {
+        return await new Promise(resolve => (resolveInstall = resolve))
+      }
+      return { marketplaces: [marketplace], plugins: [] }
+    })
+    const delayedRequest = delayedRequestMock as unknown as GatewayRequest
+    const view = render(
+      <PrivateMarketplaces
+        officialCatalog={<div>Official Catalog</div>}
+        installed={[]}
+        profile="same"
+        request={delayedRequest}
+        scopeKey="one::same"
+      />
+    )
+
+    ;(await screen.findByRole('tab', { name: 'Private Market' })).click()
+    await screen.findByText('Private Plugin')
+    screen.getByRole('button', { name: 'Install' }).click()
+    await screen.findByText('Install Private Plugin?')
+    screen.getAllByRole('button', { name: 'Install' }).at(-1)?.click()
+    await waitFor(() => expect(resolveInstall).toBeTypeOf('function'))
+
+    view.rerender(
+      <PrivateMarketplaces
+        officialCatalog={<div>Official Catalog</div>}
+        installed={[]}
+        profile="same"
+        request={delayedRequest}
+        scopeKey="two::same"
+      />
+    )
+    resolveInstall?.({ ok: true, plugin_name: 'private-plugin' })
+    await waitFor(() => expect(screen.queryByText('Install Private Plugin?')).toBeNull())
+
+    expect(delayedRequestMock.mock.calls.some(([, params]) => params?.action === 'list')).toBe(false)
+  })
+
+  it('adds a marketplace URL through the profile-scoped backend', async () => {
+    render(
+      <PrivateMarketplaces
+        officialCatalog={<div>Official Catalog</div>}
+        installed={[]}
+        profile="workbot"
+        request={request}
+        scopeKey="workbot"
+      />
+    )
+
+    screen.getByRole('button', { name: 'Add marketplace' }).click()
+    const input = await screen.findByRole('textbox', { name: 'Marketplace repository URL' })
+    fireEvent.change(input, {
+      target: { value: 'https://github.com/example/marketplace' }
+    })
+    screen.getByRole('button', { name: 'Add marketplace' }).click()
+
+    await waitFor(() =>
+      expect(requestMock).toHaveBeenCalledWith(
+        'plugins.manage',
+        expect.objectContaining({
+          action: 'marketplace_add',
+          profile: 'workbot',
+          url: 'https://github.com/example/marketplace'
+        })
+      )
+    )
+  })
+
+  it('tabs between the official catalog and marketplace display names', async () => {
+    const second: PluginMarketplace = {
+      ...marketplace,
+      id: 'market-2',
+      name: 'Automation Lab',
+      entries: [{ ...marketplace.entries[0], display_name: 'Automation Plugin', name: 'automation-plugin' }]
+    }
+    const tabsRequest = vi.fn(async () => ({
+      marketplaces: [marketplace, second],
+      plugins: []
+    })) as unknown as GatewayRequest
+
+    render(
+      <PrivateMarketplaces
+        installed={[]}
+        officialCatalog={<div>Official Catalog</div>}
+        profile={null}
+        request={tabsRequest}
+        scopeKey="default"
+      />
+    )
+
+    expect(screen.getByText('Official Catalog')).toBeTruthy()
+    ;(await screen.findByRole('tab', { name: 'Private Market' })).click()
+    expect(await screen.findByText('Private Plugin')).toBeTruthy()
+    expect(screen.queryByText('Automation Plugin')).toBeNull()
+
+    screen.getByRole('tab', { name: 'Automation Lab' }).click()
+    expect(await screen.findByText('Automation Plugin')).toBeTruthy()
+    expect(screen.queryByText('Private Plugin')).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/skills/private-marketplaces.tsx
+++ b/apps/desktop/src/app/skills/private-marketplaces.tsx
@@ -1,0 +1,369 @@
+import { useStore } from '@nanostores/react'
+import { useEffect, useState, type ReactNode } from 'react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { useI18n } from '@/i18n'
+import { Loader2, Package, Plus, RefreshCw, Trash2 } from '@/lib/icons'
+import {
+  installAgentPlugin,
+  loadAgentPlugins,
+  updateAgentPlugin,
+  type AgentPluginRow,
+  type GatewayRequest
+} from '@/store/agent-plugins'
+import {
+  $pluginMarketplaceBusy,
+  $pluginMarketplaceScope,
+  $pluginMarketplaces,
+  $pluginMarketplacesError,
+  $pluginMarketplacesStatus,
+  addPluginMarketplace,
+  loadPluginMarketplaces,
+  removePluginMarketplace,
+  type MarketplacePlugin,
+  type PluginMarketplace
+} from '@/store/plugin-marketplaces'
+import { notify } from '@/store/notifications'
+
+interface PendingInstall {
+  entry: MarketplacePlugin
+  marketplace: PluginMarketplace
+  profile: null | string
+  scopeKey: string
+}
+
+export function PrivateMarketplaces({
+  installed,
+  officialCatalog,
+  profile,
+  request,
+  scopeKey
+}: {
+  installed: AgentPluginRow[]
+  officialCatalog: ReactNode
+  profile: null | string
+  request: GatewayRequest
+  scopeKey: string
+}) {
+  const { t } = useI18n()
+  const copy = t.skills.plugins.marketplaces
+  const savedMarketplaces = useStore($pluginMarketplaces)
+  const marketplaceScope = useStore($pluginMarketplaceScope)
+  const savedStatus = useStore($pluginMarketplacesStatus)
+  const savedError = useStore($pluginMarketplacesError)
+  const sameScope = marketplaceScope === scopeKey
+  const marketplaces = sameScope ? savedMarketplaces : []
+  const status = sameScope ? savedStatus : 'loading'
+  const error = sameScope ? savedError : null
+  const busy = useStore($pluginMarketplaceBusy)
+  const [adding, setAdding] = useState(false)
+  const [url, setUrl] = useState('')
+  const [pendingInstall, setPendingInstall] = useState<PendingInstall | null>(null)
+  const [installing, setInstalling] = useState(false)
+  const [installError, setInstallError] = useState<string | null>(null)
+  const [selectedMarketplace, setSelectedMarketplace] = useState('official')
+
+  useEffect(() => {
+    void loadPluginMarketplaces(request, profile, false, scopeKey)
+  }, [profile, request, scopeKey])
+
+  useEffect(() => {
+    setAdding(false)
+    setUrl('')
+    setPendingInstall(null)
+    setInstalling(false)
+    setInstallError(null)
+    setSelectedMarketplace('official')
+  }, [scopeKey])
+
+  useEffect(() => {
+    if (selectedMarketplace !== 'official' && !marketplaces.some(item => item.id === selectedMarketplace)) {
+      setSelectedMarketplace('official')
+    }
+  }, [marketplaces, selectedMarketplace])
+
+  const add = async () => {
+    if (!url.trim()) {
+      return
+    }
+    const added = await addPluginMarketplace(request, url.trim(), profile, scopeKey)
+    if (added && $pluginMarketplaceScope.get() === scopeKey) {
+      setAdding(false)
+      setUrl('')
+      notify({ kind: 'success', message: copy.added })
+    }
+  }
+
+  const install = async () => {
+    if (!pendingInstall || pendingInstall.scopeKey !== scopeKey) {
+      return
+    }
+    const pending = pendingInstall
+    setInstalling(true)
+    setInstallError(null)
+    const result = await installAgentPlugin(request, {
+      identifier: '',
+      marketplaceId: pending.marketplace.id,
+      marketplacePluginName: pending.entry.name,
+      profile: pending.profile
+    })
+    if ($pluginMarketplaceScope.get() !== scopeKey) {
+      return
+    }
+    setInstalling(false)
+    if (!result.ok) {
+      setInstallError(result.error || copy.installFailed(pending.entry.display_name))
+      return
+    }
+    await loadAgentPlugins(request, profile, scopeKey)
+    if ($pluginMarketplaceScope.get() !== scopeKey) {
+      return
+    }
+    notify({ kind: 'success', message: copy.installedSuccess(pending.entry.display_name) })
+    setPendingInstall(null)
+  }
+
+  return (
+    <section className="max-h-80 overflow-y-auto border-t border-(--ui-stroke-secondary)">
+      <div className="flex items-center justify-between gap-2 px-3 py-2">
+        <div>
+          <div className="text-[length:var(--conversation-caption-font-size)] font-medium text-foreground">
+            {copy.title}
+          </div>
+          <div className="text-[0.65rem] text-(--ui-text-quaternary)">{copy.hint}</div>
+        </div>
+        <div className="flex items-center gap-1">
+          <Button
+            aria-label={copy.refresh}
+            disabled={status === 'loading'}
+            onClick={() => void loadPluginMarketplaces(request, profile, true, scopeKey)}
+            size="xs"
+            variant="text"
+          >
+            <RefreshCw className={status === 'loading' ? 'size-3 animate-spin' : 'size-3'} />
+          </Button>
+          <Button onClick={() => setAdding(true)} size="xs" variant="outline">
+            <Plus className="size-3" />
+            {copy.add}
+          </Button>
+        </div>
+      </div>
+
+      {error && <p className="px-3 pb-2 text-xs text-destructive">{error}</p>}
+
+      <div
+        aria-label={copy.title}
+        className="flex gap-1 overflow-x-auto border-t border-(--ui-stroke-tertiary) px-3 py-2"
+        role="tablist"
+      >
+        <Button
+          aria-selected={selectedMarketplace === 'official'}
+          onClick={() => setSelectedMarketplace('official')}
+          role="tab"
+          size="xs"
+          variant={selectedMarketplace === 'official' ? 'outline' : 'text'}
+        >
+          {copy.official}
+        </Button>
+        {marketplaces.map(marketplace => (
+          <Button
+            aria-selected={selectedMarketplace === marketplace.id}
+            key={marketplace.id}
+            onClick={() => setSelectedMarketplace(marketplace.id)}
+            role="tab"
+            size="xs"
+            variant={selectedMarketplace === marketplace.id ? 'outline' : 'text'}
+          >
+            {marketplace.name}
+          </Button>
+        ))}
+      </div>
+
+      {selectedMarketplace === 'official' ? (
+        <div role="tabpanel">{officialCatalog}</div>
+      ) : marketplaces.length === 0 && status !== 'loading' ? (
+        <p className="px-3 pb-3 text-xs text-(--ui-text-tertiary)">{copy.empty}</p>
+      ) : (
+        marketplaces
+          .filter(marketplace => marketplace.id === selectedMarketplace)
+          .map(marketplace => (
+            <div className="border-t border-(--ui-stroke-tertiary)" key={marketplace.id}>
+              <div className="flex items-start justify-between gap-2 px-3 py-2">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2 text-xs font-medium text-foreground">
+                    <span className="truncate">{marketplace.name}</span>
+                    {marketplace.stale && <span className="text-(--ui-text-quaternary)">{copy.stale}</span>}
+                  </div>
+                  <div className="truncate text-[0.65rem] text-(--ui-text-quaternary)">{marketplace.url}</div>
+                  {marketplace.error && <div className="mt-1 text-[0.65rem] text-destructive">{marketplace.error}</div>}
+                </div>
+                <Button
+                  aria-label={copy.remove(marketplace.name)}
+                  disabled={busy === marketplace.id}
+                  onClick={() => void removePluginMarketplace(request, marketplace.id, profile, scopeKey)}
+                  size="xs"
+                  variant="text"
+                >
+                  {busy === marketplace.id ? (
+                    <Loader2 className="size-3 animate-spin" />
+                  ) : (
+                    <Trash2 className="size-3" />
+                  )}
+                </Button>
+              </div>
+
+              {!marketplace.available && marketplace.entries.length === 0 && (
+                <p className="px-3 pb-3 text-xs text-(--ui-text-tertiary)">{copy.unavailable}</p>
+              )}
+
+              {marketplace.entries.map(entry => {
+                const current = installed.find(
+                  row => row.marketplace_id === marketplace.id && row.marketplace_plugin_name === entry.name
+                )
+                const action =
+                  current?.update_available && current.key ? (
+                    <Button
+                      onClick={() =>
+                        void updateAgentPlugin(
+                          request,
+                          current.key!,
+                          copy.updateFailed(entry.display_name),
+                          profile,
+                          scopeKey
+                        )
+                      }
+                      size="xs"
+                      variant="outline"
+                    >
+                      {copy.update}
+                    </Button>
+                  ) : current ? (
+                    <Button disabled size="xs" variant="text">
+                      {current.marketplace_available === false ? copy.sourceUnavailable : copy.installed}
+                    </Button>
+                  ) : !marketplace.available || marketplace.stale ? (
+                    <Button disabled size="xs" variant="text">
+                      {copy.sourceUnavailable}
+                    </Button>
+                  ) : entry.compatible ? (
+                    <Button
+                      onClick={() => {
+                        setInstallError(null)
+                        setPendingInstall({ entry, marketplace, profile, scopeKey })
+                      }}
+                      size="xs"
+                      variant="outline"
+                    >
+                      {copy.install}
+                    </Button>
+                  ) : (
+                    <Button disabled size="xs" title={entry.incompatibility_reason} variant="text">
+                      {copy.incompatible}
+                    </Button>
+                  )
+
+                return (
+                  <div
+                    className="flex items-start gap-3 border-t border-(--ui-stroke-tertiary) px-3 py-2"
+                    key={`${marketplace.id}:${entry.name}`}
+                  >
+                    <Package aria-hidden className="mt-0.5 size-4 shrink-0 text-(--ui-text-tertiary)" />
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2 text-xs font-medium text-foreground">
+                        {entry.display_name}
+                        {entry.version && <span className="text-(--ui-text-quaternary)">v{entry.version}</span>}
+                      </div>
+                      {entry.description && (
+                        <div className="mt-0.5 text-[0.7rem] text-(--ui-text-tertiary)">{entry.description}</div>
+                      )}
+                      {!entry.compatible && entry.incompatibility_reason && (
+                        <div className="mt-0.5 text-[0.65rem] text-(--ui-text-quaternary)">
+                          {entry.incompatibility_reason}
+                        </div>
+                      )}
+                    </div>
+                    <div className="shrink-0">{action}</div>
+                  </div>
+                )
+              })}
+            </div>
+          ))
+      )}
+
+      <Dialog onOpenChange={setAdding} open={adding}>
+        <DialogContent className="max-w-lg">
+          <form
+            onSubmit={event => {
+              event.preventDefault()
+              void add()
+            }}
+          >
+            <DialogHeader>
+              <DialogTitle>{copy.addTitle}</DialogTitle>
+              <DialogDescription>{copy.addDescription}</DialogDescription>
+            </DialogHeader>
+            <Input
+              aria-label={copy.urlLabel}
+              autoFocus
+              className="mt-4"
+              onChange={event => setUrl(event.target.value)}
+              placeholder="https://github.com/owner/plugin-marketplace"
+              value={url}
+            />
+            {error && <p className="mt-2 text-xs text-destructive">{error}</p>}
+            <DialogFooter className="mt-4">
+              <Button disabled={busy === 'add'} onClick={() => setAdding(false)} type="button" variant="ghost">
+                {copy.cancel}
+              </Button>
+              <Button disabled={busy === 'add' || !url.trim()} type="submit">
+                {busy === 'add' && <Loader2 className="size-3 animate-spin" />}
+                {copy.add}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        onOpenChange={open => {
+          if (!open && !installing) {
+            setPendingInstall(null)
+            setInstallError(null)
+          }
+        }}
+        open={pendingInstall?.scopeKey === scopeKey}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>{copy.installTitle(pendingInstall?.entry.display_name || '')}</DialogTitle>
+            <DialogDescription>
+              {copy.installDescription(
+                pendingInstall?.entry.display_name || '',
+                pendingInstall?.marketplace.name || ''
+              )}
+            </DialogDescription>
+          </DialogHeader>
+          {installError && <p className="text-xs text-destructive">{installError}</p>}
+          <DialogFooter>
+            <Button disabled={installing} onClick={() => setPendingInstall(null)} variant="ghost">
+              {copy.cancel}
+            </Button>
+            <Button disabled={installing} onClick={() => void install()}>
+              {installing && <Loader2 className="size-3 animate-spin" />}
+              {installing ? copy.installing : copy.install}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </section>
+  )
+}

--- a/apps/desktop/src/app/skills/private-marketplaces.tsx
+++ b/apps/desktop/src/app/skills/private-marketplaces.tsx
@@ -1,5 +1,5 @@
 import { useStore } from '@nanostores/react'
-import { useEffect, useState, type ReactNode } from 'react'
+import { type ReactNode, useEffect, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import {
@@ -14,25 +14,25 @@ import { Input } from '@/components/ui/input'
 import { useI18n } from '@/i18n'
 import { Loader2, Package, Plus, RefreshCw, Trash2 } from '@/lib/icons'
 import {
+  type AgentPluginRow,
+  type GatewayRequest,
   installAgentPlugin,
   loadAgentPlugins,
-  updateAgentPlugin,
-  type AgentPluginRow,
-  type GatewayRequest
+  updateAgentPlugin
 } from '@/store/agent-plugins'
+import { notify } from '@/store/notifications'
 import {
   $pluginMarketplaceBusy,
-  $pluginMarketplaceScope,
   $pluginMarketplaces,
+  $pluginMarketplaceScope,
   $pluginMarketplacesError,
   $pluginMarketplacesStatus,
   addPluginMarketplace,
   loadPluginMarketplaces,
-  removePluginMarketplace,
   type MarketplacePlugin,
-  type PluginMarketplace
+  type PluginMarketplace,
+  removePluginMarketplace
 } from '@/store/plugin-marketplaces'
-import { notify } from '@/store/notifications'
 
 interface PendingInstall {
   entry: MarketplacePlugin
@@ -95,7 +95,9 @@ export function PrivateMarketplaces({
     if (!url.trim()) {
       return
     }
+
     const added = await addPluginMarketplace(request, url.trim(), profile, scopeKey)
+
     if (added && $pluginMarketplaceScope.get() === scopeKey) {
       setAdding(false)
       setUrl('')
@@ -107,27 +109,36 @@ export function PrivateMarketplaces({
     if (!pendingInstall || pendingInstall.scopeKey !== scopeKey) {
       return
     }
+
     const pending = pendingInstall
     setInstalling(true)
     setInstallError(null)
+
     const result = await installAgentPlugin(request, {
       identifier: '',
       marketplaceId: pending.marketplace.id,
       marketplacePluginName: pending.entry.name,
       profile: pending.profile
     })
+
     if ($pluginMarketplaceScope.get() !== scopeKey) {
       return
     }
+
     setInstalling(false)
+
     if (!result.ok) {
       setInstallError(result.error || copy.installFailed(pending.entry.display_name))
+
       return
     }
+
     await loadAgentPlugins(request, profile, scopeKey)
+
     if ($pluginMarketplaceScope.get() !== scopeKey) {
       return
     }
+
     notify({ kind: 'success', message: copy.installedSuccess(pending.entry.display_name) })
     setPendingInstall(null)
   }
@@ -203,7 +214,6 @@ export function PrivateMarketplaces({
                     <span className="truncate">{marketplace.name}</span>
                     {marketplace.stale && <span className="text-(--ui-text-quaternary)">{copy.stale}</span>}
                   </div>
-                  <div className="truncate text-[0.65rem] text-(--ui-text-quaternary)">{marketplace.url}</div>
                   {marketplace.error && <div className="mt-1 text-[0.65rem] text-destructive">{marketplace.error}</div>}
                 </div>
                 <Button
@@ -229,6 +239,7 @@ export function PrivateMarketplaces({
                 const current = installed.find(
                   row => row.marketplace_id === marketplace.id && row.marketplace_plugin_name === entry.name
                 )
+
                 const action =
                   current?.update_available && current.key ? (
                     <Button

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1327,11 +1327,41 @@ export const en: Translations = {
         'Hit "+ Add to this Agent" on any plugin — reviewed entries install at their pinned commit into the selected profile. Bundled agent+desktop plugins offer both halves.',
       alreadyInstalled: (name: string) => `${name} is already installed in this profile.`,
       catalogProvenance: (sha: string) => `Installed from the Hermes catalog${sha ? ` at pin ${sha}` : ''}.`,
+      marketplaceProvenance: (source: string, sha: string) => `Installed from ${source}${sha ? ` at pin ${sha}` : ''}.`,
       tierOfficial: 'official',
       tierCommunity: 'community',
       updateToPin: (sha: string) => `Update to ${sha}`,
       updateFailed: (name: string) => `Could not update ${name}`,
-      updated: (name: string) => `${name} updated to the current catalog pin. Restart the gateway to apply.`
+      updated: (name: string) => `${name} updated to the current catalog pin. Restart the gateway to apply.`,
+      marketplaces: {
+        title: 'My Marketplaces',
+        official: 'Official',
+        hint: 'Private and team plugin catalogues from Git repositories.',
+        add: 'Add marketplace',
+        addTitle: 'Add marketplace from URL',
+        addDescription:
+          'Paste the HTTPS URL of a Git repository containing .claude-plugin/marketplace.json. The selected agent uses its existing Git credentials.',
+        urlLabel: 'Marketplace repository URL',
+        added: 'Marketplace added',
+        refresh: 'Refresh marketplaces',
+        remove: (name: string) => `Remove ${name}`,
+        empty: 'Add a marketplace to browse private or team plugins here.',
+        install: 'Install',
+        installed: 'Installed',
+        update: 'Update',
+        incompatible: 'Needs Hermes manifest',
+        updateFailed: (name: string) => `Could not update ${name}`,
+        stale: 'cached',
+        unavailable: 'This marketplace is unavailable. Refresh it after fixing Git access.',
+        sourceUnavailable: 'Source unavailable',
+        installTitle: (name: string) => `Install ${name}?`,
+        installDescription: (name: string, marketplace: string) =>
+          `Hermes will install ${name} from ${marketplace} at the exact commit resolved by the selected agent.`,
+        installing: 'Installing…',
+        installFailed: (name: string) => `Could not install ${name}`,
+        installedSuccess: (name: string) => `${name} installed. Restart the gateway to apply.`,
+        cancel: 'Cancel'
+      }
     },
     hub: {
       searchPlaceholder: 'Search the skill hub',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1161,11 +1161,39 @@ export interface Translations {
       catalogHint: string
       alreadyInstalled: (name: string) => string
       catalogProvenance: (sha: string) => string
+      marketplaceProvenance: (source: string, sha: string) => string
       tierOfficial: string
       tierCommunity: string
       updateToPin: (sha: string) => string
       updateFailed: (name: string) => string
       updated: (name: string) => string
+      marketplaces: {
+        title: string
+        official: string
+        hint: string
+        add: string
+        addTitle: string
+        addDescription: string
+        urlLabel: string
+        added: string
+        refresh: string
+        remove: (name: string) => string
+        empty: string
+        install: string
+        installed: string
+        update: string
+        incompatible: string
+        updateFailed: (name: string) => string
+        stale: string
+        unavailable: string
+        sourceUnavailable: string
+        installTitle: (name: string) => string
+        installDescription: (name: string, marketplace: string) => string
+        installing: string
+        installFailed: (name: string) => string
+        installedSuccess: (name: string) => string
+        cancel: string
+      }
     }
     hub: {
       searchPlaceholder: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -411,8 +411,7 @@ export const zh: Translations = {
         '这是捆绑插件的桌面部分，但其 agent 部分未安装在当前连接的后端/配置上。请在 能力 → 插件 中安装。',
       agent: {
         title: 'Agent 插件',
-        movedToCapabilities:
-          'Agent 插件按配置在「能力」页管理 — 已安装列表、开关和插件目录都在那里。',
+        movedToCapabilities: 'Agent 插件按配置在「能力」页管理 — 已安装列表、开关和插件目录都在那里。',
         openCapabilities: '打开 能力 → 插件'
       },
       installModal: {
@@ -1515,11 +1514,41 @@ export const zh: Translations = {
         '点击任意插件上的「+ Add to this Agent」— 经过审核的条目会以其固定提交安装到所选配置。捆绑的 agent+桌面插件会同时提供两部分。',
       alreadyInstalled: (name: string) => `${name} 已安装在此配置中。`,
       catalogProvenance: (sha: string) => `从 Hermes 目录安装${sha ? `，固定提交 ${sha}` : ''}。`,
+      marketplaceProvenance: (source: string, sha: string) => `从 ${source} 安装${sha ? `，固定提交 ${sha}` : ''}。`,
       tierOfficial: '官方',
       tierCommunity: '社区',
       updateToPin: (sha: string) => `更新到 ${sha}`,
       updateFailed: (name: string) => `无法更新 ${name}`,
-      updated: (name: string) => `${name} 已更新到当前目录固定提交。重启网关后生效。`
+      updated: (name: string) => `${name} 已更新到当前目录固定提交。重启网关后生效。`,
+      marketplaces: {
+        title: '你的插件市场',
+        official: '官方',
+        hint: '来自 Git 仓库的私有和团队插件目录。',
+        add: '添加插件市场',
+        addTitle: '从 URL 添加插件市场',
+        addDescription:
+          '粘贴包含 .claude-plugin/marketplace.json 的 Git 仓库 HTTPS URL。所选代理将使用其现有 Git 凭据。',
+        urlLabel: '插件市场仓库 URL',
+        added: '插件市场已添加',
+        refresh: '刷新插件市场',
+        remove: (name: string) => `移除 ${name}`,
+        empty: '添加插件市场后，可在此浏览私有或团队插件。',
+        install: '安装',
+        installed: '已安装',
+        update: '更新',
+        incompatible: '需要 Hermes 清单',
+        updateFailed: (name: string) => `无法更新 ${name}`,
+        stale: '缓存',
+        unavailable: '此插件市场不可用。修复 Git 访问后请刷新。',
+        sourceUnavailable: '来源不可用',
+        installTitle: (name: string) => `安装 ${name}？`,
+        installDescription: (name: string, marketplace: string) =>
+          `Hermes 将从 ${marketplace} 安装 ${name}，并使用所选代理解析的精确提交。`,
+        installing: '安装中…',
+        installFailed: (name: string) => `无法安装 ${name}`,
+        installedSuccess: (name: string) => `${name} 已安装。请重启网关以应用。`,
+        cancel: '取消'
+      }
     },
     hub: {
       searchPlaceholder: '搜索技能中心',

--- a/apps/desktop/src/store/agent-plugins.ts
+++ b/apps/desktop/src/store/agent-plugins.ts
@@ -102,6 +102,7 @@ export function loadAgentPlugins(
     $agentPluginBusy.set(null)
     $agentPluginsStatus.set('loading')
   }
+
   $agentPluginScope.set(scope)
 
   if (inflight && inflightProfile === scope) {

--- a/apps/desktop/src/store/agent-plugins.ts
+++ b/apps/desktop/src/store/agent-plugins.ts
@@ -34,6 +34,14 @@ export interface AgentPluginRow {
   catalog_sha?: string
   /** Installed SHA differs from the catalog pin — an update is available. */
   update_available?: boolean
+  marketplace_id?: string
+  marketplace_name?: string
+  marketplace_plugin_name?: string
+  marketplace_available?: boolean
+  installed_repo_sha?: string
+  installed_tree_sha?: string
+  current_repo_sha?: string
+  current_tree_sha?: string
 }
 
 export type AgentPluginsStatus = 'idle' | 'loading' | 'ready' | 'error'
@@ -44,6 +52,7 @@ export type GatewayRequest = <T>(method: string, params?: Record<string, unknown
 export const $agentPlugins = atom<AgentPluginRow[]>([])
 export const $agentPluginsStatus = atom<AgentPluginsStatus>('idle')
 export const $agentPluginsError = atom<string | null>(null)
+export const $agentPluginScope = atom<string | null>(null)
 /** Best available address of the row whose toggle RPC is in flight. */
 export const $agentPluginBusy = atom<string | null>(null)
 
@@ -80,8 +89,20 @@ const withProfile = (params: Record<string, unknown>, profile?: string | null) =
  *  backend); concurrent callers for the SAME profile share one in-flight
  *  request — a different profile starts fresh so a scope switch can't get a
  *  stale list. */
-export function loadAgentPlugins(request: GatewayRequest, profile?: string | null): Promise<void> {
-  const scope = profile ?? null
+export function loadAgentPlugins(
+  request: GatewayRequest,
+  profile?: string | null,
+  scopeKey = profile ?? 'default'
+): Promise<void> {
+  const scope = scopeKey
+
+  if ($agentPluginScope.get() !== scope) {
+    $agentPlugins.set([])
+    $agentPluginsError.set(null)
+    $agentPluginBusy.set(null)
+    $agentPluginsStatus.set('loading')
+  }
+  $agentPluginScope.set(scope)
 
   if (inflight && inflightProfile === scope) {
     return inflight
@@ -98,7 +119,7 @@ export function loadAgentPlugins(request: GatewayRequest, profile?: string | nul
     try {
       const result = await request<{ plugins?: AgentPluginRow[] }>(
         'plugins.manage',
-        withProfile({ action: 'list' }, scope)
+        withProfile({ action: 'list' }, profile)
       )
 
       if (generation !== loadGeneration) {
@@ -138,7 +159,8 @@ export async function toggleAgentPlugin(
   key: string,
   enable: boolean,
   failMessage: string,
-  profile?: string | null
+  profile?: string | null,
+  scopeKey = profile ?? 'default'
 ): Promise<boolean> {
   $agentPluginBusy.set(key)
 
@@ -159,21 +181,29 @@ export async function toggleAgentPlugin(
       throw new Error(failMessage)
     }
 
+    if ($agentPluginScope.get() !== scopeKey) {
+      return false
+    }
+
     const refreshed = result.plugin
 
     if (refreshed) {
       $agentPlugins.set($agentPlugins.get().map(row => (row.key === key ? { ...row, ...refreshed } : row)))
     } else {
-      await loadAgentPlugins(request, profile)
+      await loadAgentPlugins(request, profile, scopeKey)
     }
 
     return true
   } catch (e) {
-    notifyError(e, failMessage)
+    if ($agentPluginScope.get() === scopeKey) {
+      notifyError(e, failMessage)
+    }
 
     return false
   } finally {
-    $agentPluginBusy.set(null)
+    if ($agentPluginScope.get() === scopeKey) {
+      $agentPluginBusy.set(null)
+    }
   }
 }
 
@@ -194,6 +224,9 @@ export async function installAgentPlugin(
     /** Curated-catalog install: the backend resolves repo + pinned SHA from
      *  its own plugin-catalog and records provenance in the sidecar. */
     catalogName?: string
+    /** Saved Git marketplace install; backend resolves source and pin. */
+    marketplaceId?: string
+    marketplacePluginName?: string
     /** Target profile's HERMES_HOME (null/undefined = backend launch profile). */
     profile?: string | null
   }
@@ -205,13 +238,21 @@ export async function installAgentPlugin(
       warnings?: string[]
       missing_env?: string[]
       error?: string
-    }>('plugins.manage', withProfile({
-      action: 'install',
-      identifier: opts.identifier,
-      force: Boolean(opts.force),
-      enable: opts.enable ?? true,
-      ...(opts.catalogName ? { catalog_name: opts.catalogName } : {})
-    }, opts.profile))
+    }>(
+      'plugins.manage',
+      withProfile(
+        {
+          action: 'install',
+          identifier: opts.identifier,
+          force: Boolean(opts.force),
+          enable: opts.enable ?? true,
+          ...(opts.catalogName ? { catalog_name: opts.catalogName } : {}),
+          ...(opts.marketplaceId ? { marketplace_id: opts.marketplaceId } : {}),
+          ...(opts.marketplacePluginName ? { marketplace_plugin_name: opts.marketplacePluginName } : {})
+        },
+        opts.profile
+      )
+    )
 
     if (!result?.ok) {
       return { ok: false, error: result?.error || 'Install failed' }
@@ -233,30 +274,43 @@ export async function installAgentPlugin(
  *  success. Returns whether the update applied. */
 export async function updateAgentPlugin(
   request: GatewayRequest,
-  name: string,
+  key: string,
   failMessage: string,
-  profile?: string | null
+  profile?: string | null,
+  scopeKey = profile ?? 'default'
 ): Promise<boolean> {
-  $agentPluginBusy.set(name)
+  $agentPluginBusy.set(key)
 
   try {
     const result = await request<{ ok?: boolean; unchanged?: boolean }>(
       'plugins.manage',
-      withProfile({ action: 'update', name }, profile)
+      withProfile({ action: 'update', key }, profile)
     )
 
     if (!result?.ok) {
       throw new Error(failMessage)
     }
 
-    await loadAgentPlugins(request, profile)
+    if ($agentPluginScope.get() !== scopeKey) {
+      return false
+    }
+
+    await loadAgentPlugins(request, profile, scopeKey)
+
+    if ($agentPluginScope.get() !== scopeKey) {
+      return false
+    }
 
     return !result.unchanged
   } catch (e) {
-    notifyError(e, failMessage)
+    if ($agentPluginScope.get() === scopeKey) {
+      notifyError(e, failMessage)
+    }
 
     return false
   } finally {
-    $agentPluginBusy.set(null)
+    if ($agentPluginScope.get() === scopeKey) {
+      $agentPluginBusy.set(null)
+    }
   }
 }

--- a/apps/desktop/src/store/plugin-install-request.ts
+++ b/apps/desktop/src/store/plugin-install-request.ts
@@ -17,6 +17,10 @@ export interface PluginInstallRequest {
   /** Capabilities profile scope the pick was made under; the agent half
    *  installs into THIS profile (null/undefined = active profile). */
   profile?: string | null
+  /** Durable backend selected when the catalog row was picked. */
+  connectionId?: string | null
+  /** Composite backend/profile cache scope for the post-install refresh. */
+  scopeKey?: string
 }
 
 export const $pluginInstallRequest = atom<PluginInstallRequest | null>(null)

--- a/apps/desktop/src/store/plugin-marketplaces.test.ts
+++ b/apps/desktop/src/store/plugin-marketplaces.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  $agentPluginBusy,
+  $agentPluginScope,
+  $agentPlugins,
+  loadAgentPlugins,
+  updateAgentPlugin,
+  type GatewayRequest
+} from '@/store/agent-plugins'
+import {
+  $pluginMarketplaces,
+  $pluginMarketplaceScope,
+  $pluginMarketplacesStatus,
+  loadPluginMarketplaces,
+  type PluginMarketplace
+} from '@/store/plugin-marketplaces'
+
+const source = (name: string): PluginMarketplace => ({
+  available: true,
+  entries: [],
+  id: name,
+  name,
+  stale: false,
+  url: `https://github.com/example/${name}`
+})
+
+describe('plugin marketplace store', () => {
+  beforeEach(() => {
+    $pluginMarketplaces.set([])
+    $pluginMarketplaceScope.set(null)
+    $pluginMarketplacesStatus.set('idle')
+  })
+
+  it('ignores a slow response from the previous profile', async () => {
+    const resolvers = new Map<string, (value: unknown) => void>()
+    const request = vi.fn(
+      async (_method: string, params?: Record<string, unknown>) =>
+        await new Promise(resolve => resolvers.set(String(params?.profile), resolve))
+    ) as unknown as GatewayRequest
+
+    const firstOldLoad = loadPluginMarketplaces(request, 'old-profile')
+    resolvers.get('old-profile')?.({ marketplaces: [source('old')] })
+    await firstOldLoad
+    expect($pluginMarketplaces.get().map(item => item.name)).toEqual(['old'])
+
+    const staleOldLoad = loadPluginMarketplaces(request, 'old-profile')
+    const newLoad = loadPluginMarketplaces(request, 'new-profile')
+    expect($pluginMarketplaces.get()).toEqual([])
+    expect($pluginMarketplacesStatus.get()).toBe('loading')
+    resolvers.get('new-profile')?.({ marketplaces: [source('new')] })
+    await newLoad
+    resolvers.get('old-profile')?.({ marketplaces: [source('stale-old')] })
+    await staleOldLoad
+
+    expect($pluginMarketplaces.get().map(item => item.name)).toEqual(['new'])
+  })
+
+  it('isolates same-named profiles on different connections', async () => {
+    let resolveOld: ((value: unknown) => void) | undefined
+    const oldRequest = vi.fn(
+      async () => await new Promise(resolve => (resolveOld = resolve))
+    ) as unknown as GatewayRequest
+    const newRequest = vi.fn(async () => ({ marketplaces: [source('new')] })) as unknown as GatewayRequest
+
+    const oldLoad = loadPluginMarketplaces(oldRequest, 'same', false, 'old::same')
+    await loadPluginMarketplaces(newRequest, 'same', false, 'new::same')
+    resolveOld?.({ marketplaces: [source('old')] })
+    await oldLoad
+
+    expect($pluginMarketplaceScope.get()).toBe('new::same')
+    expect($pluginMarketplaces.get().map(item => item.name)).toEqual(['new'])
+  })
+
+  it('does not publish an update continuation after the selected backend changes', async () => {
+    let resolveUpdate: ((value: unknown) => void) | undefined
+    const request = vi.fn(
+      async () => await new Promise(resolve => (resolveUpdate = resolve))
+    ) as unknown as GatewayRequest
+    const current = {
+      description: '',
+      key: 'demo',
+      name: 'demo-b',
+      source: 'git',
+      status: 'enabled' as const,
+      version: '2.0.0'
+    }
+    $agentPluginScope.set('connection-a::same')
+
+    const update = updateAgentPlugin(request, 'demo', 'failed', 'same', 'connection-a::same')
+    $agentPluginScope.set('connection-b::same')
+    $agentPlugins.set([current])
+    resolveUpdate?.({ ok: true, unchanged: false })
+
+    expect(await update).toBe(false)
+    expect($agentPlugins.get()).toEqual([current])
+    expect(request).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not report update success when scope changes during refresh', async () => {
+    let resolveRefresh: ((value: unknown) => void) | undefined
+    let calls = 0
+    const request = vi.fn(async () => {
+      calls += 1
+      if (calls === 1) {
+        return { ok: true, unchanged: false }
+      }
+      return await new Promise(resolve => (resolveRefresh = resolve))
+    }) as unknown as GatewayRequest
+    $agentPluginScope.set('connection-a::same')
+
+    const update = updateAgentPlugin(request, 'demo', 'failed', 'same', 'connection-a::same')
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2))
+    $agentPluginScope.set('connection-b::same')
+    resolveRefresh?.({ plugins: [] })
+
+    expect(await update).toBe(false)
+    expect($agentPluginScope.get()).toBe('connection-b::same')
+  })
+
+  it('clears plugin busy state when the selected backend changes', async () => {
+    $agentPluginScope.set('old::same')
+    $agentPluginBusy.set('demo')
+    const request = vi.fn(async () => ({ plugins: [] })) as unknown as GatewayRequest
+
+    await loadAgentPlugins(request, 'same', 'new::same')
+
+    expect($agentPluginBusy.get()).toBeNull()
+  })
+})

--- a/apps/desktop/src/store/plugin-marketplaces.test.ts
+++ b/apps/desktop/src/store/plugin-marketplaces.test.ts
@@ -2,11 +2,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   $agentPluginBusy,
-  $agentPluginScope,
   $agentPlugins,
+  $agentPluginScope,
+  type GatewayRequest,
   loadAgentPlugins,
-  updateAgentPlugin,
-  type GatewayRequest
+  updateAgentPlugin
 } from '@/store/agent-plugins'
 import {
   $pluginMarketplaces,
@@ -21,8 +21,7 @@ const source = (name: string): PluginMarketplace => ({
   entries: [],
   id: name,
   name,
-  stale: false,
-  url: `https://github.com/example/${name}`
+  stale: false
 })
 
 describe('plugin marketplace store', () => {
@@ -34,6 +33,7 @@ describe('plugin marketplace store', () => {
 
   it('ignores a slow response from the previous profile', async () => {
     const resolvers = new Map<string, (value: unknown) => void>()
+
     const request = vi.fn(
       async (_method: string, params?: Record<string, unknown>) =>
         await new Promise(resolve => resolvers.set(String(params?.profile), resolve))
@@ -58,9 +58,11 @@ describe('plugin marketplace store', () => {
 
   it('isolates same-named profiles on different connections', async () => {
     let resolveOld: ((value: unknown) => void) | undefined
+
     const oldRequest = vi.fn(
       async () => await new Promise(resolve => (resolveOld = resolve))
     ) as unknown as GatewayRequest
+
     const newRequest = vi.fn(async () => ({ marketplaces: [source('new')] })) as unknown as GatewayRequest
 
     const oldLoad = loadPluginMarketplaces(oldRequest, 'same', false, 'old::same')
@@ -74,9 +76,11 @@ describe('plugin marketplace store', () => {
 
   it('does not publish an update continuation after the selected backend changes', async () => {
     let resolveUpdate: ((value: unknown) => void) | undefined
+
     const request = vi.fn(
       async () => await new Promise(resolve => (resolveUpdate = resolve))
     ) as unknown as GatewayRequest
+
     const current = {
       description: '',
       key: 'demo',
@@ -85,6 +89,7 @@ describe('plugin marketplace store', () => {
       status: 'enabled' as const,
       version: '2.0.0'
     }
+
     $agentPluginScope.set('connection-a::same')
 
     const update = updateAgentPlugin(request, 'demo', 'failed', 'same', 'connection-a::same')
@@ -100,13 +105,17 @@ describe('plugin marketplace store', () => {
   it('does not report update success when scope changes during refresh', async () => {
     let resolveRefresh: ((value: unknown) => void) | undefined
     let calls = 0
+
     const request = vi.fn(async () => {
       calls += 1
+
       if (calls === 1) {
         return { ok: true, unchanged: false }
       }
+
       return await new Promise(resolve => (resolveRefresh = resolve))
     }) as unknown as GatewayRequest
+
     $agentPluginScope.set('connection-a::same')
 
     const update = updateAgentPlugin(request, 'demo', 'failed', 'same', 'connection-a::same')

--- a/apps/desktop/src/store/plugin-marketplaces.ts
+++ b/apps/desktop/src/store/plugin-marketplaces.ts
@@ -17,7 +17,6 @@ export interface MarketplacePlugin {
 export interface PluginMarketplace {
   id: string
   name: string
-  url: string
   available: boolean
   stale: boolean
   entries: MarketplacePlugin[]
@@ -41,13 +40,16 @@ export async function loadPluginMarketplaces(
   scopeKey = profile ?? 'default'
 ): Promise<void> {
   const generation = ++loadGeneration
+
   if ($pluginMarketplaceScope.get() !== scopeKey) {
     $pluginMarketplaceBusy.set(null)
     $pluginMarketplaces.set([])
     $pluginMarketplacesError.set(null)
     $pluginMarketplacesStatus.set('loading')
   }
+
   $pluginMarketplaceScope.set(scopeKey)
+
   if ($pluginMarketplacesStatus.get() !== 'ready') {
     $pluginMarketplacesStatus.set('loading')
   }
@@ -57,9 +59,11 @@ export async function loadPluginMarketplaces(
       'plugins.manage',
       scoped({ action: force ? 'marketplace_refresh' : 'marketplaces' }, profile)
     )
+
     if (generation !== loadGeneration || $pluginMarketplaceScope.get() !== scopeKey) {
       return
     }
+
     $pluginMarketplaces.set(result.marketplaces ?? [])
     $pluginMarketplacesError.set(null)
     $pluginMarketplacesStatus.set('ready')
@@ -67,6 +71,7 @@ export async function loadPluginMarketplaces(
     if (generation !== loadGeneration || $pluginMarketplaceScope.get() !== scopeKey) {
       return
     }
+
     $pluginMarketplacesError.set(error instanceof Error ? error.message : String(error))
     $pluginMarketplacesStatus.set('error')
   }
@@ -82,14 +87,17 @@ export async function addPluginMarketplace(
 
   try {
     await request('plugins.manage', scoped({ action: 'marketplace_add', url }, profile))
+
     if ($pluginMarketplaceScope.get() === scopeKey) {
       await loadPluginMarketplaces(request, profile, false, scopeKey)
     }
+
     return true
   } catch (error) {
     if ($pluginMarketplaceScope.get() === scopeKey) {
       $pluginMarketplacesError.set(error instanceof Error ? error.message : String(error))
     }
+
     return false
   } finally {
     if ($pluginMarketplaceScope.get() === scopeKey) {
@@ -108,14 +116,17 @@ export async function removePluginMarketplace(
 
   try {
     await request('plugins.manage', scoped({ action: 'marketplace_remove', source_id: sourceId }, profile))
+
     if ($pluginMarketplaceScope.get() === scopeKey) {
       await loadPluginMarketplaces(request, profile, false, scopeKey)
     }
+
     return true
   } catch (error) {
     if ($pluginMarketplaceScope.get() === scopeKey) {
       $pluginMarketplacesError.set(error instanceof Error ? error.message : String(error))
     }
+
     return false
   } finally {
     if ($pluginMarketplaceScope.get() === scopeKey) {

--- a/apps/desktop/src/store/plugin-marketplaces.ts
+++ b/apps/desktop/src/store/plugin-marketplaces.ts
@@ -1,0 +1,125 @@
+import { atom } from 'nanostores'
+
+import type { GatewayRequest } from '@/store/agent-plugins'
+
+export interface MarketplacePlugin {
+  compatible: boolean
+  description: string
+  display_name: string
+  incompatibility_reason: string
+  maintainer: string
+  name: string
+  source_id: string
+  source_name: string
+  version: string
+}
+
+export interface PluginMarketplace {
+  id: string
+  name: string
+  url: string
+  available: boolean
+  stale: boolean
+  entries: MarketplacePlugin[]
+  error?: string
+}
+
+export const $pluginMarketplaces = atom<PluginMarketplace[]>([])
+export const $pluginMarketplaceScope = atom<string | null>(null)
+export const $pluginMarketplacesStatus = atom<'idle' | 'loading' | 'ready' | 'error'>('idle')
+export const $pluginMarketplacesError = atom<string | null>(null)
+export const $pluginMarketplaceBusy = atom<string | null>(null)
+
+const scoped = (params: Record<string, unknown>, profile?: string | null) => (profile ? { ...params, profile } : params)
+
+let loadGeneration = 0
+
+export async function loadPluginMarketplaces(
+  request: GatewayRequest,
+  profile?: string | null,
+  force = false,
+  scopeKey = profile ?? 'default'
+): Promise<void> {
+  const generation = ++loadGeneration
+  if ($pluginMarketplaceScope.get() !== scopeKey) {
+    $pluginMarketplaceBusy.set(null)
+    $pluginMarketplaces.set([])
+    $pluginMarketplacesError.set(null)
+    $pluginMarketplacesStatus.set('loading')
+  }
+  $pluginMarketplaceScope.set(scopeKey)
+  if ($pluginMarketplacesStatus.get() !== 'ready') {
+    $pluginMarketplacesStatus.set('loading')
+  }
+
+  try {
+    const result = await request<{ marketplaces?: PluginMarketplace[] }>(
+      'plugins.manage',
+      scoped({ action: force ? 'marketplace_refresh' : 'marketplaces' }, profile)
+    )
+    if (generation !== loadGeneration || $pluginMarketplaceScope.get() !== scopeKey) {
+      return
+    }
+    $pluginMarketplaces.set(result.marketplaces ?? [])
+    $pluginMarketplacesError.set(null)
+    $pluginMarketplacesStatus.set('ready')
+  } catch (error) {
+    if (generation !== loadGeneration || $pluginMarketplaceScope.get() !== scopeKey) {
+      return
+    }
+    $pluginMarketplacesError.set(error instanceof Error ? error.message : String(error))
+    $pluginMarketplacesStatus.set('error')
+  }
+}
+
+export async function addPluginMarketplace(
+  request: GatewayRequest,
+  url: string,
+  profile?: string | null,
+  scopeKey = profile ?? 'default'
+): Promise<boolean> {
+  $pluginMarketplaceBusy.set('add')
+
+  try {
+    await request('plugins.manage', scoped({ action: 'marketplace_add', url }, profile))
+    if ($pluginMarketplaceScope.get() === scopeKey) {
+      await loadPluginMarketplaces(request, profile, false, scopeKey)
+    }
+    return true
+  } catch (error) {
+    if ($pluginMarketplaceScope.get() === scopeKey) {
+      $pluginMarketplacesError.set(error instanceof Error ? error.message : String(error))
+    }
+    return false
+  } finally {
+    if ($pluginMarketplaceScope.get() === scopeKey) {
+      $pluginMarketplaceBusy.set(null)
+    }
+  }
+}
+
+export async function removePluginMarketplace(
+  request: GatewayRequest,
+  sourceId: string,
+  profile?: string | null,
+  scopeKey = profile ?? 'default'
+): Promise<boolean> {
+  $pluginMarketplaceBusy.set(sourceId)
+
+  try {
+    await request('plugins.manage', scoped({ action: 'marketplace_remove', source_id: sourceId }, profile))
+    if ($pluginMarketplaceScope.get() === scopeKey) {
+      await loadPluginMarketplaces(request, profile, false, scopeKey)
+    }
+    return true
+  } catch (error) {
+    if ($pluginMarketplaceScope.get() === scopeKey) {
+      $pluginMarketplacesError.set(error instanceof Error ? error.message : String(error))
+    }
+    return false
+  } finally {
+    if ($pluginMarketplaceScope.get() === scopeKey) {
+      $pluginMarketplaceBusy.set(null)
+    }
+  }
+}

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -191,7 +191,7 @@ describe('reportBackendContract', () => {
   })
 
   it('dismisses the toast when the backend meets the contract', () => {
-    reportBackendContract(6)
+    reportBackendContract(7)
     expect(dismissSpy).toHaveBeenCalledWith('backend-contract-skew')
     expect(notifySpy).not.toHaveBeenCalled()
   })
@@ -231,8 +231,8 @@ describe('reportBackendContract', () => {
     lastToast().onDismiss()
     notifySpy.mockClear()
 
-    reportBackendContract(6) // backend updated → satisfied, snooze cleared
-    reportBackendContract(5) // a later regression must warn immediately
+    reportBackendContract(7) // backend updated → satisfied, snooze cleared
+    reportBackendContract(6) // a later regression must warn immediately
     expect(notifySpy).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -101,7 +101,8 @@ function isUpdateToastSnoozed(): boolean {
 // v5: requires raised WebSocket frame size for large one-shot file.attach.
 // v6: requires key-addressed plugins.manage rows (keyless rows render
 //     read-only in Settings → Plugins).
-const REQUIRED_BACKEND_CONTRACT = 6
+// v7: requires profile-scoped Git marketplace source management.
+const REQUIRED_BACKEND_CONTRACT = 7
 const SKEW_TOAST_ID = 'backend-contract-skew'
 // The contract check runs on every session.resume (applyRuntimeInfo), so
 // without a snooze the warning re-popped on every thread the user opened, even

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -89,7 +89,7 @@ from hermes_cli.config import (
 )
 from hermes_constants import OPENROUTER_BASE_URL, secure_parent_dir
 from agent.credential_persistence import sanitize_borrowed_credential_payload
-from utils import atomic_replace, atomic_yaml_write, env_float, is_truthy_value
+from utils import atomic_replace, env_float, is_truthy_value
 
 logger = logging.getLogger(__name__)
 
@@ -7586,7 +7586,9 @@ def _update_config_for_provider(
 
     config["model"] = model_cfg
 
-    atomic_yaml_write(config_path, config, sort_keys=False)
+    from hermes_cli.config import atomic_config_write
+
+    atomic_config_write(config_path, config, sort_keys=False)
     return config_path
 
 
@@ -7654,7 +7656,9 @@ def _reset_config_provider() -> Path:
         model["provider"] = "auto"
         if "base_url" in model:
             model["base_url"] = OPENROUTER_BASE_URL
-    atomic_yaml_write(config_path, config, sort_keys=False)
+    from hermes_cli.config import atomic_config_write
+
+    atomic_config_write(config_path, config, sort_keys=False)
     return config_path
 
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -359,7 +359,7 @@ def config_write_lock():
         flags = os.O_RDWR | os.O_CREAT | os.O_APPEND | getattr(os, "O_CLOEXEC", 0)
         from utils import secure_open_file
 
-        fd = secure_open_file(path, get_hermes_home(), flags, create_parent=True)
+        fd = secure_open_file(path, path.parent, flags, create_parent=True)
         with os.fdopen(fd, "a+b") as handle:
             if os.name == "nt":
                 import errno

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -30,6 +30,7 @@ import tempfile
 import threading
 import time
 import unicodedata
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Any, Optional, List, Tuple, Set
@@ -163,6 +164,7 @@ def _warn_config_parse_failure(
     except Exception:
         pass
 
+
 _IS_WINDOWS = platform.system() == "Windows"
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
@@ -206,36 +208,65 @@ _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 # planting them.
 _ENV_VAR_NAME_DENYLIST: frozenset[str] = frozenset({
     # Loader / linker
-    "LD_PRELOAD", "LD_LIBRARY_PATH", "LD_AUDIT", "LD_DEBUG",
-    "DYLD_INSERT_LIBRARIES", "DYLD_LIBRARY_PATH", "DYLD_FRAMEWORK_PATH",
-    "DYLD_FALLBACK_LIBRARY_PATH", "DYLD_FALLBACK_FRAMEWORK_PATH",
+    "LD_PRELOAD",
+    "LD_LIBRARY_PATH",
+    "LD_AUDIT",
+    "LD_DEBUG",
+    "DYLD_INSERT_LIBRARIES",
+    "DYLD_LIBRARY_PATH",
+    "DYLD_FRAMEWORK_PATH",
+    "DYLD_FALLBACK_LIBRARY_PATH",
+    "DYLD_FALLBACK_FRAMEWORK_PATH",
     # Python
-    "PYTHONPATH", "PYTHONHOME", "PYTHONSTARTUP", "PYTHONUSERBASE",
-    "PYTHONEXECUTABLE", "PYTHONNOUSERSITE",
+    "PYTHONPATH",
+    "PYTHONHOME",
+    "PYTHONSTARTUP",
+    "PYTHONUSERBASE",
+    "PYTHONEXECUTABLE",
+    "PYTHONNOUSERSITE",
     # Node
-    "NODE_OPTIONS", "NODE_PATH",
+    "NODE_OPTIONS",
+    "NODE_PATH",
     # General
-    "PATH", "SHELL", "BROWSER", "EDITOR", "VISUAL", "PAGER",
+    "PATH",
+    "SHELL",
+    "BROWSER",
+    "EDITOR",
+    "VISUAL",
+    "PAGER",
     # Git
-    "GIT_SSH_COMMAND", "GIT_EXEC_PATH", "GIT_SHELL",
+    "GIT_SSH_COMMAND",
+    "GIT_EXEC_PATH",
+    "GIT_SHELL",
     # Hermes runtime location — never via dashboard env writer.
     # NOT a HERMES_* blanket: integration credentials (HERMES_GEMINI_*,
     # HERMES_LANGFUSE_*, HERMES_SPOTIFY_*, ...) ARE allowed.
-    "HERMES_HOME", "HERMES_PROFILE", "HERMES_CONFIG", "HERMES_ENV",
-    "HERMES_CONFIG_PATH", "HERMES_ENV_PATH",
+    "HERMES_HOME",
+    "HERMES_PROFILE",
+    "HERMES_CONFIG",
+    "HERMES_ENV",
+    "HERMES_CONFIG_PATH",
+    "HERMES_ENV_PATH",
     # MCP catalog trust root. Package-manager wrappers may still provide this
     # in the process environment; only generic persistence writes are blocked.
     "HERMES_OPTIONAL_MCPS",
     # Local ACP subprocess selection. Existing operator/package-manager values
     # remain readable; generic writers cannot acquire executable/argv authority.
-    "HERMES_COPILOT_ACP_COMMAND", "HERMES_COPILOT_ACP_ARGS",
+    "HERMES_COPILOT_ACP_COMMAND",
+    "HERMES_COPILOT_ACP_ARGS",
     # Hermes security policy / approval-routing context. These remain available
     # through their dedicated CLI/config/session controls, but a generic
     # credential writer must not persist them for the next process startup.
-    "HERMES_YOLO_MODE", "HERMES_ACCEPT_HOOKS", "HERMES_REDACT_SECRETS",
-    "HERMES_INTERACTIVE", "HERMES_EXEC_ASK", "HERMES_GATEWAY_SESSION",
-    "HERMES_CRON_SESSION", "HERMES_SINGLE_QUERY_SESSION",
-    "HERMES_SESSION_KEY", "HERMES_SESSION_PLATFORM",
+    "HERMES_YOLO_MODE",
+    "HERMES_ACCEPT_HOOKS",
+    "HERMES_REDACT_SECRETS",
+    "HERMES_INTERACTIVE",
+    "HERMES_EXEC_ASK",
+    "HERMES_GATEWAY_SESSION",
+    "HERMES_CRON_SESSION",
+    "HERMES_SINGLE_QUERY_SESSION",
+    "HERMES_SESSION_KEY",
+    "HERMES_SESSION_PLATFORM",
 })
 
 
@@ -278,6 +309,7 @@ def validate_env_var_name_for_write(key: str) -> None:
         raise ValueError(f"Invalid environment variable name: {key!r}")
     _reject_denylisted_env_var(key)
 
+
 _LAST_EXPANDED_CONFIG_BY_PATH: Dict[str, Any] = {}
 # (path, mtime_ns, size) -> cached expanded config dict.
 # load_config() returns a deepcopy of the cached value when the file
@@ -291,7 +323,9 @@ _LAST_EXPANDED_CONFIG_BY_PATH: Dict[str, Any] = {}
 # editing the managed-scope config.yaml invalidates the cache (see
 # managed_scope), and the env snapshot invalidates it when a referenced ${VAR}
 # changes value (late .env load, in-process rotation — #58514).
-_LOAD_CONFIG_CACHE: Dict[str, Tuple[int, int, int, int, Dict[str, Any], Dict[str, Optional[str]]]] = {}
+_LOAD_CONFIG_CACHE: Dict[
+    str, Tuple[int, int, int, int, Dict[str, Any], Dict[str, Optional[str]]]
+] = {}
 # (path, mtime_ns, size) -> cached raw yaml dict. Same pattern as
 # _LOAD_CONFIG_CACHE but for read_raw_config() — used when callers want
 # the user's on-disk values without defaults merged in.
@@ -304,40 +338,146 @@ _RAW_CONFIG_CACHE: Dict[str, Tuple[int, int, Dict[str, Any]]] = {}
 # calls read_raw_config. Also covers mutation of the module-level cache
 # dicts above.
 _CONFIG_LOCK = threading.RLock()
+_CONFIG_WRITE_PROCESS_LOCK = threading.RLock()
+_CONFIG_WRITE_DEPTH = threading.local()
+
+
+@contextmanager
+def config_write_lock():
+    """Serialize config read-modify-write transactions across processes."""
+    with _CONFIG_WRITE_PROCESS_LOCK:
+        depth = getattr(_CONFIG_WRITE_DEPTH, "value", 0)
+        if depth:
+            _CONFIG_WRITE_DEPTH.value = depth + 1
+            try:
+                yield
+            finally:
+                _CONFIG_WRITE_DEPTH.value -= 1
+            return
+
+        path = Path(str(get_config_path()) + ".lock")
+        flags = os.O_RDWR | os.O_CREAT | os.O_APPEND | getattr(os, "O_CLOEXEC", 0)
+        from utils import secure_open_file
+
+        fd = secure_open_file(path, get_hermes_home(), flags, create_parent=True)
+        with os.fdopen(fd, "a+b") as handle:
+            if os.name == "nt":
+                import errno
+                import msvcrt
+
+                handle.seek(0, os.SEEK_END)
+                if handle.tell() == 0:
+                    handle.write(b"0")
+                    handle.flush()
+                while True:
+                    handle.seek(0)
+                    try:
+                        msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+                        break
+                    except OSError as exc:
+                        if exc.errno not in {errno.EACCES, errno.EAGAIN, errno.EDEADLK}:
+                            raise
+                        time.sleep(0.1)
+            else:
+                import fcntl
+
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            _CONFIG_WRITE_DEPTH.value = 1
+            try:
+                yield
+            finally:
+                _CONFIG_WRITE_DEPTH.value = 0
+                if os.name == "nt":
+                    import msvcrt
+
+                    handle.seek(0)
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
 # Env var names written to .env that aren't in OPTIONAL_ENV_VARS
 # (managed by setup/provider flows directly).
 _EXTRA_ENV_KEYS = frozenset({
-    "OPENAI_API_KEY", "OPENAI_BASE_URL",
-    "ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN",
-    "DISCORD_HOME_CHANNEL", "DISCORD_HOME_CHANNEL_NAME",
-    "TELEGRAM_HOME_CHANNEL", "TELEGRAM_HOME_CHANNEL_NAME",
-    "SLACK_HOME_CHANNEL", "SLACK_HOME_CHANNEL_NAME",
-    "SIGNAL_ACCOUNT", "SIGNAL_HTTP_URL",
-    "SIGNAL_ALLOWED_USERS", "SIGNAL_GROUP_ALLOWED_USERS",
-    "SIGNAL_HOME_CHANNEL", "SIGNAL_HOME_CHANNEL_NAME",
-    "SMS_HOME_CHANNEL", "SMS_HOME_CHANNEL_NAME",
-    "DINGTALK_CLIENT_ID", "DINGTALK_CLIENT_SECRET",
-    "DINGTALK_HOME_CHANNEL", "DINGTALK_HOME_CHANNEL_NAME",
-    "FEISHU_APP_ID", "FEISHU_APP_SECRET", "FEISHU_ENCRYPT_KEY", "FEISHU_VERIFICATION_TOKEN",
-    "FEISHU_HOME_CHANNEL", "FEISHU_HOME_CHANNEL_NAME",
-    "YUANBAO_HOME_CHANNEL", "YUANBAO_HOME_CHANNEL_NAME",
-    "WECOM_BOT_ID", "WECOM_SECRET",
-    "WECOM_CALLBACK_CORP_ID", "WECOM_CALLBACK_CORP_SECRET", "WECOM_CALLBACK_AGENT_ID",
-    "WECOM_CALLBACK_TOKEN", "WECOM_CALLBACK_ENCODING_AES_KEY",
-    "WECOM_CALLBACK_HOST", "WECOM_CALLBACK_PORT",
-    "WECOM_HOME_CHANNEL", "WECOM_HOME_CHANNEL_NAME",
-    "WEIXIN_ACCOUNT_ID", "WEIXIN_TOKEN", "WEIXIN_BASE_URL", "WEIXIN_CDN_BASE_URL",
-    "WEIXIN_HOME_CHANNEL", "WEIXIN_HOME_CHANNEL_NAME", "WEIXIN_DM_POLICY", "WEIXIN_GROUP_POLICY",
-    "WEIXIN_ALLOWED_USERS", "WEIXIN_GROUP_ALLOWED_USERS", "WEIXIN_ALLOW_ALL_USERS",
-    "BLUEBUBBLES_SERVER_URL", "BLUEBUBBLES_PASSWORD",
-    "BLUEBUBBLES_HOME_CHANNEL", "BLUEBUBBLES_HOME_CHANNEL_NAME",
-    "QQ_APP_ID", "QQ_CLIENT_SECRET", "QQBOT_HOME_CHANNEL", "QQBOT_HOME_CHANNEL_NAME",
-    "QQ_HOME_CHANNEL", "QQ_HOME_CHANNEL_NAME",  # legacy aliases (pre-rename, still read for back-compat)
-    "QQ_ALLOWED_USERS", "QQ_GROUP_ALLOWED_USERS", "QQ_ALLOW_ALL_USERS", "QQ_MARKDOWN_SUPPORT",
-    "QQ_STT_API_KEY", "QQ_STT_BASE_URL", "QQ_STT_MODEL",
-    "IRC_SERVER", "IRC_PORT", "IRC_NICKNAME", "IRC_CHANNEL",
-    "IRC_USE_TLS", "IRC_SERVER_PASSWORD", "IRC_NICKSERV_PASSWORD",
-    "TERMINAL_ENV", "TERMINAL_SSH_KEY", "TERMINAL_SSH_PORT",
+    "OPENAI_API_KEY",
+    "OPENAI_BASE_URL",
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_TOKEN",
+    "DISCORD_HOME_CHANNEL",
+    "DISCORD_HOME_CHANNEL_NAME",
+    "TELEGRAM_HOME_CHANNEL",
+    "TELEGRAM_HOME_CHANNEL_NAME",
+    "SLACK_HOME_CHANNEL",
+    "SLACK_HOME_CHANNEL_NAME",
+    "SIGNAL_ACCOUNT",
+    "SIGNAL_HTTP_URL",
+    "SIGNAL_ALLOWED_USERS",
+    "SIGNAL_GROUP_ALLOWED_USERS",
+    "SIGNAL_HOME_CHANNEL",
+    "SIGNAL_HOME_CHANNEL_NAME",
+    "SMS_HOME_CHANNEL",
+    "SMS_HOME_CHANNEL_NAME",
+    "DINGTALK_CLIENT_ID",
+    "DINGTALK_CLIENT_SECRET",
+    "DINGTALK_HOME_CHANNEL",
+    "DINGTALK_HOME_CHANNEL_NAME",
+    "FEISHU_APP_ID",
+    "FEISHU_APP_SECRET",
+    "FEISHU_ENCRYPT_KEY",
+    "FEISHU_VERIFICATION_TOKEN",
+    "FEISHU_HOME_CHANNEL",
+    "FEISHU_HOME_CHANNEL_NAME",
+    "YUANBAO_HOME_CHANNEL",
+    "YUANBAO_HOME_CHANNEL_NAME",
+    "WECOM_BOT_ID",
+    "WECOM_SECRET",
+    "WECOM_CALLBACK_CORP_ID",
+    "WECOM_CALLBACK_CORP_SECRET",
+    "WECOM_CALLBACK_AGENT_ID",
+    "WECOM_CALLBACK_TOKEN",
+    "WECOM_CALLBACK_ENCODING_AES_KEY",
+    "WECOM_CALLBACK_HOST",
+    "WECOM_CALLBACK_PORT",
+    "WECOM_HOME_CHANNEL",
+    "WECOM_HOME_CHANNEL_NAME",
+    "WEIXIN_ACCOUNT_ID",
+    "WEIXIN_TOKEN",
+    "WEIXIN_BASE_URL",
+    "WEIXIN_CDN_BASE_URL",
+    "WEIXIN_HOME_CHANNEL",
+    "WEIXIN_HOME_CHANNEL_NAME",
+    "WEIXIN_DM_POLICY",
+    "WEIXIN_GROUP_POLICY",
+    "WEIXIN_ALLOWED_USERS",
+    "WEIXIN_GROUP_ALLOWED_USERS",
+    "WEIXIN_ALLOW_ALL_USERS",
+    "BLUEBUBBLES_SERVER_URL",
+    "BLUEBUBBLES_PASSWORD",
+    "BLUEBUBBLES_HOME_CHANNEL",
+    "BLUEBUBBLES_HOME_CHANNEL_NAME",
+    "QQ_APP_ID",
+    "QQ_CLIENT_SECRET",
+    "QQBOT_HOME_CHANNEL",
+    "QQBOT_HOME_CHANNEL_NAME",
+    "QQ_HOME_CHANNEL",
+    "QQ_HOME_CHANNEL_NAME",  # legacy aliases (pre-rename, still read for back-compat)
+    "QQ_ALLOWED_USERS",
+    "QQ_GROUP_ALLOWED_USERS",
+    "QQ_ALLOW_ALL_USERS",
+    "QQ_MARKDOWN_SUPPORT",
+    "QQ_STT_API_KEY",
+    "QQ_STT_BASE_URL",
+    "QQ_STT_MODEL",
+    "IRC_SERVER",
+    "IRC_PORT",
+    "IRC_NICKNAME",
+    "IRC_CHANNEL",
+    "IRC_USE_TLS",
+    "IRC_SERVER_PASSWORD",
+    "IRC_NICKSERV_PASSWORD",
+    "TERMINAL_ENV",
+    "TERMINAL_SSH_KEY",
+    "TERMINAL_SSH_PORT",
     # HERMES_TOOL_PROGRESS_MODE is deprecated (replaced by display.tool_progress
     # in config.yaml) but STILL READ at runtime by the gateway as a back-compat
     # fallback, so it must stay known to reload/compat paths. The boolean
@@ -345,10 +485,19 @@ _EXTRA_ENV_KEYS = frozenset({
     # support floor retired its only consumer (the v3→4 migration): it is no
     # longer listed here and doctor flags it as ignored.
     "HERMES_TOOL_PROGRESS_MODE",
-    "WHATSAPP_MODE", "WHATSAPP_ENABLED",
-    "MATTERMOST_HOME_CHANNEL", "MATTERMOST_HOME_CHANNEL_NAME", "MATTERMOST_REPLY_MODE",
-    "MATRIX_PASSWORD", "MATRIX_ENCRYPTION", "MATRIX_DEVICE_ID", "MATRIX_HOME_ROOM",
-    "MATRIX_REQUIRE_MENTION", "MATRIX_FREE_RESPONSE_ROOMS", "MATRIX_AUTO_THREAD", "MATRIX_DM_AUTO_THREAD",
+    "WHATSAPP_MODE",
+    "WHATSAPP_ENABLED",
+    "MATTERMOST_HOME_CHANNEL",
+    "MATTERMOST_HOME_CHANNEL_NAME",
+    "MATTERMOST_REPLY_MODE",
+    "MATRIX_PASSWORD",
+    "MATRIX_ENCRYPTION",
+    "MATRIX_DEVICE_ID",
+    "MATRIX_HOME_ROOM",
+    "MATRIX_REQUIRE_MENTION",
+    "MATRIX_FREE_RESPONSE_ROOMS",
+    "MATRIX_AUTO_THREAD",
+    "MATRIX_DM_AUTO_THREAD",
     "MATRIX_RECOVERY_KEY",
     # Langfuse observability plugin — optional tuning keys + standard SDK vars.
     # Activation is via plugins.enabled (opt-in through `hermes plugins enable
@@ -412,7 +561,12 @@ def get_managed_system() -> Optional[str]:
         # names the system that manages the install.
         if managed_marker.exists():
             try:
-                marker = managed_marker.read_text(encoding="utf-8", errors="replace").strip().lower()
+                marker = (
+                    managed_marker
+                    .read_text(encoding="utf-8", errors="replace")
+                    .strip()
+                    .lower()
+                )
             except OSError:
                 marker = ""
 
@@ -522,7 +676,15 @@ def detect_install_method(project_root: Optional[Path] = None) -> str:
     # "home-manager" is here because step 3 can return it. A stamp must name
     # every method that this function returns. Without it, the stamp of a
     # home-manager install gives "unknown".
-    supported_methods = {"apt", "docker", "nix", "nixos", "home-manager", "git", "unknown"}
+    supported_methods = {
+        "apt",
+        "docker",
+        "nix",
+        "nixos",
+        "home-manager",
+        "git",
+        "unknown",
+    }
 
     # 1. Code-scoped stamp — authoritative, immune to shared $HERMES_HOME.
     try:
@@ -543,7 +705,9 @@ def detect_install_method(project_root: Optional[Path] = None) -> str:
             .strip()
             .lower()
         )
-        if method in supported_methods and not (method == "docker" and not _running_in_container()):
+        if method in supported_methods and not (
+            method == "docker" and not _running_in_container()
+        ):
             return method
     except OSError:
         pass
@@ -705,6 +869,7 @@ def format_managed_message(action: str = "modify this Hermes installation") -> s
         "Use your package manager to upgrade or reinstall Hermes."
     )
 
+
 def managed_error(action: str = "modify configuration"):
     """Print user-friendly error for managed mode."""
     print(format_managed_message(action), file=sys.stderr)
@@ -713,6 +878,7 @@ def managed_error(action: str = "modify configuration"):
 # =============================================================================
 # Container-aware CLI (NixOS container mode)
 # =============================================================================
+
 
 def get_container_exec_info() -> Optional[dict]:
     """Read container mode metadata from HERMES_HOME/.container-mode.
@@ -729,6 +895,7 @@ def get_container_exec_info() -> Optional[dict]:
         return None
 
     from hermes_constants import is_container
+
     if is_container():
         return None
 
@@ -767,17 +934,21 @@ def get_container_exec_info() -> Optional[dict]:
 from hermes_constants import get_hermes_home, get_process_hermes_home  # noqa: F811,E402
 from utils import atomic_replace, fast_safe_load
 
+
 def get_config_path() -> Path:
     """Get the main config file path."""
     return get_hermes_home() / "config.yaml"
+
 
 def get_env_path() -> Path:
     """Get the .env file path (for API keys)."""
     return get_hermes_home() / ".env"
 
+
 def get_project_root() -> Path:
     """Get the project installation directory."""
     return Path(__file__).parent.parent.resolve()
+
 
 def _resolve_hermes_uid_gid() -> tuple[Optional[int], Optional[int]]:
     """Read the HERMES_UID / HERMES_GID env vars set by Docker deployments.
@@ -888,7 +1059,11 @@ def _is_container() -> bool:
     try:
         with open("/proc/1/cgroup", "r", encoding="utf-8") as f:
             cgroup_content = f.read()
-        if "docker" in cgroup_content or "lxc" in cgroup_content or "kubepods" in cgroup_content:
+        if (
+            "docker" in cgroup_content
+            or "lxc" in cgroup_content
+            or "kubepods" in cgroup_content
+        ):
             return True
     except (OSError, IOError):
         pass
@@ -979,8 +1154,16 @@ def ensure_hermes_home():
         home.mkdir(parents=True, exist_ok=True)
         _secure_dir(home)
         for subdir in (
-            "cron", "sessions", "logs", "logs/curator", "memories",
-            "pairing", "hooks", "image_cache", "audio_cache", "skills",
+            "cron",
+            "sessions",
+            "logs",
+            "logs/curator",
+            "memories",
+            "pairing",
+            "hooks",
+            "image_cache",
+            "audio_cache",
+            "skills",
         ):
             d = home / subdir
             d.mkdir(parents=True, exist_ok=True)
@@ -993,9 +1176,7 @@ def ensure_hermes_home():
 def _ensure_hermes_home_managed(home: Path):
     """Managed-mode variant: verify dirs exist (activation creates them), seed SOUL.md."""
     if not home.is_dir():
-        raise RuntimeError(
-            f"HERMES_HOME {home} does not exist."
-        )
+        raise RuntimeError(f"HERMES_HOME {home} does not exist.")
     for subdir in ("cron", "sessions", "logs", "memories"):
         d = home / subdir
         if not d.is_dir():
@@ -1021,10 +1202,21 @@ from hermes_cli.config_defaults import DEFAULT_CONFIG, OPTIONAL_ENV_VARS  # noqa
 # Track which env vars were introduced in each config version.
 # Migration only mentions vars new since the user's previous version.
 ENV_VARS_BY_VERSION: Dict[int, List[str]] = {
-    3: ["FIRECRAWL_API_KEY", "BROWSERBASE_API_KEY", "BROWSERBASE_PROJECT_ID", "FAL_KEY"],
+    3: [
+        "FIRECRAWL_API_KEY",
+        "BROWSERBASE_API_KEY",
+        "BROWSERBASE_PROJECT_ID",
+        "FAL_KEY",
+    ],
     4: ["VOICE_TOOLS_OPENAI_KEY", "ELEVENLABS_API_KEY"],
-    5: ["WHATSAPP_ENABLED", "WHATSAPP_MODE", "WHATSAPP_ALLOWED_USERS",
-        "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_ALLOWED_USERS"],
+    5: [
+        "WHATSAPP_ENABLED",
+        "WHATSAPP_MODE",
+        "WHATSAPP_ALLOWED_USERS",
+        "SLACK_BOT_TOKEN",
+        "SLACK_APP_TOKEN",
+        "SLACK_ALLOWED_USERS",
+    ],
     10: ["TAVILY_API_KEY"],
     11: ["TERMINAL_MODAL_MODE"],
 }
@@ -1042,22 +1234,22 @@ REQUIRED_ENV_VARS = {}
 def get_missing_env_vars(required_only: bool = False) -> List[Dict[str, Any]]:
     """
     Check which environment variables are missing.
-    
+
     Returns list of dicts with var info for missing variables.
     """
     missing = []
-    
+
     # Check required vars
     for var_name, info in REQUIRED_ENV_VARS.items():
         if not get_env_value(var_name):
             missing.append({"name": var_name, **info, "is_required": True})
-    
+
     # Check optional vars (if not required_only)
     if not required_only:
         for var_name, info in OPTIONAL_ENV_VARS.items():
             if not get_env_value(var_name):
                 missing.append({"name": var_name, **info, "is_required": False})
-    
+
     return missing
 
 
@@ -1227,20 +1419,38 @@ def _is_env_config_key(key: str) -> bool:
         return False
     key_upper = key.upper()
     api_keys = [
-        'OPENROUTER_API_KEY', 'OPENAI_API_KEY', 'ANTHROPIC_API_KEY', 'VOICE_TOOLS_OPENAI_KEY',
-        'EXA_API_KEY', 'PARALLEL_API_KEY', 'FIRECRAWL_API_KEY', 'FIRECRAWL_API_URL',
-        'FIRECRAWL_GATEWAY_URL', 'TOOL_GATEWAY_DOMAIN', 'TOOL_GATEWAY_SCHEME',
-        'TOOL_GATEWAY_USER_TOKEN', 'TAVILY_API_KEY',
-        'BROWSERBASE_API_KEY', 'BROWSERBASE_PROJECT_ID', 'BROWSER_USE_API_KEY',
-        'FAL_KEY', 'TELEGRAM_BOT_TOKEN', 'DISCORD_BOT_TOKEN',
-        'TERMINAL_SSH_HOST', 'TERMINAL_SSH_USER', 'TERMINAL_SSH_KEY',
-        'SUDO_PASSWORD', 'SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN',
-        'GITHUB_TOKEN', 'HONCHO_API_KEY',
+        "OPENROUTER_API_KEY",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "VOICE_TOOLS_OPENAI_KEY",
+        "EXA_API_KEY",
+        "PARALLEL_API_KEY",
+        "FIRECRAWL_API_KEY",
+        "FIRECRAWL_API_URL",
+        "FIRECRAWL_GATEWAY_URL",
+        "TOOL_GATEWAY_DOMAIN",
+        "TOOL_GATEWAY_SCHEME",
+        "TOOL_GATEWAY_USER_TOKEN",
+        "TAVILY_API_KEY",
+        "BROWSERBASE_API_KEY",
+        "BROWSERBASE_PROJECT_ID",
+        "BROWSER_USE_API_KEY",
+        "FAL_KEY",
+        "TELEGRAM_BOT_TOKEN",
+        "DISCORD_BOT_TOKEN",
+        "TERMINAL_SSH_HOST",
+        "TERMINAL_SSH_USER",
+        "TERMINAL_SSH_KEY",
+        "SUDO_PASSWORD",
+        "SLACK_BOT_TOKEN",
+        "SLACK_APP_TOKEN",
+        "GITHUB_TOKEN",
+        "HONCHO_API_KEY",
     ]
     return (
         key_upper in api_keys
-        or key_upper.endswith(('_API_KEY', '_TOKEN', '_SECRET'))
-        or key_upper.startswith('TERMINAL_SSH')
+        or key_upper.endswith(("_API_KEY", "_TOKEN", "_SECRET"))
+        or key_upper.startswith("TERMINAL_SSH")
     )
 
 
@@ -1248,6 +1458,7 @@ def _format_config_get_value(value, *, as_json: bool) -> str:
     """Format a config value for command-line output."""
     if as_json:
         import json
+
         return json.dumps(value, ensure_ascii=False)
     if isinstance(value, bool):
         return "true" if value else "false"
@@ -1261,7 +1472,7 @@ def _format_config_get_value(value, *, as_json: bool) -> str:
 def get_missing_config_fields() -> List[Dict[str, Any]]:
     """
     Check which config fields are missing or outdated (recursive).
-    
+
     Walks the DEFAULT_CONFIG tree at arbitrary depth and reports any keys
     present in defaults but absent from the user's loaded config.
     """
@@ -1270,7 +1481,7 @@ def get_missing_config_fields() -> List[Dict[str, Any]]:
 
     def _check(defaults: dict, current: dict, prefix: str = ""):
         for key, default_value in defaults.items():
-            if key.startswith('_'):
+            if key.startswith("_"):
                 continue
             full_key = key if not prefix else f"{prefix}.{key}"
             if key not in current:
@@ -1294,7 +1505,10 @@ def get_missing_skill_config_vars() -> List[Dict[str, Any]]:
     config.yaml.  Returns a list of dicts suitable for prompting.
     """
     try:
-        from agent.skill_utils import discover_all_skill_config_vars, SKILL_CONFIG_PREFIX
+        from agent.skill_utils import (
+            discover_all_skill_config_vars,
+            SKILL_CONFIG_PREFIX,
+        )
     except Exception:
         return []
 
@@ -1305,6 +1519,7 @@ def get_missing_skill_config_vars() -> List[Dict[str, Any]]:
         # should never break `hermes update`.  Skill-config prompting is a
         # post-migration nicety, not a blocker.
         import logging
+
         logging.getLogger(__name__).debug(
             "discover_all_skill_config_vars failed: %s", e
         )
@@ -1417,7 +1632,9 @@ def stringify_provider_map(providers: Any) -> dict:
     return out
 
 
-def find_provider_entry(providers: Any, key: Any) -> Tuple[Any, Optional[Dict[str, Any]]]:
+def find_provider_entry(
+    providers: Any, key: Any
+) -> Tuple[Any, Optional[Dict[str, Any]]]:
     """Return ``(stored_key, entry)`` matching *key* by string identity.
 
     Needed because PyYAML may have stored the key as ``2070`` (int) while
@@ -1478,30 +1695,50 @@ def _normalize_custom_provider_entry(
         # into provider entries. Accept it silently so those (self-written)
         # configs don't warn on every load.
         "provider",
-        "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
+        "name",
+        "api",
+        "url",
+        "base_url",
+        "api_key",
+        "key_env",
+        "api_key_env",
         "key_cmd",
-        "api_mode", "transport", "model", "default_model", "models",
+        "api_mode",
+        "transport",
+        "model",
+        "default_model",
+        "models",
         "models_discovered",
-        "context_length", "rate_limit_delay",
-        "request_timeout_seconds", "stale_timeout_seconds",
-        "discover_models", "extra_body", "extra_headers",
-        "ssl_ca_cert", "ssl_verify",
+        "context_length",
+        "rate_limit_delay",
+        "request_timeout_seconds",
+        "stale_timeout_seconds",
+        "discover_models",
+        "extra_body",
+        "extra_headers",
+        "ssl_ca_cert",
+        "ssl_verify",
     }
     for camel, snake in _CAMEL_ALIASES.items():
         if camel in entry and snake not in entry:
             _warn_once_per_provider(
-                provider_key, f"camel:{camel}",
+                provider_key,
+                f"camel:{camel}",
                 "providers.%s: camelCase key '%s' auto-mapped to '%s' "
                 "(use snake_case to avoid this warning)",
-                provider_key or "?", camel, snake,
+                provider_key or "?",
+                camel,
+                snake,
             )
             entry[snake] = entry[camel]
     unknown = set(entry.keys()) - _KNOWN_KEYS - set(_CAMEL_ALIASES.keys())
     if unknown:
         _warn_once_per_provider(
-            provider_key, "unknown:" + ",".join(sorted(unknown)),
+            provider_key,
+            "unknown:" + ",".join(sorted(unknown)),
             "providers.%s: unknown config keys ignored: %s",
-            provider_key or "?", ", ".join(sorted(unknown)),
+            provider_key or "?",
+            ", ".join(sorted(unknown)),
         )
 
     from urllib.parse import urlparse
@@ -1527,7 +1764,9 @@ def _normalize_custom_provider_entry(
                 logger.warning(
                     "providers.%s: '%s' value '%s' is not a valid URL "
                     "(no scheme or host) — skipped",
-                    provider_key or "?", url_key, candidate,
+                    provider_key or "?",
+                    url_key,
+                    candidate,
                 )
     if not base_url:
         return None
@@ -1599,9 +1838,7 @@ def _normalize_custom_provider_entry(
                 model_id = item.get("name")
             if not isinstance(model_id, str) or not model_id.strip():
                 continue
-            model_meta = {
-                k: v for k, v in item.items() if k not in {"id", "name"}
-            }
+            model_meta = {k: v for k, v in item.items() if k not in {"id", "name"}}
             normalized_models[model_id.strip()] = model_meta
         if normalized_models:
             normalized["models"] = normalized_models
@@ -1881,7 +2118,9 @@ def apply_custom_provider_extra_headers_to_client_kwargs(
 
     SECURITY: values may carry credentials — never log them.
     """
-    extra_headers = get_custom_provider_extra_headers(base_url, custom_providers, config)
+    extra_headers = get_custom_provider_extra_headers(
+        base_url, custom_providers, config
+    )
     if not extra_headers:
         return
     merged = dict(client_kwargs.get("default_headers") or {})
@@ -2078,40 +2317,48 @@ def check_config_version() -> Tuple[int, int]:
 # absent from DEFAULT_CONFIG (omitted when unused / alternate schema forms).
 _EXTRA_KNOWN_ROOT_KEYS = {
     "custom_providers",  # legacy list form; modern equivalent is providers: {}
-    "fallback_model",    # optional single dict or chain list; omitted when disabled
-    "mcp_servers",       # MCP server definitions written by setup/tools flows
+    "fallback_model",  # optional single dict or chain list; omitted when disabled
+    "mcp_servers",  # MCP server definitions written by setup/tools flows
     # Roots read from the raw user YAML (or written by our own flows) that are
     # intentionally absent from DEFAULT_CONFIG:
-    "image_gen",         # image-generation provider config (agent/image_gen_registry.py)
-    "video_gen",         # video-generation provider config (agent/video_gen_registry.py)
-    "plugins",           # plugin enable/disable lists (hermes_cli/plugins_cmd.py)
-    "smart_model_routing",   # written by the setup wizard (hermes_cli/setup.py)
-    "platform_toolsets",     # written by the setup wizard (hermes_cli/setup.py)
-    "known_plugin_toolsets", # written/read by hermes_cli/tools_config.py toolset-save flow
+    "image_gen",  # image-generation provider config (agent/image_gen_registry.py)
+    "video_gen",  # video-generation provider config (agent/video_gen_registry.py)
+    "plugins",  # plugin enable/disable lists (hermes_cli/plugins_cmd.py)
+    "smart_model_routing",  # written by the setup wizard (hermes_cli/setup.py)
+    "platform_toolsets",  # written by the setup wizard (hermes_cli/setup.py)
+    "known_plugin_toolsets",  # written/read by hermes_cli/tools_config.py toolset-save flow
     "known_builtin_toolsets",  # ditto — which builtin toolsets a platform's checklist has offered
     "tool_gateway_declined_tools",  # per-tool Tool Gateway offer declines (hermes_cli/nous_subscription.py, #92647)
-    "session_reset",         # top-level form read by gateway/config.py + setup
-    "group_sessions_per_user",   # top-level form bridged by gateway/config.py
+    "session_reset",  # top-level form read by gateway/config.py + setup
+    "group_sessions_per_user",  # top-level form bridged by gateway/config.py
     "thread_sessions_per_user",  # top-level form bridged by gateway/config.py
-    "stt_echo_transcripts",      # top-level form bridged by gateway/config.py
-    "reset_triggers",            # top-level form bridged by gateway/config.py
-    "always_log_local",          # top-level form bridged by gateway/config.py
+    "stt_echo_transcripts",  # top-level form bridged by gateway/config.py
+    "reset_triggers",  # top-level form bridged by gateway/config.py
+    "always_log_local",  # top-level form bridged by gateway/config.py
     "filter_silence_narration",  # top-level form bridged by gateway/config.py
-    "multiplex_profiles",    # top-level form accepted alongside gateway.multiplex_profiles
-    "profile_routes",        # top-level form accepted alongside gateway.profile_routes
-    "platforms",             # top-level per-platform map merged by gateway/config.py
-    "require_mention",       # top-level convenience form honored by the gateway (#3979)
+    "multiplex_profiles",  # top-level form accepted alongside gateway.multiplex_profiles
+    "profile_routes",  # top-level form accepted alongside gateway.profile_routes
+    "platforms",  # top-level per-platform map merged by gateway/config.py
+    "require_mention",  # top-level convenience form honored by the gateway (#3979)
     "unauthorized_dm_behavior",  # top-level form read by gateway/config.py
-    "signal",            # Signal settings bridged to env vars by gateway/config.py
-    "timeouts",          # unified timeout resolution section (agent/deadline.py, #85125)
+    "signal",  # Signal settings bridged to env vars by gateway/config.py
+    "timeouts",  # unified timeout resolution section (agent/deadline.py, #85125)
 }
 _KNOWN_ROOT_KEYS = frozenset(DEFAULT_CONFIG.keys()) | _EXTRA_KNOWN_ROOT_KEYS
 
 # Valid fields inside a custom_providers list entry
 _VALID_CUSTOM_PROVIDER_FIELDS = {
-    "name", "base_url", "api_key", "api_mode", "model", "models",
-    "context_length", "rate_limit_delay", "extra_body",
-    "ssl_ca_cert", "ssl_verify",
+    "name",
+    "base_url",
+    "api_key",
+    "api_mode",
+    "model",
+    "models",
+    "context_length",
+    "rate_limit_delay",
+    "extra_body",
+    "ssl_ca_cert",
+    "ssl_verify",
     # key_env is read at runtime by runtime_provider.py and auxiliary_client.py
     # — include it here so the set accurately describes the supported schema.
     "key_env",
@@ -2130,7 +2377,9 @@ class ConfigIssue:
     hint: str
 
 
-def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["ConfigIssue"]:
+def validate_config_structure(
+    config: Optional[Dict[str, Any]] = None,
+) -> List["ConfigIssue"]:
     """Validate config.yaml structure and return a list of detected issues.
 
     Catches common YAML formatting mistakes that produce confusing runtime
@@ -2142,7 +2391,13 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
         try:
             config = load_config()
         except Exception:
-            return [ConfigIssue("error", "Could not load config.yaml", "Run 'hermes setup' to create a valid config")]
+            return [
+                ConfigIssue(
+                    "error",
+                    "Could not load config.yaml",
+                    "Run 'hermes setup' to create a valid config",
+                )
+            ]
 
     issues: List[ConfigIssue] = []
 
@@ -2154,56 +2409,68 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
             submit_mode.strip().lower() if isinstance(submit_mode, str) else None
         )
         if normalized_submit_mode not in {"direct", "draft"}:
-            issues.append(ConfigIssue(
-                "error",
-                f"voice.submit_mode must be 'direct' or 'draft', got {submit_mode!r}",
-                "Set voice.submit_mode to direct (submit immediately) or draft (edit before sending)",
-            ))
+            issues.append(
+                ConfigIssue(
+                    "error",
+                    f"voice.submit_mode must be 'direct' or 'draft', got {submit_mode!r}",
+                    "Set voice.submit_mode to direct (submit immediately) or draft (edit before sending)",
+                )
+            )
 
     # ── custom_providers must be a list, not a dict ──────────────────────
     cp = config.get("custom_providers")
     if cp is not None:
         if isinstance(cp, dict):
-            issues.append(ConfigIssue(
-                "error",
-                "custom_providers is a dict — it must be a YAML list (items prefixed with '-')",
-                "Change to:\n"
-                "  custom_providers:\n"
-                "    - name: my-provider\n"
-                "      base_url: https://...\n"
-                "      api_key: ...",
-            ))
+            issues.append(
+                ConfigIssue(
+                    "error",
+                    "custom_providers is a dict — it must be a YAML list (items prefixed with '-')",
+                    "Change to:\n"
+                    "  custom_providers:\n"
+                    "    - name: my-provider\n"
+                    "      base_url: https://...\n"
+                    "      api_key: ...",
+                )
+            )
             # Check if dict keys look like they should be list-entry fields
             cp_keys = set(cp.keys()) if isinstance(cp, dict) else set()
             suspicious = cp_keys & _CUSTOM_PROVIDER_LIKE_FIELDS
             if suspicious:
-                issues.append(ConfigIssue(
-                    "warning",
-                    f"Root-level keys {sorted(suspicious)} look like custom_providers entry fields",
-                    "These should be indented under a '- name: ...' list entry, not at root level",
-                ))
+                issues.append(
+                    ConfigIssue(
+                        "warning",
+                        f"Root-level keys {sorted(suspicious)} look like custom_providers entry fields",
+                        "These should be indented under a '- name: ...' list entry, not at root level",
+                    )
+                )
         elif isinstance(cp, list):
             # Validate each entry in the list
             for i, entry in enumerate(cp):
                 if not isinstance(entry, dict):
-                    issues.append(ConfigIssue(
-                        "warning",
-                        f"custom_providers[{i}] is not a dict (got {type(entry).__name__})",
-                        "Each entry should have at minimum: name, base_url",
-                    ))
+                    issues.append(
+                        ConfigIssue(
+                            "warning",
+                            f"custom_providers[{i}] is not a dict (got {type(entry).__name__})",
+                            "Each entry should have at minimum: name, base_url",
+                        )
+                    )
                     continue
                 if not entry.get("name"):
-                    issues.append(ConfigIssue(
-                        "warning",
-                        f"custom_providers[{i}] is missing 'name' field",
-                        "Add a name, e.g.: name: my-provider",
-                    ))
+                    issues.append(
+                        ConfigIssue(
+                            "warning",
+                            f"custom_providers[{i}] is missing 'name' field",
+                            "Add a name, e.g.: name: my-provider",
+                        )
+                    )
                 if not entry.get("base_url"):
-                    issues.append(ConfigIssue(
-                        "warning",
-                        f"custom_providers[{i}] is missing 'base_url' field",
-                        "Add the API endpoint URL, e.g.: base_url: https://api.example.com/v1",
-                    ))
+                    issues.append(
+                        ConfigIssue(
+                            "warning",
+                            f"custom_providers[{i}] is missing 'base_url' field",
+                            "Add the API endpoint URL, e.g.: base_url: https://api.example.com/v1",
+                        )
+                    )
 
     # ── fallback_model: single dict OR list of dicts (chain) ─────────────
     fb = config.get("fallback_model")
@@ -2212,67 +2479,87 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
             # Chain fallback — validate each entry
             for i, entry in enumerate(fb):
                 if not isinstance(entry, dict):
-                    issues.append(ConfigIssue(
-                        "error",
-                        f"fallback_model[{i}] should be a dict, got {type(entry).__name__}",
-                        "Each entry needs provider + model",
-                    ))
+                    issues.append(
+                        ConfigIssue(
+                            "error",
+                            f"fallback_model[{i}] should be a dict, got {type(entry).__name__}",
+                            "Each entry needs provider + model",
+                        )
+                    )
                 else:
                     if not entry.get("provider"):
-                        issues.append(ConfigIssue(
-                            "warning",
-                            f"fallback_model[{i}] is missing 'provider' field",
-                            "Add: provider: openrouter (or another provider)",
-                        ))
+                        issues.append(
+                            ConfigIssue(
+                                "warning",
+                                f"fallback_model[{i}] is missing 'provider' field",
+                                "Add: provider: openrouter (or another provider)",
+                            )
+                        )
                     if not entry.get("model"):
-                        issues.append(ConfigIssue(
-                            "warning",
-                            f"fallback_model[{i}] is missing 'model' field",
-                            "Add: model: <model-name>",
-                        ))
+                        issues.append(
+                            ConfigIssue(
+                                "warning",
+                                f"fallback_model[{i}] is missing 'model' field",
+                                "Add: model: <model-name>",
+                            )
+                        )
         elif not isinstance(fb, dict):
-            issues.append(ConfigIssue(
-                "error",
-                f"fallback_model should be a dict with 'provider' and 'model', got {type(fb).__name__}",
-                "Change to:\n"
-                "  fallback_model:\n"
-                "    provider: openrouter\n"
-                "    model: anthropic/claude-sonnet-4",
-            ))
+            issues.append(
+                ConfigIssue(
+                    "error",
+                    f"fallback_model should be a dict with 'provider' and 'model', got {type(fb).__name__}",
+                    "Change to:\n"
+                    "  fallback_model:\n"
+                    "    provider: openrouter\n"
+                    "    model: anthropic/claude-sonnet-4",
+                )
+            )
         elif fb:
             if not fb.get("provider"):
-                issues.append(ConfigIssue(
-                    "warning",
-                    "fallback_model is missing 'provider' field — fallback will be disabled",
-                    "Add: provider: openrouter (or another provider)",
-                ))
+                issues.append(
+                    ConfigIssue(
+                        "warning",
+                        "fallback_model is missing 'provider' field — fallback will be disabled",
+                        "Add: provider: openrouter (or another provider)",
+                    )
+                )
             if not fb.get("model"):
-                issues.append(ConfigIssue(
-                    "warning",
-                    "fallback_model is missing 'model' field — fallback will be disabled",
-                    "Add: model: anthropic/claude-sonnet-4 (or another model)",
-                ))
+                issues.append(
+                    ConfigIssue(
+                        "warning",
+                        "fallback_model is missing 'model' field — fallback will be disabled",
+                        "Add: model: anthropic/claude-sonnet-4 (or another model)",
+                    )
+                )
 
     # ── Check for fallback_model accidentally nested inside custom_providers ──
-    if isinstance(cp, dict) and "fallback_model" not in config and "fallback_model" in (cp or {}):
-        issues.append(ConfigIssue(
-            "error",
-            "fallback_model appears inside custom_providers instead of at root level",
-            "Move fallback_model to the top level of config.yaml (no indentation)",
-        ))
+    if (
+        isinstance(cp, dict)
+        and "fallback_model" not in config
+        and "fallback_model" in (cp or {})
+    ):
+        issues.append(
+            ConfigIssue(
+                "error",
+                "fallback_model appears inside custom_providers instead of at root level",
+                "Move fallback_model to the top level of config.yaml (no indentation)",
+            )
+        )
 
     # ── model section: should exist when custom_providers is configured ──
     model_cfg = config.get("model")
     if cp and not model_cfg:
-        issues.append(ConfigIssue(
-            "warning",
-            "custom_providers defined but no 'model' section — Hermes won't know which provider to use",
-            "Add a model section:\n"
-            "  model:\n"
-            "    provider: custom\n"
-            "    default: your-model-name\n"
-            "    base_url: https://...",
-        ))
+        issues.append(
+            ConfigIssue(
+                "warning",
+                "custom_providers defined but no 'model' section — Hermes won't know which provider to use",
+                "Add a model section:\n"
+                "  model:\n"
+                "    provider: custom\n"
+                "    default: your-model-name\n"
+                "    base_url: https://...",
+            )
+        )
 
     # ── Root-level keys that look misplaced ──────────────────────────────
     # Only provider-like fields (base_url, api_key, …) are flagged. Arbitrary
@@ -2284,11 +2571,13 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
         if key.startswith("_"):
             continue
         if key not in _KNOWN_ROOT_KEYS and key in _CUSTOM_PROVIDER_LIKE_FIELDS:
-            issues.append(ConfigIssue(
-                "warning",
-                f"Root-level key '{key}' looks misplaced — should it be under 'model:' or inside a 'custom_providers' entry?",
-                f"Move '{key}' under the appropriate section",
-            ))
+            issues.append(
+                ConfigIssue(
+                    "warning",
+                    f"Root-level key '{key}' looks misplaced — should it be under 'model:' or inside a 'custom_providers' entry?",
+                    f"Move '{key}' under the appropriate section",
+                )
+            )
 
     return issues
 
@@ -2357,7 +2646,12 @@ def warn_deprecated_cwd_env_vars() -> None:
         sys.stderr.write("\n".join(lines) + "\n\n")
 
 
-def _persist_migration(config: Dict[str, Any]) -> None:
+def _persist_migration(
+    config: Dict[str, Any],
+    *,
+    preserve_plugin_state: bool = True,
+    preserve_platform_toolsets: bool = True,
+) -> None:
     """Persist a migrated config under the migration write invariant.
 
     THE INVARIANT (single source of truth for the whole migration pipeline):
@@ -2380,17 +2674,29 @@ def _persist_migration(config: Dict[str, Any]) -> None:
     just deleted. Partial-save preservation for unrelated top-level sections
     belongs on ``save_config(..., merge_existing=True)``, not here.
     """
-    save_config(config)
+    save_config(
+        config,
+        preserve_plugin_state=preserve_plugin_state,
+        preserve_platform_toolsets=preserve_platform_toolsets,
+    )
 
 
 def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, Any]:
+    """Run the complete migration decision and write sequence transactionally."""
+    with config_write_lock():
+        return _migrate_config_locked(interactive=interactive, quiet=quiet)
+
+
+def _migrate_config_locked(
+    interactive: bool = True, quiet: bool = False
+) -> Dict[str, Any]:
     """
     Migrate config to latest version, prompting for new required fields.
-    
+
     Args:
         interactive: If True, prompt user for missing values
         quiet: If True, suppress output
-        
+
     Returns:
         Dict with migration results: {"env_added": [...], "config_added": [...], "warnings": [...]}
     """
@@ -2451,7 +2757,8 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
         # original sequential if-block semantics byte-for-byte. Imported lazily
         # to avoid a module-level import cycle (the steps call back into this
         # module for read_raw_config/_persist_migration/etc. at call time).
-        run_migrations(current_ver, results, quiet)
+        with config_write_lock():
+            run_migrations(current_ver, results, quiet)
 
     # ── Post-migration: disable exfiltration-shaped MCP stdio entries ──
     # Users can hand-edit mcp_servers, and older installs may already contain a
@@ -2461,7 +2768,9 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
     raw_mcp_servers = config.get("mcp_servers")
     if isinstance(raw_mcp_servers, dict):
         try:
-            from hermes_cli.mcp_security import validate_mcp_server_entry as _validate_mcp_server_entry
+            from hermes_cli.mcp_security import (
+                validate_mcp_server_entry as _validate_mcp_server_entry,
+            )
         except Exception:
             _validate_mcp_server_entry = None
         if _validate_mcp_server_entry:
@@ -2510,40 +2819,43 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
 
     # Check for missing required env vars
     missing_env = get_missing_env_vars(required_only=True)
-    
+
     if missing_env and not quiet:
         print("\n⚠️  Missing required environment variables:")
         for var in missing_env:
             print(f"   • {var['name']}: {var['description']}")
-    
+
     if interactive and missing_env:
         print("\nLet's configure them now:\n")
         for var in missing_env:
             if var.get("url"):
                 print(f"  Get your key at: {var['url']}")
-            
+
             if var.get("password"):
                 value = masked_secret_prompt(f"  {var['prompt']}: ")
             else:
                 value = line_input(f"  {var['prompt']}: ").strip()
-            
+
             if value:
                 save_env_value(var["name"], value)
                 results["env_added"].append(var["name"])
                 print(f"  ✓ Saved {var['name']}")
             else:
-                results["warnings"].append(f"Skipped {var['name']} - some features may not work")
+                results["warnings"].append(
+                    f"Skipped {var['name']} - some features may not work"
+                )
             print()
-    
+
     # Check for missing optional env vars and offer to configure interactively
     # Skip "advanced" vars (like OPENAI_BASE_URL) -- those are for power users
     missing_optional = get_missing_env_vars(required_only=False)
     required_names = {v["name"] for v in missing_env} if missing_env else set()
     missing_optional = [
-        v for v in missing_optional
+        v
+        for v in missing_optional
         if v["name"] not in required_names and not v.get("advanced")
     ]
-    
+
     # Only offer to configure env vars that are NEW since the user's previous version
     new_var_names = set()
     for ver in range(current_ver + 1, latest_ver + 1):
@@ -2578,7 +2890,9 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                             f"  {info.get('prompt', name)} (Enter to skip): "
                         )
                     else:
-                        value = line_input(f"  {info.get('prompt', name)} (Enter to skip): ").strip()
+                        value = line_input(
+                            f"  {info.get('prompt', name)} (Enter to skip): "
+                        ).strip()
                     if value:
                         save_env_value(name, value)
                         results["env_added"].append(name)
@@ -2586,7 +2900,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                     print()
             else:
                 print("  Set later with: hermes config set <key> <value>")
-    
+
     # Check for missing config fields.
     #
     # New default keys are NOT materialised to disk: load_config() deep-merges
@@ -2612,7 +2926,9 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
         print(f"\n  {len(missing_skill_config)} skill setting(s) not configured:")
         for var in missing_skill_config:
             skill_name = var.get("skill", "unknown")
-            print(f"    • {var['key']} — {var['description']} (from skill: {skill_name})")
+            print(
+                f"    • {var['key']} — {var['description']} (from skill: {skill_name})"
+            )
         print()
         try:
             answer = input("  Configure skill settings? [y/N]: ").strip().lower()
@@ -2683,11 +2999,7 @@ def _deep_merge(base: dict, override: dict) -> dict:
     """
     result = base.copy()
     for key, value in override.items():
-        if (
-            key in result
-            and isinstance(result[key], dict)
-            and isinstance(value, dict)
-        ):
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
             result[key] = _deep_merge(result[key], value)
         elif key in result and isinstance(result[key], dict) and value is None:
             continue
@@ -2740,7 +3052,7 @@ def _env_expand_match(m: re.Match) -> str:
     raw = m.group(0)
     inner = m.group(1).strip()
     if inner.startswith("env:"):
-        name = inner[len("env:"):].strip()
+        name = inner[len("env:") :].strip()
         if not name:
             return raw
         val = os.environ.get(name)
@@ -2748,7 +3060,9 @@ def _env_expand_match(m: re.Match) -> str:
             return val
         logger.warning(
             "Config ref %r: %s is not set (check ~/.hermes/.env); "
-            "keeping the literal placeholder", raw, name,
+            "keeping the literal placeholder",
+            raw,
+            name,
         )
         return raw
     if ":" in inner and re.match(r"^[a-z][a-z0-9_-]*:", inner):
@@ -2760,7 +3074,8 @@ def _env_expand_match(m: re.Match) -> str:
             "Config ref %r uses source %r which is not resolvable in "
             "config.yaml — external secret sources inject env vars at "
             "startup, so reference the variable as ${env:NAME} instead",
-            raw, inner.split(":", 1)[0],
+            raw,
+            inner.split(":", 1)[0],
         )
         return raw
     # Legacy ``${VAR}`` — bare name.
@@ -2772,7 +3087,7 @@ def _env_ref_var_name(ref: str) -> Optional[str]:
     when the ref uses a non-env source and never touches the environment."""
     ref = ref.strip()
     if ref.startswith("env:"):
-        name = ref[len("env:"):].strip()
+        name = ref[len("env:") :].strip()
         return name or None
     if ":" in ref and re.match(r"^[a-z][a-z0-9_-]*:", ref):
         return None
@@ -2856,7 +3171,11 @@ def _preserve_env_ref_templates(current, raw, loaded_expanded=None):
     rotation between load and save while still treating mixed literal/template
     string edits as caller-owned once their rendered value diverges.
     """
-    if isinstance(current, str) and isinstance(raw, str) and re.search(r"\${[^}]+}", raw):
+    if (
+        isinstance(current, str)
+        and isinstance(raw, str)
+        and re.search(r"\${[^}]+}", raw)
+    ):
         if current == raw:
             return raw
         if isinstance(loaded_expanded, str) and current == loaded_expanded:
@@ -2888,7 +3207,9 @@ def _preserve_env_ref_templates(current, raw, loaded_expanded=None):
                 _preserve_env_ref_templates(
                     item,
                     raw_by_name.get(item.get("name")),
-                    loaded_by_name.get(item.get("name")) if loaded_by_name is not None else None,
+                    loaded_by_name.get(item.get("name"))
+                    if loaded_by_name is not None
+                    else None,
                 )
                 for item in current
             ]
@@ -3056,7 +3377,12 @@ def _normalize_root_model_keys(config: Dict[str, Any]) -> Dict[str, Any]:
     has_root = any(
         config.get(k) for k in ("provider", "base_url", "context_length", "api_base")
     )
-    if not has_root and not model_has_alias and not model_needs_canon and not _has_nested_default:
+    if (
+        not has_root
+        and not model_has_alias
+        and not model_needs_canon
+        and not _has_nested_default
+    ):
         return config
 
     config = dict(config)
@@ -3184,8 +3510,15 @@ TURN_LIMIT_UNLIMITED = sys.maxsize
 # String spellings that mean "no limit".  Lowercased, whitespace-stripped
 # before comparison so ``"None"``, ``" unlimited "`` etc. all match.
 _UNLIMITED_SPELLINGS = frozenset({
-    "none", "null", "unlimited", "infinite", "infinity", "inf",
-    "∞", "-1", "0",
+    "none",
+    "null",
+    "unlimited",
+    "infinite",
+    "infinity",
+    "inf",
+    "∞",
+    "-1",
+    "0",
 })
 
 
@@ -3236,13 +3569,22 @@ def resolve_turn_limit(raw: Any, default: int = TURN_LIMIT_UNLIMITED) -> int:
             try:
                 n = int(float(s))
             except ValueError:
-                logger.debug("resolve_turn_limit: unparseable value %r → default %d", raw, default)
+                logger.debug(
+                    "resolve_turn_limit: unparseable value %r → default %d",
+                    raw,
+                    default,
+                )
                 return default
         if n <= 0:
             return TURN_LIMIT_UNLIMITED
         return n
     # Unknown type (list, dict, …) — don't crash the agent over a bad config.
-    logger.debug("resolve_turn_limit: unsupported type %s (%r) → default %d", type(raw).__name__, raw, default)
+    logger.debug(
+        "resolve_turn_limit: unsupported type %s (%r) → default %d",
+        type(raw).__name__,
+        raw,
+        default,
+    )
     return default
 
 
@@ -3293,7 +3635,9 @@ def cfg_get(cfg: Optional[Dict[str, Any]], *keys: str, default: Any = None) -> A
 
 
 # Back-compat alias — canonical set lives in hermes_cli.personality.
-from hermes_cli.personality import NEUTRAL_PERSONALITY_NAMES as _NEUTRAL_PERSONALITY_NAMES  # noqa: F401
+from hermes_cli.personality import (
+    NEUTRAL_PERSONALITY_NAMES as _NEUTRAL_PERSONALITY_NAMES,
+)  # noqa: F401
 
 
 def _prompt_text(value: Any) -> str:
@@ -3544,7 +3888,47 @@ def _load_user_config_for_mutation(config_path: Path) -> Dict[str, Any]:
     return loaded
 
 
-def atomic_config_write(config_path: Path, data: Any, **kwargs: Any) -> None:
+def preserve_plugin_runtime_state(
+    current: Dict[str, Any],
+    incoming: Dict[str, Any],
+    *,
+    preserve_plugin_lists: bool,
+    preserve_platform_toolsets: bool,
+) -> None:
+    """Keep concurrently-authoritative plugin activation state in *incoming*."""
+    if preserve_plugin_lists:
+        current_plugins = current.get("plugins")
+        incoming_plugins = incoming.get("plugins")
+        has_current_lists = isinstance(current_plugins, dict) and any(
+            key in current_plugins for key in ("enabled", "disabled")
+        )
+        if not isinstance(incoming_plugins, dict):
+            if has_current_lists:
+                incoming_plugins = {}
+                incoming["plugins"] = incoming_plugins
+            else:
+                incoming_plugins = None
+        if isinstance(incoming_plugins, dict):
+            for key in ("enabled", "disabled"):
+                if isinstance(current_plugins, dict) and key in current_plugins:
+                    incoming_plugins[key] = copy.deepcopy(current_plugins[key])
+                else:
+                    incoming_plugins.pop(key, None)
+    if preserve_platform_toolsets:
+        if "platform_toolsets" in current:
+            incoming["platform_toolsets"] = copy.deepcopy(current["platform_toolsets"])
+        else:
+            incoming.pop("platform_toolsets", None)
+
+
+def atomic_config_write(
+    config_path: Path,
+    data: Any,
+    *,
+    preserve_plugin_state: bool = True,
+    preserve_platform_toolsets: bool = True,
+    **kwargs: Any,
+) -> None:
     """Fail-closed atomic write for ``config.yaml``.
 
     The single chokepoint every config-update path should use instead of
@@ -3567,8 +3951,22 @@ def atomic_config_write(config_path: Path, data: Any, **kwargs: Any) -> None:
     """
     from utils import atomic_yaml_write
 
-    require_readable_config_before_write(config_path)
-    atomic_yaml_write(config_path, data, **kwargs)
+    with config_write_lock(), _CONFIG_LOCK:
+        had_existing = config_path.exists()
+        current = require_readable_config_before_write(config_path)
+        if (
+            (preserve_plugin_state or preserve_platform_toolsets)
+            and had_existing
+            and isinstance(data, dict)
+        ):
+            data = copy.deepcopy(data)
+            preserve_plugin_runtime_state(
+                current,
+                data,
+                preserve_plugin_lists=preserve_plugin_state,
+                preserve_platform_toolsets=preserve_platform_toolsets,
+            )
+        atomic_yaml_write(config_path, data, **kwargs)
 
 
 def load_config() -> Dict[str, Any]:
@@ -3705,7 +4103,7 @@ def terminal_config_env_var_for_key(key: str) -> Optional[str]:
     prefix = "terminal."
     if not key.startswith(prefix):
         return None
-    return TERMINAL_CONFIG_ENV_MAP.get(key[len(prefix):])
+    return TERMINAL_CONFIG_ENV_MAP.get(key[len(prefix) :])
 
 
 def _is_ssh_remote_tilde_cwd(backend: str, cwd: str) -> bool:
@@ -3755,7 +4153,9 @@ def apply_terminal_config_to_env(
     # normal merged-config path, only keys present in raw config.yaml may
     # override existing env values; keys inherited from DEFAULT_CONFIG are
     # backfill-only.
-    explicit_keys = terminal_cfg.keys() if config is not None else raw_terminal_cfg.keys()
+    explicit_keys = (
+        terminal_cfg.keys() if config is not None else raw_terminal_cfg.keys()
+    )
     backend_is_explicit = config is not None or "backend" in raw_terminal_cfg
     if backend_is_explicit:
         terminal_backend = str(
@@ -3873,6 +4273,7 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
                     # expanded one. Expand defensively — idempotent when the
                     # stored value is already expanded.
                     from typing import cast as _cast
+
                     lkg_copy: Dict[str, Any] = _cast(
                         Dict[str, Any], _expand_env_vars(copy.deepcopy(lkg))
                     )
@@ -3883,9 +4284,12 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
                         # signature and triggers a normal reload.
                         _empty_env: Dict[str, Optional[str]] = {}
                         _LOAD_CONFIG_CACHE[path_key] = (
-                            cache_sig[0], cache_sig[1],
-                            cache_sig[2], cache_sig[3],
-                            lkg_copy, _empty_env,
+                            cache_sig[0],
+                            cache_sig[1],
+                            cache_sig[2],
+                            cache_sig[3],
+                            lkg_copy,
+                            _empty_env,
                         )
                     return copy.deepcopy(lkg_copy) if want_deepcopy else lkg_copy
 
@@ -4022,6 +4426,8 @@ def save_config(
     strip_defaults: bool = True,
     preserve_keys: Optional[Set[Tuple[str, ...]]] = None,
     merge_existing: bool = False,
+    preserve_plugin_state: bool = True,
+    preserve_platform_toolsets: bool = True,
 ):
     """Save configuration to ~/.hermes/config.yaml.\n
 
@@ -4036,8 +4442,13 @@ def save_config(
     ``_persist_migration``) cannot drop unrelated sections the caller omitted.
     Full-document replacement callers (dashboard raw YAML editor, callers that
     already deep-merge) must leave this False so intentional deletions survive.
+
+    ``preserve_plugin_state`` and ``preserve_platform_toolsets`` default to True
+    so stale full-document writers cannot overwrite concurrent plugin/toolset
+    transactions. Intentional setup and tool-selection writers pass False for
+    the field they own.
     """
-    with _CONFIG_LOCK:
+    with config_write_lock(), _CONFIG_LOCK:
         if is_managed():
             managed_error("save configuration")
             return
@@ -4067,6 +4478,15 @@ def save_config(
         # DEFAULT_CONFIG; using the raw dict preserves which paths the
         # user actually set so _strip_default_values can keep them.
         _raw_for_paths = read_raw_config()
+        if (preserve_plugin_state or preserve_platform_toolsets) and isinstance(
+            _raw_for_paths, dict
+        ):
+            preserve_plugin_runtime_state(
+                _raw_for_paths,
+                config,
+                preserve_plugin_lists=preserve_plugin_state,
+                preserve_platform_toolsets=preserve_platform_toolsets,
+            )
         explicit_raw_paths: Optional[Set[Tuple[str, ...]]] = (
             _explicit_config_paths(_raw_for_paths) if _raw_for_paths else None
         )
@@ -4074,7 +4494,9 @@ def save_config(
             config = _merge_partial_save(_raw_for_paths, config)
         # ----------------------------------------------------------------
 
-        current_normalized = _normalize_root_model_keys(_normalize_max_turns_config(config))
+        current_normalized = _normalize_root_model_keys(
+            _normalize_max_turns_config(config)
+        )
         normalized = current_normalized
         raw_existing = (
             _normalize_root_model_keys(_normalize_max_turns_config(_raw_for_paths))
@@ -4100,6 +4522,7 @@ def save_config(
         if strip_defaults and effective_preserve_keys:
             # _preserve_env_ref_templates may return Any; cast for type-checker.
             from typing import cast as _cast
+
             normalized = _cast(Dict[str, Any], normalized)
             normalized = _strip_default_values(
                 normalized,  # type: ignore[arg-type]
@@ -4116,7 +4539,9 @@ def save_config(
         fb = normalized.get("fallback_model", {})
         fb_is_valid = False
         if isinstance(fb, list):
-            fb_is_valid = any(isinstance(e, dict) and e.get("provider") and e.get("model") for e in fb)
+            fb_is_valid = any(
+                isinstance(e, dict) and e.get("provider") and e.get("model") for e in fb
+            )
         elif isinstance(fb, dict):
             fb_is_valid = bool(fb.get("provider") and fb.get("model"))
         if not fb_is_valid:
@@ -4129,7 +4554,9 @@ def save_config(
         )
         _secure_file(config_path)
         _RAW_CONFIG_CACHE.pop(str(config_path), None)
-        _LAST_EXPANDED_CONFIG_BY_PATH[str(config_path)] = copy.deepcopy(current_normalized)
+        _LAST_EXPANDED_CONFIG_BY_PATH[str(config_path)] = copy.deepcopy(
+            current_normalized
+        )
 
 
 def _parse_env_value(raw_value: str) -> str:
@@ -4199,13 +4626,13 @@ def load_env() -> Dict[str, str]:
         lines = _sanitize_env_lines(raw_lines)
         for line in lines:
             line = line.strip()
-            if line and not line.startswith('#') and '=' in line:
+            if line and not line.startswith("#") and "=" in line:
                 # Strip the bash-compatible ``export `` prefix so lines like
                 # ``export API_KEY=...`` parse as ``API_KEY`` rather than being
                 # stored under the wrong key ``"export API_KEY"`` (#6659).
-                if line.startswith('export '):
+                if line.startswith("export "):
                     line = line[7:]
-                key, _, value = line.partition('=')
+                key, _, value = line.partition("=")
                 env_vars[key.strip()] = _parse_env_value(value)
 
     if cache_key is not None:
@@ -4219,7 +4646,9 @@ def load_env() -> Dict[str, str]:
 # is the explicit knob for writers that update .env via this module
 # (set_env_value, save_env, etc.) without relying on filesystem mtime
 # resolution.
-_env_cache: Optional[Tuple[Tuple[str, Optional[float], Optional[int]], Dict[str, str]]] = None
+_env_cache: Optional[
+    Tuple[Tuple[str, Optional[float], Optional[int]], Dict[str, str]]
+] = None
 
 
 def invalidate_env_cache() -> None:
@@ -4283,7 +4712,9 @@ def sanitize_env_file() -> int:
         fixes = sum(1 for a, b in zip(original_lines, sanitized) if a != b)
         fixes += abs(len(sanitized) - len(original_lines))
 
-    fd, tmp_path = tempfile.mkstemp(dir=str(env_path.parent), suffix=".tmp", prefix=".env_")
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(env_path.parent), suffix=".tmp", prefix=".env_"
+    )
     try:
         with os.fdopen(fd, "w", **write_kw) as f:
             f.writelines(sanitized)
@@ -4444,8 +4875,10 @@ def save_env_value(key: str, value: str):
         if lines and not lines[-1].endswith("\n"):
             lines[-1] += "\n"
         lines.append(f"{key}={serialized_value}\n")
-    
-    fd, tmp_path = tempfile.mkstemp(dir=str(env_path.parent), suffix='.tmp', prefix='.env_')
+
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(env_path.parent), suffix=".tmp", prefix=".env_"
+    )
     # Preserve original permissions so Docker volume mounts aren't clobbered.
     original_mode = None
     if env_path.exists():
@@ -4454,7 +4887,7 @@ def save_env_value(key: str, value: str):
         except OSError:
             pass
     try:
-        with os.fdopen(fd, 'w', **write_kw) as f:
+        with os.fdopen(fd, "w", **write_kw) as f:
             f.writelines(lines)
             f.flush()
             os.fsync(f.fileno())
@@ -4536,7 +4969,9 @@ def remove_env_value(key: str) -> bool:
     found = len(new_lines) < len(lines)
 
     if found:
-        fd, tmp_path = tempfile.mkstemp(dir=str(env_path.parent), suffix='.tmp', prefix='.env_')
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(env_path.parent), suffix=".tmp", prefix=".env_"
+        )
         # Preserve original permissions so Docker volume mounts aren't clobbered.
         original_mode = None
         try:
@@ -4544,7 +4979,7 @@ def remove_env_value(key: str) -> bool:
         except OSError:
             pass
         try:
-            with os.fdopen(fd, 'w', **write_kw) as f:
+            with os.fdopen(fd, "w", **write_kw) as f:
                 f.writelines(new_lines)
                 f.flush()
                 os.fsync(f.fileno())
@@ -4604,7 +5039,6 @@ def save_env_value_secure(key: str, value: str) -> Dict[str, Any]:
         "stored_as": key,
         "validated": False,
     }
-
 
 
 def reload_env() -> int:
@@ -4704,6 +5138,7 @@ def get_env_value_prefer_dotenv(key: str) -> Optional[str]:
 # Config display
 # =============================================================================
 
+
 def redact_key(key: str) -> str:
     """Redact an API key for display.
 
@@ -4711,6 +5146,7 @@ def redact_key(key: str) -> str:
     "(not set)" placeholder in dim color for the empty case.
     """
     from agent.redact import mask_secret
+
     return mask_secret(key, empty=color("(not set)", Colors.DIM))
 
 
@@ -4758,7 +5194,12 @@ def redact_config_value(value: Any, _depth: int = 0) -> Any:
     if isinstance(value, dict):
         out = {}
         for k, v in value.items():
-            if isinstance(k, str) and k.lower() in _SECRET_CONFIG_KEYS and isinstance(v, str) and v:
+            if (
+                isinstance(k, str)
+                and k.lower() in _SECRET_CONFIG_KEYS
+                and isinstance(v, str)
+                and v
+            ):
                 out[k] = mask_secret(v)
             else:
                 out[k] = redact_config_value(v, _depth + 1)
@@ -4773,9 +5214,19 @@ def show_config():
     config = load_config()
 
     print()
-    print(color("┌─────────────────────────────────────────────────────────┐", Colors.CYAN))
-    print(color("│              ⚕ Hermes Configuration                    │", Colors.CYAN))
-    print(color("└─────────────────────────────────────────────────────────┘", Colors.CYAN))
+    print(
+        color(
+            "┌─────────────────────────────────────────────────────────┐", Colors.CYAN
+        )
+    )
+    print(
+        color("│              ⚕ Hermes Configuration                    │", Colors.CYAN)
+    )
+    print(
+        color(
+            "└─────────────────────────────────────────────────────────┘", Colors.CYAN
+        )
+    )
 
     # Managed scope: surface that some settings are administrator-pinned so the
     # user understands why their config.yaml value may not be the effective one.
@@ -4786,22 +5237,28 @@ def show_config():
     if _managed_keys or _managed_env:
         _managed_dir = managed_scope.get_managed_dir()
         print()
-        print(color(
-            f"  ⚷ Some settings are managed by your administrator ({_managed_dir}) "
-            f"and cannot be changed",
-            Colors.YELLOW,
-            Colors.BOLD,
-        ))
+        print(
+            color(
+                f"  ⚷ Some settings are managed by your administrator ({_managed_dir}) "
+                f"and cannot be changed",
+                Colors.YELLOW,
+                Colors.BOLD,
+            )
+        )
         if _managed_keys:
-            print(color(
-                f"    Managed config keys: {', '.join(sorted(_managed_keys))}",
-                Colors.YELLOW,
-            ))
+            print(
+                color(
+                    f"    Managed config keys: {', '.join(sorted(_managed_keys))}",
+                    Colors.YELLOW,
+                )
+            )
         if _managed_env:
-            print(color(
-                f"    Managed env keys: {', '.join(sorted(_managed_env))}",
-                Colors.YELLOW,
-            ))
+            print(
+                color(
+                    f"    Managed env keys: {', '.join(sorted(_managed_env))}",
+                    Colors.YELLOW,
+                )
+            )
 
     # Paths
     print()
@@ -4809,11 +5266,11 @@ def show_config():
     print(f"  Config:       {get_config_path()}")
     print(f"  Secrets:      {get_env_path()}")
     print(f"  Install:      {get_project_root()}")
-    
+
     # API Keys
     print()
     print(color("◆ API Keys", Colors.CYAN, Colors.BOLD))
-    
+
     keys = [
         ("OPENROUTER_API_KEY", "OpenRouter"),
         ("VOICE_TOOLS_OPENAI_KEY", "OpenAI (STT/TTS)"),
@@ -4825,85 +5282,109 @@ def show_config():
         ("BROWSER_USE_API_KEY", "Browser Use"),
         ("FAL_KEY", "FAL"),
     ]
-    
+
     for env_key, name in keys:
         value = get_env_value(env_key)
         print(f"  {name:<14} {redact_key(value)}")
     from hermes_cli.auth import get_anthropic_key
+
     anthropic_value = get_anthropic_key()
     print(f"  {'Anthropic':<14} {redact_key(anthropic_value)}")
-    
+
     # Model settings
     print()
     print(color("◆ Model", Colors.CYAN, Colors.BOLD))
     print(f"  Model:        {redact_config_value(config.get('model', 'not set'))}")
-    _cfg_max_turns = config.get('agent', {}).get('max_turns', DEFAULT_CONFIG['agent']['max_turns'])
+    _cfg_max_turns = config.get("agent", {}).get(
+        "max_turns", DEFAULT_CONFIG["agent"]["max_turns"]
+    )
     print(f"  Max turns:    {_cfg_max_turns}")
     # Warn on stale HERMES_MAX_ITERATIONS ghost in .env that disagrees with
     # config.yaml (issue #17534). Read the .env FILE directly so we catch the
     # ghost even when the gateway bridge already overrode os.environ.
     try:
         _env_ghost = load_env().get("HERMES_MAX_ITERATIONS")
-        if _env_ghost is not None and str(_env_ghost).strip() != str(_cfg_max_turns).strip():
-            print(color(
-                f"                ⚠ .env has stale HERMES_MAX_ITERATIONS={_env_ghost} "
-                f"(run 'hermes doctor --fix' to remove)",
-                Colors.YELLOW,
-            ))
+        if (
+            _env_ghost is not None
+            and str(_env_ghost).strip() != str(_cfg_max_turns).strip()
+        ):
+            print(
+                color(
+                    f"                ⚠ .env has stale HERMES_MAX_ITERATIONS={_env_ghost} "
+                    f"(run 'hermes doctor --fix' to remove)",
+                    Colors.YELLOW,
+                )
+            )
     except Exception:
         pass
-    
+
     # Display
     print()
     print(color("◆ Display", Colors.CYAN, Colors.BOLD))
-    display = config.get('display', {})
+    display = config.get("display", {})
     try:
         from hermes_cli.personality import active_personality_name
 
-        _active_personality = active_personality_name(config) or 'none'
+        _active_personality = active_personality_name(config) or "none"
     except Exception:
-        _active_personality = display.get('personality') or 'none'
+        _active_personality = display.get("personality") or "none"
     print(f"  Personality:  {_active_personality}")
     print(f"  Reasoning:    {'on' if display.get('show_reasoning', True) else 'off'}")
-    print(f"  Bell:         {'on' if display.get('bell_on_complete', False) else 'off'}")
-    ump = display.get('user_message_preview', {}) if isinstance(display.get('user_message_preview', {}), dict) else {}
-    ump_first = ump.get('first_lines', 2)
-    ump_last = ump.get('last_lines', 2)
+    print(
+        f"  Bell:         {'on' if display.get('bell_on_complete', False) else 'off'}"
+    )
+    ump = (
+        display.get("user_message_preview", {})
+        if isinstance(display.get("user_message_preview", {}), dict)
+        else {}
+    )
+    ump_first = ump.get("first_lines", 2)
+    ump_last = ump.get("last_lines", 2)
     print(f"  User preview: first {ump_first} line(s), last {ump_last} line(s)")
 
     # Terminal
     print()
     print(color("◆ Terminal", Colors.CYAN, Colors.BOLD))
-    terminal = config.get('terminal', {})
+    terminal = config.get("terminal", {})
     print(f"  Backend:      {terminal.get('backend', 'local')}")
     print(f"  Working dir:  {terminal.get('cwd', '.')}")
     print(f"  Timeout:      {terminal.get('timeout', 60)}s")
-    
-    if terminal.get('backend') == 'docker':
-        print(f"  Docker image: {terminal.get('docker_image', 'nikolaik/python-nodejs:python3.11-nodejs20')}")
-    elif terminal.get('backend') == 'singularity':
-        print(f"  Image:        {terminal.get('singularity_image', 'docker://nikolaik/python-nodejs:python3.11-nodejs20')}")
-    elif terminal.get('backend') == 'modal':
-        print(f"  Modal image:  {terminal.get('modal_image', 'nikolaik/python-nodejs:python3.11-nodejs20')}")
-        modal_token = get_env_value('MODAL_TOKEN_ID')
+
+    if terminal.get("backend") == "docker":
+        print(
+            f"  Docker image: {terminal.get('docker_image', 'nikolaik/python-nodejs:python3.11-nodejs20')}"
+        )
+    elif terminal.get("backend") == "singularity":
+        print(
+            f"  Image:        {terminal.get('singularity_image', 'docker://nikolaik/python-nodejs:python3.11-nodejs20')}"
+        )
+    elif terminal.get("backend") == "modal":
+        print(
+            f"  Modal image:  {terminal.get('modal_image', 'nikolaik/python-nodejs:python3.11-nodejs20')}"
+        )
+        modal_token = get_env_value("MODAL_TOKEN_ID")
         print(f"  Modal token:  {'configured' if modal_token else '(not set)'}")
-    elif terminal.get('backend') == 'daytona':
-        print(f"  Daytona image: {terminal.get('daytona_image', 'nikolaik/python-nodejs:python3.11-nodejs20')}")
-        daytona_key = get_env_value('DAYTONA_API_KEY')
+    elif terminal.get("backend") == "daytona":
+        print(
+            f"  Daytona image: {terminal.get('daytona_image', 'nikolaik/python-nodejs:python3.11-nodejs20')}"
+        )
+        daytona_key = get_env_value("DAYTONA_API_KEY")
         print(f"  API key:      {'configured' if daytona_key else '(not set)'}")
-    elif terminal.get('backend') == 'vercel_sandbox':
+    elif terminal.get("backend") == "vercel_sandbox":
         print(f"  Vercel runtime: {terminal.get('vercel_runtime', 'node24')}")
-        print(f"  Vercel auth:    {'configured' if get_env_value('VERCEL_OIDC_TOKEN') or (get_env_value('VERCEL_TOKEN') and get_env_value('VERCEL_PROJECT_ID') and get_env_value('VERCEL_TEAM_ID')) else '(not set)'}")
-    elif terminal.get('backend') == 'ssh':
-        ssh_host = get_env_value('TERMINAL_SSH_HOST')
-        ssh_user = get_env_value('TERMINAL_SSH_USER')
+        print(
+            f"  Vercel auth:    {'configured' if get_env_value('VERCEL_OIDC_TOKEN') or (get_env_value('VERCEL_TOKEN') and get_env_value('VERCEL_PROJECT_ID') and get_env_value('VERCEL_TEAM_ID')) else '(not set)'}"
+        )
+    elif terminal.get("backend") == "ssh":
+        ssh_host = get_env_value("TERMINAL_SSH_HOST")
+        ssh_user = get_env_value("TERMINAL_SSH_USER")
         print(f"  SSH host:     {ssh_host or '(not set)'}")
         print(f"  SSH user:     {ssh_user or '(not set)'}")
-    
+
     # Timezone
     print()
     print(color("◆ Timezone", Colors.CYAN, Colors.BOLD))
-    tz = config.get('timezone', '')
+    tz = config.get("timezone", "")
     if tz:
         print(f"  Timezone:     {tz}")
     else:
@@ -4912,63 +5393,77 @@ def show_config():
     # Compression
     print()
     print(color("◆ Context Compression", Colors.CYAN, Colors.BOLD))
-    compression = config.get('compression', {})
-    enabled = compression.get('enabled', True)
+    compression = config.get("compression", {})
+    enabled = compression.get("enabled", True)
     print(f"  Enabled:      {'yes' if enabled else 'no'}")
     if enabled:
         print(f"  Threshold:    {compression.get('threshold', 0.50) * 100:.0f}%")
-        _tt = compression.get('threshold_tokens')
+        _tt = compression.get("threshold_tokens")
         if _tt is not None:
             try:
                 _tt = int(_tt)
                 if _tt > 0:
-                    print(f"  Token cap:    {_tt:,} tokens (takes lower of ratio vs absolute)")
+                    print(
+                        f"  Token cap:    {_tt:,} tokens (takes lower of ratio vs absolute)"
+                    )
             except (TypeError, ValueError):
                 pass
-        print(f"  Target ratio: {compression.get('target_ratio', 0.20) * 100:.0f}% of threshold preserved")
+        print(
+            f"  Target ratio: {compression.get('target_ratio', 0.20) * 100:.0f}% of threshold preserved"
+        )
         print(f"  Protect last: {compression.get('protect_last_n', 20)} messages")
-        print(f"  Protect first: {compression.get('protect_first_n', 3)} non-system head messages")
-        _aux_comp = config.get('auxiliary', {}).get('compression', {})
-        _sm = _aux_comp.get('model', '') or '(auto)'
+        print(
+            f"  Protect first: {compression.get('protect_first_n', 3)} non-system head messages"
+        )
+        _aux_comp = config.get("auxiliary", {}).get("compression", {})
+        _sm = _aux_comp.get("model", "") or "(auto)"
         print(f"  Model:        {_sm}")
-        comp_provider = _aux_comp.get('provider', 'auto')
-        if comp_provider and comp_provider != 'auto':
+        comp_provider = _aux_comp.get("provider", "auto")
+        if comp_provider and comp_provider != "auto":
             print(f"  Provider:     {comp_provider}")
-    
+
     # Auxiliary models
-    auxiliary = config.get('auxiliary', {})
+    auxiliary = config.get("auxiliary", {})
     aux_tasks = {
-        "Vision":      auxiliary.get('vision', {}),
+        "Vision": auxiliary.get("vision", {}),
     }
     has_overrides = any(
-        t.get('provider', 'auto') != 'auto' or t.get('model', '')
+        t.get("provider", "auto") != "auto" or t.get("model", "")
         for t in aux_tasks.values()
     )
     if has_overrides:
         print()
         print(color("◆ Auxiliary Models (overrides)", Colors.CYAN, Colors.BOLD))
         for label, task_cfg in aux_tasks.items():
-            prov = task_cfg.get('provider', 'auto')
-            mdl = task_cfg.get('model', '')
-            if prov != 'auto' or mdl:
+            prov = task_cfg.get("provider", "auto")
+            mdl = task_cfg.get("model", "")
+            if prov != "auto" or mdl:
                 parts = [f"provider={prov}"]
                 if mdl:
                     parts.append(f"model={mdl}")
                 print(f"  {label:12s}  {', '.join(parts)}")
-    
+
     # Messaging
     print()
     print(color("◆ Messaging Platforms", Colors.CYAN, Colors.BOLD))
-    
-    telegram_token = get_env_value('TELEGRAM_BOT_TOKEN')
-    discord_token = get_env_value('DISCORD_BOT_TOKEN')
-    
-    print(f"  Telegram:     {'configured' if telegram_token else color('not configured', Colors.DIM)}")
-    print(f"  Discord:      {'configured' if discord_token else color('not configured', Colors.DIM)}")
-    
+
+    telegram_token = get_env_value("TELEGRAM_BOT_TOKEN")
+    discord_token = get_env_value("DISCORD_BOT_TOKEN")
+
+    print(
+        f"  Telegram:     {'configured' if telegram_token else color('not configured', Colors.DIM)}"
+    )
+    print(
+        f"  Discord:      {'configured' if discord_token else color('not configured', Colors.DIM)}"
+    )
+
     # Skill config
     try:
-        from agent.skill_utils import discover_all_skill_config_vars, resolve_skill_config_values
+        from agent.skill_utils import (
+            discover_all_skill_config_vars,
+            resolve_skill_config_values,
+        )
+
         skill_vars = discover_all_skill_config_vars()
         if skill_vars:
             resolved = resolve_skill_config_values(skill_vars)
@@ -4979,7 +5474,9 @@ def show_config():
                 value = resolved.get(key, "")
                 skill_name = var.get("skill", "")
                 display_val = str(value) if value else color("(not set)", Colors.DIM)
-                print(f"  {key:<20s} {display_val}  {color(f'[{skill_name}]', Colors.DIM)}")
+                print(
+                    f"  {key:<20s} {display_val}  {color(f'[{skill_name}]', Colors.DIM)}"
+                )
     except Exception:
         pass
 
@@ -4997,14 +5494,14 @@ def edit_config():
         managed_error("edit configuration")
         return
     config_path = get_config_path()
-    
+
     # Ensure config exists
     if not config_path.exists():
         save_config(DEFAULT_CONFIG, strip_defaults=False)
         print(f"Created {config_path}")
-    
+
     # Find editor
-    editor = os.getenv('EDITOR') or os.getenv('VISUAL')
+    editor = os.getenv("EDITOR") or os.getenv("VISUAL")
 
     if not editor:
         # Try common editors — order is platform-aware so Windows users
@@ -5013,20 +5510,21 @@ def edit_config():
         # it's more likely to be present on headless / server systems.
         import shutil
         import sys as _sys
+
         if _sys.platform == "win32":
-            candidates = ['notepad', 'code', 'vim', 'vi', 'nano']
+            candidates = ["notepad", "code", "vim", "vi", "nano"]
         else:
-            candidates = ['nano', 'vim', 'vi', 'code', 'notepad']
+            candidates = ["nano", "vim", "vi", "code", "notepad"]
         for cmd in candidates:
             if shutil.which(cmd):
                 editor = cmd
                 break
-    
+
     if not editor:
         print("No editor found. Config file is at:")
         print(f"  {config_path}")
         return
-    
+
     print(f"Opening {config_path} in {editor}...")
     subprocess.run([editor, str(config_path)])
 
@@ -5246,13 +5744,11 @@ def build_cron_model_impact(
             continue
         result["affected_count"] += 1
         if len(result["jobs"]) < _CRON_MODEL_IMPACT_JOB_LIMIT:
-            result["jobs"].append(
-                {
-                    "id": job_id,
-                    "name": _cron_impact_job_name(job.get("name"), job_id),
-                    "drifted_axes": axes,
-                }
-            )
+            result["jobs"].append({
+                "id": job_id,
+                "name": _cron_impact_job_name(job.get("name"), job_id),
+                "drifted_axes": axes,
+            })
 
     result["truncated"] = result["affected_count"] > len(result["jobs"])
     return result
@@ -5346,11 +5842,25 @@ _OPEN_DICT_TOP_LEVEL_KEYS = frozenset({
 # etc.). For these we validate the FIRST segment but accept anything below.
 _SCHEMA_DEFINED_DICT_KEYS = frozenset({
     # Platform configs — PlatformConfig dataclass + dynamic extras
-    "discord", "telegram", "slack", "whatsapp", "signal", "mattermost",
-    "matrix", "feishu", "wecom", "weixin", "bluebubbles", "qqbot", "yuanbao",
-    "email", "sms", "dingtalk",
+    "discord",
+    "telegram",
+    "slack",
+    "whatsapp",
+    "signal",
+    "mattermost",
+    "matrix",
+    "feishu",
+    "wecom",
+    "weixin",
+    "bluebubbles",
+    "qqbot",
+    "yuanbao",
+    "email",
+    "sms",
+    "dingtalk",
     # MCP server template / dynamic auth dicts
-    "sessions", "checkpoints",
+    "sessions",
+    "checkpoints",
     # Plugin settings — enable/disable lists and per-plugin entries
     # (hermes_cli/plugins_cmd.py). Absent from DEFAULT_CONFIG (written only
     # when used), so listed here for `hermes config set plugins....`
@@ -5389,7 +5899,9 @@ def _known_top_level_keys() -> set[str]:
     return keys
 
 
-def _suggest_closest_key(key: str, candidates: set[str], cutoff: float = 0.6) -> Optional[str]:
+def _suggest_closest_key(
+    key: str, candidates: set[str], cutoff: float = 0.6
+) -> Optional[str]:
     """Return the closest valid key name from ``candidates`` if any are
     similar enough to ``key``, else None.  Used by ``hermes config set``
     to point users at the right path when they've typo'd a top-level key.
@@ -5399,6 +5911,7 @@ def _suggest_closest_key(key: str, candidates: set[str], cutoff: float = 0.6) ->
     than mislead a user toward a wrong-but-similar key.
     """
     import difflib
+
     matches = difflib.get_close_matches(key, sorted(candidates), n=1, cutoff=cutoff)
     return matches[0] if matches else None
 
@@ -5464,7 +5977,11 @@ def _validate_config_key(key: str) -> tuple[bool, Optional[str]]:
     #   - A schema-defined-but-extensible dict (accept anything below)
     #   - A leaf scalar (the user's key is fully consumed and valid)
     #   - An unknown sub-key (return False with a same-level suggestion)
-    if top in _OPEN_DICT_TOP_LEVEL_KEYS or top in _DYNAMIC_TOP_LEVEL_KEYS or top in _SCHEMA_DEFINED_DICT_KEYS:
+    if (
+        top in _OPEN_DICT_TOP_LEVEL_KEYS
+        or top in _DYNAMIC_TOP_LEVEL_KEYS
+        or top in _SCHEMA_DEFINED_DICT_KEYS
+    ):
         # Any path below these is accepted — the user defines the inner
         # shape themselves (mcp_servers.<name>.command, discord.<extras>,
         # providers.<name>.api_key, etc.).
@@ -5516,20 +6033,20 @@ def _looks_structured_value(value: str) -> bool:
     other dash-prefixed single-line scalars must remain strings.
     """
     stripped = value.lstrip()
-    if stripped[:1] in ('[', '{'):
+    if stripped[:1] in ("[", "{"):
         return True
-    if '\n' not in value:
+    if "\n" not in value:
         return False
     for line in value.splitlines():
         item = line.strip()
-        if item == '-' or item.startswith('- '):
+        if item == "-" or item.startswith("- "):
             return True
         # ``key: value`` / ``key:`` mapping-entry shape (no whitespace in the
         # key, colon followed by a space or end-of-line).
-        head, sep, _rest = item.partition(': ')
-        if sep and head and ' ' not in head and not head.startswith('#'):
+        head, sep, _rest = item.partition(": ")
+        if sep and head and " " not in head and not head.startswith("#"):
             return True
-        if item.endswith(':') and ' ' not in item[:-1] and item[:-1]:
+        if item.endswith(":") and " " not in item[:-1] and item[:-1]:
             return True
     return False
 
@@ -5571,6 +6088,12 @@ def _coerce_float(value: str):
 
 
 def set_config_value(key: str, value: str, force: bool = False):
+    """Set one value under the shared cross-process config transaction."""
+    with config_write_lock():
+        return _set_config_value_locked(key, value, force=force)
+
+
+def _set_config_value_locked(key: str, value: str, force: bool = False):
     """Set a configuration value.
 
     Args:
@@ -5592,8 +6115,10 @@ def set_config_value(key: str, value: str, force: bool = False):
     # config["agent"][""] = ..., polluting a live schema section with a
     # garbage empty-string key that round-tripped through get (CFG-04).
     if key != key.strip() or not key.strip():
-        print(f"✗ Invalid config key: {key!r} (empty or surrounding whitespace).",
-              file=sys.stderr)
+        print(
+            f"✗ Invalid config key: {key!r} (empty or surrounding whitespace).",
+            file=sys.stderr,
+        )
         sys.exit(1)
     if any(seg == "" for seg in key.split(".")):
         print(
@@ -5644,7 +6169,7 @@ def set_config_value(key: str, value: str, force: bool = False):
     # Fail-closed parse via require_readable (unparseable / non-mapping
     # refuse-write); returns the mapping so we do not re-parse / collapse.
     user_config = require_readable_config_before_write(config_path)
-    
+
     # Handle nested keys (e.g., "tts.provider") including numeric list
     # indices (e.g., "custom_providers.0.api_key").  Delegates to
     # _set_nested which preserves list-typed nodes; before #17876 the
@@ -5657,11 +6182,11 @@ def set_config_value(key: str, value: str, force: bool = False):
     if not isinstance(_default_value_for_key(key), str):
         _stripped = value.strip()
         _lower = _stripped.lower()
-        if _lower in {'true', 'yes', 'on'}:
+        if _lower in {"true", "yes", "on"}:
             coerced_value = True
-        elif _lower in {'false', 'no', 'off'}:
+        elif _lower in {"false", "no", "off"}:
             coerced_value = False
-        elif _lower in {'null', 'none', '~'}:
+        elif _lower in {"null", "none", "~"}:
             # YAML null / "off" state. Many DEFAULT_CONFIG leaves default to
             # None and are documented as "null/absent = off"; without this,
             # ``config set X null`` stored the truthy string "null" and the
@@ -5785,11 +6310,25 @@ def set_config_value(key: str, value: str, force: bool = False):
         user_config = _normalize_root_model_keys(user_config)
         key = "model.base_url"
         print("  (note: 'api_base' is an alias — saved as model.base_url)")
-    # Write only user config back (not the full merged defaults)
+    # Write only user config back (not the full merged defaults). The shared
+    # transaction is already held by set_config_value; explicit plugin-state
+    # edits opt out of stale-writer preservation so the requested edit lands.
     ensure_hermes_home()
-    from utils import atomic_yaml_write
-    atomic_yaml_write(config_path, user_config, sort_keys=False)
-    
+    changes_plugin_lists = key == "plugins" or key.startswith((
+        "plugins.enabled",
+        "plugins.disabled",
+    ))
+    changes_platform_toolsets = key == "platform_toolsets" or key.startswith(
+        "platform_toolsets."
+    )
+    atomic_config_write(
+        config_path,
+        user_config,
+        sort_keys=False,
+        preserve_plugin_state=not changes_plugin_lists,
+        preserve_platform_toolsets=not changes_platform_toolsets,
+    )
+
     # Keep .env in sync for keys that terminal_tool reads directly from env vars.
     # config.yaml is authoritative, but terminal_tool only reads TERMINAL_ENV etc.
     env_var = terminal_config_env_var_for_key(key)
@@ -5816,6 +6355,7 @@ def set_config_value(key: str, value: str, force: bool = False):
     _leaf_key = key.rsplit(".", 1)[-1].lower()
     if _leaf_key in _SECRET_CONFIG_KEYS and isinstance(value, str) and value:
         from agent.redact import mask_secret
+
         _display_value = mask_secret(value)
     else:
         _display_value = value
@@ -5825,19 +6365,23 @@ def set_config_value(key: str, value: str, force: bool = False):
     # Post-write unknown-key notice (#34067): value IS saved, but tell the
     # user the runtime may never read it and suggest the likely-intended path.
     if not is_known and not force:
-        print(color(
-            f"⚠ '{key}' is not a recognized config key — it was saved anyway, "
-            "but Hermes may not read it.",
-            Colors.YELLOW,
-        ))
+        print(
+            color(
+                f"⚠ '{key}' is not a recognized config key — it was saved anyway, "
+                "but Hermes may not read it.",
+                Colors.YELLOW,
+            )
+        )
         if suggestion:
             print(color(f"  Did you mean: {suggestion}", Colors.YELLOW))
-        print(color(
-            "  (Custom top-level keys are supported and bridged to the "
-            "environment for skills/external tools. Use --force to skip "
-            "this notice.)",
-            Colors.DIM,
-        ))
+        print(
+            color(
+                "  (Custom top-level keys are supported and bridged to the "
+                "environment for skills/external tools. Use --force to skip "
+                "this notice.)",
+                Colors.DIM,
+            )
+        )
 
 
 def get_config_value(key: str, *, as_json: bool = False):
@@ -5856,6 +6400,12 @@ def get_config_value(key: str, *, as_json: bool = False):
 
 
 def unset_config_value(key: str):
+    """Unset one value under the shared cross-process config transaction."""
+    with config_write_lock():
+        return _unset_config_value_locked(key)
+
+
+def _unset_config_value_locked(key: str):
     """Remove a user-set configuration or .env value."""
     if is_managed():
         managed_error("unset configuration values")
@@ -5903,8 +6453,20 @@ def unset_config_value(key: str):
         sys.exit(1)
 
     ensure_hermes_home()
-    from utils import atomic_yaml_write
-    atomic_yaml_write(config_path, user_config, sort_keys=False)
+    changes_plugin_lists = key == "plugins" or key.startswith((
+        "plugins.enabled",
+        "plugins.disabled",
+    ))
+    changes_platform_toolsets = key == "platform_toolsets" or key.startswith(
+        "platform_toolsets."
+    )
+    atomic_config_write(
+        config_path,
+        user_config,
+        sort_keys=False,
+        preserve_plugin_state=not changes_plugin_lists,
+        preserve_platform_toolsets=not changes_platform_toolsets,
+    )
     print(f"✓ Unset {key} from {config_path}")
 
 
@@ -5912,18 +6474,19 @@ def unset_config_value(key: str):
 # Command handler
 # =============================================================================
 
+
 def config_command(args):
     """Handle config subcommands."""
-    subcmd = getattr(args, 'config_command', None)
-    
+    subcmd = getattr(args, "config_command", None)
+
     if subcmd is None or subcmd == "show":
         show_config()
-    
+
     elif subcmd == "edit":
         edit_config()
-    
+
     elif subcmd == "get":
-        key = getattr(args, 'key', None)
+        key = getattr(args, "key", None)
         if not key:
             print("Usage: hermes config get <key> [--json]")
             print()
@@ -5932,12 +6495,12 @@ def config_command(args):
             print("  hermes config get terminal.backend")
             print("  hermes config get skills.config --json")
             sys.exit(1)
-        get_config_value(key, as_json=getattr(args, 'json', False))
+        get_config_value(key, as_json=getattr(args, "json", False))
 
     elif subcmd == "set":
-        key = getattr(args, 'key', None)
-        value = getattr(args, 'value', None)
-        force = bool(getattr(args, 'force', False))
+        key = getattr(args, "key", None)
+        value = getattr(args, "value", None)
+        force = bool(getattr(args, "force", False))
         if not key or value is None:
             print("Usage: hermes config set [--force] <key> <value>")
             print()
@@ -5958,7 +6521,7 @@ def config_command(args):
             sys.exit(1)
 
     elif subcmd == "unset":
-        key = getattr(args, 'key', None)
+        key = getattr(args, "key", None)
         if not key:
             print("Usage: hermes config unset <key>")
             print()
@@ -5973,81 +6536,89 @@ def config_command(args):
             # Same fail-closed guard surface as `config set` above.
             print(f"✗ {exc}", file=sys.stderr)
             sys.exit(1)
-    
+
     elif subcmd == "path":
         print(get_config_path())
-    
+
     elif subcmd == "env-path":
         print(get_env_path())
-    
+
     elif subcmd == "migrate":
         print()
-        print(color("🔄 Checking configuration for updates...", Colors.CYAN, Colors.BOLD))
+        print(
+            color("🔄 Checking configuration for updates...", Colors.CYAN, Colors.BOLD)
+        )
         print()
-        
+
         # Check what's missing
         missing_env = get_missing_env_vars(required_only=False)
         missing_config = get_missing_config_fields()
         current_ver, latest_ver = check_config_version()
-        
+
         if not missing_env and not missing_config and current_ver >= latest_ver:
             print(color("✓ Configuration is up to date!", Colors.GREEN))
             print()
             return
-        
+
         # Show what needs to be updated
         if current_ver < latest_ver:
             print(f"  Config version: {current_ver} → {latest_ver}")
-        
+
         if missing_config:
-            print(f"\n  {len(missing_config)} new config option(s) will be added with defaults")
-        
+            print(
+                f"\n  {len(missing_config)} new config option(s) will be added with defaults"
+            )
+
         required_missing = [v for v in missing_env if v.get("is_required")]
         optional_missing = [
-            v for v in missing_env
-            if not v.get("is_required") and not v.get("advanced")
+            v for v in missing_env if not v.get("is_required") and not v.get("advanced")
         ]
-        
+
         if required_missing:
             print(f"\n  ⚠️  {len(required_missing)} required API key(s) missing:")
             for var in required_missing:
                 print(f"     • {var['name']}")
-        
+
         if optional_missing:
             print(f"\n  ℹ️  {len(optional_missing)} optional API key(s) not configured:")
             for var in optional_missing:
                 tools = var.get("tools", [])
                 tools_str = f" (enables: {', '.join(tools[:2])})" if tools else ""
                 print(f"     • {var['name']}{tools_str}")
-        
+
         print()
-        
+
         # Run migration
         results = migrate_config(interactive=True, quiet=False)
-        
+
         print()
         if results["env_added"] or results["config_added"]:
             print(color("✓ Configuration updated!", Colors.GREEN))
-        
+
         if results["warnings"]:
             print()
             for warning in results["warnings"]:
                 print(color(f"  ⚠️  {warning}", Colors.YELLOW))
-        
+
         print()
-    
+
     elif subcmd == "check":
         # Non-interactive check for what's missing
         print()
         print(color("📋 Configuration Status", Colors.CYAN, Colors.BOLD))
         print()
-        
+
         current_ver, latest_ver = check_config_version()
         if current_ver >= latest_ver:
             print(f"  Config version: {current_ver} ✓")
         else:
-            print(color(f"  Config version: {current_ver} → {latest_ver} (update available)", Colors.YELLOW))
-        
+            print(
+                color(
+                    f"  Config version: {current_ver} → {latest_ver} (update available)",
+                    Colors.YELLOW,
+                )
+            )
+
         print()
         print(color("  Required:", Colors.BOLD))
         for var_name in REQUIRED_ENV_VARS:
@@ -6055,7 +6626,7 @@ def config_command(args):
                 print(f"    ✓ {var_name}")
             else:
                 print(color(f"    ✗ {var_name} (missing)", Colors.RED))
-        
+
         print()
         print(color("  Optional:", Colors.BOLD))
         for var_name, info in OPTIONAL_ENV_VARS.items():
@@ -6065,15 +6636,20 @@ def config_command(args):
                 tools = info.get("tools", [])
                 tools_str = f" → {', '.join(tools[:2])}" if tools else ""
                 print(color(f"    ○ {var_name}{tools_str}", Colors.DIM))
-        
+
         missing_config = get_missing_config_fields()
         if missing_config:
             print()
-            print(color(f"  {len(missing_config)} new config option(s) available", Colors.YELLOW))
+            print(
+                color(
+                    f"  {len(missing_config)} new config option(s) available",
+                    Colors.YELLOW,
+                )
+            )
             print("    Run 'hermes config migrate' to add them")
-        
+
         print()
-    
+
     else:
         print(f"Unknown config command: {subcmd}")
         print()
@@ -6109,8 +6685,11 @@ def _inject_profile_env_vars() -> None:
     _profile_env_vars_injected = True
     try:
         from providers import list_providers
+
         for _pp in list_providers():
-            if _pp.auth_type not in {"api_key",}:
+            if _pp.auth_type not in {
+                "api_key",
+            }:
                 continue
             for _var in _pp.env_vars:
                 if _var in OPTIONAL_ENV_VARS:
@@ -6213,8 +6792,7 @@ def _inject_platform_plugin_env_vars() -> None:
                     )
                 OPTIONAL_ENV_VARS[name] = {
                     "description": (
-                        meta.get("description")
-                        or f"{label} configuration"
+                        meta.get("description") or f"{label} configuration"
                     ),
                     "prompt": meta.get("prompt") or name,
                     "url": meta.get("url") or None,

--- a/hermes_cli/config_migrations.py
+++ b/hermes_cli/config_migrations.py
@@ -344,7 +344,11 @@ def _migrate_to_21(results: Dict[str, Any], quiet: bool) -> None:
 
         plugins_cfg["enabled"] = grandfathered
         config["plugins"] = plugins_cfg
-        _persist_migration(config)
+        _persist_migration(
+            config,
+            preserve_plugin_state=False,
+            preserve_platform_toolsets=True,
+        )
         results["config_added"].append(
             f"plugins.enabled (opt-in allow-list, {len(grandfathered)} grandfathered)"
         )
@@ -816,7 +820,11 @@ def _migrate_to_38(results: Dict[str, Any], quiet: bool) -> None:
 
     plugins["enabled"] = [value for value in enabled if value not in removed]
     config["plugins"] = plugins
-    _persist_migration(config)
+    _persist_migration(
+        config,
+        preserve_plugin_state=False,
+        preserve_platform_toolsets=True,
+    )
     message = (
         "Removed legacy Relay plugin from plugins.enabled: "
         f"{', '.join(removed)}. Configure native Relay plugins with "
@@ -853,7 +861,11 @@ def _migrate_to_39(results: Dict[str, Any], quiet: bool) -> None:
         if changed:
             config[section] = mapping
     if changed:
-        _persist_migration(config)
+        _persist_migration(
+            config,
+            preserve_plugin_state=True,
+            preserve_platform_toolsets=False,
+        )
         results["config_added"].append("removed retired 'bfl' toolset from saved toolset lists")
         if not quiet:
             print(

--- a/hermes_cli/credential_lifecycle.py
+++ b/hermes_cli/credential_lifecycle.py
@@ -108,6 +108,15 @@ def _prune_env_pool_entries(env_var: str) -> List[str]:
 
 
 def _scrub_config_yaml_mirrors(old_value: str, new_value: str | None) -> List[str]:
+    from hermes_cli.config import config_write_lock
+
+    with config_write_lock():
+        return _scrub_config_yaml_mirrors_locked(old_value, new_value)
+
+
+def _scrub_config_yaml_mirrors_locked(
+    old_value: str, new_value: str | None
+) -> List[str]:
     """Reconcile config.yaml api_key mirrors that hold ``old_value``.
 
     Value-matched on purpose: we only touch a config entry when it provably
@@ -121,12 +130,9 @@ def _scrub_config_yaml_mirrors(old_value: str, new_value: str | None) -> List[st
     """
     if not old_value:
         return []
-    from utils import atomic_yaml_write, fast_safe_load
+    from utils import fast_safe_load
 
-    from hermes_cli.config import (
-        get_config_path,
-        require_readable_config_before_write,
-    )
+    from hermes_cli.config import atomic_config_write, get_config_path
 
     config_path = get_config_path()
     if not config_path.exists():
@@ -170,8 +176,7 @@ def _scrub_config_yaml_mirrors(old_value: str, new_value: str | None) -> List[st
             _fix(entry, f"custom_providers.{name}")
 
     if touched:
-        require_readable_config_before_write(config_path)
-        atomic_yaml_write(config_path, user_config, sort_keys=False)
+        atomic_config_write(config_path, user_config, sort_keys=False)
     return touched
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11794,29 +11794,34 @@ def _maybe_setup_dashboard_auth_interactively(args) -> None:
     secret = secrets.token_urlsafe(32)
 
     try:
-        from hermes_cli.config import load_config, save_config
+        from hermes_cli.config import config_write_lock, load_config, save_config
         from hermes_cli.plugins_cmd import ensure_basic_auth_plugin_enabled_in_config
 
-        cfg = load_config()
-        dash = cfg.setdefault("dashboard", {})
-        basic = dash.setdefault("basic_auth", {})
-        basic["username"] = username
-        basic["password_hash"] = password_hash
-        # Never persist plaintext: clear any stale plaintext password key.
-        basic["password"] = ""
-        if not str(basic.get("secret", "") or "").strip():
-            basic["secret"] = secret
-        # The bundled basic provider is a backend plugin that still honours
-        # plugins.disabled. Unblock it when we just wrote basic_auth so the
-        # discover_plugins(force=True) call below can register the provider
-        # (#54489). Surface the mutation so an operator who deliberately
-        # disabled it isn't surprised.
-        if ensure_basic_auth_plugin_enabled_in_config(cfg):
-            print(
-                "  ✓ Re-enabled the bundled 'basic' auth plugin "
-                "(was in plugins.disabled)"
+        with config_write_lock():
+            cfg = load_config()
+            dash = cfg.setdefault("dashboard", {})
+            basic = dash.setdefault("basic_auth", {})
+            basic["username"] = username
+            basic["password_hash"] = password_hash
+            # Never persist plaintext: clear any stale plaintext password key.
+            basic["password"] = ""
+            if not str(basic.get("secret", "") or "").strip():
+                basic["secret"] = secret
+            # The bundled basic provider is a backend plugin that still honours
+            # plugins.disabled. Unblock it when we just wrote basic_auth so the
+            # discover_plugins(force=True) call below can register the provider
+            # (#54489). Surface the mutation so an operator who deliberately
+            # disabled it isn't surprised.
+            if ensure_basic_auth_plugin_enabled_in_config(cfg):
+                print(
+                    "  ✓ Re-enabled the bundled 'basic' auth plugin "
+                    "(was in plugins.disabled)"
+                )
+            save_config(
+                cfg,
+                preserve_plugin_state=False,
+                preserve_platform_toolsets=False,
             )
-        save_config(cfg)
     except Exception as exc:
         print(f"  ✗ Failed to write config.yaml: {exc}")
         sys.exit(1)

--- a/hermes_cli/plugin_install_state.py
+++ b/hermes_cli/plugin_install_state.py
@@ -1,0 +1,328 @@
+"""Profile-local plugin install metadata, locking, and crash recovery."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import threading
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Optional
+
+from hermes_constants import get_hermes_home
+from utils import (
+    secure_atomic_write_text,
+    secure_open_file,
+    secure_parent_directory,
+    secure_replace,
+    secure_rmtree,
+    secure_unlink,
+)
+
+_INSTALL_METADATA_FILE = ".install-metadata.json"
+_INSTALL_TRANSACTION_FILE = ".install-transaction.json"
+_PROCESS_INSTALL_METADATA_LOCK = threading.RLock()
+
+
+class PluginOperationError(Exception):
+    """Recoverable plugin install/update failure (CLI exits; HTTP maps to 4xx)."""
+
+
+def _plugins_dir() -> Path:
+    plugins = get_hermes_home() / "plugins"
+    plugins.mkdir(parents=True, exist_ok=True)
+    return plugins
+
+
+def _lock_file(handle) -> None:
+    """Acquire a blocking one-byte cross-process lock."""
+    if os.name == "nt":
+        import errno
+        import msvcrt
+
+        handle.seek(0, os.SEEK_END)
+        if handle.tell() == 0:
+            handle.write(b"0")
+            handle.flush()
+        while True:
+            handle.seek(0)
+            try:
+                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+                return
+            except OSError as exc:
+                if exc.errno not in {errno.EACCES, errno.EAGAIN, errno.EDEADLK}:
+                    raise
+                time.sleep(0.1)
+    else:
+        import fcntl
+
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+
+
+def _unlock_file(handle) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+    else:
+        import fcntl
+
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def _open_lock_path(path: Path):
+    """Open a regular lock file beneath a held no-follow parent."""
+    if path.is_symlink():
+        raise PluginOperationError(f"Lock path must not be a symlink: {path}")
+    flags = os.O_RDWR | os.O_CREAT | os.O_APPEND | getattr(os, "O_CLOEXEC", 0)
+    try:
+        fd = secure_open_file(path, get_hermes_home(), flags, create_parent=True)
+    except OSError as exc:
+        raise PluginOperationError(
+            f"Could not safely open lock file {path}: {exc}"
+        ) from exc
+    if not stat.S_ISREG(os.fstat(fd).st_mode):
+        os.close(fd)
+        raise PluginOperationError(f"Lock path must be a regular file: {path}")
+    return os.fdopen(fd, "a+b")
+
+
+def _read_control_json(path: Path, label: str) -> object:
+    """Read one regular control file beneath a held no-follow parent."""
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    try:
+        fd = secure_open_file(path, get_hermes_home(), flags)
+    except OSError as exc:
+        raise PluginOperationError(f"Could not read {label}: {exc}") from exc
+    try:
+        with os.fdopen(fd, "r", encoding="utf-8") as handle:
+            fd = -1
+            return json.load(handle)
+    except json.JSONDecodeError as exc:
+        raise PluginOperationError(f"Could not read {label}: {exc}") from exc
+    finally:
+        if fd >= 0:
+            os.close(fd)
+
+
+@contextmanager
+def _install_metadata_lock():
+    """Serialize profile-local install metadata and target commits."""
+    get_hermes_home().mkdir(parents=True, exist_ok=True)
+    path = _install_metadata_path().with_suffix(".lock")
+    namespace = secure_parent_directory(path, get_hermes_home(), create=True)
+    try:
+        namespace.__enter__()
+    except OSError as exc:
+        raise PluginOperationError(
+            f"Plugin install namespace is unsafe: {exc}"
+        ) from exc
+    try:
+        with _PROCESS_INSTALL_METADATA_LOCK, _open_lock_path(path) as handle:
+            _lock_file(handle)
+            try:
+                _recover_install_transaction()
+                yield
+            finally:
+                _unlock_file(handle)
+    finally:
+        namespace.__exit__(None, None, None)
+
+
+def _install_metadata_path() -> Path:
+    return get_hermes_home() / "plugins" / _INSTALL_METADATA_FILE
+
+
+def _install_transaction_path() -> Path:
+    return get_hermes_home() / "plugins" / _INSTALL_TRANSACTION_FILE
+
+
+def _read_install_metadata() -> dict[str, dict[str, object]]:
+    """Read profile-local, non-secret plugin source metadata from disk."""
+    path = _install_metadata_path()
+    if path.is_symlink():
+        raise PluginOperationError(
+            "Plugin install metadata path must not be a symlink."
+        )
+    if not path.exists():
+        return {}
+    value = _read_control_json(path, "plugin install metadata")
+    if not isinstance(value, dict):
+        raise PluginOperationError("Plugin install metadata must be a JSON object.")
+    for key, entry in value.items():
+        if not isinstance(key, str) or not isinstance(entry, dict):
+            raise PluginOperationError(
+                "Plugin install metadata entries must map plugin names to objects."
+            )
+    return value
+
+
+def _write_install_metadata(metadata: dict[str, dict[str, object]]) -> None:
+    """Atomically replace the profile-local plugin install metadata sidecar."""
+    secure_atomic_write_text(
+        _install_metadata_path(),
+        json.dumps(metadata, indent=2, sort_keys=True) + "\n",
+        get_hermes_home(),
+    )
+
+
+def _plugin_membership(name: str) -> tuple[bool, bool]:
+    from hermes_cli.config import config_write_lock, load_config
+
+    with config_write_lock():
+        config = load_config()
+        plugins = config.get("plugins")
+        plugins = plugins if isinstance(plugins, dict) else {}
+        enabled = plugins.get("enabled")
+        disabled = plugins.get("disabled")
+        return (
+            isinstance(enabled, list) and name in enabled,
+            isinstance(disabled, list) and name in disabled,
+        )
+
+
+def _restore_plugin_membership(
+    name: str, was_enabled: bool, was_disabled: bool
+) -> None:
+    """Restore only *name* without overwriting newer state for other plugins."""
+    from hermes_cli.config import config_write_lock, load_config, save_config
+
+    with config_write_lock():
+        config = load_config()
+        plugins = config.setdefault("plugins", {})
+        if not isinstance(plugins, dict):
+            plugins = {}
+            config["plugins"] = plugins
+        raw_enabled = plugins.get("enabled")
+        raw_disabled = plugins.get("disabled")
+        enabled = set(raw_enabled) if isinstance(raw_enabled, list) else set()
+        disabled = set(raw_disabled) if isinstance(raw_disabled, list) else set()
+        (enabled.add if was_enabled else enabled.discard)(name)
+        (disabled.add if was_disabled else disabled.discard)(name)
+        plugins["enabled"] = sorted(enabled)
+        plugins["disabled"] = sorted(disabled)
+        save_config(
+            config,
+            preserve_plugin_state=False,
+            preserve_platform_toolsets=False,
+        )
+
+
+def _write_install_transaction(value: dict[str, object]) -> None:
+    secure_atomic_write_text(
+        _install_transaction_path(),
+        json.dumps(value, indent=2, sort_keys=True) + "\n",
+        get_hermes_home(),
+    )
+
+
+def _recover_install_transaction() -> None:
+    """Roll back an interrupted install before any new plugin mutation."""
+    journal = _install_transaction_path()
+    if journal.is_symlink():
+        raise PluginOperationError(
+            "Plugin install transaction path must not be a symlink."
+        )
+    if not journal.exists():
+        return
+    value = _read_control_json(journal, "plugin install transaction")
+    if not isinstance(value, dict) or value.get("version") != 1:
+        raise PluginOperationError("Plugin install transaction is malformed.")
+
+    name = value.get("plugin_name")
+    transaction_dir = value.get("transaction_dir")
+    old_metadata = value.get("old_metadata")
+    if (
+        not isinstance(name, str)
+        or not isinstance(transaction_dir, str)
+        or not transaction_dir.startswith(".install-")
+        or "/" in transaction_dir
+        or "\\" in transaction_dir
+        or not isinstance(old_metadata, dict)
+        or any(
+            not isinstance(key, str) or not isinstance(entry, dict)
+            for key, entry in old_metadata.items()
+        )
+        or not isinstance(value.get("was_enabled"), bool)
+        or not isinstance(value.get("was_disabled"), bool)
+    ):
+        raise PluginOperationError("Plugin install transaction is malformed.")
+
+    from hermes_cli.plugins_cmd import _sanitize_plugin_name
+
+    plugins_dir = _plugins_dir()
+    try:
+        target = _sanitize_plugin_name(name, plugins_dir)
+    except ValueError as exc:
+        raise PluginOperationError(str(exc)) from exc
+    transaction_root = plugins_dir / transaction_dir
+    if (
+        transaction_root.is_symlink()
+        or not transaction_root.is_dir()
+        or transaction_root.resolve().parent != plugins_dir.resolve()
+    ):
+        raise PluginOperationError("Plugin install transaction directory is unsafe.")
+    backup = transaction_root / "previous-plugin"
+    if backup.is_symlink() or (backup.exists() and not backup.is_dir()):
+        raise PluginOperationError("Plugin install transaction backup is unsafe.")
+    replaced_existing = value.get("replaced_existing") is True
+
+    from hermes_cli.config import config_write_lock
+
+    with config_write_lock():
+        if replaced_existing and backup.exists():
+            if target.exists():
+                if target.is_dir():
+                    secure_rmtree(target, plugins_dir)
+                else:
+                    secure_unlink(target, plugins_dir)
+            secure_replace(backup, target, plugins_dir)
+        elif replaced_existing and not target.exists():
+            raise PluginOperationError(
+                "Interrupted plugin install is missing both target and backup."
+            )
+        elif not replaced_existing and target.exists():
+            if target.is_dir():
+                secure_rmtree(target, plugins_dir)
+            else:
+                secure_unlink(target, plugins_dir)
+
+        if old_metadata:
+            _write_install_metadata(old_metadata)
+        else:
+            secure_unlink(_install_metadata_path(), get_hermes_home(), missing_ok=True)
+        _restore_plugin_membership(
+            name,
+            value.get("was_enabled") is True,
+            value.get("was_disabled") is True,
+        )
+        secure_unlink(journal, get_hermes_home(), missing_ok=True)
+
+    if transaction_root.exists():
+        try:
+            secure_rmtree(transaction_root, plugins_dir)
+        except OSError:
+            pass
+
+
+def _marketplace_metadata(entry) -> dict[str, object]:
+    """Return private-marketplace provenance for atomic install metadata."""
+    return {
+        "marketplace_id": entry.source_id,
+        "marketplace_name": entry.source_name,
+        "marketplace_plugin_name": entry.name,
+        "source": entry.repo,
+        "subdir": entry.subdir,
+        "installed_repo_sha": entry.sha,
+        "installed_tree_sha": entry.tree_sha,
+    }
+
+
+def _marketplace_install(plugin_name: str) -> Optional[dict[str, object]]:
+    value = _read_install_metadata().get(plugin_name)
+    if not isinstance(value, dict) or not value.get("marketplace_id"):
+        return None
+    return value

--- a/hermes_cli/plugin_marketplaces.py
+++ b/hermes_cli/plugin_marketplaces.py
@@ -1,0 +1,739 @@
+"""Profile-scoped Git plugin marketplaces.
+
+Custom marketplaces use Claude's ``.claude-plugin/marketplace.json`` as the
+catalogue format. Only repository-local ``./path`` sources are supported.
+Repositories are fetched through the selected profile host's existing Git
+credentials and reduced to a bounded, non-secret JSON cache for Desktop.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+
+import subprocess
+import tempfile
+import threading
+import time
+import urllib.parse
+from dataclasses import dataclass
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+from hermes_cli._subprocess_compat import noninteractive_git_env
+from utils import (
+    secure_atomic_write_text,
+    secure_open_file,
+    secure_parent_directory,
+    secure_unlink,
+)
+
+logger = logging.getLogger(__name__)
+
+_REGISTRY_VERSION = 1
+_CACHE_TTL = 6 * 60 * 60
+_MAX_MANIFEST_BYTES = 1024 * 1024
+_MAX_ENTRIES = 500
+_MAX_NAME_LENGTH = 128
+_MAX_TEXT_LENGTH = 4096
+_SOURCE_ID_RE = re.compile(r"^[0-9a-f]{16}$")
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+_PROCESS_REGISTRY_LOCK = threading.RLock()
+_PROCESS_REFRESH_LOCK = threading.RLock()
+
+
+class MarketplaceError(ValueError):
+    """A marketplace URL, checkout, or manifest is invalid."""
+
+
+@dataclass(frozen=True)
+class MarketplaceCatalogEntry:
+    name: str
+    repo: str
+    sha: str
+    description: str
+    maintainer: str
+    subdir: str
+    source_id: str
+    source_name: str
+    display_name: str
+    version: str
+    tree_sha: str
+    compatible: bool
+    tier: str = "community"
+
+
+def _registry_path() -> Path:
+    return get_hermes_home() / "plugin-marketplaces.json"
+
+
+def _cache_dir() -> Path:
+    return get_hermes_home() / "cache" / "plugin-marketplaces"
+
+
+def _ensure_cache_dir() -> Path:
+    path = _cache_dir()
+    try:
+        with secure_parent_directory(
+            path / ".sentinel", get_hermes_home(), create=True
+        ):
+            pass
+    except OSError as exc:
+        raise MarketplaceError(
+            f"Marketplace cache path contains a symlink or is unsafe: {exc}"
+        ) from exc
+    return path
+
+
+def _open_marketplace_lock(path: Path):
+    from hermes_cli.plugins_cmd import PluginOperationError, _open_lock_path
+
+    try:
+        return _open_lock_path(path)
+    except PluginOperationError as exc:
+        raise MarketplaceError(str(exc)) from exc
+
+
+@contextmanager
+def _registry_lock():
+    """Serialize profile-local registry read-modify-write transactions."""
+    path = _registry_path().with_suffix(".lock")
+    with _PROCESS_REGISTRY_LOCK, _open_marketplace_lock(path) as handle:
+        from hermes_cli.plugins_cmd import _lock_file, _unlock_file
+
+        _lock_file(handle)
+        try:
+            yield
+        finally:
+            _unlock_file(handle)
+
+
+@contextmanager
+def _refresh_lock(source_id: str):
+    """Serialize one source's clone/parse/cache transaction across processes."""
+    source_id = _validated_source_id(source_id)
+    cache = _ensure_cache_dir()
+    path = cache / f".{source_id}.refresh.lock"
+    # ponytail: process-global lock; split per source if refresh throughput matters.
+    with _PROCESS_REFRESH_LOCK, _open_marketplace_lock(path) as handle:
+        from hermes_cli.plugins_cmd import _lock_file, _unlock_file
+
+        _lock_file(handle)
+        try:
+            yield
+        finally:
+            _unlock_file(handle)
+
+
+def _source_id(url: str) -> str:
+    return hashlib.sha256(url.encode("utf-8")).hexdigest()[:16]
+
+
+def _validated_source_id(value: Any) -> str:
+    if not isinstance(value, str) or not _SOURCE_ID_RE.fullmatch(value):
+        raise MarketplaceError(
+            "Plugin marketplace registry contains an invalid source ID."
+        )
+    return value
+
+
+def _text(value: Any, *, label: str, maximum: int = _MAX_TEXT_LENGTH) -> str:
+    if not isinstance(value, str):
+        raise MarketplaceError(f"{label} must be a string.")
+    value = value.strip()
+    if not value:
+        raise MarketplaceError(f"{label} must not be empty.")
+    if len(value) > maximum:
+        raise MarketplaceError(f"{label} exceeds the {maximum}-character limit.")
+    if any(ord(char) < 32 for char in value):
+        raise MarketplaceError(f"{label} contains control characters.")
+    return value
+
+
+def _optional_text(value: Any, *, label: str, maximum: int = _MAX_TEXT_LENGTH) -> str:
+    if value in (None, ""):
+        return ""
+    return _text(value, label=label, maximum=maximum)
+
+
+def _read_json(path: Path, *, label: str) -> Any:
+    try:
+        if path.stat().st_size > _MAX_MANIFEST_BYTES:
+            raise MarketplaceError(f"{label} exceeds the 1 MB limit.")
+        return json.loads(path.read_text(encoding="utf-8"))
+    except MarketplaceError:
+        raise
+    except (OSError, json.JSONDecodeError) as exc:
+        raise MarketplaceError(f"Could not read {label}: {exc}") from exc
+
+
+def _read_control_json(path: Path, *, label: str) -> Any:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    try:
+        fd = secure_open_file(path, get_hermes_home(), flags)
+    except OSError as exc:
+        raise MarketplaceError(f"Could not read {label}: {exc}") from exc
+    try:
+        info = os.fstat(fd)
+        if info.st_size > _MAX_MANIFEST_BYTES:
+            raise MarketplaceError(f"{label} exceeds the 1 MB limit.")
+        with os.fdopen(fd, "r", encoding="utf-8") as handle:
+            fd = -1
+            return json.load(handle)
+    except json.JSONDecodeError as exc:
+        raise MarketplaceError(f"Could not read {label}: {exc}") from exc
+    finally:
+        if fd >= 0:
+            os.close(fd)
+
+
+def _read_registry() -> list[dict[str, str]]:
+    path = _registry_path()
+    if path.is_symlink():
+        raise MarketplaceError("Plugin marketplace registry must not be a symlink.")
+    if not path.exists():
+        return []
+    value = _read_control_json(path, label="plugin marketplace registry")
+    if not isinstance(value, dict) or value.get("version") != _REGISTRY_VERSION:
+        raise MarketplaceError("Plugin marketplace registry has an unsupported format.")
+    sources = value.get("marketplaces")
+    if not isinstance(sources, list):
+        raise MarketplaceError(
+            "Plugin marketplace registry must contain a marketplaces list."
+        )
+    out: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for source in sources:
+        if not isinstance(source, dict):
+            raise MarketplaceError(
+                "Plugin marketplace registry contains an invalid source."
+            )
+        sid = _validated_source_id(source.get("id"))
+        name = source.get("name")
+        url = source.get("url")
+        if not isinstance(name, str) or not name or not isinstance(url, str) or not url:
+            raise MarketplaceError(
+                "Plugin marketplace registry contains an invalid source."
+            )
+        normalized = _normalize_url(url, allow_file=url.startswith("file://"))
+        if sid != _source_id(normalized) or sid in seen:
+            raise MarketplaceError(
+                "Plugin marketplace registry contains an invalid source."
+            )
+        seen.add(sid)
+        out.append({
+            "id": sid,
+            "name": _text(name, label="marketplace name", maximum=_MAX_NAME_LENGTH),
+            "url": normalized,
+        })
+    return out
+
+
+def _write_registry(sources: list[dict[str, str]]) -> None:
+    path = _registry_path()
+    if path.is_symlink():
+        raise MarketplaceError("Plugin marketplace registry must not be a symlink.")
+    secure_atomic_write_text(
+        path,
+        json.dumps(
+            {"marketplaces": sources, "version": _REGISTRY_VERSION},
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        get_hermes_home(),
+    )
+
+
+def _normalize_url(url: str, *, allow_file: bool = False) -> str:
+    from hermes_cli.plugins_cmd import _resolve_git_url, _scrub_git_url
+
+    candidate = (url or "").strip()
+    if not candidate:
+        raise MarketplaceError("Marketplace URL is required.")
+    if "\\" in candidate or any(ord(char) < 32 for char in candidate):
+        raise MarketplaceError("Marketplace URL contains unsupported characters.")
+    raw = urllib.parse.urlsplit(candidate)
+    if raw.query or raw.fragment:
+        raise MarketplaceError("Marketplace URL must not contain a query or fragment.")
+    try:
+        git_url, subdir = _resolve_git_url(candidate)
+    except ValueError as exc:
+        raise MarketplaceError(str(exc)) from exc
+    if subdir:
+        raise MarketplaceError("Marketplace URL must point to a repository root.")
+    parsed = urllib.parse.urlsplit(git_url)
+    if parsed.username or parsed.password:
+        raise MarketplaceError("Marketplace URLs must not contain credentials.")
+    if parsed.query or parsed.fragment:
+        raise MarketplaceError("Marketplace URL must not contain a query or fragment.")
+    if parsed.scheme == "file" and allow_file:
+        return git_url
+    if parsed.scheme != "https":
+        raise MarketplaceError("Marketplace URL must use https://.")
+    return _scrub_git_url(git_url).rstrip("/")
+
+
+def _git(repo: Path, *args: str) -> str:
+    from hermes_cli.plugins_cmd import _resolve_git_executable, _safe_git_error
+
+    git = _resolve_git_executable()
+    if not git:
+        raise MarketplaceError("git is not installed or not in PATH.")
+    try:
+        result = subprocess.run(
+            [git, *args],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=20,
+            stdin=subprocess.DEVNULL,
+            env=noninteractive_git_env(),
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise MarketplaceError("Git command timed out after 20 seconds.") from exc
+    if result.returncode != 0:
+        raise MarketplaceError(_safe_git_error(result))
+    return result.stdout.strip().lower()
+
+
+def _clone(url: str, target: Path) -> None:
+    from hermes_cli.plugins_cmd import _resolve_git_executable, _safe_git_error
+
+    git = _resolve_git_executable()
+    if not git:
+        raise MarketplaceError("git is not installed or not in PATH.")
+    try:
+        result = subprocess.run(
+            [git, "clone", "--depth", "1", url, str(target)],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=60,
+            stdin=subprocess.DEVNULL,
+            env=noninteractive_git_env(),
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise MarketplaceError("Marketplace clone timed out after 60 seconds.") from exc
+    if result.returncode != 0:
+        raise MarketplaceError(f"Git clone failed:\n{_safe_git_error(result, url)}")
+
+
+def _author_name(value: Any, fallback: str) -> str:
+    if isinstance(value, dict):
+        value = value.get("name")
+    if isinstance(value, str) and value.strip():
+        return _text(value, label="plugin author")
+    return fallback
+
+
+def _manifest_file(root: Path, path: Path, label: str) -> Path:
+    if path.is_symlink():
+        raise MarketplaceError(f"{label} must not be a symlink.")
+    try:
+        path.resolve().relative_to(root.resolve())
+    except ValueError as exc:
+        raise MarketplaceError(
+            f"{label} must stay inside the marketplace repository."
+        ) from exc
+    if not path.is_file():
+        raise MarketplaceError(f"Repository has no {label}.")
+    return path
+
+
+def _compatibility(plugin_root: Path, plugin_name: str) -> tuple[bool, str]:
+    for filename in ("plugin.yaml", "plugin.yml", "plugin.json"):
+        manifest = plugin_root / filename
+        if manifest.is_symlink():
+            return False, f"{filename} must not be a symlink"
+        if manifest.is_file():
+            try:
+                from hermes_cli.plugins_cmd import _read_manifest
+
+                parsed = _read_manifest(plugin_root)
+            except Exception as exc:
+                return False, str(exc)
+            if not parsed:
+                return False, f"Could not validate {filename}"
+            if parsed.get("name") != plugin_name:
+                return False, "Hermes plugin name must match the marketplace entry"
+            return True, ""
+    return False, "Requires a root Hermes plugin.json or plugin.yaml manifest"
+
+
+def _parse_checkout(root: Path, source: dict[str, str]) -> list[dict[str, Any]]:
+    from hermes_cli.plugins_cmd import PluginOperationError, _resolve_subdir_within
+
+    marketplace_path = _manifest_file(
+        root,
+        root / ".claude-plugin" / "marketplace.json",
+        ".claude-plugin/marketplace.json",
+    )
+    manifest = _read_json(marketplace_path, label="marketplace manifest")
+    if not isinstance(manifest, dict):
+        raise MarketplaceError("Marketplace manifest must be a JSON object.")
+    name = (
+        _text(
+            manifest.get("name"),
+            label="marketplace name",
+            maximum=_MAX_NAME_LENGTH,
+        )
+        .replace("-", " ")
+        .replace("_", " ")
+        .title()
+    )
+    plugins = manifest.get("plugins")
+    if not isinstance(plugins, list) or not plugins:
+        raise MarketplaceError("Marketplace manifest must contain at least one plugin.")
+    if len(plugins) > _MAX_ENTRIES:
+        raise MarketplaceError(f"Marketplace exceeds the {_MAX_ENTRIES}-plugin limit.")
+    owner = _author_name(manifest.get("owner"), name)
+    head = _git(root, "rev-parse", "HEAD")
+    entries: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for raw in plugins:
+        if not isinstance(raw, dict):
+            raise MarketplaceError("Marketplace plugins must be JSON objects.")
+        plugin_name = _text(
+            raw.get("name"),
+            label="plugin name",
+            maximum=_MAX_NAME_LENGTH,
+        )
+        if plugin_name in seen:
+            raise MarketplaceError(
+                f"Marketplace contains duplicate plugin '{plugin_name}'."
+            )
+        seen.add(plugin_name)
+        source_path = raw.get("source")
+        if not isinstance(source_path, str):
+            raise MarketplaceError(
+                f"Marketplace plugin '{plugin_name}' uses an unsupported object source."
+            )
+        if "\\" in source_path or not source_path.startswith("./"):
+            raise MarketplaceError(
+                f"Marketplace plugin '{plugin_name}' source must be a relative './...' path."
+            )
+        subdir = source_path[2:].strip("/")
+        if not subdir:
+            raise MarketplaceError(
+                f"Marketplace plugin '{plugin_name}' source is empty."
+            )
+        relative = Path(subdir)
+        if any(
+            (root.joinpath(*relative.parts[:index])).is_symlink()
+            for index in range(1, len(relative.parts) + 1)
+        ):
+            raise MarketplaceError(
+                f"Marketplace plugin '{plugin_name}' root must not contain symlinks."
+            )
+        try:
+            plugin_root = _resolve_subdir_within(root, subdir)
+        except PluginOperationError as exc:
+            raise MarketplaceError(
+                f"Marketplace plugin '{plugin_name}' source must stay inside the marketplace repository."
+            ) from exc
+        if _git(root, "cat-file", "-t", f"HEAD:{subdir}") != "tree":
+            raise MarketplaceError(
+                f"Marketplace plugin '{plugin_name}' source must be a directory tree."
+            )
+        claude_manifest = plugin_root / ".claude-plugin" / "plugin.json"
+        metadata: dict[str, Any] = {}
+        if claude_manifest.exists() or claude_manifest.is_symlink():
+            value = _read_json(
+                _manifest_file(
+                    root, claude_manifest, f"plugin manifest for {plugin_name}"
+                ),
+                label=f"plugin manifest for {plugin_name}",
+            )
+            if not isinstance(value, dict):
+                raise MarketplaceError(
+                    f"Plugin manifest for '{plugin_name}' must be a JSON object."
+                )
+            metadata = value
+        compatible, reason = _compatibility(plugin_root, plugin_name)
+        entries.append({
+            "compatible": compatible,
+            "description": _optional_text(
+                raw.get("description") or metadata.get("description"),
+                label=f"description for {plugin_name}",
+            ),
+            "display_name": _optional_text(
+                raw.get("displayName")
+                or raw.get("display_name")
+                or metadata.get("displayName")
+                or plugin_name,
+                label=f"display name for {plugin_name}",
+                maximum=_MAX_NAME_LENGTH,
+            ),
+            "incompatibility_reason": reason,
+            "maintainer": _author_name(
+                raw.get("author") or metadata.get("author"), owner
+            ),
+            "name": plugin_name,
+            "repo": source["url"],
+            "sha": head,
+            "source_id": source["id"],
+            "source_name": name,
+            "subdir": subdir,
+            "tree_sha": _git(root, "rev-parse", f"HEAD:{subdir}"),
+            "version": _optional_text(
+                raw.get("version") or metadata.get("version"),
+                label=f"version for {plugin_name}",
+                maximum=_MAX_NAME_LENGTH,
+            ),
+        })
+    source["name"] = name
+    return entries
+
+
+def _cache_path(source_id: str) -> Path:
+    return _cache_dir() / f"{_validated_source_id(source_id)}.json"
+
+
+def _remove_cache(source_id: str) -> None:
+    try:
+        secure_unlink(_cache_path(source_id), get_hermes_home(), missing_ok=True)
+    except OSError as exc:
+        logger.warning("Marketplace removed; cache cleanup deferred: %s", exc)
+
+
+def _write_cache(source: dict[str, str], entries: list[dict[str, Any]]) -> None:
+    path = _cache_path(source["id"])
+    if path.is_symlink():
+        raise MarketplaceError("Plugin marketplace cache must not be a symlink.")
+    secure_atomic_write_text(
+        path,
+        json.dumps({"entries": entries, "source": source}, indent=2, sort_keys=True)
+        + "\n",
+        get_hermes_home(),
+    )
+
+
+def _read_cache(source: dict[str, str]) -> dict[str, Any] | None:
+    path = _cache_path(source["id"])
+    _ensure_cache_dir()
+    if path.is_symlink():
+        return None
+    if not path.is_file():
+        return None
+    try:
+        value = _read_control_json(path, label=f"cache for {source['name']}")
+    except MarketplaceError:
+        return None
+    if not isinstance(value, dict) or not isinstance(value.get("entries"), list):
+        return None
+    cached_source = value.get("source")
+    if not isinstance(cached_source, dict) or cached_source.get("url") != source["url"]:
+        return None
+    for entry in value["entries"]:
+        if not isinstance(entry, dict) or not isinstance(entry.get("compatible"), bool):
+            return None
+        required = (
+            "name",
+            "repo",
+            "sha",
+            "source_id",
+            "source_name",
+            "subdir",
+            "tree_sha",
+        )
+        if not all(isinstance(entry.get(key), str) for key in required):
+            return None
+        if entry["repo"] != source["url"] or entry["source_id"] != source["id"]:
+            return None
+        if not _SHA_RE.fullmatch(entry["sha"]) or not _SHA_RE.fullmatch(
+            entry["tree_sha"]
+        ):
+            return None
+        subdir = entry["subdir"]
+        if (
+            not subdir
+            or "\\" in subdir
+            or subdir.startswith("/")
+            or ".." in Path(subdir).parts
+        ):
+            return None
+        for key in (
+            "description",
+            "display_name",
+            "incompatibility_reason",
+            "maintainer",
+            "version",
+        ):
+            if not isinstance(entry.get(key, ""), str):
+                return None
+    return {**source, "available": True, "entries": value["entries"], "stale": False}
+
+
+def _refresh(source: dict[str, str]) -> dict[str, Any]:
+    with _refresh_lock(source["id"]):
+        resolved = dict(source)
+        _ensure_cache_dir()
+        with tempfile.TemporaryDirectory(prefix="marketplace-") as tmp:
+            clone = Path(tmp) / "repo"
+            _clone(resolved["url"], clone)
+            entries = _parse_checkout(clone, resolved)
+        _write_cache(resolved, entries)
+        return {**resolved, "available": True, "entries": entries, "stale": False}
+
+
+def add_marketplace(url: str, *, allow_file: bool = False) -> dict[str, Any]:
+    """Validate, persist, and return one Git marketplace."""
+    normalized = _normalize_url(url, allow_file=allow_file)
+    sid = _source_id(normalized)
+    source = {
+        "id": sid,
+        "name": normalized.rsplit("/", 1)[-1],
+        "url": normalized,
+    }
+    refreshed = _refresh(source)
+    source["name"] = str(refreshed["name"])
+    with _registry_lock():
+        sources = _read_registry()
+        existing = next((saved for saved in sources if saved["id"] == sid), None)
+        if existing is None:
+            sources.append({key: source[key] for key in ("id", "name", "url")})
+        else:
+            existing["name"] = source["name"]
+        _write_registry(sources)
+    return refreshed
+
+
+def list_marketplaces(*, force: bool = False) -> list[dict[str, Any]]:
+    """Return saved marketplaces, retaining validated stale snapshots on errors."""
+    out: list[dict[str, Any]] = []
+    for source in _read_registry():
+        cached = _read_cache(source)
+        cache_path = _cache_path(source["id"])
+        fresh = False
+        if cached is not None and not force:
+            try:
+                fresh = time.time() - cache_path.stat().st_mtime < _CACHE_TTL
+            except OSError:
+                pass
+        if fresh and cached is not None:
+            out.append(cached)
+            continue
+        try:
+            refreshed = _refresh(source)
+            if refreshed["name"] != source["name"]:
+                with _registry_lock():
+                    sources = _read_registry()
+                    for saved in sources:
+                        if saved["id"] == source["id"]:
+                            saved["name"] = str(refreshed["name"])
+                    _write_registry(sources)
+            out.append(refreshed)
+        except MarketplaceError as exc:
+            if cached is not None:
+                out.append({**cached, "error": str(exc), "stale": True})
+            else:
+                out.append({
+                    **source,
+                    "available": False,
+                    "entries": [],
+                    "error": str(exc),
+                    "stale": False,
+                })
+    return out
+
+
+def remove_marketplace(source_id: str) -> bool:
+    source_id = _validated_source_id(source_id)
+    with _registry_lock():
+        sources = _read_registry()
+        kept = [source for source in sources if source["id"] != source_id]
+        if len(kept) == len(sources):
+            return False
+        _write_registry(kept)
+    _remove_cache(source_id)
+    return True
+
+
+@contextmanager
+def marketplace_authority(source_id: str, url: str):
+    """Hold source registration stable across an install commit."""
+    with _registry_lock():
+        yield any(
+            source["id"] == source_id and source["url"] == url
+            for source in _read_registry()
+        )
+
+
+def get_marketplace_entry(
+    source_id: str, name: str, *, force: bool = False
+) -> dict[str, Any] | None:
+    for source in list_marketplaces(force=force):
+        if (
+            source["id"] != source_id
+            or not source.get("available")
+            or (force and source.get("stale"))
+        ):
+            continue
+        for entry in source.get("entries", []):
+            if isinstance(entry, dict) and entry.get("name") == name:
+                # Refresh runs without the registry lock. Re-check authority
+                # before returning so a concurrently removed source cannot
+                # authorize an install from its detached refresh result.
+                with _registry_lock():
+                    if not any(
+                        saved["id"] == source_id and saved["url"] == source["url"]
+                        for saved in _read_registry()
+                    ):
+                        _remove_cache(source_id)
+                        return None
+                return entry
+    return None
+
+
+def public_marketplace(value: dict[str, Any]) -> dict[str, Any]:
+    """Remove clone/install coordinates before data reaches the renderer."""
+    entry_fields = {
+        "compatible",
+        "description",
+        "display_name",
+        "incompatibility_reason",
+        "maintainer",
+        "name",
+        "source_id",
+        "source_name",
+        "version",
+    }
+    return {
+        key: value[key]
+        for key in ("available", "entries", "error", "id", "name", "stale", "url")
+        if key in value
+    } | {
+        "entries": [
+            {key: entry.get(key) for key in entry_fields}
+            for entry in value.get("entries", [])
+            if isinstance(entry, dict)
+        ]
+    }
+
+
+def as_catalog_entry(value: dict[str, Any]):
+    """Adapt trusted marketplace metadata to the existing catalog contract."""
+    return MarketplaceCatalogEntry(
+        name=str(value["name"]),
+        repo=str(value["repo"]),
+        sha=str(value["sha"]),
+        description=str(value.get("description") or ""),
+        maintainer=str(value.get("maintainer") or value.get("source_name") or ""),
+        tier="community",
+        subdir=str(value.get("subdir") or ""),
+        source_id=str(value.get("source_id") or ""),
+        source_name=str(value.get("source_name") or ""),
+        display_name=str(value.get("display_name") or value.get("name") or ""),
+        version=str(value.get("version") or ""),
+        tree_sha=str(value.get("tree_sha") or ""),
+        compatible=bool(value.get("compatible")),
+    )

--- a/hermes_cli/plugin_marketplaces.py
+++ b/hermes_cli/plugin_marketplaces.py
@@ -91,7 +91,7 @@ def _ensure_cache_dir() -> Path:
 
 
 def _open_marketplace_lock(path: Path):
-    from hermes_cli.plugins_cmd import PluginOperationError, _open_lock_path
+    from hermes_cli.plugin_install_state import PluginOperationError, _open_lock_path
 
     try:
         return _open_lock_path(path)
@@ -104,7 +104,7 @@ def _registry_lock():
     """Serialize profile-local registry read-modify-write transactions."""
     path = _registry_path().with_suffix(".lock")
     with _PROCESS_REGISTRY_LOCK, _open_marketplace_lock(path) as handle:
-        from hermes_cli.plugins_cmd import _lock_file, _unlock_file
+        from hermes_cli.plugin_install_state import _lock_file, _unlock_file
 
         _lock_file(handle)
         try:
@@ -121,7 +121,7 @@ def _refresh_lock(source_id: str):
     path = cache / f".{source_id}.refresh.lock"
     # ponytail: process-global lock; split per source if refresh throughput matters.
     with _PROCESS_REFRESH_LOCK, _open_marketplace_lock(path) as handle:
-        from hermes_cli.plugins_cmd import _lock_file, _unlock_file
+        from hermes_cli.plugin_install_state import _lock_file, _unlock_file
 
         _lock_file(handle)
         try:
@@ -709,7 +709,7 @@ def public_marketplace(value: dict[str, Any]) -> dict[str, Any]:
     }
     return {
         key: value[key]
-        for key in ("available", "entries", "error", "id", "name", "stale", "url")
+        for key in ("available", "entries", "error", "id", "name", "stale")
         if key in value
     } | {
         "entries": [

--- a/hermes_cli/plugin_packs.py
+++ b/hermes_cli/plugin_packs.py
@@ -470,13 +470,9 @@ def install_pack_plugins(
     from hermes_cli.plugins_cmd import (
         PluginOperationError,
         _declared_capabilities_from_manifest,
-        _get_disabled_set,
-        _get_enabled_set,
         _install_plugin_core,
         _prompt_plugin_env_vars,
         _run_capability_consent,
-        _save_disabled_set,
-        _save_enabled_set,
     )
 
     results: List[PackInstallResult] = []
@@ -491,7 +487,7 @@ def install_pack_plugins(
         console.print(f"[dim]Installing {display} @ {rp.entry.ref[:12]}...[/dim]")
         try:
             target, manifest, installed_name = _install_plugin_core(
-                rp.identifier, force=force, ref=rp.entry.ref
+                rp.identifier, force=force, ref=rp.entry.ref, enable_on_commit=True
             )
         except PluginOperationError as exc:
             results.append(PackInstallResult(display=display, ok=False, error=str(exc)))
@@ -509,13 +505,6 @@ def install_pack_plugins(
         except Exception:
             logger.debug("requires_env prompt failed for %s", installed_name, exc_info=True)
 
-        # Enable: the user confirmed the mandatory review screen.
-        enabled = _get_enabled_set()
-        disabled = _get_disabled_set()
-        enabled.add(installed_name)
-        disabled.discard(installed_name)
-        _save_enabled_set(enabled)
-        _save_disabled_set(disabled)
 
         # Per-plugin capability consent — the SAME flow as a single
         # install (#64228). A pack never bulk-grants capabilities.

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -4324,6 +4324,12 @@ class PluginManager:
         sessions without requiring a full agent restart.
         """
         with self._discovery_lock, _plugin_home_scope(self.home_path):
+            # Recover any crash-interrupted artifact/provenance/config commit
+            # before plugin code can be imported from the replaced directory.
+            from hermes_cli.plugins_cmd import _install_metadata_lock
+
+            with _install_metadata_lock():
+                pass
             if self._discovered and not force:
                 return
             if force:

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -18,26 +18,22 @@ import logging
 import os
 import re
 import shutil
-import stat
 import subprocess
 import sys
 import tempfile
-import time
 import urllib.parse
-import threading
 import unicodedata
-from contextlib import contextmanager, nullcontext
+from contextlib import nullcontext
 from pathlib import Path
 from typing import Any, Optional
 
 from hermes_constants import get_hermes_home
 from hermes_cli._subprocess_compat import noninteractive_git_env
 from hermes_cli.config import cfg_get
+from hermes_cli import plugin_install_state as _install_state
 from hermes_cli.secret_prompt import masked_secret_prompt
 from utils import (
     secure_atomic_write_text,
-    secure_open_file,
-    secure_parent_directory,
     secure_replace,
     secure_rmtree,
     secure_unlink,
@@ -79,8 +75,7 @@ def _resolve_git_executable() -> Optional[str]:
     return None
 
 
-class PluginOperationError(Exception):
-    """Recoverable plugin install/update failure (CLI exits; HTTP maps to 4xx)."""
+PluginOperationError = _install_state.PluginOperationError
 
 
 class PluginScanBlocked(PluginOperationError):
@@ -633,316 +628,52 @@ def _require_installed_plugin(name: str, plugins_dir: Path, console) -> Path:
 
 
 _EXACT_COMMIT_RE = re.compile(r"^[0-9a-fA-F]{40}$")
-_INSTALL_METADATA_FILE = ".install-metadata.json"
-_INSTALL_TRANSACTION_FILE = ".install-transaction.json"
-_PROCESS_INSTALL_METADATA_LOCK = threading.RLock()
 
 
-def _lock_file(handle) -> None:
-    """Acquire a blocking one-byte cross-process lock."""
-    if os.name == "nt":
-        import errno
-        import msvcrt
-
-        handle.seek(0, os.SEEK_END)
-        if handle.tell() == 0:
-            handle.write(b"0")
-            handle.flush()
-        while True:
-            handle.seek(0)
-            try:
-                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
-                return
-            except OSError as exc:
-                if exc.errno not in {errno.EACCES, errno.EAGAIN, errno.EDEADLK}:
-                    raise
-                time.sleep(0.1)
-    else:
-        import fcntl
-
-        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
-
-
-def _unlock_file(handle) -> None:
-    if os.name == "nt":
-        import msvcrt
-
-        handle.seek(0)
-        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
-    else:
-        import fcntl
-
-        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
-
-
-def _reject_symlink_components(path: Path, root: Path) -> None:
-    """Reject symlinks below a trusted root before control-file operations."""
-    root = root.absolute()
-    try:
-        relative = path.absolute().relative_to(root)
-    except ValueError as exc:
-        raise PluginOperationError(f"Control path escapes {root}.") from exc
-    current = root
-    for part in relative.parts:
-        current /= part
-        if current.is_symlink():
-            raise PluginOperationError(
-                f"Control path must not contain symlinks: {path}"
-            )
-
-
-def _open_lock_path(path: Path):
-    """Open a regular lock file beneath a held no-follow parent."""
-    if path.is_symlink():
-        raise PluginOperationError(f"Lock path must not be a symlink: {path}")
-    flags = os.O_RDWR | os.O_CREAT | os.O_APPEND | getattr(os, "O_CLOEXEC", 0)
-    try:
-        fd = secure_open_file(path, get_hermes_home(), flags, create_parent=True)
-    except OSError as exc:
-        raise PluginOperationError(
-            f"Could not safely open lock file {path}: {exc}"
-        ) from exc
-    if not stat.S_ISREG(os.fstat(fd).st_mode):
-        os.close(fd)
-        raise PluginOperationError(f"Lock path must be a regular file: {path}")
-    return os.fdopen(fd, "a+b")
-
-
-def _read_control_json(path: Path, label: str) -> object:
-    """Read one regular control file beneath a held no-follow parent."""
-    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
-    try:
-        fd = secure_open_file(path, get_hermes_home(), flags)
-    except OSError as exc:
-        raise PluginOperationError(f"Could not read {label}: {exc}") from exc
-    try:
-        with os.fdopen(fd, "r", encoding="utf-8") as handle:
-            fd = -1
-            return json.load(handle)
-    except json.JSONDecodeError as exc:
-        raise PluginOperationError(f"Could not read {label}: {exc}") from exc
-    finally:
-        if fd >= 0:
-            os.close(fd)
-
-
-@contextmanager
 def _install_metadata_lock():
-    """Serialize profile-local install metadata and target commits."""
-    path = _install_metadata_path().with_suffix(".lock")
-    namespace = secure_parent_directory(path, get_hermes_home(), create=True)
-    try:
-        namespace.__enter__()
-    except OSError as exc:
-        raise PluginOperationError(
-            f"Plugin install namespace is unsafe: {exc}"
-        ) from exc
-    try:
-        with _PROCESS_INSTALL_METADATA_LOCK, _open_lock_path(path) as handle:
-            _lock_file(handle)
-            try:
-                _recover_install_transaction()
-                yield
-            finally:
-                _unlock_file(handle)
-    finally:
-        namespace.__exit__(None, None, None)
+    return _install_state._install_metadata_lock()
 
 
 def _install_metadata_path() -> Path:
-    return get_hermes_home() / "plugins" / _INSTALL_METADATA_FILE
+    return _install_state._install_metadata_path()
 
 
 def _install_transaction_path() -> Path:
-    return get_hermes_home() / "plugins" / _INSTALL_TRANSACTION_FILE
+    return _install_state._install_transaction_path()
 
 
 def _read_install_metadata() -> dict[str, dict[str, object]]:
-    """Read profile-local, non-secret plugin source metadata from disk."""
-    path = _install_metadata_path()
-    if path.is_symlink():
-        raise PluginOperationError(
-            "Plugin install metadata path must not be a symlink."
-        )
-    if not path.exists():
-        return {}
-    value = _read_control_json(path, "plugin install metadata")
-    if not isinstance(value, dict):
-        raise PluginOperationError("Plugin install metadata must be a JSON object.")
-    for key, entry in value.items():
-        if not isinstance(key, str) or not isinstance(entry, dict):
-            raise PluginOperationError(
-                "Plugin install metadata entries must map plugin names to objects."
-            )
-    return value
+    return _install_state._read_install_metadata()
 
 
 def _write_install_metadata(metadata: dict[str, dict[str, object]]) -> None:
-    """Atomically replace the profile-local plugin install metadata sidecar."""
-    path = _install_metadata_path()
-    secure_atomic_write_text(
-        path,
-        json.dumps(metadata, indent=2, sort_keys=True) + "\n",
-        get_hermes_home(),
-    )
+    _install_state._write_install_metadata(metadata)
 
 
 def _plugin_membership(name: str) -> tuple[bool, bool]:
-    from hermes_cli.config import config_write_lock, load_config
-
-    with config_write_lock():
-        config = load_config()
-        plugins = config.get("plugins")
-        plugins = plugins if isinstance(plugins, dict) else {}
-        enabled = plugins.get("enabled")
-        disabled = plugins.get("disabled")
-        return (
-            isinstance(enabled, list) and name in enabled,
-            isinstance(disabled, list) and name in disabled,
-        )
+    return _install_state._plugin_membership(name)
 
 
 def _restore_plugin_membership(
     name: str, was_enabled: bool, was_disabled: bool
 ) -> None:
-    """Restore only *name* without overwriting newer state for other plugins."""
-    from hermes_cli.config import config_write_lock, load_config, save_config
-
-    with config_write_lock():
-        config = load_config()
-        plugins = config.setdefault("plugins", {})
-        if not isinstance(plugins, dict):
-            plugins = {}
-            config["plugins"] = plugins
-        raw_enabled = plugins.get("enabled")
-        raw_disabled = plugins.get("disabled")
-        enabled = set(raw_enabled) if isinstance(raw_enabled, list) else set()
-        disabled = set(raw_disabled) if isinstance(raw_disabled, list) else set()
-        (enabled.add if was_enabled else enabled.discard)(name)
-        (disabled.add if was_disabled else disabled.discard)(name)
-        plugins["enabled"] = sorted(enabled)
-        plugins["disabled"] = sorted(disabled)
-        save_config(
-            config,
-            preserve_plugin_state=False,
-            preserve_platform_toolsets=False,
-        )
+    _install_state._restore_plugin_membership(name, was_enabled, was_disabled)
 
 
 def _write_install_transaction(value: dict[str, object]) -> None:
-    path = _install_transaction_path()
-    secure_atomic_write_text(
-        path,
-        json.dumps(value, indent=2, sort_keys=True) + "\n",
-        get_hermes_home(),
-    )
+    _install_state._write_install_transaction(value)
 
 
 def _recover_install_transaction() -> None:
-    """Roll back an interrupted install before any new plugin mutation."""
-    journal = _install_transaction_path()
-    if journal.is_symlink():
-        raise PluginOperationError(
-            "Plugin install transaction path must not be a symlink."
-        )
-    if not journal.exists():
-        return
-    value = _read_control_json(journal, "plugin install transaction")
-    if not isinstance(value, dict) or value.get("version") != 1:
-        raise PluginOperationError("Plugin install transaction is malformed.")
-
-    name = value.get("plugin_name")
-    transaction_dir = value.get("transaction_dir")
-    old_metadata = value.get("old_metadata")
-    if (
-        not isinstance(name, str)
-        or not isinstance(transaction_dir, str)
-        or not transaction_dir.startswith(".install-")
-        or "/" in transaction_dir
-        or "\\" in transaction_dir
-        or not isinstance(old_metadata, dict)
-        or any(
-            not isinstance(key, str) or not isinstance(entry, dict)
-            for key, entry in old_metadata.items()
-        )
-        or not isinstance(value.get("was_enabled"), bool)
-        or not isinstance(value.get("was_disabled"), bool)
-    ):
-        raise PluginOperationError("Plugin install transaction is malformed.")
-
-    plugins_dir = _plugins_dir()
-    try:
-        target = _sanitize_plugin_name(name, plugins_dir)
-    except ValueError as exc:
-        raise PluginOperationError(str(exc)) from exc
-    transaction_root = plugins_dir / transaction_dir
-    if (
-        transaction_root.is_symlink()
-        or not transaction_root.is_dir()
-        or transaction_root.resolve().parent != plugins_dir.resolve()
-    ):
-        raise PluginOperationError("Plugin install transaction directory is unsafe.")
-    backup = transaction_root / "previous-plugin"
-    if backup.is_symlink() or (backup.exists() and not backup.is_dir()):
-        raise PluginOperationError("Plugin install transaction backup is unsafe.")
-    replaced_existing = value.get("replaced_existing") is True
-
-    from hermes_cli.config import config_write_lock
-
-    with config_write_lock():
-        if replaced_existing and backup.exists():
-            if target.exists():
-                if target.is_dir():
-                    secure_rmtree(target, plugins_dir)
-                else:
-                    secure_unlink(target, plugins_dir)
-            secure_replace(backup, target, plugins_dir)
-        elif replaced_existing and not target.exists():
-            raise PluginOperationError(
-                "Interrupted plugin install is missing both target and backup."
-            )
-        elif not replaced_existing and target.exists():
-            if target.is_dir():
-                secure_rmtree(target, plugins_dir)
-            else:
-                secure_unlink(target, plugins_dir)
-
-        if old_metadata:
-            _write_install_metadata(old_metadata)
-        else:
-            secure_unlink(_install_metadata_path(), get_hermes_home(), missing_ok=True)
-        _restore_plugin_membership(
-            name,
-            value.get("was_enabled") is True,
-            value.get("was_disabled") is True,
-        )
-        secure_unlink(journal, get_hermes_home(), missing_ok=True)
-
-    if transaction_root.exists():
-        try:
-            secure_rmtree(transaction_root, plugins_dir)
-        except OSError:
-            pass
+    _install_state._recover_install_transaction()
 
 
 def _marketplace_metadata(entry) -> dict[str, object]:
-    """Return private-marketplace provenance for atomic install metadata."""
-    return {
-        "marketplace_id": entry.source_id,
-        "marketplace_name": entry.source_name,
-        "marketplace_plugin_name": entry.name,
-        "source": entry.repo,
-        "subdir": entry.subdir,
-        "installed_repo_sha": entry.sha,
-        "installed_tree_sha": entry.tree_sha,
-    }
+    return _install_state._marketplace_metadata(entry)
 
 
 def _marketplace_install(plugin_name: str) -> Optional[dict[str, object]]:
-    value = _read_install_metadata().get(plugin_name)
-    if not isinstance(value, dict) or not value.get("marketplace_id"):
-        return None
-    return value
+    return _install_state._marketplace_install(plugin_name)
 
 
 def _normalize_exact_revision(ref: str) -> str:
@@ -1962,6 +1693,20 @@ def _get_enabled_set() -> set:
         return set(enabled) if isinstance(enabled, list) else set()
     except Exception:
         return set()
+
+
+def _save_enabled_set(enabled: set) -> None:
+    """Replace the enabled set under the shared config transaction."""
+    from hermes_cli.config import config_write_lock, load_config, save_config
+
+    with config_write_lock():
+        config = load_config()
+        plugins = config.setdefault("plugins", {})
+        if not isinstance(plugins, dict):
+            plugins = {}
+            config["plugins"] = plugins
+        plugins["enabled"] = sorted(enabled)
+        save_config(config, preserve_plugin_state=False)
 
 
 def _mutate_plugin_state_locked(

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -10,6 +10,7 @@ rendered with Rich Markdown.  Otherwise a default confirmation is shown.
 from __future__ import annotations
 from hermes_cli.cli_output import line_input
 
+import copy
 import functools
 import importlib.metadata
 import json
@@ -17,10 +18,15 @@ import logging
 import os
 import re
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
+import time
 import urllib.parse
+import threading
+import unicodedata
+from contextlib import contextmanager, nullcontext
 from pathlib import Path
 from typing import Any, Optional
 
@@ -28,7 +34,14 @@ from hermes_constants import get_hermes_home
 from hermes_cli._subprocess_compat import noninteractive_git_env
 from hermes_cli.config import cfg_get
 from hermes_cli.secret_prompt import masked_secret_prompt
-from utils import atomic_write_text
+from utils import (
+    secure_atomic_write_text,
+    secure_open_file,
+    secure_parent_directory,
+    secure_replace,
+    secure_rmtree,
+    secure_unlink,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -54,12 +67,10 @@ def _resolve_git_executable() -> Optional[str]:
             os.path.join(prog_x86, "Git", "bin", "git.exe"),
         ]
         if local:
-            candidates.extend(
-                (
-                    os.path.join(local, "Programs", "Git", "cmd", "git.exe"),
-                    os.path.join(local, "Programs", "Git", "bin", "git.exe"),
-                )
-            )
+            candidates.extend((
+                os.path.join(local, "Programs", "Git", "cmd", "git.exe"),
+                os.path.join(local, "Programs", "Git", "bin", "git.exe"),
+            ))
     else:
         candidates = ["/usr/bin/git", "/usr/local/bin/git", "/bin/git"]
     for c in candidates:
@@ -92,13 +103,16 @@ def _scan_on_install_enabled() -> bool:
     """
     try:
         from hermes_cli.config import load_config
+
         config = load_config()
         return bool(cfg_get(config, "plugins", "scan_on_install", default=True))
     except Exception:
         return True
 
 
-def _scan_plugin_tree(plugin_dir: Path, identifier: str, *, force: bool, scan_decision_cb=None):
+def _scan_plugin_tree(
+    plugin_dir: Path, identifier: str, *, force: bool, scan_decision_cb=None
+):
     """Scan *plugin_dir* and enforce the install policy.
 
     Verdicts: safe → proceed; caution → needs confirmation (``force=True``
@@ -185,14 +199,61 @@ def _sanitize_plugin_name(
             f"Invalid plugin name '{name}': must not reference the plugins directory itself."
         )
 
+    root_name = name.split("/", 1)[0]
+    if root_name.casefold().startswith(".install-"):
+        raise ValueError(f"Invalid plugin name '{name}': reserved for installer state.")
+
     # Reject obvious traversal characters
     bad_chars = ("\\", "..") if allow_subdir else ("/", "\\", "..")
     for bad in bad_chars:
         if bad in name:
             raise ValueError(f"Invalid plugin name '{name}': must not contain '{bad}'.")
 
-    target = (plugins_dir / name).resolve()
+    windows_reserved = {"con", "prn", "aux", "nul", "clock$", "conin$", "conout$"} | {
+        f"{prefix}{number}" for prefix in ("com", "lpt") for number in range(1, 10)
+    }
+    parts = name.split("/")
+    for part in parts:
+        if part.endswith((".", " ")):
+            raise ValueError(
+                f"Invalid plugin name '{name}': path components must not end in a dot or space."
+            )
+        windows_stem = unicodedata.normalize("NFKC", part.split(".", 1)[0]).casefold()
+        if windows_stem in windows_reserved:
+            raise ValueError(
+                f"Invalid plugin name '{name}': contains a reserved filesystem name."
+            )
+        if any(char in part for char in '<>:"|?*'):
+            raise ValueError(
+                f"Invalid plugin name '{name}': contains a reserved filesystem character."
+            )
+
     plugins_resolved = plugins_dir.resolve()
+    lexical_target = plugins_resolved.joinpath(*parts)
+    current = plugins_resolved
+    for part in parts:
+        if current.is_dir():
+            alias = next(
+                (
+                    child
+                    for child in current.iterdir()
+                    if unicodedata.normalize("NFC", child.name).casefold()
+                    == unicodedata.normalize("NFC", part).casefold()
+                    and child.name != part
+                ),
+                None,
+            )
+            if alias is not None:
+                raise ValueError(
+                    f"Invalid plugin name '{name}': aliases existing path '{alias.name}'."
+                )
+        current = current / part
+        if current.is_symlink():
+            raise ValueError(
+                f"Invalid plugin name '{name}': symlink destinations are not allowed."
+            )
+
+    target = lexical_target.resolve()
 
     if target == plugins_resolved:
         raise ValueError(
@@ -255,7 +316,11 @@ def _resolve_git_url(identifier: str) -> tuple[str, Optional[str]]:
             path = identifier[len("https://github.com/") :]
             path = path.split("?", 1)[0].split("#", 1)[0].strip("/")
             parts = path.split("/")
-            if len(parts) >= 3 and all(parts[:2]) and parts[2] in _GITHUB_BROWSER_SEGMENTS:
+            if (
+                len(parts) >= 3
+                and all(parts[:2])
+                and parts[2] in _GITHUB_BROWSER_SEGMENTS
+            ):
                 repo = parts[1].removesuffix(".git")
                 subdir = None
                 if parts[2] == "tree" and len(parts) >= 5:
@@ -396,7 +461,9 @@ def _missing_requires_env_names(manifest: dict) -> list[str]:
         elif isinstance(entry, dict) and entry.get("name"):
             env_specs.append(entry)
 
-    return [s["name"] for s in env_specs if s.get("name") and not get_env_value(s["name"])]
+    return [
+        s["name"] for s in env_specs if s.get("name") and not get_env_value(s["name"])
+    ]
 
 
 def _print_python_dependencies(manifest: dict, console) -> None:
@@ -466,7 +533,9 @@ def _prompt_plugin_env_vars(manifest: dict, console) -> None:
         return
 
     plugin_name = manifest.get("name", "this plugin")
-    console.print(f"\n[bold]{plugin_name}[/bold] requires the following environment variables:\n")
+    console.print(
+        f"\n[bold]{plugin_name}[/bold] requires the following environment variables:\n"
+    )
 
     for spec in missing:
         name = spec["name"]
@@ -487,7 +556,9 @@ def _prompt_plugin_env_vars(manifest: dict, console) -> None:
             else:
                 value = line_input(f"  {name}: ").strip()
         except (EOFError, KeyboardInterrupt):
-            console.print(f"\n[dim]  Skipped (you can set these later in {display_hermes_home()}/.env)[/dim]")
+            console.print(
+                f"\n[dim]  Skipped (you can set these later in {display_hermes_home()}/.env)[/dim]"
+            )
             return
 
         if value:
@@ -495,7 +566,9 @@ def _prompt_plugin_env_vars(manifest: dict, console) -> None:
             os.environ[name] = value
             console.print(f"  [green]✓[/green] Saved to {display_hermes_home()}/.env")
         else:
-            console.print(f"  [dim]  Skipped (set {name} in {display_hermes_home()}/.env later)[/dim]")
+            console.print(
+                f"  [dim]  Skipped (set {name} in {display_hermes_home()}/.env later)[/dim]"
+            )
 
     console.print()
 
@@ -543,7 +616,9 @@ def _require_installed_plugin(name: str, plugins_dir: Path, console) -> Path:
     """Return the plugin path if it exists, or exit with an error listing installed plugins."""
     target = _sanitize_plugin_name(name, plugins_dir, allow_subdir=True)
     if not target.exists():
-        installed = ", ".join(d.name for d in plugins_dir.iterdir() if d.is_dir()) or "(none)"
+        installed = (
+            ", ".join(d.name for d in plugins_dir.iterdir() if d.is_dir()) or "(none)"
+        )
         console.print(
             f"[red]Error:[/red] Plugin '{name}' not found in {plugins_dir}.\n"
             f"Installed plugins: {installed}"
@@ -559,33 +634,315 @@ def _require_installed_plugin(name: str, plugins_dir: Path, console) -> Path:
 
 _EXACT_COMMIT_RE = re.compile(r"^[0-9a-fA-F]{40}$")
 _INSTALL_METADATA_FILE = ".install-metadata.json"
+_INSTALL_TRANSACTION_FILE = ".install-transaction.json"
+_PROCESS_INSTALL_METADATA_LOCK = threading.RLock()
+
+
+def _lock_file(handle) -> None:
+    """Acquire a blocking one-byte cross-process lock."""
+    if os.name == "nt":
+        import errno
+        import msvcrt
+
+        handle.seek(0, os.SEEK_END)
+        if handle.tell() == 0:
+            handle.write(b"0")
+            handle.flush()
+        while True:
+            handle.seek(0)
+            try:
+                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+                return
+            except OSError as exc:
+                if exc.errno not in {errno.EACCES, errno.EAGAIN, errno.EDEADLK}:
+                    raise
+                time.sleep(0.1)
+    else:
+        import fcntl
+
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+
+
+def _unlock_file(handle) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+    else:
+        import fcntl
+
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def _reject_symlink_components(path: Path, root: Path) -> None:
+    """Reject symlinks below a trusted root before control-file operations."""
+    root = root.absolute()
+    try:
+        relative = path.absolute().relative_to(root)
+    except ValueError as exc:
+        raise PluginOperationError(f"Control path escapes {root}.") from exc
+    current = root
+    for part in relative.parts:
+        current /= part
+        if current.is_symlink():
+            raise PluginOperationError(
+                f"Control path must not contain symlinks: {path}"
+            )
+
+
+def _open_lock_path(path: Path):
+    """Open a regular lock file beneath a held no-follow parent."""
+    if path.is_symlink():
+        raise PluginOperationError(f"Lock path must not be a symlink: {path}")
+    flags = os.O_RDWR | os.O_CREAT | os.O_APPEND | getattr(os, "O_CLOEXEC", 0)
+    try:
+        fd = secure_open_file(path, get_hermes_home(), flags, create_parent=True)
+    except OSError as exc:
+        raise PluginOperationError(
+            f"Could not safely open lock file {path}: {exc}"
+        ) from exc
+    if not stat.S_ISREG(os.fstat(fd).st_mode):
+        os.close(fd)
+        raise PluginOperationError(f"Lock path must be a regular file: {path}")
+    return os.fdopen(fd, "a+b")
+
+
+def _read_control_json(path: Path, label: str) -> object:
+    """Read one regular control file beneath a held no-follow parent."""
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    try:
+        fd = secure_open_file(path, get_hermes_home(), flags)
+    except OSError as exc:
+        raise PluginOperationError(f"Could not read {label}: {exc}") from exc
+    try:
+        with os.fdopen(fd, "r", encoding="utf-8") as handle:
+            fd = -1
+            return json.load(handle)
+    except json.JSONDecodeError as exc:
+        raise PluginOperationError(f"Could not read {label}: {exc}") from exc
+    finally:
+        if fd >= 0:
+            os.close(fd)
+
+
+@contextmanager
+def _install_metadata_lock():
+    """Serialize profile-local install metadata and target commits."""
+    path = _install_metadata_path().with_suffix(".lock")
+    namespace = secure_parent_directory(path, get_hermes_home(), create=True)
+    try:
+        namespace.__enter__()
+    except OSError as exc:
+        raise PluginOperationError(
+            f"Plugin install namespace is unsafe: {exc}"
+        ) from exc
+    try:
+        with _PROCESS_INSTALL_METADATA_LOCK, _open_lock_path(path) as handle:
+            _lock_file(handle)
+            try:
+                _recover_install_transaction()
+                yield
+            finally:
+                _unlock_file(handle)
+    finally:
+        namespace.__exit__(None, None, None)
+
 
 def _install_metadata_path() -> Path:
     return get_hermes_home() / "plugins" / _INSTALL_METADATA_FILE
 
 
+def _install_transaction_path() -> Path:
+    return get_hermes_home() / "plugins" / _INSTALL_TRANSACTION_FILE
+
+
 def _read_install_metadata() -> dict[str, dict[str, object]]:
     """Read profile-local, non-secret plugin source metadata from disk."""
     path = _install_metadata_path()
+    if path.is_symlink():
+        raise PluginOperationError(
+            "Plugin install metadata path must not be a symlink."
+        )
     if not path.exists():
         return {}
-    try:
-        value = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise PluginOperationError(f"Could not read plugin install metadata: {exc}") from exc
+    value = _read_control_json(path, "plugin install metadata")
     if not isinstance(value, dict):
         raise PluginOperationError("Plugin install metadata must be a JSON object.")
+    for key, entry in value.items():
+        if not isinstance(key, str) or not isinstance(entry, dict):
+            raise PluginOperationError(
+                "Plugin install metadata entries must map plugin names to objects."
+            )
     return value
 
 
 def _write_install_metadata(metadata: dict[str, dict[str, object]]) -> None:
     """Atomically replace the profile-local plugin install metadata sidecar."""
     path = _install_metadata_path()
-    atomic_write_text(
+    secure_atomic_write_text(
         path,
         json.dumps(metadata, indent=2, sort_keys=True) + "\n",
-        tmp_prefix=f"{path.name}.tmp-",
+        get_hermes_home(),
     )
+
+
+def _plugin_membership(name: str) -> tuple[bool, bool]:
+    from hermes_cli.config import config_write_lock, load_config
+
+    with config_write_lock():
+        config = load_config()
+        plugins = config.get("plugins")
+        plugins = plugins if isinstance(plugins, dict) else {}
+        enabled = plugins.get("enabled")
+        disabled = plugins.get("disabled")
+        return (
+            isinstance(enabled, list) and name in enabled,
+            isinstance(disabled, list) and name in disabled,
+        )
+
+
+def _restore_plugin_membership(
+    name: str, was_enabled: bool, was_disabled: bool
+) -> None:
+    """Restore only *name* without overwriting newer state for other plugins."""
+    from hermes_cli.config import config_write_lock, load_config, save_config
+
+    with config_write_lock():
+        config = load_config()
+        plugins = config.setdefault("plugins", {})
+        if not isinstance(plugins, dict):
+            plugins = {}
+            config["plugins"] = plugins
+        raw_enabled = plugins.get("enabled")
+        raw_disabled = plugins.get("disabled")
+        enabled = set(raw_enabled) if isinstance(raw_enabled, list) else set()
+        disabled = set(raw_disabled) if isinstance(raw_disabled, list) else set()
+        (enabled.add if was_enabled else enabled.discard)(name)
+        (disabled.add if was_disabled else disabled.discard)(name)
+        plugins["enabled"] = sorted(enabled)
+        plugins["disabled"] = sorted(disabled)
+        save_config(
+            config,
+            preserve_plugin_state=False,
+            preserve_platform_toolsets=False,
+        )
+
+
+def _write_install_transaction(value: dict[str, object]) -> None:
+    path = _install_transaction_path()
+    secure_atomic_write_text(
+        path,
+        json.dumps(value, indent=2, sort_keys=True) + "\n",
+        get_hermes_home(),
+    )
+
+
+def _recover_install_transaction() -> None:
+    """Roll back an interrupted install before any new plugin mutation."""
+    journal = _install_transaction_path()
+    if journal.is_symlink():
+        raise PluginOperationError(
+            "Plugin install transaction path must not be a symlink."
+        )
+    if not journal.exists():
+        return
+    value = _read_control_json(journal, "plugin install transaction")
+    if not isinstance(value, dict) or value.get("version") != 1:
+        raise PluginOperationError("Plugin install transaction is malformed.")
+
+    name = value.get("plugin_name")
+    transaction_dir = value.get("transaction_dir")
+    old_metadata = value.get("old_metadata")
+    if (
+        not isinstance(name, str)
+        or not isinstance(transaction_dir, str)
+        or not transaction_dir.startswith(".install-")
+        or "/" in transaction_dir
+        or "\\" in transaction_dir
+        or not isinstance(old_metadata, dict)
+        or any(
+            not isinstance(key, str) or not isinstance(entry, dict)
+            for key, entry in old_metadata.items()
+        )
+        or not isinstance(value.get("was_enabled"), bool)
+        or not isinstance(value.get("was_disabled"), bool)
+    ):
+        raise PluginOperationError("Plugin install transaction is malformed.")
+
+    plugins_dir = _plugins_dir()
+    try:
+        target = _sanitize_plugin_name(name, plugins_dir)
+    except ValueError as exc:
+        raise PluginOperationError(str(exc)) from exc
+    transaction_root = plugins_dir / transaction_dir
+    if (
+        transaction_root.is_symlink()
+        or not transaction_root.is_dir()
+        or transaction_root.resolve().parent != plugins_dir.resolve()
+    ):
+        raise PluginOperationError("Plugin install transaction directory is unsafe.")
+    backup = transaction_root / "previous-plugin"
+    if backup.is_symlink() or (backup.exists() and not backup.is_dir()):
+        raise PluginOperationError("Plugin install transaction backup is unsafe.")
+    replaced_existing = value.get("replaced_existing") is True
+
+    from hermes_cli.config import config_write_lock
+
+    with config_write_lock():
+        if replaced_existing and backup.exists():
+            if target.exists():
+                if target.is_dir():
+                    secure_rmtree(target, plugins_dir)
+                else:
+                    secure_unlink(target, plugins_dir)
+            secure_replace(backup, target, plugins_dir)
+        elif replaced_existing and not target.exists():
+            raise PluginOperationError(
+                "Interrupted plugin install is missing both target and backup."
+            )
+        elif not replaced_existing and target.exists():
+            if target.is_dir():
+                secure_rmtree(target, plugins_dir)
+            else:
+                secure_unlink(target, plugins_dir)
+
+        if old_metadata:
+            _write_install_metadata(old_metadata)
+        else:
+            secure_unlink(_install_metadata_path(), get_hermes_home(), missing_ok=True)
+        _restore_plugin_membership(
+            name,
+            value.get("was_enabled") is True,
+            value.get("was_disabled") is True,
+        )
+        secure_unlink(journal, get_hermes_home(), missing_ok=True)
+
+    if transaction_root.exists():
+        try:
+            secure_rmtree(transaction_root, plugins_dir)
+        except OSError:
+            pass
+
+
+def _marketplace_metadata(entry) -> dict[str, object]:
+    """Return private-marketplace provenance for atomic install metadata."""
+    return {
+        "marketplace_id": entry.source_id,
+        "marketplace_name": entry.source_name,
+        "marketplace_plugin_name": entry.name,
+        "source": entry.repo,
+        "subdir": entry.subdir,
+        "installed_repo_sha": entry.sha,
+        "installed_tree_sha": entry.tree_sha,
+    }
+
+
+def _marketplace_install(plugin_name: str) -> Optional[dict[str, object]]:
+    value = _read_install_metadata().get(plugin_name)
+    if not isinstance(value, dict) or not value.get("marketplace_id"):
+        return None
+    return value
 
 
 def _normalize_exact_revision(ref: str) -> str:
@@ -618,7 +975,9 @@ def _git_head_revision(repo: Path, git_exe: str) -> str:
     )
     if result.returncode != 0:
         err = _safe_git_error(result)
-        raise PluginOperationError(f"Could not determine installed Git revision:\n{err}")
+        raise PluginOperationError(
+            f"Could not determine installed Git revision:\n{err}"
+        )
     return result.stdout.strip().lower()
 
 
@@ -680,9 +1039,7 @@ def _scrub_git_url(git_url: str) -> str:
         host = f"[{parsed.hostname}]" if ":" in parsed.hostname else parsed.hostname
         if parsed.port is not None:
             host = f"{host}:{parsed.port}"
-        return urllib.parse.urlunsplit(
-            (parsed.scheme, host, parsed.path, "", "")
-        )
+        return urllib.parse.urlunsplit((parsed.scheme, host, parsed.path, "", ""))
     return git_url
 
 
@@ -730,6 +1087,9 @@ def _install_plugin_core(
     ref: Optional[str] = None,
     scan_decision_cb=None,
     skip_removed_check: bool = False,
+    metadata_extra: Optional[dict[str, object]] = None,
+    catalog_entry=None,
+    enable_on_commit: bool = False,
 ) -> tuple[Path, dict, str]:
     """Clone a Git plugin and atomically record its source and exact revision.
 
@@ -776,7 +1136,9 @@ def _install_plugin_core(
             if isinstance(revision, str):
                 requested_revision = _normalize_exact_revision(revision)
 
-    with tempfile.TemporaryDirectory(prefix=".install-", dir=plugins_dir) as tmp:
+    with tempfile.TemporaryDirectory(
+        prefix=".install-", dir=plugins_dir, ignore_cleanup_errors=True
+    ) as tmp:
         tmp_clone = Path(tmp) / "plugin"
         git_exe = _resolve_git_executable()
         if not git_exe:
@@ -790,7 +1152,9 @@ def _install_plugin_core(
             result = subprocess.run(
                 clone_args,
                 capture_output=True,
-                text=True, encoding='utf-8', errors='replace',
+                text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=60,
                 stdin=subprocess.DEVNULL,
                 env=noninteractive_git_env(),
@@ -808,9 +1172,7 @@ def _install_plugin_core(
             _checkout_exact_revision(tmp_clone, git_exe, requested_revision)
         installed_revision = _git_head_revision(tmp_clone, git_exe)
 
-        tmp_target = (
-            _resolve_subdir_within(tmp_clone, subdir) if subdir else tmp_clone
-        )
+        tmp_target = _resolve_subdir_within(tmp_clone, subdir) if subdir else tmp_clone
         has_native_manifest = (tmp_target / "plugin.yaml").exists() or (
             tmp_target / "plugin.yml"
         ).exists()
@@ -831,7 +1193,9 @@ def _install_plugin_core(
         else:
             manifest = _read_manifest(tmp_target)
         plugin_name = manifest.get("name") or (
-            subdir.rstrip("/").rsplit("/", 1)[-1] if subdir else _repo_name_from_url(git_url)
+            subdir.rstrip("/").rsplit("/", 1)[-1]
+            if subdir
+            else _repo_name_from_url(git_url)
         )
         try:
             target = _sanitize_plugin_name(plugin_name, plugins_dir)
@@ -868,46 +1232,100 @@ def _install_plugin_core(
             scan_decision_cb=scan_decision_cb,
         )
 
-        if target.exists() and not force:
-            raise PluginOperationError(
-                f"Plugin '{plugin_name}' already exists. Use force reinstall "
-                f"or run `hermes plugins update {plugin_name}`."
-            )
-        prior = old_metadata.get(plugin_name)
-        if (
-            target.exists()
-            and requested_revision is None
-            and isinstance(prior, dict)
-            and prior.get("pinned") is True
-        ):
-            raise PluginOperationError(
-                f"Plugin '{plugin_name}' is pinned. Reinstall it with an explicit "
-                "--ref <40-character commit SHA> to change its source or revision."
-            )
+        if catalog_entry is not None:
+            _write_catalog_sidecar(tmp_target, catalog_entry, strict=True)
 
-        new_metadata = dict(old_metadata)
-        new_metadata[plugin_name] = {
-            "pinned": requested_revision is not None,
-            "revision": installed_revision,
-            "source": source,
-        }
-        backup = Path(tmp) / "previous-plugin"
-        replaced_existing = target.exists()
-        if replaced_existing:
-            os.replace(target, backup)
-        try:
-            os.replace(tmp_target, target)
-            _write_install_metadata(new_metadata)
-        except Exception:
-            if target.exists():
-                shutil.rmtree(target)
-            if replaced_existing and backup.exists():
-                os.replace(backup, target)
-            if old_metadata:
-                _write_install_metadata(old_metadata)
-            else:
-                _install_metadata_path().unlink(missing_ok=True)
-            raise
+        marketplace_id = str((metadata_extra or {}).get("marketplace_id") or "")
+        marketplace_url = str((metadata_extra or {}).get("source") or "")
+        if marketplace_id:
+            from hermes_cli.plugin_marketplaces import marketplace_authority
+
+            authority = marketplace_authority(marketplace_id, marketplace_url)
+        else:
+            authority = nullcontext(True)
+
+        with authority as authorized:
+            if not authorized:
+                raise PluginOperationError(
+                    "The plugin marketplace was removed before installation completed."
+                )
+            with _install_metadata_lock():
+                try:
+                    locked_target = _sanitize_plugin_name(plugin_name, plugins_dir)
+                except ValueError as exc:
+                    raise PluginOperationError(str(exc)) from exc
+                if locked_target != target:
+                    raise PluginOperationError(
+                        f"Plugin destination for '{plugin_name}' changed during installation."
+                    )
+                current_metadata = _read_install_metadata()
+                prior = current_metadata.get(plugin_name)
+                if target.exists() and not force:
+                    raise PluginOperationError(
+                        f"Plugin '{plugin_name}' already exists. Use force reinstall "
+                        f"or run `hermes plugins update {plugin_name}`."
+                    )
+                if (
+                    marketplace_id
+                    and target.exists()
+                    and (
+                        not isinstance(prior, dict)
+                        or prior.get("marketplace_id") != marketplace_id
+                    )
+                ):
+                    raise PluginOperationError(
+                        f"Plugin '{plugin_name}' is already installed from another source; "
+                        "remove it explicitly before installing this marketplace entry."
+                    )
+                if (
+                    target.exists()
+                    and requested_revision is None
+                    and isinstance(prior, dict)
+                    and prior.get("pinned") is True
+                ):
+                    raise PluginOperationError(
+                        f"Plugin '{plugin_name}' is pinned. Reinstall it with an explicit "
+                        "--ref <40-character commit SHA> to change its source or revision."
+                    )
+
+                new_metadata = dict(current_metadata)
+                new_metadata[plugin_name] = {
+                    "pinned": requested_revision is not None,
+                    "revision": installed_revision,
+                    "source": source,
+                    **(metadata_extra or {}),
+                }
+                backup = Path(tmp) / "previous-plugin"
+                replaced_existing = target.exists()
+                from hermes_cli.config import config_write_lock
+
+                with config_write_lock():
+                    was_enabled, was_disabled = _plugin_membership(plugin_name)
+                    _write_install_transaction({
+                        "version": 1,
+                        "plugin_name": plugin_name,
+                        "transaction_dir": Path(tmp).name,
+                        "replaced_existing": replaced_existing,
+                        "old_metadata": current_metadata,
+                        "was_enabled": was_enabled,
+                        "was_disabled": was_disabled,
+                    })
+                    try:
+                        if replaced_existing:
+                            secure_replace(target, backup, plugins_dir)
+                        secure_replace(tmp_target, target, plugins_dir)
+                        _write_install_metadata(new_metadata)
+                        if enable_on_commit:
+                            _mutate_plugin_state_locked(enable={plugin_name})
+                        secure_unlink(
+                            _install_transaction_path(),
+                            get_hermes_home(),
+                            missing_ok=True,
+                        )
+
+                    except BaseException:
+                        _recover_install_transaction()
+                        raise
 
     has_yaml = (target / "plugin.yaml").exists() or (target / "plugin.yml").exists()
     has_portable = (target / "plugin.json").exists()
@@ -943,8 +1361,18 @@ def _looks_like_catalog_name(identifier: str) -> bool:
     return bool(_NAME_RE.match(identifier))
 
 
-def _get_live_catalog_entry(name: str):
-    """Look up *name* in the live-refreshed catalog (falls back in-tree)."""
+def _get_live_catalog_entry(
+    name: str, source_id: str = "official", *, force: bool = False
+):
+    """Look up *name* in the official catalog or a saved Git marketplace."""
+    if source_id != "official":
+        from hermes_cli.plugin_marketplaces import (
+            as_catalog_entry,
+            get_marketplace_entry,
+        )
+
+        value = get_marketplace_entry(source_id, name, force=force)
+        return as_catalog_entry(value) if value is not None else None
     from hermes_cli.plugin_catalog import load_catalog_live
 
     for entry in load_catalog_live():
@@ -964,7 +1392,7 @@ def _catalog_install_identifier(entry) -> str:
     return entry.repo
 
 
-def _write_catalog_sidecar(target: Path, entry) -> None:
+def _write_catalog_sidecar(target: Path, entry, *, strict: bool = False) -> None:
     """Record catalog provenance in ``.hermes-catalog.json`` inside *target*.
 
     The sidecar is how ``update``/``list``/``doctor`` know the plugin came
@@ -976,23 +1404,35 @@ def _write_catalog_sidecar(target: Path, entry) -> None:
         "catalog_name": entry.name,
         "repo": entry.repo,
         "sha": entry.sha,
-        "installed_at": datetime.datetime.now(datetime.timezone.utc)
+        "installed_at": datetime.datetime
+        .now(datetime.timezone.utc)
         .isoformat(timespec="seconds")
         .replace("+00:00", "Z"),
         "tier": entry.tier,
     }
+    path = target / _CATALOG_SIDECAR
+    if path.is_symlink():
+        error = PluginOperationError("Catalog sidecar must not be a symlink.")
+        if strict:
+            raise error
+        logger.warning("Failed to write catalog sidecar in %s: %s", target, error)
+        return
     try:
-        (target / _CATALOG_SIDECAR).write_text(
-            json.dumps(sidecar, indent=2) + "\n", encoding="utf-8"
+        secure_atomic_write_text(
+            path,
+            json.dumps(sidecar, indent=2) + "\n",
+            target.parent,
         )
     except OSError as exc:
+        if strict:
+            raise
         logger.warning("Failed to write catalog sidecar in %s: %s", target, exc)
 
 
 def _read_catalog_sidecar(plugin_dir: Path) -> Optional[dict]:
     """Return the parsed catalog provenance sidecar, or None."""
     path = plugin_dir / _CATALOG_SIDECAR
-    if not path.is_file():
+    if path.is_symlink() or not path.is_file():
         return None
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
@@ -1145,9 +1585,13 @@ def cmd_install(
         if not (sys.stdin.isatty() and sys.stdout.isatty()):
             return False
         try:
-            answer = input(
-                "  Install anyway? Only continue if you trust the source. [y/N]: ",
-            ).strip().lower()
+            answer = (
+                input(
+                    "  Install anyway? Only continue if you trust the source. [y/N]: ",
+                )
+                .strip()
+                .lower()
+            )
         except (EOFError, KeyboardInterrupt):
             return False
         return answer in {"y", "yes"}
@@ -1159,6 +1603,8 @@ def cmd_install(
             ref=ref,
             scan_decision_cb=_interactive_scan_decision,
             skip_removed_check=allow_removed,
+            catalog_entry=entry,
+            enable_on_commit=enable is True,
         )
     except PluginScanBlocked as e:
         console.print(f"[red]Blocked:[/red] {e}")
@@ -1167,12 +1613,12 @@ def cmd_install(
         console.print(f"[red]Error:[/red] {e}")
         sys.exit(1)
 
-    if entry is not None:
-        _write_catalog_sidecar(target, entry)
-
-    if not (target / "plugin.yaml").exists() and not (target / "plugin.yml").exists() and not (target / "plugin.json").exists() and not (
-        target / "__init__.py"
-    ).exists():
+    if (
+        not (target / "plugin.yaml").exists()
+        and not (target / "plugin.yml").exists()
+        and not (target / "plugin.json").exists()
+        and not (target / "__init__.py").exists()
+    ):
         console.print(
             f"[yellow]Warning:[/yellow] {installed_name} doesn't contain plugin.yaml, "
             f"plugin.json, or __init__.py. It may not be a valid Hermes plugin.",
@@ -1188,9 +1634,13 @@ def cmd_install(
     if should_enable is None:
         if sys.stdin.isatty() and sys.stdout.isatty():
             try:
-                answer = input(
-                    f"  Enable '{installed_name}' now? [y/N]: ",
-                ).strip().lower()
+                answer = (
+                    input(
+                        f"  Enable '{installed_name}' now? [y/N]: ",
+                    )
+                    .strip()
+                    .lower()
+                )
                 should_enable = answer in {"y", "yes"}
             except (EOFError, KeyboardInterrupt):
                 should_enable = False
@@ -1198,12 +1648,7 @@ def cmd_install(
             should_enable = False
 
     if should_enable:
-        enabled = _get_enabled_set()
-        disabled = _get_disabled_set()
-        enabled.add(installed_name)
-        disabled.discard(installed_name)
-        _save_enabled_set(enabled)
-        _save_disabled_set(disabled)
+        _mutate_plugin_state(enable={installed_name})
         console.print(
             f"[green]✓[/green] Plugin [bold]{installed_name}[/bold] enabled.",
         )
@@ -1249,42 +1694,43 @@ def cmd_update(name: str) -> None:
         _update_catalog_plugin(name, target, sidecar, console)
         return
 
-    try:
-        metadata = _read_install_metadata()
-    except PluginOperationError as exc:
-        console.print(f"[red]Error:[/red] {exc}")
-        sys.exit(1)
-    install_record = metadata.get(target.name, {})
-    if install_record.get("pinned") is True:
-        recorded_source = escape(str(install_record.get("source", "<source>")))
-        console.print(
-            f"[red]Error:[/red] Plugin '{name}' is pinned to "
-            f"{install_record.get('revision')}. To move it, run "
-            f"`hermes plugins install {recorded_source} --force "
-            "--ref <40-character commit SHA>`."
-        )
-        sys.exit(1)
+    with _install_metadata_lock():
+        try:
+            metadata = _read_install_metadata()
+        except PluginOperationError as exc:
+            console.print(f"[red]Error:[/red] {exc}")
+            sys.exit(1)
+        install_record = metadata.get(target.name, {})
+        if install_record.get("pinned") is True:
+            recorded_source = escape(str(install_record.get("source", "<source>")))
+            console.print(
+                f"[red]Error:[/red] Plugin '{name}' is pinned to "
+                f"{install_record.get('revision')}. To move it, run "
+                f"`hermes plugins install {recorded_source} --force "
+                "--ref <40-character commit SHA>`."
+            )
+            sys.exit(1)
 
-    if not (target / ".git").exists():
-        console.print(
-            f"[red]Error:[/red] Plugin '{name}' was not installed from git "
-            f"(no .git directory). Cannot update."
-        )
-        sys.exit(1)
+        if not (target / ".git").exists():
+            console.print(
+                f"[red]Error:[/red] Plugin '{name}' was not installed from git "
+                f"(no .git directory). Cannot update."
+            )
+            sys.exit(1)
 
-    console.print(f"[dim]Updating {name}...[/dim]")
+        console.print(f"[dim]Updating {name}...[/dim]")
 
-    ok, output = _git_pull_plugin_dir(target)
-    if not ok:
-        console.print(f"[red]Error:[/red] {output}")
-        sys.exit(1)
+        ok, output = _git_pull_plugin_dir(target)
+        if not ok:
+            console.print(f"[red]Error:[/red] {output}")
+            sys.exit(1)
 
-    if install_record:
-        git_exe = _resolve_git_executable()
-        if git_exe:
-            install_record["revision"] = _git_head_revision(target, git_exe)
-            metadata[target.name] = install_record
-            _write_install_metadata(metadata)
+        if install_record:
+            git_exe = _resolve_git_executable()
+            if git_exe:
+                install_record["revision"] = _git_head_revision(target, git_exe)
+                metadata[target.name] = install_record
+                _write_install_metadata(metadata)
 
     # Re-scan after update — Cowork re-scans skills/plugins on edit, and an
     # update can introduce malicious content into a previously clean plugin.
@@ -1306,13 +1752,7 @@ def cmd_update(name: str) -> None:
             )
             console.print(format_scan_report(scan_result))
             if scan_result.verdict == "dangerous":
-                enabled = _get_enabled_set()
-                disabled = _get_disabled_set()
-                if name in enabled or name not in disabled:
-                    enabled.discard(name)
-                    disabled.add(name)
-                    _save_enabled_set(enabled)
-                    _save_disabled_set(disabled)
+                _mutate_plugin_state(disable={name})
                 console.print(
                     f"[red]Plugin '{name}' has been disabled.[/red] Review the "
                     f"findings, then re-enable with `hermes plugins enable {name}` "
@@ -1334,20 +1774,17 @@ def cmd_update(name: str) -> None:
     # (non-interactive updates leave them ungranted — fail closed).
     updated_manifest = _read_manifest(target)
     plugin_id = updated_manifest.get("name") or target.name
-    declared_caps = _declared_capabilities_from_manifest(
-        updated_manifest, plugin_id
-    )
+    declared_caps = _declared_capabilities_from_manifest(updated_manifest, plugin_id)
     if declared_caps:
         from hermes_cli.plugin_capabilities import (
             declared_set_changed,
             pending_capabilities,
         )
+
         if pending_capabilities(plugin_id, declared_caps) or declared_set_changed(
             plugin_id, declared_caps
         ):
-            _run_capability_consent(
-                console, plugin_id, declared_caps, context="update"
-            )
+            _run_capability_consent(console, plugin_id, declared_caps, context="update")
 
     out = output.strip()
     if "Already up to date" in out:
@@ -1360,32 +1797,49 @@ def cmd_update(name: str) -> None:
 
 
 def _remove_plugin_core(target: Path) -> None:
-    """Remove one plugin and its metadata without splitting their state."""
-    metadata = _read_install_metadata()
-    if target.name not in metadata:
-        shutil.rmtree(target)
-        return
+    """Remove one plugin, its provenance, and enabled state transactionally."""
+    with _install_metadata_lock():
+        from hermes_cli.config import config_write_lock
 
-    updated = dict(metadata)
-    updated.pop(target.name)
-    staging = Path(
-        tempfile.mkdtemp(prefix=f".{target.name}.remove-", dir=target.parent)
-    )
-    backup = staging / "plugin"
-    os.replace(target, backup)
-    try:
-        _write_install_metadata(updated)
-    except Exception:
-        try:
-            os.replace(backup, target)
-        except OSError as restore_exc:
-            raise PluginOperationError(
-                f"Plugin metadata update failed and '{target.name}' could not be "
-                f"restored automatically; recovery copy remains at {backup}."
-            ) from restore_exc
-        shutil.rmtree(staging, ignore_errors=True)
-        raise
-    shutil.rmtree(staging)
+        with config_write_lock():
+            metadata = _read_install_metadata()
+            updated = dict(metadata)
+            tracked = updated.pop(target.name, None) is not None
+            staging = Path(
+                tempfile.mkdtemp(prefix=".install-remove-", dir=target.parent)
+            )
+            backup = staging / "previous-plugin"
+            was_enabled, was_disabled = _plugin_membership(target.name)
+            _write_install_transaction({
+                "version": 1,
+                "plugin_name": target.name,
+                "transaction_dir": staging.name,
+                "replaced_existing": True,
+                "old_metadata": metadata,
+                "was_enabled": was_enabled,
+                "was_disabled": was_disabled,
+            })
+            try:
+                secure_replace(target, backup, target.parent)
+                if tracked:
+                    _write_install_metadata(updated)
+                _mutate_plugin_state_locked(
+                    enabled_remove={target.name}, disabled_remove={target.name}
+                )
+                secure_unlink(
+                    _install_transaction_path(), get_hermes_home(), missing_ok=True
+                )
+            except BaseException:
+                _recover_install_transaction()
+                raise
+            try:
+                secure_rmtree(staging, target.parent)
+            except OSError as exc:
+                logger.warning(
+                    "Plugin removal committed; cleanup deferred for %s: %s",
+                    staging,
+                    exc,
+                )
 
 
 def _update_catalog_plugin(name: str, target: Path, sidecar: dict, console) -> None:
@@ -1413,24 +1867,16 @@ def _update_catalog_plugin(name: str, target: Path, sidecar: dict, console) -> N
         f"{installed_sha[:8] or '(unknown)'} → {entry.sha[:8]}"
     )
 
-    # Preserve enabled state across the force reinstall.
-    was_enabled = _get_enabled_set()
-
     try:
-        new_target, _manifest, _installed_name = _install_plugin_core(
+        _new_target, _manifest, _installed_name = _install_plugin_core(
             _catalog_install_identifier(entry),
             force=True,
             ref=entry.sha,
+            catalog_entry=entry,
         )
     except PluginOperationError as e:
         console.print(f"[red]Error:[/red] {e}")
         sys.exit(1)
-
-    _write_catalog_sidecar(new_target, entry)
-    # Restore the pre-update enabled/disabled state verbatim (the reinstall
-    # itself never touches it, but be explicit in case core ever does).
-    _save_enabled_set(was_enabled)
-
     console.print(
         f"[green]✓[/green] Plugin [bold]{catalog_name}[/bold] updated to "
         f"{entry.sha[:8]}."
@@ -1466,21 +1912,12 @@ def _get_disabled_set() -> set:
     """
     try:
         from hermes_cli.config import load_config
+
         config = load_config()
         disabled = cfg_get(config, "plugins", "disabled", default=[])
         return set(disabled) if isinstance(disabled, list) else set()
     except Exception:
         return set()
-
-
-def _save_disabled_set(disabled: set) -> None:
-    """Write the disabled plugins list to config.yaml."""
-    from hermes_cli.config import load_config, save_config
-    config = load_config()
-    if "plugins" not in config:
-        config["plugins"] = {}
-    config["plugins"]["disabled"] = sorted(disabled)
-    save_config(config)
 
 
 _BASIC_AUTH_PLUGIN_KEYS = frozenset({"basic", "dashboard_auth/basic"})
@@ -1504,9 +1941,7 @@ def ensure_basic_auth_plugin_enabled_in_config(cfg: dict) -> bool:
         return False
     if not (set(disabled) & _BASIC_AUTH_PLUGIN_KEYS):
         return False
-    plugins_cfg["disabled"] = sorted(
-        set(disabled) - _BASIC_AUTH_PLUGIN_KEYS
-    )
+    plugins_cfg["disabled"] = sorted(set(disabled) - _BASIC_AUTH_PLUGIN_KEYS)
     return True
 
 
@@ -1518,6 +1953,7 @@ def _get_enabled_set() -> set:
     """
     try:
         from hermes_cli.config import load_config
+
         config = load_config()
         plugins_cfg = config.get("plugins", {})
         if not isinstance(plugins_cfg, dict):
@@ -1528,14 +1964,84 @@ def _get_enabled_set() -> set:
         return set()
 
 
-def _save_enabled_set(enabled: set) -> None:
-    """Write the enabled plugins list to config.yaml."""
-    from hermes_cli.config import load_config, save_config
-    config = load_config()
-    if "plugins" not in config:
-        config["plugins"] = {}
-    config["plugins"]["enabled"] = sorted(enabled)
-    save_config(config)
+def _mutate_plugin_state_locked(
+    *,
+    enable: set[str] | None = None,
+    disable: set[str] | None = None,
+    enabled_remove: set[str] | None = None,
+    disabled_remove: set[str] | None = None,
+    toolset_name: str | None = None,
+    toolset_enable: bool = False,
+) -> bool:
+    """Apply one plugin-state delta while the install lock is held."""
+    from hermes_cli.config import config_write_lock, load_config, save_config
+
+    with config_write_lock():
+        config = load_config()
+        plugins = config.setdefault("plugins", {})
+        if not isinstance(plugins, dict):
+            plugins = {}
+            config["plugins"] = plugins
+        enabled_present = "enabled" in plugins
+        disabled_present = "disabled" in plugins
+        raw_enabled = plugins.get("enabled")
+        raw_disabled = plugins.get("disabled")
+        old_enabled = set(raw_enabled) if isinstance(raw_enabled, list) else set()
+        old_disabled = set(raw_disabled) if isinstance(raw_disabled, list) else set()
+        old_toolsets = copy.deepcopy(config.get("platform_toolsets"))
+        new_enabled = set(old_enabled)
+        new_disabled = set(old_disabled)
+        for name in enable or set():
+            new_enabled.add(name)
+            new_disabled.discard(name)
+        for name in disable or set():
+            new_enabled.discard(name)
+            new_disabled.add(name)
+        new_enabled.difference_update(enabled_remove or set())
+        new_disabled.difference_update(disabled_remove or set())
+        toolsets_changed = bool(
+            toolset_name
+            and _toggle_plugin_toolset(config, toolset_name, enable=toolset_enable)
+        )
+        if (
+            new_enabled == old_enabled
+            and new_disabled == old_disabled
+            and not toolsets_changed
+        ):
+            return False
+        plugins["enabled"] = sorted(new_enabled)
+        plugins["disabled"] = sorted(new_disabled)
+        try:
+            save_config(
+                config,
+                preserve_plugin_state=False,
+                preserve_platform_toolsets=False,
+            )
+        except Exception:
+            if enabled_present:
+                plugins["enabled"] = sorted(old_enabled)
+            else:
+                plugins.pop("enabled", None)
+            if disabled_present:
+                plugins["disabled"] = sorted(old_disabled)
+            else:
+                plugins.pop("disabled", None)
+            if old_toolsets is None:
+                config.pop("platform_toolsets", None)
+            else:
+                config["platform_toolsets"] = old_toolsets
+            save_config(
+                config,
+                preserve_plugin_state=False,
+                preserve_platform_toolsets=False,
+            )
+            raise
+        return True
+
+
+def _mutate_plugin_state(**changes) -> bool:
+    with _install_metadata_lock():
+        return _mutate_plugin_state_locked(**changes)
 
 
 def _resolve_plugin_key(name: str) -> Optional[str]:
@@ -1578,8 +2084,7 @@ def _resolve_plugin_key_and_source(name: str) -> Optional[tuple]:
         if name == entry[5] or name == entry[0]:
             return (entry[5], entry[3])
     leaf_matches = [
-        (entry[5], entry[3]) for entry in entries
-        if name == entry[5].split("/")[-1]
+        (entry[5], entry[3]) for entry in entries if name == entry[5].split("/")[-1]
     ]
     if len(leaf_matches) == 1:
         return leaf_matches[0]
@@ -1589,6 +2094,7 @@ def _resolve_plugin_key_and_source(name: str) -> Optional[tuple]:
 def _set_plugin_entry_flag(plugin_id: str, key: str, value: bool) -> None:
     """Write ``plugins.entries.<plugin_id>.<key> = value`` into config.yaml."""
     from hermes_cli.config import load_config, save_config
+
     config = load_config()
     plugins_cfg = config.setdefault("plugins", {})
     if not isinstance(plugins_cfg, dict):
@@ -1645,31 +2151,14 @@ def cmd_enable(name: str, allow_tool_override: Optional[bool] = None) -> None:
         )
         sys.exit(1)
 
-    enabled = _get_enabled_set()
-    disabled = _get_disabled_set()
-
-    already_enabled = key in enabled and key not in disabled
-
-    if not already_enabled:
-        enabled.add(key)
-        disabled.discard(key)
-        # Drop every alias of this plugin from the disabled list so an
-        # explicit disable under a different form can't keep it off. The
-        # loader's disable check matches on BOTH the canonical key
-        # (``web/firecrawl``) AND the manifest name (``web-firecrawl``);
-        # a stale entry under either form makes "explicit disable wins"
-        # (plugins.py) silently veto this enable. Discard the key, its
-        # bare leaf, and the manifest name. (#40190 follow-up.)
-        bare = key.split("/")[-1]
-        if bare != key:
-            disabled.discard(bare)
-        for entry in _discover_all_plugins():
-            # entry = (name, version, description, source, dir_path, key)
-            if entry[5] == key:
-                disabled.discard(entry[0])
-                break
-        _save_enabled_set(enabled)
-        _save_disabled_set(disabled)
+    # Drop every alias of this plugin from the disabled list so an explicit
+    # disable under a different form can't keep it off (#40190 follow-up).
+    disabled_aliases = {key, key.split("/")[-1]}
+    for entry in _discover_all_plugins():
+        if entry[5] == key:
+            disabled_aliases.add(entry[0])
+            break
+    if _mutate_plugin_state(enable={key}, disabled_remove=disabled_aliases):
         console.print(
             f"[green]✓[/green] Plugin [bold]{key}[/bold] enabled. "
             "Takes effect on next session."
@@ -1699,7 +2188,9 @@ def cmd_enable(name: str, allow_tool_override: Optional[bool] = None) -> None:
 # ── Capability consent flow (#64228) ─────────────────────────────────────────
 
 
-def _declared_capabilities_from_manifest(manifest: dict, plugin_name: str = "?") -> list:
+def _declared_capabilities_from_manifest(
+    manifest: dict, plugin_name: str = "?"
+) -> list:
     """Extract + normalize the ``capabilities:`` declaration from a manifest."""
     from hermes_cli.plugin_capabilities import parse_declared_capabilities
 
@@ -1836,9 +2327,9 @@ def cmd_capabilities(name: Optional[str] = None) -> None:
             CAPABILITY_REGISTRY,
             plugin_capability_granted,
         )
+
         effective = {
-            cap for cap in CAPABILITY_REGISTRY
-            if plugin_capability_granted(key, cap)
+            cap for cap in CAPABILITY_REGISTRY if plugin_capability_granted(key, cap)
         }
         if not declared and not effective and name is None:
             continue
@@ -1866,8 +2357,7 @@ def cmd_capabilities(name: Optional[str] = None) -> None:
             console.print(f"  {cap}: {mark}")
         for cap in sorted(effective - set(declared)):
             console.print(
-                f"  {cap}: [green]granted[/green] "
-                "[dim](not declared in manifest)[/dim]"
+                f"  {cap}: [green]granted[/green] [dim](not declared in manifest)[/dim]"
             )
 
 
@@ -1921,22 +2411,12 @@ def cmd_disable(name: str) -> None:
         console.print(f"[red]Plugin '{name}' is not installed or bundled.[/red]")
         sys.exit(1)
 
-    enabled = _get_enabled_set()
-    disabled = _get_disabled_set()
-
-    if key not in enabled and key in disabled:
+    bare = key.split("/")[-1]
+    if not _mutate_plugin_state(
+        disable={key}, enabled_remove={bare} if bare != key else set()
+    ):
         console.print(f"[dim]Plugin '{key}' is already disabled.[/dim]")
         return
-
-    enabled.discard(key)
-    # Drop any legacy bare-name entry from the allow-list too, so a stale
-    # bare name can't keep a nested plugin loading after an explicit disable.
-    bare = key.split("/")[-1]
-    if bare != key:
-        enabled.discard(bare)
-    disabled.add(key)
-    _save_enabled_set(enabled)
-    _save_disabled_set(disabled)
     console.print(
         f"[yellow]\u2298[/yellow] Plugin [bold]{key}[/bold] disabled. "
         "Takes effect on next session."
@@ -2085,6 +2565,7 @@ def _discover_all_plugins() -> list:
     # provider registry (providers/__init__.py), not the general PluginManager
     # opt-in surface, so listing them as toggleable plugins is misleading.
     from hermes_cli.plugins import get_bundled_plugins_dir
+
     repo_plugins = get_bundled_plugins_dir()
     for base, source, skip in (
         (repo_plugins, "bundled", {"memory", "context_engine", "model-providers"}),
@@ -2141,14 +2622,17 @@ def _plugin_status(name: str, enabled: set, disabled: set, key: str = "") -> str
     return "not enabled"
 
 
-def _filter_plugin_entries(entries: list, args: Any, enabled: set, disabled: set) -> list:
+def _filter_plugin_entries(
+    entries: list, args: Any, enabled: set, disabled: set
+) -> list:
     """Apply ``hermes plugins list`` CLI filters."""
     filtered = entries
     if getattr(args, "no_bundled", False) or getattr(args, "user", False):
         filtered = [entry for entry in filtered if entry[3] != "bundled"]
     if getattr(args, "enabled", False):
         filtered = [
-            entry for entry in filtered
+            entry
+            for entry in filtered
             if _plugin_status(entry[0], enabled, disabled, key=entry[5]) == "enabled"
         ]
     return filtered
@@ -2233,7 +2717,9 @@ def cmd_list(args: Any | None = None) -> None:
     console.print("[dim]Compact view:[/dim] hermes plugins list --plain --no-bundled")
     console.print("[dim]Interactive toggle:[/dim] hermes plugins")
     console.print("[dim]Enable/disable:[/dim] hermes plugins enable/disable <name>")
-    console.print("[dim]Plugins are opt-in by default — only 'enabled' plugins load.[/dim]")
+    console.print(
+        "[dim]Plugins are opt-in by default — only 'enabled' plugins load.[/dim]"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -2245,6 +2731,7 @@ def _discover_memory_providers() -> list[tuple[str, str]]:
     """Return [(name, description), ...] for available memory providers."""
     try:
         from plugins.memory import discover_memory_providers
+
         return [(name, desc) for name, desc, _avail in discover_memory_providers()]
     except Exception:
         return []
@@ -2263,6 +2750,7 @@ def _discover_context_engines() -> list[tuple[str, str]]:
 
     try:
         from plugins.context_engine import discover_context_engines
+
         for name, desc, _avail in discover_context_engines():
             if name not in seen:
                 engines.append((name, desc))
@@ -2272,9 +2760,14 @@ def _discover_context_engines() -> list[tuple[str, str]]:
 
     try:
         from hermes_cli.plugins import discover_plugins, get_plugin_context_engine
+
         discover_plugins()
         plugin_engine = get_plugin_context_engine()
-        if plugin_engine and getattr(plugin_engine, "name", None) and plugin_engine.name not in seen:
+        if (
+            plugin_engine
+            and getattr(plugin_engine, "name", None)
+            and plugin_engine.name not in seen
+        ):
             engines.append((plugin_engine.name, "installed plugin"))
     except Exception:
         pass
@@ -2286,6 +2779,7 @@ def _get_current_memory_provider() -> str:
     """Return the current memory.provider from config (empty = built-in)."""
     try:
         from hermes_cli.config import load_config
+
         config = load_config()
         return cfg_get(config, "memory", "provider", default="") or ""
     except Exception:
@@ -2296,8 +2790,11 @@ def _get_current_context_engine() -> str:
     """Return the current context.engine from config."""
     try:
         from hermes_cli.config import load_config
+
         config = load_config()
-        return cfg_get(config, "context", "engine", default="compressor") or "compressor"
+        return (
+            cfg_get(config, "context", "engine", default="compressor") or "compressor"
+        )
     except Exception:
         return "compressor"
 
@@ -2305,6 +2802,7 @@ def _get_current_context_engine() -> str:
 def _save_memory_provider(name: str) -> None:
     """Persist memory.provider to config.yaml."""
     from hermes_cli.config import load_config, save_config
+
     config = load_config()
     if "memory" not in config:
         config["memory"] = {}
@@ -2315,6 +2813,7 @@ def _save_memory_provider(name: str) -> None:
 def _save_context_engine(name: str) -> None:
     """Persist context.engine to config.yaml."""
     from hermes_cli.config import load_config, save_config
+
     config = load_config()
     if "context" not in config:
         config["context"] = {}
@@ -2437,7 +2936,9 @@ def cmd_show(name: str) -> None:
     status = _plugin_status(pname, enabled, disabled, key=key)
 
     console.print()
-    console.print(f"[bold]{pname}[/bold]" + (f" [dim]v{version}[/dim]" if version else ""))
+    console.print(
+        f"[bold]{pname}[/bold]" + (f" [dim]v{version}[/dim]" if version else "")
+    )
     if description:
         console.print(description)
     console.print(f"[dim]Status:[/dim] {status}")
@@ -2447,7 +2948,8 @@ def cmd_show(name: str) -> None:
         "[dim]Emits:[/dim] " + (", ".join(emits) if emits else "[dim](none)[/dim]")
     )
     console.print(
-        "[dim]Listens:[/dim] " + (", ".join(listens) if listens else "[dim](none)[/dim]")
+        "[dim]Listens:[/dim] "
+        + (", ".join(listens) if listens else "[dim](none)[/dim]")
     )
     console.print()
 
@@ -2504,7 +3006,9 @@ def cmd_toggle() -> None:
     has_categories = bool(categories)
 
     if not has_plugins and not has_categories:
-        console.print("[dim]No plugins installed and no provider categories available.[/dim]")
+        console.print(
+            "[dim]No plugins installed and no provider categories available.[/dim]"
+        )
         console.print("[dim]Install with:[/dim] hermes plugins install owner/repo")
         return
 
@@ -2516,15 +3020,30 @@ def cmd_toggle() -> None:
     # Launch the composite curses UI
     try:
         import curses
-        _run_composite_ui(curses, plugin_keys, plugin_labels, plugin_selected,
-                          disabled_set, categories, console)
+
+        _run_composite_ui(
+            curses,
+            plugin_keys,
+            plugin_labels,
+            plugin_selected,
+            disabled_set,
+            categories,
+            console,
+        )
     except ImportError:
-        _run_composite_fallback(plugin_keys, plugin_labels, plugin_selected,
-                                disabled_set, categories, console)
+        _run_composite_fallback(
+            plugin_keys,
+            plugin_labels,
+            plugin_selected,
+            disabled_set,
+            categories,
+            console,
+        )
 
 
-def _run_composite_ui(curses, plugin_keys, plugin_labels, plugin_selected,
-                      disabled, categories, console):
+def _run_composite_ui(
+    curses, plugin_keys, plugin_labels, plugin_selected, disabled, categories, console
+):
     """Custom curses screen with checkboxes + category action rows."""
     from hermes_cli.curses_ui import flush_stdin
 
@@ -2545,7 +3064,9 @@ def _run_composite_ui(curses, plugin_keys, plugin_labels, plugin_selected,
             curses.init_pair(1, curses.COLOR_GREEN, -1)
             curses.init_pair(2, curses.COLOR_YELLOW, -1)
             curses.init_pair(3, curses.COLOR_CYAN, -1)
-            curses.init_pair(4, 8 if curses.COLORS > 8 else curses.COLOR_WHITE, -1)  # dim gray
+            curses.init_pair(
+                4, 8 if curses.COLORS > 8 else curses.COLOR_WHITE, -1
+            )  # dim gray
         cursor = 0
         scroll_offset = 0
 
@@ -2560,9 +3081,11 @@ def _run_composite_ui(curses, plugin_keys, plugin_labels, plugin_selected,
                     hattr |= curses.color_pair(2)
                 stdscr.addnstr(0, 0, "Plugins", max_x - 1, hattr)
                 stdscr.addnstr(
-                    1, 0,
+                    1,
+                    0,
                     "  ↑↓/j/k navigate  PgUp/PgDn page  SPACE toggle  ENTER configure/confirm  ESC done",
-                    max_x - 1, curses.A_DIM,
+                    max_x - 1,
+                    curses.A_DIM,
                 )
             except curses.error:
                 pass
@@ -2586,7 +3109,6 @@ def _run_composite_ui(curses, plugin_keys, plugin_labels, plugin_selected,
             # Determine which items are visible based on scroll
             # We need to map logical cursor positions to screen rows
             # accounting for non-navigable separator/headers
-
 
             # --- General Plugins section ---
             if n_plugins > 0:
@@ -2687,7 +3209,8 @@ def _run_composite_ui(curses, plugin_keys, plugin_labels, plugin_selected,
                             # Refresh current values
                             categories[ci] = (
                                 _cat_name,
-                                _get_current_memory_provider() or "built-in" if ci == 0
+                                _get_current_memory_provider() or "built-in"
+                                if ci == 0
                                 else _get_current_context_engine(),
                                 cat_fn,
                             )
@@ -2702,7 +3225,9 @@ def _run_composite_ui(curses, plugin_keys, plugin_labels, plugin_selected,
                             curses.init_pair(1, curses.COLOR_GREEN, -1)
                             curses.init_pair(2, curses.COLOR_YELLOW, -1)
                             curses.init_pair(3, curses.COLOR_CYAN, -1)
-                            curses.init_pair(4, 8 if curses.COLORS > 8 else curses.COLOR_WHITE, -1)
+                            curses.init_pair(
+                                4, 8 if curses.COLORS > 8 else curses.COLOR_WHITE, -1
+                            )
                         curses.curs_set(0)
             elif key in {curses.KEY_ENTER, 10, 13}:
                 if cursor < n_plugins:
@@ -2720,7 +3245,8 @@ def _run_composite_ui(curses, plugin_keys, plugin_labels, plugin_selected,
                             result_holder["providers_changed"] = True
                             categories[ci] = (
                                 _cat_name,
-                                _get_current_memory_provider() or "built-in" if ci == 0
+                                _get_current_memory_provider() or "built-in"
+                                if ci == 0
                                 else _get_current_context_engine(),
                                 cat_fn,
                             )
@@ -2734,7 +3260,9 @@ def _run_composite_ui(curses, plugin_keys, plugin_labels, plugin_selected,
                             curses.init_pair(1, curses.COLOR_GREEN, -1)
                             curses.init_pair(2, curses.COLOR_YELLOW, -1)
                             curses.init_pair(3, curses.COLOR_CYAN, -1)
-                            curses.init_pair(4, 8 if curses.COLORS > 8 else curses.COLOR_WHITE, -1)
+                            curses.init_pair(
+                                4, 8 if curses.COLORS > 8 else curses.COLOR_WHITE, -1
+                            )
                         curses.curs_set(0)
             elif key in {27, ord("q")}:
                 # Save plugin changes on exit
@@ -2750,7 +3278,9 @@ def _run_composite_ui(curses, plugin_keys, plugin_labels, plugin_selected,
     # manifest name), so the disabled-list can't drift out of sync with
     # what ``cmd_enable`` clears or what PluginManager gates on (#40190).
     new_enabled: set = set()
-    new_disabled: set = set(disabled)  # preserve existing disabled state for unseen plugins
+    new_disabled: set = set(
+        disabled
+    )  # preserve existing disabled state for unseen plugins
     for i, key in enumerate(plugin_keys):
         bare = key.split("/")[-1]
         if i in chosen:
@@ -2763,13 +3293,16 @@ def _run_composite_ui(curses, plugin_keys, plugin_labels, plugin_selected,
         else:
             new_disabled.add(key)
 
-    prev_enabled = _get_enabled_set()
-    enabled_changed = new_enabled != prev_enabled
-    disabled_changed = new_disabled != disabled
-
-    if enabled_changed or disabled_changed:
-        _save_enabled_set(new_enabled)
-        _save_disabled_set(new_disabled)
+    selected_keys = {plugin_keys[i] for i in chosen}
+    disabled_keys = set(plugin_keys) - selected_keys
+    stale_aliases = {
+        key.split("/")[-1] for key in selected_keys if key.split("/")[-1] != key
+    }
+    if _mutate_plugin_state(
+        enable=selected_keys,
+        disable=disabled_keys,
+        disabled_remove=stale_aliases,
+    ):
         console.print(
             f"\n[green]\u2713[/green] General plugins: {len(new_enabled)} enabled, "
             f"{len(plugin_keys) - len(new_enabled)} disabled."
@@ -2790,8 +3323,9 @@ def _run_composite_ui(curses, plugin_keys, plugin_labels, plugin_selected,
     console.print()
 
 
-def _run_composite_fallback(plugin_keys, plugin_labels, plugin_selected,
-                            disabled, categories, console):
+def _run_composite_fallback(
+    plugin_keys, plugin_labels, plugin_selected, disabled, categories, console
+):
     """Text-based fallback for the composite plugins UI."""
     from hermes_cli.colors import Colors, color
 
@@ -2809,7 +3343,9 @@ def _run_composite_fallback(plugin_keys, plugin_labels, plugin_selected,
                 print(f"  {marker} {i + 1:>2}. {label}")
             print()
             try:
-                val = input(color("  Toggle # (or Enter to confirm): ", Colors.DIM)).strip()
+                val = input(
+                    color("  Toggle # (or Enter to confirm): ", Colors.DIM)
+                ).strip()
                 if not val:
                     break
                 idx = int(val) - 1
@@ -2833,10 +3369,16 @@ def _run_composite_fallback(plugin_keys, plugin_labels, plugin_selected,
                     new_disabled.discard(bare)
             else:
                 new_disabled.add(key)
-        prev_enabled = _get_enabled_set()
-        if new_enabled != prev_enabled or new_disabled != disabled:
-            _save_enabled_set(new_enabled)
-            _save_disabled_set(new_disabled)
+        selected_keys = {plugin_keys[i] for i in chosen}
+        disabled_keys = set(plugin_keys) - selected_keys
+        stale_aliases = {
+            key.split("/")[-1] for key in selected_keys if key.split("/")[-1] != key
+        }
+        _mutate_plugin_state(
+            enable=selected_keys,
+            disable=disabled_keys,
+            disabled_remove=stale_aliases,
+        )
 
     # Provider categories
     if categories:
@@ -2862,6 +3404,7 @@ def dashboard_install_plugin(
     force: bool,
     enable: bool,
     catalog_name: Optional[str] = None,
+    catalog_source: str = "official",
 ) -> dict[str, Any]:
     """Non-interactive install for the web dashboard. Returns a JSON-serializable dict.
 
@@ -2875,9 +3418,9 @@ def dashboard_install_plugin(
     ref: Optional[str] = None
 
     if catalog_name:
-        from hermes_cli.plugin_catalog import find_removed, get_catalog_entry
+        from hermes_cli.plugin_catalog import find_removed
 
-        removed = find_removed(catalog_name)
+        removed = find_removed(catalog_name) if catalog_source == "official" else None
         if removed is not None:
             detail = removed.reason or "no reason recorded"
             if removed.date:
@@ -2889,11 +3432,25 @@ def dashboard_install_plugin(
                     f"plugin catalog and is blocked from installation: {detail}"
                 ),
             }
-        entry = get_catalog_entry(catalog_name)
+        # Mutation paths refresh Git marketplaces and resolve coordinates
+        # server-side; renderer cache data is never authoritative.
+        entry = _get_live_catalog_entry(
+            catalog_name,
+            catalog_source,
+            force=catalog_source != "official",
+        )
         if entry is None:
             return {
                 "ok": False,
-                "error": f"'{catalog_name}' is not in the Hermes plugin catalog.",
+                "error": f"'{catalog_name}' is not in the selected plugin marketplace.",
+            }
+        if catalog_source != "official" and not entry.compatible:
+            return {
+                "ok": False,
+                "error": (
+                    f"'{catalog_name}' has no root plugin.yaml or portable plugin.json "
+                    "and cannot be installed by Hermes."
+                ),
             }
         identifier = _catalog_install_identifier(entry)
         ref = entry.sha
@@ -2907,11 +3464,19 @@ def dashboard_install_plugin(
         except ValueError:
             pass
 
+    install_options = {}
+    if entry is not None and catalog_source != "official":
+        install_options["metadata_extra"] = _marketplace_metadata(entry)
+    elif entry is not None:
+        install_options["catalog_entry"] = entry
+
     try:
         target, installed_manifest, installed_name = _install_plugin_core(
             identifier,
             force=force,
             ref=ref,
+            enable_on_commit=enable,
+            **install_options,
         )
     except PluginScanBlocked as exc:
         findings = []
@@ -2937,20 +3502,7 @@ def dashboard_install_plugin(
     except PluginOperationError as exc:
         return {"ok": False, "error": str(exc)}
 
-    if entry is not None:
-        try:
-            write_catalog_sidecar(target, entry)
-        except OSError as exc:
-            warnings.append(f"Could not record catalog provenance: {exc}")
-
     missing_env = _missing_requires_env_names(installed_manifest)
-    if enable:
-        en = _get_enabled_set()
-        dis = _get_disabled_set()
-        en.add(installed_name)
-        dis.discard(installed_name)
-        _save_enabled_set(en)
-        _save_disabled_set(dis)
 
     hint: str | None = None
     ap = target / "after-install.md"
@@ -2982,6 +3534,7 @@ def _get_plugin_toolset_key(name: str) -> Optional[str]:
     # Check the plugin manager for tools this plugin registered
     try:
         from hermes_cli.plugins import discover_plugins, get_plugin_manager
+
         discover_plugins()  # idempotent — ensures plugins are loaded
         manager = get_plugin_manager()
         for _key, loaded in manager._plugins.items():
@@ -2997,6 +3550,7 @@ def _get_plugin_toolset_key(name: str) -> Optional[str]:
     # Fallback: read provides_tools from manifest on disk and query registry
     try:
         from hermes_cli.plugins import get_bundled_plugins_dir
+
         for base in (get_bundled_plugins_dir(), _plugins_dir()):
             if not base.is_dir():
                 continue
@@ -3013,25 +3567,19 @@ def _get_plugin_toolset_key(name: str) -> Optional[str]:
     return None
 
 
-def _toggle_plugin_toolset(name: str, *, enable: bool) -> None:
-    """Add or remove a plugin's toolset from platform_toolsets for all platforms.
-
-    Only acts if the plugin actually provides tools (has a toolset key).
-    """
+def _toggle_plugin_toolset(config: dict, name: str, *, enable: bool) -> bool:
+    """Update one plugin toolset inside an already-loaded config."""
     toolset_key = _get_plugin_toolset_key(name)
     if not toolset_key:
-        return
+        return False
 
-    from hermes_cli.config import load_config, save_config
-
-    config = load_config()
     platform_toolsets = config.get("platform_toolsets")
     if not isinstance(platform_toolsets, dict):
         platform_toolsets = {}
         config["platform_toolsets"] = platform_toolsets
 
     changed = False
-    for platform, ts_list in platform_toolsets.items():
+    for _platform, ts_list in platform_toolsets.items():
         if not isinstance(ts_list, list):
             continue
         if enable:
@@ -3042,13 +3590,10 @@ def _toggle_plugin_toolset(name: str, *, enable: bool) -> None:
             ts_list.remove(toolset_key)
             changed = True
 
-    # If enabling and no platforms have toolset lists yet, add to "cli" at minimum
     if enable and not changed and not platform_toolsets:
         platform_toolsets["cli"] = [toolset_key]
         changed = True
-
-    if changed:
-        save_config(config)
+    return changed
 
 
 def dashboard_set_agent_plugin_enabled(name: str, *, enabled: bool) -> dict[str, Any]:
@@ -3060,28 +3605,16 @@ def dashboard_set_agent_plugin_enabled(name: str, *, enabled: bool) -> dict[str,
     if not _plugin_exists(name):
         return {"ok": False, "error": f"Plugin '{name}' is not installed or bundled."}
 
-    en = _get_enabled_set()
-    dis = _get_disabled_set()
-
-    if enabled:
-        if name in en and name not in dis:
+    with _install_metadata_lock():
+        changed = _mutate_plugin_state_locked(
+            enable={name} if enabled else None,
+            disable={name} if not enabled else None,
+            toolset_name=name,
+            toolset_enable=enabled,
+        )
+        if not changed:
             return {"ok": True, "name": name, "unchanged": True}
-        en.add(name)
-        dis.discard(name)
-        _save_enabled_set(en)
-        _save_disabled_set(dis)
-        _toggle_plugin_toolset(name, enable=True)
         return {"ok": True, "name": name, "unchanged": False}
-
-    if name not in en and name in dis:
-        return {"ok": True, "name": name, "unchanged": True}
-
-    en.discard(name)
-    dis.add(name)
-    _save_enabled_set(en)
-    _save_disabled_set(dis)
-    _toggle_plugin_toolset(name, enable=False)
-    return {"ok": True, "name": name, "unchanged": False}
 
 
 def _user_installed_plugin_dir(name: str) -> Optional[Path]:
@@ -3103,38 +3636,39 @@ def dashboard_update_user_plugin(name: str) -> dict[str, Any]:
             "error": f"Plugin '{name}' was not found under {_plugins_dir()}.",
         }
 
-    try:
-        metadata = _read_install_metadata()
-    except PluginOperationError as exc:
-        return {"ok": False, "error": str(exc)}
-    install_record = metadata.get(target.name, {})
-    if install_record.get("pinned") is True:
-        recorded_source = install_record.get("source", "<source>")
-        return {
-            "ok": False,
-            "error": (
-                f"Plugin '{name}' is pinned to {install_record.get('revision')}; "
-                f"run `hermes plugins install {recorded_source} --force "
-                "--ref <40-character commit SHA>` to move it."
-            ),
-        }
+    with _install_metadata_lock():
+        try:
+            metadata = _read_install_metadata()
+        except PluginOperationError as exc:
+            return {"ok": False, "error": str(exc)}
+        install_record = metadata.get(target.name, {})
+        if install_record.get("pinned") is True:
+            recorded_source = install_record.get("source", "<source>")
+            return {
+                "ok": False,
+                "error": (
+                    f"Plugin '{name}' is pinned to {install_record.get('revision')}; "
+                    f"run `hermes plugins install {recorded_source} --force "
+                    "--ref <40-character commit SHA>` to move it."
+                ),
+            }
 
-    if not (target / ".git").exists():
-        return {
-            "ok": False,
-            "error": f"Plugin '{name}' is not a git checkout; cannot pull updates.",
-        }
+        if not (target / ".git").exists():
+            return {
+                "ok": False,
+                "error": f"Plugin '{name}' is not a git checkout; cannot pull updates.",
+            }
 
-    ok, msg = _git_pull_plugin_dir(target)
-    if not ok:
-        return {"ok": False, "error": msg}
+        ok, msg = _git_pull_plugin_dir(target)
+        if not ok:
+            return {"ok": False, "error": msg}
 
-    if install_record:
-        git_exe = _resolve_git_executable()
-        if git_exe:
-            install_record["revision"] = _git_head_revision(target, git_exe)
-            metadata[target.name] = install_record
-            _write_install_metadata(metadata)
+        if install_record:
+            git_exe = _resolve_git_executable()
+            if git_exe:
+                install_record["revision"] = _git_head_revision(target, git_exe)
+                metadata[target.name] = install_record
+                _write_install_metadata(metadata)
 
     # Sibling of the CLI ``hermes plugins update`` path: drop bytecode
     # compiled from the pre-pull plugin revision.
@@ -3178,7 +3712,9 @@ def _run_plugin_git(
     return subprocess.run(
         [git_exe, *args],
         capture_output=True,
-        text=True, encoding='utf-8', errors='replace',
+        text=True,
+        encoding="utf-8",
+        errors="replace",
         timeout=timeout,
         cwd=str(target),
         stdin=subprocess.DEVNULL,
@@ -3221,9 +3757,13 @@ def _git_pull_plugin_dir(target: Path) -> tuple[bool, str]:
         if dirty:
             pre_stash = _stash_ref(git_exe, target)
             push = _run_plugin_git(
-                git_exe, target,
-                "stash", "push", "--include-untracked",
-                "-m", "hermes-plugin-update-autostash",
+                git_exe,
+                target,
+                "stash",
+                "push",
+                "--include-untracked",
+                "-m",
+                "hermes-plugin-update-autostash",
             )
             post_stash = _stash_ref(git_exe, target)
             stash_created = bool(post_stash) and post_stash != pre_stash
@@ -3247,7 +3787,9 @@ def _git_pull_plugin_dir(target: Path) -> tuple[bool, str]:
             err = _safe_git_error(result)
             if stash_created:
                 # Put the user's edits back before reporting the failure.
-                restore = _run_plugin_git(git_exe, target, "stash", "apply", "stash@{0}")
+                restore = _run_plugin_git(
+                    git_exe, target, "stash", "apply", "stash@{0}"
+                )
                 if restore.returncode == 0:
                     _run_plugin_git(git_exe, target, "stash", "drop", "stash@{0}")
                     note = "Local changes were restored."
@@ -3271,7 +3813,10 @@ def _git_pull_plugin_dir(target: Path) -> tuple[bool, str]:
 
         if restore.returncode == 0 and not has_conflicts:
             _run_plugin_git(git_exe, target, "stash", "drop", "stash@{0}")
-            return True, pulled + "\nLocal changes were re-applied on top of the update."
+            return (
+                True,
+                pulled + "\nLocal changes were re-applied on top of the update.",
+            )
 
         # Conflicted re-apply: leave the plugin importable on the updated
         # revision; the user's edits stay safe in the stash entry.
@@ -3293,7 +3838,10 @@ def dashboard_remove_user_plugin(name: str) -> dict[str, Any]:
     plugins_dir = _plugins_dir()
     for n, _ver, _d, src, _path, _key in _discover_all_plugins():
         if n == name and src == "bundled":
-            return {"ok": False, "error": "Bundled plugins cannot be removed from the dashboard."}
+            return {
+                "ok": False,
+                "error": "Bundled plugins cannot be removed from the dashboard.",
+            }
 
     target = _user_installed_plugin_dir(name)
     if target is None:
@@ -3418,9 +3966,15 @@ def cmd_info(name: str) -> None:
     if entry.docs_url:
         console.print(f"[dim]Docs:[/dim]        {entry.docs_url}")
     console.print()
-    console.print(f"[dim]Tools:[/dim]       {', '.join(caps.provides_tools) or '(none)'}")
-    console.print(f"[dim]Hooks:[/dim]       {', '.join(caps.provides_hooks) or '(none)'}")
-    console.print(f"[dim]Middleware:[/dim]  {', '.join(caps.provides_middleware) or '(none)'}")
+    console.print(
+        f"[dim]Tools:[/dim]       {', '.join(caps.provides_tools) or '(none)'}"
+    )
+    console.print(
+        f"[dim]Hooks:[/dim]       {', '.join(caps.provides_hooks) or '(none)'}"
+    )
+    console.print(
+        f"[dim]Middleware:[/dim]  {', '.join(caps.provides_middleware) or '(none)'}"
+    )
     console.print(f"[dim]Env vars:[/dim]    {', '.join(caps.requires_env) or '(none)'}")
     console.print()
 
@@ -3429,9 +3983,7 @@ def cmd_info(name: str) -> None:
         detail = removed.reason or "no reason recorded"
         if removed.date:
             detail += f" (removed {removed.date})"
-        console.print(
-            f"[red bold]✗ REMOVED from catalog: {detail}[/red bold]"
-        )
+        console.print(f"[red bold]✗ REMOVED from catalog: {detail}[/red bold]")
         console.print()
 
     console.print(f"[dim]Install:[/dim]     hermes plugins install {entry.name}")
@@ -3513,7 +4065,6 @@ def cmd_search(
             console.print("[dim]No catalog entries available.[/dim]")
         return
     _render_catalog_entries(matches, console)
-
 
 
 def plugins_command(args) -> None:

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -3578,7 +3578,7 @@ def _run_blank_slate_setup(config: dict, hermes_home, is_existing: bool):
     # ── Step 3: Lock in the minimal toolset + minimized config knobs ──
     _blank_slate_minimal_toolsets(config)
     _blank_slate_minimize_config(config)
-    save_config(config)
+    save_config(config, preserve_platform_toolsets=False)
     print()
     print_success("Minimal baseline applied:")
     print_info("  Toolsets: file, terminal, vision, skills (everything else off)")

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2312,14 +2312,11 @@ def _run_post_setup(post_setup_key: str):
         # The plugin ships in the repo but doesn't load until the user enables
         # it (standalone plugins are opt-in).
         try:
-            from hermes_cli.plugins_cmd import _get_enabled_set, _save_enabled_set
-            enabled = _get_enabled_set()
-            if "observability/langfuse" in enabled or "langfuse" in enabled:
-                _print_success("    Plugin observability/langfuse already enabled")
-            else:
-                enabled.add("observability/langfuse")
-                _save_enabled_set(enabled)
+            from hermes_cli.plugins_cmd import _mutate_plugin_state
+            if _mutate_plugin_state(enable={"observability/langfuse"}):
                 _print_success("    Plugin observability/langfuse enabled")
+            else:
+                _print_success("    Plugin observability/langfuse already enabled")
         except Exception as exc:
             _print_warning(f"    Could not enable plugin automatically: {exc}")
             _print_info("    Run manually: hermes plugins enable observability/langfuse")
@@ -3028,7 +3025,7 @@ def _save_platform_tools(config: dict, platform: str, enabled_toolset_keys: Set[
                 if remaining != parsed_disabled:
                     agent_cfg["disabled_toolsets"] = remaining
 
-    save_config(config)
+    save_config(config, preserve_platform_toolsets=False)
 
 
 def _toolset_has_keys(

--- a/hermes_cli/xai_retirement.py
+++ b/hermes_cli/xai_retirement.py
@@ -172,6 +172,19 @@ def _walk_to_parent(yaml_doc: Any, dotted_path: str) -> "tuple[Any, str]":
 def apply_migration(
     config_path: Path,
     issues: List[RetirementIssue],
+    *,
+    backup: bool = True,
+) -> ApplyResult:
+    from hermes_cli.config import config_write_lock
+
+    with config_write_lock():
+        return _apply_migration_locked(config_path, issues, backup=backup)
+
+
+def _apply_migration_locked(
+    config_path: Path,
+    issues: List[RetirementIssue],
+    *,
     backup: bool = True,
 ) -> ApplyResult:
     """Rewrite ``config_path`` in-place so each issue is resolved.

--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -131,15 +131,19 @@ class HolographicMemoryProvider(MemoryProvider):
         from pathlib import Path
         config_path = Path(hermes_home) / "config.yaml"
         try:
-            import yaml
             # Write-back round-trip: raw read is correct (merged defaults
             # must not be persisted back into the user's file).
-            from hermes_cli.config import read_user_config_raw
-            existing = read_user_config_raw(config_path)
-            existing.setdefault("plugins", {})
-            existing["plugins"]["hermes-memory-store"] = values
-            with open(config_path, "w", encoding="utf-8") as f:
-                yaml.dump(existing, f, default_flow_style=False)
+            from hermes_cli.config import (
+                atomic_config_write,
+                config_write_lock,
+                read_user_config_raw,
+            )
+
+            with config_write_lock():
+                existing = read_user_config_raw(config_path)
+                existing.setdefault("plugins", {})
+                existing["plugins"]["hermes-memory-store"] = values
+                atomic_config_write(config_path, existing, sort_keys=False)
         except Exception:
             pass
 

--- a/tests/hermes_cli/test_model_provider_persistence.py
+++ b/tests/hermes_cli/test_model_provider_persistence.py
@@ -54,8 +54,8 @@ class TestSaveModelChoiceAlwaysDict:
 
 
 class TestProviderPersistsAfterModelSave:
-    def test_update_config_for_provider_uses_atomic_yaml_write(self, config_home):
-        """Provider switches should delegate config writes to atomic_yaml_write."""
+    def test_update_config_for_provider_uses_atomic_config_write(self, config_home):
+        """Provider switches use the guarded config.yaml write chokepoint."""
         from hermes_cli.auth import _update_config_for_provider
 
         config_path = config_home / "config.yaml"
@@ -69,7 +69,7 @@ class TestProviderPersistsAfterModelSave:
             assert kwargs["sort_keys"] is False
             raise OSError("simulated atomic write failure")
 
-        with patch("hermes_cli.auth.atomic_yaml_write", side_effect=_boom) as mock_write:
+        with patch("hermes_cli.config.atomic_config_write", side_effect=_boom) as mock_write:
             with pytest.raises(OSError, match="simulated atomic write failure"):
                 _update_config_for_provider(
                     "nous",

--- a/tests/hermes_cli/test_plugin_marketplaces.py
+++ b/tests/hermes_cli/test_plugin_marketplaces.py
@@ -16,6 +16,7 @@ from hermes_cli.plugin_marketplaces import (
     MarketplaceError,
     add_marketplace,
     list_marketplaces,
+    public_marketplace,
     remove_marketplace,
 )
 
@@ -130,6 +131,10 @@ def test_add_lists_and_persists_private_marketplace(tmp_path: Path) -> None:
         ],
         "version": 1,
     }
+
+    public = public_marketplace(added)
+    assert "url" not in public
+    assert "repo" not in public["entries"][0]
 
 
 def test_add_rejects_embedded_credentials() -> None:
@@ -344,7 +349,7 @@ def test_refresh_lock_serializes_independent_processes(tmp_path: Path) -> None:
 
 
 def test_windows_lock_retries_past_msvcrt_ten_second_limit(monkeypatch) -> None:
-    import hermes_cli.plugins_cmd as plugins_cmd
+    import hermes_cli.plugin_install_state as install_state
 
     calls = 0
 
@@ -360,10 +365,10 @@ def test_windows_lock_retries_past_msvcrt_ten_second_limit(monkeypatch) -> None:
         locking=locking,
     )
     with tempfile.TemporaryFile() as handle, monkeypatch.context() as patcher:
-        patcher.setattr(plugins_cmd.os, "name", "nt")
-        patcher.setattr(plugins_cmd.time, "sleep", lambda _seconds: None)
+        patcher.setattr(install_state.os, "name", "nt")
+        patcher.setattr(install_state.time, "sleep", lambda _seconds: None)
         patcher.setitem(sys.modules, "msvcrt", fake_msvcrt)
-        plugins_cmd._lock_file(handle)
+        install_state._lock_file(handle)
 
     assert calls == 13
 

--- a/tests/hermes_cli/test_plugin_marketplaces.py
+++ b/tests/hermes_cli/test_plugin_marketplaces.py
@@ -1,0 +1,1429 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import types
+import errno
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.plugin_marketplaces import (
+    MarketplaceError,
+    add_marketplace,
+    list_marketplaces,
+    remove_marketplace,
+)
+
+
+def _git(repo: Path, *args: str) -> str:
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "test",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "test",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+    }
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    return result.stdout.strip()
+
+
+def _marketplace_repo(
+    tmp_path: Path, *, compatible: bool = True, name: str = "demo"
+) -> Path:
+    repo = tmp_path / "marketplace"
+    plugin = repo / "plugins" / name
+    (repo / ".claude-plugin").mkdir(parents=True)
+    (plugin / ".claude-plugin").mkdir(parents=True)
+    (plugin / "skills" / "demo").mkdir(parents=True)
+    (repo / ".claude-plugin" / "marketplace.json").write_text(
+        json.dumps({
+            "name": "test-marketplace",
+            "owner": {"name": "Test Publisher"},
+            "plugins": [
+                {
+                    "name": name,
+                    "displayName": f"{name.title()} Plugin",
+                    "description": "A private marketplace plugin.",
+                    "source": f"./plugins/{name}",
+                }
+            ],
+        }),
+        encoding="utf-8",
+    )
+    (plugin / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps({
+            "name": name,
+            "displayName": f"{name.title()} Plugin",
+            "version": "1.0.0",
+            "description": "A private marketplace plugin.",
+            "author": {"name": "Test Publisher"},
+        }),
+        encoding="utf-8",
+    )
+    if compatible:
+        (plugin / "plugin.json").write_text(
+            json.dumps({
+                "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+                "name": name,
+                "version": "1.0.0",
+                "description": "A private marketplace plugin.",
+            }),
+            encoding="utf-8",
+        )
+    (plugin / "skills" / "demo" / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: Demo.\n---\n\n# Demo\n",
+        encoding="utf-8",
+    )
+    _git(repo, "init", "-b", "main")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "initial")
+    return repo
+
+
+def test_add_lists_and_persists_private_marketplace(tmp_path: Path) -> None:
+    repo = _marketplace_repo(tmp_path)
+
+    added = add_marketplace(f"file://{repo}", allow_file=True)
+    listed = list_marketplaces()
+
+    assert added["name"] == "Test Marketplace"
+    assert len(listed) == 1
+    assert listed[0]["id"] == added["id"]
+    assert listed[0]["url"] == f"file://{repo}"
+    assert listed[0]["entries"][0] == {
+        "compatible": True,
+        "description": "A private marketplace plugin.",
+        "display_name": "Demo Plugin",
+        "incompatibility_reason": "",
+        "maintainer": "Test Publisher",
+        "name": "demo",
+        "repo": f"file://{repo}",
+        "sha": _git(repo, "rev-parse", "HEAD"),
+        "source_id": added["id"],
+        "source_name": "Test Marketplace",
+        "subdir": "plugins/demo",
+        "tree_sha": _git(repo, "rev-parse", "HEAD:plugins/demo"),
+        "version": "1.0.0",
+    }
+
+    registry = Path(os.environ["HERMES_HOME"]) / "plugin-marketplaces.json"
+    saved = json.loads(registry.read_text(encoding="utf-8"))
+    assert saved == {
+        "marketplaces": [
+            {
+                "id": added["id"],
+                "name": "Test Marketplace",
+                "url": f"file://{repo}",
+            }
+        ],
+        "version": 1,
+    }
+
+
+def test_add_rejects_embedded_credentials() -> None:
+    with pytest.raises(MarketplaceError, match="credentials"):
+        add_marketplace("https://user:secret@example.com/private/repo.git")
+
+
+@pytest.mark.parametrize(
+    ("source_id", "url"),
+    [
+        ("../../outside", "https://github.com/example/repo.git"),
+        ("0123456789abcdef", "https://user:secret@example.com/repo.git"),
+        ("0123456789abcdef", "https://github.com/example/repo.git"),
+    ],
+)
+def test_registry_rejects_untrusted_source_identity_without_touching_cache(
+    source_id: str, url: str
+) -> None:
+    home = Path(os.environ["HERMES_HOME"])
+    outside = home.parent / "outside.json"
+    outside.write_text("sentinel", encoding="utf-8")
+    (home / "plugin-marketplaces.json").write_text(
+        json.dumps({
+            "marketplaces": [{"id": source_id, "name": "bad", "url": url}],
+            "version": 1,
+        }),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(MarketplaceError, match="invalid source|credentials"):
+        list_marketplaces()
+    with pytest.raises(MarketplaceError, match="invalid source|credentials"):
+        remove_marketplace(source_id)
+
+    assert outside.read_text(encoding="utf-8") == "sentinel"
+
+
+def test_registry_absolute_id_cannot_delete_outside_cache(tmp_path: Path) -> None:
+    home = Path(os.environ["HERMES_HOME"])
+    outside = tmp_path / "outside.json"
+    outside.write_text("sentinel", encoding="utf-8")
+    source_id = str(outside.with_suffix(""))
+    (home / "plugin-marketplaces.json").write_text(
+        json.dumps({
+            "marketplaces": [
+                {
+                    "id": source_id,
+                    "name": "bad",
+                    "url": "https://github.com/example/repo.git",
+                }
+            ],
+            "version": 1,
+        }),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(MarketplaceError, match="invalid source ID"):
+        remove_marketplace(source_id)
+
+    assert outside.read_text(encoding="utf-8") == "sentinel"
+
+
+def test_add_rejects_query_and_external_source_forms(tmp_path: Path) -> None:
+    with pytest.raises(MarketplaceError, match="query or fragment"):
+        add_marketplace("https://github.com/example/repo?token=nope")
+
+    repo = _marketplace_repo(tmp_path)
+    manifest = repo / ".claude-plugin" / "marketplace.json"
+    data = json.loads(manifest.read_text(encoding="utf-8"))
+    data["plugins"][0]["source"] = {
+        "source": "url",
+        "url": "https://example.com/plugin.git",
+    }
+    manifest.write_text(json.dumps(data), encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "external source")
+    with pytest.raises(MarketplaceError, match="unsupported object source"):
+        add_marketplace(f"file://{repo}", allow_file=True)
+
+
+def test_add_rejects_plugin_path_escape(tmp_path: Path) -> None:
+    repo = _marketplace_repo(tmp_path)
+    manifest = repo / ".claude-plugin" / "marketplace.json"
+    data = json.loads(manifest.read_text(encoding="utf-8"))
+    data["plugins"][0]["source"] = "./../outside"
+    manifest.write_text(json.dumps(data), encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "escape")
+
+    with pytest.raises(MarketplaceError, match="inside the marketplace"):
+        add_marketplace(f"file://{repo}", allow_file=True)
+
+    assert not (Path(os.environ["HERMES_HOME"]) / "plugin-marketplaces.json").exists()
+
+
+def test_add_rejects_symlinked_plugin_root(tmp_path: Path) -> None:
+    repo = _marketplace_repo(tmp_path)
+    real = repo / "plugins" / "real"
+    (repo / "plugins" / "demo").rename(real)
+    (repo / "plugins" / "demo").symlink_to(real.name, target_is_directory=True)
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "symlink plugin root")
+
+    with pytest.raises(MarketplaceError, match="symlink"):
+        add_marketplace(f"file://{repo}", allow_file=True)
+
+
+def test_only_plugin_subtree_change_advertises_new_tree(tmp_path: Path) -> None:
+    repo = _marketplace_repo(tmp_path)
+    source = add_marketplace(f"file://{repo}", allow_file=True)
+    first = source["entries"][0]
+
+    (repo / "README.md").write_text("unrelated\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "unrelated")
+    unrelated = list_marketplaces(force=True)[0]["entries"][0]
+
+    assert unrelated["sha"] != first["sha"]
+    assert unrelated["tree_sha"] == first["tree_sha"]
+
+    skill = repo / "plugins" / "demo" / "skills" / "demo" / "SKILL.md"
+    skill.write_text(
+        skill.read_text(encoding="utf-8") + "\nChanged.\n", encoding="utf-8"
+    )
+    _git(repo, "add", "plugins/demo")
+    _git(repo, "commit", "-m", "plugin update")
+    changed = list_marketplaces(force=True)[0]["entries"][0]
+
+    assert changed["tree_sha"] != first["tree_sha"]
+
+
+def test_concurrent_refreshes_serialize_cache_commits(
+    tmp_path: Path, monkeypatch
+) -> None:
+    from concurrent.futures import ThreadPoolExecutor
+    from threading import Event, Lock
+
+    import hermes_cli.plugin_marketplaces as marketplaces
+
+    repo = _marketplace_repo(tmp_path)
+    add_marketplace(f"file://{repo}", allow_file=True)
+    clone = marketplaces._clone
+    first_entered = Event()
+    second_entered = Event()
+    allow_first = Event()
+    calls = 0
+    calls_lock = Lock()
+
+    def controlled_clone(url, target):
+        nonlocal calls
+        with calls_lock:
+            calls += 1
+            call = calls
+        if call == 1:
+            first_entered.set()
+            assert allow_first.wait(timeout=5)
+        else:
+            second_entered.set()
+        clone(url, target)
+
+    monkeypatch.setattr(marketplaces, "_clone", controlled_clone)
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(list_marketplaces, force=True)
+        assert first_entered.wait(timeout=5)
+        second = pool.submit(list_marketplaces, force=True)
+        assert second_entered.wait(timeout=0.2) is False
+        allow_first.set()
+        first.result(timeout=10)
+        second.result(timeout=10)
+
+    assert second_entered.is_set()
+
+
+def test_refresh_lock_serializes_independent_processes(tmp_path: Path) -> None:
+    home = Path(os.environ["HERMES_HOME"])
+    ready = tmp_path / "ready"
+    acquired = tmp_path / "acquired"
+    source_id = "0123456789abcdef"
+    first_code = (
+        "import time; from pathlib import Path; "
+        "from hermes_cli.plugin_marketplaces import _refresh_lock; "
+        f"p=Path({str(ready)!r}); "
+        f"c=_refresh_lock({source_id!r}); c.__enter__(); "
+        "p.write_text('ready'); time.sleep(1.0); c.__exit__(None,None,None)"
+    )
+    second_code = (
+        "from pathlib import Path; "
+        "from hermes_cli.plugin_marketplaces import _refresh_lock; "
+        f"p=Path({str(acquired)!r}); "
+        f"c=_refresh_lock({source_id!r}); c.__enter__(); "
+        "p.write_text('acquired'); c.__exit__(None,None,None)"
+    )
+    env = {**os.environ, "HERMES_HOME": str(home)}
+    first = subprocess.Popen([sys.executable, "-c", first_code], env=env)
+    second = None
+    try:
+        deadline = time.monotonic() + 5
+        while not ready.exists() and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert ready.exists()
+        second = subprocess.Popen([sys.executable, "-c", second_code], env=env)
+        time.sleep(0.2)
+        assert not acquired.exists()
+        assert first.wait(timeout=5) == 0
+        assert second.wait(timeout=5) == 0
+        assert acquired.read_text(encoding="utf-8") == "acquired"
+    finally:
+        if first.poll() is None:
+            first.kill()
+        if second is not None and second.poll() is None:
+            second.kill()
+
+
+def test_windows_lock_retries_past_msvcrt_ten_second_limit(monkeypatch) -> None:
+    import hermes_cli.plugins_cmd as plugins_cmd
+
+    calls = 0
+
+    def locking(_fd, _mode, _length):
+        nonlocal calls
+        calls += 1
+        if calls <= 12:
+            raise OSError(errno.EACCES, "locked")
+
+    fake_msvcrt = types.SimpleNamespace(
+        LK_NBLCK=1,
+        LK_UNLCK=2,
+        locking=locking,
+    )
+    with tempfile.TemporaryFile() as handle, monkeypatch.context() as patcher:
+        patcher.setattr(plugins_cmd.os, "name", "nt")
+        patcher.setattr(plugins_cmd.time, "sleep", lambda _seconds: None)
+        patcher.setitem(sys.modules, "msvcrt", fake_msvcrt)
+        plugins_cmd._lock_file(handle)
+
+    assert calls == 13
+
+
+def test_forced_refresh_never_authorizes_stale_cache(
+    tmp_path: Path, monkeypatch
+) -> None:
+    import hermes_cli.plugin_marketplaces as marketplaces
+
+    repo = _marketplace_repo(tmp_path)
+    source = add_marketplace(f"file://{repo}", allow_file=True)
+
+    def offline(_source):
+        raise MarketplaceError("offline")
+
+    monkeypatch.setattr(marketplaces, "_refresh", offline)
+
+    stale = list_marketplaces(force=True)[0]
+    assert stale["available"] is True
+    assert stale["stale"] is True
+    assert marketplaces.get_marketplace_entry(source["id"], "demo", force=True) is None
+
+
+@pytest.mark.parametrize("cache_kind", ["malformed", "oversized"])
+def test_refresh_recovers_from_non_authoritative_corrupt_cache(
+    tmp_path: Path, cache_kind: str
+) -> None:
+    contents = "{broken" if cache_kind == "malformed" else "x" * (1024 * 1024 + 1)
+    repo = _marketplace_repo(tmp_path)
+    source = add_marketplace(f"file://{repo}", allow_file=True)
+    cache = (
+        Path(os.environ["HERMES_HOME"])
+        / "cache"
+        / "plugin-marketplaces"
+        / f"{source['id']}.json"
+    )
+    cache.write_text(contents, encoding="utf-8")
+
+    refreshed = list_marketplaces(force=True)
+
+    assert refreshed[0]["entries"][0]["name"] == "demo"
+    assert json.loads(cache.read_text(encoding="utf-8"))["source"]["id"] == source["id"]
+
+
+def test_removed_source_cannot_authorize_inflight_refresh(
+    tmp_path: Path, monkeypatch
+) -> None:
+    import hermes_cli.plugin_marketplaces as marketplaces
+
+    repo = _marketplace_repo(tmp_path)
+    source = add_marketplace(f"file://{repo}", allow_file=True)
+    refresh = marketplaces._refresh
+
+    def remove_during_refresh(saved):
+        remove_marketplace(saved["id"])
+        return refresh(saved)
+
+    monkeypatch.setattr(marketplaces, "_refresh", remove_during_refresh)
+
+    assert marketplaces.get_marketplace_entry(source["id"], "demo", force=True) is None
+    assert list_marketplaces() == []
+
+
+def test_claude_only_package_is_visible_but_not_installable(tmp_path: Path) -> None:
+    repo = _marketplace_repo(tmp_path, compatible=False)
+
+    source = add_marketplace(f"file://{repo}", allow_file=True)
+
+    assert source["entries"][0]["compatible"] is False
+
+
+def test_remove_marketplace_keeps_other_sources(tmp_path: Path) -> None:
+    first = _marketplace_repo(tmp_path / "one")
+    second = _marketplace_repo(tmp_path / "two")
+    first_source = add_marketplace(f"file://{first}", allow_file=True)
+    second_source = add_marketplace(f"file://{second}", allow_file=True)
+
+    assert remove_marketplace(first_source["id"]) is True
+    assert [source["id"] for source in list_marketplaces()] == [second_source["id"]]
+    assert remove_marketplace(first_source["id"]) is False
+
+
+def test_concurrent_adds_do_not_lose_registry_entries(tmp_path: Path) -> None:
+    from concurrent.futures import ThreadPoolExecutor
+
+    repos = [
+        _marketplace_repo(tmp_path / "one"),
+        _marketplace_repo(tmp_path / "two"),
+    ]
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        sources = list(
+            pool.map(
+                lambda repo: add_marketplace(f"file://{repo}", allow_file=True),
+                repos,
+            )
+        )
+
+    assert {item["id"] for item in list_marketplaces()} == {
+        source["id"] for source in sources
+    }
+
+
+def test_dashboard_install_resolves_private_entry_server_side(
+    tmp_path: Path, monkeypatch
+) -> None:
+    import hermes_cli.plugin_catalog as plugin_catalog
+    import hermes_cli.plugins_cmd as plugins_cmd
+    from hermes_cli.plugin_marketplaces import as_catalog_entry
+
+    target = tmp_path / "installed" / "demo"
+    entry = as_catalog_entry({
+        "compatible": True,
+        "description": "Demo.",
+        "display_name": "Demo",
+        "maintainer": "Test",
+        "name": "demo",
+        "repo": "https://github.com/example/private-marketplace",
+        "sha": "a" * 40,
+        "source_id": "private-source",
+        "source_name": "Private Market",
+        "subdir": "plugins/demo",
+        "tree_sha": "b" * 40,
+        "version": "1.0.0",
+    })
+    calls: list[dict] = []
+
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_get_live_catalog_entry",
+        lambda name, source_id="official", **_kwargs: (
+            entry if (name, source_id) == ("demo", "private-source") else None
+        ),
+    )
+    monkeypatch.setattr(
+        plugin_catalog,
+        "find_removed",
+        lambda _name: pytest.fail("private marketplace consulted official removals"),
+    )
+
+    def fake_install(identifier, **kwargs):
+        calls.append({"identifier": identifier, **kwargs})
+        return target, {"name": "demo", "version": "1.0.0"}, "demo"
+
+    monkeypatch.setattr(plugins_cmd, "_install_plugin_core", fake_install)
+    monkeypatch.setattr(plugins_cmd, "_plugins_dir", lambda: tmp_path / "installed")
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set())
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
+
+    result = plugins_cmd.dashboard_install_plugin(
+        "attacker-controlled-display-value",
+        force=False,
+        enable=False,
+        catalog_name="demo",
+        catalog_source="private-source",
+    )
+
+    assert result["ok"] is True
+    assert calls == [
+        {
+            "enable_on_commit": False,
+            "force": False,
+            "identifier": "https://github.com/example/private-marketplace#plugins/demo",
+            "metadata_extra": {
+                "installed_repo_sha": "a" * 40,
+                "installed_tree_sha": "b" * 40,
+                "marketplace_id": "private-source",
+                "marketplace_name": "Private Market",
+                "marketplace_plugin_name": "demo",
+                "source": "https://github.com/example/private-marketplace",
+                "subdir": "plugins/demo",
+            },
+            "ref": "a" * 40,
+        }
+    ]
+
+
+def test_native_manifest_name_cannot_force_overwrite_another_source(
+    tmp_path: Path,
+) -> None:
+    import hermes_cli.plugins_cmd as plugins_cmd
+
+    repo = _marketplace_repo(tmp_path)
+    plugin = repo / "plugins" / "demo"
+    (plugin / "plugin.json").unlink()
+    (plugin / "plugin.yaml").write_text(
+        "name: victim\nversion: 1.0.0\ndescription: Wrong target\n",
+        encoding="utf-8",
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "mismatched native manifest")
+
+    source = add_marketplace(f"file://{repo}", allow_file=True)
+    assert source["entries"][0]["compatible"] is False
+    assert "name must match" in source["entries"][0]["incompatibility_reason"]
+
+    victim = Path(os.environ["HERMES_HOME"]) / "plugins" / "victim"
+    victim.mkdir(parents=True)
+    marker = victim / "keep.txt"
+    marker.write_text("original", encoding="utf-8")
+
+    with pytest.raises(plugins_cmd.PluginOperationError, match="another source"):
+        plugins_cmd._install_plugin_core(
+            f"file://{repo}#plugins/demo",
+            force=True,
+            ref=_git(repo, "rev-parse", "HEAD"),
+            metadata_extra={
+                "marketplace_id": source["id"],
+                "source": f"file://{repo}",
+            },
+        )
+
+    assert marker.read_text(encoding="utf-8") == "original"
+
+
+def test_internal_install_lock_name_cannot_be_installed(tmp_path: Path) -> None:
+    import hermes_cli.plugins_cmd as plugins_cmd
+
+    repo = _marketplace_repo(tmp_path)
+    plugin = repo / "plugins" / "demo"
+    (plugin / "plugin.json").unlink()
+    (plugin / "plugin.yaml").write_text(
+        "name: .install-metadata.lock\nversion: 1.0.0\ndescription: reserved\n",
+        encoding="utf-8",
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "reserved name")
+    with plugins_cmd._install_metadata_lock():
+        pass
+
+    with pytest.raises(plugins_cmd.PluginOperationError, match="reserved"):
+        plugins_cmd._install_plugin_core(
+            f"file://{repo}#plugins/demo",
+            force=True,
+            ref=_git(repo, "rev-parse", "HEAD"),
+        )
+
+    lock = Path(os.environ["HERMES_HOME"]) / "plugins" / ".install-metadata.lock"
+    assert lock.is_file()
+
+
+@pytest.mark.parametrize("reserved_name", [".INSTALL-METADATA.LOCK", ".Install-temp"])
+def test_reserved_installer_names_are_case_insensitive(
+    tmp_path: Path, reserved_name: str
+) -> None:
+    import hermes_cli.plugins_cmd as plugins_cmd
+
+    plugins_dir = tmp_path / "plugins"
+    plugins_dir.mkdir()
+    with pytest.raises(ValueError, match="reserved for installer state"):
+        plugins_cmd._sanitize_plugin_name(reserved_name, plugins_dir)
+
+
+def test_existing_symlink_cannot_alias_plugin_destination(tmp_path: Path) -> None:
+    import hermes_cli.plugins_cmd as plugins_cmd
+
+    plugins_dir = tmp_path / "plugins"
+    victim = plugins_dir / "victim"
+    victim.mkdir(parents=True)
+    (plugins_dir / "alias").symlink_to(victim, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="symlink destinations"):
+        plugins_cmd._sanitize_plugin_name("alias", plugins_dir)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "demo.",
+        "demo ",
+        "CON",
+        "lpt1.txt",
+        "COM¹",
+        "COM².txt",
+        "LPT³",
+        "CLOCK$",
+        "CONIN$",
+        "CONOUT$.txt",
+        "demo:name",
+    ],
+)
+def test_cross_platform_filesystem_alias_names_are_rejected(
+    tmp_path: Path, name: str
+) -> None:
+    import hermes_cli.plugins_cmd as plugins_cmd
+
+    plugins_dir = tmp_path / "plugins"
+    plugins_dir.mkdir()
+    with pytest.raises(ValueError):
+        plugins_cmd._sanitize_plugin_name(name, plugins_dir)
+
+
+def test_unicode_normalization_alias_is_rejected(tmp_path: Path) -> None:
+    import hermes_cli.plugins_cmd as plugins_cmd
+
+    plugins_dir = tmp_path / "plugins"
+    plugins_dir.mkdir()
+    (plugins_dir / "caf\N{LATIN SMALL LETTER E WITH ACUTE}").mkdir()
+
+    with pytest.raises(ValueError, match="aliases existing path"):
+        plugins_cmd._sanitize_plugin_name("cafe\N{COMBINING ACUTE ACCENT}", plugins_dir)
+
+
+def test_marketplace_registry_and_cache_symlinks_do_not_write_external_files(
+    tmp_path: Path,
+) -> None:
+    import hermes_cli.plugin_marketplaces as marketplaces
+
+    external = tmp_path / "external.json"
+    external.write_text("unchanged", encoding="utf-8")
+    registry = marketplaces._registry_path()
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    registry.symlink_to(external)
+    with pytest.raises(MarketplaceError, match="symlink"):
+        marketplaces._write_registry([])
+    assert external.read_text(encoding="utf-8") == "unchanged"
+    registry.unlink()
+
+    marketplaces._ensure_cache_dir()
+    cache_file = marketplaces._cache_path("0" * 16)
+    cache_file.symlink_to(external)
+    source = {"id": "0" * 16, "name": "test", "url": "https://example.com/x.git"}
+    with pytest.raises(MarketplaceError, match="symlink"):
+        marketplaces._write_cache(source, [])
+    assert external.read_text(encoding="utf-8") == "unchanged"
+
+
+def test_registry_parent_swap_does_not_write_external_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import hermes_cli.plugin_marketplaces as marketplaces
+    import utils
+
+    home = Path(os.environ["HERMES_HOME"])
+    saved = home.with_name("hermes-saved")
+    outside = tmp_path / "outside-home"
+    outside.mkdir()
+    real_open = utils.os.open
+    swapped = False
+
+    def swapping_open(candidate, flags, mode=0o777, *, dir_fd=None):
+        nonlocal swapped
+        if Path(candidate) == home and dir_fd is None and not swapped:
+            swapped = True
+            home.rename(saved)
+            home.symlink_to(outside, target_is_directory=True)
+        return real_open(candidate, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(utils.os, "open", swapping_open)
+    with pytest.raises(OSError):
+        marketplaces._write_registry([])
+    assert not (outside / "plugin-marketplaces.json").exists()
+
+
+def test_marketplace_cache_directory_symlink_is_rejected(tmp_path: Path) -> None:
+    import hermes_cli.plugin_marketplaces as marketplaces
+
+    cache = marketplaces._cache_dir()
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    outside = tmp_path / "outside-cache"
+    outside.mkdir()
+    cache.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(MarketplaceError, match="symlink"):
+        marketplaces._ensure_cache_dir()
+
+
+def test_remove_marketplace_does_not_delete_through_cache_symlink(
+    tmp_path: Path,
+) -> None:
+    import hermes_cli.plugin_marketplaces as marketplaces
+
+    source = {
+        "id": marketplaces._source_id("https://example.com/test.git"),
+        "name": "test",
+        "url": "https://example.com/test.git",
+    }
+    marketplaces._write_registry([source])
+    cache = marketplaces._cache_dir()
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    outside = tmp_path / "outside-cache"
+    outside.mkdir()
+    external = outside / f"{source['id']}.json"
+    external.write_text("keep", encoding="utf-8")
+    cache.symlink_to(outside, target_is_directory=True)
+
+    assert marketplaces.remove_marketplace(source["id"]) is True
+    assert external.read_text(encoding="utf-8") == "keep"
+
+
+def test_malformed_install_metadata_entry_fails_closed() -> None:
+    import hermes_cli.plugins_cmd as plugins_cmd
+
+    path = plugins_cmd._install_metadata_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text('{"bad":"value"}', encoding="utf-8")
+
+    with pytest.raises(plugins_cmd.PluginOperationError, match="map plugin names"):
+        plugins_cmd._read_install_metadata()
+
+
+@pytest.mark.parametrize("kind", ["metadata", "lock", "transaction"])
+def test_install_control_symlinks_fail_closed(tmp_path: Path, kind: str) -> None:
+    import hermes_cli.plugins_cmd as plugins_cmd
+
+    plugins_dir = Path(os.environ["HERMES_HOME"]) / "plugins"
+    plugins_dir.mkdir(parents=True, exist_ok=True)
+    outside = tmp_path / "outside"
+    outside.write_text("{}", encoding="utf-8")
+    paths = {
+        "metadata": plugins_cmd._install_metadata_path(),
+        "lock": plugins_cmd._install_metadata_path().with_suffix(".lock"),
+        "transaction": plugins_cmd._install_transaction_path(),
+    }
+    path = paths[kind]
+    path.unlink(missing_ok=True)
+    path.symlink_to(outside)
+
+    if kind == "metadata":
+        with pytest.raises(
+            plugins_cmd.PluginOperationError, match="must not be a symlink"
+        ):
+            plugins_cmd._read_install_metadata()
+    else:
+        with pytest.raises(
+            plugins_cmd.PluginOperationError, match="must not be a symlink"
+        ):
+            with plugins_cmd._install_metadata_lock():
+                pass
+
+
+def test_lock_parent_swap_to_symlink_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import hermes_cli.plugins_cmd as plugins_cmd
+    import utils
+
+    plugins_dir = Path(os.environ["HERMES_HOME"]) / "plugins"
+    plugins_dir.mkdir(parents=True, exist_ok=True)
+    saved = plugins_dir.with_name("plugins-saved")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    real_open = utils.os.open
+    swapped = False
+
+    def swapping_open(candidate, flags, mode=0o777, *, dir_fd=None):
+        nonlocal swapped
+        if candidate == "plugins" and dir_fd is not None and not swapped:
+            swapped = True
+            plugins_dir.rename(saved)
+            plugins_dir.symlink_to(outside, target_is_directory=True)
+        return real_open(candidate, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(utils.os, "open", swapping_open)
+    with pytest.raises(plugins_cmd.PluginOperationError):
+        with plugins_cmd._install_metadata_lock():
+            pass
+    assert not (outside / ".install-metadata.lock").exists()
+
+
+def test_interrupted_new_install_is_rolled_back_without_losing_other_state() -> None:
+    import hermes_cli.plugins_cmd as plugins_cmd
+    from hermes_cli.config import load_config, save_config
+
+    plugins_dir = Path(os.environ["HERMES_HOME"]) / "plugins"
+    target = plugins_dir / "demo"
+    target.mkdir(parents=True)
+    (target / "new.txt").write_text("new", encoding="utf-8")
+    transaction = plugins_dir / ".install-test-new"
+    transaction.mkdir()
+    plugins_cmd._write_install_metadata({
+        "demo": {"source": "new"},
+        "other": {"source": "keep"},
+    })
+    save_config(
+        {"plugins": {"enabled": ["demo", "other"], "disabled": ["blocked"]}},
+        preserve_plugin_state=False,
+        preserve_platform_toolsets=False,
+    )
+    plugins_cmd._write_install_transaction({
+        "version": 1,
+        "plugin_name": "demo",
+        "transaction_dir": transaction.name,
+        "replaced_existing": False,
+        "old_metadata": {"other": {"source": "keep"}},
+        "was_enabled": False,
+        "was_disabled": False,
+    })
+
+    with plugins_cmd._install_metadata_lock():
+        pass
+
+    config = load_config()
+    assert not target.exists()
+    assert plugins_cmd._read_install_metadata() == {"other": {"source": "keep"}}
+    assert config["plugins"]["enabled"] == ["other"]
+    assert config["plugins"]["disabled"] == ["blocked"]
+    assert not plugins_cmd._install_transaction_path().exists()
+
+
+def test_interrupted_forced_install_restores_previous_artifact() -> None:
+    import hermes_cli.plugins_cmd as plugins_cmd
+    from hermes_cli.config import save_config
+
+    plugins_dir = Path(os.environ["HERMES_HOME"]) / "plugins"
+    target = plugins_dir / "demo"
+    target.mkdir(parents=True)
+    (target / "marker.txt").write_text("new", encoding="utf-8")
+    transaction = plugins_dir / ".install-test-replace"
+    backup = transaction / "previous-plugin"
+    backup.mkdir(parents=True)
+    (backup / "marker.txt").write_text("old", encoding="utf-8")
+    plugins_cmd._write_install_metadata({"demo": {"source": "new"}})
+    save_config(
+        {"plugins": {"enabled": ["demo"], "disabled": []}},
+        preserve_plugin_state=False,
+        preserve_platform_toolsets=False,
+    )
+    plugins_cmd._write_install_transaction({
+        "version": 1,
+        "plugin_name": "demo",
+        "transaction_dir": transaction.name,
+        "replaced_existing": True,
+        "old_metadata": {"demo": {"source": "old"}},
+        "was_enabled": True,
+        "was_disabled": False,
+    })
+
+    with plugins_cmd._install_metadata_lock():
+        pass
+
+    assert (target / "marker.txt").read_text(encoding="utf-8") == "old"
+    assert plugins_cmd._read_install_metadata() == {"demo": {"source": "old"}}
+
+
+def test_removed_marketplace_cannot_commit_install_after_resolution(
+    tmp_path: Path, monkeypatch
+) -> None:
+    import hermes_cli.plugins_cmd as plugins_cmd
+
+    repo = _marketplace_repo(tmp_path)
+    source = add_marketplace(f"file://{repo}", allow_file=True)
+    scan = plugins_cmd._scan_plugin_tree
+
+    def remove_after_resolution(*args, **kwargs):
+        scan(*args, **kwargs)
+        assert remove_marketplace(source["id"]) is True
+
+    monkeypatch.setattr(plugins_cmd, "_scan_plugin_tree", remove_after_resolution)
+
+    result = plugins_cmd.dashboard_install_plugin(
+        "",
+        force=False,
+        enable=False,
+        catalog_name="demo",
+        catalog_source=source["id"],
+    )
+
+    assert result["ok"] is False
+    assert "removed" in result["error"]
+    assert not (Path(os.environ["HERMES_HOME"]) / "plugins" / "demo").exists()
+
+
+def test_concurrent_marketplace_installs_preserve_both_provenance_entries(
+    tmp_path: Path,
+) -> None:
+    from concurrent.futures import ThreadPoolExecutor
+
+    import hermes_cli.plugins_cmd as plugins_cmd
+
+    sources = []
+    for name in ("alpha", "beta"):
+        repo = _marketplace_repo(tmp_path / name, name=name)
+        sources.append(add_marketplace(f"file://{repo}", allow_file=True))
+
+    def install(source):
+        name = source["entries"][0]["name"]
+        return plugins_cmd.dashboard_install_plugin(
+            "",
+            force=False,
+            enable=False,
+            catalog_name=name,
+            catalog_source=source["id"],
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(install, sources))
+
+    assert all(result["ok"] is True for result in results)
+    metadata = plugins_cmd._read_install_metadata()
+    assert {name: value["marketplace_id"] for name, value in metadata.items()} == {
+        source["entries"][0]["name"]: source["id"] for source in sources
+    }
+
+
+def test_concurrent_enabled_installs_preserve_both_config_entries(
+    tmp_path: Path,
+) -> None:
+    from concurrent.futures import ThreadPoolExecutor
+
+    import hermes_cli.plugins_cmd as plugins_cmd
+
+    sources = []
+    for name in ("alpha", "beta"):
+        repo = _marketplace_repo(tmp_path / name, name=name)
+        sources.append(add_marketplace(f"file://{repo}", allow_file=True))
+
+    def install(source):
+        name = source["entries"][0]["name"]
+        return plugins_cmd.dashboard_install_plugin(
+            "",
+            force=False,
+            enable=True,
+            catalog_name=name,
+            catalog_source=source["id"],
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(install, sources))
+
+    assert all(result["ok"] is True for result in results)
+    assert plugins_cmd._get_enabled_set() == {"alpha", "beta"}
+
+
+def test_unrelated_stale_config_save_preserves_plugin_state() -> None:
+    from hermes_cli.config import load_config, save_config
+
+    save_config(
+        {
+            "plugins": {"enabled": [], "disabled": []},
+            "platform_toolsets": {"cli": ["file"]},
+        },
+        preserve_plugin_state=False,
+        preserve_platform_toolsets=False,
+    )
+    stale = load_config()
+    current = load_config()
+    current["plugins"]["enabled"] = ["demo"]
+    current["platform_toolsets"]["cli"].append("demo-tools")
+    save_config(
+        current,
+        preserve_plugin_state=False,
+        preserve_platform_toolsets=False,
+    )
+    stale.setdefault("display", {})["tool_progress"] = "off"
+    save_config(stale)
+
+    persisted = load_config()
+    assert persisted["plugins"]["enabled"] == ["demo"]
+    assert persisted["platform_toolsets"]["cli"] == ["file", "demo-tools"]
+
+
+def test_unrelated_atomic_writer_preserves_plugin_runtime_state() -> None:
+    from hermes_cli.config import (
+        atomic_config_write,
+        get_config_path,
+        load_config,
+        save_config,
+    )
+
+    save_config(
+        {
+            "plugins": {"enabled": [], "disabled": []},
+            "platform_toolsets": {"cli": ["file"]},
+        },
+        preserve_plugin_state=False,
+        preserve_platform_toolsets=False,
+    )
+    stale = load_config()
+    current = load_config()
+    current["plugins"]["enabled"] = ["demo"]
+    current["platform_toolsets"]["cli"].append("demo-tools")
+    save_config(
+        current,
+        preserve_plugin_state=False,
+        preserve_platform_toolsets=False,
+    )
+    stale["display"] = {"tool_progress": "compact"}
+
+    atomic_config_write(get_config_path(), stale, sort_keys=False)
+
+    persisted = load_config()
+    assert persisted["plugins"]["enabled"] == ["demo"]
+    assert persisted["platform_toolsets"]["cli"] == ["file", "demo-tools"]
+
+
+def test_unrelated_migration_preserves_plugin_runtime_state() -> None:
+    from hermes_cli.config import _persist_migration, load_config, save_config
+
+    save_config(
+        {
+            "plugins": {"enabled": [], "disabled": []},
+            "platform_toolsets": {"cli": ["file"]},
+        },
+        preserve_plugin_state=False,
+        preserve_platform_toolsets=False,
+    )
+    stale = load_config()
+    current = load_config()
+    current["plugins"]["enabled"] = ["demo"]
+    current["platform_toolsets"]["cli"].append("demo-tools")
+    save_config(
+        current,
+        preserve_plugin_state=False,
+        preserve_platform_toolsets=False,
+    )
+    stale["_config_version"] = 999
+
+    _persist_migration(stale)
+
+    persisted = load_config()
+    assert persisted["plugins"]["enabled"] == ["demo"]
+    assert persisted["platform_toolsets"]["cli"] == ["file", "demo-tools"]
+
+
+def test_cross_process_stale_config_save_preserves_plugin_state(tmp_path: Path) -> None:
+    import hermes_cli.plugins_cmd as plugins_cmd
+    from hermes_cli.config import load_config, save_config
+
+    save_config(
+        {
+            "plugins": {"enabled": [], "disabled": []},
+            "platform_toolsets": {"cli": ["file"]},
+        },
+        preserve_plugin_state=False,
+        preserve_platform_toolsets=False,
+    )
+    ready = tmp_path / "ready"
+    proceed = tmp_path / "proceed"
+    code = f"""import time
+from pathlib import Path
+from hermes_cli.config import load_config, save_config
+c = load_config()
+Path({str(ready)!r}).write_text('ready')
+p = Path({str(proceed)!r})
+deadline = time.monotonic() + 5
+while not p.exists() and time.monotonic() < deadline:
+    time.sleep(0.02)
+c.setdefault('display', {{}})['tool_progress'] = 'compact'
+save_config(c)
+"""
+    process = subprocess.Popen(
+        [sys.executable, "-c", code],
+        env={**os.environ, "HERMES_HOME": os.environ["HERMES_HOME"]},
+    )
+    try:
+        deadline = time.monotonic() + 5
+        while not ready.exists() and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert ready.exists()
+        current = load_config()
+        current["plugins"]["enabled"] = ["demo"]
+        current["platform_toolsets"]["cli"].append("demo-tools")
+        save_config(
+            current,
+            preserve_plugin_state=False,
+            preserve_platform_toolsets=False,
+        )
+        proceed.write_text("go", encoding="utf-8")
+        assert process.wait(timeout=5) == 0
+    finally:
+        if process.poll() is None:
+            process.kill()
+
+    assert plugins_cmd._get_enabled_set() == {"demo"}
+    assert load_config()["platform_toolsets"]["cli"] == ["file", "demo-tools"]
+
+
+def test_install_rolls_back_config_after_write_then_raise(
+    tmp_path: Path, monkeypatch
+) -> None:
+    import hermes_cli.config as config_module
+    import hermes_cli.plugins_cmd as plugins_cmd
+
+    repo = _marketplace_repo(tmp_path)
+    real_save = config_module.save_config
+    calls = 0
+
+    def write_then_raise(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        real_save(*args, **kwargs)
+        if calls == 1:
+            raise OSError("injected post-write failure")
+
+    monkeypatch.setattr(config_module, "save_config", write_then_raise)
+
+    with pytest.raises(OSError, match="post-write failure"):
+        plugins_cmd._install_plugin_core(
+            f"file://{repo}#plugins/demo",
+            force=False,
+            ref=_git(repo, "rev-parse", "HEAD"),
+            enable_on_commit=True,
+        )
+
+    assert not (Path(os.environ["HERMES_HOME"]) / "plugins" / "demo").exists()
+    assert "demo" not in plugins_cmd._get_enabled_set()
+    assert plugins_cmd._read_install_metadata() == {}
+
+
+def test_remove_cleans_enabled_state_in_same_transaction(tmp_path: Path) -> None:
+    import hermes_cli.plugins_cmd as plugins_cmd
+
+    repo = _marketplace_repo(tmp_path)
+    source = add_marketplace(f"file://{repo}", allow_file=True)
+    result = plugins_cmd.dashboard_install_plugin(
+        "",
+        force=False,
+        enable=True,
+        catalog_name="demo",
+        catalog_source=source["id"],
+    )
+    assert result["ok"] is True
+    target = Path(os.environ["HERMES_HOME"]) / "plugins" / "demo"
+    assert "demo" in plugins_cmd._get_enabled_set()
+
+    plugins_cmd._remove_plugin_core(target)
+
+    assert not target.exists()
+    assert "demo" not in plugins_cmd._get_enabled_set()
+
+
+def test_concurrent_remove_and_install_preserve_new_provenance(
+    tmp_path: Path, monkeypatch
+) -> None:
+    from concurrent.futures import ThreadPoolExecutor
+    from threading import Event
+
+    import hermes_cli.plugins_cmd as plugins_cmd
+
+    sources = {}
+    for name in ("alpha", "beta", "gamma"):
+        repo = _marketplace_repo(tmp_path / name, name=name)
+        sources[name] = add_marketplace(f"file://{repo}", allow_file=True)
+    for name in ("alpha", "beta"):
+        result = plugins_cmd.dashboard_install_plugin(
+            "",
+            force=False,
+            enable=False,
+            catalog_name=name,
+            catalog_source=sources[name]["id"],
+        )
+        assert result["ok"] is True
+
+    remove_writing = Event()
+    allow_remove = Event()
+    write_metadata = plugins_cmd._write_install_metadata
+
+    def paused_write(metadata):
+        if "alpha" not in metadata and "gamma" not in metadata:
+            remove_writing.set()
+            assert allow_remove.wait(timeout=5)
+        write_metadata(metadata)
+
+    monkeypatch.setattr(plugins_cmd, "_write_install_metadata", paused_write)
+    alpha = Path(os.environ["HERMES_HOME"]) / "plugins" / "alpha"
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        removing = pool.submit(plugins_cmd._remove_plugin_core, alpha)
+        assert remove_writing.wait(timeout=5)
+        installing = pool.submit(
+            plugins_cmd.dashboard_install_plugin,
+            "",
+            force=False,
+            enable=False,
+            catalog_name="gamma",
+            catalog_source=sources["gamma"]["id"],
+        )
+        allow_remove.set()
+        removing.result(timeout=10)
+        assert installing.result(timeout=10)["ok"] is True
+
+    metadata = plugins_cmd._read_install_metadata()
+    assert set(metadata) == {"beta", "gamma"}
+    assert metadata["gamma"]["marketplace_id"] == sources["gamma"]["id"]
+
+
+def test_concurrent_official_and_custom_installs_keep_provenance_with_artifact(
+    tmp_path: Path, monkeypatch
+) -> None:
+    from concurrent.futures import ThreadPoolExecutor
+    from threading import Event
+    from types import SimpleNamespace
+
+    import hermes_cli.plugins_cmd as plugins_cmd
+
+    official = _marketplace_repo(tmp_path / "official")
+    custom = _marketplace_repo(tmp_path / "custom")
+    custom_manifest = custom / "plugins" / "demo" / "plugin.json"
+    value = json.loads(custom_manifest.read_text(encoding="utf-8"))
+    value["description"] = "custom-unreviewed"
+    custom_manifest.write_text(json.dumps(value), encoding="utf-8")
+    _git(custom, "add", "-A")
+    _git(custom, "commit", "-m", "custom")
+
+    custom_scanning = Event()
+    allow_custom = Event()
+    scan = plugins_cmd._scan_plugin_tree
+
+    def controlled_scan(plugin_dir, identifier, **kwargs):
+        scan(plugin_dir, identifier, **kwargs)
+        if str(custom) in identifier:
+            custom_scanning.set()
+            assert allow_custom.wait(timeout=5)
+
+    monkeypatch.setattr(plugins_cmd, "_scan_plugin_tree", controlled_scan)
+    entry = SimpleNamespace(
+        name="demo",
+        repo=f"file://{official}",
+        sha=_git(official, "rev-parse", "HEAD"),
+        subdir="plugins/demo",
+        tier="official",
+    )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        custom_install = pool.submit(
+            plugins_cmd._install_plugin_core,
+            f"file://{custom}#plugins/demo",
+            force=True,
+            ref=_git(custom, "rev-parse", "HEAD"),
+        )
+        assert custom_scanning.wait(timeout=5)
+        official_install = pool.submit(
+            plugins_cmd._install_plugin_core,
+            f"file://{official}#plugins/demo",
+            force=True,
+            ref=entry.sha,
+            catalog_entry=entry,
+        )
+        official_install.result(timeout=10)
+        allow_custom.set()
+        custom_install.result(timeout=10)
+
+    target = Path(os.environ["HERMES_HOME"]) / "plugins" / "demo"
+    assert (
+        json.loads((target / "plugin.json").read_text(encoding="utf-8"))["description"]
+        == "custom-unreviewed"
+    )
+    assert plugins_cmd._read_catalog_sidecar(target) is None
+
+
+def test_real_private_marketplace_install_and_subtree_update(tmp_path: Path) -> None:
+    import hermes_cli.plugins_cmd as plugins_cmd
+    from tui_gateway import server
+
+    repo = _marketplace_repo(tmp_path)
+    source = add_marketplace(f"file://{repo}", allow_file=True)
+    installed = plugins_cmd.dashboard_install_plugin(
+        "",
+        force=False,
+        enable=False,
+        catalog_name="demo",
+        catalog_source=source["id"],
+    )
+
+    assert installed["ok"] is True
+    metadata = plugins_cmd._read_install_metadata()["demo"]
+    original_tree = metadata["installed_tree_sha"]
+    assert metadata["marketplace_id"] == source["id"]
+    assert metadata["installed_repo_sha"] == source["entries"][0]["sha"]
+
+    skill = repo / "plugins" / "demo" / "skills" / "demo" / "SKILL.md"
+    skill.write_text(
+        skill.read_text(encoding="utf-8") + "\nUpdated.\n", encoding="utf-8"
+    )
+    _git(repo, "add", "plugins/demo")
+    _git(repo, "commit", "-m", "update plugin")
+
+    response = server.handle_request({
+        "id": "update",
+        "method": "plugins.manage",
+        "params": {"action": "update", "key": "demo"},
+    })
+
+    assert response is not None
+    assert response["result"]["ok"] is True
+    assert response["result"]["unchanged"] is False
+    refreshed = plugins_cmd._read_install_metadata()["demo"]
+    assert refreshed["installed_tree_sha"] != original_tree
+
+
+def test_catalog_sidecar_symlink_does_not_write_external_file(tmp_path: Path) -> None:
+    import hermes_cli.plugins_cmd as plugins_cmd
+
+    target = tmp_path / "plugin"
+    target.mkdir()
+    external = tmp_path / "external.json"
+    external.write_text("unchanged", encoding="utf-8")
+    (target / plugins_cmd._CATALOG_SIDECAR).symlink_to(external)
+    entry = types.SimpleNamespace(
+        name="demo",
+        repo="https://example.com/demo.git",
+        sha="0" * 40,
+        tier="official",
+    )
+
+    with pytest.raises(plugins_cmd.PluginOperationError, match="must not be a symlink"):
+        plugins_cmd._write_catalog_sidecar(target, entry, strict=True)
+    assert external.read_text(encoding="utf-8") == "unchanged"
+
+
+def test_remove_cleanup_failure_does_not_report_committed_removal_as_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import hermes_cli.plugins_cmd as plugins_cmd
+    import utils
+
+    plugins_dir = Path(os.environ["HERMES_HOME"]) / "plugins"
+    target = plugins_dir / "demo"
+    target.mkdir(parents=True)
+    (target / "plugin.json").write_text('{"name":"demo"}', encoding="utf-8")
+
+    def fail_cleanup(*_args, **_kwargs):
+        raise OSError("cleanup fault")
+
+    monkeypatch.setattr(utils.shutil, "rmtree", fail_cleanup)
+    plugins_cmd._remove_plugin_core(target)
+    assert not target.exists()
+    assert not plugins_cmd._install_transaction_path().exists()
+
+
+def test_platform_toolset_set_and_unset_land_on_disk() -> None:
+    from hermes_cli.config import read_raw_config, set_config_value, unset_config_value
+
+    set_config_value("platform_toolsets.cli", '["old"]')
+    set_config_value("platform_toolsets.cli", '["new"]')
+    assert read_raw_config()["platform_toolsets"]["cli"] == ["new"]
+
+    unset_config_value("platform_toolsets.cli")
+    assert "cli" not in read_raw_config().get("platform_toolsets", {})
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows reparse-point semantics")
+def test_secure_rmtree_pins_windows_leaf_during_junction_swap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import utils
+
+    root = tmp_path / "root"
+    victim = root / "victim"
+    outside = tmp_path / "outside"
+    junction = root / "replacement"
+    victim.mkdir(parents=True)
+    outside.mkdir()
+    (victim / "payload").write_text("x", encoding="utf-8")
+    created = subprocess.run(
+        ["cmd", "/c", "mklink", "/J", str(junction), str(outside)],
+        capture_output=True,
+        check=False,
+    )
+    if created.returncode:
+        pytest.skip("junction creation unavailable")
+
+    def race(candidate: Path) -> None:
+        with pytest.raises(PermissionError):
+            os.rename(candidate, root / "moved")
+        (candidate / "payload").unlink()
+        raise PermissionError("pinned root blocks final rmdir")
+
+    monkeypatch.setattr(utils.shutil, "rmtree", race)
+    utils.secure_rmtree(victim, root)
+
+    assert not victim.exists()
+    assert outside.exists()

--- a/tests/hermes_cli/test_plugin_packs.py
+++ b/tests/hermes_cli/test_plugin_packs.py
@@ -244,10 +244,6 @@ def _fanout_patches(install_side_effect, consent_mock=None):
     patches = {
         "_install_plugin_core": mock.MagicMock(side_effect=install_side_effect),
         "_prompt_plugin_env_vars": mock.MagicMock(),
-        "_get_enabled_set": mock.MagicMock(return_value=set()),
-        "_get_disabled_set": mock.MagicMock(return_value=set()),
-        "_save_enabled_set": mock.MagicMock(),
-        "_save_disabled_set": mock.MagicMock(),
         "_run_capability_consent": consent_mock or mock.MagicMock(return_value=True),
         "_declared_capabilities_from_manifest": mock.MagicMock(
             side_effect=lambda manifest, name: manifest.get("capabilities", [])
@@ -281,8 +277,8 @@ def test_install_fan_out_passes_pinned_refs_to_installer(tmp_path):
 
     assert [r.ok for r in results] == [True, True]
     assert installer.call_args_list == [
-        mock.call("o/a", force=False, ref=SHA_A),
-        mock.call("o/b", force=False, ref=SHA_B),
+        mock.call("o/a", force=False, ref=SHA_A, enable_on_commit=True),
+        mock.call("o/b", force=False, ref=SHA_B, enable_on_commit=True),
     ]
 
 
@@ -333,7 +329,7 @@ def test_install_fan_out_continues_past_failures_and_reports():
         )
     )
 
-    def installer(identifier, *, force, ref):
+    def installer(identifier, *, force, ref, enable_on_commit=False):
         if "bad" in identifier:
             raise PluginOperationError("clone exploded")
         return (mock.MagicMock(), {"name": "good"}, "good")
@@ -364,7 +360,7 @@ def test_pack_install_exits_nonzero_on_partial_failure(tmp_path, monkeypatch):
     )
     from hermes_cli.plugins_cmd import PluginOperationError
 
-    def installer(identifier, *, force, ref):
+    def installer(identifier, *, force, ref, enable_on_commit=False):
         if "bad" in identifier:
             raise PluginOperationError("boom")
         return (mock.MagicMock(), {"name": "good"}, "good")

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -447,8 +447,8 @@ class TestCmdRemove:
 
     @patch("hermes_cli.plugins_cmd._sanitize_plugin_name")
     @patch("hermes_cli.plugins_cmd._plugins_dir")
-    @patch("hermes_cli.plugins_cmd.shutil.rmtree")
-    def test_remove_deletes_plugin(self, mock_rmtree, mock_plugins_dir, mock_sanitize):
+    @patch("hermes_cli.plugins_cmd._remove_plugin_core")
+    def test_remove_deletes_plugin(self, mock_remove, mock_plugins_dir, mock_sanitize):
         from hermes_cli.plugins_cmd import cmd_remove
 
         mock_plugins_dir.return_value = MagicMock()
@@ -458,7 +458,7 @@ class TestCmdRemove:
 
         cmd_remove("test-plugin")
 
-        mock_rmtree.assert_called_once_with(mock_target)
+        mock_remove.assert_called_once_with(mock_target)
 
     @patch("hermes_cli.plugins_cmd._sanitize_plugin_name")
     @patch("hermes_cli.plugins_cmd._plugins_dir")

--- a/tests/hermes_cli/test_plugins_cmd_catalog.py
+++ b/tests/hermes_cli/test_plugins_cmd_catalog.py
@@ -86,9 +86,20 @@ def fake_core(monkeypatch, tmp_path):
     calls: list[dict] = []
     target = tmp_path / "fake-installed"
 
-    def fake(identifier, *, force, ref=None, skip_removed_check=False,
-             scan_decision_cb=None):
+    def fake(
+        identifier,
+        *,
+        force,
+        ref=None,
+        skip_removed_check=False,
+        scan_decision_cb=None,
+        metadata_extra=None,
+        catalog_entry=None,
+        enable_on_commit=False,
+    ):
         target.mkdir(parents=True, exist_ok=True)
+        if catalog_entry is not None:
+            plugins_cmd._write_catalog_sidecar(target, catalog_entry, strict=True)
         calls.append(
             {
                 "identifier": identifier,
@@ -256,7 +267,7 @@ class TestCatalogUpdate:
                 "installed_at": "2026-01-01T00:00:00Z",
             },
         )
-        plugins_cmd._save_enabled_set({"my-entry"})
+        plugins_cmd._mutate_plugin_state(enable={"my-entry"})
         plugins_cmd.cmd_update("my-entry")
         assert "my-entry" in plugins_cmd._get_enabled_set()
 

--- a/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
+++ b/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
@@ -86,13 +86,9 @@ class TestResolvePluginKey:
 class TestEnableDisableNested:
     @patch("hermes_cli.plugins.get_bundled_plugins_dir")
     @patch("hermes_cli.plugins_cmd._plugins_dir")
-    @patch("hermes_cli.plugins_cmd._save_disabled_set")
-    @patch("hermes_cli.plugins_cmd._save_enabled_set")
-    @patch("hermes_cli.plugins_cmd._get_disabled_set", return_value=set())
-    @patch("hermes_cli.plugins_cmd._get_enabled_set", return_value=set())
+    @patch("hermes_cli.plugins_cmd._mutate_plugin_state", return_value=True)
     def test_enable_bare_name_writes_key(
-        self, mock_en, mock_dis, mock_save_en, mock_save_dis,
-        mock_user, mock_bundled, nested_plugin_env,
+        self, mutate, mock_user, mock_bundled, nested_plugin_env,
     ):
         from hermes_cli.plugins_cmd import cmd_enable
         mock_user.return_value = nested_plugin_env
@@ -100,11 +96,7 @@ class TestEnableDisableNested:
 
         cmd_enable("trace_sink", allow_tool_override=False)  # bare name
 
-        saved = mock_save_en.call_args[0][0]
-        # The canonical key — NOT the bare name — must be persisted, because
-        # that is what PluginManager matches when deciding to load.
-        assert "observability/trace_sink" in saved
-        assert "trace_sink" not in saved or "observability/trace_sink" in saved
+        assert mutate.call_args.kwargs["enable"] == {"observability/trace_sink"}
 
 
     @patch("hermes_cli.plugins.get_bundled_plugins_dir")
@@ -118,13 +110,9 @@ class TestEnableDisableNested:
 
     @patch("hermes_cli.plugins.get_bundled_plugins_dir")
     @patch("hermes_cli.plugins_cmd._plugins_dir")
-    @patch("hermes_cli.plugins_cmd._save_disabled_set")
-    @patch("hermes_cli.plugins_cmd._save_enabled_set")
-    @patch("hermes_cli.plugins_cmd._get_disabled_set", return_value=set())
-    @patch("hermes_cli.plugins_cmd._get_enabled_set", return_value=set())
+    @patch("hermes_cli.plugins_cmd._mutate_plugin_state", return_value=True)
     def test_enable_flat_plugin_unchanged(
-        self, mock_en, mock_dis, mock_save_en, mock_save_dis,
-        mock_user, mock_bundled, nested_plugin_env,
+        self, mutate, mock_user, mock_bundled, nested_plugin_env,
     ):
         """Flat plugins keep writing their bare name (key == name) — no regression."""
         from hermes_cli.plugins_cmd import cmd_enable
@@ -132,8 +120,7 @@ class TestEnableDisableNested:
         mock_bundled.return_value = nested_plugin_env / "nonexistent"
 
         cmd_enable("disk-cleanup", allow_tool_override=False)
-        saved = mock_save_en.call_args[0][0]
-        assert "disk-cleanup" in saved
+        assert mutate.call_args.kwargs["enable"] == {"disk-cleanup"}
 
 
 # ---------------------------------------------------------------------------
@@ -150,13 +137,9 @@ class TestEnableToolOverrideConsent:
     @patch("hermes_cli.plugins.get_bundled_plugins_dir")
     @patch("hermes_cli.plugins_cmd._plugins_dir")
     @patch("hermes_cli.plugins_cmd._set_plugin_entry_flag")
-    @patch("hermes_cli.plugins_cmd._save_disabled_set")
-    @patch("hermes_cli.plugins_cmd._save_enabled_set")
-    @patch("hermes_cli.plugins_cmd._get_disabled_set", return_value=set())
-    @patch("hermes_cli.plugins_cmd._get_enabled_set", return_value=set())
+    @patch("hermes_cli.plugins_cmd._mutate_plugin_state", return_value=True)
     def test_interactive_eof_defaults_to_deny(
-        self, mock_en, mock_dis, mock_save_en, mock_save_dis, mock_set_flag,
-        mock_user, mock_bundled, nested_plugin_env,
+        self, mock_mutate, mock_set_flag, mock_user, mock_bundled, nested_plugin_env,
     ):
         """Non-interactive stdin (EOFError) must fail closed to deny."""
         from hermes_cli.plugins_cmd import cmd_enable
@@ -173,13 +156,9 @@ class TestEnableToolOverrideConsent:
     @patch("hermes_cli.plugins.get_bundled_plugins_dir")
     @patch("hermes_cli.plugins_cmd._plugins_dir")
     @patch("hermes_cli.plugins_cmd._set_plugin_entry_flag")
-    @patch("hermes_cli.plugins_cmd._save_disabled_set")
-    @patch("hermes_cli.plugins_cmd._save_enabled_set")
-    @patch("hermes_cli.plugins_cmd._get_disabled_set", return_value=set())
-    @patch("hermes_cli.plugins_cmd._get_enabled_set", return_value=set())
+    @patch("hermes_cli.plugins_cmd._mutate_plugin_state", return_value=True)
     def test_bundled_plugin_never_prompts_or_writes_entry(
-        self, mock_en, mock_dis, mock_save_en, mock_save_dis, mock_set_flag,
-        mock_user, mock_bundled, tmp_path,
+        self, mock_mutate, mock_set_flag, mock_user, mock_bundled, tmp_path,
     ):
         """Bundled plugins are trusted — no consent prompt, no entry write."""
         from hermes_cli.plugins_cmd import cmd_enable
@@ -205,11 +184,9 @@ class TestCompositeMenuWritesCanonicalKey:
     name is what silently vetoed a bundled backend forever (pi314).
     """
 
-    @patch("hermes_cli.plugins_cmd._save_disabled_set")
-    @patch("hermes_cli.plugins_cmd._save_enabled_set")
-    @patch("hermes_cli.plugins_cmd._get_enabled_set", return_value=set())
+    @patch("hermes_cli.plugins_cmd._mutate_plugin_state", return_value=True)
     def test_fallback_unchecked_plugin_disables_by_key_not_name(
-        self, mock_en, mock_save_en, mock_save_dis,
+        self, mutate,
     ):
         from hermes_cli.plugins_cmd import _run_composite_fallback
         from rich.console import Console
@@ -227,6 +204,4 @@ class TestCompositeMenuWritesCanonicalKey:
                 set(), [], Console(),
             )
 
-        saved_dis = mock_save_dis.call_args[0][0]
-        assert "web/firecrawl" in saved_dis      # canonical key persisted
-        assert "web-firecrawl" not in saved_dis   # never the bare name
+        assert mutate.call_args.kwargs["disable"] == {"web/firecrawl"}

--- a/tests/hermes_cli/test_setup_blank_slate.py
+++ b/tests/hermes_cli/test_setup_blank_slate.py
@@ -92,7 +92,7 @@ class TestBlankSlateFork:
         # Neutralize side-effecting setup steps and I/O.
         monkeypatch.setattr(s, "setup_model_provider", lambda cfg, **k: None)
         monkeypatch.setattr(s, "setup_terminal_backend", lambda cfg, **k: None)
-        monkeypatch.setattr(s, "save_config", lambda cfg: None)
+        monkeypatch.setattr(s, "save_config", lambda cfg, **kwargs: None)
         monkeypatch.setattr(s, "_print_setup_summary", lambda cfg, home: None)
         monkeypatch.setattr(s, "print_header", lambda *a, **k: None)
         monkeypatch.setattr(s, "print_info", lambda *a, **k: None)

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -233,7 +233,7 @@ def test_first_install_nous_auto_configures_video_gen(monkeypatch):
         "hermes_cli.tools_config._prompt_toolset_checklist",
         lambda *args, **kwargs: {"video_gen"},
     )
-    monkeypatch.setattr("hermes_cli.tools_config.save_config", lambda config: None)
+    monkeypatch.setattr("hermes_cli.tools_config.save_config", lambda config, **kwargs: None)
     monkeypatch.setattr(
         "hermes_cli.tools_config._get_enabled_platforms",
         lambda: ["cli"],

--- a/tests/hermes_cli/test_web_plugins_catalog.py
+++ b/tests/hermes_cli/test_web_plugins_catalog.py
@@ -240,7 +240,16 @@ class TestDashboardPluginCatalog:
 
         captured = {}
 
-        def fake_core(identifier, *, force, ref=None, skip_removed_check=False):
+        def fake_core(
+            identifier,
+            *,
+            force,
+            ref=None,
+            skip_removed_check=False,
+            metadata_extra=None,
+            catalog_entry=None,
+            enable_on_commit=False,
+        ):
             captured["identifier"] = identifier
             captured["ref"] = ref
             target = get_hermes_home() / "plugins" / "alpha-plugin"
@@ -248,6 +257,8 @@ class TestDashboardPluginCatalog:
             (target / "plugin.yaml").write_text(
                 yaml.safe_dump({"name": "alpha-plugin"}), encoding="utf-8"
             )
+            if catalog_entry is not None:
+                plugins_cmd._write_catalog_sidecar(target, catalog_entry, strict=True)
             return target, {"name": "alpha-plugin"}, "alpha-plugin"
 
         monkeypatch.setattr(plugins_cmd, "_install_plugin_core", fake_core)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -85,7 +85,7 @@ def _install_example_plugin(_isolate_hermes_home):
     if "example" not in _enabled:
         _enabled.append("example")
     _plugins_cfg["enabled"] = _enabled
-    save_config(_cfg)
+    save_config(_cfg, preserve_plugin_state=False)
 
     # Snapshot the existing routes BEFORE mounting so we can:
     #   1. Identify the routes the mount call appends.

--- a/tests/test_utils_atomic_roundtrip_yaml_save.py
+++ b/tests/test_utils_atomic_roundtrip_yaml_save.py
@@ -196,6 +196,35 @@ class TestAtomicRoundtripYamlSave:
         result = yaml.safe_load(config_path.read_text(encoding="utf-8"))
         assert result["toolsets"] == ["three"]
 
+    def test_stale_writer_preserves_plugin_runtime_state(self, config_path):
+        from utils import atomic_roundtrip_yaml_save
+
+        config_path.write_text(
+            "plugins:\n"
+            "  enabled: [new-plugin]\n"
+            "  disabled: [blocked]\n"
+            "platform_toolsets:\n"
+            "  cli: [file, new-tools]\n"
+            "display:\n"
+            "  skin: default\n",
+            encoding="utf-8",
+        )
+        stale = {
+            "plugins": {"enabled": [], "disabled": []},
+            "platform_toolsets": {"cli": ["file"]},
+            "display": {"skin": "mono"},
+        }
+
+        saved = atomic_roundtrip_yaml_save(config_path, stale)
+
+        result = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert result["plugins"] == {
+            "enabled": ["new-plugin"],
+            "disabled": ["blocked"],
+        }
+        assert result["platform_toolsets"]["cli"] == ["file", "new-tools"]
+        assert saved["plugins"] == result["plugins"]
+
     def test_recurses_into_nested_dicts(self, config_path):
         """Deep mutations target the matching subtree, not the whole parent.
 

--- a/tests/tui_gateway/test_plugins_manage_install.py
+++ b/tests/tui_gateway/test_plugins_manage_install.py
@@ -1,5 +1,8 @@
 """Gateway plugins.manage install action."""
 
+import json
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from tui_gateway import server
@@ -18,18 +21,16 @@ def test_plugins_manage_install_success():
         "hermes_cli.plugins_cmd.dashboard_install_plugin",
         return_value=payload,
     ) as mock_install:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "plugins.manage",
-                "params": {
-                    "action": "install",
-                    "repo": "owner/hello-world",
-                    "force": True,
-                    "enable": False,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "plugins.manage",
+            "params": {
+                "action": "install",
+                "repo": "owner/hello-world",
+                "force": True,
+                "enable": False,
+            },
+        })
 
     assert "result" in resp
     assert resp["result"]["plugin_name"] == "hello-world"
@@ -38,17 +39,16 @@ def test_plugins_manage_install_success():
         force=True,
         enable=False,
         catalog_name=None,
+        catalog_source="official",
     )
 
 
 def test_plugins_manage_install_missing_identifier():
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "plugins.manage",
-            "params": {"action": "install"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "plugins.manage",
+        "params": {"action": "install"},
+    })
 
     assert "error" in resp
     assert "identifier" in resp["error"]["message"]
@@ -59,16 +59,14 @@ def test_plugins_manage_install_failure():
         "hermes_cli.plugins_cmd.dashboard_install_plugin",
         return_value={"ok": False, "error": "Git clone failed"},
     ):
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "plugins.manage",
-                "params": {
-                    "action": "install",
-                    "identifier": "bad/repo",
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "plugins.manage",
+            "params": {
+                "action": "install",
+                "identifier": "bad/repo",
+            },
+        })
 
     assert "error" in resp
     assert "Git clone failed" in resp["error"]["message"]
@@ -81,17 +79,15 @@ def test_plugins_manage_install_catalog_name_only():
         "hermes_cli.plugins_cmd.dashboard_install_plugin",
         return_value=payload,
     ) as mock_install:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "plugins.manage",
-                "params": {
-                    "action": "install",
-                    "catalog_name": "weather-plugin",
-                    "enable": False,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "plugins.manage",
+            "params": {
+                "action": "install",
+                "catalog_name": "weather-plugin",
+                "enable": False,
+            },
+        })
 
     assert "result" in resp
     mock_install.assert_called_once_with(
@@ -99,7 +95,215 @@ def test_plugins_manage_install_catalog_name_only():
         force=False,
         enable=False,
         catalog_name="weather-plugin",
+        catalog_source="official",
     )
+
+
+def test_plugins_manage_install_private_marketplace_entry():
+    payload = {"ok": True, "plugin_name": "private-plugin", "enabled": True}
+    with patch(
+        "hermes_cli.plugins_cmd.dashboard_install_plugin",
+        return_value=payload,
+    ) as mock_install:
+        resp = server.handle_request({
+            "id": "1",
+            "method": "plugins.manage",
+            "params": {
+                "action": "install",
+                "marketplace_id": "abc123",
+                "marketplace_plugin_name": "private-plugin",
+            },
+        })
+
+    assert "result" in resp
+    mock_install.assert_called_once_with(
+        "",
+        force=False,
+        enable=True,
+        catalog_name="private-plugin",
+        catalog_source="abc123",
+    )
+
+
+def test_plugins_manage_marketplace_actions():
+    marketplace = {
+        "available": True,
+        "entries": [
+            {
+                "compatible": True,
+                "description": "Private plugin",
+                "display_name": "Private Plugin",
+                "incompatibility_reason": "",
+                "maintainer": "Team",
+                "name": "private-plugin",
+                "repo": "https://github.com/o/r",
+                "sha": "a" * 40,
+                "source_id": "abc123",
+                "source_name": "Private",
+                "subdir": "plugins/private-plugin",
+                "tree_sha": "b" * 40,
+                "version": "1.0.0",
+            }
+        ],
+        "id": "abc123",
+        "name": "Private",
+        "stale": False,
+        "url": "https://github.com/o/r",
+    }
+    with (
+        patch(
+            "hermes_cli.plugin_marketplaces.add_marketplace",
+            return_value=marketplace,
+        ) as mock_add,
+        patch(
+            "hermes_cli.plugin_marketplaces.list_marketplaces",
+            return_value=[marketplace],
+        ) as mock_list,
+        patch(
+            "hermes_cli.plugin_marketplaces.remove_marketplace",
+            return_value=True,
+        ) as mock_remove,
+    ):
+        added = server.handle_request({
+            "id": "1",
+            "method": "plugins.manage",
+            "params": {"action": "marketplace_add", "url": "https://github.com/o/r"},
+        })
+        listed = server.handle_request({
+            "id": "2",
+            "method": "plugins.manage",
+            "params": {"action": "marketplace_refresh"},
+        })
+        removed = server.handle_request({
+            "id": "3",
+            "method": "plugins.manage",
+            "params": {"action": "marketplace_remove", "source_id": "abc123"},
+        })
+
+    public = added["result"]["marketplace"]
+    assert public["id"] == "abc123"
+    assert public["entries"][0]["name"] == "private-plugin"
+    assert "repo" not in public["entries"][0]
+    assert "sha" not in public["entries"][0]
+    assert "subdir" not in public["entries"][0]
+    assert listed["result"]["marketplaces"] == [public]
+    assert removed["result"]["removed"] is True
+    mock_add.assert_called_once_with("https://github.com/o/r")
+    mock_list.assert_called_once_with(force=True)
+    mock_remove.assert_called_once_with("abc123")
+
+
+def test_marketplace_provenance_does_not_leak_to_same_basename_key(
+    tmp_path: Path, monkeypatch
+):
+    import hermes_cli.plugin_catalog as catalog
+    import hermes_cli.plugin_marketplaces as marketplaces
+    import hermes_cli.plugins_cmd as plugins_cmd
+
+    plugins_root = tmp_path / "plugins"
+    top = plugins_root / "foo"
+    nested = plugins_root / "category" / "foo"
+    top.mkdir(parents=True)
+    nested.mkdir(parents=True)
+    monkeypatch.setattr(plugins_cmd, "_plugins_dir", lambda: plugins_root)
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_discover_all_plugins",
+        lambda: [
+            ("foo", "1", "top", "user", top, "foo"),
+            ("foo", "1", "nested", "user", nested, "category/foo"),
+        ],
+    )
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_read_install_metadata",
+        lambda: {
+            "foo": {
+                "marketplace_id": "market",
+                "marketplace_name": "Private",
+                "marketplace_plugin_name": "foo",
+                "installed_repo_sha": "a" * 40,
+                "installed_tree_sha": "b" * 40,
+            }
+        },
+    )
+    monkeypatch.setattr(catalog, "load_catalog_live", lambda: [])
+    monkeypatch.setattr(
+        marketplaces,
+        "list_marketplaces",
+        lambda **_kwargs: [
+            {
+                "id": "market",
+                "entries": [{"name": "foo", "sha": "a" * 40, "tree_sha": "b" * 40}],
+            }
+        ],
+    )
+
+    listed = server.handle_request({
+        "id": "list",
+        "method": "plugins.manage",
+        "params": {"action": "list"},
+    })
+    assert listed is not None
+    rows = {row["key"]: row for row in listed["result"]["plugins"]}
+    assert rows["foo"]["marketplace_id"] == "market"
+    assert "marketplace_id" not in rows["category/foo"]
+
+    updated = server.handle_request({
+        "id": "update",
+        "method": "plugins.manage",
+        "params": {"action": "update", "key": "category/foo"},
+    })
+    assert updated is not None
+    assert "not a catalog or marketplace install" in updated["error"]["message"]
+
+
+def test_private_registry_failure_keeps_official_update_pin(tmp_path, monkeypatch):
+    import hermes_cli.plugin_catalog as catalog
+    import hermes_cli.plugin_marketplaces as marketplaces
+    import hermes_cli.plugins_cmd as plugins_cmd
+
+    plugins_root = tmp_path / "plugins"
+    target = plugins_root / "official-plugin"
+    target.mkdir(parents=True)
+    (target / ".hermes-catalog.json").write_text(
+        json.dumps({
+            "catalog_name": "official-plugin",
+            "sha": "a" * 40,
+            "tier": "official",
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(plugins_cmd, "_plugins_dir", lambda: plugins_root)
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_discover_all_plugins",
+        lambda: [
+            ("official-plugin", "1", "official", "user", target, "official-plugin")
+        ],
+    )
+    monkeypatch.setattr(plugins_cmd, "_read_install_metadata", lambda: {})
+    monkeypatch.setattr(
+        catalog,
+        "load_catalog_live",
+        lambda: [SimpleNamespace(name="official-plugin", sha="b" * 40)],
+    )
+    monkeypatch.setattr(
+        marketplaces,
+        "list_marketplaces",
+        lambda: (_ for _ in ()).throw(ValueError("malformed private registry")),
+    )
+
+    listed = server.handle_request({
+        "id": "list",
+        "method": "plugins.manage",
+        "params": {"action": "list"},
+    })
+
+    assert listed is not None
+    row = listed["result"]["plugins"][0]
+    assert row["catalog_sha"] == "b" * 40
+    assert row["update_available"] is True
 
 
 def test_plugins_manage_update_requires_catalog_sidecar(tmp_path, monkeypatch):
@@ -110,13 +314,11 @@ def test_plugins_manage_update_requires_catalog_sidecar(tmp_path, monkeypatch):
     (plugins_root / "plain-git-plugin").mkdir(parents=True)
     monkeypatch.setattr(plugins_cmd, "_plugins_dir", lambda: plugins_root)
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "plugins.manage",
-            "params": {"action": "update", "name": "plain-git-plugin"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "plugins.manage",
+        "params": {"action": "update", "key": "plain-git-plugin"},
+    })
 
     assert "error" in resp
-    assert "not a catalog install" in resp["error"]["message"]
+    assert "not a catalog or marketplace install" in resp["error"]["message"]

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -2466,38 +2466,19 @@ def _(rid, params: dict) -> dict:
             _plugin_status,
             _read_catalog_sidecar,
         )
-
-        def _catalog_pins():
-            """{(source, name): {sha, tree_sha}} from every saved catalog."""
-            try:
-                from hermes_cli.plugin_catalog import load_catalog_live
-
-                pins = {
-                    ("official", e.name): {"sha": e.sha, "tree_sha": ""}
-                    for e in load_catalog_live()
-                }
-            except Exception:
-                pins = {}
-            try:
-                from hermes_cli.plugin_marketplaces import list_marketplaces
-
-                for marketplace in list_marketplaces():
-                    if not marketplace.get("available") or marketplace.get("stale"):
-                        continue
-                    for entry in marketplace.get("entries", []):
-                        if isinstance(entry, dict) and entry.get("name"):
-                            pins[(marketplace["id"], str(entry["name"]))] = {
-                                "sha": str(entry.get("sha") or ""),
-                                "tree_sha": str(entry.get("tree_sha") or ""),
-                            }
-            except Exception:
-                pass
-            return pins
+        from tui_gateway.plugin_marketplace_actions import (
+            MARKETPLACE_ACTIONS,
+            MarketplaceRequestError,
+            catalog_install_args,
+            catalog_pins,
+            manage_marketplace,
+            update_plugin,
+        )
 
         def _rows():
             enabled = _get_enabled_set()
             disabled = _get_disabled_set()
-            pins = _catalog_pins()
+            pins = catalog_pins()
             from hermes_cli.plugins_cmd import _read_install_metadata
 
             install_metadata = _read_install_metadata()
@@ -2594,44 +2575,11 @@ def _(rid, params: dict) -> dict:
                 },
             )
 
-        if action in {
-            "marketplaces",
-            "marketplace_add",
-            "marketplace_remove",
-            "marketplace_refresh",
-        }:
-            from hermes_cli.plugin_marketplaces import (
-                add_marketplace,
-                list_marketplaces,
-                public_marketplace,
-                remove_marketplace,
-            )
-
-            if action == "marketplace_add":
-                marketplace = add_marketplace(str(params.get("url") or "").strip())
-                return _ok(
-                    rid,
-                    {"ok": True, "marketplace": public_marketplace(marketplace)},
-                )
-            if action == "marketplace_remove":
-                source_id = str(params.get("source_id") or "").strip()
-                if not source_id:
-                    return _err(rid, 4019, "marketplace_remove requires 'source_id'")
-                return _ok(
-                    rid,
-                    {"ok": True, "removed": remove_marketplace(source_id)},
-                )
-            return _ok(
-                rid,
-                {
-                    "marketplaces": [
-                        public_marketplace(marketplace)
-                        for marketplace in list_marketplaces(
-                            force=action == "marketplace_refresh"
-                        )
-                    ]
-                },
-            )
+        if action in MARKETPLACE_ACTIONS:
+            try:
+                return _ok(rid, manage_marketplace(action, params))
+            except MarketplaceRequestError as exc:
+                return _err(rid, exc.code, str(exc))
 
         if action == "toggle":
             from hermes_cli.plugins_cmd import dashboard_set_agent_plugin_enabled
@@ -2661,123 +2609,26 @@ def _(rid, params: dict) -> dict:
         if action == "install":
             from hermes_cli.plugins_cmd import dashboard_install_plugin
 
-            ident = (
-                params.get("identifier") or params.get("repo") or ""
-            ).strip()
-            # Curated-catalog install: resolve repo + pinned SHA server-side
-            # (same contract as the dashboard endpoint). ``catalog_name``
-            # alone is enough — identifier may be empty.
-            catalog_name = str(params.get("catalog_name") or "").strip()
-            catalog_source = "official"
-            marketplace_id = str(params.get("marketplace_id") or "").strip()
-            marketplace_plugin_name = str(
-                params.get("marketplace_plugin_name") or ""
-            ).strip()
-            if marketplace_id:
-                if not marketplace_plugin_name:
-                    return _err(
-                        rid,
-                        4019,
-                        "marketplace install requires 'marketplace_plugin_name'",
-                    )
-                catalog_source = marketplace_id
-                catalog_name = marketplace_plugin_name
-            if not ident and not catalog_name:
-                return _err(
-                    rid, 4019,
-                    "plugins.install requires 'identifier', 'repo', or 'catalog_name'",
-                )
+            try:
+                ident, catalog_name, catalog_source = catalog_install_args(params)
+            except MarketplaceRequestError as exc:
+                return _err(rid, exc.code, str(exc))
             result = dashboard_install_plugin(
                 ident,
                 force=bool(params.get("force")),
                 enable=params.get("enable", True),
                 catalog_name=catalog_name or None,
-                catalog_source=catalog_source or "official",
+                catalog_source=catalog_source,
             )
             if not result.get("ok"):
                 return _err(rid, 5026, result.get("error") or "install failed")
             return _ok(rid, result)
 
         if action == "update":
-            from hermes_cli.plugins_cmd import (
-                PluginOperationError,
-                _catalog_install_identifier,
-                _get_live_catalog_entry,
-                _install_plugin_core,
-                _marketplace_install,
-                _marketplace_metadata,
-                _plugins_dir,
-                _sanitize_plugin_name,
-            )
-
-            key = str(params.get("key") or "").strip()
-            if not key:
-                return _err(rid, 4019, "plugins.update requires a canonical 'key'")
             try:
-                target = _sanitize_plugin_name(key, _plugins_dir(), allow_subdir=True)
-            except ValueError as exc:
-                return _err(rid, 4019, str(exc))
-            if not target.is_dir():
-                return _err(rid, 4020, f"Plugin '{key}' is not installed")
-
-            marketplace = _marketplace_install(key) if key == target.name else None
-            sidecar = None if marketplace else _read_catalog_sidecar(target)
-            if marketplace:
-                marketplace_id = str(marketplace["marketplace_id"])
-                marketplace_plugin_name = str(
-                    marketplace.get("marketplace_plugin_name") or target.name
-                )
-                entry = _get_live_catalog_entry(
-                    marketplace_plugin_name,
-                    marketplace_id,
-                    force=True,
-                )
-                if entry is None:
-                    return _err(
-                        rid,
-                        4021,
-                        f"Marketplace source for '{marketplace_plugin_name}' is unavailable",
-                    )
-                installed_tree = str(
-                    marketplace.get("installed_tree_sha") or ""
-                ).lower()
-                if installed_tree and installed_tree == entry.tree_sha:
-                    return _ok(
-                        rid, {"ok": True, "unchanged": True, "sha": entry.sha}
-                    )
-                metadata_extra = _marketplace_metadata(entry)
-            elif sidecar and sidecar.get("catalog_name"):
-                entry = _get_live_catalog_entry(str(sidecar["catalog_name"]))
-                if entry is None:
-                    return _err(
-                        rid,
-                        4021,
-                        f"'{sidecar['catalog_name']}' is no longer in the catalog",
-                    )
-                installed_sha = str(sidecar.get("sha") or "").lower()
-                if installed_sha == entry.sha:
-                    return _ok(
-                        rid, {"ok": True, "unchanged": True, "sha": entry.sha}
-                    )
-                metadata_extra = None
-            else:
-                return _err(
-                    rid,
-                    4020,
-                    f"'{key}' is not a catalog or marketplace install",
-                )
-
-            try:
-                _new_target, _manifest, _installed = _install_plugin_core(
-                    _catalog_install_identifier(entry),
-                    force=True,
-                    ref=entry.sha,
-                    metadata_extra=metadata_extra,
-                    catalog_entry=entry if marketplace is None else None,
-                )
-            except PluginOperationError as exc:
-                return _err(rid, 5026, str(exc))
-            return _ok(rid, {"ok": True, "unchanged": False, "sha": entry.sha})
+                return _ok(rid, update_plugin(params))
+            except MarketplaceRequestError as exc:
+                return _err(rid, exc.code, str(exc))
 
         return _err(rid, 4017, f"unknown plugins action: {action}")
     except Exception as e:

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -2468,18 +2468,39 @@ def _(rid, params: dict) -> dict:
         )
 
         def _catalog_pins():
-            """{catalog_name: pinned_sha} from the live catalog (best effort)."""
+            """{(source, name): {sha, tree_sha}} from every saved catalog."""
             try:
                 from hermes_cli.plugin_catalog import load_catalog_live
 
-                return {e.name: e.sha for e in load_catalog_live()}
+                pins = {
+                    ("official", e.name): {"sha": e.sha, "tree_sha": ""}
+                    for e in load_catalog_live()
+                }
             except Exception:
-                return {}
+                pins = {}
+            try:
+                from hermes_cli.plugin_marketplaces import list_marketplaces
+
+                for marketplace in list_marketplaces():
+                    if not marketplace.get("available") or marketplace.get("stale"):
+                        continue
+                    for entry in marketplace.get("entries", []):
+                        if isinstance(entry, dict) and entry.get("name"):
+                            pins[(marketplace["id"], str(entry["name"]))] = {
+                                "sha": str(entry.get("sha") or ""),
+                                "tree_sha": str(entry.get("tree_sha") or ""),
+                            }
+            except Exception:
+                pass
+            return pins
 
         def _rows():
             enabled = _get_enabled_set()
             disabled = _get_disabled_set()
             pins = _catalog_pins()
+            from hermes_cli.plugins_cmd import _read_install_metadata
+
+            install_metadata = _read_install_metadata()
             out = []
             for name, version, desc, source, _dir, key in sorted(
                 _discover_all_plugins()
@@ -2499,35 +2520,65 @@ def _(rid, params: dict) -> dict:
                     "name": name,
                     # Canonical registry key (e.g. ``image_gen/fal``). Names
                     # can collide across category dirs — both fal backends
-                    # are named "fal" — so toggles must address the key.
+                    # are named "fal" — so mutations must address the key.
                     "key": key,
                     "version": str(version or ""),
                     "description": desc or "",
                     "source": source,
                     "status": status,
-                    # Agent Plugins v1 package (plugin.json — the portable
-                    # skills/MCP format) vs a native Hermes plugin.
                     "portable": _is_portable_plugin_dir(_dir),
                 }
-                # Catalog provenance (``.hermes-catalog.json`` sidecar) +
-                # whether the catalog pin has moved past the installed SHA —
-                # powers the desktop's "Update to <pin>" affordance.
-                try:
-                    sidecar = _read_catalog_sidecar(_Path(_dir)) if _dir else None
-                except Exception:
-                    sidecar = None
-                if sidecar and sidecar.get("catalog_name"):
-                    catalog_name = str(sidecar["catalog_name"])
-                    installed_sha = str(sidecar.get("sha") or "").lower()
-                    pin = pins.get(catalog_name)
-                    row["catalog_name"] = catalog_name
-                    row["catalog_tier"] = str(sidecar.get("tier") or "community")
-                    row["installed_sha"] = installed_sha
+                plugin_dir_name = _Path(_dir).name if _dir else ""
+                provenance = install_metadata.get(key) if key == plugin_dir_name else None
+                if isinstance(provenance, dict) and provenance.get("marketplace_id"):
+                    marketplace_id = str(provenance["marketplace_id"])
+                    plugin_name = str(provenance.get("marketplace_plugin_name") or name)
+                    pin = pins.get((marketplace_id, plugin_name))
+                    installed_tree = str(
+                        provenance.get("installed_tree_sha") or ""
+                    ).lower()
+                    row.update(
+                        {
+                            "marketplace_id": marketplace_id,
+                            "marketplace_name": str(
+                                provenance.get("marketplace_name") or marketplace_id
+                            ),
+                            "marketplace_plugin_name": plugin_name,
+                            "installed_repo_sha": str(
+                                provenance.get("installed_repo_sha") or ""
+                            ).lower(),
+                            "installed_tree_sha": installed_tree,
+                            "marketplace_available": pin is not None,
+                        }
+                    )
                     if pin:
-                        row["catalog_sha"] = pin
+                        current_tree = str(pin["tree_sha"]).lower()
+                        row["current_repo_sha"] = str(pin["sha"]).lower()
+                        row["current_tree_sha"] = current_tree
                         row["update_available"] = bool(
-                            installed_sha and installed_sha != pin
+                            installed_tree and current_tree and installed_tree != current_tree
                         )
+                else:
+                    # Official catalogue provenance remains in the parent PR's
+                    # in-package sidecar for backwards compatibility.
+                    try:
+                        sidecar = _read_catalog_sidecar(_Path(_dir)) if _dir else None
+                    except Exception:
+                        sidecar = None
+                    if sidecar and sidecar.get("catalog_name"):
+                        catalog_name = str(sidecar["catalog_name"])
+                        installed_sha = str(sidecar.get("sha") or "").lower()
+                        pin = pins.get(("official", catalog_name))
+                        row["catalog_name"] = catalog_name
+                        row["catalog_tier"] = str(
+                            sidecar.get("tier") or "community"
+                        )
+                        row["installed_sha"] = installed_sha
+                        if pin:
+                            row["catalog_sha"] = pin["sha"]
+                            row["update_available"] = bool(
+                                installed_sha and installed_sha != pin["sha"]
+                            )
                 out.append(row)
             return out
 
@@ -2540,6 +2591,45 @@ def _(rid, params: dict) -> dict:
                     "plugins": rows,
                     "user_count": user_count,
                     "bundled_count": len(rows) - user_count,
+                },
+            )
+
+        if action in {
+            "marketplaces",
+            "marketplace_add",
+            "marketplace_remove",
+            "marketplace_refresh",
+        }:
+            from hermes_cli.plugin_marketplaces import (
+                add_marketplace,
+                list_marketplaces,
+                public_marketplace,
+                remove_marketplace,
+            )
+
+            if action == "marketplace_add":
+                marketplace = add_marketplace(str(params.get("url") or "").strip())
+                return _ok(
+                    rid,
+                    {"ok": True, "marketplace": public_marketplace(marketplace)},
+                )
+            if action == "marketplace_remove":
+                source_id = str(params.get("source_id") or "").strip()
+                if not source_id:
+                    return _err(rid, 4019, "marketplace_remove requires 'source_id'")
+                return _ok(
+                    rid,
+                    {"ok": True, "removed": remove_marketplace(source_id)},
+                )
+            return _ok(
+                rid,
+                {
+                    "marketplaces": [
+                        public_marketplace(marketplace)
+                        for marketplace in list_marketplaces(
+                            force=action == "marketplace_refresh"
+                        )
+                    ]
                 },
             )
 
@@ -2578,6 +2668,20 @@ def _(rid, params: dict) -> dict:
             # (same contract as the dashboard endpoint). ``catalog_name``
             # alone is enough — identifier may be empty.
             catalog_name = str(params.get("catalog_name") or "").strip()
+            catalog_source = "official"
+            marketplace_id = str(params.get("marketplace_id") or "").strip()
+            marketplace_plugin_name = str(
+                params.get("marketplace_plugin_name") or ""
+            ).strip()
+            if marketplace_id:
+                if not marketplace_plugin_name:
+                    return _err(
+                        rid,
+                        4019,
+                        "marketplace install requires 'marketplace_plugin_name'",
+                    )
+                catalog_source = marketplace_id
+                catalog_name = marketplace_plugin_name
             if not ident and not catalog_name:
                 return _err(
                     rid, 4019,
@@ -2588,56 +2692,91 @@ def _(rid, params: dict) -> dict:
                 force=bool(params.get("force")),
                 enable=params.get("enable", True),
                 catalog_name=catalog_name or None,
+                catalog_source=catalog_source or "official",
             )
             if not result.get("ok"):
                 return _err(rid, 5026, result.get("error") or "install failed")
             return _ok(rid, result)
 
         if action == "update":
-            # Catalog installs only: re-pin to the current catalog SHA (the
-            # same semantics as `hermes plugins update <name>` for sidecar
-            # installs). Non-catalog installs keep their CLI-only flows.
             from hermes_cli.plugins_cmd import (
+                PluginOperationError,
                 _catalog_install_identifier,
                 _get_live_catalog_entry,
                 _install_plugin_core,
+                _marketplace_install,
+                _marketplace_metadata,
                 _plugins_dir,
-                _write_catalog_sidecar,
-                PluginOperationError,
+                _sanitize_plugin_name,
             )
 
-            name = (params.get("name") or "").strip()
-            if not name:
-                return _err(rid, 4019, "plugins.update requires a 'name'")
-            target = _plugins_dir() / name
-            sidecar = _read_catalog_sidecar(target) if target.is_dir() else None
-            if not sidecar or not sidecar.get("catalog_name"):
-                return _err(
-                    rid, 4020,
-                    f"'{name}' is not a catalog install — update it via the CLI",
-                )
-            entry = _get_live_catalog_entry(str(sidecar["catalog_name"]))
-            if entry is None:
-                return _err(
-                    rid, 4021,
-                    f"'{sidecar['catalog_name']}' is no longer in the catalog",
-                )
-            installed_sha = str(sidecar.get("sha") or "").lower()
-            if installed_sha == entry.sha:
-                return _ok(rid, {"ok": True, "unchanged": True, "sha": entry.sha})
-            was_enabled = _get_enabled_set()
+            key = str(params.get("key") or "").strip()
+            if not key:
+                return _err(rid, 4019, "plugins.update requires a canonical 'key'")
             try:
-                new_target, _manifest, _installed = _install_plugin_core(
+                target = _sanitize_plugin_name(key, _plugins_dir(), allow_subdir=True)
+            except ValueError as exc:
+                return _err(rid, 4019, str(exc))
+            if not target.is_dir():
+                return _err(rid, 4020, f"Plugin '{key}' is not installed")
+
+            marketplace = _marketplace_install(key) if key == target.name else None
+            sidecar = None if marketplace else _read_catalog_sidecar(target)
+            if marketplace:
+                marketplace_id = str(marketplace["marketplace_id"])
+                marketplace_plugin_name = str(
+                    marketplace.get("marketplace_plugin_name") or target.name
+                )
+                entry = _get_live_catalog_entry(
+                    marketplace_plugin_name,
+                    marketplace_id,
+                    force=True,
+                )
+                if entry is None:
+                    return _err(
+                        rid,
+                        4021,
+                        f"Marketplace source for '{marketplace_plugin_name}' is unavailable",
+                    )
+                installed_tree = str(
+                    marketplace.get("installed_tree_sha") or ""
+                ).lower()
+                if installed_tree and installed_tree == entry.tree_sha:
+                    return _ok(
+                        rid, {"ok": True, "unchanged": True, "sha": entry.sha}
+                    )
+                metadata_extra = _marketplace_metadata(entry)
+            elif sidecar and sidecar.get("catalog_name"):
+                entry = _get_live_catalog_entry(str(sidecar["catalog_name"]))
+                if entry is None:
+                    return _err(
+                        rid,
+                        4021,
+                        f"'{sidecar['catalog_name']}' is no longer in the catalog",
+                    )
+                installed_sha = str(sidecar.get("sha") or "").lower()
+                if installed_sha == entry.sha:
+                    return _ok(
+                        rid, {"ok": True, "unchanged": True, "sha": entry.sha}
+                    )
+                metadata_extra = None
+            else:
+                return _err(
+                    rid,
+                    4020,
+                    f"'{key}' is not a catalog or marketplace install",
+                )
+
+            try:
+                _new_target, _manifest, _installed = _install_plugin_core(
                     _catalog_install_identifier(entry),
                     force=True,
                     ref=entry.sha,
+                    metadata_extra=metadata_extra,
+                    catalog_entry=entry if marketplace is None else None,
                 )
-            except PluginOperationError as e:
-                return _err(rid, 5026, str(e))
-            _write_catalog_sidecar(new_target, entry)
-            from hermes_cli.plugins_cmd import _save_enabled_set
-
-            _save_enabled_set(was_enabled)
+            except PluginOperationError as exc:
+                return _err(rid, 5026, str(exc))
             return _ok(rid, {"ok": True, "unchanged": False, "sha": entry.sha})
 
         return _err(rid, 4017, f"unknown plugins action: {action}")

--- a/tui_gateway/plugin_marketplace_actions.py
+++ b/tui_gateway/plugin_marketplace_actions.py
@@ -1,0 +1,165 @@
+"""Gateway helpers for Git-backed plugin marketplace requests."""
+
+from __future__ import annotations
+
+MARKETPLACE_ACTIONS = {
+    "marketplaces",
+    "marketplace_add",
+    "marketplace_remove",
+    "marketplace_refresh",
+}
+
+
+class MarketplaceRequestError(ValueError):
+    def __init__(self, message: str, code: int = 4019):
+        super().__init__(message)
+        self.code = code
+
+
+def catalog_pins() -> dict[tuple[str, str], dict[str, str]]:
+    """Return current commit pins from official and private catalogues."""
+    try:
+        from hermes_cli.plugin_catalog import load_catalog_live
+
+        pins = {
+            ("official", entry.name): {"sha": entry.sha, "tree_sha": ""}
+            for entry in load_catalog_live()
+        }
+    except Exception:
+        pins = {}
+
+    try:
+        from hermes_cli.plugin_marketplaces import list_marketplaces
+
+        for marketplace in list_marketplaces():
+            if not marketplace.get("available") or marketplace.get("stale"):
+                continue
+            for entry in marketplace.get("entries", []):
+                if isinstance(entry, dict) and entry.get("name"):
+                    pins[(marketplace["id"], str(entry["name"]))] = {
+                        "sha": str(entry.get("sha") or ""),
+                        "tree_sha": str(entry.get("tree_sha") or ""),
+                    }
+    except Exception:
+        pass
+    return pins
+
+
+def manage_marketplace(action: str, params: dict) -> dict:
+    """Run one profile-scoped marketplace mutation or listing action."""
+    from hermes_cli.plugin_marketplaces import (
+        add_marketplace,
+        list_marketplaces,
+        public_marketplace,
+        remove_marketplace,
+    )
+
+    if action == "marketplace_add":
+        marketplace = add_marketplace(str(params.get("url") or "").strip())
+        return {"ok": True, "marketplace": public_marketplace(marketplace)}
+    if action == "marketplace_remove":
+        source_id = str(params.get("source_id") or "").strip()
+        if not source_id:
+            raise MarketplaceRequestError("marketplace_remove requires 'source_id'")
+        return {"ok": True, "removed": remove_marketplace(source_id)}
+    return {
+        "marketplaces": [
+            public_marketplace(marketplace)
+            for marketplace in list_marketplaces(force=action == "marketplace_refresh")
+        ]
+    }
+
+
+def catalog_install_args(params: dict) -> tuple[str, str, str]:
+    """Resolve the identifier and catalogue source for one install request."""
+    identifier = str(params.get("identifier") or params.get("repo") or "").strip()
+    catalog_name = str(params.get("catalog_name") or "").strip()
+    catalog_source = "official"
+    marketplace_id = str(params.get("marketplace_id") or "").strip()
+    if marketplace_id:
+        catalog_name = str(params.get("marketplace_plugin_name") or "").strip()
+        if not catalog_name:
+            raise MarketplaceRequestError(
+                "marketplace install requires 'marketplace_plugin_name'"
+            )
+        catalog_source = marketplace_id
+    if not identifier and not catalog_name:
+        raise MarketplaceRequestError(
+            "plugins.install requires 'identifier', 'repo', or 'catalog_name'"
+        )
+    return identifier, catalog_name, catalog_source
+
+
+def update_plugin(params: dict) -> dict:
+    """Update one installed catalogue or marketplace plugin to its current pin."""
+    from hermes_cli.plugins_cmd import (
+        PluginOperationError,
+        _catalog_install_identifier,
+        _get_live_catalog_entry,
+        _install_plugin_core,
+        _marketplace_install,
+        _marketplace_metadata,
+        _plugins_dir,
+        _read_catalog_sidecar,
+        _sanitize_plugin_name,
+    )
+
+    key = str(params.get("key") or "").strip()
+    if not key:
+        raise MarketplaceRequestError("plugins.update requires a canonical 'key'")
+    try:
+        target = _sanitize_plugin_name(key, _plugins_dir(), allow_subdir=True)
+    except ValueError as exc:
+        raise MarketplaceRequestError(str(exc)) from exc
+    if not target.is_dir():
+        raise MarketplaceRequestError(f"Plugin '{key}' is not installed", 4020)
+
+    marketplace = _marketplace_install(key) if key == target.name else None
+    sidecar = None if marketplace else _read_catalog_sidecar(target)
+    if marketplace:
+        marketplace_id = str(marketplace["marketplace_id"])
+        marketplace_plugin_name = str(
+            marketplace.get("marketplace_plugin_name") or target.name
+        )
+        entry = _get_live_catalog_entry(
+            marketplace_plugin_name,
+            marketplace_id,
+            force=True,
+        )
+        if entry is None:
+            raise MarketplaceRequestError(
+                f"Marketplace source for '{marketplace_plugin_name}' is unavailable",
+                4021,
+            )
+        installed_tree = str(marketplace.get("installed_tree_sha") or "").lower()
+        current_tree = str(getattr(entry, "tree_sha", "")).lower()
+        if installed_tree and installed_tree == current_tree:
+            return {"ok": True, "unchanged": True, "sha": entry.sha}
+        metadata_extra = _marketplace_metadata(entry)
+    elif sidecar and sidecar.get("catalog_name"):
+        entry = _get_live_catalog_entry(str(sidecar["catalog_name"]))
+        if entry is None:
+            raise MarketplaceRequestError(
+                f"'{sidecar['catalog_name']}' is no longer in the catalog",
+                4021,
+            )
+        installed_sha = str(sidecar.get("sha") or "").lower()
+        if installed_sha == entry.sha:
+            return {"ok": True, "unchanged": True, "sha": entry.sha}
+        metadata_extra = None
+    else:
+        raise MarketplaceRequestError(
+            f"'{key}' is not a catalog or marketplace install", 4020
+        )
+
+    try:
+        _install_plugin_core(
+            _catalog_install_identifier(entry),
+            force=True,
+            ref=entry.sha,
+            metadata_extra=metadata_extra,
+            catalog_entry=entry if marketplace is None else None,
+        )
+    except PluginOperationError as exc:
+        raise MarketplaceRequestError(str(exc), 5026) from exc
+    return {"ok": True, "unchanged": False, "sha": entry.sha}

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4415,9 +4415,9 @@ def _save_cfg(cfg: dict):
     # mangled to \\uXXXX escapes). Fails closed on an unreadable existing
     # config.yaml the same way atomic_config_write does (see
     # atomic_roundtrip_yaml_save's require_readable_config_before_write call).
-    atomic_roundtrip_yaml_save(path, cfg)
+    saved_cfg = atomic_roundtrip_yaml_save(path, cfg)
     with _cfg_lock:
-        _cfg_cache = copy.deepcopy(cfg)
+        _cfg_cache = copy.deepcopy(saved_cfg)
         _cfg_path = path
         try:
             _cfg_mtime = path.stat().st_mtime
@@ -7048,7 +7048,8 @@ def _current_profile_name() -> str:
 # v5: uvicorn ws_max_size raised for one-shot base64 file.attach frames (>16 MiB).
 # v6: plugins.manage list rows carry the canonical registry key; toggles are
 #     key-addressed (keyless rows render read-only in Desktop Settings).
-DESKTOP_BACKEND_CONTRACT = 6
+# v7: plugins.manage adds profile-scoped Git marketplace source management.
+DESKTOP_BACKEND_CONTRACT = 7
 
 
 def _session_usage_snapshot(session: dict | None) -> dict:

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,6 @@
 """Shared utility functions for hermes-agent."""
 
+import copy
 import errno
 import json
 import logging
@@ -8,6 +9,7 @@ import shutil
 import stat
 import tempfile
 import time
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Union
 from urllib.parse import urlparse
@@ -18,6 +20,458 @@ logger = logging.getLogger(__name__)
 
 
 TRUTHY_STRINGS = frozenset({"1", "true", "yes", "on"})
+
+
+def sync_directory(path: Union[str, Path]) -> None:
+    """Flush directory-entry changes on POSIX and Windows."""
+    if os.name != "nt":
+        fd = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+        try:
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+        return
+
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.CreateFileW.argtypes = (
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    )
+    kernel32.CreateFileW.restype = wintypes.HANDLE
+    kernel32.FlushFileBuffers.argtypes = (wintypes.HANDLE,)
+    kernel32.FlushFileBuffers.restype = wintypes.BOOL
+    kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+    kernel32.CloseHandle.restype = wintypes.BOOL
+    handle = kernel32.CreateFileW(
+        str(path),
+        0xC0000000,
+        0x00000001 | 0x00000002,
+        None,
+        3,
+        0x02000000 | 0x00200000,
+        None,
+    )
+    invalid = wintypes.HANDLE(-1).value
+    if handle == invalid:
+        raise ctypes.WinError(ctypes.get_last_error())
+    try:
+        if not kernel32.FlushFileBuffers(handle):
+            raise ctypes.WinError(ctypes.get_last_error())
+    finally:
+        kernel32.CloseHandle(handle)
+
+
+@contextmanager
+def secure_parent_directory(
+    path: Union[str, Path], root: Union[str, Path], *, create: bool = False
+):
+    """Hold a no-follow parent descriptor for a path beneath a trusted root."""
+    path = Path(path).absolute()
+    root = Path(root).absolute()
+    try:
+        relative = path.relative_to(root)
+    except ValueError as exc:
+        raise OSError(errno.EPERM, f"Path escapes trusted root: {path}") from exc
+    if not relative.parts:
+        raise OSError(errno.EINVAL, "A child path is required")
+
+    root_real = root.resolve(strict=True)
+    if os.name != "posix":
+        import ctypes
+        from ctypes import wintypes
+
+        class FileAttributeTagInfo(ctypes.Structure):
+            _fields_ = [
+                ("file_attributes", wintypes.DWORD),
+                ("reparse_tag", wintypes.DWORD),
+            ]
+
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32.CreateFileW.argtypes = (
+            wintypes.LPCWSTR,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            wintypes.HANDLE,
+        )
+        kernel32.CreateFileW.restype = wintypes.HANDLE
+        kernel32.GetFileInformationByHandleEx.argtypes = (
+            wintypes.HANDLE,
+            ctypes.c_int,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+        )
+        kernel32.GetFileInformationByHandleEx.restype = wintypes.BOOL
+        kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+        kernel32.CloseHandle.restype = wintypes.BOOL
+        invalid = wintypes.HANDLE(-1).value
+        handles = []
+        parent = root_real
+        paths = [root_real]
+        for part in relative.parts[:-1]:
+            parent /= part
+            paths.append(parent)
+        try:
+            for current in paths:
+                if not current.exists():
+                    if create:
+                        current.mkdir()
+                    else:
+                        raise FileNotFoundError(current)
+                handle = kernel32.CreateFileW(
+                    str(current),
+                    0x00000080,
+                    0x00000001 | 0x00000002,
+                    None,
+                    3,
+                    0x02000000 | 0x00200000,
+                    None,
+                )
+                if handle == invalid:
+                    raise ctypes.WinError(ctypes.get_last_error())
+                info = FileAttributeTagInfo()
+                if not kernel32.GetFileInformationByHandleEx(
+                    handle, 9, ctypes.byref(info), ctypes.sizeof(info)
+                ):
+                    kernel32.CloseHandle(handle)
+                    raise ctypes.WinError(ctypes.get_last_error())
+                if info.file_attributes & 0x400:
+                    kernel32.CloseHandle(handle)
+                    raise OSError(errno.ELOOP, f"Unsafe reparse-point path: {current}")
+                handles.append(handle)
+            yield None, parent, relative.name
+        finally:
+            for handle in reversed(handles):
+                kernel32.CloseHandle(handle)
+        return
+
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    fd = os.open(root_real, flags)
+    try:
+        for part in relative.parts[:-1]:
+            try:
+                child = os.open(part, flags, dir_fd=fd)
+            except FileNotFoundError:
+                if not create:
+                    raise
+                try:
+                    os.mkdir(part, 0o700, dir_fd=fd)
+                except FileExistsError:
+                    pass
+                child = os.open(part, flags, dir_fd=fd)
+            os.close(fd)
+            fd = child
+        yield fd, root_real.joinpath(*relative.parts[:-1]), relative.name
+    finally:
+        os.close(fd)
+
+
+def secure_open_file(
+    path: Union[str, Path],
+    root: Union[str, Path],
+    flags: int,
+    mode: int = 0o600,
+    *,
+    create_parent: bool = False,
+) -> int:
+    """Open a regular child without releasing parent containment first."""
+    with secure_parent_directory(path, root, create=create_parent) as (
+        parent_fd,
+        parent,
+        name,
+    ):
+        nofollow = getattr(os, "O_NOFOLLOW", 0)
+        candidate = parent / name
+        if parent_fd is None and os.name == "nt":
+            import ctypes
+            import msvcrt
+            from ctypes import wintypes
+
+            kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+            kernel32.CreateFileW.argtypes = (
+                wintypes.LPCWSTR,
+                wintypes.DWORD,
+                wintypes.DWORD,
+                wintypes.LPVOID,
+                wintypes.DWORD,
+                wintypes.DWORD,
+                wintypes.HANDLE,
+            )
+            kernel32.CreateFileW.restype = wintypes.HANDLE
+            kernel32.GetFileInformationByHandleEx.argtypes = (
+                wintypes.HANDLE,
+                ctypes.c_int,
+                wintypes.LPVOID,
+                wintypes.DWORD,
+            )
+            kernel32.GetFileInformationByHandleEx.restype = wintypes.BOOL
+            kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+            kernel32.CloseHandle.restype = wintypes.BOOL
+
+            access = 0x80000000
+            if flags & (os.O_WRONLY | os.O_RDWR):
+                access |= 0x40000000
+            if flags & os.O_CREAT:
+                creation = 1 if flags & os.O_EXCL else 2 if flags & os.O_TRUNC else 4
+            else:
+                creation = 5 if flags & os.O_TRUNC else 3
+            handle = kernel32.CreateFileW(
+                str(candidate),
+                access,
+                0x00000001 | 0x00000002,
+                None,
+                creation,
+                0x00000080 | 0x00200000,
+                None,
+            )
+            invalid = wintypes.HANDLE(-1).value
+            if handle == invalid:
+                raise ctypes.WinError(ctypes.get_last_error())
+
+            class FileAttributeTagInfo(ctypes.Structure):
+                _fields_ = [
+                    ("file_attributes", wintypes.DWORD),
+                    ("reparse_tag", wintypes.DWORD),
+                ]
+
+            info = FileAttributeTagInfo()
+            if not kernel32.GetFileInformationByHandleEx(
+                handle, 9, ctypes.byref(info), ctypes.sizeof(info)
+            ):
+                kernel32.CloseHandle(handle)
+                raise ctypes.WinError(ctypes.get_last_error())
+            if info.file_attributes & (0x10 | 0x400):
+                kernel32.CloseHandle(handle)
+                raise OSError(errno.ELOOP, f"Unsafe control path: {candidate}")
+            try:
+                fd_flags = flags & (
+                    os.O_APPEND
+                    | os.O_WRONLY
+                    | os.O_RDWR
+                    | getattr(os, "O_TEXT", 0)
+                    | getattr(os, "O_BINARY", 0)
+                )
+                return msvcrt.open_osfhandle(handle, fd_flags)
+            except BaseException:
+                kernel32.CloseHandle(handle)
+                raise
+
+        fd = (
+            os.open(name, flags | nofollow, mode, dir_fd=parent_fd)
+            if parent_fd is not None
+            else os.open(candidate, flags | nofollow, mode)
+        )
+        info = os.fstat(fd)
+        if not stat.S_ISREG(info.st_mode):
+            os.close(fd)
+            raise OSError(errno.EPERM, f"Control path is not a regular file: {path}")
+        return fd
+
+
+def secure_atomic_write_text(
+    path: Union[str, Path],
+    content: str,
+    root: Union[str, Path],
+    *,
+    encoding: str = "utf-8",
+) -> None:
+    """Atomically write beneath a held no-follow parent directory."""
+    with secure_parent_directory(path, root, create=True) as (parent_fd, parent, name):
+        if parent_fd is None:
+            atomic_write_text(
+                parent / name, content, encoding=encoding, follow_symlinks=False
+            )
+            sync_directory(parent)
+            return
+        tmp_name = f".{name}.tmp-{os.getpid()}-{time.time_ns()}"
+        fd = os.open(
+            tmp_name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0),
+            0o600,
+            dir_fd=parent_fd,
+        )
+        try:
+            with os.fdopen(fd, "w", encoding=encoding) as handle:
+                fd = -1
+                handle.write(content)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp_name, name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+            os.fsync(parent_fd)
+        finally:
+            if fd >= 0:
+                os.close(fd)
+            try:
+                os.unlink(tmp_name, dir_fd=parent_fd)
+            except FileNotFoundError:
+                pass
+
+
+def secure_unlink(
+    path: Union[str, Path], root: Union[str, Path], *, missing_ok: bool = False
+) -> None:
+    """Unlink a child through a held no-follow parent directory."""
+    with secure_parent_directory(path, root) as (parent_fd, parent, name):
+        try:
+            if parent_fd is not None:
+                os.unlink(name, dir_fd=parent_fd)
+                os.fsync(parent_fd)
+            else:
+                os.unlink(parent / name)
+                sync_directory(parent)
+        except FileNotFoundError:
+            if not missing_ok:
+                raise
+
+
+def secure_replace(
+    source: Union[str, Path], target: Union[str, Path], root: Union[str, Path]
+) -> None:
+    """Replace one child with another while both parent namespaces stay pinned."""
+    source = Path(source)
+    target = Path(target)
+    with secure_parent_directory(source, root) as (src_fd, src_parent, src_name):
+        with secure_parent_directory(target, root, create=True) as (
+            dst_fd,
+            dst_parent,
+            dst_name,
+        ):
+            src_info = (
+                os.stat(src_name, dir_fd=src_fd, follow_symlinks=False)
+                if src_fd is not None
+                else os.lstat(src_parent / src_name)
+            )
+            src_attrs = getattr(src_info, "st_file_attributes", 0)
+            reparse = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+            if stat.S_ISLNK(src_info.st_mode) or src_attrs & reparse:
+                raise OSError(errno.ELOOP, f"Refusing reparse-point source: {source}")
+            try:
+                dst_info = (
+                    os.stat(dst_name, dir_fd=dst_fd, follow_symlinks=False)
+                    if dst_fd is not None
+                    else os.lstat(dst_parent / dst_name)
+                )
+            except FileNotFoundError:
+                dst_info = None
+            if dst_info is not None:
+                dst_attrs = getattr(dst_info, "st_file_attributes", 0)
+                if stat.S_ISLNK(dst_info.st_mode) or dst_attrs & reparse:
+                    raise OSError(
+                        errno.ELOOP, f"Refusing reparse-point target: {target}"
+                    )
+            if src_fd is not None and dst_fd is not None:
+                os.replace(
+                    src_name,
+                    dst_name,
+                    src_dir_fd=src_fd,
+                    dst_dir_fd=dst_fd,
+                )
+                os.fsync(src_fd)
+                if dst_fd != src_fd:
+                    os.fsync(dst_fd)
+            else:
+                os.replace(src_parent / src_name, dst_parent / dst_name)
+                sync_directory(src_parent)
+                if dst_parent != src_parent:
+                    sync_directory(dst_parent)
+
+
+def secure_rmtree(path: Union[str, Path], root: Union[str, Path]) -> None:
+    """Remove a directory tree without following a swapped parent or leaf."""
+    path = Path(path)
+    with secure_parent_directory(path, root) as (parent_fd, parent, name):
+        candidate = parent / name
+        info = (
+            os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+            if parent_fd is not None
+            else os.lstat(candidate)
+        )
+        attrs = getattr(info, "st_file_attributes", 0)
+        reparse = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+        if stat.S_ISLNK(info.st_mode) or attrs & reparse:
+            raise OSError(errno.ELOOP, f"Refusing symlinked directory tree: {path}")
+        if parent_fd is not None:
+            shutil.rmtree(name, dir_fd=parent_fd)
+            os.fsync(parent_fd)
+        elif os.name == "nt":
+            import ctypes
+            from ctypes import wintypes
+
+            kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+            kernel32.CreateFileW.argtypes = (
+                wintypes.LPCWSTR,
+                wintypes.DWORD,
+                wintypes.DWORD,
+                wintypes.LPVOID,
+                wintypes.DWORD,
+                wintypes.DWORD,
+                wintypes.HANDLE,
+            )
+            kernel32.CreateFileW.restype = wintypes.HANDLE
+            kernel32.GetFileInformationByHandleEx.argtypes = (
+                wintypes.HANDLE,
+                ctypes.c_int,
+                wintypes.LPVOID,
+                wintypes.DWORD,
+            )
+            kernel32.GetFileInformationByHandleEx.restype = wintypes.BOOL
+            kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+            kernel32.CloseHandle.restype = wintypes.BOOL
+            handle = kernel32.CreateFileW(
+                str(candidate),
+                0x00000080,
+                0x00000001 | 0x00000002,
+                None,
+                3,
+                0x02000000 | 0x00200000,
+                None,
+            )
+            invalid = wintypes.HANDLE(-1).value
+            if handle == invalid:
+                raise ctypes.WinError(ctypes.get_last_error())
+
+            class FileAttributeTagInfo(ctypes.Structure):
+                _fields_ = [
+                    ("file_attributes", wintypes.DWORD),
+                    ("reparse_tag", wintypes.DWORD),
+                ]
+
+            try:
+                opened = FileAttributeTagInfo()
+                if not kernel32.GetFileInformationByHandleEx(
+                    handle, 9, ctypes.byref(opened), ctypes.sizeof(opened)
+                ):
+                    raise ctypes.WinError(ctypes.get_last_error())
+                if not opened.file_attributes & 0x10 or opened.file_attributes & 0x400:
+                    raise OSError(errno.ELOOP, f"Unsafe directory tree: {path}")
+                try:
+                    shutil.rmtree(candidate)
+                except PermissionError:
+                    # ponytail: the pinned leaf blocks only the final rmdir;
+                    # split into a plain rmdir unless deeper cleanup failed.
+                    if next(candidate.iterdir(), None) is not None:
+                        raise
+            finally:
+                kernel32.CloseHandle(handle)
+            try:
+                os.rmdir(candidate)
+            except FileNotFoundError:
+                pass
+            sync_directory(parent)
+        else:
+            shutil.rmtree(candidate)
+            sync_directory(parent)
 
 
 def is_truthy_value(value: Any, default: bool = False) -> bool:
@@ -191,7 +645,12 @@ def _copy_fallback(tmp_str: str, real_path: str) -> None:
     os.unlink(tmp_str)
 
 
-def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
+def atomic_replace(
+    tmp_path: Union[str, Path],
+    target: Union[str, Path],
+    *,
+    follow_symlinks: bool = True,
+) -> str:
     """Atomically move *tmp_path* onto *target*, preserving symlinks.
 
     ``os.replace(tmp, target)`` atomically swaps ``tmp`` into place at
@@ -224,7 +683,11 @@ def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
     need to re-apply permissions can target it instead of the symlink.
     """
     target_str = str(target)
-    real_path = os.path.realpath(target_str) if os.path.islink(target_str) else target_str
+    real_path = (
+        os.path.realpath(target_str)
+        if follow_symlinks and os.path.islink(target_str)
+        else target_str
+    )
     tmp_str = str(tmp_path)
     try:
         os.replace(tmp_str, real_path)
@@ -284,6 +747,7 @@ def atomic_write_text(
     tmp_prefix: str = ".tmp_",
     preserve_mode: bool = False,
     create_mode: "int | None" = None,
+    follow_symlinks: bool = True,
 ) -> None:
     """Write *content* to *path* via temp file + fsync + atomic rename.
 
@@ -307,6 +771,9 @@ def atomic_write_text(
         create_mode: Permission bits to apply when the target does not yet
             exist (otherwise the new file keeps mkstemp's 0600).  Never
             applied to an existing file.
+        follow_symlinks: Preserve the historical managed-file behaviour when
+            True. Set False for security control files so a swapped target
+            symlink is replaced lexically rather than followed.
     """
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -330,7 +797,11 @@ def atomic_write_text(
             handle.write(content)
             handle.flush()
             os.fsync(handle.fileno())
-        real_path = atomic_replace(tmp_path, path)
+        real_path = (
+            atomic_replace(tmp_path, path)
+            if follow_symlinks
+            else atomic_replace(tmp_path, path, follow_symlinks=False)
+        )
         if preserve_mode:
             _restore_file_owner(Path(real_path), original_owner)
         if effective_mode is not None and not hasattr(os, "fchmod"):
@@ -558,6 +1029,18 @@ def atomic_roundtrip_yaml_update(
     key_path: str,
     value: Any,
 ) -> None:
+    """Update one dotted YAML key under the shared config transaction."""
+    from hermes_cli.config import config_write_lock
+
+    with config_write_lock():
+        _atomic_roundtrip_yaml_update_locked(path, key_path, value)
+
+
+def _atomic_roundtrip_yaml_update_locked(
+    path: Union[str, Path],
+    key_path: str,
+    value: Any,
+) -> None:
     """Update one dotted YAML key while preserving comments and readable text.
 
     This is intentionally narrower than :func:`atomic_yaml_write`: it is for
@@ -623,6 +1106,33 @@ def atomic_roundtrip_yaml_update(
 def atomic_roundtrip_yaml_save(
     path: Union[str, Path],
     new_state: dict,
+) -> dict:
+    """Comment-preserving config save under the shared config transaction."""
+    from hermes_cli.config import (
+        config_write_lock,
+        preserve_plugin_runtime_state,
+        require_readable_config_before_write,
+    )
+
+    path = Path(path)
+    with config_write_lock():
+        had_existing = path.exists()
+        current = require_readable_config_before_write(path)
+        state = copy.deepcopy(new_state)
+        if had_existing:
+            preserve_plugin_runtime_state(
+                current,
+                state,
+                preserve_plugin_lists=True,
+                preserve_platform_toolsets=True,
+            )
+        _atomic_roundtrip_yaml_save_locked(path, state)
+        return state
+
+
+def _atomic_roundtrip_yaml_save_locked(
+    path: Union[str, Path],
+    new_state: dict,
 ) -> None:
     """Persist a full config-state dict while preserving comments and ordering.
 
@@ -657,11 +1167,8 @@ def atomic_roundtrip_yaml_save(
     from ruamel.yaml.comments import CommentedMap
     from ruamel.yaml.scalarstring import DoubleQuotedScalarString
 
-    from hermes_cli.config import require_readable_config_before_write
-
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
-    require_readable_config_before_write(path)
 
     yaml_rt = YAML(typ="rt")
     yaml_rt.preserve_quotes = True
@@ -687,7 +1194,16 @@ def atomic_roundtrip_yaml_save(
     # yaml.safe_load. Force-quote any new string value that YAML 1.1 would
     # otherwise misparse as bool/null.
     _YAML11_AMBIGUOUS_WORDS = {
-        "y", "n", "yes", "no", "true", "false", "on", "off", "null", "~",
+        "y",
+        "n",
+        "yes",
+        "no",
+        "true",
+        "false",
+        "on",
+        "off",
+        "null",
+        "~",
     }
 
     def _quote_if_yaml11_ambiguous(value):
@@ -816,8 +1332,12 @@ def env_bool(key: str, default: bool = False) -> bool:
 
 
 _PROXY_ENV_KEYS = (
-    "HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
-    "https_proxy", "http_proxy", "all_proxy",
+    "HTTPS_PROXY",
+    "HTTP_PROXY",
+    "ALL_PROXY",
+    "https_proxy",
+    "http_proxy",
+    "all_proxy",
 )
 
 
@@ -832,7 +1352,7 @@ def normalize_proxy_url(proxy_url: str | None) -> str | None:
     if not candidate:
         return None
     if candidate.lower().startswith("socks://"):
-        return f"socks5://{candidate[len('socks://'):]}"
+        return f"socks5://{candidate[len('socks://') :]}"
     return candidate
 
 

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -352,6 +352,22 @@ hermes plugins disable my-plugin             # remove from allow-list + add to d
 hermes plugins capabilities [my-plugin]      # declared vs granted capabilities
 ```
 
+### Git marketplaces (Desktop)
+
+The official Hermes catalogue remains available in **Capabilities → Plugins**.
+To add a private or team catalogue, choose **Add marketplace**, paste an HTTPS
+Git repository URL, and confirm. The selected agent host uses its existing Git
+credential helper, so private repositories work without sending credentials to
+the Desktop renderer.
+
+A repository must contain `.claude-plugin/marketplace.json`. This first version
+supports repository-local string sources such as `"source": "./plugins/demo"`.
+Each installable package must also contain a root Hermes `plugin.json`,
+`plugin.yaml`, or `plugin.yml`; Claude-only packages remain visible but disabled
+with an explanation. Installs and updates are resolved by the backend, pinned to
+an exact repository commit, and compare the plugin subtree rather than unrelated
+marketplace commits. Updates are manual through the displayed **Update** button.
+
 ### One-click install links (Desktop)
 
 Hermes Desktop registers the `hermes://` URL scheme, so a website, README, or


### PR DESCRIPTION
## Summary

Extends #69446 with profile-scoped Git marketplaces for private and team plugin repositories.

- Add a marketplace from a GitHub URL using Claude's `.claude-plugin/marketplace.json` format
- Keep the official Hermes catalogue alongside saved marketplaces
- Browse Official and private marketplaces as tabs using friendly display names
- Install and update compatible Hermes plugins from the selected profile/backend
- Preserve exact repository and subtree provenance without exposing clone coordinates to the renderer
- Fail closed on stale sources, malformed state, traversal, symlinks/reparse points and cross-source replacement

This PR is intentionally based on `feat/plugin-catalog` so the original #69446 commits and authorship remain intact.

## User flow

1. Open **Capabilities → Plugins**
2. Select **Add marketplace**
3. Paste a Git repository URL
4. Switch between **Official** and marketplace tabs
5. Install or update a compatible plugin

Marketplace slugs are rendered as friendly names, for example `automation-lab` → `Automation Lab`.

## Verification

- 487 focused Python tests passed, with 16 platform-specific skips on macOS
- 86 focused Desktop tests passed
- Desktop TypeScript typecheck passed
- Ruff, Prettier and `git diff --check` passed
- Production Desktop build and isolated packaged-app visual QA passed
- Independent fail-closed review passed for exact staged diff SHA-256 `c9499411aa96578b68e5a27f703ee3ce5a2fbd1dda3eb56a85a8905a18e8c649`

## Notes

- Private Git authentication stays on the selected profile host and uses its existing Git credentials.
- The renderer receives bounded display metadata only.
- Repositories whose entries do not yet contain a root Hermes `plugin.json` or `plugin.yaml` remain visible but are marked incompatible.

Depends on #69446.