### PR TITLE
fix(contributors): add_contributor.py refuses case-colliding email files (salvage #88472, supersedes #100055)

### DIFF
--- a/scripts/add_contributor.py
+++ b/scripts/add_contributor.py
@@ -55,6 +55,22 @@ def _legacy_login(email: str) -> str | None:
         return None
 
 
+def _case_collision(email: str) -> str | None:
+    """An existing mapping whose filename differs from `email` only in case.
+
+    Returns the colliding filename, or None. Exact matches are not collisions --
+    that is the ordinary "already mapped" path handled by the caller.
+    """
+    if not EMAILS_DIR.is_dir():
+        return None
+
+    folded = email.lower()
+    for entry in EMAILS_DIR.iterdir():
+        if entry.name != email and entry.name.lower() == folded:
+            return entry.name
+    return None
+
+
 def add_contributor(email: str, login: str, comment: str = "") -> int:
     email = email.strip()
     login = login.strip().lstrip("@")
@@ -67,6 +83,23 @@ def add_contributor(email: str, login: str, comment: str = "") -> int:
         return 2
 
     path = EMAILS_DIR / email
+
+    # One file per email means the FILENAME is the key, and on a
+    # case-insensitive filesystem (Windows, default macOS) two emails differing
+    # only in case are the same file. Creating both makes the repo impossible to
+    # check out cleanly there -- `git status` reports a phantom modification
+    # forever, because whichever file git wrote second wins on disk. Refuse for
+    # the same reason a conflicting login is refused: resolve it deliberately.
+    collision = _case_collision(email)
+    if collision is not None:
+        print(
+            f"error: {email} collides with existing mapping {collision} on "
+            "case-insensitive filesystems (Windows/macOS) — the two are the same "
+            "file there. Reuse that mapping, or resolve manually.",
+            file=sys.stderr,
+        )
+        return 1
+
     existing = read_mapping_file(path) if path.is_file() else None
     if existing is None:
         existing = _legacy_login(email)

--- a/scripts/add_contributor.py
+++ b/scripts/add_contributor.py
@@ -64,9 +64,11 @@ def _case_collision(email: str) -> str | None:
     if not EMAILS_DIR.is_dir():
         return None
 
-    folded = email.lower()
+    # casefold (not lower) matches how macOS/Windows fold non-ASCII text —
+    # same key scripts/check-case-collisions.py uses repo-wide.
+    folded = email.casefold()
     for entry in EMAILS_DIR.iterdir():
-        if entry.name != email and entry.name.lower() == folded:
+        if entry.name != email and entry.name.casefold() == folded:
             return entry.name
     return None
 

--- a/tests/scripts/test_contributor_map.py
+++ b/tests/scripts/test_contributor_map.py
@@ -116,3 +116,55 @@ def test_cli_entrypoint_end_to_end(tmp_path):
     assert proc.returncode == 0, proc.stderr
     out = (tmp_path / "contributors" / "emails" / "cli@example.com").read_text(encoding="utf-8")
     assert out.splitlines()[0] == "cliperson"
+
+
+# ── case-insensitive filename collisions ──────────────────────────────
+#
+# The mapping key IS the filename, so two emails differing only in case are the
+# same file on Windows and on default macOS. When both exist, git writes one and
+# then reports the other as modified in a FRESH clone, permanently: the repo can
+# never be checked out clean on those platforms.
+#
+# This pair is a real conflict in the tree today and needs a maintainer to say
+# which login is correct -- they point at different logins, so deleting either
+# silently reassigns commits. It is pinned here so the breakage is visible and,
+# more importantly, so it cannot spread.
+KNOWN_CASE_CONFLICTS = {
+    frozenset(
+        {
+            "agent@Agents-Mac-mini.local",
+            "agent@agents-Mac-mini.local",
+        }
+    )
+}
+
+EMAILS_DIR = REPO_ROOT / "contributors" / "emails"
+
+
+def test_no_new_case_insensitive_mapping_collisions():
+    groups: dict[str, set[str]] = {}
+    for entry in EMAILS_DIR.iterdir():
+        if entry.is_file():
+            groups.setdefault(entry.name.lower(), set()).add(entry.name)
+
+    collisions = {frozenset(names) for names in groups.values() if len(names) > 1}
+    unexpected = collisions - KNOWN_CASE_CONFLICTS
+
+    assert not unexpected, (
+        "contributor mappings differing only in case cannot coexist on "
+        "case-insensitive filesystems (Windows, default macOS) — a fresh clone "
+        f"there is permanently dirty: {sorted(sorted(c) for c in unexpected)}"
+    )
+
+
+def test_add_contributor_refuses_a_case_collision(tmp_path, monkeypatch):
+    d = tmp_path / "emails"
+    d.mkdir()
+    (d / "agent@Example-Host.local").write_text("someone\n")
+
+    import add_contributor as mod
+
+    monkeypatch.setattr(mod, "EMAILS_DIR", d)
+
+    assert mod.add_contributor("agent@example-host.local", "otherperson") == 1
+    assert not (d / "agent@example-host.local").exists()

--- a/tests/scripts/test_contributor_map.py
+++ b/tests/scripts/test_contributor_map.py
@@ -125,35 +125,25 @@ def test_cli_entrypoint_end_to_end(tmp_path):
 # then reports the other as modified in a FRESH clone, permanently: the repo can
 # never be checked out clean on those platforms.
 #
-# This pair is a real conflict in the tree today and needs a maintainer to say
-# which login is correct -- they point at different logins, so deleting either
-# silently reassigns commits. It is pinned here so the breakage is visible and,
-# more importantly, so it cannot spread.
-KNOWN_CASE_CONFLICTS = {
-    frozenset(
-        {
-            "agent@Agents-Mac-mini.local",
-            "agent@agents-Mac-mini.local",
-        }
-    )
-}
-
+# The historical agent@Agents-Mac-mini.local / agent@agents-Mac-mini.local pair
+# was removed from the tree (fcdae2cf0b), so there is no allowlist: any pair
+# is a regression. scripts/check-case-collisions.py enforces the same
+# invariant repo-wide in CI; this test keeps it visible next to the writer.
 EMAILS_DIR = REPO_ROOT / "contributors" / "emails"
 
 
-def test_no_new_case_insensitive_mapping_collisions():
+def test_no_case_insensitive_mapping_collisions():
     groups: dict[str, set[str]] = {}
     for entry in EMAILS_DIR.iterdir():
         if entry.is_file():
-            groups.setdefault(entry.name.lower(), set()).add(entry.name)
+            groups.setdefault(entry.name.casefold(), set()).add(entry.name)
 
     collisions = {frozenset(names) for names in groups.values() if len(names) > 1}
-    unexpected = collisions - KNOWN_CASE_CONFLICTS
 
-    assert not unexpected, (
+    assert not collisions, (
         "contributor mappings differing only in case cannot coexist on "
         "case-insensitive filesystems (Windows, default macOS) — a fresh clone "
-        f"there is permanently dirty: {sorted(sorted(c) for c in unexpected)}"
+        f"there is permanently dirty: {sorted(sorted(c) for c in collisions)}"
     )
 
 
@@ -168,3 +158,24 @@ def test_add_contributor_refuses_a_case_collision(tmp_path, monkeypatch):
 
     assert mod.add_contributor("agent@example-host.local", "otherperson") == 1
     assert not (d / "agent@example-host.local").exists()
+
+
+def test_add_contributor_refuses_case_collision_even_for_same_login(emails_dir, capsys):
+    # Same login, different spelling: still refused — the problem is the
+    # filename pair, not the login. The exact spelling is what's "present".
+    emails_dir.mkdir(parents=True)
+    (emails_dir / "Foo@Example.com").write_text("foouser\n")
+
+    assert add_contributor("foo@example.com", "foouser") == 1
+    assert "Foo@Example.com" in capsys.readouterr().err
+    assert sorted(p.name for p in emails_dir.iterdir()) == ["Foo@Example.com"]
+    # Exact-case re-add is the ordinary idempotent path.
+    assert add_contributor("Foo@Example.com", "foouser") == 0
+
+
+def test_case_collision_uses_casefold(emails_dir):
+    # casefold, not lower: matches how macOS/Windows fold non-ASCII (ß ~ ss).
+    emails_dir.mkdir(parents=True)
+    (emails_dir / "strasse@example.com").write_text("someone\n")
+    assert add_contributor("STRASSE@example.com", "someone") == 1
+    assert add_contributor("straße@example.com", "someone") == 1


### PR DESCRIPTION
## Summary
`scripts/add_contributor.py` now refuses to create a `contributors/emails/` file whose name differs only by case from an existing mapping — the pair that made every macOS/Windows clone permanently dirty (#88168, #100047, #99966, #99821) can no longer be recreated.

Salvage of #88472 (@james47kjv, first clean writer-side fix). Also resolves the intent of #100055 (@alfred-amanda), #99995 (@Sahilvishnaliya), #88998 (@EvenXieWF), #88273 (@paoloantinori) — all attack the same class; those carried extra baggage (deleting an already-deleted file, un-freezing `LEGACY_AUTHOR_MAP`, lowercasing filenames, a sidecar JSON, or a new workflow step).

## Changes
- `scripts/add_contributor.py`: `_case_collision()` scans `contributors/emails/` with `str.casefold()` (same key `scripts/check-case-collisions.py` uses repo-wide) and exits 1 with an actionable error before writing. Exact-spelling re-adds stay idempotent.
- `tests/scripts/test_contributor_map.py`: repo-wide zero-collision invariant (no allowlist — the historical `agent@Agents-Mac-mini.local` pair was already removed on main in fcdae2cf0b), writer refusal, same-login/different-spelling refusal, casefold-vs-lower coverage.
- Deliberately NOT touched: `.github/workflows/contributor-check.yml` (the 375ce8eee5 `case-collision-check` job already blocks collisions repo-wide in CI, so a second awk step is redundant and would trip the protected-workflow review gate), `scripts/release.py` (`LEGACY_AUTHOR_MAP` stays frozen), any `contributors/emails/` file.

## Validation
| Check | Result |
|---|---|
| `pytest tests/scripts/test_contributor_map.py tests/scripts/test_case_collision_check.py` | 15 passed |
| Sabotage run (main's `add_contributor.py` + salvaged tests) | `test_add_contributor_refuses_a_case_collision` FAILED (file was created) — test bites |
| `ruff check` on both files | clean |
| `scripts/audit_pr_attribution.py --fix` | all emails mapped (`ijnotion@pm.me` already → james47kjv) |

**Live repro:** `python3 scripts/add_contributor.py Foo@Example.com foouser && python3 scripts/add_contributor.py foo@example.com foouser` in the worktree — before (origin/main 2659c917c1): both `added:` exit 0, two case-colliding files on disk; `scripts/check-case-collisions.py` then flagged the pair only once staged. After: second call → `error: foo@example.com collides with existing mapping Foo@Example.com on case-insensitive filesystems (Windows/macOS) …` exit 1, only `Foo@Example.com` on disk.

Salvages #88472 (cherry-picked, authorship preserved). Supersedes #100055, #99995, #88998, #88273 (co-credited in the follow-up commit).

## Infographic
![case-collision-guard](https://v3b.fal.media/files/b/0aa8c3bf/xBk2iBoHXhFCJz_Ru6zOw_tMqvixXv.png)
