### PR TITLE
fix(pricing): add claude-opus-5 official docs pricing entry

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -204,6 +204,23 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         source_url="https://openai.com/index/previewing-gpt-5-6-sol/",
         pricing_version="openai-gpt-5.6-2026-07",
     ),
+    # ── Anthropic Claude Opus 5 ─────────────────────────────────────────
+    # Current flagship. Same $5/$25 base as the 4.5–4.8 Opus line; cache
+    # writes use the schema's 5-minute bucket ($6.25 = 1.25x input — the
+    # 1h-TTL write is $10.00, which the single-bucket snapshot can't hold).
+    # Source: https://platform.claude.com/docs/en/about-claude/pricing
+    (
+        "anthropic",
+        "claude-opus-5",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("5.00"),
+        output_cost_per_million=Decimal("25.00"),
+        cache_read_cost_per_million=Decimal("0.50"),
+        cache_write_cost_per_million=Decimal("6.25"),
+        source="official_docs_snapshot",
+        source_url="https://platform.claude.com/docs/en/about-claude/pricing",
+        pricing_version="anthropic-pricing-2026-09",
+    ),
     # ── Anthropic Claude 4.8 ─────────────────────────────────────────────
     # Same $5/$25 base pricing as 4.6/4.7.  Fast-mode variant is a separate
     # model ID with 2x premium (vs the 6x premium on older Opus generations).

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -84,6 +84,51 @@ def test_normalize_usage_openai_reads_top_level_anthropic_cache_fields():
 
 
 
+def test_claude_opus_5_pricing_entry_exists():
+    """Regression test: claude-opus-5 must have a pricing entry.
+
+    Before this fix, claude-opus-5 sessions showed as unknown cost / $0 in
+    /usage, the dashboard, and cost aggregation because the
+    _OFFICIAL_DOCS_PRICING table had no entry for the model.  See #100848.
+    Rates track Anthropic's published Opus 5 pricing ($5/$25 per MTok,
+    $0.50 cache reads; cache writes use the schema's 5-minute bucket at
+    1.25x input).
+    """
+    entry = get_pricing_entry(
+        "claude-opus-5",
+        provider="anthropic",
+    )
+
+    assert entry is not None
+    assert float(entry.input_cost_per_million) == 5.00
+    assert float(entry.output_cost_per_million) == 25.00
+    assert float(entry.cache_read_cost_per_million) == 0.50
+    assert float(entry.cache_write_cost_per_million) == 6.25
+
+
+def test_claude_opus_5_session_estimates_cost_not_unknown():
+    """A direct-Anthropic claude-opus-5 session must produce a dollar
+    estimate, not ``unknown`` — the user-visible symptom in #100848.
+    """
+    usage = SimpleNamespace(
+        input_tokens=55,
+        output_tokens=7113,
+        cache_read_input_tokens=1369379,
+        cache_creation_input_tokens=42135,
+    )
+    canonical = normalize_usage(
+        usage, provider="anthropic", api_mode="anthropic_messages"
+    )
+
+    result = estimate_usage_cost(
+        "claude-opus-5",
+        canonical,
+        provider="anthropic",
+    )
+    assert result.status == "estimated"
+    assert result.amount_usd is not None
+
+
 def test_deepseek_v4_pro_pricing_entry_exists():
     """Regression test: deepseek-v4-pro must have a pricing entry.
 


### PR DESCRIPTION
## What does this PR do?

Adds the missing `claude-opus-5` entry to `_OFFICIAL_DOCS_PRICING` in `agent/usage_pricing.py`. Without it, every usage row for the model is written with `cost_status='unknown'` and `estimated_cost_usd` 0, so `/usage`, the dashboard, and cost aggregation all report **$0** for Opus 5 sessions. `_normalize_anthropic_model_name` already maps the id correctly — the lookup simply missed because the table jumped from the Opus 4.x line straight past Opus 5.

Rates are Anthropic's published Opus 5 pricing (checked 2026-09-02): $5/$25 per MTok, $0.50 cache reads. Cache writes use the schema's existing 5-minute bucket convention ($6.25 = 1.25x input, matching the Opus 4.x entries; the 1h-TTL write of $10.00 can't be expressed in the single-bucket snapshot and is called out in the entry comment).

## Related Issue

Fixes #100848

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/usage_pricing.py`: added the `("anthropic", "claude-opus-5")` row to `_OFFICIAL_DOCS_PRICING` ($5.00 input / $25.00 output / $0.50 cache read / $6.25 cache write, `anthropic-pricing-2026-09`), placed at the top of the Anthropic block ahead of the 4.8 entries, with a comment noting the 5m cache-write bucket semantics.
- `tests/agent/test_usage_pricing.py`: added `test_claude_opus_5_pricing_entry_exists` (entry resolves with the exact rates) and `test_claude_opus_5_session_estimates_cost_not_unknown` (a cached direct-Anthropic session prices as `estimated`, not `unknown` — the user-visible symptom).

## How to Test

1. Before the fix: `get_pricing_entry("claude-opus-5", provider="anthropic")` returns `None`; after: it returns the entry with `5.00/25.00/0.50/6.25`.
2. `pytest tests/agent/test_usage_pricing.py -q` — Observed result: **48 passed** (46 pre-existing + 2 new) on the fix branch.
3. `ruff check agent/usage_pricing.py tests/agent/test_usage_pricing.py` — Observed result: All checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
