### PR TITLE
feat(cron): allow script-owned delivery body

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -532,6 +532,7 @@ def _coerce_job_text(value: Any, fallback: str = "") -> str:
 
 # Fields whose presence in an update can turn a runnable job into an empty one.
 _PAYLOAD_FIELDS = frozenset({"prompt", "script", "skill", "skills", "no_agent"})
+_DELIVERY_SOURCES = frozenset({"agent", "script"})
 
 EMPTY_PAYLOAD_ERROR = (
     "Cron job has nothing to run: the prompt is blank and no script or "
@@ -2205,6 +2206,7 @@ def _validate_job_mode_invariants(
     monitor_url: Optional[str],
     no_agent: bool,
     script: Optional[str],
+    delivery_source: Optional[str] = None,
 ) -> None:
     """Shared create/update validation for job execution-mode invariants.
 
@@ -2225,6 +2227,29 @@ def _validate_job_mode_invariants(
         )
     if no_agent and not script:
         raise ValueError(NO_AGENT_WITHOUT_SCRIPT_ERROR)
+    if delivery_source == "script" and no_agent:
+        raise ValueError(
+            "delivery_source='script' cannot be combined with no_agent=True — "
+            "no_agent already delivers script stdout without running an agent."
+        )
+    if delivery_source == "script" and not script:
+        raise ValueError(
+            "delivery_source='script' requires a pre-run script."
+        )
+
+
+def _normalize_delivery_source(value: Any) -> Optional[str]:
+    """Normalize the opt-in delivery source; ``None`` means legacy agent output."""
+    if value is None:
+        return None
+    normalized = str(value).strip().lower()
+    if normalized in {"", "agent"}:
+        return None
+    if normalized not in _DELIVERY_SOURCES:
+        raise ValueError(
+            "delivery_source must be one of: agent, script"
+        )
+    return normalized
 
 
 def create_job(
@@ -2248,6 +2273,7 @@ def create_job(
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
+    delivery_source: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -2315,6 +2341,11 @@ def create_job(
                 exactly like config-set effort. Inert with ``no_agent=True``
                 (no LLM call to configure). None/empty = unset (job follows
                 config resolution, pre-existing behavior).
+        delivery_source: Optional operator-owned delivery boundary. ``script``
+                keeps the agent run and full saved transcript, but successful
+                chat delivery uses the pre-run script stdout as its body. Script
+                failure fails closed and never falls back to agent narration.
+                ``None``/``agent`` preserves the existing final-response path.
 
     Returns:
         The created job dict
@@ -2344,6 +2375,7 @@ def create_job(
     normalized_base_url = _normalize_job_optional_text(base_url, strip_trailing_slash=True)
     normalized_script = str(script).strip() if isinstance(script, str) else None
     normalized_script = normalized_script or None
+    normalized_delivery_source = _normalize_delivery_source(delivery_source)
     normalized_toolsets = [str(t).strip() for t in enabled_toolsets if str(t).strip()] if enabled_toolsets else None
     normalized_toolsets = normalized_toolsets or None
     normalized_workdir = _normalize_workdir(workdir)
@@ -2366,6 +2398,7 @@ def create_job(
         normalized_monitor_url,
         normalized_no_agent,
         normalized_script,
+        normalized_delivery_source,
     )
 
     # Normalize context_from: accept str or list of str, store as list or None
@@ -2457,6 +2490,8 @@ def create_job(
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
     }
+    if normalized_delivery_source is not None:
+        job["delivery_source"] = normalized_delivery_source
     # Only persist attach_to_session when explicitly set, so existing jobs and
     # the common case stay byte-identical (absent key => fall back to the
     # global cron.mirror_delivery config, default off).
@@ -2572,6 +2607,11 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     _mv = str(_mv).strip() if isinstance(_mv, str) else None
                     updates[_mon_field] = _mv or None
 
+            if "delivery_source" in updates:
+                updates["delivery_source"] = _normalize_delivery_source(
+                    updates["delivery_source"]
+                )
+
             # Validate/normalize the per-job reasoning effort pin the same
             # way create_job does: canonical grammar only, empty string (or
             # None) clears. Invalid values raise BEFORE the merge so the
@@ -2624,7 +2664,13 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
             # monitor: the scheduler's no_agent short-circuit runs before
             # the monitor gate). Scoped to changed fields so legacy records
             # untouched by this update keep loading.
-            if {"monitor_script", "monitor_url", "no_agent", "script"}.intersection(updates):
+            if {
+                "monitor_script",
+                "monitor_url",
+                "no_agent",
+                "script",
+                "delivery_source",
+            }.intersection(updates):
                 _upd_script = updated.get("script")
                 _upd_script = str(_upd_script).strip() if isinstance(_upd_script, str) else None
                 _validate_job_mode_invariants(
@@ -2632,6 +2678,7 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     updated.get("monitor_url") or None,
                     bool(updated.get("no_agent")),
                     _upd_script or None,
+                    updated.get("delivery_source") or None,
                 )
 
             if any(k in updates for k in _PAYLOAD_FIELDS):

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2207,6 +2207,7 @@ def _validate_job_mode_invariants(
     no_agent: bool,
     script: Optional[str],
     delivery_source: Optional[str] = None,
+    delivery_script: Optional[str] = None,
 ) -> None:
     """Shared create/update validation for job execution-mode invariants.
 
@@ -2232,9 +2233,9 @@ def _validate_job_mode_invariants(
             "delivery_source='script' cannot be combined with no_agent=True — "
             "no_agent already delivers script stdout without running an agent."
         )
-    if delivery_source == "script" and not script:
+    if delivery_source == "script" and not delivery_script:
         raise ValueError(
-            "delivery_source='script' requires a pre-run script."
+            "delivery_source='script' requires a post-run delivery script."
         )
 
 
@@ -2274,6 +2275,7 @@ def create_job(
     monitor_url: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
     delivery_source: Optional[str] = None,
+    delivery_script: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -2342,10 +2344,15 @@ def create_job(
                 (no LLM call to configure). None/empty = unset (job follows
                 config resolution, pre-existing behavior).
         delivery_source: Optional operator-owned delivery boundary. ``script``
-                keeps the agent run and full saved transcript, but successful
-                chat delivery uses the pre-run script stdout as its body. Script
-                failure fails closed and never falls back to agent narration.
-                ``None``/``agent`` preserves the existing final-response path.
+                keeps the agent run and full saved transcript, then runs
+                ``delivery_script`` exactly once and uses its stdout as the
+                successful chat-delivery body. Delivery-script failure fails
+                closed and never falls back to agent narration. ``None``/``agent``
+                preserves the existing final-response path.
+        delivery_script: Optional post-agent script used only with
+                ``delivery_source='script'``. It is distinct from the pre-run
+                ``script`` wake/context hook so monitor jobs can project state
+                written by the completed agent turn.
 
     Returns:
         The created job dict
@@ -2376,6 +2383,10 @@ def create_job(
     normalized_script = str(script).strip() if isinstance(script, str) else None
     normalized_script = normalized_script or None
     normalized_delivery_source = _normalize_delivery_source(delivery_source)
+    normalized_delivery_script = (
+        str(delivery_script).strip() if isinstance(delivery_script, str) else None
+    )
+    normalized_delivery_script = normalized_delivery_script or None
     normalized_toolsets = [str(t).strip() for t in enabled_toolsets if str(t).strip()] if enabled_toolsets else None
     normalized_toolsets = normalized_toolsets or None
     normalized_workdir = _normalize_workdir(workdir)
@@ -2399,6 +2410,7 @@ def create_job(
         normalized_no_agent,
         normalized_script,
         normalized_delivery_source,
+        normalized_delivery_script,
     )
 
     # Normalize context_from: accept str or list of str, store as list or None
@@ -2421,6 +2433,7 @@ def create_job(
     # covered, not just `hermes cron create`.
     from cron.lifecycle_guard import check_gateway_lifecycle
     check_gateway_lifecycle(prompt_text, normalized_script)
+    check_gateway_lifecycle(prompt_text, normalized_delivery_script)
 
     label_source = (prompt_text or (normalized_skills[0] if normalized_skills else None) or (normalized_script if normalized_no_agent else None)) or "cron job"
 
@@ -2492,6 +2505,8 @@ def create_job(
     }
     if normalized_delivery_source is not None:
         job["delivery_source"] = normalized_delivery_source
+    if normalized_delivery_script is not None:
+        job["delivery_script"] = normalized_delivery_script
     # Only persist attach_to_session when explicitly set, so existing jobs and
     # the common case stay byte-identical (absent key => fall back to the
     # global cron.mirror_delivery config, default off).
@@ -2612,6 +2627,15 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     updates["delivery_source"]
                 )
 
+            if "delivery_script" in updates:
+                _delivery_script = updates["delivery_script"]
+                _delivery_script = (
+                    str(_delivery_script).strip()
+                    if isinstance(_delivery_script, str)
+                    else None
+                )
+                updates["delivery_script"] = _delivery_script or None
+
             # Validate/normalize the per-job reasoning effort pin the same
             # way create_job does: canonical grammar only, empty string (or
             # None) clears. Invalid values raise BEFORE the merge so the
@@ -2670,6 +2694,7 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                 "no_agent",
                 "script",
                 "delivery_source",
+                "delivery_script",
             }.intersection(updates):
                 _upd_script = updated.get("script")
                 _upd_script = str(_upd_script).strip() if isinstance(_upd_script, str) else None
@@ -2679,6 +2704,21 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     bool(updated.get("no_agent")),
                     _upd_script or None,
                     updated.get("delivery_source") or None,
+                    updated.get("delivery_script") or None,
+                )
+
+            if {
+                "prompt",
+                "script",
+                "delivery_source",
+                "delivery_script",
+            }.intersection(updates):
+                from cron.lifecycle_guard import check_gateway_lifecycle
+
+                _updated_prompt = _coerce_job_text(updated.get("prompt")).strip()
+                check_gateway_lifecycle(_updated_prompt, updated.get("script") or None)
+                check_gateway_lifecycle(
+                    _updated_prompt, updated.get("delivery_script") or None
                 )
 
             if any(k in updates for k in _PAYLOAD_FIELDS):

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -1214,6 +1214,7 @@ def check_gateway_lifecycle(
     """
     combined = prompt or ""
     python_script = False
+    script_dir = None
     if script:
         resolved_script = _resolve_script_path(script)
         if resolved_script is not None:
@@ -1240,10 +1241,51 @@ def check_gateway_lifecycle(
                     "(e.g. ~/.hermes/scripts/) and recreate the job."
                 )
         python_script = resolved_script is not None and resolved_script.suffix == ".py"
+        script_dir = _resolve_script_directory(script)
         script_text = _read_script_for_scanning(script)
         if script_text:
             combined = f"{combined}\n{script_text}"
 
+    _check_gateway_lifecycle_text(
+        combined,
+        python_script=python_script,
+        script_dir=script_dir,
+    )
+
+
+def check_gateway_lifecycle_bytes(
+    prompt: Optional[str],
+    script_bytes: bytes,
+    *,
+    script_suffix: str,
+    script_dir: Optional[str],
+) -> None:
+    """Validate the exact bounded script bytes that will later execute."""
+    if len(script_bytes) > _MAX_REFERENCED_SCRIPT_BYTES or _has_binary_magic(
+        script_bytes
+    ):
+        raise GatewayLifecycleBlocked(
+            "Blocked: delivery script snapshot is oversized or binary and cannot "
+            "be lifecycle-validated."
+        )
+    script_text = script_bytes.replace(b"\x00", b"").decode(
+        "utf-8", errors="replace"
+    )
+    combined = f"{prompt or ''}\n{script_text}" if script_text else (prompt or "")
+    _check_gateway_lifecycle_text(
+        combined,
+        python_script=script_suffix.casefold() == ".py",
+        script_dir=script_dir,
+    )
+
+
+def _check_gateway_lifecycle_text(
+    combined: str,
+    *,
+    python_script: bool,
+    script_dir: Optional[str],
+) -> None:
+    """Apply the lifecycle policy to already captured source text."""
     if python_script:
         # Python is executed by the interpreter, never through a POSIX
         # shell: the shell-script reference walk is a false-positive
@@ -1256,7 +1298,6 @@ def check_gateway_lifecycle(
         # via the lifecycle-shaped sentinel in _read_script_for_scanning.
         unsafe = _lifecycle_command_scan_with_data_exemption(combined)
     else:
-        script_dir = _resolve_script_directory(script) if script else None
         unsafe = contains_gateway_lifecycle_command_or_referenced_script(
             combined,
             cwd=script_dir,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -353,6 +353,11 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
             f"⚠️ Cron '{job_name}' failed: script timed out. "
             "No model was invoked. Full details saved in cron output."
         )
+    if lower.startswith("pre-run delivery script failed"):
+        return (
+            f"⚠️ Cron '{job_name}' failed: pre-run delivery script failed. "
+            "No model was invoked. Full details saved in cron output."
+        )
 
     # Provider/API failures are the common noisy path. Keep these short.
     # Match 429 as a whole token (#83188 @cation98): bare substring matching
@@ -5483,6 +5488,7 @@ def run_job(
     job: dict,
     *,
     defer_agent_teardown: Optional[list] = None,
+    script_delivery_capture: Optional[list] = None,
     extra_prompt: Optional[str] = None,
     cancel_event: Optional[_CancelEventLike] = None,
     execution_id: Optional[str] = None,
@@ -5504,11 +5510,31 @@ def run_job(
     prompt=...)`` (#57331). Appended to the stored prompt for this fire only —
     never persisted to the job definition.
 
+    ``script_delivery_capture``: optional caller-owned list populated with the
+    cached ``(success, stdout)`` result of the agent job's pre-run script. This
+    lets the end-to-end firing path use that exact stdout as an explicit
+    delivery boundary without executing the script a second time.
+
     Returns:
         Tuple of (success, full_output_doc, final_response, error_message)
     """
     job_id = job["id"]
     job_name = str(job.get("name") or job.get("prompt") or job_id or "cron job")
+    raw_delivery_source = job.get("delivery_source")
+    if raw_delivery_source not in {None, "", "agent", "script"}:
+        error = (
+            f"Invalid delivery_source {raw_delivery_source!r}; expected "
+            "'agent' or 'script'. Refusing agent-response fallback."
+        )
+        return False, f"# Cron Job: {job_name}\n\nError: {error}\n", "", error
+    if raw_delivery_source == "script" and (
+        job.get("no_agent") or not str(job.get("script") or "").strip()
+    ):
+        error = (
+            "delivery_source='script' requires an agent-backed job with a "
+            "pre-run script. Refusing agent-response fallback."
+        )
+        return False, f"# Cron Job: {job_name}\n\nError: {error}\n", "", error
 
     # Fail closed on a corrupt config.yaml before any agent-driven work
     # (issue #81952): a cron fire is fully non-interactive, and continuing
@@ -5752,7 +5778,20 @@ def run_job(
         prerun_script = _run_job_script_with_claim_heartbeat(
             job, script_path, cancel_event=cancel_event,
         )
+        if script_delivery_capture is not None:
+            script_delivery_capture.append(prerun_script)
         _ran_ok, _script_output = prerun_script
+        if raw_delivery_source == "script" and not _ran_ok:
+            error = f"Pre-run delivery script failed: {_script_output}"
+            failed_doc = (
+                f"# Cron Job: {job_name}\n\n"
+                f"**Job ID:** {job_id}\n"
+                f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n"
+                "**Delivery Source:** script stdout\n"
+                "**Status:** script failed; agent not run\n\n"
+                f"{_script_output}\n"
+            )
+            return False, failed_doc, "", error
         if _ran_ok and not _parse_wake_gate(_script_output):
             logger.info(
                 "Job '%s' (ID: %s): wakeAgent=false, skipping agent run",
@@ -5795,6 +5834,15 @@ def run_job(
         return False, blocked_doc, "", str(block_exc)
     if prompt is None:
         logger.info("Job '%s': script produced no output, skipping AI call.", job_name)
+        if raw_delivery_source == "script":
+            silent_doc = (
+                f"# Cron Job: {job_name}\n\n"
+                f"**Job ID:** {job_id}\n"
+                f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n"
+                "**Delivery Source:** script stdout\n"
+                "**Status:** silent (empty script output); agent not run\n"
+            )
+            return True, silent_doc, SILENT_MARKER, None
         return True, "", SILENT_MARKER, None
     _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
 
@@ -7252,11 +7300,13 @@ def _run_one_job_body(
         # below once delivery is done. Defense-in-depth alongside the
         # interpreter-shutdown guard in _deliver_result.
         _deferred_agents: list = []
+        _script_delivery_capture: list = []
         try:
             if fire_claim_lost is None:
                 success, output, final_response, error = run_job(
                     job,
                     defer_agent_teardown=_deferred_agents,
+                    script_delivery_capture=_script_delivery_capture,
                     extra_prompt=extra_prompt,
                     execution_id=execution_id,
                 )
@@ -7264,6 +7314,7 @@ def _run_one_job_body(
                 success, output, final_response, error = run_job(
                     job,
                     defer_agent_teardown=_deferred_agents,
+                    script_delivery_capture=_script_delivery_capture,
                     extra_prompt=extra_prompt,
                     cancel_event=fire_claim_lost,
                     execution_id=execution_id,
@@ -7364,6 +7415,29 @@ def _run_one_job_body(
             drift_skip = drift_skip_silent or (
                 bool(error) and DRIFT_SKIP_MARKER in str(error)
             )
+            if (
+                success
+                and job.get("delivery_source") == "script"
+                and not _script_delivery_capture
+                and not _is_cron_silence_response(final_response)
+            ):
+                success = False
+                error = (
+                    "Script delivery source completed without a captured "
+                    "pre-run script result; refusing agent-response fallback."
+                )
+            if (
+                success
+                and job.get("delivery_source") == "script"
+                and _script_delivery_capture
+                and not _script_delivery_capture[-1][0]
+            ):
+                success = False
+                error = (
+                    "Pre-run delivery script failed; refusing agent-response "
+                    "fallback."
+                )
+
             if blocked_config and not success:
                 # Blocked-config alert: bypass the generic failure summarizer
                 # (whose auth/timeout heuristics would mislabel this as a
@@ -7381,7 +7455,14 @@ def _run_one_job_body(
                 )
             else:
                 if success:
-                    deliver_content = final_response
+                    if job.get("delivery_source") == "script" and _script_delivery_capture:
+                        _script_stdout = _script_delivery_capture[-1][1]
+                        if not _parse_wake_gate(_script_stdout):
+                            deliver_content = SILENT_MARKER
+                        else:
+                            deliver_content = _script_stdout
+                    else:
+                        deliver_content = final_response
                 else:
                     # Durable failure incident: record this job+error
                     # signature once and, when the operator already acked it,
@@ -7499,7 +7580,11 @@ def _run_one_job_body(
         # Treat empty final_response as a soft failure so last_status
         # is not "ok" — the agent ran but produced nothing useful.
         # (issue #8585)
-        if success and not final_response.strip():
+        if (
+            success
+            and job.get("delivery_source") != "script"
+            and not final_response.strip()
+        ):
             success = False
             error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -14,6 +14,7 @@ import concurrent.futures
 import contextlib
 import contextvars
 import errno
+import hashlib
 import json
 import logging
 import os
@@ -353,10 +354,10 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
             f"⚠️ Cron '{job_name}' failed: script timed out. "
             "No model was invoked. Full details saved in cron output."
         )
-    if lower.startswith("pre-run delivery script failed"):
+    if lower.startswith("post-run delivery script failed"):
         return (
-            f"⚠️ Cron '{job_name}' failed: pre-run delivery script failed. "
-            "No model was invoked. Full details saved in cron output."
+            f"⚠️ Cron '{job_name}' failed: post-run delivery script failed. "
+            "The agent response was not delivered. Full details saved in cron output."
         )
 
     # Provider/API failures are the common noisy path. Keep these short.
@@ -764,6 +765,12 @@ def _is_cron_silence_response(text: str) -> bool:
     from gateway.response_filters import is_autonomous_silence_response
 
     return is_autonomous_silence_response(text)
+
+
+def _is_script_delivery_silent(text: str) -> bool:
+    """Return whether authoritative post-run script stdout suppresses delivery."""
+    stripped = text.strip()
+    return not stripped or stripped == SILENT_MARKER
 
 # ---------------------------------------------------------------------------
 # Persistent thread pool for parallel cron jobs.
@@ -4273,6 +4280,8 @@ def _run_job_script(
     script_path: str,
     workdir: Optional[str] = None,
     cancel_event: Optional[_CancelEventLike] = None,
+    preserve_stdout: bool = False,
+    expected_sha256: Optional[str] = None,
 ) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
@@ -4355,6 +4364,19 @@ def _run_job_script(
         return False, f"Script not found: {path}"
     if not path.is_file():
         return False, f"Script path is not a file: {path}"
+    if expected_sha256 is not None:
+        try:
+            with path.open("rb") as script_file:
+                if os.fstat(script_file.fileno()).st_size > 1024 * 1024:
+                    return False, f"Script changed before execution: {path}"
+                script_bytes = script_file.read(1024 * 1024 + 1)
+            if len(script_bytes) > 1024 * 1024:
+                return False, f"Script changed before execution: {path}"
+            current_sha256 = hashlib.sha256(script_bytes).hexdigest()
+        except OSError as exc:
+            return False, f"Script identity check failed: {exc}"
+        if current_sha256 != expected_sha256:
+            return False, f"Script changed before execution: {path}"
 
     script_timeout = _get_script_timeout()
 
@@ -4445,7 +4467,9 @@ def _run_job_script(
             except subprocess.TimeoutExpired:
                 continue
 
-        stdout = (stdout_raw or "").strip()
+        stdout = stdout_raw or ""
+        if not preserve_stdout:
+            stdout = stdout.strip()
         stderr = (stderr_raw or "").strip()
 
         # Redact secrets from both stdout and stderr before any return path.
@@ -4477,6 +4501,8 @@ def _run_job_script_with_claim_heartbeat(
     script_path: str,
     workdir: Optional[str] = None,
     cancel_event: Optional[_CancelEventLike] = None,
+    preserve_stdout: bool = False,
+    expected_sha256: Optional[str] = None,
 ) -> tuple[bool, str]:
     """Run a cron script while keeping its owned one-shot claim fresh.
 
@@ -4498,7 +4524,13 @@ def _run_job_script_with_claim_heartbeat(
         and schedule.get("kind") == "once"
         and owner
     ):
-        return _run_job_script(script_path, workdir=workdir, cancel_event=cancel_event)
+        return _run_job_script(
+            script_path,
+            workdir=workdir,
+            cancel_event=cancel_event,
+            preserve_stdout=preserve_stdout,
+            expected_sha256=expected_sha256,
+        )
 
     job_id = str(job.get("id") or "")
     stop = threading.Event()
@@ -4529,15 +4561,97 @@ def _run_job_script_with_claim_heartbeat(
             job_id,
             exc_info=True,
         )
-        return _run_job_script(script_path, workdir=workdir, cancel_event=cancel_event)
+        return _run_job_script(
+            script_path,
+            workdir=workdir,
+            cancel_event=cancel_event,
+            preserve_stdout=preserve_stdout,
+            expected_sha256=expected_sha256,
+        )
 
     try:
-        return _run_job_script(script_path, workdir=workdir, cancel_event=cancel_event)
+        return _run_job_script(
+            script_path,
+            workdir=workdir,
+            cancel_event=cancel_event,
+            preserve_stdout=preserve_stdout,
+            expected_sha256=expected_sha256,
+        )
     finally:
         stop.set()
         # Event.wait() wakes immediately.  Keep completion bounded if the
         # heartbeat is already waiting on another process's jobs-file lock.
         heartbeat_thread.join(timeout=1.0)
+
+
+def _delivery_script_identity(
+    script_path: str,
+) -> Optional[tuple[str, str, bytes]]:
+    """Return the resolved path, SHA-256 and bounded immutable script bytes."""
+    scripts_dir = (_get_hermes_home() / "scripts").resolve()
+    try:
+        raw = Path(script_path).expanduser()
+        path = raw.resolve() if raw.is_absolute() else (scripts_dir / raw).resolve()
+        path.relative_to(scripts_dir)
+        if not path.is_file():
+            return None
+        with path.open("rb") as script_file:
+            if os.fstat(script_file.fileno()).st_size > 1024 * 1024:
+                return None
+            content = script_file.read(1024 * 1024 + 1)
+        if len(content) > 1024 * 1024:
+            return None
+        return str(path), hashlib.sha256(content).hexdigest(), content
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+
+def _run_delivery_script_snapshot(
+    job: dict,
+    identity: tuple[str, str, bytes],
+    workdir: Optional[str],
+    cancel_event: Optional[_CancelEventLike],
+) -> tuple[bool, str]:
+    """Execute immutable validated delivery-script bytes from a private copy."""
+    import tempfile
+
+    original_path = Path(identity[0])
+    snapshot_path: Optional[Path] = None
+    try:
+        fd, raw_snapshot_path = tempfile.mkstemp(
+            prefix=f".{original_path.stem}-delivery-",
+            suffix=original_path.suffix,
+            dir=original_path.parent,
+        )
+        snapshot_path = Path(raw_snapshot_path)
+        with os.fdopen(fd, "wb") as snapshot_file:
+            snapshot_file.write(identity[2])
+            snapshot_file.flush()
+            os.fsync(snapshot_file.fileno())
+        try:
+            snapshot_path.chmod(0o500)
+        except OSError:
+            pass
+        return _run_job_script_with_claim_heartbeat(
+            job,
+            str(snapshot_path),
+            workdir=workdir,
+            cancel_event=cancel_event,
+            preserve_stdout=True,
+            expected_sha256=identity[1],
+        )
+    except OSError as exc:
+        return False, f"Delivery script snapshot failed: {exc}"
+    finally:
+        if snapshot_path is not None:
+            try:
+                snapshot_path.unlink(missing_ok=True)
+            except OSError:
+                logger.warning(
+                    "Could not remove delivery script snapshot %s",
+                    snapshot_path,
+                    exc_info=True,
+                )
 
 
 def _parse_wake_gate(script_output: str) -> bool:
@@ -5489,6 +5603,17 @@ def run_job(
     *,
     defer_agent_teardown: Optional[list] = None,
     script_delivery_capture: Optional[list] = None,
+    delivery_script_runner: Optional[
+        Callable[
+            [
+                dict,
+                tuple[str, str, bytes],
+                Optional[str],
+                Optional[_CancelEventLike],
+            ],
+            tuple[bool, str],
+        ]
+    ] = None,
     extra_prompt: Optional[str] = None,
     cancel_event: Optional[_CancelEventLike] = None,
     execution_id: Optional[str] = None,
@@ -5511,9 +5636,14 @@ def run_job(
     never persisted to the job definition.
 
     ``script_delivery_capture``: optional caller-owned list populated with the
-    cached ``(success, stdout)`` result of the agent job's pre-run script. This
-    lets the end-to-end firing path use that exact stdout as an explicit
-    delivery boundary without executing the script a second time.
+    cached ``(success, stdout)`` result of the agent job's post-run delivery
+    script. This lets the end-to-end firing path use that exact stdout as an
+    explicit delivery boundary without executing the script a second time.
+
+    ``delivery_script_runner``: optional caller-owned execution boundary for
+    the post-run delivery script. The scheduler firing path supplies a runner
+    guarded by its durable fire-claim fence; direct callers use the ordinary
+    script runner.
 
     Returns:
         Tuple of (success, full_output_doc, final_response, error_message)
@@ -5528,13 +5658,32 @@ def run_job(
         )
         return False, f"# Cron Job: {job_name}\n\nError: {error}\n", "", error
     if raw_delivery_source == "script" and (
-        job.get("no_agent") or not str(job.get("script") or "").strip()
+        job.get("no_agent")
+        or not str(job.get("delivery_script") or "").strip()
     ):
         error = (
             "delivery_source='script' requires an agent-backed job with a "
-            "pre-run script. Refusing agent-response fallback."
+            "post-run delivery script. Refusing agent-response fallback."
         )
         return False, f"# Cron Job: {job_name}\n\nError: {error}\n", "", error
+
+    delivery_script_identity = None
+    if raw_delivery_source == "script":
+        from cron.lifecycle_guard import check_gateway_lifecycle
+
+        try:
+            check_gateway_lifecycle(
+                str(job.get("prompt") or ""), str(job["delivery_script"])
+            )
+        except Exception as exc:
+            error = f"Post-run delivery script blocked by lifecycle guard: {exc}"
+            return False, f"# Cron Job: {job_name}\n\nError: {error}\n", "", error
+        delivery_script_identity = _delivery_script_identity(
+            str(job["delivery_script"])
+        )
+        if delivery_script_identity is None:
+            error = "Post-run delivery script is missing or unreadable."
+            return False, f"# Cron Job: {job_name}\n\nError: {error}\n", "", error
 
     # Fail closed on a corrupt config.yaml before any agent-driven work
     # (issue #81952): a cron fire is fully non-interactive, and continuing
@@ -5743,6 +5892,8 @@ def run_job(
                 f"**Mode:** monitor\n"
                 f"**Status:** no_change (agent run suppressed)\n"
             )
+            if raw_delivery_source == "script" and script_delivery_capture is not None:
+                script_delivery_capture.append((True, SILENT_MARKER))
             return True, _mon_doc, SILENT_MARKER, None
         # Changed (or first run): inject the monitor context into the prompt
         # through the existing per-run context seam and fall through to a
@@ -5778,20 +5929,7 @@ def run_job(
         prerun_script = _run_job_script_with_claim_heartbeat(
             job, script_path, cancel_event=cancel_event,
         )
-        if script_delivery_capture is not None:
-            script_delivery_capture.append(prerun_script)
         _ran_ok, _script_output = prerun_script
-        if raw_delivery_source == "script" and not _ran_ok:
-            error = f"Pre-run delivery script failed: {_script_output}"
-            failed_doc = (
-                f"# Cron Job: {job_name}\n\n"
-                f"**Job ID:** {job_id}\n"
-                f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n"
-                "**Delivery Source:** script stdout\n"
-                "**Status:** script failed; agent not run\n\n"
-                f"{_script_output}\n"
-            )
-            return False, failed_doc, "", error
         if _ran_ok and not _parse_wake_gate(_script_output):
             logger.info(
                 "Job '%s' (ID: %s): wakeAgent=false, skipping agent run",
@@ -5803,6 +5941,8 @@ def run_job(
                 f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
                 "Script gate returned `wakeAgent=false` — agent skipped.\n"
             )
+            if raw_delivery_source == "script" and script_delivery_capture is not None:
+                script_delivery_capture.append((True, SILENT_MARKER))
             return True, silent_doc, SILENT_MARKER, None
 
     try:
@@ -5834,15 +5974,8 @@ def run_job(
         return False, blocked_doc, "", str(block_exc)
     if prompt is None:
         logger.info("Job '%s': script produced no output, skipping AI call.", job_name)
-        if raw_delivery_source == "script":
-            silent_doc = (
-                f"# Cron Job: {job_name}\n\n"
-                f"**Job ID:** {job_id}\n"
-                f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n"
-                "**Delivery Source:** script stdout\n"
-                "**Status:** silent (empty script output); agent not run\n"
-            )
-            return True, silent_doc, SILENT_MARKER, None
+        if raw_delivery_source == "script" and script_delivery_capture is not None:
+            script_delivery_capture.append((True, SILENT_MARKER))
         return True, "", SILENT_MARKER, None
     _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
 
@@ -6783,6 +6916,95 @@ def run_job(
         # Use a separate variable for log display; keep final_response clean
         # for delivery logic (empty response = no delivery).
         logged_response = final_response if final_response else "(No response generated)"
+
+        if raw_delivery_source == "script":
+            current_identity = _delivery_script_identity(
+                str(job["delivery_script"])
+            )
+            if current_identity != delivery_script_identity:
+                error_msg = (
+                    "Post-run delivery script changed during the agent turn; "
+                    "refusing model-influenced delivery."
+                )
+                if script_delivery_capture is not None:
+                    script_delivery_capture.append((False, error_msg))
+                output = f"""# Cron Job: {job_name} (FAILED)
+
+**Job ID:** {job_id}
+**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}
+**Schedule:** {job.get('schedule_display', 'N/A')}
+**Delivery Source:** post-run script stdout
+
+## Prompt
+
+{prompt}
+
+## Agent Response
+
+{logged_response}
+
+## Delivery Script Error
+
+{error_msg}
+"""
+                return False, output, "", error_msg
+            if delivery_script_runner is None:
+                delivery_script_result = _run_delivery_script_snapshot(
+                    job,
+                    delivery_script_identity,
+                    _job_workdir,
+                    cancel_event,
+                )
+            else:
+                delivery_script_result = delivery_script_runner(
+                    job,
+                    delivery_script_identity,
+                    _job_workdir,
+                    cancel_event,
+                )
+            if script_delivery_capture is not None:
+                script_delivery_capture.append(delivery_script_result)
+            _delivery_ok, _delivery_output = delivery_script_result
+            if not _delivery_ok:
+                error_msg = f"Post-run delivery script failed: {_delivery_output}"
+                output = f"""# Cron Job: {job_name} (FAILED)
+
+**Job ID:** {job_id}
+**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}
+**Schedule:** {job.get('schedule_display', 'N/A')}
+**Delivery Source:** post-run script stdout
+**Delivery Script:** {delivery_script_identity[0]}
+**Delivery Script SHA-256:** {delivery_script_identity[1]}
+
+## Prompt
+
+{prompt}
+
+## Agent Response
+
+{logged_response}
+
+## Delivery Script Error
+
+```
+{_delivery_output}
+```
+"""
+                _audit_duration_ms = int((time.monotonic() - _audit_t_start) * 1000)
+                _write_usage_audit({
+                    "ts": _utcnow_iso_ms(),
+                    "job_id": job_id,
+                    "fire_id": _audit_fire_id,
+                    "prompt_tokens": result.get("prompt_tokens"),
+                    "completion_tokens": result.get("completion_tokens"),
+                    "total_tokens": result.get("total_tokens"),
+                    "response_silent": False,
+                    "deliver_target": job.get("deliver"),
+                    "model": model or None,
+                    "duration_ms": _audit_duration_ms,
+                    "error": error_msg,
+                })
+                return False, output, "", error_msg
         
         output = f"""# Cron Job: {job_name}
 
@@ -6798,12 +7020,35 @@ def run_job(
 
 {logged_response}
 """
+        if raw_delivery_source == "script":
+            _audited_delivery_output = (
+                _delivery_output if _delivery_output else "(empty stdout)"
+            )
+            output += f"""
+
+## Delivery Script Output
+
+**Script:** {delivery_script_identity[0]}
+**SHA-256:** `{delivery_script_identity[1]}`
+
+{_audited_delivery_output}
+"""
         
         logger.info("Job '%s' completed successfully", job_name)
 
         # Emit one JSONL line per fire for usage audit.
         _audit_duration_ms = int((time.monotonic() - _audit_t_start) * 1000)
-        _audit_response_silent = _is_cron_silence_response(final_response or "")
+        _audit_delivery_response = (
+            _delivery_output if raw_delivery_source == "script" else final_response
+        )
+        if raw_delivery_source == "script":
+            _audit_response_silent = _is_script_delivery_silent(
+                _audit_delivery_response or ""
+            )
+        else:
+            _audit_response_silent = _is_cron_silence_response(
+                _audit_delivery_response or ""
+            )
         _write_usage_audit({
             "ts": _utcnow_iso_ms(),
             "job_id": job_id,
@@ -7037,6 +7282,8 @@ def _run_with_fire_claim_heartbeat(job: dict, run) -> bool:
     job_id = str(job.get("id") or "")
     stop = threading.Event()
     lost_ownership = threading.Event()
+    side_effect_fence_active = threading.Event()
+    lost_ownership._hermes_side_effect_fence_active = side_effect_fence_active
     heartbeat_context = contextvars.copy_context()
 
     def _finish_unstarted(error: str) -> None:
@@ -7076,6 +7323,8 @@ def _run_with_fire_claim_heartbeat(job: dict, run) -> bool:
     def _heartbeat_loop() -> None:
         last_confirmed = time.monotonic()
         while not stop.wait(_RUN_CLAIM_HEARTBEAT_SECONDS):
+            if side_effect_fence_active.is_set():
+                continue
             try:
                 if not heartbeat_fire_claim(job_id, expected_owner=owner):
                     lost_ownership.set()
@@ -7190,6 +7439,9 @@ def run_one_job(
                     if cancel_event is not None
                     else lost_ownership
                 ),
+                fire_claim_fence_active=getattr(
+                    lost_ownership, "_hermes_side_effect_fence_active", None
+                ),
                 execution_token=execution_token,
             ),
         )
@@ -7210,6 +7462,7 @@ def _run_one_job_body(
     verbose: bool = False,
     extra_prompt: Optional[str] = None,
     fire_claim_lost: Optional[_CancelEventLike] = None,
+    fire_claim_fence_active: Optional[threading.Event] = None,
     execution_token: Optional[object] = None,
 ) -> bool:
     claim = job.get("fire_claim")
@@ -7301,23 +7554,59 @@ def _run_one_job_body(
         # interpreter-shutdown guard in _deliver_result.
         _deferred_agents: list = []
         _script_delivery_capture: list = []
+
+        def _run_fenced_delivery_script(
+            script_job: dict,
+            script_identity: tuple[str, str, bytes],
+            workdir: Optional[str],
+            script_cancel_event: Optional[_CancelEventLike],
+        ) -> tuple[bool, str]:
+            if fire_claim_fence_active is not None:
+                fire_claim_fence_active.set()
+            try:
+                with _side_effect_fence() as owns_script:
+                    if not owns_script:
+                        return (
+                            False,
+                            "Fire claim ownership lost before post-run delivery script.",
+                        )
+                    result = _run_delivery_script_snapshot(
+                        script_job,
+                        script_identity,
+                        workdir,
+                        script_cancel_event,
+                    )
+                    if fire_owner is not None and not heartbeat_fire_claim(
+                        script_job["id"], expected_owner=fire_owner
+                    ):
+                        return (
+                            False,
+                            "Fire claim ownership lost after post-run delivery script.",
+                        )
+                    return result
+            finally:
+                if fire_claim_fence_active is not None:
+                    fire_claim_fence_active.clear()
+
         try:
+            _run_kwargs = {
+                "defer_agent_teardown": _deferred_agents,
+                "extra_prompt": extra_prompt,
+                "execution_id": execution_id,
+            }
+            if job.get("delivery_source") == "script":
+                _run_kwargs["script_delivery_capture"] = _script_delivery_capture
+                _run_kwargs["delivery_script_runner"] = _run_fenced_delivery_script
             if fire_claim_lost is None:
                 success, output, final_response, error = run_job(
                     job,
-                    defer_agent_teardown=_deferred_agents,
-                    script_delivery_capture=_script_delivery_capture,
-                    extra_prompt=extra_prompt,
-                    execution_id=execution_id,
+                    **_run_kwargs,
                 )
             else:
+                _run_kwargs["cancel_event"] = fire_claim_lost
                 success, output, final_response, error = run_job(
                     job,
-                    defer_agent_teardown=_deferred_agents,
-                    script_delivery_capture=_script_delivery_capture,
-                    extra_prompt=extra_prompt,
-                    cancel_event=fire_claim_lost,
-                    execution_id=execution_id,
+                    **_run_kwargs,
                 )
         except BaseException:
             # run_job's finally still hands back the agent when it raises; tear
@@ -7419,12 +7708,12 @@ def _run_one_job_body(
                 success
                 and job.get("delivery_source") == "script"
                 and not _script_delivery_capture
-                and not _is_cron_silence_response(final_response)
             ):
                 success = False
                 error = (
                     "Script delivery source completed without a captured "
-                    "pre-run script result; refusing agent-response fallback."
+                    "post-run delivery script result; refusing agent-response "
+                    "fallback."
                 )
             if (
                 success
@@ -7434,7 +7723,7 @@ def _run_one_job_body(
             ):
                 success = False
                 error = (
-                    "Pre-run delivery script failed; refusing agent-response "
+                    "Post-run delivery script failed; refusing agent-response "
                     "fallback."
                 )
 
@@ -7457,10 +7746,7 @@ def _run_one_job_body(
                 if success:
                     if job.get("delivery_source") == "script" and _script_delivery_capture:
                         _script_stdout = _script_delivery_capture[-1][1]
-                        if not _parse_wake_gate(_script_stdout):
-                            deliver_content = SILENT_MARKER
-                        else:
-                            deliver_content = _script_stdout
+                        deliver_content = _script_stdout
                     else:
                         deliver_content = final_response
                 else:
@@ -7510,7 +7796,19 @@ def _run_one_job_body(
             # a real report that merely quoted "[SILENT]" mid-sentence (#51438,
             # #46917).  Keeps the intentional bracketed-prefix / trailing-line
             # tolerance the cron contract relies on.
-            if should_deliver and success and _is_cron_silence_response(deliver_content):
+            if (
+                should_deliver
+                and success
+                and job.get("delivery_source") == "script"
+                and _is_script_delivery_silent(deliver_content)
+            ):
+                logger.info(
+                    "Job '%s': post-run delivery script returned %s — skipping delivery",
+                    job["id"],
+                    SILENT_MARKER,
+                )
+                should_deliver = False
+            elif should_deliver and success and _is_cron_silence_response(deliver_content):
                 logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
                 should_deliver = False
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -10,6 +10,7 @@ runs at a time if multiple processes overlap.
 
 import asyncio
 import atexit
+import base64
 import concurrent.futures
 import contextlib
 import contextvars
@@ -4282,6 +4283,7 @@ def _run_job_script(
     cancel_event: Optional[_CancelEventLike] = None,
     preserve_stdout: bool = False,
     expected_sha256: Optional[str] = None,
+    script_snapshot: Optional[bytes] = None,
 ) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
@@ -4360,11 +4362,15 @@ def _run_job_script(
             f"({scripts_dir_resolved}): {script_path!r}"
         )
 
-    if not path.exists():
-        return False, f"Script not found: {path}"
-    if not path.is_file():
-        return False, f"Script path is not a file: {path}"
-    if expected_sha256 is not None:
+    if script_snapshot is None:
+        if not path.exists():
+            return False, f"Script not found: {path}"
+        if not path.is_file():
+            return False, f"Script path is not a file: {path}"
+    if expected_sha256 is not None and script_snapshot is not None:
+        if hashlib.sha256(script_snapshot).hexdigest() != expected_sha256:
+            return False, f"Script snapshot identity mismatch: {path}"
+    elif expected_sha256 is not None:
         try:
             with path.open("rb") as script_file:
                 if os.fstat(script_file.fileno()).st_size > 1024 * 1024:
@@ -4385,6 +4391,7 @@ def _run_job_script(
     # shebang: the scripts dir is trusted, but keeping the interpreter
     # choice explicit here keeps the allowed surface small and auditable.
     suffix = path.suffix.lower()
+    snapshot_input: Optional[str] = None
     if suffix in {".sh", ".bash"}:
         # Resolve bash dynamically so Windows (Git Bash) and Linux/macOS
         # all work.  On native Windows without Git for Windows installed
@@ -4400,17 +4407,44 @@ def _run_job_script(
                 "On Windows, install Git for Windows (which ships Git Bash) "
                 "or rewrite the script as Python (.py)."
         )
-        argv = [_bash, str(path)]
+        if script_snapshot is None:
+            argv = [_bash, str(path)]
+            snapshot_input = None
+        else:
+            try:
+                snapshot_input = script_snapshot.decode("utf-8")
+            except UnicodeDecodeError:
+                return False, f"Shell script snapshot is not valid UTF-8: {path}"
+            argv = [_bash, "-s", "--", str(path)]
         env_overlay: dict[str, str] = {}
     else:
         python_exe, env_overlay = _windows_cron_python_invocation(sys.executable)
-        if env_overlay:
+        if script_snapshot is not None:
+            bootstrap = "import base64,os,sys;"
+            if env_overlay:
+                site_packages = (
+                    Path(env_overlay["VIRTUAL_ENV"]) / "Lib" / "site-packages"
+                )
+                bootstrap += f"import site;site.addsitedir({str(site_packages)!r});"
+            bootstrap += (
+                "script=sys.argv[1];"
+                "sys.argv=[script]+sys.argv[2:];"
+                "sys.path.insert(0,os.path.dirname(os.path.abspath(script)));"
+                "source=base64.b64decode(sys.stdin.buffer.read());"
+                "namespace={'__name__':'__main__','__file__':script,"
+                "'__package__':None,'__cached__':None};"
+                "exec(compile(source,script,'exec'),namespace)"
+            )
+            argv = [python_exe, "-c", bootstrap, str(path)]
+            snapshot_input = base64.b64encode(script_snapshot).decode("ascii")
+        elif env_overlay:
             # Overlay mode (Windows uv venv): PYTHONPATH alone cannot make
             # editable installs importable — .pth processing needs
             # site.addsitedir() (see _windows_cron_bootstrap_argv).
             argv = _windows_cron_bootstrap_argv(python_exe, env_overlay, str(path))
         else:
             argv = [python_exe, str(path)]
+            snapshot_input = None
 
     try:
         from tools.environments.local import build_subprocess_env
@@ -4432,6 +4466,7 @@ def _run_job_script(
         _script_cwd = workdir or str(path.parent)
         proc = subprocess.Popen(
             argv,
+            stdin=subprocess.PIPE if snapshot_input is not None else None,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
@@ -4440,6 +4475,7 @@ def _run_job_script(
             **popen_kwargs,
         )
         deadline = time.monotonic() + script_timeout
+        snapshot_input_pending = snapshot_input is not None
         while True:
             if cancel_event is not None and cancel_event.is_set():
                 # Same bug class as the timeout site below: a cancelled fire
@@ -4462,7 +4498,16 @@ def _run_job_script(
                 _drain_script_pipes(proc)
                 return False, f"Script timed out after {script_timeout}s: {path}"
             try:
-                stdout_raw, stderr_raw = proc.communicate(timeout=min(0.1, remaining))
+                if snapshot_input_pending:
+                    snapshot_input_pending = False
+                    stdout_raw, stderr_raw = proc.communicate(
+                        input=snapshot_input,
+                        timeout=min(0.1, remaining),
+                    )
+                else:
+                    stdout_raw, stderr_raw = proc.communicate(
+                        timeout=min(0.1, remaining)
+                    )
                 break
             except subprocess.TimeoutExpired:
                 continue
@@ -4503,6 +4548,7 @@ def _run_job_script_with_claim_heartbeat(
     cancel_event: Optional[_CancelEventLike] = None,
     preserve_stdout: bool = False,
     expected_sha256: Optional[str] = None,
+    script_snapshot: Optional[bytes] = None,
 ) -> tuple[bool, str]:
     """Run a cron script while keeping its owned one-shot claim fresh.
 
@@ -4530,6 +4576,7 @@ def _run_job_script_with_claim_heartbeat(
             cancel_event=cancel_event,
             preserve_stdout=preserve_stdout,
             expected_sha256=expected_sha256,
+            script_snapshot=script_snapshot,
         )
 
     job_id = str(job.get("id") or "")
@@ -4567,6 +4614,7 @@ def _run_job_script_with_claim_heartbeat(
             cancel_event=cancel_event,
             preserve_stdout=preserve_stdout,
             expected_sha256=expected_sha256,
+            script_snapshot=script_snapshot,
         )
 
     try:
@@ -4576,6 +4624,7 @@ def _run_job_script_with_claim_heartbeat(
             cancel_event=cancel_event,
             preserve_stdout=preserve_stdout,
             expected_sha256=expected_sha256,
+            script_snapshot=script_snapshot,
         )
     finally:
         stop.set()
@@ -4612,46 +4661,16 @@ def _run_delivery_script_snapshot(
     workdir: Optional[str],
     cancel_event: Optional[_CancelEventLike],
 ) -> tuple[bool, str]:
-    """Execute immutable validated delivery-script bytes from a private copy."""
-    import tempfile
-
-    original_path = Path(identity[0])
-    snapshot_path: Optional[Path] = None
-    try:
-        fd, raw_snapshot_path = tempfile.mkstemp(
-            prefix=f".{original_path.stem}-delivery-",
-            suffix=original_path.suffix,
-            dir=original_path.parent,
-        )
-        snapshot_path = Path(raw_snapshot_path)
-        with os.fdopen(fd, "wb") as snapshot_file:
-            snapshot_file.write(identity[2])
-            snapshot_file.flush()
-            os.fsync(snapshot_file.fileno())
-        try:
-            snapshot_path.chmod(0o500)
-        except OSError:
-            pass
-        return _run_job_script_with_claim_heartbeat(
-            job,
-            str(snapshot_path),
-            workdir=workdir,
-            cancel_event=cancel_event,
-            preserve_stdout=True,
-            expected_sha256=identity[1],
-        )
-    except OSError as exc:
-        return False, f"Delivery script snapshot failed: {exc}"
-    finally:
-        if snapshot_path is not None:
-            try:
-                snapshot_path.unlink(missing_ok=True)
-            except OSError:
-                logger.warning(
-                    "Could not remove delivery script snapshot %s",
-                    snapshot_path,
-                    exc_info=True,
-                )
+    """Execute immutable validated delivery-script bytes without reopening its path."""
+    return _run_job_script_with_claim_heartbeat(
+        job,
+        identity[0],
+        workdir=workdir,
+        cancel_event=cancel_event,
+        preserve_stdout=True,
+        expected_sha256=identity[1],
+        script_snapshot=identity[2],
+    )
 
 
 def _parse_wake_gate(script_output: str) -> bool:
@@ -5669,20 +5688,24 @@ def run_job(
 
     delivery_script_identity = None
     if raw_delivery_source == "script":
-        from cron.lifecycle_guard import check_gateway_lifecycle
-
-        try:
-            check_gateway_lifecycle(
-                str(job.get("prompt") or ""), str(job["delivery_script"])
-            )
-        except Exception as exc:
-            error = f"Post-run delivery script blocked by lifecycle guard: {exc}"
-            return False, f"# Cron Job: {job_name}\n\nError: {error}\n", "", error
         delivery_script_identity = _delivery_script_identity(
             str(job["delivery_script"])
         )
         if delivery_script_identity is None:
             error = "Post-run delivery script is missing or unreadable."
+            return False, f"# Cron Job: {job_name}\n\nError: {error}\n", "", error
+        from cron.lifecycle_guard import check_gateway_lifecycle_bytes
+
+        try:
+            delivery_path = Path(delivery_script_identity[0])
+            check_gateway_lifecycle_bytes(
+                str(job.get("prompt") or ""),
+                delivery_script_identity[2],
+                script_suffix=delivery_path.suffix,
+                script_dir=str(delivery_path.parent),
+            )
+        except Exception as exc:
+            error = f"Post-run delivery script blocked by lifecycle guard: {exc}"
             return False, f"# Cron Job: {job_name}\n\nError: {error}\n", "", error
 
     # Fail closed on a corrupt config.yaml before any agent-driven work
@@ -7283,7 +7306,11 @@ def _run_with_fire_claim_heartbeat(job: dict, run) -> bool:
     stop = threading.Event()
     lost_ownership = threading.Event()
     side_effect_fence_active = threading.Event()
+    side_effect_fence_coordination = threading.Lock()
     lost_ownership._hermes_side_effect_fence_active = side_effect_fence_active
+    side_effect_fence_active._hermes_coordination_lock = (
+        side_effect_fence_coordination
+    )
     heartbeat_context = contextvars.copy_context()
 
     def _finish_unstarted(error: str) -> None:
@@ -7323,10 +7350,14 @@ def _run_with_fire_claim_heartbeat(job: dict, run) -> bool:
     def _heartbeat_loop() -> None:
         last_confirmed = time.monotonic()
         while not stop.wait(_RUN_CLAIM_HEARTBEAT_SECONDS):
-            if side_effect_fence_active.is_set():
-                continue
             try:
-                if not heartbeat_fire_claim(job_id, expected_owner=owner):
+                with side_effect_fence_coordination:
+                    if side_effect_fence_active.is_set():
+                        continue
+                    owns_fire_claim = heartbeat_fire_claim(
+                        job_id, expected_owner=owner
+                    )
+                if not owns_fire_claim:
                     lost_ownership.set()
                     logger.warning(
                         "Job '%s': fire claim ownership lost; interrupting stale run",
@@ -7562,7 +7593,13 @@ def _run_one_job_body(
             script_cancel_event: Optional[_CancelEventLike],
         ) -> tuple[bool, str]:
             if fire_claim_fence_active is not None:
-                fire_claim_fence_active.set()
+                coordination_lock = getattr(
+                    fire_claim_fence_active,
+                    "_hermes_coordination_lock",
+                    contextlib.nullcontext(),
+                )
+                with coordination_lock:
+                    fire_claim_fence_active.set()
             try:
                 with _side_effect_fence() as owns_script:
                     if not owns_script:
@@ -7586,7 +7623,8 @@ def _run_one_job_body(
                     return result
             finally:
                 if fire_claim_fence_active is not None:
-                    fire_claim_fence_active.clear()
+                    with coordination_lock:
+                        fire_claim_fence_active.clear()
 
         try:
             _run_kwargs = {

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -254,6 +254,8 @@ def cron_list(show_all: bool = False):
                 print(f"    Changed:   {mon_state['last_changed_at']}")
         if job.get("no_agent"):
             print(f"    Mode:      {color('no-agent', Colors.DIM)} (script stdout delivered directly)")
+        elif job.get("delivery_source") == "script":
+            print("    Delivery source: script stdout (agent transcript saved)")
         workdir = job.get("workdir")
         if workdir:
             print(f"    Workdir:   {workdir}")
@@ -706,8 +708,17 @@ def _cron_doctor_issues_for_job(job: Dict[str, Any]) -> List[str]:
                 issues.append(overdue)
 
     script = str(job.get("script") or "").strip()
+    delivery_source = job.get("delivery_source")
+    if delivery_source not in {None, "", "agent", "script"}:
+        issues.append(
+            f"invalid delivery_source {delivery_source!r}; expected agent or script"
+        )
     if job.get("no_agent") and not script:
         issues.append("no-agent job has no script")
+    if job.get("delivery_source") == "script" and not script:
+        issues.append("script delivery source has no pre-run script")
+    if job.get("delivery_source") == "script" and job.get("no_agent"):
+        issues.append("script delivery source is redundant with no-agent mode")
     if script:
         script_issue = _script_health_issue(script)
         if script_issue:
@@ -770,6 +781,7 @@ def cron_create(args):
         skill=getattr(args, "skill", None),
         skills=_normalize_skills(getattr(args, "skill", None), getattr(args, "skills", None)),
         script=getattr(args, "script", None),
+        delivery_source=getattr(args, "delivery_source", None),
         workdir=getattr(args, "workdir", None),
         model=getattr(args, "model", None),
         provider=getattr(args, "model_provider", None),
@@ -796,6 +808,8 @@ def cron_create(args):
         print(f"  Monitor: {job_data['monitor_url']} (agent runs only on output change)")
     if job_data.get("no_agent"):
         print("  Mode: no-agent (script stdout delivered directly)")
+    elif job_data.get("delivery_source") == "script":
+        print("  Delivery source: script stdout (agent transcript remains saved)")
     if job_data.get("continuity"):
         print("  Continuity: on (each run sees the previous run's output)")
     if job_data.get("workdir"):
@@ -845,6 +859,7 @@ def cron_edit(args):
         repeat=getattr(args, "repeat", None),
         skills=final_skills,
         script=getattr(args, "script", None),
+        delivery_source=getattr(args, "delivery_source", None),
         workdir=getattr(args, "workdir", None),
         model=getattr(args, "model", None),
         provider=getattr(args, "model_provider", None),
@@ -874,6 +889,8 @@ def cron_edit(args):
         print(f"  Monitor: {updated['monitor_url']} (agent runs only on output change)")
     if updated.get("no_agent"):
         print("  Mode: no-agent (script stdout delivered directly)")
+    elif updated.get("delivery_source") == "script":
+        print("  Delivery source: script stdout (agent transcript remains saved)")
     if updated.get("continuity"):
         print("  Continuity: on (each run sees the previous run's output)")
     if updated.get("workdir"):

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -246,6 +246,9 @@ def cron_list(show_all: bool = False):
         script = job.get("script")
         if script:
             print(f"    Script:    {script}")
+        delivery_script = job.get("delivery_script")
+        if delivery_script:
+            print(f"    Delivery script: {delivery_script}")
         monitor_source = job.get("monitor_script") or job.get("monitor_url")
         if monitor_source:
             print(f"    Monitor:   {monitor_source} (agent runs only on output change)")
@@ -255,7 +258,7 @@ def cron_list(show_all: bool = False):
         if job.get("no_agent"):
             print(f"    Mode:      {color('no-agent', Colors.DIM)} (script stdout delivered directly)")
         elif job.get("delivery_source") == "script":
-            print("    Delivery source: script stdout (agent transcript saved)")
+            print("    Delivery source: post-run script stdout (agent transcript saved)")
         workdir = job.get("workdir")
         if workdir:
             print(f"    Workdir:   {workdir}")
@@ -708,6 +711,7 @@ def _cron_doctor_issues_for_job(job: Dict[str, Any]) -> List[str]:
                 issues.append(overdue)
 
     script = str(job.get("script") or "").strip()
+    delivery_script = str(job.get("delivery_script") or "").strip()
     delivery_source = job.get("delivery_source")
     if delivery_source not in {None, "", "agent", "script"}:
         issues.append(
@@ -715,14 +719,18 @@ def _cron_doctor_issues_for_job(job: Dict[str, Any]) -> List[str]:
         )
     if job.get("no_agent") and not script:
         issues.append("no-agent job has no script")
-    if job.get("delivery_source") == "script" and not script:
-        issues.append("script delivery source has no pre-run script")
+    if job.get("delivery_source") == "script" and not delivery_script:
+        issues.append("script delivery source has no post-run delivery script")
     if job.get("delivery_source") == "script" and job.get("no_agent"):
         issues.append("script delivery source is redundant with no-agent mode")
     if script:
         script_issue = _script_health_issue(script)
         if script_issue:
             issues.append(script_issue)
+    if job.get("delivery_source") == "script" and delivery_script:
+        delivery_script_issue = _script_health_issue(delivery_script)
+        if delivery_script_issue:
+            issues.append(delivery_script_issue)
 
     workdir = str(job.get("workdir") or "").strip()
     if workdir and not Path(workdir).expanduser().exists():
@@ -782,6 +790,7 @@ def cron_create(args):
         skills=_normalize_skills(getattr(args, "skill", None), getattr(args, "skills", None)),
         script=getattr(args, "script", None),
         delivery_source=getattr(args, "delivery_source", None),
+        delivery_script=getattr(args, "delivery_script", None),
         workdir=getattr(args, "workdir", None),
         model=getattr(args, "model", None),
         provider=getattr(args, "model_provider", None),
@@ -802,6 +811,8 @@ def cron_create(args):
     job_data = result.get("job", {})
     if job_data.get("script"):
         print(f"  Script: {job_data['script']}")
+    if job_data.get("delivery_script"):
+        print(f"  Delivery script: {job_data['delivery_script']}")
     if job_data.get("monitor_script"):
         print(f"  Monitor: {job_data['monitor_script']} (agent runs only on output change)")
     if job_data.get("monitor_url"):
@@ -809,7 +820,7 @@ def cron_create(args):
     if job_data.get("no_agent"):
         print("  Mode: no-agent (script stdout delivered directly)")
     elif job_data.get("delivery_source") == "script":
-        print("  Delivery source: script stdout (agent transcript remains saved)")
+        print("  Delivery source: post-run script stdout (agent transcript remains saved)")
     if job_data.get("continuity"):
         print("  Continuity: on (each run sees the previous run's output)")
     if job_data.get("workdir"):
@@ -860,6 +871,7 @@ def cron_edit(args):
         skills=final_skills,
         script=getattr(args, "script", None),
         delivery_source=getattr(args, "delivery_source", None),
+        delivery_script=getattr(args, "delivery_script", None),
         workdir=getattr(args, "workdir", None),
         model=getattr(args, "model", None),
         provider=getattr(args, "model_provider", None),
@@ -883,6 +895,8 @@ def cron_edit(args):
         print("  Skills: none")
     if updated.get("script"):
         print(f"  Script: {updated['script']}")
+    if updated.get("delivery_script"):
+        print(f"  Delivery script: {updated['delivery_script']}")
     if updated.get("monitor_script"):
         print(f"  Monitor: {updated['monitor_script']} (agent runs only on output change)")
     if updated.get("monitor_url"):
@@ -890,7 +904,7 @@ def cron_edit(args):
     if updated.get("no_agent"):
         print("  Mode: no-agent (script stdout delivered directly)")
     elif updated.get("delivery_source") == "script":
-        print("  Delivery source: script stdout (agent transcript remains saved)")
+        print("  Delivery source: post-run script stdout (agent transcript remains saved)")
     if updated.get("continuity"):
         print("  Continuity: on (each run sees the previous run's output)")
     if updated.get("workdir"):

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -71,6 +71,17 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         ),
     )
     cron_create.add_argument(
+        "--delivery-source",
+        choices=("agent", "script"),
+        default=None,
+        help=(
+            "Select successful delivery content. 'agent' (default) delivers "
+            "the agent's final response. 'script' requires --script, still "
+            "runs the agent, saves its transcript, and delivers the pre-run "
+            "script stdout as the delivery body; script failure fails closed."
+        ),
+    )
+    cron_create.add_argument(
         "--monitor-script",
         dest="monitor_script",
         help=(
@@ -191,6 +202,16 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         action="store_const",
         const=False,
         help="Disable no-agent mode on this job (reverts to LLM-driven execution).",
+    )
+    cron_edit.add_argument(
+        "--delivery-source",
+        choices=("agent", "script"),
+        default=None,
+        help=(
+            "Set successful delivery content. 'script' requires a pre-run "
+            "script and never falls back to agent text; 'agent' restores the "
+            "default final-response delivery."
+        ),
     )
     cron_edit.add_argument(
         "--continuity",

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -76,9 +76,18 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         default=None,
         help=(
             "Select successful delivery content. 'agent' (default) delivers "
-            "the agent's final response. 'script' requires --script, still "
-            "runs the agent, saves its transcript, and delivers the pre-run "
-            "script stdout as the delivery body; script failure fails closed."
+            "the agent's final response. 'script' requires --delivery-script, "
+            "still runs the agent, saves its transcript, and then delivers "
+            "the post-run script stdout; script failure fails closed."
+        ),
+    )
+    cron_create.add_argument(
+        "--delivery-script",
+        dest="delivery_script",
+        help=(
+            "Operator-owned script under ~/.hermes/scripts/ that runs exactly "
+            "once after a successful agent turn when --delivery-source=script. "
+            "Its stdout is authoritative for delivery; empty output is silent."
         ),
     )
     cron_create.add_argument(
@@ -208,9 +217,17 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         choices=("agent", "script"),
         default=None,
         help=(
-            "Set successful delivery content. 'script' requires a pre-run "
-            "script and never falls back to agent text; 'agent' restores the "
-            "default final-response delivery."
+            "Set successful delivery content. 'script' requires a post-run "
+            "delivery script and never falls back to agent text; 'agent' "
+            "restores the default final-response delivery."
+        ),
+    )
+    cron_edit.add_argument(
+        "--delivery-script",
+        dest="delivery_script",
+        help=(
+            "Set the post-run authoritative delivery script. Pass empty "
+            "string to clear."
         ),
     )
     cron_edit.add_argument(

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -211,6 +211,27 @@ class TestRunJobScript:
         assert "changed before execution" in output
         assert "replacement report" not in output
 
+    def test_delivery_snapshot_lifecycle_scan_uses_exact_bytes(self, cron_env):
+        from cron.lifecycle_guard import (
+            GatewayLifecycleBlocked,
+            check_gateway_lifecycle_bytes,
+        )
+
+        with pytest.raises(GatewayLifecycleBlocked):
+            check_gateway_lifecycle_bytes(
+                "Analyze",
+                b"import os\nos.system('hermes gateway restart')\n",
+                script_suffix=".py",
+                script_dir=str(cron_env / "scripts"),
+            )
+
+        check_gateway_lifecycle_bytes(
+            "Analyze",
+            b"print('safe report')\n",
+            script_suffix=".py",
+            script_dir=str(cron_env / "scripts"),
+        )
+
     @pytest.mark.parametrize("invalid_source", ["Script", "script ", "model"])
     def test_noncanonical_runtime_delivery_source_fails_closed(
         self, cron_env, invalid_source

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -70,6 +70,64 @@ class TestJobScriptField:
         updated = update_job(job["id"], {"script": "/new/script.py"})
         assert updated["script"] == "/new/script.py"
 
+    def test_script_delivery_source_is_explicit_and_validated(self, cron_env):
+        from cron.jobs import create_job
+
+        default_job = create_job(prompt="Analyze", schedule="every 1h")
+        assert "delivery_source" not in default_job
+
+        job = create_job(
+            prompt="Analyze",
+            schedule="every 1h",
+            script="report.py",
+            delivery_source="script",
+        )
+        assert job["delivery_source"] == "script"
+
+        with pytest.raises(ValueError, match="requires a pre-run script"):
+            create_job(
+                prompt="Analyze",
+                schedule="every 1h",
+                delivery_source="script",
+            )
+
+        with pytest.raises(ValueError, match="cannot be combined with no_agent"):
+            create_job(
+                prompt="Analyze",
+                schedule="every 1h",
+                script="report.py",
+                no_agent=True,
+                delivery_source="script",
+            )
+
+    def test_update_revalidates_script_delivery_source(self, cron_env):
+        from cron.jobs import create_job, get_job, update_job
+
+        job = create_job(
+            prompt="Analyze",
+            schedule="every 1h",
+            script="report.py",
+            delivery_source="script",
+        )
+
+        with pytest.raises(ValueError, match="requires a pre-run script"):
+            update_job(job["id"], {"script": None})
+        assert get_job(job["id"])["script"] == "report.py"
+
+        updated = update_job(job["id"], {"delivery_source": "agent"})
+        assert updated.get("delivery_source") is None
+
+    def test_invalid_delivery_source_is_rejected(self, cron_env):
+        from cron.jobs import create_job
+
+        with pytest.raises(ValueError, match="must be one of: agent, script"):
+            create_job(
+                prompt="Analyze",
+                schedule="every 1h",
+                script="report.py",
+                delivery_source="model",
+            )
+
 
 def test_cronjob_tool_rejects_stale_past_one_shot(cron_env, monkeypatch):
     from tools.cronjob_tools import cronjob
@@ -106,6 +164,166 @@ class TestRunJobScript:
         success, output = _run_job_script("relative.py")
         assert success is True
         assert output == "relative works"
+
+    def test_script_delivery_capture_executes_gate_once(
+        self, cron_env, monkeypatch
+    ):
+        import cron.scheduler as scheduler
+
+        calls = []
+        capture = []
+
+        def fake_script(*_args, **_kwargs):
+            calls.append("script")
+            return True, '{"wakeAgent": false}'
+
+        monkeypatch.setattr(
+            "hermes_cli.config.require_parseable_user_config", lambda: None
+        )
+        monkeypatch.setattr(
+            scheduler, "_run_job_script_with_claim_heartbeat", fake_script
+        )
+
+        success, _doc, final, error = scheduler.run_job(
+            {
+                "id": "capture-once",
+                "name": "capture-once",
+                "prompt": "Analyze",
+                "script": "report.py",
+                "delivery_source": "script",
+            },
+            script_delivery_capture=capture,
+        )
+
+        assert success is True
+        assert final == scheduler.SILENT_MARKER
+        assert error is None
+        assert calls == ["script"]
+        assert capture == [(True, '{"wakeAgent": false}')]
+
+    def test_empty_script_delivery_output_is_silent_and_auditable(
+        self, cron_env, monkeypatch
+    ):
+        import cron.scheduler as scheduler
+        import run_agent
+
+        capture = []
+
+        monkeypatch.setattr(
+            "hermes_cli.config.require_parseable_user_config", lambda: None
+        )
+        monkeypatch.setattr(
+            scheduler,
+            "_run_job_script_with_claim_heartbeat",
+            lambda *_args, **_kwargs: (True, ""),
+        )
+        monkeypatch.setattr(
+            run_agent,
+            "AIAgent",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AssertionError("agent must not run for empty script output")
+            ),
+        )
+
+        success, doc, final, error = scheduler.run_job(
+            {
+                "id": "capture-empty",
+                "name": "capture-empty",
+                "prompt": "Analyze",
+                "script": "report.py",
+                "delivery_source": "script",
+            },
+            script_delivery_capture=capture,
+        )
+
+        assert success is True
+        assert final == scheduler.SILENT_MARKER
+        assert error is None
+        assert "silent (empty script output); agent not run" in doc
+        assert capture == [(True, "")]
+
+    def test_script_delivery_failure_fails_before_agent_construction(
+        self, cron_env, monkeypatch
+    ):
+        import cron.scheduler as scheduler
+        import run_agent
+
+        calls = []
+        capture = []
+
+        def fake_script(*_args, **_kwargs):
+            calls.append("script")
+            return False, "exit code 1: upstream unavailable"
+
+        def unexpected_agent(*_args, **_kwargs):
+            raise AssertionError("agent must not be constructed after script failure")
+
+        monkeypatch.setattr(
+            "hermes_cli.config.require_parseable_user_config", lambda: None
+        )
+        monkeypatch.setattr(
+            scheduler, "_run_job_script_with_claim_heartbeat", fake_script
+        )
+        monkeypatch.setattr(run_agent, "AIAgent", unexpected_agent)
+
+        success, doc, final, error = scheduler.run_job(
+            {
+                "id": "capture-fail",
+                "name": "capture-fail",
+                "prompt": "Analyze",
+                "script": "report.py",
+                "delivery_source": "script",
+            },
+            script_delivery_capture=capture,
+        )
+
+        assert success is False
+        assert final == ""
+        assert "script failed; agent not run" in doc
+        assert "upstream unavailable" in error
+        assert calls == ["script"]
+        assert capture == [(False, "exit code 1: upstream unavailable")]
+
+    @pytest.mark.parametrize("invalid_source", ["Script", "script ", "model"])
+    def test_noncanonical_runtime_delivery_source_fails_closed(
+        self, cron_env, invalid_source
+    ):
+        import cron.scheduler as scheduler
+
+        success, _doc, final, error = scheduler.run_job(
+            {
+                "id": "invalid-source",
+                "name": "invalid-source",
+                "prompt": "Analyze",
+                "script": "report.py",
+                "delivery_source": invalid_source,
+            }
+        )
+
+        assert success is False
+        assert final == ""
+        assert "Invalid delivery_source" in error
+        assert "Refusing agent-response fallback" in error
+
+    @pytest.mark.parametrize(
+        "detail",
+        [
+            "Script timed out after 60s: report.py",
+            "HTTP 429: rate limit exceeded",
+            "authentication failed",
+        ],
+    )
+    def test_delivery_script_failure_summary_names_script_not_provider(self, detail):
+        from cron.scheduler import _summarize_cron_failure_for_delivery
+
+        summary = _summarize_cron_failure_for_delivery(
+            {"id": "delivery-timeout", "name": "research"},
+            f"Pre-run delivery script failed: {detail}",
+        )
+
+        assert "pre-run delivery script failed" in summary
+        assert "No model was invoked" in summary
+        assert "provider" not in summary.lower()
 
 
     def test_script_subprocess_env_sanitized(self, cron_env, monkeypatch):

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -79,12 +79,13 @@ class TestJobScriptField:
         job = create_job(
             prompt="Analyze",
             schedule="every 1h",
-            script="report.py",
             delivery_source="script",
+            delivery_script="report.py",
         )
         assert job["delivery_source"] == "script"
+        assert job["delivery_script"] == "report.py"
 
-        with pytest.raises(ValueError, match="requires a pre-run script"):
+        with pytest.raises(ValueError, match="requires a post-run delivery script"):
             create_job(
                 prompt="Analyze",
                 schedule="every 1h",
@@ -96,6 +97,7 @@ class TestJobScriptField:
                 prompt="Analyze",
                 schedule="every 1h",
                 script="report.py",
+                delivery_script="report.py",
                 no_agent=True,
                 delivery_source="script",
             )
@@ -106,16 +108,37 @@ class TestJobScriptField:
         job = create_job(
             prompt="Analyze",
             schedule="every 1h",
-            script="report.py",
             delivery_source="script",
+            delivery_script="report.py",
         )
 
-        with pytest.raises(ValueError, match="requires a pre-run script"):
-            update_job(job["id"], {"script": None})
-        assert get_job(job["id"])["script"] == "report.py"
+        with pytest.raises(ValueError, match="requires a post-run delivery script"):
+            update_job(job["id"], {"delivery_script": None})
+        assert get_job(job["id"])["delivery_script"] == "report.py"
 
         updated = update_job(job["id"], {"delivery_source": "agent"})
         assert updated.get("delivery_source") is None
+
+    def test_update_rescans_dormant_delivery_script_when_activated(self, cron_env):
+        from cron.jobs import create_job, get_job, update_job
+        from cron.lifecycle_guard import GatewayLifecycleBlocked
+
+        script = cron_env / "scripts" / "report.py"
+        script.write_text("print('safe report')\n", encoding="utf-8")
+        job = create_job(
+            prompt="Analyze",
+            schedule="every 1h",
+            delivery_script="report.py",
+        )
+        script.write_text(
+            "import os\nos.system('hermes gateway restart')\n",
+            encoding="utf-8",
+        )
+
+        with pytest.raises(GatewayLifecycleBlocked):
+            update_job(job["id"], {"delivery_source": "script"})
+
+        assert get_job(job["id"]).get("delivery_source") is None
 
     def test_invalid_delivery_source_is_rejected(self, cron_env):
         from cron.jobs import create_job
@@ -124,7 +147,7 @@ class TestJobScriptField:
             create_job(
                 prompt="Analyze",
                 schedule="every 1h",
-                script="report.py",
+                delivery_script="report.py",
                 delivery_source="model",
             )
 
@@ -165,124 +188,28 @@ class TestRunJobScript:
         assert success is True
         assert output == "relative works"
 
-    def test_script_delivery_capture_executes_gate_once(
-        self, cron_env, monkeypatch
+    def test_expected_delivery_script_sha_rejects_last_moment_replacement(
+        self, cron_env
     ):
-        import cron.scheduler as scheduler
+        import hashlib
 
-        calls = []
-        capture = []
+        from cron.scheduler import _run_job_script
 
-        def fake_script(*_args, **_kwargs):
-            calls.append("script")
-            return True, '{"wakeAgent": false}'
+        script = cron_env / "scripts" / "report.py"
+        original = b"print('operator report')\n"
+        script.write_bytes(original)
+        expected_sha256 = hashlib.sha256(original).hexdigest()
+        script.write_text("print('replacement report')\n", encoding="utf-8")
 
-        monkeypatch.setattr(
-            "hermes_cli.config.require_parseable_user_config", lambda: None
-        )
-        monkeypatch.setattr(
-            scheduler, "_run_job_script_with_claim_heartbeat", fake_script
-        )
-
-        success, _doc, final, error = scheduler.run_job(
-            {
-                "id": "capture-once",
-                "name": "capture-once",
-                "prompt": "Analyze",
-                "script": "report.py",
-                "delivery_source": "script",
-            },
-            script_delivery_capture=capture,
-        )
-
-        assert success is True
-        assert final == scheduler.SILENT_MARKER
-        assert error is None
-        assert calls == ["script"]
-        assert capture == [(True, '{"wakeAgent": false}')]
-
-    def test_empty_script_delivery_output_is_silent_and_auditable(
-        self, cron_env, monkeypatch
-    ):
-        import cron.scheduler as scheduler
-        import run_agent
-
-        capture = []
-
-        monkeypatch.setattr(
-            "hermes_cli.config.require_parseable_user_config", lambda: None
-        )
-        monkeypatch.setattr(
-            scheduler,
-            "_run_job_script_with_claim_heartbeat",
-            lambda *_args, **_kwargs: (True, ""),
-        )
-        monkeypatch.setattr(
-            run_agent,
-            "AIAgent",
-            lambda *_args, **_kwargs: (_ for _ in ()).throw(
-                AssertionError("agent must not run for empty script output")
-            ),
-        )
-
-        success, doc, final, error = scheduler.run_job(
-            {
-                "id": "capture-empty",
-                "name": "capture-empty",
-                "prompt": "Analyze",
-                "script": "report.py",
-                "delivery_source": "script",
-            },
-            script_delivery_capture=capture,
-        )
-
-        assert success is True
-        assert final == scheduler.SILENT_MARKER
-        assert error is None
-        assert "silent (empty script output); agent not run" in doc
-        assert capture == [(True, "")]
-
-    def test_script_delivery_failure_fails_before_agent_construction(
-        self, cron_env, monkeypatch
-    ):
-        import cron.scheduler as scheduler
-        import run_agent
-
-        calls = []
-        capture = []
-
-        def fake_script(*_args, **_kwargs):
-            calls.append("script")
-            return False, "exit code 1: upstream unavailable"
-
-        def unexpected_agent(*_args, **_kwargs):
-            raise AssertionError("agent must not be constructed after script failure")
-
-        monkeypatch.setattr(
-            "hermes_cli.config.require_parseable_user_config", lambda: None
-        )
-        monkeypatch.setattr(
-            scheduler, "_run_job_script_with_claim_heartbeat", fake_script
-        )
-        monkeypatch.setattr(run_agent, "AIAgent", unexpected_agent)
-
-        success, doc, final, error = scheduler.run_job(
-            {
-                "id": "capture-fail",
-                "name": "capture-fail",
-                "prompt": "Analyze",
-                "script": "report.py",
-                "delivery_source": "script",
-            },
-            script_delivery_capture=capture,
+        success, output = _run_job_script(
+            str(script),
+            preserve_stdout=True,
+            expected_sha256=expected_sha256,
         )
 
         assert success is False
-        assert final == ""
-        assert "script failed; agent not run" in doc
-        assert "upstream unavailable" in error
-        assert calls == ["script"]
-        assert capture == [(False, "exit code 1: upstream unavailable")]
+        assert "changed before execution" in output
+        assert "replacement report" not in output
 
     @pytest.mark.parametrize("invalid_source", ["Script", "script ", "model"])
     def test_noncanonical_runtime_delivery_source_fails_closed(
@@ -295,7 +222,7 @@ class TestRunJobScript:
                 "id": "invalid-source",
                 "name": "invalid-source",
                 "prompt": "Analyze",
-                "script": "report.py",
+                "delivery_script": "report.py",
                 "delivery_source": invalid_source,
             }
         )
@@ -318,11 +245,11 @@ class TestRunJobScript:
 
         summary = _summarize_cron_failure_for_delivery(
             {"id": "delivery-timeout", "name": "research"},
-            f"Pre-run delivery script failed: {detail}",
+            f"Post-run delivery script failed: {detail}",
         )
 
-        assert "pre-run delivery script failed" in summary
-        assert "No model was invoked" in summary
+        assert "post-run delivery script failed" in summary
+        assert "agent response was not delivered" in summary
         assert "provider" not in summary.lower()
 
 

--- a/tests/cron/test_monitor_kind.py
+++ b/tests/cron/test_monitor_kind.py
@@ -76,6 +76,9 @@ def _install_agent_stubs(monkeypatch, observed: dict):
         def run_conversation(self, prompt, *_a, **_kw):
             observed["agent_runs"] += 1
             observed["prompts"].append(prompt)
+            callback = observed.get("on_agent_run")
+            if callback:
+                callback()
             return {"final_response": "agent done", "messages": []}
 
         def get_activity_summary(self):
@@ -268,11 +271,11 @@ def test_unified_diff_is_capped(hermes_env):
 def _make_monitor_job(hermes_env, script_body: str):
     from cron.jobs import create_job
 
-    _write_script(hermes_env, "mon.sh", script_body)
+    _write_script(hermes_env, "mon.py", script_body)
     return create_job(
         prompt="Summarize what changed",
         schedule="every 5m",
-        monitor_script="mon.sh",
+        monitor_script="mon.py",
         deliver="local",
     )
 
@@ -280,7 +283,7 @@ def _make_monitor_job(hermes_env, script_body: str):
 def test_first_run_always_runs_agent(hermes_env, monkeypatch):
     from cron.scheduler import run_job
 
-    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    job = _make_monitor_job(hermes_env, "print('state A')\n")
     observed: dict = {}
     _install_agent_stubs(monkeypatch, observed)
 
@@ -292,11 +295,215 @@ def test_first_run_always_runs_agent(hermes_env, monkeypatch):
     assert "state A" in observed["prompts"][0]
 
 
+def test_monitor_job_runs_delivery_script_once_after_agent(
+    hermes_env, monkeypatch
+):
+    from cron.jobs import create_job, get_job
+    from cron.scheduler import SILENT_MARKER, run_job
+
+    _write_script(hermes_env, "mon.py", "print('active packet')\n")
+    state_path = hermes_env / "agent-state.txt"
+    count_path = hermes_env / "delivery-count.txt"
+    _write_script(
+        hermes_env,
+        "deliver.py",
+        "from pathlib import Path\n"
+        f"state = Path({str(state_path)!r})\n"
+        f"count = Path({str(count_path)!r})\n"
+        "n = int(count.read_text() or '0') + 1 if count.exists() else 1\n"
+        "count.write_text(str(n))\n"
+        "print(state.read_text())\n",
+    )
+    job = create_job(
+        prompt="Process the active packet",
+        schedule="every 5m",
+        monitor_script="mon.py",
+        delivery_source="script",
+        delivery_script="deliver.py",
+        deliver="local",
+    )
+    observed = {"on_agent_run": lambda: state_path.write_text("exact report")}
+    _install_agent_stubs(monkeypatch, observed)
+
+    capture = []
+    success, doc, final, error = run_job(
+        job, script_delivery_capture=capture
+    )
+    assert success is True
+    assert error is None
+    assert final == "agent done"
+    assert capture == [(True, "exact report\n")]
+    assert count_path.read_text() == "1"
+    assert "## Delivery Script Output" in doc
+    assert "exact report" in doc
+
+    # An unchanged monitor tick suppresses both the agent and the post-run
+    # delivery script. The previously rendered report is not replayed.
+    capture = []
+    success, doc, final, error = run_job(
+        get_job(job["id"]), script_delivery_capture=capture
+    )
+    assert success is True
+    assert error is None
+    assert final == SILENT_MARKER
+    assert "no_change" in doc
+    assert capture == [(True, SILENT_MARKER)]
+    assert observed["agent_runs"] == 1
+    assert count_path.read_text() == "1"
+
+
+def test_delivery_script_change_during_agent_turn_fails_closed(
+    hermes_env, monkeypatch
+):
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+
+    _write_script(hermes_env, "mon.py", "print('active packet')\n")
+    _write_script(hermes_env, "deliver.py", "print('operator report')\n")
+    delivery_path = hermes_env / "scripts" / "deliver.py"
+    job = create_job(
+        prompt="Process the active packet",
+        schedule="every 5m",
+        monitor_script="mon.py",
+        delivery_source="script",
+        delivery_script="deliver.py",
+        deliver="local",
+    )
+    observed = {
+        "on_agent_run": lambda: delivery_path.write_text(
+            "print('model-controlled report')\n", encoding="utf-8"
+        )
+    }
+    _install_agent_stubs(monkeypatch, observed)
+
+    capture = []
+    success, doc, final, error = run_job(
+        job, script_delivery_capture=capture
+    )
+
+    assert success is False
+    assert final == ""
+    assert "changed during the agent turn" in error
+    assert "model-controlled report" not in doc
+    assert capture == [(False, error)]
+
+
+def test_delivery_script_uses_job_workdir_without_capture(hermes_env, monkeypatch):
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+
+    _write_script(hermes_env, "mon.py", "print('active packet')\n")
+    _write_script(
+        hermes_env,
+        "deliver.py",
+        "from pathlib import Path\nprint(Path('projection.txt').read_text())\n",
+    )
+    workdir = hermes_env / "research"
+    workdir.mkdir()
+    projection = workdir / "projection.txt"
+    job = create_job(
+        prompt="Process the active packet",
+        schedule="every 5m",
+        monitor_script="mon.py",
+        delivery_source="script",
+        delivery_script="deliver.py",
+        workdir=str(workdir),
+        deliver="local",
+    )
+    observed = {"on_agent_run": lambda: projection.write_text("workdir report")}
+    _install_agent_stubs(monkeypatch, observed)
+
+    success, doc, final, error = run_job(job)
+
+    assert success is True
+    assert error is None
+    assert final == "agent done"
+    assert "## Delivery Script Output" in doc
+    assert "workdir report" in doc
+
+
+@pytest.mark.parametrize(
+    ("script_body", "expected_delivery", "expected_silent"),
+    [
+        ("pass\n", [], True),
+        ("print('[SILENT]')\n", [], True),
+        ("print('{\"wakeAgent\": false}')\n", ['{"wakeAgent": false}\n'], False),
+    ],
+)
+def test_real_delivery_script_stdout_contract(
+    hermes_env, monkeypatch, script_body, expected_delivery, expected_silent
+):
+    from cron.jobs import create_job, get_job
+    from cron.scheduler import run_one_job
+
+    _write_script(hermes_env, "mon.py", "print('active packet')\n")
+    _write_script(hermes_env, "deliver.py", script_body)
+    job = create_job(
+        prompt="Process the active packet",
+        schedule="every 5m",
+        monitor_script="mon.py",
+        delivery_source="script",
+        delivery_script="deliver.py",
+        deliver="local",
+    )
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed)
+    delivered = []
+    usage_audits = []
+    monkeypatch.setattr(
+        "cron.scheduler._deliver_result",
+        lambda _job, content, **_kw: delivered.append(content) or None,
+    )
+    monkeypatch.setattr("cron.scheduler._write_usage_audit", usage_audits.append)
+
+    assert run_one_job(job) is True
+    assert delivered == expected_delivery
+    assert observed["agent_runs"] == 1
+    assert get_job(job["id"])["last_status"] == "ok"
+    assert usage_audits[-1]["response_silent"] is expected_silent
+
+
+def test_post_run_delivery_script_failure_never_returns_agent_text(
+    hermes_env, monkeypatch
+):
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+
+    _write_script(hermes_env, "mon.py", "print('active packet')\n")
+    _write_script(
+        hermes_env,
+        "deliver.py",
+        "raise SystemExit('renderer unavailable')\n",
+    )
+    job = create_job(
+        prompt="Process the active packet",
+        schedule="every 5m",
+        monitor_script="mon.py",
+        delivery_source="script",
+        delivery_script="deliver.py",
+        deliver="local",
+    )
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed)
+
+    capture = []
+    success, doc, final, error = run_job(
+        job, script_delivery_capture=capture
+    )
+    assert success is False
+    assert final == ""
+    assert "agent done" in doc
+    assert "renderer unavailable" in doc
+    assert "Post-run delivery script failed" in error
+    assert capture and capture[0][0] is False
+    assert observed["agent_runs"] == 1
+
+
 def test_unchanged_output_suppresses_agent_run(hermes_env, monkeypatch):
     from cron.jobs import get_job
     from cron.scheduler import SILENT_MARKER, run_job
 
-    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    job = _make_monitor_job(hermes_env, "print('state A')\n")
     observed: dict = {}
     _install_agent_stubs(monkeypatch, observed)
 
@@ -317,14 +524,14 @@ def test_changed_output_injects_diff(hermes_env, monkeypatch):
     from cron.jobs import get_job
     from cron.scheduler import run_job
 
-    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    job = _make_monitor_job(hermes_env, "print('state A')\n")
     observed: dict = {}
     _install_agent_stubs(monkeypatch, observed)
 
     run_job(job)
 
     # Mutate the monitored source, then fire again.
-    _write_script(hermes_env, "mon.sh", "echo 'state B'\n")
+    _write_script(hermes_env, "mon.py", "print('state B')\n")
     job = get_job(job["id"])
     success, doc, final, error = run_job(job)
     assert success is True
@@ -342,7 +549,7 @@ def test_hash_persists_across_scheduler_restart(hermes_env, monkeypatch):
 
     from cron.scheduler import run_job
 
-    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    job = _make_monitor_job(hermes_env, "print('state A')\n")
     observed: dict = {}
     _install_agent_stubs(monkeypatch, observed)
 
@@ -370,7 +577,7 @@ def test_monitor_script_failure_is_error_not_change(hermes_env, monkeypatch):
     from cron.jobs import get_job
     from cron.scheduler import run_job
 
-    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    job = _make_monitor_job(hermes_env, "print('state A')\n")
     observed: dict = {}
     _install_agent_stubs(monkeypatch, observed)
 
@@ -378,7 +585,11 @@ def test_monitor_script_failure_is_error_not_change(hermes_env, monkeypatch):
     stored_hash = get_job(job["id"])["monitor_state"]["last_output_hash"]
 
     # Break the source: non-zero exit must be an error, never a "change".
-    _write_script(hermes_env, "mon.sh", "echo boom >&2\nexit 3\n")
+    _write_script(
+        hermes_env,
+        "mon.py",
+        "import sys\nprint('boom', file=sys.stderr)\nraise SystemExit(3)\n",
+    )
     job = get_job(job["id"])
     success, doc, final, error = run_job(job)
     assert success is False

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -78,6 +78,149 @@ def test_run_one_job_success_sequence(monkeypatch):
     assert calls[-1] == ("mark", "j2", True)
 
 
+def test_script_delivery_source_hands_exact_stdout_to_delivery(monkeypatch):
+    """Agent narration stays auditable but never enters the delivery body."""
+    delivered = []
+    marked = []
+    saved = []
+    payload = (
+        "**Research report**\nExact script output\n"
+        'TELEGRAM_BUTTONS:{"inline_keyboard":[[{"text":"Chart","url":"https://example.com"}]]}'
+    )
+
+    def fake_run_job(job, *, script_delivery_capture=None, **_kw):
+        script_delivery_capture.append((True, payload))
+        return True, "full transcript including model narration", "I will persist this next.", None
+
+    monkeypatch.setattr(s, "run_job", fake_run_job)
+    monkeypatch.setattr(
+        s,
+        "save_job_output",
+        lambda job_id, output: saved.append((job_id, output)) or "/tmp/out.md",
+    )
+    monkeypatch.setattr(
+        s,
+        "_deliver_result",
+        lambda _job, content, **_kw: delivered.append(content) or None,
+    )
+    monkeypatch.setattr(
+        s,
+        "mark_job_run",
+        lambda job_id, ok, error=None, **_kw: marked.append((job_id, ok, error)),
+    )
+
+    assert s.run_one_job(
+        {
+            "id": "script-source",
+            "name": "research",
+            "deliver": "telegram",
+            "delivery_source": "script",
+        }
+    ) is True
+    assert delivered == [payload]
+    assert "I will persist" not in delivered[0]
+    assert "TELEGRAM_BUTTONS:" in delivered[0]
+    assert saved == [
+        ("script-source", "full transcript including model narration")
+    ]
+    assert marked == [("script-source", True, None)]
+
+
+def test_script_delivery_source_honors_silent_stdout(monkeypatch):
+    delivered = []
+
+    def fake_run_job(job, *, script_delivery_capture=None, **_kw):
+        script_delivery_capture.append((True, "[SILENT]"))
+        return True, "saved agent transcript", "agent narration", None
+
+    monkeypatch.setattr(s, "run_job", fake_run_job)
+    monkeypatch.setattr(s, "save_job_output", lambda *_a, **_kw: "/tmp/out.md")
+    monkeypatch.setattr(
+        s,
+        "_deliver_result",
+        lambda _job, content, **_kw: delivered.append(content) or None,
+    )
+    monkeypatch.setattr(s, "mark_job_run", lambda *_a, **_kw: None)
+
+    assert s.run_one_job(
+        {
+            "id": "script-silent",
+            "name": "research",
+            "deliver": "telegram",
+            "delivery_source": "script",
+        }
+    ) is True
+    assert delivered == []
+
+
+def test_script_delivery_source_does_not_require_agent_final_text(monkeypatch):
+    delivered = []
+    marked = []
+
+    def fake_run_job(job, *, script_delivery_capture=None, **_kw):
+        script_delivery_capture.append((True, "authoritative report"))
+        return True, "saved agent transcript", "", None
+
+    monkeypatch.setattr(s, "run_job", fake_run_job)
+    monkeypatch.setattr(s, "save_job_output", lambda *_a, **_kw: "/tmp/out.md")
+    monkeypatch.setattr(
+        s,
+        "_deliver_result",
+        lambda _job, content, **_kw: delivered.append(content) or None,
+    )
+    monkeypatch.setattr(
+        s,
+        "mark_job_run",
+        lambda job_id, ok, error=None, **_kw: marked.append((job_id, ok, error)),
+    )
+
+    assert s.run_one_job(
+        {
+            "id": "script-empty-agent",
+            "name": "research",
+            "deliver": "telegram",
+            "delivery_source": "script",
+        }
+    ) is True
+    assert delivered == ["authoritative report"]
+    assert marked == [("script-empty-agent", True, None)]
+
+
+def test_script_delivery_source_never_falls_back_when_capture_is_missing(monkeypatch):
+    delivered = []
+    marked = []
+
+    monkeypatch.setattr(
+        s,
+        "run_job",
+        lambda *_a, **_kw: (True, "saved transcript", "unsafe agent narration", None),
+    )
+    monkeypatch.setattr(s, "save_job_output", lambda *_a, **_kw: "/tmp/out.md")
+    monkeypatch.setattr(
+        s,
+        "_deliver_result",
+        lambda _job, content, **_kw: delivered.append(content) or None,
+    )
+    monkeypatch.setattr(
+        s,
+        "mark_job_run",
+        lambda job_id, ok, error=None, **_kw: marked.append((job_id, ok, error)),
+    )
+
+    assert s.run_one_job(
+        {
+            "id": "script-missing",
+            "name": "research",
+            "deliver": "telegram",
+            "delivery_source": "script",
+        }
+    ) is True
+    assert len(delivered) == 1
+    assert "unsafe agent narration" not in delivered[0]
+    assert "without a captured pre-run script result" in delivered[0]
+    assert marked[0][1] is False
+
+
 def test_run_one_job_exception_delivers_failure_alert(monkeypatch):
     """An exception escaping the run body must not become a silent error row."""
     delivered = []
@@ -376,5 +519,3 @@ def test_run_one_job_installs_secret_scope_under_multiplex(monkeypatch, tmp_path
     assert scope_during_delivery["base_url"] == "https://openrouter.ai/api/v1"
     # And it was torn down after the full lifecycle returned (no leak).
     assert ss.current_secret_scope() is None
-
-

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -10,6 +10,8 @@ The first test characterizes the sequence as driven through `tick()` (proving
 the extraction didn't change `tick`'s behavior); the rest unit-test the
 extracted helper directly.
 """
+import contextlib
+
 import pytest
 
 import cron.scheduler as s
@@ -115,6 +117,7 @@ def test_script_delivery_source_hands_exact_stdout_to_delivery(monkeypatch):
             "name": "research",
             "deliver": "telegram",
             "delivery_source": "script",
+            "delivery_script": "render.py",
         }
     ) is True
     assert delivered == [payload]
@@ -124,6 +127,118 @@ def test_script_delivery_source_hands_exact_stdout_to_delivery(monkeypatch):
         ("script-source", "full transcript including model narration")
     ]
     assert marked == [("script-source", True, None)]
+
+
+def test_post_run_delivery_script_executes_inside_fire_claim_fence(monkeypatch):
+    fence_active = False
+    delivered = []
+
+    @contextlib.contextmanager
+    def owned_fence(_job_id, *, expected_owner):
+        nonlocal fence_active
+        assert expected_owner == "owner-1"
+        fence_active = True
+        try:
+            yield True
+        finally:
+            fence_active = False
+
+    def fake_snapshot_runner(job, identity, workdir=None, cancel_event=None):
+        assert fence_active is True
+        assert identity == ("render.py", "expected-sha", b"script")
+        assert workdir == "C:/research"
+        return True, "fenced report"
+
+    def fake_run_job(
+        job,
+        *,
+        script_delivery_capture=None,
+        delivery_script_runner=None,
+        **_kw,
+    ):
+        result = delivery_script_runner(
+            job,
+            (job["delivery_script"], "expected-sha", b"script"),
+            job["workdir"],
+            None,
+        )
+        script_delivery_capture.append(result)
+        return True, "saved transcript", "agent narration", None
+
+    monkeypatch.setattr(s, "fire_claim_fence", owned_fence)
+    monkeypatch.setattr(s, "heartbeat_fire_claim", lambda *_a, **_kw: True)
+    monkeypatch.setattr(s, "_run_delivery_script_snapshot", fake_snapshot_runner)
+    monkeypatch.setattr(s, "run_job", fake_run_job)
+    monkeypatch.setattr(s, "save_job_output", lambda *_a, **_kw: "/tmp/out.md")
+    monkeypatch.setattr(
+        s,
+        "_deliver_result",
+        lambda _job, content, **_kw: delivered.append(content) or None,
+    )
+    monkeypatch.setattr(s, "mark_job_run", lambda *_a, **_kw: True)
+
+    assert s.run_one_job(
+        {
+            "id": "fenced-script",
+            "name": "research",
+            "deliver": "telegram",
+            "delivery_source": "script",
+            "delivery_script": "render.py",
+            "workdir": "C:/research",
+            "fire_claim": {"by": "owner-1"},
+        }
+    ) is True
+    assert delivered == ["fenced report"]
+
+
+def test_lost_fire_claim_prevents_post_run_delivery_script_execution(monkeypatch):
+    script_calls = []
+    delivered = []
+
+    @contextlib.contextmanager
+    def lost_fence(_job_id, *, expected_owner):
+        yield False
+
+    def fake_snapshot_runner(*_args, **_kwargs):
+        script_calls.append(True)
+        return True, "must not run"
+
+    def fake_run_job(
+        job,
+        *,
+        script_delivery_capture=None,
+        delivery_script_runner=None,
+        **_kw,
+    ):
+        result = delivery_script_runner(
+            job, (job["delivery_script"], "expected-sha", b"script"), None, None
+        )
+        script_delivery_capture.append(result)
+        return False, "stale transcript", "", result[1]
+
+    monkeypatch.setattr(s, "fire_claim_fence", lost_fence)
+    monkeypatch.setattr(s, "heartbeat_fire_claim", lambda *_a, **_kw: False)
+    monkeypatch.setattr(s, "_run_delivery_script_snapshot", fake_snapshot_runner)
+    monkeypatch.setattr(s, "run_job", fake_run_job)
+    monkeypatch.setattr(s, "save_job_output", lambda *_a, **_kw: "/tmp/out.md")
+    monkeypatch.setattr(
+        s,
+        "_deliver_result",
+        lambda _job, content, **_kw: delivered.append(content) or None,
+    )
+
+    assert s.run_one_job(
+        {
+            "id": "stale-script",
+            "name": "research",
+            "deliver": "telegram",
+            "delivery_source": "script",
+            "delivery_script": "render.py",
+            "fire_claim": {"by": "stale-owner"},
+        }
+    ) is True
+    assert script_calls == []
+    assert delivered == []
 
 
 def test_script_delivery_source_honors_silent_stdout(monkeypatch):
@@ -148,9 +263,166 @@ def test_script_delivery_source_honors_silent_stdout(monkeypatch):
             "name": "research",
             "deliver": "telegram",
             "delivery_source": "script",
+            "delivery_script": "render.py",
         }
     ) is True
     assert delivered == []
+
+
+def test_script_delivery_source_honors_empty_stdout(monkeypatch):
+    payload = ""
+    delivered = []
+    marked = []
+    saved = []
+
+    def fake_run_job(job, *, script_delivery_capture=None, **_kw):
+        script_delivery_capture.append((True, payload))
+        return True, "saved agent transcript", "agent narration", None
+
+    monkeypatch.setattr(s, "run_job", fake_run_job)
+    monkeypatch.setattr(
+        s,
+        "save_job_output",
+        lambda job_id, output: saved.append((job_id, output)) or "/tmp/out.md",
+    )
+    monkeypatch.setattr(
+        s,
+        "_deliver_result",
+        lambda _job, content, **_kw: delivered.append(content) or None,
+    )
+    monkeypatch.setattr(
+        s,
+        "mark_job_run",
+        lambda job_id, ok, error=None, **_kw: marked.append((job_id, ok, error)),
+    )
+
+    assert s.run_one_job(
+        {
+            "id": "script-other-silent",
+            "name": "research",
+            "deliver": "telegram",
+            "delivery_source": "script",
+            "delivery_script": "render.py",
+        }
+    ) is True
+    assert delivered == []
+    assert saved == [("script-other-silent", "saved agent transcript")]
+    assert marked == [("script-other-silent", True, None)]
+
+
+def test_script_delivery_source_delivers_wake_gate_shaped_stdout_verbatim(monkeypatch):
+    payload = '{"wakeAgent": false}'
+    delivered = []
+
+    def fake_run_job(job, *, script_delivery_capture=None, **_kw):
+        script_delivery_capture.append((True, payload))
+        return True, "saved agent transcript", "agent narration", None
+
+    monkeypatch.setattr(s, "run_job", fake_run_job)
+    monkeypatch.setattr(s, "save_job_output", lambda *_a, **_kw: "/tmp/out.md")
+    monkeypatch.setattr(
+        s,
+        "_deliver_result",
+        lambda _job, content, **_kw: delivered.append(content) or None,
+    )
+    monkeypatch.setattr(s, "mark_job_run", lambda *_a, **_kw: True)
+
+    assert s.run_one_job(
+        {
+            "id": "script-wake-shaped-output",
+            "name": "research",
+            "deliver": "telegram",
+            "delivery_source": "script",
+            "delivery_script": "render.py",
+        }
+    ) is True
+    assert delivered == [payload]
+
+
+def test_post_run_delivery_script_failure_alert_never_leaks_agent_text(monkeypatch):
+    delivered = []
+    marked = []
+    saved = []
+
+    def fake_run_job(job, *, script_delivery_capture=None, **_kw):
+        script_delivery_capture.append((False, "renderer timed out"))
+        return (
+            False,
+            "saved transcript with unsafe agent narration",
+            "",
+            "Post-run delivery script failed: renderer timed out",
+        )
+
+    monkeypatch.setattr(s, "run_job", fake_run_job)
+    monkeypatch.setattr(
+        s,
+        "save_job_output",
+        lambda job_id, output: saved.append((job_id, output)) or "/tmp/out.md",
+    )
+    monkeypatch.setattr(
+        s,
+        "_deliver_result",
+        lambda _job, content, **_kw: delivered.append(content) or None,
+    )
+    monkeypatch.setattr(
+        s,
+        "mark_job_run",
+        lambda job_id, ok, error=None, **_kw: marked.append((job_id, ok, error)),
+    )
+
+    assert s.run_one_job(
+        {
+            "id": "script-failed",
+            "name": "research",
+            "deliver": "telegram",
+            "delivery_source": "script",
+            "delivery_script": "render.py",
+        }
+    ) is True
+    assert len(delivered) == 1
+    assert "post-run delivery script failed" in delivered[0]
+    assert "agent response was not delivered" in delivered[0]
+    assert "unsafe agent narration" not in delivered[0]
+    assert saved == [
+        ("script-failed", "saved transcript with unsafe agent narration")
+    ]
+    assert marked[0][1] is False
+
+
+def test_agent_failure_before_delivery_script_preserves_original_error(monkeypatch):
+    delivered = []
+    marked = []
+
+    def fake_run_job(job, *, script_delivery_capture=None, **_kw):
+        assert script_delivery_capture == []
+        return False, "saved failed agent transcript", "", "provider unavailable"
+
+    monkeypatch.setattr(s, "run_job", fake_run_job)
+    monkeypatch.setattr(s, "save_job_output", lambda *_a, **_kw: "/tmp/out.md")
+    monkeypatch.setattr(
+        s,
+        "_deliver_result",
+        lambda _job, content, **_kw: delivered.append(content) or None,
+    )
+    monkeypatch.setattr(
+        s,
+        "mark_job_run",
+        lambda job_id, ok, error=None, **_kw: marked.append((job_id, ok, error)),
+    )
+
+    assert s.run_one_job(
+        {
+            "id": "agent-failed",
+            "name": "research",
+            "deliver": "telegram",
+            "delivery_source": "script",
+            "delivery_script": "render.py",
+        }
+    ) is True
+    assert len(delivered) == 1
+    assert "provider unavailable" in delivered[0]
+    assert "captured post-run" not in delivered[0]
+    assert marked == [("agent-failed", False, "provider unavailable")]
 
 
 def test_script_delivery_source_does_not_require_agent_final_text(monkeypatch):
@@ -180,6 +452,7 @@ def test_script_delivery_source_does_not_require_agent_final_text(monkeypatch):
             "name": "research",
             "deliver": "telegram",
             "delivery_source": "script",
+            "delivery_script": "render.py",
         }
     ) is True
     assert delivered == ["authoritative report"]
@@ -213,11 +486,12 @@ def test_script_delivery_source_never_falls_back_when_capture_is_missing(monkeyp
             "name": "research",
             "deliver": "telegram",
             "delivery_source": "script",
+            "delivery_script": "render.py",
         }
     ) is True
     assert len(delivered) == 1
     assert "unsafe agent narration" not in delivered[0]
-    assert "without a captured pre-run script result" in delivered[0]
+    assert "without a captured post-run delivery script result" in delivered[0]
     assert marked[0][1] is False
 
 

--- a/tests/cron/test_script_claim_heartbeat.py
+++ b/tests/cron/test_script_claim_heartbeat.py
@@ -354,6 +354,33 @@ def test_run_one_job_refreshes_fire_claim_in_profile_store(tmp_path, monkeypatch
     assert refreshed["by"] == original_claim["by"]
 
 
+def test_fire_claim_heartbeat_pauses_while_side_effect_fence_is_active(monkeypatch):
+    import cron.scheduler as scheduler
+
+    calls = []
+    monkeypatch.setattr(scheduler, "_RUN_CLAIM_HEARTBEAT_SECONDS", 0.01)
+    monkeypatch.setattr(
+        scheduler,
+        "heartbeat_fire_claim",
+        lambda *_a, **_kw: calls.append(time.monotonic()) or True,
+    )
+
+    def run(lost_ownership):
+        fence_active = lost_ownership._hermes_side_effect_fence_active
+        fence_active.set()
+        try:
+            time.sleep(0.06)
+            assert lost_ownership.is_set() is False
+            assert len(calls) == 1
+        finally:
+            fence_active.clear()
+        return True
+
+    assert scheduler._run_with_fire_claim_heartbeat(
+        {"id": "fenced", "fire_claim": {"by": "owner"}}, run
+    ) is True
+
+
 def test_lost_fire_claim_stops_stale_delivery(monkeypatch):
     """A runner that loses its durable owner must not deliver its stale result."""
     import cron.scheduler as scheduler

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -17,12 +17,17 @@ def tmp_cron_dir(tmp_path, monkeypatch):
     monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
     monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
     monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "scripts").mkdir()
     return tmp_path
 
 
 class TestCronCommandLifecycle:
 
     def test_create_and_edit_script_delivery_source(self, tmp_cron_dir, capsys):
+        (tmp_cron_dir / "scripts" / "report.py").write_text(
+            "print('report')\n", encoding="utf-8"
+        )
         parser = argparse.ArgumentParser(prog="hermes")
         subparsers = parser.add_subparsers(dest="command")
         build_cron_parser(subparsers, cmd_cron=cron_command)
@@ -33,7 +38,7 @@ class TestCronCommandLifecycle:
                 "create",
                 "every 1h",
                 "Analyze the report",
-                "--script",
+                "--delivery-script",
                 "report.py",
                 "--delivery-source",
                 "script",
@@ -66,9 +71,9 @@ class TestCronCommandLifecycle:
         )
         assert cron_command(enable_args) == 0
         assert get_job(job["id"])["delivery_source"] == "script"
-        assert "Delivery source: script stdout" in capsys.readouterr().out
+        assert "Delivery source: post-run script stdout" in capsys.readouterr().out
 
-    def test_create_script_delivery_without_script_fails_closed(
+    def test_create_script_delivery_without_delivery_script_fails_closed(
         self, tmp_cron_dir, capsys
     ):
         parser = argparse.ArgumentParser(prog="hermes")
@@ -88,7 +93,7 @@ class TestCronCommandLifecycle:
 
         assert cron_command(args) == 1
         assert list_jobs() == []
-        assert "requires a pre-run script" in capsys.readouterr().out
+        assert "requires a post-run delivery script" in capsys.readouterr().out
 
     def test_edit_persists_user_owned_inference_pins(self, tmp_cron_dir, capsys):
         job = create_job(prompt="Daily report", schedule="every 1h")
@@ -218,7 +223,7 @@ class TestCronDoctor:
 
     def test_doctor_reports_healthy_jobs(self, tmp_cron_dir, capsys):
         scripts_dir = tmp_cron_dir / "scripts"
-        scripts_dir.mkdir()
+        scripts_dir.mkdir(exist_ok=True)
         (scripts_dir / "ok.py").write_text("print('ok')\n", encoding="utf-8")
         create_job(prompt="Daily digest", schedule="every 1h", script="ok.py")
 
@@ -227,6 +232,20 @@ class TestCronDoctor:
         out = capsys.readouterr().out
         assert rc == 0
         assert "✓ Cron doctor found no issues" in out
+
+    def test_doctor_ignores_missing_dormant_delivery_script(
+        self, tmp_cron_dir, capsys
+    ):
+        create_job(
+            prompt="Analyze",
+            schedule="every 1h",
+            delivery_script="unused.py",
+        )
+
+        rc = cron_command(Namespace(cron_command="doctor"))
+
+        assert rc == 0
+        assert "✓ Cron doctor found no issues" in capsys.readouterr().out
 
     def test_doctor_flags_overdue_next_run(self, tmp_cron_dir, capsys):
         from datetime import datetime, timedelta, timezone

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -22,6 +22,74 @@ def tmp_cron_dir(tmp_path, monkeypatch):
 
 class TestCronCommandLifecycle:
 
+    def test_create_and_edit_script_delivery_source(self, tmp_cron_dir, capsys):
+        parser = argparse.ArgumentParser(prog="hermes")
+        subparsers = parser.add_subparsers(dest="command")
+        build_cron_parser(subparsers, cmd_cron=cron_command)
+
+        create_args = parser.parse_args(
+            [
+                "cron",
+                "create",
+                "every 1h",
+                "Analyze the report",
+                "--script",
+                "report.py",
+                "--delivery-source",
+                "script",
+            ]
+        )
+        assert cron_command(create_args) == 0
+        job = list_jobs()[0]
+        assert job["delivery_source"] == "script"
+
+        edit_args = parser.parse_args(
+            [
+                "cron",
+                "edit",
+                job["id"],
+                "--delivery-source",
+                "agent",
+            ]
+        )
+        assert cron_command(edit_args) == 0
+        assert get_job(job["id"]).get("delivery_source") is None
+
+        enable_args = parser.parse_args(
+            [
+                "cron",
+                "edit",
+                job["id"],
+                "--delivery-source",
+                "script",
+            ]
+        )
+        assert cron_command(enable_args) == 0
+        assert get_job(job["id"])["delivery_source"] == "script"
+        assert "Delivery source: script stdout" in capsys.readouterr().out
+
+    def test_create_script_delivery_without_script_fails_closed(
+        self, tmp_cron_dir, capsys
+    ):
+        parser = argparse.ArgumentParser(prog="hermes")
+        subparsers = parser.add_subparsers(dest="command")
+        build_cron_parser(subparsers, cmd_cron=cron_command)
+
+        args = parser.parse_args(
+            [
+                "cron",
+                "create",
+                "every 1h",
+                "Analyze the report",
+                "--delivery-source",
+                "script",
+            ]
+        )
+
+        assert cron_command(args) == 1
+        assert list_jobs() == []
+        assert "requires a pre-run script" in capsys.readouterr().out
+
     def test_edit_persists_user_owned_inference_pins(self, tmp_cron_dir, capsys):
         job = create_job(prompt="Daily report", schedule="every 1h")
         parser = argparse.ArgumentParser(prog="hermes")

--- a/tests/tools/test_cronjob_run_background.py
+++ b/tests/tools/test_cronjob_run_background.py
@@ -129,8 +129,8 @@ class TestBackgroundDispatch:
 
         script_job = {
             **_job("job-bg-script-source"),
-            "script": "report.py",
             "delivery_source": "script",
+            "delivery_script": "report.py",
         }
         with _bound_session_key("agent:main:telegram:dm:779"):
             with patch(

--- a/tests/tools/test_cronjob_run_background.py
+++ b/tests/tools/test_cronjob_run_background.py
@@ -122,6 +122,49 @@ class TestBackgroundDispatch:
         assert "bg run" in (found.get("summary") or "")
         assert "Next scheduled run" in found["summary"]
 
+    def test_script_delivery_completion_omits_agent_output_excerpt(self):
+        import time
+
+        from tools.process_registry import process_registry
+
+        script_job = {
+            **_job("job-bg-script-source"),
+            "script": "report.py",
+            "delivery_source": "script",
+        }
+        with _bound_session_key("agent:main:telegram:dm:779"):
+            with patch(
+                "tools.cronjob_tools.claim_job_for_fire",
+                return_value={**script_job, "fire_claim": {"by": "bg-owner"}},
+            ), patch(
+                "cron.scheduler.run_one_job", return_value=True
+            ), patch(
+                "tools.cronjob_tools.get_job",
+                return_value={"last_status": "ok", "last_error": None},
+            ), patch(
+                "tools.cronjob_tools._latest_job_output_excerpt",
+                return_value="unsafe agent narration",
+            ):
+                res = _try_dispatch_background_run(script_job)
+                assert res["dispatched"] is True
+
+                found = None
+                for _ in range(100):
+                    try:
+                        evt = process_registry.completion_queue.get_nowait()
+                    except Exception:
+                        time.sleep(0.05)
+                        continue
+                    if evt.get("delegation_id") == res["delegation_id"]:
+                        found = evt
+                        break
+                    process_registry.completion_queue.put(evt)
+                    time.sleep(0.05)
+
+        assert found is not None
+        assert "unsafe agent narration" not in found["summary"]
+        assert "output excerpt omitted" in found["summary"].lower()
+
     def test_failed_run_reports_error_status_in_event(self):
         import time
 

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -482,6 +482,53 @@ class TestAgentCannotSetModelPin:
         assert stored["name"] == "renamed"
 
 
+class TestAgentCannotSetDeliverySource:
+    """The delivery boundary is operator-owned like inference pins."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_cron_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+        monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+        monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+
+    def test_schema_has_no_delivery_source_param(self):
+        from tools.cronjob_tools import CRONJOB_SCHEMA
+
+        assert "delivery_source" not in CRONJOB_SCHEMA["parameters"]["properties"]
+
+    def test_handler_update_leaves_operator_delivery_source_untouched(self):
+        from cron.jobs import get_job
+        from tools.registry import registry
+
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Check",
+                schedule="every 1h",
+                script="report.py",
+                delivery_source="script",
+            )
+        )
+        job_id = created["job_id"]
+
+        updated = json.loads(
+            registry.dispatch(
+                "cronjob",
+                {
+                    "action": "update",
+                    "job_id": job_id,
+                    "name": "renamed",
+                    "delivery_source": "agent",
+                },
+            )
+        )
+
+        assert updated["success"] is True
+        stored = get_job(job_id)
+        assert stored["delivery_source"] == "script"
+        assert stored["name"] == "renamed"
+
+
 class TestRegisteredHandlerForwardsAttachToSession:
     """#84802 — schema + cronjob() already accept attach_to_session, but the
     registry adapter must forward it or create silently drops the field and

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -228,6 +228,10 @@ class TestUnifiedCronjobTool:
         monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
         monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
         monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        scripts = tmp_path / "scripts"
+        scripts.mkdir()
+        (scripts / "report.py").write_text("print('report')\n", encoding="utf-8")
 
     def test_create_and_list(self):
         created = json.loads(
@@ -495,6 +499,7 @@ class TestAgentCannotSetDeliverySource:
         from tools.cronjob_tools import CRONJOB_SCHEMA
 
         assert "delivery_source" not in CRONJOB_SCHEMA["parameters"]["properties"]
+        assert "delivery_script" not in CRONJOB_SCHEMA["parameters"]["properties"]
 
     def test_handler_update_leaves_operator_delivery_source_untouched(self):
         from cron.jobs import get_job
@@ -505,8 +510,8 @@ class TestAgentCannotSetDeliverySource:
                 action="create",
                 prompt="Check",
                 schedule="every 1h",
-                script="report.py",
                 delivery_source="script",
+                delivery_script="report.py",
             )
         )
         job_id = created["job_id"]
@@ -519,6 +524,7 @@ class TestAgentCannotSetDeliverySource:
                     "job_id": job_id,
                     "name": "renamed",
                     "delivery_source": "agent",
+                    "delivery_script": "attacker.py",
                 },
             )
         )
@@ -526,6 +532,7 @@ class TestAgentCannotSetDeliverySource:
         assert updated["success"] is True
         stored = get_job(job_id)
         assert stored["delivery_source"] == "script"
+        assert stored["delivery_script"] == "report.py"
         assert stored["name"] == "renamed"
 
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -429,6 +429,12 @@ def _mode_guidance_notes(job: Dict[str, Any], user_deliver: Optional[str]) -> Li
             "there is nothing to report). Non-zero exit or timeout sends an "
             "error alert. prompt/skills are ignored."
         )
+    if job.get("delivery_source") == "script":
+        notes.append(
+            "Script delivery source: the agent still runs and its transcript "
+            "is saved, but successful chat delivery uses the pre-run script "
+            "stdout as its body. Script failure never falls back to agent text."
+        )
     _deliver = (user_deliver or "").strip().lower()
     if _deliver:
         if "all" in _deliver.split(","):
@@ -779,6 +785,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
     }
     if job.get("script"):
         result["script"] = job["script"]
+    if job.get("delivery_source"):
+        result["delivery_source"] = job["delivery_source"]
     if job.get("reasoning_effort"):
         result["reasoning_effort"] = job["reasoning_effort"]
     if job.get("monitor_script"):
@@ -1353,10 +1361,17 @@ def _try_dispatch_background_run(
         ]
         if refreshed.get("next_run_at"):
             lines.append(f"Next scheduled run: {refreshed['next_run_at']}")
-        excerpt = _latest_job_output_excerpt(job_id)
-        if excerpt:
-            lines.append("--- JOB OUTPUT ---")
-            lines.append(excerpt)
+        if job.get("delivery_source") == "script":
+            lines.append(
+                "Job output excerpt omitted: this operator-owned job delivers "
+                "only its script output; the full agent transcript remains in "
+                "cron storage."
+            )
+        else:
+            excerpt = _latest_job_output_excerpt(job_id)
+            if excerpt:
+                lines.append("--- JOB OUTPUT ---")
+                lines.append(excerpt)
         return {
             "status": "completed" if res.get("success") else "error",
             "summary": "\n".join(lines),
@@ -1484,6 +1499,7 @@ def cronjob(
     reasoning_effort: Optional[str] = None,
     task_id: str = None,
     session_id: Optional[str] = None,
+    delivery_source: Optional[str] = None,
 ) -> str:
     """Unified cron job management tool."""
     del task_id  # unused but kept for handler signature compatibility
@@ -1585,6 +1601,7 @@ def cronjob(
                     provider=_normalize_optional_job_value(provider),
                     base_url=_normalize_optional_job_value(base_url, strip_trailing_slash=True),
                     script=_normalize_optional_job_value(script),
+                    delivery_source=delivery_source,
                     context_from=context_from,
                     enabled_toolsets=enabled_toolsets or None,
                     workdir=_normalize_optional_job_value(workdir),
@@ -1840,6 +1857,8 @@ def cronjob(
                     if script_error:
                         return tool_error(script_error, success=False)
                 updates["script"] = _normalize_optional_job_value(script) if script else None
+            if delivery_source is not None:
+                updates["delivery_source"] = delivery_source
             if monitor_script is not None:
                 # Pass empty string to clear an existing monitor_script
                 if monitor_script:
@@ -1956,7 +1975,7 @@ CRONJOB_SCHEMA = {
     "name": "cronjob",
     "description": """Manage scheduled cron jobs: action='create' schedules a job from a prompt and/or skills; 'list' inspects jobs; 'update'/'pause'/'resume'/'remove' manage one by job_id (always list first — never guess job IDs); 'run' fires a job immediately in the BACKGROUND (returns a handle at once, outcome re-enters the conversation when done — do not wait or poll; optional 'prompt' adds transient context for that fire only).
 
-Jobs run in a fresh session with no current-chat context, so prompts must be self-contained, and the agent's FINAL RESPONSE is what gets delivered — cron runs are autonomous and cannot ask questions. Prefer updating an existing job over creating near-duplicates.""",
+Jobs run in a fresh session with no current-chat context, so prompts must be self-contained. By default the agent's FINAL RESPONSE is delivered; operator-owned jobs may instead expose a read-only `delivery_source='script'` status, where script output is authoritative and agent narration stays in cron storage. Cron runs are autonomous and cannot ask questions. Prefer updating an existing job over creating near-duplicates.""",
     "parameters": {
         "type": "object",
         "properties": {

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -432,8 +432,9 @@ def _mode_guidance_notes(job: Dict[str, Any], user_deliver: Optional[str]) -> Li
     if job.get("delivery_source") == "script":
         notes.append(
             "Script delivery source: the agent still runs and its transcript "
-            "is saved, but successful chat delivery uses the pre-run script "
-            "stdout as its body. Script failure never falls back to agent text."
+            "is saved, then the operator-owned delivery script runs exactly "
+            "once. Its stdout is authoritative; failure never falls back to "
+            "agent text."
         )
     _deliver = (user_deliver or "").strip().lower()
     if _deliver:
@@ -787,6 +788,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["script"] = job["script"]
     if job.get("delivery_source"):
         result["delivery_source"] = job["delivery_source"]
+    if job.get("delivery_script"):
+        result["delivery_script"] = job["delivery_script"]
     if job.get("reasoning_effort"):
         result["reasoning_effort"] = job["reasoning_effort"]
     if job.get("monitor_script"):
@@ -1500,6 +1503,7 @@ def cronjob(
     task_id: str = None,
     session_id: Optional[str] = None,
     delivery_source: Optional[str] = None,
+    delivery_script: Optional[str] = None,
 ) -> str:
     """Unified cron job management tool."""
     del task_id  # unused but kept for handler signature compatibility
@@ -1540,6 +1544,10 @@ def cronjob(
                 script_error = _validate_cron_script_path(script)
                 if script_error:
                     return tool_error(script_error, success=False)
+            if delivery_script:
+                delivery_script_error = _validate_cron_script_path(delivery_script)
+                if delivery_script_error:
+                    return tool_error(delivery_script_error, success=False)
 
             # Validate monitor source (same containment rules as script).
             if monitor_script:
@@ -1602,6 +1610,7 @@ def cronjob(
                     base_url=_normalize_optional_job_value(base_url, strip_trailing_slash=True),
                     script=_normalize_optional_job_value(script),
                     delivery_source=delivery_source,
+                    delivery_script=_normalize_optional_job_value(delivery_script),
                     context_from=context_from,
                     enabled_toolsets=enabled_toolsets or None,
                     workdir=_normalize_optional_job_value(workdir),
@@ -1859,6 +1868,16 @@ def cronjob(
                 updates["script"] = _normalize_optional_job_value(script) if script else None
             if delivery_source is not None:
                 updates["delivery_source"] = delivery_source
+            if delivery_script is not None:
+                if delivery_script:
+                    delivery_script_error = _validate_cron_script_path(delivery_script)
+                    if delivery_script_error:
+                        return tool_error(delivery_script_error, success=False)
+                updates["delivery_script"] = (
+                    _normalize_optional_job_value(delivery_script)
+                    if delivery_script
+                    else None
+                )
             if monitor_script is not None:
                 # Pass empty string to clear an existing monitor_script
                 if monitor_script:
@@ -1975,7 +1994,7 @@ CRONJOB_SCHEMA = {
     "name": "cronjob",
     "description": """Manage scheduled cron jobs: action='create' schedules a job from a prompt and/or skills; 'list' inspects jobs; 'update'/'pause'/'resume'/'remove' manage one by job_id (always list first — never guess job IDs); 'run' fires a job immediately in the BACKGROUND (returns a handle at once, outcome re-enters the conversation when done — do not wait or poll; optional 'prompt' adds transient context for that fire only).
 
-Jobs run in a fresh session with no current-chat context, so prompts must be self-contained. By default the agent's FINAL RESPONSE is delivered; operator-owned jobs may instead expose a read-only `delivery_source='script'` status, where script output is authoritative and agent narration stays in cron storage. Cron runs are autonomous and cannot ask questions. Prefer updating an existing job over creating near-duplicates.""",
+Jobs run in a fresh session with no current-chat context, so prompts must be self-contained. By default the agent's FINAL RESPONSE is delivered; operator-owned jobs may instead expose read-only `delivery_source='script'` and `delivery_script` status, where post-run script output is authoritative and agent narration stays in cron storage. Cron runs are autonomous and cannot ask questions. Prefer updating an existing job over creating near-duplicates.""",
     "parameters": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
## Summary
- add an opt-in, operator-owned `delivery_source=script` mode for agent cron jobs
- run a distinct `delivery_script` exactly once after a successful agent turn and deliver its stdout while retaining the full agent transcript
- support the production monitor shape (`monitor_script` with no pre-run `script`) so the renderer can project state written by the completed agent
- keep the default agent-response path and the model-facing mutation surface unchanged

## Safety
- atomically bounded-read and lifecycle-validate the exact delivery-script bytes before inference, then execute those immutable bytes through interpreter stdin without reopening the mutable path
- fail closed if the configured script changes during the agent turn, lifecycle validation fails, execution fails, or the authoritative capture is missing
- execute the snapshot under the fire-claim side-effect fence, coordinate the heartbeat while the fence is held, and refresh the claim before releasing it
- preserve redacted renderer stdout exactly; only empty stdout and exact `[SILENT]` suppress delivery, while `{"wakeAgent": false}` remains ordinary output
- persist the renderer path, SHA-256, and actual delivery output in the durable cron transcript
- keep `delivery_source` and `delivery_script` CLI/direct-API operator-owned; the model tool can inspect but cannot mutate them
- keep no-agent jobs as a separate, incompatible mode

## Verification
- `210 passed, 3 skipped, 2 deselected` across focused cron, scheduler, CLI, tool, monitor, lifecycle, and claim-fence tests
- the two deselected tests are pre-existing Windows process-tree descendant cleanup failures
- broad cron suite: `1171 passed, 41 skipped`; 15 Windows/environment failures reproduced in unchanged Bash, POSIX permission, process-tree, HOME, and media-policy behavior
- Ruff passed on all touched files
- `git diff --check` passed
