### PR TITLE
fix(caching): report prompt-cache status so a disabled cache is not silent

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1670,15 +1670,23 @@ def init_agent(
         prompt_preview = agent.ephemeral_system_prompt[:60] + "..." if len(agent.ephemeral_system_prompt) > 60 else agent.ephemeral_system_prompt
         print(f"🔒 Ephemeral system prompt: '{prompt_preview}' (not saved to trajectories)")
     
-    # Show prompt caching status
-    if agent._use_prompt_caching and not agent.quiet_mode:
-        if agent._use_native_cache_layout and agent.provider == "anthropic":
-            source = "native Anthropic"
-        elif agent._use_native_cache_layout:
-            source = "Anthropic-compatible endpoint"
-        else:
-            source = "Claude via OpenRouter"
-        print(f"💾 Prompt caching: ENABLED ({source}, {agent._cache_ttl} TTL)")
+    # Report prompt caching status. Logged always, printed only when the agent
+    # is not quiet.
+    #
+    # The log line is the point. Until now this block had no DISABLED branch,
+    # so a route that resolved to (False, False) re-billed the whole prompt on
+    # every API call and said nothing about it, anywhere. The ACP adapter also
+    # forces quiet_mode=True (acp_adapter/session.py) and routes logging to
+    # stderr (acp_adapter/entry.py), so editor/harness sessions had no signal
+    # in either direction. Logging at INFO keeps stdout clean for the ACP
+    # JSON-RPC transport while making the state discoverable.
+    from agent.agent_runtime_helpers import prompt_cache_status_summary
+
+    cache_status = prompt_cache_status_summary(agent)
+    logger.info("Prompt caching: %s", cache_status)
+    if not agent.quiet_mode:
+        icon = "💾" if agent._use_prompt_caching else "⚠️"
+        print(f"{icon} Prompt caching: {cache_status}")
     
     # Session logging setup - auto-save conversation trajectories for debugging
     agent.session_start = datetime.now()

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2708,6 +2708,85 @@ def anthropic_prompt_cache_policy(
     return False, False
 
 
+def prompt_cache_status_summary(agent) -> str:
+    """Describe the resolved prompt-cache state for this agent in one line.
+
+    ``anthropic_prompt_cache_policy`` above is the only decision-maker; this
+    helper never re-implements it. When caching is off it re-runs the same
+    policy with ONE input counterfactually flipped to find which input is the
+    blocker, so the explanation can never drift away from the rule that
+    actually fired.
+
+    Why this exists: a disabled cache is invisible today. The ENABLED banner in
+    ``agent_init`` has no DISABLED counterpart and is suppressed under
+    ``quiet_mode``, which the ACP adapter forces on. A route that resolves to
+    ``(False, False)`` therefore re-bills the entire prompt on every single API
+    call with no signal anywhere, on any surface. #11970 (Bedrock never
+    injected cachePoint) and #17332 (MiniMax's own models on the native wire)
+    were both instances of that class, each found only after the fact.
+
+    Returns a string like::
+
+        ENABLED (native Anthropic, 5m TTL)
+        DISABLED (api_mode is unset; set model.api_mode: anthropic_messages if
+                  this endpoint speaks the Anthropic Messages protocol)
+    """
+    should_cache = bool(getattr(agent, "_use_prompt_caching", False))
+    ttl = getattr(agent, "_cache_ttl", None) or "5m"
+
+    if should_cache:
+        if getattr(agent, "_use_native_cache_layout", False):
+            source = (
+                "native Anthropic"
+                if getattr(agent, "provider", "") == "anthropic"
+                else "Anthropic-compatible endpoint"
+            )
+        else:
+            source = "Claude via OpenRouter"
+        return f"ENABLED ({source}, {ttl} TTL)"
+
+    return f"DISABLED ({_prompt_cache_disabled_reason(agent)})"
+
+
+def _prompt_cache_disabled_reason(agent) -> str:
+    """Name the input that keeps ``anthropic_prompt_cache_policy`` at False.
+
+    Counterfactual probing rather than a second copy of the branch table: flip
+    one input, ask the real policy again, and report whichever flip turns
+    caching on. A branch added to the policy is picked up here for free.
+    """
+    if getattr(agent, "_cache_disabled", False):
+        return "prompt_caching.cache_ttl is set to a disable value in config.yaml"
+
+    api_mode = (getattr(agent, "api_mode", "") or "").strip()
+    model = (getattr(agent, "model", "") or "").strip()
+
+    if api_mode != "anthropic_messages":
+        native, _ = anthropic_prompt_cache_policy(agent, api_mode="anthropic_messages")
+        if native:
+            spelled = f"api_mode is {api_mode!r}" if api_mode else "api_mode is unset"
+            return (
+                f"{spelled}; set model.api_mode: anthropic_messages in config.yaml "
+                "if this endpoint speaks the Anthropic Messages protocol"
+            )
+
+    if "claude" not in model.lower():
+        # Probe with a Claude-named model to distinguish "the model is what
+        # blocks this route" from "this route has no cache layout at all".
+        claude_ok, _ = anthropic_prompt_cache_policy(agent, model="claude-sonnet-4-5")
+        if claude_ok:
+            return (
+                f"model {model!r} is not recognised as a Claude-family model on this "
+                "transport, and no other cache layout covers it"
+            )
+
+    provider = (getattr(agent, "provider", "") or "").strip() or "(unset)"
+    return (
+        f"no supported cache layout for provider={provider!r} "
+        f"api_mode={api_mode or '(unset)'!r} model={model or '(unset)'!r}"
+    )
+
+
 
 def _provider_supplied_client(agent, client_kwargs: dict) -> Any | None:
     """Ask the registered ProviderProfile for a custom client, if any.

--- a/tests/agent/test_prompt_cache_status.py
+++ b/tests/agent/test_prompt_cache_status.py
@@ -1,0 +1,117 @@
+"""Prompt-cache status reporting: a disabled cache must not be silent.
+
+``anthropic_prompt_cache_policy`` can resolve to ``(False, False)`` for a route
+that looks perfectly healthy — most commonly a Claude model on an
+Anthropic-compatible gateway whose ``model.api_mode`` was never set, which the
+URL heuristics cannot detect and which therefore defaults to
+``chat_completions``. Nothing then emits a single cache_control breakpoint and
+the provider re-bills the entire prompt on every API call.
+
+These tests pin the reporting contract only. They never assert a policy
+outcome, so a new branch in the policy cannot break them.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from agent.agent_runtime_helpers import (
+    anthropic_prompt_cache_policy,
+    prompt_cache_status_summary,
+)
+
+GATEWAY = "https://gateway.example.test"
+
+
+def _agent(**overrides):
+    """Minimal destination stub, then resolve the real policy onto it."""
+    base = dict(
+        provider="custom",
+        base_url=GATEWAY,
+        api_mode="anthropic_messages",
+        model="claude-sonnet-4-5",
+        _custom_providers=[],
+        _cache_disabled=False,
+        verbose_logging=False,
+    )
+    base.update(overrides)
+    agent = SimpleNamespace(**base)
+    agent._use_prompt_caching, agent._use_native_cache_layout = (
+        anthropic_prompt_cache_policy(agent)
+    )
+    agent._cache_ttl = None if agent._cache_disabled else "5m"
+    return agent
+
+
+class TestPromptCacheStatusSummary:
+    def test_enabled_summary_keeps_the_historical_banner_text(self):
+        """The ENABLED wording is unchanged, so operator greps still match."""
+        agent = _agent(provider="anthropic", base_url="https://api.anthropic.com")
+        assert agent._use_prompt_caching is True
+        assert (
+            prompt_cache_status_summary(agent)
+            == "ENABLED (native Anthropic, 5m TTL)"
+        )
+
+    def test_enabled_summary_names_a_third_party_gateway(self):
+        agent = _agent()
+        assert agent._use_prompt_caching is True
+        assert prompt_cache_status_summary(agent) == (
+            "ENABLED (Anthropic-compatible endpoint, 5m TTL)"
+        )
+
+    def test_unset_api_mode_is_reported_and_names_the_config_key(self):
+        """The regression this exists for: silent (False, False) on a Claude route."""
+        agent = _agent(api_mode="")
+        assert agent._use_prompt_caching is False
+
+        summary = prompt_cache_status_summary(agent)
+        assert summary.startswith("DISABLED (")
+        assert "api_mode is unset" in summary
+        # Actionable: the operator must be told which key to set.
+        assert "model.api_mode: anthropic_messages" in summary
+
+    def test_openai_wire_api_mode_is_quoted_back(self):
+        agent = _agent(api_mode="chat_completions")
+        assert agent._use_prompt_caching is False
+
+        summary = prompt_cache_status_summary(agent)
+        assert "api_mode is 'chat_completions'" in summary
+        assert "model.api_mode: anthropic_messages" in summary
+
+    def test_non_claude_model_on_the_native_wire_blames_the_model(self):
+        """api_mode is already correct here, so the model must be named instead."""
+        agent = _agent(model="some-other-model-9")
+        assert agent._use_prompt_caching is False
+
+        summary = prompt_cache_status_summary(agent)
+        assert "api_mode" not in summary
+        assert "'some-other-model-9'" in summary
+
+    def test_operator_disable_is_reported_as_config_not_as_a_route_problem(self):
+        agent = _agent(_cache_disabled=True)
+        assert agent._use_prompt_caching is False
+
+        summary = prompt_cache_status_summary(agent)
+        assert "prompt_caching.cache_ttl" in summary
+        # Not a misdiagnosis of the route.
+        assert "api_mode" not in summary
+
+    def test_configured_1h_tier_is_reported(self):
+        agent = _agent()
+        agent._cache_ttl = "1h"
+        assert prompt_cache_status_summary(agent).endswith("1h TTL)")
+
+    def test_disabled_reason_is_derived_from_the_policy_not_hardcoded(self):
+        """Guard against the explanation drifting away from the real rule.
+
+        The reason is produced by re-running the policy with one input flipped.
+        If a future branch makes an unset api_mode cacheable on this route, the
+        summary must stop blaming api_mode without anyone editing this helper.
+        """
+        agent = _agent(api_mode="")
+        native_ok, _ = anthropic_prompt_cache_policy(
+            agent, api_mode="anthropic_messages"
+        )
+        blames_api_mode = "api_mode" in prompt_cache_status_summary(agent)
+        assert blames_api_mode is native_ok


### PR DESCRIPTION
## What does this PR do?

`anthropic_prompt_cache_policy` can resolve to `(False, False)` for a route that looks completely healthy, and nothing anywhere says so.

The status block in `agent_init` only ever had an ENABLED branch, and that branch is suppressed under `quiet_mode` — which the ACP adapter forces on (`acp_adapter/session.py`). So a session that emits zero `cache_control` breakpoints and re-bills the entire prompt on every API call is indistinguishable from one that is caching perfectly.

The most common way to land there is a Claude model on an Anthropic-compatible gateway whose `model.api_mode` was never set. `_detect_api_mode_for_url` recognises only `api.anthropic.com`, a `/anthropic` path suffix, `api.kimi.com/coding`, and the OpenAI/xAI hosts — so an ordinary self-hosted relay (`https://gateway.example/v1`) detects as nothing and `_resolve_plain_custom_api_mode` falls back to `chat_completions`. `api_mode` has no environment override either; it exists only in `config.yaml`. A user who never learned the key has no way to notice.

Measured on this branch, with a stub for a generic gateway:

```
gateway + anthropic_messages + claude-sonnet-4-5  -> (True, True)
gateway + api_mode unset     + claude-sonnet-4-5  -> (False, False)
gateway + chat_completions   + claude-sonnet-4-5  -> (False, False)
gateway + anthropic_messages + some-other-model   -> (False, False)
```

This is a recurring class rather than a one-off. #11970 (Bedrock Converse never injected `cachePoint`) and #17332 (MiniMax's own models on the native wire) were both silent-disable reports, each closed by adding one more provider branch to the policy. The branch table keeps growing; the silence never got fixed. This PR fixes the silence, and changes no caching behaviour at all.

**Why this approach.** The reason string is produced by re-running the real policy with one input counterfactually flipped, rather than by keeping a second copy of the branch table. A branch added to `anthropic_prompt_cache_policy` is picked up here for free, and the explanation can never drift from the rule that actually fired. `cli.py`'s local `cache_enabled` predicate (which re-implements two of the branches inline) is exactly the drift this avoids.

A follow-up PR adds a `hermes doctor` section that renders the same summary, so the state is answerable before a run rather than only during one. It depends on the helper introduced here; this PR stands on its own.

## Related Issue

No open issue for the observability gap — I searched before writing (see checklist). The two closed issues above are prior instances of the class this reports.

_No existing issue — the problem statement above is the report. Happy to split it into an issue first if you prefer that order._

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/agent_runtime_helpers.py` — new `prompt_cache_status_summary(agent)`, placed next to the policy it describes. The ENABLED wording is byte-identical to the banner it replaces, so existing operator greps keep matching.
- `agent/agent_runtime_helpers.py` — new `_prompt_cache_disabled_reason(agent)`, which names the blocking input via counterfactual probing of the real policy. Distinguishes: operator `prompt_caching.cache_ttl` disable / `api_mode` not on the native wire / model not covered on this transport / no supported layout at all.
- `agent/agent_init.py` — logs the resolved status at INFO unconditionally and keeps the human banner for non-quiet runs, now with a DISABLED counterpart. Logging is the load-bearing half: ACP routes logging to stderr (`acp_adapter/entry.py`), so stdout stays clean for the JSON-RPC transport.
- `tests/agent/test_prompt_cache_status.py` — new, 8 cases.

No change to the policy, the marker layout, or TTL handling. This only reports what was already decided.

## How to Test

1. Point a `provider: custom` entry at an Anthropic-compatible gateway with a Claude model and **no** `api_mode` in `~/.hermes/config.yaml`:
   ```yaml
   model:
     provider: custom
     base_url: https://gateway.example/v1
     default: claude-sonnet-4-5
   ```
2. Run `hermes -q "hi"` and check the log. Before this change: nothing. After:
   ```
   Prompt caching: DISABLED (api_mode is unset; set model.api_mode: anthropic_messages
   in config.yaml if this endpoint speaks the Anthropic Messages protocol)
   ```
   Interactively (non-quiet) the same line is printed with a ⚠️ prefix.
3. Add `api_mode: anthropic_messages` and re-run. The line returns to the historical wording:
   ```
   💾 Prompt caching: ENABLED (Anthropic-compatible endpoint, 5m TTL)
   ```
4. `pytest tests/agent/test_prompt_cache_status.py -q` → 8 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — nothing covers the reporting gap. Adjacent but distinct work I deliberately did not touch: #31763 (enable caching for Qwen on the Anthropic-compatible wire), #85481 / #89515 (compression re-sends the transcript with no prefix reuse), #24131 (prompt caching mode override).
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — see the note below
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04, Python 3.12

> **Note on the full suite.** I could not install the dev extras in this environment, so I ran a bare `pytest` without `pytest-asyncio`. What I did run:
> - `tests/agent/test_prompt_cache_status.py` → 8 passed
> - `tests/agent/test_prompt_caching.py`, `tests/agent/test_cache_disabled_on_stubs.py`, `tests/run_agent/test_anthropic_prompt_cache_policy.py` + the new file → **152 passed**
> - the whole `tests/agent` tree, then re-ran every failure on pristine `main` and on this branch under identical conditions: **the two failure sets are byte-identical (31 tests)**, and all 31 fail with `async def functions are not natively supported`, i.e. the missing plugin, not this change.
>
> Please let CI run `scripts/run_tests.sh` for the authoritative result.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the new helpers carry full docstrings; no user-facing doc describes the banner, so nothing else needed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no new config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure string formatting plus a `logger.info` call; no paths, no subprocesses, no platform branches
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before, on a gateway route with `api_mode` unset (nothing is emitted at all):

```
(no output)
```

After:

```
INFO run_agent: Prompt caching: DISABLED (api_mode is unset; set model.api_mode: anthropic_messages in config.yaml if this endpoint speaks the Anthropic Messages protocol)
```

And on a correctly configured route, unchanged from today:

```
INFO run_agent: Prompt caching: ENABLED (Anthropic-compatible endpoint, 5m TTL)
```

---

## Evidence from a self-hosted deployment

All numbers below come from `sessions` / `session_model_usage` rows in a live
`state.db`, or from calling the policy function directly. Hostnames, keys and
gateway model aliases are omitted; the shape of the failure does not depend on
them.

### 1. The policy resolves to "no breakpoints at all", silently

Calling `anthropic_prompt_cache_policy` directly on a `provider: custom` route
pointed at an Anthropic-capable gateway:

| model name | `api_mode` | `should_cache` | `native_layout` |
| --- | --- | --- | --- |
| contains `claude` | `anthropic_messages` | `True` | `True` |
| contains `claude` | `chat_completions` | `False` | `False` |
| no `claude` | `anthropic_messages` | `False` | `False` |
| no `claude` | `chat_completions` | `False` | `False` |

`(False, False)` means zero `cache_control` breakpoints are attached, so the
whole prompt is re-billed on every call. Today nothing reports this: the
`agent_init` banner is suppressed whenever `quiet_mode` is on (which the ACP
adapter forces), and `hermes doctor` has no prompt-cache field at all.

### 2. The `(False, False)` state is reachable from a perfectly plausible config

A `provider: custom` route with no explicit `api_mode` falls through:

```python
return configured_mode or detected_mode or "chat_completions"
```

`_detect_api_mode_for_url` cannot recognise a self-hosted gateway hostname, so
`detected_mode` is `None` and the effective mode becomes `chat_completions` —
i.e. an Anthropic-capable endpoint serving Claude models ends up on the OpenAI
wire with zero breakpoints. The config that produces this contains no wrong
value; it is missing one optional key whose default is "auto-detect".

### 3. Adding the explicit `api_mode` flips it — measured at 4-second resolution

Session rows around the moment `api_mode: anthropic_messages` was written to
the config:

```
11:28:04   api_mode: anthropic_messages written to config.yaml
11:28:08   cache_write = 24,656   cache_read =      0   uncached_input =  2
11:28:14   cache_write =     28   cache_read = 24,628   uncached_input =  2
```

Before that edit: 26 sessions, **0 of them ever sent a breakpoint**. After it,
every Claude-model session did. The config edit and the behaviour change are
four seconds apart, which is as close to a controlled experiment as production
data gets.

### 4. Cross-process reuse, to confirm the wire and not just the flag

Two independent one-shot invocations 8 seconds apart, identical ~26K-token
system prompt, separate processes and separate session ids:

```
call #1   cache_write = 26,130   cache_read =      0    hit   0.0%
call #2   cache_write =      0   cache_read = 26,130    hit 100.0%
```

`cache_creation_input_tokens` only exists on the Anthropic-native wire, so a
non-zero `cache_write` also proves the request really went out as
`/v1/messages` rather than being translated to chat completions.

### 5. Two things that look like the cause but are not

Both were checked so reviewers do not have to re-derive them:

- **A trailing `/v1` on `base_url` is harmless.** `build_anthropic_client`
  strips `/v1/?$` unconditionally, with no provider or api_mode gating.
  Verified with a live pair of calls from a throwaway `HERMES_HOME` whose
  `base_url` carried `/v1`: both requests succeeded, `cache_write = 19,726`
  then `cache_read = 19,726`. Caching is unaffected by the URL shape.
- **The model name is a second, independent gate.** A non-Claude model name
  returns `(False, False)` even with `api_mode: anthropic_messages`, because
  `is_claude = "claude" in model_lower` decides the layout. In the deployment
  above this produced two zero-breakpoint sessions that had nothing to do with
  the api_mode problem — they were simply running non-Claude models. A
  gateway alias that serves a Claude model under a name without the substring
  `claude` therefore loses caching silently too.

### Why this PR reports rather than repairs

Both gates are legitimate: `chat_completions` genuinely cannot carry
breakpoints, and the layout genuinely depends on the Anthropic schema. The
defect is that the resulting state is unobservable. On the deployment above the
misconfigured window ran for days before the bill made it visible, and the
reason strings in this PR would have named it on the first line of the first
session.

### There is already a display that gets this wrong

`cli.py` computes the "Prompt caching" line of `hermes model` by hand instead
of asking the policy:

```python
cache_enabled = (
    (base_url_host_matches(result.base_url or "", "openrouter.ai")
     and "claude" in result.new_model.lower())
    or result.api_mode == "anthropic_messages"
)
if cache_enabled:
    _cprint("    Prompt caching: enabled")
```

The second branch never looks at the model name, so for any non-Claude model
on an `anthropic_messages` route this prints `Prompt caching: enabled` while
`anthropic_prompt_cache_policy` returns `(False, False)` and no breakpoint is
ever attached. That is a live false positive today, and it is the strongest
argument for the approach taken here: the reason strings in this PR are
produced by re-running the real policy with a single input flipped, never by
restating the branch table, so they cannot drift away from the behaviour they
describe.

Happy to fix that `cli.py` expression in this PR too, or leave it for a
follow-up — say which you prefer.
