### PR TITLE
fix(gateway): multiplexed hygiene compaction no longer loses the profile secret scope (salvage #100849)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -210,6 +210,20 @@ _TRUNCATED_SUMMARY_MARKER = "finish_reason=length"
 def _is_summary_access_or_quota_error(exc: Exception) -> bool:
     """Return True for non-retryable summary auth, permission, or quota errors."""
 
+    # A credential read that failed closed because no profile secret scope
+    # was active (multiplexed gateway, worker thread without the caller's
+    # ContextVars) is a missing-credential failure of our own making: the
+    # summary model cannot be reached until the spawn site is fixed, and a
+    # placeholder summary would only destroy the middle window for nothing.
+    # Classify it with the credential class so compress() preserves the
+    # session unchanged (#100849 bundle: every hygiene pass truncated).
+    try:
+        from agent.secret_scope import UnscopedSecretError
+    except Exception:  # pragma: no cover - import guard
+        UnscopedSecretError = ()  # type: ignore[assignment]
+    if UnscopedSecretError and isinstance(exc, UnscopedSecretError):
+        return True
+
     classified = classify_api_error(exc)
     if classified.reason is FailoverReason.rate_limit:
         return False

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -392,8 +392,12 @@ async def run_codex_hygiene_compaction(
     count_before = getattr(compressor, "compression_count", 0)
     try:
         await asyncio.wait_for(
+            # copy_context().run: keep the caller's profile secret scope /
+            # HERMES_HOME override in the worker (multiplex_profiles) — same
+            # class as the detached-agent hygiene path below.
             loop.run_in_executor(
                 None,
+                copy_context().run,
                 lambda: agent._compress_context(
                     history,
                     "",
@@ -21305,8 +21309,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                     _hyg_commit_fence = CompressionCommitFence(
                                         total_ceiling_seconds=_hyg_total_ceiling_seconds
                                     )
+                                    # Default executor (NOT self._get_executor):
+                                    # a fence-cancelled hung summary must never
+                                    # occupy one of the gateway's agent-work
+                                    # slots. But it MUST run inside the caller's
+                                    # contextvars: under multiplex_profiles the
+                                    # profile secret scope / HERMES_HOME override
+                                    # live in ContextVars, and a bare
+                                    # run_in_executor worker starts with an empty
+                                    # Context — the summary model's
+                                    # get_secret(<PROVIDER>_API_KEY) then fails
+                                    # closed (UnscopedSecretError) and every
+                                    # hygiene compaction silently degrades to a
+                                    # lossy truncation (#100849 bundle).
                                     _hyg_future = loop.run_in_executor(
                                         None,
+                                        copy_context().run,
                                         lambda: _hyg_agent._compress_context(
                                             _hyg_msgs, "",
                                             approx_tokens=_approx_tokens,

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -855,6 +855,19 @@ class TestAuthFailureAborts:
         )
         assert _is_summary_access_or_quota_error(err) is True
 
+    def test_unscoped_secret_read_is_terminal_access_failure(self):
+        # Multiplexed gateway: a credential read reached get_secret() from a
+        # worker thread without the profile scope. The summary model is
+        # unreachable until the spawn site is fixed — abort and preserve the
+        # session rather than truncating the middle window (#100849 bundle).
+        from agent.secret_scope import UnscopedSecretError
+
+        err = UnscopedSecretError(
+            "get_secret('SURPLUS_API_KEY') called with no profile secret scope "
+            "active while multiplexing is on."
+        )
+        assert _is_summary_access_or_quota_error(err) is True
+
 
 
 

--- a/tests/agent/test_secret_scope.py
+++ b/tests/agent/test_secret_scope.py
@@ -347,3 +347,34 @@ class TestRelayRoutingStampGlobals:
             ss.set_multiplex_active(False)
         for name in self.AUTH_VARS:
             assert not ss._is_global_env(name), name
+
+
+class TestSecretScopeAcrossExecutorThreads:
+    """Multiplexed profile state must reach pool workers (see #95119).
+
+    The context-compression timeout fence runs auxiliary LLM calls in a
+    daemon thread pool.  Bundled CPython runtime builds omit
+    ``ThreadPoolExecutor``'s context propagation, so the profile secret
+    scope was absent in the worker and ``get_secret`` failed closed with
+    ``UnscopedSecretError``, silently degrading compression to lossy
+    deterministic summaries.  ``DaemonThreadPoolExecutor.submit`` restores
+    stdlib context semantics; these tests lock that in.
+    """
+
+    def test_scoped_read_works_in_daemon_pool_worker(self, monkeypatch):
+        from tools.daemon_pool import DaemonThreadPoolExecutor
+
+        monkeypatch.setenv("SURPLUS_API_KEY", "env-key")
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({"SURPLUS_API_KEY": "scope-key"})
+        pool = DaemonThreadPoolExecutor(max_workers=1)
+        try:
+            # The scope (authoritative under multiplex) must reach the worker.
+            seen = pool.submit(ss.get_secret, "SURPLUS_API_KEY").result(timeout=10)
+            assert seen == "scope-key"
+            # A scoped miss must still not borrow the (cross-profile) env value.
+            monkeypatch.setenv("OPENAI_API_KEY", "env-leak")
+            assert pool.submit(ss.get_secret, "OPENAI_API_KEY").result(timeout=10) is None
+        finally:
+            pool.shutdown(wait=True)
+            ss.reset_secret_scope(token)

--- a/tests/gateway/test_codex_hygiene_compaction.py
+++ b/tests/gateway/test_codex_hygiene_compaction.py
@@ -336,3 +336,46 @@ def test_manual_compress_without_live_thread_reports_honestly():
         host._compress_codex_app_server_session("tg:123", "sess-1")
     )
     assert "Nothing to compact" in reply
+
+
+# ---------------------------------------------------------------------------
+# Multiplexed gateway: the hygiene worker must see the caller's ContextVars
+# (profile secret scope / HERMES_HOME override). A bare run_in_executor worker
+# starts with an EMPTY Context, so get_secret(<PROVIDER>_API_KEY) inside the
+# summary path fails closed and every hygiene compaction degrades to a lossy
+# truncation (#100849 bundle).
+# ---------------------------------------------------------------------------
+
+def test_hygiene_worker_inherits_caller_contextvars(tmp_path):
+    import contextvars
+    import threading
+
+    marker = contextvars.ContextVar("hygiene_scope_marker", default=None)
+    seen = {}
+
+    class ScopeProbeAgent(LiveCodexAgent):
+        def _compress_context(self, messages, system_message, **kwargs):
+            seen["value"] = marker.get()
+            seen["thread"] = threading.current_thread().name
+            return super()._compress_context(messages, system_message, **kwargs)
+
+    agent = ScopeProbeAgent(mode="hermes")
+    key = "tg:ctx"
+    gw, _db = _gateway(tmp_path, key, agent)
+
+    async def _scoped():
+        token = marker.set("profile-scope")
+        try:
+            return await run_codex_hygiene_compaction(
+                gw, key, agent.session_id, auto_mode="hermes",
+                history=_history(), approx_tokens=345_000, timeout_seconds=30.0,
+            )
+        finally:
+            marker.reset(token)
+
+    assert asyncio.run(_scoped()) == "compacted"
+    assert seen["thread"] != "MainThread", "compaction must still run off-loop"
+    assert seen["value"] == "profile-scope", (
+        "hygiene worker lost the caller's ContextVars — under multiplex_profiles "
+        "this is the UnscopedSecretError / lossy-truncation regression"
+    )

--- a/tests/tools/test_daemon_pool.py
+++ b/tests/tools/test_daemon_pool.py
@@ -69,6 +69,30 @@ def test_wedged_worker_does_not_block_interpreter_exit():
     assert "main-done" in proc.stdout
 
 
+def test_submit_propagates_caller_contextvars():
+    """Pool workers inherit contextvars set in the submitting context.
+
+    Stdlib ThreadPoolExecutor snapshots the caller's context with
+    ``copy_context()``; some bundled CPython runtime builds strip that, so
+    the daemon pool restores it explicitly.  Without the fix this returns
+    the default because the worker runs in a bare context.
+    """
+    from contextvars import ContextVar
+
+    var = ContextVar("daemon_pool_test_var", default="unset")
+
+    pool = DaemonThreadPoolExecutor(max_workers=1)
+    try:
+        token = var.set("hello")
+        try:
+            seen = pool.submit(var.get).result(timeout=10)
+        finally:
+            var.reset(token)
+        assert seen == "hello"
+    finally:
+        pool.shutdown(wait=True)
+
+
 def _repo_root():
     import pathlib
 

--- a/tools/daemon_pool.py
+++ b/tools/daemon_pool.py
@@ -16,16 +16,16 @@ exit hook insists on joining.
   - the interpreter's non-daemon thread join at shutdown skips them.
 
 Semantics are otherwise identical (initializer/initargs, work queue,
-idle-thread reuse) and, since #95119, so is context propagation:
-``submit`` snapshots the submitting context with ``copy_context()`` and
-runs each work item inside it, matching stdlib ``ThreadPoolExecutor``.
-That matters because some bundled CPython runtime builds omit stdlib's
-context propagation entirely, which silently drops contextvar-based state
-(profile secret scope, HERMES_HOME override) in pool workers — e.g. the
-context-compression timeout fence resolved auxiliary provider keys with
-``UnscopedSecretError`` under the multiplexed gateway.  Use it for any
-pool whose work is best-effort or
-independently interruptible and must never hold the process open:
+idle-thread reuse), plus context propagation: ``submit`` snapshots the
+submitting context with ``copy_context()`` and runs each work item inside
+it.  Stdlib ``ThreadPoolExecutor`` only does this from Python 3.14; on the
+3.11-3.13 runtimes Hermes ships, a bare pool worker starts with an EMPTY
+Context and silently drops contextvar-based state (profile secret scope,
+HERMES_HOME override) — under the multiplexed gateway a credential read in
+such a worker fails closed with ``UnscopedSecretError``.  Propagating by
+default makes every consumer safe even when it forgets
+``propagate_context_to_thread``.  Use it for any pool whose work is
+best-effort or independently interruptible and must never hold the process open:
 concurrent tool execution, background memory sync, catalog fan-out,
 subagent timeout wrappers.  Do NOT use it for work that must complete
 before exit (durable writes) — those belong on foreground threads with
@@ -49,17 +49,14 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
     def submit(self, fn, /, *args, **kwargs):
         """Submit a callable, propagating the caller's contextvars.
 
-        Stdlib ``ThreadPoolExecutor`` snapshots the submitting context with
-        ``copy_context()`` and runs each work item inside it, so pool
-        workers inherit contextvar state such as the multiplexed profile
-        secret scope.  Some bundled CPython runtime builds strip that
-        propagation from the stdlib executor (their ``_WorkItem.run`` calls
-        the callable directly), which broke auxiliary LLM key resolution
-        from the context-compression timeout fence with
-        ``UnscopedSecretError``.  Restore the stdlib behavior explicitly so
-        the daemon pool behaves identically on every runtime; on runtimes
-        that already propagate, the inner ``ctx.run`` re-applies the same
-        immutable context and is a no-op.
+        Python 3.14's ``ThreadPoolExecutor`` snapshots the submitting
+        context with ``copy_context()`` and runs each work item inside it;
+        3.11-3.13 (the runtimes Hermes ships) do not, so a pool worker
+        starts with an empty Context and loses the multiplexed profile
+        secret scope / HERMES_HOME override.  Do it here unconditionally so
+        the daemon pool behaves identically on every runtime; on 3.14+ the
+        inner ``ctx.run`` re-applies the same immutable context and is a
+        no-op.
         """
         ctx = copy_context()
 

--- a/tools/daemon_pool.py
+++ b/tools/daemon_pool.py
@@ -16,7 +16,15 @@ exit hook insists on joining.
   - the interpreter's non-daemon thread join at shutdown skips them.
 
 Semantics are otherwise identical (initializer/initargs, work queue,
-idle-thread reuse).  Use it for any pool whose work is best-effort or
+idle-thread reuse) and, since #95119, so is context propagation:
+``submit`` snapshots the submitting context with ``copy_context()`` and
+runs each work item inside it, matching stdlib ``ThreadPoolExecutor``.
+That matters because some bundled CPython runtime builds omit stdlib's
+context propagation entirely, which silently drops contextvar-based state
+(profile secret scope, HERMES_HOME override) in pool workers — e.g. the
+context-compression timeout fence resolved auxiliary provider keys with
+``UnscopedSecretError`` under the multiplexed gateway.  Use it for any
+pool whose work is best-effort or
 independently interruptible and must never hold the process open:
 concurrent tool execution, background memory sync, catalog fan-out,
 subagent timeout wrappers.  Do NOT use it for work that must complete
@@ -30,12 +38,35 @@ import threading
 import weakref
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures.thread import _worker
+from contextvars import copy_context
 
 __all__ = ["DaemonThreadPoolExecutor"]
 
 
 class DaemonThreadPoolExecutor(ThreadPoolExecutor):
     """ThreadPoolExecutor variant whose workers do not block process exit."""
+
+    def submit(self, fn, /, *args, **kwargs):
+        """Submit a callable, propagating the caller's contextvars.
+
+        Stdlib ``ThreadPoolExecutor`` snapshots the submitting context with
+        ``copy_context()`` and runs each work item inside it, so pool
+        workers inherit contextvar state such as the multiplexed profile
+        secret scope.  Some bundled CPython runtime builds strip that
+        propagation from the stdlib executor (their ``_WorkItem.run`` calls
+        the callable directly), which broke auxiliary LLM key resolution
+        from the context-compression timeout fence with
+        ``UnscopedSecretError``.  Restore the stdlib behavior explicitly so
+        the daemon pool behaves identically on every runtime; on runtimes
+        that already propagate, the inner ``ctx.run`` re-applies the same
+        immutable context and is a no-op.
+        """
+        ctx = copy_context()
+
+        def _run_with_context(*call_args, **call_kwargs):
+            return ctx.run(fn, *call_args, **call_kwargs)
+
+        return super().submit(_run_with_context, *args, **kwargs)
 
     def _adjust_thread_count(self) -> None:
         # Mirrors CPython's implementation (3.8–3.13) with two changes:


### PR DESCRIPTION
## Summary

Multiplexed-gateway session-hygiene compaction can reach the summary model again: the hygiene worker now inherits the caller's profile secret scope instead of failing closed with `UnscopedSecretError` and silently truncating the middle of the conversation on every pass (salvages #100849 by @MattMaximo).

Root cause: `gateway/run.py` hygiene ran `_compress_context` on a bare `loop.run_in_executor(None, ...)` worker. Under `gateway.multiplex_profiles` the profile secret scope and `HERMES_HOME` override are ContextVars installed per turn by `_profile_runtime_scope`; a bare worker starts with an empty Context, so `get_secret("<PROVIDER>_API_KEY")` in the summary path raised `UnscopedSecretError`, the summary was "unavailable", and the compressor fell through to the lossy placeholder-and-drop path. In the reporter's debug bundle every hygiene pass took that route (`697→642`, `645→426` messages, no LLM summary).

## Changes
- `gateway/run.py`: both hygiene executor hops (detached-agent path and codex app-server path) run inside `copy_context().run`. Default executor kept on purpose — a fence-cancelled hung summary must never occupy a gateway agent-work slot.
- `agent/context_compressor.py`: `UnscopedSecretError` classified as a missing-credential failure → compress() aborts and preserves the session unchanged (same carve-out as 401/402/403), instead of dropping the middle window for a placeholder.
- `tools/daemon_pool.py` (salvaged from #100849, @MattMaximo): `DaemonThreadPoolExecutor.submit` propagates the caller's contextvars by default, so every pool consumer is safe even without `propagate_context_to_thread`. Docstring corrected: stdlib only does this from Python 3.14; nothing is stripped from the bundled runtime.
- Tests: hygiene worker inherits caller ContextVars (verified to fail with the bare `run_in_executor`), `UnscopedSecretError` → access-failure class, plus the salvaged daemon-pool / secret-scope tests.

## Validation
| Surface | Before (origin/main) | After |
|---|---|---|
| Real `get_secret("SURPLUS_API_KEY")` in a `run_in_executor` worker, multiplex on, profile `.env` scope installed (`/tmp/hyg_ab.py`) | `UnscopedSecretError` | returns scoped value |
| `_is_summary_access_or_quota_error(UnscopedSecretError(...))` | `False` → truncation | `True` → abort, session preserved |
| `test_hygiene_worker_inherits_caller_contextvars` with `copy_context().run` removed | — | FAILS (sabotage check) |
| `tests/gateway/test_codex_hygiene_compaction.py`, `tests/tools/test_daemon_pool.py`, `tests/agent/test_secret_scope.py`, `-k access_failure` | — | 46 passed |

Note on #100849's stated mechanism: the daemon pool consumer (`conversation_compression._run_compress_with_timeout`) already wrapped its worker with `propagate_context_to_thread`; the scope was lost one layer up in gateway hygiene, which never touches the daemon pool. The pool change is kept as defense in depth for other `submit()` callers.

Related: #76574 (secret-scope residuals), #100697 / #100709 (unscoped-probe log noise).

## Infographic

![Hygiene compaction keeps profile secrets](https://v3b.fal.media/files/b/0aa8c499/-yX9CvArZin8Bfo4Ef7va_B5r7QcWk.png)
