### PR TITLE
feat(doctor): check whether prompt caching is actually on for this route

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1670,15 +1670,23 @@ def init_agent(
         prompt_preview = agent.ephemeral_system_prompt[:60] + "..." if len(agent.ephemeral_system_prompt) > 60 else agent.ephemeral_system_prompt
         print(f"🔒 Ephemeral system prompt: '{prompt_preview}' (not saved to trajectories)")
     
-    # Show prompt caching status
-    if agent._use_prompt_caching and not agent.quiet_mode:
-        if agent._use_native_cache_layout and agent.provider == "anthropic":
-            source = "native Anthropic"
-        elif agent._use_native_cache_layout:
-            source = "Anthropic-compatible endpoint"
-        else:
-            source = "Claude via OpenRouter"
-        print(f"💾 Prompt caching: ENABLED ({source}, {agent._cache_ttl} TTL)")
+    # Report prompt caching status. Logged always, printed only when the agent
+    # is not quiet.
+    #
+    # The log line is the point. Until now this block had no DISABLED branch,
+    # so a route that resolved to (False, False) re-billed the whole prompt on
+    # every API call and said nothing about it, anywhere. The ACP adapter also
+    # forces quiet_mode=True (acp_adapter/session.py) and routes logging to
+    # stderr (acp_adapter/entry.py), so editor/harness sessions had no signal
+    # in either direction. Logging at INFO keeps stdout clean for the ACP
+    # JSON-RPC transport while making the state discoverable.
+    from agent.agent_runtime_helpers import prompt_cache_status_summary
+
+    cache_status = prompt_cache_status_summary(agent)
+    logger.info("Prompt caching: %s", cache_status)
+    if not agent.quiet_mode:
+        icon = "💾" if agent._use_prompt_caching else "⚠️"
+        print(f"{icon} Prompt caching: {cache_status}")
     
     # Session logging setup - auto-save conversation trajectories for debugging
     agent.session_start = datetime.now()

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2708,6 +2708,85 @@ def anthropic_prompt_cache_policy(
     return False, False
 
 
+def prompt_cache_status_summary(agent) -> str:
+    """Describe the resolved prompt-cache state for this agent in one line.
+
+    ``anthropic_prompt_cache_policy`` above is the only decision-maker; this
+    helper never re-implements it. When caching is off it re-runs the same
+    policy with ONE input counterfactually flipped to find which input is the
+    blocker, so the explanation can never drift away from the rule that
+    actually fired.
+
+    Why this exists: a disabled cache is invisible today. The ENABLED banner in
+    ``agent_init`` has no DISABLED counterpart and is suppressed under
+    ``quiet_mode``, which the ACP adapter forces on. A route that resolves to
+    ``(False, False)`` therefore re-bills the entire prompt on every single API
+    call with no signal anywhere, on any surface. #11970 (Bedrock never
+    injected cachePoint) and #17332 (MiniMax's own models on the native wire)
+    were both instances of that class, each found only after the fact.
+
+    Returns a string like::
+
+        ENABLED (native Anthropic, 5m TTL)
+        DISABLED (api_mode is unset; set model.api_mode: anthropic_messages if
+                  this endpoint speaks the Anthropic Messages protocol)
+    """
+    should_cache = bool(getattr(agent, "_use_prompt_caching", False))
+    ttl = getattr(agent, "_cache_ttl", None) or "5m"
+
+    if should_cache:
+        if getattr(agent, "_use_native_cache_layout", False):
+            source = (
+                "native Anthropic"
+                if getattr(agent, "provider", "") == "anthropic"
+                else "Anthropic-compatible endpoint"
+            )
+        else:
+            source = "Claude via OpenRouter"
+        return f"ENABLED ({source}, {ttl} TTL)"
+
+    return f"DISABLED ({_prompt_cache_disabled_reason(agent)})"
+
+
+def _prompt_cache_disabled_reason(agent) -> str:
+    """Name the input that keeps ``anthropic_prompt_cache_policy`` at False.
+
+    Counterfactual probing rather than a second copy of the branch table: flip
+    one input, ask the real policy again, and report whichever flip turns
+    caching on. A branch added to the policy is picked up here for free.
+    """
+    if getattr(agent, "_cache_disabled", False):
+        return "prompt_caching.cache_ttl is set to a disable value in config.yaml"
+
+    api_mode = (getattr(agent, "api_mode", "") or "").strip()
+    model = (getattr(agent, "model", "") or "").strip()
+
+    if api_mode != "anthropic_messages":
+        native, _ = anthropic_prompt_cache_policy(agent, api_mode="anthropic_messages")
+        if native:
+            spelled = f"api_mode is {api_mode!r}" if api_mode else "api_mode is unset"
+            return (
+                f"{spelled}; set model.api_mode: anthropic_messages in config.yaml "
+                "if this endpoint speaks the Anthropic Messages protocol"
+            )
+
+    if "claude" not in model.lower():
+        # Probe with a Claude-named model to distinguish "the model is what
+        # blocks this route" from "this route has no cache layout at all".
+        claude_ok, _ = anthropic_prompt_cache_policy(agent, model="claude-sonnet-4-5")
+        if claude_ok:
+            return (
+                f"model {model!r} is not recognised as a Claude-family model on this "
+                "transport, and no other cache layout covers it"
+            )
+
+    provider = (getattr(agent, "provider", "") or "").strip() or "(unset)"
+    return (
+        f"no supported cache layout for provider={provider!r} "
+        f"api_mode={api_mode or '(unset)'!r} model={model or '(unset)'!r}"
+    )
+
+
 
 def _provider_supplied_client(agent, client_kwargs: dict) -> Any | None:
     """Ask the registered ProviderProfile for a custom client, if any.

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -541,6 +541,77 @@ def _fail_and_issue(text: str, detail: str, fix: str, issues: list[str]) -> None
     issues.append(fix)
 
 
+def _prompt_caching_section(issues: list[str]) -> None:
+    """Report whether this route will actually get cache_control breakpoints.
+
+    Whether a route gets them is decided per request by
+    ``anthropic_prompt_cache_policy``, and until this section existed there was
+    no way to ask. The only signal was an ENABLED banner in ``agent_init`` — it
+    has no DISABLED counterpart and is suppressed under ``quiet_mode``, which
+    the ACP adapter forces on. A Claude model on an Anthropic-compatible
+    gateway whose ``model.api_mode`` was never set resolves to
+    ``(False, False)`` and re-bills the whole prompt as uncached input on every
+    API call, silently. #11970 (Bedrock cachePoint) and #17332 (MiniMax on the
+    native wire) were both instances of that class, each found after the fact.
+
+    Offline by construction: resolve the same destination the agent will use and
+    ask the real policy. No HTTP, so this stays out of the threaded
+    connectivity probes.
+    """
+    _section("Prompt Caching")
+    try:
+        from agent.agent_runtime_helpers import (
+            anthropic_prompt_cache_policy,
+            blank_cache_policy_stub,
+            configured_cache_ttl,
+            prompt_cache_status_summary,
+        )
+        from hermes_cli.config import load_config
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        model_cfg = (load_config() or {}).get("model")
+        if isinstance(model_cfg, dict):
+            model = str(model_cfg.get("default") or "")
+        else:
+            model = str(model_cfg or "")
+
+        rt = resolve_runtime_provider()
+        # blank_cache_policy_stub is the sanctioned constructor: it carries
+        # _cache_disabled from config, so an operator disable is honored here
+        # without doctor re-reading that key itself (#76085).
+        route = blank_cache_policy_stub()
+        route.provider = str(rt.get("provider") or "")
+        route.base_url = str(rt.get("base_url") or "")
+        route.api_mode = str(rt.get("api_mode") or "")
+        route.model = model
+        route._use_prompt_caching, route._use_native_cache_layout = (
+            anthropic_prompt_cache_policy(route)
+        )
+        route._cache_ttl = (
+            None if route._cache_disabled else (configured_cache_ttl() or "5m")
+        )
+
+        summary = prompt_cache_status_summary(route)
+        if route._use_prompt_caching:
+            check_ok("Prompt caching", f"({summary})")
+            return
+
+        check_warn("Prompt caching", f"({summary})")
+        # An explicit `prompt_caching.cache_ttl` opt-out is a choice, not a
+        # fault: report it, but keep it out of the issues list so it does not
+        # read as something to fix.
+        if not route._cache_disabled:
+            check_info(
+                "the full prompt is re-billed as uncached input on every API call"
+            )
+            issues.append(
+                f"Prompt caching is off for provider='{route.provider}' "
+                f"model='{route.model}': {summary}"
+            )
+    except Exception as e:
+        check_warn("Could not resolve prompt caching status", f"({e})")
+
+
 # Deprecated / legacy config keys still read for back-compat. Doctor surfaces
 # them as non-failing warnings with the modern replacement — it does not
 # auto-migrate or delete (migrations live in config.py version steps).
@@ -3193,6 +3264,8 @@ def run_doctor(args):
             _issues_to_add = []
         for _issue in _issues_to_add:
             issues.append(_issue)
+
+    _prompt_caching_section(issues)
 
     _section("Tool Availability")
     try:

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -557,6 +557,13 @@ def _prompt_caching_section(issues: list[str]) -> None:
     Offline by construction: resolve the same destination the agent will use and
     ask the real policy. No HTTP, so this stays out of the threaded
     connectivity probes.
+
+    Scope: this resolves the *persisted* configuration, so it answers "what
+    will this config do on a clean run" — the right question for a pre-flight
+    check. It is not a statement about a session already running under an
+    exported override. ``ANTHROPIC_BASE_URL`` is the practical case: its mere
+    presence flips the resolved wire, so a live agent can be on a different
+    route than the one reported here.
     """
     _section("Prompt Caching")
     try:

--- a/tests/agent/test_prompt_cache_status.py
+++ b/tests/agent/test_prompt_cache_status.py
@@ -1,0 +1,117 @@
+"""Prompt-cache status reporting: a disabled cache must not be silent.
+
+``anthropic_prompt_cache_policy`` can resolve to ``(False, False)`` for a route
+that looks perfectly healthy — most commonly a Claude model on an
+Anthropic-compatible gateway whose ``model.api_mode`` was never set, which the
+URL heuristics cannot detect and which therefore defaults to
+``chat_completions``. Nothing then emits a single cache_control breakpoint and
+the provider re-bills the entire prompt on every API call.
+
+These tests pin the reporting contract only. They never assert a policy
+outcome, so a new branch in the policy cannot break them.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from agent.agent_runtime_helpers import (
+    anthropic_prompt_cache_policy,
+    prompt_cache_status_summary,
+)
+
+GATEWAY = "https://gateway.example.test"
+
+
+def _agent(**overrides):
+    """Minimal destination stub, then resolve the real policy onto it."""
+    base = dict(
+        provider="custom",
+        base_url=GATEWAY,
+        api_mode="anthropic_messages",
+        model="claude-sonnet-4-5",
+        _custom_providers=[],
+        _cache_disabled=False,
+        verbose_logging=False,
+    )
+    base.update(overrides)
+    agent = SimpleNamespace(**base)
+    agent._use_prompt_caching, agent._use_native_cache_layout = (
+        anthropic_prompt_cache_policy(agent)
+    )
+    agent._cache_ttl = None if agent._cache_disabled else "5m"
+    return agent
+
+
+class TestPromptCacheStatusSummary:
+    def test_enabled_summary_keeps_the_historical_banner_text(self):
+        """The ENABLED wording is unchanged, so operator greps still match."""
+        agent = _agent(provider="anthropic", base_url="https://api.anthropic.com")
+        assert agent._use_prompt_caching is True
+        assert (
+            prompt_cache_status_summary(agent)
+            == "ENABLED (native Anthropic, 5m TTL)"
+        )
+
+    def test_enabled_summary_names_a_third_party_gateway(self):
+        agent = _agent()
+        assert agent._use_prompt_caching is True
+        assert prompt_cache_status_summary(agent) == (
+            "ENABLED (Anthropic-compatible endpoint, 5m TTL)"
+        )
+
+    def test_unset_api_mode_is_reported_and_names_the_config_key(self):
+        """The regression this exists for: silent (False, False) on a Claude route."""
+        agent = _agent(api_mode="")
+        assert agent._use_prompt_caching is False
+
+        summary = prompt_cache_status_summary(agent)
+        assert summary.startswith("DISABLED (")
+        assert "api_mode is unset" in summary
+        # Actionable: the operator must be told which key to set.
+        assert "model.api_mode: anthropic_messages" in summary
+
+    def test_openai_wire_api_mode_is_quoted_back(self):
+        agent = _agent(api_mode="chat_completions")
+        assert agent._use_prompt_caching is False
+
+        summary = prompt_cache_status_summary(agent)
+        assert "api_mode is 'chat_completions'" in summary
+        assert "model.api_mode: anthropic_messages" in summary
+
+    def test_non_claude_model_on_the_native_wire_blames_the_model(self):
+        """api_mode is already correct here, so the model must be named instead."""
+        agent = _agent(model="some-other-model-9")
+        assert agent._use_prompt_caching is False
+
+        summary = prompt_cache_status_summary(agent)
+        assert "api_mode" not in summary
+        assert "'some-other-model-9'" in summary
+
+    def test_operator_disable_is_reported_as_config_not_as_a_route_problem(self):
+        agent = _agent(_cache_disabled=True)
+        assert agent._use_prompt_caching is False
+
+        summary = prompt_cache_status_summary(agent)
+        assert "prompt_caching.cache_ttl" in summary
+        # Not a misdiagnosis of the route.
+        assert "api_mode" not in summary
+
+    def test_configured_1h_tier_is_reported(self):
+        agent = _agent()
+        agent._cache_ttl = "1h"
+        assert prompt_cache_status_summary(agent).endswith("1h TTL)")
+
+    def test_disabled_reason_is_derived_from_the_policy_not_hardcoded(self):
+        """Guard against the explanation drifting away from the real rule.
+
+        The reason is produced by re-running the policy with one input flipped.
+        If a future branch makes an unset api_mode cacheable on this route, the
+        summary must stop blaming api_mode without anyone editing this helper.
+        """
+        agent = _agent(api_mode="")
+        native_ok, _ = anthropic_prompt_cache_policy(
+            agent, api_mode="anthropic_messages"
+        )
+        blames_api_mode = "api_mode" in prompt_cache_status_summary(agent)
+        assert blames_api_mode is native_ok

--- a/tests/hermes_cli/test_doctor_prompt_caching.py
+++ b/tests/hermes_cli/test_doctor_prompt_caching.py
@@ -1,0 +1,115 @@
+"""`hermes doctor` must be able to answer "is my prompt cache actually on?".
+
+Before this section existed the only signal was an ENABLED banner in
+`agent_init`, which has no DISABLED counterpart and is suppressed under
+`quiet_mode` (the ACP adapter forces it on). An operator whose gateway route
+silently resolves to `(False, False)` had nothing to run.
+
+The section is offline by construction — it resolves the same destination the
+agent will use and asks `anthropic_prompt_cache_policy` — so these tests stub
+only the two resolvers and never touch the network.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+GATEWAY = "https://gateway.example.test"
+
+
+def _run_section(capsys, *, api_mode, model, provider="custom", cache_ttl="5m"):
+    """Render the Prompt Caching section alone and return (stdout, issues)."""
+    from hermes_cli import doctor as doctor_mod
+
+    issues: list[str] = []
+
+    with (
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "provider": provider,
+                "base_url": GATEWAY,
+                "api_mode": api_mode,
+                "api_key": "sk-test",
+            },
+        ),
+        patch(
+            "hermes_cli.config.load_config",
+            return_value={"model": {"default": model}},
+        ),
+        patch(
+            "hermes_cli.config.load_config_readonly",
+            return_value={"prompt_caching": {"cache_ttl": cache_ttl}},
+        ),
+    ):
+        doctor_mod._prompt_caching_section(issues)
+
+    return capsys.readouterr().out, issues
+
+
+@pytest.fixture(autouse=True)
+def _require_extracted_section():
+    """The section must be callable on its own, not welded into run_doctor."""
+    from hermes_cli import doctor as doctor_mod
+
+    assert hasattr(doctor_mod, "_prompt_caching_section"), (
+        "expected doctor to expose the prompt-caching check as its own helper"
+    )
+
+
+class TestDoctorPromptCachingSection:
+    def test_reports_ok_on_the_native_wire(self, capsys):
+        out, issues = _run_section(
+            capsys, api_mode="anthropic_messages", model="claude-sonnet-4-5"
+        )
+        assert "Prompt caching" in out
+        assert "ENABLED" in out
+        assert issues == []
+
+    def test_flags_an_unset_api_mode_and_names_the_config_key(self, capsys):
+        """The regression this section exists for."""
+        out, issues = _run_section(capsys, api_mode="", model="claude-sonnet-4-5")
+
+        assert "DISABLED" in out
+        assert "model.api_mode: anthropic_messages" in out
+        # The consequence must be spelled out, not left as an inference.
+        assert "re-billed as uncached input" in out
+        assert len(issues) == 1
+        assert "Prompt caching is off" in issues[0]
+
+    def test_flags_the_openai_wire(self, capsys):
+        out, issues = _run_section(
+            capsys, api_mode="chat_completions", model="claude-sonnet-4-5"
+        )
+        assert "DISABLED" in out
+        assert len(issues) == 1
+
+    def test_an_explicit_cache_ttl_optout_is_reported_but_not_an_issue(self, capsys):
+        """A deliberate operator choice must not read as something to fix."""
+        out, issues = _run_section(
+            capsys,
+            api_mode="anthropic_messages",
+            model="claude-sonnet-4-5",
+            cache_ttl="off",
+        )
+        assert "DISABLED" in out
+        assert "prompt_caching.cache_ttl" in out
+        assert "re-billed" not in out
+        assert issues == []
+
+    def test_a_resolver_failure_degrades_to_a_warning(self, capsys):
+        """doctor must never crash on a route it cannot resolve."""
+        from hermes_cli import doctor as doctor_mod
+
+        issues: list[str] = []
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            side_effect=RuntimeError("no provider configured"),
+        ):
+            doctor_mod._prompt_caching_section(issues)
+
+        out = capsys.readouterr().out
+        assert "Could not resolve prompt caching status" in out
+        assert issues == []


### PR DESCRIPTION
> **Depends on #100921** (`fix(caching): report prompt-cache status so a disabled cache is not silent`). This branch is stacked on it and reuses the `prompt_cache_status_summary` helper it introduces. Happy to rebase once that lands, or to fold both into one PR if you'd rather review them together.

## What does this PR do?

`hermes doctor` cannot answer "is my prompt cache actually on?".

Whether a route receives `cache_control` breakpoints is decided per request by `anthropic_prompt_cache_policy`, and nothing exposes the verdict. The only signal is the ENABLED banner in `agent_init`, which has no DISABLED counterpart and is suppressed under `quiet_mode` — which the ACP adapter forces on. So the state is unanswerable before a run, and invisible during one.

The route that fails silently is an ordinary one. `_detect_api_mode_for_url` recognises only `api.anthropic.com`, an `/anthropic` path suffix, `api.kimi.com/coding` and the OpenAI/xAI hosts, so a self-hosted Anthropic-compatible relay (`https://gateway.example/v1`) detects as nothing and `_resolve_plain_custom_api_mode` falls back to `chat_completions`. A Claude model on that route resolves to `(False, False)` and the whole prompt is re-billed as uncached input on every API call. `api_mode` has no environment override — it lives only in `config.yaml` — so an operator who never learned the key has nothing to notice and nothing to run.

This adds the thing they can run:

```
◆ Prompt Caching
  ⚠ Prompt caching (DISABLED (api_mode is unset; set model.api_mode:
    anthropic_messages in config.yaml if this endpoint speaks the Anthropic
    Messages protocol))
    → the full prompt is re-billed as uncached input on every API call
```

and on a healthy route:

```
◆ Prompt Caching
  ✓ Prompt caching (ENABLED (Anthropic-compatible endpoint, 5m TTL))
```

**Why this approach**

- **Offline by construction.** It resolves the same destination the agent will use — `resolve_runtime_provider()` plus `model.default` from config — and asks the real policy. No HTTP, so it sits outside the threaded connectivity probes and adds no wall time to that section.
- **Goes through `blank_cache_policy_stub`**, the sanctioned constructor, so an operator `prompt_caching.cache_ttl` disable is honored without doctor re-reading that key itself (#76085).
- **An explicit `cache_ttl` opt-out is reported but not appended to `issues`.** It is a choice, not a fault, and should not read as something to fix.
- **Extracted as `_prompt_caching_section(issues)`** rather than inlined, so it is testable without running all of `run_doctor` — matching the existing `_report_database_journal_modes` shape.
- **A resolver failure degrades to a warning.** doctor must never crash on a route it cannot resolve.

## Related Issue

_No existing issue. `in:title doctor cache` returns 0 results; this is the first proposal for a doctor-side check._

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/doctor.py` — new `_prompt_caching_section(issues)` helper, and one call site between the API Connectivity and Tool Availability sections.
- `tests/hermes_cli/test_doctor_prompt_caching.py` — new, 5 cases.

No change to the policy, the marker layout, or TTL handling. This only reports what was already decided.

## How to Test

1. Configure a `provider: custom` route at an Anthropic-compatible gateway with a Claude model and **no** `api_mode`:
   ```yaml
   model:
     provider: custom
     base_url: https://gateway.example/v1
     default: claude-sonnet-4-5
   ```
2. `hermes doctor` → the new section reports DISABLED, names `model.api_mode`, spells out the consequence, and the line also appears in doctor's issues summary.
3. Add `api_mode: anthropic_messages`, re-run → `✓ Prompt caching (ENABLED (Anthropic-compatible endpoint, 5m TTL))` and no issue.
4. Set `prompt_caching.cache_ttl: off` → reported as DISABLED naming that key, and deliberately **not** listed as an issue.
5. `pytest tests/hermes_cli/test_doctor_prompt_caching.py -q` → 5 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — `in:title doctor cache` returns 0 results; no PR or issue proposes a doctor check for cache state.
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits) — two commits, the first being its stated dependency
- [ ] I've run `pytest tests/ -q` and all tests pass — see the note below
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04, Python 3.12

> **Note on the suite.** Dev extras could not be installed in this environment, so I ran a bare `pytest` without `pytest-asyncio`. What I did run:
> - `tests/hermes_cli/test_doctor_prompt_caching.py` → 5 passed
> - all pre-existing doctor tests (`test_doctor.py`, `test_doctor_command_install.py`, `test_doctor_dedicated_provider_skip.py`, `test_doctor_journal_modes.py`) → 107 passed, 1 failed: `test_doctor_reports_vercel_backend_diagnostics`, which **fails identically on pristine `main`** in this environment and is unrelated to this change.
> - the cache-policy suites plus both new files → 157 passed.
>
> Please let CI run `scripts/run_tests.sh` for the authoritative result.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the new helper carries a full docstring; doctor sections are not individually documented
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, reads existing keys only (`model.default`, `model.api_mode`, `prompt_caching.cache_ttl`)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — config reads and string formatting only; no paths, no subprocesses, no platform branches
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Unhealthy route:

```
◆ Prompt Caching
  ⚠ Prompt caching (DISABLED (api_mode is unset; set model.api_mode: anthropic_messages in config.yaml if this endpoint speaks the Anthropic Messages protocol))
    → the full prompt is re-billed as uncached input on every API call
```

Healthy route:

```
◆ Prompt Caching
  ✓ Prompt caching (ENABLED (Anthropic-compatible endpoint, 5m TTL))
```

Deliberate opt-out (reported, not an issue):

```
◆ Prompt Caching
  ⚠ Prompt caching (DISABLED (prompt_caching.cache_ttl is set to a disable value in config.yaml))
```
