### PR TITLE
fix(streaming): fall back on HTTP 405

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -72,6 +72,20 @@ from agent.message_sanitization import (
 # DEFAULT_DB_PATH = get_hermes_home() / "state.db" breaks tests that
 # monkeypatch get_hermes_home to return a str).
 _STALE_MARKER_RE = re.compile(r"^\[[A-Za-z_][A-Za-z0-9_.-]*\]$")
+
+
+def _is_streaming_method_not_allowed(exc: BaseException) -> bool:
+    """Return whether a streaming request was rejected with HTTP 405."""
+    status_code = getattr(exc, "status_code", None)
+    response = getattr(exc, "response", None)
+    if status_code is None and response is not None:
+        status_code = getattr(response, "status_code", None)
+    if str(status_code) == "405":
+        return True
+    error_text = str(exc).lower()
+    return "error code: 405" in error_text or "http 405" in error_text
+
+
 from agent.model_metadata import (
     MINIMUM_CONTEXT_LENGTH,
     _estimate_tools_tokens_rough,
@@ -3457,17 +3471,13 @@ def run_conversation(
                     if isinstance(getattr(agent, "client", None), Mock):
                         _use_streaming = False
 
-                def _perform_api_call(next_api_kwargs):
+                def _perform_non_streaming_api_call(next_api_kwargs):
                     if agent.api_mode == "codex_responses":
                         next_api_kwargs = agent._get_transport().preflight_kwargs(
                             next_api_kwargs,
                             allow_stream=False,
                             is_github_responses=agent._is_copilot_url(),
                             sanitize_harmony_tokens=agent._is_codex_backend(),
-                        )
-                    if _use_streaming:
-                        return agent._interruptible_streaming_api_call(
-                            next_api_kwargs, on_first_delta=_stop_spinner
                         )
                     from agent import relay_llm
 
@@ -3491,6 +3501,29 @@ def run_conversation(
                         },
                         defer_logical_completion=True,
                     )
+
+                def _perform_api_call(next_api_kwargs):
+                    if _use_streaming:
+                        try:
+                            return agent._interruptible_streaming_api_call(
+                                next_api_kwargs, on_first_delta=_stop_spinner
+                            )
+                        except Exception as exc:
+                            # Some OpenAI-compatible gateways accept ordinary
+                            # chat completions but reject stream=true with 405.
+                            # Retry the same request non-streaming and remember
+                            # the capability for the rest of this session.
+                            if _is_streaming_method_not_allowed(exc):
+                                agent._disable_streaming = True
+                                logger.info(
+                                    "Provider rejected streaming with HTTP 405; "
+                                    "retrying %s/%s non-streaming for this session.",
+                                    agent.provider or "unknown",
+                                    agent.model or "unknown",
+                                )
+                                return _perform_non_streaming_api_call(next_api_kwargs)
+                            raise
+                    return _perform_non_streaming_api_call(next_api_kwargs)
 
                 from hermes_cli.middleware import run_llm_execution_middleware
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -27,6 +27,40 @@ from run_agent import AIAgent
 from agent.error_classifier import FailoverReason
 from agent.memory_manager import MemoryManager
 from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
+from agent.conversation_loop import _is_streaming_method_not_allowed
+
+
+class _StatusError(Exception):
+    def __init__(self, status_code=None, response=None, message=""):
+        super().__init__(message)
+        self.status_code = status_code
+        self.response = response
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        _StatusError(status_code=405),
+        _StatusError(response=SimpleNamespace(status_code=405)),
+        _StatusError(message="Error code: 405 - Method Not Allowed"),
+        _StatusError(message="HTTP 405: Method Not Allowed"),
+    ],
+)
+def test_streaming_405_is_detected_across_error_shapes(error):
+    assert _is_streaming_method_not_allowed(error) is True
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        _StatusError(status_code=400),
+        _StatusError(status_code=404),
+        _StatusError(status_code=500),
+        _StatusError(message="HTTP 200: completed response"),
+    ],
+)
+def test_other_statuses_do_not_trigger_streaming_405_fallback(error):
+    assert _is_streaming_method_not_allowed(error) is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Some OpenAI-compatible providers accept ordinary Chat Completions requests but reject `stream=true` with HTTP 405. Hermes currently surfaces that error even though the same request succeeds without streaming.

When a chat-completions streaming request receives HTTP 405, retry the request through the existing non-streaming path and remember the capability for the remainder of the current session.

## Changes

- Detect HTTP 405 across the status-code and wrapped SDK error shapes.
- Retry the same request once via the non-streaming path.
- Disable streaming for subsequent requests in the current session.
- Add regression coverage for supported error shapes and non-405 boundaries.

## Testing

- `python -m pytest -q tests/run_agent/test_run_agent.py`
- Result: 289 passed, 1 pre-existing thread warning
- `python -m py_compile agent/conversation_loop.py tests/run_agent/test_run_agent.py`
- `git diff --check`