### PR TITLE
fix(tools): propagate caller contextvars in DaemonThreadPoolExecutor.submit

### DIFF
--- a/tests/agent/test_secret_scope.py
+++ b/tests/agent/test_secret_scope.py
@@ -347,3 +347,34 @@ class TestRelayRoutingStampGlobals:
             ss.set_multiplex_active(False)
         for name in self.AUTH_VARS:
             assert not ss._is_global_env(name), name
+
+
+class TestSecretScopeAcrossExecutorThreads:
+    """Multiplexed profile state must reach pool workers (see #95119).
+
+    The context-compression timeout fence runs auxiliary LLM calls in a
+    daemon thread pool.  Bundled CPython runtime builds omit
+    ``ThreadPoolExecutor``'s context propagation, so the profile secret
+    scope was absent in the worker and ``get_secret`` failed closed with
+    ``UnscopedSecretError``, silently degrading compression to lossy
+    deterministic summaries.  ``DaemonThreadPoolExecutor.submit`` restores
+    stdlib context semantics; these tests lock that in.
+    """
+
+    def test_scoped_read_works_in_daemon_pool_worker(self, monkeypatch):
+        from tools.daemon_pool import DaemonThreadPoolExecutor
+
+        monkeypatch.setenv("SURPLUS_API_KEY", "env-key")
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({"SURPLUS_API_KEY": "scope-key"})
+        pool = DaemonThreadPoolExecutor(max_workers=1)
+        try:
+            # The scope (authoritative under multiplex) must reach the worker.
+            seen = pool.submit(ss.get_secret, "SURPLUS_API_KEY").result(timeout=10)
+            assert seen == "scope-key"
+            # A scoped miss must still not borrow the (cross-profile) env value.
+            monkeypatch.setenv("OPENAI_API_KEY", "env-leak")
+            assert pool.submit(ss.get_secret, "OPENAI_API_KEY").result(timeout=10) is None
+        finally:
+            pool.shutdown(wait=True)
+            ss.reset_secret_scope(token)

--- a/tests/tools/test_daemon_pool.py
+++ b/tests/tools/test_daemon_pool.py
@@ -69,6 +69,30 @@ def test_wedged_worker_does_not_block_interpreter_exit():
     assert "main-done" in proc.stdout
 
 
+def test_submit_propagates_caller_contextvars():
+    """Pool workers inherit contextvars set in the submitting context.
+
+    Stdlib ThreadPoolExecutor snapshots the caller's context with
+    ``copy_context()``; some bundled CPython runtime builds strip that, so
+    the daemon pool restores it explicitly.  Without the fix this returns
+    the default because the worker runs in a bare context.
+    """
+    from contextvars import ContextVar
+
+    var = ContextVar("daemon_pool_test_var", default="unset")
+
+    pool = DaemonThreadPoolExecutor(max_workers=1)
+    try:
+        token = var.set("hello")
+        try:
+            seen = pool.submit(var.get).result(timeout=10)
+        finally:
+            var.reset(token)
+        assert seen == "hello"
+    finally:
+        pool.shutdown(wait=True)
+
+
 def _repo_root():
     import pathlib
 

--- a/tools/daemon_pool.py
+++ b/tools/daemon_pool.py
@@ -16,7 +16,15 @@ exit hook insists on joining.
   - the interpreter's non-daemon thread join at shutdown skips them.
 
 Semantics are otherwise identical (initializer/initargs, work queue,
-idle-thread reuse).  Use it for any pool whose work is best-effort or
+idle-thread reuse) and, since #95119, so is context propagation:
+``submit`` snapshots the submitting context with ``copy_context()`` and
+runs each work item inside it, matching stdlib ``ThreadPoolExecutor``.
+That matters because some bundled CPython runtime builds omit stdlib's
+context propagation entirely, which silently drops contextvar-based state
+(profile secret scope, HERMES_HOME override) in pool workers — e.g. the
+context-compression timeout fence resolved auxiliary provider keys with
+``UnscopedSecretError`` under the multiplexed gateway.  Use it for any
+pool whose work is best-effort or
 independently interruptible and must never hold the process open:
 concurrent tool execution, background memory sync, catalog fan-out,
 subagent timeout wrappers.  Do NOT use it for work that must complete
@@ -30,12 +38,35 @@ import threading
 import weakref
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures.thread import _worker
+from contextvars import copy_context
 
 __all__ = ["DaemonThreadPoolExecutor"]
 
 
 class DaemonThreadPoolExecutor(ThreadPoolExecutor):
     """ThreadPoolExecutor variant whose workers do not block process exit."""
+
+    def submit(self, fn, /, *args, **kwargs):
+        """Submit a callable, propagating the caller's contextvars.
+
+        Stdlib ``ThreadPoolExecutor`` snapshots the submitting context with
+        ``copy_context()`` and runs each work item inside it, so pool
+        workers inherit contextvar state such as the multiplexed profile
+        secret scope.  Some bundled CPython runtime builds strip that
+        propagation from the stdlib executor (their ``_WorkItem.run`` calls
+        the callable directly), which broke auxiliary LLM key resolution
+        from the context-compression timeout fence with
+        ``UnscopedSecretError``.  Restore the stdlib behavior explicitly so
+        the daemon pool behaves identically on every runtime; on runtimes
+        that already propagate, the inner ``ctx.run`` re-applies the same
+        immutable context and is a no-op.
+        """
+        ctx = copy_context()
+
+        def _run_with_context(*call_args, **call_kwargs):
+            return ctx.run(fn, *call_args, **call_kwargs)
+
+        return super().submit(_run_with_context, *args, **kwargs)
 
     def _adjust_thread_count(self) -> None:
         # Mirrors CPython's implementation (3.8–3.13) with two changes:


### PR DESCRIPTION
## What does this PR do?

Fixes a multiplexed-gateway regression where `DaemonThreadPoolExecutor` workers lose all caller contextvars on the bundled CPython runtime, which silently degraded context compression.

**Repro (observed in production):** with `gateway.multiplex_profiles: true`, the context-compression timeout fence (agent/conversation_compression.py -> tools/daemon_pool.py) resolves the auxiliary provider's API key inside a pool worker. The bundled CPython runtime strips stdlib `ThreadPoolExecutor`'s `copy_context()` propagation (its `_WorkItem.run` calls the callable directly, no `with self.context:`), so the profile secret scope set by the per-turn `_profile_runtime_scope` never reaches the worker. `get_secret("SURPLUS_API_KEY")` then fails closed with `UnscopedSecretError`, the LLM summary is unavailable, and Hermes silently falls back to lossy deterministic summaries (`abort_on_summary_failure: false`). In the affected session this dropped the model's read position, driving 1,200+ identical `read_file` retries.

**Fix:** `DaemonThreadPoolExecutor.submit()` now snapshots the caller's context with `copy_context()` and runs the callable inside it — restoring stdlib semantics that the runtime's modified `_WorkItem` removes. On runtimes that already propagate, the inner `ctx.run` re-applies the same immutable context and is a no-op. This mirrors the existing `gateway.run._run_in_executor_with_context` pattern and fixes every daemon-pool consumer (compression timeout fence, concurrent tool batches, background memory sync), not just compression.

## Related Issue

No dedicated issue; related follow-up in the secret-scope residuals tracking: #76574. (The separate unscoped-probe log noise is tracked in #100697 / #100709.)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/daemon_pool.py` — add `submit()` override that copies the caller's context and runs work items inside it; document why (bundled runtime strips stdlib context propagation).
- `tests/tools/test_daemon_pool.py` — `test_submit_propagates_caller_contextvars`: a ContextVar set by the submitter is visible inside the worker (fails on the unpatched runtime).
- `tests/agent/test_secret_scope.py` — `TestSecretScopeAcrossExecutorThreads.test_scoped_read_works_in_daemon_pool_worker`: under multiplex, a scoped `get_secret` reaches a daemon-pool worker, and a scoped miss still returns default instead of leaking the environ value (security invariant preserved across the thread boundary).

## How to Test

1. `./venv/bin/python3 -m pytest tests/tools/test_daemon_pool.py tests/agent/test_secret_scope.py -q` — all pass with the fix; the new contextvar test fails on the unpatched bundled runtime.
2. Without the fix, in a multiplexed gateway, submit `get_secret` for a key present in the installed scope to `DaemonThreadPoolExecutor` — the worker raises `UnscopedSecretError`. With the fix it returns the scoped value.
3. `./venv/bin/python3 -m pytest tests/agent/test_compress_context_progress_timeout.py tests/run_agent/test_sequential_tool_timeout.py -q` — no regressions in compression/tool timeout paths that use the daemon pool.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md) guide.
- [x] I have performed a self-review of my code.
- [x] My changes are covered by tests and the tests pass.
- [x] I have added a concise, focused commit message.
