### PR TITLE
fix(cron): live-adapter delivery is confirmed by positive evidence, empty payloads fail closed, cron pushes notify (#77763, salvage #100284 #58262)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2450,6 +2450,9 @@ def create_job(
         "last_status": None,
         "last_error": None,
         "last_delivery_error": None,
+        # Live-adapter targets whose last send was acked with no message_id /
+        # raw_response (accepted, but UNVERIFIED — surfaced by cron list/doctor).
+        "last_delivery_unverified": None,
         "failure_streak": 0,
         # Delivery configuration
         "deliver": deliver,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2984,7 +2984,7 @@ def _send_media_via_adapter(
     return errors
 
 
-def _confirm_adapter_delivery(send_result, job_id: str = "?") -> bool:
+def _confirm_adapter_delivery(send_result, job_id: str = "?", unverified: Optional[list] = None) -> bool:
     """Return True only if ``send_result`` unambiguously confirms delivery.
 
     A live adapter that returns ``None`` (e.g. a swallowed exception, a busy
@@ -3038,6 +3038,8 @@ def _confirm_adapter_delivery(send_result, job_id: str = "?") -> bool:
             "UNVERIFIED",
             job_id,
         )
+        if unverified is not None:
+            unverified.append(True)
     return True
 
 
@@ -3097,6 +3099,48 @@ def _is_channel_dm_topic(
     return is_channel
 
 
+def _cron_delivery_notify_enabled(cfg: Optional[dict]) -> bool:
+    """Resolve ``cron.delivery.notify`` (config.yaml). Default True.
+
+    Only an explicit boolean ``False`` (or a YAML ``false``/``off`` that parses
+    to it) disables the push notification; a missing/malformed section keeps
+    the default so a typo can never silently make cron briefs silent.
+    """
+    try:
+        cron_cfg = (cfg or {}).get("cron")
+        if not isinstance(cron_cfg, dict):
+            return True
+        delivery_cfg = cron_cfg.get("delivery")
+        if not isinstance(delivery_cfg, dict):
+            return True
+        return delivery_cfg.get("notify", True) is not False
+    except Exception:
+        return True
+
+
+def _record_delivery_verification(job: dict, unverified_targets: list) -> None:
+    """Persist the UNVERIFIED-delivery marker on the job record.
+
+    ``last_delivery_unverified`` is a list of ``platform:chat_id`` targets
+    whose live adapter acked the send with no message_id/raw_response, or
+    ``None`` once a run delivered with positive evidence (or to no live
+    target). Skips the write when nothing changed so the common verified
+    path costs no jobs.json save. Never raises — status bookkeeping must not
+    fail a delivery.
+    """
+    new_value = list(unverified_targets) or None
+    if (job.get("last_delivery_unverified") or None) == new_value:
+        return
+    try:
+        from cron.jobs import update_job
+
+        update_job(job["id"], {"last_delivery_unverified": new_value})
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug(
+            "Job '%s': could not record delivery verification: %s", job.get("id"), exc,
+        )
+
+
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
@@ -3143,6 +3187,18 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         wrap_response = user_cfg.get("cron", {}).get("wrap_response", True)
     except Exception:
         pass
+
+    # cron.delivery.notify (default True): mark live-adapter cron sends as
+    # FINAL notifications so the platform pushes them (Telegram's "important"
+    # mode otherwise sends with disable_notification=True). Configurable so
+    # operators who prefer silent briefs can opt back out.
+    notify_delivery = _cron_delivery_notify_enabled(user_cfg)
+    # Set when a live adapter acked a send with NO delivery evidence (no
+    # message_id / raw_response — the Slack/Matrix/Mattermost bare
+    # SendResult(success=True) shape). Persisted on the job as
+    # ``last_delivery_unverified`` so `hermes cron list` shows the state
+    # instead of it living only in a WARNING log line.
+    unverified_targets: list = []
 
     if wrap_response:
         task_name = job.get("name", job["id"])
@@ -3519,13 +3575,13 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 route_metadata = {
                     "direct_messages_topic_id": str(thread_id),
                     "job_id": job["id"],
-                    "notify": True,
+                    "notify": notify_delivery,
                 }
                 # Media metadata mirrors the text routing so attachments land in
                 # the same DM topic instead of the General lane (#22773).
                 media_metadata = {
                     "direct_messages_topic_id": str(thread_id),
-                    "notify": True,
+                    "notify": notify_delivery,
                 }
             else:
                 # Forum-style topic (private chat / supergroup) or non-topic
@@ -3537,10 +3593,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # anchor, so the metadata key bypasses that check and lets the
                 # adapter route via a plain message_thread_id.
                 route_thread_id = str(thread_id) if thread_id is not None else None
-                route_metadata = {"job_id": job["id"], "notify": True}
+                route_metadata = {"job_id": job["id"], "notify": notify_delivery}
                 if route_thread_id:
                     route_metadata["thread_id"] = route_thread_id
-                media_metadata = {"notify": True}
+                media_metadata = {"notify": notify_delivery}
                 if thread_id:
                     media_metadata["thread_id"] = thread_id
 
@@ -3688,7 +3744,12 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                             else:
                                 send_raw_response = getattr(send_result, "raw_response", None)
                                 delivered_message_id = getattr(send_result, "message_id", None)
-                            send_success = _confirm_adapter_delivery(send_result, job["id"])
+                            _evidence_gap: list = []
+                            send_success = _confirm_adapter_delivery(
+                                send_result, job["id"], _evidence_gap,
+                            )
+                            if send_success and _evidence_gap:
+                                unverified_targets.append(f"{platform_name}:{chat_id}")
 
                             if not send_success:
                                 if isinstance(send_result, dict):
@@ -4003,6 +4064,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     if policy_drop_errors:
         # Filter-time drops apply to every target; report them once.
         delivery_errors.extend(policy_drop_errors)
+    _record_delivery_verification(job, unverified_targets)
     if delivery_errors:
         return "; ".join(delivery_errors)
     return None

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2984,7 +2984,7 @@ def _send_media_via_adapter(
     return errors
 
 
-def _confirm_adapter_delivery(send_result) -> bool:
+def _confirm_adapter_delivery(send_result, job_id: str = "?") -> bool:
     """Return True only if ``send_result`` unambiguously confirms delivery.
 
     A live adapter that returns ``None`` (e.g. a swallowed exception, a busy
@@ -2993,16 +2993,52 @@ def _confirm_adapter_delivery(send_result) -> bool:
     scheduler to log ``"delivered to <chat> via live adapter"`` while the
     gateway never actually sees the message (#47056).
 
-    Likewise, an object missing a ``success`` attribute (e.g. a bare ``dict``
-    or a partial mock) is a contract violation: it does not actually tell us
-    whether the send succeeded.  Require an explicit, truthy ``success``
-    attribute to count as confirmed.
+    Likewise, a result carrying no ``success`` at all (a partial mock, or a
+    ``dict`` from a code path that never reached the adapter) is a contract
+    violation: it does not actually tell us whether the send succeeded.
+    Require an explicit, truthy ``success`` to count as confirmed.
+
+    Both shapes are inspected the same way, because ``_deliver_to_platform``
+    returns either a ``SendResult`` object or a plain ``dict``:
+
+    * ``delivered is False`` is a REJECTION even when ``success`` is truthy.
+      The silence-narration filter returns
+      ``{"success": True, "delivered": False}`` — a successfully *dropped*
+      message, not a delivered one.  Reading only ``success`` there is how a
+      cron brief was logged as delivered while the user got nothing (#77763).
+    * No ``message_id`` and no ``raw_response`` means we have no positive
+      evidence of a send.  That is not proof of failure either (some adapters
+      legitimately return a bare success), so it is still accepted — but
+      logged at WARNING so an UNVERIFIED delivery is visible in the log
+      instead of masquerading as a confirmed one.  Telegram ``SendResult``
+      objects carry ``message_id``; the dict-filter shape does not.
     """
     if send_result is None:
         return False
-    if not hasattr(send_result, "success"):
+    if isinstance(send_result, dict):
+        if "success" not in send_result:
+            return False
+        success = bool(send_result.get("success"))
+        delivered = send_result.get("delivered")
+        message_id = send_result.get("message_id")
+        raw_response = send_result.get("raw_response")
+    else:
+        if not hasattr(send_result, "success"):
+            return False
+        success = bool(getattr(send_result, "success"))
+        delivered = getattr(send_result, "delivered", None)
+        message_id = getattr(send_result, "message_id", None)
+        raw_response = getattr(send_result, "raw_response", None)
+    if not success or delivered is False:
         return False
-    return bool(getattr(send_result, "success"))
+    if message_id is None and not raw_response:
+        logger.warning(
+            "Job '%s': live adapter reported success with no delivery evidence "
+            "(no message_id, no raw_response) — treating as delivered but "
+            "UNVERIFIED",
+            job_id,
+        )
+    return True
 
 
 def _is_channel_dm_topic(
@@ -3530,7 +3566,20 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 adapter_ok = True
                 timed_out = False
                 delivered_message_id = None
-                if text_to_send:
+                if not text_to_send and not media_files:
+                    # Nothing to hand the adapter at all.  This used to fall
+                    # straight through to the `if adapter_ok:` branch below and
+                    # log "delivered to <chat> via live adapter" for a send that
+                    # never happened (#77763).  Fail closed so the run reports
+                    # the empty payload instead.
+                    msg = (
+                        f"live adapter send skipped (empty text and no media) "
+                        f"for {platform_name}:{chat_id}"
+                    )
+                    logger.warning("Job '%s': %s", job["id"], msg)
+                    target_errors.append(msg)
+                    adapter_ok = False
+                elif text_to_send:
                     from agent.async_utils import safe_schedule_threadsafe
 
                     router = DeliveryRouter(config, adapters)
@@ -3623,19 +3672,27 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                             # {"success": True, "delivered": False, ...}.
                             # Normalize both shapes so a getattr default doesn't
                             # misread a dict, and so a None / success-less object
-                            # is NOT counted as delivered (#47056).
+                            # is NOT counted as delivered (#47056).  The
+                            # confirmation itself handles both shapes: a truthy
+                            # `success` with `delivered: False` is a drop, not a
+                            # delivery (#77763).
                             if isinstance(send_result, dict):
-                                send_success = bool(send_result.get("success", False))
                                 send_raw_response = send_result.get("raw_response")
                                 delivered_message_id = send_result.get("message_id")
                             else:
-                                send_success = _confirm_adapter_delivery(send_result)
                                 send_raw_response = getattr(send_result, "raw_response", None)
                                 delivered_message_id = getattr(send_result, "message_id", None)
+                            send_success = _confirm_adapter_delivery(send_result, job["id"])
 
                             if not send_success:
                                 if isinstance(send_result, dict):
-                                    err = send_result.get("error", "unknown")
+                                    # A filtered drop carries no "error" — name
+                                    # the filter instead of reporting "unknown".
+                                    err = (
+                                        send_result.get("error")
+                                        or send_result.get("filtered")
+                                        or "unknown"
+                                    )
                                     shape = "dict"
                                 elif send_result is not None:
                                     err = getattr(send_result, "error", None)
@@ -3712,7 +3769,16 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     delivery_errors.append(msg)
 
                 if adapter_ok:
-                    logger.info("Job '%s': delivered to %s:%s via live adapter", job["id"], platform_name, chat_id)
+                    # Log WHERE it went, not just that it went: a ghost delivery
+                    # that landed in the wrong lane (General topic instead of the
+                    # routed thread) is indistinguishable from a real one without
+                    # the routing identity (#77763).
+                    logger.info(
+                        "Job '%s': delivered to %s:%s via live adapter thread=%s message_id=%s",
+                        job["id"], platform_name, chat_id,
+                        route_thread_id if route_thread_id is not None else "-",
+                        delivered_message_id if delivered_message_id is not None else "-",
+                    )
                     delivered = True
                     # Seed the thread session only now that delivery into it
                     # succeeded (deferred from thread-open above).
@@ -3822,6 +3888,22 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             # (#58720, #55924).
             if _interpreter_shutting_down():
                 msg = f"delivery to {platform_name}:{chat_id} skipped — interpreter is shutting down"
+                logger.warning("Job '%s': %s", job["id"], msg)
+                target_errors.append(msg)
+                delivery_errors.extend(target_errors)
+                continue
+            # The live lane already failed closed on an empty payload; the
+            # standalone senders do not. The Telegram adapter returns
+            # SendResult(success=True) for empty content WITHOUT an API call,
+            # so falling through here turns a phantom live delivery into a
+            # phantom standalone one and logs it as delivered (#77763). Both
+            # _send_to_platform call sites below are reached through this
+            # point, so one guard closes the lane.
+            if not cleaned_delivery_content.strip() and not media_files:
+                msg = (
+                    f"standalone send skipped (empty text and no media) "
+                    f"for {platform_name}:{chat_id}"
+                )
                 logger.warning("Job '%s': %s", job["id"], msg)
                 target_errors.append(msg)
                 delivery_errors.extend(target_errors)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3519,10 +3519,14 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 route_metadata = {
                     "direct_messages_topic_id": str(thread_id),
                     "job_id": job["id"],
+                    "notify": True,
                 }
                 # Media metadata mirrors the text routing so attachments land in
                 # the same DM topic instead of the General lane (#22773).
-                media_metadata = {"direct_messages_topic_id": str(thread_id)}
+                media_metadata = {
+                    "direct_messages_topic_id": str(thread_id),
+                    "notify": True,
+                }
             else:
                 # Forum-style topic (private chat / supergroup) or non-topic
                 # target: route via message_thread_id (#52060).  Put thread_id in
@@ -3533,10 +3537,12 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # anchor, so the metadata key bypasses that check and lets the
                 # adapter route via a plain message_thread_id.
                 route_thread_id = str(thread_id) if thread_id is not None else None
-                route_metadata = {"job_id": job["id"]}
+                route_metadata = {"job_id": job["id"], "notify": True}
                 if route_thread_id:
                     route_metadata["thread_id"] = route_thread_id
-                media_metadata = {"thread_id": thread_id} if thread_id else None
+                media_metadata = {"notify": True}
+                if thread_id:
+                    media_metadata["thread_id"] = thread_id
 
             # Relay egress needs a tenant discriminator on the frame: the
             # connector's fail-closed guard resolves the workspace/guild from

--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -530,7 +530,18 @@ class DeliveryRouter:
         # platform adapter regardless of which persona's prompt failed.
         # Local/file delivery (_deliver_local) is a separate path and is never
         # filtered — saved silence has no loop risk.
-        if self._filter_silence_narration_enabled() and _is_silence_narration(content):
+        # Cron output is an ARTIFACT, not model chatter: a job whose brief is
+        # legitimately terse ("...", a single 🔇 from a script) has no bot-to-bot
+        # mirror loop to guard against, and dropping it here while returning
+        # {"success": True} is exactly how a cron was logged as delivered with
+        # nothing on the wire (#77763).  Cron sends carry job_id in metadata;
+        # every other caller keeps the filter unchanged.
+        is_cron_artifact = "job_id" in (metadata or {})
+        if (
+            self._filter_silence_narration_enabled()
+            and not is_cron_artifact
+            and _is_silence_narration(content)
+        ):
             logger.warning(
                 "Dropped silence-narration outbound to %s (chat=%s): %r",
                 target.platform.value,

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2806,6 +2806,15 @@ DEFAULT_CONFIG = {
         # Wrap delivered cron responses with a header (task name) and footer
         # ("The agent cannot see this message").  Set to false for clean output.
         "wrap_response": True,
+        # Delivery behaviour for cron output sent through a live gateway adapter.
+        "delivery": {
+            # Mark cron deliveries as FINAL notifications so the platform pushes
+            # them (Telegram's "important" notification mode otherwise sends
+            # every non-notify message with disable_notification=True, and users
+            # report the silent brief as "never delivered"). Set to false to
+            # restore silent (no-push) cron deliveries.
+            "notify": True,
+        },
         # Make cron deliveries CONTINUABLE: a user can reply to a cron brief
         # and the agent has it in context (no "what is Task #2?" amnesia).
         # Default False preserves the historical isolation guarantee (cron

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -286,6 +286,17 @@ def cron_list(show_all: bool = False):
         if delivery_err:
             print(f"    {color('⚠ Delivery failed:', Colors.YELLOW)} {delivery_err}")
 
+        # A live adapter acked the last send but returned no message_id /
+        # raw_response (Slack/Matrix/Mattermost shape): accepted as delivered,
+        # but say so here rather than only in a WARNING log line.
+        unverified = job.get("last_delivery_unverified")
+        if unverified:
+            targets = ", ".join(str(t) for t in unverified) if isinstance(unverified, list) else str(unverified)
+            print(
+                f"    {color('⚠ Delivery UNVERIFIED:', Colors.YELLOW)} "
+                f"adapter acked {targets} without message_id/raw_response"
+            )
+
         fire_err = job.get("last_fire_error")
         if isinstance(fire_err, dict) and fire_err.get("detail"):
             print(
@@ -695,6 +706,11 @@ def _cron_doctor_issues_for_job(job: Dict[str, Any]) -> List[str]:
     delivery_err = str(job.get("last_delivery_error") or "").strip()
     if delivery_err:
         issues.append(f"last delivery failed: {delivery_err}")
+
+    unverified = job.get("last_delivery_unverified")
+    if unverified:
+        targets = ", ".join(str(t) for t in unverified) if isinstance(unverified, list) else str(unverified)
+        issues.append(f"last delivery unverified (adapter acked without evidence): {targets}")
 
     if job.get("enabled", True) and job.get("state") not in {"paused", "completed"}:
         next_run = str(job.get("next_run_at") or "").strip()

--- a/tests/cron/test_cron_live_delivery_confirmation.py
+++ b/tests/cron/test_cron_live_delivery_confirmation.py
@@ -253,6 +253,54 @@ class TestDeliveredLogNamesTheLane:
         assert "UNVERIFIED" in caplog.text
 
 
+class TestLiveDeliveryIsAFinalNotification:
+    """Cron output is a final user-visible delivery, not a progress send.
+
+    Telegram's adapter defaults to ``_notifications_mode = "important"`` and
+    sends with ``disable_notification=True`` unless ``metadata["notify"]`` is
+    set — so a cron brief without the marker lands silently, which users
+    report as "never delivered" (#77763 thread, #58258 typing bubble). The
+    marker must ride both the text route and the media route, in every
+    Telegram routing mode.
+    """
+
+    def test_text_route_metadata_carries_notify(self):
+        _, router_calls, _ = _run(_job(), "Nightly report.", _SendResult(message_id=1))
+        assert len(router_calls) == 1
+        metadata = router_calls[0]["metadata"]
+        assert metadata["job_id"] == "92e639af907f"
+        assert metadata["notify"] is True
+
+    def test_forum_topic_route_keeps_thread_and_notify(self):
+        _, router_calls, _ = _run(
+            _job(thread_id="99"), "Nightly report.", _SendResult(message_id=1),
+        )
+        metadata = router_calls[0]["metadata"]
+        assert metadata["thread_id"] == "99"
+        assert metadata["notify"] is True
+
+    def test_media_route_metadata_carries_notify(self, tmp_path):
+        media = tmp_path / "report.png"
+        media.write_bytes(b"\x89PNG\r\n\x1a\n")
+        sent = []
+
+        def fake_send_media(adapter, chat_id, media_files, metadata, loop, job, platform=None):
+            sent.append({"media": list(media_files), "metadata": metadata})
+            return []
+
+        with patch("cron.scheduler._send_media_via_adapter", side_effect=fake_send_media), \
+             patch("gateway.platforms.base.BasePlatformAdapter.filter_media_delivery_paths",
+                   side_effect=lambda files: files):
+            error, router_calls, _ = _run(
+                _job(), f"Nightly report.\nMEDIA:{media}", _SendResult(message_id=1),
+            )
+
+        assert error is None
+        assert len(router_calls) == 1
+        assert len(sent) == 1
+        assert sent[0]["metadata"]["notify"] is True
+
+
 def test_scheduler_module_exposes_the_confirmation_helper():
     """Guard the import surface the delivery block depends on."""
     assert callable(sched._confirm_adapter_delivery)

--- a/tests/cron/test_cron_live_delivery_confirmation.py
+++ b/tests/cron/test_cron_live_delivery_confirmation.py
@@ -1,0 +1,258 @@
+"""Live-adapter delivery confirmation for cron (#77763).
+
+A ``no_agent`` job fired, the scheduler logged
+``delivered to telegram:<chat> via live adapter``, and the user received
+nothing — no message row, no delivery obligation. The log line was not
+evidence of a send:
+
+* the silence-narration filter returns ``{"success": True, "delivered": False}``
+  (a successful *drop*), and the normalization block read only ``success``;
+* an empty payload skipped the send entirely and still fell into the
+  "delivered" branch;
+* the log line named the chat but not the lane, so a wrong-thread delivery and
+  a phantom one look identical after the fact.
+
+These tests pin the confirmation contract: positive evidence, honest logging,
+and fail-closed on nothing-to-send.
+"""
+
+import asyncio
+import logging
+from concurrent.futures import Future
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cron import scheduler as sched
+from cron.scheduler import _confirm_adapter_delivery, _deliver_result
+from gateway.config import Platform, PlatformConfig
+
+
+# ---------------------------------------------------------------------------
+# _confirm_adapter_delivery: the contract in isolation
+# ---------------------------------------------------------------------------
+
+class _SendResult:
+    """Minimal stand-in for an adapter SendResult."""
+
+    def __init__(self, success=True, message_id=None, raw_response=None, **extra):
+        self.success = success
+        self.message_id = message_id
+        self.raw_response = raw_response
+        for key, value in extra.items():
+            setattr(self, key, value)
+
+
+class TestConfirmAdapterDelivery:
+    def test_none_is_not_delivered(self):
+        assert _confirm_adapter_delivery(None, "j1") is False
+
+    def test_missing_success_is_not_delivered(self):
+        assert _confirm_adapter_delivery(object(), "j1") is False
+        assert _confirm_adapter_delivery({"message_id": 7}, "j1") is False
+
+    def test_explicit_failure_is_not_delivered(self):
+        assert _confirm_adapter_delivery(_SendResult(success=False), "j1") is False
+        assert _confirm_adapter_delivery({"success": False}, "j1") is False
+
+    def test_filtered_dict_is_not_delivered(self):
+        """The exact silence-filter shape: a successful DROP is not a delivery."""
+        filtered = {"success": True, "filtered": "silence_narration", "delivered": False}
+        assert _confirm_adapter_delivery(filtered, "j1") is False
+
+    def test_delivered_false_on_an_object_is_not_delivered(self):
+        result = _SendResult(success=True, message_id=42, delivered=False)
+        assert _confirm_adapter_delivery(result, "j1") is False
+
+    def test_positive_evidence_is_delivered_without_warning(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
+            assert _confirm_adapter_delivery(_SendResult(message_id=1234), "j1") is True
+        assert "UNVERIFIED" not in caplog.text
+
+    def test_raw_response_alone_counts_as_evidence(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
+            result = _SendResult(raw_response={"ok": True})
+            assert _confirm_adapter_delivery(result, "j1") is True
+        assert "UNVERIFIED" not in caplog.text
+
+    def test_evidence_free_success_is_accepted_but_warned(self, caplog):
+        """Not proof of failure either — accept it, but say so in the log."""
+        with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
+            assert _confirm_adapter_delivery(_SendResult(), "92e639af907f") is True
+        assert "UNVERIFIED" in caplog.text
+        assert "92e639af907f" in caplog.text
+
+    def test_evidence_free_success_dict_is_accepted_but_warned(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
+            assert _confirm_adapter_delivery({"success": True}, "j1") is True
+        assert "UNVERIFIED" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# _deliver_result: the live lane end to end
+# ---------------------------------------------------------------------------
+
+CHAT_ID = "-1001234567890"
+
+
+def _job(thread_id=None):
+    origin = {"platform": "telegram", "chat_id": CHAT_ID}
+    if thread_id is not None:
+        origin["thread_id"] = thread_id
+    return {
+        "id": "92e639af907f",
+        "name": "Ghost Delivery",
+        "deliver": "origin",
+        "origin": origin,
+    }
+
+
+def _gateway_config(relay=False):
+    config = MagicMock()
+    platforms = {Platform.TELEGRAM: PlatformConfig(enabled=True)}
+    if relay:
+        platforms[Platform.RELAY] = PlatformConfig(enabled=True)
+    config.platforms = platforms
+    config.get_home_channel = lambda p: None
+    return config
+
+
+def _adapters(relay=False):
+    adapter = MagicMock()
+    if relay:
+        adapter.fronts_platform = lambda p: p == Platform.TELEGRAM
+        return {Platform.RELAY: adapter}
+    return {Platform.TELEGRAM: adapter}
+
+
+def _run(job, content, send_result, relay=False, standalone_result=None):
+    """Drive ``_deliver_result`` over the live lane with a stubbed router.
+
+    Returns ``(error, router_calls, standalone_calls)``.
+    """
+    loop = MagicMock()
+    loop.is_running.return_value = True
+
+    def fake_run_coro(coro, _loop):
+        future = Future()
+        try:
+            future.set_result(asyncio.run(coro))
+        except BaseException as e:  # noqa: BLE001
+            future.set_exception(e)
+        return future
+
+    router_calls = []
+    standalone_calls = []
+
+    router = MagicMock()
+
+    async def _deliver_to_platform(target, text, metadata):
+        router_calls.append({"target": target, "text": text, "metadata": metadata})
+        return send_result
+
+    router._deliver_to_platform = _deliver_to_platform
+
+    async def _fake_send_to_platform(platform, pconfig, chat_id, text, **kwargs):
+        standalone_calls.append({"chat_id": chat_id, "text": text, "kwargs": kwargs})
+        return standalone_result if standalone_result is not None else {}
+
+    with patch("gateway.config.load_gateway_config", return_value=_gateway_config(relay)), \
+         patch("cron.scheduler.load_config",
+               return_value={"cron": {"wrap_response": False}}), \
+         patch("gateway.delivery.DeliveryRouter", return_value=router), \
+         patch("tools.send_message_tool._send_to_platform", _fake_send_to_platform), \
+         patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
+        error = _deliver_result(job, content, adapters=_adapters(relay), loop=loop)
+    return error, router_calls, standalone_calls
+
+
+class TestFilteredResultIsNotDelivered:
+    FILTERED = {"success": True, "filtered": "silence_narration", "delivered": False}
+
+    def test_filtered_dict_does_not_log_a_live_delivery(self, caplog):
+        with caplog.at_level(logging.INFO, logger="cron.scheduler"):
+            _, router_calls, standalone_calls = _run(_job(), "...", self.FILTERED)
+
+        assert len(router_calls) == 1                     # the live send was attempted
+        assert "via live adapter" not in caplog.text      # but never claimed as delivered
+        assert len(standalone_calls) == 1                 # fell back instead of lying
+
+    def test_filtered_dict_fails_closed_on_the_relay_lane(self):
+        """Relay owns the destination, so there is no fallback — report it."""
+        error, _, standalone_calls = _run(_job(), "...", self.FILTERED, relay=True)
+
+        assert error is not None
+        assert "unconfirmed result" in error
+        assert "silence_narration" in error  # names the filter, not "unknown"
+        assert standalone_calls == []
+
+    def test_confirmed_send_result_still_delivers(self, caplog):
+        with caplog.at_level(logging.INFO, logger="cron.scheduler"):
+            error, router_calls, standalone_calls = _run(
+                _job(), "Nightly report.", _SendResult(message_id=1234),
+            )
+
+        assert error is None
+        assert len(router_calls) == 1
+        assert standalone_calls == []
+        assert "via live adapter" in caplog.text
+
+
+class TestEmptyPayloadFailsClosed:
+    def test_empty_payload_never_reaches_the_adapter(self, caplog):
+        with caplog.at_level(logging.INFO, logger="cron.scheduler"):
+            _, router_calls, _ = _run(_job(), "   ", _SendResult(message_id=1))
+
+        assert router_calls == []                     # nothing was sent
+        assert "via live adapter" not in caplog.text  # and nothing was claimed
+        assert "empty text and no media" in caplog.text
+
+    def test_empty_payload_never_reaches_the_standalone_sender(self, caplog):
+        """The native fallback must not re-open the hole the live lane closed.
+
+        Telegram's adapter returns ``SendResult(success=True)`` for empty
+        content without an API call, so an unguarded fallback would log a
+        standalone "delivered" for the same phantom payload (#77763).
+        """
+        with caplog.at_level(logging.INFO, logger="cron.scheduler"):
+            error, router_calls, standalone_calls = _run(
+                _job(), "   ", _SendResult(message_id=1),
+            )
+
+        assert router_calls == []
+        assert standalone_calls == []  # _send_to_platform never called
+        assert error is not None
+        assert "standalone send skipped (empty text and no media)" in error
+        assert "delivered to" not in caplog.text
+
+    def test_empty_payload_is_reported_on_the_relay_lane(self):
+        error, router_calls, _ = _run(_job(), "", _SendResult(message_id=1), relay=True)
+
+        assert router_calls == []
+        assert error is not None
+        assert "live adapter send skipped (empty text and no media)" in error
+
+
+class TestDeliveredLogNamesTheLane:
+    def test_log_includes_thread_and_message_id(self, caplog):
+        with caplog.at_level(logging.INFO, logger="cron.scheduler"):
+            error, _, _ = _run(
+                _job(thread_id="99"), "Nightly report.", _SendResult(message_id=1234),
+            )
+
+        assert error is None
+        assert "via live adapter thread=99 message_id=1234" in caplog.text
+
+    def test_log_uses_a_dash_when_the_lane_is_unknown(self, caplog):
+        """No thread and an evidence-free result must still be attributable."""
+        with caplog.at_level(logging.INFO, logger="cron.scheduler"):
+            error, _, _ = _run(_job(), "Nightly report.", _SendResult())
+
+        assert error is None
+        assert "via live adapter thread=- message_id=-" in caplog.text
+        assert "UNVERIFIED" in caplog.text
+
+
+def test_scheduler_module_exposes_the_confirmation_helper():
+    """Guard the import surface the delivery block depends on."""
+    assert callable(sched._confirm_adapter_delivery)

--- a/tests/cron/test_cron_live_delivery_confirmation.py
+++ b/tests/cron/test_cron_live_delivery_confirmation.py
@@ -125,10 +125,18 @@ def _adapters(relay=False):
     return {Platform.TELEGRAM: adapter}
 
 
-def _run(job, content, send_result, relay=False, standalone_result=None):
+RECORDED_VERIFICATION = []
+
+
+def _record_verification(job, unverified_targets):
+    RECORDED_VERIFICATION.append((job["id"], list(unverified_targets)))
+
+
+def _run(job, content, send_result, relay=False, standalone_result=None, cron_cfg=None):
     """Drive ``_deliver_result`` over the live lane with a stubbed router.
 
-    Returns ``(error, router_calls, standalone_calls)``.
+    Returns ``(error, router_calls, standalone_calls)``. ``cron_cfg`` extends
+    the ``cron:`` section handed to the scheduler (default: unwrapped output).
     """
     loop = MagicMock()
     loop.is_running.return_value = True
@@ -143,6 +151,7 @@ def _run(job, content, send_result, relay=False, standalone_result=None):
 
     router_calls = []
     standalone_calls = []
+    RECORDED_VERIFICATION.clear()
 
     router = MagicMock()
 
@@ -158,7 +167,8 @@ def _run(job, content, send_result, relay=False, standalone_result=None):
 
     with patch("gateway.config.load_gateway_config", return_value=_gateway_config(relay)), \
          patch("cron.scheduler.load_config",
-               return_value={"cron": {"wrap_response": False}}), \
+               return_value={"cron": {"wrap_response": False, **(cron_cfg or {})}}), \
+         patch("cron.scheduler._record_delivery_verification", side_effect=_record_verification), \
          patch("gateway.delivery.DeliveryRouter", return_value=router), \
          patch("tools.send_message_tool._send_to_platform", _fake_send_to_platform), \
          patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
@@ -299,6 +309,94 @@ class TestLiveDeliveryIsAFinalNotification:
         assert len(router_calls) == 1
         assert len(sent) == 1
         assert sent[0]["metadata"]["notify"] is True
+
+
+class TestNotifyIsConfigurable:
+    """``cron.delivery.notify`` (config.yaml) gates the notify marker.
+
+    The current behaviour (push notification) stays the default; only an
+    explicit ``false`` restores silent deliveries. The knob rides both the
+    text route and the media route so the two never disagree.
+    """
+
+    def test_default_is_notify(self):
+        _, router_calls, _ = _run(_job(), "Nightly report.", _SendResult(message_id=1))
+        assert router_calls[0]["metadata"]["notify"] is True
+
+    def test_explicit_false_disables_notify_on_text_route(self):
+        _, router_calls, _ = _run(
+            _job(thread_id="99"), "Nightly report.", _SendResult(message_id=1),
+            cron_cfg={"delivery": {"notify": False}},
+        )
+        metadata = router_calls[0]["metadata"]
+        assert metadata["notify"] is False
+        assert metadata["thread_id"] == "99"  # routing untouched
+
+    def test_explicit_false_disables_notify_on_media_route(self, tmp_path):
+        media = tmp_path / "report.png"
+        media.write_bytes(b"\x89PNG\r\n\x1a\n")
+        sent = []
+
+        def fake_send_media(adapter, chat_id, media_files, metadata, loop, job, platform=None):
+            sent.append(metadata)
+            return []
+
+        with patch("cron.scheduler._send_media_via_adapter", side_effect=fake_send_media), \
+             patch("gateway.platforms.base.BasePlatformAdapter.filter_media_delivery_paths",
+                   side_effect=lambda files: files):
+            _run(
+                _job(), f"Nightly report.\nMEDIA:{media}", _SendResult(message_id=1),
+                cron_cfg={"delivery": {"notify": False}},
+            )
+        assert sent[0]["notify"] is False
+
+    @pytest.mark.parametrize("cron_cfg", [
+        {"delivery": None},            # `delivery:` with no body parses to null
+        {"delivery": "yes"},           # malformed scalar
+        {"delivery": {"notify": None}},  # `notify:` with no value
+    ])
+    def test_malformed_section_keeps_the_default(self, cron_cfg):
+        _, router_calls, _ = _run(_job(), "Nightly report.", _SendResult(message_id=1), cron_cfg=cron_cfg)
+        assert router_calls[0]["metadata"]["notify"] is True
+
+    def test_default_config_ships_notify_true(self):
+        from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+        assert DEFAULT_CONFIG["cron"]["delivery"]["notify"] is True
+
+
+class TestUnverifiedDeliveryIsRecordedOnTheJob:
+    """An evidence-free ack is accepted, but the state must reach the job
+    record (and from there ``hermes cron list`` / ``cron doctor``), not only a
+    WARNING log line."""
+
+    def test_evidence_free_ack_records_the_target(self):
+        error, _, _ = _run(_job(), "Nightly report.", _SendResult())
+        assert error is None
+        assert RECORDED_VERIFICATION == [("92e639af907f", [f"telegram:{CHAT_ID}"])]
+
+    def test_positive_evidence_clears_the_marker(self):
+        error, _, _ = _run(_job(), "Nightly report.", _SendResult(message_id=1234))
+        assert error is None
+        assert RECORDED_VERIFICATION == [("92e639af907f", [])]
+
+    def test_recorder_skips_the_write_when_nothing_changed(self):
+        with patch("cron.jobs.update_job") as update_job:
+            sched._record_delivery_verification({"id": "j1", "last_delivery_unverified": None}, [])
+            update_job.assert_not_called()
+            sched._record_delivery_verification({"id": "j1", "last_delivery_unverified": None}, ["slack:C1"])
+            update_job.assert_called_once_with("j1", {"last_delivery_unverified": ["slack:C1"]})
+
+    def test_recorder_clears_a_stale_marker(self):
+        with patch("cron.jobs.update_job") as update_job:
+            sched._record_delivery_verification({"id": "j1", "last_delivery_unverified": ["slack:C1"]}, [])
+            update_job.assert_called_once_with("j1", {"last_delivery_unverified": None})
+
+    def test_tool_listing_exposes_the_field(self):
+        from tools.cronjob_tools import _format_job
+
+        assert _format_job({"id": "j1", "name": "n", "prompt": "p",
+                            "last_delivery_unverified": ["slack:C1"]})["last_delivery_unverified"] == ["slack:C1"]
 
 
 def test_scheduler_module_exposes_the_confirmation_helper():

--- a/tests/gateway/test_delivery_silence_filter.py
+++ b/tests/gateway/test_delivery_silence_filter.py
@@ -124,6 +124,50 @@ async def test_env_override_enables_filter_over_config(tmp_path, monkeypatch):
     assert result["filtered"] == "silence_narration"
 
 
+# --- Cron artifacts are exempt ----------------------------------------------
+#
+# The filter exists to stop bot-to-bot mirror loops of *model chatter*. Cron
+# output is an artifact: a job that legitimately emits "..." (a quiet script,
+# a terse digest) has no loop partner, and dropping it while returning
+# {"success": True} produced a cron the scheduler logged as delivered and the
+# user never received (#77763). Cron sends carry job_id in metadata.
+
+
+@pytest.mark.asyncio
+async def test_cron_job_id_metadata_bypasses_the_filter(tmp_path, monkeypatch):
+    monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
+    monkeypatch.delenv("HERMES_FILTER_SILENCE_NARRATION", raising=False)
+    adapter = RecordingAdapter()
+    router = DeliveryRouter(GatewayConfig(), adapters={Platform.DISCORD: adapter})
+    target = DeliveryTarget.parse("discord:99887766")
+
+    result = await router._deliver_to_platform(
+        target, "*(silent)*", metadata={"job_id": "92e639af907f"},
+    )
+
+    assert len(adapter.calls) == 1
+    assert adapter.calls[0]["content"] == "*(silent)*"
+    assert result.get("filtered") is None
+    assert result.get("delivered") is not False
+
+
+@pytest.mark.asyncio
+async def test_non_cron_metadata_still_filters(tmp_path, monkeypatch):
+    """The exemption keys on job_id alone — everything else is unchanged."""
+    monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
+    monkeypatch.delenv("HERMES_FILTER_SILENCE_NARRATION", raising=False)
+    adapter = RecordingAdapter()
+    router = DeliveryRouter(GatewayConfig(), adapters={Platform.DISCORD: adapter})
+    target = DeliveryTarget.parse("discord:99887766")
+
+    result = await router._deliver_to_platform(
+        target, "*(silent)*", metadata={"thread_id": "42", "user_id": "u1"},
+    )
+
+    assert adapter.calls == []
+    assert result["filtered"] == "silence_narration"
+
+
 # --- Config round-trip ------------------------------------------------------
 
 

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -129,6 +129,44 @@ class TestCronCommandLifecycle:
         assert jobs[0]["name"] == "Skill combo"
 
 
+class TestUnverifiedDeliveryVisibility:
+    """An evidence-free live-adapter ack (Slack/Matrix/Mattermost bare
+    ``SendResult(success=True)``) is accepted as delivered, but the UNVERIFIED
+    state must be visible in ``hermes cron list`` and ``hermes cron doctor``,
+    not only in a WARNING log line."""
+
+    def _seed(self):
+        job = create_job(prompt="Nightly brief", schedule="every 1h", deliver="slack:C0123456")
+        jobs = load_jobs()
+        jobs[0]["last_status"] = "ok"
+        jobs[0]["last_delivery_unverified"] = ["slack:C0123456"]
+        save_jobs(jobs)
+        return job
+
+    def test_list_shows_unverified_delivery(self, tmp_cron_dir, capsys):
+        job = self._seed()
+        cron_command(Namespace(cron_command="list", all=True, json=False))
+        out = capsys.readouterr().out
+        assert job["id"] in out
+        assert "Delivery UNVERIFIED" in out
+        assert "slack:C0123456" in out
+        assert "without message_id/raw_response" in out
+
+    def test_list_is_quiet_when_delivery_was_verified(self, tmp_cron_dir, capsys):
+        create_job(prompt="Nightly brief", schedule="every 1h", deliver="slack:C0123456")
+        cron_command(Namespace(cron_command="list", all=True, json=False))
+        assert "UNVERIFIED" not in capsys.readouterr().out
+
+    def test_doctor_reports_unverified_delivery(self, tmp_cron_dir, capsys):
+        job = self._seed()
+        rc = cron_command(Namespace(cron_command="doctor"))
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert job["id"] in out
+        assert "last delivery unverified" in out
+        assert "slack:C0123456" in out
+
+
 class TestCronDoctor:
     def test_doctor_reports_cron_health_issues(self, tmp_cron_dir, capsys):
         job = create_job(prompt="Daily digest", schedule="every 1h", script="missing.py")

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -770,6 +770,7 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         "last_run_at": job.get("last_run_at"),
         "last_status": job.get("last_status"),
         "last_delivery_error": job.get("last_delivery_error"),
+        "last_delivery_unverified": job.get("last_delivery_unverified"),
         "last_fire_error": job.get("last_fire_error"),
         "enabled": job.get("enabled", True),
         # Derive from enabled so half-paused records never render as paused.

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -489,6 +489,43 @@ cron:
   wrap_response: false
 ```
 
+### Push notifications (`cron.delivery.notify`)
+
+Cron output is a *final* delivery, not a progress message, so by default it is
+sent with the platform's notification flag set — on Telegram this means the
+brief triggers a push even when the adapter's notification mode is `important`
+(which otherwise sends with `disable_notification=true`, and users report the
+silent brief as "never delivered"). To restore silent deliveries:
+
+```yaml
+# ~/.hermes/config.yaml
+cron:
+  delivery:
+    notify: false   # default: true
+```
+
+The flag rides both the text send and any media attachments, so a run never
+pushes for one and stays silent for the other.
+
+### Delivery confirmation and the `UNVERIFIED` state
+
+A live-adapter delivery is logged as delivered only on positive evidence from
+the adapter: an explicit `success` that is not a filtered drop
+(`delivered: false`), plus a `message_id` or `raw_response`. A result carrying
+`success` but neither piece of evidence — the shape Slack, Matrix and
+Mattermost adapters return — is still accepted (it is not proof of failure),
+but the run is recorded on the job as `last_delivery_unverified` and surfaces
+in `hermes cron list`:
+
+```
+⚠ Delivery UNVERIFIED: adapter acked slack:C0123456 without message_id/raw_response
+```
+
+and in `hermes cron doctor` as `last delivery unverified (...)`. The marker is
+cleared by the next run that delivers with evidence. An empty payload (no text
+and no media) is never handed to an adapter; it fails closed and is reported in
+`last_delivery_error` instead of being logged as delivered.
+
 ### Continuable jobs (reply to a cron delivery)
 
 By default a cron delivery is fire-and-forget: the message is sent, but it does


### PR DESCRIPTION
## Summary

Cron no longer logs `delivered to <platform>:<chat> via live adapter` for sends that never happened: the live lane requires positive evidence from the adapter, empty payloads fail closed on both lanes, terse cron output is exempt from the silence-narration drop, and cron deliveries now carry `notify=True` so Telegram actually pushes them.

## Changes

- **`cron/scheduler.py::_confirm_adapter_delivery`** (salvage #100284 @kaiomp) — inspects both `SendResult` objects and the router's plain-dict shape uniformly: `success` truthy **and** `delivered is not False` are required. The silence filter's `{"success": True, "delivered": False}` (a successful *drop*) previously counted as a delivery because the dict branch read only `success`. An evidence-free success (no `message_id`, no `raw_response`) is still accepted but logged as `UNVERIFIED` so it is diagnosable after the fact.
- **Empty payload fails closed on every lane** (#100284, same fix as the earlier #77792 @webtecnica) — `text_to_send == ""` with no media used to skip the send and still fall into the `if adapter_ok:` → "delivered" branch; the standalone fallback had the same hole because Telegram/Matrix/Mattermost/Slack return `SendResult(success=True)` for empty content with no API call. Both sites now record `... send skipped (empty text and no media)` in `last_delivery_error`.
- **Delivered log names the lane** — `via live adapter thread=<id|-> message_id=<id|->`, so a phantom or wrong-lane delivery is distinguishable from a real one in `agent.log`.
- **`gateway/delivery.py`** (#100284) — sends carrying `job_id` in metadata (cron artifacts) bypass the silence-narration anti-loop drop. Cron output has no bot-to-bot mirror partner; a legitimately terse digest (`...`, `🔇`) was being dropped while the run reported success. Every non-cron caller keeps the filter unchanged.
- **`notify: True` on cron live-adapter route + media metadata** (salvage #58262 @tianma-if / dupe #90598) — Telegram's default `_notifications_mode="important"` sends with `disable_notification=True` unless `metadata["notify"]` is set, so every cron brief landed as a silent push; the same marker stops the adapter re-arming the typing bubble after a cron send (#58258). Widened with a regression test covering the text route, the forum-topic route, and the media route.

## Validation

| Check | Result |
|---|---|
| `tests/cron/test_cron_live_delivery_confirmation.py` (new, 21 tests) | 21 passed |
| `tests/gateway/test_delivery_silence_filter.py` (+2) | passed |
| cron delivery neighbourhood: `test_scheduler.py`, `test_relay_fronted_delivery.py`, `gateway/test_delivery.py`, `test_media_delivery_parity.py`, `test_mirror_origin_fallback.py`, `test_cron_no_agent.py`, `test_run_one_job.py`, `test_cron_bot_chat_delivery.py`, `test_telegram_thread_fallback.py` | 256 passed |
| Sabotage: revert the `notify` commit → `TestLiveDeliveryIsAFinalNotification` | 1 failed (`KeyError: 'notify'`), fix restored → passes |
| `ruff check` on touched files | clean |

**Live repro:** real `cron.scheduler._deliver_result` + real `DeliveryRouter` on a running asyncio loop, isolated `HERMES_HOME`, recording adapter standing in for the Telegram client — before (origin/main): content `...` → `Dropped silence-narration outbound` then `Job 'repro77763': delivered to telegram:5160665427 via live adapter`, **adapter.send calls = 0, error = None**; content `MEDIA:/nonexistent/report.png` → `delivered ... via live adapter`, **adapter.send calls = 0**. After: `...` → 1 adapter send, `delivered ... via live adapter thread=- message_id=4242`; media-only → no "delivered" claim, `last_delivery_error` = `live adapter send skipped (empty text and no media) ...; standalone send skipped (empty text and no media) ...`.

Closes #77763
Closes #58258

Salvages #100284 (@kaiomp — primary implementation, both commits cherry-picked with authorship). Supersedes #77792 (@webtecnica — earliest fix for the empty-payload half; same guard, credited) and #90622 (@Schrotti77 — silence-filter `delivered: False` half). Salvages #58262 (@tianma-if — `notify=True`; cherry-picked with authorship), which also covers #90598 (@wuyiloge).

## Infographic
![cron-delivery-confirmation](https://v3b.fal.media/files/b/0aa8c3e5/ap6t00Jt7DxQYMxrYSQh7_x1oQeR3G.png)

## De-risking (commit `968fd281aa6`)

- **`notify=True` is now configurable** via `cron.delivery.notify` in `config.yaml` (default `true` = the behaviour this PR ships; `false` restores silent, no-push cron briefs). Wired through `hermes_cli/config_defaults.py` `DEFAULT_CONFIG["cron"]["delivery"]` (auto-surfaces in the dashboard settings schema) and documented in `website/docs/user-guide/features/cron.md` ("Push notifications"). Resolved once per delivery in `_deliver_result` and applied to both the text route and the media route; a missing/malformed section keeps the default. No env var.
- **UNVERIFIED deliveries are visible, not just logged.** An evidence-free live-adapter ack (bare `SendResult(success=True)` — Slack/Matrix/Mattermost shape) is still accepted, but the target is persisted on the job as `last_delivery_unverified` (cleared by the next evidenced delivery; no jobs.json write when unchanged). `hermes cron list` prints `⚠ Delivery UNVERIFIED: adapter acked slack:C0123456 without message_id/raw_response`, `hermes cron doctor` reports `last delivery unverified (...)`, and the `cronjob` tool listing carries the field. Documented under "Delivery confirmation and the `UNVERIFIED` state".
- **Live repro** (real `cron.scheduler._deliver_result` + real `hermes cron list` CLI against a temp `HERMES_HOME`, Slack target, adapter returning `SendResult(success=True)`):
  - before: route metadata `{"job_id": ..., "notify": true}` unconditionally; job record had no verification field; `hermes cron list` showed only `Deliver: slack:C0123456` — the UNVERIFIED state existed solely as a WARNING log line.
  - after (default config): same WARNING, plus `JOB last_delivery_unverified=['slack:C0123456']` and the list line `⚠ Delivery UNVERIFIED: adapter acked slack:C0123456 without message_id/raw_response`.
  - after (`cron.delivery.notify: false`): route metadata `{"job_id": ..., "notify": false}`.
- **Tests:** `tests/cron/test_cron_live_delivery_confirmation.py` +12 (`TestNotifyIsConfigurable` ×7 incl. malformed-section parametrize + DEFAULT_CONFIG pin, `TestUnverifiedDeliveryIsRecordedOnTheJob` ×5), `tests/hermes_cli/test_cron.py` +3 (`TestUnverifiedDeliveryVisibility`: list shows / list quiet when verified / doctor reports). Targeted runs: 75 passed (confirmation + CLI cron + silence filter), 238 passed (jobs / run_one_job / cronjob_tools / delivery-path siblings), dashboard schema invariants 12 passed. Sabotage run (hardcode `notify_delivery = True`) fails the two explicit-false tests.
