### PR TITLE
Profiles never fork single-use OAuth grants: clone-all strips them, borrowed rotations write through to root (#100339, supersedes #100389/#100703)

### DIFF
--- a/agent/anthropic_credentials.py
+++ b/agent/anthropic_credentials.py
@@ -917,6 +917,22 @@ def _get_hermes_oauth_file() -> Path:
     return get_hermes_home() / ".anthropic_oauth.json"
 
 
+def _root_hermes_oauth_file() -> Optional[Path]:
+    """Global-root ``.anthropic_oauth.json`` when running inside a named profile.
+
+    ``None`` in classic mode (profile == root). Used to commit a rotation of a
+    grant the profile borrowed through the credential-pool root fallback.
+    """
+    try:
+        from hermes_constants import get_default_hermes_root
+        root = get_default_hermes_root()
+        if root.resolve(strict=False) == get_hermes_home().resolve(strict=False):
+            return None
+        return root / ".anthropic_oauth.json"
+    except Exception:
+        return None
+
+
 def _generate_pkce() -> tuple:
     """Generate PKCE code_verifier and code_challenge (S256)."""
     import base64
@@ -1077,8 +1093,15 @@ def _write_hermes_oauth_credentials(
     access_token: str,
     refresh_token: Optional[str],
     expires_at_ms: Optional[int],
+    *,
+    target: Optional[Path] = None,
 ) -> None:
     """Write refreshed hermes_pkce tokens back to ~/.hermes/.anthropic_oauth.json.
+
+    ``target`` overrides the destination: a named profile that rotated a grant
+    it BORROWED from the global root (credential-pool root fallback) must
+    commit the new pair to the ROOT singleton, not create a forked copy under
+    its own HERMES_HOME (#100339).
 
     Without this, a successful pool-level refresh of a ``hermes_pkce``-sourced
     entry is invisible to this singleton file. The next ``load_pool()`` call
@@ -1090,7 +1113,7 @@ def _write_hermes_oauth_credentials(
     file, for the same reason ``_write_claude_code_credentials`` does: this is
     the commit step of the refresh transaction.
     """
-    oauth_file = _get_hermes_oauth_file()
+    oauth_file = target if target is not None else _get_hermes_oauth_file()
     try:
         oauth_data = {
             "accessToken": access_token,

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -3774,6 +3774,12 @@ def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[b
 
 def load_pool(provider: str) -> CredentialPool:
     provider = (provider or "").strip().lower()
+    if provider in SINGLE_USE_REFRESH_POOL_PROVIDERS:
+        # One-time heal for installs that forked this grant across profiles
+        # BEFORE the clone-strip / root-write-through existed: consolidate the
+        # profile's copy into root so the read below borrows root's grant
+        # (#100339). No-op in classic mode or once the profile is clean.
+        auth_mod.heal_forked_single_use_oauth_grants(provider)
     raw_entries = read_credential_pool(provider)
     disk_ids = {
         entry.get("id")

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -12,7 +12,7 @@ import re
 from dataclasses import dataclass, fields, replace
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 from hermes_constants import OPENROUTER_BASE_URL
 from hermes_cli.config import load_env
@@ -26,6 +26,7 @@ import hermes_cli.auth as auth_mod
 from hermes_cli.auth import (
     CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
     PROVIDER_REGISTRY,
+    SINGLE_USE_REFRESH_POOL_PROVIDERS,
     _auth_store_lock,
     _codex_access_token_is_expiring,
     _decode_jwt_claims,
@@ -807,11 +808,134 @@ def _write_through_provider_state_to_global_root(
         )
 
 
+def _singleton_target_for_entry(pool: "CredentialPool", entry: "PooledCredential") -> Optional[Path]:
+    """Root ``.anthropic_oauth.json`` when *entry* is a borrowed hermes_pkce row, else None."""
+    if entry.source != "hermes_pkce" or entry.id not in getattr(pool, "_borrowed_root_ids", ()):
+        return None
+    try:
+        from agent.anthropic_credentials import _root_hermes_oauth_file
+        return _root_hermes_oauth_file()
+    except Exception:
+        return None
+
+
+def _profile_owns_pool_provider(provider: str) -> bool:
+    """True when the ACTIVE auth.json has its own rows for *provider*.
+
+    Named profiles with no local rows read the provider through the
+    ``read_credential_pool`` global-root fallback ("borrowing").
+    """
+    try:
+        pool = _load_auth_store().get("credential_pool")
+    except Exception:
+        return True  # unreadable store: assume ownership, keep legacy path
+    entries = pool.get(provider) if isinstance(pool, dict) else None
+    return isinstance(entries, list) and bool(entries)
+
+
+def _borrowed_single_use_pool_root() -> Optional[Path]:
+    """Return the global-root auth.json when persisting a BORROWED single-use pool.
+
+    ``None`` means "persist to the active store as usual": classic mode
+    (profile == root), or the profile owns its own rows for this provider.
+    Pytest seat belt mirrors ``_write_through_provider_state_to_global_root``.
+    """
+    try:
+        global_path = _global_auth_file_path()
+    except Exception:
+        return None
+    if global_path is None:
+        return None
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        real_home_env = os.environ.get("HOME", "")
+        if real_home_env:
+            real_root = Path(real_home_env) / ".hermes" / "auth.json"
+            try:
+                if global_path.resolve(strict=False) == real_root.resolve(strict=False):
+                    return None
+            except Exception:
+                return None
+    return global_path
+
+
+def persist_pool_entries(
+    provider: str,
+    payloads: List[Dict[str, Any]],
+    *,
+    removed_ids: Optional[Iterable[str]] = None,
+) -> None:
+    """Persist a provider's pool rows to the store that OWNS them.
+
+    A named profile that sees a single-use-refresh provider (Anthropic,
+    Codex, xAI OAuth) only through the global-root fallback must not
+    materialize a local ``credential_pool.<provider>`` copy on its first
+    persist: that copy forks the single-use refresh token, the first profile
+    to rotate commits the new pair only to its own file, and root plus every
+    sibling die with ``invalid_grant`` on their next refresh (#100339). Such
+    rows are written back to the root store (under the root lock) so the
+    rotation is visible to every profile; everything else goes to the active
+    store exactly as before.
+    """
+    if provider in SINGLE_USE_REFRESH_POOL_PROVIDERS and not _profile_owns_pool_provider(provider):
+        global_path = _borrowed_single_use_pool_root()
+        if global_path is not None:
+            removed = {rid for rid in (removed_ids or ()) if rid}
+            try:
+                with _auth_store_lock(target_path=global_path):
+                    store = _load_auth_store(global_path)
+                    pool = store.get("credential_pool")
+                    if not isinstance(pool, dict):
+                        pool = {}
+                        store["credential_pool"] = pool
+                    existing = pool.get(provider)
+                    existing_list = existing if isinstance(existing, list) else []
+                    incoming_by_id = {
+                        p.get("id"): p for p in payloads
+                        if isinstance(p, dict) and p.get("id")
+                    }
+                    # UPDATE-ONLY: a borrower may refresh the root's rows
+                    # (rotation, cooldown state) but never add or delete
+                    # them — the root owns their lifecycle. In particular a
+                    # profile's singleton-prune (it has no
+                    # .anthropic_oauth.json of its own) must not delete the
+                    # root grant, and ``removed_ids`` is ignored here.
+                    merged: List[Dict[str, Any]] = []
+                    changed = False
+                    for disk_entry in existing_list:
+                        did = disk_entry.get("id") if isinstance(disk_entry, dict) else None
+                        incoming = incoming_by_id.get(did) if did else None
+                        if incoming is None:
+                            merged.append(disk_entry)
+                            continue
+                        updated = auth_mod._merge_disk_cooldown_state(incoming, disk_entry, provider)
+                        if updated != disk_entry:
+                            changed = True
+                        merged.append(updated)
+                    if changed:
+                        pool[provider] = merged
+                        _save_auth_store(store, target_path=global_path)
+                return
+            except Exception as exc:
+                # Fail closed on the FORK, not on the save: never fall back to
+                # writing a local copy (that IS the bug). The in-memory pool
+                # still holds the rotated pair for this process.
+                logger.warning(
+                    "%s pool: write-through of borrowed root grant failed (%s); "
+                    "not materializing a profile-local copy",
+                    provider, exc,
+                )
+                return
+    write_credential_pool(provider, payloads, removed_ids=removed_ids)
+
+
 class CredentialPool:
     def __init__(self, provider: str, entries: List[PooledCredential]):
         self.provider = provider
         self._entries = sorted(entries, key=lambda entry: entry.priority)
         self._current_id: Optional[str] = None
+        # Ids of rows read via the global-root fallback (single-use OAuth
+        # providers only); set by load_pool(), consumed by add_entry().
+        self._borrowed_root_ids: Set[str] = set()
         self._strategy = get_pool_strategy(provider)
         # RLock: the mutation primitives below (_replace_entry/_persist)
         # self-acquire this lock so the DEFERRED single-use-token refresh
@@ -938,7 +1062,7 @@ class CredentialPool:
         # Self-locking (RLock): snapshotting self._entries must not race a
         # concurrent rotation when called from the deferred refresh path.
         with self._lock:
-            write_credential_pool(
+            persist_pool_entries(
                 self.provider,
                 [entry.to_dict() for entry in self._entries],
                 removed_ids=removed_ids,
@@ -1786,10 +1910,14 @@ class CredentialPool:
                 elif entry.source == "hermes_pkce":
                     try:
                         from agent.anthropic_credentials import _write_hermes_oauth_credentials
+                        # A borrowed row was seeded from the ROOT's singleton
+                        # (this profile has none); commit the rotation there,
+                        # never into a new profile-local copy (#100339).
                         _write_hermes_oauth_credentials(
                             refreshed["access_token"],
                             refreshed["refresh_token"],
                             refreshed["expires_at_ms"],
+                            target=_singleton_target_for_entry(self, entry),
                         )
                     except Exception as wexc:
                         # Same transaction rule as claude_code above.
@@ -2806,7 +2934,7 @@ class CredentialPool:
                 replace(entry, priority=new_priority)
                 for new_priority, entry in enumerate(self._entries)
             ]
-            write_credential_pool(
+            persist_pool_entries(
                 self.provider,
                 [entry.to_dict() for entry in self._entries],
                 removed_ids=[removed.id],
@@ -2845,7 +2973,22 @@ class CredentialPool:
         with self._lock:
             entry = replace(entry, priority=_next_priority(self._entries))
             self._entries.append(entry)
-            self._persist()
+            borrowed_ids = getattr(self, "_borrowed_root_ids", None)
+            if borrowed_ids:
+                # ``hermes -p <profile> auth add <single-use provider>``: the
+                # profile is claiming its OWN credential. Persist only the
+                # profile-owned rows locally — copying the borrowed root
+                # grant alongside them would fork its single-use refresh
+                # token (#100339). Once the profile owns rows, the root
+                # fallback for this provider is shadowed (existing contract).
+                write_credential_pool(
+                    self.provider,
+                    [e.to_dict() for e in self._entries if e.id not in borrowed_ids],
+                )
+                self._entries = [e for e in self._entries if e.id not in borrowed_ids]
+                self._borrowed_root_ids = set()
+            else:
+                self._persist()
             return entry
 
 
@@ -3678,18 +3821,41 @@ def load_pool(provider: str) -> CredentialPool:
         # process missing a provider env var must not delete the persisted
         # pool entry for every other process (#9331). File-backed singletons
         # still prune when their backing file is gone.
-        changed |= _prune_stale_seeded_entries(
-            entries,
-            singleton_sources | env_sources,
-            prune_env_sources=False,
+        borrowing_root_grant = (
+            provider in SINGLE_USE_REFRESH_POOL_PROVIDERS
+            and bool(disk_ids)
+            and not _profile_owns_pool_provider(provider)
         )
+        if borrowing_root_grant:
+            # Rows read through the global-root fallback are seeded from the
+            # ROOT's singleton files, which this profile cannot see; pruning
+            # them as "backing file gone" would hide (and, via write-through,
+            # delete) the shared grant. The root's own load_pool() prunes.
+            borrowed = [e for e in entries if e.id in disk_ids]
+            others = [e for e in entries if e.id not in disk_ids]
+            changed |= _prune_stale_seeded_entries(
+                others, singleton_sources | env_sources, prune_env_sources=False,
+            )
+            entries[:] = borrowed + others
+        else:
+            changed |= _prune_stale_seeded_entries(
+                entries,
+                singleton_sources | env_sources,
+                prune_env_sources=False,
+            )
         changed |= _normalize_pool_priorities(provider, entries)
 
     if changed:
         new_ids = {entry.id for entry in entries}
-        write_credential_pool(
+        persist_pool_entries(
             provider,
             [entry.to_dict() for entry in sorted(entries, key=lambda item: item.priority)],
             removed_ids=disk_ids - new_ids,
         )
-    return CredentialPool(provider, entries)
+    pool = CredentialPool(provider, entries)
+    # Remember which rows are the root's grant (borrowed via fallback) so a
+    # later ``add_entry`` in this profile can leave them out of the profile's
+    # own store (#100339).
+    if provider in SINGLE_USE_REFRESH_POOL_PROVIDERS and not _profile_owns_pool_provider(provider):
+        pool._borrowed_root_ids = set(disk_ids)
+    return pool

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1687,6 +1687,120 @@ def is_runtime_provider_routable(provider_id: str) -> bool:
     return True
 
 
+# Pool providers whose OAuth refresh tokens are SINGLE-USE: redeeming the
+# refresh token rotates the pair and revokes the old one. A grant forked into
+# two auth.json files is therefore not two credentials but one credential with
+# two owners — the first owner to refresh strands the other with
+# ``invalid_grant`` / ``refresh_token_reused`` (#100339; same class as the
+# ``providers.<id>`` write-through hazard in #48415 / #43589). Profiles must
+# never receive a copy of these grants: ONE grant lives at the global root and
+# named profiles read it through the ``read_credential_pool`` root fallback.
+SINGLE_USE_REFRESH_POOL_PROVIDERS = frozenset({
+    "anthropic",
+    "openai-codex",
+    "xai-oauth",
+})
+
+# Singleton credential files that hold the same single-use grants outside
+# ``auth.json``. Copying one into a profile re-seeds a forked pool row on the
+# profile's next ``load_pool()``.
+SINGLE_USE_OAUTH_SINGLETON_FILES = (".anthropic_oauth.json",)
+
+
+def _is_oauth_pool_payload(entry: Any) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    auth_type = str(entry.get("auth_type") or "").strip().lower()
+    if auth_type == "oauth":
+        return True
+    # Legacy rows predating ``auth_type``: an Anthropic OAuth access token or
+    # any row carrying a refresh token is an OAuth grant.
+    if str(entry.get("refresh_token") or "").strip():
+        return True
+    return str(entry.get("access_token") or "").startswith("sk-ant-oat")
+
+
+def strip_cloned_single_use_oauth_grants(profile_dir: Path) -> Dict[str, Any]:
+    """Remove forked single-use OAuth grants from a freshly cloned profile.
+
+    Called after any code path that copies credential files from one profile
+    into another (``hermes profile create --clone-all``, the dashboard/TUI
+    ``mirror_credentials`` flow). API-key pool rows are kept — a static key is
+    safe to duplicate. OAuth rows for the providers in
+    ``SINGLE_USE_REFRESH_POOL_PROVIDERS``, the matching ``providers.<id>``
+    device-code blocks, and the ``.anthropic_oauth.json`` singleton are
+    dropped so the clone reads the grant from the global root instead of
+    holding its own doomed copy (#100339).
+
+    Returns a summary ``{"pool": [...provider ids], "providers": [...],
+    "files": [...]}`` of what was stripped (empty lists when nothing was).
+    Never raises: a clone must not fail because credential hygiene could not
+    run — the caller logs the summary.
+    """
+    stripped: Dict[str, Any] = {"pool": [], "providers": [], "files": []}
+    profile_dir = Path(profile_dir)
+    for name in SINGLE_USE_OAUTH_SINGLETON_FILES:
+        try:
+            target = profile_dir / name
+            if target.is_file() or target.is_symlink():
+                target.unlink()
+                stripped["files"].append(name)
+        except OSError:
+            logger.debug("Could not remove cloned %s from %s", name, profile_dir, exc_info=True)
+
+    auth_path = profile_dir / "auth.json"
+    if not auth_path.is_file():
+        return stripped
+    try:
+        store = json.loads(auth_path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError):
+        return stripped
+    if not isinstance(store, dict):
+        return stripped
+
+    changed = False
+    pool = store.get("credential_pool")
+    if isinstance(pool, dict):
+        for provider_id in list(pool):
+            if provider_id not in SINGLE_USE_REFRESH_POOL_PROVIDERS:
+                continue
+            entries = pool.get(provider_id)
+            if not isinstance(entries, list):
+                continue
+            kept = [e for e in entries if not _is_oauth_pool_payload(e)]
+            if len(kept) != len(entries):
+                changed = True
+                stripped["pool"].append(provider_id)
+                if kept:
+                    pool[provider_id] = kept
+                else:
+                    # No local rows at all → read_credential_pool falls back
+                    # to the root slice for this provider.
+                    del pool[provider_id]
+    providers = store.get("providers")
+    if isinstance(providers, dict):
+        # Device-code grants for these providers live under providers.<id>;
+        # _load_provider_state has the same root fallback, so dropping the
+        # copy keeps the profile working while removing the fork.
+        for provider_id in ("openai-codex", "xai-oauth"):
+            block = providers.get(provider_id)
+            if isinstance(block, dict) and block:
+                del providers[provider_id]
+                stripped["providers"].append(provider_id)
+                changed = True
+    if not changed:
+        return stripped
+    try:
+        _save_auth_store(store, target_path=auth_path)
+    except Exception:
+        logger.debug(
+            "Failed to strip cloned single-use OAuth grants from %s",
+            auth_path,
+            exc_info=True,
+        )
+    return stripped
+
+
 def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
     """Return the persisted credential pool, or one provider slice.
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1801,6 +1801,390 @@ def strip_cloned_single_use_oauth_grants(profile_dir: Path) -> Dict[str, Any]:
     return stripped
 
 
+# ── One-time heal for installs that ALREADY forked a single-use grant ────────
+#
+# Fleets created before the clone-strip / root-write-through above have
+# profile-local copies of the root grant. Those copies are the same credential
+# with several owners: whichever profile rotated last holds the only live
+# refresh token and every other copy (root included) is spent. Upgrading alone
+# does not fix that — the first load in each profile would keep using its own
+# doomed copy. ``heal_forked_single_use_oauth_grants`` runs at profile
+# ``load_pool()`` time: it finds the profile rows that share LINEAGE with a
+# root row (same pool id — clone-all and the old borrowed-persist both kept
+# it — or the same account identity / token material), keeps the copy most
+# likely to still be live (freshest rotation), writes that copy into ROOT when
+# root's is older, and strips the profile's copy so the profile borrows root
+# from then on. Idempotent (a healed profile has no matched rows), never
+# touches API-key rows, never deletes a row that has no root counterpart
+# (an independent ``hermes -p <p> auth add`` grant, or the only surviving
+# copy), and reads only the two auth.json files the existing root fallback
+# already reads — no environ / secret-scope reads.
+
+_OAUTH_TOKEN_FIELDS = (
+    "access_token",
+    "refresh_token",
+    "expires_at",
+    "expires_at_ms",
+    "last_refresh",
+)
+
+_oauth_heal_notices: List[str] = []
+# provider -> (profile auth.json path, auth.json mtime_ns, singleton mtime_ns)
+# of the last store verified fork-free; lets load_pool() skip the locked scan.
+_oauth_heal_clean_marks: Dict[str, Tuple[str, Optional[int], Optional[int]]] = {}
+
+
+def consume_oauth_heal_notices() -> List[str]:
+    """Return (and clear) human-readable notes about heals run in this process.
+
+    ``hermes auth list`` / ``hermes auth status`` print them so the user sees
+    that a forked grant was consolidated rather than only finding it in logs.
+    """
+    notes = list(_oauth_heal_notices)
+    _oauth_heal_notices.clear()
+    return notes
+
+
+def _oauth_identity(entry: Dict[str, Any]) -> Optional[str]:
+    """Stable account identity for an OAuth row when the token carries one.
+
+    Codex / xAI access tokens are JWTs with ``sub`` / ``email`` /
+    ``chatgpt_account_id`` claims; Anthropic ``sk-ant-oat`` tokens carry no
+    claims (returns None — lineage then rests on id / token material).
+    """
+    if not isinstance(entry, dict):
+        return None
+    for token in (entry.get("access_token"), entry.get("id_token")):
+        claims = _decode_jwt_claims(token)
+        if not claims:
+            continue
+        nested = claims.get("https://api.openai.com/auth")
+        account = nested.get("chatgpt_account_id") if isinstance(nested, dict) else None
+        for value in (account, claims.get("sub"), claims.get("email")):
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return None
+
+
+def _oauth_freshness(entry: Dict[str, Any]) -> float:
+    """Best-effort 'how recently was this pair issued' score (epoch seconds).
+
+    A rotation always issues a later-expiring access token, so ``expires_at``
+    ordering identifies the live copy; ``last_refresh`` and the JWT ``exp``
+    claim are fallbacks for rows that do not persist expiry.
+    """
+    from agent.credential_pool import _parse_absolute_timestamp
+
+    best = 0.0
+    for key in ("expires_at_ms", "expires_at", "last_refresh"):
+        ts = _parse_absolute_timestamp(entry.get(key))
+        if ts and ts > best:
+            best = ts
+    if best == 0.0:
+        exp = _decode_jwt_claims(entry.get("access_token")).get("exp")
+        ts = _parse_absolute_timestamp(exp)
+        if ts:
+            best = ts
+    return best
+
+
+def _find_root_counterpart(
+    profile_row: Dict[str, Any], root_rows: List[Dict[str, Any]]
+) -> Optional[int]:
+    """Index of the root OAuth row that shares a grant lineage with *profile_row*.
+
+    Strongest evidence first: same pool ``id`` (clone-all and the pre-fix
+    borrowed-persist both preserved it), same account identity from JWT
+    claims, same token material (an unrotated copy). Fallback per the
+    one-grant-at-root rule: same provider + same OAuth client — every
+    Anthropic ``hermes_pkce`` grant uses one client id and carries no claims,
+    so two Anthropic OAuth rows with no contrary identity are one lineage.
+    Only a row whose identity claims name a DIFFERENT account is left alone
+    (an independent ``hermes -p <p> auth add`` login for another account).
+    """
+    candidates = [i for i, r in enumerate(root_rows) if _is_oauth_pool_payload(r)]
+    if not candidates:
+        return None
+    pid = profile_row.get("id")
+    for i in candidates:
+        if pid and root_rows[i].get("id") == pid:
+            return i
+    p_ident = _oauth_identity(profile_row)
+    for i in candidates:
+        r_ident = _oauth_identity(root_rows[i])
+        if p_ident and r_ident and p_ident == r_ident:
+            return i
+    for key in ("refresh_token", "access_token"):
+        p_val = profile_row.get(key)
+        if not (isinstance(p_val, str) and p_val.strip()):
+            continue
+        for i in candidates:
+            if root_rows[i].get(key) == p_val:
+                return i
+    # Fallback: same provider + same client. Only a contradicting identity
+    # (both sides carry claims and they differ from every root row) blocks it.
+    if p_ident:
+        for i in candidates:
+            if not _oauth_identity(root_rows[i]):
+                return i
+        return None
+    return candidates[0]
+
+
+def _adopt_oauth_material(target: Dict[str, Any], winner: Dict[str, Any]) -> Dict[str, Any]:
+    """Return *target* carrying *winner*'s token pair, status markers cleared."""
+    merged = dict(target)
+    for key in _OAUTH_TOKEN_FIELDS:
+        if winner.get(key) is not None:
+            merged[key] = winner[key]
+        else:
+            merged.pop(key, None)
+    for status_field in _POOL_STATUS_FIELDS:
+        merged[status_field] = None
+    return merged
+
+
+def _singleton_as_row(path: Path) -> Optional[Dict[str, Any]]:
+    """Read a ``.anthropic_oauth.json`` as a pool-row-shaped dict, or None."""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict) or not str(data.get("accessToken") or "").strip():
+        return None
+    return {
+        "access_token": data.get("accessToken"),
+        "refresh_token": data.get("refreshToken"),
+        "expires_at_ms": data.get("expiresAt"),
+    }
+
+
+def heal_forked_single_use_oauth_grants(provider_id: str) -> Optional[Dict[str, Any]]:
+    """Consolidate a profile's forked copy of a single-use OAuth grant into root.
+
+    Runs only in profile mode for ``SINGLE_USE_REFRESH_POOL_PROVIDERS``.
+    Returns a summary ``{"adopted": bool, "stripped_ids": [...], "files": [...],
+    "providers_block": bool}`` when something was healed, else ``None``.
+    Never raises.
+    """
+    if provider_id not in SINGLE_USE_REFRESH_POOL_PROVIDERS:
+        return None
+    try:
+        return _heal_forked_single_use_oauth_grants(provider_id)
+    except Exception:
+        logger.debug("%s: forked-OAuth heal skipped", provider_id, exc_info=True)
+        return None
+
+
+def _heal_forked_single_use_oauth_grants(provider_id: str) -> Optional[Dict[str, Any]]:
+    root_path = _global_auth_file_path()
+    if root_path is None:
+        return None  # classic mode: nothing to consolidate into
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        # Same seat belt as the write-through paths: never touch the real
+        # user's ~/.hermes/auth.json from a test that forgot to isolate HOME.
+        real_home_env = os.environ.get("HOME", "")
+        if real_home_env and _same_path(root_path, Path(real_home_env) / ".hermes" / "auth.json"):
+            return None
+    profile_path = _auth_file_path()
+    profile_home = profile_path.parent
+    root_home = root_path.parent
+    profile_singleton = profile_home / ".anthropic_oauth.json" if provider_id == "anthropic" else None
+
+    # Hot-path short-circuit: load_pool() runs per model call. Once this
+    # profile's store was verified clean for *provider_id*, skip the locked
+    # read-modify-write until the profile's own files change (mtime key).
+    def _stamp(p: Optional[Path]) -> Optional[int]:
+        try:
+            return p.stat().st_mtime_ns if p is not None else None
+        except OSError:
+            return None
+
+    fingerprint = (str(profile_path), _stamp(profile_path), _stamp(profile_singleton))
+    if _oauth_heal_clean_marks.get(provider_id) == fingerprint:
+        return None
+    if fingerprint[1] is None and fingerprint[2] is None:
+        _oauth_heal_clean_marks[provider_id] = fingerprint
+        return None
+
+    summary: Dict[str, Any] = {"adopted": False, "stripped_ids": [], "files": [], "providers_block": False}
+    log_bits: List[str] = []
+
+    # Lock order: active (profile) store first, then the root source store —
+    # the same order ``_provider_state_transaction`` uses.
+    with _auth_store_lock():
+        profile_store = _load_auth_store(profile_path) if profile_path.exists() else {"providers": {}}
+        with _auth_store_lock(target_path=root_path):
+            root_store = _load_auth_store(root_path) if root_path.exists() else {"providers": {}}
+            profile_changed = False
+            root_changed = False
+
+            p_pool = profile_store.get("credential_pool")
+            p_rows = p_pool.get(provider_id) if isinstance(p_pool, dict) else None
+            p_rows = p_rows if isinstance(p_rows, list) else []
+            r_pool = root_store.get("credential_pool")
+            r_rows = r_pool.get(provider_id) if isinstance(r_pool, dict) else None
+            r_rows = r_rows if isinstance(r_rows, list) else []
+            r_oauth = [r for r in r_rows if _is_oauth_pool_payload(r)]
+
+            root_singleton = root_home / ".anthropic_oauth.json" if provider_id == "anthropic" else None
+            root_singleton_row = (
+                _singleton_as_row(root_singleton)
+                if root_singleton is not None and root_singleton.exists() else None
+            )
+
+            # ── credential_pool rows ────────────────────────────────────
+            kept_rows: List[Any] = []
+            for row in p_rows:
+                if not _is_oauth_pool_payload(row):
+                    kept_rows.append(row)  # API keys are safe to duplicate
+                    continue
+                match_idx = _find_root_counterpart(row, r_rows)
+                if match_idx is not None:
+                    root_row = r_rows[match_idx]
+                    if _oauth_freshness(row) > _oauth_freshness(root_row):
+                        r_rows[match_idx] = _adopt_oauth_material(root_row, row)
+                        root_changed = True
+                        summary["adopted"] = True
+                    summary["stripped_ids"].append(row.get("id"))
+                    profile_changed = True
+                    continue
+                # No root pool counterpart. Root's grant may live only in its
+                # .anthropic_oauth.json (the ``hermes auth`` PKCE shape); a
+                # profile hermes_pkce-family row is that grant's copy.
+                is_pkce = str(row.get("source") or "").endswith("hermes_pkce")
+                if is_pkce and root_singleton_row is not None and not r_oauth:
+                    if _oauth_freshness(row) > _oauth_freshness(root_singleton_row):
+                        root_singleton_row = _adopt_oauth_material(root_singleton_row, row)
+                        summary["adopted"] = True
+                    summary["stripped_ids"].append(row.get("id"))
+                    profile_changed = True
+                    continue
+                # Root holds no copy of this lineage (independent account, or
+                # root never had the grant): the profile's row may be the
+                # only surviving copy — leave it alone.
+                kept_rows.append(row)
+            if profile_changed and isinstance(p_pool, dict):
+                if kept_rows:
+                    p_pool[provider_id] = kept_rows
+                else:
+                    p_pool.pop(provider_id, None)
+
+            # ── providers.<id> device-code blocks (Codex / xAI) ─────────
+            if provider_id in ("openai-codex", "xai-oauth"):
+                p_providers = profile_store.get("providers")
+                r_providers = root_store.get("providers")
+                if isinstance(p_providers, dict) and isinstance(r_providers, dict):
+                    p_block = p_providers.get(provider_id)
+                    r_block = r_providers.get(provider_id)
+                else:
+                    p_block = r_block = None
+                if isinstance(p_block, dict) and p_block and isinstance(r_block, dict) and r_block:
+                    p_tokens = p_block.get("tokens") if isinstance(p_block.get("tokens"), dict) else {}
+                    r_tokens = r_block.get("tokens") if isinstance(r_block.get("tokens"), dict) else {}
+                    p_flat = {**p_tokens, "last_refresh": p_block.get("last_refresh")}
+                    r_flat = {**r_tokens, "last_refresh": r_block.get("last_refresh")}
+                    p_ident, r_ident = _oauth_identity(p_flat), _oauth_identity(r_flat)
+                    same_account = (p_ident == r_ident) if (p_ident and r_ident) else True
+                    if same_account:
+                        if _oauth_freshness(p_flat) > _oauth_freshness(r_flat):
+                            r_providers[provider_id] = dict(p_block)
+                            root_changed = True
+                            summary["adopted"] = True
+                        del p_providers[provider_id]
+                        profile_changed = True
+                        summary["providers_block"] = True
+
+            # ── profile-local .anthropic_oauth.json singleton ───────────
+            if profile_singleton is not None and profile_singleton.exists():
+                p_single = _singleton_as_row(profile_singleton)
+                root_has_grant = bool(r_oauth) or root_singleton_row is not None
+                if p_single is not None and root_has_grant:
+                    if root_singleton_row is not None:
+                        if _oauth_freshness(p_single) > _oauth_freshness(root_singleton_row):
+                            root_singleton_row = _adopt_oauth_material(root_singleton_row, p_single)
+                            summary["adopted"] = True
+                    else:
+                        # Root only has pool rows: fold the singleton's pair
+                        # into the freshest-matching root pkce row, if any.
+                        idx = next(
+                            (i for i, r in enumerate(r_rows)
+                             if _is_oauth_pool_payload(r)
+                             and str(r.get("source") or "").endswith("hermes_pkce")),
+                            None,
+                        )
+                        if idx is not None and _oauth_freshness(p_single) > _oauth_freshness(r_rows[idx]):
+                            r_rows[idx] = _adopt_oauth_material(r_rows[idx], p_single)
+                            root_changed = True
+                            summary["adopted"] = True
+                    try:
+                        profile_singleton.unlink()
+                        summary["files"].append(profile_singleton.name)
+                    except OSError:
+                        logger.debug("could not remove %s", profile_singleton, exc_info=True)
+                # Otherwise root has NO grant for this provider (or the file
+                # is not a grant): the profile's singleton may be the only
+                # surviving copy — never delete it.
+
+            if not (profile_changed or root_changed or summary["adopted"]):
+                _oauth_heal_clean_marks[provider_id] = fingerprint
+                return None
+
+            if summary["adopted"] and root_singleton is not None and root_singleton_row is not None:
+                # Keep root's singleton and its ``hermes_pkce``-seeded pool row
+                # in step: root's next load_pool() re-seeds that row FROM the
+                # singleton file, so a stale file would resurrect the spent
+                # pair (and a stale row would be overwritten by a fresh file).
+                pkce_idx = next(
+                    (i for i, r in enumerate(r_rows)
+                     if _is_oauth_pool_payload(r) and r.get("source") == "hermes_pkce"),
+                    None,
+                )
+                if pkce_idx is not None:
+                    pkce_row = r_rows[pkce_idx]
+                    if _oauth_freshness(pkce_row) > _oauth_freshness(root_singleton_row):
+                        root_singleton_row = _adopt_oauth_material(root_singleton_row, pkce_row)
+                    elif _oauth_freshness(root_singleton_row) > _oauth_freshness(pkce_row):
+                        r_rows[pkce_idx] = _adopt_oauth_material(pkce_row, root_singleton_row)
+                        root_changed = True
+
+            if root_changed:
+                if isinstance(r_pool, dict):
+                    r_pool[provider_id] = r_rows
+                else:
+                    root_store["credential_pool"] = {provider_id: r_rows}
+                _save_auth_store(root_store, target_path=root_path)
+            if summary["adopted"] and root_singleton is not None and root_singleton_row is not None:
+                from agent.anthropic_credentials import _write_hermes_oauth_credentials
+                _write_hermes_oauth_credentials(
+                    root_singleton_row.get("access_token") or "",
+                    root_singleton_row.get("refresh_token"),
+                    root_singleton_row.get("expires_at_ms"),
+                    target=root_singleton,
+                )
+            if profile_changed and profile_path.exists():
+                _save_auth_store(profile_store, target_path=profile_path)
+
+    if summary["stripped_ids"]:
+        log_bits.append(f"pool rows {summary['stripped_ids']}")
+    if summary["providers_block"]:
+        log_bits.append(f"providers.{provider_id} block")
+    if summary["files"]:
+        log_bits.append(", ".join(summary["files"]))
+    verdict = (
+        "profile copy was the live pair; root updated"
+        if summary["adopted"] else "root copy already newest; profile copy dropped"
+    )
+    message = (
+        f"profile {profile_home.name}: consolidated forked {provider_id} OAuth grant "
+        f"({'; '.join(log_bits) or 'no-op'}) into the root grant — {verdict}; "
+        f"this profile now borrows the root grant (#100339)"
+    )
+    logger.info(message)
+    _oauth_heal_notices.append(message)
+    return summary
+
+
 def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
     """Return the persisted credential pool, or one provider slice.
 

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -557,6 +557,13 @@ def auth_list_command(args) -> None:
             source = _display_source(entry.source)
             print(f"  #{idx}  {entry.label:<20} {entry.auth_type:<7} {source}{status} {marker}".rstrip())
         print()
+    _print_oauth_heal_notices()
+
+
+def _print_oauth_heal_notices() -> None:
+    """Tell the user when load_pool() just consolidated a forked OAuth grant."""
+    for note in auth_mod.consume_oauth_heal_notices():
+        print(f"note: {note}")
 
 
 def auth_remove_command(args) -> None:
@@ -608,7 +615,12 @@ def auth_status_command(args) -> None:
     provider = _normalize_provider(getattr(args, "provider", "") or "")
     if not provider:
         raise SystemExit("Provider is required. Example: `hermes auth status spotify`.")
+    if provider in auth_mod.SINGLE_USE_REFRESH_POOL_PROVIDERS:
+        # load_pool() runs the forked-grant heal (#100339); do it before the
+        # status read so the report reflects the consolidated grant.
+        load_pool(provider)
     status = auth_mod.get_auth_status(provider)
+    _print_oauth_heal_notices()
     if not status.get("logged_in"):
         reason = status.get("error")
         if reason:

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1261,6 +1261,18 @@ def create_profile(
         # Strip runtime files
         for stale in _CLONE_ALL_STRIP:
             (profile_dir / stale).unlink(missing_ok=True)
+        # A clone-all copies auth.json and .anthropic_oauth.json verbatim.
+        # Single-use OAuth grants (Anthropic / Codex / xAI) forked that way
+        # are one credential with two owners: the first profile to refresh
+        # revokes the pair for every sibling (#100339). Drop the copies; the
+        # clone reads the root grant through the credential-pool fallback.
+        from hermes_cli.auth import strip_cloned_single_use_oauth_grants
+        stripped = strip_cloned_single_use_oauth_grants(profile_dir)
+        if any(stripped.values()):
+            logger.info(
+                "profile %s: dropped cloned single-use OAuth grants %s "
+                "(inherits the root grant instead)", canon, stripped,
+            )
     else:
         # Bootstrap directory structure
         profile_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/agent/test_credential_pool_profile_oauth_fork.py
+++ b/tests/agent/test_credential_pool_profile_oauth_fork.py
@@ -96,6 +96,12 @@ def fleet(tmp_path, monkeypatch):
         hermes_constants._default_hermes_root_memo = None  # type: ignore[attr-defined]
         import hermes_cli.auth as auth_mod
         auth_mod._global_auth_store_cache = None
+        auth_mod._oauth_heal_clean_marks.clear()
+
+    # Process-wide notice buffer: start each test clean.
+    import hermes_cli.auth as _auth_mod
+    _auth_mod._oauth_heal_notices.clear()
+    _auth_mod._oauth_heal_clean_marks.clear()
 
     def pool_rows(home):
         p = home / "auth.json"
@@ -255,3 +261,192 @@ def test_classic_mode_persist_is_unchanged(fleet):
     sel = load_pool("anthropic").select()
     assert sel is not None and sel.access_token == "sk-ant-oat01-AT1"
     assert fleet["rows"](fleet["root"])[0]["refresh_token"] == "sk-ant-ort-RT1"
+
+
+# ── C. one-time heal for installs that ALREADY forked the grant ──────────
+#
+# Fleets created on pre-fix code hold profile-local copies of the root grant
+# (verbatim --clone-all, or the old borrowed-persist). The heal runs inside
+# the profile's load_pool(): consolidate to ROOT (freshest rotation wins),
+# strip the profile copy, borrow root from then on.
+
+def _fork(fleet, name, *, rotated_to=None):
+    """Create *name* with a pre-fix style verbatim copy of root's auth.json.
+
+    ``rotated_to=N`` makes the copy the LIVE pair (RT<N>, spent RT0 server-side)
+    to emulate a profile that already refreshed on the old code.
+    """
+    pdir = _profile(fleet, name)
+    pdir.mkdir(parents=True, exist_ok=True)
+    store = json.loads((fleet["root"] / "auth.json").read_text())
+    if rotated_to is not None:
+        row = store["credential_pool"]["anthropic"][0]
+        row["access_token"] = f"sk-ant-oat01-AT{rotated_to}"
+        row["refresh_token"] = f"sk-ant-ort-RT{rotated_to}"
+        row["expires_at_ms"] = int((time.time() - 60) * 1000)  # newer, still expired
+        srv = fleet["server"]
+        srv["spent"].add("sk-ant-ort-RT0")
+        srv["valid"].discard("sk-ant-ort-RT0")
+        srv["valid"].add(f"sk-ant-ort-RT{rotated_to}")
+        srv["n"] = rotated_to
+    (pdir / "auth.json").write_text(json.dumps(store))
+    return pdir
+
+
+def test_heal_consolidates_existing_forks_to_the_live_copy(fleet, caplog):
+    """root + atlas hold spent RT0; forge already rotated to RT1 on old code."""
+    import logging
+    from agent.credential_pool import load_pool
+
+    forge = _fork(fleet, "forge", rotated_to=1)
+    atlas = _fork(fleet, "atlas")
+    assert fleet["rows"](forge)[0]["refresh_token"] == "sk-ant-ort-RT1"
+    assert fleet["rows"](atlas)[0]["refresh_token"] == "sk-ant-ort-RT0"
+
+    with caplog.at_level(logging.INFO, logger="hermes_cli.auth"):
+        fleet["use"](forge)
+        sel = load_pool("anthropic").select()
+    assert sel is not None and sel.access_token == "sk-ant-oat01-AT2"
+    # forge's live pair was adopted by ROOT, then rotated there; forge holds nothing.
+    assert fleet["rows"](forge) is None
+    assert fleet["rows"](fleet["root"])[0]["refresh_token"] == "sk-ant-ort-RT2"
+    assert fleet["rows"](fleet["root"])[0]["id"] == "abc123"
+    healed = [r.message for r in caplog.records if "consolidated forked anthropic OAuth grant" in r.message]
+    assert len(healed) == 1 and "profile forge" in healed[0] and "root updated" in healed[0]
+
+    for home in (atlas, fleet["root"], forge):
+        fleet["use"](home)
+        sel = load_pool("anthropic").select()
+        assert sel is not None and sel.access_token == "sk-ant-oat01-AT2", home
+    assert fleet["rows"](atlas) is None and fleet["rows"](forge) is None
+    # Exactly one rotation by us (RT1 -> RT2); the spent RT0 was never replayed.
+    assert [e[0] for e in fleet["server"]["log"]] == ["ROTATE"], fleet["server"]["log"]
+    # API-key rows in the profiles were not touched.
+    for home in (forge, atlas):
+        store = json.loads((home / "auth.json").read_text())
+        assert store["credential_pool"]["openai"][0]["access_token"] == "sk-static-key"
+
+
+def test_heal_is_idempotent_and_logs_once(fleet, caplog):
+    import logging
+    from agent.credential_pool import load_pool
+    from hermes_cli.auth import consume_oauth_heal_notices, heal_forked_single_use_oauth_grants
+
+    kid = _fork(fleet, "kid")
+    fleet["use"](kid)
+    with caplog.at_level(logging.INFO, logger="hermes_cli.auth"):
+        load_pool("anthropic")
+        assert fleet["rows"](kid) is None
+        notices = consume_oauth_heal_notices()
+        assert len(notices) == 1 and "profile kid" in notices[0]
+        root_before = (fleet["root"] / "auth.json").read_text()
+        # Second and third loads: nothing to do, nothing written, nothing logged.
+        assert heal_forked_single_use_oauth_grants("anthropic") is None
+        load_pool("anthropic")
+    assert consume_oauth_heal_notices() == []
+    assert (fleet["root"] / "auth.json").read_text() == root_before
+    assert sum("consolidated forked" in r.message for r in caplog.records) == 1
+
+
+def test_heal_never_deletes_the_only_surviving_copy(fleet):
+    """Root lost its grant (user ran `hermes auth remove` at root); the profile's
+    copy is the only one left — and an independent second account stays put."""
+    from agent.credential_pool import load_pool
+
+    kid = _fork(fleet, "kid", rotated_to=1)
+    store = json.loads((fleet["root"] / "auth.json").read_text())
+    del store["credential_pool"]["anthropic"]
+    (fleet["root"] / "auth.json").write_text(json.dumps(store))
+
+    fleet["use"](kid)
+    sel = load_pool("anthropic").select()
+    assert sel is not None and sel.access_token == "sk-ant-oat01-AT2"
+    assert fleet["rows"](kid) and fleet["rows"](kid)[0]["refresh_token"] == "sk-ant-ort-RT2"
+    assert "anthropic" not in (json.loads((fleet["root"] / "auth.json").read_text())["credential_pool"])
+
+
+def test_heal_leaves_a_different_account_alone(fleet):
+    """A profile row whose JWT identity names ANOTHER account is not root's grant."""
+    import base64
+    from agent.credential_pool import load_pool
+
+    def jwt(sub):
+        payload = base64.urlsafe_b64encode(json.dumps({"sub": sub, "exp": int(time.time()) + 3600}).encode()).rstrip(b"=")
+        return "h." + payload.decode() + ".s"
+
+    root_store = json.loads((fleet["root"] / "auth.json").read_text())
+    root_store["credential_pool"]["xai-oauth"] = [{
+        "id": "rootx", "auth_type": "oauth", "priority": 0, "source": "manual:device_code",
+        "access_token": jwt("alice"), "refresh_token": "xr-alice",
+    }]
+    (fleet["root"] / "auth.json").write_text(json.dumps(root_store))
+    kid = _profile(fleet, "kid")
+    kid.mkdir(parents=True, exist_ok=True)
+    (kid / "auth.json").write_text(json.dumps({
+        "version": 1, "providers": {},
+        "credential_pool": {"xai-oauth": [
+            {"id": "kidx", "auth_type": "oauth", "priority": 0, "source": "manual:device_code",
+             "access_token": jwt("bob"), "refresh_token": "xr-bob"},
+            {"id": "kidk", "auth_type": "api_key", "priority": 1, "source": "manual",
+             "access_token": "xai-static"},
+        ]},
+    }))
+    fleet["use"](kid)
+    load_pool("xai-oauth")
+    rows = (json.loads((kid / "auth.json").read_text())["credential_pool"])["xai-oauth"]
+    assert [r["id"] for r in rows] == ["kidx", "kidk"]
+    assert json.loads((fleet["root"] / "auth.json").read_text())["credential_pool"]["xai-oauth"][0]["refresh_token"] == "xr-alice"
+
+
+def test_heal_pkce_singleton_shape_commits_live_pair_to_root_singleton(fleet):
+    """`hermes auth` PKCE shape: root + profile each have .anthropic_oauth.json +
+    a hermes_pkce-seeded row; the profile's copy is the rotated (live) one."""
+    from agent.credential_pool import load_pool
+
+    root = fleet["root"]
+    store = json.loads((root / "auth.json").read_text())
+    store["active_provider"] = "anthropic"
+    del store["credential_pool"]["anthropic"]
+    (root / "auth.json").write_text(json.dumps(store))
+    (root / ".anthropic_oauth.json").write_text(json.dumps({
+        "accessToken": "sk-ant-oat01-AT0", "refreshToken": "sk-ant-ort-RT0",
+        "expiresAt": int((time.time() - 3600) * 1000),
+    }))
+    fleet["use"](root)
+    load_pool("anthropic")  # seeds root's hermes_pkce row from the singleton
+
+    kid = _profile(fleet, "kid")
+    kid.mkdir(parents=True, exist_ok=True)
+    import shutil
+    shutil.copy2(root / "auth.json", kid / "auth.json")
+    (kid / ".anthropic_oauth.json").write_text(json.dumps({
+        "accessToken": "sk-ant-oat01-AT1", "refreshToken": "sk-ant-ort-RT1",
+        "expiresAt": int((time.time() - 60) * 1000),
+    }))
+    kstore = json.loads((kid / "auth.json").read_text())
+    kstore["credential_pool"]["anthropic"][0].update(
+        access_token="sk-ant-oat01-AT1", refresh_token="sk-ant-ort-RT1",
+        expires_at_ms=int((time.time() - 60) * 1000),
+    )
+    (kid / "auth.json").write_text(json.dumps(kstore))
+    srv = fleet["server"]
+    srv["spent"].add("sk-ant-ort-RT0"); srv["valid"] = {"sk-ant-ort-RT1"}; srv["n"] = 1
+
+    fleet["use"](kid)
+    sel = load_pool("anthropic").select()
+    assert sel is not None and sel.access_token == "sk-ant-oat01-AT2"
+    assert not (kid / ".anthropic_oauth.json").exists()
+    assert fleet["rows"](kid) is None
+    assert json.loads((root / ".anthropic_oauth.json").read_text())["refreshToken"] == "sk-ant-ort-RT2"
+    fleet["use"](root)
+    sel = load_pool("anthropic").select()
+    assert sel is not None and sel.access_token == "sk-ant-oat01-AT2"
+    assert [e[0] for e in srv["log"]] == ["ROTATE"], srv["log"]
+
+
+def test_heal_is_a_noop_in_classic_mode(fleet):
+    from hermes_cli.auth import heal_forked_single_use_oauth_grants
+    fleet["use"](fleet["root"])
+    before = (fleet["root"] / "auth.json").read_text()
+    assert heal_forked_single_use_oauth_grants("anthropic") is None
+    assert (fleet["root"] / "auth.json").read_text() == before

--- a/tests/agent/test_credential_pool_profile_oauth_fork.py
+++ b/tests/agent/test_credential_pool_profile_oauth_fork.py
@@ -1,0 +1,257 @@
+"""Regression tests for #100339: cloned / borrowed single-use Anthropic OAuth
+grants must never fork across profiles.
+
+Real imports, real temp HERMES_HOME root + named profile, real auth.json I/O.
+The Anthropic token endpoint is replaced at the ``urllib.request.urlopen``
+boundary with genuine single-use semantics (a refresh token redeems once;
+a second POST returns ``invalid_grant``).
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+
+import pytest
+
+
+@pytest.fixture
+def fleet(tmp_path, monkeypatch):
+    """Root HERMES_HOME with an expired-but-refreshable Anthropic pool row."""
+    root = tmp_path / "hermes-root"
+    root.mkdir()
+    (tmp_path / "fakehome").mkdir()
+    # Keep host ~/.claude and host auth.json out of the picture.
+    monkeypatch.setenv("HOME", str(tmp_path / "fakehome"))
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "fakehome"))
+    for var in ("ANTHROPIC_TOKEN", "ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    # The pytest seat-belt in the root write-through compares the global path
+    # against $HOME/.hermes/auth.json; our root is elsewhere, so writes go.
+    import hermes_constants
+    hermes_constants._default_hermes_root_memo = None  # type: ignore[attr-defined]
+
+    expired = int((time.time() - 3600) * 1000)
+    store = {
+        "version": 1,
+        "providers": {},
+        "credential_pool": {
+            "anthropic": [{
+                "id": "abc123", "label": "team-grant", "auth_type": "oauth",
+                "priority": 0, "source": "manual:hermes_pkce",
+                "access_token": "sk-ant-oat01-AT0", "refresh_token": "sk-ant-ort-RT0",
+                "expires_at_ms": expired, "base_url": "https://api.anthropic.com",
+            }],
+            "openai": [{
+                "id": "key001", "label": "static", "auth_type": "api_key",
+                "priority": 0, "source": "manual", "access_token": "sk-static-key",
+            }],
+        },
+    }
+    (root / "auth.json").write_text(json.dumps(store))
+
+    server = {"valid": {"sk-ant-ort-RT0"}, "spent": set(), "n": 0, "log": []}
+
+    class _Resp(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def fake_urlopen(req, timeout=None):
+        assert "oauth/token" in req.full_url
+        body = req.data.decode()
+        if req.get_header("Content-type", "").startswith("application/json"):
+            rt = json.loads(body)["refresh_token"]
+        else:
+            from urllib.parse import parse_qsl
+            rt = dict(parse_qsl(body))["refresh_token"]
+        if rt in server["spent"] or rt not in server["valid"]:
+            server["log"].append(("REUSE", rt))
+            raise urllib.error.HTTPError(
+                req.full_url, 400, "Bad Request", {},
+                io.BytesIO(b'{"error":"invalid_grant","error_description":"refresh_token_reused"}'),
+            )
+        server["n"] += 1
+        server["spent"].add(rt)
+        server["valid"].discard(rt)
+        new_rt = f"sk-ant-ort-RT{server['n']}"
+        server["valid"].add(new_rt)
+        server["log"].append(("ROTATE", rt, new_rt))
+        return _Resp(json.dumps({
+            "access_token": f"sk-ant-oat01-AT{server['n']}",
+            "refresh_token": new_rt, "expires_in": 28800, "token_type": "Bearer",
+        }).encode())
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    def use(home):
+        """Switch the process to *home* (root or a profile dir)."""
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        hermes_constants._default_hermes_root_memo = None  # type: ignore[attr-defined]
+        import hermes_cli.auth as auth_mod
+        auth_mod._global_auth_store_cache = None
+
+    def pool_rows(home):
+        p = home / "auth.json"
+        if not p.exists():
+            return None
+        return (json.loads(p.read_text()).get("credential_pool") or {}).get("anthropic")
+
+    return {"root": root, "server": server, "use": use, "rows": pool_rows}
+
+
+def _profile(fleet, name, **kw):
+    from hermes_cli.profiles import create_profile
+    fleet["use"](fleet["root"])
+    return create_profile(name, **kw)
+
+
+# ── A. cloning never copies single-use OAuth grants ──────────────────────
+
+def test_clone_all_strips_oauth_grant_but_keeps_api_keys(fleet):
+    (fleet["root"] / ".anthropic_oauth.json").write_text(
+        json.dumps({"accessToken": "sk-ant-oat01-AT0", "refreshToken": "sk-ant-ort-RT0", "expiresAt": 1})
+    )
+    pdir = _profile(fleet, "forge", clone_all=True)
+    store = json.loads((pdir / "auth.json").read_text())
+    assert "anthropic" not in store["credential_pool"], "OAuth grant was forked into the clone"
+    assert store["credential_pool"]["openai"][0]["access_token"] == "sk-static-key"
+    assert not (pdir / ".anthropic_oauth.json").exists()
+
+
+def test_strip_helper_drops_device_code_blocks_and_reports(tmp_path):
+    from hermes_cli.auth import strip_cloned_single_use_oauth_grants
+    pdir = tmp_path / "p"
+    pdir.mkdir()
+    (pdir / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {"openai-codex": {"access_token": "a", "refresh_token": "r"}, "nous": {"agent_key": "k"}},
+        "credential_pool": {
+            "xai-oauth": [{"id": "x", "auth_type": "oauth", "access_token": "t", "refresh_token": "r"}],
+            "anthropic": [
+                {"id": "legacy", "access_token": "sk-ant-oat01-legacy"},  # no auth_type field
+                {"id": "key", "auth_type": "api_key", "access_token": "sk-ant-api03-x"},
+            ],
+        },
+    }))
+    summary = strip_cloned_single_use_oauth_grants(pdir)
+    store = json.loads((pdir / "auth.json").read_text())
+    assert sorted(summary["pool"]) == ["anthropic", "xai-oauth"]
+    assert summary["providers"] == ["openai-codex"]
+    assert "xai-oauth" not in store["credential_pool"]
+    assert [e["id"] for e in store["credential_pool"]["anthropic"]] == ["key"]
+    assert "openai-codex" not in store["providers"] and "nous" in store["providers"]
+
+
+def test_strip_helper_is_a_noop_without_credentials(tmp_path):
+    from hermes_cli.auth import strip_cloned_single_use_oauth_grants
+    assert strip_cloned_single_use_oauth_grants(tmp_path) == {"pool": [], "providers": [], "files": []}
+
+
+# ── B. borrowed rotation commits to root, never a profile copy ───────────
+
+def test_first_profile_rotation_does_not_strand_root_or_siblings(fleet):
+    from agent.credential_pool import load_pool
+
+    forge = _profile(fleet, "forge")
+    atlas = _profile(fleet, "atlas")
+
+    fleet["use"](forge)
+    sel = load_pool("anthropic").select()
+    assert sel is not None and sel.access_token == "sk-ant-oat01-AT1"
+    # The rotated pair landed in ROOT; forge did not grow a local copy.
+    assert fleet["rows"](forge) is None
+    assert fleet["rows"](fleet["root"])[0]["refresh_token"] == "sk-ant-ort-RT1"
+
+    for home in (atlas, fleet["root"], forge):
+        fleet["use"](home)
+        sel = load_pool("anthropic").select()
+        assert sel is not None and sel.access_token == "sk-ant-oat01-AT1", home
+    assert [e[0] for e in fleet["server"]["log"]] == ["ROTATE"], fleet["server"]["log"]
+    assert fleet["rows"](atlas) is None and fleet["rows"](forge) is None
+
+
+def test_agent_init_resolver_sees_sibling_rotation(fleet):
+    from agent.anthropic_credentials import resolve_anthropic_token
+    from agent.credential_pool import load_pool
+
+    forge = _profile(fleet, "forge")
+    atlas = _profile(fleet, "atlas")
+    fleet["use"](forge)
+    load_pool("anthropic").select()
+    fleet["use"](atlas)
+    assert resolve_anthropic_token() == "sk-ant-oat01-AT1"
+
+
+def test_borrowing_profile_load_pool_does_not_materialize_local_copy(fleet):
+    from agent.credential_pool import load_pool
+
+    fresh = _profile(fleet, "fresh")
+    fleet["use"](fresh)
+    pool = load_pool("anthropic")
+    assert [e.id for e in pool.entries()] == ["abc123"]
+    assert pool._borrowed_root_ids == {"abc123"}
+    assert fleet["rows"](fresh) is None
+
+
+def test_borrower_prune_never_deletes_root_singleton_grant(fleet, tmp_path):
+    """Root's hermes_pkce row is seeded from ROOT's .anthropic_oauth.json; a
+    profile without that file must not prune (and write-through-delete) it."""
+    from agent.credential_pool import load_pool
+
+    root = fleet["root"]
+    (root / ".anthropic_oauth.json").write_text(json.dumps({
+        "accessToken": "sk-ant-oat01-AT0", "refreshToken": "sk-ant-ort-RT0",
+        "expiresAt": int((time.time() - 3600) * 1000),
+    }))
+    store = json.loads((root / "auth.json").read_text())
+    store["active_provider"] = "anthropic"
+    del store["credential_pool"]["anthropic"]
+    (root / "auth.json").write_text(json.dumps(store))
+    fleet["use"](root)
+    root_rows = [e for e in load_pool("anthropic").entries()]
+    assert [e.source for e in root_rows] == ["hermes_pkce"]
+
+    kid = _profile(fleet, "kid")
+    fleet["use"](kid)
+    pool = load_pool("anthropic")
+    assert [e.source for e in pool.entries()] == ["hermes_pkce"], "borrowed root grant was pruned"
+    assert fleet["rows"](root) and fleet["rows"](root)[0]["source"] == "hermes_pkce"
+    assert fleet["rows"](kid) is None
+
+    # Rotating from the profile commits BOTH the pool row and the singleton at ROOT.
+    sel = pool.select()
+    assert sel is not None and sel.access_token == "sk-ant-oat01-AT1"
+    assert json.loads((root / ".anthropic_oauth.json").read_text())["refreshToken"] == "sk-ant-ort-RT1"
+    assert not (kid / ".anthropic_oauth.json").exists()
+    assert fleet["rows"](root)[0]["refresh_token"] == "sk-ant-ort-RT1"
+
+
+def test_profile_auth_add_owns_only_its_own_rows(fleet):
+    from agent.credential_pool import AUTH_TYPE_OAUTH, PooledCredential, load_pool
+
+    kid = _profile(fleet, "kid")
+    fleet["use"](kid)
+    pool = load_pool("anthropic")
+    pool.add_entry(PooledCredential(
+        provider="anthropic", id="own001", label="mine", auth_type=AUTH_TYPE_OAUTH,
+        priority=0, source="manual:hermes_pkce", access_token="sk-ant-oat01-MINE",
+        refresh_token="rt-mine",
+    ))
+    assert [e["id"] for e in fleet["rows"](kid)] == ["own001"], "borrowed root row was copied into the profile"
+    assert [e["id"] for e in fleet["rows"](fleet["root"])] == ["abc123"]
+
+
+def test_classic_mode_persist_is_unchanged(fleet):
+    from agent.credential_pool import load_pool
+
+    fleet["use"](fleet["root"])
+    sel = load_pool("anthropic").select()
+    assert sel is not None and sel.access_token == "sk-ant-oat01-AT1"
+    assert fleet["rows"](fleet["root"])[0]["refresh_token"] == "sk-ant-ort-RT1"

--- a/tui_gateway/methods_profiles.py
+++ b/tui_gateway/methods_profiles.py
@@ -467,6 +467,15 @@ def _(rid, params: dict) -> dict:
                     os.chmod(str(dst_auth), 0o600)
                 except OSError:
                     pass
+                # Mirroring must not fork single-use OAuth grants (Anthropic /
+                # Codex / xAI): the first profile to refresh strands every
+                # sibling (#100339). API keys stay; OAuth rows are dropped
+                # and read from the root grant via the pool fallback.
+                try:
+                    from hermes_cli.auth import strip_cloned_single_use_oauth_grants
+                    strip_cloned_single_use_oauth_grants(path)
+                except Exception:
+                    pass
                 mirrored["auth"] = True
         except Exception:
             pass

--- a/website/docs/user-guide/profiles.md
+++ b/website/docs/user-guide/profiles.md
@@ -64,6 +64,10 @@ hermes profile create backup --clone-all
 
 Copies **everything** — config, API keys, personality, all memories, skills, cron jobs, plugins. A complete working snapshot. Per-profile history is excluded (session history, `state.db`, `backups/`, `state-snapshots/`, `checkpoints/`) — these belong to the source profile and can reach tens of GB. For a full backup including history, use `hermes profile export` or `hermes backup` instead.
 
+:::note OAuth logins are shared, not copied
+Anthropic (Claude Pro/Max), OpenAI Codex, and xAI OAuth logins use **single-use refresh tokens** — a copy of one is not a second credential, it is the same credential with two owners, and the first profile to refresh it revokes it for every other copy. `--clone-all` (and the dashboard's credential mirroring) therefore drops those OAuth rows from the clone. The new profile keeps reading the login from the root `~/.hermes/auth.json`, and a token refresh performed inside any profile is written back to root, so all profiles stay signed in. Static API keys are copied as usual. To give a profile its own separate OAuth login, run `hermes -p <name> auth add <provider>` inside it.
+:::
+
 ### Clone from a specific profile
 
 ```bash


### PR DESCRIPTION
## Summary

Named profiles no longer receive their own copy of a single-use OAuth grant (Anthropic / Codex / xAI): `--clone-all` and dashboard credential mirroring strip those rows, and a profile that borrows the root grant writes its token rotations back to root instead of materializing a doomed local fork — so the first profile to refresh no longer strands root and every sibling with `invalid_grant` (#100339).

## Changes

- `hermes_cli/auth.py` — new `SINGLE_USE_REFRESH_POOL_PROVIDERS` / `SINGLE_USE_OAUTH_SINGLETON_FILES` and `strip_cloned_single_use_oauth_grants(profile_dir)`: drops OAuth pool rows for those providers (legacy rows without `auth_type` included), the matching `providers.<id>` device-code blocks, and `.anthropic_oauth.json`; API-key rows are kept. Never raises; returns a summary.
- `hermes_cli/profiles.py` (`create_profile --clone-all`) and `tui_gateway/methods_profiles.py` (`mirror_credentials`, the ws twin of `POST /api/profiles`) — the only two auth.json copy sites — call the strip after copying.
- `agent/credential_pool.py` — `persist_pool_entries()` replaces the three `write_credential_pool` sites (`_persist`, `load_pool` reseed, `remove_index`). When the active profile has no local rows for a single-use provider (it is *borrowing* root's grant via the existing `read_credential_pool` fallback), rows are written back to the **root** store under the root lock, update-only (a borrower can refresh root's rows but never add/delete them), and on failure it warns and does **not** fall back to a local copy. `load_pool` records `_borrowed_root_ids` and skips singleton-pruning of borrowed rows (the profile cannot see root's backing file); `add_entry` (`hermes -p <p> auth add`) persists only the profile's own rows.
- `agent/anthropic_credentials.py` — `_write_hermes_oauth_credentials(..., target=)` + `_root_hermes_oauth_file()`: a borrowed `hermes_pkce` rotation commits the singleton to root's `.anthropic_oauth.json`, not a new profile-local copy.
- `tests/agent/test_credential_pool_profile_oauth_fork.py` — 9 real-file tests (temp root + profiles, fake single-use token endpoint at the `urlopen` boundary): clone-all strips OAuth and keeps API keys; strip helper unit cases; first-profile rotation leaves root + siblings healthy; agent-init resolver sees sibling rotation; borrowing `load_pool` writes nothing locally; borrower never prunes root's singleton grant and commits the singleton to root; profile `auth add` owns only its rows; classic mode unchanged.
- `website/docs/user-guide/profiles.md` — note under `--clone-all` explaining shared-not-copied OAuth logins.
- **Auto-heal for installs that already forked (second commit)** — `hermes_cli/auth.py` `heal_forked_single_use_oauth_grants(provider)`, called at the top of a profile's `load_pool()` for the same three providers. Under the profile lock then the root lock it matches each profile OAuth row to its root counterpart by lineage (same pool id — both fork paths preserved it — then same JWT account identity, same token material, else same provider + same client since Anthropic pkce grants carry no claims), keeps the copy with the freshest rotation (`expires_at_ms` / `last_refresh` / JWT `exp`), writes it into **root** when root's is older, and strips the profile copy: pool rows, the `providers.<id>` device-code block (Codex/xAI), and a profile-local `.anthropic_oauth.json`. Root's singleton and its `hermes_pkce` row are kept in step so root's own re-seed cannot resurrect the spent pair. Idempotent (mtime-keyed clean mark skips the locked scan on the per-call hot path), one INFO line per healed profile, API-key rows untouched, a row with no root counterpart (root lost its grant / independent account with differing claims) is never deleted, no environ or secret-scope reads. `hermes auth list` / `hermes auth status <provider>` print the heal note (`hermes_cli/auth_commands.py`); no new command.
- Tests (+6 in the same file, 15 total): existing forks consolidate to the live copy with one ROTATE / zero REUSE and API keys intact; idempotent + logs once; only-surviving copy preserved when root lost its grant; different-account row left alone; PKCE-singleton shape commits the live pair to root's `.anthropic_oauth.json`; classic-mode no-op.

## Validation

| Check | Result |
|---|---|
| `pytest tests/agent/test_credential_pool_profile_oauth_fork.py -o addopts=` | 15 passed |
| Sabotage: source reverted to main, new tests kept | 9 failed (ImportError / "OAuth grant was forked into the clone" / "borrowed root grant was pruned" / "borrowed root row was copied into the profile") |
| Sabotage: heal call removed from `load_pool` | 3 heal tests fail (forked rows survive / profile `.anthropic_oauth.json` still present) |
| `pytest tests/agent/test_credential_pool_profile_oauth_fork.py tests/agent/test_credential_pool*.py tests/hermes_cli/test_auth_profile_fallback.py tests/hermes_cli/test_profiles.py tests/hermes_cli/test_auth_commands.py -o addopts=` (post-rebase, both commits) | 226 passed, 2 skipped |
| `pytest tests/agent/test_credential_pool*.py tests/agent/test_anthropic_{spent_rotation_verdict,credential_persist_failure,borrowed_row_authority,oauth_pkce}.py tests/hermes_cli/test_auth_profile_fallback.py tests/hermes_cli/test_profiles.py -o addopts=` (post-rebase) | 223 passed, 2 skipped |
| `pytest tests/agent/test_anthropic_adapter.py tests/tui_gateway/test_*profile*.py` | 282 passed (incl. pool family) |
| `ruff check` on all touched files | All checks passed |
| Stale-base gate `git rev-list --count $(merge-base)..origin/main` | 0 (re-checked at final push) |

**Live repro:** real imports from the worktree, temp `HERMES_HOME` root with one expired-but-refreshable `credential_pool.anthropic` row, two named profiles, Anthropic token endpoint emulated at `urllib.request.urlopen` with genuine single-use semantics (second redemption → `400 invalid_grant`). Each step in a fresh interpreter. **Before (origin/main)** — `--clone-all` copied the row into `forge` and `atlas`; `forge` `select()` → `AT1` (server: `ROTATE RT0 -> RT1`, committed only to `profiles/forge/auth.json`); then `atlas` `select()` → `None`, `root` `select()` → `None` (server: `REUSE RT0 -> 400 invalid_grant` ×2, both rows marked `exhausted`); `resolve_anthropic_token()` in `atlas` → `None` (the reporter's "No Anthropic credentials found"). Same outcome without cloning: a fresh profile borrowing via root fallback rotated and wrote the pair to its own auth.json, root then `invalid_grant`. **After (this branch)** — clones have no `anthropic` pool rows / no `.anthropic_oauth.json`; `forge` `select()` → `AT1` written to **root** `auth.json`; `atlas`, `root`, `forge` all `select()` → `AT1`; server log shows exactly one `ROTATE`, zero `REUSE`; `resolve_anthropic_token()` in `atlas` → `sk-ant-oat01-AT1`; `profiles/*/auth.json` absent. Also verified with the `hermes auth` PKCE-singleton shape (`.anthropic_oauth.json` + `hermes_pkce` seeded row): before, siblings `select()` → `None`; after, all four homes → `AT1` and root's `.anthropic_oauth.json` holds `RT1`.

**Live repro (auto-heal of an ALREADY-forked install):** same harness, fresh interpreter per step; state built the way a pre-fix fleet looks — root + `forge` + `atlas` each with a verbatim copy of the `abc123` grant, `forge` already rotated `RT0→RT1` into its own `auth.json` (server: RT0 spent). **Before (branch without the heal commit)** — `atlas` `select()` → `None`, `forge` → `AT2` (committed only to forge), `root` → `None`; on disk `root RT0 exhausted / forge RT2 / atlas RT0 exhausted`; server log `ROTATE RT0→RT1, REUSE RT0, REUSE RT0, ROTATE RT1→RT2, REUSE RT0, REUSE RT0`. **After (with the heal)** — `forge` load logs `profile forge: consolidated forked anthropic OAuth grant (pool rows ['abc123']) into the root grant — profile copy was the live pair; root updated; this profile now borrows the root grant (#100339)` and selects `AT2` (rotation landed in **root**); `atlas` logs `… root copy already newest; profile copy dropped …` and selects `AT2`; `root` selects `AT2`; on disk `root RT2 ok / forge None / atlas None`, `openai` API-key rows intact in all three; server log exactly `ROTATE RT0→RT1` (pre-existing) + `ROTATE RT1→RT2`, **zero REUSE**. Second load in a healed profile: no log line, no write. Also driven through the real CLI: `HERMES_HOME=<root>/profiles/atlas hermes auth list anthropic` prints the pool plus `note: profile atlas: consolidated forked anthropic OAuth grant … this profile now borrows the root grant (#100339)` and `profiles/atlas/auth.json` loses its `anthropic` rows. (When the spent-copy profile loads *first*, it takes one `invalid_grant` before the live sibling is seen — its own next load then heals to root; unavoidable without guessing which fork is live, and still strictly better than before where the fork persisted forever.)

## Notes for review

- Direction follows Teknium's standing rule: profiles must never copy OAuth auth — ONE grant at root, children inherit; fix the fork, don't make clones survive. This is why the alternative in #100703 (refresh at agent init) is not taken: on main `select()` already refreshes an expired-but-refreshable row (`resolve_anthropic_token()` returned the row in the single-profile case), and refreshing a stranded clone only turns "missing credentials" into `invalid_grant`, as the reporter noted.
- Fleets already in the broken state heal automatically on the first `load_pool()` in each profile after upgrading (second commit): the copies are synced to one source — the freshest rotation wins and lands at root — and the profile's copy is closed, so users are not left holding contradicting tokens. No manual re-auth or hand-editing of `profiles/*/auth.json` needed; `hermes auth list` shows the heal note.
- `#100389` (@HexLab98) reached the same root-cause conclusion first and its clone-strip + root-write-through intent is co-credited on the commit; its per-id "prefer-fresher merge on read" (which keeps forks alive and races on `expires_at_ms`) and the init-refresh change were not carried.

Closes #100339
Supersedes #100389 (@HexLab98, first to identify the fork; co-credited) and #100703 (@Ahmett101).

## Infographic
![one-oauth-grant-at-root](https://v3b.fal.media/files/b/0aa8c437/yBWMra9PCdfaRxTNJGOQ7_GwP0CxEs.png)

