### PR TITLE
fix(dashboard-auth): request offline access from Google OIDC to obtain refresh_token (#100147)

### DIFF
--- a/plugins/dashboard_auth/self_hosted/__init__.py
+++ b/plugins/dashboard_auth/self_hosted/__init__.py
@@ -223,6 +223,14 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
         )
         state = _b64url_no_pad(secrets.token_bytes(32))
 
+        # Google's OAuth2 (when used via self_hosted against
+        # accounts.google.com) only issues a refresh_token when
+        # access_type=offline is requested; prompt=consent ensures the
+        # consent screen re-issues it on re-auth. Without these the
+        # dashboard gets only a 1h access token and forces full
+        # re-login on expiry (#100147). Generic OIDC providers ignore
+        # unknown authorize params per RFC 6749, so this is safe to
+        # send unconditionally.
         params = {
             "response_type": "code",
             "client_id": self._client_id,
@@ -231,6 +239,8 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
             "state": state,
             "code_challenge": code_challenge,
             "code_challenge_method": "S256",
+            "access_type": "offline",
+            "prompt": "consent",
         }
         redirect_url = (
             f"{disco['authorization_endpoint']}?{urllib.parse.urlencode(params)}"


### PR DESCRIPTION
Fixes #100147

Self-hosted OIDC provider used as generic OIDC against Google (`accounts.google.com`) never received a `refresh_token` because `start_login` omitted Google's required `access_type=offline` and `prompt=consent` authorize params. The dashboard therefore only held a 1h access token and forced a full browser re-login on every expiry.

Add `access_type=offline` + `prompt=consent` to the authorize URL. Per RFC 6749 unknown params are ignored by generic OIDC providers (Keycloak, Authentik, etc.), so this is safe unconditionally.

Validated: `tests/plugins/dashboard_auth/test_self_hosted_provider.py` 29 passed; manual check shows authorize URL now contains `access_type=offline&prompt=consent`.