### PR TITLE
feat(cost-visibility): per-reply cost footer, spend warnings, /new handoff note

### DIFF
--- a/agent/cost_visibility.py
+++ b/agent/cost_visibility.py
@@ -1,0 +1,707 @@
+"""User-facing cost visibility: status footer, threshold warnings, /new handoff.
+
+Self-contained by design. This module is carried as a LOCAL PATCH on a pinned
+branch (see ``LOCAL_PATCHES.md`` at the repo root), so the whole feature lives
+here and the call sites elsewhere are deliberately tiny — the cherry-pick onto
+the next pin should be one commit, not a scatter of edits.
+
+Three surfaces, all config-gated under the ``cost_visibility`` section of
+``config.yaml`` (user-owned, so a code-replacing upgrade cannot reset them):
+
+1. ``render_footer()`` — one line appended to every reply:
+       ctx 42% · turn $0.31 · session $4.10
+2. ``check_warnings()`` — session-cost and context-percentage warnings, each
+   fired exactly once per threshold crossing and reset by /new.
+3. ``build_handoff_note()`` / ``store_handoff()`` / ``consume_handoff()`` —
+   a <=300 word summary written at /new and injected into the next session.
+
+Design notes that are load-bearing:
+
+* **Pricing is not reimplemented.** ``agent/usage_pricing.py`` already owns the
+  price tables, provider routing and cache-token semantics; the agent loop
+  already folds each call's cost into ``agent.session_estimated_cost_usd``.
+  We read that number and difference it. Adding a second price table here
+  would guarantee the footer and the billing analytics disagree.
+* **The ledger is on disk, keyed by durable session id.** The gateway evicts
+  cached agents (and restarts), which zeroes ``session_estimated_cost_usd``
+  on a fresh agent object for a conversation that is still very much alive.
+  A purely in-memory counter would silently reset the "session $" figure —
+  precisely the blind spot this feature exists to close. The ledger detects
+  a counter that went backwards and treats the new value as a delta rather
+  than losing the accumulated total.
+* **Nothing here mutates the system prompt or past context.** The handoff is
+  injected as a prefix on the next *user* message, never as a system-prompt
+  edit, so per-conversation prompt caching is preserved (AGENTS.md: "Prompt
+  caching is sacred").
+* **Every public entry point is failure-isolated by its caller** and returns a
+  falsy value rather than raising: cost telemetry must never break a reply.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import tempfile
+import threading
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "CostVisibilityConfig",
+    "load_cost_visibility_config",
+    "format_footer_line",
+    "render_footer",
+    "check_warnings",
+    "build_handoff_note",
+    "store_handoff",
+    "consume_handoff",
+    "reset_session_state",
+    "selfcheck_line",
+    "log_selfcheck",
+]
+
+# Config section name in config.yaml.
+CONFIG_SECTION = "cost_visibility"
+
+# Ledger bound: keep the newest N sessions so the file cannot grow forever.
+_MAX_LEDGER_ENTRIES = 300
+
+_DEFAULTS: Dict[str, Any] = {
+    "enabled": True,
+    "footer": True,
+    "warnings": True,
+    "handoff": True,
+    "cost_warn_usd": 25.0,
+    "ctx_warn_pct": 80,
+    "handoff_max_words": 300,
+    "include_cli": False,
+}
+
+_lock = threading.RLock()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Config
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class CostVisibilityConfig:
+    enabled: bool = True
+    footer: bool = True
+    warnings: bool = True
+    handoff: bool = True
+    cost_warn_usd: float = 25.0
+    ctx_warn_pct: float = 80.0
+    handoff_max_words: int = 300
+    include_cli: bool = False
+
+    def as_log_fields(self) -> str:
+        return (
+            f"enabled={self.enabled} footer={self.footer} "
+            f"warnings={self.warnings} handoff={self.handoff} "
+            f"cost_warn_usd={self.cost_warn_usd} "
+            f"ctx_warn_pct={self.ctx_warn_pct} "
+            f"handoff_max_words={self.handoff_max_words} "
+            f"include_cli={self.include_cli}"
+        )
+
+
+def _coerce_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() not in {"0", "false", "no", "off", ""}
+    return bool(value)
+
+
+def _coerce_float(value: Any, default: float) -> float:
+    try:
+        out = float(value)
+    except (TypeError, ValueError):
+        return default
+    return out if out >= 0 else default
+
+
+def _coerce_int(value: Any, default: int) -> int:
+    try:
+        out = int(value)
+    except (TypeError, ValueError):
+        return default
+    return out if out > 0 else default
+
+
+def load_cost_visibility_config(
+    config: Optional[Dict[str, Any]] = None,
+) -> CostVisibilityConfig:
+    """Resolve the ``cost_visibility`` config section.
+
+    Reads the persisted user config when *config* is not supplied so the
+    gateway, the CLI and the tests all land on the same values. Unknown or
+    malformed values fall back to the shipped default rather than raising —
+    a typo in config.yaml must not take the gateway down.
+    """
+    section: Dict[str, Any] = {}
+    try:
+        if config is None:
+            from hermes_cli.config import load_config as _load_config
+
+            config = _load_config() or {}
+        if isinstance(config, dict):
+            raw = config.get(CONFIG_SECTION)
+            if isinstance(raw, dict):
+                section = raw
+    except Exception:  # pragma: no cover - defensive
+        section = {}
+
+    return CostVisibilityConfig(
+        enabled=_coerce_bool(section.get("enabled"), _DEFAULTS["enabled"]),
+        footer=_coerce_bool(section.get("footer"), _DEFAULTS["footer"]),
+        warnings=_coerce_bool(section.get("warnings"), _DEFAULTS["warnings"]),
+        handoff=_coerce_bool(section.get("handoff"), _DEFAULTS["handoff"]),
+        cost_warn_usd=_coerce_float(
+            section.get("cost_warn_usd"), _DEFAULTS["cost_warn_usd"]
+        ),
+        ctx_warn_pct=_coerce_float(
+            section.get("ctx_warn_pct"), _DEFAULTS["ctx_warn_pct"]
+        ),
+        handoff_max_words=_coerce_int(
+            section.get("handoff_max_words"), _DEFAULTS["handoff_max_words"]
+        ),
+        include_cli=_coerce_bool(
+            section.get("include_cli"), _DEFAULTS["include_cli"]
+        ),
+    )
+
+
+def surface_enabled(agent: Any, config: CostVisibilityConfig) -> bool:
+    """Whether the reply surface driving *agent* should carry the footer.
+
+    The footer targets messaging surfaces (Telegram et al.), where there is no
+    other cost read-out and the $191 incident was invisible. The CLI and TUI
+    already render live cost in the status bar, so adding a footer there just
+    duplicates it — opt in with ``cost_visibility.include_cli: true``.
+    """
+    if config.include_cli:
+        return True
+    platform = str(getattr(agent, "platform", "") or "cli").strip().lower()
+    return platform not in {"", "cli", "local"}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Ledger — durable per-session accumulation
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _ledger_path() -> str:
+    from hermes_constants import get_hermes_home
+
+    base = os.path.join(str(get_hermes_home()), "cost_visibility")
+    os.makedirs(base, exist_ok=True)
+    return os.path.join(base, "ledger.json")
+
+
+def _read_ledger() -> Dict[str, Any]:
+    try:
+        with open(_ledger_path(), "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        return data if isinstance(data, dict) else {}
+    except FileNotFoundError:
+        return {}
+    except Exception:
+        # A corrupt ledger must not break replies; start clean.
+        logger.debug("cost_visibility: unreadable ledger, starting fresh", exc_info=True)
+        return {}
+
+
+def _write_ledger(data: Dict[str, Any]) -> None:
+    # Bound the file: keep the newest entries by last-touch ordinal.
+    if len(data) > _MAX_LEDGER_ENTRIES:
+        ordered = sorted(
+            data.items(), key=lambda kv: kv[1].get("seq", 0) if isinstance(kv[1], dict) else 0
+        )
+        data = dict(ordered[-_MAX_LEDGER_ENTRIES:])
+    path = _ledger_path()
+    try:
+        fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path), suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump(data, fh)
+            os.replace(tmp, path)
+        except Exception:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+    except Exception:
+        logger.debug("cost_visibility: ledger write failed", exc_info=True)
+
+
+def _blank_entry() -> Dict[str, Any]:
+    return {
+        "session_cost_usd": 0.0,
+        "last_agent_cost": 0.0,
+        "turn_cost_usd": 0.0,
+        "warned_cost": False,
+        "warned_ctx": False,
+        "seq": 0,
+    }
+
+
+def reset_session_state(session_id: str) -> None:
+    """Drop all accumulated state for *session_id* (called on /new).
+
+    This is what makes the warnings "reset on /new": both latch flags and the
+    running total disappear with the entry.
+    """
+    if not session_id:
+        return
+    with _lock:
+        data = _read_ledger()
+        if session_id in data:
+            data.pop(session_id, None)
+            _write_ledger(data)
+
+
+def _observe_cost(session_id: str, agent_cost: float) -> Tuple[float, float]:
+    """Fold the agent's cumulative cost into the durable ledger.
+
+    Returns ``(turn_cost, session_cost)``.
+
+    ``agent.session_estimated_cost_usd`` counts from the moment the *agent
+    object* was constructed, not from the start of the conversation. The
+    gateway evicts and rebuilds agents (cache pressure, /model, restart), so
+    the raw counter periodically drops back toward zero mid-conversation.
+    Differencing naively against the previous observation would yield a
+    negative turn cost and stall the session total; treating a decrease as
+    "new agent, this value is itself the delta" keeps the running total
+    monotonic across those rebuilds.
+    """
+    with _lock:
+        data = _read_ledger()
+        entry = data.get(session_id)
+        if not isinstance(entry, dict):
+            entry = _blank_entry()
+
+        prev_agent = float(entry.get("last_agent_cost", 0.0) or 0.0)
+        if agent_cost >= prev_agent:
+            delta = agent_cost - prev_agent
+        else:
+            # Counter went backwards → the agent object was rebuilt.
+            delta = max(0.0, agent_cost)
+
+        session_cost = float(entry.get("session_cost_usd", 0.0) or 0.0) + delta
+        entry["session_cost_usd"] = session_cost
+        entry["last_agent_cost"] = agent_cost
+        entry["turn_cost_usd"] = delta
+        entry["seq"] = int(entry.get("seq", 0) or 0) + 1
+
+        data[session_id] = entry
+        _write_ledger(data)
+        return delta, session_cost
+
+
+def _peek(session_id: str) -> Dict[str, Any]:
+    with _lock:
+        entry = _read_ledger().get(session_id)
+        return entry if isinstance(entry, dict) else _blank_entry()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Measurement helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _agent_cost(agent: Any) -> float:
+    try:
+        return max(0.0, float(getattr(agent, "session_estimated_cost_usd", 0.0) or 0.0))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def context_usage(agent: Any) -> Tuple[int, int]:
+    """Return ``(used_tokens, window_tokens)``; either may be 0 when unknown.
+
+    ``last_prompt_tokens`` is the provider-exact prompt size of the most recent
+    request. It parks at a ``-1`` sentinel immediately after a compression
+    (see ``agent/conversation_compression.py``), which is reported as unknown
+    rather than as a bogus percentage.
+    """
+    comp = getattr(agent, "context_compressor", None)
+    if comp is None:
+        return 0, 0
+    try:
+        used = int(getattr(comp, "last_prompt_tokens", 0) or 0)
+    except (TypeError, ValueError):
+        used = 0
+    try:
+        window = int(getattr(comp, "context_length", 0) or 0)
+    except (TypeError, ValueError):
+        window = 0
+    if used < 0:
+        used = 0
+    if window < 0:
+        window = 0
+    return used, window
+
+
+def context_pct(agent: Any) -> Optional[float]:
+    used, window = context_usage(agent)
+    if used <= 0 or window <= 0:
+        return None
+    return min(100.0, (used / window) * 100.0)
+
+
+def _money(amount: float) -> str:
+    """Render a USD amount for the footer.
+
+    Sub-cent amounts render at 4dp so a cheap turn never displays as a
+    dishonest ``$0.00`` (the same concern ``usage_pricing.format_cost_label``
+    handles for the CLI cost labels).
+    """
+    try:
+        value = float(amount)
+    except (TypeError, ValueError):
+        value = 0.0
+    if value <= 0:
+        return "$0.00"
+    if value < 0.01:
+        return f"${value:.4f}"
+    return f"${value:,.2f}"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. Status footer
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def format_footer_line(
+    ctx_pct: Optional[float], turn_usd: float, session_usd: float
+) -> str:
+    """Build the footer string. Pure — this is the unit under test."""
+    ctx_part = "ctx —" if ctx_pct is None else f"ctx {int(round(ctx_pct))}%"
+    return f"{ctx_part} · turn {_money(turn_usd)} · session {_money(session_usd)}"
+
+
+def render_footer(
+    agent: Any,
+    session_id: str,
+    config: Optional[CostVisibilityConfig] = None,
+    *,
+    observe: bool = True,
+) -> str:
+    """Return the footer line for this turn, or ``""`` when disabled.
+
+    ``observe=True`` advances the ledger (once per turn). ``check_warnings``
+    then reads the already-advanced totals, so a turn is only counted once.
+    """
+    cfg = config or load_cost_visibility_config()
+    if not cfg.enabled or not cfg.footer:
+        return ""
+    sid = session_id or getattr(agent, "session_id", "") or ""
+    if not sid:
+        return ""
+
+    if observe:
+        turn_usd, session_usd = _observe_cost(sid, _agent_cost(agent))
+    else:
+        entry = _peek(sid)
+        turn_usd = float(entry.get("turn_cost_usd", 0.0) or 0.0)
+        session_usd = float(entry.get("session_cost_usd", 0.0) or 0.0)
+
+    return format_footer_line(context_pct(agent), turn_usd, session_usd)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. Threshold warnings
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def check_warnings(
+    agent: Any,
+    session_id: str,
+    config: Optional[CostVisibilityConfig] = None,
+) -> List[str]:
+    """Return any warnings that should fire now.
+
+    Each warning latches: the flag is persisted in the ledger, so a threshold
+    fires on the crossing turn and never again for the life of the session.
+    ``reset_session_state`` (called by /new) clears the latches.
+    """
+    cfg = config or load_cost_visibility_config()
+    if not cfg.enabled or not cfg.warnings:
+        return []
+    sid = session_id or getattr(agent, "session_id", "") or ""
+    if not sid:
+        return []
+
+    pct = context_pct(agent)
+    out: List[str] = []
+
+    with _lock:
+        data = _read_ledger()
+        entry = data.get(sid)
+        if not isinstance(entry, dict):
+            entry = _blank_entry()
+        session_usd = float(entry.get("session_cost_usd", 0.0) or 0.0)
+        dirty = False
+
+        if (
+            cfg.cost_warn_usd > 0
+            and session_usd >= cfg.cost_warn_usd
+            and not entry.get("warned_cost")
+        ):
+            ctx_txt = "unknown" if pct is None else f"{int(round(pct))}%"
+            out.append(
+                f"Session at {_money(session_usd)}. Context {ctx_txt}. "
+                "Consider /new if the remaining work doesn't need this history."
+            )
+            entry["warned_cost"] = True
+            dirty = True
+
+        if (
+            cfg.ctx_warn_pct > 0
+            and pct is not None
+            and pct >= cfg.ctx_warn_pct
+            and not entry.get("warned_ctx")
+        ):
+            out.append(
+                f"Context at {int(round(pct))}% — compaction will start soon. "
+                "/new now if you want a clean handoff."
+            )
+            entry["warned_ctx"] = True
+            dirty = True
+
+        if dirty:
+            data[sid] = entry
+            _write_ledger(data)
+
+    return out
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. /new handoff note
+# ─────────────────────────────────────────────────────────────────────────────
+
+_HANDOFF_HEADER = "[handoff from previous session]"
+
+# Tools whose arguments name a file the session touched.
+_FILE_TOOLS = {
+    "write_file": ("path",),
+    "read_file": ("path",),
+    "patch": ("path",),
+    "search_files": ("path",),
+    "skill_manage": ("file_path",),
+}
+
+
+def _iter_tool_calls(messages: List[dict]):
+    for msg in messages or []:
+        if not isinstance(msg, dict):
+            continue
+        for call in msg.get("tool_calls") or []:
+            if not isinstance(call, dict):
+                continue
+            fn = call.get("function") or {}
+            name = fn.get("name") or call.get("name") or ""
+            raw_args = fn.get("arguments")
+            args: Dict[str, Any] = {}
+            if isinstance(raw_args, dict):
+                args = raw_args
+            elif isinstance(raw_args, str):
+                try:
+                    parsed = json.loads(raw_args)
+                    if isinstance(parsed, dict):
+                        args = parsed
+                except Exception:
+                    args = {}
+            yield str(name), args
+
+
+def _files_touched(messages: List[dict], limit: int = 8) -> List[str]:
+    seen: List[str] = []
+    for name, args in _iter_tool_calls(messages):
+        for key in _FILE_TOOLS.get(name, ()):
+            val = args.get(key)
+            if isinstance(val, str) and val.strip():
+                short = val.strip()
+                if short not in seen:
+                    seen.append(short)
+    return seen[:limit]
+
+
+def _last_user_message(messages: List[dict]) -> str:
+    for msg in reversed(messages or []):
+        if not isinstance(msg, dict) or msg.get("role") != "user":
+            continue
+        content = msg.get("content")
+        if isinstance(content, str) and content.strip():
+            return content.strip()
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and isinstance(block.get("text"), str):
+                    if block["text"].strip():
+                        return block["text"].strip()
+    return ""
+
+
+def _open_todos(agent: Any) -> List[str]:
+    """Best-effort read of the live todo list as 'open items'."""
+    items: List[str] = []
+    try:
+        todos = getattr(agent, "_todo_items", None) or getattr(agent, "todos", None)
+        if isinstance(todos, list):
+            for entry in todos:
+                if not isinstance(entry, dict):
+                    continue
+                status = str(entry.get("status", "")).lower()
+                if status in {"completed", "cancelled"}:
+                    continue
+                content = str(entry.get("content", "")).strip()
+                if content:
+                    items.append(content)
+    except Exception:
+        return []
+    return items[:6]
+
+
+def _truncate_words(text: str, max_words: int) -> str:
+    words = text.split()
+    if len(words) <= max_words:
+        return text
+    return " ".join(words[:max_words]).rstrip(" ,;:.") + " …"
+
+
+def _condense(text: str, max_chars: int) -> str:
+    flat = re.sub(r"\s+", " ", (text or "").strip())
+    if len(flat) <= max_chars:
+        return flat
+    return flat[: max_chars - 1].rstrip() + "…"
+
+
+def build_handoff_note(
+    agent: Any,
+    messages: Optional[List[dict]] = None,
+    config: Optional[CostVisibilityConfig] = None,
+) -> str:
+    """Compose the <=N word handoff summary.
+
+    Deliberately derived from conversation structure rather than an LLM call:
+    /new must stay instant and free, and a summarizer that fails (or costs
+    money) inside a cost-visibility feature would be self-defeating.
+    """
+    cfg = config or load_cost_visibility_config()
+    msgs = messages if messages is not None else (getattr(agent, "messages", None) or [])
+
+    last_req = _condense(_last_user_message(msgs), 320)
+    files = _files_touched(msgs)
+    todos = _open_todos(agent)
+
+    tool_names: List[str] = []
+    for name, _args in _iter_tool_calls(msgs):
+        if name and name not in tool_names:
+            tool_names.append(name)
+
+    turns = sum(
+        1 for m in msgs if isinstance(m, dict) and m.get("role") == "user"
+    )
+
+    entry = _peek(getattr(agent, "session_id", "") or "")
+    spend = float(entry.get("session_cost_usd", 0.0) or 0.0)
+
+    lines: List[str] = [_HANDOFF_HEADER]
+    summary_bits = [f"{turns} user turn(s)"]
+    if spend > 0:
+        summary_bits.append(f"~{_money(spend)} spent")
+    if tool_names:
+        summary_bits.append("tools: " + ", ".join(tool_names[:6]))
+    lines.append("Context: " + "; ".join(summary_bits) + ".")
+
+    if last_req:
+        lines.append(f"Last user request: {last_req}")
+    if files:
+        lines.append("Files touched: " + ", ".join(files))
+    if todos:
+        lines.append("Open items: " + "; ".join(todos))
+
+    lines.append(
+        "This is a summary of a prior session that was cleared with /new. "
+        "Treat it as background only; ask before assuming it is still current."
+    )
+
+    note = "\n".join(lines)
+    return _truncate_words(note, cfg.handoff_max_words)
+
+
+def _handoff_path(session_key: str) -> str:
+    from hermes_constants import get_hermes_home
+
+    base = os.path.join(str(get_hermes_home()), "cost_visibility", "handoff")
+    os.makedirs(base, exist_ok=True)
+    safe = re.sub(r"[^A-Za-z0-9_.-]", "_", session_key or "default")[:180]
+    return os.path.join(base, f"{safe}.json")
+
+
+def store_handoff(session_key: str, note: str) -> bool:
+    """Persist *note* for *session_key*.
+
+    Written to disk, not memory: the gateway may restart between the /new and
+    the user's next message, and the requirement is that the handoff survives
+    that gap.
+    """
+    if not note or not session_key:
+        return False
+    try:
+        path = _handoff_path(session_key)
+        fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path), suffix=".tmp")
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump({"note": note}, fh)
+        os.replace(tmp, path)
+        return True
+    except Exception:
+        logger.debug("cost_visibility: handoff write failed", exc_info=True)
+        return False
+
+
+def consume_handoff(session_key: str) -> str:
+    """Return and delete the stored handoff note (one-shot)."""
+    if not session_key:
+        return ""
+    try:
+        path = _handoff_path(session_key)
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+        note = data.get("note") if isinstance(data, dict) else ""
+        return note if isinstance(note, str) else ""
+    except FileNotFoundError:
+        return ""
+    except Exception:
+        logger.debug("cost_visibility: handoff read failed", exc_info=True)
+        return ""
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Startup self-check
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def selfcheck_line(config: Optional[CostVisibilityConfig] = None) -> str:
+    cfg = config or load_cost_visibility_config()
+    return f"cost_visibility loaded — {cfg.as_log_fields()}"
+
+
+def log_selfcheck(target_logger: Optional[logging.Logger] = None) -> str:
+    line = selfcheck_line()
+    (target_logger or logger).info(line)
+    return line

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -601,6 +601,35 @@ def finalize_turn(
         except Exception as _exp_err:
             logger.debug("turn-completion explainer failed: %s", _exp_err)
 
+    # Cost-visibility status footer + threshold warnings (LOCAL PATCH — see
+    # LOCAL_PATCHES.md and agent/cost_visibility.py).
+    #
+    # Placed here, before the result dict is built, so the line rides the
+    # authoritative ``final_response`` the streaming consumer receives via
+    # finish(final_text). Appending it later (in an adapter, after the stream
+    # sealed) would mutate the final after the seal and re-open the
+    # duplicate-final bug class documented in AGENTS.md.
+    #
+    # Isolated in a try/except: cost telemetry must never break a reply.
+    if final_response and not interrupted:
+        try:
+            from agent import cost_visibility as _cv
+
+            _cv_cfg = _cv.load_cost_visibility_config()
+            if _cv_cfg.enabled and _cv.surface_enabled(agent, _cv_cfg):
+                _cv_sid = getattr(agent, "session_id", "") or ""
+                # render_footer advances the durable ledger exactly once per
+                # turn; check_warnings then reads the advanced totals.
+                _cv_footer = _cv.render_footer(agent, _cv_sid, _cv_cfg)
+                _cv_warnings = _cv.check_warnings(agent, _cv_sid, _cv_cfg)
+                _cv_tail = "\n\n".join(_cv_warnings) if _cv_warnings else ""
+                if _cv_tail:
+                    final_response = final_response.rstrip() + "\n\n" + _cv_tail
+                if _cv_footer:
+                    final_response = final_response.rstrip() + "\n\n" + _cv_footer
+        except Exception as _cv_err:
+            logger.debug("cost_visibility footer failed: %s", _cv_err)
+
     _response_transformed = False
     _pre_transform_response = None
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6943,10 +6943,45 @@ class TurnRunner:
                 _run_message,
                 observed_group_context,
             )
+
+            # Cost-visibility handoff injection (LOCAL PATCH — see
+            # LOCAL_PATCHES.md and agent/cost_visibility.py). A note stored by
+            # /new is consumed exactly once and prefixed onto the first user
+            # message of the new session, so the fresh agent opens with the
+            # prior session's context.
+            #
+            # Prefixing the USER turn (rather than editing the system prompt)
+            # is deliberate: the system prompt must stay byte-stable for the
+            # life of a conversation or per-conversation prompt caching breaks.
+            # Only fires on a genuinely fresh conversation (no history), and
+            # `persist_user_message` is pinned to the user's ORIGINAL text so
+            # the stored transcript/UI shows what they actually typed.
+            _cv_handoff = ""
+            try:
+                if not agent_history:
+                    from agent import cost_visibility as _cv
+
+                    _cv_cfg_run = _cv.load_cost_visibility_config()
+                    if _cv_cfg_run.enabled and _cv_cfg_run.handoff:
+                        _cv_handoff = _cv.consume_handoff(ctx.session_key or "")
+            except Exception:
+                logger.debug("cost_visibility: handoff consume failed", exc_info=True)
+
+            if _cv_handoff:
+                _cv_block = _cv_handoff + "\n\n---\n\n"
+                if isinstance(_api_run_message, str):
+                    _api_run_message = _cv_block + _api_run_message
+                elif isinstance(_api_run_message, list):
+                    _api_run_message = [
+                        {"type": "text", "text": _cv_block}
+                    ] + _api_run_message
+
             _conversation_kwargs = {
                 "conversation_history": agent_history,
                 "task_id": ctx.session_id,
             }
+            if _cv_handoff and _persist_user_message_override is None and not observed_group_context:
+                _conversation_kwargs["persist_user_message"] = ctx.message
             if _persist_user_message_override is not None:
                 _conversation_kwargs["persist_user_message"] = _persist_user_message_override
             elif observed_group_context:
@@ -13432,6 +13467,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         Returns True if at least one adapter connected successfully.
         """
         logger.info("Starting Hermes Gateway...")
+
+        # Cost-visibility self-check (LOCAL PATCH — see LOCAL_PATCHES.md and
+        # agent/cost_visibility.py). Confirms the module imported and reports
+        # its live config. If an upgrade drops the local patch, this logs a
+        # LOUD warning rather than letting the gateway run silently without
+        # cost visibility — the failure mode that made the $191 session
+        # invisible in the first place.
+        try:
+            from agent.cost_visibility import log_selfcheck as _cv_selfcheck
+
+            _cv_selfcheck(logger)
+        except Exception as _cv_exc:
+            logger.warning(
+                "!!! cost_visibility MODULE FAILED TO LOAD (%s) — replies will "
+                "have NO cost footer and NO spend warnings. This local patch is "
+                "probably missing after an upgrade; see LOCAL_PATCHES.md.",
+                _cv_exc,
+            )
         # Enable faulthandler for stack dumps on freezes/crashes (#70344).
         # Falls back to a log file when sys.stderr is None (Windows VBS /
         # pythonw / detached service) — otherwise the gateway would die

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -172,11 +172,32 @@ class GatewaySlashCommandsMixin:
         # thread (via the contextvar-preserving executor helper) with a bounded
         # timeout so the loop is never blocked.
         _cache_lock = getattr(self, "_agent_cache_lock", None)
+        _old_agent = None
         if _cache_lock is not None:
             with _cache_lock:
                 _cached = self._agent_cache.get(session_key)
                 _old_agent = _cached[0] if isinstance(_cached, tuple) else _cached if _cached else None
             if _old_agent is not None:
+                # Cost-visibility handoff (LOCAL PATCH — see LOCAL_PATCHES.md
+                # and agent/cost_visibility.py). Capture BEFORE resource
+                # cleanup: that step can wedge for its full timeout, and the
+                # note must not be lost to a slow teardown. Persisted keyed by
+                # session_key so it survives a gateway restart between this
+                # /new and the user's next message; it is consumed as a prefix
+                # on that next user message, never as a system-prompt edit
+                # (which would break prompt caching).
+                try:
+                    from agent import cost_visibility as _cv
+
+                    _cv_cfg = _cv.load_cost_visibility_config()
+                    if _cv_cfg.enabled and _cv_cfg.handoff:
+                        _cv_note = _cv.build_handoff_note(_old_agent, config=_cv_cfg)
+                        if _cv_note:
+                            _cv.store_handoff(session_key, _cv_note)
+                except Exception:
+                    logger.debug(
+                        "cost_visibility: handoff capture failed", exc_info=True
+                    )
                 try:
                     await asyncio.wait_for(
                         self._run_in_executor_with_context(
@@ -200,6 +221,18 @@ class GatewaySlashCommandsMixin:
                         "reset: %s (#35994)",
                         session_key, cleanup_exc,
                     )
+
+        # Clear the durable cost ledger for the expiring session: this is what
+        # resets the once-per-crossing warning latches on /new.
+        try:
+            from agent import cost_visibility as _cv_reset
+
+            _cv_reset.reset_session_state(
+                str(getattr(old_entry, "session_id", "") or "")
+            )
+        except Exception:
+            logger.debug("cost_visibility: ledger reset failed", exc_info=True)
+
         self._evict_cached_agent(session_key)
 
         # Conversation boundary: clear ALL conversation-scoped per-session

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -814,6 +814,22 @@ DEFAULT_CONFIG = {
         "max_line_length": 2000,
     },
 
+    # User-facing cost visibility (agent/cost_visibility.py): a per-reply
+    # status footer ("ctx 42% · turn $0.31 · session $4.10"), one-shot
+    # threshold warnings, and a handoff note written at /new. Thresholds live
+    # here rather than in code so an upgrade that replaces code cannot reset
+    # them. See LOCAL_PATCHES.md.
+    "cost_visibility": {
+        "enabled": True,          # master switch for all three surfaces
+        "footer": True,           # append the status line to every reply
+        "warnings": True,         # session-cost / context-percentage warnings
+        "handoff": True,          # write + inject a handoff note on /new
+        "cost_warn_usd": 25.0,    # warn once when session spend crosses this
+        "ctx_warn_pct": 80,       # warn once when context use crosses this %
+        "handoff_max_words": 300, # hard cap on the /new handoff note
+        "include_cli": False,     # CLI/TUI already show cost in the status bar
+    },
+
     # Tool loop guardrails nudge models when they repeat failed or
     # non-progressing tool calls. Soft warnings are always-on by default;
     # hard stops are opt-in so interactive CLI/TUI sessions keep flowing.

--- a/tests/agent/test_cost_visibility.py
+++ b/tests/agent/test_cost_visibility.py
@@ -1,0 +1,320 @@
+"""Tests for the cost-visibility local patch (agent/cost_visibility.py).
+
+Covers the three behaviours the feature is accountable for:
+
+1. Footer math — ctx percentage and the turn/session dollar split.
+2. Warnings — each threshold fires exactly once per crossing, and /new
+   (``reset_session_state``) re-arms them.
+3. Handoff — the note is written at /new, survives as a file, is consumed
+   once, and respects the configured word cap.
+
+These are behaviour contracts, not snapshots: nothing here asserts a
+specific price-table entry or a config version literal.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest.mock import patch
+
+from agent import cost_visibility as cv
+
+
+class _FakeCompressor:
+    def __init__(self, last_prompt_tokens=0, context_length=0):
+        self.last_prompt_tokens = last_prompt_tokens
+        self.context_length = context_length
+
+
+class _FakeAgent:
+    """Minimal stand-in for AIAgent exposing only what the module reads."""
+
+    def __init__(
+        self,
+        session_id="sess-1",
+        cost=0.0,
+        used=0,
+        window=0,
+        platform="telegram",
+        messages=None,
+    ):
+        self.session_id = session_id
+        self.session_estimated_cost_usd = cost
+        self.context_compressor = _FakeCompressor(used, window)
+        self.platform = platform
+        self.messages = messages or []
+
+
+class CostVisibilityTestBase(unittest.TestCase):
+    """Anchors HERMES_HOME at a temp dir so no test touches the real ledger."""
+
+    def setUp(self):
+        import tempfile
+
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        patcher = patch.dict(os.environ, {"HERMES_HOME": self._tmp.name})
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    @staticmethod
+    def cfg(**kwargs):
+        return cv.CostVisibilityConfig(**kwargs)
+
+
+class TestFooterMath(CostVisibilityTestBase):
+    def test_format_matches_spec(self):
+        line = cv.format_footer_line(42.0, 0.31, 4.10)
+        self.assertEqual(line, "ctx 42% · turn $0.31 · session $4.10")
+
+    def test_ctx_percentage_is_used_over_window(self):
+        agent = _FakeAgent(used=80_000, window=200_000)
+        pct = cv.context_pct(agent)
+        assert pct is not None
+        self.assertAlmostEqual(pct, 40.0)
+
+    def test_ctx_unknown_when_window_missing(self):
+        self.assertIsNone(cv.context_pct(_FakeAgent(used=100, window=0)))
+        self.assertIn("ctx —", cv.format_footer_line(None, 0.0, 0.0))
+
+    def test_ctx_unknown_after_compression_sentinel(self):
+        """last_prompt_tokens parks at -1 right after a compaction."""
+        agent = _FakeAgent(used=-1, window=200_000)
+        self.assertIsNone(cv.context_pct(agent))
+
+    def test_turn_cost_is_delta_and_session_accumulates(self):
+        cfg = self.cfg()
+        agent = _FakeAgent(session_id="s-delta", cost=1.00, used=10, window=100)
+
+        first = cv.render_footer(agent, "s-delta", cfg)
+        self.assertEqual(first, "ctx 10% · turn $1.00 · session $1.00")
+
+        # Agent's cumulative counter advances; the turn figure is the delta.
+        agent.session_estimated_cost_usd = 1.75
+        second = cv.render_footer(agent, "s-delta", cfg)
+        self.assertEqual(second, "ctx 10% · turn $0.75 · session $1.75")
+
+    def test_session_total_survives_agent_rebuild(self):
+        """A rebuilt agent restarts its counter; the session total must not."""
+        cfg = self.cfg()
+        agent = _FakeAgent(session_id="s-rebuild", cost=4.00, used=10, window=100)
+        cv.render_footer(agent, "s-rebuild", cfg)
+
+        # Gateway evicts the agent and builds a fresh one for the SAME session.
+        rebuilt = _FakeAgent(session_id="s-rebuild", cost=0.50, used=10, window=100)
+        line = cv.render_footer(rebuilt, "s-rebuild", cfg)
+
+        # Session keeps accumulating rather than collapsing back to $0.50.
+        self.assertEqual(line, "ctx 10% · turn $0.50 · session $4.50")
+
+    def test_subcent_turn_is_not_rendered_as_zero(self):
+        line = cv.format_footer_line(5.0, 0.0004, 0.0004)
+        self.assertIn("$0.0004", line)
+        self.assertNotIn("$0.00 ", line)
+
+    def test_footer_disabled_by_config(self):
+        agent = _FakeAgent(session_id="s-off", cost=1.0, used=10, window=100)
+        self.assertEqual(cv.render_footer(agent, "s-off", self.cfg(footer=False)), "")
+        self.assertEqual(cv.render_footer(agent, "s-off", self.cfg(enabled=False)), "")
+
+    def test_cli_surface_excluded_unless_opted_in(self):
+        cli_agent = _FakeAgent(platform="cli")
+        self.assertFalse(cv.surface_enabled(cli_agent, self.cfg()))
+        self.assertTrue(cv.surface_enabled(cli_agent, self.cfg(include_cli=True)))
+        self.assertTrue(cv.surface_enabled(_FakeAgent(platform="telegram"), self.cfg()))
+
+
+class TestWarnings(CostVisibilityTestBase):
+    def test_cost_warning_fires_once_per_crossing(self):
+        cfg = self.cfg(cost_warn_usd=25.0, ctx_warn_pct=80)
+        agent = _FakeAgent(session_id="s-cost", cost=26.0, used=61, window=100)
+
+        cv.render_footer(agent, "s-cost", cfg)
+        first = cv.check_warnings(agent, "s-cost", cfg)
+        self.assertEqual(len(first), 1)
+        self.assertIn("Session at $26.00", first[0])
+        self.assertIn("Context 61%", first[0])
+        self.assertIn("/new", first[0])
+
+        # Still over the threshold on later turns — must stay silent.
+        for extra in (27.0, 40.0):
+            agent.session_estimated_cost_usd = extra
+            cv.render_footer(agent, "s-cost", cfg)
+            self.assertEqual(cv.check_warnings(agent, "s-cost", cfg), [])
+
+    def test_no_cost_warning_below_threshold(self):
+        cfg = self.cfg(cost_warn_usd=25.0)
+        agent = _FakeAgent(session_id="s-under", cost=24.99, used=10, window=100)
+        cv.render_footer(agent, "s-under", cfg)
+        self.assertEqual(cv.check_warnings(agent, "s-under", cfg), [])
+
+    def test_context_warning_fires_once_per_crossing(self):
+        cfg = self.cfg(cost_warn_usd=1000.0, ctx_warn_pct=80)
+        agent = _FakeAgent(session_id="s-ctx", cost=0.5, used=80, window=100)
+
+        cv.render_footer(agent, "s-ctx", cfg)
+        first = cv.check_warnings(agent, "s-ctx", cfg)
+        self.assertEqual(len(first), 1)
+        self.assertIn("Context at 80%", first[0])
+        self.assertIn("compaction will start soon", first[0])
+
+        agent.context_compressor.last_prompt_tokens = 92
+        cv.render_footer(agent, "s-ctx", cfg)
+        self.assertEqual(cv.check_warnings(agent, "s-ctx", cfg), [])
+
+    def test_thresholds_come_from_config_not_code(self):
+        cfg = self.cfg(cost_warn_usd=2.0, ctx_warn_pct=10)
+        agent = _FakeAgent(session_id="s-cfg", cost=2.5, used=15, window=100)
+        cv.render_footer(agent, "s-cfg", cfg)
+        warnings = cv.check_warnings(agent, "s-cfg", cfg)
+        self.assertEqual(len(warnings), 2)
+
+    def test_reset_rearms_warnings(self):
+        """/new clears the latches so a new session can warn again."""
+        cfg = self.cfg(cost_warn_usd=25.0)
+        agent = _FakeAgent(session_id="s-reset", cost=30.0, used=10, window=100)
+
+        cv.render_footer(agent, "s-reset", cfg)
+        self.assertEqual(len(cv.check_warnings(agent, "s-reset", cfg)), 1)
+        self.assertEqual(cv.check_warnings(agent, "s-reset", cfg), [])
+
+        cv.reset_session_state("s-reset")
+
+        # Fresh session: totals restart, and the threshold can fire again.
+        agent2 = _FakeAgent(session_id="s-reset", cost=26.0, used=10, window=100)
+        cv.render_footer(agent2, "s-reset", cfg)
+        self.assertEqual(len(cv.check_warnings(agent2, "s-reset", cfg)), 1)
+
+    def test_warnings_disabled_by_config(self):
+        cfg = self.cfg(warnings=False, cost_warn_usd=1.0)
+        agent = _FakeAgent(session_id="s-nowarn", cost=99.0, used=99, window=100)
+        cv.render_footer(agent, "s-nowarn", cfg)
+        self.assertEqual(cv.check_warnings(agent, "s-nowarn", cfg), [])
+
+    def test_sessions_latch_independently(self):
+        cfg = self.cfg(cost_warn_usd=10.0)
+        a = _FakeAgent(session_id="s-a", cost=11.0, used=10, window=100)
+        b = _FakeAgent(session_id="s-b", cost=11.0, used=10, window=100)
+        cv.render_footer(a, "s-a", cfg)
+        cv.render_footer(b, "s-b", cfg)
+        self.assertEqual(len(cv.check_warnings(a, "s-a", cfg)), 1)
+        self.assertEqual(len(cv.check_warnings(b, "s-b", cfg)), 1)
+
+
+class TestHandoff(CostVisibilityTestBase):
+    @staticmethod
+    def _conversation():
+        return [
+            {"role": "user", "content": "Analyse the inverter photos and log faults."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "read_file",
+                            "arguments": '{"path": "/tmp/site_a.csv"}',
+                        }
+                    },
+                    {
+                        "function": {
+                            "name": "write_file",
+                            "arguments": '{"path": "/tmp/report.md"}',
+                        }
+                    },
+                ],
+            },
+            {"role": "user", "content": "Now summarise the faults by site."},
+        ]
+
+    def test_note_captures_session_shape(self):
+        agent = _FakeAgent(session_id="s-h", messages=self._conversation())
+        note = cv.build_handoff_note(agent, config=self.cfg())
+
+        self.assertIn("handoff from previous session", note)
+        self.assertIn("Now summarise the faults by site.", note)
+        self.assertIn("/tmp/report.md", note)
+        self.assertIn("read_file", note)
+
+    def test_note_respects_word_cap(self):
+        long_msg = " ".join(f"word{i}" for i in range(2000))
+        agent = _FakeAgent(
+            session_id="s-long", messages=[{"role": "user", "content": long_msg}]
+        )
+        note = cv.build_handoff_note(agent, config=self.cfg(handoff_max_words=300))
+        self.assertLessEqual(len(note.split()), 300)
+
+    def test_store_then_consume_is_one_shot(self):
+        note = "[handoff from previous session]\nDid a thing."
+        self.assertTrue(cv.store_handoff("telegram:123", note))
+
+        self.assertEqual(cv.consume_handoff("telegram:123"), note)
+        # Second read returns nothing — the note is not re-injected forever.
+        self.assertEqual(cv.consume_handoff("telegram:123"), "")
+
+    def test_handoff_survives_a_restart(self):
+        """The note is on disk, so a gateway restart between /new and the
+        next message does not lose it. Simulated by clearing all in-memory
+        state and re-importing the module."""
+        import importlib
+
+        cv.store_handoff("telegram:restart", "[handoff from previous session]\nX")
+
+        reloaded = importlib.reload(cv)
+        self.assertIn("handoff", reloaded.consume_handoff("telegram:restart"))
+
+    def test_consume_missing_key_is_empty(self):
+        self.assertEqual(cv.consume_handoff("telegram:never-written"), "")
+        self.assertEqual(cv.consume_handoff(""), "")
+
+    def test_session_key_is_sanitised_into_a_filename(self):
+        weird = "telegram:-100123/thread 7"
+        self.assertTrue(cv.store_handoff(weird, "note body"))
+        self.assertEqual(cv.consume_handoff(weird), "note body")
+
+
+class TestSelfCheckAndConfig(CostVisibilityTestBase):
+    def test_selfcheck_reports_live_values(self):
+        line = cv.selfcheck_line(self.cfg(cost_warn_usd=25.0, ctx_warn_pct=80))
+        self.assertIn("cost_visibility loaded", line)
+        self.assertIn("cost_warn_usd=25.0", line)
+        self.assertIn("ctx_warn_pct=80", line)
+
+    def test_shipped_defaults_match_the_documented_contract(self):
+        """The defaults the feature promises: on, $25, 80%, 300 words."""
+        cfg = cv.load_cost_visibility_config({})
+        self.assertTrue(cfg.enabled)
+        self.assertTrue(cfg.footer)
+        self.assertEqual(cfg.cost_warn_usd, 25.0)
+        self.assertEqual(cfg.ctx_warn_pct, 80.0)
+        self.assertEqual(cfg.handoff_max_words, 300)
+
+    def test_user_config_overrides_defaults(self):
+        cfg = cv.load_cost_visibility_config(
+            {"cost_visibility": {"cost_warn_usd": 5, "ctx_warn_pct": 50, "footer": False}}
+        )
+        self.assertEqual(cfg.cost_warn_usd, 5.0)
+        self.assertEqual(cfg.ctx_warn_pct, 50.0)
+        self.assertFalse(cfg.footer)
+
+    def test_malformed_config_falls_back_to_defaults(self):
+        cfg = cv.load_cost_visibility_config(
+            {"cost_visibility": {"cost_warn_usd": "not-a-number", "ctx_warn_pct": None}}
+        )
+        self.assertEqual(cfg.cost_warn_usd, 25.0)
+        self.assertEqual(cfg.ctx_warn_pct, 80.0)
+
+    def test_config_section_is_present_in_shipped_defaults(self):
+        """The section must exist in DEFAULT_CONFIG or an upgrade's deep-merge
+        will not create it for existing users."""
+        from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+        self.assertIn(cv.CONFIG_SECTION, DEFAULT_CONFIG)
+        section = DEFAULT_CONFIG[cv.CONFIG_SECTION]
+        for key in ("enabled", "cost_warn_usd", "ctx_warn_pct", "handoff_max_words"):
+            self.assertIn(key, section)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

A long image-analysis session cost **$191.61** and there was no way to see it
happening. Hermes tracks per-call cost internally (`session_estimated_cost_usd`,
`agent/usage_pricing.py`) but on messaging surfaces none of it reaches the user,
so a runaway session is only discovered on the bill.

Two related gaps: nothing warns as spend or context climbs, and `/new` — the
recommended remedy — throws away all continuity, which discourages using it.

## What this adds

One self-contained module, `agent/cost_visibility.py`, providing three
config-gated surfaces:

**1. Status footer** on every messaging reply:

```
ctx 42% · turn $0.31 · session $4.10
```

**2. Threshold warnings**, each latched to fire exactly once per crossing and
re-armed by `/new`:

```
Session at $25.10. Context 61%. Consider /new if the remaining work doesn't need this history.
Context at 80% — compaction will start soon. /new now if you want a clean handoff.
```

**3. `/new` handoff** — a ≤300 word note (what the session was doing, files
touched, open items, last request) captured before the reset and injected once
as a prefix on the first user message of the new session.

Defaults: on, `$25`, `80%`, `300` words — all in `config.yaml` under
`cost_visibility.*`.

## Design notes

- **Pricing is not reimplemented.** `agent/usage_pricing.py` already owns the
  price tables and cache-token semantics, and the agent loop already folds each
  call into `session_estimated_cost_usd`; this differences that counter. A
  second price table would drift from the billing analytics.
- **The footer rides `finish(final_text)`.** It is appended to `final_response`
  inside `finalize_turn`, not emitted after the stream seals — per the
  streaming delivery contract in `AGENTS.md`, post-seal augmentation re-opens
  the duplicate-final bug class.
- **The handoff is prefixed onto the next *user* message**, never injected into
  the system prompt, so per-conversation prompt caching stays byte-stable. It is
  persisted to disk, so it survives a gateway restart between the `/new` and the
  user's next message, and is consumed one-shot.
- **Cost accumulates in a durable ledger, not memory.** The gateway evicts and
  rebuilds agent objects (cache pressure, `/model`, restart), which resets
  `session_estimated_cost_usd` mid-conversation. An in-memory counter would
  silently zero the "session $" figure — exactly the blind spot this closes. A
  counter that goes backwards is treated as an agent rebuild, not a negative
  turn.
- **Footprint.** Per the footprint ladder this is not a new tool and adds no
  model-facing schema — it is display behavior on an existing path. All logic
  is in the one module; the four edited files hold only a guarded call into it,
  each wrapped so cost telemetry can never break a reply.
- **Surface scope.** Messaging surfaces only by default; the CLI/TUI already
  show cost in the status bar (opt in with `cost_visibility.include_cli`).

## Startup self-check

The gateway logs its live config on start, and warns loudly rather than
silently running blind if the module fails to import:

```
INFO  cost_visibility loaded — enabled=True footer=True warnings=True handoff=True cost_warn_usd=25.0 ctx_warn_pct=80.0 handoff_max_words=300 include_cli=False
```

## Tests

`tests/agent/test_cost_visibility.py` — 27 tests, all passing:

```
=== Summary: 1 files, 27 tests passed, 0 failed (100% complete) in 0.5s ===
```

Covers footer math (including the agent-rebuild case and the post-compaction
`-1` sentinel rendering as unknown rather than a bogus percentage),
once-per-crossing latching plus `/new` re-arming, thresholds coming from config
rather than code, and the handoff write/consume round-trip across a simulated
restart. Behavior contracts only — no snapshots of price tables or config
version literals.
