### PR TITLE
fix(sessions): keep WSL recovery alive through transient read IOERR

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -374,7 +374,8 @@ DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 # query; short enough that transient fd pressure doesn't strand the read pool.
 _READ_OPEN_RETRY_SECONDS = 60.0
 
-# Transient SQLITE_IOERR retry budget for READ-ONLY opens (#100436). A WAL
+# Transient SQLITE_IOERR retry budget for read-only opens and pooled reads
+# (#100436, #100871). A WAL
 # database being actively written (checkpoint, WAL reset/truncate, frame
 # flush) can surface "disk I/O error" to a concurrent ``mode=ro`` reader in
 # a millisecond-wide transition window: the read-only connection cannot
@@ -2126,7 +2127,7 @@ def is_transient_sqlite_error(exc: BaseException) -> bool:
 
 
 def _is_transient_read_only_ioerr(exc: sqlite3.OperationalError, *, attempt: int) -> bool:
-    """True when a read-only open should be retried rather than raised.
+    """True when a read-only SQLite operation should retry rather than raise.
 
     A ``mode=ro`` connection cannot perform WAL recovery (recovery needs to
     write the -shm index, which read-only mode refuses), so a concurrent WAL
@@ -2140,6 +2141,35 @@ def _is_transient_read_only_ioerr(exc: sqlite3.OperationalError, *, attempt: int
         attempt < _READ_ONLY_IOERR_RETRY_ATTEMPTS
         and _DISK_IO_ERROR_MARKER in str(exc).lower()
     )
+
+
+class _RetryingReadConnection:
+    """Retry transient IOERRs from an already-open pooled WAL reader.
+
+    The constructor retry above covers opening a read-only connection, but a
+    warm pooled connection can hit the same WAL transition later when its
+    SELECT executes (#100871). Reads through this wrapper are idempotent, so
+    replaying the statement is safe. The retry deliberately stays on the same
+    connection: close-and-reopen can cancel POSIX locks held by sibling SQLite
+    connections in this process.
+    """
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._conn, name)
+
+    def execute(self, sql: str, parameters=(), /):
+        attempt = 0
+        while True:
+            try:
+                return self._conn.execute(sql, parameters)
+            except sqlite3.OperationalError as exc:
+                if not _is_transient_read_only_ioerr(exc, attempt=attempt):
+                    raise
+                attempt += 1
+                time.sleep(_READ_ONLY_IOERR_RETRY_BACKOFF_S)
 
 
 def is_malformed_schema_error(exc: BaseException) -> bool:
@@ -5495,6 +5525,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # registry, not the database file, so mode=ro is fine.
             if self._fts_cjk_loaded:
                 load_fts5_cjk_extension(conn)
+            conn = _RetryingReadConnection(conn)
         except sqlite3.Error:
             # A partially-constructed connection — _connect_tracked_db
             # succeeded, the CJK extension load did not — must be closed here.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2148,10 +2148,10 @@ class _RetryingReadConnection:
 
     The constructor retry above covers opening a read-only connection, but a
     warm pooled connection can hit the same WAL transition later when its
-    SELECT executes (#100871). Reads through this wrapper are idempotent, so
-    replaying the statement is safe. The retry deliberately stays on the same
-    connection: close-and-reopen can cancel POSIX locks held by sibling SQLite
-    connections in this process.
+    SELECT executes or steps its result set (#100871). Reads through this
+    wrapper are idempotent, so replaying the statement is safe. The retry
+    deliberately stays on the same connection: close-and-reopen can cancel
+    POSIX locks held by sibling SQLite connections in this process.
     """
 
     def __init__(self, conn: sqlite3.Connection) -> None:
@@ -2165,6 +2165,18 @@ class _RetryingReadConnection:
         while True:
             try:
                 return self._conn.execute(sql, parameters)
+            except sqlite3.OperationalError as exc:
+                if not _is_transient_read_only_ioerr(exc, attempt=attempt):
+                    raise
+                attempt += 1
+                time.sleep(_READ_ONLY_IOERR_RETRY_BACKOFF_S)
+
+    def execute_fetchone(self, sql: str, parameters=(), /):
+        """Execute and step one row within a single bounded retry boundary."""
+        attempt = 0
+        while True:
+            try:
+                return self._conn.execute(sql, parameters).fetchone()
             except sqlite3.OperationalError as exc:
                 if not _is_transient_read_only_ioerr(exc, attempt=attempt):
                     raise
@@ -10496,15 +10508,18 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # totals. No-op attribute check when nothing is queued.
         self.flush_token_counts()
         with self._read_ctx() as conn:
-            cursor = conn.execute(
+            sql = (
                 "SELECT s.*, "
                 "COALESCE(sp.prompt, s.system_prompt) AS _system_prompt_resolved "
                 "FROM sessions s "
                 "LEFT JOIN system_prompts sp ON sp.hash = s.system_prompt_hash "
-                "WHERE s.id = ?",
-                (session_id,),
+                "WHERE s.id = ?"
             )
-            row = cursor.fetchone()
+            parameters = (session_id,)
+            if isinstance(conn, _RetryingReadConnection):
+                row = conn.execute_fetchone(sql, parameters)
+            else:
+                row = conn.execute(sql, parameters).fetchone()
         return self._session_row_dict(row) if row else None
 
     def get_dominant_session_model_route(

--- a/tests/test_session_db_read_conn_pool.py
+++ b/tests/test_session_db_read_conn_pool.py
@@ -36,6 +36,7 @@ connection count and make such assertions flaky.
 """
 
 import queue
+import sqlite3
 import threading
 
 import pytest
@@ -123,6 +124,73 @@ def test_pooled_conn_is_usable_from_another_thread(db):
     t.start()
     t.join()
     assert not errors, f"pooled connection unusable off-thread: {errors}"
+
+
+def test_pooled_get_session_retries_transient_ioerr(db, monkeypatch):
+    """A transient IOERR from a warm WAL reader must not abort recovery.
+
+    The read-only constructor retry does not cover this path: the connection
+    has already opened and the error is raised later by get_session's SELECT.
+    Re-running that read on the same connection is safe and avoids closing a
+    SQLite fd while sibling connections may hold POSIX locks on the file.
+    """
+    import hermes_state as hs
+
+    real_connect = hs._connect_tracked_db
+    attempts = 0
+
+    class FlakyReadConnection:
+        def __init__(self, conn):
+            object.__setattr__(self, "_conn", conn)
+
+        def __getattr__(self, name):
+            return getattr(self._conn, name)
+
+        def __setattr__(self, name, value):
+            setattr(self._conn, name, value)
+
+        def execute(self, sql, parameters=()):
+            nonlocal attempts
+            if "FROM sessions s" in sql:
+                attempts += 1
+                if attempts == 1:
+                    raise sqlite3.OperationalError("disk I/O error")
+            return self._conn.execute(sql, parameters)
+
+    def flaky_connect(*args, **kwargs):
+        conn = real_connect(*args, **kwargs)
+        if args and isinstance(args[0], str) and "mode=ro" in args[0]:
+            return FlakyReadConnection(conn)
+        return conn
+
+    monkeypatch.setattr(hs, "_connect_tracked_db", flaky_connect)
+    monkeypatch.setattr(hs, "_READ_ONLY_IOERR_RETRY_BACKOFF_S", 0.0)
+    db._wal_active = True
+
+    assert db.get_session("s1")["id"] == "s1"
+    assert attempts == 2
+
+
+def test_pooled_read_persistent_ioerr_exhausts_retry_budget(monkeypatch):
+    """A real storage failure must still surface after bounded retries."""
+    import hermes_state as hs
+
+    class BrokenReadConnection:
+        def __init__(self):
+            self.attempts = 0
+
+        def execute(self, _sql, _parameters=()):
+            self.attempts += 1
+            raise sqlite3.OperationalError("disk I/O error")
+
+    broken = BrokenReadConnection()
+    conn = hs._RetryingReadConnection(broken)
+    monkeypatch.setattr(hs, "_READ_ONLY_IOERR_RETRY_BACKOFF_S", 0.0)
+
+    with pytest.raises(sqlite3.OperationalError, match="disk I/O error"):
+        conn.execute("SELECT 1")
+
+    assert broken.attempts == hs._READ_ONLY_IOERR_RETRY_ATTEMPTS + 1
 
 
 @pytest.mark.requires_wal

--- a/tests/test_session_db_read_conn_pool.py
+++ b/tests/test_session_db_read_conn_pool.py
@@ -171,6 +171,97 @@ def test_pooled_get_session_retries_transient_ioerr(db, monkeypatch):
     assert attempts == 2
 
 
+def test_pooled_get_session_retries_transient_fetchone_ioerr(db, monkeypatch):
+    """The retry boundary includes SQLite stepping the selected row."""
+    import hermes_state as hs
+
+    real_connect = hs._connect_tracked_db
+    attempts = 0
+
+    class FlakyCursor:
+        def __init__(self, cursor):
+            self._cursor = cursor
+
+        def fetchone(self):
+            raise sqlite3.OperationalError("disk I/O error")
+
+    class FlakyReadConnection:
+        def __init__(self, conn):
+            object.__setattr__(self, "_conn", conn)
+
+        def __getattr__(self, name):
+            return getattr(self._conn, name)
+
+        def __setattr__(self, name, value):
+            setattr(self._conn, name, value)
+
+        def execute(self, sql, parameters=()):
+            nonlocal attempts
+            cursor = self._conn.execute(sql, parameters)
+            if "FROM sessions s" in sql:
+                attempts += 1
+                if attempts == 1:
+                    return FlakyCursor(cursor)
+            return cursor
+
+    def flaky_connect(*args, **kwargs):
+        conn = real_connect(*args, **kwargs)
+        if args and isinstance(args[0], str) and "mode=ro" in args[0]:
+            return FlakyReadConnection(conn)
+        return conn
+
+    monkeypatch.setattr(hs, "_connect_tracked_db", flaky_connect)
+    monkeypatch.setattr(hs, "_READ_ONLY_IOERR_RETRY_BACKOFF_S", 0.0)
+    db._wal_active = True
+
+    assert db.get_session("s1")["id"] == "s1"
+    assert attempts == 2
+
+
+def test_pooled_get_session_persistent_fetchone_ioerr_is_bounded(db, monkeypatch):
+    """Persistent fetch-time IOERR propagates after the existing retry budget."""
+    import hermes_state as hs
+
+    real_connect = hs._connect_tracked_db
+    attempts = 0
+
+    class BrokenCursor:
+        def fetchone(self):
+            raise sqlite3.OperationalError("disk I/O error")
+
+    class BrokenReadConnection:
+        def __init__(self, conn):
+            object.__setattr__(self, "_conn", conn)
+
+        def __getattr__(self, name):
+            return getattr(self._conn, name)
+
+        def __setattr__(self, name, value):
+            setattr(self._conn, name, value)
+
+        def execute(self, sql, parameters=()):
+            nonlocal attempts
+            if "FROM sessions s" in sql:
+                attempts += 1
+                return BrokenCursor()
+            return self._conn.execute(sql, parameters)
+
+    def broken_connect(*args, **kwargs):
+        conn = real_connect(*args, **kwargs)
+        if args and isinstance(args[0], str) and "mode=ro" in args[0]:
+            return BrokenReadConnection(conn)
+        return conn
+
+    monkeypatch.setattr(hs, "_connect_tracked_db", broken_connect)
+    monkeypatch.setattr(hs, "_READ_ONLY_IOERR_RETRY_BACKOFF_S", 0.0)
+    db._wal_active = True
+
+    with pytest.raises(sqlite3.OperationalError, match="disk I/O error"):
+        db.get_session("s1")
+
+    assert attempts == hs._READ_ONLY_IOERR_RETRY_ATTEMPTS + 1
+
+
 def test_pooled_read_persistent_ioerr_exhausts_retry_budget(monkeypatch):
     """A real storage failure must still surface after bounded retries."""
     import hermes_state as hs


### PR DESCRIPTION
## What does this PR do?

Hermes session recovery no longer aborts when an already-open pooled WAL reader hits a transient `sqlite3.OperationalError: disk I/O error`. The pooled read connection retries the idempotent SELECT on the same connection with the existing bounded read-only IOERR budget, preserving WAL concurrency without switching the store to DELETE mode.

### Symptom

On WSL2 ext4-on-vhdx with multiple Hermes processes sharing `state.db`, `SessionDB.get_session()` can raise `disk I/O error` from its SELECT. The failure interrupts session and compression recovery even though `PRAGMA quick_check` reports a healthy database.

### Impact

Affected gateway and CLI turns can fail to recover their persisted session during a transient WAL transition. Switching to DELETE journal mode is not a viable mitigation for this workload because it serializes readers against writers and causes severe read throughput loss.

### Bug Cause

**Trigger:** `hermes_state.py:10468` / `SessionDB.get_session()` executes a SELECT through a pooled read-only connection while another process is updating WAL state.

**Causal chain:**
1. A pooled `mode=ro` connection remains open across session reads.
2. A later SELECT lands in a transient WAL checkpoint, reset, or frame-flush window and SQLite raises `SQLITE_IOERR`.
3. `_read_ctx()` returns the error directly, so session recovery fails instead of riding out the short transition.

**Why it is wrong:** The existing bounded retry covers read-only connection construction, but not statements executed later through warm pooled connections.

**Working sibling / contrast:** A transient IOERR during a fresh read-only open already uses the bounded read-only retry budget. Pooled reads bypass that constructor path once their connection is warm.

**Ruled out:** Database corruption, file-descriptor exhaustion, and disk-full conditions were excluded in the issue evidence through `PRAGMA quick_check`, fd counts, and available disk space. The retry remains bounded so persistent storage failures still surface.

### Fix

Wrap pooled read-only connections with an execute shim that retries only `disk I/O error`, using the existing bounded attempt and backoff settings. The statement is retried on the same connection because pooled reads are idempotent and closing a SQLite connection can cancel POSIX locks held by sibling connections in the process. Other SQLite errors propagate unchanged, and persistent IOERR exhausts the budget and raises.

## Related Issue

Fixes #100871

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py` - retry transient IOERR from statements executed on pooled read-only connections.
- `tests/test_session_db_read_conn_pool.py` - cover transient recovery on the exact `get_session()` path and bounded propagation for persistent IOERR.

## How to Test

1. Inject one `disk I/O error` into the pooled `get_session()` SELECT and verify the same read succeeds on retry.
2. Inject persistent IOERR and verify the configured retry budget is exhausted before the original error propagates.
3. Run:

```bash
scripts/run_tests.sh tests/test_session_db_read_conn_pool.py tests/test_session_db_read_path_split.py tests/test_hermes_state.py -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant SessionDB tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested the deterministic regression on Windows 11 with Python 3.11 and SQLite 3.50.4

### Documentation & Housekeeping

- [x] Relevant behavior is documented in code and regression-test docstrings
- [x] N/A - no config keys changed
- [x] N/A - no contributor workflow changed
- [x] Cross-platform impact considered: the wrapper is platform-neutral and only activates on pooled WAL reads
- [x] N/A - no tool schema changed

## Screenshots / Logs

Relevant test result: 252 passed, 26 skipped, 0 failed.
