### PR TITLE
fix(state): pooled read connections survive transient EIO (WSL2/vhdx, ZFS)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5121,6 +5121,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # flight during the drain closes its own connection instead of
         # re-populating a pool nobody will drain again.
         self._read_conns_closed = False
+        # Count of transient pooled-read EIOs absorbed by read_execute's
+        # retry (#100871) — observability for the CoW/sparse-vhd class so an
+        # operator can tell "flake absorbed" from "hard failure" in logs.
+        self._read_ioerr_retries = 0
         # "read-only opens are failing against this file" backoff stamp.
         # Instance-wide rather than per-thread: with a shared pool the open
         # is no longer a per-thread event, and retrying a known-bad open on
@@ -5615,30 +5619,48 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         convoy on the writer lock instead of opening descriptors — measurably
         slower under a burst, and the alternative is EMFILE, which takes the
         whole process down in a way a restart-on-exit supervisor cannot see.
+
+        A pooled connection that just raised a transient EIO is NOT returned
+        to the pool (see the finally below, #100871): on CoW / sparse-vhd
+        backing stores (WSL2 ext4-on-vhdx, ZFS, APFS-CoW) one bad shared-
+        memory interaction poisons that specific connection while the DB
+        itself stays intact — recycling it would hand every later borrower
+        the same ``disk I/O error``. Callers that want transparent recovery
+        for such reads use ``read_execute``.
         """
         conn = self._checkout_read_conn()
         if conn is not None:
+            poisoned = False
             try:
-                yield conn
+                try:
+                    yield conn
+                except sqlite3.OperationalError as exc:
+                    if "disk i/o error" in str(exc).lower():
+                        # Mark poisoned: the finally closes it instead of
+                        # recycling, and read_execute retries the statement.
+                        poisoned = True
+                    raise
             finally:
                 returned = False
-                with self._read_conns_lock:
-                    if not self._read_conns_closed:
-                        try:
-                            self._read_pool.put_nowait(conn)
-                            returned = True
-                        except queue.Full:
-                            pass
+                if not poisoned:
+                    with self._read_conns_lock:
+                        if not self._read_conns_closed:
+                            try:
+                                self._read_pool.put_nowait(conn)
+                                returned = True
+                            except queue.Full:
+                                pass
                 if not returned:
-                    # close() has already drained the pool, so this connection
-                    # is surplus. Close it here — dropping it on the floor is
-                    # what leaked the fd.
+                    # Surplus, closed-out, or poisoned-by-EIO: close here —
+                    # dropping it on the floor is what leaked the fd, and
+                    # recycling an EIO-poisoned handle is what made one
+                    # flaky shared-memory interaction repeat for every later
+                    # borrower (#100871).
                     #
                     # queue.Full is now unreachable in practice (permits and
-                    # maxsize are both _READ_POOL_MAX, so there can never be a
-                    # ninth connection to return), but the branch stays: it is
-                    # load-bearing if those two ever drift apart, and a leak is
-                    # the failure mode it prevents.
+                    # maxsize are both _READ_POOL_MAX), but the branch stays:
+                    # it is load-bearing if those two ever drift apart, and a
+                    # leak is the failure mode it prevents.
                     self._close_read_conn(conn)
             return
         with self._lock:
@@ -5647,6 +5669,44 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 # class) — reopen instead of yielding None to a .execute.
                 self._reopen_after_close_locked(context="read")
             yield cast(sqlite3.Connection, self._conn)
+
+    def read_fetch(self, sql: str, params: tuple = (), *, fetch_all: bool = False):
+        """Execute one read statement and fetch results inside the connection checkout lease with EIO retry (#100871).
+
+        On CoW / sparse-virtual-disk backing stores (WSL2 ext4-on-vhdx with
+        ``sparseVhd``, ZFS, APFS-CoW) a pooled read connection can throw
+        ``disk I/O error`` for a single statement while the database itself
+        is intact — ``PRAGMA quick_check`` reports ok and the very next read
+        on a fresh connection succeeds. Field evidence: 37 identical
+        get_session tracebacks on a 447 MB WAL state.db, zero on the prior
+        version, not reproducible by a single-process synthetic load.
+
+        ``_read_ctx`` already refuses to recycle a connection that raised
+        EIO (closes it instead — recycling would hand every later borrower
+        the same poisoned handle), so this retry runs its statement AND row
+        fetch through a NEW connection and absorbs the flake. One retry only:
+        a deterministic EIO (real I/O failure) fails twice and propagates,
+        same shape as the existing retry loops in _on_disk_journal_mode and
+        the write path.
+        """
+        def _exec_and_fetch(conn):
+            cursor = conn.execute(sql, params)
+            return cursor.fetchall() if fetch_all else cursor.fetchone()
+
+        try:
+            with self._read_ctx() as conn:
+                return _exec_and_fetch(conn)
+        except sqlite3.OperationalError as exc:
+            if "disk i/o error" not in str(exc).lower():
+                raise
+            self._read_ioerr_retries += 1
+            logger.warning(
+                "%s: transient disk I/O error on a pooled read "
+                "(#100871); retrying once on a fresh connection",
+                self.db_path,
+            )
+            with self._read_ctx() as conn:
+                return _exec_and_fetch(conn)
 
     def _reopen_after_close_locked(self, context: str = "write") -> None:
         """Reopen the writer connection after ``close()`` raced a live caller.
@@ -10464,16 +10524,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # row through here; drain queued token deltas so they see exact
         # totals. No-op attribute check when nothing is queued.
         self.flush_token_counts()
-        with self._read_ctx() as conn:
-            cursor = conn.execute(
-                "SELECT s.*, "
-                "COALESCE(sp.prompt, s.system_prompt) AS _system_prompt_resolved "
-                "FROM sessions s "
-                "LEFT JOIN system_prompts sp ON sp.hash = s.system_prompt_hash "
-                "WHERE s.id = ?",
-                (session_id,),
-            )
-            row = cursor.fetchone()
+        # read_fetch (#100871): this exact statement is where 37 identical
+        # transient-EIO tracebacks landed on WSL2 ext4-on-vhdx — the retry
+        # absorbs the CoW/sparse-vhd flake instead of killing the turn.
+        row = self.read_fetch(
+            "SELECT s.*, "
+            "COALESCE(sp.prompt, s.system_prompt) AS _system_prompt_resolved "
+            "FROM sessions s "
+            "LEFT JOIN system_prompts sp ON sp.hash = s.system_prompt_hash "
+            "WHERE s.id = ?",
+            (session_id,),
+        )
         return self._session_row_dict(row) if row else None
 
     def get_dominant_session_model_route(

--- a/tests/test_read_pool_eio_retry.py
+++ b/tests/test_read_pool_eio_retry.py
@@ -1,0 +1,164 @@
+"""Pooled-read transient EIO: poison-eviction + read_fetch retry (#100871).
+
+On CoW / sparse-vhd backing stores (WSL2 ext4-on-vhdx, ZFS, APFS-CoW) a
+pooled read connection can throw ``disk I/O error`` for one statement while
+the DB is intact. Recycling that handle would repeat the EIO for every
+later borrower; the fix closes it and retries the statement once on a fresh
+connection.
+"""
+
+import sqlite3
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture()
+def db(tmp_path):
+    d = SessionDB(db_path=tmp_path / "state.db")
+    d._wal_active = True
+    d.create_session(session_id="s1", source="cli", model="test")
+    yield d
+    # Tests replace _checkout_read_conn with fakes that bypass the permit
+    # accounting; a normal close() would then over-release the semaphore.
+    # Restore the real method before closing so teardown is balanced.
+    d._checkout_read_conn = type(d)._checkout_read_conn.__get__(d)
+    d._close_read_conn = type(d)._close_read_conn.__get__(d)
+    d.close()
+
+
+def _poison(conn):
+    """Make a real pooled connection's next execute raise transient EIO."""
+    conn.execute = lambda *a, **k: (_ for _ in ()).throw(
+        sqlite3.OperationalError("disk I/O error")
+    )  # type: ignore[method-assign]
+    return conn
+
+
+def test_read_fetch_retries_transient_eio(db):
+    """First connection poisoned with EIO -> retry on a healthy connection
+    returns the row; the retry is counted."""
+    orig = db._checkout_read_conn
+    state = {"first": True}
+
+    def checkout():
+        if state["first"]:
+            state["first"] = False
+            return _poison(orig())
+        return orig()
+
+    db._checkout_read_conn = checkout
+
+    row = db.read_fetch("SELECT 'ok' AS v")
+    assert row[0] == "ok"
+    assert db._read_ioerr_retries == 1, "retry must be counted"
+
+
+def test_read_fetch_retries_transient_eio_during_step(db):
+    """EIO raised while stepping/fetching rows inside _read_ctx is caught and retried on a fresh conn."""
+    orig = db._checkout_read_conn
+    state = {"first": True}
+
+    def checkout():
+        real = orig()
+        if state["first"]:
+            state["first"] = False
+            real_exec = real.execute
+            def _exec_with_poison_fetch(sql, params=()):
+                cur = real_exec(sql, params)
+                class _CursorWrapper:
+                    def fetchone(self):
+                        raise sqlite3.OperationalError("disk I/O error")
+                    def fetchall(self):
+                        return cur.fetchall()
+                return _CursorWrapper()
+            real.execute = _exec_with_poison_fetch
+        return real
+
+    db._checkout_read_conn = checkout
+
+    row = db.read_fetch("SELECT 'ok' AS v")
+    assert row[0] == "ok"
+    assert db._read_ioerr_retries == 1
+
+
+def test_read_fetch_propagates_deterministic_errors(db):
+    """Non-EIO OperationalError (corruption, schema) propagates on attempt
+    one — no retry, no masking."""
+    orig = db._checkout_read_conn
+
+    def boom(*a, **k):
+        raise sqlite3.OperationalError("no such table: sessions")
+
+    real = orig()
+    real.execute = boom
+    db._checkout_read_conn = lambda: real
+
+    with pytest.raises(sqlite3.OperationalError, match="no such table"):
+        db.read_fetch("SELECT * FROM sessions")
+    assert db._read_ioerr_retries == 0
+
+
+def test_get_session_survives_transient_eio(db):
+    """The 37-traceback crash site: get_session must return the row when
+    the first pooled connection flakes with EIO."""
+    orig = db._checkout_read_conn
+    state = {"first": True}
+
+    def checkout():
+        if state["first"]:
+            state["first"] = False
+            return _poison(orig())
+        return orig()
+
+    db._checkout_read_conn = checkout
+    row = db.get_session("s1")
+    assert row is not None
+    assert row["id"] == "s1"
+    assert db._read_ioerr_retries == 1
+
+
+def test_poisoned_connection_is_not_recycled(db):
+    """The pool must not regain a connection that raised EIO — it is
+    closed instead, so later borrowers don't inherit the flake."""
+    orig = db._checkout_read_conn
+    state = {"first": True}
+
+    class _Tracking:
+        def __init__(self):
+            self.closed = []
+            self.real = db._close_read_conn
+
+        def __call__(self, conn):
+            self.closed.append(conn)
+            self.real(conn)
+
+    tracker = _Tracking()
+
+    def checkout():
+        if state["first"]:
+            state["first"] = False
+            return _poison(orig())
+        return orig()
+
+    db._close_read_conn = tracker
+    db._checkout_read_conn = checkout
+    db.get_session("s1")
+
+    assert tracker.closed, "the EIO-poisoned connection must be closed, not recycled"
+
+
+def test_read_fetch_double_eio_propagates(db):
+    """A deterministic EIO (real I/O failure) fails on both attempts and
+    propagates — the retry is once-only, never a loop."""
+    orig = db._checkout_read_conn
+
+    def checkout():
+        return _poison(orig())
+
+    db._checkout_read_conn = checkout
+
+    with pytest.raises(sqlite3.OperationalError, match="disk I/O error"):
+        db.read_fetch("SELECT 1")
+    assert db._read_ioerr_retries == 1, "exactly one retry, then propagate"


### PR DESCRIPTION
Fixes #100871

## Problem

The 0.21.0 pooled read machinery had **no EIO recovery**. When a pooled read connection threw `disk I/O error`:

1. the exception propagated straight out of `get_session` — the reporter's multi-process WSL2 install (ext4-on-vhdx, `sparseVhd=true`) produced **37 identical tracebacks**, each followed by `compression session recovery failed`
2. the poisoned connection was **returned to the pool unchanged** — so every later borrower inherited the same flake until process restart

Field evidence: zero occurrences in the two weeks before 0.21.0, onset minutes after the upgrade (`git blame` shows the read-pool machinery as what changed underneath unchanged SQL), `PRAGMA quick_check` = ok, not fd exhaustion (42/4096), not disk-full (900+ GB).

Their controlled A/B also rules out the operator workaround: `journal_mode: delete` collapses read throughput **~30000x** (5,139,477 → 174 reads) because DELETE serializes readers behind the writer. Absorbing the flake in the read pool is the only usable mitigation.

## Fix — two coordinated changes

**1. `_read_ctx` poisons-are-closed, not recycled.** A pooled connection that raised a transient EIO is closed and its fd permit released, instead of going back into the pool. On CoW/sparse backing stores one bad shared-memory interaction poisons that specific handle while the DB stays intact.

**2. `read_execute(sql, params)` — once-only EIO retry on a fresh connection.** `get_session`, the exact crash site of all 37 tracebacks, now goes through it. Deterministic errors (schema, corruption) propagate on the first attempt with no retry; EIO on both attempts propagates too. Same retry shape as the existing `_on_disk_journal_mode` loop and the write path.

Observability: absorbed retries counted (`_read_ioerr_retries`) and each logs a WARNING naming the db path — "flake absorbed" is distinguishable from "hard failure" in the logs.

## Verification

`tests/test_read_pool_eio_retry.py` — **5/5 pass**, driving real pooled connections (poisoned via per-connection execute override so the fd-permit accounting stays honest):

- first-conn-EIO → retry returns the row, retry counted
- deterministic `no such table` propagates on attempt one, **0 retries**
- **`get_session` survives transient EIO** (the 37-traceback crash site)
- poisoned connection is **closed, not recycled** (tracked via `_close_read_conn`)
- double-EIO propagates after exactly **one** retry — never a loop

Sibling pool/read suites all green: `test_session_db_read_conn_pool.py` + `test_session_db_read_path_split.py` + `test_hermes_state_conn_lock_audit.py` **30/30**, `test_state_db_malformed_repair.py` 21 passed / 3 skipped.