### PR TITLE
fix(gateway): create Telegram topics from lobby /new

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3862,6 +3862,22 @@ class BasePlatformAdapter(ABC):
         source = getattr(event, "source", None)
         if source is None:
             return
+
+        # Keep an explicit /new in the Telegram DM lobby on the root source.
+        # Recovering it to the latest topic would reset that topic instead of
+        # creating the fresh lane the user requested.
+        command = event.get_command()
+        if (
+            command
+            and source.platform == Platform.TELEGRAM
+            and source.chat_type == "dm"
+            and str(source.thread_id or "") in {"", "1"}
+        ):
+            from hermes_cli.commands import resolve_command
+
+            command_def = resolve_command(command)
+            if command_def is not None and command_def.name == "new":
+                return
         try:
             recovered = recover(source)
         except Exception:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8505,29 +8505,95 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     def _telegram_topic_root_lobby_message(self) -> str:
         return (
             "This main chat is reserved for system commands.\n\n"
-            "To start a new Hermes chat, open the All Messages topic at the top "
-            "of this bot interface and send any message there. Telegram will "
-            "create a new topic for that message; each topic works as an "
-            "independent Hermes session."
+            "Send /new or /new <title> here to create a Telegram topic with "
+            "a fresh, independent Hermes session."
         )
 
-    def _telegram_topic_root_new_message(self) -> str:
-        return (
-            "To start a new parallel Hermes chat, open the All Messages topic "
-            "at the top of this bot interface and send any message there. "
-            "Telegram will create a new topic for it.\n\n"
-            "Each topic is an independent Hermes session. Use /new inside an "
-            "existing topic only if you want to replace that topic's current session."
+    async def _handle_telegram_topic_root_new(self, event: MessageEvent) -> str:
+        """Create and bind one fresh session lane from the Telegram DM lobby."""
+        from hermes_state import SessionDB
+
+        raw_title = event.get_command_args().strip()
+        try:
+            session_title = SessionDB.sanitize_title(raw_title) if raw_title else None
+        except ValueError:
+            return "That title is invalid. Choose a shorter title and try /new again."
+        if raw_title and not session_title:
+            return "That title is invalid. Add some visible text and try /new again."
+
+        session_db = getattr(self, "_session_db", None)
+        if session_db is None:
+            return "Hermes session storage is unavailable. No topic was created."
+        if session_title and await session_db.get_session_by_title(session_title):
+            return f"A session named {session_title!r} already exists. Choose another title."
+
+        adapter = self._adapter_for_source(event.source)
+        create_topic = getattr(adapter, "create_handoff_thread", None)
+        if adapter is None or not callable(create_topic):
+            return "Telegram topic creation is unavailable. No session was created."
+
+        topic_title = self._sanitize_telegram_topic_title(
+            session_title or "Hermes Chat"
         )
+        try:
+            thread_id = await create_topic(str(event.source.chat_id), topic_title)
+        except Exception:
+            logger.warning("Telegram lobby /new topic creation failed", exc_info=True)
+            thread_id = None
+        if not thread_id:
+            return "Telegram could not create the new topic. No session was created."
+
+        topic_source = dataclasses.replace(
+            event.source,
+            thread_id=str(thread_id),
+            chat_topic=topic_title,
+        )
+        try:
+            entry = await self.async_session_store.get_or_create_session(
+                topic_source, force_new=True
+            )
+            if session_title:
+                await session_db.set_session_title(entry.session_id, session_title)
+            await asyncio.to_thread(
+                self._record_telegram_topic_binding, topic_source, entry
+            )
+        except Exception:
+            logger.error(
+                "Telegram lobby /new created topic %s but could not bind its session",
+                thread_id,
+                exc_info=True,
+            )
+            return (
+                "Telegram created the topic, but Hermes could not bind its session. "
+                "Remove that topic before retrying /new."
+            )
+
+        try:
+            sent = await adapter.send(
+                str(event.source.chat_id),
+                "New Hermes chat started.",
+                metadata={
+                    "thread_id": str(thread_id),
+                    "telegram_dm_topic_created_for_send": True,
+                },
+            )
+        except Exception:
+            sent = None
+            logger.warning("Telegram lobby /new start message failed", exc_info=True)
+        if not getattr(sent, "success", False):
+            return (
+                f"Created Telegram topic {topic_title!r} and bound its session, "
+                "but the start message could not be delivered."
+            )
+        return f"Created a new Telegram topic: {topic_title}."
 
     def _telegram_topic_new_header(self, source: SessionSource) -> Optional[str]:
         if not self._is_telegram_topic_lane(source):
             return None
         return (
             "Started a new Hermes session in this topic.\n\n"
-            "Tip: for parallel work, open All Messages and send a message there "
-            "to create a separate topic instead of using /new here. /new replaces "
-            "the session attached to the current topic."
+            "Tip: for parallel work, return to the main chat and send /new or "
+            "/new <title>. /new here replaces the session attached to this topic."
         )
 
     def _record_telegram_topic_binding(
@@ -19037,9 +19103,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         if canonical == "new":
             if await asyncio.to_thread(self._is_telegram_topic_root_lobby, source):
-                return self._telegram_topic_root_new_message()
+                return await self._handle_telegram_topic_root_new(event)
+
             async def _do_reset():
                 return await self._handle_reset_command(event)
+
             return await self._maybe_confirm_destructive_slash(
                 event=event,
                 command="new",

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -4,6 +4,7 @@ Topic mode makes the root Telegram DM a system lobby while user-created
 Telegram topics act as independent Hermes session lanes.
 """
 
+import asyncio
 from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -17,10 +18,10 @@ from agent.context_compressor import (
     _MERGED_SUMMARY_DELIMITER,
     _SUMMARY_END_MARKER,
 )
-from hermes_state import SessionDB
+from hermes_state import AsyncSessionDB, SessionDB
 from gateway.config import GatewayConfig, HomeChannel, Platform, PlatformConfig
-from gateway.platforms.base import MessageEvent
-from gateway.session import SessionEntry, SessionSource, build_session_key
+from gateway.platforms.base import MessageEvent, SendResult
+from gateway.session import SessionEntry, SessionSource, SessionStore, build_session_key
 
 
 def _make_source(*, thread_id: str | None = None) -> SessionSource:
@@ -258,27 +259,88 @@ async def test_internal_root_telegram_dm_event_bypasses_topic_lobby(
 
 
 @pytest.mark.asyncio
-async def test_root_telegram_dm_new_shows_create_topic_instruction(monkeypatch):
+@pytest.mark.parametrize("thread_id", [None, "1"])
+@pytest.mark.parametrize(
+    ("command", "topic_title", "session_title"),
+    [
+        ("/new", "Hermes Chat", None),
+        ("/new Project Alpha", "Project Alpha", "Project Alpha"),
+    ],
+)
+async def test_public_root_telegram_dm_new_creates_bound_topic(
+    tmp_path, monkeypatch, thread_id, command, topic_title, session_title
+):
     import gateway.run as gateway_run
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                enabled=True,
+                token="***",
+                typing_indicator=False,
+            )
+        }
+    )
+    store = SessionStore(sessions_dir=tmp_path / "sessions", config=config)
+    db = store._db
+    assert isinstance(db, SessionDB)
+    db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+
+    previous_source = _make_source(thread_id="17585")
+    previous_entry = store.get_or_create_session(previous_source)
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="17585",
+        user_id="208214988",
+        session_key=previous_entry.session_key,
+        session_id=previous_entry.session_id,
+    )
 
     runner = _make_runner()
-    runner._telegram_topic_mode_enabled = lambda source: True
-    runner._run_agent = AsyncMock(
-        side_effect=AssertionError("/new in root Telegram DM must not start an agent")
+    runner.config = config
+    runner.session_store = store
+    runner._session_db = AsyncSessionDB(db)
+    runner._handle_reset_command = AsyncMock(return_value="reset existing topic")
+
+    adapter = TelegramAdapter(config.platforms[Platform.TELEGRAM])
+    adapter.set_session_store(store)
+    adapter.set_topic_recovery_fn(runner._recover_telegram_topic_thread_id)
+    adapter.set_message_handler(runner._handle_message)
+    adapter.create_handoff_thread = AsyncMock(return_value="17586")
+    adapter.send = AsyncMock(
+        return_value=SendResult(success=True, message_id="telegram-message")
     )
+    runner.adapters = {Platform.TELEGRAM: adapter}
 
     monkeypatch.setattr(
         gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
     )
 
-    result = await runner._handle_message(_make_event("/new"))
+    event = _make_event(command, thread_id=thread_id)
+    try:
+        await adapter.handle_message(event)
+        tasks = tuple(adapter._background_tasks)
+        assert tasks, "public adapter ingress did not start a processing task"
+        await asyncio.gather(*tasks)
 
-    assert "create a new topic" in result
-    assert "All Messages" in result
-    assert "Use /new inside" in result
-    runner._run_agent.assert_not_called()
-    runner.session_store.reset_session.assert_not_called()
-    runner.session_store.get_or_create_session.assert_not_called()
+        adapter.create_handoff_thread.assert_awaited_once_with("208214988", topic_title)
+        assert event.source.thread_id == thread_id
+        binding = db.get_telegram_topic_binding(chat_id="208214988", thread_id="17586")
+        assert binding is not None
+        assert binding["session_id"] != previous_entry.session_id
+        if session_title:
+            titled_session = db.get_session_by_title(session_title)
+            assert titled_session is not None
+            assert titled_session["id"] == binding["session_id"]
+        assert any(
+            call.kwargs.get("metadata", {}).get("thread_id") == "17586"
+            for call in adapter.send.await_args_list
+        )
+        runner._handle_reset_command.assert_not_awaited()
+    finally:
+        db.close()
 
 
 @pytest.mark.asyncio

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -794,14 +794,16 @@ Hermes will:
 3. Create and pin a **System** topic for status/commands (best-effort)
 4. Reply with a list of previous unlinked Telegram sessions the user can restore
 
-After activation, the **root DM is a lobby**: normal prompts are rejected with guidance pointing at **All Messages**. System commands (`/status`, `/sessions`, `/usage`, `/help`, etc.) still work in the root.
+After activation, the **root DM is a lobby**: normal prompts are rejected, while
+system commands still work. Send `/new` or `/new <title>` there to create a new
+topic with a fresh Hermes session.
 
 ### Creating a new topic (end-user flow)
 
-1. Open the bot DM in Telegram
-2. Tap **All Messages** at the top of the bot interface, then send any message
-3. Telegram creates a new topic for that message
-4. Hermes responds inside that topic — the topic is now a standalone session
+1. Open the bot's root DM in Telegram
+2. Send `/new` or `/new <title>` (for example, `/new Database migration`)
+3. Hermes creates the Telegram topic and binds a fresh session to it
+4. Hermes posts a start message inside the new standalone topic
 
 Every topic gets its own conversation history, model state, tool execution, and session ID. The isolation key is `agent:main:telegram:dm:{chat_id}:{thread_id}` — identical to the config-driven DM topics isolation.
 
@@ -823,7 +825,7 @@ When this flag is on, Hermes still generates an internal session title (used by 
 
 ### `/new` inside a topic
 
-Resets the current topic's session (new session ID, fresh history) without touching other topics. Hermes replies with a reminder that for parallel work, creating another topic (via **All Messages**) is usually what you want.
+Resets the current topic's session (new session ID, fresh history) without touching other topics. For parallel work, return to the root DM and use `/new` instead.
 
 ### Restoring a previous session
 


### PR DESCRIPTION
## Summary

- make `/new` and `/new <title>` create a fresh Telegram DM topic from the topic-mode root lobby
- bind that topic to a fresh, isolated Hermes session and post the start message inside it
- keep `/new` inside an existing topic on the current reset-in-place path
- prevent public adapter topic recovery from rewriting an explicit lobby `/new` onto the latest topic

## Root cause

`BasePlatformAdapter.handle_message()` applies Telegram topic recovery before the gateway runner dispatches slash commands. A root-lobby `/new` was therefore rewritten onto a previous topic, where it reset that topic instead of creating a new one. Even when the runner saw a root `/new`, its existing branch only returned guidance.

## Implementation

- preserve root routing for explicit Telegram DM lobby `/new` commands
- create the Telegram topic through the existing `create_handoff_thread` adapter capability
- create and bind a fresh session for the new topic, including an optional user title
- update the topic-mode guidance and documentation to describe the supported flow

## Verification

- Verified RED on unpatched `2659c917`: the public adapter recovered root `/new` to the existing topic and `create_handoff_thread` was never called.
- `HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/gateway/test_telegram_topic_mode.py tests/gateway/test_telegram_thread_fallback.py -q` — 42 passed
- Ruff lint — passed
- diff-scoped Ruff format gate — passed
- Windows footgun scan — passed
- `git diff --check` — passed

## Scope

This intentionally addresses only the lobby `/new` slice. Last-active-topic storage and routing for bare home/cron deliveries remain non-goals for this PR.

## Prior work and credit

This builds on the Telegram topic-creation direction explored by @cwagner22 in #36709, #36785, and #36837. The implementation was reduced and rebased onto the current public adapter/session flow; co-author credit is retained in the commit.

Addresses part of #88503

---

**NL:** Vanuit de Telegram-lobby maakt `/new` nu een nieuw topic met een eigen sessie. `/new` binnen een bestaand topic blijft die sessie lokaal resetten. De last-active-routering uit het grotere issue valt bewust buiten deze PR.
