### PR TITLE
fix(desktop): preserve star map context menu

### DIFF
--- a/apps/desktop/src/app/context-menu/app-context-menu.tsx
+++ b/apps/desktop/src/app/context-menu/app-context-menu.tsx
@@ -40,8 +40,8 @@ import {
 import { isWebUrl, resolveDomTarget } from './target'
 
 /** Marks a surface that owns PLAIN right-clicks itself (the user-message
- *  reaction bubble). Owned targets inside it — links, images, editables,
- *  selections — still get the app menu. */
+ *  reaction bubble and the Star Map canvas). Owned targets inside it — links,
+ *  images, editables, selections — still get the app menu. */
 export const CONTEXT_MENU_SKIP_ATTR = 'data-context-menu-skip'
 
 const LOOPBACK_HOST_RE = /^(localhost|127\.0\.0\.1|0\.0\.0\.0|\[?::1\]?)$/i
@@ -648,8 +648,8 @@ export function AppContextMenu() {
       const target = resolveDomTarget(element)
       const owned = Boolean(target.linkUrl || target.onImage || target.editable || target.selectionText)
 
-      // The reaction bubble owns bare right-clicks; a link inside it still
-      // opens the link menu.
+      // Skip-marked surfaces own bare right-clicks; owned DOM targets inside
+      // them still open the corresponding app menu.
       if (!owned && element?.closest(`[${CONTEXT_MENU_SKIP_ATTR}]`)) {
         return
       }

--- a/apps/desktop/src/app/context-menu/app-context-menu.tsx
+++ b/apps/desktop/src/app/context-menu/app-context-menu.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react'
 import { useNavigate } from 'react-router'
 
 import { terminalMenuHandleFor } from '@/app/right-sidebar/terminal/terminal-context-menu'
+import { openStarMapNodeMenuFor } from '@/app/starmap/context-menu-handle'
 import { toggleTargetZoneTabStrip } from '@/components/pane-shell/tree/store'
 import { Codicon } from '@/components/ui/codicon'
 import { HERMES_CONTEXT_MENU_TRIGGER_ATTR } from '@/components/ui/context-menu'
@@ -40,8 +41,8 @@ import {
 import { isWebUrl, resolveDomTarget } from './target'
 
 /** Marks a surface that owns PLAIN right-clicks itself (the user-message
- *  reaction bubble and the Star Map canvas). Owned targets inside it — links,
- *  images, editables, selections — still get the app menu. */
+ *  reaction bubble). Owned targets inside it — links, images, editables,
+ *  selections — still get the app menu. */
 export const CONTEXT_MENU_SKIP_ATTR = 'data-context-menu-skip'
 
 const LOOPBACK_HOST_RE = /^(localhost|127\.0\.0\.1|0\.0\.0\.0|\[?::1\]?)$/i
@@ -605,8 +606,8 @@ function shellSections({ navigate, t }: ShellVerbs): ReactNode[][] {
  *
  * Every right-click in the app resolves here first. Radix-owned surfaces
  * (session rows and other `context-menu-trigger` wrappers) keep their own
- * menus; the reaction bubble keeps plain right-clicks; terminals answer
- * through their registered xterm handles; everything else gets a menu
+ * menus; the reaction bubble keeps plain right-clicks; terminals and the
+ * Star Map answer through registered handles; everything else gets a menu
  * assembled from what the click landed on — link, image, editable,
  * selection — with the window verbs as the empty-target fallback. Replaced
  * both the native Electron menu and the shell fallback wrapper, so labels
@@ -634,6 +635,15 @@ export function AppContextMenu() {
         return
       }
 
+      // The Star Map owns node hits, but empty canvas space still reaches the
+      // shell fallback below. A canvas-wide opt-out would lose that fallback.
+      if (openStarMapNodeMenuFor(element, event.clientX, event.clientY)) {
+        event.preventDefault()
+        event.stopPropagation()
+
+        return
+      }
+
       // A terminal's canvas has no DOM to resolve; its registered handle
       // carries the xterm selection and paste path instead.
       const terminal = terminalMenuHandleFor(element)
@@ -648,8 +658,8 @@ export function AppContextMenu() {
       const target = resolveDomTarget(element)
       const owned = Boolean(target.linkUrl || target.onImage || target.editable || target.selectionText)
 
-      // Skip-marked surfaces own bare right-clicks; owned DOM targets inside
-      // them still open the corresponding app menu.
+      // The reaction bubble owns bare right-clicks; a link inside it still
+      // opens the link menu.
       if (!owned && element?.closest(`[${CONTEXT_MENU_SKIP_ATTR}]`)) {
         return
       }

--- a/apps/desktop/src/app/starmap/context-menu-handle.ts
+++ b/apps/desktop/src/app/starmap/context-menu-handle.ts
@@ -1,0 +1,36 @@
+/**
+ * Registered context-menu ownership for the Star Map canvas.
+ *
+ * The app-wide menu listens on window during capture, before React's canvas
+ * handler. It asks this handle whether the click hit a node: hits belong to
+ * the Star Map, while misses keep flowing to the shell fallback.
+ */
+
+export interface StarMapContextMenuHandle {
+  openNodeMenuAt: (clientX: number, clientY: number) => boolean
+}
+
+const handles = new WeakMap<HTMLCanvasElement, StarMapContextMenuHandle>()
+
+/** Register the handle for a Star Map canvas. Returns an idempotent remove. */
+export function registerStarMapContextMenu(
+  canvas: HTMLCanvasElement,
+  handle: StarMapContextMenuHandle
+): () => void {
+  handles.set(canvas, handle)
+
+  return () => {
+    if (handles.get(canvas) === handle) {
+      handles.delete(canvas)
+    }
+  }
+}
+
+/** Open the node menu when element is a registered canvas and the point hits a node. */
+export function openStarMapNodeMenuFor(element: Element | null, clientX: number, clientY: number): boolean {
+  if (!(element instanceof HTMLCanvasElement)) {
+    return false
+  }
+
+  return handles.get(element)?.openNodeMenuAt(clientX, clientY) ?? false
+}

--- a/apps/desktop/src/app/starmap/star-map-context-menu.test.tsx
+++ b/apps/desktop/src/app/starmap/star-map-context-menu.test.tsx
@@ -1,0 +1,98 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { AppContextMenu } from '@/app/context-menu/app-context-menu'
+import { $contextMenu } from '@/app/context-menu/store'
+import type { StarmapGraph } from '@/types/hermes'
+
+import { StarMap } from './star-map'
+
+class TestResizeObserver {
+  constructor(private readonly callback: ResizeObserverCallback) {}
+
+  disconnect() {}
+
+  observe(target: Element) {
+    Object.defineProperties(target, {
+      clientHeight: { configurable: true, value: 300 },
+      clientWidth: { configurable: true, value: 400 }
+    })
+    this.callback([{ target } as ResizeObserverEntry], this as unknown as ResizeObserver)
+  }
+
+  unobserve() {}
+}
+
+const graph: StarmapGraph = {
+  clusters: [],
+  edges: [],
+  memory: [],
+  nodes: [
+    {
+      category: 'coding',
+      createdBy: null,
+      id: 'skill-a',
+      kind: 'skill',
+      label: 'Skill A',
+      pinned: false,
+      state: 'active',
+      useCount: 1
+    }
+  ],
+  stats: {}
+}
+
+vi.mock('./simulation', () => ({
+  buildSimulation: (input: StarmapGraph) => {
+    const nodes = input.nodes.map(node => ({
+      ...node,
+      outerRingIndex: 0,
+      rec: 1,
+      tr: 0,
+      vx: 0,
+      vy: 0,
+      x: 0,
+      y: 0
+    }))
+
+    return {
+      byId: new Map(nodes.map(node => [node.id, node])),
+      links: [],
+      nodes,
+      rings: [{ label: null, r: 200, ratio: 1 }],
+      sim: { stop: vi.fn() }
+    }
+  }
+}))
+
+afterEach(() => {
+  $contextMenu.set(null)
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('StarMap context menu ownership', () => {
+  it('keeps the canvas gesture so a node can open its Edit/Delete menu', async () => {
+    vi.stubGlobal('ResizeObserver', TestResizeObserver)
+    vi.spyOn(window, 'requestAnimationFrame').mockReturnValue(1)
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined)
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null)
+
+    const { container } = render(
+      <MemoryRouter>
+        <AppContextMenu />
+        <StarMap graph={graph} />
+      </MemoryRouter>
+    )
+
+    const canvas = container.querySelector('canvas')!
+
+    await waitFor(() => expect(canvas.style.width).toBe('400px'))
+    fireEvent.contextMenu(canvas, { clientX: 200, clientY: 165 })
+
+    expect(await screen.findByText('Edit skill…')).toBeTruthy()
+    expect(screen.getByText('Archive skill')).toBeTruthy()
+    expect($contextMenu.get()).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/starmap/star-map-context-menu.test.tsx
+++ b/apps/desktop/src/app/starmap/star-map-context-menu.test.tsx
@@ -95,4 +95,26 @@ describe('StarMap context menu ownership', () => {
     expect(screen.getByText('Archive skill')).toBeTruthy()
     expect($contextMenu.get()).toBeNull()
   })
+
+  it('keeps the shell fallback on empty starfield', async () => {
+    vi.stubGlobal('ResizeObserver', TestResizeObserver)
+    vi.spyOn(window, 'requestAnimationFrame').mockReturnValue(1)
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined)
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null)
+
+    const { container } = render(
+      <MemoryRouter>
+        <AppContextMenu />
+        <StarMap graph={graph} />
+      </MemoryRouter>
+    )
+
+    const canvas = container.querySelector('canvas')!
+
+    await waitFor(() => expect(canvas.style.width).toBe('400px'))
+    fireEvent.contextMenu(canvas, { clientX: 20, clientY: 20 })
+
+    expect(await screen.findByText('Settings')).toBeTruthy()
+    expect(screen.queryByText('Edit skill…')).toBeNull()
+  })
 })

--- a/apps/desktop/src/app/starmap/star-map.tsx
+++ b/apps/desktop/src/app/starmap/star-map.tsx
@@ -925,6 +925,7 @@ export function StarMap({
     <div className="relative min-h-0 flex-1 overflow-hidden" ref={wrapRef}>
       <canvas
         className="block touch-none select-none text-foreground"
+        data-context-menu-skip=""
         onContextMenu={onContextMenu}
         onDoubleClick={resetView}
         onMouseDown={onMouseDown}

--- a/apps/desktop/src/app/starmap/star-map.tsx
+++ b/apps/desktop/src/app/starmap/star-map.tsx
@@ -8,6 +8,7 @@ import type { StarmapGraph } from '@/types/hermes'
 
 import { computePalette, memoryInkFor, resolveRgb, rgba } from './color'
 import { RING_OUTER, TILT, ZOOM_MAX, ZOOM_MIN } from './constants'
+import { registerStarMapContextMenu } from './context-menu-handle'
 import { clamp, distToSegmentSq, fitScale, fitViewport, nodeRadius } from './geometry'
 import { NodeContextMenu, type NodeMenuTarget } from './node-context-menu'
 import { drawScene, drawScramble } from './render'
@@ -698,7 +699,7 @@ export function StarMap({
   }, [invalidate, size])
 
   // ── Pointer interactions (invert the tilted projection for hit-testing) ─────
-  const pickNode = (cssX: number, cssY: number): null | SimNode => {
+  const pickNode = useCallback((cssX: number, cssY: number): null | SimNode => {
     const vp = viewportRef.current
     // Hit radius mirrors the billboarded draw: rested fit scale, screen space.
     const nodeK = fitScale(sizeRef.current.w, sizeRef.current.h, ringsRef.current)
@@ -718,7 +719,7 @@ export function StarMap({
     }
 
     return best
-  }
+  }, [])
 
   // Nearest link within ~5px of the cursor (screen space), or null.
   const pickLink = (cssX: number, cssY: number): null | string => {
@@ -767,6 +768,37 @@ export function StarMap({
 
     return { x: e.clientX - (rect?.left ?? 0), y: e.clientY - (rect?.top ?? 0) }
   }
+
+  const openNodeMenuAt = useCallback(
+    (clientX: number, clientY: number): boolean => {
+      const rect = canvasRef.current?.getBoundingClientRect()
+      const node = pickNode(clientX - (rect?.left ?? 0), clientY - (rect?.top ?? 0))
+
+      if (!node) {
+        setMenuTarget(null)
+
+        return false
+      }
+
+      setSelectedId(node.id)
+      setMenuTarget({
+        id: node.id,
+        kind: node.kind === 'memory' ? 'memory' : 'skill',
+        label: node.label,
+        x: clientX,
+        y: clientY
+      })
+
+      return true
+    },
+    [pickNode]
+  )
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+
+    return canvas ? registerStarMapContextMenu(canvas, { openNodeMenuAt }) : undefined
+  }, [openNodeMenuAt])
 
   const resetView = () => {
     setPlaying(false)
@@ -878,22 +910,9 @@ export function StarMap({
   }
 
   const onContextMenu = (e: React.MouseEvent<HTMLCanvasElement>) => {
-    e.preventDefault()
-    const { x, y } = localXY(e)
-    const node = pickNode(x, y)
-
-    if (!node) {
-      return setMenuTarget(null)
+    if (openNodeMenuAt(e.clientX, e.clientY)) {
+      e.preventDefault()
     }
-
-    setSelectedId(node.id)
-    setMenuTarget({
-      id: node.id,
-      kind: node.kind === 'memory' ? 'memory' : 'skill',
-      label: node.label,
-      x: e.clientX,
-      y: e.clientY
-    })
   }
 
   const onWheel = (e: React.WheelEvent<HTMLCanvasElement>) => {
@@ -925,7 +944,6 @@ export function StarMap({
     <div className="relative min-h-0 flex-1 overflow-hidden" ref={wrapRef}>
       <canvas
         className="block touch-none select-none text-foreground"
-        data-context-menu-skip=""
         onContextMenu={onContextMenu}
         onDoubleClick={resetView}
         onMouseDown={onMouseDown}


### PR DESCRIPTION
## Summary

- route Star Map node hits through a registered context-menu handle
- keep the app shell fallback menu on empty starfield
- preserve link, editable, terminal, Radix, and generic app menu paths
- add focused JSDOM regressions for both node hits and empty-canvas misses

## Root cause

`AppContextMenu` listens during capture and stopped propagation for the canvas before the Star Map React handler could perform node hit-testing. A canvas-wide `data-context-menu-skip` opt-out restores the node menu, but also removes the documented shell fallback from empty starfield.

The Star Map now registers a node-hit-aware handle with the app coordinator. A node hit opens `NodeContextMenu` and consumes the gesture; a miss continues through the existing DOM resolver to `shellSections()`.

## Validation

Initial implementation validation on head `dcf81836ac934668ad2fb99ab03a46336e64ca8a`:

- `vitest run --project ui src/app/context-menu/app-context-menu.test.tsx src/app/starmap` — 49 tests passed across 4 files
- `tsc -p . --noEmit`
- focused ESLint and Prettier checks
- `git diff --check`

Follow-up `82d2385052bc9f9967221ca5f740541e53d1db83`:

- added a regression that fails under the canvas-wide opt-out because an empty-starfield right-click opens no menu
- `git diff --check` passed
- a merge-tree check against current `main` (`1c671beab29164d8931c5d01c5739502267089d8`) completed without conflicts
- focused Vitest, TypeScript, ESLint, and Prettier were not rerun locally: dependencies are absent after cache cleanup, and the current high-swap machine has no complete safe install/test peak envelope. No package was installed. The new checks remain to be run by CI or a resource-safe environment.

Automated validation ran with Node 24 on macOS for the initial head; I did not run a packaged Electron build manually.

Fixes #100676