### PR TITLE
fix(mcp): stdio tool calls no longer leak an un-awaited watcher coroutine per call (#95938, salvage #96251)

### DIFF
--- a/tests/tools/test_mcp_stdio_children_dead.py
+++ b/tests/tools/test_mcp_stdio_children_dead.py
@@ -92,3 +92,36 @@ def test_watcher_resolves_when_all_children_are_dead():
             )
 
     asyncio.run(_run())
+
+
+def test_watch_ok_probe_does_not_create_unawaited_coroutine():
+    """The fast-fail gate must inspect the watcher, not call it (#96044).
+
+    The old probe — inspect.isawaitable(_watch_children()) — created a
+    fresh coroutine per stdio tool call and never awaited it, emitting
+    'coroutine ... was never awaited' RuntimeWarnings under -W error and
+    churning the GC. Pin that the shipped source no longer calls the
+    watcher during the probe.
+    """
+    import inspect as _inspect
+
+    import tools.mcp_tool as mcp_mod
+
+    src = _inspect.getsource(mcp_mod)
+    assert "isawaitable(_watch_children())" not in src
+    assert "iscoroutinefunction(_watch_children)" in src
+
+
+def test_watch_ok_semantics_mock_vs_real():
+    """MagicMock watchers stay on the plain-await path; real async defs
+    (and AsyncMock) qualify for the fast-fail race — same split the old
+    isawaitable(call) probe produced, without the coroutine leak."""
+    import inspect as _inspect
+    from unittest.mock import AsyncMock, MagicMock
+
+    async def _real_watcher():  # what the real method looks like
+        pass
+
+    assert _inspect.iscoroutinefunction(_real_watcher) is True
+    assert _inspect.iscoroutinefunction(AsyncMock()) is True
+    assert _inspect.iscoroutinefunction(MagicMock()) is False

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6186,7 +6186,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     _watch_children = getattr(server, "_watch_stdio_children", None)
                     _watch_ok = (
                         _watch_children is not None
-                        and inspect.isawaitable(_watch_children())
+                        and (inspect.iscoroutinefunction(_watch_children) or callable(_watch_children))
                         and asyncio.iscoroutine(_call_coro)
                     )
                     if not _watch_ok:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6186,7 +6186,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     _watch_children = getattr(server, "_watch_stdio_children", None)
                     _watch_ok = (
                         _watch_children is not None
-                        and (inspect.iscoroutinefunction(_watch_children) or callable(_watch_children))
+                        and inspect.iscoroutinefunction(_watch_children)
                         and asyncio.iscoroutine(_call_coro)
                     )
                     if not _watch_ok:


### PR DESCRIPTION
## Summary

MCP stdio tool calls no longer leak an un-awaited `_watch_stdio_children` coroutine on every call (the `RuntimeWarning: coroutine 'MCPServerTask._watch_stdio_children' was never awaited` spam at `tools/mcp_tool.py:6189`).

Root cause: the #81995 fast-fail gate probed awaitability by **calling** the watcher (`inspect.isawaitable(_watch_children())`), creating a fresh coroutine per call that was then discarded. The probe now inspects the function (`inspect.iscoroutinefunction(_watch_children)`) without invoking it.

Salvage of #96251 (@kshitijk4poor), which itself carries the unique hunk from #96044 by @loulanyue. Authorship preserved on both commits; branch rebased onto current main (clean cherry-pick).

## Changes

- `tools/mcp_tool.py` (@loulanyue): probe `_watch_children` without calling it.
- `tests/tools/test_mcp_stdio_children_dead.py` (@kshitijk4poor): pin that the probe no longer calls the watcher + semantic contract (real `async def` / `AsyncMock` → race path, `MagicMock` → plain await; the `or callable(...)` arm from the original PR was dropped because `callable(MagicMock)` is True and would flip stubbed sessions into the race).

## Validation

**Live repro:** real `_make_tool_handler` driven against a stub server with a genuine `async def` watcher and healthy children, `warnings.simplefilter("always")`, `gc.collect()`:

| | never-awaited RuntimeWarnings |
|---|---|
| origin/main, 5 calls | 5 |
| this branch, 5 calls | 0 |

- `tests/tools/test_mcp_stdio_children_dead.py` + `test_mcp_stdio_fastfail_reconnect.py`: 12 passed
- ruff clean; `scripts/audit_pr_attribution.py --fix`: all emails mapped

## Credit

Fix by @loulanyue (#96044); tests + tightening by @kshitijk4poor (#96251). First report @glupta #95938; independent reports @ilgo #96030, #100472. Earlier equivalent fix shape by @liuhao1024 in #95939 (create-once-and-reuse). Same-shape open PRs #98088 (@Serph91P) and #98810 (@MaartenDMT) will be closed with credit once this lands.

Closes #95938. Closes #96030. Closes #100472. Closes #96044.

## Infographic

![MCP stdio watcher — no more leaked coroutines](https://v3b.fal.media/files/b/0aa8c42e/5yNZ9zqzQYXMyrwP0qVwo_n1UwUYXg.png)
