### PR TITLE
fix(gateway): an explicit --profile default names the default profile

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -404,7 +404,13 @@ def _command_line_belongs_to_profile(command: str, profile_home: Path) -> bool:
         return profile_flag_value(command_lc) == profile_name.lower() or f"hermes_home={home_lc}" in command_lc
     # Default profile: accept unless argv names another profile or a conflicting explicit
     # HERMES_HOME= (its absence is not disqualifying -- HERMES_HOME usually arrives via the env).
-    if "--profile " in command_lc or " -p " in command_lc:
+    # An explicit "--profile default"/"-p default" names THE DEFAULT PROFILE
+    # ITSELF (hand-written launchd plists mirror the named-profile service
+    # shape to make identity explicit), so it belongs to the default home --
+    # rejecting it reported a running default gateway as stopped (#100817).
+    if "--profile default" in command_lc or " -p default" in command_lc:
+        pass  # explicitly the default profile -- belongs to this home
+    elif "--profile " in command_lc or " -p " in command_lc:
         return False
     return not ("hermes_home=" in command_lc and f"hermes_home={home_lc}" not in command_lc)
 

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -383,6 +383,38 @@ class TestGatewayRuntimeStatus:
         cmdline = r"hermes_home=c:\opt\data\profiles\coder hermes gateway run --replace"
         assert status._command_line_belongs_to_profile(cmdline, home) is True
 
+    def test_explicit_profile_default_belongs_to_default_home(self):
+        """An explicit ``--profile default`` names THE DEFAULT PROFILE, so a
+        hand-written launchd plist mirroring the named-profile service shape
+        (to make identity explicit) must still be reported running. The old
+        bare 'any --profile flag disqualifies' branch reported a live
+        default gateway as stopped (#100817)."""
+        from hermes_constants import get_hermes_home
+
+        default_home = get_hermes_home()
+        for cmdline in (
+            "hermes --profile default gateway run --replace --external-supervisor",
+            "/opt/hermes/.venv/bin/hermes -p default gateway run",
+        ):
+            assert (
+                status._command_line_belongs_to_profile(cmdline, default_home) is True
+            ), cmdline
+
+    def test_foreign_profile_still_rejected_for_default_home(self):
+        """Guard: the #100817 carve-out must not swallow the original
+        protection — a named-profile gateway's PID must still NOT count as
+        the default profile's gateway."""
+        from hermes_constants import get_hermes_home
+
+        default_home = get_hermes_home()
+        for cmdline in (
+            "hermes --profile joi gateway run",
+            "hermes -p coder gateway run",
+        ):
+            assert (
+                status._command_line_belongs_to_profile(cmdline, default_home) is False
+            ), cmdline
+
 
     def test_write_runtime_status_explicit_none_clears_stale_fields(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))


### PR DESCRIPTION
Fixes #100817

## Problem

`_command_line_belongs_to_profile()`'s default-profile branch rejected **any** `--profile`/`-p` flag as advertising a foreign profile:

```python
if "--profile " in command_lc or " -p " in command_lc:
    return False
```

But `--profile default` names **the default profile itself** — a common deployment shape where a hand-written launchd LaunchAgent mirrors the named-profile service form to make identity explicit. The result: a **running, healthy default gateway** (`gateway_state.json` running, Signal/A2A connected, messages delivering) was reported **stopped** by the dashboard and the cross-profile liveness check.

The reporter reproduced it directly: replicate `_command_line_belongs_to_profile()` with a `--profile default` cmdline against the default home → `False`.

The official plist generator is unaffected (it emits no flag for the default home via `_profile_arg()`), which is why the mismatch only shows up with hand-written plists.

## Fix

The reporter's exact suggested fix — accept an explicit default before the foreign-profile rejection:

```python
if "--profile default" in command_lc or " -p default" in command_lc:
    pass  # explicitly the default profile — belongs to this home
elif "--profile " in command_lc or " -p " in command_lc:
    return False
```

## Verification

`tests/gateway/test_status.py`: **76 passed** (2 pre-existing platform failures reproduce with the change stashed).

Two new tests:
- `--profile default` and `-p default` cmdlines **belong** to the default home
- **guard**: foreign profiles (`--profile joi`, `-p coder`) are still rejected for the default home, so the PID-recycling protection that motivated the original branch is unchanged