### PR TITLE
fix(cli): let an exported TERMINAL_ENV select the terminal backend

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -553,6 +553,9 @@ def load_cli_config() -> Dict[str, Any]:
     # overwrite env vars that were already set by .env -- only a user's config
     # file should be authoritative.
     _file_has_terminal_config = False
+    # Whether config.yaml explicitly pins a backend. Only an explicit pin
+    # outranks an exported TERMINAL_ENV when selecting effective_backend below.
+    _file_pins_backend = False
 
     # Load from file if exists
     if config_path.exists():
@@ -563,6 +566,10 @@ def load_cli_config() -> Dict[str, Any]:
                 file_config = _normalize_root_model_keys(fast_safe_load(f) or {})
             
             _file_has_terminal_config = "terminal" in file_config
+            _file_terminal_section = file_config.get("terminal")
+            _file_pins_backend = isinstance(_file_terminal_section, dict) and bool(
+                {"backend", "env_type"} & set(_file_terminal_section)
+            )
 
             # Handle model config - can be string (new format) or dict (old format)
             if "model" in file_config:
@@ -642,6 +649,16 @@ def load_cli_config() -> Dict[str, Any]:
     # Non-local with placeholder: pop so terminal_tool uses its per-backend default.
     # Non-local with explicit path: keep as-is.
     _CWD_PLACEHOLDERS = (".", "auto", "cwd")
+    # An exported TERMINAL_ENV selects the backend unless config.yaml explicitly
+    # pins one. Without this, an install with no `terminal:` section always
+    # computed "local" here — even under `TERMINAL_ENV=ssh` — and so took the
+    # branch below that force-exports TERMINAL_CWD=os.getcwd(). That is an
+    # AGENT-HOST path, which does not exist on an ssh/container target, so every
+    # command died in the wrapper's `cd` with exit 126 before running. Mirrors
+    # hermes_cli/config.py: only explicit config keys outrank the environment.
+    _env_backend = os.environ.get("TERMINAL_ENV", "").strip()
+    if _env_backend and not _file_pins_backend:
+        terminal_config["env_type"] = _env_backend
     effective_backend = terminal_config.get("env_type", "local")
 
     if effective_backend == "local":

--- a/tests/cli/test_cwd_env_respect.py
+++ b/tests/cli/test_cwd_env_respect.py
@@ -1,6 +1,8 @@
 """Tests for CLI/TUI CWD resolution in load_cli_config().
 
 Rules:
+- Backend selection: an exported TERMINAL_ENV wins unless config.yaml
+  explicitly pins terminal.backend / terminal.env_type.
 - Local backend CLI/TUI: always os.getcwd(), ignoring config and inherited env.
 - Non-local with placeholder: pop cwd for backend default.
 - Non-local with explicit path: keep as-is.
@@ -10,8 +12,17 @@ Rules:
 _CWD_PLACEHOLDERS = (".", "auto", "cwd")
 
 
-def _resolve_cwd(terminal_config: dict, defaults: dict, env: dict):
-    """Mirror the CWD resolution logic from cli.py load_cli_config()."""
+def _resolve_cwd(terminal_config: dict, defaults: dict, env: dict,
+                 file_pins_backend: bool = False):
+    """Mirror the CWD resolution logic from cli.py load_cli_config().
+
+    ``file_pins_backend`` mirrors whether config.yaml explicitly set
+    ``terminal.backend`` / ``terminal.env_type``. Only an explicit pin
+    outranks an exported TERMINAL_ENV.
+    """
+    env_backend = env.get("TERMINAL_ENV", "").strip()
+    if env_backend and not file_pins_backend:
+        terminal_config["env_type"] = env_backend
     effective_backend = terminal_config.get("env_type", "local")
 
     if effective_backend == "local":
@@ -79,6 +90,42 @@ class TestNonLocalBackends:
         tc = {"cwd": "auto", "env_type": "modal"}
         d = {"terminal": {"cwd": "auto"}}
         assert _resolve_cwd(tc, d, env) == ""
+
+
+class TestEnvSelectedBackend:
+    """An exported TERMINAL_ENV selects the backend when config doesn't pin one.
+
+    Regression: with no ``terminal:`` section in config.yaml, effective_backend
+    was read from merged DEFAULTS ("local") even under TERMINAL_ENV=ssh, so the
+    local branch force-exported TERMINAL_CWD=os.getcwd() — an agent-host path.
+    On an ssh target that path doesn't exist, so the tool wrapper's `cd` failed
+    with exit 126 before any command ran.
+    """
+
+    def test_ssh_env_preserves_wrapper_cwd(self):
+        env = {"TERMINAL_ENV": "ssh", "TERMINAL_CWD": "/srv/project"}
+        tc = {"cwd": ".", "env_type": "local"}  # merged default
+        d = {"terminal": {"cwd": "."}}
+        assert _resolve_cwd(tc, d, env) == "/srv/project"
+
+    def test_ssh_env_without_cwd_pops_for_remote_default(self):
+        env = {"TERMINAL_ENV": "ssh"}
+        tc = {"cwd": ".", "env_type": "local"}
+        d = {"terminal": {"cwd": "."}}
+        # Popped, so terminal_tool falls back to the remote home (~).
+        assert _resolve_cwd(tc, d, env) == ""
+
+    def test_explicit_config_pin_still_wins(self):
+        env = {"TERMINAL_ENV": "ssh", "TERMINAL_CWD": "/srv/project"}
+        tc = {"cwd": ".", "env_type": "local"}
+        d = {"terminal": {"cwd": "."}}
+        assert _resolve_cwd(tc, d, env, file_pins_backend=True) == "/fake/getcwd"
+
+    def test_local_env_still_uses_getcwd(self):
+        env = {"TERMINAL_ENV": "local", "TERMINAL_CWD": "/stale/value"}
+        tc = {"cwd": ".", "env_type": "local"}
+        d = {"terminal": {"cwd": "."}}
+        assert _resolve_cwd(tc, d, env) == "/fake/getcwd"
 
 
 class TestGatewayLazyImport:


### PR DESCRIPTION
## Problem

`load_cli_config()` computes `effective_backend` from the merged config only — it never reads the `TERMINAL_ENV` environment variable:

```python
effective_backend = terminal_config.get("env_type", "local")

if effective_backend == "local":
    terminal_config["cwd"] = os.getcwd()
```

On an install with no `terminal:` section in `config.yaml`, that always resolves to the `"local"` default, **even under `TERMINAL_ENV=ssh`**. The local branch then runs and force-exports `TERMINAL_CWD = os.getcwd()`.

That is a path on the *agent host*. On a remote backend it does not exist on the target, so the terminal tool's `cd <cwd>` preamble fails and every command returns exit 126 before its body runs:

```
bash: line 3: cd: /home/agent: No such file or directory
```

The backend itself is still correctly `ssh` (`terminal_tool` reads `TERMINAL_ENV` directly), so the session connects to the right host and then fails on every call — with an exit code whose stock hint blames file permissions.

## Why this is a bug, not intended precedence

- `TERMINAL_ENV` is a documented configuration surface: `.env.example` documents `TERMINAL_ENV` and the `TERMINAL_SSH_*` group under "for `TERMINAL_ENV=ssh`".
- `hermes_cli/config.py`'s `apply_terminal_config_to_env()` already implements the intended rule for the same bridge — *"Explicit keys in the user config's `terminal` section are authoritative... Merged defaults only backfill missing env vars; they never replace unrelated exported/.env values."* `cli.py` diverges from it by letting a merged **default** decide.

## Reproduce

`config.yaml` with no `terminal:` section, and in `.env`:

```
TERMINAL_ENV=ssh
TERMINAL_SSH_HOST=...
TERMINAL_SSH_USER=...
TERMINAL_CWD=/srv/project
```

```
after .env load     TERMINAL_ENV='ssh'  TERMINAL_CWD='/srv/project'
after config bridge                     TERMINAL_CWD='/home/agent'   <- agent host
```

## Fix

An exported `TERMINAL_ENV` selects the backend unless `config.yaml` explicitly pins `terminal.backend` / `terminal.env_type`. With the backend correctly identified as remote, the placeholder `cwd` is popped as it already is for other non-local backends, so `TERMINAL_CWD` survives — and when it is unset, `terminal_tool` falls back to the remote default (`~`) rather than an agent-host path.

An install that pins a backend in `config.yaml` is unaffected.

## Testing

`tests/cli/test_cwd_env_respect.py` — 4 new cases in `TestEnvSelectedBackend` (env-selected ssh preserves the cwd; without a cwd it pops for the remote default; an explicit config pin still wins; `TERMINAL_ENV=local` still uses `os.getcwd()`). The file's `_resolve_cwd` mirror is updated to match. 13 passed.

Verified end to end against a live ssh backend: with no `workdir` argument, a command now runs in the configured remote directory instead of failing with exit 126.

## Related but distinct

- #100189 stops a *correct* `TERMINAL_CWD` being used as a local path in `agent/runtime_cwd.py`. This PR is upstream of that: it stops `TERMINAL_CWD` being overwritten in the first place. No overlap in files.
- #84599 is a different mechanism (one-shot bridge vs. idle-environment re-creation) on a config that *does* pin `terminal.backend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014t2orLkMsRGHwuBir7qFym