### PR TITLE
fix(gateway): allow receipt readback after restart

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1558,17 +1558,22 @@ def build_resume_recovery_note(
             "on what the user is asking now."
         )
         tail_guidance = (
-            "Do NOT re-execute old tool calls — skip any "
-            "unfinished work from the conversation history."
+            "Do NOT re-execute old tool calls. A targeted read-only status "
+            "or receipt check is allowed when needed to answer the new "
+            "message; do not continue other unfinished mutating work unless "
+            "the new message requests it."
         )
     elif interactive:
         resume_guidance = (
-            "Report to the user that the session was restored "
-            "successfully and ask what they would like to do next."
+            "If the interrupted task declares a required post-restart "
+            "completion check, perform exactly one targeted read-only status "
+            "or receipt check and report the terminal state. Otherwise, "
+            "report to the user that the session was restored successfully "
+            "and ask what they would like to do next."
         )
         tail_guidance = (
-            "Do NOT re-execute old tool calls — skip any "
-            "unfinished work from the conversation history."
+            "Do NOT re-execute old tool calls and do not continue unfinished "
+            "mutating work."
         )
     else:
         resume_guidance = (
@@ -1586,7 +1591,7 @@ def build_resume_recovery_note(
         f"[System note: The previous turn was interrupted by "
         f"{reason_phrase}; the gateway is now back online. "
         f"Any restart/shutdown command in the history has already "
-        f"run — do NOT re-execute or verify it. {resume_guidance} "
+        f"run — do NOT re-execute it. {resume_guidance} "
         f"{tail_guidance}]"
         + (f"\n\n{message}" if message else "")
     )

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -300,6 +300,29 @@ class TestResumePendingSystemNote:
             last_resume_marked_at=now,
         )
 
+    def test_interactive_resume_allows_one_required_read_only_completion_check(self):
+        """A restart must block replay, not the receipt that proves completion."""
+        note = build_resume_recovery_note(
+            "shutdown_timeout", "", interactive=True
+        )
+
+        assert "do NOT re-execute it" in note
+        assert "exactly one targeted read-only status or receipt check" in note
+        assert "report the terminal state" in note
+        assert "do NOT re-execute or verify it" not in note
+        assert "do not continue unfinished mutating work" in note
+
+    def test_new_user_message_may_request_read_only_completion_check(self):
+        """A user's completion question must not be blocked by the replay guard."""
+        note = build_resume_recovery_note(
+            "restart_timeout", "Did the release finish?", interactive=True
+        )
+
+        assert "Address the user's NEW message" in note
+        assert "targeted read-only status or receipt check is allowed" in note
+        assert "Did the release finish?" in note
+        assert "unless the new message requests it" in note
+
 
     def test_empty_message_noninteractive_note_continues_task(self):
         """Non-interactive platforms (webhook, API server): nobody can answer


### PR DESCRIPTION
## Problem
When a Gateway restart interrupts a turn, the recovery note currently says the agent must not "re-execute or verify" the restart and must skip unfinished work. That correctly prevents replay, but it also blocks the one read-only status/receipt check that some already-started operations require to prove their terminal state. Users then see `STARTED`, the Gateway returns, and every follow-up still lacks the durable completion receipt.

## Fix
- keep restart/shutdown and old tool-call replay prohibited
- keep unfinished mutating work blocked unless the user explicitly requests it
- allow exactly one targeted read-only status or receipt check when an interrupted task declares a post-restart completion check
- allow the same targeted readback when needed to answer a new user message

## Tests
- added two behavior regressions in `test_restart_resume_pending.py`
- `scripts/run_tests.sh tests/gateway/test_restart_resume_pending.py tests/gateway/test_auto_continue.py -q`
- 45 passed