### PR TITLE
fix(auxiliary): treat YAML null task-config values as unset, never as 'None' literal

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5437,6 +5437,31 @@ def _preserve_provider_with_base_url(prov: Optional[str]) -> bool:
         }
 
 
+def _normalize_optional_string(value: object) -> Optional[str]:
+    """Normalize an optional auxiliary-task config string.
+
+    YAML ``null`` and empty / whitespace-only / null-ish values all mean
+    "unset": return None. Otherwise return the stripped string.
+
+    Note on the null-ish literals: this helper treats the case-insensitive
+    strings ``"null"`` / ``"None"`` as unset. A real provider/model name will
+    never collide with either of those tokens in a meaningful way, so the
+    over-match is intentional and documented here. If a future provider ever
+    legitimately uses one of those tokens, this helper must not be applied to
+    that field.
+
+    A previous version used ``str(task_config.get(field, "")).strip() or None``,
+    which stringified the YAML ``null`` token into the string "None" and sent
+    that to the provider as a model ID / base URL / API key (#100835).
+    """
+    if value is None:
+        return None
+    s = str(value).strip()
+    if not s or s.lower() in {"none", "null"}:
+        return None
+    return s
+
+
 def _resolve_task_provider_model(
     task: str = None, provider: str = None, model: str = None, base_url: Optional[str] = None,
     api_key: Optional[str] = None,
@@ -5450,15 +5475,17 @@ def _resolve_task_provider_model(
     cfg_provider = cfg_model = cfg_base_url = cfg_api_key = resolved_api_mode = None
     if task:
         task_config = _get_auxiliary_task_config(task)
-        cfg_provider = str(task_config.get("provider", "")).strip() or None
-        cfg_model = str(task_config.get("model", "")).strip() or None
-        cfg_base_url = str(task_config.get("base_url", "")).strip() or None
-        cfg_api_key = str(task_config.get("api_key", "")).strip() or None
+        cfg_provider = _normalize_optional_string(task_config.get("provider"))
+        cfg_model = _normalize_optional_string(task_config.get("model"))
+        cfg_base_url = _normalize_optional_string(task_config.get("base_url"))
+        cfg_api_key = _normalize_optional_string(task_config.get("api_key"))
         if not cfg_api_key:  # key_env → env var when api_key is not set directly
-            cfg_key_env = str(task_config.get("key_env") or task_config.get("api_key_env") or "").strip()
+            cfg_key_env = _normalize_optional_string(
+                task_config.get("key_env") or task_config.get("api_key_env")
+            ) or ""
             if cfg_key_env:
                 cfg_api_key = _scoped_key_env(cfg_key_env) or None
-        resolved_api_mode = str(task_config.get("api_mode", "")).strip() or None
+        resolved_api_mode = _normalize_optional_string(task_config.get("api_mode"))
     # 'auto' is a sentinel ("inherit / auto-detect"), not a model id — leaking it to the wire
     # yields a 200 with an error-text body that consumers accept as output. The explicit `model`
     # kwarg needs the same normalization: MoA slots forward preset `model:` fields through it.

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -265,6 +265,52 @@ class TestResolveTaskProviderModel:
 
 
 
+    @pytest.mark.parametrize("field", ["provider", "model", "base_url", "api_key", "api_mode"])
+    @pytest.mark.parametrize("null_value", [None, "", "   ", "null", "None", "NULL"])
+    def test_null_config_values_are_not_stringified(self, field, null_value):
+        """YAML null (None) and null-ish strings must resolve to None, never
+        the literal "None" string (#100835).
+
+        Previous implementation: str(task_config.get(field, "")).strip() or None
+        stringified the YAML ``null`` token into "None" and forwarded it to the
+        provider as a literal model/base_url value.
+        """
+        task_config = {"provider": "auto", field: null_value}
+        with patch("agent.auxiliary_client._get_auxiliary_task_config", return_value=task_config):
+            resolved_provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(
+                task="compression",
+            )
+
+        # The whole-point invariant: the null-ish field must NOT appear in the
+        # resolution as the literal string "None"/"null" — it either resolves
+        # to None (unset) or, for provider, falls through to auto-resolution.
+        field_outputs = {
+            "provider": resolved_provider,
+            "model": model,
+            "base_url": base_url,
+            "api_key": api_key,
+            "api_mode": api_mode,
+        }
+        for name, value in field_outputs.items():
+            if name == field:
+                assert value != "None" and value != "null", (
+                    f"{field}={null_value!r} resolved to {value!r} "
+                    f"(null must not stringify)"
+                )
+            # And specifically: the null-ish field must itself be None or 'auto'
+            if name == field and field != "provider":
+                assert value is None, (
+                    f"{field}={null_value!r} resolved to {value!r} "
+                    f"(expected None — null must not be forwarded)"
+                )
+        # Provider, when null-ish, is normalized away and falls through to the
+        # auto-resolution path — the only legal outcome in this configuration
+        # is the literal "auto" sentinel (neither a user deny nor a hardline
+        # fires for a null provider).
+        if field == "provider":
+            assert resolved_provider == "auto"
+
+
 class TestMoaAggregatorSharedResolution:
     """The shared MoA→aggregator helper and the layers that consume it.
 


### PR DESCRIPTION
Fixes #100835

## What

A single helper `_normalize_optional_string()` centralizes the YAML-`null` →
`None` conversion for the five optional fields read from
`auxiliary.<task>` in `_resolve_task_provider_model`:
`provider`, `model`, `base_url`, `api_key`, `api_mode`.

Previously each site used the same idiom:

    str(task_config.get(field, "")).strip() or None

which stringified the YAML `null` token into the literal string `"None"` and
forwarded it to the provider as a model ID (`auxiliary.compression.model:
null` became model `"None"`), or as a base URL / API key.

## Why

The reported symptom:

```yaml
model:
  default: gpt-5.6-sol
auxiliary:
  compression:
    provider: auto
    model: null          # YAML null
```

resolved to `('auto', 'None', None, None, None)` and the provider rejected
the literal model `"None"` with HTTP 400. The same pattern exists in the
other four sibling fields; fixing only `model` would leave the bug class
alive (see also #18349, which covered only `base_url`).

## Change

- Add `_normalize_optional_string(value)`: returns `None` for `None`, `""`,
  whitespace, and the null-ish strings `"null"` / `"None"` (case-insensitive);
  otherwise returns the trimmed string.
- Route all five `cfg_*` reads through it (including the `key_env` /
  `api_key_env` fallback inside the `api_key` branch).
- Behavior identical for any non-null config value.

## Testing

`tests/agent/test_auxiliary_client.py::TestResolveTaskProviderModel` gains a
parametrized regression test: 5 fields × 6 null-ish values (`None`, `""`,
`"   "`, `"null"`, `"None"`, `"NULL"`) — 30 cases asserting the resolved
value is `None` (or the `"auto"` provider fallback on the `provider` leg),
never the literal string `"None"`.

Full file run: **218/218 pass**.

## Follow-ups

- `959c883c35` — documented the deliberate over-match of `"null"`/`"None"` in
  the helper docstring, and pinned the provider-null test to assert
  `resolved_provider == "auto"` exactly (instead of the permissive
  `"auto" or None`), addressing the AI review notes.

## Notes

- Supersedes the narrower fix in #18349 (base_url only, stalled since May).
- No new dependencies, no config surface, no behavior change for non-null
  configs.

---

**🛠️ Dev:** Halldrix
**🤖 Sidekick:** Hermes Agent v0.21.0
**🐞 Reproduction:** ✅ Confirmed
**📌 Status:** Open
