### PR TITLE
fix(recovery): session salvage no longer drops the gateway delivery ledger (#100313 salvage gap, salvage #100350)

### DIFF
--- a/hermes_cli/session_lost_and_found.py
+++ b/hermes_cli/session_lost_and_found.py
@@ -334,11 +334,17 @@ def _copy_direct_tables(
         "compression_locks",
         "gateway_routing",
         "async_delegations",
+        "delivery_obligations",
     ):
         source_columns = _table_columns(lf_conn, table)
         if not source_columns:
             continue
         dest_columns = _table_columns(dest, table)
+        if table == "delivery_obligations" and not dest_columns:
+            from gateway.delivery_ledger import _initialize_schema
+
+            _initialize_schema(dest)
+            dest_columns = _table_columns(dest, table)
         columns = [c for c in dest_columns if c in source_columns]
         if not columns:
             continue

--- a/hermes_cli/session_lost_and_found.py
+++ b/hermes_cli/session_lost_and_found.py
@@ -325,25 +325,24 @@ def _copy_direct_tables(
 ) -> dict[str, int]:
     """Copy rows .recover managed to attribute to real canonical tables."""
 
+    # Lazy import: session_recovery imports this module inside a function, so
+    # a module-level import here would be circular.
+    from hermes_cli.session_recovery import (
+        _AUXILIARY_TABLE_SCHEMAS,
+        _AUXILIARY_TABLES,
+        _CANONICAL_TABLES,
+    )
+
     copied: dict[str, int] = {}
-    for table in (
-        "system_prompts",
-        "sessions",
-        "messages",
-        "session_model_usage",
-        "compression_locks",
-        "gateway_routing",
-        "async_delegations",
-        "delivery_obligations",
-    ):
+    for table in (*_CANONICAL_TABLES, *_AUXILIARY_TABLES):
         source_columns = _table_columns(lf_conn, table)
         if not source_columns:
             continue
         dest_columns = _table_columns(dest, table)
-        if table == "delivery_obligations" and not dest_columns:
-            from gateway.delivery_ledger import _initialize_schema
-
-            _initialize_schema(dest)
+        if not dest_columns and table in _AUXILIARY_TABLE_SCHEMAS:
+            # Lazily-created gateway table: base SessionDB never made it on
+            # the fresh destination, so create it before copying.
+            _AUXILIARY_TABLE_SCHEMAS[table](dest)
             dest_columns = _table_columns(dest, table)
         columns = [c for c in dest_columns if c in source_columns]
         if not columns:

--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -45,12 +45,26 @@ _TOPIC_TABLES = (
     "telegram_dm_topic_bindings",
 )
 
-# Durable gateway outbox. Created lazily by gateway.delivery_ledger, so a
-# fresh SessionDB destination does not have the table until we initialize it.
-# Omitting it from the copy inventory drops owed replies (#100313, #86236).
-_AUXILIARY_TABLES = (
-    "delivery_obligations",
-)
+
+
+def _init_delivery_ledger_schema(conn: sqlite3.Connection) -> None:
+    from gateway.delivery_ledger import _initialize_schema
+
+    _initialize_schema(conn)
+
+
+# Tables that live in state.db but are created lazily by a gateway module on
+# first use, so base ``SessionDB`` never creates them on a fresh destination.
+# Every entry maps the table to the initializer that owns its DDL; recovery
+# creates the table on the destination before copying, so owed rows survive
+# instead of silently vanishing from a "complete" salvage (#100313, #86236).
+# Add new lazily-created state.db tables HERE, never as one-off ``if table ==``
+# branches.
+_AUXILIARY_TABLE_SCHEMAS: dict[str, Callable[[sqlite3.Connection], None]] = {
+    "delivery_obligations": _init_delivery_ledger_schema,
+}
+
+_AUXILIARY_TABLES = tuple(_AUXILIARY_TABLE_SCHEMAS)
 
 _INVENTORY_TABLES = (
     *_CANONICAL_TABLES,
@@ -410,10 +424,12 @@ def _ensure_auxiliary_destination_schema(
     would report ``missing`` / ``no compatible columns`` and drop the rows.
     """
 
-    if table == "delivery_obligations":
-        from gateway.delivery_ledger import _initialize_schema
-
-        _initialize_schema(destination)
+    initialize = _AUXILIARY_TABLE_SCHEMAS.get(table)
+    if initialize is None:
+        raise SessionRecoverySafetyError(
+            f"no destination schema initializer registered for table {table!r}"
+        )
+    initialize(destination)
 
 
 def _copy_table(

--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -45,6 +45,20 @@ _TOPIC_TABLES = (
     "telegram_dm_topic_bindings",
 )
 
+# Durable gateway outbox. Created lazily by gateway.delivery_ledger, so a
+# fresh SessionDB destination does not have the table until we initialize it.
+# Omitting it from the copy inventory drops owed replies (#100313, #86236).
+_AUXILIARY_TABLES = (
+    "delivery_obligations",
+)
+
+_INVENTORY_TABLES = (
+    *_CANONICAL_TABLES,
+    "state_meta",
+    *_TOPIC_TABLES,
+    *_AUXILIARY_TABLES,
+)
+
 # These values describe derived indexes or the schema that owns an optional
 # table. A fresh destination must generate them from its own current schema.
 _GENERATED_META_KEYS = frozenset({
@@ -305,7 +319,7 @@ def _inspect_connection(conn: sqlite3.Connection) -> dict[str, Any]:
         # A damaged journal pragma must not block rows that are still readable.
         report["warnings"].append(f"journal mode: {exc}")
 
-    for table in (*_CANONICAL_TABLES, "state_meta", *_TOPIC_TABLES):
+    for table in _INVENTORY_TABLES:
         report["tables"][table] = _table_inventory(conn, table)
 
     for required in ("sessions", "messages"):
@@ -383,6 +397,23 @@ def inspect_session_database(
         }
     finally:
         temp_dir.cleanup()
+
+
+def _ensure_auxiliary_destination_schema(
+    destination: sqlite3.Connection,
+    table: str,
+) -> None:
+    """Create a lazy auxiliary table on the recovered destination.
+
+    Recovery initializes the destination through base ``SessionDB``, which
+    does not create gateway-owned tables. Copying into a missing dest table
+    would report ``missing`` / ``no compatible columns`` and drop the rows.
+    """
+
+    if table == "delivery_obligations":
+        from gateway.delivery_ledger import _initialize_schema
+
+        _initialize_schema(destination)
 
 
 def _copy_table(
@@ -1243,7 +1274,7 @@ def _verify_recovered_database(
             )
 
         counts: dict[str, int] = {}
-        for table in (*_CANONICAL_TABLES, "state_meta", *_TOPIC_TABLES):
+        for table in _INVENTORY_TABLES:
             columns = _table_columns(conn, table)
             if columns:
                 counts[table] = int(
@@ -1251,7 +1282,7 @@ def _verify_recovered_database(
                 )
         verification["table_counts"] = counts
 
-        for table in ("sessions", "messages"):
+        for table in ("sessions", "messages", *_AUXILIARY_TABLES):
             expected = expected_counts.get(table)
             if expected is not None and counts.get(table) != expected:
                 message = (
@@ -1662,6 +1693,27 @@ def recover_session_database(
                     progress_cb=progress_cb,
                     source_rows=table_inspection.get("rows"),
                 )
+
+            for table in _AUXILIARY_TABLES:
+                table_inspection = inspection["tables"][table]
+                if not table_inspection.get("available"):
+                    copy_report[table] = {
+                        "status": "missing",
+                        "copied_rows": 0,
+                    }
+                    continue
+                _ensure_auxiliary_destination_schema(destination_conn, table)
+                copy_function = (
+                    _copy_table_salvage if allow_partial else _copy_table
+                )
+                copy_report[table] = copy_function(
+                    source_conn,
+                    destination_conn,
+                    table,
+                    chunk_size=chunk_size,
+                    progress_cb=progress_cb,
+                    source_rows=table_inspection.get("rows"),
+                )
             orphan_cleanup = (
                 _cleanup_partial_orphans(destination_conn)
                 if allow_partial
@@ -1678,8 +1730,15 @@ def recover_session_database(
         verification = _verify_recovered_database(
             output,
             expected_counts={
-                table: inspection["tables"][table].get("rows")
-                for table in _CANONICAL_TABLES
+                **{
+                    table: inspection["tables"][table].get("rows")
+                    for table in _CANONICAL_TABLES
+                },
+                **{
+                    table: inspection["tables"][table].get("rows")
+                    for table in _AUXILIARY_TABLES
+                    if inspection["tables"].get(table, {}).get("available")
+                },
             },
             copy_report=copy_report,
             allow_partial=allow_partial,

--- a/tests/hermes_cli/test_session_recovery.py
+++ b/tests/hermes_cli/test_session_recovery.py
@@ -753,3 +753,83 @@ def test_recovery_without_delivery_ledger_is_not_lossy(tmp_path: Path) -> None:
 
 
 
+
+
+def test_recovery_flags_delivery_obligation_count_mismatch_as_loss(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A source-vs-destination ledger count mismatch must not verify as complete.
+
+    The destination table is created through the registered initializer; a
+    real SQL trigger that silently drops one row stands in for the "rows went
+    missing on the way over" failure the verifier has to catch.
+    """
+
+    from hermes_cli import session_recovery
+
+    source = tmp_path / "state.db"
+    output = tmp_path / "recovered.db"
+    _make_source(source)
+    now = 1_720_000_000.0
+    _insert_delivery_obligations(
+        source,
+        [
+            ("ob-a", "k", "telegram", "chat-1", None, "a", "pending", 0, now, now, None, None, None, "default"),
+            ("ob-b", "k", "telegram", "chat-1", None, "b", "pending", 0, now, now, None, None, None, "default"),
+        ],
+    )
+
+    real_init = session_recovery._AUXILIARY_TABLE_SCHEMAS["delivery_obligations"]
+
+    def lossy_init(conn: sqlite3.Connection) -> None:
+        real_init(conn)
+        conn.execute(
+            """CREATE TRIGGER drop_ob_b BEFORE INSERT ON delivery_obligations
+               WHEN NEW.obligation_id = 'ob-b' BEGIN SELECT RAISE(IGNORE); END"""
+        )
+
+    monkeypatch.setitem(
+        session_recovery._AUXILIARY_TABLE_SCHEMAS, "delivery_obligations", lossy_init
+    )
+
+    report = recover_session_database(source, output, work_dir=tmp_path)
+    assert report["verification"]["table_counts"]["delivery_obligations"] == 1
+    assert report["complete"] is False
+    assert any(
+        "delivery_obligations count is 1, expected 2" in error
+        for error in report["verification"]["errors"]
+    )
+
+
+def test_lost_and_found_direct_copy_creates_lazy_delivery_ledger(tmp_path: Path) -> None:
+    """The .recover lane copies the ledger even though SessionDB never made it."""
+
+    from hermes_cli.session_lost_and_found import _copy_direct_tables
+
+    recovered_source = tmp_path / "lost_and_found.db"
+    now = 1_720_000_000.0
+    _insert_delivery_obligations(
+        recovered_source,
+        [
+            ("ob-1", "k", "telegram", "chat-1", None, "one", "pending", 0, now, now, None, None, None, "default"),
+            ("ob-2", "k", "telegram", "chat-1", None, "two", "failed", 3, now, now, None, None, "boom", "default"),
+        ],
+    )
+    output = tmp_path / "rebuilt.db"
+    SessionDB(db_path=output).close()
+
+    lf_conn = sqlite3.connect(str(recovered_source), isolation_level=None)
+    dest = sqlite3.connect(str(output), isolation_level=None)
+    try:
+        assert not dest.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='delivery_obligations'"
+        ).fetchall()
+        copied = _copy_direct_tables(lf_conn, dest)
+        assert copied["delivery_obligations"] == 2
+        rows = dest.execute(
+            "SELECT obligation_id, state, last_error FROM delivery_obligations ORDER BY obligation_id"
+        ).fetchall()
+    finally:
+        lf_conn.close()
+        dest.close()
+    assert rows == [("ob-1", "pending", None), ("ob-2", "failed", "boom")]

--- a/tests/hermes_cli/test_session_recovery.py
+++ b/tests/hermes_cli/test_session_recovery.py
@@ -648,4 +648,108 @@ def test_partial_recovery_clears_only_unreadable_system_prompt_refs(
         conn.close()
 
 
+def _insert_delivery_obligations(path: Path, rows: list[tuple[object, ...]]) -> None:
+    from gateway.delivery_ledger import _initialize_schema
+
+    conn = sqlite3.connect(str(path), isolation_level=None)
+    try:
+        _initialize_schema(conn)
+        conn.executemany(
+            """INSERT INTO delivery_obligations (
+                obligation_id, session_key, platform, chat_id, thread_id,
+                content, state, attempts, created_at, updated_at,
+                owner_pid, owner_started_at, last_error, adapter_profile
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            rows,
+        )
+    finally:
+        conn.close()
+
+
+def test_recovery_copies_delivery_obligations(tmp_path: Path) -> None:
+    """Owed replies must survive salvage — #100313 lost 6 obligation rows."""
+
+    source = tmp_path / "state.db"
+    output = tmp_path / "recovered.db"
+    _make_source(source)
+    now = 1_720_000_000.0
+    _insert_delivery_obligations(
+        source,
+        [
+            (
+                "ob-pending",
+                "telegram:1:chat-1",
+                "telegram",
+                "chat-1",
+                None,
+                "owed reply",
+                "pending",
+                0,
+                now,
+                now,
+                4242,
+                99,
+                None,
+                "default",
+            ),
+            (
+                "ob-delivered",
+                "telegram:1:chat-1",
+                "telegram",
+                "chat-1",
+                None,
+                "already sent",
+                "delivered",
+                1,
+                now,
+                now + 1,
+                None,
+                None,
+                None,
+                "default",
+            ),
+        ],
+    )
+
+    inspection = inspect_session_database(source, work_dir=tmp_path)
+    assert inspection["tables"]["delivery_obligations"]["available"] is True
+    assert inspection["tables"]["delivery_obligations"]["rows"] == 2
+
+    report = recover_session_database(source, output, work_dir=tmp_path)
+    copied = report["copy"]["delivery_obligations"]
+    assert copied["status"] == "complete"
+    assert copied["copied_rows"] == 2
+    assert report["verification"]["table_counts"]["delivery_obligations"] == 2
+    assert report["complete"] is True
+    assert report["verified"] is True
+    assert report["installed"] is False
+
+    conn = sqlite3.connect(str(output))
+    try:
+        recovered = conn.execute(
+            """SELECT obligation_id, state, content, owner_pid, adapter_profile
+               FROM delivery_obligations ORDER BY obligation_id"""
+        ).fetchall()
+    finally:
+        conn.close()
+    assert recovered == [
+        ("ob-delivered", "delivered", "already sent", None, "default"),
+        ("ob-pending", "pending", "owed reply", 4242, "default"),
+    ]
+
+
+def test_recovery_without_delivery_ledger_is_not_lossy(tmp_path: Path) -> None:
+    """CLI-only stores never created the lazy table; that is not data loss."""
+
+    source = tmp_path / "state.db"
+    output = tmp_path / "recovered.db"
+    _make_source(source)
+
+    report = recover_session_database(source, output, work_dir=tmp_path)
+    assert report["copy"]["delivery_obligations"]["status"] == "missing"
+    assert "delivery_obligations" not in report["verification"]["table_counts"]
+    assert report["complete"] is True
+    assert report["verified"] is True
+
+
 

--- a/website/docs/developer-guide/session-storage.md
+++ b/website/docs/developer-guide/session-storage.md
@@ -21,8 +21,14 @@ Source file: `hermes_state.py`
 ├── gateway_routing       — Gateway routing metadata
 ├── compression_locks     — Cross-process compression locking
 ├── async_delegations     — Async delegation bookkeeping
+├── delivery_obligations  — Gateway outbox (owed replies); created lazily by gateway/delivery_ledger.py
 └── schema_version        — Single-row table tracking migration state
 ```
+
+`hermes sessions recover` copies the row-bearing tables above into the
+recovered database (FTS indexes and `schema_version` are regenerated), including
+the lazily-created `delivery_obligations` ledger when the source has one — its
+row count is verified like `sessions`/`messages`.
 
 Key design decisions:
 - **WAL mode** for concurrent readers + one writer (gateway multi-platform)


### PR DESCRIPTION
## Summary

`hermes sessions recover` now copies the gateway delivery ledger (`delivery_obligations`, the durable outbox of owed replies) into the recovered database and verifies its row count, instead of silently dropping it while reporting the salvage as `complete`.

Salvages #100350 by @HexLab98 (cherry-picked, authorship preserved) with a follow-up that turns the one-table fix into a registry for the whole class of lazily-created `state.db` tables.

## Changes

- **`hermes_cli/session_recovery.py`** (@HexLab98, 86d0b46 → 64bd9c3): adds the lazily-created `delivery_obligations` table to the inspection inventory, creates it on the destination via `gateway.delivery_ledger._initialize_schema` before copying, copies it through the strict or `--allow-partial` copier, and verifies source-vs-destination counts (a mismatch is `complete=False`, exactly like `sessions`/`messages`). Sources that never created the ledger (CLI-only installs) still recover as `complete: true` with status `missing`.
- **`hermes_cli/session_lost_and_found.py`** (@HexLab98): the `.recover` lost-and-found lane also copies the ledger.
- **Follow-up (ours, c1f98ef)**: replaced both `if table == "delivery_obligations"` branches with a single `_AUXILIARY_TABLE_SCHEMAS` registry (`table → destination DDL initializer`) consumed by both lanes; the `.recover` lane iterates `_CANONICAL_TABLES + _AUXILIARY_TABLES` instead of a duplicated literal list; unknown auxiliary tables raise `SessionRecoverySafetyError` rather than copying into nothing. Adding the next lazy table is one dict entry.
- **Tests** (`tests/hermes_cli/test_session_recovery.py`): @HexLab98's two tests (pending+delivered rows survive with all columns; ledger-less store is not lossy) plus two of ours (`.recover` direct-copy lane creates the missing ledger; a real SQL trigger that drops one row on the way over yields `complete=False` with `delivery_obligations count is 1, expected 2`).
- **Docs** (`website/docs/developer-guide/session-storage.md`): `state.db` table inventory lists `delivery_obligations`; notes that `sessions recover` copies and count-verifies it.

Other lazily-created `state.db` tables audited and deliberately **not** added: `hosted_rooms*` / `hosted_room_driver_*` / `hosted_room_policy_*` / `hosted_room_replica*` (gateway/hosted_room*.py). They target the *root* `state.db` (`home.parent.parent` when a profile is active — a different file from the per-profile session DB in the common case), carry FK/CHECK constraints and their own status-constraint migrations, and are replicated authority state rather than user transcripts. Worth a separate design decision; wiring them in here would be untested surface. `async_delegations`/`session_turn_leases`/`gateway_heartbeats` are in base `SCHEMA_SQL` (no gap).

## Validation

| Check | Result |
|---|---|
| `tests/hermes_cli/test_session_recovery.py` + `test_session_recovery_lost_and_found.py` (memory-capped) | 14 passed, 1 skipped (`.recover` CLI lane needs sqlite_dbpage build) |
| Sabotage: 4 `-k delivery` tests against `origin/main` copies of the two modules | 4 failed → 4 passed with fix |
| `ruff check` on touched files | clean |
| Attribution audit (`scripts/audit_pr_attribution.py --fix`) | all emails mapped (`contributors/emails/liruixinch@outlook.com` already present) |
| Stale-base gate | 0 commits behind `origin/main` |

**Live repro:** real-import harness (worktree at `sys.path[0]`, isolated `HERMES_HOME`, `SessionDB` with 3 sessions/12 messages, 3 obligations recorded through `gateway.delivery_ledger.record_obligation`, then `recover_session_database(src, out)`) — before: `RECOVERED delivery_obligations table present: False rows: 0 / report complete=True partial=False verified=True / copy[delivery_obligations]=None` → `RESULT: FIRED — 3 obligations in source, 0 in recovered output, report complete=True`; after: `RECOVERED delivery_obligations table present: True rows: 3 / copy[delivery_obligations]={'source_rows': 3, 'copied_rows': 3, ..., 'status': 'complete'} / table_counts.delivery_obligations=3` → `RESULT: CLEAN — obligations preserved and counted`.

Addresses #100313 (the salvage-omission half; the corruption producer is tracked separately via #100519 and the reporter's other findings).
Salvages #100350 by @HexLab98.
Related open PRs (not superseded by this one): #98062 (rowid-aggregate salvage budget), #86245 (report omitted recovery state).

## Infographic
![session-recovery-keeps-outbox](https://v3b.fal.media/files/b/0aa8c3cd/ceL0Zc_ayFUyE-zrIXFvi_Oxk2T2Lb.png)
