### PR TITLE
fix(windows): hide taskkill console on remaining teardown paths

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -277,6 +277,8 @@ def _write_bridge_pidfile(session_path: Path, pid: int) -> None:
 def _terminate_bridge_process(proc, *, force: bool = False) -> None:
     """Terminate the bridge process using process-tree semantics where possible."""
     if _IS_WINDOWS:
+        from hermes_cli._subprocess_compat import windows_hide_flags
+
         cmd = ["taskkill", "/PID", str(proc.pid), "/T"]
         if force:
             cmd.append("/F")
@@ -286,6 +288,7 @@ def _terminate_bridge_process(proc, *, force: bool = False) -> None:
                 capture_output=True,
                 text=True, encoding='utf-8', errors='replace',
                 timeout=10,
+                creationflags=windows_hide_flags(),
             )
         except FileNotFoundError:
             if force:

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -643,6 +643,7 @@ def _terminate_command_stt_process_tree(proc: subprocess.Popen) -> None:
                 stderr=subprocess.DEVNULL,
                 timeout=5,
                 stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
             )
         except Exception:
             proc.kill()

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1132,6 +1132,7 @@ def _terminate_command_tts_process_tree(proc: subprocess.Popen) -> None:
                 stderr=subprocess.DEVNULL,
                 timeout=5,
                 stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
             )
         except Exception:
             proc.kill()


### PR DESCRIPTION
## Summary

Three process-teardown paths still spawned `taskkill` without `creationflags`, so from the windowless `pythonw` gateway each allocated a *visible* console that briefly took foreground. This closes the gap left by the earlier `windows_hide_flags()` sweep.

## Changes

- `plugins/platforms/whatsapp/adapter.py` — `_terminate_bridge_process`: add a local `windows_hide_flags` import (the file already uses local imports for this elsewhere) and pass `creationflags=windows_hide_flags()` to the `taskkill /T` call.
- `tools/transcription_tools.py` — `_terminate_command_stt_process_tree`: add `creationflags=windows_hide_flags()` (module-level import already present).
- `tools/tts_tool.py` — `_terminate_command_tts_process_tree`: add `creationflags=windows_hide_flags()` (module-level import already present).

## Context

Matches the `windows_hide_flags()` convention already applied to `hermes_cli/dashboard_procs.py`, `hermes_cli/update_cmd.py`, `tools/browser_tool.py`, and the STT/TTS spawn paths. These three were the remaining Windows teardown paths that could flash a console from a headless gateway process.

## Test plan

- No functional change on POSIX — `_IS_WINDOWS` / `os.name == "nt"` guards are unchanged.
- On Windows, these teardown calls now pass the same hidden-window flag as the already-hardened paths.