### PR TITLE
fix(terminal): add separator after brace group when trailing command follows (#100870)

### DIFF
--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1017,7 +1017,22 @@ def _rewrite_compound_background(command: str) -> str:
         suffix = result[amp_pos + 1 :]
         # `{` needs a trailing space in bash; the closing `}` needs to be
         # preceded by `;` or `&` — we're providing `&` from the backgrounding.
-        result = prefix + "{ " + middle + "& }" + suffix
+        # The closing `}` must be terminated with `;` when a next command
+        # follows (e.g. `A && { B & } echo …`), otherwise bash fails with
+        # `syntax error near 'echo'` (#100870). Only add the separator when
+        # trailing content exists and isn't already a separator.
+        if suffix.strip():
+            stripped = suffix.lstrip()
+            # Newline terminates the brace group, no extra `;` needed.
+            leading_ws = suffix[: len(suffix) - len(stripped)] if stripped else suffix
+            if "\n" in leading_ws:
+                result = prefix + "{ " + middle + "& }" + suffix
+            elif stripped and stripped[0] not in ";|&":
+                result = prefix + "{ " + middle + "& }; " + stripped
+            else:
+                result = prefix + "{ " + middle + "& }" + suffix
+        else:
+            result = prefix + "{ " + middle + "& }" + suffix
 
     return result
 


### PR DESCRIPTION
Fixes #100870

_rewrite_trailing_background rewrote `A && B & echo foo` to `A && { B & } echo foo` — missing `;` after the closing brace, producing `bash: syntax error near unexpected token echo`. This broke remote kernel spawning on the Docker backend (`cd ... && nohup ... & echo PID:$!`), silently degrading execute_code to the slower per-call path.

Change inserts `;` after `}` only when a non-separator, non-newline command follows, preserving multiline idempotence (`A && B &\nC` stays newline-separated).

Validated: `bash -n` now accepts the rewritten kernel spawn; `tests/tools/test_terminal_compound_background.py` (15 tests) passes.