### PR TITLE
fix(state): auto-prune closes and later deletes stale open cron/kanban/subagent sessions (#54189, salvage #94095)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2429,6 +2429,65 @@ def _cross_process_repair_lock(db_path: Path):
             handle.close()
 
 
+def _try_acquire_auto_maintenance_lock(db_path: Path) -> Optional[Any]:
+    """Non-blocking cross-process lock for one auto-maintenance pass.
+
+    The kernel releases this advisory lock if the holder exits, unlike a
+    durable pid/meta marker. A caller that cannot acquire it must skip the
+    pass: otherwise two startups can both pass the interval check and the
+    second can prune a row the first has only just closed recoverably.
+    """
+    lock_path = db_path.with_name(db_path.name + ".auto-maintenance.lock")
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        handle = lock_path.open("a+b")
+    except OSError as exc:
+        logger.warning(
+            "Could not open state.db auto-maintenance lock %s (%s) — skipping "
+            "automatic maintenance.",
+            lock_path,
+            exc,
+        )
+        return None
+
+    try:
+        if _IS_WINDOWS:
+            import msvcrt
+
+            handle.seek(0)
+            msvcrt.locking(  # type: ignore[attr-defined]
+                handle.fileno(), msvcrt.LK_NBLCK, 1  # type: ignore[attr-defined]
+            )
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except (BlockingIOError, OSError):
+        handle.close()
+        return None
+    return handle
+
+
+def _release_auto_maintenance_lock(handle: Any) -> None:
+    """Release a handle returned by :func:`_try_acquire_auto_maintenance_lock`."""
+    try:
+        if _IS_WINDOWS:
+            import msvcrt
+
+            handle.seek(0)
+            msvcrt.locking(  # type: ignore[attr-defined]
+                handle.fileno(), msvcrt.LK_UNLCK, 1  # type: ignore[attr-defined]
+            )
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    except OSError:  # pragma: no cover - best effort release
+        pass
+    finally:
+        handle.close()
+
+
 def _bump_schema_cookie(conn: sqlite3.Connection) -> None:
     """Increment the schema cookie after direct ``sqlite_master`` surgery.
 
@@ -4955,6 +5014,19 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     Thread-safe for the common gateway pattern (multiple reader threads,
     single writer via WAL mode). Each method opens its own cursor.
     """
+
+    # Only these state-owned producers participate in automatic stale-open
+    # reconciliation. Messaging-platform and UI/desktop sources have separate
+    # lifecycle owners; unknown/future sources fail closed (#60609).
+    _AUTO_PRUNE_STALE_OPEN_SOURCES: Tuple[str, ...] = (
+        "cli",
+        "cron",
+        "kanban",
+        "acp",
+        "api_server",
+        "subagent",
+        "tool",
+    )
 
     # ── Write-contention tuning ──
     # With multiple hermes processes (gateway + CLI sessions + worktree agents)
@@ -10252,57 +10324,54 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         max_idle_seconds: float,
         sources: Tuple[str, ...] = ("tui", "desktop", "subagent"),
         exclude_ids: Tuple[str, ...] = (),
+        exclude_pinned: bool = False,
         heartbeat_staleness_seconds: Optional[float] = None,
         heartbeat_ownership_grace_seconds: Optional[float] = None,
+        respect_gateway_heartbeats: bool = True,
     ) -> List[str]:
         """Close session rows orphaned by a dead gateway process (#65194, #94895).
 
         The TUI/desktop gateway reaps disconnected websocket sessions with an
         in-process ``threading.Timer`` grace timer; a gateway restart destroys
-        the timer and leaves the row ``ended_at IS NULL`` forever.  This is
-        the startup-time complement: it closes rows for the given ``sources``
-        whose ``started_at`` AND newest ``messages.timestamp`` are both older
-        than ``max_idle_seconds``, with a distinct
+        the timer and leaves the row ``ended_at IS NULL`` forever. This is the
+        startup-time complement: it closes rows for the given ``sources`` whose
+        ``started_at`` and canonical last-activity time are both older than
+        ``max_idle_seconds``, with a distinct
         ``end_reason='startup_orphan_reap'`` for traceability.
 
-        Both timestamps must be stale on purpose: message recency alone would
-        sweep a freshly created compression/branch child carrying old copied
-        message timestamps, while ``started_at`` alone would sweep a
-        long-lived session that is still actively producing messages.
-        Message-less rows fall back to ``started_at`` via COALESCE.
+        Canonical activity is the newest of ``last_activity_at`` (the in-turn
+        heartbeat) and the newest durable message timestamp, falling back to
+        ``started_at``. The separate ``started_at`` predicate protects freshly
+        created compression/branch children whose copied activity is old.
 
-        Only pass sources owned by the local UI stack (never messaging-gateway
+        Only pass sources whose lifecycle the caller owns (never messaging-gateway
         platforms like ``telegram`` — ending those triggers the #60609 routing
-        loop).  ``exclude_ids`` spares rows this process still holds in
-        memory (a ``session.resume`` that landed during the startup grace
-        window).  Non-destructive: messages are preserved and the row remains
-        resumable.  First-reason-wins is preserved via ``ended_at IS NULL``.
+        loop). ``exclude_ids`` spares rows this process still holds in memory
+        (a ``session.resume`` that landed during the startup grace window).
+        ``exclude_pinned`` is intended for broad automatic sweeps; pinned rows
+        remain explicitly recoverable. Non-destructive: messages are preserved
+        and the row remains resumable. First-reason-wins is preserved via
+        ``ended_at IS NULL``.
 
-        Cross-backend liveness (#94895): when one ``state.db`` is shared by
-        N serve / gateway processes (isolated backends, fixed-port launchd
-        ``hermes serve``, desktop WS sidecar), each backend registers a row
-        in ``gateway_heartbeats`` refreshed every few seconds.  A row is
-        only reaped when ``started_at``/message staleness hold AND no live
-        backend (heartbeat refreshed within ``heartbeat_staleness_seconds``,
-        default ``2 * max_idle_seconds``) could plausibly own it.
+        Cross-backend liveness (#94895): when one ``state.db`` is shared by N
+        serve / gateway processes, each backend refreshes a row in
+        ``gateway_heartbeats``. With ``respect_gateway_heartbeats`` enabled, a
+        row is only reaped when activity staleness holds AND no live backend
+        (heartbeat refreshed within ``heartbeat_staleness_seconds``, default
+        ``2 * max_idle_seconds``) could plausibly own it. Disable that gate only
+        for sources whose lifecycle is explicitly owned by state.db itself.
 
         Ownership inference: a live backend B ``owns`` a session S if
         ``B.started_at <= S.started_at + heartbeat_ownership_grace_seconds``
-        (default ``heartbeat_staleness_seconds``).  The grace window
-        accommodates the deploy-time migration case where a backend just
-        wrote its first heartbeat row while its existing open sessions
-        predate the schema.  The grace is bounded by the staleness window
-        so a fresh PID-reuse respawn cannot indefinitely protect sessions
-        inherited from a dead predecessor.
+        (default ``heartbeat_staleness_seconds``). The grace window covers a
+        migrating backend whose existing sessions predate its first heartbeat,
+        but is bounded so a fresh PID-reuse respawn cannot protect rows forever.
+        With no fresh heartbeat the predicate falls back to the legacy sweep.
 
-        When NO backend has ever written a heartbeat (legacy deployment
-        mid-upgrade before any process has registered) the predicate falls
-        back to the original behavior so we never silently strand a row
-        that pre-dates the schema.
-
-        The SELECT + UPDATE run in one ``BEGIN IMMEDIATE`` write, so a sibling
-        process cannot sneak a new message or end-reason between the
-        staleness check and the close.  Returns the swept session ids.
+        The SELECT, live-lease validation, and UPDATE run in one
+        ``BEGIN IMMEDIATE`` transaction. Active turn leases or compression
+        locks spare the row; expired/reclaimed guards are removed so their
+        former owner is fenced. Returns the swept session ids.
         """
         srcs = tuple(s for s in sources if s)
         if max_idle_seconds <= 0 or not srcs:
@@ -10314,56 +10383,76 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         )
         hb_grace = (
             heartbeat_ownership_grace_seconds
-            if heartbeat_ownership_grace_seconds and heartbeat_ownership_grace_seconds >= 0
+            if heartbeat_ownership_grace_seconds is not None
+            and heartbeat_ownership_grace_seconds >= 0
             else hb_staleness
         )
-        cutoff = time.time() - max_idle_seconds
-        hb_cutoff = time.time() - hb_staleness
+        now = time.time()
+        cutoff = now - max_idle_seconds
+        hb_cutoff = now - hb_staleness
         placeholders = ",".join("?" for _ in srcs)
         staleness = (
-            "started_at < ? AND COALESCE((SELECT MAX(m.timestamp) FROM messages m"
-            " WHERE m.session_id = sessions.id), started_at) < ?"
+            f"started_at < ? AND {_sql_session_last_active('sessions')} < ?"
         )
-
-        def _do(conn):
-            # Cross-process liveness gate (#94895). A session is "owned by
-            # a live backend" if any row in gateway_heartbeats is fresh
-            # (last_heartbeat >= hb_cutoff) AND was alive no later than
-            # ``sessions.started_at + hb_grace`` (heartbeats.started_at <=
-            # sessions.started_at + hb_grace). If at least one live backend
-            # matches, the row is not orphaned.
-            #
-            # ``hb_cutoff`` and ``hb_grace`` are computed above so all
-            # backends running concurrent sweep queries agree on the same
-            # boundaries. We do NOT clear heartbeats here — that's each
-            # backend's atexit responsibility via ``clear_backend_heartbeat``.
-            orphan_predicate = (
-                f"{staleness} AND NOT EXISTS ("
+        pin_scope = " AND COALESCE(pinned, 0) = 0" if exclude_pinned else ""
+        heartbeat_params: Tuple[float, ...] = ()
+        orphan_predicate = staleness
+        if respect_gateway_heartbeats:
+            orphan_predicate += (
+                " AND NOT EXISTS ("
                 "SELECT 1 FROM gateway_heartbeats h"
                 " WHERE h.last_heartbeat >= ?"
-                f" AND h.started_at <= sessions.started_at + ?"
+                " AND h.started_at <= sessions.started_at + ?"
                 ")"
             )
+            heartbeat_params = (hb_cutoff, hb_grace)
+
+        def _do(conn):
             rows = conn.execute(
                 f"SELECT id FROM sessions WHERE ended_at IS NULL"
-                f" AND source IN ({placeholders}) AND {orphan_predicate}",
-                (*srcs, cutoff, cutoff, hb_cutoff, hb_grace),
+                f" AND source IN ({placeholders}){pin_scope}"
+                f" AND {orphan_predicate}",
+                (*srcs, cutoff, cutoff, *heartbeat_params),
             ).fetchall()
             excluded = {str(x) for x in exclude_ids if x}
-            victims = [str(r["id"]) for r in rows if str(r["id"]) not in excluded]
+            victims = []
+            for row in rows:
+                sid = str(row["id"])
+                if sid in excluded:
+                    continue
+                try:
+                    self._check_transcript_write_guards(
+                        conn,
+                        sid,
+                        compression_lock_holder=None,
+                        turn_lease_holder=None,
+                        reject_active_turn_lease=True,
+                        reject_active_compression_lock=True,
+                    )
+                except (
+                    SessionCompressionInProgressError,
+                    SessionTurnLeaseLostError,
+                ):
+                    continue
+                victims.append(sid)
             if not victims:
                 return []
-            now = time.time()
+            closed_at = time.time()
             marks = ",".join("?" for _ in victims)
-            # Re-apply the same predicates under the write lock so a
-            # row that raced to activity between SELECT and UPDATE is
-            # spared (and so a freshly registered heartbeat from a sibling
-            # that started during this transaction can still save the row).
+            # Re-apply every scope/liveness predicate under the write lock.
             conn.execute(
                 f"UPDATE sessions SET ended_at = ?, end_reason = 'startup_orphan_reap'"
                 f" WHERE id IN ({marks}) AND ended_at IS NULL"
+                f" AND source IN ({placeholders}){pin_scope}"
                 f" AND {orphan_predicate}",
-                (now, *victims, cutoff, cutoff, hb_cutoff, hb_grace),
+                (
+                    closed_at,
+                    *victims,
+                    *srcs,
+                    cutoff,
+                    cutoff,
+                    *heartbeat_params,
+                ),
             )
             return victims
 
@@ -11873,6 +11962,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         turn_lease_ttl_seconds: float = 300.0,
         reject_active_turn_lease: bool = False,
         reject_active_compression_lock: bool = False,
+        allow_closed_compression_parent: bool = False,
     ) -> None:
         """Transcript-write admission checks, run INSIDE the write txn.
 
@@ -11972,6 +12062,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             session is not None
             and session["ended_at"] is not None
             and session["end_reason"] == "compression"
+            and not allow_closed_compression_parent
         ):
             raise CompressionSessionClosedError(session_id)
 
@@ -14998,6 +15089,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                    ) < ?"""
             )
             params.append(last_active_before)
+            # An automatic orphan sweep closes a stale open row so the user can
+            # still recover it. Age those rows from the sweep, not from their old
+            # activity, or the next prune pass can delete them immediately.
+            clauses.append(
+                "(COALESCE(s.end_reason, '') != 'startup_orphan_reap' "
+                "OR s.ended_at < ?)"
+            )
+            params.append(last_active_before)
         if last_active_after is not None:
             clauses.append(
                 """COALESCE(
@@ -15259,6 +15358,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         older_than_days: Optional[float] = 90,
         source: str = None,
         sessions_dir: Optional[Path] = None,
+        exclude_active_write_guards: bool = False,
         **filters,
     ) -> int:
         """Delete sessions matching the filters. Returns count deleted.
@@ -15296,6 +15396,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         on-disk transcript files (``.json`` / ``.jsonl`` /
         ``request_dump_*``) for every pruned session, outside the DB
         transaction.
+
+        ``exclude_active_write_guards`` is for destructive automatic
+        maintenance: rows protected by a live turn lease or compression lock
+        are skipped, while expired or provably dead holders are reclaimed and
+        fenced in the same write transaction.
         """
         self._apply_prune_age_filter(older_than_days, filters)
         where, where_params = self._prune_filter_where(source=source, **filters)
@@ -15306,6 +15411,26 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 f"SELECT s.id FROM sessions s WHERE {where}", where_params
             )
             session_ids = {row["id"] for row in cursor.fetchall()}
+
+            if exclude_active_write_guards:
+                protected = set()
+                for sid in session_ids:
+                    try:
+                        self._check_transcript_write_guards(
+                            conn,
+                            sid,
+                            compression_lock_holder=None,
+                            turn_lease_holder=None,
+                            reject_active_turn_lease=True,
+                            reject_active_compression_lock=True,
+                            allow_closed_compression_parent=True,
+                        )
+                    except (
+                        SessionCompressionInProgressError,
+                        SessionTurnLeaseLostError,
+                    ):
+                        protected.add(sid)
+                session_ids.difference_update(protected)
 
             if not session_ids:
                 return 0
@@ -16158,6 +16283,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
           - ``"error"`` (str, optional) — present only on failure
         """
         result: Dict[str, Any] = {"skipped": False, "pruned": 0, "vacuumed": False}
+        maintenance_lock = _try_acquire_auto_maintenance_lock(self.db_path)
+        if maintenance_lock is None:
+            result["skipped"] = True
+            return result
         try:
             # Skip if another process/call did maintenance recently.
             last_raw = self.get_meta("last_auto_prune")
@@ -16171,11 +16300,26 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 except (TypeError, ValueError):
                     pass  # corrupt meta; treat as no prior run
 
+            # Delete only sessions that were already explicitly closed. A
+            # startup orphan discovered by this pass is closed *after* pruning,
+            # preserving a full retention window in which it can be resumed.
             pruned = self.prune_sessions(
                 older_than_days=retention_days,
                 sessions_dir=sessions_dir,
+                exclude_active_write_guards=True,
             )
             result["pruned"] = pruned
+
+            # Reap stale state-owned rows only. Runtime-owned messaging sources
+            # are intentionally outside this automatic destructive scope.
+            closed = self.sweep_orphaned_sessions(
+                max_idle_seconds=float(retention_days) * 86400.0,
+                sources=self._AUTO_PRUNE_STALE_OPEN_SOURCES,
+                exclude_pinned=True,
+                # These sources are owned by state.db lifecycles, not by the
+                # dashboard/TUI gateway heartbeats used by startup recovery.
+                respect_gateway_heartbeats=False,
+            )
 
             # Only VACUUM if we actually freed rows, and no more often than
             # once every min_vacuum_interval_days -- a large prune (e.g. the
@@ -16203,9 +16347,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # every startup within the min_interval_hours window.
             self.set_meta("last_auto_prune", str(now))
 
-            if pruned > 0:
+            if closed or pruned > 0:
                 logger.info(
-                    "state.db auto-maintenance: pruned %d session(s) inactive for %d days%s",
+                    "state.db auto-maintenance: closed %d stale open session(s), "
+                    "pruned %d session(s) inactive for %d days%s",
+                    len(closed),
                     pruned,
                     retention_days,
                     " + VACUUM" if result["vacuumed"] else "",
@@ -16214,6 +16360,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # Maintenance must never block startup. Log and return error marker.
             logger.warning("state.db auto-maintenance failed: %s", exc)
             result["error"] = str(exc)
+        finally:
+            _release_auto_maintenance_lock(maintenance_lock)
 
         return result
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -16273,16 +16273,33 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         (``.json`` / ``.jsonl`` / ``request_dump_*``) for pruned sessions
         are removed as part of the same sweep (issue #3015).
 
+        Stale-open reconciliation (#54189): several state-owned producers
+        (cron, kanban workers, subagents, one-shot CLI runs) never set
+        ``ended_at`` when their process dies, and ``prune_sessions`` only
+        deletes ended rows — so retention was a no-op exactly where growth
+        concentrates. After pruning, this pass closes open rows from
+        :attr:`_AUTO_PRUNE_STALE_OPEN_SOURCES` whose activity is older than
+        ``retention_days`` (``end_reason='startup_orphan_reap'``). Closed rows
+        stay resumable and are aged from their close, so they get one more
+        full retention window before a later pass deletes them. Messaging
+        and UI sources are never touched here.
+
         Never raises. On any failure, logs a warning and returns a dict
         with ``"error"`` set.
 
         Returns a dict with keys:
           - ``"skipped"`` (bool) — true if within min_interval_hours of last run
           - ``"pruned"`` (int)   — number of sessions deleted
+          - ``"closed"`` (int)   — stale open state-owned sessions marked ended
           - ``"vacuumed"`` (bool) — true if VACUUM ran
           - ``"error"`` (str, optional) — present only on failure
         """
-        result: Dict[str, Any] = {"skipped": False, "pruned": 0, "vacuumed": False}
+        result: Dict[str, Any] = {
+            "skipped": False,
+            "pruned": 0,
+            "closed": 0,
+            "vacuumed": False,
+        }
         maintenance_lock = _try_acquire_auto_maintenance_lock(self.db_path)
         if maintenance_lock is None:
             result["skipped"] = True
@@ -16320,7 +16337,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 # dashboard/TUI gateway heartbeats used by startup recovery.
                 respect_gateway_heartbeats=False,
             )
-
+            result["closed"] = len(closed)
             # Only VACUUM if we actually freed rows, and no more often than
             # once every min_vacuum_interval_days -- a large prune (e.g. the
             # first one to cross retention_days on a DB with tens of

--- a/tests/hermes_state/test_sweep_orphaned_sessions.py
+++ b/tests/hermes_state/test_sweep_orphaned_sessions.py
@@ -16,6 +16,7 @@ to be older than the cutoff:
   actively producing messages.
 """
 
+import threading
 import time
 
 import pytest
@@ -42,6 +43,15 @@ def _set_message_timestamps(db: SessionDB, session_id: str, ts: float) -> None:
         "UPDATE messages SET timestamp = ? WHERE session_id = ?", (ts, session_id)
     )
     db._conn.commit()
+
+
+def _set_last_activity(db: SessionDB, session_id: str, ts: float) -> None:
+    conn = db._conn
+    assert conn is not None
+    conn.execute(
+        "UPDATE sessions SET last_activity_at = ? WHERE id = ?", (ts, session_id)
+    )
+    conn.commit()
 
 
 def _make_session(
@@ -98,6 +108,17 @@ class TestSweepOrphanedSessions:
 
         assert db.sweep_orphaned_sessions(max_idle_seconds=IDLE_S) == []
         assert db.get_session("active")["ended_at"] is None
+
+    def test_recent_heartbeat_spares_old_session(self, db):
+        """A turn heartbeat is activity even before its next message lands."""
+        stale = time.time() - 48 * 3600
+        _make_session(
+            db, "active-heartbeat", source="tui", started_at=stale, message_at=stale
+        )
+        _set_last_activity(db, "active-heartbeat", time.time())
+
+        assert db.sweep_orphaned_sessions(max_idle_seconds=IDLE_S) == []
+        assert db.get_session("active-heartbeat")["ended_at"] is None
 
     def test_fresh_session_with_old_copied_messages_spared(self, db):
         """Compression/branch children copy history — old message timestamps
@@ -162,6 +183,355 @@ class TestSweepOrphanedSessions:
         ) == ["stale-cli"]
         assert db.get_session("stale-cli")["end_reason"] == "startup_orphan_reap"
         assert db.get_session("stale-tui")["ended_at"] is None
+
+    def test_explicit_source_scope_spares_gateway_sessions(self, db):
+        stale = time.time() - 8 * 3600
+        _make_session(
+            db, "stale-cron", source="cron", started_at=stale, message_at=stale
+        )
+        for sid, session_key in (
+            ("keyed-telegram", "telegram:chat:1"),
+            ("unkeyed-telegram", None),
+        ):
+            db.create_session(sid, source="telegram", session_key=session_key)
+            db.append_message(sid, role="user", content="hello")
+            _set_message_timestamps(db, sid, stale)
+            _backdate_session(db, sid, stale)
+
+        assert db.sweep_orphaned_sessions(
+            max_idle_seconds=IDLE_S, sources=("cron",)
+        ) == ["stale-cron"]
+        assert db.get_session("stale-cron")["end_reason"] == "startup_orphan_reap"
+        assert db.get_session("keyed-telegram")["ended_at"] is None
+        assert db.get_session("unkeyed-telegram")["ended_at"] is None
+
+    def test_automatic_source_scope_spares_pinned_session(self, db):
+        stale = time.time() - 8 * 3600
+        _make_session(
+            db, "pinned", source="cli", started_at=stale, message_at=stale
+        )
+        db.set_session_pinned("pinned", True)
+
+        assert db.sweep_orphaned_sessions(
+            max_idle_seconds=IDLE_S,
+            sources=("cli",),
+            exclude_pinned=True,
+        ) == []
+        assert db.get_session("pinned")["ended_at"] is None
+
+    def test_live_turn_lease_on_compression_lineage_spares_session(self, db):
+        stale = time.time() - 8 * 3600
+        _make_session(db, "root", source="cli", started_at=stale, message_at=stale)
+        db.end_session("root", "compression")
+        db.create_session("tip", source="cli", parent_session_id="root")
+        db.append_message("tip", role="user", content="continued")
+        _set_message_timestamps(db, "tip", stale)
+        _backdate_session(db, "tip", stale)
+        assert db.try_acquire_session_turn_lease(
+            "tip", "external-turn", ttl_seconds=300
+        )
+
+        assert db.sweep_orphaned_sessions(
+            max_idle_seconds=IDLE_S, sources=("cli",)
+        ) == []
+        assert db.get_session("tip")["ended_at"] is None
+
+    def test_active_compression_lock_spares_and_expiry_fences_owner(self, db):
+        stale = time.time() - 8 * 3600
+        _make_session(
+            db, "compressing", source="cli", started_at=stale, message_at=stale
+        )
+        assert db.try_acquire_compression_lock(
+            "compressing", "compressor", ttl_seconds=300
+        )
+
+        assert db.sweep_orphaned_sessions(
+            max_idle_seconds=IDLE_S, sources=("cli",)
+        ) == []
+
+        conn = db._conn
+        assert conn is not None
+        conn.execute(
+            "UPDATE compression_locks SET expires_at = ? WHERE session_id = ?",
+            (time.time() - 1, "compressing"),
+        )
+        conn.commit()
+
+        assert db.sweep_orphaned_sessions(
+            max_idle_seconds=IDLE_S, sources=("cli",)
+        ) == ["compressing"]
+        assert db.get_compression_lock_holder("compressing") is None
+        assert db.refresh_compression_lock("compressing", "compressor") is False
+
+    def test_expired_turn_lease_does_not_block_sweep(self, db):
+        stale = time.time() - 8 * 3600
+        _make_session(
+            db, "expired", source="cli", started_at=stale, message_at=stale
+        )
+        assert db.try_acquire_session_turn_lease(
+            "expired", "expired-turn", ttl_seconds=300
+        )
+        db._conn.execute(
+            "UPDATE session_turn_leases SET expires_at = ? WHERE conversation_id = ?",
+            (time.time() - 1, "expired"),
+        )
+        db._conn.commit()
+
+        assert db.sweep_orphaned_sessions(
+            max_idle_seconds=IDLE_S, sources=("cli",)
+        ) == ["expired"]
+        assert db.get_session("expired")["end_reason"] == "startup_orphan_reap"
+        assert db.refresh_session_turn_lease("expired", "expired-turn") is False
+
+    def test_auto_prune_closes_stale_state_owned_rows_but_spares_live_turns(self, db):
+        stale = time.time() - 100 * 86400
+        recent = time.time() - 86400
+        for sid, source in (
+            ("orphan", "cli"),
+            ("live-turn", "cli"),
+            ("stale-cron", "cron"),
+            ("runtime-owned-ui", "tui"),
+        ):
+            _make_session(db, sid, source=source, started_at=stale, message_at=stale)
+            _set_last_activity(db, sid, stale)
+        _make_session(
+            db,
+            "recent-orphan",
+            source="cli",
+            started_at=recent,
+            message_at=recent,
+        )
+        _set_last_activity(db, "recent-orphan", recent)
+        db.create_session(
+            "keyed", source="telegram", session_key="telegram:chat:1"
+        )
+        _backdate_session(db, "keyed", stale)
+        db.create_session("unkeyed-gateway", source="telegram")
+        _backdate_session(db, "unkeyed-gateway", stale)
+        _set_last_activity(db, "unkeyed-gateway", stale)
+        assert db.try_acquire_session_turn_lease(
+            "live-turn", "external-turn", ttl_seconds=300
+        )
+        db.register_backend_heartbeat(
+            backend_id="unrelated-dashboard",
+            pid=12345,
+            started_at=time.time(),
+            last_heartbeat=time.time(),
+        )
+
+        first = db.maybe_auto_prune_and_vacuum(
+            retention_days=90,
+            min_interval_hours=0,
+            vacuum=False,
+        )
+
+        assert first["pruned"] == 0
+        assert db.get_session("orphan")["end_reason"] == "startup_orphan_reap"
+        assert db.get_session("stale-cron")["end_reason"] == "startup_orphan_reap"
+        assert db.get_session("live-turn")["ended_at"] is None
+        assert db.get_session("recent-orphan")["ended_at"] is None
+        assert db.get_session("runtime-owned-ui")["ended_at"] is None
+        assert db.get_session("keyed")["ended_at"] is None
+        assert db.get_session("unkeyed-gateway")["ended_at"] is None
+
+        second = db.maybe_auto_prune_and_vacuum(
+            retention_days=90,
+            min_interval_hours=0,
+            vacuum=False,
+        )
+
+        assert second["pruned"] == 0
+        assert db.get_session("orphan") is not None
+        assert db.get_session("stale-cron") is not None
+
+        db._conn.execute(
+            "UPDATE sessions SET ended_at = ? WHERE id IN (?, ?)",
+            (stale, "orphan", "stale-cron"),
+        )
+        db._conn.commit()
+        third = db.maybe_auto_prune_and_vacuum(
+            retention_days=90,
+            min_interval_hours=0,
+            vacuum=False,
+        )
+
+        assert third["pruned"] == 2
+        assert db.get_session("orphan") is None
+        assert db.get_session("stale-cron") is None
+
+    def test_failed_maintenance_marker_keeps_newly_swept_row_recoverable(
+        self, db, monkeypatch
+    ):
+        stale = time.time() - 100 * 86400
+        _make_session(
+            db,
+            "recoverable",
+            source="cli",
+            started_at=stale,
+            message_at=stale,
+        )
+        _set_last_activity(db, "recoverable", stale)
+        set_meta = db.set_meta
+        fail_once = True
+
+        def flaky_set_meta(key, value):
+            nonlocal fail_once
+            if key == "last_auto_prune" and fail_once:
+                fail_once = False
+                raise RuntimeError("injected marker failure")
+            return set_meta(key, value)
+
+        monkeypatch.setattr(db, "set_meta", flaky_set_meta)
+
+        first = db.maybe_auto_prune_and_vacuum(
+            retention_days=90,
+            min_interval_hours=0,
+            vacuum=False,
+        )
+        retry = db.maybe_auto_prune_and_vacuum(
+            retention_days=90,
+            min_interval_hours=0,
+            vacuum=False,
+        )
+
+        assert first["error"] == "injected marker failure"
+        assert retry["pruned"] == 0
+        assert db.get_session("recoverable")["end_reason"] == "startup_orphan_reap"
+
+    def test_concurrent_auto_maintenance_preserves_the_recovery_window(
+        self, db, monkeypatch
+    ):
+        stale = time.time() - 100 * 86400
+        _make_session(db, "concurrent", source="cli", started_at=stale, message_at=stale)
+        _set_last_activity(db, "concurrent", stale)
+        peer = SessionDB(db.db_path)
+        read_barrier = threading.Barrier(2)
+        second_done = threading.Event()
+        release_first_prune = threading.Event()
+        errors = []
+        results = {}
+
+        for instance in (db, peer):
+            get_meta = instance.get_meta
+
+            def synchronized_get_meta(key, *, _get_meta=get_meta):
+                value = _get_meta(key)
+                if key == "last_auto_prune":
+                    try:
+                        read_barrier.wait(timeout=1)
+                    except threading.BrokenBarrierError:
+                        pass
+                return value
+
+            monkeypatch.setattr(instance, "get_meta", synchronized_get_meta)
+
+        prune_sessions = db.prune_sessions
+
+        def delayed_prune(*args, **kwargs):
+            assert release_first_prune.wait(timeout=5)
+            return prune_sessions(*args, **kwargs)
+
+        monkeypatch.setattr(db, "prune_sessions", delayed_prune)
+
+        def run(name, instance, *, done=None):
+            try:
+                results[name] = instance.maybe_auto_prune_and_vacuum(
+                    retention_days=90,
+                    min_interval_hours=24,
+                    vacuum=False,
+                )
+            except BaseException as exc:  # pragma: no cover - asserted below
+                errors.append(exc)
+            finally:
+                if done is not None:
+                    done.set()
+
+        first = threading.Thread(target=run, args=("first", db))
+        second = threading.Thread(
+            target=run, args=("second", peer), kwargs={"done": second_done}
+        )
+        try:
+            first.start()
+            second.start()
+            assert second_done.wait(timeout=5)
+            release_first_prune.set()
+        finally:
+            release_first_prune.set()
+            first.join(timeout=5)
+            second.join(timeout=5)
+            peer.close()
+
+        assert not first.is_alive()
+        assert not second.is_alive()
+        assert errors == []
+        assert sum(bool(result["skipped"]) for result in results.values()) == 1
+        assert sum(int(result["pruned"]) for result in results.values()) == 0
+        assert db.get_session("concurrent")["end_reason"] == "startup_orphan_reap"
+
+    def test_auto_prune_spares_compression_root_of_live_turn(self, db):
+        stale = time.time() - 100 * 86400
+        _make_session(db, "root", source="cli", started_at=stale, message_at=stale)
+        db.end_session("root", "compression")
+        db.create_session("tip", source="cli", parent_session_id="root")
+        db.append_message("tip", role="user", content="continued")
+        _set_message_timestamps(db, "tip", stale)
+        _backdate_session(db, "tip", stale)
+        _set_last_activity(db, "tip", stale)
+        assert db.try_acquire_session_turn_lease(
+            "tip", "external-turn", ttl_seconds=300
+        )
+
+        result = db.maybe_auto_prune_and_vacuum(
+            retention_days=90,
+            min_interval_hours=0,
+            vacuum=False,
+        )
+
+        assert result["pruned"] == 0
+        assert db.get_session("root") is not None
+        assert db.get_session("tip")["ended_at"] is None
+
+    def test_auto_prune_spares_prior_sweep_row_with_new_turn_lease(self, db):
+        stale = time.time() - 100 * 86400
+        _make_session(db, "racy", source="cli", started_at=stale, message_at=stale)
+        _set_last_activity(db, "racy", stale)
+        db.end_session("racy", "startup_orphan_reap")
+        assert db.try_acquire_session_turn_lease(
+            "racy", "arriving-turn", ttl_seconds=300
+        )
+
+        result = db.maybe_auto_prune_and_vacuum(
+            retention_days=90,
+            min_interval_hours=0,
+            vacuum=False,
+        )
+
+        assert result["pruned"] == 0
+        assert db.get_session("racy") is not None
+
+    def test_auto_prune_spares_prior_sweep_row_with_new_compression_lock(self, db):
+        stale = time.time() - 100 * 86400
+        _make_session(
+            db,
+            "racy-compression",
+            source="cli",
+            started_at=stale,
+            message_at=stale,
+        )
+        _set_last_activity(db, "racy-compression", stale)
+        db.end_session("racy-compression", "startup_orphan_reap")
+        assert db.try_acquire_compression_lock(
+            "racy-compression", "arriving-compressor", ttl_seconds=300
+        )
+
+        result = db.maybe_auto_prune_and_vacuum(
+            retention_days=90,
+            min_interval_hours=0,
+            vacuum=False,
+        )
+
+        assert result["pruned"] == 0
+        assert db.get_session("racy-compression") is not None
 
     def test_returns_empty_on_empty_db(self, db):
         assert db.sweep_orphaned_sessions(max_idle_seconds=IDLE_S) == []

--- a/tests/hermes_state/test_sweep_orphaned_sessions.py
+++ b/tests/hermes_state/test_sweep_orphaned_sessions.py
@@ -536,6 +536,46 @@ class TestSweepOrphanedSessions:
     def test_returns_empty_on_empty_db(self, db):
         assert db.sweep_orphaned_sessions(max_idle_seconds=IDLE_S) == []
 
+    def test_auto_prune_reports_closed_count_and_deletes_after_second_window(
+        self, db
+    ):
+        """#54189 end-to-end: leaky producers (cron/kanban/subagent) never set
+        ``ended_at``; pass 1 closes them (reported via ``closed``), pass 2 —
+        after a further retention window — deletes them, and a messaging row
+        is never touched by either pass."""
+        stale = time.time() - 200 * 86400
+        for sid, source in (
+            ("cron-0", "cron"),
+            ("kanban-1", "kanban"),
+            ("subagent-2", "subagent"),
+            ("telegram-3", "telegram"),
+        ):
+            _make_session(db, sid, source=source, started_at=stale, message_at=stale)
+            _set_last_activity(db, sid, stale)
+
+        first = db.maybe_auto_prune_and_vacuum(
+            retention_days=90, min_interval_hours=0, vacuum=False
+        )
+        assert first["closed"] == 3
+        assert first["pruned"] == 0
+        for sid in ("cron-0", "kanban-1", "subagent-2"):
+            assert db.get_session(sid)["end_reason"] == "startup_orphan_reap"
+        assert db.get_session("telegram-3")["ended_at"] is None
+
+        # Simulate the next maintenance pass after another retention window.
+        db._conn.execute(
+            "UPDATE sessions SET ended_at = ended_at - 91 * 86400 "
+            "WHERE end_reason = 'startup_orphan_reap'"
+        )
+        db._conn.commit()
+        second = db.maybe_auto_prune_and_vacuum(
+            retention_days=90, min_interval_hours=0, vacuum=False
+        )
+        assert second["closed"] == 0
+        assert second["pruned"] == 3
+        remaining = [r["id"] for r in db._conn.execute("SELECT id FROM sessions")]
+        assert remaining == ["telegram-3"]
+
     def test_zero_ttl_is_noop(self, db):
         stale = time.time() - 8 * 3600
         _make_session(db, "stale-tui", source="tui", started_at=stale, message_at=stale)

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -888,6 +888,19 @@ Active sessions are never auto-pruned, regardless of age. Ended sessions are
 aged from their latest message, so a long-lived conversation used recently is
 not deleted merely because it began before the retention window.
 
+**Stale open sessions from automation.** Some producers — cron jobs, kanban
+workers, subagents, one-shot CLI runs — can die without ever marking their
+session ended, and pruning only deletes *ended* rows. To keep those from
+accumulating forever, each auto-prune pass also *closes* open sessions from
+those state-owned sources (`cli`, `cron`, `kanban`, `acp`, `api_server`,
+`subagent`, `tool`) whose last activity is older than `retention_days`
+(`end_reason: startup_orphan_reap`). Closing is non-destructive — the
+session stays resumable — and the row is aged from its close, so it is only
+deleted by a *later* pass after a further full retention window. Messaging
+platform sessions (Telegram, Discord, …), TUI/desktop sessions, pinned
+sessions, and sessions with a live turn or compression in progress are
+never closed by this sweep.
+
 ### Oversized-Transcript Guards
 
 Two limits stop a runaway transcript from being loaded into memory all at once


### PR DESCRIPTION
## Summary

`sessions.auto_prune` now actually reclaims the sessions that drive state.db growth: stale open rows left by state-owned producers (cron, kanban workers, subagents, one-shot CLI, acp, api_server, tool) that never set `ended_at` are closed on one maintenance pass and deleted on a later one — the `ended_at`-producer gap that made retention a no-op exactly where growth concentrates (#54189).

## Changes

- **Salvaged #94095 (@stepanov1975, cherry-picked with authorship preserved):**
  - `maybe_auto_prune_and_vacuum()` runs a stale-open reconciliation after pruning: `sweep_orphaned_sessions()` over a fail-closed source allowlist (`_AUTO_PRUNE_STALE_OPEN_SOURCES`), `exclude_pinned=True`, gateway-heartbeat gate bypassed only for that allowlist (unrelated dashboard heartbeats no longer suppress cleanup).
  - Rows closed as `startup_orphan_reap` are aged from their close time in the prune filter, so a swept row keeps a full retention window before deletion (prune-before-close ordering + filter clause).
  - Live turn leases / compression locks spare a row; expired or dead-holder guards are reclaimed inside the same `BEGIN IMMEDIATE` transaction (`exclude_active_write_guards`, `allow_closed_compression_parent`).
  - Concurrent maintenance callers are serialized with a non-blocking, crash-released sidecar flock (`state.db.auto-maintenance.lock`) — the second caller skips instead of pruning a row the first just closed.
  - Staleness uses canonical last-activity (`_sql_session_last_active`) instead of a raw message-timestamp subquery.
- **Follow-up (this PR):** result dict gains `"closed"` (count of stale open rows ended) so entrypoints don't have to parse logs; docstring explains the two-window lifecycle; new regression test for the full cron/kanban/subagent close→delete flow with a telegram row untouched; `website/docs/user-guide/sessions.md` documents the sweep.

## Validation

| Check | Result |
|---|---|
| `tests/hermes_state/test_sweep_orphaned_sessions.py` | 25 passed |
| Sabotage run (main's `hermes_state.py` + salvaged tests) | 11 failed / 13 passed → proves the tests bite |
| Sibling suites: `test_94895_orphan_sweep_cross_backend`, `test_never_active_keyed_prune`, `test_empty_sweep_archived_transcript_95868`, `test_88197_automatic_ended_stamp`, `test_session_vacuum_config`, `gateway/test_async_session_db`, `hermes_cli/test_prune_spares_pinned` | 77 passed |
| `tests/test_hermes_state.py -k "prune or vacuum or sweep or orphan or maintenance or retention"` | 28 passed |
| `ruff check` | clean |
| Stale-base gate (`rev-list merge-base..origin/main`) | 0 |

**Live repro:** real-import harness (worktree at `sys.path[0]`, temp `HERMES_HOME`, real `SessionDB` on disk) — cron/kanban/subagent/telegram sessions aged 200 days with `ended_at NULL`, `maybe_auto_prune_and_vacuum(retention_days=90)` twice with a retention window between — **before (origin/main):** `run1 {'pruned': 0}`, `run2 {'pruned': 0}`, all four rows still present with `ended_at NULL` (retention is a no-op); **after:** `run1 {'pruned': 0, 'closed': 3}` (cron/kanban/subagent → `startup_orphan_reap`, telegram untouched), `run2 {'pruned': 3, 'closed': 0}`, only `telegram-3` remains.

Partially addresses #54189 (the `ended_at`-producer gap; the safe-defaults and FTS-amplification gaps remain `needs-decision`).
Salvages #94095 — thanks @stepanov1975 (commit cherry-picked, authorship preserved).

## Producer-side closes — verified live, no new code needed

Teknium asked that cron / kanban / subagent / one-shot CLI runs close their own rows on normal completion so the sweep above is a backstop, not the primary mechanism. Live check on current `origin/main` (real `hermes` CLI + real `cron.scheduler.run_job` + real `delegate_task`, stub OpenAI-compatible LLM on loopback, temp `HERMES_HOME`, real `state.db`): **every one of those producers already ends its row on normal completion** — so there is nothing to add on this branch and the sweep really is a backstop for abnormal exits only.

| Producer | Path that already ends the row (on main) | Live result |
|---|---|---|
| cron `run_job` | `cron/scheduler.py` finally → `end_session(tip, "cron_complete" \| "cron_incomplete_no_output")` (650b400c980, #2998) | `('cron_88499ea8a3c5_…', 'cron', 1788332796.4, 'cron_complete')` |
| kanban worker (`hermes chat -q -Q` with `HERMES_KANBAN_TASK` + `HERMES_SESSION_SOURCE=kanban`) | `cli._finalize_single_query` → `_flush_one_shot_session_store` → `end_session(…, "cli_close")` (56de3c14281); SIGTERM path calls the same helper before `os._exit` | `('20260902_001234_87017b', 'kanban', 1788333155.9, 'cli_close')` |
| one-shot `hermes chat -q` | same `_finalize_single_query` path | `('20260902_001231_a2f966', 'cli', 1788333153.9, 'cli_close')` |
| one-shot `hermes --oneshot` (`hermes_cli/oneshot.py`) | `agent.close()` → `end_session(…, "agent_close")` (b17180d950b) | `('20260902_001237_324911', 'cli', 1788333158.3, 'agent_close')` |
| subagent (`delegate_task`) | `_run_single_child` finally → `child.close()` → `end_session(…, "agent_close")` (b17180d950b, `_owns_session_db=True`) | `('20260902_000922_e6f3c5', 'subagent', 1788332962.8, 'agent_close', parent='20260902_000922_79b6ce')` |

Same harness on this branch: identical rows (`cron_complete` / `cli_close` / `agent_close`), i.e. the salvage does not disturb the producer closes.

What the open rows on the dev box actually are (read-only query against the live `state.db`): `cron` 10 open of 253 — all end mid-tool-call (last row `role=tool`) in the same minute a gateway was killed/restarted; `subagent` 4 open of 916 — all children of a currently-running parent; `cli` 33 open — interactive sessions still resumable by design plus 0-message rows from Feb-2026 pre-`_flush_one_shot_session_store` builds. Those are exactly the abnormal-exit / still-live shapes the sweep is for; none are normal completions that a producer failed to close.

Related open PRs re-checked against main, none cherry-picked because main already covers them: #76995 (@webtecnica — kanban `ended_at`; superseded by `_flush_one_shot_session_store`, 56de3c14281), #44088 (@schlaufuchs26 — oneshot `end_session`; superseded by `AIAgent.close()` finalization, b17180d950b), #62663 (@yingliang-zhang — cron tick reaper; a second reaping mechanism alongside this PR's sweep, and cron already ends its row on completion).

**Live repro (producer closes):** stub-LLM `hermes chat -q` / `-Q` kanban-shaped worker / `hermes --oneshot` / `cron.scheduler.run_job` / `delegate_task` against temp `HERMES_HOME` — before (origin/main) and after (this branch) both show `ended_at` set with `cli_close` / `cli_close` / `agent_close` / `cron_complete` / `agent_close` respectively; no producer left `ended_at NULL` on normal completion, so there was no fix to apply and none is included.

## Infographic
![statedb-stale-open-retention](https://v3b.fal.media/files/b/0aa8c3c3/vMlmnpPetVPaeUpM_Sem4_hYZB0LMT.png)

