### PR TITLE
fix(doctor): close the session-probe connection on every path

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2045,9 +2045,19 @@ def run_doctor(args):
         try:
             import sqlite3
             conn = sqlite3.connect(str(state_db_path))
-            cursor = conn.execute("SELECT COUNT(*) FROM sessions")
-            count = cursor.fetchone()[0]
-            conn.close()
+            # try/finally, not bare close-after-read (#100836): on a
+            # malformed DB, execute() raises and the except path below calls
+            # repair_state_db_schema(), whose _live_writer_holds_db() probe
+            # fails against THIS leaked connection (SQLITE_BUSY on
+            # BEGIN IMMEDIATE) — doctor self-detects as the live writer and
+            # refuses to repair after the operator already stopped the
+            # gateway. Close on every path so the probe only sees real
+            # external holders.
+            try:
+                cursor = conn.execute("SELECT COUNT(*) FROM sessions")
+                count = cursor.fetchone()[0]
+            finally:
+                conn.close()
             check_ok(f"{_DHH}/state.db exists ({count} sessions)")
 
             # FTS write-health probe (#50502): `SELECT COUNT(*)` above succeeds
@@ -2106,10 +2116,15 @@ def run_doctor(args):
                     if report.get("repaired"):
                         try:
                             conn = sqlite3.connect(str(state_db_path))
-                            count = conn.execute(
-                                "SELECT COUNT(*) FROM sessions"
-                            ).fetchone()[0]
-                            conn.close()
+                            # Same leak shape as the pre-repair probe (#100836):
+                            # close on every path so a post-repair failure
+                            # never leaks a second blocking connection.
+                            try:
+                                count = conn.execute(
+                                    "SELECT COUNT(*) FROM sessions"
+                                ).fetchone()[0]
+                            finally:
+                                conn.close()
                         except Exception:
                             count = "?"
                         backup_name = (

--- a/tests/hermes_cli/test_doctor_probe_connection_leak.py
+++ b/tests/hermes_cli/test_doctor_probe_connection_leak.py
@@ -1,0 +1,90 @@
+"""doctor's session probes must never leak a blocking connection (#100836).
+
+On a malformed state.db the COUNT(*) probe raises; without try/finally the
+connection stays open, and the except path's repair_state_db_schema() then
+fails its own _live_writer_holds_db() probe against that leaked connection —
+doctor self-detects as the live writer and refuses to repair even after the
+operator stopped the gateway.
+"""
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import doctor  # noqa: E402
+
+
+def test_probe_closes_connection_on_malformed_db(tmp_path):
+    """The COUNT(*) probe must close its connection even when the DB is
+    malformed — otherwise doctor's own repair path is blocked by its own
+    leaked handle (#100836)."""
+    db_path = tmp_path / "state.db"
+    # Structural corruption that makes SELECT COUNT(*) fail: valid SQLite
+    # header, garbage body -> DatabaseError on first statement.
+    header = b"SQLite format 3\x00" + b"\x10\x00" + b"\x00" * 100
+    db_path.write_bytes(header + b"\x00" * 4096)
+
+    closed = {"n": 0}
+    real_connect = sqlite3.connect
+
+    class _TrackingConn:
+        def __init__(self, conn):
+            self._conn = conn
+
+        def execute(self, *a, **kw):
+            return self._conn.execute(*a, **kw)
+
+        def close(self):
+            closed["n"] += 1
+            self._conn.close()
+
+    def connect_tracking(path, *a, **kw):
+        return _TrackingConn(real_connect(path, *a, **kw))
+
+    orig_connect = sqlite3.connect
+    sqlite3.connect = connect_tracking
+    try:
+        # The pre-fix shape: bare execute, close only on success.
+        # (Simulates the original code path to demonstrate the leak.)
+        try:
+            conn = sqlite3.connect(str(db_path))
+            conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+            conn.close()  # pre-fix: never reached on error
+        except sqlite3.DatabaseError:
+            pass  # pre-fix: conn leaked here
+        leaked = closed["n"] == 0
+        assert leaked, "pre-fix shape demonstrates the leak (close skipped)"
+
+        # The fixed shape: try/finally guarantees close on every path.
+        closed["n"] = 0
+        try:
+            conn = sqlite3.connect(str(db_path))
+            try:
+                conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+            finally:
+                conn.close()
+        except sqlite3.DatabaseError:
+            pass
+        assert closed["n"] == 1, (
+            "fixed shape must close exactly once on the error path (#100836)"
+        )
+    finally:
+        sqlite3.connect = orig_connect
+
+
+def test_doctor_probe_uses_try_finally_shape():
+    """Source-shape guard: the probe block in doctor.py must wrap
+    execute/close in try/finally so the leak class cannot silently return."""
+    source = Path(doctor.__file__).read_text(encoding="utf-8")
+    probe_at = source.index('conn.execute("SELECT COUNT(*) FROM sessions")')
+    window = source[probe_at - 500: probe_at + 500]
+    assert "finally:" in window, (
+        "the probe's execute/close must be inside try/finally (#100836)"
+    )
+    # The repaired-recount site too
+    probe2 = source.index('"SELECT COUNT(*) FROM sessions"', probe_at + 1)
+    window2 = source[probe2 - 500: probe2 + 500]
+    assert "finally:" in window2, (
+        "the post-repair recount must also close in a finally (#100836)"
+    )


### PR DESCRIPTION
Fixes #100836

## Problem

On a malformed `state.db`, the `COUNT(*)` session probe raised and control jumped to the except handler, **leaving its sqlite3 connection open**. The handler then called `repair_state_db_schema()`, whose `_live_writer_holds_db()` probe fails against the leaked handle (`SQLITE_BUSY` on `BEGIN IMMEDIATE`) — doctor **self-detected as the live writer** and refused to repair:

```
state.db repair skipped: a live writer still holds state.db; skipped schema surgery
to avoid tearing b-tree pages under a concurrent writer. Stop the gateway
(hermes gateway stop) and retry.
```

…even after the operator had already stopped the gateway. The documented recovery path was defeated by doctor blocking itself.

The reporter's repro is precise: corrupt `state.db` structurally so `SELECT COUNT(*) FROM sessions` fails, stop the gateway, run `hermes doctor --fix` — repair still skipped, no other holder present.

## Fix

Both probe sites close in `finally`:

1. the pre-repair `COUNT(*)` check — the reporter's exact suggested fix
2. the post-repair recount in the `should_fix` branch — the same leak shape the reporter flagged for consistency

With the handle always released, `_live_writer_holds_db()` sees only genuine external holders. Same missing-`finally` class as #86517 (`state_search.py`).

## Verification

New `tests/hermes_cli/test_doctor_probe_connection_leak.py`:

- **tracking-connection harness** on a really-malformed DB (valid SQLite header + garbage): the pre-fix shape demonstrably skips close on error (the leak), the fixed shape closes **exactly once on the error path**
- **source-shape guard** asserting both probe blocks retain their `try/finally`, so the leak class cannot silently return

Doctor suites green: `test_doctor.py` + `test_doctor_dedicated_provider_skip.py` **69/69**.