### PR TITLE
ci.yaml runs dispatch jobs again — misplaced ')}' delimiter rejected the workflow on every run since Sep 1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,7 +123,7 @@ jobs:
     # single job in the workflow — while still running the full pytest lanes.
     #
     # Re-disabled (Sep 2026): the Sep 1 re-enable is still incredibly flaky.
-    if: ${{ false && (needs.detect.outputs.python_prod == 'true' || needs.detect.outputs.frontend == 'true' })}
+    if: ${{ false && (needs.detect.outputs.python_prod == 'true' || needs.detect.outputs.frontend == 'true') }}
     uses: ./.github/workflows/e2e-desktop.yml
 
   docs-site:


### PR DESCRIPTION
## Summary
Every `ci.yaml` run (main pushes and all PRs) has been failing with **zero jobs** since Sep 1 22:08Z. Root cause: 24f5a60ed1 ("fix: re-disable e2e") wrote the gate as `${{ false && (... == 'true' })}` — the closing paren landed outside the `}}` delimiter, so the expression is `false && (...` which Actions cannot parse, and the whole workflow is rejected at startup.

## Changes
- `.github/workflows/ci.yaml`: `'true' })}` → `'true') }}` on the e2e-desktop `if:`. One character of intent, e2e stays disabled.

## Validation
| | Before | After |
|---|---|---|
| ci.yaml runs on main | `failure`, 0 jobs (every push since 24f5a60ed1) | this PR's own ci.yaml run dispatches jobs |

The CI run on THIS PR is itself the proof — ci.yaml could not dispatch a single job on any branch containing 24f5a60ed1.
