### PR TITLE
fix(codex_responses): capture and replay plaintext reasoning items from third-party Responses gateways

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -486,8 +486,17 @@ def _chat_messages_to_responses_input(
         message_items = _replay_message_items(msg, is_github_responses=is_github_responses)
         emit(message_items, msg)
         if not message_items:
-            # Every reasoning item needs a following item (else missing_following_item), hence the "" fallback.
-            fallback = content_parts or (content_text if content_text.strip() else "" if reasoning_items else None)
+            # Every reasoning item needs a following item (else missing_following_item), hence the "" fallback —
+            # but only when nothing else follows. The function_call items already satisfy the rule, and translating
+            # gateways turn an empty assistant message into an empty text block that Anthropic/Bedrock reject
+            # (HTTP 400 "text content blocks must be non-empty"). Trigger was any Claude turn that thinks, writes
+            # no prose, and calls a tool. Same filter as _replay_tool_call_items so the two agree on "has calls".
+            has_tool_calls = any(
+                isinstance(tc, dict) and _nonblank((tc.get("function") or {}).get("name"))
+                for tc in _as_list(msg.get("tool_calls"))
+            )
+            needs_stub = bool(reasoning_items) and not has_tool_calls
+            fallback = content_parts or (content_text if content_text.strip() else "" if needs_stub else None)
             if fallback is not None:
                 emit([{"role": "assistant", "content": fallback}], msg)
         emit(_replay_tool_call_items(msg, start_index=len(items)), msg)

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -30,6 +30,30 @@ def _classify_responses_issuer(
     return f"other:{base_url}" if base_url else "other"
 
 
+# Issuers whose reasoning continuity is carried only by ``encrypted_content``. Plaintext reasoning items
+# (visible ``content``/``summary`` text, no blob) are the third-party-gateway shape (issuer ``other[:base_url]``,
+# e.g. Kimi or DeepSeek behind a translating gateway) and are never captured for or replayed to these.
+_ENCRYPTED_REASONING_ISSUERS = frozenset({"codex_backend", "xai_responses", "github_responses"})
+
+
+def _reasoning_plaintext(item: Any) -> tuple[List[str], List[str]]:
+    """``(content reasoning_text texts, summary texts)`` of a reasoning item (dict or SDK object)."""
+    content_texts = [
+        text for part in _as_list(_field(item, "content"))
+        if _field(part, "type") == "reasoning_text" and _nonempty_str(text := _field(part, "text"))
+    ]
+    summary_texts = [text for part in _as_list(_field(item, "summary")) if _nonempty_str(text := _field(part, "text"))]
+    return content_texts, summary_texts
+
+
+def _is_plaintext_reasoning_item(item: Any) -> bool:
+    """Reasoning item with visible text but no ``encrypted_content`` blob."""
+    if _nonempty_str(_field(item, "encrypted_content")):
+        return False
+    content_texts, summary_texts = _reasoning_plaintext(item)
+    return bool(content_texts or summary_texts)
+
+
 # Per-process throttle for the cross-issuer skip warning.
 _CROSS_ISSUER_WARN_EMITTED = False
 
@@ -332,8 +356,13 @@ def _replay_reasoning_items(
     global _CROSS_ISSUER_WARN_EMITTED
     replayed: List[Dict[str, Any]] = []
     for ri in _as_list(msg.get("codex_reasoning_items")):
-        if not (isinstance(ri, dict) and ri.get("encrypted_content")):
+        if not isinstance(ri, dict):
             continue
+        if not ri.get("encrypted_content"):
+            # Plaintext reasoning replays only to third-party issuers; first-party backends seal continuity in
+            # encrypted_content, so even an unstamped legacy plaintext item never reaches them.
+            if not _is_plaintext_reasoning_item(ri) or current_issuer_kind in _ENCRYPTED_REASONING_ISSUERS:
+                continue
         item_id = ri.get("id")
         if (item_id and item_id in seen_item_ids) or (ri.get("type") == "compaction" and not native_compaction_eligible):
             continue
@@ -620,23 +649,28 @@ def _preflight_function_call_output(item: Dict[str, Any], idx: int, ctx: _Prefli
 
 
 def _preflight_encrypted(item: Dict[str, Any], idx: int, ctx: _PreflightCtx) -> Optional[Dict[str, Any]]:
-    """``reasoning`` / ``compaction`` items: opaque, issuer-sealed; forward only API-defined fields."""
+    """``reasoning`` / ``compaction`` items: opaque, issuer-sealed; forward only API-defined fields. A
+    ``reasoning`` item with visible text and no blob (third-party gateway) is forwarded as ``summary`` + ``content``."""
     encrypted = item.get("encrypted_content")
-    if not _nonempty_str(encrypted):
-        return None
     if item["type"] == "compaction":
-        return {"type": "compaction", "encrypted_content": encrypted}
+        return {"type": "compaction", "encrypted_content": encrypted} if _nonempty_str(encrypted) else None
+    plaintext = not _nonempty_str(encrypted)
+    if plaintext and not _is_plaintext_reasoning_item(item):
+        return None
     # ``id`` is used only for local dedup and NOT forwarded (store=False → server-side 404).
     item_id = item.get("id")
     if _nonempty_str(item_id):
         if item_id in ctx.seen_ids:
             return None
         ctx.seen_ids.add(item_id)
-    summary = _as_list(item.get("summary"))
-    return {
-        "type": "reasoning", "encrypted_content": encrypted,
-        "summary": _neutralize_harmony_structure(summary) if ctx.sanitize_harmony_tokens else summary,
-    }
+    sanitize = _neutralize_harmony_structure if ctx.sanitize_harmony_tokens else (lambda value: value)
+    out: Dict[str, Any] = {"type": "reasoning", "summary": sanitize(_as_list(item.get("summary")))}
+    if plaintext:
+        if isinstance(item.get("content"), list):
+            out["content"] = sanitize(item["content"])
+    else:
+        out["encrypted_content"] = encrypted
+    return out
 
 
 def _preflight_message(item: Dict[str, Any], idx: int, ctx: _PreflightCtx) -> Dict[str, Any]:
@@ -846,8 +880,10 @@ def _extract_responses_message_text(item: Any) -> str:
 
 
 def _extract_responses_reasoning_text(item: Any) -> str:
-    """Compact reasoning text from a Responses reasoning item (summary, else ``text``)."""
-    chunks = _text_chunks(getattr(item, "summary", None))
+    """Compact reasoning text from a Responses reasoning item: full ``content`` reasoning_text (third-party
+    gateways) first, else ``summary``, else ``text``."""
+    content_texts, summary_texts = _reasoning_plaintext(item)
+    chunks = content_texts or summary_texts
     text = getattr(item, "text", None)
     return "\n".join(chunks).strip() if chunks else (text.strip() if isinstance(text, str) else "")
 
@@ -905,6 +941,33 @@ def _capture_encrypted_item(item: Any, item_type: str, issuer_kind: Optional[str
     return raw_item
 
 
+def _capture_plaintext_reasoning(item: Any, issuer_kind: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Replay item for a reasoning item that carries visible text but no ``encrypted_content`` (third-party
+    gateways fronting Kimi, DeepSeek, ...). Mirrors the received ``summary``/``content`` shape and stamps the
+    issuer. Never captured for first-party issuers: their continuity contract is the encrypted blob, and this
+    keeps their wire byte-identical. Without replay, Preserved-Thinking models lose their chain after the first
+    tool call, stop reasoning, and end the turn early."""
+    if issuer_kind in _ENCRYPTED_REASONING_ISSUERS:
+        return None
+    content_texts, summary_texts = _reasoning_plaintext(item)
+    if not (content_texts or summary_texts):
+        return None
+    item_id = getattr(item, "id", None)
+    if isinstance(item_id, str) and item_id.startswith("rs_tmp_"):
+        logger.debug("Skipping transient Codex reasoning item during normalization: %s", item_id)
+        return None
+    raw_item: Dict[str, Any] = {
+        "type": "reasoning", "summary": [{"type": "summary_text", "text": text} for text in summary_texts],
+    }
+    if content_texts:
+        raw_item["content"] = [{"type": "reasoning_text", "text": text} for text in content_texts]
+    if issuer_kind:
+        raw_item["_issuer_kind"] = issuer_kind
+    if _nonempty_str(item_id):
+        raw_item["id"] = item_id
+    return raw_item
+
+
 class _OutputScan:
     """Accumulated view of one Responses ``output`` list (phase 1 of normalization)."""
 
@@ -933,6 +996,8 @@ class _OutputScan:
                 # Compaction checkpoints ride the codex_reasoning_items sidecar (persistence,
                 # replay, cross-issuer guard and kill switch for free).
                 raw_item = _capture_encrypted_item(item, item_type, issuer_kind)
+                if raw_item is None and item_type == "reasoning":
+                    raw_item = _capture_plaintext_reasoning(item, issuer_kind)
                 if raw_item is not None:
                     self.reasoning_items_raw.append(raw_item)
                     if item_type == "compaction":
@@ -1025,9 +1090,7 @@ def _normalize_codex_response(response: Any, *, issuer_kind: Optional[str] = Non
     # Reasoning-only: for Codex/xAI/GitHub, status=completed means "still thinking" → incomplete so the continuation
     # retries. Other backends trust response.status — forcing incomplete there stalls for minutes on a final state.
     reasoning_only = (scan.reasoning_items_raw or reasoning_parts or scan.saw_reasoning_item) and not final_text
-    trusted_final = (
-        response_status == "completed" and issuer_kind not in ("codex_backend", "xai_responses", "github_responses")
-    )
+    trusted_final = response_status == "completed" and issuer_kind not in _ENCRYPTED_REASONING_ISSUERS
     if tool_calls:
         finish_reason = "tool_calls"
     elif response_incomplete_content_filter:

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -2222,6 +2222,38 @@ def test_chat_messages_to_responses_input_reasoning_only_has_following_item(monk
     assert following.get("role") == "assistant"
 
 
+def test_chat_messages_to_responses_input_reasoning_with_tool_calls_skips_empty_stub():
+    """A reasoning turn that ALSO carries tool calls must not emit an empty assistant message.
+    The function_call items already satisfy the "following item" rule, and translating gateways
+    turn the empty message into an empty text block that Anthropic/Bedrock reject with HTTP 400
+    "text content blocks must be non-empty"."""
+    from agent.codex_responses_adapter import _chat_messages_to_responses_input
+
+    messages = [
+        {"role": "user", "content": "run a command"},
+        {
+            "role": "assistant",
+            "content": "",
+            "codex_reasoning_items": [
+                {"type": "reasoning", "id": "rs_1", "encrypted_content": "enc_abc", "summary": []},
+            ],
+            "tool_calls": [
+                {"id": "call_1", "type": "function", "function": {"name": "terminal", "arguments": "{}"}},
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "name": "terminal", "content": "ok"},
+    ]
+    items = _chat_messages_to_responses_input(messages)
+    kinds = [it.get("type") or f"message:{it.get('role')}" for it in items]
+    assert kinds == ["message:user", "reasoning", "function_call", "function_call_output"], kinds
+
+    # Malformed tool_calls (no function name) produce no function_call item, so the stub is still required.
+    messages[1]["tool_calls"] = [{"id": "call_1", "type": "function", "function": {"arguments": "{}"}}]
+    items = _chat_messages_to_responses_input(messages[:2])
+    kinds = [it.get("type") or f"message:{it.get('role')}" for it in items]
+    assert kinds == ["message:user", "reasoning", "message:assistant"], kinds
+
+
 
 
 def test_duplicate_detection_distinguishes_different_codex_reasoning(monkeypatch):

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -2254,6 +2254,132 @@ def test_chat_messages_to_responses_input_reasoning_with_tool_calls_skips_empty_
     assert kinds == ["message:user", "reasoning", "message:assistant"], kinds
 
 
+def _plaintext_reasoning_response():
+    """Shape a third-party Responses gateway returns for a thinking model it cannot seal (Kimi K3 behind
+    Aperture / Vercel AI Gateway, 2026-09-01): reasoning_text content, empty summary, no encrypted_content."""
+    return SimpleNamespace(
+        status="completed",
+        output=[
+            SimpleNamespace(
+                type="reasoning", id="rs_1", summary=[],
+                content=[SimpleNamespace(type="reasoning_text", text="think A")],
+            ),
+            SimpleNamespace(
+                type="function_call", id="fc_1", call_id="call_1", name="terminal", arguments="{}", status="completed",
+            ),
+        ],
+    )
+
+
+def test_normalize_codex_response_captures_plaintext_reasoning_for_other_issuers():
+    """Plaintext reasoning must be displayed (msg.reasoning) AND persisted for replay, mirroring the received
+    shape and stamped with the issuer, or Preserved-Thinking models lose their chain after the first tool call."""
+    from agent.codex_responses_adapter import _normalize_codex_response
+
+    msg, finish_reason = _normalize_codex_response(
+        _plaintext_reasoning_response(), issuer_kind="other:https://ai.corp.ts.net/v1"
+    )
+    assert finish_reason == "tool_calls"
+    assert msg.reasoning == "think A"
+    assert msg.codex_reasoning_items == [{
+        "type": "reasoning", "summary": [], "content": [{"type": "reasoning_text", "text": "think A"}],
+        "_issuer_kind": "other:https://ai.corp.ts.net/v1", "id": "rs_1",
+    }]
+
+
+@pytest.mark.parametrize("issuer", ["codex_backend", "xai_responses", "github_responses"])
+def test_normalize_codex_response_plaintext_reasoning_not_captured_for_first_party(issuer):
+    """First-party backends carry continuity in encrypted_content only; their wire stays unchanged. The
+    thinking text still surfaces for display."""
+    from agent.codex_responses_adapter import _normalize_codex_response
+
+    msg, finish_reason = _normalize_codex_response(_plaintext_reasoning_response(), issuer_kind=issuer)
+    assert finish_reason == "tool_calls"
+    assert msg.reasoning == "think A"
+    assert msg.codex_reasoning_items is None
+
+
+def _plaintext_history(stamp):
+    item = {
+        "type": "reasoning", "id": "rs_1",
+        "summary": [{"type": "summary_text", "text": "sum"}],
+        "content": [{"type": "reasoning_text", "text": "think A"}],
+    }
+    if stamp:
+        item["_issuer_kind"] = stamp
+    return [
+        {"role": "user", "content": "run a command"},
+        {
+            "role": "assistant", "content": "", "codex_reasoning_items": [item],
+            "tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "terminal", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "name": "terminal", "content": "ok"},
+    ]
+
+
+def test_chat_messages_to_responses_input_replays_plaintext_reasoning_for_same_issuer():
+    """Same issuer: the plaintext item replays ahead of the tool call with id/_issuer_kind stripped and no
+    empty assistant stub. Different issuer: the cross-issuer guard drops it."""
+    from agent.codex_responses_adapter import _chat_messages_to_responses_input
+
+    issuer = "other:https://ai.corp.ts.net/v1"
+    items = _chat_messages_to_responses_input(_plaintext_history(issuer), current_issuer_kind=issuer)
+    kinds = [it.get("type") or f"message:{it.get('role')}" for it in items]
+    assert kinds == ["message:user", "reasoning", "function_call", "function_call_output"], kinds
+    assert items[1] == {
+        "type": "reasoning", "summary": [{"type": "summary_text", "text": "sum"}],
+        "content": [{"type": "reasoning_text", "text": "think A"}],
+    }
+    other = _chat_messages_to_responses_input(_plaintext_history(issuer), current_issuer_kind="other:https://elsewhere/v1")
+    assert all(it.get("type") != "reasoning" for it in other)
+
+
+@pytest.mark.parametrize("issuer", ["codex_backend", "xai_responses", "github_responses"])
+def test_chat_messages_to_responses_input_never_replays_plaintext_reasoning_to_first_party(issuer):
+    """An unstamped legacy plaintext item passes the cross-issuer guard but must still never reach a
+    first-party issuer, whose contract is encrypted_content."""
+    from agent.codex_responses_adapter import _chat_messages_to_responses_input
+
+    items = _chat_messages_to_responses_input(_plaintext_history(stamp=None), current_issuer_kind=issuer)
+    assert all(it.get("type") != "reasoning" for it in items)
+    items = _chat_messages_to_responses_input(_plaintext_history(stamp=None), current_issuer_kind="other")
+    assert items[1]["type"] == "reasoning"
+
+
+def test_extract_responses_reasoning_text_prefers_content_over_summary():
+    """Full content reasoning_text first, then summary; parts may be SDK objects or raw dicts."""
+    from agent.codex_responses_adapter import _extract_responses_reasoning_text
+
+    as_object = SimpleNamespace(
+        type="reasoning",
+        summary=[SimpleNamespace(type="summary_text", text="short")],
+        content=[SimpleNamespace(type="reasoning_text", text="full thought")],
+    )
+    assert _extract_responses_reasoning_text(as_object) == "full thought"
+    as_dict = {"type": "reasoning", "summary": [{"type": "summary_text", "text": "short"}], "content": []}
+    assert _extract_responses_reasoning_text(as_dict) == "short"
+    assert _extract_responses_reasoning_text(SimpleNamespace(type="reasoning", summary=[], content=[])) == ""
+
+
+def test_preflight_codex_input_items_passes_plaintext_reasoning_through():
+    """Preflight forwards plaintext reasoning (summary + content, id dropped, dedup by id) and still drops a
+    reasoning item that has neither a blob nor text."""
+    from agent.codex_responses_adapter import _preflight_codex_input_items
+
+    raw = [{
+        "type": "reasoning", "id": "rs_1",
+        "summary": [{"type": "summary_text", "text": "sum"}],
+        "content": [{"type": "reasoning_text", "text": "think A"}],
+    }]
+    expected = [{
+        "type": "reasoning", "summary": [{"type": "summary_text", "text": "sum"}],
+        "content": [{"type": "reasoning_text", "text": "think A"}],
+    }]
+    assert _preflight_codex_input_items(raw) == expected
+    assert _preflight_codex_input_items(raw + raw) == expected
+    assert _preflight_codex_input_items([{"type": "reasoning", "id": "rs_2", "summary": []}]) == []
+
+
 
 
 def test_duplicate_detection_distinguishes_different_codex_reasoning(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Fixes the Codex/Responses transport silently discarding a model's reasoning when the Responses endpoint is a third-party gateway that returns reasoning as **plaintext** (`content: [{type: "reasoning_text"}]` and/or `summary: [{type: "summary_text"}]`) with **no `encrypted_content`**.

Today `agent/codex_responses_adapter.py` treats `encrypted_content` as the only replayable form. On such gateways, three things go wrong at once:

1. `_extract_responses_reasoning_text` reads only `summary[]` and `item.text`, so the thinking is never displayed or stored (`messages.reasoning` is NULL).
2. `_normalize_codex_response` only appends to `codex_reasoning_items` when `encrypted_content` is non-empty, so nothing is persisted.
3. `_chat_messages_to_responses_input` and `_preflight_codex_input_items` drop any reasoning item without the blob, so nothing is replayed.

For Preserved-Thinking models this is the documented degradation path. Kimi's platform docs state that historical `reasoning_content` **must** be kept in the message history. Observed live with `moonshotai/kimi-k3` behind a corporate gateway (Aperture, Vercel AI Gateway shape): `reasoning_tokens` fell to 0 on 4 of 7 calls in a tool loop, and on call 7 the model wrote a status report instead of the next tool call. Hermes saw `finish_reason=stop` and ended the turn. The user had to type "continue" every few turns. The same task on `chat_completions` (which echoes `reasoning_content`) runs to completion.

This is the same bug class as #91104 (Actual relay serving Kimi K3, gated to `api.actual.inc`) and #97241 (DeepSeek V4, gated to `api.deepseek.com`). Each of those fixes one host. This PR fixes the class: plaintext reasoning is captured and replayed for **every issuer that is not a first-party encrypted-continuity backend** (`codex_backend`, `xai_responses`, `github_responses`), so the next gateway to hit this does not need a fourth host-specific PR. First-party routes are byte-for-byte unchanged.

**Depends on #100750** (first commit in this PR). Without it, a replayed reasoning item on a tool-calling turn also triggers the empty assistant stub, producing `reasoning, assistant(""), function_call`. The wire shape verified live here had both fixes. Review the second commit; I will rebase once #100750 lands.

## Related Issue

No existing issue. Related PRs: #91104, #97241, #100750.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

`agent/codex_responses_adapter.py`

- New module constant `_ENCRYPTED_REASONING_ISSUERS` (`codex_backend`, `xai_responses`, `github_responses`); replaces three inline copies of the same tuple, including the pre-existing finish-reason branch.
- New helpers `_responses_part_attr`, `_reasoning_item_plaintext_texts`, `_is_plaintext_reasoning_item`; all work on pydantic SDK objects and persisted dicts.
- `_extract_responses_reasoning_text`: prefers `content[].reasoning_text`, then `summary`, then `item.text`.
- `_normalize_codex_response`: for non-first-party issuers, captures a plaintext reasoning item that mirrors the received shape (`summary`, `content` when present), stamps `_issuer_kind`, keeps `rs_tmp_` skipping. Encrypted branch untouched.
- `_chat_messages_to_responses_input`: replays plaintext items under the existing cross-issuer guard; strips `id` / `_issuer_kind` as before; never replays plaintext items to a first-party issuer even when unstamped.
- `_preflight_codex_input_items`: passes plaintext items through with `summary`/`content` preserved, Harmony sanitization applied when requested, id dedup kept.

`tests/run_agent/test_run_agent_codex_responses.py`: 6 new tests covering capture for `other:*` issuers, no capture for `codex_backend`, replay ordering with no empty stub, cross-issuer drop, unstamped-item drop for all three first-party issuers, extractor precedence on objects and dicts, preflight pass-through with dedup.

No config keys, no new tools, no change to the streaming consumer (`_consume_codex_event_stream` keeps `output_item.done` items verbatim, so `content` parts already reach the normalizer).

## How to Test

1. `scripts/run_tests.sh tests/run_agent/test_run_agent_codex_responses.py tests/agent/test_codex_responses_adapter.py tests/agent/transports/test_codex_transport.py tests/run_agent/test_provider_parity.py -q` — 255 passed, 0 failed. `ruff check` clean.
2. Gateway capability proof (any Responses gateway that returns plaintext reasoning): replay a hand-built reasoning item containing a marker word, then ask the model to recall it. On Aperture/kimi-k3, n=3: no reasoning item 0/3, `content:[reasoning_text]` 2/3, `summary:[summary_text]` 3/3, all HTTP 200. This shows the gateway forwards replayed plaintext reasoning to the model.
3. End to end: `hermes --provider <responses-gateway> --model moonshotai/kimi-k3 -z "Use the terminal tool three times, one command per call: date, uname -s, whoami, then reply with all three."` Before: `state.db` `messages.codex_reasoning_items` NULL on every assistant row and no reasoning items in any continuation request. After: `codex_reasoning_items` populated on turns where the model reasoned, and each continuation request carries `reasoning(content=1)` ahead of the tool history (verified on the gateway's request log).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — #91104 and #97241 are host-scoped fixes for the same class; this PR generalizes them and is cross-referenced on both
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits) — plus the #100750 commit it depends on
- [x] I've run `pytest tests/ -q` and all tests pass — touched suites via `scripts/run_tests.sh` (255 passed); broader Codex/compaction/parity set 562 passed
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 27.0 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings and inline comments; no user-facing docs change
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python, no paths
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Failing session, gateway request log, continuation input (no reasoning item anywhere):

```
 0 user
 1 function_call skill_view
 2 function_call_output
 3 function_call read_file
 4 function_call_output
 ...
```

Same gateway after the fix:

```
user, reasoning(enc=0, content=1, summary=0), function_call terminal, function_call_output
user, reasoning(enc=0, content=1, summary=0), function_call, output, function_call, output
user, reasoning(enc=0, content=1, summary=0), function_call, output, function_call, output, function_call, output
```
