### PR TITLE
ci: correct the e2e-desktop disable comment — the cause was a bracket transposition, not the ${{ }} form

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,11 +123,25 @@ jobs:
     # single job in the workflow — while still running the full pytest lanes.
     #
     # Re-disabled (Sep 2026): the Sep 1 re-enable is still incredibly flaky.
-    # Keep this a bare `if: false`. The earlier
-    # `${{ false && (... || ...) }}` form on this reusable-workflow job made
-    # GitHub's workflow parser fail at startup ("An unexpected error has
-    # occurred") — every ci.yaml run repo-wide dispatched 0 jobs from
-    # 24f5a60ed1 until this line changed. To re-enable, restore:
+    #
+    # Keep this a bare `if: false` — it is the clearest way to disable a job.
+    # But the Sep 1 outage was NOT caused by putting a `${{ }}` expression on
+    # this reusable-workflow job. The line 24f5a60ed1 shipped transposed its
+    # closing brackets:
+    #
+    #     ${{ false && (... == 'true' || ... == 'true' })}
+    #                                                  ^^^  `}` before `)`
+    #
+    # which leaves `${{` unclosed. GitHub's expression parser rejects that
+    # before it creates any job, so every ci.yaml run repo-wide dispatched
+    # 0 jobs from 24f5a60ed1 until it was fixed. Note how it escaped review:
+    # a workflow GitHub cannot parse produces no run at all, so the required
+    # `CI` check did not go red — it stopped existing, and there was nothing
+    # pending for the gate to block on.
+    #
+    # The balanced form loads fine — #100754 and #100757 restored exactly it
+    # and their ci.yaml runs dispatched 23 and 30 jobs — so the expression
+    # below is safe to restore as-is when re-enabling:
     #   if: ${{ needs.detect.outputs.python_prod == 'true' || needs.detect.outputs.frontend == 'true' }}
     if: false
     uses: ./.github/workflows/e2e-desktop.yml


### PR DESCRIPTION
Comment-only follow-up to #100752, which fixed the outage correctly. Its committed comment misattributes the cause, and the misattribution contradicts the comment's own restore instruction.

## What the comment says vs what happened

`ci.yaml:125-127` on `main` now reads:

> Keep this a bare `if: false`. The earlier `${{ false && (... || ...) }}` form on this reusable-workflow job made GitHub's workflow parser fail at startup

The form was not the problem. The line `24f5a60ed1` shipped transposed its closing brackets. `ci.yaml:126` as it stood, last 13 bytes:

```
$ git show 24f5a60ed1:.github/workflows/ci.yaml | sed -n '126p' | tail -c 14 | od -c
0000000   =   =       '   t   r   u   e   '       }   )   }  \n
```

`}` before `)`, so `${{` never closes. GitHub's expression parser rejects that before it creates any job — hence 0 jobs, repo-wide.

## The balanced form loads fine — measured

#100754 and #100757 restored exactly `${{ false && (needs.detect.outputs.python_prod == 'true' || needs.detect.outputs.frontend == 'true') }}` on this same reusable-workflow job:

| PR | form | `ci.yaml` run | jobs dispatched |
|---|---|---|---|
| #100754 | balanced `${{ false && (…) }}` | `CI` | **23** |
| #100757 | balanced `${{ false && (…) }}` | `CI` | **30** |
| #100752 | bare `if: false` | `CI` | **30** |

The run **name** is the tell: `CI` when the file parses, `.github/workflows/ci.yaml` when it does not. All three parse.

Independently, this job carried a `${{ }}` `if:` before `24f5a60ed1` and worked:

```yaml
# b3576a29c, same job, same `uses: ./.github/workflows/e2e-desktop.yml`
if: ${{ needs.detect.outputs.python_prod == 'true' || needs.detect.outputs.frontend == 'true' }}
```

## Why this is worth a PR rather than leaving it

The comment tells the next person a working construct is forbidden — and the restore line it offers is itself a `${{ }}` expression on this job. So following its own instruction looks like reintroducing the outage it warns about. Someone re-enabling Desktop E2E has to either disbelieve the comment or work around a constraint that does not exist.

`if: false` is genuinely the cleaner way to disable a job and this PR keeps it. Only the explanation changes.

## Also recorded

The revised comment keeps #100752's blast-radius note and adds how the breakage escaped review, which is the transferable lesson: an unparseable workflow produces **no run**, so the required `CI` check did not go red — it stopped existing, and no pending check remained for a required-check gate to block on. The PR that shipped it was green. #100812 (@JoaoMarcos44) adds the lint that catches this class; this PR just stops the file from misdescribing it in the meantime.

Comment-only; no behaviour change. `ci.yaml` re-verified as parseable (22 jobs).
