### PR TITLE
fix(agent): persist the wire bytes any reload rewrite would drop

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2513,23 +2513,33 @@ class AIAgent:
                 # Store the sidecar only when it actually differs.
                 if _row_api_content == content:
                     _row_api_content = None
-                # Load-time sanitize divergence: get_messages_as_conversation
+                # Load-time reload divergence: get_messages_as_conversation
                 # replays user/assistant rows through
-                # ``sanitize_context(content).strip()``, so content that
-                # sanitize would rewrite (echoed/pasted <memory-context>
-                # fences or system notes) replays different bytes after a
-                # session reload even though THIS turn sent it verbatim.
+                # ``sanitize_context(content).strip()``, so content the
+                # reload would rewrite — echoed/pasted <memory-context>
+                # fences and system notes (sanitize), or plain surrounding
+                # whitespace (strip) — replays different bytes after a
+                # session rebuild even though THIS turn sent it verbatim.
                 # Capture the sent bytes in the sidecar so a reloaded session
-                # replays what was actually on the wire. Compared in wire form
-                # (both sides .strip()-ed — the api_messages build strips
-                # every outgoing content string) so plain surrounding
-                # whitespace doesn't grow redundant sidecars.
+                # replays what was actually on the wire.
+                #
+                # Compared against ``content`` UNSTRIPPED (#100795): nothing
+                # on the outgoing path strips message content. The wire copy
+                # is a structural clone of this dict and the transports only
+                # drop non-provider keys, so a user turn carrying a trailing
+                # newline goes out with it while its rebuilt-from-state.db
+                # replay does not — the state-rebuild payload divergence that
+                # breaks a provider's exact-prefix cache at that message for
+                # one shot after any agent teardown/eviction. Comparing both
+                # sides ``.strip()``-ed (the previous shape) assumed a
+                # wire-side strip that does not exist and let that whole
+                # class through.
                 if (
                     _row_api_content is None
                     and role in ("user", "assistant")
                     and isinstance(content, str)
                     and content
-                    and sanitize_context(content).strip() != content.strip()
+                    and sanitize_context(content).strip() != content
                 ):
                     _row_api_content = content
                 # Persist multimodal tool results as their text summary only —

--- a/tests/run_agent/test_state_rebuild_payload_parity.py
+++ b/tests/run_agent/test_state_rebuild_payload_parity.py
@@ -1,0 +1,147 @@
+"""State-rebuild payload parity — issue #100795.
+
+A session that has been serving turns from its LIVE in-memory transcript can
+lose that transcript at any teardown boundary (gateway LRU / memory-pressure
+eviction, background-review lifecycle, process restart). The next user turn is
+then rebuilt from ``state.db`` and must produce the SAME request bytes the
+provider's prompt cache was built from — otherwise the rebuilt request diverges
+at the first rewritten message and the exact-prefix cache misses for one shot.
+
+``get_messages_as_conversation`` replays user/assistant rows through
+``sanitize_context(content).strip()``. Nothing on the outgoing path strips
+message content, so any content carrying surrounding whitespace used to replay
+SHORTER than it was sent. ``_flush_messages_to_session_db`` is the chokepoint
+that captures the exact sent bytes in the ``api_content`` sidecar; these tests
+pin that it covers the whole reload-divergence set, and that clean content
+still grows no redundant sidecar.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+
+
+@pytest.fixture()
+def agent():
+    """Minimal AIAgent with mocked OpenAI client and tool loading."""
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    a.client = MagicMock()
+    return a
+
+
+@pytest.fixture()
+def persisted_agent(agent, tmp_path):
+    """``agent`` bound to a real on-disk SessionDB with an open session row."""
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "sess-100795"
+    db.create_session(session_id, "cli", model="test-model")
+    agent._session_db = db
+    agent._session_db_created = True
+    agent.session_id = session_id
+    agent._persist_disabled = False
+    try:
+        yield agent, db, session_id
+    finally:
+        db.close()
+
+
+def _rebuilt_wire_content(row):
+    """The content the api_messages build would send for a restored row.
+
+    Historical user/assistant rows get their ``api_content`` sidecar
+    substituted into ``content`` (see ``substitute_api_content``); rows
+    without a sidecar are sent as stored.
+    """
+    sidecar = row.get("api_content")
+    return sidecar if isinstance(sidecar, str) and sidecar else row.get("content")
+
+
+@pytest.mark.parametrize(
+    "live_content",
+    [
+        "Summarize the log below:\n",
+        "  and now the diff",
+        "trailing spaces   ",
+        "\n\nleading and trailing\n",
+    ],
+    ids=["trailing-newline", "leading-spaces", "trailing-spaces", "both"],
+)
+def test_rebuilt_user_turn_replays_the_bytes_that_were_sent(
+    persisted_agent, live_content
+):
+    """Whitespace-carrying user content survives the persist/rebuild round-trip.
+
+    Without the sidecar capture the rebuilt request sends ``content.strip()``
+    while the cache was warmed with ``content`` — a mid-history prefix break
+    on the first shot after any agent teardown.
+    """
+    agent, db, session_id = persisted_agent
+    live = [{"role": "user", "content": live_content}]
+
+    agent._flush_messages_to_session_db([dict(m) for m in live], [])
+
+    rebuilt = db.get_messages_as_conversation(session_id)
+    assert len(rebuilt) == 1
+    assert _rebuilt_wire_content(rebuilt[0]) == live_content
+
+
+def test_rebuilt_assistant_turn_replays_the_bytes_that_were_sent(persisted_agent):
+    """Assistant rows take the same reload strip, so they need the same cover.
+
+    ``build_assistant_message`` strips the mainline assistant turn, but the
+    recovery/continuation paths append ``final_response`` / partial text
+    verbatim, so unstripped assistant content does reach the transcript.
+    """
+    agent, db, session_id = persisted_agent
+    live_content = "Here is the patch:\n\n"
+    live = [
+        {"role": "user", "content": "patch it"},
+        {"role": "assistant", "content": live_content},
+    ]
+
+    agent._flush_messages_to_session_db([dict(m) for m in live], [])
+
+    rebuilt = db.get_messages_as_conversation(session_id)
+    assert _rebuilt_wire_content(rebuilt[1]) == live_content
+
+
+def test_clean_content_grows_no_sidecar(persisted_agent):
+    """Content the reload would not rewrite must not duplicate itself on disk."""
+    agent, db, session_id = persisted_agent
+    live = [
+        {"role": "user", "content": "no surrounding whitespace"},
+        {"role": "assistant", "content": "none here either"},
+    ]
+
+    agent._flush_messages_to_session_db([dict(m) for m in live], [])
+
+    rebuilt = db.get_messages_as_conversation(session_id)
+    assert [r.get("api_content") for r in rebuilt] == [None, None]
+    assert [r["content"] for r in rebuilt] == [m["content"] for m in live]
+
+
+def test_injection_sidecar_is_not_overwritten(persisted_agent):
+    """A prologue-stamped sidecar keeps priority over the reload capture."""
+    agent, db, session_id = persisted_agent
+    injected = "ask\n\n<memory-context>recalled</memory-context>"
+    live = [{"role": "user", "content": "ask\n", "api_content": injected}]
+
+    agent._flush_messages_to_session_db([dict(m) for m in live], [])
+
+    rebuilt = db.get_messages_as_conversation(session_id)
+    assert rebuilt[0]["api_content"] == injected


### PR DESCRIPTION
## What does this PR do?

Makes the request rebuilt from `state.db` byte-identical to the request the provider's prompt cache was built from, closing the whitespace half of the state-rebuild divergence class.

A session that has been serving turns from its **live in-memory transcript** loses that transcript at any teardown boundary — gateway LRU / memory-pressure eviction, a background-review lifecycle event, a process restart. The next user turn is rebuilt from persisted state, and today that rebuild does not reproduce what was sent.

`get_messages_as_conversation` replays every `user`/`assistant` row through `sanitize_context(content).strip()`. Nothing on the outgoing path strips message content: `_clone_message_for_send` is a structural clone and the transports only drop non-provider keys. So a user turn carrying a trailing newline **goes out with it**, and its rebuilt replay **goes out without it** — the request diverges at that message, the exact-prefix cache misses from there on for one shot, then recovers once the rebuilt form is itself cached. That is exactly the reported "one shot at 0–85%, next shot back to 97–100%" signature.

`_flush_messages_to_session_db` already owns the fix for this class: it stamps the exact sent bytes into the `api_content` sidecar so a reloaded session replays what was actually on the wire. Its predicate compared **both sides `.strip()`-ed**, on the stated premise that *"the api_messages build strips every outgoing content string"*. That premise is false — there is no content strip anywhere on the send path — and stripping the right-hand side excluded the whole whitespace class from the capture.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A["🩸 Live turn N — content ends with a newline"] -->|"structural clone, no strip"| B["🔥 Wire bytes: newline included"]
    A -->|"flush to state.db"| C{"⚔️ Would the reload rewrite this?<br/>sanitize+strip vs stored content"}
    C -->|"BEFORE: strip vs strip — whitespace invisible"| D["☠️ api_content = NULL"]
    C -->|"AFTER: compared against verbatim content"| E["🛡️ api_content = exact sent bytes"]
    D --> F["💀 Rebuilt replay drops the newline<br/>prefix breaks at this message"]
    E --> G["✅ Rebuilt replay is byte-identical<br/>prefix intact"]
    B -.->|"agent close / cache eviction"| H["🕯️ Turn N+1 rebuilt from state.db"]
    H --> F
    H --> G
```

## Related Issue

Fixes #100795

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `run_agent.py` — in `_flush_messages_to_session_db_unlocked`, compare the reload form `sanitize_context(content).strip()` against the **verbatim** live `content` instead of `content.strip()`, so any content the reload would rewrite (sanitize *or* strip) gets its sent bytes captured in the `api_content` sidecar. The comment is rewritten to record why the old premise was wrong.
- `tests/run_agent/test_state_rebuild_payload_parity.py` — new focused suite: real `AIAgent` + real on-disk `SessionDB`, flush then `get_messages_as_conversation`, asserting the rebuilt wire projection is byte-identical to the live one for user and assistant rows; plus two negative pins (clean content grows **no** sidecar; a prologue-stamped injection sidecar is not overwritten).

## Scope — what this does and does not claim

The issue grades three causes. This PR fixes **cause 2, message-level divergence**, at the chokepoint that already exists for it. Deliberately out of scope:

- **Cause 1 (system prompt NULL, rebuilt from scratch, 0%)** belongs to the open #96570 restore path, not here.
- **Cause 3 (semantic loss on large tool results)** is the *designed* multimodal persistence trade-off in the same flush loop: a multimodal tool result is stored as its text summary (`[screenshot]`) because base64 in `state.db` was rejected on purpose. Restoring byte-parity there means persisting the payload, which is a separate design decision.
- The reporter's build `261a4efb90` (2026-08-22) does **not** contain `fcd5bbb3f` — the already-merged fix that removed `review_agent.close()` from the background-review teardown. Their logged `client closed (agent_close, shared=True)` and `mem_trim: reason=agent close` come from that `close()`, which ran with the fork's **pinned parent `session_id`** as `task_id` and therefore also reached the parent's process registry, terminal sandbox, browser daemon and computer-use session. On current `main` the review lifecycle is only the *trigger* for the live-to-rebuilt flip; the divergence itself is generic to every teardown boundary, which is why the fix belongs at the persistence chokepoint rather than in the review fork.
- No overlap with #100802, which isolates the review fork's transcript snapshot from the parent's nested structures — a different layer (aliasing at the spawn sites) that this predicate change neither touches nor duplicates.

## Cost

Rows whose content carries surrounding whitespace now store the original string in `api_content` alongside the cleaned `content`. That is the standing price of the "persist what you send" invariant, and it is bounded to exactly the rows that would otherwise replay wrong.

## How to Test

1. Reproduce the divergence on `main` (real flush + real reload, no mocks):

   ```bash
   python -m pytest tests/run_agent/test_state_rebuild_payload_parity.py -q
   ```

   On `main` before this change: `5 failed, 2 passed` — every whitespace-carrying user/assistant row replays shorter than it was sent.
   With this change: `7 passed`.

2. Focused suites:

   ```bash
   python -m pytest tests/run_agent/test_state_rebuild_payload_parity.py tests/run_agent/test_background_review.py tests/agent/test_system_prompt_restore.py -q
   ```

   Result: `37 passed`.

3. Regression baseline for the file this touches (`tests/run_agent/test_run_agent.py`, Windows / py3.14 local): `30 failed, 251 passed` **before** the change and the **same 30** failures after — all pre-existing local noise, zero new failures. Running the api_content-adjacent set together (`test_run_agent.py`, `test_steer.py`, `test_message_sequence_repair.py`, `test_sanitiser_escalation.py`, `test_session_meta_filtering.py`): `30 failed, 368 passed` — the same 30.

4. Static validation:

   ```bash
   ruff check run_agent.py tests/run_agent/test_state_rebuild_payload_parity.py
   git diff --check
   ```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate (#100802 sits on a different layer — see Scope)
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows (baseline-compared)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings/comments) — the flush-site comment now records the corrected invariant
- [x] I've updated cli-config.yaml.example if I added/changed config keys — N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure string comparison)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before (real `_flush_messages_to_session_db` into real `get_messages_as_conversation`):

```
[0] role=user      byte_identical=False sidecar=no
    live wire    : 'Summarize the log below:\n'
    rebuilt wire : 'Summarize the log below:'
[1] role=assistant byte_identical=True  sidecar=no
[2] role=user      byte_identical=False sidecar=no
    live wire    : '  and now the diff'
    rebuilt wire : 'and now the diff'

diverging messages: 2/3
```

After:

```
[0] role=user      byte_identical=True sidecar=yes
[1] role=assistant byte_identical=True sidecar=no
[2] role=user      byte_identical=True sidecar=yes

diverging messages: 0/3
```

 