### PR TITLE
fix(desktop): approvals on single-connection installs route through the event's exact owner (#96394, salvage #97519)

### DIFF
--- a/apps/desktop/src/store/session-states-runtime-map.test.ts
+++ b/apps/desktop/src/store/session-states-runtime-map.test.ts
@@ -7,8 +7,10 @@ import { isSessionOwnerResolutionError } from '@/store/session-owner-resolution'
 import {
   $sessionTiles,
   clearAllSessionStates,
+  dropSessionState,
   knownOwnerForSession,
   publishSessionState,
+  recordSessionEventScope,
   requestForOwnedSession,
   storedSessionIdForRuntimeId
 } from '@/store/session-states'
@@ -125,5 +127,45 @@ describe('knownOwnerForSession / requestForOwnedSession', () => {
       requestForOwnedSession('rt-orphan', ambient as never, 'approval.respond', { session_id: 'rt-orphan' })
     ).resolves.toEqual({ ok: true })
     expect(ambient).toHaveBeenCalledWith('approval.respond', { session_id: 'rt-orphan' })
+  })
+
+  it('routes a connection-tagged orphan runtime through the owner its inbound event recorded (#97511)', () => {
+    // Registry topology, multiple profiles, no tile/hint/row binding for the
+    // runtime — the approval.request event itself proved the exact owner.
+    $profiles.set([{ name: 'default' }, { name: 'omar' }] as never)
+    recordSessionEventScope({ connectionId: 'homelab', profile: 'omar', session_id: 'rt-unbound' })
+
+    expect(knownOwnerForSession('rt-unbound')).toEqual({ connectionId: 'homelab', profile: 'omar' })
+
+    // An event without a profile tag still records the 'default' convention
+    // every other owner source uses.
+    recordSessionEventScope({ connectionId: 'homelab', session_id: 'rt-unprofiled' })
+    expect(knownOwnerForSession('rt-unprofiled')).toEqual({ connectionId: 'homelab', profile: 'default' })
+  })
+
+  it('still prefers the durable stored owner when a stale runtime ledger entry collides with a stored id (#97511)', () => {
+    // Pathological collision: some dead runtime's id equals a live stored id.
+    // The persisted hint (durable identity) must outrank the ledger entry.
+    setSessionOwnerHint('stored-live', { connectionId: 'local', profile: 'omar' })
+    recordSessionEventScope({ connectionId: 'spark', profile: 'default', session_id: 'stored-live' })
+
+    expect(knownOwnerForSession('stored-live')).toEqual({ connectionId: 'local', profile: 'omar' })
+  })
+
+  it('keeps failing closed for untagged or unknown runtimes in multi-profile topology (#97511)', () => {
+    $profiles.set([{ name: 'default' }, { name: 'omar' }] as never)
+    // Untagged events carry no connectionId and record nothing.
+    recordSessionEventScope({ profile: 'omar', session_id: 'rt-untagged' })
+
+    expect(knownOwnerForSession('rt-untagged')).toBeUndefined()
+    expect(knownOwnerForSession('rt-never-seen')).toBeUndefined()
+  })
+
+  it('drops the recorded event owner together with the runtime state (#97511)', () => {
+    recordSessionEventScope({ connectionId: 'homelab', profile: 'omar', session_id: 'rt-dropped' })
+    expect(knownOwnerForSession('rt-dropped')).toEqual({ connectionId: 'homelab', profile: 'omar' })
+
+    dropSessionState('rt-dropped')
+    expect(knownOwnerForSession('rt-dropped')).toBeUndefined()
   })
 })

--- a/apps/desktop/src/store/session-states-runtime-map.test.ts
+++ b/apps/desktop/src/store/session-states-runtime-map.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { createClientSessionState } from '@/lib/chat-runtime'
+import { $connectionsRegistry } from '@/store/connection-registry-state'
+import { setPrimaryGateway, setPrimaryGatewayConnection } from '@/store/gateway'
 import { $profiles } from '@/store/profile'
 import { _resetSessionOwnerHintsForTests, setSessionOwnerHint, setSessions } from '@/store/session'
 import { isSessionOwnerResolutionError } from '@/store/session-owner-resolution'
@@ -167,5 +169,46 @@ describe('knownOwnerForSession / requestForOwnedSession', () => {
 
     dropSessionState('rt-dropped')
     expect(knownOwnerForSession('rt-dropped')).toBeUndefined()
+  })
+
+  it('answers an approval on a sole-local registry install through the primary socket (#96394)', async () => {
+    // The reported topology: a modern Desktop (connections bridge present,
+    // registry loaded with exactly one `local` connection), one profile, and
+    // an approval.request whose runtime id has no tile / hint / row binding.
+    // hasRegistryTopology() is true here, so the ambient escape hatch is
+    // closed by design — the exact owner must come from the event itself.
+    ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = { connections: { list: async () => null } }
+    $connectionsRegistry.set({
+      activeConnectionId: 'local',
+      connections: [{ id: 'local', kind: 'local', label: 'Local' }]
+    } as never)
+    $profiles.set([{ name: 'default' }] as never)
+
+    const primaryRequest = vi.fn(async (method: string, params: unknown) => ({ method, params, via: 'primary' }))
+
+    setPrimaryGateway({ onEvent: () => () => undefined, request: primaryRequest, state: 'open' } as never, 'default')
+    setPrimaryGatewayConnection({ connectionId: 'local' })
+
+    const ambient = vi.fn(async () => ({ via: 'ambient' }))
+
+    try {
+      // Before the event lands the owner is unknown and routing still fails closed.
+      await expect(
+        requestForOwnedSession('rt-approval', ambient as never, 'approval.respond', { session_id: 'rt-approval' })
+      ).rejects.toSatisfy(isSessionOwnerResolutionError)
+
+      // use-gateway-boot stamps every primary event with the active connection
+      // id (Electron resolves the sole local connection to `local`).
+      recordSessionEventScope({ connectionId: 'local', profile: 'default', session_id: 'rt-approval' })
+
+      await expect(
+        requestForOwnedSession('rt-approval', ambient as never, 'approval.respond', { session_id: 'rt-approval' })
+      ).resolves.toEqual({ method: 'approval.respond', params: { session_id: 'rt-approval' }, via: 'primary' })
+      expect(ambient).not.toHaveBeenCalled()
+    } finally {
+      setPrimaryGateway(null)
+      $connectionsRegistry.set(null)
+      delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+    }
   })
 })

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -83,9 +83,22 @@ export const $sessionStates = atom<Record<string, ClientSessionState>>({})
 
 const sessionScopeByRuntimeId = new Map<string, string>()
 
+// Structured twin of the scope ledger: the same inbound events also carry the
+// exact (connectionId, profile) owner, which the composite scope string
+// cannot give back. Consumed as the LAST rung of knownOwnerForSession so a
+// runtime whose event source already proved its owner can still route
+// session-scoped RPCs (approval.respond) when every durable binding
+// (tile / hint / row) is absent — while durable stored identity keeps
+// outranking it (#97511).
+const sessionOwnerByRuntimeId = new Map<string, SessionOwnerRoute>()
+
 export function recordSessionEventScope(event: { connectionId?: string; profile?: string; session_id?: string }): void {
   if (event.session_id && event.connectionId) {
     sessionScopeByRuntimeId.set(event.session_id, registryBackendScopeKey(event.connectionId, event.profile))
+    sessionOwnerByRuntimeId.set(event.session_id, {
+      connectionId: event.connectionId,
+      profile: String(event.profile ?? '').trim() || 'default'
+    })
   }
 }
 
@@ -506,6 +519,7 @@ export function dropSessionState(runtimeId: string) {
   clearWatchdog(runtimeId)
   clearSessionProviderWait(runtimeId)
   sessionScopeByRuntimeId.delete(runtimeId)
+  sessionOwnerByRuntimeId.delete(runtimeId)
 
   const current = $sessionStates.get()
   setSessionStalled(current[runtimeId]?.storedSessionId, false)
@@ -532,6 +546,7 @@ export function clearAllSessionStates() {
   settledExpiry.clear()
   clearAllProviderWaits()
   sessionScopeByRuntimeId.clear()
+  sessionOwnerByRuntimeId.clear()
   $stalledSessionIds.set([])
   $sessionStates.set({})
 }
@@ -970,6 +985,13 @@ export function openTileGatewayScopes(): Set<string> {
  * `profile` stamp) was already loaded for the sidebar's cron section. The
  * hint outranks the row for the same reason as contrib/wiring's ladder: a
  * row can be stamped from the ambient profile and carries no connection.
+ * Last rung: the owner recorded from the inbound runtime event itself
+ * (sessionOwnerByRuntimeId, #97511) — an orphan runtime whose tile/hint/row
+ * binding is absent or stale still routes through the exact
+ * (connectionId, profile) its events proved, while every durable rung above
+ * keeps outranking it, so a stored-id collision never inherits a stale
+ * runtime ledger entry. Untagged events record nothing, so unknown owners in
+ * multi-profile topology still fail closed.
  * Returns undefined when no owner is known — the caller fails closed
  * (assertSessionOwnerResolved), never falls to "active".
  */
@@ -983,7 +1005,8 @@ export function knownOwnerForSession(sessionId: null | string | undefined): Sess
   return (
     sessionTileOwnerRoute(storedSessionId) ??
     getSessionOwnerHint(storedSessionId) ??
-    knownSessionOwner(ownerLookupSessionRows(), storedSessionId)
+    knownSessionOwner(ownerLookupSessionRows(), storedSessionId) ??
+    sessionOwnerByRuntimeId.get(sessionId)
   )
 }
 


### PR DESCRIPTION
## Summary

Desktop approvals are answerable again on a single-connection / single-profile install: `approval.respond` now routes through the exact `(connectionId, profile)` owner the inbound `approval.request` event already carried, instead of failing owner resolution because the registry-topology escape hatch (`ambientGatewayOwnsEverySession()`) is unreachable on every modern Desktop.

Salvage of #97519 by @liuhao1024 (commit cherry-picked, authorship preserved) + one regression test for the #96394 topology.

## Changes

- `apps/desktop/src/store/session-states.ts` — `sessionOwnerByRuntimeId`, a structured twin of the existing `sessionScopeByRuntimeId` ledger, written in `recordSessionEventScope` (only for connection-tagged events), cleared in `dropSessionState` / `clearAllSessionStates`, and consumed as the **last** rung of `knownOwnerForSession` after every durable rung (tile route → owner hint → session row). Untagged events record nothing, so unknown owners in multi-profile topology still fail closed — this is exact-owner evidence, not an ambient guess.
- `apps/desktop/src/store/session-states-runtime-map.test.ts` — @liuhao1024's 4 tests (orphan runtime routes via recorded owner; durable hint outranks a colliding ledger entry; untagged/unknown still fail closed; ledger entry drops with runtime state) + 1 new test pinning the #96394 report: registry loaded with exactly one `local` connection, one profile, unbound runtime → `approval.respond` resolves through the primary socket once the event owner is recorded, still rejects before it.

Why this direction over #96399 (sole-local ambient fallback): the fallback needs an authoritative profile inventory (`$profiles` starts `[]`, is lazily refreshed and sticky after a failed refresh — flagged by @R3defined and acknowledged by @huklaa, PR marked DO NOT MERGE). The event-owner rung needs no new authority: `use-gateway-boot` already stamps every primary event with `activeGatewayConnectionId()` (Electron resolves a sole `local` connection to `local` in `resolvedConnectionId`), and `requestGatewayForAgent` collapses that route onto the primary socket via `isPrimaryRegistryRoute`. It also fixes the multi-profile case from #97511 with the same mechanism.

## Validation

| Check | Result |
|---|---|
| `npx vitest run src/store/session-states-runtime-map.test.ts` | 13 passed |
| 9 related suites (owner-resolution, session-states*, gateway*, approval.tsx) | 149 passed / 9 files |
| Sabotage (main's `session-states.ts`, new tests kept) | 3 failed (the 2 #97511 ledger tests + the #96394 test), 10 passed |
| `npx tsc --noEmit -p tsconfig.json` | exit 0 |
| `npx eslint` on the two touched files | exit 0 |
| Stale-base gate | 0 behind `origin/main` at push |

**Live repro:** real store modules under vitest (`connection-registry-state`, `profile`, `gateway`, `session-states`, `session-owner-resolution`), modern-Desktop shape (`window.hermesDesktop.connections.list` present, registry `{connections:[{id:'local',kind:'local'}]}`, `$profiles=[default]`, primary gateway published with `connectionId:'local'`) — before (origin/main `ff7745fb0a`): `hasRegistryTopology=true`, `knownOwnerForSession(rt)=undefined`, `ambientGatewayOwnsEverySession()=false`, `requestForOwnedSession('approval.respond') → REJECTED SessionOwnerResolutionError` (the exact message from the report), even after `recordSessionEventScope({connectionId:'local', profile:'default', session_id})`; after: `knownOwnerForSession(rt)={connectionId:'local',profile:'default'}`, `→ RESOLVED via PRIMARY socket`.

Credit: @liuhao1024 (#97519, first exact-owner fix, 2026-08-28); @trevornk (#97533, same premise one day later, scoped to the approval store); @huklaa (#96399, sole-local fallback direction) and @Bardioc1977 / @enihcam for the #96394 diagnosis and Linux confirmation.

Closes #96394
Closes #97511
Closes #97519

## Infographic

![desktop-approval-event-owner](https://v3b.fal.media/files/b/0aa8c43a/jlqTO6NSSoZdqpiI-WRbs_Xv5Wr7eS.png)
