### PR TITLE
feat(desktop): preview file card gains 'Open in system app' action

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.media-md.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.media-md.test.tsx
@@ -29,9 +29,9 @@ describe('markdown documents delivered via MEDIA', () => {
 
     // PreviewAttachment renders an "open preview" toggle button; the old
     // MediaAttachment 'file' fallback rendered a bare "Open ..." anchor.
-    // Two buttons now: Download + Open preview (maintainer-requested).
+    // Three buttons now: Open in system app + Download + Open preview.
     const buttons = await screen.findAllByRole('button')
-    expect(buttons.length).toBe(2)
+    expect(buttons.length).toBe(3)
     expect(screen.getByText('Download')).toBeTruthy()
     expect(screen.queryByText(/^Loading /)).toBeNull()
     expect(screen.getByText('report.md')).toBeTruthy()
@@ -48,7 +48,7 @@ describe('markdown documents delivered via MEDIA', () => {
     render(<MarkdownTextContent isRunning={false} text={`[archive.zip](${href})`} />)
 
     const buttons = await screen.findAllByRole('button')
-    expect(buttons.length).toBe(2)
+    expect(buttons.length).toBe(3)
     expect(screen.getByText('Download')).toBeTruthy()
     expect(screen.getByText('archive.zip')).toBeTruthy()
     expect(screen.queryByText(/^Open archive/)).toBeNull()
@@ -60,7 +60,7 @@ describe('markdown documents delivered via MEDIA', () => {
     render(<MarkdownTextContent isRunning={false} text={`[report.pdf](${href})`} />)
 
     const buttons = await screen.findAllByRole('button')
-    expect(buttons.length).toBe(2)
+    expect(buttons.length).toBe(3)
     expect(screen.getByText('report.pdf')).toBeTruthy()
   })
 })

--- a/apps/desktop/src/components/chat/preview-attachment.test.tsx
+++ b/apps/desktop/src/components/chat/preview-attachment.test.tsx
@@ -1,0 +1,87 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { PreviewAttachment } from '@/components/chat/preview-attachment'
+
+// Behavior contract for the delivered-file card (#97812 follow-up):
+// MEDIA-delivered files must offer "Open in system app" (OS file association,
+// e.g. WPS for .docx) alongside the preview/download actions, and the button
+// must hand the normalized absolute path to the OS as a file:// URL.
+
+describe('PreviewAttachment', () => {
+  const previousDesktop = window.hermesDesktop
+
+  afterEach(() => {
+    window.hermesDesktop = previousDesktop
+    vi.restoreAllMocks()
+  })
+
+  function mountDesktopStub() {
+    const openExternal = vi.fn(async () => undefined)
+    const normalizePreviewTarget = vi.fn(async (_target: string) => ({
+      binary: false,
+      byteSize: 1024,
+      kind: 'file',
+      label: 'doc.docx',
+      language: 'text',
+      mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      path: 'D:\\work\\doc.docx',
+      previewKind: 'binary',
+      source: 'file:///D:/work/doc.docx',
+      url: 'file:///D:/work/doc.docx'
+    }))
+    window.hermesDesktop = {
+      normalizePreviewTarget,
+      openExternal
+    } as never
+
+    return { normalizePreviewTarget, openExternal }
+  }
+
+  it('renders the open-in-system, download and preview actions', async () => {
+    mountDesktopStub()
+
+    await act(async () => {
+      render(<PreviewAttachment source="tool-result" target="file:///D:/work/doc.docx" />)
+    })
+
+    expect(screen.getByRole('button', { name: 'Open in system app' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Download' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Open preview' })).toBeTruthy()
+  })
+
+  it('opens the file in the OS via openExternal with a file:// URL', async () => {
+    const { normalizePreviewTarget, openExternal } = mountDesktopStub()
+
+    await act(async () => {
+      render(<PreviewAttachment source="tool-result" target="file:///D:/work/doc.docx" />)
+    })
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Open in system app' }))
+    })
+
+    expect(normalizePreviewTarget).toHaveBeenCalledTimes(1)
+    expect(normalizePreviewTarget.mock.calls[0][0]).toBe('file:///D:/work/doc.docx')
+    expect(openExternal).toHaveBeenCalledTimes(1)
+    expect(openExternal).toHaveBeenCalledWith('file:///D:/work/doc.docx')
+  })
+
+  it('does not call openExternal for a non-file target', async () => {
+    const openExternal = vi.fn(async () => undefined)
+    window.hermesDesktop = {
+      normalizePreviewTarget: vi.fn(async () => null),
+      openExternal
+    } as never
+
+    await act(async () => {
+      render(<PreviewAttachment source="tool-result" target="https://example.com/report.pdf" />)
+    })
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Open in system app' }))
+    })
+
+    expect(openExternal).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/components/chat/preview-attachment.tsx
+++ b/apps/desktop/src/components/chat/preview-attachment.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react'
 
 import { useSessionView } from '@/app/chat/session-view'
 import { useI18n } from '@/i18n'
-import { Download, MonitorPlay } from '@/lib/icons'
+import { Download, ExternalLink, MonitorPlay } from '@/lib/icons'
 import { normalizeOrLocalPreviewTarget } from '@/lib/local-preview'
 import { downloadGatewayMediaFile } from '@/lib/media'
 import { previewName } from '@/lib/preview-targets'
@@ -125,6 +125,37 @@ export function PreviewAttachment({ source = 'manual', target }: { source?: Prev
     }
   }
 
+  async function openInSystem() {
+    if (opening) {
+      return
+    }
+
+    setOpening(true)
+
+    try {
+      // Resolve the raw target the same way the preview pipeline does (the
+      // Electron main process normalizes `file://` URLs and absolute paths);
+      // then hand a `file://` URL to the OS file association via openExternal.
+      const preview = await normalizeOrLocalPreviewTarget(target, cwd || undefined)
+
+      if (!preview || preview.kind !== 'file' || !preview.path) {
+        throw new Error(`Could not resolve file path: ${target}`)
+      }
+
+      const fileUrl = `file://${preview.path.startsWith('/') ? '' : '/'}${preview.path.replace(/\\/g, '/')}`
+
+      await window.hermesDesktop?.openExternal(fileUrl)
+    } catch (error) {
+      if (mountedRef.current) {
+        notifyError(error, t.fileMenu.downloadFailed)
+      }
+    } finally {
+      if (mountedRef.current) {
+        setOpening(false)
+      }
+    }
+  }
+
   return (
     <div className="flex w-full max-w-160 items-center gap-2 rounded-lg border border-(--ui-stroke-tertiary) bg-card/55 px-2.5 py-1.5 text-sm">
       <span className="grid size-6 shrink-0 place-items-center rounded-md bg-muted/55 text-muted-foreground/85">
@@ -133,6 +164,17 @@ export function PreviewAttachment({ source = 'manual', target }: { source?: Prev
       <span className="min-w-0 flex-1 truncate text-[0.78rem] font-medium text-foreground/90" title={target}>
         {name}
       </span>
+      <button
+        aria-label={t.fileMenu.openInSystem}
+        className="flex shrink-0 items-center gap-1 rounded-md border border-(--ui-stroke-tertiary) bg-background/40 px-2 py-1 text-[0.7rem] font-medium text-muted-foreground transition-colors hover:bg-accent/55 hover:text-foreground disabled:opacity-50"
+        disabled={opening}
+        onClick={() => void openInSystem()}
+        title={t.fileMenu.openInSystem}
+        type="button"
+      >
+        <ExternalLink className="size-3" />
+        {t.fileMenu.openInSystem}
+      </button>
       <button
         aria-label={t.fileMenu.download}
         className="flex shrink-0 items-center gap-1 rounded-md border border-(--ui-stroke-tertiary) bg-background/40 px-2 py-1 text-[0.7rem] font-medium text-muted-foreground transition-colors hover:bg-accent/55 hover:text-foreground disabled:opacity-50"

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -68,6 +68,7 @@ export const ar = defineLocale({
     revealInSidebar: 'إظهار في شجرة الملفات',
     copyPath: 'نسخ المسار',
     copyRelativePath: 'نسخ المسار النسبي',
+    openInSystem: 'فتح في تطبيق النظام',
     download: 'تنزيل',
     downloadSaved: 'تم الحفظ',
     downloadFailed: 'فشل التنزيل',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -52,6 +52,7 @@ export const en: Translations = {
     revealInSidebar: 'Reveal in filetree',
     copyPath: 'Copy path',
     copyRelativePath: 'Copy relative path',
+    openInSystem: 'Open in system app',
     download: 'Download',
     downloadSaved: 'Saved',
     downloadFailed: 'Download failed',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -52,6 +52,7 @@ export const ja = defineLocale({
     revealInSidebar: 'ファイルツリーで表示',
     copyPath: 'パスをコピー',
     copyRelativePath: '相対パスをコピー',
+    openInSystem: 'システムアプリで開く',
     download: 'ダウンロード',
     downloadSaved: '保存しました',
     downloadFailed: 'ダウンロードに失敗しました',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -100,6 +100,7 @@ export interface Translations {
     revealInSidebar: string
     copyPath: string
     copyRelativePath: string
+    openInSystem: string
     download: string
     downloadSaved: string
     downloadFailed: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -52,6 +52,7 @@ export const zhHant = defineLocale({
     revealInSidebar: '在檔案樹中顯示',
     copyPath: '複製路徑',
     copyRelativePath: '複製相對路徑',
+    openInSystem: '用系統應用程式開啟',
     download: '下載',
     downloadSaved: '已儲存',
     downloadFailed: '下載失敗',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -52,6 +52,7 @@ export const zh: Translations = {
     revealInSidebar: '在文件树中显示',
     copyPath: '复制路径',
     copyRelativePath: '复制相对路径',
+    openInSystem: '用系统应用打开',
     download: '下载',
     downloadSaved: '已保存',
     downloadFailed: '下载失败',


### PR DESCRIPTION
## Problem

After the #97812 preview-card rework (Aug 29), MEDIA-delivered non-media files (docx, pdf, xlsx...) render the file card with **Download + Open preview** only. There is no way to open a delivered Office file in its native application — a lawyer receiving a .docx has to download it, find it on disk, and open WPS/Word manually. The artifact card already had this capability via `openExternal` (shell.openPath); the delivered-file card lost it in the rework.

## Fix

Add an **Open in system app** button to `PreviewAttachment` (the delivered-file card):

1. Resolve the raw target through the same hardened pipeline the preview uses (`normalizeOrLocalPreviewTarget` → Electron main `normalizePreviewTarget` → `resolveRequestedPathForIpc`), so `file://` URLs and absolute paths resolve consistently with the rest of the app.
2. Hand the resolved path to the OS file association as a `file://` URL via the existing `hermes:openExternal` IPC (Electron `shell.openPath`), the same mechanism `preview-artifact.tsx` already uses.

Card actions are now: **Open in system app | Download | Open preview**. i18n keys added for en/zh/zh-hant/ja/ar.

## Test

- New `preview-attachment.test.tsx`: renders the three actions; clicking Open-in-system calls `openExternal` with the normalized `file://` URL; a non-file target never reaches `openExternal`.
- `markdown-text.media-md.test.tsx` button-count assertions updated 2 → 3.

All 11 related tests pass; `tsc --noEmit` clean.