### PR TITLE
fix(cron): delivery failures record last_status=delivery_failed and surface in list/doctor/manual run (#83993, salvage #100163 #86622)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/cron-detail.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/cron-detail.test.tsx
@@ -28,7 +28,8 @@ vi.mock('@hermes/plugin-sdk', async importOriginal => {
   return { ...sdk, host: { ...sdk.host, request } }
 })
 
-const { RoutineDetailDialog, RoutineRow, routineDetailIssue, routineDetailRows } = await import('./cron')
+const { RoutineDetailDialog, RoutineRow, routineDetailIssue, routineDetailRows, routineLastResult } =
+  await import('./cron')
 
 const activeJob: RoutineJob = {
   deliver: 'bot-chat',
@@ -86,6 +87,22 @@ describe('the facts the row never showed', () => {
 
     expect(valueOf(passthrough, 'Schedule (raw)')).toBeUndefined()
     expect(valueOf(passthrough, 'Schedule')).toBe('0 9 * * 1-5')
+  })
+
+  it('spells out every last_status the scheduler writes', () => {
+    // The gateway's literal set is closed; each one gets a human reading, and
+    // delivery_failed in particular must not read as a success.
+    expect(routineLastResult('ok')).toBe('Succeeded')
+    expect(routineLastResult('error')).toBe('Failed')
+    expect(routineLastResult('delivery_failed')).toBe('Ran, but delivery failed')
+    expect(routineLastResult('blocked_config')).toBe('Blocked by configuration (not run)')
+    // Unknown literals pass through rather than vanish.
+    expect(routineLastResult('something_new')).toBe('something_new')
+    expect(routineLastResult(undefined)).toBeNull()
+
+    expect(valueOf(routineDetailRows({ ...activeJob, last_status: 'delivery_failed' }), 'Last result')).toBe(
+      'Ran, but delivery failed'
+    )
   })
 
   it('explains a failing or scheduler-paused job in failure order', () => {

--- a/apps/desktop/src/plugins/hermes-bots/cron.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/cron.tsx
@@ -331,6 +331,36 @@ function routineTimestamp(value: string | undefined): null | string {
   return Number.isFinite(ms) ? `${relativeTime(ms)} · ${new Date(ms).toLocaleString()}` : null
 }
 
+/** The scheduler's `last_status` literals, spelled out for the inspector. The
+ *  set is closed on the gateway side, so every literal is named here — an
+ *  unknown one is passed through verbatim rather than hidden. `delivery_failed`
+ *  means the agent run succeeded but the brief never reached its target; it
+ *  must read as a failure, not as a run result the user can trust. */
+export function routineLastResult(status: string | null | undefined): null | string {
+  const raw = String(status || '').trim()
+
+  if (!raw) {
+    return null
+  }
+
+  switch (raw) {
+    case 'ok':
+      return 'Succeeded'
+
+    case 'error':
+      return 'Failed'
+
+    case 'delivery_failed':
+      return 'Ran, but delivery failed'
+
+    case 'blocked_config':
+      return 'Blocked by configuration (not run)'
+
+    default:
+      return raw
+  }
+}
+
 /** The facts `cron.manage list` already sends with every job, as label/value
  *  rows. Pure so the detail contract is testable without a renderer, and so
  *  the dialog cannot invent a field the gateway never sent: an absent value
@@ -353,7 +383,7 @@ export function routineDetailRows(job: RoutineJob | null | undefined): Array<{ l
       ['Repeat', job?.repeat],
       ['Next run', paused ? null : routineTimestamp(job?.next_run_at)],
       ['Last run', routineTimestamp(job?.last_run_at)],
-      ['Last result', job?.last_status],
+      ['Last result', routineLastResult(job?.last_status)],
       ['Delivers to', job?.deliver],
       ['Model', job?.model],
       ['Working directory', job?.workdir]

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -3033,7 +3033,13 @@ def _mark_job_run_locked(
     ``delivery_error`` is tracked separately from the agent error — a job
     can succeed (agent produced output) but fail delivery (platform down).
 
-    ``status`` overrides the derived ``last_status`` ("ok"/"error") with a
+    A run that succeeded but failed delivery records
+    ``last_status = "delivery_failed"`` (never "ok") so the failure is
+    visible to every reader, while ``failure_streak`` stays untouched —
+    the agent did its job.
+
+    ``status`` overrides the derived ``last_status`` ("ok"/"error"/
+    "delivery_failed") with a
     specific terminal status for this run — e.g. ``"blocked_config"`` when
     the pre-dispatch configuration validation refused to run the agent
     (T1-26), so `cronjob list` distinguishes "your config is broken" from
@@ -3058,7 +3064,21 @@ def _mark_job_run_locked(
                 # The transient manual-run context is single-fire: whatever
                 # run just completed consumed it (or superseded it).
                 job.pop("manual_run_prompt", None)
-                job["last_status"] = status or ("ok" if success else "error")
+                # A run whose agent succeeded but whose delivery failed is NOT
+                # "ok": recording it as such hid last_delivery_error behind a
+                # green status in `cron list`/the UI and made a job that never
+                # reached the user look like a quiet success (#83993). It gets
+                # its own status so every reader that keys off "ok" (CLI list,
+                # doctor, cronjob_tools) sees the failure. An explicit
+                # ``status`` override (e.g. "blocked_config") still wins.
+                if status:
+                    job["last_status"] = status
+                elif not success:
+                    job["last_status"] = "error"
+                elif isinstance(delivery_error, str) and delivery_error.strip():
+                    job["last_status"] = "delivery_failed"
+                else:
+                    job["last_status"] = "ok"
                 job["last_error"] = error if not success else None
                 # A healthy run means the configuration validates again — drop
                 # the preflight alert-dedup marker so a FUTURE config break

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1986,7 +1986,13 @@ class CLICommandsMixin:
                     print(f"  Skills: {', '.join(job['skills'])}")
                 print(f"  Prompt: {job.get('prompt_preview', '')}")
                 if job.get("last_run_at"):
-                    print(f"  Last run: {job['last_run_at']} ({job.get('last_status', '?')})")
+                    status = job.get("last_status") or "?"
+                    # delivery_failed: the agent ran fine but the output never
+                    # reached the target — name the delivery reason, which
+                    # lives in last_delivery_error (last_error is None).
+                    if status == "delivery_failed" and job.get("last_delivery_error"):
+                        status = f"delivery_failed: {job['last_delivery_error']}"
+                    print(f"  Last run: {job['last_run_at']} ({status})")
                 print()
             return
 

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -264,6 +264,12 @@ def cron_list(show_all: bool = False):
             last_run = job.get("last_run_at", "?")
             if last_status == "ok":
                 status_display = color("ok", Colors.GREEN)
+            elif last_status == "delivery_failed":
+                # The agent succeeded but the result never reached the user —
+                # not green, and the detail lives in last_delivery_error
+                # (last_error is None for these runs).
+                detail = job.get("last_delivery_error") or "?"
+                status_display = color(f"delivery_failed: {detail}", Colors.YELLOW)
             else:
                 status_display = color(f"{last_status}: {job.get('last_error', '?')}", Colors.RED)
                 streak = int(job.get("failure_streak") or 0)
@@ -688,7 +694,10 @@ def _cron_doctor_issues_for_job(job: Dict[str, Any]) -> List[str]:
     issues: List[str] = []
 
     last_status = str(job.get("last_status") or "").strip().lower()
-    if last_status and last_status != "ok":
+    # "delivery_failed" means the agent run itself succeeded, so it is not a
+    # failed last run — the dedicated delivery issue below reports it (and
+    # last_error is None, which would render as "unknown error" here).
+    if last_status and last_status not in {"ok", "delivery_failed"}:
         err = str(job.get("last_error") or "unknown error").strip()
         issues.append(f"last run failed: {err}")
 

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -645,6 +645,8 @@ class TestMarkJobRun:
         assert updated is not None
         assert updated["state"] == "completed"
         assert updated["last_delivery_error"] == "platform 'telegram' not configured"
+        # A terminal completion that never reached the user is not a success.
+        assert updated["last_status"] == "delivery_failed"
 
     def test_completed_oneshot_visible_in_list(self, tmp_cron_dir):
         """list_jobs(include_disabled=True) surfaces the completed record."""
@@ -654,6 +656,7 @@ class TestMarkJobRun:
         assert job["id"] in listed
         assert listed[job["id"]]["state"] == "completed"
         assert listed[job["id"]]["last_delivery_error"] == "send failed: 502"
+        assert listed[job["id"]]["last_status"] == "delivery_failed"
         # Default (enabled-only) listing hides it, matching paused/disabled jobs.
         assert job["id"] not in {j["id"] for j in list_jobs()}
 
@@ -672,13 +675,53 @@ class TestMarkJobRun:
         assert updated["last_error"] == "timeout"
 
     def test_delivery_error_tracked_separately(self, tmp_cron_dir):
-        """Agent succeeds but delivery fails — both tracked independently."""
+        """Agent succeeds but delivery fails — surfaced, not hidden behind ok.
+
+        Regression guard for #83993: recording ``last_status="ok"`` made a run
+        the user never received look like a quiet success everywhere that keys
+        off "ok". The agent error stays independent of the delivery error, and
+        the delivery failure is not an agent failure (no streak).
+        """
         job = create_job(prompt="Report", schedule="every 1h")
-        mark_job_run(job["id"], success=True, delivery_error="platform 'telegram' not configured")
+        mark_job_run(job["id"], success=True, delivery_error="send failed: 502")
         updated = get_job(job["id"])
-        assert updated["last_status"] == "ok"
+        assert updated["last_status"] == "delivery_failed"
         assert updated["last_error"] is None
-        assert updated["last_delivery_error"] == "platform 'telegram' not configured"
+        assert updated["last_delivery_error"] == "send failed: 502"
+        assert updated["failure_streak"] == 0
+
+    def test_success_without_delivery_error_stays_ok(self, tmp_cron_dir):
+        """A fully successful run is still plain "ok"."""
+        job = create_job(prompt="Report", schedule="every 1h")
+        mark_job_run(job["id"], success=True)
+        assert get_job(job["id"])["last_status"] == "ok"
+        # An empty delivery error is no error at all.
+        mark_job_run(job["id"], success=True, delivery_error="")
+        assert get_job(job["id"])["last_status"] == "ok"
+
+    def test_agent_failure_still_error_with_delivery_error(self, tmp_cron_dir):
+        """An agent failure outranks delivery: still "error", still a streak."""
+        job = create_job(prompt="Report", schedule="every 1h")
+        mark_job_run(
+            job["id"], success=False, error="timeout",
+            delivery_error="send failed: 502",
+        )
+        updated = get_job(job["id"])
+        assert updated["last_status"] == "error"
+        assert updated["last_error"] == "timeout"
+        assert updated["failure_streak"] == 1
+
+    def test_explicit_status_override_wins_over_delivery_failed(self, tmp_cron_dir):
+        """An explicit terminal status (T1-26 blocked_config) still wins."""
+        job = create_job(prompt="Report", schedule="every 1h")
+        mark_job_run(
+            job["id"], success=True,
+            delivery_error="send failed: 502",
+            status="blocked_config",
+        )
+        updated = get_job(job["id"])
+        assert updated["last_status"] == "blocked_config"
+        assert updated["last_delivery_error"] == "send failed: 502"
 
     def test_failure_streak_increments_and_resets(self, tmp_cron_dir):
         """failure_streak counts consecutive agent failures; success resets."""

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -160,6 +160,28 @@ class TestCronDoctor:
         assert rc == 0
         assert "✓ Cron doctor found no issues" in out
 
+    def test_doctor_reports_delivery_failure_once(self, tmp_cron_dir, capsys):
+        """A delivery_failed run is a delivery issue, not a failed agent run.
+
+        The agent succeeded (last_error is None), so the generic last-run-failed
+        line would only ever say "unknown error" — double-reporting the same
+        incident (#83993).
+        """
+        create_job(prompt="Daily digest", schedule="every 1h")
+        jobs = load_jobs()
+        jobs[0]["last_status"] = "delivery_failed"
+        jobs[0]["last_error"] = None
+        jobs[0]["last_delivery_error"] = "telegram timeout"
+        save_jobs(jobs)
+
+        rc = cron_command(Namespace(cron_command="doctor"))
+
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "last delivery failed: telegram timeout" in out
+        assert "last run failed" not in out
+        assert "unknown error" not in out
+
     def test_doctor_flags_overdue_next_run(self, tmp_cron_dir, capsys):
         from datetime import datetime, timedelta, timezone
 
@@ -191,6 +213,48 @@ class TestCronDoctor:
         out = capsys.readouterr().out
         assert rc == 0
         assert "✓ Cron doctor found no issues" in out
+
+
+class TestCronListStatusRendering:
+    """`cron list` must never paint an undelivered run as a success (#83993)."""
+
+    def test_delivery_failed_is_not_green_ok(self, tmp_cron_dir, capsys, monkeypatch):
+        monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [1])
+        # capsys is not a tty, so force colors on to check the paint itself.
+        monkeypatch.setattr("hermes_cli.colors.should_use_color", lambda: True)
+        create_job(prompt="Daily digest", schedule="every 1h")
+        jobs = load_jobs()
+        jobs[0]["last_run_at"] = "2026-09-01T09:00:00+00:00"
+        jobs[0]["last_status"] = "delivery_failed"
+        jobs[0]["last_error"] = None
+        jobs[0]["last_delivery_error"] = "telegram timeout"
+        save_jobs(jobs)
+
+        cron_command(Namespace(cron_command="list", all=True))
+
+        out = capsys.readouterr().out
+        last_run_line = next(l for l in out.splitlines() if "Last run:" in l)
+        assert "delivery_failed" in last_run_line
+        assert "telegram timeout" in last_run_line, (
+            "the delivery detail lives in last_delivery_error, not last_error"
+        )
+        assert cron_cli.Colors.GREEN not in last_run_line
+
+    def test_ok_run_still_green(self, tmp_cron_dir, capsys, monkeypatch):
+        monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [1])
+        monkeypatch.setattr("hermes_cli.colors.should_use_color", lambda: True)
+        create_job(prompt="Daily digest", schedule="every 1h")
+        jobs = load_jobs()
+        jobs[0]["last_run_at"] = "2026-09-01T09:00:00+00:00"
+        jobs[0]["last_status"] = "ok"
+        save_jobs(jobs)
+
+        cron_command(Namespace(cron_command="list", all=True))
+
+        out = capsys.readouterr().out
+        last_run_line = next(l for l in out.splitlines() if "Last run:" in l)
+        assert f"{cron_cli.Colors.GREEN}ok" in last_run_line
+        assert "delivery_failed" not in last_run_line
 
 
 class TestGatewayNotRunningWarning:

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -510,3 +510,41 @@ class TestCronRunBackgroundDispatch:
         assert rc == 0
         assert "Running in background (delegation del-xyz)." in out
         assert "failed" not in out.lower()
+
+
+class TestSlashCronListLastStatus:
+    """The in-chat ``/cron list`` (cli_commands_mixin) renders every
+    ``last_status`` literal explicitly — ``delivery_failed`` names the delivery
+    reason (last_error is None for those runs) instead of printing the bare
+    literal next to a run that looks otherwise fine."""
+
+    def _run_list(self, tmp_cron_dir, capsys):
+        from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
+        class _Host(CLICommandsMixin):
+            pass
+
+        _Host()._handle_cron_command("/cron list --all")
+        return capsys.readouterr().out
+
+    def test_delivery_failed_names_the_delivery_error(self, tmp_cron_dir, capsys):
+        create_job(prompt="Nightly brief", schedule="every 1h", deliver="telegram:1")
+        jobs = load_jobs()
+        jobs[0]["last_run_at"] = "2026-09-01T07:00:00+00:00"
+        jobs[0]["last_status"] = "delivery_failed"
+        jobs[0]["last_error"] = None
+        jobs[0]["last_delivery_error"] = "telegram: 502 Bad Gateway"
+        save_jobs(jobs)
+
+        out = self._run_list(tmp_cron_dir, capsys)
+        assert "Last run: 2026-09-01T07:00:00+00:00 (delivery_failed: telegram: 502 Bad Gateway)" in out
+
+    def test_ok_stays_plain(self, tmp_cron_dir, capsys):
+        create_job(prompt="Nightly brief", schedule="every 1h")
+        jobs = load_jobs()
+        jobs[0]["last_run_at"] = "2026-09-01T07:00:00+00:00"
+        jobs[0]["last_status"] = "ok"
+        save_jobs(jobs)
+
+        out = self._run_list(tmp_cron_dir, capsys)
+        assert "(ok)" in out

--- a/tests/tools/test_cronjob_run_delivery_notice.py
+++ b/tests/tools/test_cronjob_run_delivery_notice.py
@@ -136,6 +136,25 @@ class TestDeliveryNote:
             == expected
         )
 
+    def test_empty_or_missing_deliver_reads_saved_locally(self):
+        """Falsy deliver = no target, and the fire-time path treats it as
+        "local" (no delivery, no delivery error) — the note must not claim
+        "delivered there" for a target that doesn't exist (#83993 class)."""
+        expected = " (output saved locally only)"
+        assert _manual_run_delivery_note("", {}) == expected
+        assert _manual_run_delivery_note(None, {}) == expected
+        # Falsy deliver never attempts delivery — a stale error (e.g. from an
+        # earlier deliver config) must not flip the wording either.
+        assert _manual_run_delivery_note("", {"last_delivery_error": "old"}) == expected
+
+    def test_whitespace_deliver_defers_to_error_record(self):
+        """Whitespace-only deliver is NOT folded into local: fire time lets it
+        through as a target that fails to resolve, so the recorded error must
+        stay visible rather than being masked by a saved-locally wording."""
+        note = _manual_run_delivery_note(" ", {"last_delivery_error": "no target"})
+        assert "delivery FAILED" in note
+        assert "no target" in note
+
     def test_remote_with_error_says_delivery_failed(self):
         note = _manual_run_delivery_note(
             "telegram", {"last_delivery_error": "send failed: 400 Bad Request"}
@@ -177,6 +196,29 @@ class TestRunnerSummaryWiring:
         assert "Delivery target: telegram" in summary
         assert "delivery FAILED" in summary
         assert "telegram send failed: 400" in summary
+        assert "delivered there by the job itself" not in summary
+
+    def test_empty_deliver_summary_states_local_not_phantom_target(self):
+        """End-to-end: an empty stored deliver must render as the local target
+        it behaves as at fire time — never a bare "Delivery target: " followed
+        by a delivered-there claim."""
+        from tools.cronjob_tools import _try_dispatch_background_run
+
+        with _bound_session_key("agent:main:telegram:dm:86622"):
+            with (
+                patch("tools.cronjob_tools.claim_job_for_fire", return_value=True),
+                patch("cron.scheduler.run_one_job", return_value=True),
+                patch(
+                    "tools.cronjob_tools.get_job",
+                    return_value={"last_status": "ok", "last_error": None},
+                ),
+            ):
+                res = _try_dispatch_background_run(_job("job-dn-03", ""))
+                assert res["dispatched"] is True
+                evt = _drain_completion_event(res["delegation_id"])
+        assert evt is not None, "completion event never reached the queue"
+        summary = evt.get("summary") or ""
+        assert "Delivery target: local (output saved locally only)" in summary
         assert "delivered there by the job itself" not in summary
 
     def test_delivery_success_wording_unchanged_in_completion_summary(self):

--- a/tests/tools/test_cronjob_run_delivery_notice.py
+++ b/tests/tools/test_cronjob_run_delivery_notice.py
@@ -1,0 +1,202 @@
+"""Honesty of the manual-run delivery notice (issue #83993).
+
+A manual ``cronjob(action='run')`` finishes with a completion summary line
+
+    Delivery target: <target> (output was delivered there by the job itself)
+
+that was appended UNCONDITIONALLY for non-local targets — even when
+``run_one_job`` had just written ``last_delivery_error`` onto the refreshed
+job record because the post-run delivery (telegram/discord/…) failed. The
+calling agent then relayed "all good" over a failed delivery.
+
+The note must follow the refreshed job record: a set ``last_delivery_error``
+means delivery FAILED with the error text surfaced; an empty/missing error
+keeps the legacy wording byte-for-byte (zero regression), and local jobs
+always say saved-locally.
+"""
+
+import contextlib
+import time
+from unittest.mock import patch
+
+import pytest
+
+from tools.cronjob_tools import _manual_run_delivery_note
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    """Reset the shared async-delegation world around each test.
+
+    The dispatch tests below submit real workers onto the process-wide
+    daemon executor in ``tools.async_delegation``. A finished worker parks
+    idle holding an ``_idle_semaphore`` token, so the NEXT dispatch in this
+    process REUSES that thread instead of spawning a fresh one — and only
+    the fresh-spawn path keeps upstream's dispatch-and-return test winning
+    its patch-visibility race: ``Thread.start()`` blocks the dispatching
+    thread until the worker has bootstrapped, so the worker performs
+    ``_run_claimed_job``'s lazy ``from cron.scheduler import run_one_job``
+    while the test's patches are still active. On the idle-reuse path
+    ``submit`` returns with the GIL still held, the patch block unwinds
+    first, and the worker binds the REAL ``run_one_job`` — which then runs
+    the fake job for real ("no model configured") and the mock never fires.
+    Without this reset, test_cronjob_run_background.py's
+    ``test_dispatches_and_returns_handle_immediately`` fails
+    deterministically whenever this file runs before it. Mirrors
+    ``tests/tools/test_async_delegation.py::_clean_state``.
+    """
+    from tools import async_delegation as ad
+    from tools.process_registry import process_registry
+
+    ad._reset_for_tests()
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+    yield
+    # Give just-drained workers a beat to finalize BEFORE resetting, so
+    # their completion events land now instead of leaking into the next
+    # test's queue (mirrors test_async_delegation.py).
+    deadline = time.monotonic() + 2.0
+    while ad.active_count() and time.monotonic() < deadline:
+        time.sleep(0.02)
+    ad._reset_for_tests()
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+
+
+def _job(job_id, deliver):
+    """Per-test job dict with a UNIQUE id.
+
+    Background workers outlive their test (daemon executor) and hold the id
+    in the scheduler's shared running set until the run finishes; reusing an
+    id across tests trips the in-flight dedupe guard on a straggler.
+    """
+    return {
+        "id": job_id,
+        "name": f"dn run {job_id}",
+        "prompt": "hi",
+        "schedule": {"kind": "cron", "expr": "0 9 * * *"},
+        "deliver": deliver,
+    }
+
+
+@contextlib.contextmanager
+def _bound_session_key(key):
+    """Bind the approval session key contextvar (background dispatch gate)."""
+    from tools.approval import _approval_session_key
+
+    token = _approval_session_key.set(key)
+    try:
+        yield
+    finally:
+        _approval_session_key.reset(token)
+
+
+def _drain_completion_event(delegation_id):
+    """Wait (bounded) for this delegation's completion event; requeue others.
+
+    The runner executes on a daemon thread, so this must be called while the
+    test's patches are still active.
+    """
+    from tools.process_registry import process_registry
+
+    for _ in range(100):
+        try:
+            evt = process_registry.completion_queue.get_nowait()
+        except Exception:
+            time.sleep(0.05)
+            continue
+        if evt.get("delegation_id") == delegation_id:
+            return evt
+        process_registry.completion_queue.put(evt)
+        time.sleep(0.05)
+    return None
+
+
+class TestDeliveryNote:
+    """``_manual_run_delivery_note`` — the summary-line wording contract."""
+
+    def test_local_always_saved_locally_only(self):
+        expected = " (output saved locally only)"
+        assert _manual_run_delivery_note("local", {}) == expected
+        # Local jobs never deliver — a stale delivery error must not leak in.
+        assert (
+            _manual_run_delivery_note("local", {"last_delivery_error": "telegram 400"})
+            == expected
+        )
+
+    def test_remote_without_error_keeps_legacy_wording(self):
+        expected = " (output was delivered there by the job itself)"
+        assert _manual_run_delivery_note("telegram", {}) == expected
+        assert (
+            _manual_run_delivery_note("telegram", {"last_delivery_error": None})
+            == expected
+        )
+        assert (
+            _manual_run_delivery_note("discord:#ops", {"last_delivery_error": "   "})
+            == expected
+        )
+
+    def test_remote_with_error_says_delivery_failed(self):
+        note = _manual_run_delivery_note(
+            "telegram", {"last_delivery_error": "send failed: 400 Bad Request"}
+        )
+        assert "delivery FAILED" in note
+        assert "send failed: 400 Bad Request" in note
+
+    def test_remote_error_text_truncated_to_200_chars(self):
+        note = _manual_run_delivery_note("telegram", {"last_delivery_error": "E" * 500})
+        assert "E" * 200 in note
+        assert "E" * 201 not in note
+
+
+class TestRunnerSummaryWiring:
+    """The completion event the calling agent actually sees must follow the
+    refreshed job record — both directions of issue #83993."""
+
+    def test_delivery_failure_surfaces_in_completion_summary(self):
+        from tools.cronjob_tools import _try_dispatch_background_run
+
+        with _bound_session_key("agent:main:telegram:dm:83993"):
+            with (
+                patch("tools.cronjob_tools.claim_job_for_fire", return_value=True),
+                patch("cron.scheduler.run_one_job", return_value=True),
+                patch(
+                    "tools.cronjob_tools.get_job",
+                    return_value={
+                        "last_status": "ok",
+                        "last_error": None,
+                        "last_delivery_error": "telegram send failed: 400",
+                    },
+                ),
+            ):
+                res = _try_dispatch_background_run(_job("job-dn-01", "telegram"))
+                assert res["dispatched"] is True
+                evt = _drain_completion_event(res["delegation_id"])
+        assert evt is not None, "completion event never reached the queue"
+        summary = evt.get("summary") or ""
+        assert "Delivery target: telegram" in summary
+        assert "delivery FAILED" in summary
+        assert "telegram send failed: 400" in summary
+        assert "delivered there by the job itself" not in summary
+
+    def test_delivery_success_wording_unchanged_in_completion_summary(self):
+        from tools.cronjob_tools import _try_dispatch_background_run
+
+        with _bound_session_key("agent:main:telegram:dm:83994"):
+            with (
+                patch("tools.cronjob_tools.claim_job_for_fire", return_value=True),
+                patch("cron.scheduler.run_one_job", return_value=True),
+                patch(
+                    "tools.cronjob_tools.get_job",
+                    return_value={"last_status": "ok", "last_error": None},
+                ),
+            ):
+                res = _try_dispatch_background_run(_job("job-dn-02", "telegram"))
+                assert res["dispatched"] is True
+                evt = _drain_completion_event(res["delegation_id"])
+        assert evt is not None, "completion event never reached the queue"
+        summary = evt.get("summary") or ""
+        assert (
+            "Delivery target: telegram (output was delivered there by the job itself)"
+        ) in summary
+        assert "delivery FAILED" not in summary

--- a/tests/tools/test_cronjob_run_delivery_notice.py
+++ b/tests/tools/test_cronjob_run_delivery_notice.py
@@ -199,7 +199,9 @@ class TestRunnerSummaryWiring:
                 patch(
                     "tools.cronjob_tools.get_job",
                     return_value={
-                        "last_status": "ok",
+                        # Post-#83993 record shape: mark_job_run writes
+                        # delivery_failed (not ok) when only delivery failed.
+                        "last_status": "delivery_failed",
                         "last_error": None,
                         "last_delivery_error": "telegram send failed: 400",
                     },
@@ -214,6 +216,9 @@ class TestRunnerSummaryWiring:
         assert "delivery FAILED" in summary
         assert "telegram send failed: 400" in summary
         assert "delivered there by the job itself" not in summary
+        # The headline must not read "Result: ok" over an undelivered run.
+        assert "Result: FAILED" in summary
+        assert "Result: ok" not in summary
 
     def test_empty_deliver_summary_states_local_not_phantom_target(self):
         """End-to-end: an empty stored deliver must render as the local target

--- a/tests/tools/test_cronjob_run_delivery_notice.py
+++ b/tests/tools/test_cronjob_run_delivery_notice.py
@@ -91,6 +91,19 @@ def _bound_session_key(key):
         _approval_session_key.reset(token)
 
 
+def _dispatch_diag(res) -> str:
+    """Failure renderer for the wiring tests' dispatch asserts: the result
+    dict plus the scheduler running set, so a broken assert names the return
+    path that was actually taken instead of a bare KeyError."""
+    try:
+        from cron.scheduler import get_running_job_ids
+
+        running = sorted(get_running_job_ids())
+    except Exception as e:  # pragma: no cover - diagnostic only
+        running = f"<unavailable: {e}>"
+    return f"dispatch result: {res!r}; running: {running}"
+
+
 def _drain_completion_event(delegation_id):
     """Wait (bounded) for this delegation's completion event; requeue others.
 
@@ -175,9 +188,13 @@ class TestRunnerSummaryWiring:
     def test_delivery_failure_surfaces_in_completion_summary(self):
         from tools.cronjob_tools import _try_dispatch_background_run
 
+        job = _job("job-dn-01", "telegram")
         with _bound_session_key("agent:main:telegram:dm:83993"):
             with (
-                patch("tools.cronjob_tools.claim_job_for_fire", return_value=True),
+                patch(
+                    "tools.cronjob_tools.claim_job_for_fire",
+                    return_value=job,  # claimed snapshot (return_job=True API)
+                ),
                 patch("cron.scheduler.run_one_job", return_value=True),
                 patch(
                     "tools.cronjob_tools.get_job",
@@ -188,8 +205,8 @@ class TestRunnerSummaryWiring:
                     },
                 ),
             ):
-                res = _try_dispatch_background_run(_job("job-dn-01", "telegram"))
-                assert res["dispatched"] is True
+                res = _try_dispatch_background_run(job)
+                assert res.get("dispatched") is True, _dispatch_diag(res)
                 evt = _drain_completion_event(res["delegation_id"])
         assert evt is not None, "completion event never reached the queue"
         summary = evt.get("summary") or ""
@@ -204,17 +221,21 @@ class TestRunnerSummaryWiring:
         by a delivered-there claim."""
         from tools.cronjob_tools import _try_dispatch_background_run
 
+        job = _job("job-dn-03", "")
         with _bound_session_key("agent:main:telegram:dm:86622"):
             with (
-                patch("tools.cronjob_tools.claim_job_for_fire", return_value=True),
+                patch(
+                    "tools.cronjob_tools.claim_job_for_fire",
+                    return_value=job,  # claimed snapshot (return_job=True API)
+                ),
                 patch("cron.scheduler.run_one_job", return_value=True),
                 patch(
                     "tools.cronjob_tools.get_job",
                     return_value={"last_status": "ok", "last_error": None},
                 ),
             ):
-                res = _try_dispatch_background_run(_job("job-dn-03", ""))
-                assert res["dispatched"] is True
+                res = _try_dispatch_background_run(job)
+                assert res.get("dispatched") is True, _dispatch_diag(res)
                 evt = _drain_completion_event(res["delegation_id"])
         assert evt is not None, "completion event never reached the queue"
         summary = evt.get("summary") or ""
@@ -224,17 +245,21 @@ class TestRunnerSummaryWiring:
     def test_delivery_success_wording_unchanged_in_completion_summary(self):
         from tools.cronjob_tools import _try_dispatch_background_run
 
+        job = _job("job-dn-02", "telegram")
         with _bound_session_key("agent:main:telegram:dm:83994"):
             with (
-                patch("tools.cronjob_tools.claim_job_for_fire", return_value=True),
+                patch(
+                    "tools.cronjob_tools.claim_job_for_fire",
+                    return_value=job,  # claimed snapshot (return_job=True API)
+                ),
                 patch("cron.scheduler.run_one_job", return_value=True),
                 patch(
                     "tools.cronjob_tools.get_job",
                     return_value={"last_status": "ok", "last_error": None},
                 ),
             ):
-                res = _try_dispatch_background_run(_job("job-dn-02", "telegram"))
-                assert res["dispatched"] is True
+                res = _try_dispatch_background_run(job)
+                assert res.get("dispatched") is True, _dispatch_diag(res)
                 evt = _drain_completion_event(res["delegation_id"])
         assert evt is not None, "completion event never reached the queue"
         summary = evt.get("summary") or ""

--- a/tests/tools/test_cronjob_run_immediate.py
+++ b/tests/tools/test_cronjob_run_immediate.py
@@ -291,3 +291,37 @@ class TestCronjobRunExecutesImmediately:
             assert len(calls) >= 2, calls
         finally:
             set_activity_callback(None)
+
+
+class TestManualRunReportsDeliveryFailure:
+    """#83993: a manual run whose agent succeeded but whose delivery failed
+    must not come back as success=True with no error — the calling agent
+    relays that result to the user."""
+
+    def test_delivery_failed_status_is_not_success_and_surfaces_reason(self):
+        refreshed = {
+            "id": "job-run-1",
+            "last_status": "delivery_failed",
+            "last_error": None,
+            "last_delivery_error": "live adapter send failed: 502 (target telegram:123)",
+        }
+        with patch("tools.cronjob_tools.claim_job_for_fire",
+                   return_value={**_JOB, "fire_claim": {"by": "manual-owner"}}), \
+             patch("cron.scheduler.run_one_job", return_value=True), \
+             patch("tools.cronjob_tools.get_job", return_value=refreshed):
+            res = _execute_job_now(dict(_JOB))
+
+        assert res["claimed"] is True
+        assert res["success"] is False
+        assert "502" in res["error"]
+
+    def test_plain_ok_is_still_success_with_no_error(self):
+        with patch("tools.cronjob_tools.claim_job_for_fire",
+                   return_value={**_JOB, "fire_claim": {"by": "manual-owner"}}), \
+             patch("cron.scheduler.run_one_job", return_value=True), \
+             patch("tools.cronjob_tools.get_job",
+                   return_value={"id": "job-run-1", "last_status": "ok", "last_error": None,
+                                 "last_delivery_error": None}):
+            res = _execute_job_now(dict(_JOB))
+        assert res["success"] is True
+        assert res["error"] is None

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1124,11 +1124,21 @@ def _run_claimed_job(
             _registered = False
             release_running_job(job_id)
         refreshed = get_job(job_id) or {}
-        ok = refreshed.get("last_status") == "ok"
+        last_status = refreshed.get("last_status")
+        # "delivery_failed" (#83993): the agent run itself succeeded but the
+        # output never reached the user. That is NOT a success for the caller
+        # — the calling agent relays this result — so report it as failed
+        # and surface the delivery error, which lives in last_delivery_error
+        # (last_error is None for these runs, and a bare success=False with
+        # error=None reads as an unexplained failure).
+        ok = last_status == "ok"
+        run_error = refreshed.get("last_error")
+        if last_status == "delivery_failed" and not run_error:
+            run_error = refreshed.get("last_delivery_error")
         return {
             "claimed": True,
             "success": bool(processed and ok),
-            "error": refreshed.get("last_error"),
+            "error": run_error,
         }
 
     except Exception as e:

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -930,7 +930,13 @@ def _manual_run_delivery_note(deliver: str, refreshed: Dict[str, Any]) -> str:
     never deliver; an empty/missing error keeps the legacy wording
     byte-for-byte.
     """
-    if deliver == "local":
+    # Falsy deliver ("", stored JSON null) means no delivery target — the
+    # fire-time path normalizes it to "local" (no delivery, output persisted
+    # in last_output, no delivery error), so it must read as saved-locally,
+    # not as a delivered remote target. Whitespace-only values are NOT folded
+    # in here: they keep falling through to the error check, where the
+    # fire-time "no delivery target resolved" error gets surfaced.
+    if not deliver or deliver == "local":
         return " (output saved locally only)"
     err = str(refreshed.get("last_delivery_error") or "").strip()
     if not err:
@@ -1352,7 +1358,12 @@ def _try_dispatch_background_run(
         max_async = 3
 
     started_at = time.time()
-    deliver = job.get("deliver", "local")
+    # Canonicalize with the scheduler's own normalizer so the summary states
+    # the same target fire time will use: falsy ("", stored JSON null) reads
+    # "local", legacy list-form deliver flattens to its comma string.
+    from cron.scheduler import _normalize_deliver_value
+
+    deliver = _normalize_deliver_value(job.get("deliver", "local"))
 
     def _runner() -> Dict[str, Any]:
         res = _run_claimed_job(claimed_job, extra_prompt=extra_prompt)

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1360,10 +1360,12 @@ def _try_dispatch_background_run(
     started_at = time.time()
     # Canonicalize with the scheduler's own normalizer so the summary states
     # the same target fire time will use: falsy ("", stored JSON null) reads
-    # "local", legacy list-form deliver flattens to its comma string.
+    # "local", legacy list-form deliver flattens to its comma string. Read
+    # from the claimed snapshot — the owner-bearing record the run actually
+    # executes — not the pre-claim `job` the tool loaded.
     from cron.scheduler import _normalize_deliver_value
 
-    deliver = _normalize_deliver_value(job.get("deliver", "local"))
+    deliver = _normalize_deliver_value(claimed_job.get("deliver", "local"))
 
     def _runner() -> Dict[str, Any]:
         res = _run_claimed_job(claimed_job, extra_prompt=extra_prompt)

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -920,6 +920,24 @@ def _forward_relay_fronted_run(
     )
 
 
+def _manual_run_delivery_note(deliver: str, refreshed: Dict[str, Any]) -> str:
+    """Parenthetical delivery note for a manual run's completion summary.
+
+    Follows the refreshed job record (#83993): ``run_one_job`` writes
+    ``last_delivery_error`` via ``mark_job_run`` when the post-run delivery
+    (telegram/discord/…) failed, and the summary must not claim success over
+    that record — the calling agent relays this line to the user. Local jobs
+    never deliver; an empty/missing error keeps the legacy wording
+    byte-for-byte.
+    """
+    if deliver == "local":
+        return " (output saved locally only)"
+    err = str(refreshed.get("last_delivery_error") or "").strip()
+    if not err:
+        return " (output was delivered there by the job itself)"
+    return f" (⚠ delivery FAILED: {err[:200]})"
+
+
 def _execute_job_now(
     job: Dict[str, Any], extra_prompt: Optional[str] = None
 ) -> Dict[str, Any]:
@@ -1345,11 +1363,7 @@ def _try_dispatch_background_run(
             f"Result: {'ok' if res.get('success') else 'FAILED'}"
             + (f" — {res.get('error')}" if res.get("error") else ""),
             f"Delivery target: {deliver}"
-            + (
-                " (output was delivered there by the job itself)"
-                if deliver != "local"
-                else " (output saved locally only)"
-            ),
+            + _manual_run_delivery_note(deliver, refreshed),
         ]
         if refreshed.get("next_run_at"):
             lines.append(f"Next scheduled run: {refreshed['next_run_at']}")

--- a/web/src/lib/cron-job.test.ts
+++ b/web/src/lib/cron-job.test.ts
@@ -4,6 +4,7 @@ import {
   buildCronJobPayload,
   cronJobHasExecutionContent,
   cronJobFormFromJob,
+  cronLastResult,
   splitCronList,
   type CronJobFormState,
 } from "./cron-job";
@@ -151,5 +152,51 @@ describe("cronJobFormFromJob", () => {
     expect(cronJobFormFromJob(job)).toMatchObject({
       schedule: "2026-02-03T14:00:00+08:00",
     });
+  });
+});
+
+describe("cronLastResult", () => {
+  it("renders nothing for a job that never ran", () => {
+    expect(cronLastResult({ last_status: null })).toBeNull();
+    expect(cronLastResult({ last_status: "" })).toBeNull();
+  });
+
+  it("is green for ok with no detail", () => {
+    expect(cronLastResult({ last_status: "ok", last_error: null })).toEqual({
+      status: "ok",
+      tone: "success",
+      detail: null,
+    });
+  });
+
+  it("is amber for delivery_failed and explains it from last_delivery_error", () => {
+    // The agent run succeeded (last_error is null for these runs); the reason
+    // lives in last_delivery_error. Must never render as green or as "unknown".
+    expect(
+      cronLastResult({
+        last_status: "delivery_failed",
+        last_error: null,
+        last_delivery_error: "telegram: 502 Bad Gateway",
+      }),
+    ).toEqual({
+      status: "delivery_failed",
+      tone: "warning",
+      detail: "telegram: 502 Bad Gateway",
+    });
+  });
+
+  it("is red for error and any unrecognised literal", () => {
+    expect(cronLastResult({ last_status: "error", last_error: "boom" })).toEqual({
+      status: "error",
+      tone: "destructive",
+      detail: "boom",
+    });
+    expect(cronLastResult({ last_status: "something_new" })?.tone).toBe("destructive");
+  });
+
+  it("is amber for blocked_config (preflight refused to burn a run)", () => {
+    expect(
+      cronLastResult({ last_status: "blocked_config", last_error: "missing API key" }),
+    ).toEqual({ status: "blocked_config", tone: "warning", detail: "missing API key" });
   });
 });

--- a/web/src/lib/cron-job.ts
+++ b/web/src/lib/cron-job.ts
@@ -102,3 +102,39 @@ export function cronJobFormFromJob(job: CronJob): CronJobFormState {
     workdir: asString(job.workdir),
   };
 }
+
+/** How a job's `last_status` should render. The scheduler writes a small,
+ *  closed set of literals; every literal maps to an explicit tone here so a
+ *  new status can never fall through to a neutral "unknown"-looking badge.
+ *  In particular `delivery_failed` (agent run succeeded, output never reached
+ *  the target) is amber, not green and not the same red as a run error, and
+ *  its detail lives in `last_delivery_error` (last_error is null for it). */
+export type CronLastResultTone = "success" | "warning" | "destructive";
+
+export interface CronLastResult {
+  status: string;
+  tone: CronLastResultTone;
+  /** Human detail to show next to the badge; null when nothing to add. */
+  detail: string | null;
+}
+
+const CRON_LAST_RESULT_TONE: Record<string, CronLastResultTone> = {
+  ok: "success",
+  delivery_failed: "warning",
+  blocked_config: "warning",
+  error: "destructive",
+};
+
+export function cronLastResult(
+  job: Pick<CronJob, "last_status" | "last_error" | "last_delivery_error">,
+): CronLastResult | null {
+  const status = asString(job.last_status).trim();
+  if (!status) return null;
+  const tone = CRON_LAST_RESULT_TONE[status] ?? "destructive";
+  if (status === "ok") return { status, tone, detail: null };
+  const detail =
+    status === "delivery_failed"
+      ? asString(job.last_delivery_error).trim() || asString(job.last_error).trim()
+      : asString(job.last_error).trim() || asString(job.last_delivery_error).trim();
+  return { status, tone, detail: detail || null };
+}

--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -22,6 +22,7 @@ import {
   buildCronJobPayload,
   cronJobHasExecutionContent,
   cronJobFormFromJob,
+  cronLastResult,
   type CronJobFormState,
 } from "@/lib/cron-job";
 import { DeleteConfirmDialog } from "@/components/DeleteConfirmDialog";
@@ -1100,6 +1101,7 @@ export default function CronPage() {
           const toolsets = Array.isArray(job.enabled_toolsets)
             ? job.enabled_toolsets.filter(Boolean)
             : [];
+          const lastResult = cronLastResult(job);
 
           return (
             <Card key={jobKey}>
@@ -1112,6 +1114,15 @@ export default function CronPage() {
                     <Badge tone={STATUS_TONE[state] ?? "secondary"}>
                       {state}
                     </Badge>
+                    {lastResult && lastResult.status !== "ok" && (
+                      <Badge
+                        tone={lastResult.tone}
+                        title={lastResult.detail ?? undefined}
+                        data-testid="cron-last-result"
+                      >
+                        {lastResult.status}
+                      </Badge>
+                    )}
                     <Badge tone="outline">{profileLabel(profile)}</Badge>
                     {deliver && deliver !== "local" && (
                       <Badge tone="outline">{deliver}</Badge>

--- a/website/docs/developer-guide/cron-internals.md
+++ b/website/docs/developer-guide/cron-internals.md
@@ -63,6 +63,20 @@ Jobs are stored in `~/.hermes/cron/jobs.json` with atomic write semantics (write
 }
 ```
 
+### `last_status` literals
+
+`last_status` is a closed set written only by `cron.jobs.mark_job_run`. Every
+renderer (`hermes cron list`/`doctor`, the `cronjob` tool, the web dashboard
+badge, the Desktop routine inspector) maps each literal explicitly — a consumer
+must never test `== "ok"` for "the user got their result":
+
+| Literal | Meaning | Detail field |
+|---------|---------|--------------|
+| `ok` | Agent run succeeded and (if targeted) delivery was confirmed | — |
+| `error` | Agent run failed | `last_error` |
+| `delivery_failed` | Agent run succeeded, but the output never reached its target | `last_delivery_error` (`last_error` is `null`) |
+| `blocked_config` | Pre-dispatch validation refused to burn a run | `last_error` |
+
 ### Job Lifecycle States
 
 | State | Meaning |

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -440,6 +440,19 @@ When scheduling jobs, you specify where the output goes:
 
 The agent's final response is automatically delivered to the configured `deliver:` target — the agent does not send messages itself, so there is nothing to call in the cron prompt.
 
+### Delivery failures are a distinct status
+
+Execution and delivery are tracked separately. When the agent run succeeds but
+the output never reaches the target (platform 5xx, rate limit, stale session,
+adapter returned no positive evidence of a send), the job records
+`last_status: delivery_failed` — never a plain `ok` — with the reason in
+`last_delivery_error`. `hermes cron list` shows it in yellow as
+`delivery_failed: <reason>`, `hermes cron doctor` reports it as a delivery
+issue, and a manual `cronjob run` reports `success: false` with the delivery
+error. A delivery failure does not count toward the job's `failure_streak`
+(the agent did its job); the next fully successful run returns the status to
+`ok`.
+
 ### Bot Chat delivery (`bot-chat`)
 
 `bot-chat` delivers the output **into a profile's canonical "Bot Chat" session as a real message**. Unlike every other target — where the recipient is a human reading a channel — the recipient here is the bot itself: it receives the output as an incoming message, acts on anything that needs action, and responds in its chat. Use it when scheduled output should be *processed*, not just posted.


### PR DESCRIPTION
## Summary

A cron run whose agent succeeded but whose output never reached the user is no longer recorded or shown as `ok`: it gets a distinct `last_status: delivery_failed`, `hermes cron list` renders it yellow with the reason, `cron doctor` reports it as a delivery issue, and a manual `cronjob run` reports `success: false` with the delivery error instead of a green result.

## Changes

- **`cron/jobs.py::mark_job_run`** (salvage #100163 @jwilson411) — derives `last_status` as `error` > `delivery_failed` > `ok` (an explicit `status=` override such as `blocked_config` still wins). `failure_streak` is untouched by delivery failures (the agent did its job); `last_error` stays `None`. This is the storage-level fix the issue asked for: everything that keys off `"ok"` now sees the failure.
- **`hermes_cli/cron.py`** (#100163) — `cron list` renders `delivery_failed: <last_delivery_error>` in yellow (the "⚠ Delivery failed" detail line stays); `cron doctor` no longer double-reports a delivery failure as "last run failed: unknown error".
- **`tools/cronjob_tools.py::_run_claimed_job`** (re-applies the #84006 @webtecnica direction) — a manual run returns `success: false` and surfaces `last_delivery_error` as the error when the record is `delivery_failed`; previously it derived success from `== "ok"` and read only `last_error`, so a delivery-failed run came back as an unexplained failure.
- **`tools/cronjob_tools.py::_manual_run_delivery_note`** (salvage #86622 @strzhao) — the manual-run completion summary no longer appends "output was delivered there by the job itself" over a failed delivery; it follows the refreshed record (`⚠ delivery FAILED: <reason>`), treats a falsy `deliver` as local, and reads the target from the claimed snapshot. Pinned so the headline reads `Result: FAILED` rather than `Result: ok` for such runs.
- **Docs** — `website/docs/user-guide/features/cron.md` gains a "Delivery failures are a distinct status" section.

Not taken: #84006's `"ok (delivery failed)"` string status (a compound value every `== "ok"` reader would have to parse; `delivery_failed` is the cleaner enum) and #89132's `delivery_state == "pending" && delivery_attempts == 0` heuristic (those fields are not written anywhere on main; the storage-level status makes the CLI heuristic unnecessary).

## Validation

| Check | Result |
|---|---|
| `tests/cron/test_jobs.py`, `tests/hermes_cli/test_cron.py` (new: delivery_failed status, override precedence, streak, doctor) | passed |
| `tests/tools/test_cronjob_run_delivery_notice.py` (new, 15 tests incl. real background-dispatch summary) | passed |
| `tests/tools/test_cronjob_run_immediate.py` (+2: manual run reports delivery_failed) | passed |
| Neighbourhood: `test_cronjob_run_background.py`, `test_cronjob_tools.py`, `test_run_one_job.py`, `test_preflight_config.py`, `test_scheduler.py`, `test_cron_incidents.py`, `test_execution_ledger.py` | 400 passed total |
| Sabotage: stash the `_run_claimed_job` change → `test_delivery_failed_status_is_not_success_and_surfaces_reason` | 1 failed; restored → passes |
| `ruff check` on touched files | clean |

**Live repro:** real `cron.jobs` store under an isolated `HERMES_HOME`, real `mark_job_run(job, True, None, delivery_error="live adapter send failed: 502 ...")` (the exact call `run_job` makes), then the real `hermes cron list` renderer — before (origin/main): record `last_status='ok'`, list shows `Last run: 2026-09-01T21:22:33  ok` with the failure only on a secondary `⚠ Delivery failed:` line; `_format_job` → `last_status='ok'`. After: record `last_status='delivery_failed'`, list shows `Last run: ...  delivery_failed: live adapter send failed: 502 Bad Gateway (target telegram:5160665427)`; `_format_job` → `last_status='delivery_failed'`.

Closes #83993

Salvages #100163 (@jwilson411 — storage + CLI status; cherry-picked with authorship) and #86622 (@strzhao, issue author — manual-run notice honesty; 3 commits cherry-picked with authorship). Supersedes #84006 (@webtecnica — earliest submission for this issue; its tool-result direction is re-applied here with co-author credit) and #89132 (@LeonardoLGDS — CLI-only rendering, superseded by the status-level fix).

## Infographic
![cron-delivery-failed-status](https://v3b.fal.media/files/b/0aa8c401/5UL2OO1dZfmDpEy5normN_RnvOBjRc.png)

## De-risking (commit `dcd9d294415`)

Audit of every `last_status` consumer outside the scheduler (`rg -n last_status` across `web/`, `apps/desktop/`, `hermes_cli/`, `tui_gateway/`, `tools/`, `scripts/`, `website/`; the `auth.py`/`web_server.py:14288`/video-gen hits are unrelated credential-pool / polling fields):

| Consumer | Before | After |
|---|---|---|
| web dashboard `CronPage.tsx` | `last_status` never rendered — a `delivery_failed` job showed a green `scheduled` badge + a small red `delivery:` line | new pure `cronLastResult()` (`web/src/lib/cron-job.ts`) maps the closed literal set to tones (`ok`→success, `delivery_failed`/`blocked_config`→warning, `error`/unknown→destructive); card shows an amber `delivery_failed` badge (`title` = `last_delivery_error`) |
| Desktop hermes-bots routine inspector (`cron.tsx`) | `Last result` printed the raw literal | `routineLastResult()` spells out each literal (`Ran, but delivery failed`, `Blocked by configuration (not run)`, …); unknown passes through |
| in-chat `/cron list` (`cli_commands_mixin.py`) | `Last run: <ts> (delivery_failed)` with no reason (`last_error` is `None`) | appends the delivery reason: `(delivery_failed: telegram: 502 Bad Gateway)` |
| `hermes cron list` / `cron doctor` / `cronjob` tool | already handled on this branch | unchanged |
| `== "ok"` for success | only `tools/cronjob_tools.py` manual-run path — already fixed by this branch | no other consumer compares `== "ok"` |
| docs | — | `developer-guide/cron-internals.md`: table of `last_status` literals + which field carries the detail |

- **Live repro** (real `hermes dashboard` on a temp `HERMES_HOME` seeded with a `delivery_failed` job, real `/api/cron/jobs`, `CronPage` rendered against it): before — card badges `[scheduled, default, telegram:123]`; after — `[scheduled, delivery_failed (border-warning/30 bg-warning/15 text-warning, title "telegram: 502 Bad Gateway", data-testid cron-last-result), default, telegram:123]`.
- **Tests:** `web/src/lib/cron-job.test.ts` +5 (`cronLastResult`), `apps/desktop/src/plugins/hermes-bots/cron-detail.test.tsx` +1 (`routineLastResult` for every literal), `tests/hermes_cli/test_cron.py` +2 (`TestSlashCronListLastStatus`). Runs: web vitest 15 passed, desktop vitest 10 passed, `tsc --noEmit` + eslint clean in both, Python 160 passed (`test_cron.py`, `test_cronjob_run_delivery_notice.py`, `test_cronjob_run_immediate.py`, `test_jobs.py`).
