### PR TITLE
feat(lsp): project-pinned language servers now win over global PATH installs (port omo#7424)

### DIFF
--- a/agent/lsp/servers.py
+++ b/agent/lsp/servers.py
@@ -188,8 +188,91 @@ def _file_ext_or_basename(path: str) -> str:
     return base
 
 
-def _which(*names: str) -> Optional[str]:
-    """Return the full path of the first command found on PATH."""
+# Marker-gated repo-local bin directories, probed BEFORE falling back to
+# PATH.  A local bin dir is only trusted when a sibling marker proves the
+# directory belongs to a project of that ecosystem — a stray, unmarked
+# ``node_modules/.bin`` cannot inject an executable into the resolution
+# order.  Ported/adapted from oh-my-openagent PR #7424.
+_LOCAL_BIN_RULES: Tuple[Tuple[Tuple[str, ...], Tuple[str, ...]], ...] = (
+    (
+        ("package.json", "bun.lock", "bun.lockb", "package-lock.json",
+         "yarn.lock", "pnpm-lock.yaml"),
+        (os.path.join("node_modules", ".bin"),),
+    ),
+    (
+        ("pyproject.toml", "requirements.txt", "setup.py", "setup.cfg",
+         "Pipfile", "pyrightconfig.json", "ruff.toml", ".ruff.toml"),
+        (os.path.join(".venv", "bin"), os.path.join(".venv", "Scripts"),
+         os.path.join("venv", "bin"), os.path.join("venv", "Scripts")),
+    ),
+    (
+        ("Gemfile", "Gemfile.lock"),
+        (os.path.join("vendor", "bundle", "bin"), "bin"),
+    ),
+    (
+        ("go.mod", "go.sum", "go.work"),
+        ("bin",),
+    ),
+)
+
+# Per-process cache: (root, name) -> resolved path or None.  LSP spawn
+# resolution runs on every first-touch of a language in a session; the
+# marker walk is pure filesystem probing, so memoize it.
+_LOCAL_RESOLVE_CACHE: Dict[Tuple[str, str], Optional[str]] = {}
+
+
+def _resolve_local_binary(name: str, root: str) -> Optional[str]:
+    """Resolve ``name`` from marker-gated project-local bin dirs.
+
+    Walks upward from ``root``, probing each ecosystem's bin directories
+    only when a sibling marker file authorizes them.  The walk ends at a
+    ``.git`` boundary (that directory is still probed) — tooling above a
+    repository root belongs to a different project.  ``shutil.which`` with
+    an explicit ``path=`` handles executability and Windows PATHEXT.
+    """
+    key = (root, name)
+    if key in _LOCAL_RESOLVE_CACHE:
+        return _LOCAL_RESOLVE_CACHE[key]
+    resolved: Optional[str] = None
+    current = os.path.abspath(root)
+    while True:
+        for markers, bin_dirs in _LOCAL_BIN_RULES:
+            if not any(os.path.exists(os.path.join(current, m)) for m in markers):
+                continue
+            for bin_dir in bin_dirs:
+                cand_dir = os.path.join(current, bin_dir)
+                if not os.path.isdir(cand_dir):
+                    continue
+                found = shutil.which(name, path=cand_dir)
+                if found:
+                    resolved = found
+                    break
+            if resolved:
+                break
+        if resolved or os.path.exists(os.path.join(current, ".git")):
+            break
+        parent = os.path.dirname(current)
+        if parent == current:
+            break
+        current = parent
+    _LOCAL_RESOLVE_CACHE[key] = resolved
+    return resolved
+
+
+def _which(*names: str, root: Optional[str] = None) -> Optional[str]:
+    """Return the full path of the first command found.
+
+    When ``root`` is given, marker-gated project-local bin directories
+    (``node_modules/.bin``, ``.venv/bin``, ...) are probed first, walking
+    up from ``root`` to the nearest ``.git`` boundary — so a project's own
+    pinned language server wins over a globally installed one.  PATH is
+    the fallback either way.
+    """
+    if root:
+        for n in names:
+            path = _resolve_local_binary(n, root)
+            if path:
+                return path
     for n in names:
         path = shutil.which(n)
         if path:
@@ -231,8 +314,7 @@ def _root_or_workspace(file_path: str, workspace: str, markers: Sequence[str], e
 
 def _spawn_pyright(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     bin_path = _resolve_override(ctx, "pyright") or _which(
-        "pyright-langserver", "pyright"
-    )
+        "pyright-langserver", "pyright", root=root)
     if bin_path is None:
         from agent.lsp.install import try_install
         bin_path = try_install("pyright", ctx.install_strategy)
@@ -275,7 +357,7 @@ def _detect_python(root: str) -> Optional[str]:
 
 
 def _spawn_typescript(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
-    bin_path = _resolve_override(ctx, "typescript") or _which("typescript-language-server")
+    bin_path = _resolve_override(ctx, "typescript") or _which("typescript-language-server", root=root)
     if bin_path is None:
         from agent.lsp.install import try_install
         bin_path = try_install("typescript-language-server", ctx.install_strategy)
@@ -292,7 +374,7 @@ def _spawn_typescript(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
 
 
 def _spawn_gopls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
-    bin_path = _resolve_override(ctx, "gopls") or _which("gopls")
+    bin_path = _resolve_override(ctx, "gopls") or _which("gopls", root=root)
     if bin_path is None:
         from agent.lsp.install import try_install
         bin_path = try_install("gopls", ctx.install_strategy)
@@ -308,7 +390,7 @@ def _spawn_gopls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
 
 
 def _spawn_rust_analyzer(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
-    bin_path = _resolve_override(ctx, "rust-analyzer") or _which("rust-analyzer")
+    bin_path = _resolve_override(ctx, "rust-analyzer") or _which("rust-analyzer", root=root)
     if bin_path is None:
         from agent.lsp.install import try_install
         bin_path = try_install("rust-analyzer", ctx.install_strategy)
@@ -324,7 +406,7 @@ def _spawn_rust_analyzer(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
 
 
 def _spawn_clangd(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
-    bin_path = _resolve_override(ctx, "clangd") or _which("clangd")
+    bin_path = _resolve_override(ctx, "clangd") or _which("clangd", root=root)
     if bin_path is None:
         from agent.lsp.install import try_install
         bin_path = try_install("clangd", ctx.install_strategy)
@@ -343,7 +425,7 @@ _BASH_SHELLCHECK_WARNED = False
 
 
 def _spawn_bash_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
-    bin_path = _resolve_override(ctx, "bash-language-server") or _which("bash-language-server")
+    bin_path = _resolve_override(ctx, "bash-language-server") or _which("bash-language-server", root=root)
     if bin_path is None:
         from agent.lsp.install import try_install
         bin_path = try_install("bash-language-server", ctx.install_strategy)
@@ -371,7 +453,7 @@ def _spawn_bash_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
 
 
 def _spawn_yaml_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
-    bin_path = _resolve_override(ctx, "yaml-language-server") or _which("yaml-language-server")
+    bin_path = _resolve_override(ctx, "yaml-language-server") or _which("yaml-language-server", root=root)
     if bin_path is None:
         from agent.lsp.install import try_install
         bin_path = try_install("yaml-language-server", ctx.install_strategy)
@@ -387,7 +469,7 @@ def _spawn_yaml_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
 
 
 def _spawn_lua_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
-    bin_path = _resolve_override(ctx, "lua-language-server") or _which("lua-language-server")
+    bin_path = _resolve_override(ctx, "lua-language-server") or _which("lua-language-server", root=root)
     if bin_path is None:
         from agent.lsp.install import try_install
         bin_path = try_install("lua-language-server", ctx.install_strategy)
@@ -403,7 +485,7 @@ def _spawn_lua_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
 
 
 def _spawn_intelephense(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
-    bin_path = _resolve_override(ctx, "intelephense") or _which("intelephense")
+    bin_path = _resolve_override(ctx, "intelephense") or _which("intelephense", root=root)
     if bin_path is None:
         from agent.lsp.install import try_install
         bin_path = try_install("intelephense", ctx.install_strategy)
@@ -421,7 +503,7 @@ def _spawn_intelephense(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
 
 
 def _spawn_ocamllsp(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
-    bin_path = _resolve_override(ctx, "ocaml-lsp") or _which("ocamllsp")
+    bin_path = _resolve_override(ctx, "ocaml-lsp") or _which("ocamllsp", root=root)
     if bin_path is None:
         return None
     return SpawnSpec(
@@ -434,7 +516,7 @@ def _spawn_ocamllsp(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
 
 
 def _spawn_dockerfile_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
-    bin_path = _resolve_override(ctx, "dockerfile-ls") or _which("docker-langserver")
+    bin_path = _resolve_override(ctx, "dockerfile-ls") or _which("docker-langserver", root=root)
     if bin_path is None:
         from agent.lsp.install import try_install
         bin_path = try_install("dockerfile-language-server-nodejs", ctx.install_strategy)
@@ -450,7 +532,7 @@ def _spawn_dockerfile_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
 
 
 def _spawn_terraform_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
-    bin_path = _resolve_override(ctx, "terraform-ls") or _which("terraform-ls")
+    bin_path = _resolve_override(ctx, "terraform-ls") or _which("terraform-ls", root=root)
     if bin_path is None:
         return None  # terraform-ls is heavy to auto-install; require user
     init = {
@@ -470,7 +552,7 @@ def _spawn_terraform_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
 
 
 def _spawn_dart(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
-    bin_path = _resolve_override(ctx, "dart") or _which("dart")
+    bin_path = _resolve_override(ctx, "dart") or _which("dart", root=root)
     if bin_path is None:
         return None
     return SpawnSpec(
@@ -484,8 +566,7 @@ def _spawn_dart(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
 
 def _spawn_haskell_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     bin_path = _resolve_override(ctx, "haskell-language-server") or _which(
-        "haskell-language-server-wrapper", "haskell-language-server"
-    )
+        "haskell-language-server-wrapper", "haskell-language-server", root=root)
     if bin_path is None:
         return None
     return SpawnSpec(
@@ -498,7 +579,7 @@ def _spawn_haskell_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
 
 
 def _spawn_julia(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
-    bin_path = _resolve_override(ctx, "julia") or _which("julia")
+    bin_path = _resolve_override(ctx, "julia") or _which("julia", root=root)
     if bin_path is None:
         return None
     return SpawnSpec(
@@ -517,7 +598,7 @@ def _spawn_julia(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
 
 
 def _spawn_clojure_lsp(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
-    bin_path = _resolve_override(ctx, "clojure-lsp") or _which("clojure-lsp")
+    bin_path = _resolve_override(ctx, "clojure-lsp") or _which("clojure-lsp", root=root)
     if bin_path is None:
         return None
     return SpawnSpec(
@@ -530,7 +611,7 @@ def _spawn_clojure_lsp(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
 
 
 def _spawn_nixd(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
-    bin_path = _resolve_override(ctx, "nixd") or _which("nixd")
+    bin_path = _resolve_override(ctx, "nixd") or _which("nixd", root=root)
     if bin_path is None:
         return None
     return SpawnSpec(
@@ -543,7 +624,7 @@ def _spawn_nixd(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
 
 
 def _spawn_zls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
-    bin_path = _resolve_override(ctx, "zls") or _which("zls")
+    bin_path = _resolve_override(ctx, "zls") or _which("zls", root=root)
     if bin_path is None:
         return None
     return SpawnSpec(
@@ -556,7 +637,7 @@ def _spawn_zls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
 
 
 def _spawn_gleam(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
-    bin_path = _resolve_override(ctx, "gleam") or _which("gleam")
+    bin_path = _resolve_override(ctx, "gleam") or _which("gleam", root=root)
     if bin_path is None:
         return None
     return SpawnSpec(
@@ -569,7 +650,7 @@ def _spawn_gleam(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
 
 
 def _spawn_elixir_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
-    bin_path = _resolve_override(ctx, "elixir-ls") or _which("elixir-ls", "language_server.sh")
+    bin_path = _resolve_override(ctx, "elixir-ls") or _which("elixir-ls", "language_server.sh", root=root)
     if bin_path is None:
         return None
     return SpawnSpec(
@@ -582,7 +663,7 @@ def _spawn_elixir_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
 
 
 def _spawn_prisma(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
-    bin_path = _resolve_override(ctx, "prisma") or _which("prisma")
+    bin_path = _resolve_override(ctx, "prisma") or _which("prisma", root=root)
     if bin_path is None:
         return None
     return SpawnSpec(
@@ -596,8 +677,7 @@ def _spawn_prisma(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
 
 def _spawn_kotlin_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     bin_path = _resolve_override(ctx, "kotlin-language-server") or _which(
-        "kotlin-language-server"
-    )
+        "kotlin-language-server", root=root)
     if bin_path is None:
         return None
     return SpawnSpec(
@@ -613,7 +693,7 @@ def _spawn_jdtls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     # jdtls has a complex install flow.  We require a manual install
     # for now and look for the wrapper script that the jdtls install
     # produces.
-    bin_path = _resolve_override(ctx, "jdtls") or _which("jdtls")
+    bin_path = _resolve_override(ctx, "jdtls") or _which("jdtls", root=root)
     if bin_path is None:
         return None
     return SpawnSpec(
@@ -627,8 +707,7 @@ def _spawn_jdtls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
 
 def _spawn_vue(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     bin_path = _resolve_override(ctx, "vue-language-server") or _which(
-        "vue-language-server"
-    )
+        "vue-language-server", root=root)
     if bin_path is None:
         from agent.lsp.install import try_install
         bin_path = try_install("@vue/language-server", ctx.install_strategy)
@@ -645,8 +724,7 @@ def _spawn_vue(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
 
 def _spawn_svelte(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     bin_path = _resolve_override(ctx, "svelte-language-server") or _which(
-        "svelteserver", "svelte-language-server"
-    )
+        "svelteserver", "svelte-language-server", root=root)
     if bin_path is None:
         from agent.lsp.install import try_install
         bin_path = try_install("svelte-language-server", ctx.install_strategy)
@@ -663,8 +741,7 @@ def _spawn_svelte(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
 
 def _spawn_astro(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     bin_path = _resolve_override(ctx, "astro-language-server") or _which(
-        "astro-ls", "astro-language-server"
-    )
+        "astro-ls", "astro-language-server", root=root)
     if bin_path is None:
         from agent.lsp.install import try_install
         bin_path = try_install("@astrojs/language-server", ctx.install_strategy)

--- a/tests/agent/lsp/test_local_binary_resolution.py
+++ b/tests/agent/lsp/test_local_binary_resolution.py
@@ -1,0 +1,133 @@
+"""Tests for marker-gated repo-local LSP binary resolution.
+
+Ported/adapted from oh-my-openagent PR #7424: a project's own pinned
+language server (``node_modules/.bin``, ``.venv/bin``, ...) must win over
+a globally installed one, but only when a sibling ecosystem marker file
+authorizes the bin directory — an unmarked stray directory must never
+inject an executable into the resolution order.
+"""
+import os
+import stat
+import sys
+
+import pytest
+
+from agent.lsp import servers as srv
+
+
+def _make_exe(directory: str, name: str) -> str:
+    os.makedirs(directory, exist_ok=True)
+    if sys.platform == "win32":
+        path = os.path.join(directory, name + ".cmd")
+        with open(path, "w") as f:
+            f.write("@echo off\n")
+    else:
+        path = os.path.join(directory, name)
+        with open(path, "w") as f:
+            f.write("#!/bin/sh\n")
+        os.chmod(path, os.stat(path).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return path
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    srv._LOCAL_RESOLVE_CACHE.clear()
+    yield
+    srv._LOCAL_RESOLVE_CACHE.clear()
+
+
+def test_node_local_bin_wins_when_marked(tmp_path, monkeypatch):
+    root = tmp_path / "proj"
+    root.mkdir()
+    (root / "package.json").write_text("{}")
+    local = _make_exe(str(root / "node_modules" / ".bin"), "typescript-language-server")
+    monkeypatch.setattr(srv.shutil, "which", lambda n, path=None: (
+        local if path and os.path.dirname(local) == path else "/usr/bin/" + n))
+    assert srv._which("typescript-language-server", root=str(root)) == local
+
+
+def test_unmarked_node_modules_is_ignored(tmp_path):
+    root = tmp_path / "proj"
+    root.mkdir()
+    # bin exists but NO package.json / lockfile marker → must not resolve
+    _make_exe(str(root / "node_modules" / ".bin"), "evil-langserver")
+    assert srv._resolve_local_binary("evil-langserver", str(root)) is None
+
+
+def test_python_venv_bin_resolves_with_marker(tmp_path):
+    root = tmp_path / "pyproj"
+    root.mkdir()
+    (root / "pyproject.toml").write_text("[project]\nname='x'\n")
+    sub = "Scripts" if sys.platform == "win32" else "bin"
+    local = _make_exe(str(root / ".venv" / sub), "pyright-langserver")
+    assert srv._resolve_local_binary("pyright-langserver", str(root)) == local
+
+
+def test_walk_up_stops_at_git_boundary(tmp_path):
+    # repo/.git + repo/package.json + repo/node_modules/.bin/tool
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    (repo / "package.json").write_text("{}")
+    local = _make_exe(str(repo / "node_modules" / ".bin"), "some-ls")
+    nested = repo / "packages" / "app"
+    nested.mkdir(parents=True)
+    # Nested dir with no markers walks up and finds the repo-level bin.
+    assert srv._resolve_local_binary("some-ls", str(nested)) == local
+
+    # Tooling ABOVE the repo root must not leak in: outer dir has a marked
+    # bin, but the walk from inside the repo ends at repo/.git.
+    (tmp_path / "package.json").write_text("{}")
+    _make_exe(str(tmp_path / "node_modules" / ".bin"), "outer-ls")
+    assert srv._resolve_local_binary("outer-ls", str(nested)) is None
+
+
+def test_path_fallback_when_no_local(tmp_path, monkeypatch):
+    root = tmp_path / "plain"
+    root.mkdir()
+    monkeypatch.setattr(srv.shutil, "which", lambda n, path=None: (
+        None if path else "/usr/local/bin/" + n))
+    assert srv._which("gopls", root=str(root)) == "/usr/local/bin/gopls"
+
+
+def test_which_without_root_unchanged(monkeypatch):
+    monkeypatch.setattr(srv.shutil, "which", lambda n, path=None: (
+        "/usr/bin/rust-analyzer" if n == "rust-analyzer" else None))
+    assert srv._which("rust-analyzer") == "/usr/bin/rust-analyzer"
+    assert srv._which("nope-ls") is None
+
+
+def test_resolution_is_cached(tmp_path, monkeypatch):
+    root = tmp_path / "proj"
+    root.mkdir()
+    (root / "package.json").write_text("{}")
+    local = _make_exe(str(root / "node_modules" / ".bin"), "cached-ls")
+    calls = {"n": 0}
+    real_which = srv.shutil.which
+
+    def counting(n, path=None):
+        calls["n"] += 1
+        return real_which(n, path=path)
+
+    monkeypatch.setattr(srv.shutil, "which", counting)
+    first = srv._resolve_local_binary("cached-ls", str(root))
+    n_after_first = calls["n"]
+    second = srv._resolve_local_binary("cached-ls", str(root))
+    assert first == second == local
+    assert calls["n"] == n_after_first  # no new probes on the cached call
+
+
+def test_spawn_typescript_uses_project_local_server(tmp_path, monkeypatch):
+    """E2E through a real spawn builder: SpawnSpec.command[0] is the local bin."""
+    root = tmp_path / "webapp"
+    root.mkdir()
+    (root / "package.json").write_text("{}")
+    local = _make_exe(str(root / "node_modules" / ".bin"), "typescript-language-server")
+    # Global PATH also has one — the local pin must win.
+    monkeypatch.setattr(
+        srv.shutil, "which",
+        lambda n, path=None: (local if path == os.path.dirname(local)
+                              else "/usr/bin/typescript-language-server"))
+    ctx = srv.ServerContext(workspace_root=str(root), install_strategy="off")
+    spec = srv._spawn_typescript(str(root), ctx)
+    assert spec is not None
+    assert spec.command[0] == local

--- a/website/docs/user-guide/features/lsp.md
+++ b/website/docs/user-guide/features/lsp.md
@@ -93,6 +93,25 @@ manager makes sense for that language (rustup, ghcup, opam, brew,
 …). Hermes auto-detects the binary on PATH or in
 `<HERMES_HOME>/lsp/bin/`.
 
+### Project-local servers win over global ones
+
+Before falling back to PATH, Hermes probes the project's own bin
+directories, walking up from the resolved project root to the nearest
+`.git` boundary:
+
+| Ecosystem | Marker (must exist as sibling) | Bin directories probed |
+|-----------|-------------------------------|------------------------|
+| Node | `package.json`, any lockfile | `node_modules/.bin` |
+| Python | `pyproject.toml`, `requirements.txt`, `setup.py`/`.cfg`, `Pipfile`, `pyrightconfig.json`, `ruff.toml` | `.venv/bin`, `venv/bin` (`Scripts` on Windows) |
+| Ruby | `Gemfile`, `Gemfile.lock` | `vendor/bundle/bin`, `bin` |
+| Go | `go.mod`, `go.sum`, `go.work` | `bin` |
+
+So a repo that pins `typescript-language-server` or `pyright` as a
+dev dependency gets diagnostics from **its own pinned version**, not
+whatever happens to be installed globally. A bin directory is only
+trusted when the sibling marker file proves it belongs to a project of
+that ecosystem — a stray, unmarked `node_modules/.bin` is ignored.
+
 ### PowerShell
 
 PowerShellEditorServices isn't a single binary — it's a PowerShell


### PR DESCRIPTION
## Summary
LSP diagnostics now come from the project's own pinned language server: marker-gated project-local bin directories (`node_modules/.bin`, `.venv/bin`, `vendor/bundle/bin`, go `bin`) are probed before PATH when spawning a server. Ported/adapted from [code-yeongyu/oh-my-openagent#7424](https://github.com/code-yeongyu/oh-my-openagent/pull/7424).

Previously a repo that pinned `typescript-language-server` or `pyright` as a dev dependency was silently diagnosed by whatever global install happened to be on PATH — version-mismatched diagnostics, or no server at all when nothing was installed globally despite the project shipping its own.

## Changes
- `agent/lsp/servers.py`: new `_resolve_local_binary()` — walks up from the resolved project root probing ecosystem bin dirs, gated on sibling marker files (`package.json`/lockfiles → `node_modules/.bin`; `pyproject.toml` etc. → `.venv|venv/{bin,Scripts}`; `Gemfile` → `vendor/bundle/bin`, `bin`; `go.mod` → `bin`). Walk stops at the `.git` boundary so tooling above the repo root can't leak in. Per-process memoized. Wired via `_which(..., root=root)` at all 26 spawn-builder lookup sites; config `binary_overrides` still win, PATH remains the fallback.
- `tests/agent/lsp/test_local_binary_resolution.py`: 8 tests — local-pin-wins, unmarked-dir-ignored, venv marker gating, `.git` boundary (both directions), PATH fallback, no-root unchanged, cache, and an E2E through `_spawn_typescript`.
- `website/docs/user-guide/features/lsp.md`: resolution-order table.

## Ours vs theirs
- omo resolves at their flat server-registry lookup (`server-resolution.ts`) with a bespoke suffix prober; Hermes already routes every lookup through `_which()`, so the port hooks there — `shutil.which(name, path=...)` handles executability + Windows PATHEXT for free.
- Kept their marker-gating and `.git`-boundary security semantics intact (unmarked bin dirs cannot inject an executable).
- Dropped their `node`-interpreter special case (no Hermes server def spawns via a bare `node` command) and their `Gemfile`-less Ruby `bin` probing quirks beyond what our servers need.

## Validation
Live before/after (fake project pinning `typescript-language-server` locally, decoy global on PATH):

| | `_spawn_typescript(...).command[0]` |
|---|---|
| Before (origin/main) | `/tmp/.../globalbin/typescript-language-server` |
| After (this branch) | `/tmp/.../webapp/node_modules/.bin/typescript-language-server` |

**Live repro:** confirmed on origin/main (global decoy chosen despite local pin) and re-run on this branch (local pin chosen) via real `agent.lsp.servers` imports, no mocks.

Tests: `tests/agent/lsp/` — 82 passed, 1 skipped (74+8). Ruff clean.

## Infographic

![Project-local LSP resolution](https://v3b.fal.media/files/b/0aa8c36b/H-DbElBk1ejuMCbPoTGOS_B6A5Atbs.png)
