### PR TITLE
gateway: explicit platforms.<x>.enabled: false no longer overridden by env credentials (#48820 Bug 2, salvage #48852)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1980,6 +1980,64 @@ def _validate_gateway_config(config: "GatewayConfig") -> None:
                 pconfig.enabled = False
 
 
+# Platforms for which the "explicitly disabled in config.yaml, but credentials
+# are present in the environment" WARNING has already been emitted in this
+# process. The gateway reloads its config on every turn (and other surfaces
+# call load_gateway_config() repeatedly), so the notice is one-time per
+# platform per process — loud once at startup, never a per-turn drumbeat.
+_EXPLICIT_DISABLE_WARNED: set = set()
+
+
+# Env var(s) whose presence drives each platform's env-enable branch, for the
+# explicit-disable WARNING below. Kept next to the branches that read them.
+_ENV_ENABLE_CREDENTIALS: dict = {
+    Platform.TELEGRAM: ("TELEGRAM_BOT_TOKEN",),
+    Platform.DISCORD: ("DISCORD_BOT_TOKEN",),
+    Platform.SLACK: ("SLACK_BOT_TOKEN",),
+    Platform.WHATSAPP_CLOUD: ("WHATSAPP_CLOUD_PHONE_NUMBER_ID", "WHATSAPP_CLOUD_ACCESS_TOKEN"),
+    Platform.SIGNAL: ("SIGNAL_HTTP_URL",),
+    Platform.MATTERMOST: ("MATTERMOST_TOKEN",),
+    Platform.MATRIX: ("MATRIX_ACCESS_TOKEN", "MATRIX_PASSWORD"),
+    Platform.HOMEASSISTANT: ("HASS_TOKEN",),
+    Platform.EMAIL: ("EMAIL_ADDRESS", "EMAIL_PASSWORD", "EMAIL_IMAP_HOST", "EMAIL_SMTP_HOST"),
+    Platform.SMS: ("TWILIO_ACCOUNT_SID",),
+    Platform.DINGTALK: ("DINGTALK_CLIENT_ID", "DINGTALK_CLIENT_SECRET"),
+    Platform.FEISHU: ("FEISHU_APP_ID", "FEISHU_APP_SECRET"),
+    Platform.WECOM: ("WECOM_BOT_ID", "WECOM_SECRET"),
+    Platform.WECOM_CALLBACK: ("WECOM_CALLBACK_CORP_ID", "WECOM_CALLBACK_CORP_SECRET"),
+    Platform.WEIXIN: ("WEIXIN_TOKEN", "WEIXIN_ACCOUNT_ID"),
+    Platform.BLUEBUBBLES: ("BLUEBUBBLES_SERVER_URL", "BLUEBUBBLES_PASSWORD"),
+    Platform.QQBOT: ("QQ_APP_ID", "QQ_CLIENT_SECRET"),
+    Platform.YUANBAO: ("YUANBAO_APP_ID", "YUANBAO_APP_SECRET"),
+    Platform.RELAY: ("GATEWAY_RELAY_URL",),
+}
+
+
+def _warn_explicit_disable_beats_env(platform: Platform) -> None:
+    """One-time WARNING: ``platforms.<x>.enabled: false`` wins over env creds.
+
+    Until #48820 the credential-presence branches force-enabled twelve
+    platforms regardless of an explicit ``enabled: false`` in config.yaml, so
+    users who relied on "creds in .env = platform on" would see it go dark
+    after the fix with no explanation. Name the platform, the config key that
+    is winning, and the env var(s) that used to override it.
+    """
+    if platform in _EXPLICIT_DISABLE_WARNED:
+        return
+    _EXPLICIT_DISABLE_WARNED.add(platform)
+    names = _ENV_ENABLE_CREDENTIALS.get(platform) or ()
+    present = [n for n in names if (os.environ.get(n) or "").strip()]
+    creds = ", ".join(present or names) or "its credentials"
+    logger.warning(
+        "Platform '%s' is explicitly disabled by platforms.%s.enabled: false in "
+        "config.yaml, so the credentials found in the environment (%s) will NOT "
+        "start its adapter. Environment credentials no longer override an "
+        "explicit disable. Remove the key or set platforms.%s.enabled: true to "
+        "turn it back on.",
+        platform.value, platform.value, creds, platform.value,
+    )
+
+
 def _apply_env_overrides(config: GatewayConfig) -> None:
     """Apply environment variable overrides to config."""
     getenv = _getenv_str
@@ -1998,8 +2056,13 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         # flag is cleared once for all platforms in the final cleanup at the
         # end of _apply_env_overrides.
         enabled_was_explicit = bool(platform_config.extra.get("_enabled_explicit", False))
-        if not platform_config.enabled and not enabled_was_explicit:
-            platform_config.enabled = True
+        if not platform_config.enabled:
+            if enabled_was_explicit:
+                # Credentials are present (that is why we are here) but the
+                # user said no in config.yaml. Say so once (#48820).
+                _warn_explicit_disable_beats_env(platform)
+            else:
+                platform_config.enabled = True
         return platform_config
     
     # Telegram
@@ -2150,6 +2213,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 # turn an env-token setup into a disabled platform. Only an
                 # explicit slack.enabled/platforms.slack.enabled false should.
                 slack_config.enabled = True
+            elif not slack_config.enabled:
+                _warn_explicit_disable_beats_env(Platform.SLACK)
         # If yaml config exists, respect its enabled flag (don't override
         # explicit enabled: false). Token is still stored so skills that
         # send Slack messages can use it without activating the gateway adapter.

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -2083,9 +2083,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     whatsapp_cloud_phone_id = getenv("WHATSAPP_CLOUD_PHONE_NUMBER_ID")
     whatsapp_cloud_token = getenv("WHATSAPP_CLOUD_ACCESS_TOKEN")
     if whatsapp_cloud_phone_id and whatsapp_cloud_token:
-        if Platform.WHATSAPP_CLOUD not in config.platforms:
-            config.platforms[Platform.WHATSAPP_CLOUD] = PlatformConfig()
-        config.platforms[Platform.WHATSAPP_CLOUD].enabled = True
+        # Honors an explicit ``platforms.whatsapp_cloud.enabled: false`` (#48820).
+        _enable_from_env(Platform.WHATSAPP_CLOUD)
         config.platforms[Platform.WHATSAPP_CLOUD].extra.update({
             "phone_number_id": whatsapp_cloud_phone_id,
             "access_token": whatsapp_cloud_token,
@@ -2248,9 +2247,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # Home Assistant
     hass_token = getenv("HASS_TOKEN")
     if hass_token:
-        if Platform.HOMEASSISTANT not in config.platforms:
-            config.platforms[Platform.HOMEASSISTANT] = PlatformConfig()
-        config.platforms[Platform.HOMEASSISTANT].enabled = True
+        # Honors an explicit ``platforms.homeassistant.enabled: false`` (#48820).
+        _enable_from_env(Platform.HOMEASSISTANT)
         config.platforms[Platform.HOMEASSISTANT].token = hass_token
         hass_url = getenv("HASS_URL")
         if hass_url:
@@ -2262,9 +2260,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     email_imap = getenv("EMAIL_IMAP_HOST")
     email_smtp = getenv("EMAIL_SMTP_HOST")
     if all([email_addr, email_pwd, email_imap, email_smtp]):
-        if Platform.EMAIL not in config.platforms:
-            config.platforms[Platform.EMAIL] = PlatformConfig()
-        config.platforms[Platform.EMAIL].enabled = True
+        # Honors an explicit ``platforms.email.enabled: false`` (#48820).
+        _enable_from_env(Platform.EMAIL)
         config.platforms[Platform.EMAIL].extra.update({
             "address": email_addr,
             "imap_host": email_imap,
@@ -2282,9 +2279,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # SMS (Twilio)
     twilio_sid = getenv("TWILIO_ACCOUNT_SID")
     if twilio_sid:
-        if Platform.SMS not in config.platforms:
-            config.platforms[Platform.SMS] = PlatformConfig()
-        config.platforms[Platform.SMS].enabled = True
+        # Honors an explicit ``platforms.sms.enabled: false`` (#48820).
+        _enable_from_env(Platform.SMS)
         config.platforms[Platform.SMS].api_key = getenv("TWILIO_AUTH_TOKEN", "")
     sms_home = getenv("SMS_HOME_CHANNEL")
     if sms_home and Platform.SMS in config.platforms:
@@ -2410,9 +2406,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     dingtalk_client_id = getenv("DINGTALK_CLIENT_ID")
     dingtalk_client_secret = getenv("DINGTALK_CLIENT_SECRET")
     if dingtalk_client_id and dingtalk_client_secret:
-        if Platform.DINGTALK not in config.platforms:
-            config.platforms[Platform.DINGTALK] = PlatformConfig()
-        config.platforms[Platform.DINGTALK].enabled = True
+        # Honors an explicit ``platforms.dingtalk.enabled: false`` (#48820).
+        _enable_from_env(Platform.DINGTALK)
         config.platforms[Platform.DINGTALK].extra.update({
             "client_id": dingtalk_client_id,
             "client_secret": dingtalk_client_secret,
@@ -2430,9 +2425,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     feishu_app_id = getenv("FEISHU_APP_ID")
     feishu_app_secret = getenv("FEISHU_APP_SECRET")
     if feishu_app_id and feishu_app_secret:
-        if Platform.FEISHU not in config.platforms:
-            config.platforms[Platform.FEISHU] = PlatformConfig()
-        config.platforms[Platform.FEISHU].enabled = True
+        # Honors an explicit ``platforms.feishu.enabled: false`` (#48820).
+        _enable_from_env(Platform.FEISHU)
         config.platforms[Platform.FEISHU].extra.update({
             "app_id": feishu_app_id,
             "app_secret": feishu_app_secret,
@@ -2458,9 +2452,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     wecom_bot_id = getenv("WECOM_BOT_ID")
     wecom_secret = getenv("WECOM_SECRET")
     if wecom_bot_id and wecom_secret:
-        if Platform.WECOM not in config.platforms:
-            config.platforms[Platform.WECOM] = PlatformConfig()
-        config.platforms[Platform.WECOM].enabled = True
+        # Honors an explicit ``platforms.wecom.enabled: false`` (#48820).
+        _enable_from_env(Platform.WECOM)
         config.platforms[Platform.WECOM].extra.update({
             "bot_id": wecom_bot_id,
             "secret": wecom_secret,
@@ -2481,9 +2474,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     wecom_callback_corp_id = getenv("WECOM_CALLBACK_CORP_ID")
     wecom_callback_corp_secret = getenv("WECOM_CALLBACK_CORP_SECRET")
     if wecom_callback_corp_id and wecom_callback_corp_secret:
-        if Platform.WECOM_CALLBACK not in config.platforms:
-            config.platforms[Platform.WECOM_CALLBACK] = PlatformConfig()
-        config.platforms[Platform.WECOM_CALLBACK].enabled = True
+        # Honors an explicit ``platforms.wecom_callback.enabled: false`` (#48820).
+        _enable_from_env(Platform.WECOM_CALLBACK)
         config.platforms[Platform.WECOM_CALLBACK].extra.update({
             "corp_id": wecom_callback_corp_id,
             "corp_secret": wecom_callback_corp_secret,
@@ -2501,9 +2493,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     weixin_token = getenv("WEIXIN_TOKEN")
     weixin_account_id = getenv("WEIXIN_ACCOUNT_ID")
     if weixin_token or weixin_account_id:
-        if Platform.WEIXIN not in config.platforms:
-            config.platforms[Platform.WEIXIN] = PlatformConfig()
-        config.platforms[Platform.WEIXIN].enabled = True
+        # Honors an explicit ``platforms.weixin.enabled: false`` (#48820).
+        _enable_from_env(Platform.WEIXIN)
         if weixin_token:
             config.platforms[Platform.WEIXIN].token = weixin_token
         extra = config.platforms[Platform.WEIXIN].extra
@@ -2543,9 +2534,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     bluebubbles_server_url = getenv("BLUEBUBBLES_SERVER_URL")
     bluebubbles_password = getenv("BLUEBUBBLES_PASSWORD")
     if bluebubbles_server_url and bluebubbles_password:
-        if Platform.BLUEBUBBLES not in config.platforms:
-            config.platforms[Platform.BLUEBUBBLES] = PlatformConfig()
-        config.platforms[Platform.BLUEBUBBLES].enabled = True
+        # Honors an explicit ``platforms.bluebubbles.enabled: false`` (#48820).
+        _enable_from_env(Platform.BLUEBUBBLES)
         config.platforms[Platform.BLUEBUBBLES].extra.update({
             "server_url": bluebubbles_server_url.rstrip("/"),
             "password": bluebubbles_password,
@@ -2583,9 +2573,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     qq_app_id = getenv("QQ_APP_ID")
     qq_client_secret = getenv("QQ_CLIENT_SECRET")
     if qq_app_id or qq_client_secret:
-        if Platform.QQBOT not in config.platforms:
-            config.platforms[Platform.QQBOT] = PlatformConfig()
-        config.platforms[Platform.QQBOT].enabled = True
+        # Honors an explicit ``platforms.qqbot.enabled: false`` (#48820).
+        _enable_from_env(Platform.QQBOT)
         extra = config.platforms[Platform.QQBOT].extra
         if qq_app_id:
             extra["app_id"] = qq_app_id
@@ -2625,9 +2614,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     yuanbao_app_id = getenv("YUANBAO_APP_ID") or getenv("YUANBAO_APP_KEY")
     yuanbao_app_secret = getenv("YUANBAO_APP_SECRET")
     if yuanbao_app_id and yuanbao_app_secret:
-        if Platform.YUANBAO not in config.platforms:
-            config.platforms[Platform.YUANBAO] = PlatformConfig()
-        config.platforms[Platform.YUANBAO].enabled = True
+        # Honors an explicit ``platforms.yuanbao.enabled: false`` (#48820).
+        _enable_from_env(Platform.YUANBAO)
         extra = config.platforms[Platform.YUANBAO].extra
         extra["app_id"] = yuanbao_app_id
         extra["app_secret"] = yuanbao_app_secret

--- a/tests/gateway/test_env_override_explicit_disable_48820.py
+++ b/tests/gateway/test_env_override_explicit_disable_48820.py
@@ -1,0 +1,121 @@
+"""Regression tests for #48820 Bug 2: an explicit ``platforms.<x>.enabled: false``
+in config.yaml must survive ``_apply_env_overrides`` when that platform's
+credentials are present in the environment.
+
+Before the fix, twelve credential-presence branches (weixin, whatsapp_cloud,
+homeassistant, email, sms, dingtalk, feishu, wecom, wecom_callback, bluebubbles,
+qqbot, yuanbao) force-set ``enabled = True`` unconditionally, while Telegram /
+Discord / Slack routed through ``_enable_from_env`` and honored the
+``_enabled_explicit`` marker.  These tests drive the real ``load_gateway_config``
+against a temp HERMES_HOME — real YAML I/O, no mocks of the code under test.
+"""
+
+import pytest
+
+from gateway.config import Platform, load_gateway_config
+
+
+# platform -> env credentials that trigger its env-enable branch
+CRED_ENV = {
+    "weixin": {
+        "WEIXIN_TOKEN": "wx_9f8e7d6c5b4a3f2e1d0c9b8a7f6e5d4c3b2a1f0e",
+        "WEIXIN_ACCOUNT_ID": "acct_12345",
+    },
+    "whatsapp_cloud": {
+        "WHATSAPP_CLOUD_PHONE_NUMBER_ID": "1234567890",
+        "WHATSAPP_CLOUD_ACCESS_TOKEN": "EAAB-test-access-token",
+    },
+    "homeassistant": {"HASS_TOKEN": "hass-long-lived-token"},
+    "email": {
+        "EMAIL_ADDRESS": "bot@example.com",
+        "EMAIL_PASSWORD": "app-password",
+        "EMAIL_IMAP_HOST": "imap.example.com",
+        "EMAIL_SMTP_HOST": "smtp.example.com",
+    },
+    "sms": {"TWILIO_ACCOUNT_SID": "ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"},
+    "dingtalk": {"DINGTALK_CLIENT_ID": "ding-id", "DINGTALK_CLIENT_SECRET": "ding-secret"},
+    "feishu": {"FEISHU_APP_ID": "cli_feishu", "FEISHU_APP_SECRET": "feishu-secret"},
+    "wecom": {"WECOM_BOT_ID": "wecom-bot", "WECOM_SECRET": "wecom-secret"},
+    "wecom_callback": {
+        "WECOM_CALLBACK_CORP_ID": "corp-id",
+        "WECOM_CALLBACK_CORP_SECRET": "corp-secret",
+    },
+    "bluebubbles": {
+        "BLUEBUBBLES_SERVER_URL": "http://127.0.0.1:1234",
+        "BLUEBUBBLES_PASSWORD": "bb-password",
+    },
+    "qqbot": {"QQ_APP_ID": "qq-app", "QQ_CLIENT_SECRET": "qq-secret"},
+    "yuanbao": {"YUANBAO_APP_ID": "yb-app", "YUANBAO_APP_SECRET": "yb-secret"},
+    # control: the pattern that always honored the explicit disable
+    "telegram": {"TELEGRAM_BOT_TOKEN": "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"},
+}
+
+_PLATFORM_ENV_PREFIXES = (
+    "TELEGRAM_", "DISCORD_", "SLACK_", "WEIXIN_", "WHATSAPP_", "HASS_", "EMAIL_",
+    "TWILIO_", "DINGTALK_", "FEISHU_", "WECOM_", "BLUEBUBBLES_", "QQ_", "QQBOT_",
+    "YUANBAO_", "GATEWAY_RELAY", "SIGNAL_", "MATTERMOST_", "MATRIX_",
+)
+
+
+def _isolate(monkeypatch, tmp_path, env):
+    import os
+
+    for key in list(os.environ):
+        if key.startswith(_PLATFORM_ENV_PREFIXES):
+            monkeypatch.delenv(key, raising=False)
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    return hermes_home
+
+
+@pytest.mark.parametrize("platform", sorted(CRED_ENV))
+def test_yaml_explicit_disable_survives_env_credentials(platform, tmp_path, monkeypatch):
+    """``platforms.<x>.enabled: false`` + credentials in env -> stays disabled."""
+    hermes_home = _isolate(monkeypatch, tmp_path, CRED_ENV[platform])
+    (hermes_home / "config.yaml").write_text(
+        f"platforms:\n  {platform}:\n    enabled: false\n", encoding="utf-8"
+    )
+
+    config = load_gateway_config()
+
+    cfg = config.platforms.get(Platform(platform))
+    assert cfg is not None
+    assert cfg.enabled is False, (
+        f"{platform}: env credentials re-enabled a platform the user explicitly "
+        "disabled in config.yaml (#48820 Bug 2)"
+    )
+
+
+@pytest.mark.parametrize("platform", sorted(CRED_ENV))
+def test_env_credentials_still_enable_without_yaml_opinion(platform, tmp_path, monkeypatch):
+    """No ``enabled`` key in YAML + credentials in env -> env-only setup still works."""
+    hermes_home = _isolate(monkeypatch, tmp_path, CRED_ENV[platform])
+    (hermes_home / "config.yaml").write_text("platforms: {}\n", encoding="utf-8")
+
+    config = load_gateway_config()
+
+    cfg = config.platforms.get(Platform(platform))
+    assert cfg is not None and cfg.enabled is True, (
+        f"{platform}: env-only configuration must still enable the platform"
+    )
+
+
+def test_env_credentials_still_populate_extra_when_yaml_disables(tmp_path, monkeypatch):
+    """The disable only gates ``enabled``; credentials are still wired through
+    (mirrors the Slack/API-server contract so send-only tooling keeps working)."""
+    hermes_home = _isolate(monkeypatch, tmp_path, CRED_ENV["weixin"])
+    (hermes_home / "config.yaml").write_text(
+        "platforms:\n  weixin:\n    enabled: false\n", encoding="utf-8"
+    )
+
+    config = load_gateway_config()
+
+    cfg = config.platforms[Platform.WEIXIN]
+    assert cfg.enabled is False
+    assert cfg.token == CRED_ENV["weixin"]["WEIXIN_TOKEN"]
+    assert cfg.extra.get("account_id") == "acct_12345"
+    # marker never leaks out of config load
+    assert "_enabled_explicit" not in cfg.extra

--- a/tests/gateway/test_env_override_explicit_disable_48820.py
+++ b/tests/gateway/test_env_override_explicit_disable_48820.py
@@ -10,8 +10,11 @@ Discord / Slack routed through ``_enable_from_env`` and honored the
 against a temp HERMES_HOME — real YAML I/O, no mocks of the code under test.
 """
 
+import logging
+
 import pytest
 
+from gateway import config as gateway_config
 from gateway.config import Platform, load_gateway_config
 
 
@@ -119,3 +122,78 @@ def test_env_credentials_still_populate_extra_when_yaml_disables(tmp_path, monke
     assert cfg.extra.get("account_id") == "acct_12345"
     # marker never leaks out of config load
     assert "_enabled_explicit" not in cfg.extra
+
+
+@pytest.fixture()
+def _fresh_warn_dedup(monkeypatch):
+    """The explicit-disable notice is one-time per process; start each test clean."""
+    monkeypatch.setattr(gateway_config, "_EXPLICIT_DISABLE_WARNED", set())
+
+
+@pytest.mark.usefixtures("_fresh_warn_dedup")
+@pytest.mark.parametrize("platform", sorted(CRED_ENV))
+def test_explicit_disable_with_env_credentials_warns_once(platform, tmp_path, monkeypatch, caplog):
+    """Users who relied on 'creds in .env = platform on' must be told why it went
+    dark: one WARNING naming the platform, the winning config key, and the env
+    credential(s) — emitted once per process, not on every config reload."""
+    hermes_home = _isolate(monkeypatch, tmp_path, CRED_ENV[platform])
+    (hermes_home / "config.yaml").write_text(
+        f"platforms:\n  {platform}:\n    enabled: false\n", encoding="utf-8"
+    )
+
+    with caplog.at_level(logging.WARNING, logger="gateway.config"):
+        load_gateway_config()
+        load_gateway_config()  # reload: must not repeat
+
+    hits = [
+        r for r in caplog.records
+        if r.levelno == logging.WARNING and f"platforms.{platform}.enabled: false" in r.getMessage()
+    ]
+    assert len(hits) == 1, [r.getMessage() for r in caplog.records]
+    msg = hits[0].getMessage()
+    assert f"Platform '{platform}'" in msg
+    for env_name in CRED_ENV[platform]:
+        assert env_name in msg
+    assert f"platforms.{platform}.enabled: true" in msg  # the remedy
+
+
+@pytest.mark.usefixtures("_fresh_warn_dedup")
+def test_no_warning_when_yaml_has_no_opinion_or_is_enabled(tmp_path, monkeypatch, caplog):
+    hermes_home = _isolate(monkeypatch, tmp_path, {**CRED_ENV["weixin"], **CRED_ENV["homeassistant"]})
+    (hermes_home / "config.yaml").write_text(
+        "platforms:\n  homeassistant:\n    enabled: true\n", encoding="utf-8"
+    )
+
+    with caplog.at_level(logging.WARNING, logger="gateway.config"):
+        config = load_gateway_config()
+
+    assert config.platforms[Platform.WEIXIN].enabled is True
+    assert config.platforms[Platform.HOMEASSISTANT].enabled is True
+    assert not [r for r in caplog.records if "explicitly disabled" in r.getMessage()]
+
+
+@pytest.mark.usefixtures("_fresh_warn_dedup")
+def test_no_warning_when_disabled_and_no_env_credentials(tmp_path, monkeypatch, caplog):
+    """The notice is about credentials being IGNORED; a plain disable is silent."""
+    hermes_home = _isolate(monkeypatch, tmp_path, {})
+    (hermes_home / "config.yaml").write_text(
+        "platforms:\n  weixin:\n    enabled: false\n", encoding="utf-8"
+    )
+
+    with caplog.at_level(logging.WARNING, logger="gateway.config"):
+        config = load_gateway_config()
+
+    assert config.platforms[Platform.WEIXIN].enabled is False
+    assert not [r for r in caplog.records if "explicitly disabled" in r.getMessage()]
+
+
+def test_every_env_enable_branch_is_named_for_the_warning():
+    """Each platform routed through ``_enable_from_env`` needs a credential
+    entry so the WARNING can name what is being ignored."""
+    import inspect, re
+
+    src = inspect.getsource(gateway_config._apply_env_overrides)
+    routed = {Platform[name] for name in re.findall(r"_enable_from_env\(Platform\.([A-Z_]+)\)", src)}
+    routed.add(Platform.SLACK)  # Slack has its own inline copy of the logic
+    missing = {p.value for p in routed} - {p.value for p in gateway_config._ENV_ENABLE_CREDENTIALS}
+    assert not missing, f"platforms without a credential entry for the explicit-disable warning: {missing}"

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -673,6 +673,36 @@ Once the gateway is running, use the `/platform` slash command from any connecte
 
 See also the broader status summary command [`/platforms`](../../reference/slash-commands.md#info).
 
+### Disabling a platform whose credentials are still in `.env`
+
+`platforms.<name>.enabled: false` in `~/.hermes/config.yaml` is authoritative.
+Credentials for that platform left in the environment (`TELEGRAM_BOT_TOKEN`,
+`WEIXIN_TOKEN`, `HASS_TOKEN`, `EMAIL_*`, `TWILIO_ACCOUNT_SID`, ...) are still
+wired into the platform's config so send-only tooling keeps working, but they
+no longer start the adapter:
+
+```yaml title="~/.hermes/config.yaml"
+platforms:
+  weixin:
+    enabled: false   # wins over WEIXIN_TOKEN in .env
+```
+
+Earlier releases let the mere presence of credentials re-enable twelve
+platforms (Weixin, WhatsApp Cloud, Home Assistant, Email, SMS, DingTalk, Feishu,
+WeCom, WeCom callback, BlueBubbles, QQ Bot, Yuanbao) regardless of that key. If
+you relied on that, the gateway now logs one WARNING per affected platform at
+startup so it does not just go dark:
+
+```
+Platform 'weixin' is explicitly disabled by platforms.weixin.enabled: false in config.yaml,
+so the credentials found in the environment (WEIXIN_TOKEN, WEIXIN_ACCOUNT_ID) will NOT start
+its adapter. Environment credentials no longer override an explicit disable. Remove the key
+or set platforms.weixin.enabled: true to turn it back on.
+```
+
+Omitting the `enabled` key entirely keeps the env-only behaviour: credentials
+present → adapter starts.
+
 ### Automatic circuit breaker
 
 Each adapter is wrapped in a circuit breaker. Repeated retryable failures (network blips, rate-limit replies, 5xx upstream responses, websocket disconnects) cause the breaker to trip — the adapter is auto-paused, an operator notification is sent to the home channel of another live platform when one is configured, and a structured log line is emitted.


### PR DESCRIPTION
## Summary

An explicit `platforms.<x>.enabled: false` in `config.yaml` is now honored for all twelve platforms whose env-credential branch previously force-set `enabled = True` (Bug 2 of #48820).

## Changes

- `gateway/config.py` — the weixin, whatsapp_cloud, homeassistant, email, sms, dingtalk, feishu, wecom, wecom_callback, bluebubbles, qqbot and yuanbao branches of `_apply_env_overrides` now route through the existing `_enable_from_env()` helper (which reads the `_enabled_explicit` marker written by `load_gateway_config`) instead of an unconditional `config.platforms[P].enabled = True`. Telegram/Discord/Slack/Signal/Matrix/api_server already did this; this fixes the class at every remaining sibling site, not just the reported Weixin one.
- Credentials are still wired into the (disabled) `PlatformConfig` — same contract Slack and api_server follow, so send-only tooling keeps working.
- `tests/gateway/test_env_override_explicit_disable_48820.py` — 27 real-import tests against a temp `HERMES_HOME` (real YAML I/O, no mocks): explicit-false survives env creds for all 12 platforms (+ telegram control), env-only setup still enables each platform, and credentials still populate `extra` when disabled.

Fix direction and analysis by @JoaoMarcos44 in #48852 (`Co-authored-by` on the commit). The June branch of #48852 no longer applies to main (8 files conflict, `_enable_from_env` semantics changed in #41112), so the Bug-2 half was surgically reapplied here. The watchdog and `trust_env` halves of #48852 are deliberately NOT in this PR (see notes below).

## Validation

| Check | Result |
|---|---|
| New regression file (with fix) | 27 passed |
| Sabotage run (fix stashed, same file) | 13 failed / 14 passed — the 12 platform cases + the extra-population case fail; telegram control and env-only cases pass |
| `tests/gateway/test_config.py` + `test_platform_connected_checkers.py` + platform config tests | 280 passed |
| 26 test files touching the affected env vars (`WEIXIN_TOKEN` … `YUANBAO_APP_SECRET`) | 682 passed, 27 skipped, 1 failed — `tests/integration/test_ha_integration.py::TestGatewayWebSocket::test_event_received_and_forwarded`, which fails identically with the fix stashed (pre-existing on main, unrelated) |
| `ruff check` on both files | clean |
| `scripts/audit_pr_attribution.py --fix` | all contributor emails mapped (`contributors/emails/joaomarcosdias444@gmail.com` already present) |

**Live repro:** real `load_gateway_config()` from the worktree against a temp `HERMES_HOME` with `platforms.<x>.enabled: false` in config.yaml and the platform's credentials in env — before (origin/main `2659c917c1`): 12/13 platforms came back `enabled=True` (only the telegram control honored the yaml); after: 0/13 flipped, all `enabled=False`, telegram unchanged.

## Scope notes (for reviewers)

- Bug 1 (watchdog / silent relaunch death) of #48820 already landed via #45610, #84185, #91675 and #100594 (`ab9866bc64`) — not touched here.
- Bug 3 (`trust_env=True` proxy routing) is still open on main (6 sites in `gateway/platforms/weixin.py`, plus qqbot and the google_chat/teams/sms/wecom/matrix/slack/line plugins) and needs a design decision on the config surface — not touched here.

Partially addresses #48820 (Bug 2). Salvages the Bug-2 half of #48852.

## Infographic
![48820-bug2-explicit-disable](https://v3b.fal.media/files/b/0aa8c3c0/DiJ64Tup8o6yZ-VVHk45f_ZbBgzIra.png)

## De-risking (commit `a7eb54efe90`)

- **One-time startup WARNING when the new precedence bites.** `_enable_from_env` (and Slack's inline copy) now log once per platform per process when the platform is explicitly disabled in `config.yaml` **and** its env credentials are present, naming the platform, the winning key, the ignored env var(s) and the remedy:
  `Platform 'weixin' is explicitly disabled by platforms.weixin.enabled: false in config.yaml, so the credentials found in the environment (WEIXIN_TOKEN, WEIXIN_ACCOUNT_ID) will NOT start its adapter. Environment credentials no longer override an explicit disable. Remove the key or set platforms.weixin.enabled: true to turn it back on.`
  Silent for: a plain disable with no credentials, an enabled platform, the env-only (no YAML opinion) path, and repeated config reloads (dedup set `_EXPLICIT_DISABLE_WARNED`). `_ENV_ENABLE_CREDENTIALS` maps every `_enable_from_env` platform to its triggering env var(s); a test pins that the map covers every routed branch.
- **Docs:** `website/docs/user-guide/messaging/index.md` gains "Disabling a platform whose credentials are still in `.env`" with the precedence rule, the list of the twelve formerly-overridden platforms, and the exact warning text.
- **Live repro** (real `load_gateway_config()` on a temp `HERMES_HOME`: `platforms.weixin/telegram.enabled: false`, `homeassistant.enabled: true`, `WEIXIN_TOKEN`/`TELEGRAM_BOT_TOKEN`/`HASS_TOKEN` in env, loaded twice): before — `weixin: enabled=False`, `telegram: enabled=False`, `homeassistant: enabled=True` with **zero** log output; after — one WARNING each for weixin and telegram (text above), nothing for homeassistant, nothing on the second load.
- **Tests:** `tests/gateway/test_env_override_explicit_disable_48820.py` +16 (`warns_once` ×13 platforms incl. reload-dedup, no-warning-when-enabled/no-opinion, no-warning-without-creds, credential-map-covers-every-branch). Runs: 105 passed (this file + `test_config.py`), 341 passed / 18 skipped across the per-platform config test files (`test_bluebubbles/email/slack_mention/startup_no_eager_platform_install/sms/weixin/matrix/discord_reply_mode/feishu/mattermost`). Sabotage run (drop the warn call) fails all 13 `warns_once` cases.
