### PR TITLE
fix(pricing): add claude-opus-5 to the official-docs pricing snapshot

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -292,6 +292,23 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
     ),
     (
         "anthropic",
+        "claude-opus-5",
+    ): PricingEntry(
+        # Published Anthropic rates (claude-opus-5 announcement + pricing
+        # docs, checked 2026-09-02, #100848). cache_write is the 5m-TTL
+        # rate (1.25x input) to match the single-number snapshot format;
+        # the 1h rate is 2x input (10.00) — see #88374 for making the TTL
+        # explicit per-entry.
+        input_cost_per_million=Decimal("5.00"),
+        output_cost_per_million=Decimal("25.00"),
+        cache_read_cost_per_million=Decimal("0.50"),
+        cache_write_cost_per_million=Decimal("6.25"),
+        source="official_docs_snapshot",
+        source_url="https://platform.claude.com/docs/en/about-claude/pricing",
+        pricing_version="anthropic-pricing-2026-09-opus5",
+    ),
+    (
+        "anthropic",
         "claude-opus-4-6-20250414",
     ): PricingEntry(
         input_cost_per_million=Decimal("5.00"),

--- a/tests/agent/test_opus5_pricing.py
+++ b/tests/agent/test_opus5_pricing.py
@@ -1,0 +1,76 @@
+"""claude-opus-5 must resolve pricing like its siblings (#100848)."""
+
+import sys
+
+sys.path.insert(0, r"C:\Users\salma\dev\hermes-agent")
+
+from agent.usage_pricing import (  # noqa: E402
+    CanonicalUsage,
+    estimate_usage_cost,
+    get_pricing_entry,
+)
+
+
+def test_claude_opus_5_has_pricing_entry():
+    entry = get_pricing_entry("claude-opus-5", provider="anthropic")
+    assert entry is not None, "claude-opus-5 must have an official-docs row"
+    assert str(entry.input_cost_per_million) == "5.00"
+    assert str(entry.output_cost_per_million) == "25.00"
+    assert str(entry.cache_read_cost_per_million) == "0.50"
+    assert str(entry.cache_write_cost_per_million) == "6.25"
+
+
+def test_claude_opus_5_estimates_instead_of_unknown():
+    usage = CanonicalUsage(
+        input_tokens=1_000_000,
+        output_tokens=1_000_000,
+    )
+    result = estimate_usage_cost(
+        model_name="claude-opus-5",
+        usage=usage,
+        provider="anthropic",
+    )
+    assert result.status == "estimated", (
+        f"expected estimated, got {result.status} — $0/unknown is the #100848 bug"
+    )
+    assert result.amount_usd is not None
+    # 1M input ($5) + 1M output ($25) = $30
+    assert abs(float(result.amount_usd) - 30.00) < 0.01
+
+
+def test_cache_components_price_at_published_rates():
+    usage = CanonicalUsage(
+        input_tokens=0,
+        output_tokens=0,
+        cache_read_tokens=2_000_000,   # $0.50/M -> $1.00
+        cache_write_tokens=2_000_000,  # $6.25/M -> $12.50 (5m TTL rate)
+    )
+    result = estimate_usage_cost(
+        model_name="claude-opus-5",
+        usage=usage,
+        provider="anthropic",
+    )
+    assert result.status == "estimated"
+    assert abs(float(result.amount_usd) - 13.50) < 0.01
+
+
+def test_prefixed_form_resolves():
+    """anthropic/claude-opus-5 must resolve to the same entry via the
+    Anthropic prefix-strip normalization path."""
+    entry = get_pricing_entry("anthropic/claude-opus-5", provider="anthropic")
+    assert entry is not None
+    assert str(entry.input_cost_per_million) == "5.00"
+
+
+def test_dot_notation_form_matches_sibling_behavior():
+    """claude-opus-5.0 (dot form) is NOT normalized to the dash key today —
+    the same is true for the existing claude-opus-4-6.0 sibling. Pinning the
+    current sibling-consistent behavior; if the dot-notation gap is ever
+    fixed for the 4-x family, this test reminds the fixer to cover opus-5
+    at the same time."""
+    entry = get_pricing_entry("claude-opus-4-6.0", provider="anthropic")
+    ours = get_pricing_entry("claude-opus-5.0", provider="anthropic")
+    # Whatever the behavior is, opus-5 must not be worse than its sibling.
+    assert (ours is None) == (entry is None), (
+        "opus-5 dot-notation behavior diverged from the 4-6 sibling"
+    )


### PR DESCRIPTION
Fixes #100848

## Problem

`claude-opus-5` had no row in `_OFFICIAL_DOCS_PRICING`, so every usage row for it was written with `cost_status='unknown'` and `estimated_cost_usd` **0** — `/usage`, the dashboard, and cost aggregation all reported **$0** for the model. On the reporter's host, 236 of 300 `session_model_usage` rows were unknown-cost, including a session whose real billed cost was **$191.61**.

Verified live before the fix:

```python
get_pricing_entry("claude-opus-5", provider="anthropic")      # None   <- the bug
get_pricing_entry("claude-sonnet-4-5", provider="anthropic")  # priced (control)
```

Same bug class as #43321 (`claude-fable-5`) and the explicitly-out-of-scope tail of #92673 — a flagship model simply missing from the snapshot.

## Fix

One snapshot entry with the reporter's published rates (checked 2026-09-02 against the opus-5 announcement + pricing docs):

| | input | output | cache read | cache write (5m) |
|---|---|---|---|---|
| claude-opus-5 | $5.00 | $25.00 | $0.50 | $6.25 |

The cache-write number is the **5m-TTL rate** (1.25× input) to match the single-number snapshot format — the reporter's note that the 1h rate (2× input) is what `cache_ttl: 1h` users actually pay is real, but that TTL-explicitness question belongs to #88374, and the entry documents which rate it carries.

## Verification

`tests/agent/test_opus5_pricing.py` — **4 new tests**, full pricing suite **51/51 green**:

- entry exists with all four rates
- end-to-end through `estimate_usage_cost`: 1M input + 1M output → **$30, status `estimated`** (not `unknown` — the bug's exact signature)
- cache components price at $0.50/M + $6.25/M
- `anthropic/`-prefixed form resolves via the prefix-strip path

Plus a **sibling-consistency test**: `claude-opus-5.0` (dot form) behaves identically to the existing `claude-opus-4-6.0` — unnormalized today, and pinned so a future dot-normalization fix can't cover one family but not the other.