### PR TITLE
fix(tui_gateway): failed turns name their cause in the turn-finished record (#89117, salvage #89211)

### DIFF
--- a/tests/tui_gateway/test_turn_finished_failure_cause.py
+++ b/tests/tui_gateway/test_turn_finished_failure_cause.py
@@ -1,0 +1,290 @@
+"""A failed TUI turn must say why in its own record (#89117).
+
+#89117 is a report made entirely of two log lines::
+
+    tui_turn finished: ui_session=0dfcee58 status=error error_retained=True duration=0.9s
+    tui_turn finished: ui_session=093285e9 status=error error_retained=True duration=0.9s
+
+That is the whole evidence, and it is not enough to act on: a provider 4xx, a
+budget wall, a billing block and a crashed finalizer all produce exactly those
+characters. The bookend was added by #86865 to trace compression rotations, so
+it carries identities and a coarse status by design — but it is also the *only*
+record the returned-error path writes. A sub-second failure almost always takes
+that path (the provider rejected the request before any work happened), so the
+quietest failures are precisely the ones with nothing to read. The exception
+path at least prints ``[gateway-turn] <Type>: <msg>`` to stderr.
+
+These tests pin the cause into the record on both failure paths, and pin the
+content discipline #86865 established while doing it: prompts are never logged,
+and the provider's message is redacted and length-capped, because a 4xx body
+can quote the request that produced it.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import types
+
+import pytest
+
+from tui_gateway import server
+
+
+class _InlineThread:
+    """Run the turn synchronously so tests observe its final state."""
+
+    def __init__(self, target=None, daemon=None, args=(), kwargs=None):
+        self._target = target
+        self._args = args
+        self._kwargs = kwargs or {}
+
+    def start(self):
+        if self._target is not None:
+            self._target(*self._args, **self._kwargs)
+
+    def is_alive(self):
+        return False
+
+    def join(self, timeout=None):
+        return None
+
+
+def _session(agent=None, **extra):
+    return {
+        "agent": agent if agent is not None else types.SimpleNamespace(),
+        "session_key": "gw-session-key",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": True,
+        "attached_images": [],
+        "image_counter": 0,
+        "cols": 80,
+        "slash_worker": None,
+        "show_reasoning": False,
+        "tool_progress_mode": "all",
+        "inflight_turn": None,
+        **extra,
+    }
+
+
+@pytest.fixture()
+def turn_env(monkeypatch, tmp_path):
+    """Neutralize the turn pipeline's environment-heavy side paths."""
+    monkeypatch.setattr(server.threading, "Thread", _InlineThread)
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda sid: None)
+    monkeypatch.setattr(server, "_sync_agent_model_with_config", lambda sid, session: None)
+    monkeypatch.setattr(server, "_session_cwd", lambda session: str(tmp_path))
+    monkeypatch.setattr(server, "_register_session_cwd", lambda session: None)
+    monkeypatch.setattr(server, "_tts_stream_begin", lambda: None)
+    monkeypatch.setattr(server, "_sync_session_key_after_compress", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_get_usage", lambda agent: {})
+
+
+def _finished(caplog):
+    records = [r for r in caplog.records if "tui turn finished" in r.getMessage()]
+    assert len(records) == 1, f"expected exactly one bookend, got {len(records)}"
+    return records[0].getMessage()
+
+
+def _run(session, prompt="go"):
+    server._run_prompt_submit("rid", "ui-sid", session, prompt)
+
+
+def _agent_returning(result):
+    return types.SimpleNamespace(
+        session_id="agent-sid-1",
+        run_conversation=lambda *a, **k: result,
+        clear_interrupt=lambda: None,
+    )
+
+
+class TestTheReportedRecordNowNamesItsCause:
+
+    def test_returned_error_carries_the_provider_message(self, turn_env, caplog):
+        """The reporter's exact line shape, with the missing half filled in."""
+        session = _session(agent=_agent_returning({
+            "final_response": "",
+            "error": "Error code: 402 - {'error': {'message': 'insufficient credits'}}",
+            "failed": True,
+        }))
+
+        with caplog.at_level(logging.INFO, logger="tui_gateway.server"):
+            _run(session)
+
+        msg = _finished(caplog)
+        assert "status=error" in msg
+        assert "error_retained=True" in msg
+        assert "insufficient credits" in msg, (
+            "a record that says only status=error is what #89117 is about"
+        )
+
+    def test_structured_failure_reason_is_logged_when_present(self, turn_env, caplog):
+        """The billing wall already ships a machine-readable reason; use it.
+
+        ``failure_reason`` is the field the client renders a billing-specific
+        recovery surface from, so it is the one field guaranteed to be stable
+        enough to grep a log for across releases.
+        """
+        session = _session(agent=_agent_returning({
+            "final_response": "",
+            "error": "payment required",
+            "failure_reason": "billing_wall",
+            "failed": True,
+        }))
+
+        with caplog.at_level(logging.INFO, logger="tui_gateway.server"):
+            _run(session)
+
+        assert "failure_reason=billing_wall" in _finished(caplog)
+
+    def test_exception_path_carries_the_exception(self, turn_env, caplog):
+        """The other failure path, so one grep covers both."""
+        def _boom(*a, **k):
+            raise RuntimeError("connection reset mid-stream")
+
+        session = _session(agent=types.SimpleNamespace(
+            session_id="agent-sid-1",
+            run_conversation=_boom,
+            clear_interrupt=lambda: None,
+        ))
+
+        with caplog.at_level(logging.INFO, logger="tui_gateway.server"):
+            _run(session)
+
+        msg = _finished(caplog)
+        assert "status=error" in msg
+        assert "failure_reason=RuntimeError" in msg
+        assert "connection reset mid-stream" in msg
+
+    def test_successful_turn_stays_exactly_as_it_was(self, turn_env, caplog):
+        """No cost to the common case: a clean turn gains no new fields."""
+        session = _session(agent=_agent_returning({"final_response": "done"}))
+
+        with caplog.at_level(logging.INFO, logger="tui_gateway.server"):
+            _run(session)
+
+        msg = _finished(caplog)
+        assert "status=complete" in msg
+        assert "cause=" not in msg
+        assert "failure_reason=" not in msg
+
+
+class TestContentDiscipline:
+    """#86865's rule — the record logs identities, never content."""
+
+    SECRETISH_PROMPT = "please rotate QDRANT_API_KEY=hunter2-super-secret now"
+
+    def test_prompt_is_never_logged_even_when_the_turn_fails(self, turn_env, caplog):
+        session = _session(agent=_agent_returning({
+            "final_response": "",
+            "error": "provider rejected the request",
+            "failed": True,
+        }))
+
+        with caplog.at_level(logging.INFO, logger="tui_gateway.server"):
+            _run(session, self.SECRETISH_PROMPT)
+
+        msg = _finished(caplog)
+        assert "hunter2" not in msg
+        assert "QDRANT_API_KEY" not in msg
+
+    def test_secrets_echoed_back_by_the_provider_are_redacted(self, turn_env, caplog):
+        """The load-bearing safety test.
+
+        A 4xx body frequently quotes the request. Without redaction, adding the
+        cause to a log record would take a header the user never chose to log
+        and write it to disk — turning a diagnostics improvement into a secret
+        leak. This is why the cause goes through ``redact_sensitive_text`` and
+        not ``str()``.
+        """
+        session = _session(agent=_agent_returning({
+            "final_response": "",
+            "error": (
+                "400 from provider; request headers were "
+                "Authorization: Bearer sk-proj-abcdefghijklmnopqrstuvwxyz0123456789"
+            ),
+            "failed": True,
+        }))
+
+        with caplog.at_level(logging.INFO, logger="tui_gateway.server"):
+            _run(session)
+
+        msg = _finished(caplog)
+        assert "sk-proj-abcdefghijklmnopqrstuvwxyz0123456789" not in msg
+        # The diagnostic value survives the redaction — this is the point.
+        assert "400 from provider" in msg
+
+    def test_a_huge_provider_body_cannot_flood_the_log(self, turn_env, caplog):
+        """An HTML error page or a full request echo is a log-volume problem."""
+        session = _session(agent=_agent_returning({
+            "final_response": "",
+            "error": "upstream said: " + ("x" * 9000),
+            "failed": True,
+        }))
+
+        with caplog.at_level(logging.INFO, logger="tui_gateway.server"):
+            _run(session)
+
+        msg = _finished(caplog)
+        assert len(msg) < 700
+        assert "upstream said" in msg
+        assert "…" in msg, "truncation should be visible, not silent"
+
+    def test_a_multiline_traceback_stays_one_record(self, turn_env, caplog):
+        """One accepted prompt, one finished record — including its cause.
+
+        A cause spanning lines would break every log pipeline that treats the
+        bookend as a single greppable line, which is the only reason it is
+        useful for an intermittent bug like this one.
+        """
+        def _boom(*a, **k):
+            raise RuntimeError("first line\nsecond line\n\tthird")
+
+        session = _session(agent=types.SimpleNamespace(
+            session_id="agent-sid-1",
+            run_conversation=_boom,
+            clear_interrupt=lambda: None,
+        ))
+
+        with caplog.at_level(logging.INFO, logger="tui_gateway.server"):
+            _run(session)
+
+        msg = _finished(caplog)
+        assert "\n" not in msg
+        assert "first line second line third" in msg
+
+
+class TestDetailHelperDirectly:
+    """``_turn_failure_detail`` in isolation — the branches the paths can't reach."""
+
+    def test_nothing_to_say_produces_nothing(self):
+        assert server._turn_failure_detail("", None) == ""
+        assert server._turn_failure_detail(None) == ""
+
+    def test_fragment_carries_its_own_leading_space(self):
+        """The bookend appends it unconditionally, so it must self-format."""
+        out = server._turn_failure_detail("boom")
+        assert out.startswith(" ")
+
+    def test_an_exception_with_no_message_still_names_its_type(self):
+        assert "KeyError" in server._turn_failure_detail(KeyError())
+
+    def test_a_broken_redactor_fails_closed(self, monkeypatch):
+        """If redaction cannot run, the raw message must not reach the log.
+
+        Failing open here would be worse than logging nothing: the whole reason
+        the cause is safe to log is that it went through the redactor.
+        """
+        import agent.redact
+
+        def _explode(*a, **k):
+            raise RuntimeError("redactor unavailable")
+
+        monkeypatch.setattr(agent.redact, "redact_sensitive_text", _explode)
+
+        out = server._turn_failure_detail("Bearer sk-proj-supersecretvalue")
+        assert "supersecretvalue" not in out
+        assert "unredactable" in out

--- a/tests/tui_gateway/test_turn_finished_failure_cause.py
+++ b/tests/tui_gateway/test_turn_finished_failure_cause.py
@@ -217,6 +217,56 @@ class TestContentDiscipline:
         # The diagnostic value survives the redaction — this is the point.
         assert "400 from provider" in msg
 
+    SENTINEL = "the marmalade inventory for Q3 was discontinued in March"
+
+    def test_a_prompt_the_provider_quotes_back_does_not_reach_the_record(
+        self, turn_env, caplog
+    ):
+        """Secret redaction is not prompt omission, and this is the difference.
+
+        A provider that rejects a request routinely quotes it back. The quoted
+        material is the user's own prose: it matches no credential pattern, so
+        ``redact_sensitive_text`` passes it through untouched, and adding the
+        cause to this record would newly persist user content that #86865
+        deliberately kept out of it. The sentinel here is deliberately benign
+        for that reason: nothing about it looks like a secret.
+        """
+        session = _session(agent=_agent_returning({
+            "final_response": "",
+            "error": (
+                "400 Bad Request from provider: messages[0].content was "
+                "rejected: '" + self.SENTINEL + "'"
+            ),
+            "failed": True,
+        }))
+
+        with caplog.at_level(logging.INFO, logger="tui_gateway.server"):
+            _run(session, "Summarise this: " + self.SENTINEL)
+
+        msg = _finished(caplog)
+        assert self.SENTINEL not in msg
+        assert "marmalade" not in msg
+        assert "<prompt>" in msg, "the removal should be visible, not silent"
+        # The whole point of the cause survives the removal.
+        assert "400 Bad Request from provider" in msg
+
+    def test_a_provider_message_that_shares_nothing_is_untouched(
+        self, turn_env, caplog
+    ):
+        """The echo strip must not eat diagnostics that merely sit near a prompt."""
+        session = _session(agent=_agent_returning({
+            "final_response": "",
+            "error": "429 rate limited; retry after 30s",
+            "failed": True,
+        }))
+
+        with caplog.at_level(logging.INFO, logger="tui_gateway.server"):
+            _run(session, "Summarise this: " + self.SENTINEL)
+
+        msg = _finished(caplog)
+        assert "429 rate limited; retry after 30s" in msg
+        assert "<prompt>" not in msg
+
     def test_a_huge_provider_body_cannot_flood_the_log(self, turn_env, caplog):
         """An HTML error page or a full request echo is a log-volume problem."""
         session = _session(agent=_agent_returning({
@@ -272,6 +322,11 @@ class TestDetailHelperDirectly:
     def test_an_exception_with_no_message_still_names_its_type(self):
         assert "KeyError" in server._turn_failure_detail(KeyError())
 
+    def test_the_prompt_argument_is_optional(self):
+        """Callers without a prompt in scope still get the secret contract."""
+        out = server._turn_failure_detail("Bearer sk-proj-supersecretvalue1234")
+        assert "supersecretvalue1234" not in out
+
     def test_a_broken_redactor_fails_closed(self, monkeypatch):
         """If redaction cannot run, the raw message must not reach the log.
 
@@ -288,3 +343,43 @@ class TestDetailHelperDirectly:
         out = server._turn_failure_detail("Bearer sk-proj-supersecretvalue")
         assert "supersecretvalue" not in out
         assert "unredactable" in out
+
+
+class TestPromptEchoStripping:
+    """``_strip_prompt_echo`` in isolation: the boundaries of the guarantee."""
+
+    def test_an_overlap_below_the_window_is_not_an_echo(self):
+        """Short shared phrases are coincidence, and eating them costs detail."""
+        out = server._strip_prompt_echo("400: invalid model", "invalid model")
+        assert out == "400: invalid model"
+
+    def test_a_json_escaped_echo_is_stripped_too(self):
+        """A provider handing back its own request body often hands it escaped."""
+        prompt = "please summarise the Q3 marmalade inventory memo for me"
+        message = 'upstream body: {"messages": [{"content": "' + prompt + '"}]}'
+        out = server._strip_prompt_echo(message, prompt)
+        assert "marmalade" not in out
+        assert "<prompt>" in out
+
+    def test_an_echo_is_removed_before_the_length_cap_applies(self):
+        """A quote must not survive by starting inside the kept prefix."""
+        prompt = "the confidential merger memorandum for the northern division"
+        error = ("x" * 200) + " echoed request: " + prompt
+        out = server._turn_failure_detail(error, None, prompt)
+        assert "merger memorandum" not in out
+        assert "confidential" not in out
+
+    def test_a_prompt_shorter_than_the_window_cannot_blank_the_message(self):
+        """A one-word prompt must not turn every message into <prompt>."""
+        out = server._strip_prompt_echo("provider said no", "hi")
+        assert out == "provider said no"
+
+    def test_whitespace_shape_does_not_hide_an_echo(self):
+        """Both sides are collapsed, so a re-wrapped quote still matches."""
+        prompt = "the marmalade inventory for Q3 was discontinued in March"
+        error = (
+            "rejected:    the marmalade inventory\n"
+            " for Q3 was discontinued in March"
+        )
+        out = server._turn_failure_detail(error, None, prompt)
+        assert "marmalade" not in out

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9977,6 +9977,54 @@ def _fail_inflight_turn(
     session["inflight_turn"] = turn
 
 
+_TURN_FAILURE_DETAIL_LIMIT = 240
+
+
+def _turn_failure_detail(error: Any, reason: Any = None) -> str:
+    """Render why a turn failed, for the ``tui turn finished`` bookend.
+
+    Returns ``""`` when there is nothing to say, otherwise a fragment that
+    already carries its own leading space, so the caller can append it to the
+    record unconditionally.
+
+    #86865 added the bookend to trace compression rotations, so it logs
+    identities and a coarse ``status`` and deliberately logs no content.
+    #89117 is what the missing cause costs: a report consisting of two lines
+    reading ``status=error error_retained=True duration=0.9s`` with no way to
+    tell a provider 4xx from a budget wall from a crashed finalizer. The
+    returned-error path -- the one a 0.9 s failure almost always takes --
+    emits no other log line at all; only the exception path prints to stderr,
+    which is why the quiet failures are the ones that get filed.
+
+    Content discipline follows #86865's: the prompt is never logged, and the
+    provider's message is redacted and truncated before it reaches a log file,
+    because a 4xx body can quote the request that produced it.
+    """
+    reason_text = str(reason or "").strip()
+    message = str(error or "").strip()
+    if isinstance(error, BaseException):
+        message = message or type(error).__name__
+    if not message and not reason_text:
+        return ""
+    try:
+        from agent.redact import redact_sensitive_text
+
+        message = redact_sensitive_text(message, force=True)
+    except Exception:
+        # A redactor that cannot run must not be able to leak the raw
+        # message into the log by failing open.
+        message = "<unredactable>"
+    message = " ".join(message.split())
+    if len(message) > _TURN_FAILURE_DETAIL_LIMIT:
+        message = message[:_TURN_FAILURE_DETAIL_LIMIT] + "\u2026"
+    out = ""
+    if reason_text:
+        out += " failure_reason=%s" % " ".join(reason_text.split())
+    if message:
+        out += " cause=%r" % message
+    return out
+
+
 # ── Auto-continue: resume a turn killed by a process/machine death ────
 #
 # A turn that concludes — success, handled error, interrupt — clears its
@@ -12957,6 +13005,11 @@ def _run_prompt_submit(
         # True once a failed turn's snapshot was retained for resume replay —
         # tells the finally below to skip the normal inflight clear.
         turn_error_retained = False
+        # One-line cause for the "tui turn finished" bookend below. The record
+        # fires from a `finally`, where neither `result` nor the caught
+        # exception is reliably in scope, so both failure paths stash their
+        # cause here on the way past.
+        turn_error_detail = ""
         # Durable crash marker: written before the turn runs, retired the
         # moment its outcome reaches the client (see _retire_turn_marker).
         # Any concluded turn — success, handled error, interrupt — retires
@@ -13476,6 +13529,10 @@ def _run_prompt_submit(
                         error_surface=_error_surface,
                     )
                     turn_error_retained = True
+                    turn_error_detail = _turn_failure_detail(
+                        (result.get("error") if isinstance(result, dict) else raw),
+                        (result.get("failure_reason") if isinstance(result, dict) else None),
+                    )
                 else:
                     _clear_inflight_turn(session)
             if status == "error":
@@ -13704,6 +13761,7 @@ def _run_prompt_submit(
                     retire_marker=terminal_receipt_committed,
                 )
                 turn_error_retained = True
+                turn_error_detail = _turn_failure_detail(e, type(e).__name__)
             except Exception as emit_exc:
                 print(
                     f"[gateway-turn] terminal error emit failed: "
@@ -13779,7 +13837,8 @@ def _run_prompt_submit(
             # without reaching this finally.
             logger.info(
                 "tui turn finished: ui_session=%s session_key=%s "
-                "agent_session_id=%s status=%s error_retained=%s duration=%.1fs",
+                "agent_session_id=%s status=%s error_retained=%s duration=%.1fs"
+                "%s",
                 sid,
                 session.get("session_key") or "",
                 getattr(agent, "session_id", "") or "",
@@ -13794,6 +13853,7 @@ def _run_prompt_submit(
                 else ("error" if turn_error_retained else "complete"),
                 turn_error_retained,
                 time.monotonic() - _turn_started_monotonic,
+                turn_error_detail,
             )
             # Backstop for turns that never reached a terminal frame (the
             # frame paths retire the marker as they emit).

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9978,9 +9978,70 @@ def _fail_inflight_turn(
 
 
 _TURN_FAILURE_DETAIL_LIMIT = 240
+# Shortest run of the submitted prompt that counts as the provider quoting it
+# back. Long enough that shared boilerplate ("Invalid request for model ") does
+# not trip it, short enough to catch a quoted sentence.
+_TURN_PROMPT_ECHO_WINDOW = 24
+# Ceiling on the prompt we shingle. An @-expanded prompt can carry a whole
+# file; the failure path must stay cheap.
+_TURN_PROMPT_ECHO_MAX_PROMPT = 65536
 
 
-def _turn_failure_detail(error: Any, reason: Any = None) -> str:
+def _strip_prompt_echo(message: str, prompt: Any) -> str:
+    """Blank runs of the submitted prompt that ``message`` quotes back.
+
+    Secret redaction and prompt omission are different contracts, and only the
+    first one is pattern-based. A provider 4xx that echoes the request carries
+    ordinary private prose -- a paragraph about a person, a pasted file from an
+    ``@`` reference -- that matches no credential pattern and would otherwise
+    reach the log intact. This closes that path directly: anything the message
+    shares with the prompt for ``_TURN_PROMPT_ECHO_WINDOW`` characters or more
+    becomes ``<prompt>``.
+
+    Shingle-set matching, not a diff: cost is linear in both strings, which
+    matters because this runs on every failed turn and an ``@`` reference can
+    make the prompt arbitrarily long. The JSON-escaped form of the prompt is
+    shingled too, since a provider that hands back its own request body often
+    hands it back escaped.
+
+    Verbatim echo is what this stops. A paraphrase, a re-encoding (base64, a
+    different unicode normalization) or a summary of the prompt would survive,
+    so this is a floor and not a proof; the guarantee it does give is that the
+    prompt cannot reach the record by being quoted.
+    """
+    if not message or not prompt:
+        return message
+    needle = " ".join(str(prompt).split())[:_TURN_PROMPT_ECHO_MAX_PROMPT]
+    window = _TURN_PROMPT_ECHO_WINDOW
+    if len(needle) < window or len(message) < window:
+        return message
+    shingles = {needle[i:i + window] for i in range(len(needle) - window + 1)}
+    try:
+        escaped = json.dumps(needle)[1:-1]
+    except Exception:
+        escaped = ""
+    if escaped and escaped != needle:
+        shingles.update(
+            escaped[i:i + window] for i in range(len(escaped) - window + 1)
+        )
+    out: list[str] = []
+    i = 0
+    n = len(message)
+    while i <= n - window:
+        if message[i:i + window] in shingles:
+            j = i + window
+            while j < n and message[j - window + 1:j + 1] in shingles:
+                j += 1
+            out.append("<prompt>")
+            i = j
+        else:
+            out.append(message[i])
+            i += 1
+    out.append(message[i:])
+    return "".join(out)
+
+
+def _turn_failure_detail(error: Any, reason: Any = None, prompt: Any = None) -> str:
     """Render why a turn failed, for the ``tui turn finished`` bookend.
 
     Returns ``""`` when there is nothing to say, otherwise a fragment that
@@ -9996,9 +10057,18 @@ def _turn_failure_detail(error: Any, reason: Any = None) -> str:
     emits no other log line at all; only the exception path prints to stderr,
     which is why the quiet failures are the ones that get filed.
 
-    Content discipline follows #86865's: the prompt is never logged, and the
-    provider's message is redacted and truncated before it reaches a log file,
-    because a 4xx body can quote the request that produced it.
+    Content discipline follows #86865's, and it takes two separate steps
+    because it is two separate contracts. ``redact_sensitive_text`` removes
+    credentials, which are pattern-shaped. It does nothing about a 4xx body
+    that quotes the request back, because ordinary private prose is not
+    pattern-shaped -- so ``_strip_prompt_echo`` removes that separately, using
+    the submitted ``prompt`` itself as the thing to look for. The invariant the
+    two of them keep is: this record may gain failure classification and
+    provider detail, and may not newly persist the user's own content.
+
+    ``prompt`` is optional so the helper stays callable from a path that has no
+    prompt in scope, but the turn paths always pass it; without it, only the
+    secret contract is enforced.
     """
     reason_text = str(reason or "").strip()
     message = str(error or "").strip()
@@ -10015,6 +10085,10 @@ def _turn_failure_detail(error: Any, reason: Any = None) -> str:
         # message into the log by failing open.
         message = "<unredactable>"
     message = " ".join(message.split())
+    # After the collapse, so both sides are compared in the same shape, and
+    # before the truncation, so a quote that starts inside the kept prefix
+    # cannot survive by being cut mid-run.
+    message = _strip_prompt_echo(message, prompt)
     if len(message) > _TURN_FAILURE_DETAIL_LIMIT:
         message = message[:_TURN_FAILURE_DETAIL_LIMIT] + "\u2026"
     out = ""
@@ -13010,6 +13084,11 @@ def _run_prompt_submit(
         # exception is reliably in scope, so both failure paths stash their
         # cause here on the way past.
         turn_error_detail = ""
+        # What this turn actually submitted, kept only so the cause can be
+        # checked for quoting it back (see _strip_prompt_echo). Bound here
+        # rather than read from the turn body because the exception path can
+        # fire before the prompt is resolved.
+        turn_prompt_text = ""
         # Durable crash marker: written before the turn runs, retired the
         # moment its outcome reaches the client (see _retire_turn_marker).
         # Any concluded turn — success, handled error, interrupt — retires
@@ -13115,6 +13194,11 @@ def _run_prompt_submit(
                     )
                     return
                 prompt = ctx.message
+
+            # After @-expansion on purpose: an injected file's contents are
+            # exactly the kind of private material a provider echo would carry
+            # back, and they are not in `text`.
+            turn_prompt_text = prompt if isinstance(prompt, str) else ""
 
             # Decide image routing per-turn based on active provider/model.
             # "native" → pass pixels to the main model as OpenAI-style content
@@ -13532,6 +13616,7 @@ def _run_prompt_submit(
                     turn_error_detail = _turn_failure_detail(
                         (result.get("error") if isinstance(result, dict) else raw),
                         (result.get("failure_reason") if isinstance(result, dict) else None),
+                        turn_prompt_text,
                     )
                 else:
                     _clear_inflight_turn(session)
@@ -13761,7 +13846,9 @@ def _run_prompt_submit(
                     retire_marker=terminal_receipt_committed,
                 )
                 turn_error_retained = True
-                turn_error_detail = _turn_failure_detail(e, type(e).__name__)
+                turn_error_detail = _turn_failure_detail(
+                    e, type(e).__name__, turn_prompt_text
+                )
             except Exception as emit_exc:
                 print(
                     f"[gateway-turn] terminal error emit failed: "


### PR DESCRIPTION
## Summary

A failed TUI/Desktop turn's `tui turn finished` bookend now names its cause (`failure_reason=` + redacted, prompt-echo-stripped, 240-char-capped `cause=`) on both the returned-error and exception paths, so a report like #89117 is diagnosable from the one record the failure path is guaranteed to write.

## Changes

- `tui_gateway/server.py`: new `_turn_failure_detail(error, reason, prompt)` and `_strip_prompt_echo(message, prompt)` helpers; `_run_prompt_submit` stashes `turn_error_detail` at the two failure sites (returned-error result → `result["error"]` + `result["failure_reason"]`; exception → `type(e).__name__` + message) and appends it to the `tui turn finished` record. Successful turns are byte-identical to before.
- Content discipline from #86865 preserved and strengthened: `redact_sensitive_text(force=True)` fails closed to `<unredactable>`; any ≥24-char run the message shares with the submitted (post-`@`-expansion) prompt — raw or JSON-escaped — becomes `<prompt>`; whitespace-collapsed then capped at 240 chars.
- `tests/tui_gateway/test_turn_finished_failure_cause.py` (new, 20 tests): both failure paths carry a cause, `failure_reason` surfaces when present, prompt never logged directly or by provider echo, secrets redacted, cap enforced, success record unchanged.

Salvage of #89211 by @jackulau — both commits cherry-picked with authorship intact (`66be7019a5`, `61b8fdc8f8`), applied cleanly onto current main.

## Validation

| Check | Result |
|---|---|
| `pytest tests/tui_gateway/test_turn_finished_failure_cause.py tests/tui_gateway/test_prompt_accept_logging.py tests/tui_gateway/test_failed_turn_retention.py` | 34 passed |
| Sabotage: new test file against `origin/main`'s `server.py` | 18 failed / 2 passed (tests genuinely pin the fix) |
| `ruff check tui_gateway/server.py tests/tui_gateway/test_turn_finished_failure_cause.py` | All checks passed |
| `scripts/audit_pr_attribution.py --fix` | all contributor emails mapped |

**Live repro:** `/tmp/c1b_repro_rotation_89211.py` — real `tui_gateway.server._run_prompt_submit` with a returning-error agent (402 body that echoes the prompt) and a raising agent. Before (main `ff7745fb0a`): both bookends read `... status=error error_retained=True duration=0.3s` with no cause → `REPRO_FIRES`. After: `... failure_reason=billing cause="Error code: 402 - {...'insufficient credits for request: <prompt>'}"` and `... failure_reason=RuntimeError cause='finalizer crashed: <prompt>'`; prompt sentinel absent from both → `CLEAN`.

Closes #89117
Closes #89211

Credit: @jackulau (#89211) — fix and tests, including the prompt-echo shingle stripper prompted by @keeltrace's privacy review.

## Infographic
![turn-finished-cause](https://v3b.fal.media/files/b/0aa8c3b1/nls-5il8wYlROX_pcc776_UMaHRNz9.png)
