### PR TITLE
fix(agent): add claude-opus-5 to pricing table (#100848)

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -249,6 +249,20 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         source_url="https://platform.claude.com/docs/en/about-claude/pricing",
         pricing_version="anthropic-pricing-2026-06-intro",
     ),
+    # ── Anthropic Claude Opus 5 ──────────────────────────────────────────
+    # Source: https://platform.claude.com/docs/en/about-claude/pricing
+    (
+        "anthropic",
+        "claude-opus-5",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("5.00"),
+        output_cost_per_million=Decimal("25.00"),
+        cache_read_cost_per_million=Decimal("0.50"),
+        cache_write_cost_per_million=Decimal("6.25"),
+        source="official_docs_snapshot",
+        source_url="https://platform.claude.com/docs/en/about-claude/pricing",
+        pricing_version="anthropic-pricing-2026-09",
+    ),
     # ── Anthropic Claude 4.7 ─────────────────────────────────────────────
     # Opus 4.5/4.6/4.7 share $5/$25 pricing (new tokenizer, up to 35% more
     # tokens for the same text).
@@ -738,6 +752,18 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         source="official_docs_snapshot",
         source_url="https://aws.amazon.com/bedrock/pricing/",
         pricing_version="bedrock-pricing-2026-06",
+    ),
+    (
+        "bedrock",
+        "anthropic.claude-opus-5",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("5.00"),
+        output_cost_per_million=Decimal("25.00"),
+        cache_read_cost_per_million=Decimal("0.50"),
+        cache_write_cost_per_million=Decimal("6.25"),
+        source="official_docs_snapshot",
+        source_url="https://aws.amazon.com/bedrock/pricing/",
+        pricing_version="bedrock-pricing-2026-09",
     ),
     (
         "bedrock",


### PR DESCRIPTION
## Problem

`claude-opus-5` has no row in `_OFFICIAL_DOCS_PRICING`, so every usage row is written with `cost_status='unknown'` and `estimated_cost_usd` 0. The `/usage` command, dashboard, and cost aggregation all report $0 for this flagship model.

## Fix

Add pricing entries for `claude-opus-5` in both the direct Anthropic and Bedrock sections:

| | input | output | cache read | cache write (5m) |
|---|---|---|---|---|
| claude-opus-5 | $5.00 | $25.00 | $0.50 | $6.25 |

Source: [Anthropic pricing docs](https://platform.claude.com/docs/en/about-claude/pricing)

## Testing

```python
from agent.usage_pricing import get_pricing_entry as g
assert g("claude-opus-5", provider="anthropic") is not None
assert g("anthropic.claude-opus-5", provider="bedrock") is not None
```

Fixes #100848