### PR TITLE
fix(process): hint terminal tool when models call action=run (salvage of #64258)

### DIFF
--- a/tests/tools/test_process_run_alias.py
+++ b/tests/tools/test_process_run_alias.py
@@ -1,0 +1,40 @@
+"""process(action='run') should redirect models to the terminal tool."""
+
+import json
+
+
+def test_process_run_action_hints_terminal_tool():
+    from tools.process_registry import _handle_process
+
+    raw = _handle_process({"action": "run", "command": "pwd"})
+    assert isinstance(raw, str)
+    # tool_error wraps JSON payload
+    try:
+        payload = json.loads(raw)
+        text = json.dumps(payload)
+    except Exception:
+        text = raw
+    assert "run" in text.lower()
+    assert "terminal" in text.lower()
+    assert "Unknown process action" not in text
+
+
+def test_process_execute_alias_same_hint():
+    from tools.process_registry import _handle_process
+
+    raw = _handle_process({"action": "EXECUTE"})
+    text = raw if isinstance(raw, str) else json.dumps(raw)
+    try:
+        text = json.dumps(json.loads(raw))
+    except Exception:
+        pass
+    assert "terminal" in text.lower()
+
+
+def test_unknown_action_still_lists_valid():
+    from tools.process_registry import _handle_process
+
+    raw = _handle_process({"action": "frobnicate"})
+    text = raw if isinstance(raw, str) else str(raw)
+    assert "Unknown process action" in text
+    assert "list" in text

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -3376,7 +3376,9 @@ PROCESS_SCHEMA = {
         "poll: status + new output. log: full output, paged. wait: block "
         "until exit or timeout (partial output on timeout). write vs "
         "submit: submit appends Enter — use it to answer prompts; write "
-        "sends raw bytes, no newline. close: EOF stdin. kill: terminate."
+        "sends raw bytes, no newline. close: EOF stdin. kill: terminate. "
+        "To start a command, call terminal (optionally background=true); "
+        "process has no run/exec action."
     ),
     "parameters": {
         "type": "object",
@@ -3443,8 +3445,22 @@ def _handle_process(args, **kw):
     action = args.get("action", "")
     # Coerce to string — some models send session_id as an integer
     session_id = str(args.get("session_id", "")) if args.get("session_id") is not None else ""
+    # Coerce non-string actions (some models send structured values)
+    if not isinstance(action, str):
+        action = str(action or "")
+    action_norm = action.strip().lower()
 
-    if action == "list":
+    # Models often invent process(action="run") for what is actually terminal().
+    # Give a pointer instead of the generic unknown-action error (#63477 logs).
+    if action_norm in {"run", "exec", "execute", "start", "command"}:
+        return tool_error(
+            "process has no 'run' action. To execute a command, call the terminal "
+            "tool (set background=true for long-running work, then process "
+            "action=poll/log/wait). Valid process actions: list, poll, log, wait, "
+            "kill, write, submit, close."
+        )
+
+    if action_norm == "list":
         # Surface session-scoped background processes (e.g. a forgotten
         # preview server) in addition to this task's own — they share the
         # gateway session_key and can block session reset (#29177).
@@ -3462,26 +3478,26 @@ def _handle_process(args, **kw):
             },
             ensure_ascii=False,
         )
-    elif action in {"poll", "log", "wait", "kill", "write", "submit", "close"}:
+    elif action_norm in {"poll", "log", "wait", "kill", "write", "submit", "close"}:
         if not session_id:
-            return tool_error(f"session_id is required for {action}")
-        if action == "poll":
+            return tool_error(f"session_id is required for {action_norm}")
+        if action_norm == "poll":
             return json.dumps(_redact_process_result(process_registry.poll(session_id)), ensure_ascii=False)
-        elif action == "log":
+        elif action_norm == "log":
             return json.dumps(_redact_process_result(process_registry.read_log(
                 session_id, offset=args.get("offset"), limit=args.get("limit", 200))), ensure_ascii=False)
-        elif action == "wait":
+        elif action_norm == "wait":
             return json.dumps(_redact_process_result(process_registry.wait(session_id, timeout=args.get("timeout"))), ensure_ascii=False)
-        elif action == "kill":
+        elif action_norm == "kill":
             return json.dumps(
                 _redact_process_result(process_registry.kill_process(session_id)),
                 ensure_ascii=False,
             )
-        elif action == "write":
+        elif action_norm == "write":
             return json.dumps(process_registry.write_stdin(session_id, str(args.get("data", ""))), ensure_ascii=False)
-        elif action == "submit":
+        elif action_norm == "submit":
             return json.dumps(process_registry.submit_stdin(session_id, str(args.get("data", ""))), ensure_ascii=False)
-        elif action == "close":
+        elif action_norm == "close":
             return json.dumps(process_registry.close_stdin(session_id), ensure_ascii=False)
     return tool_error(f"Unknown process action: {action}. Use: list, poll, log, wait, kill, write, submit, close")
 


### PR DESCRIPTION
## Summary
- Detect `process(action=run/exec/start/...)` and return a directed error pointing models at the **terminal** tool
- Normalize process action casing
- Rebuild of #64258 on current `main` (old PR was CONFLICTING/DIRTY)

## Credit
Salvage of https://github.com/NousResearch/hermes-agent/pull/64258 (Bartok9). Same intent; schema description updated for the post-#97279 dieted PROCESS_SCHEMA.

## Motivation
Related to #63477. Local/Ollama sessions frequently log `Unknown process action: run.` Models invent a process run verb for shell execution. `process` is the control plane for background sessions and never starts commands — `terminal` does.

## Verification
- `python3 -m py_compile tools/process_registry.py tests/tools/test_process_run_alias.py`
- `pytest tests/tools/test_process_run_alias.py -q` — 3 passed

## Test plan
- [x] Call process with action=run → redirect message (no generic Unknown)
- [x] EXECUTE casing → same hint
- [x] Truly unknown action still lists valid actions