### PR TITLE
fix(browser): reap persistent Browser Use daemons

### DIFF
--- a/tests/tools/test_browser_orphan_reaper.py
+++ b/tests/tools/test_browser_orphan_reaper.py
@@ -141,6 +141,26 @@ class TestReapOrphanedBrowserSessions:
         _reap_orphaned_browser_sessions()
         assert not d.exists()
 
+    def test_browser_harness_dead_owner_reaps_bu_pid(self, fake_tmpdir):
+        from tools.browser_tool import _reap_orphaned_browser_sessions
+
+        session = "hermes_bh_111_alpha"
+        d = _make_socket_dir(fake_tmpdir, session, owner_pid=111)
+        (d / "bu.pid").write_text("222")
+        terminated = []
+
+        with patch("gateway.status._pid_exists", side_effect=[False, True]), \
+             patch("gateway.status.get_process_start_time", return_value=333), \
+             patch("tools.browser_tool._verify_reapable_browser_daemon", return_value=True), \
+             patch(
+                 "tools.process_registry.ProcessRegistry._terminate_host_pid",
+                 side_effect=lambda pid, expected_start=None: terminated.append(pid),
+             ):
+            _reap_orphaned_browser_sessions()
+
+        assert terminated == [222]
+        assert not d.exists()
+
 
 class TestOwnerPidCrossProcess:
     """Tests for owner_pid-based cross-process safe reaping.
@@ -296,7 +316,8 @@ class TestReaperIdentityGuard:
             return self._environ
 
     def _run(self, fake_proc, socket_dir, session_name="h_sess123456",
-             daemon_pid=12345, no_such=False, access_denied=False):
+             daemon_pid=12345, no_such=False, access_denied=False,
+             expected_start=None):
         import psutil
         from tools.browser_tool import _verify_reapable_browser_daemon
 
@@ -309,7 +330,9 @@ class TestReaperIdentityGuard:
 
         with patch("psutil.Process", side_effect=_factory):
             return _verify_reapable_browser_daemon(
-                daemon_pid, socket_dir, session_name)
+                daemon_pid, socket_dir, session_name,
+                expected_start=expected_start,
+            )
 
     def test_real_daemon_bound_via_cmdline_is_reapable(self):
         socket_dir = "/tmp/agent-browser-h_sess123456"
@@ -329,6 +352,50 @@ class TestReaperIdentityGuard:
         )
         assert self._run(proc, socket_dir) is True
 
+
+    def test_harness_daemon_bound_via_runtime_env_is_reapable(self):
+        socket_dir = "/tmp/agent-browser-hermes_bh_111_alpha"
+        proc = self._FakeProc(
+            name="python",
+            cmdline=["python", "-m", "browser_harness.daemon"],
+            environ={"BH_RUNTIME_DIR": socket_dir},
+        )
+        assert self._run(
+            proc, socket_dir, session_name="hermes_bh_111_alpha"
+        ) is True
+
+    def test_harness_recycled_pid_with_other_runtime_is_refused(self):
+        socket_dir = "/tmp/agent-browser-hermes_bh_111_alpha"
+        proc = self._FakeProc(
+            name="python",
+            cmdline=["python", "-m", "browser_harness.daemon"],
+            environ={"BH_RUNTIME_DIR": "/tmp/agent-browser-hermes_bh_111_other"},
+        )
+        assert self._run(
+            proc, socket_dir, session_name="hermes_bh_111_alpha"
+        ) is False
+
+    def test_fingerprint_uses_same_cross_platform_source(self):
+        socket_dir = "/tmp/agent-browser-h_sess123456"
+        proc = self._FakeProc(
+            name="agent-browser",
+            cmdline=["agent-browser", "--socket-dir", socket_dir],
+        )
+        with patch("gateway.status.get_process_start_time", return_value=123456):
+            assert self._run(
+                proc, socket_dir, expected_start=123456
+            ) is True
+
+    def test_fingerprint_mismatch_refuses_recycled_pid(self):
+        socket_dir = "/tmp/agent-browser-h_sess123456"
+        proc = self._FakeProc(
+            name="agent-browser",
+            cmdline=["agent-browser", "--socket-dir", socket_dir],
+        )
+        with patch("gateway.status.get_process_start_time", return_value=999999):
+            assert self._run(
+                proc, socket_dir, expected_start=123456
+            ) is False
 
     def test_recycled_pid_browser_not_bound_to_our_dir_is_refused(self):
         """An agent-browser process for a DIFFERENT session must not be reaped.

--- a/tests/tools/test_browser_orphan_reaper.py
+++ b/tests/tools/test_browser_orphan_reaper.py
@@ -16,11 +16,14 @@ def fake_tmpdir(tmp_path):
 
 
 @pytest.fixture(autouse=True)
-def _isolate_sessions():
+def _isolate_sessions(monkeypatch):
     """Ensure _active_sessions is empty for each test."""
     import tools.browser_tool as bt
     orig = bt._active_sessions.copy()
     bt._active_sessions.clear()
+    # Existing unit fixtures create complete PID files immediately. Disable
+    # only the real-time settle delay unless a test explicitly exercises it.
+    monkeypatch.setattr(bt, "BROWSER_PID_FILE_SETTLE_SECONDS", 0.0)
     yield
     bt._active_sessions.clear()
     bt._active_sessions.update(orig)
@@ -53,8 +56,8 @@ class TestReapOrphanedBrowserSessions:
         from tools.browser_tool import _reap_orphaned_browser_sessions
         _reap_orphaned_browser_sessions()  # should not raise
 
-    def test_stale_dir_without_pid_file_is_removed(self, fake_tmpdir):
-        """Socket dir with no PID file is cleaned up."""
+    def test_stale_dir_without_pid_file_is_retained(self, fake_tmpdir):
+        """Without a PID, daemon death cannot be confirmed; retain evidence."""
         from tools.browser_tool import _reap_orphaned_browser_sessions
         d = _make_socket_dir(fake_tmpdir, "h_abc1234567")
         assert d.exists()
@@ -63,7 +66,7 @@ class TestReapOrphanedBrowserSessions:
             return_value=10_000,
         ):
             _reap_orphaned_browser_sessions()
-        assert not d.exists()
+        assert d.exists()
 
     def test_fresh_dir_without_pid_file_survives_creator_race(self, fake_tmpdir):
         """A concurrent reaper must not delete a session still starting."""
@@ -136,6 +139,27 @@ class TestReapOrphanedBrowserSessions:
 
         assert terminate_calls == []
 
+
+    def test_fresh_numeric_pid_prefix_is_retained(self, fake_tmpdir, monkeypatch):
+        """An integer-looking partial write must not select/dead-check that PID."""
+        import tools.browser_tool as bt
+
+        session = "hermes_bh_111_partial"
+        d = _make_socket_dir(fake_tmpdir, session, owner_pid=111)
+        (d / "bu.pid").write_text("2")  # possible prefix while writing 222
+        monkeypatch.setattr(bt, "BROWSER_PID_FILE_SETTLE_SECONDS", 1.0)
+        pid_probes = []
+
+        def _pid_exists(pid):
+            pid_probes.append(pid)
+            return False  # owner 111 is dead; PID 2 must never be probed
+
+        with patch("gateway.status._pid_exists", side_effect=_pid_exists):
+            bt._reap_orphaned_browser_sessions()
+
+        assert pid_probes == [111]
+        assert d.exists()
+        assert (d / "bu.pid").read_text() == "2"
 
     def test_corrupt_pid_file_is_retained_for_later_sweep(self, fake_tmpdir):
         """A malformed PID file is ambiguous, so retain all runtime evidence.

--- a/tests/tools/test_browser_orphan_reaper.py
+++ b/tests/tools/test_browser_orphan_reaper.py
@@ -137,15 +137,22 @@ class TestReapOrphanedBrowserSessions:
         assert terminate_calls == []
 
 
-    def test_corrupt_pid_file_is_cleaned(self, fake_tmpdir):
-        """PID file with non-integer content is cleaned up."""
+    def test_corrupt_pid_file_is_retained_for_later_sweep(self, fake_tmpdir):
+        """A malformed PID file is ambiguous, so retain all runtime evidence.
+
+        Browser Harness may expose a truncate-then-write window while creating
+        ``bu.pid``. Deleting the directory on a parse error can therefore hide
+        a live daemon and race its ``bu.sock`` creation. A later periodic sweep
+        can retry after the file becomes readable.
+        """
         from tools.browser_tool import _reap_orphaned_browser_sessions
 
         d = _make_socket_dir(fake_tmpdir, "h_corrupt1234")
         (d / "h_corrupt1234.pid").write_text("not-a-number")
 
         _reap_orphaned_browser_sessions()
-        assert not d.exists()
+        assert d.exists()
+        assert (d / "h_corrupt1234.pid").read_text() == "not-a-number"
 
     def test_browser_harness_dead_owner_reaps_bu_pid(self, fake_tmpdir):
         from tools.browser_tool import _reap_orphaned_browser_sessions

--- a/tests/tools/test_browser_orphan_reaper.py
+++ b/tests/tools/test_browser_orphan_reaper.py
@@ -189,6 +189,65 @@ class TestReapOrphanedBrowserSessions:
         assert d.exists()
         assert pid_file.read_text() == "2"
 
+    def test_pid_record_replaced_during_dead_probe_is_retained(
+        self, fake_tmpdir
+    ):
+        """A replacement after parsing must veto dead-PID directory removal."""
+        from tools.browser_tool import _reap_orphaned_browser_sessions
+
+        session = "hermes_bh_111_deadprobe"
+        d = _make_socket_dir(fake_tmpdir, session, owner_pid=111)
+        pid_file = d / "bu.pid"
+        pid_file.write_text("222")
+        probes = []
+
+        def _pid_exists(pid):
+            probes.append(pid)
+            if pid == 222:
+                pid_file.write_text("333")
+            return False
+
+        with patch("gateway.status._pid_exists", side_effect=_pid_exists):
+            _reap_orphaned_browser_sessions()
+
+        assert probes == [111, 222]
+        assert d.exists()
+        assert pid_file.read_text() == "333"
+
+    def test_pid_record_replaced_after_termination_is_retained(
+        self, fake_tmpdir
+    ):
+        """Post-kill cleanup must bind to the same PID record it verified."""
+        from tools.browser_tool import _reap_orphaned_browser_sessions
+
+        session = "hermes_bh_111_postkill"
+        d = _make_socket_dir(fake_tmpdir, session, owner_pid=111)
+        pid_file = d / "bu.pid"
+        pid_file.write_text("222")
+        probes = []
+
+        def _pid_exists(pid):
+            probes.append(pid)
+            if probes == [111, 222, 222]:
+                pid_file.write_text("333")
+                return False
+            return pid == 222
+
+        with patch(
+            "gateway.status._pid_exists", side_effect=_pid_exists
+        ), patch(
+            "gateway.status.get_process_start_time", return_value=444
+        ), patch(
+            "tools.browser_tool._verify_reapable_browser_daemon", return_value=True
+        ), patch(
+            "tools.process_registry.ProcessRegistry._terminate_host_pid"
+        ):
+            _reap_orphaned_browser_sessions()
+
+        assert probes == [111, 222, 222]
+        assert d.exists()
+        assert pid_file.read_text() == "333"
+
     def test_fresh_numeric_pid_prefix_is_retained(self, fake_tmpdir, monkeypatch):
         """An integer-looking partial write must not select/dead-check that PID."""
         import tools.browser_tool as bt

--- a/tests/tools/test_browser_orphan_reaper.py
+++ b/tests/tools/test_browser_orphan_reaper.py
@@ -3,6 +3,7 @@ daemons whose Python parent exited without cleaning up."""
 
 import os
 import time
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -139,6 +140,54 @@ class TestReapOrphanedBrowserSessions:
 
         assert terminate_calls == []
 
+
+    def test_nonpositive_pid_file_is_retained(self, fake_tmpdir):
+        """Zero/negative integers are malformed PID records, not dead daemons."""
+        from tools.browser_tool import _reap_orphaned_browser_sessions
+
+        for index, value in enumerate(("0", "-7")):
+            session = f"hermes_bh_111_invalid{index}"
+            d = _make_socket_dir(fake_tmpdir, session, owner_pid=111)
+            (d / "bu.pid").write_text(value)
+            with patch("gateway.status._pid_exists", return_value=False):
+                _reap_orphaned_browser_sessions()
+            assert d.exists()
+            assert (d / "bu.pid").read_text() == value
+
+    def test_pid_record_replaced_during_read_is_retained(
+        self, fake_tmpdir, monkeypatch
+    ):
+        """A settled-file check must bind to the bytes actually parsed."""
+        import tools.browser_tool as bt
+
+        session = "hermes_bh_111_replaced"
+        d = _make_socket_dir(fake_tmpdir, session, owner_pid=111)
+        pid_file = d / "bu.pid"
+        pid_file.write_text("222")
+        _age_socket_dir(d, 60)
+        monkeypatch.setattr(bt, "BROWSER_PID_FILE_SETTLE_SECONDS", 1.0)
+        original_read_text = Path.read_text
+
+        def replace_during_read(path, *args, **kwargs):
+            if path == pid_file:
+                pid_file.write_text("2")
+                return "2"
+            return original_read_text(path, *args, **kwargs)
+
+        pid_probes = []
+
+        def _pid_exists(pid):
+            pid_probes.append(pid)
+            return False
+
+        with patch.object(Path, "read_text", replace_during_read), patch(
+            "gateway.status._pid_exists", side_effect=_pid_exists
+        ):
+            bt._reap_orphaned_browser_sessions()
+
+        assert pid_probes == [111]
+        assert d.exists()
+        assert pid_file.read_text() == "2"
 
     def test_fresh_numeric_pid_prefix_is_retained(self, fake_tmpdir, monkeypatch):
         """An integer-looking partial write must not select/dead-check that PID."""

--- a/tests/tools/test_browser_orphan_reaper.py
+++ b/tests/tools/test_browser_orphan_reaper.py
@@ -99,10 +99,16 @@ class TestReapOrphanedBrowserSessions:
         def mock_terminate(pid, expected_start=None):
             terminate_calls.append(pid)
 
-        with patch("gateway.status._pid_exists", return_value=True), \
-             patch("gateway.status.get_process_start_time", return_value=777), \
-             patch("tools.browser_tool._verify_reapable_browser_daemon", return_value=True), \
-             patch("tools.process_registry.ProcessRegistry._terminate_host_pid", side_effect=mock_terminate):
+        with patch(
+            "gateway.status._pid_exists", side_effect=[True, False]
+        ), patch(
+            "gateway.status.get_process_start_time", return_value=777
+        ), patch(
+            "tools.browser_tool._verify_reapable_browser_daemon", return_value=True
+        ), patch(
+            "tools.process_registry.ProcessRegistry._terminate_host_pid",
+            side_effect=mock_terminate,
+        ):
             _reap_orphaned_browser_sessions()
 
         assert 12345 in terminate_calls
@@ -149,17 +155,80 @@ class TestReapOrphanedBrowserSessions:
         (d / "bu.pid").write_text("222")
         terminated = []
 
-        with patch("gateway.status._pid_exists", side_effect=[False, True]), \
-             patch("gateway.status.get_process_start_time", return_value=333), \
-             patch("tools.browser_tool._verify_reapable_browser_daemon", return_value=True), \
-             patch(
-                 "tools.process_registry.ProcessRegistry._terminate_host_pid",
-                 side_effect=lambda pid, expected_start=None: terminated.append(pid),
-             ):
+        with patch(
+            "gateway.status._pid_exists",
+            side_effect=[False, True, False],
+        ), patch(
+            "gateway.status.get_process_start_time", return_value=333
+        ), patch(
+            "tools.browser_tool._verify_reapable_browser_daemon", return_value=True
+        ), patch(
+            "tools.process_registry.ProcessRegistry._terminate_host_pid",
+            side_effect=lambda pid, expected_start=None: terminated.append(pid),
+        ):
             _reap_orphaned_browser_sessions()
 
         assert terminated == [222]
         assert not d.exists()
+
+    def test_browser_harness_runtime_dir_survives_failed_termination(
+        self, fake_tmpdir
+    ):
+        """Never delete a live daemon's control files after a failed kill.
+
+        The termination helper is best-effort and can return while the process
+        is still alive (access denial, taskkill failure, or a PID-generation
+        race). Removing ``bu.pid`` / ``bu.sock`` then would hide the survivor
+        from every later sweep. Keep the whole abandoned runtime directory so
+        the periodic reaper can retry safely.
+        """
+        from tools.browser_tool import _reap_orphaned_browser_sessions
+
+        session = "hermes_bh_111_survivor"
+        d = _make_socket_dir(fake_tmpdir, session, owner_pid=111)
+        (d / "bu.pid").write_text("222")
+        (d / "bu.sock").write_text("runtime endpoint")
+
+        with patch(
+            "gateway.status._pid_exists",
+            side_effect=[False, True, True],
+        ), patch(
+            "gateway.status.get_process_start_time", return_value=333
+        ), patch(
+            "tools.browser_tool._verify_reapable_browser_daemon", return_value=True
+        ), patch(
+            "tools.process_registry.ProcessRegistry._terminate_host_pid"
+        ):
+            _reap_orphaned_browser_sessions()
+
+        assert d.exists()
+        assert (d / "bu.pid").read_text() == "222"
+        assert (d / "bu.sock").read_text() == "runtime endpoint"
+
+    def test_browser_harness_runtime_dir_survives_termination_error(
+        self, fake_tmpdir
+    ):
+        """An explicit termination failure retains evidence for a later retry."""
+        from tools.browser_tool import _reap_orphaned_browser_sessions
+
+        session = "hermes_bh_111_denied"
+        d = _make_socket_dir(fake_tmpdir, session, owner_pid=111)
+        (d / "bu.pid").write_text("222")
+
+        with patch(
+            "gateway.status._pid_exists", side_effect=[False, True]
+        ), patch(
+            "gateway.status.get_process_start_time", return_value=333
+        ), patch(
+            "tools.browser_tool._verify_reapable_browser_daemon", return_value=True
+        ), patch(
+            "tools.process_registry.ProcessRegistry._terminate_host_pid",
+            side_effect=PermissionError("denied"),
+        ):
+            _reap_orphaned_browser_sessions()
+
+        assert d.exists()
+        assert (d / "bu.pid").exists()
 
 
 class TestOwnerPidCrossProcess:
@@ -552,11 +621,16 @@ class TestLeakedDaemonWithLiveOwner:
         _age_socket_dir(d, BROWSER_ORPHAN_GRACE_SECONDS + 600)
         kill_calls = []
 
-        with patch("gateway.status._pid_exists", return_value=True), \
-             patch("gateway.status.get_process_start_time", return_value=777), \
-             patch("tools.browser_tool._verify_reapable_browser_daemon", return_value=True), \
-             patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
-                   side_effect=lambda pid, expected_start=None: kill_calls.append(pid)):
+        with patch(
+            "gateway.status._pid_exists", side_effect=[True, True, False]
+        ), patch(
+            "gateway.status.get_process_start_time", return_value=777
+        ), patch(
+            "tools.browser_tool._verify_reapable_browser_daemon", return_value=True
+        ), patch(
+            "tools.process_registry.ProcessRegistry._terminate_host_pid",
+            side_effect=lambda pid, expected_start=None: kill_calls.append(pid),
+        ):
             _reap_orphaned_browser_sessions()
 
         assert 12345 in kill_calls

--- a/tests/tools/test_browser_orphan_reaper.py
+++ b/tests/tools/test_browser_orphan_reaper.py
@@ -211,8 +211,9 @@ class TestReapOrphanedBrowserSessions:
             _reap_orphaned_browser_sessions()
 
         assert probes == [111, 222]
-        assert d.exists()
-        assert pid_file.read_text() == "333"
+        retained = list(fake_tmpdir.glob(".hermes-browser-reap-*"))
+        assert len(retained) == 1
+        assert (retained[0] / "bu.pid").read_text() == "333"
 
     def test_pid_record_replaced_after_termination_is_retained(
         self, fake_tmpdir
@@ -245,8 +246,9 @@ class TestReapOrphanedBrowserSessions:
             _reap_orphaned_browser_sessions()
 
         assert probes == [111, 222, 222]
-        assert d.exists()
-        assert pid_file.read_text() == "333"
+        retained = list(fake_tmpdir.glob(".hermes-browser-reap-*"))
+        assert len(retained) == 1
+        assert (retained[0] / "bu.pid").read_text() == "333"
 
     def test_fresh_numeric_pid_prefix_is_retained(self, fake_tmpdir, monkeypatch):
         """An integer-looking partial write must not select/dead-check that PID."""

--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -15,6 +15,7 @@ import json
 import os
 import stat
 import time
+from pathlib import Path
 
 import pytest
 
@@ -100,6 +101,40 @@ class TestSubprocessEnvironment:
         monkeypatch.setitem(sys.modules, "tools.browser_tool", browser_tool)
         env = bu_cli._base_subprocess_env()
         assert env["ANONYMIZED_TELEMETRY"] == "false"
+
+    def test_harness_runtime_matches_v019_layout_and_isolates_names(
+        self, monkeypatch, tmp_path
+    ):
+        import tools.browser_tool as browser_tool
+
+        monkeypatch.setattr(browser_tool, "_socket_safe_tmpdir", lambda: str(tmp_path))
+        first = bu_cli._base_subprocess_env(session_name="alpha")
+        same = bu_cli._base_subprocess_env(session_name="alpha")
+        other = bu_cli._base_subprocess_env(session_name="beta")
+
+        assert first["BH_RUNTIME_DIR"] == first["BH_TMP_DIR"]
+        assert first["BH_RUNTIME_DIR"] == same["BH_RUNTIME_DIR"]
+        assert first["BH_RUNTIME_DIR"] != other["BH_RUNTIME_DIR"]
+        assert "BH_RUNTIME_DIR_SHARED" not in first
+        assert "AGENT_BROWSER_SOCKET_DIR" not in first
+        runtime = Path(first["BH_RUNTIME_DIR"])
+        identity = runtime.name.removeprefix("agent-browser-")
+        assert identity.startswith(f"hermes_bh_{os.getpid()}_")
+        assert (runtime / f"{identity}.owner_pid").is_file()
+
+    def test_browser_exec_starts_orphan_cleanup(self, monkeypatch, tmp_path):
+        import tools.browser_tool as browser_tool
+
+        cli = _fake_cli(tmp_path, "cat > /dev/null\n")
+        starts = []
+        monkeypatch.setattr(bu_cli, "_find_cli", lambda: [cli])
+        monkeypatch.setattr(
+            browser_tool, "_start_browser_cleanup_thread", lambda: starts.append(True)
+        )
+
+        bu_cli.browser_exec("print(1)", session="alpha")
+
+        assert starts == [True]
 
     def test_subprocess_env_strips_parent_python_import_paths(self, monkeypatch):
         """#83427/#84841/#86006/#86104: the browser-use CLI runs under its

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2605,14 +2605,9 @@ def _remove_confirmed_runtime_dir(
     if not _pid_file_still_matches(
         claimed_pid_file, expected_text, expected_stat
     ):
-        # The runtime changed after our last validation. Put the claimed
-        # directory back when the public name is still free; otherwise retain
-        # the private claim rather than deleting uncertain evidence.
-        try:
-            if not os.path.exists(socket_dir):
-                os.rename(claim, socket_dir)
-        except OSError:
-            pass
+        # The runtime changed after our claim. Keep the private claim intact as
+        # uncertain evidence. Never rename it back: on POSIX rename can replace
+        # an empty directory created concurrently at the public name.
         return False
 
     shutil.rmtree(claim, ignore_errors=True)

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2188,6 +2188,11 @@ BROWSER_ORPHAN_REAP_INTERVAL = 300  # seconds
 # Deliberately a large multiple of the inactivity timeout so a legitimately
 # busy session is never touched.
 BROWSER_ORPHAN_GRACE_SECONDS = max(3600, BROWSER_SESSION_INACTIVITY_TIMEOUT * 20)
+# A daemon PID file is not an atomic record: Browser Harness opens it with
+# truncate-then-write semantics.  Let the file settle before parsing so an
+# all-digit prefix (for example ``2`` while writing ``222``) can never be
+# mistaken for a complete, already-dead PID and trigger runtime deletion.
+BROWSER_PID_FILE_SETTLE_SECONDS = 1.0
 
 # Track last activity time per session
 _session_last_activity: Dict[str, float] = {}
@@ -2671,15 +2676,21 @@ def _reap_orphaned_browser_sessions():
             "bu.pid" if harness_daemon else f"{session_name}.pid",
         )
         if not os.path.isfile(pid_file):
-            # A newly-created session directory exists briefly before
-            # agent-browser writes its PID/owner files. Another Hermes process
-            # may run this global reaper during that window. Treat a pidless
-            # directory as stale only after the orphan grace period; deleting
-            # it immediately races the creator's first stdout/stderr open.
-            idle_s = _socket_dir_idle_seconds(socket_dir)
-            if idle_s is None or idle_s < BROWSER_ORPHAN_GRACE_SECONDS:
-                continue
-            shutil.rmtree(socket_dir, ignore_errors=True)
+            # Without a PID there is no process identity to verify and no way
+            # to prove the daemon is dead. The directory may also be in the
+            # creator's mkdir→pid-write window. Retain it fail-closed; bounded
+            # namespaced residue is preferable to deleting the only endpoint
+            # evidence for a live orphan.
+            continue
+
+        # PID files are written truncate-then-write rather than via atomic
+        # replace.  Even an integer-looking snapshot can therefore be an
+        # incomplete prefix.  Never parse or delete from a fresh PID file.
+        try:
+            pid_file_age = time.time() - os.path.getmtime(pid_file)
+        except OSError:
+            continue
+        if pid_file_age < BROWSER_PID_FILE_SETTLE_SECONDS:
             continue
 
         try:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2720,17 +2720,33 @@ def _reap_orphaned_browser_sessions():
         # Daemon is alive and its owner is dead (or legacy + untracked).  Reap.
         # Use the process-tree termination helper so Chromium children
         # (renderer, GPU, etc.) are cleaned up, not just the daemon parent.
+        terminated = False
         try:
             from tools.process_registry import ProcessRegistry
             ProcessRegistry._terminate_host_pid(daemon_pid, daemon_start)
-            logger.info("Reaped orphaned browser daemon PID %d (session %s)",
-                        daemon_pid, session_name)
-            reaped += 1
+            # The termination helper is deliberately best-effort and can return
+            # after a denied/failed signal.  Re-probe before deleting the only
+            # PID/runtime evidence a later periodic sweep can use.
+            terminated = not _pid_exists(daemon_pid)
+            if terminated:
+                logger.info("Reaped orphaned browser daemon PID %d (session %s)",
+                            daemon_pid, session_name)
+                reaped += 1
+            else:
+                logger.warning(
+                    "Browser daemon PID %d (session %s) survived termination; "
+                    "retaining runtime directory for a later retry",
+                    daemon_pid, session_name,
+                )
         except (ProcessLookupError, PermissionError, OSError):
-            pass
+            logger.warning(
+                "Could not terminate browser daemon PID %d (session %s); "
+                "retaining runtime directory for a later retry",
+                daemon_pid, session_name,
+            )
 
-        # Clean up the socket directory
-        shutil.rmtree(socket_dir, ignore_errors=True)
+        if terminated:
+            shutil.rmtree(socket_dir, ignore_errors=True)
 
     if reaped:
         logger.info("Reaped %d orphaned browser session(s) from previous run(s)", reaped)

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2687,14 +2687,21 @@ def _reap_orphaned_browser_sessions():
         # replace.  Even an integer-looking snapshot can therefore be an
         # incomplete prefix.  Never parse or delete from a fresh PID file.
         try:
-            pid_file_age = time.time() - os.path.getmtime(pid_file)
-        except OSError:
-            continue
-        if pid_file_age < BROWSER_PID_FILE_SETTLE_SECONDS:
-            continue
-
-        try:
-            daemon_pid = int(Path(pid_file).read_text(encoding="utf-8").strip())
+            pid_stat_before = os.stat(pid_file)
+            if time.time() - pid_stat_before.st_mtime < BROWSER_PID_FILE_SETTLE_SECONDS:
+                continue
+            pid_text = Path(pid_file).read_text(encoding="utf-8").strip()
+            pid_stat_after = os.stat(pid_file)
+            if (
+                pid_stat_after.st_mtime_ns != pid_stat_before.st_mtime_ns
+                or pid_stat_after.st_size != pid_stat_before.st_size
+                or pid_stat_after.st_ino != pid_stat_before.st_ino
+            ):
+                # Replaced or rewritten between the settle check and read.
+                continue
+            daemon_pid = int(pid_text)
+            if daemon_pid <= 0:
+                continue
         except (ValueError, OSError):
             # Ambiguous: the daemon may be in a truncate-then-write startup
             # window, or the file may be temporarily unreadable. Keep the PID

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2577,6 +2577,48 @@ def _pid_file_still_matches(
         return False
 
 
+def _remove_confirmed_runtime_dir(
+    socket_dir: str,
+    pid_file: str,
+    expected_text: str,
+    expected_stat: os.stat_result,
+) -> bool:
+    """Atomically claim an obsolete runtime directory, then remove the claim.
+
+    Renaming is the only operation that can bind cleanup to the directory entry
+    we inspected. A concurrent Browser Harness writer either keeps the original
+    directory busy (rename fails, so we retain it) or recreates the original
+    name after our rename; in the latter case we delete only our private claim,
+    never the replacement session.
+    """
+    parent = os.path.dirname(socket_dir)
+    claim = os.path.join(
+        parent,
+        f".hermes-browser-reap-{os.getpid()}-{time.time_ns()}",
+    )
+    try:
+        os.rename(socket_dir, claim)
+    except OSError:
+        return False
+
+    claimed_pid_file = os.path.join(claim, os.path.basename(pid_file))
+    if not _pid_file_still_matches(
+        claimed_pid_file, expected_text, expected_stat
+    ):
+        # The runtime changed after our last validation. Put the claimed
+        # directory back when the public name is still free; otherwise retain
+        # the private claim rather than deleting uncertain evidence.
+        try:
+            if not os.path.exists(socket_dir):
+                os.rename(claim, socket_dir)
+        except OSError:
+            pass
+        return False
+
+    shutil.rmtree(claim, ignore_errors=True)
+    return True
+
+
 def _reap_orphaned_browser_sessions():
     """Scan for orphaned agent-browser daemon processes from previous runs.
 
@@ -2730,8 +2772,9 @@ def _reap_orphaned_browser_sessions():
         # is NOT a no-op — use the handle-based existence check.
         from gateway.status import _pid_exists
         if not _pid_exists(daemon_pid):
-            if _pid_file_still_matches(pid_file, pid_text, pid_stat_after):
-                shutil.rmtree(socket_dir, ignore_errors=True)
+            _remove_confirmed_runtime_dir(
+                socket_dir, pid_file, pid_text, pid_stat_after
+            )
             continue
 
         # The PID is live — but the .pid file lives in a world-writable,
@@ -2784,10 +2827,10 @@ def _reap_orphaned_browser_sessions():
                 daemon_pid, session_name,
             )
 
-        if terminated and _pid_file_still_matches(
-            pid_file, pid_text, pid_stat_after
-        ):
-            shutil.rmtree(socket_dir, ignore_errors=True)
+        if terminated:
+            _remove_confirmed_runtime_dir(
+                socket_dir, pid_file, pid_text, pid_stat_after
+            )
 
     if reaped:
         logger.info("Reaped %d orphaned browser session(s) from previous run(s)", reaped)

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2685,7 +2685,10 @@ def _reap_orphaned_browser_sessions():
         try:
             daemon_pid = int(Path(pid_file).read_text(encoding="utf-8").strip())
         except (ValueError, OSError):
-            shutil.rmtree(socket_dir, ignore_errors=True)
+            # Ambiguous: the daemon may be in a truncate-then-write startup
+            # window, or the file may be temporarily unreadable. Keep the PID
+            # and endpoint evidence so a later periodic sweep can retry; only a
+            # confirmed-dead daemon permits directory removal.
             continue
 
         # Check if the daemon is still alive. ``os.kill(pid, 0)`` on Windows

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2560,6 +2560,23 @@ def _socket_dir_idle_seconds(socket_dir: str) -> Optional[float]:
     return max(0.0, time.time() - latest)
 
 
+def _pid_file_still_matches(
+    pid_file: str, expected_text: str, expected_stat: os.stat_result
+) -> bool:
+    """Return whether a PID record is still the exact settled file we parsed."""
+    try:
+        current_stat = os.stat(pid_file)
+        if (
+            current_stat.st_mtime_ns != expected_stat.st_mtime_ns
+            or current_stat.st_size != expected_stat.st_size
+            or current_stat.st_ino != expected_stat.st_ino
+        ):
+            return False
+        return Path(pid_file).read_text(encoding="utf-8").strip() == expected_text
+    except OSError:
+        return False
+
+
 def _reap_orphaned_browser_sessions():
     """Scan for orphaned agent-browser daemon processes from previous runs.
 
@@ -2713,7 +2730,8 @@ def _reap_orphaned_browser_sessions():
         # is NOT a no-op — use the handle-based existence check.
         from gateway.status import _pid_exists
         if not _pid_exists(daemon_pid):
-            shutil.rmtree(socket_dir, ignore_errors=True)
+            if _pid_file_still_matches(pid_file, pid_text, pid_stat_after):
+                shutil.rmtree(socket_dir, ignore_errors=True)
             continue
 
         # The PID is live — but the .pid file lives in a world-writable,
@@ -2766,7 +2784,9 @@ def _reap_orphaned_browser_sessions():
                 daemon_pid, session_name,
             )
 
-        if terminated:
+        if terminated and _pid_file_still_matches(
+            pid_file, pid_text, pid_stat_after
+        ):
             shutil.rmtree(socket_dir, ignore_errors=True)
 
     if reaped:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2414,8 +2414,13 @@ def _write_owner_pid(socket_dir: str, session_name: str) -> None:
                      session_name, exc)
 
 
-def _verify_reapable_browser_daemon(daemon_pid: int, socket_dir: str,
-                                    session_name: str) -> bool:
+def _verify_reapable_browser_daemon(
+    daemon_pid: int,
+    socket_dir: str,
+    session_name: str,
+    *,
+    expected_start: Optional[int] = None,
+) -> bool:
     """Confirm a live PID is genuinely *this* session's agent-browser daemon.
 
     The orphan reaper scans world-writable, predictably-named temp paths
@@ -2455,6 +2460,14 @@ def _verify_reapable_browser_daemon(daemon_pid: int, socket_dir: str,
 
     try:
         proc = psutil.Process(daemon_pid)
+        if expected_start is not None:
+            # Use the same cross-platform fingerprint source as the caller and
+            # final termination guard. Linux returns /proc start ticks; other
+            # platforms return quantized psutil epoch time.
+            from gateway.status import get_process_start_time
+
+            if get_process_start_time(daemon_pid) != expected_start:
+                return False
         name = (proc.name() or "").lower()
         cmdline = " ".join(proc.cmdline() or []).lower()
     except psutil.NoSuchProcess:
@@ -2467,11 +2480,16 @@ def _verify_reapable_browser_daemon(daemon_pid: int, socket_dir: str,
             daemon_pid, session_name, exc)
         return False
 
-    looks_like_browser = "agent-browser" in name or "agent-browser" in cmdline
+    harness_daemon = session_name.startswith("hermes_bh_")
+    if harness_daemon:
+        looks_like_browser = "browser_harness.daemon" in cmdline
+    else:
+        looks_like_browser = "agent-browser" in name or "agent-browser" in cmdline
     if not looks_like_browser:
+        expected_kind = "browser-harness" if harness_daemon else "agent-browser"
         logger.warning(
-            "Refusing to reap PID %d (session %s): not an agent-browser "
-            "process (name=%r)", daemon_pid, session_name, name)
+            "Refusing to reap PID %d (session %s): not a %s "
+            "process (name=%r)", daemon_pid, session_name, expected_kind, name)
         return False
 
     # Binding check: the live process must reference *this* socket dir.
@@ -2481,8 +2499,11 @@ def _verify_reapable_browser_daemon(daemon_pid: int, socket_dir: str,
         socket_base_l and socket_base_l in cmdline)
     if not bound:
         try:
-            env_dir = (proc.environ() or {}).get(
-                "AGENT_BROWSER_SOCKET_DIR", "")
+            env = proc.environ() or {}
+            env_dir = env.get(
+                "BH_RUNTIME_DIR" if harness_daemon else "AGENT_BROWSER_SOCKET_DIR",
+                "",
+            )
             bound = bool(env_dir) and os.path.normpath(env_dir) == \
                 os.path.normpath(socket_dir)
         except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
@@ -2644,7 +2665,11 @@ def _reap_orphaned_browser_sessions():
                 continue
 
         # owner_alive is False (dead owner) OR legacy daemon not tracked here.
-        pid_file = os.path.join(socket_dir, f"{session_name}.pid")
+        harness_daemon = session_name.startswith("hermes_bh_")
+        pid_file = os.path.join(
+            socket_dir,
+            "bu.pid" if harness_daemon else f"{session_name}.pid",
+        )
         if not os.path.isfile(pid_file):
             # A newly-created session directory exists briefly before
             # agent-browser writes its PID/owner files. Another Hermes process
@@ -2677,26 +2702,26 @@ def _reap_orphaned_browser_sessions():
         # otherwise (don't touch the process, leave the socket dir for a later
         # sweep once the imposter PID is gone).  Fixes the arbitrary same-user
         # process DoS in issue #14073.
+        # Capture the process generation before identity verification. Passing
+        # the same fingerprint into both verification and termination closes
+        # the verify→start-time PID-recycle window.
+        from gateway.status import get_process_start_time
+        daemon_start = get_process_start_time(daemon_pid)
+        if daemon_start is None:
+            logger.warning(
+                "Refusing to reap browser daemon PID %d (session %s): "
+                "no start-time fingerprint available", daemon_pid, session_name)
+            continue
         if not _verify_reapable_browser_daemon(
-                daemon_pid, socket_dir, session_name):
+                daemon_pid, socket_dir, session_name,
+                expected_start=daemon_start):
             continue
 
         # Daemon is alive and its owner is dead (or legacy + untracked).  Reap.
         # Use the process-tree termination helper so Chromium children
         # (renderer, GPU, etc.) are cleaned up, not just the daemon parent.
         try:
-            from gateway.status import get_process_start_time
             from tools.process_registry import ProcessRegistry
-            daemon_start = get_process_start_time(daemon_pid)
-            if daemon_start is None:
-                # Identity can't be fingerprinted — the verify above matched,
-                # but without a start time _terminate_host_pid cannot rule out
-                # a recycle between verify and kill. Refuse; a later sweep
-                # retries once the process table settles.
-                logger.warning(
-                    "Refusing to reap browser daemon PID %d (session %s): "
-                    "no start-time fingerprint available", daemon_pid, session_name)
-                continue
             ProcessRegistry._terminate_host_pid(daemon_pid, daemon_start)
             logger.info("Reaped orphaned browser daemon PID %d (session %s)",
                         daemon_pid, session_name)

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -5,6 +5,8 @@ instead of default browser tools
 """
 
 import json
+import hashlib
+import importlib
 import logging
 import os
 import re
@@ -104,10 +106,24 @@ def _blocked_url_in_code(code: str) -> Optional[str]:
     return None
 
 
-def _base_subprocess_env() -> dict:
-    from tools.browser_tool import _build_browser_env
-
-    env = _build_browser_env()
+def _base_subprocess_env(session_name: str = "") -> dict:
+    browser_tool = importlib.import_module("tools.browser_tool")
+    env = browser_tool._build_browser_env()
+    socket_tmpdir = getattr(browser_tool, "_socket_safe_tmpdir", None)
+    write_owner_pid = getattr(browser_tool, "_write_owner_pid", None)
+    if socket_tmpdir is not None and write_owner_pid is not None:
+        effective_name = session_name or "default"
+        name_hash = hashlib.sha256(effective_name.encode("utf-8")).hexdigest()[:12]
+        runtime_identity = f"hermes_bh_{os.getpid()}_{name_hash}"
+        runtime_dir = os.path.join(
+            socket_tmpdir(), f"agent-browser-{runtime_identity}"
+        )
+        os.makedirs(runtime_dir, mode=0o700, exist_ok=True)
+        write_owner_pid(runtime_dir, runtime_identity)
+        # Browser Harness v0.1.9 treats a caller-supplied runtime directory as
+        # one daemon namespace and writes bare bu.pid/bu.sock (or bu.port).
+        env["BH_RUNTIME_DIR"] = runtime_dir
+        env["BH_TMP_DIR"] = runtime_dir
     # The browser-use CLI runs under its own Python (uv tool / uvx), which
     # may differ from Hermes's venv Python. PYTHONPATH/PYTHONHOME inherited
     # from the agent process point at Hermes's venv site-packages, and a
@@ -750,14 +766,23 @@ def browser_exec(
             "to verify the setup."
         )
 
-    env = _base_subprocess_env()
     if session:
         if not _SESSION_RE.match(session):
             return tool_error(
                 f"Invalid session name {session!r}: use 1-64 letters, digits, "
                 "dashes, or underscores (e.g. 'r7k2')."
             )
+    env = _base_subprocess_env(session_name=session)
+    if session:
         env["BU_NAME"] = session
+    # browser_exec can be the only browser surface loaded in this process, so
+    # start the existing idempotent periodic orphan reaper explicitly.
+    try:
+        from tools.browser_tool import _start_browser_cleanup_thread
+
+        _start_browser_cleanup_thread()
+    except Exception as e:
+        logger.debug("Browser orphan cleanup unavailable: %s", e)
     # Real-profile consent: on a local backend this upgrades the attach to
     # the user's default browser (profile snapshot, logins included); with
     # local=True it forces that even under a cloud backend. Runs BEFORE


### PR DESCRIPTION
## What does this PR do?

Makes persistent Browser Use CLI daemons visible to Hermes' existing orphan reaper.

Browser Harness v0.1.9 stores a caller-isolated daemon under `BH_RUNTIME_DIR` / `BH_TMP_DIR` with bare `bu.pid` and `bu.sock` / `bu.port`. The `browser_exec` lane previously left that state under Browser Harness' default location, outside Hermes' discoverable `agent-browser-*` namespace.

This change gives each effective `BU_NAME` a stable, process-owned `agent-browser-hermes_bh_*` runtime directory, writes the existing owner-PID marker there, and starts the existing periodic browser cleanup thread from `browser_exec`. The reaper recognizes Browser Harness' real `bu.pid` layout and validates both daemon identity and runtime binding before tree termination.

The generic PID-recycle guard now captures one platform-native process-start fingerprint before identity verification and passes the same fingerprint through the final termination check. Linux uses `/proc` start ticks; macOS and Windows use quantized psutil creation time.

Real-profile behavior is intentionally unchanged and is not part of this reduced PR.

## Related Issue

Related to #100855 — fixes the `browser_exec` / Browser Harness lane only; the distinct shared `hermes-real-profile` lifecycle remainder stays open.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/browser_use_cli.py`
  - derive an isolated Browser Harness runtime directory from the Hermes PID and effective `BU_NAME`;
  - export `BH_RUNTIME_DIR` and `BH_TMP_DIR` without shared-directory mode;
  - write the existing owner-PID marker and start the idempotent periodic cleanup thread.
- `tools/browser_tool.py`
  - consume Browser Harness' bare `bu.pid` layout for `hermes_bh_*` runtimes;
  - verify `browser_harness.daemon` identity and `BH_RUNTIME_DIR` binding;
  - use one platform-native start fingerprint across verify and terminate.
- `tests/tools/test_browser_use_cli.py`
  - cover v0.1.9 layout, same-name reuse, distinct-name isolation, marker creation, and cleanup-thread startup.
- `tests/tools/test_browser_orphan_reaper.py`
  - cover `bu.pid` reaping, correct/wrong runtime binding, matching/mismatched cross-platform fingerprints, and fail-closed abandoned-runtime cleanup under PID-record races.
- `tools/browser_tool.py` cleanup policy
  - delete a runtime directory only after the verified daemon is confirmed dead;
  - atomically claim the stale directory before deletion so a concurrent replacement cannot be clobbered;
  - retain missing, malformed, fresh, replaced, or otherwise uncertain PID/runtime evidence for a later periodic sweep.

## How to Test

1. Run the focused affected suite:
   `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/tools/test_browser_orphan_reaper.py tests/tools/test_browser_use_cli.py::TestSubprocessEnvironment -q`
2. Confirm the real Browser Harness v0.1.9 producer creates bare `bu.pid` in the supplied runtime directory and that Hermes terminates the verified daemon after its owner exits.
3. Run `git diff --check` and inspect GitHub CI.

Validated at exact head `d2f90eac9d690b8fbea278aa762e2bbbd657f72a`:

- focused local suite: **40 passed, 3 skipped**;
- orphan-reaper suite: **29 passed**;
- Browser Harness v0.1.9 producer → reaper E2E: **passed**;
- Codex exact-head review at `47686566b19fe0ad212c30f9e0ba5d76cc4df418`: **PASS**;
- Claude Code exact-head review at `47686566b19fe0ad212c30f9e0ba5d76cc4df418`: **PASS**;
- `git diff --check`: **passed**;
- GitHub CI: **24 passed, 0 pending, 0 failed**.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — the focused affected suite and all GitHub CI checks pass; a local all-tests run was not performed
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11; Linux-specific fingerprint semantics are covered by the shared source test and GitHub CI

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing workflow changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; existing lifecycle and fingerprint primitives are reused
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Windows/macOS CI passes and Linux retains `/proc` start-tick semantics
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; the tool schema is unchanged

## Screenshots / Logs

Not applicable; this is background process-lifecycle behavior. Test and CI results are summarized above.


