### PR TITLE
fix(cli): add explicit encoding to tasklist subprocess call (#100880)

### DIFF
--- a/hermes_cli/gitlock.py
+++ b/hermes_cli/gitlock.py
@@ -61,7 +61,8 @@ def _git_proc_running() -> bool:
         if os.name == "nt":
             out = subprocess.run(
                 ["tasklist", "/FI", "IMAGENAME eq git.exe", "/FO", "CSV"],
-                capture_output=True, text=True, timeout=10,
+                capture_output=True, text=True, encoding="utf-8",
+                errors="replace", timeout=10,
             ).stdout.lower()
             return "git.exe" in out
         out = subprocess.run(


### PR DESCRIPTION
## Problem

On CJK-locale Windows, `tasklist` outputs bytes in the system codepage (e.g. GBK/CP936). Python's UTF-8 mode (PYTHONUTF8/PEP 686) forces UTF-8 decoding via `text=True`, causing `UnicodeDecodeError` on every CLI startup.

## Fix

Add `encoding="utf-8", errors="replace"` to the `subprocess.run` call so non-UTF-8 bytes are replaced with the Unicode replacement character instead of crashing.

## Testing

- On CJK Windows: `hermes --version` no longer prints UnicodeDecodeError tracebacks
- On non-CJK Windows: behavior unchanged (UTF-8 output decodes cleanly)

Fixes #100880