### PR TITLE
fix(agent): GLM on Ollama Cloud no longer falsely truncated (#72316, #98406)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4993,12 +4993,13 @@ class APIServerAdapter(BasePlatformAdapter):
                         else ""
                     ),
                 )
+                is_partial = bool(result.get("partial")) if isinstance(result, dict) else False
                 await queue.put(_event_payload("assistant.completed", {
                     "session_id": effective_session_id,
                     "message_id": message_id,
                     "content": final_response,
                     "completed": True,
-                    "partial": False,
+                    "partial": is_partial,
                     "interrupted": False,
                     "runtime": effective_runtime,
                 }))

--- a/run_agent.py
+++ b/run_agent.py
@@ -1885,12 +1885,20 @@ class AIAgent:
         (LiteLLM/sglang/vLLM/LM Studio proxies, Tailscale boxes), which
         report finish_reason correctly and were the source of #13971's
         false-positive truncation continuations.
+
+        Also excludes Ollama Cloud (ollama.com) — the hosted service
+        correctly reports finish_reason and is not affected by the local
+        Ollama stop-reason bug (GH-72316).
         """
         model_lower = (self.model or "").lower()
         provider_lower = (self.provider or "").lower()
         if "glm" not in model_lower and provider_lower != "zai":
             return False
-        if "ollama" in self._base_url_lower or ":11434" in self._base_url_lower:
+        base = self._base_url_lower
+        # Exclude Ollama Cloud (ollama.com) — hosted service, not local Ollama
+        if "ollama.com" in base:
+            return False
+        if "ollama" in base or ":11434" in base:
             return True
         return provider_lower == "ollama"
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -1886,17 +1886,23 @@ class AIAgent:
         report finish_reason correctly and were the source of #13971's
         false-positive truncation continuations.
 
-        Also excludes Ollama Cloud (ollama.com) — the hosted service
-        correctly reports finish_reason and is not affected by the local
-        Ollama stop-reason bug (GH-72316).
+        Also excludes Ollama Cloud — the hosted service correctly reports
+        finish_reason and is not affected by the local Ollama stop-reason
+        bug (GH-72316).  Two signatures identify it: the ``ollama.com`` host
+        (provider ``ollama-cloud``) and the ``:cloud`` model suffix (cloud
+        generation proxied through a local 11434 endpoint, #98406).  Applying
+        the stop→length rewrite to them manufactures false truncations and
+        causes the continuation nudge to consume the model's output budget
+        on the next retry, making further false-positives more likely.
         """
         model_lower = (self.model or "").lower()
         provider_lower = (self.provider or "").lower()
         if "glm" not in model_lower and provider_lower != "zai":
             return False
         base = self._base_url_lower
-        # Exclude Ollama Cloud (ollama.com) — hosted service, not local Ollama
-        if "ollama.com" in base:
+        # Ollama Cloud (hosted service or :cloud proxy) forwards finish_reason
+        # faithfully — do not rewrite.
+        if "ollama.com" in base or ":cloud" in model_lower:
             return False
         if "ollama" in base or ":11434" in base:
             return True

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4340,11 +4340,11 @@ class TestRunConversation:
         assert requested_caps == [65536, 65536]
 
     def test_ollama_glm_stop_after_tools_without_terminal_boundary_requests_continuation(self, agent):
-        """Ollama-hosted GLM responses can misreport truncated output as stop."""
+        """Local Ollama-hosted GLM (no :cloud suffix) misreports truncated output as stop."""
         self._setup_agent(agent)
         agent.base_url = "http://localhost:11434/v1"
         agent._base_url_lower = agent.base_url.lower()
-        agent.model = "glm-5.1:cloud"
+        agent.model = "glm-4-9b"  # local GLM — no :cloud suffix
 
         tool_turn = _mock_response(
             content="",
@@ -4384,11 +4384,18 @@ class TestRunConversation:
         assert third_call_messages[-1]["role"] == "user"
         assert "truncated by the output length limit" in third_call_messages[-1]["content"]
 
-
-
-
-
-
+    @pytest.mark.parametrize("base_url, model", [
+        ("https://ollama.com/v1", "glm-5.3-flash"),      # Ollama Cloud host (#72316)
+        ("http://localhost:11434/v1", "glm-5.1:cloud"),  # :cloud via local proxy (#98406)
+    ])
+    def test_ollama_cloud_glm_stop_is_never_rewritten(self, agent, base_url, model):
+        """Ollama Cloud reports finish_reason faithfully — an unpunctuated stop stays stop."""
+        self._setup_agent(agent)
+        agent.base_url = base_url
+        agent._base_url_lower = base_url.lower()
+        agent.model = model
+        unpunctuated = SimpleNamespace(content="Based on the results the best next step is to update the config", tool_calls=None)
+        assert agent._should_treat_stop_as_truncated("stop", unpunctuated, [{"role": "tool", "content": "r"}]) is False
 
     def test_length_thinking_exhausted_skips_continuation(self, agent):
         """When finish_reason='length' but content is only thinking, skip retries."""


### PR DESCRIPTION
## Summary
GLM models on Ollama Cloud (`ollama.com` host, or `:cloud` model suffix through a local Ollama proxy) no longer get a correct `finish_reason=stop` rewritten to `length`, so the "Response remained truncated after 4 continuation attempts" error and the spurious continuation nudges stop.

Root cause: `_is_ollama_glm_backend()` matched any base URL containing `ollama`, including `https://ollama.com/v1`, so the local-Ollama misreport heuristic fired on a provider that reports finish_reason correctly, burning 4 full generations per turn and surfacing an error on a complete answer.

Fixes #72316, fixes #98406. Salvages #73223 (@JonthanaHanh) and #98415 (@salch-cred); credits #72332 (@kyssta-exe, earliest cloud-exclusion + SSE partial fix) and #98410 (@0xSteveTheHead, whose continuation cap is unnecessary once cloud is exempt).

## Changes
- `run_agent.py`: `_is_ollama_glm_backend()` returns False for `ollama.com` hosts and `:cloud` model ids.
- `gateway/platforms/api_server.py`: SSE `assistant.completed` propagates `result["partial"]` instead of hardcoding `False`.
- `tests/run_agent/test_run_agent.py`: existing local-Ollama test retargeted off `:cloud`; one parametrized test pins both cloud signatures (fails on main, passes here).

## Validation
**Live repro:** real `AIAgent` over HTTP against a scripted Ollama-shaped SSE server (tool turn, then unpunctuated `stop` replies), `provider=ollama-cloud` / `glm-5.3-flash` (the diag config).

| | main | this PR |
|---|---|---|
| ollama-cloud glm-5.3-flash | 5 API calls, 6 nudges, `completed=False`, "Response remained truncated after 4 continuation attempts" | 2 API calls, 0 nudges, `completed=True`, no error |
| local ollama glm-4-9b | heuristic fires (unchanged) | heuristic fires (unchanged) |

Targeted tests: `-k ollama` 6 passed; sabotage (gate removed) → both parametrized cases fail.

## Infographic

![GLM on Ollama Cloud: no more false truncation](https://v3b.fal.media/files/b/0aa8c427/rGWPs8JPrD2ZNBobY7EfW_hiem4QSQ.png)
