### PR TITLE
fix(desktop): the sidebar keeps its sessions when a scan hits transient SQLite I/O

### DIFF
--- a/apps/desktop/src/api/sessions.ts
+++ b/apps/desktop/src/api/sessions.ts
@@ -148,6 +148,11 @@ export interface SidebarSessionSlice {
   /** Per-profile tokens and spend over every session, not just this window.
    *  Absent from the legacy per-slice endpoint, which has no aggregate. */
   profiles_usage?: Record<string, { cost_usd: number; tokens: number }>
+  /** Profiles whose scan for THIS slice failed. Batched `/sidebar` stamps the
+   *  same profile errors on every slice (one DB open). Legacy per-slice calls
+   *  stamp only the slice that actually failed, so a cron I/O error cannot
+   *  carry-forward recents. */
+  errors?: Array<{ profile: string; error: string }>
 }
 
 /** Which profiles filled their per-profile window in a returned page. The
@@ -216,16 +221,24 @@ async function listSidebarSessionsLegacy(req: SidebarSessionsRequest): Promise<S
     })
   ])
 
-  const errors = [...(recents.errors ?? []), ...(cron.errors ?? []), ...(messaging.errors ?? [])]
+  const recentsErrors = recents.errors ?? []
+  const cronErrors = cron.errors ?? []
+  const messagingErrors = messaging.errors ?? []
 
   return {
     recents: {
       profiles_truncated: profilesTruncatedFrom(recents.sessions, req.recentsLimit),
-      sessions: recents.sessions
+      sessions: recents.sessions,
+      ...(recentsErrors.length ? { errors: recentsErrors } : {})
     },
-    cron: { sessions: cron.sessions },
-    messaging: { sessions: messaging.sessions },
-    ...(errors.length ? { errors } : {})
+    cron: {
+      sessions: cron.sessions,
+      ...(cronErrors.length ? { errors: cronErrors } : {})
+    },
+    messaging: {
+      sessions: messaging.sessions,
+      ...(messagingErrors.length ? { errors: messagingErrors } : {})
+    }
   }
 }
 
@@ -288,9 +301,21 @@ export async function listSidebarSessions(req: SidebarSessionsRequest): Promise<
   }
 
   return {
-    recents: { ...result.recents, sessions: stampActiveConnectionOwner(result.recents?.sessions ?? []) },
-    cron: { ...result.cron, sessions: stampActiveConnectionOwner(result.cron?.sessions ?? []) },
-    messaging: { ...result.messaging, sessions: stampActiveConnectionOwner(result.messaging?.sessions ?? []) },
+    recents: {
+      ...result.recents,
+      sessions: stampActiveConnectionOwner(result.recents?.sessions ?? []),
+      ...(result.errors?.length ? { errors: result.errors } : {})
+    },
+    cron: {
+      ...result.cron,
+      sessions: stampActiveConnectionOwner(result.cron?.sessions ?? []),
+      ...(result.errors?.length ? { errors: result.errors } : {})
+    },
+    messaging: {
+      ...result.messaging,
+      sessions: stampActiveConnectionOwner(result.messaging?.sessions ?? []),
+      ...(result.errors?.length ? { errors: result.errors } : {})
+    },
     errors: result.errors
   }
 }

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
@@ -216,6 +216,57 @@ describe('refreshSessions identity + loading hygiene', () => {
     expect($sessions.get().map(s => s.id)).toEqual(['a'])
   })
 
+  it('keeps idle recents when the sidebar returns an empty page plus profile errors', async () => {
+    // Backend contract on disk I/O / lock: HTTP 200, recents=[], errors=[{profile}].
+    // mergeSessionPage only keeps working/pinned/selected, so Yesterday/This-week
+    // idle rows must be carried forward from the previous list — not clobbered.
+    const idle = [row('yesterday'), row('week')]
+    listSidebarSessions.mockResolvedValue(sidebar({ sessions: idle }))
+
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'default' }))
+
+    await act(async () => {
+      await result.current.refreshSessions()
+    })
+
+    expect($sessions.get().map(s => s.id)).toEqual(['yesterday', 'week'])
+
+    setSessionProfilesTruncated({ default: true })
+    setSessionProfilesUsage({ default: { cost_usd: 3, tokens: 30 } })
+    setMessagingTruncated(true)
+
+    listSidebarSessions.mockResolvedValue({
+      ...sidebar({ sessions: [] }),
+      errors: [{ error: 'disk I/O error', profile: 'default' }]
+    })
+
+    await act(async () => {
+      await result.current.refreshSessions()
+    })
+
+    expect($sessions.get().map(s => s.id)).toEqual(['yesterday', 'week'])
+    expect($sessionProfilesTruncated.get()).toEqual({ default: true })
+    expect($sessionProfilesUsage.get()).toEqual({ default: { cost_usd: 3, tokens: 30 } })
+    expect($messagingTruncated.get()).toBe(true)
+  })
+
+  it('still accepts a genuine empty recents page when the backend reported no errors', async () => {
+    listSidebarSessions.mockResolvedValue(sidebar({ sessions: [row('a')] }))
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'default' }))
+
+    await act(async () => {
+      await result.current.refreshSessions()
+    })
+
+    listSidebarSessions.mockResolvedValue(sidebar({ sessions: [] }))
+
+    await act(async () => {
+      await result.current.refreshSessions()
+    })
+
+    expect($sessions.get()).toEqual([])
+  })
+
   it('drops tombstoned rows from the messaging slice and per-platform paging too (#50928)', async () => {
     // The same delete race exists on every ingestion point: the batched
     // refresh's messaging slice and the per-platform "load more" pager must

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -24,7 +24,9 @@ import {
   $messagingSessions,
   $selectedStoredSessionId,
   $sessions,
+  carryForwardFailedProfileSessions,
   CRON_SECTION_LIMIT,
+  keepFailedProfileMeta,
   mergeSessionPage,
   MESSAGING_SECTION_LIMIT,
   setCronSessions,
@@ -198,7 +200,11 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
 
       setMessagingSessions(prev => [
         ...prev.filter(s => !inPlatform(s)),
-        ...mergeSessionPage(prev.filter(inPlatform), incoming, sessionsToKeep())
+        ...mergeSessionPage(
+          prev.filter(inPlatform),
+          carryForwardFailedProfileSessions(prev.filter(inPlatform), incoming, result.errors),
+          sessionsToKeep()
+        )
       ])
 
       const total = result.total ?? incoming.length
@@ -282,13 +288,19 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
           // in-flight mutation and the backend page still carries the doomed row.
           // Honoring the optimistic tombstone keeps the removal from flashing back
           // (the tombstone self-clears once projects.tree confirms the delete).
-          const incoming = dropTombstoned(recents.sessions)
-
           // Signature-gate the swap (same pattern as cron/messaging): a refresh
           // that returns content-identical rows must keep the previous array
           // identity, or every sidebar memo keyed on $sessions recomputes and the
           // whole list re-renders once per turn/broadcast for nothing.
           setSessions(prev => {
+            const incoming = dropTombstoned(
+              carryForwardFailedProfileSessions(
+                prev,
+                recents.sessions ?? [],
+                recents.errors ?? result.errors
+              )
+            )
+
             const next = mergeSessionPage(prev, incoming, sessionsToKeep())
 
             return sameCronSignature(prev, next) ? prev : next
@@ -298,8 +310,9 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
           // top of the rows it already read (the old exact totals ran a COUNT(*)
           // per profile DB on every refresh). Reference-stable when unchanged so
           // the sidebar's group memos don't recompute per refresh.
+          const recentsErrors = recents.errors ?? result.errors
           setSessionProfilesTruncated(prev => {
-            const next = recents.profiles_truncated ?? {}
+            const next = keepFailedProfileMeta(prev, recents.profiles_truncated ?? {}, recentsErrors)
             const prevKeys = Object.keys(prev)
 
             return prevKeys.length === Object.keys(next).length && prevKeys.every(key => prev[key] === next[key])
@@ -309,7 +322,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
           // Same identity gate: these totals only move when a session bills, and
           // a fresh object every refresh would repaint every profile header.
           setSessionProfilesUsage(prev => {
-            const next = recents.profiles_usage ?? {}
+            const next = keepFailedProfileMeta(prev, recents.profiles_usage ?? {}, recentsErrors)
             const prevKeys = Object.keys(prev)
 
             return prevKeys.length === Object.keys(next).length &&
@@ -322,16 +335,35 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
 
           // Cron section: latest N cron sessions (kept so a pinned cron run still
           // resolves via sessionByAnyId), signature-gated like above.
-          setCronSessions(prev => (sameCronSignature(prev, result.cron.sessions) ? prev : result.cron.sessions))
+          setCronSessions(prev => {
+            const incoming = carryForwardFailedProfileSessions(
+              prev,
+              result.cron.sessions ?? [],
+              result.cron.errors ?? result.errors
+            )
+
+            return sameCronSignature(prev, incoming) ? prev : incoming
+          })
 
           // Messaging sections: drop any non-messaging source the broad exclude
           // didn't catch (custom sources stay in local recents), then split per
           // platform in the UI.
-          const messagingRows = dropTombstoned(result.messaging.sessions.filter(s => isMessagingSource(s.source)))
+          const messagingErrors = result.messaging.errors ?? result.errors
+          setMessagingSessions(prev => {
+            const messagingRows = dropTombstoned(
+              carryForwardFailedProfileSessions(
+                prev,
+                (result.messaging.sessions ?? []).filter(s => isMessagingSource(s.source)),
+                messagingErrors
+              )
+            )
 
-          setMessagingSessions(prev => (sameCronSignature(prev, messagingRows) ? prev : messagingRows))
+            return sameCronSignature(prev, messagingRows) ? prev : messagingRows
+          })
           // Hit the cap → at least one platform may have more on disk than loaded.
-          setMessagingTruncated(result.messaging.sessions.length >= MESSAGING_SECTION_LIMIT)
+          setMessagingTruncated(prev =>
+            messagingErrors?.length ? prev : result.messaging.sessions.length >= MESSAGING_SECTION_LIMIT
+          )
         }
       } finally {
         // Request identity preserves the zero-argument refresh contract across a

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -290,6 +290,43 @@ describe('Hermes REST helpers', () => {
     expect(paths).toContainEqual(expect.stringContaining('exclude_sources=cron%2Ctool'))
   })
 
+  it('keeps per-slice errors on the legacy fallback so a cron failure does not taint recents', async () => {
+    resetSidebarBatchCapability()
+    const row = (id: string) => ({ id, title: id, profile: 'default' })
+
+    api.mockImplementation(({ path }: { path: string }) => {
+      if (path.startsWith('/api/profiles/sessions/sidebar')) {
+        return Promise.reject(
+          new Error('404: {"detail":"No such API endpoint: /api/profiles/sessions/sidebar"}')
+        )
+      }
+
+      if (path.includes('source=cron')) {
+        return Promise.resolve({
+          ...emptySessionsResponse,
+          sessions: [],
+          errors: [{ profile: 'default', error: 'disk I/O error' }]
+        })
+      }
+
+      return Promise.resolve({ ...emptySessionsResponse, sessions: [row('recent-1')] })
+    })
+
+    const result = await listSidebarSessions({
+      recentsProfile: 'default',
+      recentsLimit: 20,
+      recentsExclude: [],
+      cronLimit: 50,
+      messagingLimit: 100,
+      messagingExclude: []
+    })
+
+    expect(result.recents.sessions.map(s => s.id)).toEqual(['recent-1'])
+    expect(result.recents.errors).toBeUndefined()
+    expect(result.cron.errors).toEqual([{ profile: 'default', error: 'disk I/O error' }])
+    expect(result.errors).toBeUndefined()
+  })
+
   it('remembers endpoint-missing and skips re-probing the batched route on later refreshes', async () => {
     api.mockImplementation(({ path }: { path: string }) =>
       path.startsWith('/api/profiles/sessions/sidebar')

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -30,6 +30,7 @@ import {
   _resetLegacyDiscardForTests,
   _resetSessionOwnerHintsForTests,
   applyConfiguredDefaultProjectDir,
+  carryForwardFailedProfileSessions,
   commitWorkspaceCwdForSelectedSession,
   ensureDefaultWorkspaceCwd,
   forgetSessionOwnerHintsForConnection,
@@ -41,6 +42,7 @@ import {
   getSessionOwnerHint,
   getSessionOwnerHints,
   hydrateSessionOwnerHints,
+  keepFailedProfileMeta,
   knownSessionOwner,
   knownSessionProfile,
   mergeSessionPage,
@@ -670,6 +672,87 @@ describe('mergeSessionPage', () => {
 
     expect(merged.map(s => s.id)).toEqual(['bumped', 'survivor'])
     expect(merged[0]?.last_active).toBe(300)
+  })
+})
+
+describe('carryForwardFailedProfileSessions', () => {
+  it('is a no-op when the backend reported no profile errors', () => {
+    const previous = [session({ id: 'yesterday', profile: 'default' })]
+    const incoming = [session({ id: 'today', profile: 'default' })]
+
+    expect(carryForwardFailedProfileSessions(previous, incoming, undefined)).toBe(incoming)
+    expect(carryForwardFailedProfileSessions(previous, incoming, [])).toBe(incoming)
+  })
+
+  it('re-attaches idle rows for a profile whose slice failed (empty 200 + errors)', () => {
+    // Repro: current session is running, sidebar scan hits disk I/O, backend
+    // returns recents=[] with errors=[{profile:default}]. mergeSessionPage then
+    // keeps only working/pinned/selected and Yesterday/This-week vanish.
+    const previous = [
+      session({ id: 'running', last_active: 300, profile: 'default', title: 'Now' }),
+      session({ id: 'yesterday', last_active: 200, profile: 'default', title: 'Yesterday' }),
+      session({ id: 'week', last_active: 100, profile: 'default', title: 'This week' })
+    ]
+
+    const carried = carryForwardFailedProfileSessions(previous, [], [
+      { profile: 'default', error: 'disk I/O error' }
+    ])
+
+    expect(carried.map(s => s.id)).toEqual(['running', 'yesterday', 'week'])
+    expect(carried[1]).toBe(previous[1])
+  })
+
+  it('does not resurrect a successful profile’s omitted rows, and does not duplicate', () => {
+    const previous = [
+      session({ id: 'work-old', profile: 'work' }),
+      session({ id: 'home-idle', profile: 'default' }),
+      session({ id: 'home-fresh', profile: 'default' })
+    ]
+
+    const incoming = [session({ id: 'home-fresh', message_count: 4, profile: 'default' })]
+
+    const carried = carryForwardFailedProfileSessions(previous, incoming, [{ profile: 'work' }])
+
+    expect(carried.map(s => `${s.profile}:${s.id}`)).toEqual(['default:home-fresh', 'work:work-old'])
+  })
+
+  it('re-ranks carried rows by recency instead of parking them at the tail', () => {
+    const previous = [
+      session({ id: 'idle-newer', last_active: 500, profile: 'work' }),
+      session({ id: 'idle-older', last_active: 50, profile: 'work' })
+    ]
+
+    const incoming = [session({ id: 'home', last_active: 100, profile: 'default' })]
+
+    expect(
+      carryForwardFailedProfileSessions(previous, incoming, [{ profile: 'work' }]).map(s => s.id)
+    ).toEqual(['idle-newer', 'home', 'idle-older'])
+  })
+
+  it('treats a missing profile tag on the error as default', () => {
+    const previous = [session({ id: 'idle', profile: 'default' })]
+
+    expect(carryForwardFailedProfileSessions(previous, [], [{ error: 'disk I/O error' }]).map(s => s.id)).toEqual([
+      'idle'
+    ])
+  })
+})
+
+describe('keepFailedProfileMeta', () => {
+  it('is a no-op when the backend reported no profile errors', () => {
+    const incoming = { default: { cost_usd: 1, tokens: 2 } }
+
+    expect(keepFailedProfileMeta({ default: { cost_usd: 9, tokens: 9 } }, incoming, [])).toBe(incoming)
+  })
+
+  it('restores previous usage/truncated flags for profiles whose slice failed', () => {
+    const previous = { default: { cost_usd: 4, tokens: 40 }, work: { cost_usd: 1, tokens: 10 } }
+    const incoming = { work: { cost_usd: 2, tokens: 20 } }
+
+    expect(keepFailedProfileMeta(previous, incoming, [{ profile: 'default' }])).toEqual({
+      default: { cost_usd: 4, tokens: 40 },
+      work: { cost_usd: 2, tokens: 20 }
+    })
   })
 })
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -629,6 +629,85 @@ export function mergeSessionPage(
   return interleaved
 }
 
+function sidebarProfileKey(session: Pick<SessionInfo, 'profile'>): string {
+  return (session.profile ?? '').trim() || 'default'
+}
+
+function sessionListIdentity(session: Pick<SessionInfo, 'id' | 'profile'>): string {
+  return `${sidebarProfileKey(session)}::${session.id}`
+}
+
+/**
+ * Re-attach previous rows for profiles whose sidebar slice failed this refresh.
+ *
+ * The batched sidebar endpoint reports a disk I/O / lock failure as HTTP 200
+ * with `recents: []` and `errors: [{ profile }]`. `mergeSessionPage` only keeps
+ * working / pinned / selected ids, so idle Yesterday / This-week rows would
+ * otherwise vanish until a later successful scan (#73847, #88528).
+ *
+ * Successful profiles are left alone: their incoming page is still authoritative.
+ */
+export function carryForwardFailedProfileSessions(
+  previous: SessionInfo[],
+  incoming: SessionInfo[],
+  errors: Array<{ profile?: string; error?: string }> | undefined | null
+): SessionInfo[] {
+  if (!errors?.length || previous.length === 0) {
+    return incoming
+  }
+
+  const failed = new Set(errors.map(error => (error.profile ?? '').trim() || 'default'))
+  const incomingIds = new Set(incoming.map(sessionListIdentity))
+  const carried: SessionInfo[] = []
+
+  for (const session of previous) {
+    if (!failed.has(sidebarProfileKey(session)) || incomingIds.has(sessionListIdentity(session))) {
+      continue
+    }
+
+    carried.push(session)
+  }
+
+  if (carried.length === 0) {
+    return incoming
+  }
+
+  // Incoming-first concat parks the failed profile at the tail of an
+  // all-profiles list. Re-rank by the same recency key the backend uses.
+  const recency = (session: SessionInfo): number => Math.max(session.last_active || 0, session.started_at || 0)
+
+  return [...incoming, ...carried].sort((a, b) => recency(b) - recency(a))
+}
+
+/** Keep previous per-profile sidebar meta for profiles whose slice failed.
+ *
+ *  A failed scan returns `{}` / falsey truncated flags. Applying those
+ *  would zero usage and hide Load more under a list we just carried forward.
+ */
+export function keepFailedProfileMeta<T>(
+  previous: Record<string, T>,
+  incoming: Record<string, T>,
+  errors: Array<{ profile?: string; error?: string }> | undefined | null
+): Record<string, T> {
+  if (!errors?.length) {
+    return incoming
+  }
+
+  const next = { ...incoming }
+
+  for (const error of errors) {
+    const key = (error.profile ?? '').trim() || 'default'
+
+    if (Object.prototype.hasOwnProperty.call(previous, key)) {
+      next[key] = previous[key]
+    } else {
+      delete next[key]
+    }
+  }
+
+  return next
+}
+
 /** Raise a session in recents on user send (before stream / turn resolve). */
 export function touchSessionActivity(
   sessionId: string | null | undefined,

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -197,6 +197,11 @@ def _sidebar_singleflight_cache(func):
             if cached is not miss:
                 return cached
             result = func(*args, **kwargs)
+            # A 200 carrying errors[] is a FAILED profile scan, not a
+            # successful empty page. Caching it holds the empty recents in
+            # front of a store that has already recovered, for the whole TTL.
+            if isinstance(result, dict) and result.get("errors"):
+                return result
             try:
                 snapshot = copy.deepcopy(result)
             except Exception:

--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -31,7 +31,7 @@ from hermes_cli.web_models import (
     SessionPrune,
     SessionRename,
 )
-from hermes_state import is_malformed_db_error
+from hermes_state import is_malformed_db_error, is_transient_sqlite_error
 
 # Same logger the handlers used before extraction (identical logger object).
 _log = logging.getLogger("hermes_cli.web_server")
@@ -197,6 +197,22 @@ def get_sessions(
             db.close()
     except HTTPException:
         raise
+    except sqlite3.OperationalError as exc:
+        _log.exception("GET /api/sessions failed")
+        # 503, not 500: the store is busy, not gone. The desktop keeps the
+        # sidebar it already has instead of reading a 500 as an authoritative
+        # empty list. Retrying the OPEN here is deliberately not done — the
+        # bounded retry lives in SessionDB's read-only constructor, so every
+        # read-only opener gets it, not just this route.
+        transient = is_transient_sqlite_error(exc)
+        raise HTTPException(
+            status_code=503 if transient else 500,
+            detail=(
+                "Session store is busy (disk I/O or lock). Retry; the list was not cleared."
+                if transient
+                else "Internal server error"
+            ),
+        ) from exc
     except Exception:
         _log.exception("GET /api/sessions failed")
         raise HTTPException(status_code=500, detail="Internal server error")

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -374,6 +374,20 @@ DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 # query; short enough that transient fd pressure doesn't strand the read pool.
 _READ_OPEN_RETRY_SECONDS = 60.0
 
+# Transient SQLITE_IOERR retry budget for READ-ONLY opens (#100436). A WAL
+# database being actively written (checkpoint, WAL reset/truncate, frame
+# flush) can surface "disk I/O error" to a concurrent ``mode=ro`` reader in
+# a millisecond-wide transition window: the read-only connection cannot
+# perform the WAL recovery a read through a stale or mid-update -shm file
+# needs, because recovery requires writing the -shm index, which mode=ro
+# refuses. The window closes on its own (the writer finishes the transition),
+# so a bounded number of short retries makes the open succeed instead of
+# 500-ing the whole /api/sessions poll (or any other read-only opener).
+# Deliberately NOT attempted on writable opens: a writer owns the
+# transition, so an IOERR there means a real storage/fd problem.
+_READ_ONLY_IOERR_RETRY_ATTEMPTS = 3
+_READ_ONLY_IOERR_RETRY_BACKOFF_S = 0.05
+
 # Hard ceiling on read-only connections ALIVE at once against one database
 # FILE — pooled idle ones and checked-out ones together, summed over every
 # SessionDB in this process that points at that file. See _PathReadBudget.
@@ -2080,6 +2094,52 @@ def is_malformed_db_error(exc: BaseException) -> bool:
     if not isinstance(exc, sqlite3.DatabaseError):
         return False
     return any(marker in str(exc).lower() for marker in _MALFORMED_DB_MARKERS)
+
+
+# SQLITE_IOERR, matched as a plain substring so wrapped error strings still
+# classify. Shared by the read-only open retry and the write-path BEGIN retry.
+_DISK_IO_ERROR_MARKER = "disk i/o error"
+
+# Broader set for HTTP classification: a read that failed for one of these
+# reasons found the store BUSY, not gone. Callers map it to 503 (retry, the
+# list was not cleared) instead of 500. Corruption is deliberately absent —
+# a malformed store must surface, not be retried into a timeout.
+_TRANSIENT_SQLITE_MARKERS = (
+    _DISK_IO_ERROR_MARKER,
+    "database is locked",
+    "database table is locked",
+    "busy",
+)
+
+
+def is_transient_sqlite_error(exc: BaseException) -> bool:
+    """True when a SQLite failure means "busy right now", not "damaged".
+
+    One predicate so the read paths cannot drift apart on what counts as
+    recoverable: the read-only open retry, and the HTTP 503-vs-500 split on
+    the session-list endpoints, classify the same way.
+    """
+    if not isinstance(exc, sqlite3.OperationalError):
+        return False
+    message = str(exc).lower()
+    return any(marker in message for marker in _TRANSIENT_SQLITE_MARKERS)
+
+
+def _is_transient_read_only_ioerr(exc: sqlite3.OperationalError, *, attempt: int) -> bool:
+    """True when a read-only open should be retried rather than raised.
+
+    A ``mode=ro`` connection cannot perform WAL recovery (recovery needs to
+    write the -shm index, which read-only mode refuses), so a concurrent WAL
+    checkpoint / reset / frame-flush can surface ``SQLITE_IOERR`` ("disk I/O
+    error") to a reader on an otherwise healthy database (#100436). The
+    transition is millisecond-scale, so a bounded number of short retries
+    clears it without changing classification for genuine storage failures —
+    a persistent IOERR still exhausts the budget and propagates.
+    """
+    return (
+        attempt < _READ_ONLY_IOERR_RETRY_ATTEMPTS
+        and _DISK_IO_ERROR_MARKER in str(exc).lower()
+    )
 
 
 def is_malformed_schema_error(exc: BaseException) -> bool:
@@ -5123,46 +5183,67 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 # must already exist + be initialised (callers guard on
                 # db_path.exists()); a SELECT against an empty file raises and
                 # the caller degrades per-profile.
-                self._conn = _connect_tracked_db(
-                    f"file:{self.db_path}?mode=ro",
-                    tracking_path=self.db_path,
-                    uri=True,
-                    check_same_thread=False,
-                    timeout=1.0,
-                    isolation_level=None,
-                )
-                self._conn.row_factory = sqlite3.Row
-                # FTS capability flags normally come from writable schema
-                # initialisation. Probe existing virtual tables with SELECTs
-                # only so read-only search keeps its FTS and trigram paths.
-                # Close the connection on ANY probe failure (e.g. malformed
-                # schema raises DatabaseError, not the OperationalError the
-                # probe handles). The constructor's outer finally also covers
-                # failures before this probe and BaseException paths, so a
-                # leaked tracked connection cannot block _backup_db_file's
-                # raw-copy for the rest of the process — the writable heal
-                # that follows would then repair WITHOUT its forensic backup.
-                try:
-                    apply_database_pragmas(self._conn, db_label="state.db")
-                    cursor = self._conn.cursor()
-                    self._fts_enabled = (
-                        self._fts_table_probe(cursor, "messages_fts") is True
-                    )
-                    if self._fts_enabled:
-                        self._trigram_available = (
-                            self._fts_table_probe(
-                                cursor,
-                                "messages_fts_trigram",
-                            )
-                            is True
-                        )
-                except BaseException:
-                    conn, self._conn = self._conn, None
+                open_attempt = 0
+                while True:
                     try:
-                        conn.close()
-                    except Exception:
-                        pass
-                    raise
+                        self._conn = _connect_tracked_db(
+                            f"file:{self.db_path}?mode=ro",
+                            tracking_path=self.db_path,
+                            uri=True,
+                            check_same_thread=False,
+                            timeout=1.0,
+                            isolation_level=None,
+                        )
+                        self._conn.row_factory = sqlite3.Row
+                        # FTS capability flags normally come from writable schema
+                        # initialisation. Probe existing virtual tables with
+                        # SELECTs only so read-only search keeps its FTS and
+                        # trigram paths. Close the connection on ANY probe
+                        # failure (e.g. malformed schema raises DatabaseError,
+                        # not the OperationalError the probe handles). The
+                        # constructor's outer finally also covers failures
+                        # before this probe and BaseException paths, so a
+                        # leaked tracked connection cannot block
+                        # _backup_db_file's raw-copy for the rest of the
+                        # process — the writable heal that follows would then
+                        # repair WITHOUT its forensic backup.
+                        try:
+                            apply_database_pragmas(self._conn, db_label="state.db")
+                            cursor = self._conn.cursor()
+                            self._fts_enabled = (
+                                self._fts_table_probe(cursor, "messages_fts")
+                                is True
+                            )
+                            if self._fts_enabled:
+                                self._trigram_available = (
+                                    self._fts_table_probe(
+                                        cursor,
+                                        "messages_fts_trigram",
+                                    )
+                                    is True
+                                )
+                        except BaseException:
+                            conn, self._conn = self._conn, None
+                            try:
+                                conn.close()
+                            except Exception:
+                                pass
+                            raise
+                        break
+                    except sqlite3.OperationalError as ioerr:
+                        # A WAL checkpoint / reset / frame-flush in flight on
+                        # the writer side can surface SQLITE_IOERR to a
+                        # concurrent mode=ro reader (it cannot perform the
+                        # recovery the read needs — recovery writes the -shm
+                        # index, which mode=ro refuses). The transition closes
+                        # in milliseconds, so retry a bounded number of times
+                        # before classifying the store as failed (#100436).
+                        if not _is_transient_read_only_ioerr(
+                            ioerr, attempt=open_attempt
+                        ):
+                            raise
+                        open_attempt += 1
+                        time.sleep(_READ_ONLY_IOERR_RETRY_BACKOFF_S)
                 self._record_db_file_identity()
                 initialization_complete = True
                 return
@@ -5930,6 +6011,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # Set on the first compression-busy collision so the short wait is
         # measured from then, not from the start of the write.
         compression_deadline: Optional[float] = None
+        # One retry for SQLITE_IOERR raised by BEGIN IMMEDIATE itself. The
+        # callback has not run at that point, so there is no durable effect
+        # to replay and the retry is exactly-once safe (#99502's contract).
+        # Once the callback starts, an IOERR leaves the write's settlement
+        # unknown and must propagate — this helper owns non-idempotent
+        # transcript/counter mutations, not just idempotent UPSERTs.
+        ioerr_begin_retried = False
 
         # Transient engine-level error observed on contended WAL appends
         # (dual gateway/agent writers; FTS5 trigram sync holds the write
@@ -5943,6 +6031,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         while True:
             self._raise_if_db_replaced()
+            fn_started = False
             try:
                 with self._lock:
                     if self._conn is None:
@@ -5951,6 +6040,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         self._reopen_after_close_locked(context="write")
                     self._conn.execute("BEGIN IMMEDIATE")
                     try:
+                        fn_started = True
                         result = fn(self._conn)
                         self._conn.commit()
                     except BaseException:
@@ -6003,7 +6093,21 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     ) from exc
                 if _is_no_more_rows(exc) and self._sleep_before_write_retry(deadline, patience_s):
                     continue
-                # Non-lock error or patience exhausted — propagate.
+                if (
+                    _DISK_IO_ERROR_MARKER in err_msg
+                    and not fn_started
+                    and not ioerr_begin_retried
+                    and self._sleep_before_write_retry(deadline, patience_s)
+                ):
+                    # BEGIN IMMEDIATE itself hit a transient WAL-transition
+                    # IOERR. Nothing has been mutated, so retrying on the SAME
+                    # connection replays nothing. Never close()+reopen to
+                    # "heal" it: close() cancels this process's POSIX locks on
+                    # the file for every sibling connection (howtocorrupt §2.2).
+                    ioerr_begin_retried = True
+                    continue
+                # Non-lock error, the callback already ran (settlement is
+                # unknown — do not replay), or patience exhausted.
                 raise
             except sqlite3.DatabaseError as exc:
                 if _is_no_more_rows(exc) and self._sleep_before_write_retry(deadline, patience_s):

--- a/tests/hermes_cli/test_profiles_sidebar_cache.py
+++ b/tests/hermes_cli/test_profiles_sidebar_cache.py
@@ -128,6 +128,30 @@ class SidebarCacheTests(unittest.TestCase):
         self.assertEqual(scan(), {"ok": True})
         self.assertEqual(calls, 2)
 
+    def test_does_not_cache_payloads_that_carry_profile_errors(self):
+        # A 200 with a non-empty errors[] is how a failed profile scan is
+        # reported. Caching it for the TTL keeps the empty recents page in
+        # front of a store that has already recovered.
+        calls = 0
+
+        @profiles._sidebar_singleflight_cache
+        def scan():
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return {
+                    "errors": [{"profile": "default", "error": "disk I/O error"}],
+                    "recents": {"sessions": []},
+                }
+            return {"errors": [], "recents": {"sessions": [{"id": "yesterday"}]}}
+
+        first = scan()
+        second = scan()
+
+        self.assertEqual(first["errors"][0]["error"], "disk I/O error")
+        self.assertEqual(second["recents"]["sessions"], [{"id": "yesterday"}])
+        self.assertEqual(calls, 2)
+
     def test_can_be_disabled(self):
         calls = 0
 

--- a/tests/hermes_cli/test_session_list_reader_disposable.py
+++ b/tests/hermes_cli/test_session_list_reader_disposable.py
@@ -1,0 +1,96 @@
+"""Read-only session-list opens must stay disposable.
+
+Two properties that a "keep the read-only handle for the process lifetime"
+optimisation silently destroys. Both are asserted against the real
+``_open_session_db_at_path`` read path the sidebar poll uses, because both
+failures are invisible in a unit test that mocks the store.
+
+1. **The store on disk is the truth.** Recovering a corrupt ``state.db``
+   is a file swap (``mv state.db state.db.corrupt-…; cp -a recovered.db
+   state.db``) performed while the backend is stopped, but a poll can also
+   race a restore. A reader pinned to the old inode keeps serving
+   pre-recovery rows forever, so the user "recovers" and still sees the
+   broken list.
+
+2. **Forensic backup must stay reachable.** ``offline_file_access`` refuses
+   raw byte access while ANY tracked connection is registered for the path,
+   because a raw ``close()`` would cancel this process's POSIX advisory locks
+   (howtocorrupt §2.2). ``_backup_db_file`` (the copy taken BEFORE a malformed
+   store is repaired) and ``_db_fingerprint`` (the repair-attempt ledger key)
+   both go through it. A never-closed list reader makes both fail for the rest
+   of the process, so a repair runs without its forensic backup and the
+   ledger degrades to a size-only key.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+from hermes_cli.sqlite_safe_read import LiveConnectionError, offline_file_access
+from hermes_cli.web_server import _open_session_db_at_path
+from hermes_state import SessionDB, _db_fingerprint
+
+
+def _ids(db) -> list:
+    return [row["id"] for row in db.list_sessions_rich(limit=10, compact_rows=True)]
+
+
+def test_poll_observes_a_replaced_state_db(tmp_path):
+    db_path = tmp_path / "state.db"
+    old = SessionDB(db_path=db_path)
+    old.create_session("before-recovery", source="cli")
+    old.close()
+
+    first = _open_session_db_at_path(db_path, read_only=True)
+    try:
+        assert _ids(first) == ["before-recovery"]
+    finally:
+        first.close()
+
+    # `hermes sessions recover` writes a clean database, which the operator
+    # then installs over the corrupt one.
+    recovered = tmp_path / "recovered-state.db"
+    rebuilt = SessionDB(db_path=recovered)
+    rebuilt.create_session("after-recovery", source="cli")
+    rebuilt.close()
+
+    for suffix in ("-wal", "-shm"):
+        sidecar = db_path.with_name(db_path.name + suffix)
+        if sidecar.exists():
+            sidecar.unlink()
+    db_path.unlink()
+    shutil.copy2(recovered, db_path)
+
+    second = _open_session_db_at_path(db_path, read_only=True)
+    try:
+        assert _ids(second) == ["after-recovery"]
+    finally:
+        second.close()
+
+
+def test_poll_leaves_forensic_backup_reachable(tmp_path):
+    db_path = tmp_path / "state.db"
+    writer = SessionDB(db_path=db_path)
+    writer.create_session("s1", source="cli")
+    writer.close()
+
+    baseline = _db_fingerprint(db_path)
+    assert baseline is not None
+
+    poll = _open_session_db_at_path(db_path, read_only=True)
+    try:
+        assert _ids(poll) == ["s1"]
+    finally:
+        poll.close()
+
+    # The raw-copy path a malformed-store repair takes before it touches
+    # anything must still be permitted after the poll.
+    try:
+        with offline_file_access(db_path, what="forensic-backup"):
+            pass
+    except LiveConnectionError as exc:  # pragma: no cover - failure detail
+        raise AssertionError(
+            f"a session-list poll left a tracked connection open: {exc}"
+        ) from exc
+
+    assert _db_fingerprint(db_path) == baseline

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -319,6 +319,29 @@ class TestWebServerEndpoints:
                 monitor.close()
             writer.close()
 
+    def test_get_sessions_transient_ioerr_is_503(self, monkeypatch):
+        """Busy store, not a gone store: the desktop keeps the list it has."""
+        import sqlite3
+
+        from hermes_cli import web_server
+
+        def boom(*_args, **_kwargs):
+            raise sqlite3.OperationalError("disk I/O error")
+
+        monkeypatch.setattr(web_server, "_open_session_db_for_profile", boom)
+        assert self.client.get("/api/sessions?limit=1&offset=0").status_code == 503
+
+    def test_get_sessions_non_transient_operational_error_is_500(self, monkeypatch):
+        import sqlite3
+
+        from hermes_cli import web_server
+
+        def boom(*_args, **_kwargs):
+            raise sqlite3.OperationalError("no such table: sessions")
+
+        monkeypatch.setattr(web_server, "_open_session_db_for_profile", boom)
+        assert self.client.get("/api/sessions?limit=1&offset=0").status_code == 500
+
     def test_get_status_loads_gateway_config_off_event_loop(self, monkeypatch):
         """Cold gateway config loading must not block the WebSocket loop.
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -281,6 +281,83 @@ class TestConnectionLifecycle:
         healed.close()
         assert list(tmp_path.glob("*malformed-backup*"))
 
+    def test_read_only_open_retries_transient_wal_ioerr(self, tmp_path, monkeypatch):
+        """A transient SQLITE_IOERR on a read-only open must retry, not raise.
+
+        A ``mode=ro`` connection cannot perform WAL recovery (recovery would
+        need to write the -shm index, which read-only mode refuses), so a
+        concurrent checkpoint / WAL reset / frame-flush on the writer side can
+        surface "disk I/O error" to a reader on a perfectly healthy database
+        (#100436). The transition window is millisecond-scale; a bounded retry
+        must let the open succeed instead of 500-ing the /api/sessions poll
+        and every other read-only opener.
+        """
+        import sqlite3
+
+        from hermes_cli.sqlite_safe_read import has_live_connection
+
+        db_path = tmp_path / "state.db"
+        writable = SessionDB(db_path=db_path)
+        writable.create_session("wal-race", source="cli")
+        writable.close()
+
+        real_connect = hermes_state._connect_tracked_db
+        attempts = []
+
+        def flaky_connect(*args, **kwargs):
+            attempts.append(kwargs.get("uri"))
+            if len(attempts) == 1:
+                # First open lands inside the writer's WAL transition window.
+                raise sqlite3.OperationalError("disk I/O error")
+            return real_connect(*args, **kwargs)
+
+        monkeypatch.setattr(hermes_state, "_connect_tracked_db", flaky_connect)
+        # Keep the test fast: one backoff tick is enough; the retry budget
+        # itself is exercised by the attempt count below.
+        monkeypatch.setattr(hermes_state, "_READ_ONLY_IOERR_RETRY_BACKOFF_S", 0.0)
+
+        read_only = SessionDB(db_path=db_path, read_only=True)
+        try:
+            assert read_only._fts_enabled is True
+            matches = read_only.search_messages("wal-race")
+        finally:
+            read_only.close()
+
+        assert len(attempts) >= 2, "the transient IOERR must be retried"
+        assert has_live_connection(db_path) is False  # no leaked connections
+
+    def test_read_only_open_exhausts_retry_budget_for_persistent_ioerr(
+        self, tmp_path, monkeypatch
+    ):
+        """A persistent SQLITE_IOERR must exhaust the budget and raise.
+
+        The retry exists to ride out a millisecond WAL transition — a
+        storage layer that keeps failing after the full budget is genuinely
+        broken and must surface the error (and not loop forever).
+        """
+        import sqlite3
+
+        db_path = tmp_path / "state.db"
+        writable = SessionDB(db_path=db_path)
+        writable.create_session("broken-disk", source="cli")
+        writable.close()
+
+        attempts = []
+
+        def bad_connect(*args, **kwargs):
+            attempts.append(1)
+            raise sqlite3.OperationalError("disk I/O error")
+
+        monkeypatch.setattr(hermes_state, "_connect_tracked_db", bad_connect)
+        monkeypatch.setattr(hermes_state, "_READ_ONLY_IOERR_RETRY_BACKOFF_S", 0.0)
+        budget = hermes_state._READ_ONLY_IOERR_RETRY_ATTEMPTS
+
+        with pytest.raises(sqlite3.OperationalError, match="disk I/O error"):
+            SessionDB(db_path=db_path, read_only=True)
+
+        # budget + 1 = the initial attempt plus `budget` retries.
+        assert len(attempts) == budget + 1
+
 
 # =========================================================================
 # Session lifecycle

--- a/tests/test_state_db_notadb_fail_closed.py
+++ b/tests/test_state_db_notadb_fail_closed.py
@@ -1,9 +1,10 @@
 """Tests for fail-closed state.db NOTADB handling and journal-mode EIO retries.
 
-Covers the two independently-valuable pieces salvaged from the state.db
-hardening rollup:
+Covers:
 
 * fail closed when a live write connection reports ``file is not a database``;
+* the write-path SQLITE_IOERR retry boundary: admitted only when the callback
+  has provably not run, never by closing and replaying;
 * transient ``disk i/o error`` retry in ``_on_disk_journal_mode`` so a
   one-shot EIO doesn't push callers onto the fail-closed unknown-mode branch.
 """
@@ -46,6 +47,89 @@ class TestFailClosedAfterNotADb:
             reopen.assert_not_called()
         finally:
             db._conn = real_conn
+            db.close()
+
+
+class TestWriteIoerrRetryBoundary:
+    """IOERR retry is admitted by EFFECT POSITION, not error spelling.
+
+    ``_execute_write`` owns non-idempotent transcript/counter mutations, so
+    replaying its callback is only safe when the first attempt provably did
+    nothing. SQLite does not define ``SQLITE_IOERR`` as pre-effect-only (an
+    IOERR at fsync/commit may or may not have landed), so the admission gate
+    is "did the callback start", not "does the message say disk I/O".
+    """
+
+    def test_ioerr_on_begin_retries_because_the_callback_never_ran(self, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        real_conn = db._conn
+        try:
+
+            class _BeginIoerrOnce:
+                def __init__(self, conn):
+                    self._real = conn
+                    self.begins = 0
+
+                def execute(self, sql, *args, **kwargs):
+                    if str(sql).strip().upper().startswith("BEGIN") and self.begins == 0:
+                        self.begins += 1
+                        raise sqlite3.OperationalError("disk I/O error")
+                    return self._real.execute(sql, *args, **kwargs)
+
+                def __getattr__(self, name):
+                    return getattr(self._real, name)
+
+            proxy = _BeginIoerrOnce(real_conn)
+            db._conn = proxy
+            db.create_session(session_id="s1", source="cli", model="test")
+            assert proxy.begins == 1
+        finally:
+            db._conn = real_conn
+
+        rows = db.list_sessions_rich(limit=10, compact_rows=True)
+        assert [row["id"] for row in rows] == ["s1"]
+        db.close()
+
+    def test_ioerr_after_the_callback_mutates_does_not_replay(self, tmp_path):
+        """Settlement is unknown once the callback has run — surface, don't rerun."""
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            calls = []
+
+            def mutate_then_fail(conn):
+                calls.append(1)
+                conn.execute(
+                    "INSERT INTO sessions (id, started_at, source) VALUES (?, ?, ?)",
+                    (f"row-{len(calls)}", 1.0, "cli"),
+                )
+                raise sqlite3.OperationalError("disk I/O error")
+
+            with pytest.raises(sqlite3.OperationalError, match="disk I/O error"):
+                db._execute_write(mutate_then_fail)
+
+            assert calls == [1], "a started write must not be replayed"
+            assert db.list_sessions_rich(limit=10, compact_rows=True) == []
+        finally:
+            db.close()
+
+    def test_write_ioerr_never_closes_the_connection(self, tmp_path, monkeypatch):
+        """close() cancels this process's POSIX locks for every sibling fd."""
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            closed = []
+            monkeypatch.setattr(
+                type(db._conn), "close", lambda self: closed.append(1), raising=False
+            )
+
+            def always_ioerr(conn):
+                raise sqlite3.OperationalError("disk I/O error")
+
+            with pytest.raises(sqlite3.OperationalError):
+                db._execute_write(always_ioerr)
+
+            assert closed == []
+            assert db._conn is not None
+        finally:
             db.close()
 
 


### PR DESCRIPTION
The desktop sidebar can go blank while `state.db` is perfectly healthy, and the cause is on both sides of the wire: the backend reports a read it could not complete as a successful empty page, and the renderer treats that page as authoritative.

A concurrent WAL checkpoint / reset / frame-flush surfaces `SQLITE_IOERR` to a `mode=ro` reader, because a read-only connection cannot run the WAL recovery the read needs — recovery writes the `-shm` index and read-only mode refuses. The window is millisecond-scale, but nothing rides it out. `/api/profiles/sessions[/sidebar]` answers HTTP 200 with `recents: []` and `errors: [{profile}]`, `mergeSessionPage` keeps only working / pinned / selected rows, and every idle Yesterday / This-week session vanishes. The 5s coalescing cache then serves that empty payload back for the rest of its TTL, so the list stays blank after the store has recovered. On `/api/sessions` the same error becomes a 500, which the desktop also reads as "no sessions."

This fixes the read at its source and stops the client from believing a failure.

**Read path.** The bounded IOERR retry lives in `SessionDB`'s read-only constructor, so every read-only opener gets it — the sidebar poll, cross-profile aggregation, recall, browse — not one route. A persistent IOERR still exhausts the budget and propagates. What survives the retry answers `503`, not `500`: the store is busy, not gone.

**Write path.** `BEGIN IMMEDIATE` can hit the same transient IOERR before the callback runs. That is safe to retry on the same connection, because nothing has been mutated. Once the callback starts, settlement is unknown and the error propagates — `_execute_write` owns non-idempotent transcript and counter mutations, so the admission gate is effect position, not error spelling.

**Renderer.** Previous rows are carried forward for exactly the profiles named in `errors[]`, keyed by `profile::id` so a twin id in another profile is never stitched in. Profiles that scanned cleanly stay authoritative, and a genuinely empty page with no errors still clears the list. Usage and truncation flags follow the same rule instead of zeroing under a list that was kept.

## On not "healing" IOERR by closing the connection

An earlier version of this work closed and replayed the writer, and retained read-only handles for the process lifetime, on the theory that a list poll's `close()` was cancelling the live writer's POSIX locks and truncating the WAL to 0. Measured against this code, that does not happen — SQLite's unix VFS defers `close()` while sibling connections hold locks on the inode, which is why `unixInodeInfo` keeps a pending-close list. 100 real read-only poll open/close cycles against a live writer holding `BEGIN IMMEDIATE`, with an out-of-process rival probing for the lock:

```
baseline rival:                            STOLE-WRITE-LOCK
mid-storm rival (writer holds BEGIN IMM):  BLOCKED: database is locked
wal 2558552 -> 2558552 bytes   truncated to 0: False
integrity_check: ok
```

The cancellation hazard is a *raw* `open()`/`close()`, and this repo already handles it — `hermes_cli/sqlite_safe_read.py` and `_pread_db_header`'s never-closed cached fd. A 0-byte `-wal` is also what a clean `wal_checkpoint(TRUNCATE)` leaves behind, not a corruption fingerprint.

Keeping list readers disposable is load-bearing, so two properties are now asserted directly: a poll must observe a replaced `state.db` (the file swap an operator performs after `hermes sessions recover`), and a poll must leave `offline_file_access` reachable, since `_backup_db_file`'s pre-repair forensic copy and `_db_fingerprint`'s repair-ledger key both go through it. Both fail if a reader is pinned for the process lifetime.

## Verification

- `tests/hermes_cli/test_session_list_reader_disposable.py` — replaced-inode visibility, forensic backup reachable after a poll
- `tests/test_state_db_notadb_fail_closed.py` — IOERR retries on `BEGIN`, does not replay a started callback, never closes the connection
- `tests/test_hermes_state.py` — read-only open retries a transient IOERR, exhausts the budget on a persistent one
- `tests/hermes_cli/test_web_server.py` — `/api/sessions` 503 for transient, 500 for everything else
- `tests/hermes_cli/test_profiles_sidebar_cache.py` — an `errors[]` payload is not cached
- `session.test.ts`, `use-session-list-actions.test.tsx`, `hermes.test.ts` — carry-forward, genuine-empty, meta preservation, per-slice legacy errors

245 python tests pass in the touched files (two failures in `test_hermes_state.py` reproduce on unmodified `main`); 169 vitest tests pass.

Each new test was mutation-verified: reintroducing the retained-reader cache fails both disposability tests, and dropping the effect-position gate fails the replay test with `[1, 1] == [1]` — the duplicate-row counterexample #99502's contract exists to prevent.

Supersedes #100064
Supersedes #100584
Fixes #100436
Part of #73847
Part of #88528

Complementary to #89332 (a replaced file or non-SQLite bytes still fail closed) and adjacent to #86762, which owns the persistent degraded-state latch after confirmed unrecoverable corruption — this PR is the transient-busy side of that boundary, not a substitute.
