### PR TITLE
fix(agent): thinking-only length truncations no longer wedge continuations (salvage #99622)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1932,8 +1932,43 @@ def interruptible_api_call(agent, api_kwargs: dict):
 
 
 
+def _consume_ephemeral_reasoning_off(agent) -> bool:
+    """Consume the one-shot "answer without thinking" continuation flag.
+
+    Set by the length-continuation path when a request returned reasoning
+    but NO visible content — the thinking phase consumed the entire output
+    cap (GLM-5.3 on ollama-cloud with reasoning_effort=high: reported live as
+    finish_reason="length", content="", completion_tokens == max_tokens).
+
+    Continuation turns never replay the prior reasoning, so re-running with
+    thinking ON re-derives — and re-burns — the whole thinking budget from
+    scratch instead of writing the answer (observed: 4 futile continuations
+    then "Response remained truncated after 4 continuation attempts").
+    When True is returned the caller must override the wire reasoning_config
+    with ``{"enabled": False, "effort": "none"}`` for exactly the next call.
+    """
+    if getattr(agent, "_ephemeral_reasoning_off", False):
+        agent._ephemeral_reasoning_off = False
+        return True
+    return False
+
+
+def _reasoning_config_for_wire(agent):
+    """``agent.reasoning_config`` with the one-shot reasoning-off override applied."""
+    if _consume_ephemeral_reasoning_off(agent):
+        return {
+            **(agent.reasoning_config or {}),
+            "enabled": False,
+            "effort": "none",
+        }
+    return agent.reasoning_config
+
+
 def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = None) -> dict:
     """Build the keyword arguments dict for the active API mode."""
+    # One-shot continuation override — consumed exactly once, on the FIRST
+    # request this call builds (only one api_mode branch runs per invocation).
+    _wire_reasoning_config = _reasoning_config_for_wire(agent)
     if tools_for_api is None:
         tools_for_api = agent.tools
 
@@ -1950,7 +1985,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
             messages=anthropic_messages,
             tools=tools_for_api,
             max_tokens=ephemeral_out if ephemeral_out is not None else agent.max_tokens,
-            reasoning_config=agent.reasoning_config,
+            reasoning_config=_wire_reasoning_config,
             is_oauth=agent._is_anthropic_oauth,
             preserve_dots=agent._anthropic_preserve_dots(),
             context_length=ctx_len,
@@ -2042,7 +2077,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
             model=agent.model,
             messages=_msgs_for_codex,
             tools=tools_for_api,
-            reasoning_config=agent.reasoning_config,
+            reasoning_config=_wire_reasoning_config,
             session_id=getattr(agent, "session_id", None),
             cache_scope_id=_cache_scope_id,
             base_url=agent.base_url,
@@ -2199,7 +2234,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
             max_tokens=agent.max_tokens,
             ephemeral_max_output_tokens=_ephemeral_out,
             max_tokens_param_fn=agent._max_tokens_param,
-            reasoning_config=agent.reasoning_config,
+            reasoning_config=_wire_reasoning_config,
             request_overrides=agent.request_overrides,
             session_id=getattr(agent, "session_id", None),
             cache_scope_id=_cache_scope_id,
@@ -2232,7 +2267,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
         max_tokens=agent.max_tokens,
         ephemeral_max_output_tokens=_ephemeral_out,
         max_tokens_param_fn=agent._max_tokens_param,
-        reasoning_config=agent.reasoning_config,
+        reasoning_config=_wire_reasoning_config,
         request_overrides=agent.request_overrides,
         session_id=getattr(agent, "session_id", None),
         cache_scope_id=_cache_scope_id,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1946,6 +1946,20 @@ def _consume_ephemeral_reasoning_off(agent) -> bool:
     then "Response remained truncated after 4 continuation attempts").
     When True is returned the caller must override the wire reasoning_config
     with ``{"enabled": False, "effort": "none"}`` for exactly the next call.
+
+    Prompt-cache cost (deliberate, bounded): the reasoning parameter is part
+    of the provider's cache key on config-sensitive providers — Anthropic
+    renders thinking/effort into the prompt, OpenAI lists reasoning.effort
+    among prefix-affecting settings — so THAT one request misses the prefix
+    cache and pays a cold write of the full prefix (1.25x input instead of
+    the 0.1x read).  The next request goes out with the configured reasoning
+    again and hits the thinking-on entry written by the truncated request
+    (still within TTL), so the damage is exactly one write.  Template-tail
+    providers (GLM/Qwen/Kimi-style, where thinking on/off is a chat-template
+    switch at the tail) see no prefix change at all.  The system prompt bytes
+    are never touched.  This is far cheaper than what the flag prevents: four
+    full-output-budget requests that produce nothing and end the turn with an
+    error.
     """
     if getattr(agent, "_ephemeral_reasoning_off", False):
         agent._ephemeral_reasoning_off = False

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2160,6 +2160,12 @@ def run_conversation(
     failed = False
     codex_ack_continuations = 0
     length_continue_retries = 0
+    # One-shot "continue without thinking" override is turn-scoped: a
+    # thinking-only truncation arms it right before the continuation restart,
+    # and build_api_kwargs consumes it on that call. If the turn is
+    # interrupted/errors between arm and consume, it must not fire on the
+    # next turn's first request.
+    agent._ephemeral_reasoning_off = False
     # Total outer-loop exceptions this turn (#92450) — see _MAX_OUTER_LOOP_ERRORS.
     _outer_error_count = 0
     truncated_tool_call_retries = 0
@@ -4163,7 +4169,7 @@ def run_conversation(
                             "The model used all its output tokens on reasoning "
                             "and had none left for the actual response.\n\n"
                             "To fix this:\n"
-                            "→ Lower reasoning effort: `/thinkon low` or `/thinkon minimal`\n"
+                            "→ Lower reasoning effort: `/reasoning low` or `/reasoning minimal`\n"
                             "→ Or switch to a larger/non-reasoning model with `/model`"
                         )
                         agent._cleanup_task_resources(effective_task_id)
@@ -4406,8 +4412,8 @@ def run_conversation(
                                     "continuation attempt — its reasoning "
                                     "consumed the entire budget each time.\n\n"
                                     "To fix this:\n"
-                                    "→ Lower reasoning effort: `/thinkon low` "
-                                    "or `/thinkoff`\n"
+                                    "→ Lower reasoning effort: `/reasoning low` "
+                                    "or `/reasoning none`\n"
                                     "→ Or raise max_tokens for this model"
                                 )
                             # Unanswered continue nudges made every later turn re-truncate.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4290,29 +4290,46 @@ def run_conversation(
                             )
                         if assistant_message is not None and not _trunc_has_tool_calls:
                             length_continue_retries += 1
-                            # An EMPTY partial-stream stub (stream dropped
-                            # mid tool-call before any text was delivered)
-                            # must not be appended as an interim assistant
-                            # message: it would serialize as
-                            # {"role": "assistant", "content": ""}, and
+                            # An interim assistant message with NO visible
+                            # content must not be appended — whichever way it
+                            # got that way.  An empty partial-stream stub
+                            # (stream dropped before any text was delivered)
+                            # and a response whose whole output budget went to
+                            # reasoning delivered in a separate field (GLM-5.3
+                            # on ollama-cloud with reasoning_effort=high:
+                            # finish_reason="length", content="",
+                            # completion_tokens == max_tokens) both serialize
+                            # as {"role": "assistant", "content": ""}, and
                             # strict providers (Moonshot/Kimi via OpenRouter)
                             # reject empty assistant content with HTTP 400
                             # ("message ... with role 'assistant' must not be
                             # empty") on the very next replay — permanently
-                            # poisoning the session history.  There is no
-                            # partial text to continue from anyway, so only
-                            # the continuation user-message is appended.
+                            # poisoning the session history until the pre-call
+                            # sanitizer "heals" the hole (observed 3+ healings
+                            # per turn).  There is no partial text to continue
+                            # from anyway, so only the continuation
+                            # user-message is appended.
+                            _interim_content = getattr(assistant_message, "content", None)
                             _is_empty_partial_stub = (
                                 getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID
-                                and not getattr(assistant_message, "content", None)
+                                and not _interim_content
                             )
-                            if not _is_empty_partial_stub:
+                            if not _interim_content and not _is_empty_partial_stub:
+                                # Thinking-only truncation: the model spent the
+                                # entire output cap on reasoning and produced no
+                                # visible text.  A continuation with thinking
+                                # ON would re-think the whole context from
+                                # scratch (continuations never replay prior
+                                # reasoning) and re-burn the same budget, so
+                                # the next call drops thinking for one request
+                                # — the answer must be written, not re-derived.
+                                agent._ephemeral_reasoning_off = True
+                            if _interim_content:
                                 interim_msg = agent._build_assistant_message(assistant_message, finish_reason)
                                 # Marked so the ceiling exit can drop the fragment trail.
                                 interim_msg["_length_continuation_fragment"] = True
                                 append_message(messages, interim_msg)
-                                if assistant_message.content:
-                                    truncated_response_parts.append(assistant_message.content)
+                                truncated_response_parts.append(_interim_content)
 
                             if length_continue_retries < 4:
                                 _is_partial_stream_stub = (
@@ -4356,12 +4373,42 @@ def run_conversation(
                                 break
 
                             partial_response = agent._strip_think_blocks(_join_truncated_parts(truncated_response_parts)).strip()
+                            # The pending one-shot reasoning-off override must
+                            # not leak into the next turn when the 4th
+                            # truncation goes straight to the ceiling exit
+                            # without scheduling a continuation call to
+                            # consume it.
+                            agent._ephemeral_reasoning_off = False
                             if partial_response:
                                 agent._vprint(
                                     f"{agent.log_prefix}⚠️  Response still truncated "
-                                    f"after 4 continuation attempts — keeping the "
+                                    f"after {length_continue_retries} continuation attempts — keeping the "
                                     f"partial response received so far.",
                                     force=True,
+                                )
+                                _ceiling_final = partial_response
+                            else:
+                                # Every fragment was empty — e.g. a thinking
+                                # model that spent each attempt's whole cap on
+                                # reasoning (GLM-5.3 on ollama-cloud).  Return
+                                # an actionable message instead of an invisible
+                                # None result, which only surfaces as a bare
+                                # error card.
+                                agent._vprint(
+                                    f"{agent.log_prefix}⚠️  Response still truncated "
+                                    f"after {length_continue_retries} continuation attempts — no visible "
+                                    f"text was produced.",
+                                    force=True,
+                                )
+                                _ceiling_final = (
+                                    "⚠️ **No visible answer was produced.** The "
+                                    "model hit its output-token limit on every "
+                                    "continuation attempt — its reasoning "
+                                    "consumed the entire budget each time.\n\n"
+                                    "To fix this:\n"
+                                    "→ Lower reasoning effort: `/thinkon low` "
+                                    "or `/thinkoff`\n"
+                                    "→ Or raise max_tokens for this model"
                                 )
                             # Unanswered continue nudges made every later turn re-truncate.
                             _turn_start = (
@@ -4390,7 +4437,7 @@ def run_conversation(
                             agent._cleanup_task_resources(effective_task_id)
                             agent._persist_session(messages, conversation_history)
                             return {
-                                "final_response": partial_response or None,
+                                "final_response": _ceiling_final,
                                 "messages": messages,
                                 "api_calls": api_call_count,
                                 "completed": False,

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -767,9 +767,18 @@ class ChatCompletionsTransport(ProviderTransport):
                     extra_body["reasoning"] = gh_reasoning
             else:
                 _effort = "medium"
+                _enabled = True
                 if reasoning_config and isinstance(reasoning_config, dict):
                     _effort = reasoning_config.get("effort", "medium") or "medium"
-                extra_body["reasoning"] = {"enabled": True, "effort": _effort}
+                    # Honor an explicit "thinking off" (agent.reasoning_effort:
+                    # none / the one-shot length-continuation override) the same
+                    # way the provider-profile path does — never re-enable it.
+                    if reasoning_config.get("enabled") is False or _effort == "none":
+                        _enabled = False
+                if _enabled:
+                    extra_body["reasoning"] = {"enabled": True, "effort": _effort}
+                else:
+                    extra_body["reasoning"] = {"enabled": False, "effort": "none"}
 
         if provider_name == "gemini":
             raw_thinking_config = _build_gemini_thinking_config(model, reasoning_config)

--- a/tests/run_agent/test_length_continuation_thinking_exhaustion.py
+++ b/tests/run_agent/test_length_continuation_thinking_exhaustion.py
@@ -226,3 +226,41 @@ class TestThinkingOnlyTruncation:
         assert "visible part one." in (result["final_response"] or "")
         assert "and the ending." in (result["final_response"] or "")
         assert _no_empty_assistant_rows(result["messages"]) == []
+
+class TestReasoningOffReachesTheWire:
+    def test_continuation_request_carries_reasoning_off_on_the_wire(self, loop_agent):
+        """The flag is only useful if the continuation REQUEST goes out with
+        thinking disabled — assert the OpenRouter extra_body, not the flag."""
+        loop_agent.reasoning_config = {"enabled": True, "effort": "high"}
+        loop_agent._supports_reasoning_extra_body = lambda: True
+        loop_agent.client.chat.completions.create.side_effect = [
+            _thinking_only_length_response(),
+            _full_response("Here is the full answer."),
+        ]
+        result = _run(loop_agent, "write me a long report")
+        assert result["completed"] is True
+
+        calls = loop_agent.client.chat.completions.create.call_args_list
+        assert len(calls) == 2
+        first = (calls[0].kwargs.get("extra_body") or {}).get("reasoning")
+        second = (calls[1].kwargs.get("extra_body") or {}).get("reasoning")
+        assert first == {"enabled": True, "effort": "high"}, first
+        assert second is not None and second.get("enabled") is False, (
+            f"continuation must be sent with thinking off, got {second!r}"
+        )
+
+    def test_stale_flag_does_not_leak_into_next_turn(self, loop_agent):
+        """A flag armed by a previous turn that never reached build_api_kwargs
+        (interrupt/error between arm and consume) must not silently strip
+        thinking from the next turn's first request."""
+        loop_agent.reasoning_config = {"enabled": True, "effort": "high"}
+        loop_agent._supports_reasoning_extra_body = lambda: True
+        loop_agent._ephemeral_reasoning_off = True  # stale from a prior turn
+        loop_agent.client.chat.completions.create.side_effect = [
+            _full_response("fresh turn answer."),
+        ]
+        result = _run(loop_agent, "hello")
+        assert result["completed"] is True
+        calls = loop_agent.client.chat.completions.create.call_args_list
+        first = (calls[0].kwargs.get("extra_body") or {}).get("reasoning")
+        assert first == {"enabled": True, "effort": "high"}, first

--- a/tests/run_agent/test_length_continuation_thinking_exhaustion.py
+++ b/tests/run_agent/test_length_continuation_thinking_exhaustion.py
@@ -249,6 +249,51 @@ class TestReasoningOffReachesTheWire:
             f"continuation must be sent with thinking off, got {second!r}"
         )
 
+    def test_reasoning_off_is_exactly_one_request_and_prefix_stays_stable(self, loop_agent):
+        """Prompt-cache invariant for the override.
+
+        The reasoning parameter is part of the provider's cache key on
+        config-sensitive providers (Anthropic renders thinking/effort into
+        the prompt; OpenAI lists reasoning.effort as a prefix-affecting
+        setting), so the reasoning-off request is a deliberate one-request
+        cache miss.  It must stay exactly one request: the request AFTER it
+        (a second, visible-text continuation) must go out with the
+        configured reasoning again, and the system prompt must be
+        byte-identical on every request so the miss never compounds into a
+        rebuilt prefix.
+        """
+        loop_agent.reasoning_config = {"enabled": True, "effort": "high"}
+        loop_agent._supports_reasoning_extra_body = lambda: True
+        loop_agent.client.chat.completions.create.side_effect = [
+            _thinking_only_length_response(),
+            _truncated_text_response("PART ONE of the answer"),
+            _full_response(" and PART TWO, done."),
+        ]
+        result = _run(loop_agent, "write me a long report")
+        assert result["completed"] is True
+        assert "PART ONE" in result["final_response"]
+        assert "PART TWO" in result["final_response"]
+
+        calls = loop_agent.client.chat.completions.create.call_args_list
+        assert len(calls) == 3
+        wire = [
+            (c.kwargs.get("extra_body") or {}).get("reasoning") for c in calls
+        ]
+        assert wire[0] == {"enabled": True, "effort": "high"}, wire
+        assert wire[1] == {"enabled": False, "effort": "none"}, wire
+        assert wire[2] == {"enabled": True, "effort": "high"}, (
+            f"reasoning must be restored on the very next request; got {wire!r}"
+        )
+        system_prompts = {
+            c.kwargs["messages"][0]["content"] for c in calls
+            if c.kwargs["messages"][0].get("role") == "system"
+        }
+        assert len(system_prompts) == 1, (
+            "system prompt must be byte-identical across the retry sequence "
+            "(the override may only change request parameters, never the prefix)"
+        )
+        assert loop_agent._ephemeral_reasoning_off is False
+
     def test_stale_flag_does_not_leak_into_next_turn(self, loop_agent):
         """A flag armed by a previous turn that never reached build_api_kwargs
         (interrupt/error between arm and consume) must not silently strip

--- a/tests/run_agent/test_length_continuation_thinking_exhaustion.py
+++ b/tests/run_agent/test_length_continuation_thinking_exhaustion.py
@@ -1,0 +1,228 @@
+"""Regression tests for thinking-only length truncations.
+
+GLM-5.3-flash on ollama-cloud with reasoning_effort=high can burn the ENTIRE
+output cap on reasoning delivered in a separate field and return
+finish_reason="length" with NO visible content (verified live: max_tokens=4096
+→ completion_tokens=4096, reasoning ~18.5KB, content empty).
+
+The old continuation flow handled this badly:
+  1. the empty response was appended as an interim assistant fragment,
+     poisoning the transcript until the pre-call sanitizer "healed" it
+     (observed 3+ healings per turn);
+  2. every continuation re-ran with thinking ON, re-deriving — and re-burning
+     — the whole thinking budget against a growing context, so 4 attempts
+     still produced nothing and the turn died with
+     "Response remained truncated after 4 continuation attempts".
+
+The fix: skip empty interim fragments, and issue the continuation with a
+one-shot reasoning-off override so the budget goes to writing the answer.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_constants import FINISH_REASON_LENGTH
+
+
+class _AgentStandIn:
+    """Minimal agent surface _reasoning_config_for_wire needs."""
+
+    def __init__(self, reasoning_config):
+        self.reasoning_config = reasoning_config
+
+
+class TestReasoningOffOneShotOverride:
+    def test_flag_consumed_exactly_once(self):
+        from agent.chat_completion_helpers import _reasoning_config_for_wire
+
+        agent = _AgentStandIn({"enabled": True, "effort": "high"})
+        # Without the flag the reasoning config passes through untouched.
+        assert _reasoning_config_for_wire(agent) == {
+            "enabled": True,
+            "effort": "high",
+        }
+
+        agent._ephemeral_reasoning_off = True
+        cfg = _reasoning_config_for_wire(agent)
+        assert cfg["enabled"] is False
+        assert cfg["effort"] == "none"
+        assert agent._ephemeral_reasoning_off is False, (
+            "The one-shot override must be consumed by the first call."
+        )
+
+        # Subsequent calls keep the user's own reasoning config.
+        assert _reasoning_config_for_wire(agent) == {
+            "enabled": True,
+            "effort": "high",
+        }
+
+    def test_flag_with_no_user_reasoning_config(self):
+        from agent.chat_completion_helpers import _reasoning_config_for_wire
+
+        agent = _AgentStandIn(None)
+        agent._ephemeral_reasoning_off = True
+        cfg = _reasoning_config_for_wire(agent)
+        assert cfg == {"enabled": False, "effort": "none"}
+
+
+@pytest.fixture()
+def loop_agent():
+    from run_agent import AIAgent
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        a.client = MagicMock()
+        a._cached_system_prompt = "You are helpful."
+        a._use_prompt_caching = False
+        a.compression_enabled = False
+        a.save_trajectories = False
+        return a
+
+
+def _thinking_only_length_response():
+    """finish_reason='length' with reasoning but zero visible content — the
+    live GLM-5.3-flash-on-ollama-cloud shape (normal response id, NOT the
+    partial-stream stub)."""
+    from tests.run_agent.test_run_agent import _mock_assistant_msg
+
+    return SimpleNamespace(
+        id="chatcmpl-thinking-exhausted",
+        model="test/model",
+        choices=[SimpleNamespace(
+            index=0,
+            message=_mock_assistant_msg(content=""),
+            finish_reason=FINISH_REASON_LENGTH,
+        )],
+        usage=None,
+    )
+
+
+def _full_response(content):
+    from tests.run_agent.test_run_agent import _mock_response
+
+    return _mock_response(content=content, finish_reason="stop")
+
+
+def _truncated_text_response(content):
+    from tests.run_agent.test_run_agent import _mock_response
+
+    return _mock_response(content=content, finish_reason=FINISH_REASON_LENGTH)
+
+
+def _run(agent, message, history=None):
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        return agent.run_conversation(message, conversation_history=history)
+
+
+def _no_empty_assistant_rows(messages):
+    return [
+        m for m in messages
+        if m.get("role") == "assistant"
+        and not (m.get("content") or "").strip()
+        and not m.get("tool_calls")
+    ]
+
+
+class TestThinkingOnlyTruncation:
+    def test_retry_after_thinking_only_truncation_completes(self, loop_agent):
+        """One thinking-only truncation, then a normal answer: the retry must
+        drop thinking (one-shot), boost the output cap, and finish the turn."""
+        loop_agent.client.chat.completions.create.side_effect = [
+            _thinking_only_length_response(),
+            _full_response("Here is the full answer."),
+        ]
+        result = _run(loop_agent, "write me a long report")
+
+        assert result["completed"] is True
+        assert "full answer" in (result["final_response"] or "")
+        assert _no_empty_assistant_rows(result["messages"]) == [], (
+            "An empty (thinking-only) truncated response must never be "
+            "appended to the transcript."
+        )
+
+        calls = loop_agent.client.chat.completions.create.call_args_list
+        assert len(calls) == 2
+        # Continuation retry boosts the output cap (2^1 × 4096 base floor).
+        assert calls[1].kwargs.get("max_tokens") == 8192, (
+            "The continuation retry must request a larger output budget than "
+            "the request that truncated."
+        )
+        assert loop_agent._ephemeral_reasoning_off is False, (
+            "The one-shot reasoning-off override must be consumed by the "
+            "continuation call."
+        )
+
+    def test_thinking_only_truncation_sets_reasoning_off(self, loop_agent):
+        from tests.run_agent.test_run_agent import _mock_response
+
+        loop_agent.client.chat.completions.create.side_effect = [
+            _thinking_only_length_response(),
+            _mock_response(
+                content="done", finish_reason=FINISH_REASON_LENGTH
+            ),
+            _full_response("finally complete."),
+        ]
+        _run(loop_agent, "write me a long report")
+
+        calls = loop_agent.client.chat.completions.create.call_args_list
+        assert len(calls) == 3
+        # The thinking-only fragment set the flag; it was consumed by the
+        # next call, and the SECOND truncated fragment (which had visible
+        # text) does not set it again — so the third call sees thinking ON.
+        assert loop_agent._ephemeral_reasoning_off is False
+
+    def test_full_ceiling_with_empty_fragments_still_settles(self, loop_agent):
+        """All four attempts thinking-only: the turn must exit through the
+        ceiling with an actionable final_response, no poisoned transcript,
+        and no leaked reasoning-off flag."""
+        loop_agent.client.chat.completions.create.side_effect = [
+            _thinking_only_length_response() for _ in range(4)
+        ]
+        result = _run(loop_agent, "write me a long report")
+
+        assert result["completed"] is False
+        assert result["partial"] is True
+        assert "truncated after 4 continuation attempts" in (result.get("error") or "")
+        assert result["final_response"], (
+            "An all-empty ceiling exit must still surface a user-facing "
+            "message instead of an invisible None."
+        )
+        assert "reasoning" in (result["final_response"] or "").lower()
+        assert _no_empty_assistant_rows(result["messages"]) == []
+        assert loop_agent._ephemeral_reasoning_off is False, (
+            "The ceiling exit must clear the pending one-shot override so the "
+            "next turn does not silently lose thinking."
+        )
+
+    def test_mixed_fragments_keep_visible_text(self, loop_agent):
+        """A visible fragment followed by a thinking-only one: the visible
+        text must be stitched, the empty one skipped."""
+        loop_agent.client.chat.completions.create.side_effect = [
+            _truncated_text_response("visible part one. "),
+            _thinking_only_length_response(),
+            _full_response("and the ending."),
+        ]
+        result = _run(loop_agent, "write me a long report")
+
+        assert result["completed"] is True
+        assert "visible part one." in (result["final_response"] or "")
+        assert "and the ending." in (result["final_response"] or "")
+        assert _no_empty_assistant_rows(result["messages"]) == []

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4421,7 +4421,7 @@ class TestRunConversation:
         # Should have a user-friendly response (not None)
         assert result["final_response"] is not None
         assert "Thinking Budget Exhausted" in result["final_response"]
-        assert "/thinkon" in result["final_response"]
+        assert "/reasoning" in result["final_response"]
 
 
     def test_length_with_tool_calls_returns_partial_without_executing_tools(self, agent):


### PR DESCRIPTION
## Summary

Thinking-only `finish_reason="length"` truncations (model spends the whole output cap on reasoning, returns empty `content`) no longer burn four futile continuations and die with "Response remained truncated after 4 continuation attempts": the empty fragment is never appended, the continuation is issued with reasoning OFF for exactly one request, and the ceiling exit returns an actionable message (salvage of #99622 by @AlexGabbia, widened to the legacy chat-completions wire path).

## Changes

- `agent/conversation_loop.py` (@AlexGabbia): interim assistant fragments with no visible text are never appended (previously only the partial-stream stub was skipped — a completed thinking-only response still poisoned the transcript); a thinking-only truncation arms the one-shot `agent._ephemeral_reasoning_off`; the ceiling exit clears it and returns a user-facing `final_response` instead of `None` when every fragment was empty.
- `agent/chat_completion_helpers.py` (@AlexGabbia): `_reasoning_config_for_wire()` consumes the one-shot flag at all four `build_api_kwargs` branches (anthropic_messages, codex_responses, provider-profile, legacy).
- `agent/transports/chat_completions.py` (follow-up): the **legacy** chat-completions path always re-emitted `extra_body.reasoning = {enabled: true, effort: <x>}`, so both `reasoning_effort: none` and the new override went out as `{enabled: true, effort: "none"}`. It now honors `enabled=False` / `effort=none` like the provider-profile path.
- `agent/conversation_loop.py` (follow-up): `_ephemeral_reasoning_off` is reset at turn start so a flag armed by an interrupted/errored turn cannot silently strip thinking from the next turn's first request. User-facing hints now name the real `/reasoning` command (`/thinkon`/`/thinkoff` do not exist).
- `tests/run_agent/test_length_continuation_thinking_exhaustion.py`: 6 contributor tests + 3 follow-ups (continuation request carries `reasoning.enabled=false` on the wire; stale flag does not leak into the next turn; the override is exactly one request and the system prompt stays byte-identical — see *Prompt-cache impact*).

## Validation

| Check | Result |
|---|---|
| `test_length_continuation_thinking_exhaustion.py` | 9 passed (8 + prompt-cache invariant) |
| Sabotage (fix reverted, tests kept) | 7 failed / 1 passed |
| Sabotage (one-shot consume removed → flag sticky) | `test_reasoning_off_is_exactly_one_request_and_prefix_stays_stable` fails on request 3 |
| Rebased onto `origin/main` + `test_run_agent.py` + continuation/transport suites | 400 passed |
| `tests/plugins/model_providers` + `test_anthropic_adapter.py` | 339 passed |
| `test_continuation_ceiling_wedge.py` + `test_partial_stream_finish_reason.py` + `test_continuation_repetition_guard.py` + `test_anthropic_truncation_continuation.py` + `test_verification_continuation_budget.py` + `tests/agent/transports/test_chat_completions.py` | 98 passed |
| `tests/run_agent/test_run_agent.py` (full) + transports | 347 passed |
| `tests/plugins/model_providers` + fallback/switch-model reasoning override + runtime-restore + cache-parity | 307 passed |
| ruff | clean |

**Live repro:** real `AIAgent.run_conversation` against an in-process OpenAI-compatible HTTP mock (isolated `HERMES_HOME`; every request answered with `finish_reason=length`, `reasoning_content` only, `content=""`, unless the request arrives with reasoning disabled on the wire) — before (origin/main `c0495c6bce`, providers openai-compat / custom / ollama-cloud / openrouter): `api_calls=4`, wire reasoning `[high, high, high, high]`, `final_response=''`, `error="Response remained truncated after 4 continuation attempts"`; after (this branch, same four providers): `api_calls=2`, wire reasoning `[high, none]` (`{enabled: false, effort: none}` on openai-compat/openrouter, `reasoning_effort: none` on custom/ollama-cloud), `completed=True`, `final_response='FULL ANSWER…'`, 0 empty assistant rows.

## Prompt-cache impact

The one-shot reasoning-off continuation changes a **request parameter**, never the message prefix. Whether that costs a cache miss depends on the provider's cache key:

| Provider family | Wire change on the retry (real adapter output) | Cache effect of that ONE request |
|---|---|---|
| Anthropic adaptive (Opus 4.7 via `anthropic_messages`) | `thinking:{adaptive}` + `output_config.effort:high` → `thinking:{disabled}` | **Full prefix miss** — Anthropic renders thinking config + effort into the prompt; message-level breakpoints always miss and system/tools breakpoints can miss ([Thinking → prompt caching](https://platform.claude.com/docs/en/build-with-claude/thinking#thinking-and-prompt-caching)). One cold write (1.25× input). |
| Anthropic mandatory-thinking (Fable 5.x) | both fields omitted (`_accepts_thinking_disable` is False — the route 400s on a disable) | The model keeps thinking (no fix effect on this family — it falls through to the ceiling exit's actionable message), but the rendered config still differs (`display: summarized` + effort are dropped), so still one prefix miss. |
| Anthropic manual (Sonnet 4.5-) | `thinking:{enabled,budget_tokens}` + `temperature:1` → both omitted | Message-level breakpoints miss; system/tools may survive ([extended-thinking docs](https://platform.claude.com/docs/en/build-with-claude/extended-thinking#prompt-caching-in-manual-mode)). |
| OpenAI / Codex Responses (`agent/transports/codex.py` L802-808) | `reasoning:{effort:high,summary:auto}` + `include:[encrypted_content]` → `reasoning` omitted, `include:[]` | OpenAI lists `reasoning.effort` as a prefix-affecting setting ("can change model-side reasoning instructions") — treat as a full miss for that request ([OpenAI prompt caching](https://developers.openai.com/api/docs/guides/prompt-caching)). |
| OpenRouter / Nous / legacy chat-completions (`extra_body.reasoning`) | `{enabled:true,effort:high}` → `{enabled:false,effort:none}` (Nous: omitted when the route can't disable) | Depends on the upstream: Anthropic/OpenAI upstreams as above; open models (GLM/Qwen/Kimi/DeepSeek) implement thinking on/off as a **chat-template tail switch** — the cached prefix is byte-identical, no miss. |
| Ollama Cloud / custom / zai / kimi-coding | `reasoning_effort:high` → `none`; `thinking:{enabled}` → `{disabled}` | Same as above — template-tail models, no prefix change. This is the family the bug was reported on (GLM-5.3 on ollama-cloud, #99622/#83915; opencode-go #90422). |

Bound, verified live (real `AIAgent.run_conversation`, real `build_system_prompt`, HTTP mock recording every request; scenario = thinking-only truncation → visible-text truncation → completion):

| call | main (before) | this PR | system prompt == call 1 | prefix-preserving on config-sensitive providers |
|---|---|---|---|---|
| 1 | `{enabled:true, effort:high}` mt=4096 | `{enabled:true, effort:high}` mt=4096 | yes | yes |
| 2 | `{enabled:true, effort:high}` mt=8192 (wedge: empty again) | `{enabled:false, effort:none}` mt=8192 | yes | **NO — the one deliberate miss** |
| 3 | `{enabled:true, effort:high}` mt=16384 | `{enabled:true, effort:high}` mt=16384 | yes | yes (hits the entry call 1 wrote, within TTL) |

- Exactly **one** request is affected; the configured reasoning is restored on the very next request (not the next turn). The system prompt is byte-identical across every request. Pinned by `test_reasoning_off_is_exactly_one_request_and_prefix_stays_stable` (sabotage: sticky flag → fails on request 3).
- Worst case is one cold prefix write on an Anthropic/OpenAI-native route. The alternative it replaces (main) is four full-output-budget, cache-*hitting* requests that produce nothing, then an error — strictly more expensive in both input (4× prefix reads + growing context) and output (4× `max_tokens` of reasoning).
- Note `max_tokens` already changes on every continuation retry on main (2×/4×/8× boost, `conversation_loop.py` `restart_with_length_continuation`), and on Claude 4.6+/5 `max_tokens` is empirically part of the cache key too (live A/B, Jul 2026, in the `llm-prompt-caching` skill) — so on Anthropic the continuation path was already prefix-missing before this PR; the reasoning toggle adds no *new* miss there.

Alternatives considered and rejected: (a) *lower effort instead of disabling* — same request-parameter change, so identical cache cost on config-sensitive providers, but does not fix the symptom (#90422 reproduces at `ultra`, #99622 shows `effort:high` at 8192 barely fits; a lower effort still re-thinks the whole context from scratch); (b) *only raise `max_tokens`* — already what main does and what wedged; thinking scales with context; (c) *replay the accumulated reasoning so the model resumes* — `_drop_thinking_only_and_merge_users` deliberately drops thinking-only assistant turns, most chat-completions providers ignore/strip replayed reasoning on a non-tool continuation, and on Anthropic a thinking block that is dropped or altered changes the cached prefix from that position anyway. Disabling for one request is the least-damaging option that actually converges.

Closes #99622 (salvaged with @AlexGabbia's authorship preserved).
Fixes #83915
Fixes #90422

## Infographic

![thinking-only-continuation](https://v3b.fal.media/files/b/0aa8c3ab/LkXZgO3JjTaP5WsJXMo3R_ocPvZFgd.png)

