### PR TITLE
fix(state): unopenable state.db admission lock now defers destructive work (#100368 amplifier, salvage #100399)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2336,10 +2336,11 @@ def _cross_process_repair_lock(db_path: Path):
     """Serialize state.db schema surgery across processes.
 
     Yields True when this process holds the repair lock for *db_path*, False
-    when the bounded acquire timed out.  Unlike the kanban init lock — whose
-    critical section is idempotent, so proceeding without the lock is merely
-    redundant work — proceeding here would be exactly the unsafe interleaving
-    we are trying to prevent, so a caller that gets False must NOT do surgery.
+    when the bounded acquire timed out or the lock file could not be opened at
+    all.  Unlike the kanban init lock — whose critical section is idempotent,
+    so proceeding without the lock is merely redundant work — proceeding here
+    would be exactly the unsafe interleaving we are trying to prevent, so a
+    caller that gets False must NOT do surgery.
 
     ``flock`` is the right primitive for this: the kernel drops the lock when
     the holding process dies, so a crashed repairer cannot leave a stale lock
@@ -2357,14 +2358,22 @@ def _cross_process_repair_lock(db_path: Path):
         lock_path.parent.mkdir(parents=True, exist_ok=True)
         handle = lock_path.open("a+b")
     except OSError as exc:
-        # Read-only dir, exhausted fds, exotic filesystem: fall back to the
-        # in-process behaviour that shipped before this lock existed rather
-        # than refusing to repair a DB we could otherwise heal.
+        # Fail closed, exactly as a timed-out acquire does.  A lock file we
+        # cannot even open means the filesystem is out of space, inodes or
+        # descriptors — and a sibling that opened ITS handle before the disk
+        # filled is still inside writable_schema surgery or VACUUM.  Yielding
+        # True here let two processes run schema surgery on the same live
+        # state.db concurrently, which is itself the corruption source this
+        # lock exists to remove (#100368: the disk-full trigger, then a fresh
+        # corruption on every boot with other writers alive).  Callers already
+        # handle False by re-probing and reporting, and on a read-only
+        # directory no repair strategy could have written anyway.
         logger.warning(
-            "Could not open state.db repair lock %s (%s) — proceeding with "
-            "in-process serialisation only.", lock_path, exc,
+            "Could not open state.db repair lock %s (%s) — skipping schema "
+            "surgery rather than running it without cross-process authority.",
+            lock_path, exc,
         )
-        yield True
+        yield False
         return
 
     acquired = False
@@ -3614,16 +3623,19 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
     result = report
     with _cross_process_repair_lock(db_path) as holding_lock:
         if not holding_lock:
-            # Another process is still inside its critical section. It may
-            # nonetheless have healed the file already (long VACUUM after a
-            # successful strategy), so re-probe before reporting failure.
+            # Another process is still inside its critical section, or the
+            # lock file itself could not be opened (full disk / no fds). It
+            # may nonetheless have healed the file already (long VACUUM after
+            # a successful strategy), so re-probe before reporting failure.
             if _db_opens_cleanly(db_path) is None:
                 report["repaired"] = True
                 report["strategy"] = "repaired_by_other_process"
             else:
                 report["error"] = (
-                    "another process holds the state.db repair lock; skipped "
-                    "schema surgery to avoid racing it"
+                    "could not obtain the state.db repair lock (held by "
+                    "another process, or the lock file was unopenable); "
+                    "skipped schema surgery to avoid racing a concurrent "
+                    "repairer"
                 )
         else:
             # The fast check above avoids taking the lock for a known-exhausted

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -1132,10 +1132,11 @@ def fts_rebuild_admission(db_path):
     """Serialize full structural FTS rebuilds on *db_path* across processes.
 
     Yields True when this process holds the rebuild authority, False when the
-    bounded acquire timed out. A caller that gets False must NOT perform a
-    full rebuild — proceeding is exactly the concurrent-rebuild interleaving
-    this lock exists to prevent (fail closed). The deferred/stale breadcrumb
-    machinery already guarantees a skipped rebuild is retried later.
+    bounded acquire timed out or the lock file could not be opened at all. A
+    caller that gets False must NOT perform a full rebuild — proceeding is
+    exactly the concurrent-rebuild interleaving this lock exists to prevent
+    (fail closed). The deferred/stale breadcrumb machinery already guarantees
+    a skipped rebuild is retried later.
 
     ``db_path`` may be a str or Path; None (in-memory DB / tests without a
     file path) yields True — a private in-memory DB has no cross-process
@@ -1148,13 +1149,22 @@ def fts_rebuild_admission(db_path):
     try:
         handle = open(lock_path, "a+b")
     except OSError as exc:
-        # Read-only dir, exhausted fds, exotic filesystem: fall back to the
-        # pre-lock behaviour rather than refusing a rebuild we could run.
+        # Fail closed, exactly as a timed-out acquire does. A lock file we
+        # cannot even open means the filesystem is out of space, inodes or
+        # descriptors — and a sibling process that opened ITS handle before
+        # the disk filled is still holding the authority and rebuilding.
+        # Yielding True here handed every process on a full disk a concurrent
+        # structural rebuild of the same live state.db with no cross-process
+        # authority at all: the disk-full trigger and the re-corruption on
+        # every multi-writer boot in #100368. Deferring costs nothing that
+        # was reachable anyway — the breadcrumb retries, and on a read-only
+        # directory the rebuild's own writes could not have committed either.
         logger.warning(
-            "Could not open FTS rebuild lock %s (%s) — proceeding with "
-            "in-process serialisation only.", lock_path, exc,
+            "Could not open FTS rebuild lock %s (%s) — deferring this rebuild "
+            "rather than running it without cross-process authority.",
+            lock_path, exc,
         )
-        yield True
+        yield False
         return
 
     acquired = False

--- a/tests/state/test_state_db_lock_fail_closed.py
+++ b/tests/state/test_state_db_lock_fail_closed.py
@@ -1,0 +1,160 @@
+"""Unopenable admission lock files must fail CLOSED (#100368).
+
+`state.db` has two cross-process admission authorities that gate destructive
+work on a file several Hermes processes share (gateway service, the Desktop
+app's `hermes serve` backend, CLI sessions, the TUI slash worker):
+
+* `hermes_state_common.fts_rebuild_admission` — full structural FTS rebuilds
+* `hermes_state._cross_process_repair_lock`   — writable_schema surgery / VACUUM
+
+Both document themselves as fail-closed, and both honoured that only for a
+*timed-out* acquire. When the lock file could not be `open()`ed at all they
+yielded True and proceeded "with in-process serialisation only" — which is no
+cross-process authority whatsoever.
+
+That inversion is reachable exactly when it does the most damage. Creating the
+lock file needs a directory entry and an inode, so on a full disk `open()`
+raises ENOSPC — while a sibling process that opened ITS handle before the disk
+filled is still mid-rebuild or mid-surgery. Every process then ran concurrent
+destructive work on the same live DB, i.e. the precise interleaving PR #93200
+added these locks to prevent. #100368 reports that shape: a disk-full trigger,
+then a fresh corruption on every boot with other writers alive, and no
+re-corruption on a boot with zero other writers.
+
+These tests drive a real unopenable lock path (a directory where the code
+expects a file, so `open()` raises a genuine OSError from the kernel) rather
+than monkeypatching the helpers, and assert the deferral is honoured at both
+the primitive and the behavior level.
+"""
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+import hermes_state
+import hermes_state_common
+from hermes_state import SessionDB, repair_state_db_schema
+
+
+def _make_unopenable(lock_path: Path) -> None:
+    """Make ``open(lock_path, "a+b")`` raise a real OSError.
+
+    A directory standing where the code expects a regular file yields
+    IsADirectoryError on POSIX and PermissionError on Windows — both OSError,
+    both raised by the kernel. This stands in for the ENOSPC/EMFILE the field
+    reports hit, without needing to fill a real disk.
+    """
+    lock_path.unlink(missing_ok=True)
+    lock_path.mkdir(parents=True, exist_ok=True)
+    with pytest.raises(OSError):
+        open(lock_path, "a+b").close()
+
+
+# ── FTS rebuild authority ───────────────────────────────────────────────────
+
+
+def test_fts_admission_fails_closed_when_lock_file_is_unopenable(tmp_path):
+    """The primitive must refuse admission, not fall back to no authority."""
+    db_path = tmp_path / "state.db"
+    _make_unopenable(db_path.with_name(db_path.name + ".fts_rebuild.lock"))
+
+    with hermes_state_common.fts_rebuild_admission(db_path) as admitted:
+        assert admitted is False
+
+
+def test_fts_admission_still_admits_a_pathless_db(tmp_path):
+    """Guardrail: an in-memory store has no cross-process surface at all.
+
+    The fix must not turn the legitimate no-op case into a permanent deferral.
+    """
+    with hermes_state_common.fts_rebuild_admission(None) as admitted:
+        assert admitted is True
+
+
+def test_rebuild_fts_defers_when_lock_file_is_unopenable(tmp_path):
+    """Behavior: the rebuild entry point reports no progress and rebuilds nothing."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    if not db._fts_enabled:
+        db.close()
+        pytest.skip("FTS5 unavailable in this build")
+    try:
+        db.create_session("s1", source="test")
+        db.append_message("s1", "user", "hello world")
+
+        # Sanity: with an openable lock the rebuild really runs, so a 0 below
+        # is the deferral and not an unrelated no-op.
+        assert db.rebuild_fts() >= 1
+
+        _make_unopenable(
+            db.db_path.with_name(db.db_path.name + ".fts_rebuild.lock")
+        )
+        assert db.rebuild_fts() == 0
+    finally:
+        try:
+            db.close()
+        except Exception:
+            pass
+
+
+# ── Schema-surgery authority ────────────────────────────────────────────────
+
+
+def _build_healthy_db(db_path: Path) -> None:
+    db = SessionDB(db_path=db_path)
+    db.create_session("s1", source="test")
+    db.append_message("s1", "user", "hello world")
+    db.close()
+
+
+def _corrupt_duplicate_fts(db_path: Path) -> None:
+    """Inject a duplicate messages_fts row into sqlite_master.
+
+    Reproduces 'malformed database schema (messages_fts) - table
+    messages_fts already exists'.
+    """
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA writable_schema=ON")
+    conn.execute(
+        "INSERT INTO sqlite_master (type, name, tbl_name, rootpage, sql) "
+        "SELECT type, name, tbl_name, rootpage, sql FROM sqlite_master "
+        "WHERE name='messages_fts'"
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_repair_lock_fails_closed_when_lock_file_is_unopenable(tmp_path):
+    """The primitive must refuse the repair authority."""
+    db_path = tmp_path / "state.db"
+    _make_unopenable(db_path.with_name(db_path.name + ".repair.lock"))
+
+    with hermes_state._cross_process_repair_lock(db_path) as holding:
+        assert holding is False
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="writable_schema corruption harness")
+def test_repair_skips_surgery_when_lock_file_is_unopenable(tmp_path):
+    """Behavior: no writable_schema surgery, no forensic backup, DB untouched.
+
+    A full disk is the worst possible moment to start an unsynchronised
+    VACUUM on a live shared DB, and it is exactly when the lock file cannot
+    be created.
+    """
+    db_path = tmp_path / "state.db"
+    _build_healthy_db(db_path)
+    _corrupt_duplicate_fts(db_path)
+    assert hermes_state._db_opens_cleanly(db_path) is not None
+    before = db_path.read_bytes()
+
+    _make_unopenable(db_path.with_name(db_path.name + ".repair.lock"))
+
+    report = repair_state_db_schema(db_path)
+
+    assert report["repaired"] is False
+    assert "repair lock" in (report["error"] or "")
+    assert report["backup_path"] is None
+    assert not list(tmp_path.glob("state.db.malformed-backup-*"))
+    # The damaged image is left byte-identical for the next (authorised) pass.
+    assert db_path.read_bytes() == before


### PR DESCRIPTION
## Summary

`fts_rebuild_admission` and `_cross_process_repair_lock` now fail closed (`yield False`) when the state.db admission lock file cannot be `open()`ed at all, instead of proceeding with destructive FTS rebuilds / schema surgery under no cross-process authority — removing the disk-full re-corruption amplifier in #100368.

## Changes

- `hermes_state_common.py::fts_rebuild_admission` — `OSError` on `open(lock_path, "a+b")` now yields `False` (was `True` with a "proceeding with in-process serialisation only" warning). Docstring/warning updated.
- `hermes_state.py::_cross_process_repair_lock` — same flip; `repair_state_db_schema` error text now names both ways the authority can be missing (held elsewhere, or lock file unopenable). Still re-probes and reports `repaired_by_other_process` when applicable.
- New `tests/state/test_state_db_lock_fail_closed.py` (5 tests) — drives a **real** unopenable lock path (a directory where a file is expected → genuine kernel `OSError`), no monkeypatching of the helpers; covers both primitives, the in-memory guardrail, `rebuild_fts()==0`, and that `repair_state_db_schema` runs no surgery / takes no backup / leaves a malformed image byte-identical.

Callers on current main all handle `False` sanely (verified by reading each): `hermes_state_search.rebuild_fts` → returns 0; `hermes_state_schema._recover_stale_fts` → returns False, stale breadcrumb stays set, canonical writes + LIKE search stay available; `hermes_state_schema._run_admitted_startup_rebuild` → drops FTS triggers, persists `fts_stale`, detaches FTS for this instance; `hermes_state.repair_state_db_schema` → re-probes, reports.

**Intended trade-off (documenting explicitly):** on a *persistently* read-only / unwritable state dir, `_run_admitted_startup_rebuild` will now defer at every startup, so FTS stays detached with the stale breadcrumb set until the dir becomes writable. This is the fail-closed contract both helpers already documented — and on such a dir the rebuild's own writes could not have committed either. Transient ENOSPC/EMFILE (the #100368 shape) simply defers and retries at the next startup.

## Validation

| Check | Result |
|---|---|
| Live repro on `origin/main` (ff7745fb0a) — real `SessionDB`, isolated `HERMES_HOME`, lock paths made directories | **fires**: `admitted = True`, `holding = True`, `rebuild_fts() = 2` |
| Same repro after cherry-pick | **clean**: `admitted = False`, `holding = False`, `rebuild_fts() = 0` |
| `tests/state/test_state_db_lock_fail_closed.py` + `tests/state/test_fts_rebuild_admission.py` + `tests/test_state_db_malformed_repair.py` + `tests/test_state_db_repair_non_destructive.py` + `tests/test_state_db_repair_live_writer_guard.py` | 66 passed |
| Sabotage run (new test file against main's `hermes_state*.py`) | 4 failed / 1 passed (the in-memory guardrail) — test bites |
| `scripts/audit_pr_attribution.py --fix` | all emails mapped (`contributors/emails/liruixinch@outlook.com` already present) |
| Stale-base gate `rev-list --count merge-base..origin/main` | 0 |

**Live repro:** real-import harness (`SessionDB` on isolated `HERMES_HOME`, `<db>.fts_rebuild.lock` / `<db>.repair.lock` replaced by directories so `open()` raises `IsADirectoryError`) — before: `fts_rebuild_admission(db_path) admitted = True` / `_cross_process_repair_lock(db_path) holding = True` / `SessionDB.rebuild_fts() with unopenable lock = 2` → `VERDICT: BUG FIRES (fail-open)`; after: `admitted = False` / `holding = False` / `rebuild_fts() = 0` → `VERDICT: CLEAN (fail-closed)`.

Sibling-site sweep: `hermes_cli/kanban_db.py::kanban_dispatch_lock` also degrades to `acquired = True` on `OSError` — left as-is on purpose (single-dispatcher election, ticks are idempotent, matches the kanban note in `_cross_process_repair_lock`'s docstring). `kanban_db` init lock and `hermes_cli/backup.py::_backup_operation_lock` let the `OSError` propagate (already fail-closed). No other `open(lock_path)` helper guards destructive shared-file work with a fail-open fallback.

Overlap note: #100130 (same author, open) also edits `fts_rebuild_admission` (adds `timeout_seconds` + `is_advisory_lock_contention` classification in the *acquire* loop). It does not touch the `open()` `OSError` branch flipped here; the two are line-adjacent but semantically independent and should rebase cleanly in either order.

Addresses #100368 (the re-corruption amplifier; the corruption producer is tracked separately via #100519).
Salvages #100399 by @HexLab98 — both commits cherry-picked with authorship preserved.

## Infographic
![statedb-admission-lock-fail-closed](https://v3b.fal.media/files/b/0aa8c3ae/LN_34cvmeAwH9Noi1Ruue_Wxw9xn3p.png)
