### PR TITLE
fix(provider): preserve explicit OpenCode model endpoints

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1937,6 +1937,18 @@ def _resolve_explicit_runtime(
                     provider, base_url, target_model or model_cfg.get("default", "")
                 )
 
+        from hermes_cli.models import opencode_provider_family
+
+        if opencode_provider_family(provider) is not None:
+            from hermes_cli.models import (
+                normalize_opencode_base_url,
+                opencode_model_api_mode,
+            )
+
+            effective_model = target_model or model_cfg.get("default", "")
+            api_mode = opencode_model_api_mode(provider, effective_model)
+            base_url = normalize_opencode_base_url(provider, api_mode, base_url)
+
         if provider == "actual" and not api_key and is_actual_local_base_url(base_url):
             api_key = ACTUAL_LOCAL_NOAUTH_PLACEHOLDER
 

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -925,6 +925,30 @@ def test_opencode_go_model_derivation_beats_stale_persisted_api_mode(monkeypatch
     assert resolved["api_mode"] == "anthropic_messages"
 
 
+@pytest.mark.parametrize(
+    ("model", "expected_mode", "expected_base_url"),
+    [
+        ("qwen3.8-flash", "anthropic_messages", "https://opencode.ai/zen/go"),
+        ("glm-5.3-flash", "chat_completions", "https://opencode.ai/zen/go/v1"),
+    ],
+)
+def test_opencode_go_explicit_key_preserves_model_endpoint(
+    monkeypatch, model, expected_mode, expected_base_url
+):
+    """Explicit CLI credentials must keep OpenCode's per-model route."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "opencode-go")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+
+    resolved = rp.resolve_runtime_provider(
+        requested="opencode-go",
+        explicit_api_key="test-opencode-go-key",
+        target_model=model,
+    )
+
+    assert resolved["api_mode"] == expected_mode
+    assert resolved["base_url"] == expected_base_url
+
+
 # ------------------------------------------------------------------
 # fix #2562 — resolve_provider("custom") must not remap to "openrouter"
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- derive OpenCode Zen/Go API mode from the target model when credentials are supplied explicitly
- normalize the explicit runtime base URL for the selected transport
- cover both Anthropic-routed Qwen and OpenAI-routed GLM models

## Root cause

The explicit API-key path returned early from `_resolve_explicit_runtime` with the generic `chat_completions` mode and the `/v1` base URL. It therefore bypassed the per-model OpenCode routing and URL normalization already used by environment and credential-pool resolution. For `qwen3.8-flash`, that selected the wrong endpoint instead of the Anthropic Messages route.

## Testing

- `scripts/run_tests.sh tests/hermes_cli/test_runtime_provider_resolution.py -q`
- `scripts/run_tests.sh tests/hermes_cli/test_model_switch_opencode_anthropic.py tests/hermes_cli/test_opencode_go_validation_fallback.py tests/plugins/model_providers/test_opencode_go_profile.py -q`

Closes #100854
