### PR TITLE
Lazily installed backends are byte-compiled at install time so first import is not a foreground cold-compile stall (refs #100461, salvage #100829)

### DIFF
--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -542,6 +542,13 @@ class TestWarmInstalledBytecode:
     def test_unknown_distribution_resolves_to_nothing(self):
         assert ld._installed_dist_roots("zzz-not-installed==9.9", None) == set()
 
+    def test_dist_roots_exclude_metadata_dirs(self):
+        # ``*.dist-info`` owns RECORD/METADATA/licenses, never importable
+        # code — compiling it is wasted work on every install.
+        roots = ld._installed_dist_roots("pytest>=8", None)
+        assert roots
+        assert not any(r.name.endswith((".dist-info", ".egg-info")) for r in roots)
+
 
 class TestInstallWarmsBytecode:
     """The warm runs on install success, and only on success."""
@@ -549,6 +556,7 @@ class TestInstallWarmsBytecode:
     @staticmethod
     def _install(monkeypatch, returncode):
         calls = []
+        cmds = []
         monkeypatch.setattr(ld, "_lazy_install_target", lambda: None)
         monkeypatch.setattr(ld.shutil, "which", lambda name: "uv" if name == "uv" else None)
         monkeypatch.setattr(
@@ -561,20 +569,34 @@ class TestInstallWarmsBytecode:
                 self.stdout = "out"
                 self.stderr = "err"
 
-        monkeypatch.setattr(ld.subprocess, "run", lambda *a, **kw: _Completed())
+        def fake_run(cmd, *a, **kw):
+            cmds.append(list(cmd))
+            return _Completed()
+
+        monkeypatch.setattr(ld.subprocess, "run", fake_run)
         monkeypatch.setattr(
             ld, "_warm_installed_bytecode",
             lambda specs, target: calls.append((specs, target)),
         )
         result = ld._venv_pip_install(("zzzfake==1.0",))
-        return result, calls
+        return result, calls, cmds
 
     def test_success_warms_once_with_the_installed_specs(self, monkeypatch):
-        result, calls = self._install(monkeypatch, 0)
+        result, calls, _ = self._install(monkeypatch, 0)
         assert result.success is True
         assert calls == [(("zzzfake==1.0",), None)]
 
     def test_failed_install_does_not_warm(self, monkeypatch):
-        result, calls = self._install(monkeypatch, 1)
+        result, calls, _ = self._install(monkeypatch, 1)
         assert result.success is False
         assert calls == []
+
+    def test_uv_tier_compiles_bytecode_for_the_whole_install(self, monkeypatch):
+        # uv does not write __pycache__ unless asked (pip does). The flag
+        # covers transitive deps too, which the per-spec warm never sees.
+        _, _, cmds = self._install(monkeypatch, 0)
+        uv_cmds = [c for c in cmds if c[:3] == ["uv", "pip", "install"]]
+        assert len(uv_cmds) == 1
+        cmd = uv_cmds[0]
+        assert "--compile-bytecode" in cmd
+        assert cmd.index("--compile-bytecode") < cmd.index("zzzfake==1.0")

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -483,3 +483,98 @@ class TestInstallSpecs:
         result = ld.install_specs(["honcho-ai==2.2.0"])
         assert result.ok is False
         assert "disk on fire" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Post-install bytecode warm (#100461)
+# ---------------------------------------------------------------------------
+
+
+class TestWarmInstalledBytecode:
+    """A pip/uv install leaves ``.py`` sources with no ``__pycache__``.
+
+    Whoever imports next pays the whole compile, and for a lazily installed
+    backend that is the foreground of a user request. These tests pin that
+    the installer pays it instead.
+    """
+
+    @staticmethod
+    def _package(tmp_path):
+        pkg = tmp_path / "zzzfakepkg"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("VALUE = 1\n", encoding="utf-8")
+        (pkg / "mod.py").write_text("def f():\n    return 2\n", encoding="utf-8")
+        return pkg
+
+    def test_compiles_the_installed_package(self, tmp_path, monkeypatch):
+        pkg = self._package(tmp_path)
+        monkeypatch.setattr(ld, "_installed_dist_roots", lambda spec, target: {pkg})
+
+        assert not list(pkg.rglob("*.pyc"))
+        ld._warm_installed_bytecode(("zzzfake==1.0",), None)
+        assert len(list(pkg.rglob("*.pyc"))) == 2
+
+    def test_honors_dont_write_bytecode(self, tmp_path, monkeypatch):
+        pkg = self._package(tmp_path)
+        monkeypatch.setattr(ld, "_installed_dist_roots", lambda spec, target: {pkg})
+        monkeypatch.setattr(ld.sys, "dont_write_bytecode", True)
+
+        ld._warm_installed_bytecode(("zzzfake==1.0",), None)
+        assert not list(pkg.rglob("*.pyc"))
+
+    def test_compile_failure_never_propagates(self, tmp_path, monkeypatch):
+        # An unwritable tree (read-only mount, --target on a sealed image)
+        # must not turn a successful install into a failed one.
+        def boom(spec, target):
+            raise OSError("read-only file system")
+        monkeypatch.setattr(ld, "_installed_dist_roots", boom)
+
+        ld._warm_installed_bytecode(("zzzfake==1.0",), None)  # no exception
+
+    def test_dist_roots_resolve_from_metadata_not_the_spec_name(self):
+        # The import name is read off the distribution's own file list, so
+        # specs whose package name differs from their module name still warm.
+        roots = ld._installed_dist_roots("pytest>=8", None)
+        assert roots, "pytest is a test dependency and must resolve"
+        assert all(r.is_dir() for r in roots)
+        assert any(list(r.glob("*.py")) for r in roots)
+
+    def test_unknown_distribution_resolves_to_nothing(self):
+        assert ld._installed_dist_roots("zzz-not-installed==9.9", None) == set()
+
+
+class TestInstallWarmsBytecode:
+    """The warm runs on install success, and only on success."""
+
+    @staticmethod
+    def _install(monkeypatch, returncode):
+        calls = []
+        monkeypatch.setattr(ld, "_lazy_install_target", lambda: None)
+        monkeypatch.setattr(ld.shutil, "which", lambda name: "uv" if name == "uv" else None)
+        monkeypatch.setattr(
+            "hermes_cli.managed_uv.resolve_uv", lambda *a, **kw: "uv", raising=False
+        )
+
+        class _Completed:
+            def __init__(self):
+                self.returncode = returncode
+                self.stdout = "out"
+                self.stderr = "err"
+
+        monkeypatch.setattr(ld.subprocess, "run", lambda *a, **kw: _Completed())
+        monkeypatch.setattr(
+            ld, "_warm_installed_bytecode",
+            lambda specs, target: calls.append((specs, target)),
+        )
+        result = ld._venv_pip_install(("zzzfake==1.0",))
+        return result, calls
+
+    def test_success_warms_once_with_the_installed_specs(self, monkeypatch):
+        result, calls = self._install(monkeypatch, 0)
+        assert result.success is True
+        assert calls == [(("zzzfake==1.0",), None)]
+
+    def test_failed_install_does_not_warm(self, monkeypatch):
+        result, calls = self._install(monkeypatch, 1)
+        assert result.success is False
+        assert calls == []

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -727,6 +727,10 @@ def _installed_dist_roots(spec: str, target: Optional[Path]) -> set[Path]:
             parts = entry.parts
             if not parts or parts[0].startswith(".") or parts[0] == "__pycache__":
                 continue
+            # Metadata dirs (``foo-1.0.dist-info``, legacy ``.egg-info``) own
+            # no importable code; compiling them is wasted work.
+            if parts[0].endswith((".dist-info", ".egg-info")):
+                continue
             root = Path(dist.locate_file(parts[0]))
             if root.is_dir():
                 roots.add(root)
@@ -830,8 +834,15 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
             uv_bin = shutil.which("uv")
         if uv_bin:
             try:
+                # --compile-bytecode: uv does NOT write __pycache__ by default
+                # (pip does), so without it the first `import <backend>` in
+                # the foreground of a user request recompiles every module of
+                # the backend *and* its transitive deps (#100461). This covers
+                # the whole install; _warm_installed_bytecode below is the
+                # belt-and-braces pass for the spec's own roots on any tier.
                 r = subprocess.run(
-                    [uv_bin, "pip", "install", *target_args, *constraint_args, *specs],
+                    [uv_bin, "pip", "install", "--compile-bytecode",
+                     *target_args, *constraint_args, *specs],
                     capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=timeout, env=uv_env,
                     stdin=subprocess.DEVNULL,
                     creationflags=windows_hide_flags(),

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -699,6 +699,80 @@ def _core_constraints_file() -> Optional[Path]:
         return None
 
 
+def _installed_dist_roots(spec: str, target: Optional[Path]) -> set[Path]:
+    """Return the package directories a freshly installed *spec* owns.
+
+    Resolved from the distribution's own file list rather than guessing the
+    import name from the spec — ``python-telegram-bot`` ships ``telegram``,
+    ``firecrawl-anydoc`` ships ``anydoc``, and several specs ship more than
+    one top-level package.
+    """
+    name = _pkg_name_from_spec(spec)
+    try:
+        import importlib.metadata as _md
+
+        if target is not None:
+            dists = list(_md.distributions(name=name, path=[str(target)]))
+            dist = dists[0] if dists else None
+        else:
+            dist = _md.distribution(name)
+    except Exception:
+        return set()
+    if dist is None:
+        return set()
+
+    roots: set[Path] = set()
+    try:
+        for entry in dist.files or ():
+            parts = entry.parts
+            if not parts or parts[0].startswith(".") or parts[0] == "__pycache__":
+                continue
+            root = Path(dist.locate_file(parts[0]))
+            if root.is_dir():
+                roots.add(root)
+    except Exception:
+        return set()
+    return roots
+
+
+def _warm_installed_bytecode(specs: tuple[str, ...], target: Optional[Path]) -> None:
+    """Byte-compile what we just installed, so no user request has to.
+
+    A pip/uv install writes ``.py`` sources and no ``__pycache__`` — and an
+    install of the *same* version still deletes the cache the old copy had.
+    Whoever imports the package next pays the whole compile: for
+    ``anthropic==0.87.0`` (541 modules) on cpython-3.12.13 that measured
+    2.2-2.7s cold against 0.7-1.0s warm, and 10.5s cold under concurrent
+    load.  That bill lands wherever the first import happens, and
+    for a lazily-installed backend that is the foreground of a user request
+    (#100461) — with nothing printed while it runs, so it reads as a hang.
+    Worse, N per-profile daemons cold-starting together each pay it in full
+    before any of them has written the cache.
+
+    Paying it here instead is strictly better: the caller is already waiting
+    on an installer and can see why.  Best-effort — a compile failure never
+    invalidates an install that succeeded.
+    """
+    if sys.dont_write_bytecode:
+        return
+    try:
+        import compileall
+    except Exception:  # pragma: no cover — stdlib, but never break an install
+        return
+
+    for spec in specs:
+        try:
+            roots = _installed_dist_roots(spec, target)
+        except Exception as exc:
+            logger.debug("Bytecode warm skipped for %s: %s", spec, exc)
+            continue
+        for root in roots:
+            try:
+                compileall.compile_dir(str(root), quiet=2, force=False, workers=1)
+            except Exception as exc:
+                logger.debug("Bytecode warm skipped for %s: %s", root, exc)
+
+
 def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _InstallResult:
     """Install ``specs`` using the uv → pip → ensurepip ladder.
 
@@ -765,6 +839,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                 if r.returncode == 0:
                     if target is not None:
                         _activate_target_on_syspath(target)
+                    _warm_installed_bytecode(specs, target)
                     return _InstallResult(True, r.stdout or "", r.stderr or "")
                 logger.debug("uv pip install failed: %s", r.stderr)
                 # A resolver failure is authoritative. Falling through to pip
@@ -810,8 +885,10 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                 stdin=subprocess.DEVNULL,
                 creationflags=windows_hide_flags(),
             )
-            if r.returncode == 0 and target is not None:
-                _activate_target_on_syspath(target)
+            if r.returncode == 0:
+                if target is not None:
+                    _activate_target_on_syspath(target)
+                _warm_installed_bytecode(specs, target)
             return _InstallResult(r.returncode == 0, r.stdout or "", r.stderr or "")
         except subprocess.TimeoutExpired as e:
             return _InstallResult(False, "", f"pip install timed out: {e}")


### PR DESCRIPTION
## Summary

Lazily installed backends (`anthropic`, `firecrawl-py`, gateway platform SDKs, …) are byte-compiled inside `_venv_pip_install` at install time, so the first `import <backend>` in the foreground of a user request no longer recompiles every module of the package on the reporter's cold-start path.

## Changes

- `tools/lazy_deps.py`
  - `_installed_dist_roots(spec, target)` — resolves the top-level package dirs a freshly installed dist owns from its own `RECORD` (handles `python-telegram-bot` → `telegram`, multi-root dists); works for both venv-scoped and `--target` (durable-store) installs. Skips `*.dist-info` / `*.egg-info` roots (follow-up: they own no importable code).
  - `_warm_installed_bytecode(specs, target)` — `compileall.compile_dir(force=False)` over those roots on the **success path of both the uv and pip tiers**. Best-effort: honors `sys.dont_write_bytecode`, every failure is caught and logged at debug, and a compile failure can never turn a successful install into a failed one.
  - uv tier now passes `--compile-bytecode` (follow-up): `uv pip install` writes **no** `__pycache__` by default (pip does), so the flag warms the whole install *including transitive deps*, which the per-spec warm never sees. Measured on the real uv-managed cpython-3.12.13: `--compile-bytecode` costs +0.09s wall on `anthropic==0.87.0`.
- `tests/tools/test_lazy_deps.py` — `TestWarmInstalledBytecode` (compiles the installed package; honors `dont_write_bytecode`; compile failure never propagates; roots come from dist metadata not the spec name; unknown dist → nothing; metadata dirs excluded) and `TestInstallWarmsBytecode` (warm runs once on success with the installed specs; never on a failed install; uv tier carries `--compile-bytecode` before the specs).

## Validation

| Check | Result |
|---|---|
| `pytest tests/tools/test_lazy_deps.py tests/tools/test_lazy_deps_durable_target.py tests/tools/test_lazy_deps_managed.py tests/plugins/memory/test_memory_lazy_install.py tests/test_windows_subprocess_no_window_flags.py -o addopts=` | 109 passed, 5 skipped |
| Sabotage (revert `tools/lazy_deps.py` to main, keep tests) | 7 failed / 60 passed — new tests bite |
| Sabotage (drop `--compile-bytecode` + dist-info skip, keep tests) | 2 failed — follow-up tests bite |
| `ruff check tools/lazy_deps.py tests/tools/test_lazy_deps.py` | All checks passed |
| `git diff --check` | clean |
| Stale-base gate `git rev-list --count $(merge-base)..origin/main` | 0 |

**Live repro:** fresh `uv venv --python 3.12.13` (the reporter's interpreter, uv-managed `cpython-3.12.13-linux-x86_64-gnu`), purge `anthropic*` + all `__pycache__`, then a REAL `tools.lazy_deps._venv_pip_install(("anthropic==0.87.0",))` (uv tier) followed by `import anthropic` in a fresh process — before (origin/main): `pyc under anthropic after install: 0`, `first import 0.468s`, `second import 0.226s`; after (this branch): `pyc under anthropic after install: 546` (1212 in the whole site-packages), `first import 0.205s`, `second import 0.201s` — first import is already warm. Also confirmed the premise directly: `uv pip install anthropic==0.87.0` → 0 `.pyc`; `uv pip install --compile-bytecode` → 801 `.pyc`; `python -m pip install` → 546 `.pyc`; a same-version `uv pip install --reinstall` also leaves 0 `.pyc`.

**What this does NOT prove:** I could not reproduce any crash. 10 concurrent fresh cpython-3.12.13 processes importing the uncompiled `anthropic==0.87.0` all exited rc=0 (wall 0.69s, each import 0.52–0.55s; warm 0.22–0.39s) with no `RecursionError` / typing failure, on this box. The reporter's traceback ends in typing.py with no final exception line, consistent with a `KeyboardInterrupt` landing on a slow uncompiled import as #100829 argues — but the reporter's 10s+ stall is not reproduced here (fast NVMe, idle machine), so the interpreter-bump question in the issue thread stays open. Hence `Refs`, not `Closes`.

Refs #100461
Salvage of #100829 by @JoaoMarcos44 — original commit cherry-picked with authorship preserved; follow-up commit adds `--compile-bytecode` on the uv tier, metadata-dir skip, and tests.

## Infographic
![lazy-deps-bytecode-warm](https://v3b.fal.media/files/b/0aa8c3e1/9qqm2lApcjQZ6ZtpzYrSg_etYpams2.png)
