### PR TITLE
fix(desktop): make numeric formatting locale-stable

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -578,7 +578,7 @@ export function renderRpcResult(response: unknown, name: string): string {
     const total = Number(r.total ?? 0)
 
     const lines: string[] = [
-      `Usage: ${calls.toLocaleString()} calls · ${input.toLocaleString()} in / ${output.toLocaleString()} out · ${total.toLocaleString()} total`
+      `Usage: ${calls.toLocaleString('en-US')} calls · ${input.toLocaleString('en-US')} in / ${output.toLocaleString('en-US')} out · ${total.toLocaleString('en-US')} total`
     ]
 
     if (Array.isArray(r.credits_lines)) {

--- a/apps/desktop/src/app/settings/billing/billing-amounts.ts
+++ b/apps/desktop/src/app/settings/billing/billing-amounts.ts
@@ -114,7 +114,7 @@ export function formatMoney(value?: null | number | string): string {
     return EMPTY_BILLING_VALUE
   }
 
-  return new Intl.NumberFormat(undefined, {
+  return new Intl.NumberFormat('en-US', {
     currency: 'USD',
     maximumFractionDigits: amount % 1 === 0 ? 0 : 2,
     minimumFractionDigits: amount % 1 === 0 ? 0 : 2,

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model/format.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model/format.ts
@@ -76,7 +76,7 @@ export function clampForDisplay(value: string, max = MAX_TOOL_RENDER_CHARS): str
 
   const omitted = value.length - max
 
-  return `${value.slice(0, max)}\n\n… ${omitted.toLocaleString()} more characters truncated — use Copy for the full output.`
+  return `${value.slice(0, max)}\n\n… ${omitted.toLocaleString('en-US')} more characters truncated — use Copy for the full output.`
 }
 
 export function prettyJson(value: unknown): string {


### PR DESCRIPTION
Summary
- pin usage counters and truncation notices to en-US formatting
- pin USD billing amounts to en-US formatting
- remove dependence on the host process locale

Verification
- 118/118 focused tests pass
- focused suites pass under default, es_AR.UTF-8, and de_DE.UTF-8
- desktop TypeScript typecheck passes
- git diff --check passes

Regression note
- Full workspace check still reports unrelated pre-existing UI timeout/contention failures and Windows-vs-POSIX TUI assumptions.