### PR TITLE
fix(agent): preserve active prompt through compaction

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -310,6 +310,17 @@ def _should_skip_model_call_for_reference_handoff(
     return True
 
 
+def _reanchor_active_user_after_compaction(
+    agent: Any,
+    messages: List[Dict[str, Any]],
+    user_message: Any,
+) -> int:
+    """Point live composition and persistence at the post-compaction ask."""
+    current_turn_user_idx = reanchor_current_turn_user_idx(messages, user_message)
+    agent._persist_user_message_idx = current_turn_user_idx
+    return current_turn_user_idx
+
+
 # Fallback final_response for a turn ended by the sole-handoff skip (#80622).
 # Deliberately NOT a replay of the last assistant text: finalize_turn's
 # non-assistant-tail chokepoint (#43849) appends final_response as a fresh
@@ -3094,6 +3105,9 @@ def run_conversation(
                         final_response = _HANDOFF_SKIP_FINAL_RESPONSE
                     _turn_exit_reason = "compaction_handoff_not_actionable"
                     break
+                current_turn_user_idx = _reanchor_active_user_after_compaction(
+                    agent, messages, user_message
+                )
                 continue
         elif (
             agent.compression_enabled
@@ -7113,10 +7127,9 @@ def run_conversation(
             # Ordered AFTER the handoff guard: the guard may have re-appended
             # this turn's real user ask (restore path), and the anchor must
             # land on that restored row, not on -1 / a pre-restore index.
-            current_turn_user_idx = reanchor_current_turn_user_idx(
-                messages, user_message
+            current_turn_user_idx = _reanchor_active_user_after_compaction(
+                agent, messages, user_message
             )
-            agent._persist_user_message_idx = current_turn_user_idx
             continue
 
         if _retry.restart_with_rebuilt_messages:
@@ -8049,6 +8062,9 @@ def run_conversation(
                                 final_response = _HANDOFF_SKIP_FINAL_RESPONSE
                             _turn_exit_reason = "compaction_handoff_not_actionable"
                             break
+                        current_turn_user_idx = _reanchor_active_user_after_compaction(
+                            agent, messages, user_message
+                        )
                 elif agent.compression_enabled:
                     # Over threshold but compression is blocked (summary-LLM
                     # cooldown or anti-thrashing). Surface a deduped warning so

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -246,10 +246,30 @@ def _restore_user_after_reference_handoff(
 ) -> bool:
     """Re-append this turn's real user ask when compaction left only a handoff.
 
-    Returns True when a restore append happened. The caller has already
-    established that a reference-only handoff would drive the next model
-    call (#80622); this helper only decides whether a restorable ask exists.
+    Returns True when a restore append happened. A completed turn and a live
+    tool exchange need the same invariant: the latest compaction handoff must
+    have a real user turn after it before another model call (#80622, #100818).
     """
+    from agent.context_compressor import (
+        is_compaction_summary_message,
+        user_originated_turn_view,
+    )
+
+    last_handoff_idx = next(
+        (
+            index
+            for index in range(len(messages) - 1, -1, -1)
+            if is_compaction_summary_message(messages[index])
+        ),
+        -1,
+    )
+    if last_handoff_idx < 0:
+        return False
+    if any(
+        user_originated_turn_view(message) is not None
+        for message in messages[last_handoff_idx:]
+    ):
+        return False
     if user_message is None:
         return False
     if isinstance(user_message, str):
@@ -279,11 +299,13 @@ def _should_skip_model_call_for_reference_handoff(
     """Guard post-compaction continues against sole-handoff active turns (#80622)."""
     from agent.context_compressor import reference_handoff_would_drive_next_model_call
 
-    if not reference_handoff_would_drive_next_model_call(messages):
-        return False
     if _restore_user_after_reference_handoff(messages, user_message):
-        # The restored ask is an actionable non-synthetic user row appended
-        # after the handoff — by construction the handoff no longer drives.
+        # Compression can leave an in-flight tool exchange after the handoff.
+        # Tool rows keep the loop live, but they do not replace the active user
+        # ask. Restore it before deciding whether the synthetic handoff would
+        # otherwise drive the next model call (#100818).
+        return False
+    if not reference_handoff_would_drive_next_model_call(messages):
         return False
     return True
 

--- a/tests/agent/test_reference_handoff_active_turn.py
+++ b/tests/agent/test_reference_handoff_active_turn.py
@@ -10,6 +10,8 @@ the already-completed work.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from agent.context_compressor import (
@@ -31,6 +33,7 @@ from agent.context_compressor import (
     user_originated_turn_view,
 )
 from agent.conversation_loop import (
+    _reanchor_active_user_after_compaction,
     _should_skip_model_call_for_reference_handoff,
 )
 from agent.agent_runtime_helpers import repair_message_sequence
@@ -271,6 +274,25 @@ class TestSkipGuardRestoresRealUser:
             for message in messages
             if user_originated_turn_view(message) is not None
         ] == [{"role": "user", "content": "current ask"}]
+
+
+class TestPostCompactionActiveUserAnchor:
+    def test_restored_prompt_becomes_composition_and_persistence_anchor(self):
+        messages = [_standalone_handoff()]
+        agent = SimpleNamespace(_persist_user_message_idx=17)
+
+        assert _should_skip_model_call_for_reference_handoff(
+            messages, "prepare the scheduled briefing"
+        ) is False
+        current_turn_user_idx = _reanchor_active_user_after_compaction(
+            agent, messages, "prepare the scheduled briefing"
+        )
+
+        assert current_turn_user_idx == len(messages) - 1
+        assert messages[current_turn_user_idx]["content"] == (
+            "prepare the scheduled briefing"
+        )
+        assert agent._persist_user_message_idx == current_turn_user_idx
 
 
 class TestUserOriginatedTurnPredicate:

--- a/tests/agent/test_reference_handoff_active_turn.py
+++ b/tests/agent/test_reference_handoff_active_turn.py
@@ -233,6 +233,45 @@ class TestSkipGuardRestoresRealUser:
         ]
         assert _should_skip_model_call_for_reference_handoff(messages, None) is True
 
+    def test_restores_pending_cron_prompt_during_mid_tool_loop(self):
+        """A tool result keeps the loop live but does not replace its user ask."""
+        messages = [
+            _standalone_handoff("prepare the scheduled briefing"),
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"id": "c1", "function": {"name": "web_search"}}],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": "results"},
+        ]
+
+        assert _should_skip_model_call_for_reference_handoff(
+            messages, "prepare the scheduled briefing"
+        ) is False
+        assert messages[-1]["role"] == "user"
+        assert messages[-1]["content"] == "prepare the scheduled briefing"
+
+    def test_mid_tool_loop_keeps_existing_user_after_handoff(self):
+        messages = [
+            _standalone_handoff(),
+            {"role": "user", "content": "current ask"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"id": "c1", "function": {"name": "terminal"}}],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": "ok"},
+        ]
+
+        assert _should_skip_model_call_for_reference_handoff(
+            messages, "current ask"
+        ) is False
+        assert [
+            message
+            for message in messages
+            if user_originated_turn_view(message) is not None
+        ] == [{"role": "user", "content": "current ask"}]
+
 
 class TestUserOriginatedTurnPredicate:
     def test_standalone_handoff_not_user_originated_even_with_has_user_turn(self):


### PR DESCRIPTION
## Summary

- restore the active user prompt when compaction leaves only a reference handoff followed by an in-flight tool exchange
- avoid duplicating the prompt when a real user turn already survives after the handoff
- add regression coverage for scheduled mid-tool runs

## Testing

- `scripts/run_tests.sh tests/agent/test_reference_handoff_active_turn.py -q`
- `scripts/run_tests.sh tests/run_agent/test_post_tool_compression_attempt_cap.py tests/agent/test_compressed_summary_metadata.py tests/cron/test_scheduler.py -q`

## Related Issue

Closes #100818
