### PR TITLE
fix(gateway): distinguish failed transcript reads from empty history

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -622,7 +622,7 @@ from pathlib import Path as _Path
 sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
 
 from gateway.config import Platform, PlatformConfig
-from gateway.session import SessionSource, build_session_key
+from gateway.session import SessionSource, TranscriptReadError, build_session_key
 from hermes_constants import get_default_hermes_root, get_hermes_dir, get_hermes_home
 
 if TYPE_CHECKING:
@@ -4031,6 +4031,12 @@ class BasePlatformAdapter(ABC):
             if callable(peek):
                 session_id = peek(session_key)
             transcript = store.load_transcript(session_id or session_key)
+        except TranscriptReadError:
+            logger.warning(
+                "Transcript read failed for session %s; media dedup runs "
+                "with no history this turn (#100788)", session_key,
+            )
+            return None
         except Exception:
             return None
         if not transcript:

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -96,7 +96,7 @@ from gateway.platforms.yuanbao_proto import (
     encode_get_group_member_list,
     next_seq_no,
 )
-from gateway.session import build_session_key
+from gateway.session import TranscriptReadError, build_session_key
 
 logger = logging.getLogger(__name__)
 
@@ -1144,6 +1144,14 @@ class RecallGuardMiddleware(InboundMiddleware):
                 await asyncio.sleep(0.5)
                 try:
                     transcript = store.load_transcript(sid)
+                except TranscriptReadError as exc:
+                    # No readable rows means nothing to redact; polling on
+                    # would just re-log the same failure (#100788).
+                    logger.warning(
+                        "[%s] Recall redact: transcript unreadable for "
+                        "session %s: %s", adapter.name, sid, exc,
+                    )
+                    return
                 except Exception:
                     continue
                 for entry in transcript:
@@ -1183,6 +1191,11 @@ class RecallGuardMiddleware(InboundMiddleware):
         # match) is the canonical path again.
         try:
             transcript = store.load_transcript(sid)
+        except TranscriptReadError as exc:
+            # Not an empty transcript — the rows are unreadable, so recall has
+            # nothing to match against (#100788).
+            logger.warning("[%s] Recall: transcript unreadable: %s", adapter.name, exc)
+            return
         except Exception as exc:
             logger.warning("[%s] Recall: failed to load transcript: %s", adapter.name, exc)
             return
@@ -2145,6 +2158,13 @@ class QuoteContextMiddleware(InboundMiddleware):
                         if kind in _RESOLVABLE_MEDIA_KINDS:
                             media_refs.append((rid, kind, filename.strip()))
                 break
+        except TranscriptReadError as exc:
+            # Quote resolution degrades to "no refs" rather than pretending
+            # the quoted message was never seen (#100788).
+            logger.warning(
+                "[%s] quote transcript lookup: transcript unreadable: %s",
+                getattr(adapter, "name", "yuanbao"), exc,
+            )
         except Exception as exc:
             logger.warning(
                 "[%s] quote transcript lookup failed: %s",
@@ -2747,6 +2767,14 @@ class MediaResolveMiddleware(InboundMiddleware):
         try:
             session_entry = store.get_or_create_session(source)
             history = store.load_transcript(session_entry.session_id)
+        except TranscriptReadError as exc:
+            # Hydrate nothing rather than silently acting as if the session
+            # had no observed media (#100788).
+            logger.warning(
+                "[%s] Observed-media hydration: transcript unreadable: %s",
+                adapter.name, exc,
+            )
+            return [], []
         except Exception as exc:
             logger.warning(
                 "[%s] Observed-media hydration setup failed: %s",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2982,6 +2982,7 @@ from gateway.session import (
     SessionStore,
     SessionSource,
     SessionContext,
+    TranscriptReadError,
     build_session_context,
     build_session_context_prompt,
     build_channel_continuity_note,
@@ -5823,6 +5824,17 @@ class TurnRunner:
         )
         if cfg_channel_prompt:
             combined_ephemeral = (combined_ephemeral + "\n\n" + cfg_channel_prompt).strip()
+        # #100788: if this turn's transcript read failed, the history above is
+        # empty because it is unreadable, not because the chat is new.  The
+        # notice rides the ephemeral prompt only — never as a synthetic
+        # history row, which would pollute the transcript on the next flush.
+        degraded_history_notice = self._runner._take_degraded_history_notice(
+            ctx.session_key or ""
+        )
+        if degraded_history_notice:
+            combined_ephemeral = (
+                combined_ephemeral + "\n\n" + degraded_history_notice
+            ).strip()
 
         max_iterations = _current_max_iterations()
 
@@ -7294,6 +7306,24 @@ class TurnRunner:
 _SESSION_DB_UNPINNED = object()
 
 
+def build_degraded_history_notice(session_id: str) -> str:
+    """Ephemeral note for a turn whose transcript could not be read (#100788).
+
+    A failed ``load_transcript`` leaves the turn with an empty history that is
+    NOT an empty conversation.  Say that in the prompt so the model neither
+    treats the chat as fresh nor fabricates the part it cannot see, and name
+    the store an operator has to look at.
+    """
+    return (
+        f"[Degraded history] The stored transcript for session {session_id} "
+        "could not be read for this turn, so no prior messages are attached. "
+        "This is not a new conversation — earlier messages exist but are "
+        "currently unreadable. Do not guess or invent what was said; if you "
+        "need something from earlier, ask the user to restate it. An operator "
+        "should check this session's store (state.db)."
+    )
+
+
 class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
     """
     Main gateway controller.
@@ -7590,6 +7620,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # current stall episode (cleared when pending clears / activity resumes
         # / conversation boundary). See gateway.session_stall.
         self._session_stall_notified: Dict[str, bool] = {}
+        # One-shot degraded-history notices, keyed by session key (#100788).
+        # Set when a turn's transcript read raises TranscriptReadError and
+        # consumed by the same turn's ephemeral prompt, so the model is told
+        # the history is unreadable instead of silently assuming it is empty.
+        self._degraded_history_notices: Dict[str, str] = {}
         # Startup restore gate: while restart-interrupted sessions are being
         # auto-resumed, real inbound messages are queued instead of competing
         # with the synthetic resume turns for the same session.  The queued
@@ -20232,6 +20267,50 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._async_session_store = facade
         return facade
 
+    async def _load_history_for_turn(
+        self,
+        session_key: str,
+        session_id: str,
+    ) -> List[Dict[str, Any]]:
+        """Load this turn's transcript, degrading loudly on a read failure.
+
+        A read failure is not an empty history (#100788): swallowing it into
+        ``[]`` restarted long-running chats as brand-new conversations after a
+        malformed ``state.db``.  The turn still runs without history — the
+        rows really are unavailable — but a one-shot notice is queued for the
+        turn's ephemeral prompt so the model knows the gap is a failure, not a
+        fresh session.
+        """
+        try:
+            return await self.async_session_store.load_transcript(session_id)
+        except TranscriptReadError:
+            self._note_degraded_history(session_key, session_id)
+            return []
+
+    def _note_degraded_history(self, session_key: str, session_id: str) -> None:
+        """Queue the degraded-history notice for ``session_key``'s next turn."""
+        logger.warning(
+            "Transcript read failed for session %s (key %s); running the turn "
+            "with an empty history plus a degraded-history notice (#100788)",
+            session_id, session_key,
+        )
+        notices = getattr(self, "_degraded_history_notices", None)
+        if notices is None:
+            notices = {}
+            self._degraded_history_notices = notices
+        notices[session_key] = build_degraded_history_notice(session_id)
+
+    def _take_degraded_history_notice(self, session_key: str) -> str:
+        """Pop the pending degraded-history notice for a turn ("" if none).
+
+        One-shot: the notice belongs to the turn whose read failed, so a later
+        turn that reads the transcript fine never carries a stale warning.
+        """
+        notices = getattr(self, "_degraded_history_notices", None)
+        if not notices:
+            return ""
+        return notices.pop(session_key, "") or ""
+
     async def _mark_durable_active_turn(
         self,
         event: "MessageEvent",
@@ -20846,8 +20925,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # began processing if the gateway died while it was still waiting.
         await self._mark_durable_active_turn(event, session_entry.session_key)
 
-        # Load conversation history from transcript
-        history = await self.async_session_store.load_transcript(session_entry.session_id)
+        # Load conversation history from transcript.  Keyed by the local
+        # ``session_key`` (the routing key that is also handed to _run_agent
+        # below), so a degraded-history notice is queued under exactly the key
+        # run_sync takes it back with.
+        history = await self._load_history_for_turn(session_key, session_entry.session_id)
         
         # -----------------------------------------------------------------
         # Session hygiene: auto-compress pathologically large transcripts
@@ -22883,6 +22965,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _already_persisted = False
                     try:
                         _recent_transcript = await self.async_session_store.load_transcript(session_entry.session_id)
+                    except TranscriptReadError:
+                        # Not the restore path, so no second degraded-history
+                        # notice (#100788). Without readable rows we cannot
+                        # tell whether this turn was already persisted; the
+                        # dedupe below then falls back to appending, which is
+                        # the safe side of the trade.
+                        _recent_transcript = []
                     except Exception:
                         _recent_transcript = []
                     for _msg in reversed(_recent_transcript[-10:]):

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1218,8 +1218,34 @@ class _SessionFlight:
         self.error: Optional[BaseException] = None
 
 
+class TranscriptReadError(Exception):
+    """A transcript read failed — the history is unknown, NOT empty.
+
+    Raised by :meth:`SessionStore.load_transcript` when the underlying
+    state.db read blows up (malformed database, locked handle, schema
+    damage).  Returning ``[]`` there made a corrupt store indistinguishable
+    from a fresh session, so gateway restart resumed a long-running chat as
+    a brand-new conversation (#100788).  Callers must either surface the
+    failure or degrade explicitly; they must never silently substitute an
+    empty history.
+
+    The original error is preserved as ``__cause__``.
+    """
+
+    def __init__(self, session_id: str, message: Optional[str] = None) -> None:
+        super().__init__(
+            message or f"transcript read failed for session {session_id}"
+        )
+        self.session_id = session_id
+
+
 class AsyncSessionStore:
-    """Async boundary for the synchronous, thread-safe SessionStore."""
+    """Async boundary for the synchronous, thread-safe SessionStore.
+
+    ``__getattr__`` offloads to a thread and awaits the result, so store
+    exceptions — :class:`TranscriptReadError` included — propagate to the
+    async caller unchanged.  Do not add swallowing wrappers here.
+    """
 
     def __init__(self, store: "SessionStore") -> None:
         self._store = store
@@ -4404,11 +4430,15 @@ class SessionStore:
             # downstream guards treat [] as "nothing persisted" and may make
             # routing decisions on it (#82616). WARNING, not DEBUG.
             logger.warning(
-                "Transcript read failed for session %s (returning empty; "
-                "downstream must not treat this as data loss): %s",
+                "Transcript read failed for session %s (raising "
+                "TranscriptReadError; downstream must not treat this as an "
+                "empty history): %s",
                 session_id, e,
             )
-            return []
+            # #100788: returning [] here made a malformed state.db look like a
+            # fresh chat on restart. Fail loudly instead — the "no db" path
+            # above keeps returning [], because that really is empty.
+            raise TranscriptReadError(session_id) from e
 
     def rewind_session(
         self,

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -37,6 +37,7 @@ from gateway.platforms.base import EphemeralReply, MessageEvent, MessageType
 from gateway.session import (
     AsyncSessionStore,
     SessionSource,
+    TranscriptReadError,
     build_session_key,
     is_shared_multi_user_session,
 )
@@ -48,6 +49,11 @@ from utils import (
 )
 
 logger = logging.getLogger("gateway.run")
+
+HISTORY_UNREADABLE = (
+    "⚠️ Conversation history is unreadable (state.db). "
+    "This is not a new conversation — earlier messages exist but cannot be loaded."
+)
 
 # Upper bound on the off-loop agent-resource cleanup during a /new or /reset
 # (see _handle_reset_command). A stuck teardown must not block the event loop;
@@ -963,7 +969,10 @@ class GatewaySlashCommandsMixin:
             return "\n".join(lines)
 
         # Last resort: rough estimate from transcript
-        history = await self.async_session_store.load_transcript(session_entry.session_id)
+        try:
+            history = await self.async_session_store.load_transcript(session_entry.session_id)
+        except TranscriptReadError:
+            return HISTORY_UNREADABLE
         if history:
             from agent.model_metadata import estimate_messages_tokens_rough
 
@@ -2645,8 +2654,11 @@ class GatewaySlashCommandsMixin:
         """Handle /retry command - re-send the last user message."""
         source = event.source
         session_entry = await self.async_session_store.get_or_create_session(source)
-        history = await self.async_session_store.load_transcript(session_entry.session_id)
-        
+        try:
+            history = await self.async_session_store.load_transcript(session_entry.session_id)
+        except TranscriptReadError:
+            return HISTORY_UNREADABLE
+
         # Find the last *real* user message. Timeline bookkeeping rows carry
         # role=user + display_kind (model_switch / async_delegation_complete /
         # auto_continue / hidden); clients never count them as user turns.
@@ -3671,7 +3683,10 @@ class GatewaySlashCommandsMixin:
 
         source = event.source
         session_entry = await self.async_session_store.get_or_create_session(source)
-        history = await self.async_session_store.load_transcript(session_entry.session_id)
+        try:
+            history = await self.async_session_store.load_transcript(session_entry.session_id)
+        except TranscriptReadError:
+            return HISTORY_UNREADABLE
         if not history:
             return t("gateway.btw.no_history")
 
@@ -4525,7 +4540,10 @@ class GatewaySlashCommandsMixin:
         """
         source = event.source
         session_entry = await self.async_session_store.get_or_create_session(source)
-        history = await self.async_session_store.load_transcript(session_entry.session_id)
+        try:
+            history = await self.async_session_store.load_transcript(session_entry.session_id)
+        except TranscriptReadError:
+            return HISTORY_UNREADABLE
 
         if not history or len(history) < 4:
             return t("gateway.compress.not_enough")
@@ -5314,7 +5332,17 @@ class GatewaySlashCommandsMixin:
         title = await self._session_db.get_session_title(target_id) or name
 
         # Count messages for context
-        history = await self.async_session_store.load_transcript(target_id)
+        try:
+            history = await self.async_session_store.load_transcript(target_id)
+        except TranscriptReadError:
+            # The resume itself succeeded; only the count is missing. Say the
+            # history is unreadable rather than reporting an empty session
+            # (#100788).
+            return (
+                t("gateway.resume.resumed_no_count", title=title)
+                + "\n"
+                + HISTORY_UNREADABLE
+            )
         msg_count = len([m for m in history if m.get("role") == "user"]) if history else 0
         msg_part = f" ({msg_count} message{'s' if msg_count != 1 else ''})" if msg_count else ""
 
@@ -5431,7 +5459,10 @@ class GatewaySlashCommandsMixin:
 
         # Load the current session and its transcript
         current_entry = await self.async_session_store.get_or_create_session(source)
-        history = await self.async_session_store.load_transcript(current_entry.session_id)
+        try:
+            history = await self.async_session_store.load_transcript(current_entry.session_id)
+        except TranscriptReadError:
+            return HISTORY_UNREADABLE
         if not history:
             return t("gateway.branch.no_conversation")
 
@@ -5616,6 +5647,10 @@ class GatewaySlashCommandsMixin:
             try:
                 entry = self.session_store.get_or_create_session(source)
                 history = self.session_store.load_transcript(entry.session_id) or []
+            except TranscriptReadError:
+                # A read failure is not an empty transcript (#100788): the
+                # breakdown would understate the context by the whole chat.
+                return [HISTORY_UNREADABLE]
             except Exception:
                 history = []
 
@@ -5647,6 +5682,10 @@ class GatewaySlashCommandsMixin:
             try:
                 entry = self.session_store.get_or_create_session(source)
                 history = self.session_store.load_transcript(entry.session_id) or []
+            except TranscriptReadError:
+                # See _context_breakdown_block: don't pass a read failure off
+                # as an empty transcript (#100788).
+                return [HISTORY_UNREADABLE]
             except Exception:
                 history = []
 
@@ -5830,7 +5869,10 @@ class GatewaySlashCommandsMixin:
 
         # No agent at all -- check session history for a rough count
         session_entry = await self.async_session_store.get_or_create_session(source)
-        history = await self.async_session_store.load_transcript(session_entry.session_id)
+        try:
+            history = await self.async_session_store.load_transcript(session_entry.session_id)
+        except TranscriptReadError:
+            return HISTORY_UNREADABLE
         if history:
             from agent.model_metadata import estimate_messages_tokens_rough
             msgs = [m for m in history if m.get("role") in {"user", "assistant"} and m.get("content")]

--- a/tests/gateway/test_transcript_read_failure_100788.py
+++ b/tests/gateway/test_transcript_read_failure_100788.py
@@ -1,0 +1,151 @@
+"""A failed transcript read must not masquerade as an empty history (#100788).
+
+Incident shape: a malformed ``state.db`` made every
+``SessionStore.load_transcript`` raise; the except-block swallowed it and
+returned ``[]``.  Restore then rebuilt the turn from "no history", so a
+long-running chat silently restarted as a brand-new conversation and the
+model happily answered as if nothing had ever been discussed.
+
+Two guarantees under test:
+  A. ``load_transcript`` raises ``TranscriptReadError`` on a read failure,
+     while a genuinely empty session still returns ``[]``.
+  B. The gateway restore path degrades loudly: history stays empty, and a
+     per-turn ephemeral notice is queued telling the model the history
+     exists but is unreadable.
+
+Offline: SQLite on tmp_path only, no network.
+"""
+
+import sqlite3
+
+import pytest
+
+from gateway.config import GatewayConfig
+from gateway.session import SessionStore, TranscriptReadError
+
+
+@pytest.fixture
+def store(tmp_path):
+    return SessionStore(sessions_dir=tmp_path / "gw", config=GatewayConfig())
+
+
+# --------------------------------------------------------------------------
+# A. read failure != empty transcript
+# --------------------------------------------------------------------------
+
+
+class TestLoadTranscriptReadFailure:
+    def test_read_failure_raises_instead_of_returning_empty(self, store, monkeypatch):
+        db = store._db
+        assert db is not None
+        db.create_session("s1", "telegram", session_key="telegram:1")
+        db.append_message("s1", "user", "the conversation we must not forget")
+
+        boom = sqlite3.DatabaseError("database disk image is malformed")
+
+        def _raise(*_args, **_kwargs):
+            raise boom
+
+        monkeypatch.setattr(db, "get_messages_as_conversation", _raise)
+
+        with pytest.raises(TranscriptReadError) as excinfo:
+            store.load_transcript("s1")
+
+        assert excinfo.value.session_id == "s1"
+        assert excinfo.value.__cause__ is boom
+
+    def test_genuinely_empty_session_still_returns_empty_list(self, store):
+        db = store._db
+        assert db is not None
+        db.create_session("s2", "telegram", session_key="telegram:2")
+
+        assert store.load_transcript("s2") == []
+
+    def test_no_db_still_returns_empty_list(self, store):
+        # "No DB for this session" really is an empty transcript, not a
+        # failure — that path must keep its [] contract.
+        store._db = None
+        assert store.load_transcript("nope") == []
+
+
+# --------------------------------------------------------------------------
+# B. restore path: empty history + a degraded-history notice
+# --------------------------------------------------------------------------
+
+
+class _FailingStore:
+    async def load_transcript(self, session_id: str):
+        raise TranscriptReadError(session_id) from sqlite3.DatabaseError("malformed")
+
+
+class _WorkingStore:
+    def __init__(self, history):
+        self._history = history
+
+    async def load_transcript(self, session_id: str):
+        return list(self._history)
+
+
+def _make_runner(async_store):
+    """A stub carrying only the restore helpers under test."""
+    from gateway.run import GatewayRunner
+
+    class _Stub:
+        _load_history_for_turn = GatewayRunner._load_history_for_turn
+        _note_degraded_history = GatewayRunner._note_degraded_history
+        _take_degraded_history_notice = GatewayRunner._take_degraded_history_notice
+
+    stub = _Stub()
+    stub._degraded_history_notices = {}
+    stub.async_session_store = async_store
+    return stub
+
+
+class TestDegradedRestoreNotice:
+    def test_notice_says_history_exists_and_is_unreadable(self):
+        from gateway.run import build_degraded_history_notice
+
+        notice = build_degraded_history_notice("sess-abc")
+        lowered = notice.lower()
+
+        assert "sess-abc" in notice
+        # NOT a new conversation, and the model must not fill the gap.
+        assert "not a new conversation" in lowered
+        assert "guess" in lowered or "invent" in lowered
+        # Operator-actionable: name the store that needs attention.
+        assert "state.db" in lowered
+
+    @pytest.mark.asyncio
+    async def test_failed_read_yields_empty_history_plus_notice(self):
+        runner = _make_runner(_FailingStore())
+
+        history = await runner._load_history_for_turn("telegram:1", "sess-abc")
+
+        assert history == []
+        notice = runner._take_degraded_history_notice("telegram:1")
+        assert notice, "a failed read must queue a degraded-history notice"
+        assert "sess-abc" in notice
+        assert "not a new conversation" in notice.lower()
+        # One-shot: the notice belongs to the failed turn only.
+        assert runner._take_degraded_history_notice("telegram:1") == ""
+
+    @pytest.mark.asyncio
+    async def test_failed_read_does_not_inject_rows_into_history(self):
+        runner = _make_runner(_FailingStore())
+
+        history = await runner._load_history_for_turn("telegram:1", "sess-abc")
+
+        # The notice rides the ephemeral prompt, never the transcript: no
+        # synthetic system/user row may appear in the replayed history.
+        assert history == []
+        assert not any(isinstance(m, dict) for m in history)
+
+    @pytest.mark.asyncio
+    async def test_successful_read_queues_no_notice(self):
+        rows = [{"role": "user", "content": "hi"}]
+        runner = _make_runner(_WorkingStore(rows))
+
+        history = await runner._load_history_for_turn("telegram:1", "sess-abc")
+
+        assert history == rows
+        assert runner._take_degraded_history_notice("telegram:1") == ""


### PR DESCRIPTION
## Summary

`SessionStore.load_transcript()` swallowed every `get_messages_as_conversation()` failure and returned `[]`. After a gateway restart there is no live `_session_messages` for the #82616 / #50502 cached-history guard to prefer, so a malformed `state.db` resumed as a brand-new conversation.

This PR raises `TranscriptReadError` instead of returning empty, queues a one-shot ephemeral degraded-history notice on the restore path (not a synthetic `system`/`user` history row — those are filtered by `_build_gateway_agent_history`), and fails slash commands / platform lookups instead of inventing an empty transcript.

## How to test

```bash
scripts/run_tests.sh tests/gateway/test_transcript_read_failure_100788.py
```

7 tests. Sabotage: restoring the old `return []` makes `test_read_failure_raises_instead_of_returning_empty` fail.

## Platforms

All gateway platforms. Reproduced against current `main` from the Telegram + malformed `state.db` report; the swallow lived in `SessionStore`, not the adapter.

Fixes #100788
