### PR TITLE
fix(gateway): unreadable state.db transcript no longer resumes as a new conversation (#100788, salvage #100798)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2982,6 +2982,7 @@ from gateway.session import (
     SessionStore,
     SessionSource,
     SessionContext,
+    TranscriptReadError,
     build_session_context,
     build_session_context_prompt,
     build_channel_continuity_note,
@@ -20846,8 +20847,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # began processing if the gateway died while it was still waiting.
         await self._mark_durable_active_turn(event, session_entry.session_key)
 
-        # Load conversation history from transcript
-        history = await self.async_session_store.load_transcript(session_entry.session_id)
+        # Load conversation history from transcript. An unreadable canonical
+        # store is not an empty conversation: stop before the agent can invent
+        # continuity from a plausible-looking []. This return happens before
+        # the broad cleanup finally below, so restore task-local context here;
+        # the outer dispatch still clears the durable marker and turn lease.
+        try:
+            history = await self.async_session_store.load_transcript(
+                session_entry.session_id
+            )
+        except TranscriptReadError:
+            self._clear_session_env(_session_env_tokens)
+            return (
+                "⚠️ This session's history is temporarily unavailable, so "
+                "this message was not processed. Ask the operator to inspect "
+                "state.db, then resend after it is healthy. Use /reset only "
+                "if you intentionally want to start a new conversation."
+            )
         
         # -----------------------------------------------------------------
         # Session hygiene: auto-compress pathologically large transcripts

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -23,6 +23,14 @@ from typing import Dict, List, Optional, Any
 logger = logging.getLogger(__name__)
 
 
+class TranscriptReadError(RuntimeError):
+    """Raised when persisted history cannot be read safely."""
+
+    def __init__(self, session_id: str) -> None:
+        self.session_id = session_id
+        super().__init__(f"transcript read failed for session {session_id}")
+
+
 def _now() -> datetime:
     """Return the current local time."""
     return datetime.now()
@@ -4400,15 +4408,17 @@ class SessionStore:
                 session_id, repair_alternation=True
             )
         except Exception as e:
-            # A failed read must be distinguishable from an empty transcript:
-            # downstream guards treat [] as "nothing persisted" and may make
-            # routing decisions on it (#82616). WARNING, not DEBUG.
-            logger.warning(
-                "Transcript read failed for session %s (returning empty; "
-                "downstream must not treat this as data loss): %s",
-                session_id, e,
+            # Empty history is valid data; a failed canonical read is not.
+            # Preserve that distinction so live-replay callers can fail closed
+            # instead of starting the model with a plausible-looking [].
+            logger.error(
+                "Transcript read failed for session %s; refusing to treat the "
+                "conversation as empty: %s",
+                session_id,
+                e,
+                exc_info=True,
             )
-            return []
+            raise TranscriptReadError(session_id) from e
 
     def rewind_session(
         self,

--- a/tests/gateway/test_42039_duplicate_user_message.py
+++ b/tests/gateway/test_42039_duplicate_user_message.py
@@ -24,7 +24,7 @@ import pytest
 import gateway.run as gateway_run
 from gateway.config import GatewayConfig, Platform
 from gateway.platforms.base import MessageEvent
-from gateway.session import SessionEntry, SessionSource
+from gateway.session import SessionEntry, SessionSource, TranscriptReadError
 
 
 def _bootstrap(monkeypatch, tmp_path):
@@ -183,6 +183,24 @@ async def test_not_new_messages_skip_db_when_agent_has_session_db(
     _assert_user_call_has_skip_db(
         runner.session_store.append_to_transcript.call_args_list, True
     )
+
+
+@pytest.mark.asyncio
+async def test_transcript_read_failure_stops_turn_before_agent_or_append(
+    monkeypatch, tmp_path
+):
+    runner = _bootstrap(monkeypatch, tmp_path)
+    runner.session_store.load_transcript.side_effect = TranscriptReadError("sess-dedup")
+    runner._run_agent = AsyncMock()
+
+    response = await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    assert "history is temporarily unavailable" in response
+    assert "not processed" in response
+    runner._run_agent.assert_not_awaited()
+    runner.session_store.append_to_transcript.assert_not_called()
 
 
 # ── Post-stream MEDIA delivery keeps prior-turn deduplication ──────────

--- a/tests/gateway/test_session_continuity_82616.py
+++ b/tests/gateway/test_session_continuity_82616.py
@@ -201,6 +201,28 @@ class TestPeerResolutionRecency:
 
 
 class TestLoadTranscriptReroutes:
+    def test_load_transcript_raises_when_message_read_fails(self, tmp_path, monkeypatch):
+        from gateway.session import SessionStore, TranscriptReadError
+
+        from gateway.config import GatewayConfig
+
+        store = SessionStore(sessions_dir=tmp_path / "gw-failed-read", config=GatewayConfig())
+        db = store._db
+        assert db is not None
+        monkeypatch.setattr(db, "get_compression_tip", lambda _session_id: None)
+
+        def _malformed(_session_id, *, repair_alternation):
+            assert repair_alternation is True
+            raise RuntimeError("database disk image is malformed")
+
+        monkeypatch.setattr(db, "get_messages_as_conversation", _malformed)
+
+        with pytest.raises(TranscriptReadError) as exc_info:
+            store.load_transcript("existing-session")
+
+        assert exc_info.value.session_id == "existing-session"
+        assert isinstance(exc_info.value.__cause__, RuntimeError)
+
     def test_load_transcript_follows_reroute_chain(self, tmp_path):
         from gateway.session import SessionStore
 


### PR DESCRIPTION
## Summary
A gateway session whose canonical `state.db` transcript cannot be read no longer resumes as a brand-new conversation — `SessionStore.load_transcript()` raises `TranscriptReadError` and the inbound turn is stopped before the model runs without its history.

## Changes
- `gateway/session.py`: new `TranscriptReadError(RuntimeError)` (carries `session_id`, chained to the sqlite cause). `load_transcript()` raises it instead of swallowing the read failure into `[]` — an empty list stays the value for a genuinely empty session only.
- `gateway/run.py` (`_handle_message_with_agent`): catches `TranscriptReadError` at the history-load site, restores the task-local session env, and returns a user-visible notice ("history is temporarily unavailable … this message was not processed … use /reset only if you intentionally want a new conversation"). The agent never runs and nothing is appended to the transcript.
- Other `load_transcript()` callers (slash-command handlers, `base.py` media dedup, yuanbao) already sit inside `try/except Exception` or the adapter-level command dispatch error handler, so an unreadable store now surfaces as an error reply there instead of silently empty history.
- Tests: `test_load_transcript_raises_when_message_read_fails` (real `SessionStore` + `SessionDB`, read raising `malformed`) and `test_transcript_read_failure_stops_turn_before_agent_or_append` (`_run_agent` not awaited, `append_to_transcript` not called).

Closes the gap #82616's "prefer live cached history" guard cannot cover: after a gateway restart there is no in-memory history to prefer, so `[]` was indistinguishable from "no messages".

## Validation
| Check | Result |
|---|---|
| `tests/gateway/test_42039_duplicate_user_message.py` + `tests/gateway/test_session_continuity_82616.py` | 15 passed |
| All 47 `tests/gateway/*` files referencing `load_transcript` | 335 passed, 1 warning |
| `ruff check` on touched files | clean |
| `scripts/audit_pr_attribution.py --fix` | all contributor emails mapped |

**Live repro:** real `SessionDB` (400 messages) with the `messages` root page body overwritten (WAL checkpointed + sidecars removed first), reopened through a real `gateway.session.SessionStore` under an isolated `HERMES_HOME` — before (origin/main `ff7745fb0a`): `load_transcript('sess-A') -> []` with only a WARNING `Transcript read failed for session sess-A (returning empty …): database disk image is malformed`; after: `load_transcript raised TranscriptReadError: transcript read failed for session sess-A | cause: DatabaseError database disk image is malformed`.

Closes #100788
Salvages #100798 by @fangliquanflq (commit cherry-picked, authorship preserved).

## Infographic
![unreadable-session-fail-closed](https://v3b.fal.media/files/b/0aa8c3e1/C7Z1R6jodMe1dKUjvjq-3_Zxyef5Db.png)
