### PR TITLE
fix(plugins): let packaged Photon installs complete sidecar setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -596,8 +596,10 @@ hermes_cli = ["observability/schemas/*.json", "data/*.json", "local_runtime/*.js
 gateway = ["assets/**/*"]
 # Bundled plugin discovery reads these manifests at runtime. Keep them in
 # sealed wheels with the plugin Python modules; without this declaration the
-# wheel contains adapters but discovery finds zero bundled plugins.
-plugins = ["**/plugin.yaml", "**/plugin.yml"]
+# wheel contains adapters but discovery finds zero bundled plugins. Photon
+# additionally runs a Node sidecar whose package metadata and modules must
+# remain beside the Python adapter in packaged installs.
+plugins = ["**/plugin.yaml", "**/plugin.yml", "platforms/photon/sidecar/*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_packaging_build_guard.py
+++ b/tests/test_packaging_build_guard.py
@@ -74,12 +74,21 @@ def test_artifact_build_allows_explicit_nix_package_build_marker(kind, artifact_
     artifacts = list(tmp_path.glob(artifact_glob))
     assert artifacts
 
-    expected = {
+    expected_manifests = {
         path.relative_to(PROJECT_ROOT).as_posix()
         for pattern in ("plugin.yaml", "plugin.yml")
         for path in (PROJECT_ROOT / "plugins").rglob(pattern)
     }
-    assert expected, "expected bundled plugin manifests under plugins/"
+    assert expected_manifests, "expected bundled plugin manifests under plugins/"
+
+    photon_sidecar = PROJECT_ROOT / "plugins" / "platforms" / "photon" / "sidecar"
+    expected_sidecar = {
+        path.relative_to(PROJECT_ROOT).as_posix()
+        for path in photon_sidecar.iterdir()
+        if path.is_file() and not path.name.startswith(".")
+    }
+    assert expected_sidecar, "expected Photon sidecar runtime files"
+    expected = expected_manifests | expected_sidecar
 
     if kind == "wheel":
         with zipfile.ZipFile(artifacts[0]) as wheel:
@@ -93,4 +102,4 @@ def test_artifact_build_allows_explicit_nix_package_build_marker(kind, artifact_
             }
 
     missing = sorted(expected - shipped)
-    assert not missing, f"{kind} omits bundled plugin manifests: {missing}"
+    assert not missing, f"{kind} omits bundled plugin runtime files: {missing}"


### PR DESCRIPTION
## What does this PR do?

Packaged Hermes builds now include every runtime file required by the Photon Node sidecar. Without these files, `hermes photon setup` reaches `npm ci` but fails because the packaged sidecar has no `package.json` or entry modules. The separate deferred Photon CLI registration defect reported in the issue is already fixed on current `main`; this change closes the remaining packaged-asset failure.

### Symptom

A built Hermes wheel contains the Photon Python adapter and plugin manifest but omits the non-Python files under `plugins/platforms/photon/sidecar/`. Photon sidecar installation then fails when npm cannot read `package.json`.

### Impact

Photon cannot complete sidecar installation from a packaged Hermes build, so the iMessage platform cannot start from that installation.

### Bug Cause

**Trigger:** `pyproject.toml` / `[tool.setuptools.package-data]`

**Causal chain:**
1. The supported Nix packaging path builds a wheel through setuptools.
2. The `plugins` package-data declaration includes plugin manifests but no Photon sidecar files.
3. Setuptools excludes the sidecar package metadata and JavaScript modules, and the later `npm ci` step fails.

**Why it is wrong:** The Photon Python adapter resolves and executes a colocated Node sidecar at runtime, so those non-Python files are runtime dependencies rather than source-only development files.

**Working sibling / contrast:** Plugin manifests are already explicitly included as package data and therefore survive the same wheel build.

**Ruled out:** The files are not missing from the repository; `git ls-files plugins/platforms/photon/sidecar/**` confirms they are tracked. The omission occurs during setuptools package-data selection.

### Fix

Extend the `plugins` package-data declaration to include the Photon sidecar directory. Strengthen the real wheel/sdist build regression test so every non-hidden sidecar runtime file must appear in each allowed artifact.

## Related Issue

Closes #100824

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `pyproject.toml` - include Photon sidecar runtime files in packaged builds.
- `tests/test_packaging_build_guard.py` - verify real wheel and sdist artifacts contain every Photon sidecar runtime file.

## How to Test

1. Run `C:/workspace/hermes-agent/.venv/Scripts/python.exe -m hermes_cli.main photon --help` and confirm the Photon subcommands are listed.
2. Run the artifact build regression and confirm the generated wheel and sdist contain all sidecar files.
3. Run the deferred platform CLI registration regression.

```bash
scripts/run_tests.sh tests/test_packaging_build_guard.py -q
scripts/run_tests.sh tests/hermes_cli/test_startup_plugin_gating.py -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant tests and all 8 tests pass
- [x] I've added artifact-level regression coverage for the fix
- [x] I've tested on Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A - no user-facing workflow changed
- [x] `cli-config.yaml.example` update: N/A - no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered - package-data selection is platform-independent and both artifact kinds are tested
- [x] Tool descriptions/schemas update: N/A - no tool behavior changed

## Screenshots / Logs

N/A - the regression is verified by real artifact inspection in the test suite.
