### PR TITLE
fix(agent): bridge bare MCP catalog names; never fuzzy-match mcp__ names

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3831,8 +3831,83 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
         if c and c in agent.valid_tool_names:
             return c
 
-    # Fuzzy match as last resort.
-    matches = get_close_matches(lowered, agent.valid_tool_names, n=1, cutoff=0.7)
+    # ── MCP name bridging (#100807) ────────────────────────────────────
+    # Prompts and skills naturally teach the BARE MCP catalog name
+    # (``entity_search``), but the runtime registers tools as
+    # ``mcp__<server>__<tool>`` — a ~10-19 char prefix that pushes
+    # ``entity_search`` vs ``mcp__example_server__entity_search`` far below
+    # the 0.7 fuzzy cutoff, so the bare name was never repaired and one
+    # invalid name voided the whole tool batch.
+    #
+    # The inverse hazard is worse: the shared ``mcp__`` prefix inflates
+    # ratios BETWEEN mcp tools past the cutoff, so a hallucinated prefixed
+    # name silently fuzzy-resolves to a DIFFERENT real tool (measured 12/12
+    # hallucinations mis-routed on a 51-tool server; a cron asking for core
+    # ``kanban_list`` repaired to ``list_goals`` and ran it). So MCP names
+    # are bridged EXACTLY or not at all — never fuzzy-matched:
+    #
+    #   * bare name  -> exact ``mcp__<server>__<name>`` when exactly one
+    #     registered MCP tool has that catalog suffix (two servers exposing
+    #     the same name is ambiguous -> None, letting the model self-correct
+    #     rather than guessing the server).
+    #   * prefixed emission that does not exist -> strip the prefix and try
+    #     the bare suffix against NON-MCP (core) tools only, exactly, else
+    #     None. Never fall through to fuzzy for anything mcp-shaped.
+    mcp_valid = [t for t in agent.valid_tool_names if t.startswith("mcp__")]
+    lowered_is_mcp = lowered.startswith("mcp__")
+
+    def _mcp_bridge(candidate: str) -> str | None:
+        if mcp_valid and not lowered_is_mcp:
+            # Bare catalog name: match the suffix after the server segment.
+            # Prefixes come from the registered set itself (never by
+            # splitting on the delimiter, which breaks on servers/tools
+            # containing "__" after sanitization).
+            hits = []
+            for vt in mcp_valid:
+                rest = vt[len("mcp__"):]
+                # rest is "<server>__<tool>"; the catalog name matches when
+                # rest ends with "__<candidate>".
+                if rest.endswith(f"__{candidate}"):
+                    hits.append(vt)
+            if len(hits) == 1:
+                return hits[0]
+            # 0 hits (unknown bare name) or 2+ (ambiguous server) -> None
+            return None
+        return None
+
+    bridge = _mcp_bridge(normalized)
+    if bridge is not None:
+        logger.info(
+            "repair_tool_call: bridged bare MCP catalog name %r -> %r",
+            normalized, bridge,
+        )
+        return bridge
+
+    if lowered_is_mcp:
+        # A prefixed emission that did NOT match exactly: strip the prefix
+        # and try the bare suffix against CORE tools only (exact). This
+        # covers emissions like ``mcp__kanban_list`` where the model
+        # prefixed a CORE tool. Never fuzzy — the shared prefix mis-routes.
+        stripped = lowered[len("mcp__"):]
+        core_valid = [t for t in agent.valid_tool_names
+                      if not t.startswith("mcp__")]
+        # The core attempt needs the full candidate set (camel/snake/suffix
+        # variants) for parity with how core names are normalized above.
+        for c in (stripped, _norm(stripped), _camel_snake(stripped)):
+            if c and c in core_valid:
+                logger.info(
+                    "repair_tool_call: stripped MCP prefix from %r -> core %r",
+                    lowered, c,
+                )
+                return c
+        return None
+
+    # Fuzzy match as last resort — core tools only. MCP names never enter
+    # this step: the shared mcp__ prefix inflates every ratio between MCP
+    # tools past the cutoff, which is exactly the silent mis-route (#100807).
+    core_names = [t for t in agent.valid_tool_names
+                  if not t.startswith("mcp__")]
+    matches = get_close_matches(lowered, core_names, n=1, cutoff=0.7)
     if matches:
         return matches[0]
 

--- a/tests/run_agent/test_repair_tool_call_name.py
+++ b/tests/run_agent/test_repair_tool_call_name.py
@@ -125,3 +125,80 @@ class TestVolcEngineXmlPollution:
         # rest of the pipeline (fuzzy match at 0.7 cutoff) can still
         # recover the obvious target.
         assert repair('"terminal"') == "terminal"
+
+
+    def test_leading_quote_falls_through_to_fuzzy_match(self, repair):
+        # Sanitizer only trims when the XML char is at idx > 0 - a
+        # name that *starts* with a quote is left untouched so the
+        # rest of the pipeline (fuzzy match at 0.7 cutoff) can still
+        # recover the obvious target.
+        assert repair('"terminal"') == "terminal"
+
+
+# -- MCP name bridging (#100807) --------------------------------------------
+#
+# Prompts teach the BARE MCP catalog name; the runtime registers
+# ``mcp__<server>__<tool>``. The old bare-fuzzy failed both directions:
+# bare names scored below cutoff (whole batch voided), and hallucinated
+# prefixed names silently fuzzy-resolved to a DIFFERENT real MCP tool
+# (measured 12/12 mis-routes on a 51-tool server).
+
+MCP_VALID = {
+    "mcp__example_server__entity_search",
+    "mcp__example_server__entity_update",
+    "mcp__example_server__drive_read",
+    "mcp__example_server__calendar_update",
+    "mcp__other_server__drive_read",  # same catalog name on 2 servers
+} | VALID  # core tools still registered alongside
+
+MIXED_STUB = SimpleNamespace(valid_tool_names=MCP_VALID)
+
+
+@pytest.fixture
+def mcp_repair():
+    from run_agent import AIAgent
+    return AIAgent._repair_tool_call.__get__(MIXED_STUB, AIAgent)
+
+
+class TestMcpNameBridging:
+    def test_bare_catalog_name_bridges_to_registered_mcp_tool(self, mcp_repair):
+        """entity_search -> mcp__example_server__entity_search (exactly one
+        server exposes it)."""
+        assert mcp_repair("entity_search") == "mcp__example_server__entity_search"
+
+    def test_ambiguous_bare_name_returns_none_not_fuzzy(self, mcp_repair):
+        """drive_read is exposed by TWO servers -> ambiguous -> None. Never
+        guess the server; let the model self-correct."""
+        assert mcp_repair("drive_read") is None
+
+    def test_unknown_bare_name_returns_none_not_fuzzy(self, mcp_repair):
+        """A bare name no MCP server exposes (and no core match) -> None,
+        the existing 'does not exist' error the model self-corrects from."""
+        assert mcp_repair("entity_delete") is None
+
+    def test_hallucinated_prefixed_name_never_mis_routes(self, mcp_repair):
+        """The 12/12 mis-route class: mcp__example_server__entity_delete does
+        NOT exist; under old fuzzy it resolved to entity_update (0.906).
+        Now: None."""
+        assert mcp_repair("mcp__example_server__entity_delete") is None
+
+    def test_prefixed_core_tool_strips_to_core(self, mcp_repair):
+        """A model prefixed a CORE tool with mcp__. Strip to the bare
+        suffix and match core tools exactly."""
+        assert mcp_repair("mcp__todo") == "todo"
+        assert mcp_repair("mcp__web_search") == "web_search"
+
+    def test_exact_mcp_name_passes_through(self, mcp_repair):
+        """An exact registered mcp name is a direct hit, unchanged."""
+        assert (
+            mcp_repair("mcp__example_server__entity_search")
+            == "mcp__example_server__entity_search"
+        )
+
+    def test_core_fuzzy_still_works_alongside_mcp(self, mcp_repair):
+        """Core-only fuzzy behavior is unchanged by the MCP machinery
+        (browser_click variants still repair)."""
+        assert mcp_repair("browser-clic") == "browser_click"
+
+    def test_bare_name_not_registered_anywhere_is_none(self, mcp_repair):
+        assert mcp_repair("totally_unknown") is None

--- a/tests/run_agent/test_repair_tool_call_name.py
+++ b/tests/run_agent/test_repair_tool_call_name.py
@@ -127,14 +127,6 @@ class TestVolcEngineXmlPollution:
         assert repair('"terminal"') == "terminal"
 
 
-    def test_leading_quote_falls_through_to_fuzzy_match(self, repair):
-        # Sanitizer only trims when the XML char is at idx > 0 - a
-        # name that *starts* with a quote is left untouched so the
-        # rest of the pipeline (fuzzy match at 0.7 cutoff) can still
-        # recover the obvious target.
-        assert repair('"terminal"') == "terminal"
-
-
 # -- MCP name bridging (#100807) --------------------------------------------
 #
 # Prompts teach the BARE MCP catalog name; the runtime registers


### PR DESCRIPTION
Fixes #100807

## Problem

`repair_tool_call`'s fuzzy step (`get_close_matches` over **ALL** valid names, cutoff 0.7) failed in **both directions** once MCP tools register under `mcp__<server>__<tool>`:

**1. The bare catalog name was never repaired.** Prompts and skills teach `entity_search`, but the `mcp__<server>__` prefix keeps `SequenceMatcher("entity_search", "mcp__example_server__entity_search").ratio()` at **~0.58** — below cutoff. One invalid name then **voids the whole tool batch** in `conversation_loop` (every valid sibling discarded and re-issued, full tool catalog re-appended per miss). Reporter's measurements: ~10% of interactive sessions start with this slip; ~25–29 valid calls skipped per 14 days.

**2. Hallucinated prefixed names silently mis-routed.** The shared `mcp__` prefix inflates ratios *between* MCP tools past the cutoff, so nonexistent names resolved to a **different real tool** — the reporter measured **12 of 12** hallucinated names mis-routing on a 51-tool server (`entity_delete → entity_update` 0.906, `drive_write → drive_read` 0.915), and twice a cron asking for core `kanban_list` ran `list_goals` instead. Invisible after the fact: announced only via `print()`, and the persisted message stores the *repaired* name.

## Fix — core-tool behavior byte-identical (#14784/#33007 repairs untouched)

Per the reporter's proposed design, adapted to the 0.19+ `mcp__server__tool` naming:

- **Bare-name bridging before fuzzy**: exactly ONE registered `mcp__<server>__<name>` suffix → return it. Two+ servers exposing the same catalog name → `None` (ambiguous — never guess the server; the model self-corrects). Prefixes derived from the registered set itself, never by splitting on the delimiter.
- **`mcp__`-prefixed emission that doesn't match exactly**: strip the prefix, try the bare suffix against **core** tools only (exact) — covers a model prefixing a core tool. **Never fuzzy for anything mcp-shaped.**
- **Fuzzy step runs over non-`mcp__` names only.**
- Bridges log via `logger.info` instead of `print()` — countable in file logs.

## Verification

8 new tests in `TestMcpNameBridging` (mixed core+MCP registry, same SimpleNamespace harness as the existing suites): bare bridges to the unique server; ambiguous → `None`; unknown bare → `None`; **hallucinated prefixed → `None`** (the 12/12 class); prefixed core strips to core; exact mcp pass-through; core fuzzy unchanged; unknown → `None`.

Repair suites: **19/19 pass** (`test_repair_tool_call_name.py` 16 + `test_repair_tool_call_arguments.py` 3).