### PR TITLE
fix(desktop): Check for Updates updates this app, not the remote backend

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -73,7 +73,12 @@ export function useDesktopIntegrations({
     // Background MCP health: HTTP/SSE servers only (never spawns stdio),
     // notifies on transitions into needs-auth/error with a Sign in action.
     startMcpHealthChecker()
-    const unsubscribe = window.hermesDesktop?.onOpenUpdatesRequested?.(() => openUpdatesWindow())
+    // The native "Check for Updates…" menu item lives in the app menu next to
+    // "About Hermes" — it is the OS-standard affordance for updating THIS app,
+    // so it always opens the client overlay. Inheriting the connection-mode
+    // default pointed a Mac at its remote Linux backend and left the app itself
+    // silently stale (#70266).
+    const unsubscribe = window.hermesDesktop?.onOpenUpdatesRequested?.(() => openUpdatesWindow('client'))
 
     return () => {
       unsubscribe?.()

--- a/apps/desktop/src/app/settings/about-settings.tsx
+++ b/apps/desktop/src/app/settings/about-settings.tsx
@@ -176,7 +176,7 @@ export function AboutSettings() {
                 <Button onClick={() => startActiveUpdate()} size="sm">
                   {a.updateNow}
                 </Button>
-                <Button onClick={() => openUpdatesWindow()} size="sm" variant="textStrong">
+                <Button onClick={() => openUpdatesWindow('client')} size="sm" variant="textStrong">
                   {a.seeWhatsNew}
                 </Button>
               </>

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -662,6 +662,35 @@ describe('applyEverythingUpdate', () => {
     expect(updateAllMock).toHaveBeenCalledTimes(1)
   })
 
+  it('re-checks the client instead of trusting a stale cached status', async () => {
+    setRemote(true)
+    $backendUpdateStatus.set(status({ behind: 3 }))
+    // FAIL-BEFORE: `$updateStatus.get() ?? (await checkUpdates())` short-circuits
+    // on this cached row — captured up to a poll interval (30 min) ago, and
+    // before the backend leg ran — so the client apply was skipped and the app
+    // stayed stale. The live check says otherwise and must win.
+    $updateStatus.set(status({ behind: 0, updateAvailable: false }))
+    checkClientMock.mockResolvedValue(status({ behind: 7, updateAvailable: true }))
+
+    await applyEverythingUpdate()
+
+    expect(applyClientMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to the cached client status when the live re-check fails', async () => {
+    setRemote(true)
+    $backendUpdateStatus.set(status({ behind: 3 }))
+    $updateStatus.set(status({ behind: 7, updateAvailable: true }))
+    // `checkUpdates()` never rejects — it resolves with an error-status and
+    // overwrites the atom with it, so an unreachable bridge must not read as
+    // "client is current" and skip the leg.
+    checkClientMock.mockRejectedValue(new Error('bridge gone'))
+
+    await applyEverythingUpdate()
+
+    expect(applyClientMock).toHaveBeenCalledTimes(1)
+  })
+
   it('requestActiveUpdate routes through the everything-flow when EITHER target is behind', async () => {
     setRemote(true)
     // Backend current, client behind — the exact case the old remote-only

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -89,6 +89,8 @@ const {
   applyUpdates,
   applyEverythingUpdate,
   hasMultipleUpdateTargets,
+  openUpdatesWindow,
+  startActiveUpdate,
   $updateApply,
   $updateEverything,
   $updateOverlayOpen,
@@ -117,7 +119,7 @@ const status = (over: Partial<DesktopUpdateStatus> = {}): DesktopUpdateStatus =>
   ...over
 })
 
-const lastToast = () => notifySpy.mock.calls.at(-1)?.[0] as { onDismiss: () => void }
+const lastToast = () => notifySpy.mock.calls.at(-1)?.[0] as { action: { onClick: () => void }; onDismiss: () => void }
 
 const setRemote = (on: boolean) =>
   setConnection({
@@ -407,6 +409,102 @@ describe('requestActiveUpdate', () => {
 
     requestActiveUpdate()
     await vi.waitFor(() => expect(updateHermesSpy).toHaveBeenCalled())
+  })
+})
+
+// Surface-bound update entry points. A surface that displays ONE target's
+// status must act on that target: the overlay has no target switcher, so
+// inheriting the connection-mode default silently pointed the user at the
+// other machine. This is what left a Mac desktop on a months-old build while
+// its remote Linux backend updated fine, with no error anywhere (#70266).
+describe('explicit update targets', () => {
+  const applyClientMock = vi.fn()
+  const checkClientMock = vi.fn()
+
+  beforeEach(() => {
+    storage.clear()
+    notifySpy.mockClear()
+    dismissSpy.mockClear()
+    applyClientMock.mockReset().mockResolvedValue({ ok: true, handedOff: true })
+    checkClientMock.mockReset().mockResolvedValue(status({ behind: 4, updateAvailable: true }))
+    updateHermesSpy.mockReset().mockResolvedValue({ ok: true, name: 'update' })
+    checkHermesUpdateSpy.mockReset().mockResolvedValue({
+      install_method: 'git',
+      current_version: '0.4.2',
+      behind: 0,
+      update_available: false,
+      can_apply: true,
+      update_command: null,
+      message: null
+    })
+    getActionStatusSpy.mockReset().mockResolvedValue({ lines: [], running: false, exit_code: 0 })
+    resetUpdateApplyState()
+    $updateStatus.set(null)
+    $backendUpdateStatus.set(null)
+    $updateOverlayOpen.set(false)
+    $updateOverlayTarget.set('backend')
+    $mockConnectionsRegistry.set(null)
+    setRemote(true)
+    ;(globalThis as unknown as { window: unknown }).window = {
+      hermesDesktop: { updates: { apply: applyClientMock, check: checkClientMock } }
+    }
+    vi.useRealTimers()
+  })
+
+  afterEach(async () => {
+    await vi.waitFor(() => expect($updateEverything.get().running).toBe(false), { timeout: 5000 })
+    await vi.waitFor(() => expect($backendUpdateApply.get().applying).toBe(false), { timeout: 5000 })
+    setRemote(false)
+    delete (globalThis as unknown as { window?: unknown }).window
+  })
+
+  // The macOS "Check for Updates…" app-menu item — the OS-standard affordance
+  // for updating THIS app — routes here via `hermes:open-updates`.
+  it('opens the client overlay on an explicit client target, even in remote mode', async () => {
+    openUpdatesWindow('client')
+
+    expect($updateOverlayTarget.get()).toBe('client')
+    await vi.waitFor(() => expect(checkClientMock).toHaveBeenCalledTimes(1))
+    expect(checkHermesUpdateSpy).not.toHaveBeenCalled()
+  })
+
+  it('still defaults to the connected machine when no target is named', async () => {
+    openUpdatesWindow()
+
+    expect($updateOverlayTarget.get()).toBe('backend')
+    await vi.waitFor(() => expect(checkHermesUpdateSpy).toHaveBeenCalled())
+    expect(checkClientMock).not.toHaveBeenCalled()
+  })
+
+  it('applies the client update on an explicit client target, without fanning out', async () => {
+    startActiveUpdate('client')
+
+    expect($updateOverlayTarget.get()).toBe('client')
+    await vi.waitFor(() => expect(applyClientMock).toHaveBeenCalledTimes(1))
+    expect(updateHermesSpy).not.toHaveBeenCalled()
+    expect($updateEverything.get().running).toBe(false)
+  })
+
+  it('keeps the everything-flow for the generic, target-less apply', async () => {
+    $backendUpdateStatus.set(status({ behind: 3 }))
+
+    startActiveUpdate()
+
+    await vi.waitFor(() => expect(updateHermesSpy).toHaveBeenCalled(), { timeout: 5000 })
+  })
+
+  // A toast raised by the CLIENT check must open the client overlay: the user
+  // was told the app is behind, so landing them on the backend's (current)
+  // status reads as the update having vanished.
+  it('opens the overlay for the target whose status raised the toast', () => {
+    maybeNotifyUpdateAvailable(status(), 'client')
+    lastToast().action.onClick()
+    expect($updateOverlayTarget.get()).toBe('client')
+
+    storage.clear() // clear the snooze the click just set
+    maybeNotifyUpdateAvailable(status({ targetSha: 'sha-b' }), 'backend')
+    lastToast().action.onClick()
+    expect($updateOverlayTarget.get()).toBe('backend')
   })
 })
 

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -205,8 +205,12 @@ export function reportInstallMethodWarning(message: string | undefined): void {
  * Closing the toast — dismissing it or opening the updates window from it —
  * (re)starts the cooldown, so a busy upstream branch doesn't re-spam the user
  * on every new commit. The snooze is persisted, so it survives relaunches too.
+ *
+ * `target` is the target whose status produced this toast. The overlay has no
+ * target switcher, so a client-status toast that opened the backend overlay
+ * showed the user a machine they weren't told about, with no way back.
  */
-export function maybeNotifyUpdateAvailable(status: DesktopUpdateStatus | null) {
+export function maybeNotifyUpdateAvailable(status: DesktopUpdateStatus | null, target: UpdateTarget = 'client') {
   if (!status || status.supported === false || status.error || !status.targetSha) {
     return
   }
@@ -232,7 +236,7 @@ export function maybeNotifyUpdateAvailable(status: DesktopUpdateStatus | null) {
       label: translateNow('notifications.seeWhatsNew'),
       onClick: () => {
         snoozeUpdateToast()
-        openUpdatesWindow()
+        openUpdateOverlayFor(target)
       }
     },
     durationMs: 0,
@@ -248,8 +252,24 @@ export function maybeNotifyUpdateAvailable(status: DesktopUpdateStatus | null) {
   })
 }
 
-export function openUpdatesWindow(): void {
-  openUpdateOverlayFor(isRemoteMode() ? 'backend' : 'client')
+/** The target a generic, surface-less update command acts on: the machine the
+ *  user is connected to. Surfaces that display one target's status must pass
+ *  that target explicitly instead of inheriting this. */
+function activeUpdateTarget(): UpdateTarget {
+  return isRemoteMode() ? 'backend' : 'client'
+}
+
+/**
+ * Open the updates overlay and kick off its check.
+ *
+ * Callers tied to a specific status surface pass its target; only genuinely
+ * generic entry points take the connection-mode default. The macOS "Check for
+ * Updates…" menu item is the former — it is the OS-standard affordance for
+ * updating *this app*, so in remote mode it checked the wrong machine and the
+ * Mac client silently drifted behind (#70266).
+ */
+export function openUpdatesWindow(target: UpdateTarget = activeUpdateTarget()): void {
+  openUpdateOverlayFor(target)
 }
 
 /**
@@ -263,19 +283,22 @@ export function openUpdatesWindow(): void {
  * through the everything-flow so "update" means every machine, not just the
  * active target — the single-target ternary is what left remote-mode users
  * updating the backend forever while the GUI itself went stale.
+ *
+ * An explicit `target` opts out of both: the caller is acting on one named
+ * machine's status and must not fan out to the others.
  */
-export function startActiveUpdate(): void {
-  if (hasMultipleUpdateTargets()) {
+export function startActiveUpdate(target?: UpdateTarget): void {
+  if (!target && hasMultipleUpdateTargets()) {
     $updateOverlayOpen.set(true)
     void applyEverythingUpdate()
 
     return
   }
 
-  const target: UpdateTarget = isRemoteMode() ? 'backend' : 'client'
-  $updateOverlayTarget.set(target)
+  const effective = target ?? activeUpdateTarget()
+  $updateOverlayTarget.set(effective)
   $updateOverlayOpen.set(true)
-  void (target === 'backend' ? applyBackendUpdate() : applyUpdates())
+  void (effective === 'backend' ? applyBackendUpdate() : applyUpdates())
 }
 
 /**
@@ -304,11 +327,11 @@ export function requestActiveUpdate(): void {
     }
   }
 
-  const target: UpdateTarget = isRemoteMode() ? 'backend' : 'client'
+  const target = activeUpdateTarget()
   const status = target === 'backend' ? $backendUpdateStatus.get() : $updateStatus.get()
 
   if ((status?.behind ?? 0) > 0 || status?.updateAvailable) {
-    startActiveUpdate()
+    startActiveUpdate(target)
 
     return
   }
@@ -373,7 +396,7 @@ export async function checkBackendUpdates(): Promise<DesktopUpdateStatus | null>
   try {
     const status = mapBackendCheck(await checkHermesUpdate(true))
     $backendUpdateStatus.set(status)
-    maybeNotifyUpdateAvailable(status)
+    maybeNotifyUpdateAvailable(status, 'backend')
 
     return status
   } catch (error) {
@@ -404,7 +427,7 @@ export async function checkUpdates(): Promise<DesktopUpdateStatus | null> {
   try {
     const status = await bridge.check()
     $updateStatus.set(status)
-    maybeNotifyUpdateAvailable(status)
+    maybeNotifyUpdateAvailable(status, 'client')
     void refreshDesktopVersion()
 
     return status

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -878,6 +878,12 @@ export function applyEverythingUpdate(): Promise<void> {
 async function runEverythingUpdate(): Promise<void> {
   $updateEverything.set({ running: true })
 
+  // Snapshot the client status before any leg runs: the backend leg's own
+  // post-update nudge re-checks the client and overwrites `$updateStatus`,
+  // including with an error row when the bridge is unreachable. Step 3 needs a
+  // pre-flow value to fall back on when its own live check can't answer.
+  const cachedClientStatus = $updateStatus.get()
+
   try {
     // 1. Active backend first (remote mode), with the detailed overlay flow.
     //    Its own finish path re-checks and nudges, but the everything-flow
@@ -934,7 +940,14 @@ async function runEverythingUpdate(): Promise<void> {
 
     // 3. The client last — its apply relaunches or hands off the app, so it
     //    must come after every dispatch above. Skipped when already current.
-    const clientStatus = $updateStatus.get() ?? (await checkUpdates())
+    //    Re-check rather than trusting `$updateStatus`: the cached value can be
+    //    up to a poll interval (30 min) old and was captured BEFORE the backend
+    //    update above, so a cached `behind: 0` would skip the client leg and
+    //    leave the app stale — the exact failure this flow exists to prevent.
+    //    `checkUpdates()` resolves with an error-status rather than rejecting,
+    //    so fall back to the pre-flow snapshot when the live check can't answer.
+    const freshClientStatus = await checkUpdates().catch(() => null)
+    const clientStatus = freshClientStatus?.error ? cachedClientStatus : (freshClientStatus ?? cachedClientStatus)
 
     if ((clientStatus?.behind ?? 0) > 0 || clientStatus?.updateAvailable) {
       $updateOverlayTarget.set('client')


### PR DESCRIPTION
Update actions in remote mode acted on whichever machine you were connected to, even on the surfaces showing the desktop app's own status. The app could sit months behind its backend with nothing reporting a problem.

The macOS **Check for Updates…** app-menu item is the sharpest case. It sits next to *About Hermes* and is the OS-standard way to update this app, but on a Mac connected to a remote Linux backend it checked the Linux box. The backend was already current, so the action reported nothing, did nothing, and wrote no updater log — the user's only signal was that the app kept saying it was behind. The update-available toast was split the same way: a client check raised it, clicking it opened the backend overlay, which has no target switcher and no way back.

| Surface | Before (remote mode) | After |
|---|---|---|
| Check for Updates… (app menu) | Backend | This app |
| About → See what's new | Backend | This app |
| Update-available toast | Backend, whichever check raised it | The target that raised it |
| ⌘K → Update Hermes | Everything-flow | Unchanged |
| About → Update now | Everything-flow | Unchanged |

`openUpdatesWindow()` and `startActiveUpdate()` take an optional target; surfaces bound to one machine's status name it, and everything else keeps the connection-mode default. The command palette's remote-mode backend target and the everything-flow both behave exactly as they did.

Second commit: the everything-flow's client leg read `$updateStatus.get() ?? await checkUpdates()`, so a cached row always won. That row can be 30 minutes old and is captured before the backend leg runs, so a cached "already current" skipped the app's own update — the stale-GUI gap the flow exists to close. It now re-checks first and falls back to a pre-flow snapshot when the live check can't answer.

## Validation

- `npx vitest run src/store/updates.test.ts src/app/contrib/hooks/use-desktop-integrations.test.tsx` — 90 passed
- Four new tests mutation-verified: reverting each behavior individually fails the matching test (3 fail on the target revert, a 4th on the `startActiveUpdate` revert)
- Each commit green on its own
- Desktop typecheck, ESLint `--quiet`, Prettier, `git diff --check` — clean

Supersedes #70612, #74335, #90272, #80940. The backend false-failure half of #80940 already landed via the update-receipt path in `runBackendUpdate`, so only its client-target half is carried here.

Co-authored-by: BerneYue <14088768+yuexiongHNU@users.noreply.github.com>
Co-authored-by: David Metcalfe <80915+DavidMetcalfe@users.noreply.github.com>
Co-authored-by: clayduncan <234173110+clayduncan@users.noreply.github.com>
Co-authored-by: Dhana <227747512+whoisdhana@users.noreply.github.com>
