### PR TITLE
fix(desktop): build guard refuses a partial install before clean, for every declared dep (#86443, salvage #87980 + #100637)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -27,7 +27,7 @@
     "profile:main": "tsc --build tsconfig.electron.json && wait-on http://127.0.0.1:5174 && node scripts/bundle-electron-main.mjs --dev && cross-env XCURSOR_SIZE=24 HERMES_DESKTOP_DEV_SERVER=http://127.0.0.1:5174 electron --inspect=9229 .",
     "profile:main:cpu": "tsc --build tsconfig.electron.json && wait-on http://127.0.0.1:5174 && node scripts/bundle-electron-main.mjs --dev && cross-env XCURSOR_SIZE=24 NODE_OPTIONS=--cpu-prof HERMES_DESKTOP_DEV_SERVER=http://127.0.0.1:5174 electron .",
     "start": "npm run build && electron .",
-    "prebuild": "npm run clean",
+    "prebuild": "node scripts/assert-root-install.mjs && npm run clean",
     "build": "node scripts/assert-root-install.mjs && node scripts/write-build-stamp.mjs && vite build && node scripts/bundle-electron-main.mjs && node scripts/stage-native-deps.mjs",
     "postbuild": "node scripts/assert-dist-built.mjs",
     "prebuilder": "node scripts/patch-electron-builder-mac-binary.mjs",

--- a/apps/desktop/scripts/assert-root-install.mjs
+++ b/apps/desktop/scripts/assert-root-install.mjs
@@ -1,35 +1,118 @@
-import { accessSync, readFileSync } from "fs"
+// Build-time guard: refuse to start a build the installed tree cannot finish.
+//
+// The desktop workspace's dependencies are hoisted to the repo-root
+// `node_modules`, so a root install that only covers *part* of the workspace
+// graph leaves this app importable-looking but unbuildable. The guard exists to
+// turn that into one actionable line ("run npm ci from the repo root") instead
+// of a failure deep inside vite.
+//
+// It runs from `prebuild`, ahead of `npm run clean`, so a tree that cannot
+// build is rejected before the build starts deleting its own outputs. `build`
+// re-runs it for anyone invoking the build steps directly; the check is pure
+// filesystem lookups, so paying for it twice costs nothing.
+
+import { existsSync, readFileSync } from "fs"
 import { createRequire } from "module"
-import { resolve, join } from "path"
+import { resolve, join, dirname } from "path"
+import { isMain } from "./utils.mjs"
 
-const app = resolve(import.meta.dirname, "..")
-const root = resolve(app, "..", "..")
+// Packages the build *consumes*, as opposed to merely declares. Each one is
+// load-bearing for a distinct build step, and each one has been observed
+// missing from a partial root install:
+//
+//   vite            — bundles the renderer (`vite build`).
+//   katex           — `src/styles.css` imports `katex/dist/katex.min.css`, so
+//                     the CSS transform fails before a single chunk is emitted.
+//   electron        — the runtime electron-builder packages; without it `pack`
+//                     cannot produce an unpacked app at all.
+//   electron-builder — the packager `npm run builder` shells out to.
+//
+// Checking only `vite` (the original guard) passes a tree missing any of the
+// others, which is how an incomplete install reached `vite build` and died on
+// an unresolved `katex/dist/katex.min.css` with no hint that the install — not
+// the source — was at fault (#86443).
+const BUILD_CRITICAL_PACKAGES = ["vite", "katex", "electron", "electron-builder"]
 
-try {
-  accessSync(join(root, "node_modules", "vite", "package.json"))
-} catch {
-  console.error(`Run from repo root: cd ${root} && npm ci`)
-  process.exit(1)
+// Resolve the way Node's own lookup does — walk `node_modules` upward — rather
+// than through `require.resolve`. A package whose `exports` map does not expose
+// `./package.json` is not resolvable by path even when correctly installed, and
+// that must not read as "missing".
+function packageIsInstalled(name, fromDir) {
+  let dir = fromDir
+  for (;;) {
+    if (existsSync(join(dir, "node_modules", name, "package.json"))) return true
+    const parent = dirname(dir)
+    if (parent === dir) return false
+    dir = parent
+  }
 }
 
-// `vite.config.ts` aliases react/react-dom to whatever this workspace resolves,
-// and React refuses to run when the two come from different installed copies
-// ("Minified React error #527" — it throws before the first paint, so the app
-// window stays blank). npm stays silent about the split because the hoisted
-// react still satisfies react-dom's caret peer range. Fail the build loudly
-// instead of shipping a white screen.
-const requireFromApp = createRequire(join(app, "package.json"))
-const installedVersion = (pkg) =>
-  JSON.parse(readFileSync(requireFromApp.resolve(`${pkg}/package.json`), "utf8")).version
+// Pure check — returns { ok: true } or { ok: false, error: "..." }.
+// Kept side-effect-free so it can be unit tested without spawning a process.
+export function checkRootInstall(appDir, rootDir) {
+  const missing = BUILD_CRITICAL_PACKAGES.filter(pkg => !packageIsInstalled(pkg, appDir))
+  if (missing.length > 0) {
+    return {
+      ok: false,
+      error:
+        `the desktop build needs ${missing.join(", ")}, which the current install ` +
+        `does not provide. A partial root install leaves the workspace looking ` +
+        `present while the build cannot complete. Reinstall from the repo root: ` +
+        `cd ${rootDir} && npm ci`
+    }
+  }
 
-const react = installedVersion("react")
-const reactDom = installedVersion("react-dom")
+  // `vite.config.ts` aliases react/react-dom to whatever this workspace resolves,
+  // and React refuses to run when the two come from different installed copies
+  // ("Minified React error #527" — it throws before the first paint, so the app
+  // window stays blank). npm stays silent about the split because the hoisted
+  // react still satisfies react-dom's caret peer range. Fail the build loudly
+  // instead of shipping a white screen.
+  const requireFromApp = createRequire(join(appDir, "package.json"))
+  const installedVersion = pkg =>
+    JSON.parse(readFileSync(requireFromApp.resolve(`${pkg}/package.json`), "utf8")).version
 
-if (react !== reactDom) {
-  console.error(
-    `react@${react} / react-dom@${reactDom} version mismatch — React would fail ` +
-      `with error #527 and render a blank window. Pin both to the same version ` +
-      `in ${join(app, "package.json")}, then reinstall: cd ${root} && npm ci`
-  )
-  process.exit(1)
+  let react
+  let reactDom
+  try {
+    react = installedVersion("react")
+    reactDom = installedVersion("react-dom")
+  } catch (err) {
+    // Both are in BUILD_CRITICAL_PACKAGES' spirit but not its list: they are
+    // checked by version, and an unreadable package.json is a broken install
+    // rather than an absent one. Report it as such instead of throwing.
+    return {
+      ok: false,
+      error: `could not read the installed react/react-dom versions (${err.message}). Reinstall from the repo root: cd ${rootDir} && npm ci`
+    }
+  }
+
+  if (react !== reactDom) {
+    return {
+      ok: false,
+      error:
+        `react@${react} / react-dom@${reactDom} version mismatch — React would fail ` +
+        `with error #527 and render a blank window. Pin both to the same version ` +
+        `in ${join(appDir, "package.json")}, then reinstall: cd ${rootDir} && npm ci`
+    }
+  }
+
+  return { ok: true }
 }
+
+function main() {
+  const app = resolve(import.meta.dirname, "..")
+  const root = resolve(app, "..", "..")
+  const result = checkRootInstall(app, root)
+
+  if (!result.ok) {
+    console.error(`✗ assert-root-install: ${result.error}`)
+    process.exit(1)
+  }
+}
+
+if (isMain(import.meta.url)) {
+  main()
+}
+
+export default { checkRootInstall }

--- a/apps/desktop/scripts/assert-root-install.mjs
+++ b/apps/desktop/scripts/assert-root-install.mjs
@@ -31,13 +31,25 @@ import { isMain } from "./utils.mjs"
 // others, which is how an incomplete install reached `vite build` and died on
 // an unresolved `katex/dist/katex.min.css` with no hint that the install — not
 // the source — was at fault (#86443).
+//
+// These four are the documented floor — always checked, even when the app's
+// package.json cannot be read. The full class is wider: EVERY non-optional
+// package the workspace manifest declares is something the build may import
+// (`vite.config.ts` pulls `@rolldown/plugin-babel`, `@vitejs/plugin-react`,
+// `@tailwindcss/vite`; `bundle-electron-main.mjs` pulls `esbuild`; the renderer
+// imports the rest). A hand-maintained list drifts the moment a new import
+// lands, so `checkRootInstall` unions the floor with the manifest's declared
+// `dependencies` + `devDependencies` — a partial install is refused whichever
+// package it happened to drop. `optionalDependencies` are excluded by design:
+// npm legitimately skips them (platform-gated natives like `get-windows`).
 const BUILD_CRITICAL_PACKAGES = ["vite", "katex", "electron", "electron-builder"]
 export { BUILD_CRITICAL_PACKAGES }
 
 // Resolve the way Node's own lookup does — walk `node_modules` upward — rather
 // than through `require.resolve`. A package whose `exports` map does not expose
 // `./package.json` is not resolvable by path even when correctly installed, and
-// that must not read as "missing".
+// that must not read as "missing". Scoped names (`@scope/name`) are a nested
+// directory under `node_modules`, which `join` handles.
 function packageIsInstalled(name, fromDir) {
   let dir = fromDir
   for (;;) {
@@ -48,10 +60,27 @@ function packageIsInstalled(name, fromDir) {
   }
 }
 
+// Every package the workspace manifest at `appDir` declares as required
+// (`dependencies` + `devDependencies`; never `optionalDependencies`). An
+// unreadable or malformed manifest yields [] — the floor still applies, and
+// the build's own manifest read fails loudly on its own.
+export function requiredPackages(appDir) {
+  try {
+    const manifest = JSON.parse(readFileSync(join(appDir, "package.json"), "utf8"))
+    return [
+      ...Object.keys(manifest.dependencies ?? {}),
+      ...Object.keys(manifest.devDependencies ?? {}),
+    ]
+  } catch {
+    return []
+  }
+}
+
 // Pure check — returns { ok: true } or { ok: false, error: "..." }.
 // Kept side-effect-free so it can be unit tested without spawning a process.
 export function checkRootInstall(appDir, rootDir) {
-  const missing = BUILD_CRITICAL_PACKAGES.filter(pkg => !packageIsInstalled(pkg, appDir))
+  const wanted = [...new Set([...BUILD_CRITICAL_PACKAGES, ...requiredPackages(appDir)])]
+  const missing = wanted.filter(pkg => !packageIsInstalled(pkg, appDir))
   if (missing.length > 0) {
     return {
       ok: false,

--- a/apps/desktop/scripts/assert-root-install.mjs
+++ b/apps/desktop/scripts/assert-root-install.mjs
@@ -32,6 +32,7 @@ import { isMain } from "./utils.mjs"
 // an unresolved `katex/dist/katex.min.css` with no hint that the install — not
 // the source — was at fault (#86443).
 const BUILD_CRITICAL_PACKAGES = ["vite", "katex", "electron", "electron-builder"]
+export { BUILD_CRITICAL_PACKAGES }
 
 // Resolve the way Node's own lookup does — walk `node_modules` upward — rather
 // than through `require.resolve`. A package whose `exports` map does not expose
@@ -114,5 +115,3 @@ function main() {
 if (isMain(import.meta.url)) {
   main()
 }
-
-export default { checkRootInstall }

--- a/apps/desktop/scripts/assert-root-install.test.mjs
+++ b/apps/desktop/scripts/assert-root-install.test.mjs
@@ -4,9 +4,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { test } from 'vitest'
 
-import { checkRootInstall } from '../scripts/assert-root-install.mjs'
-
-const BUILD_CRITICAL = ['vite', 'katex', 'electron', 'electron-builder']
+import { BUILD_CRITICAL_PACKAGES as BUILD_CRITICAL, checkRootInstall } from '../scripts/assert-root-install.mjs'
 
 // Build a throwaway repo shaped like this one: an app workspace whose
 // dependencies are hoisted to the repo root, which is what the guard walks.

--- a/apps/desktop/scripts/assert-root-install.test.mjs
+++ b/apps/desktop/scripts/assert-root-install.test.mjs
@@ -4,15 +4,17 @@ import os from 'node:os'
 import path from 'node:path'
 import { test } from 'vitest'
 
-import { BUILD_CRITICAL_PACKAGES as BUILD_CRITICAL, checkRootInstall } from '../scripts/assert-root-install.mjs'
+import { BUILD_CRITICAL_PACKAGES as BUILD_CRITICAL, checkRootInstall, requiredPackages } from '../scripts/assert-root-install.mjs'
 
 // Build a throwaway repo shaped like this one: an app workspace whose
 // dependencies are hoisted to the repo root, which is what the guard walks.
-function makeTree({ rootPackages = BUILD_CRITICAL, react = '19.2.7', reactDom = '19.2.7' } = {}) {
+// `manifest` is merged into the app's package.json so tests can declare
+// dependencies the guard is expected to read.
+function makeTree({ rootPackages = BUILD_CRITICAL, react = '19.2.7', reactDom = '19.2.7', manifest = {} } = {}) {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-assert-root-'))
   const appDir = path.join(tempRoot, 'apps', 'desktop')
   fs.mkdirSync(appDir, { recursive: true })
-  fs.writeFileSync(path.join(appDir, 'package.json'), JSON.stringify({ name: 'desktop' }), 'utf8')
+  fs.writeFileSync(path.join(appDir, 'package.json'), JSON.stringify({ name: 'desktop', ...manifest }), 'utf8')
 
   const writePackage = (name, version) => {
     const dir = path.join(tempRoot, 'node_modules', name)
@@ -116,6 +118,79 @@ test('checkRootInstall accepts a package nested in the app workspace', () => {
   fs.writeFileSync(path.join(nested, 'package.json'), JSON.stringify({ name: 'katex' }), 'utf8')
   try {
     assert.deepEqual(checkRootInstall(appDir, tempRoot), { ok: true })
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+// The class, not the four instances: the floor list is what a partial install
+// has been *seen* to drop, but any declared non-optional package can be the one
+// missing next (`vite.config.ts` imports `@rolldown/plugin-babel`, which the
+// floor never named). The guard must read the manifest so the list cannot drift
+// behind a new import.
+test('checkRootInstall fails when a declared devDependency outside the floor is missing', () => {
+  const { tempRoot, appDir } = makeTree({
+    manifest: { devDependencies: { '@rolldown/plugin-babel': '1.0.0', esbuild: '1.0.0' } },
+    rootPackages: [...BUILD_CRITICAL, 'esbuild']
+  })
+  try {
+    const result = checkRootInstall(appDir, tempRoot)
+    assert.equal(result.ok, false)
+    assert.match(result.error, /@rolldown\/plugin-babel/)
+    assert.doesNotMatch(result.error, /esbuild/)
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('checkRootInstall fails when a declared runtime dependency is missing', () => {
+  const { tempRoot, appDir } = makeTree({
+    manifest: { dependencies: { '@vscode/codicons': '1.0.0' } }
+  })
+  try {
+    const result = checkRootInstall(appDir, tempRoot)
+    assert.equal(result.ok, false)
+    assert.match(result.error, /@vscode\/codicons/)
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+// npm skips optionalDependencies legitimately (platform-gated natives), so an
+// absent optional package is not a partial install.
+test('checkRootInstall ignores missing optionalDependencies', () => {
+  const { tempRoot, appDir } = makeTree({
+    manifest: { optionalDependencies: { 'get-windows': '9.3.0' } }
+  })
+  try {
+    assert.deepEqual(checkRootInstall(appDir, tempRoot), { ok: true })
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('checkRootInstall passes when every declared package is installed', () => {
+  const { tempRoot, appDir } = makeTree({
+    manifest: { dependencies: { '@scope/pkg': '1.0.0' }, devDependencies: { esbuild: '1.0.0' } },
+    rootPackages: [...BUILD_CRITICAL, '@scope/pkg', 'esbuild']
+  })
+  try {
+    assert.deepEqual(checkRootInstall(appDir, tempRoot), { ok: true })
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+// The floor is unconditional: a manifest the guard cannot parse must not turn
+// the check off.
+test('checkRootInstall keeps the floor when the manifest is unreadable', () => {
+  const { tempRoot, appDir } = makeTree({ rootPackages: ['vite'] })
+  fs.writeFileSync(path.join(appDir, 'package.json'), '{not json', 'utf8')
+  try {
+    assert.deepEqual(requiredPackages(appDir), [])
+    const result = checkRootInstall(appDir, tempRoot)
+    assert.equal(result.ok, false)
+    assert.match(result.error, /katex/)
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true })
   }

--- a/apps/desktop/scripts/assert-root-install.test.mjs
+++ b/apps/desktop/scripts/assert-root-install.test.mjs
@@ -1,0 +1,124 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { test } from 'vitest'
+
+import { checkRootInstall } from '../scripts/assert-root-install.mjs'
+
+const BUILD_CRITICAL = ['vite', 'katex', 'electron', 'electron-builder']
+
+// Build a throwaway repo shaped like this one: an app workspace whose
+// dependencies are hoisted to the repo root, which is what the guard walks.
+function makeTree({ rootPackages = BUILD_CRITICAL, react = '19.2.7', reactDom = '19.2.7' } = {}) {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-assert-root-'))
+  const appDir = path.join(tempRoot, 'apps', 'desktop')
+  fs.mkdirSync(appDir, { recursive: true })
+  fs.writeFileSync(path.join(appDir, 'package.json'), JSON.stringify({ name: 'desktop' }), 'utf8')
+
+  const writePackage = (name, version) => {
+    const dir = path.join(tempRoot, 'node_modules', name)
+    fs.mkdirSync(dir, { recursive: true })
+    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name, version }), 'utf8')
+  }
+  for (const name of rootPackages) writePackage(name, '1.0.0')
+  if (react !== null) writePackage('react', react)
+  if (reactDom !== null) writePackage('react-dom', reactDom)
+
+  return { tempRoot, appDir }
+}
+
+test('checkRootInstall passes on a complete root install', () => {
+  const { tempRoot, appDir } = makeTree()
+  try {
+    assert.deepEqual(checkRootInstall(appDir, tempRoot), { ok: true })
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+// The regression this guard was widened for: the updater's partial `npm install`
+// left katex out while vite was present, so the old vite-only check passed and
+// the build died on an unresolved `katex/dist/katex.min.css` (#86443).
+test('checkRootInstall fails when katex is missing but vite is present', () => {
+  const { tempRoot, appDir } = makeTree({
+    rootPackages: BUILD_CRITICAL.filter(name => name !== 'katex')
+  })
+  try {
+    const result = checkRootInstall(appDir, tempRoot)
+    assert.equal(result.ok, false)
+    assert.match(result.error, /katex/)
+    assert.match(result.error, /npm ci/)
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('checkRootInstall fails when electron is missing', () => {
+  const { tempRoot, appDir } = makeTree({
+    rootPackages: BUILD_CRITICAL.filter(name => name !== 'electron')
+  })
+  try {
+    const result = checkRootInstall(appDir, tempRoot)
+    assert.equal(result.ok, false)
+    assert.match(result.error, /electron/)
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('checkRootInstall reports every missing package at once', () => {
+  const { tempRoot, appDir } = makeTree({ rootPackages: ['vite'] })
+  try {
+    const result = checkRootInstall(appDir, tempRoot)
+    assert.equal(result.ok, false)
+    for (const name of ['katex', 'electron', 'electron-builder']) {
+      assert.match(result.error, new RegExp(name))
+    }
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+// The original guard's only check — kept, so widening coverage cannot silently
+// drop the case it already handled.
+test('checkRootInstall still fails when vite is missing', () => {
+  const { tempRoot, appDir } = makeTree({
+    rootPackages: BUILD_CRITICAL.filter(name => name !== 'vite')
+  })
+  try {
+    const result = checkRootInstall(appDir, tempRoot)
+    assert.equal(result.ok, false)
+    assert.match(result.error, /vite/)
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('checkRootInstall fails on a react/react-dom version split', () => {
+  const { tempRoot, appDir } = makeTree({ react: '19.2.7', reactDom: '19.1.0' })
+  try {
+    const result = checkRootInstall(appDir, tempRoot)
+    assert.equal(result.ok, false)
+    assert.match(result.error, /#527/)
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+// A package installed into the app's own node_modules rather than hoisted to the
+// root is still installed. The guard walks upward like Node does, so it must not
+// insist on the hoisted location.
+test('checkRootInstall accepts a package nested in the app workspace', () => {
+  const { tempRoot, appDir } = makeTree({
+    rootPackages: BUILD_CRITICAL.filter(name => name !== 'katex')
+  })
+  const nested = path.join(appDir, 'node_modules', 'katex')
+  fs.mkdirSync(nested, { recursive: true })
+  fs.writeFileSync(path.join(nested, 'package.json'), JSON.stringify({ name: 'katex' }), 'utf8')
+  try {
+    assert.deepEqual(checkRootInstall(appDir, tempRoot), { ok: true })
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary

`hermes desktop --build-only` (spawned by `hermes update`) no longer starts deleting its own build outputs on a tree that cannot finish building: the pre-build install guard now refuses a partial root install — naming every missing package — before `clean` runs, and covers every non-optional dependency the desktop manifest declares instead of only `vite`.

Salvage of #87980 by @jackulau (first submitter, cherry-picked with authorship preserved) plus the follow-up from #100637 by @kshitijk4poor (cherry-picked, authorship preserved), then widened to the full dependency class.

## Changes

- `apps/desktop/scripts/assert-root-install.mjs` (@jackulau, #87980): extract a pure `checkRootInstall(appDir, rootDir)`; widen the guard from `vite` to the four build-critical packages (`vite`, `katex`, `electron`, `electron-builder`) and report every missing one in a single message; walk `node_modules` upward like Node's own lookup instead of hard-coding the hoisted root path (`exports`-map packages and workspace-nested installs both resolve correctly); keep the react/react-dom #527 parity check, reporting an unreadable manifest as a broken install instead of throwing.
- `apps/desktop/package.json` (@jackulau): `prebuild` is now `node scripts/assert-root-install.mjs && npm run clean` so an unbuildable tree is rejected before the build deletes anything.
- `apps/desktop/scripts/assert-root-install.mjs` (@kshitijk4poor, #100637): export `BUILD_CRITICAL_PACKAGES` so the test shares the list; drop the dead default export.
- `apps/desktop/scripts/assert-root-install.mjs` (widening): the four packages become an unconditional floor; `checkRootInstall` unions them with every `dependencies` + `devDependencies` entry read from the workspace manifest (`requiredPackages(appDir)`), so any partially-dropped package is refused, not just the four that have been observed so far. `optionalDependencies` are skipped (npm legitimately omits platform-gated natives like `get-windows`); an unreadable manifest falls back to the floor.
- `apps/desktop/scripts/assert-root-install.test.mjs`: 7 scenarios from #87980 + 5 new (declared devDependency outside the floor missing, declared runtime dependency missing, optionalDependencies ignored, everything installed passes, unreadable manifest keeps the floor) = 12.

## Validation

| Check | Result |
|---|---|
| `npx vitest run scripts/assert-root-install.test.mjs` (12 cases) | 12 passed |
| Sabotage A — revert list to `["vite"]` | 3 of the #87980 tests fail (katex-missing, electron-missing, all-missing) |
| Sabotage B — drop the manifest union (`wanted = BUILD_CRITICAL_PACKAGES`) | 2 of the new class tests fail |
| Live repro — see below | fires on main, clean after fix |
| Live gap probe — tree with the 4 floor packages present but `@rolldown/plugin-babel` absent | floor-only guard: exit 0 (passes, `vite build` then dies loading `vite.config.ts`); widened guard: exit 1, names the missing packages |

**Live repro:** real `apps/desktop` copy of origin/main with a partial root `node_modules` (`vite` present, `katex`/`electron`/`electron-builder` absent), a pre-existing `release/linux-unpacked/Hermes` — before: `node scripts/assert-root-install.mjs` exit 0, then `npm run build` ran `prebuild` → `clean` and failed inside `vite build` with `Cannot find package '@rolldown/plugin-babel'`, exit 1, after cleanup had already run; after: `npm run build` stops in `prebuild` at `✗ assert-root-install: the desktop build needs katex, electron, electron-builder, … Reinstall from the repo root: cd <root> && npm ci`, `clean` never runs, `release/linux-unpacked/Hermes` untouched.

Scope note: on current main `clean` is three `tsc --build --clean` runs (only `build/electron-types` + tsbuildinfo) and the `--build-only` path already reports partial + exit 1 on rebuild failure (#88251). The remaining destructive window in #86443 is electron-builder packing in place over `release/<platform>-unpacked` (Windows keeps a `.bak` via before-pack.mjs; macOS/Linux do not) — that is the stage-and-swap work tracked in #91079 / #78431 / #44234 and is out of scope here. This PR is the prevention half: never start a doomed build.

Refs #86443
Closes #87980
Closes #100637

Credit: @jackulau (#87980, first submitter — commit cherry-picked with authorship preserved), @kshitijk4poor (#100637 follow-up — commit cherry-picked with authorship preserved).

## Infographic
![desktop-build-guard](https://v3b.fal.media/files/b/0aa8c3c3/dhHjn0vrkhrc8JJQpRrtO_uCy4Qp45.png)
