### PR TITLE
fix(bedrock): stop streamed reasoning being shredded by the block separator

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -615,12 +615,49 @@ def _tool_call_ns(tool_use_id: str, name: str, input_dict) -> SimpleNamespace:
     )
 
 
+def _assemble_reasoning(ordered_blocks: List[Dict[str, Any]]) -> Optional[str]:
+    """Join reasoning across BLOCKS, which is the unit ``"\n\n"`` belongs to.
+
+    Both normalizers reach this, and only one of them could ever have used a
+    flat per-call accumulator safely. :func:`normalize_converse_response` calls
+    ``absorb_reasoning`` once per content block, so appending per call meant
+    appending per block -- correct. The streaming path calls it once per
+    ``reasoningContent`` DELTA, and a delta is a fragment, routinely a fragment
+    of a single word, so the same append put the block separator between every
+    streamed token.
+
+    Measured against ``us.anthropic.claude-sonnet-4-5-20250929-v1:0`` on
+    Converse with thinking enabled, one reply arrived as 45 deltas beginning
+    ``"Let"``, ``" me check if 91 is prime"``, ... ``" div"``,
+    ``"iding by small primes:"`` -- so joining them welded 44 copies of
+    ``"\n\n"`` into the text, 88 characters the model never emitted, one of
+    them inside the word "dividing" (#98468).
+
+    ``ordered_blocks`` is the one input that means the same thing on both
+    paths: a real content block on the sync path, and a per-block accumulation
+    on the streaming path (``absorb_reasoning`` already concatenates into
+    ``block["text"]`` with no separator). Deriving from it therefore fixes the
+    streaming path and leaves the sync path byte-identical, instead of teaching
+    two callers to disagree about what they are appending.
+
+    The live display was never affected: ``on_reasoning_delta`` receives each
+    raw chunk. Only the stored copy was corrupted -- the one feeding history,
+    compression, ``/resume`` replay and token accounting.
+    """
+    texts = [
+        text
+        for block in ordered_blocks
+        if isinstance(block.get("reasoningContent"), dict)
+        and (text := block["reasoningContent"].get("text"))
+    ]
+    return "\n\n".join(texts) if texts else None
+
+
 class _ResponseParts:
     """Accumulator shared by the sync and streaming normalizers."""
 
     def __init__(self) -> None:
         self.text_parts: List[str] = []
-        self.reasoning_parts: List[str] = []
         self.reasoning_details: List[Dict[str, Any]] = []
         self.tool_calls: List[SimpleNamespace] = []
 
@@ -630,7 +667,6 @@ class _ResponseParts:
             return
         thinking_text = reasoning.get("text", "")
         if thinking_text:
-            self.reasoning_parts.append(str(thinking_text))
             if on_text:
                 on_text(thinking_text)
             block["text"] = block.get("text", "") + str(thinking_text)
@@ -645,7 +681,7 @@ class _ResponseParts:
         msg = SimpleNamespace(
             role="assistant", content="\n".join(self.text_parts) if self.text_parts else None,
             tool_calls=self.tool_calls or None, reasoning_details=self.reasoning_details or None,
-            reasoning_content="\n\n".join(self.reasoning_parts) if self.reasoning_parts else None,
+            reasoning_content=_assemble_reasoning(ordered_blocks),
             bedrock_content_blocks=ordered_blocks or None,
         )
         cache_read_tokens, cache_write_tokens, output_tokens = (

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1421,3 +1421,145 @@ class TestBearerTokenRoutesToConverse:
         runtime = self._resolve(monkeypatch, bearer=False)
         assert runtime["api_mode"] == "anthropic_messages"
         assert runtime.get("bedrock_anthropic") is True
+
+
+# Deltas 0-12 and 41-44 of one measured reply, verbatim, from
+# ``us.anthropic.claude-sonnet-4-5-20250929-v1:0`` on Converse with ``thinking``
+# enabled, prompt "Is 91 prime? Think it through briefly, then answer." -- 45
+# reasoning deltas in total.
+#
+# Two properties of the real data are what these turn on: deltas split mid-word
+# (``" div"`` then ``"iding by small primes:"``), and the model's OWN paragraph
+# breaks arrive INSIDE a delta (``"\n\nI"``). Together they mean joining deltas
+# with the block separator does not merely add noise -- it makes the model's real
+# breaks indistinguishable from manufactured ones.
+MEASURED_REASONING_DELTAS = [
+    "Let", " me check if 91 is prime", " by seeing", " if it has", " any factors",
+    " other", " than 1 and itself.", "\n\nI", "'ll try", " div",
+    "iding by small primes:", "\n- 91 \u00f7", " 2 = 45.5",
+    "\n\nSo 91 = 7", " \u00d7 13,", " which", " means 91 is not prime.",
+]
+
+
+def _reasoning_stream(delta_groups, trailing_text=None):
+    """A Converse event stream with one reasoning block per group."""
+    stream = [{"messageStart": {"role": "assistant"}}]
+    index = 0
+    for deltas in delta_groups:
+        stream.append({"contentBlockStart": {"contentBlockIndex": index, "start": {}}})
+        for d in deltas:
+            stream.append({"contentBlockDelta": {
+                "contentBlockIndex": index, "delta": {"reasoningContent": {"text": d}}}})
+        stream.append({"contentBlockStop": {"contentBlockIndex": index}})
+        index += 1
+    if trailing_text is not None:
+        stream.append({"contentBlockStart": {"contentBlockIndex": index, "start": {}}})
+        stream.append({"contentBlockDelta": {
+            "contentBlockIndex": index, "delta": {"text": trailing_text}}})
+        stream.append({"contentBlockStop": {"contentBlockIndex": index}})
+    stream.append({"messageStop": {"stopReason": "end_turn"}})
+    return {"stream": stream}
+
+
+class TestReasoningIsJoinedByBlockNotByDelta:
+    """#98468 -- ``"\n\n"`` is the separator between reasoning BLOCKS.
+
+    ``_ResponseParts`` is shared by both normalizers, and a flat per-call
+    accumulator could only ever be right for one of them: the sync path calls
+    ``absorb_reasoning`` once per content block, the streaming path once per
+    delta. Both now derive from ``ordered_blocks``, which means the same thing
+    on either path, so these tests pin both halves together.
+    """
+
+    def test_streamed_deltas_are_concatenated(self):
+        from agent.bedrock_adapter import stream_converse_with_callbacks
+        result = stream_converse_with_callbacks(
+            _reasoning_stream([MEASURED_REASONING_DELTAS], trailing_text="No."))
+        assert result.choices[0].message.reasoning_content == "".join(
+            MEASURED_REASONING_DELTAS)
+
+    def test_a_word_split_across_deltas_survives(self):
+        from agent.bedrock_adapter import stream_converse_with_callbacks
+        stored = stream_converse_with_callbacks(
+            _reasoning_stream([MEASURED_REASONING_DELTAS])
+        ).choices[0].message.reasoning_content
+        assert "dividing by small primes" in stored
+        assert "div\n\niding" not in stored
+
+    def test_only_the_breaks_the_model_sent_survive(self):
+        """The tightest statement of the bug: this reply contains exactly two
+        ``"\n\n"`` runs, both inside a single delta. The old code produced one
+        per delta boundary."""
+        from agent.bedrock_adapter import stream_converse_with_callbacks
+        stored = stream_converse_with_callbacks(
+            _reasoning_stream([MEASURED_REASONING_DELTAS])
+        ).choices[0].message.reasoning_content
+        expected = "".join(MEASURED_REASONING_DELTAS)
+        assert stored.count("\n\n") == expected.count("\n\n") == 2
+        assert len(stored) == len(expected)
+
+    def test_separate_streamed_blocks_keep_the_separator(self):
+        """The fix narrows the separator from deltas to blocks; it does not
+        remove it."""
+        from agent.bedrock_adapter import stream_converse_with_callbacks
+        assert stream_converse_with_callbacks(
+            _reasoning_stream([["first ", "thought"], ["second ", "thought"]])
+        ).choices[0].message.reasoning_content == "first thought\n\nsecond thought"
+
+    def test_the_live_callback_still_gets_every_raw_chunk(self):
+        from agent.bedrock_adapter import stream_converse_with_callbacks
+        seen = []
+        stream_converse_with_callbacks(
+            _reasoning_stream([MEASURED_REASONING_DELTAS]),
+            on_reasoning_delta=seen.append)
+        assert seen == MEASURED_REASONING_DELTAS
+
+    def test_reasoning_and_text_do_not_bleed(self):
+        from agent.bedrock_adapter import stream_converse_with_callbacks
+        msg = stream_converse_with_callbacks(
+            _reasoning_stream([["thinking"]], trailing_text="No - 91 = 7 x 13.")
+        ).choices[0].message
+        assert msg.reasoning_content == "thinking"
+        assert msg.content == "No - 91 = 7 x 13."
+
+    def test_no_reasoning_leaves_it_none(self):
+        from agent.bedrock_adapter import stream_converse_with_callbacks
+        assert stream_converse_with_callbacks(
+            _reasoning_stream([], trailing_text="plain")
+        ).choices[0].message.reasoning_content is None
+
+    def test_a_redacted_only_block_contributes_no_text(self):
+        """A block carrying only ``redactedContent`` has no text to join and
+        must not surface as an empty entry or a stray separator."""
+        from agent.bedrock_adapter import stream_converse_with_callbacks
+        events = {"stream": [
+            {"contentBlockStart": {"contentBlockIndex": 0, "start": {}}},
+            {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {
+                "reasoningContent": {"redactedContent": b"opaque"}}}},
+            {"contentBlockStop": {"contentBlockIndex": 0}},
+            {"messageStop": {"stopReason": "end_turn"}}]}
+        msg = stream_converse_with_callbacks(events).choices[0].message
+        assert msg.reasoning_content is None
+        assert msg.reasoning_details[0]["type"] == "redacted_thinking"
+
+    def test_bedrock_content_blocks_and_reasoning_agree(self):
+        """One now derives from the other, so pin them together."""
+        from agent.bedrock_adapter import stream_converse_with_callbacks
+        msg = stream_converse_with_callbacks(
+            _reasoning_stream([MEASURED_REASONING_DELTAS])).choices[0].message
+        assert msg.bedrock_content_blocks[0]["reasoningContent"]["text"] == "".join(
+            MEASURED_REASONING_DELTAS)
+        assert msg.reasoning_content == msg.bedrock_content_blocks[0]["reasoningContent"]["text"]
+
+    def test_the_sync_path_is_byte_identical(self):
+        """The sync normalizer walks real blocks, so its output must not move.
+        This is the half a streaming-only fix would have had to protect with a
+        guard; sharing the derivation makes it the same assertion."""
+        from agent.bedrock_adapter import normalize_converse_response
+        response = {"output": {"message": {"role": "assistant", "content": [
+            {"reasoningContent": {"text": "first thought"}},
+            {"reasoningContent": {"text": "second thought"}},
+            {"text": "answer"}]}}, "stopReason": "end_turn", "usage": {}}
+        msg = normalize_converse_response(response).choices[0].message
+        assert msg.reasoning_content == "first thought\n\nsecond thought"
+        assert msg.content == "answer"


### PR DESCRIPTION
Fixes #98468.

## Problem

`stream_converse_with_callbacks()` appended every `reasoningContent` **delta** to a flat list and joined that list with `"\n\n"` — the separator that belongs between reasoning **blocks**. A delta is a fragment, routinely a fragment of a single word, so the separator ended up welded between every streamed chunk.

Measured against `us.anthropic.claude-sonnet-4-5-20250929-v1:0` on Converse with `thinking` enabled, prompt *"Is 91 prime? Think it through briefly, then answer."* — 45 reasoning deltas, of which the first thirteen arrived as:

```
"Let"  " me check if 91 is prime"  " by seeing"  " if it has"  " any factors"
" other"  " than 1 and itself."  "\n\nI"  "'ll try"  " div"
"iding by small primes:"  "\n- 91 ÷"  " 2 = 45.5"
```

What the model produced, versus what `main` stores:

```
correct : "Let me check if 91 is prime by seeing if it has any factors other than 1
           and itself.\n\nI'll try dividing by small primes:\n- 91 ÷ 2 = 45.5 …"

stored  : "Let\n\n me check if 91 is prime\n\n by seeing\n\n if it has\n\n any factors\n\n
           other\n\n than 1 and itself.\n\n\n\nI\n\n'll try\n\n div\n\niding by small
           primes:\n\n\n- 91 ÷\n\n 2 = 45.5 …"
```

454 characters became 542 — **88 characters the model never emitted**, one of them inside the word *dividing*. The `"\n\n"` count states it most tightly: the model emitted **2**, `main` stores **46**.

There is a second-order problem that makes it worse than noise. The model's own paragraph breaks arrive *inside* a delta — `"\n\nI"` above — so in the stored copy a real break and a manufactured one are indistinguishable. Nothing downstream can undo the damage.

The live display was never affected, which is why this went unnoticed: `on_reasoning_delta` is handed each raw chunk, so the TUI renders the thinking perfectly as it streams. Only the **stored** `reasoning_content` is corrupted — and that is the copy that feeds conversation history, context compression, `/resume` replay, the API server's reasoning output, and token accounting.

## Fix

The fix **removes an accumulator rather than adding buffering**, because the correct one was already there.

The delta handler already accumulates per-block reasoning text by plain concatenation into `stream_blocks`, the record that also backs `bedrock_content_blocks`. `reasoning_parts` was a redundant second accumulator operating at the wrong granularity, and it was the bug. It is gone; `reasoning_content` is now derived from the same ordered blocks via a small `_assemble_streamed_reasoning()` helper.

So blocks remain the unit `"\n\n"` applies to — the separator is narrowed from deltas to blocks, not removed — and there is one place that decides how the stored text is built.

For contrast, the text path in the same function was always correct and shows the shape being restored: deltas concatenated (`"".join`), blocks joined (`"\n".join`).

## What is deliberately *not* changed

`normalize_converse_response()` uses the identical `"\n\n".join(reasoning_parts)` idiom and it is **correct** there, because that function walks genuine content blocks. `test_non_streaming_path_keeps_joining_blocks_with_the_separator` pins it, so this cannot later be "tidied" into a global replace.

That guard test uses `reasoningContent.text`, the shape the function currently consumes. On the wire, non-streaming Converse nests it one level deeper as `reasoningContent.reasoningText.text` — that mismatch is #36260 / #89671 and is untouched here, so the test pins the separator behaviour without also asserting somebody else's fix.

## Tests

10 new tests, built on the measured deltas verbatim rather than invented ones:

- deltas are concatenated, byte-for-byte equal to `"".join(measured)`
- a word split across deltas survives — `" div"` + `"iding…"` must not become `" div\n\niding"`
- the `"\n\n"` count equals what the model sent (2), and the length matches
- two separate reasoning blocks *are* still joined by `"\n\n"`
- `on_reasoning_delta` still receives every raw chunk, unchanged
- reasoning and text do not bleed into each other
- no reasoning leaves the field `None`
- a redacted-only block contributes no text and no stray separator, and still surfaces in `reasoning_details`
- `bedrock_content_blocks` and `reasoning_content` are pinned together, since one now derives from the other
- the non-streaming guard above

`tests/agent/test_bedrock_adapter.py` 90 passed. `tests/agent/ -k "bedrock or converse or reasoning"` 391 passed, 5 skipped. The direct-caller tests (`test_bedrock_interrupt_post_worker.py`, `test_budget_reasoning_details_exclusion.py`) 10 passed. `ruff check` clean.

**Mutation-checked**, so the tests fail for the reason they claim:

| mutation | reds |
|---|---|
| restore the separator between deltas (the original bug) | 5 |
| helper joins blocks with `""` instead of `"\n\n"` | 1 |
| helper keeps only the first block | 1 |
| helper always returns `None` | 6 |

Verified end to end by replaying the captured 45-delta stream through the patched adapter: `reasoning_content` equals `"".join(deltas)` exactly, and the 45 `on_reasoning_delta` calls are unchanged.
