### PR TITLE
fix(agent): guard auxiliary config against YAML null values (#100835)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8535,10 +8535,14 @@ def _resolve_task_provider_model(
 
     if task:
         task_config = _get_auxiliary_task_config(task)
-        cfg_provider = str(task_config.get("provider", "")).strip() or None
-        cfg_model = str(task_config.get("model", "")).strip() or None
-        cfg_base_url = str(task_config.get("base_url", "")).strip() or None
-        cfg_api_key = str(task_config.get("api_key", "")).strip() or None
+        _raw = task_config.get("provider")
+        cfg_provider = str(_raw).strip() if _raw is not None else None
+        _raw = task_config.get("model")
+        cfg_model = str(_raw).strip() if _raw is not None else None
+        _raw = task_config.get("base_url")
+        cfg_base_url = str(_raw).strip() if _raw is not None else None
+        _raw = task_config.get("api_key")
+        cfg_api_key = str(_raw).strip() if _raw is not None else None
         # Resolve key_env → env var when api_key is not set directly
         if not cfg_api_key:
             cfg_key_env = str(


### PR DESCRIPTION
## Problem

YAML `null` in auxiliary task config (e.g. `model: null`) becomes Python `None`, but `str(None)` produces the literal string `"None"`. This is then sent to the provider as a requested model name, breaking auto-routing.

## Fix

Check for `None` before calling `str()` on all auxiliary task config values (`model`, `provider`, `base_url`, `api_key`). When the YAML value is `null`, the resolved config correctly becomes `None`, allowing the auxiliary client to inherit the active main model.

## Testing

```python
# Before: str(None).strip() → "None" (sent as model name)
# After:  None check → None (auto-routing inherits main model)
```

Fixes #100835