### PR TITLE
feat(mattermost): separate DM and channel reply modes

### DIFF
--- a/contributors/emails/info@shogokudo.com
+++ b/contributors/emails/info@shogokudo.com
@@ -1,0 +1,1 @@
+shogo-kudo

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -136,9 +136,27 @@ class MattermostAdapter(BasePlatformAdapter):
 
         # Reply mode: "thread" to nest replies, "off" for flat messages.
         self._reply_mode: str = (
-            config.extra.get("reply_mode", "")
-            or os.getenv("MATTERMOST_REPLY_MODE", "off")
+            os.getenv("MATTERMOST_REPLY_MODE", "")
+            or config.extra.get("reply_mode", "")
+            or "off"
         ).lower()
+        # Keep the historical reply_mode behavior unless an operator opts
+        # into a DM-specific policy.  "off" leaves top-level DMs flat while
+        # preserving replies inside an existing DM thread.
+        self._dm_reply_mode: str = str(
+            config.extra.get("dm_reply_mode", "inherit") or "inherit"
+        ).strip().lower()
+        if self._dm_reply_mode not in {"inherit", "off", "thread"}:
+            logger.warning(
+                "Mattermost: invalid dm_reply_mode=%r; using 'inherit'",
+                self._dm_reply_mode,
+            )
+            self._dm_reply_mode = "inherit"
+
+        # WebSocket events include the Mattermost channel type.  Cache it so
+        # the response path can distinguish DMs from team channels without a
+        # REST lookup on every chunk/file/progress send.
+        self._channel_type_cache: Dict[str, str] = {}
 
         self._last_post_status: Optional[int] = None
         self._last_post_error: str = ""
@@ -204,18 +222,49 @@ class MattermostAdapter(BasePlatformAdapter):
 
     async def _thread_root_for_send(
         self,
+        chat_id: str,
         reply_to: Optional[str],
         metadata: Optional[Dict[str, Any]],
     ) -> Optional[str]:
-        """Resolve the Mattermost root_id from reply_to or metadata."""
+        """Resolve the Mattermost root_id under channel/DM reply policy."""
         if self._reply_mode != "thread":
             return None
         candidate = reply_to
+        candidate_is_existing_thread = False
         if not candidate and isinstance(metadata, dict):
             candidate = metadata.get("thread_id") or metadata.get("root_id")
+            candidate_is_existing_thread = bool(candidate)
         if not candidate:
             return None
-        return await self._resolve_root_id(str(candidate))
+
+        resolved_root, post_is_existing_thread = await self._resolve_root_id_details(
+            str(candidate)
+        )
+        candidate_is_existing_thread = (
+            candidate_is_existing_thread or post_is_existing_thread
+        )
+
+        if (
+            getattr(self, "_dm_reply_mode", "inherit") == "off"
+            and not candidate_is_existing_thread
+            and await self._is_direct_channel(chat_id)
+        ):
+            return None
+        return resolved_root
+
+    async def _is_direct_channel(self, chat_id: str) -> bool:
+        """Return whether ``chat_id`` is a Mattermost direct-message channel."""
+        channel_type_cache = getattr(self, "_channel_type_cache", None)
+        if channel_type_cache is None:
+            channel_type_cache = {}
+            self._channel_type_cache = channel_type_cache
+        channel_type = channel_type_cache.get(str(chat_id))
+        if channel_type is None:
+            data = await self._api_get(f"channels/{chat_id}")
+            channel_type = str(data.get("type", "")) if data else ""
+            if channel_type:
+                channel_type_cache[str(chat_id)] = channel_type
+        return channel_type == "D"
 
     def _last_post_failure_is_broken_thread_root(self) -> bool:
         """Return True only for clear invalid/missing Mattermost thread roots."""
@@ -375,13 +424,18 @@ class MattermostAdapter(BasePlatformAdapter):
         root_id instead.  Using a reply's own ID as root_id causes
         "Invalid RootId parameter" errors.
         """
+        root_id, _ = await self._resolve_root_id_details(post_id)
+        return root_id
+
+    async def _resolve_root_id_details(self, post_id: str) -> tuple[str, bool]:
+        """Return the root id and whether ``post_id`` already belongs to a thread."""
         if not post_id:
-            return post_id
-        # Check if this post has a root_id (meaning it's a reply)
+            return post_id, False
         data = await self._api_get(f"posts/{post_id}")
-        if data and data.get("root_id"):
-            return data["root_id"]
-        return post_id
+        existing_root = data.get("root_id") if data else None
+        if existing_root:
+            return str(existing_root), True
+        return post_id, False
 
     async def send(
         self,
@@ -404,7 +458,7 @@ class MattermostAdapter(BasePlatformAdapter):
                 "message": chunk,
             })
             # Thread support: reply_to or metadata["thread_id"] is the root post ID.
-            resolved_root = await self._thread_root_for_send(reply_to, metadata)
+            resolved_root = await self._thread_root_for_send(chat_id, reply_to, metadata)
             if resolved_root:
                 payload["root_id"] = resolved_root
 
@@ -586,7 +640,7 @@ class MattermostAdapter(BasePlatformAdapter):
             "message": caption or "",
             "file_ids": [file_id],
         })
-        resolved_root = await self._thread_root_for_send(reply_to, metadata)
+        resolved_root = await self._thread_root_for_send(chat_id, reply_to, metadata)
         if resolved_root:
             payload["root_id"] = resolved_root
 
@@ -627,7 +681,7 @@ class MattermostAdapter(BasePlatformAdapter):
             "message": caption or "",
             "file_ids": [file_id],
         })
-        resolved_root = await self._thread_root_for_send(reply_to, metadata)
+        resolved_root = await self._thread_root_for_send(chat_id, reply_to, metadata)
         if resolved_root:
             payload["root_id"] = resolved_root
 
@@ -715,7 +769,7 @@ class MattermostAdapter(BasePlatformAdapter):
                     "message": "\n".join(caption_parts),
                     "file_ids": file_ids,
                 })
-                resolved_root = await self._thread_root_for_send(None, metadata)
+                resolved_root = await self._thread_root_for_send(chat_id, None, metadata)
                 if resolved_root:
                     payload["root_id"] = resolved_root
                 logger.info(
@@ -854,6 +908,8 @@ class MattermostAdapter(BasePlatformAdapter):
         # Build message event.
         channel_id = post.get("channel_id", "")
         channel_type_raw = data.get("channel_type", "O")
+        if channel_id:
+            self._channel_type_cache[str(channel_id)] = str(channel_type_raw)
         chat_type = _CHANNEL_TYPE_MAP.get(channel_type_raw, "channel")
 
         # For DMs, user_id is sufficient.  For channels, check for @mention.
@@ -1239,7 +1295,7 @@ def _apply_yaml_config(yaml_cfg: dict, mattermost_cfg: dict) -> dict | None:
     Mirrors the legacy ``mattermost_cfg`` block that used to live in
     ``gateway/config.py::load_gateway_config()`` before this migration.
 
-    The MattermostAdapter reads its runtime configuration via
+    The MattermostAdapter reads its access/gating compatibility settings via
     ``os.getenv()`` for ``MATTERMOST_REQUIRE_MENTION``,
     ``MATTERMOST_FREE_RESPONSE_CHANNELS``, and
     ``MATTERMOST_ALLOWED_CHANNELS``.  Rather than rewrite those call sites
@@ -1249,8 +1305,10 @@ def _apply_yaml_config(yaml_cfg: dict, mattermost_cfg: dict) -> dict | None:
 
     Env vars take precedence over YAML — every assignment is guarded
     by ``not os.getenv(...)`` so an explicit env var survives a config.yaml
-    update.  Returns ``None`` because no extras are seeded into
-    ``PlatformConfig.extra`` directly (everything flows through env).
+    update. Reply behavior is behavioral config, so it is returned as
+    profile-scoped ``PlatformConfig.extra`` instead of adding another public
+    environment variable. The legacy ``MATTERMOST_REPLY_MODE`` remains
+    supported and takes precedence inside the adapter.
     """
     if "require_mention" in mattermost_cfg and not os.getenv("MATTERMOST_REQUIRE_MENTION"):
         os.environ["MATTERMOST_REQUIRE_MENTION"] = str(mattermost_cfg["require_mention"]).lower()
@@ -1265,7 +1323,12 @@ def _apply_yaml_config(yaml_cfg: dict, mattermost_cfg: dict) -> dict | None:
         if isinstance(ac, list):
             ac = ",".join(str(v) for v in ac)
         os.environ["MATTERMOST_ALLOWED_CHANNELS"] = str(ac)
-    return None  # all settings flow through env; nothing to merge into extras
+    extras = {}
+    if mattermost_cfg.get("reply_mode") is not None:
+        extras["reply_mode"] = str(mattermost_cfg["reply_mode"]).strip().lower()
+    if mattermost_cfg.get("dm_reply_mode") is not None:
+        extras["dm_reply_mode"] = str(mattermost_cfg["dm_reply_mode"]).strip().lower()
+    return extras or None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -65,6 +65,35 @@ class TestMattermostDisplayHygiene:
 
 class TestMattermostConfigLoading:
 
+    def test_yaml_reply_modes_are_profile_scoped_extras(self):
+        from plugins.platforms.mattermost.adapter import _apply_yaml_config
+
+        extras = _apply_yaml_config(
+            {},
+            {"reply_mode": "thread", "dm_reply_mode": "off"},
+        )
+
+        assert extras == {"reply_mode": "thread", "dm_reply_mode": "off"}
+
+    def test_legacy_reply_mode_env_overrides_yaml_extra(self, monkeypatch):
+        from plugins.platforms.mattermost.adapter import MattermostAdapter
+
+        monkeypatch.setenv("MATTERMOST_REPLY_MODE", "off")
+        adapter = MattermostAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="test-token",
+                extra={
+                    "url": "https://mm.example.com",
+                    "reply_mode": "thread",
+                    "dm_reply_mode": "off",
+                },
+            )
+        )
+
+        assert adapter._reply_mode == "off"
+        assert adapter._dm_reply_mode == "off"
+
 
     def test_mattermost_home_channel(self, monkeypatch):
         monkeypatch.setenv("MATTERMOST_TOKEN", "mm-tok-abc123")
@@ -196,6 +225,97 @@ class TestMattermostSend:
 
 
     @pytest.mark.asyncio
+    async def test_dm_reply_mode_off_keeps_top_level_dm_flat(self):
+        """A top-level DM should stay flat when dm_reply_mode is off."""
+        self.adapter._reply_mode = "thread"
+        self.adapter._dm_reply_mode = "off"
+        self.adapter._channel_type_cache["dm_1"] = "D"
+        self.adapter._api_get = AsyncMock(
+            return_value={"id": "dm_post", "root_id": ""}
+        )
+        self.adapter._api_post = AsyncMock(return_value={"id": "bot_post"})
+
+        result = await self.adapter.send(
+            "dm_1",
+            "Flat DM reply",
+            reply_to="dm_post",
+        )
+
+        assert result.success is True
+        payload = self.adapter._api_post.call_args.args[1]
+        assert "root_id" not in payload
+
+
+    @pytest.mark.asyncio
+    async def test_dm_reply_mode_off_resolves_uncached_dm_type(self):
+        """Outbound paths without an inbound cache may resolve the channel once."""
+        self.adapter._reply_mode = "thread"
+        self.adapter._dm_reply_mode = "off"
+        self.adapter._api_get = AsyncMock(
+            side_effect=[
+                {"id": "dm_post", "root_id": ""},
+                {"id": "dm_1", "type": "D"},
+            ]
+        )
+        self.adapter._api_post = AsyncMock(return_value={"id": "bot_post"})
+
+        result = await self.adapter.send(
+            "dm_1",
+            "Flat uncached DM reply",
+            reply_to="dm_post",
+        )
+
+        assert result.success is True
+        payload = self.adapter._api_post.call_args.args[1]
+        assert "root_id" not in payload
+        assert self.adapter._channel_type_cache["dm_1"] == "D"
+
+
+    @pytest.mark.asyncio
+    async def test_dm_reply_mode_off_preserves_existing_dm_thread(self):
+        """Opting out of new DM threads must not break an existing one."""
+        self.adapter._reply_mode = "thread"
+        self.adapter._dm_reply_mode = "off"
+        self.adapter._channel_type_cache["dm_1"] = "D"
+        self.adapter._api_get = AsyncMock(
+            return_value={"id": "dm_reply", "root_id": "dm_root"}
+        )
+        self.adapter._api_post = AsyncMock(return_value={"id": "bot_post"})
+
+        result = await self.adapter.send(
+            "dm_1",
+            "Continue existing DM thread",
+            reply_to="dm_reply",
+        )
+
+        assert result.success is True
+        payload = self.adapter._api_post.call_args.args[1]
+        assert payload["root_id"] == "dm_root"
+
+
+    @pytest.mark.asyncio
+    async def test_dm_reply_mode_off_does_not_change_channel_threading(self):
+        """Channel replies still thread under the triggering post."""
+        self.adapter._reply_mode = "thread"
+        self.adapter._dm_reply_mode = "off"
+        self.adapter._channel_type_cache["channel_1"] = "O"
+        self.adapter._api_get = AsyncMock(
+            return_value={"id": "channel_post", "root_id": ""}
+        )
+        self.adapter._api_post = AsyncMock(return_value={"id": "bot_post"})
+
+        result = await self.adapter.send(
+            "channel_1",
+            "Threaded channel reply",
+            reply_to="channel_post",
+        )
+
+        assert result.success is True
+        payload = self.adapter._api_post.call_args.args[1]
+        assert payload["root_id"] == "channel_post"
+
+
+    @pytest.mark.asyncio
     async def test_progress_send_with_invalid_thread_root_never_falls_back_flat(self):
         """Tool/status/progress bubbles must stay quiet when the thread is broken."""
         self.adapter._reply_mode = "thread"
@@ -298,6 +418,7 @@ class TestMattermostWebSocketParsing:
         # @mention is stripped from the message text
         assert msg_event.text == "Hello from Matrix!"
         assert msg_event.message_id == "post_abc"
+        assert self.adapter._channel_type_cache["chan_456"] == "O"
 
 
     @pytest.mark.asyncio
@@ -592,5 +713,3 @@ async def test_mattermost_top_level_channel_post_is_thread_root():
     assert msg_event.source.thread_id == "top_post_123"
     assert msg_event.source.message_id == "top_post_123"
     assert msg_event.message_id == "top_post_123"
-
-

--- a/website/docs/user-guide/messaging/mattermost.md
+++ b/website/docs/user-guide/messaging/mattermost.md
@@ -16,7 +16,7 @@ Before setup, here's the part most people want to know: how Hermes behaves once 
 
 | Context | Behavior |
 |---------|----------|
-| **DMs** | Hermes responds to every message. No `@mention` needed. Each DM has its own session. |
+| **DMs** | Hermes responds to every message. No `@mention` needed. Each DM has its own session. Set `mattermost.dm_reply_mode: off` to keep top-level DM replies flat while channel replies stay threaded. |
 | **Public/private channels** | Hermes responds when you `@mention` it. Without a mention, Hermes ignores the message. |
 | **Threads** | If `MATTERMOST_REPLY_MODE=thread`, Hermes replies in a thread under your message. Thread context stays isolated from the parent channel. |
 | **Shared channels with multiple users** | By default, Hermes isolates session history per user inside the channel. Two people talking in the same channel do not share one transcript unless you explicitly disable that. |
@@ -147,9 +147,6 @@ MATTERMOST_ALLOWED_USERS=3uo8dkh1p7g1mfk49ear5fzs5c
 # Multiple allowed users (comma-separated)
 # MATTERMOST_ALLOWED_USERS=3uo8dkh1p7g1mfk49ear5fzs5c,8fk2jd9s0a7bncm1xqw4tp6r3e
 
-# Optional: reply mode (thread or off, default: off)
-# MATTERMOST_REPLY_MODE=thread
-
 # Optional: respond without @mention (default: true = require mention)
 # MATTERMOST_REQUIRE_MENTION=false
 
@@ -161,9 +158,14 @@ Optional behavior settings in `~/.hermes/config.yaml`:
 
 ```yaml
 group_sessions_per_user: true
+mattermost:
+  reply_mode: thread      # thread | off
+  dm_reply_mode: off      # inherit | off | thread
 ```
 
 - `group_sessions_per_user: true` keeps each participant's context isolated inside shared channels and threads
+- `reply_mode: thread` keeps team-channel conversations in Mattermost threads
+- `dm_reply_mode: off` keeps top-level one-to-one DMs flat while preserving replies inside an existing DM thread
 
 ### Start the Gateway
 
@@ -199,18 +201,42 @@ Replace the ID with the actual channel ID (click the channel name → View Info 
 
 ## Reply Mode
 
-The `MATTERMOST_REPLY_MODE` setting controls how Hermes posts responses:
+The `mattermost.reply_mode` setting controls how Hermes posts responses:
 
 | Mode | Behavior |
 |------|----------|
 | `off` (default) | Hermes posts flat messages in the channel, like a normal user. |
 | `thread` | Hermes replies in a thread under your original message. Keeps channels clean when there's lots of back-and-forth. |
 
-Set it in your `~/.hermes/.env`:
+Set it in `~/.hermes/config.yaml`:
 
-```bash
-MATTERMOST_REPLY_MODE=thread
+```yaml
+mattermost:
+  reply_mode: thread
 ```
+
+`MATTERMOST_REPLY_MODE` remains supported as a legacy compatibility override
+and takes precedence when it is set.
+
+### DM reply mode
+
+Use `mattermost.dm_reply_mode` when DMs and team channels should use different
+reply placement:
+
+```yaml
+mattermost:
+  reply_mode: thread
+  dm_reply_mode: off
+```
+
+| Value | DM behavior |
+|------|-------------|
+| `inherit` (default) | Follow `reply_mode` and preserve the historical behavior. |
+| `off` | Keep replies to top-level DM messages flat. Existing DM threads remain threaded. |
+| `thread` | Explicitly thread replies in DMs. |
+
+This setting does not change channel behavior. With the example above, channel
+mentions open or continue threads while normal one-to-one DMs stay linear.
 
 ## Mention Behavior
 


### PR DESCRIPTION
## What does this PR do?

Adds a backward-compatible Mattermost DM reply policy so operators can keep one-to-one DMs flat while continuing to thread channel conversations.

```yaml
mattermost:
  reply_mode: thread
  dm_reply_mode: off
```

`dm_reply_mode` supports:

- `inherit` (default): preserve the historical `reply_mode` behavior
- `off`: keep top-level DM replies flat while preserving existing DM threads
- `thread`: explicitly thread DM replies

The adapter caches the Mattermost channel type from inbound WebSocket events and falls back to one REST lookup for uncached outbound paths. The shared thread-root resolver applies the policy consistently to text, files, and image sends.

This also makes `mattermost.reply_mode` flow through the profile-scoped YAML extras while retaining `MATTERMOST_REPLY_MODE` as the higher-precedence legacy override.

## Related Issue

Fixes #100847

Related: #54227

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added profile-scoped `mattermost.dm_reply_mode` handling.
- Preserved existing behavior by default with `inherit`.
- Kept replies inside existing DM threads threaded when top-level DM threading is disabled.
- Preserved channel thread behavior.
- Added a channel-type cache with a REST fallback for uncached sends.
- Applied the shared policy to text, file, and multi-image paths.
- Documented YAML reply configuration and the legacy env override.
- Added contributor attribution for the commit email.

## How to Test

1. Configure `mattermost.reply_mode: thread` and `mattermost.dm_reply_mode: off`.
2. Send a top-level DM message and verify the bot response has no `root_id`.
3. Reply inside an existing DM thread and verify the bot continues under its existing root.
4. Mention the bot in a public/private channel and verify the response is threaded.
5. Leave `dm_reply_mode` unset and verify the historical inherited behavior remains unchanged.

Automated verification:

```text
python -m pytest tests/gateway/test_mattermost.py -q
29 passed

python -m pytest tests/gateway/test_send_multiple_images.py tests/gateway/test_media_download_retry.py tests/gateway/test_media_metadata_contract.py -k Mattermost -q
3 passed, 21 deselected

ruff check plugins/platforms/mattermost/adapter.py tests/gateway/test_mattermost.py
All checks passed
```

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched open and closed issues/PRs for duplicates.
- [x] The PR contains only this Mattermost reply-policy change.
- [ ] I've run the entire repository test suite.
- [x] I've added focused tests for the changed behavior.
- [x] Tested on macOS with Python 3.11.

### Documentation & Housekeeping

- [x] Updated the Mattermost documentation.
- [x] `cli-config.yaml.example` is N/A; the profile-scoped platform config is documented in the existing Mattermost guide.
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes are N/A.
- [x] Considered cross-platform impact; the change is adapter-level Python with no OS-specific behavior.
- [x] Tool descriptions/schemas are N/A.
