### PR TITLE
fix: prevent disabled_toolsets from stripping kanban worker lifecycle tools

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -363,6 +363,7 @@ def _compute_tool_definitions(
     """Uncached implementation of :func:`get_tool_definitions`."""
     # Determine which tool names the caller wants
     tools_to_include: set = set()
+    _kanban_force_injected = False
 
     if enabled_toolsets is not None:
         effective_enabled_toolsets = list(enabled_toolsets)
@@ -373,6 +374,7 @@ def _compute_tool_definitions(
             # (for token/cost reasons), but that should not strip the kanban
             # worker's completion/block/heartbeat surface.
             effective_enabled_toolsets.append("kanban")
+            _kanban_force_injected = True
         for toolset_name in effective_enabled_toolsets:
             if validate_toolset(toolset_name):
                 resolved = resolve_toolset(toolset_name)
@@ -398,6 +400,10 @@ def _compute_tool_definitions(
     # stripped out. See issue #17309.
     if disabled_toolsets:
         for toolset_name in disabled_toolsets:
+            # When kanban was force-injected for a dispatcher-spawned worker,
+            # don't let the profile's disabled_toolsets strip it back out (#98808)
+            if toolset_name == "kanban" and _kanban_force_injected:
+                continue
             if validate_toolset(toolset_name):
                 from toolsets import bundle_non_core_tools, get_toolset
                 if toolset_name.startswith("hermes-") or (get_toolset(toolset_name) or {}).get("posture"):


### PR DESCRIPTION
## What changed and why

Fixes #98808.

Dispatcher-spawned Kanban workers must always receive `kanban_complete`, `kanban_block`, and `kanban_heartbeat`. The code force-injects "kanban" into enabled_toolsets when HERMES_KANBAN_TASK is set — but then the subtraction pass at the end iterates the profile's **original** disabled_toolsets and strips those same tools back out. A worker profile that disables "kanban" in its own config (a documented pattern) silently loses the lifecycle handoff surface.

## Changes

- **model_tools.py**: Track whether kanban was force-injected via `_kanban_force_injected`. In the disabled_toolsets subtraction loop, skip "kanban" when it was force-injected so the worker always keeps its completion/block/heartbeat tools.

## How to test

1. Create a worker profile with agent.disabled_toolsets: ["kanban"] in its config.yaml
2. Dispatch a kanban task to that profile
3. Verify the worker retains kanban_complete, kanban_block, kanban_heartbeat

## Platforms tested

- [x] Windows (native)
- [ ] macOS (needs manual verification)
- [ ] Linux (needs manual verification)

## Related

Closes #98808
