### PR TITLE
fix(kanban-db): converge racing same-key idempotent creates on one row

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2687,9 +2687,51 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     # is cheap thanks to ``IF NOT EXISTS`` and stays correct on fresh DBs
     # (where the columns already exist from SCHEMA_SQL).
     conn.execute("CREATE INDEX IF NOT EXISTS idx_tasks_tenant ON tasks(tenant)")
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_tasks_idempotency ON tasks(idempotency_key)"
-    )
+
+    # ``idx_tasks_idempotency`` migration: PLAIN -> UNIQUE (#64).
+    #
+    # The index was historically PLAIN, which let concurrent same-key
+    # creates (and archived-row re-admissions) insert duplicate rows the
+    # create-path guard could not see. UNIQUE makes the database itself
+    # enforce one row per idempotency key.
+    #
+    # DEPENDENCY: duplicate keys must be purged before this ships. On the
+    # deployment where the corruption was observed, 7 idempotency keys
+    # existed in duplicate (retry-storm re-admissions across archived
+    # rows); an operational cleanup (the "F2" purge script in the
+    # operator's hermes-scripts repo, review t_0345734c) removed them
+    # BEFORE this migration landed. Without that purge, CREATE UNIQUE
+    # INDEX fails with IntegrityError. Rather than bricking the board, the
+    # error is caught, the PLAIN index is kept, and a loud remediation
+    # warning is logged. The swap is retried on every init (the shape
+    # check below re-inspects the existing index), so once the duplicates
+    # are purged the next connect() converts to UNIQUE.
+    _existing_idem_idx = conn.execute(
+        "SELECT sql FROM sqlite_master "
+        "WHERE type = 'index' AND name = 'idx_tasks_idempotency'"
+    ).fetchone()
+    if (
+        _existing_idem_idx is None
+        or "UNIQUE" not in (_existing_idem_idx["sql"] or "").upper()
+    ):
+        conn.execute("DROP INDEX IF EXISTS idx_tasks_idempotency")
+        try:
+            conn.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_idempotency "
+                "ON tasks(idempotency_key)"
+            )
+        except sqlite3.IntegrityError as exc:
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_tasks_idempotency "
+                "ON tasks(idempotency_key)"
+            )
+            _log.warning(
+                "idx_tasks_idempotency: duplicate idempotency_key values "
+                "present (%s); kept the non-unique index so the board keeps "
+                "opening. Purge the duplicate rows (keep one row per key) "
+                "and re-run init to enforce uniqueness.",
+                exc,
+            )
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id)"
     )

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3599,6 +3599,24 @@ def create_task(
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
             return task_id
         except sqlite3.IntegrityError:
+            # A same-key racing creator that slipped past the pre-check above
+            # now hits the UNIQUE idx_tasks_idempotency (issue #64). Converge
+            # on the winning row instead of raising: by the time this INSERT
+            # fails, the winner's transaction has already committed
+            # (write_txn serializes writers via BEGIN IMMEDIATE), so a
+            # re-select by key is guaranteed to find it. Status-blind, like
+            # the pre-check: archived rows match too (admitted-once means
+            # admitted-forever). A miss here means the constraint that fired
+            # was the task-id PK collision, so fall through to the fresh-id
+            # retry below.
+            if idempotency_key:
+                row = conn.execute(
+                    "SELECT id FROM tasks WHERE idempotency_key = ? "
+                    "ORDER BY created_at DESC LIMIT 1",
+                    (idempotency_key,),
+                ).fetchone()
+                if row:
+                    return row["id"]
             if attempt == 1:
                 raise
             # Retry with a fresh id.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3268,6 +3268,12 @@ def create_task(
     model_override = (model_override or "").strip() or None
     provider_override = (provider_override or "").strip() or None
     reasoning_effort = normalize_reasoning_effort(reasoning_effort)
+    # '' (or whitespace) means "no key": normalize to None so the guard
+    # (truthiness check) and the INSERT (which would store '' as a value
+    # and collide under the UNIQUE index) agree. NULL never participates
+    # in the UNIQUE constraint; '' would — a second ''-key create would
+    # crash with IntegrityError instead of being an ordinary task.
+    idempotency_key = (idempotency_key or "").strip() or None
     if provider_override and not model_override:
         raise ValueError("provider_override requires a model_override")
     assignee = _canonical_assignee(assignee)

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1614,3 +1614,155 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+# ---------------------------------------------------------------------------
+# UNIQUE idx_tasks_idempotency migration (#64 / t_a886791d)
+#
+# The index was historically PLAIN, which let concurrent same-key creates
+# (and archived-row re-admissions) insert duplicate rows that the
+# create-path guard could not see. The migration below replaces the PLAIN
+# index with a UNIQUE one so the database itself enforces one row per key.
+# ---------------------------------------------------------------------------
+
+
+def _index_sql(conn, name: str) -> str | None:
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='index' AND name = ?", (name,)
+    ).fetchone()
+    return row["sql"] if row else None
+
+
+def test_fresh_db_gets_unique_idempotency_index(kanban_home):
+    """Fresh boards must come up with the UNIQUE index, not the PLAIN one."""
+    with kb.connect_closing() as conn:
+        sql = _index_sql(conn, "idx_tasks_idempotency")
+    assert sql is not None, "idx_tasks_idempotency missing on fresh DB"
+    assert "UNIQUE" in sql.upper(), f"index is not UNIQUE: {sql!r}"
+
+
+def test_legacy_db_migrates_plain_index_to_unique(kanban_home):
+    """Existing boards carrying the old PLAIN index must be converted.
+
+    Simulates a legacy board: schema + rows created with the historical
+    PLAIN index, no duplicate keys, then re-opened via connect() so the
+    additive migration pass runs and must swap PLAIN -> UNIQUE.
+    """
+    db_path = kanban_home / "kanban.db"
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    legacy = sqlite3.connect(str(db_path))
+    try:
+        legacy.execute("DROP INDEX IF EXISTS idx_tasks_idempotency")
+        legacy.execute(
+            "CREATE INDEX IF NOT EXISTS idx_tasks_idempotency ON tasks(idempotency_key)"
+        )
+        legacy.execute(
+            "INSERT INTO tasks (id, title, status, created_at, idempotency_key) "
+            "VALUES ('k1', 'legacy keyed', 'archived', 1, 'legacy-key-1')"
+        )
+        legacy.commit()
+    finally:
+        legacy.close()
+
+    with kb.connect(db_path=db_path) as conn:
+        sql = _index_sql(conn, "idx_tasks_idempotency")
+        # The row written pre-migration must survive the index swap.
+        count = conn.execute(
+            "SELECT COUNT(*) FROM tasks WHERE idempotency_key = 'legacy-key-1'"
+        ).fetchone()[0]
+    assert sql is not None and "UNIQUE" in sql.upper(), f"not UNIQUE: {sql!r}"
+    assert count == 1
+
+
+def test_unique_index_migration_falls_back_on_duplicate_keys(kanban_home, caplog):
+    """Duplicates present => migration must not brick the board.
+
+    The UNIQUE swap depends on the F2 cleanup purging pre-existing duplicate
+    keys (see review t_0345734c). If duplicates remain, CREATE UNIQUE INDEX
+    raises IntegrityError; the migration catches it, falls back to the PLAIN
+    index so the board keeps opening, and logs a loud remediation warning.
+    The conversion is retried on the next init once duplicates are purged.
+    """
+    import logging
+
+    db_path = kanban_home / "kanban.db"
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    legacy = sqlite3.connect(str(db_path))
+    try:
+        legacy.execute("DROP INDEX IF EXISTS idx_tasks_idempotency")
+        legacy.execute(
+            "CREATE INDEX IF NOT EXISTS idx_tasks_idempotency ON tasks(idempotency_key)"
+        )
+        # Two live rows sharing one key — exactly the corruption the UNIQUE
+        # index exists to prevent; the purge (F2) has not run here.
+        legacy.execute(
+            "INSERT INTO tasks (id, title, status, created_at, idempotency_key) "
+            "VALUES ('d1', 'dup one', 'ready', 1, 'dup-key')"
+        )
+        legacy.execute(
+            "INSERT INTO tasks (id, title, status, created_at, idempotency_key) "
+            "VALUES ('d2', 'dup two', 'ready', 2, 'dup-key')"
+        )
+        legacy.commit()
+    finally:
+        legacy.close()
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.kanban_db"):
+        with kb.connect(db_path=db_path) as conn:
+            sql = _index_sql(conn, "idx_tasks_idempotency")
+            dups = conn.execute(
+                "SELECT COUNT(*) FROM tasks WHERE idempotency_key = 'dup-key'"
+            ).fetchone()[0]
+    # Board still opens, both rows intact, index fell back to PLAIN.
+    assert dups == 2
+    assert sql is not None and "UNIQUE" not in sql.upper(), (
+        f"duplicates present but index is UNIQUE: {sql!r}"
+    )
+    assert any(
+        "idx_tasks_idempotency" in r.message and "unique" in r.message.lower()
+        for r in caplog.records
+    ), f"no fallback warning logged: {[r.message for r in caplog.records]}"
+
+
+def test_unique_index_retry_after_purge_succeeds(kanban_home):
+    """After the F2 purge removes duplicates, next init converts to UNIQUE.
+
+    Companion to the fallback test: proves the PLAIN fallback is not a
+    terminal state — retry semantics hold once the blocking duplicates are
+    purged.
+    """
+    db_path = kanban_home / "kanban.db"
+    # First open: simulate a legacy board that already carries duplicates
+    # under the old PLAIN index (fresh DBs get UNIQUE immediately, so the
+    # pre-state must be constructed explicitly).
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    with sqlite3.connect(str(db_path)) as raw:
+        raw.execute("DROP INDEX IF EXISTS idx_tasks_idempotency")
+        raw.execute(
+            "CREATE INDEX IF NOT EXISTS idx_tasks_idempotency ON tasks(idempotency_key)"
+        )
+        raw.execute(
+            "INSERT INTO tasks (id, title, status, created_at, idempotency_key) "
+            "VALUES ('d1', 'dup one', 'ready', 1, 'dup-key')"
+        )
+        raw.execute(
+            "INSERT INTO tasks (id, title, status, created_at, idempotency_key) "
+            "VALUES ('d2', 'dup two', 'ready', 2, 'dup-key')"
+        )
+    with kb.connect(db_path=db_path) as conn:
+        sql1 = _index_sql(conn, "idx_tasks_idempotency")
+    assert "UNIQUE" not in (sql1 or "").upper()
+
+    # Purge (simulating the F2 cleanup card)...
+    with sqlite3.connect(str(db_path)) as raw:
+        raw.execute("DELETE FROM tasks WHERE id = 'd2'")
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+    # ...and the next init retries and lands the UNIQUE index.
+    with kb.connect(db_path=db_path) as conn:
+        sql2 = _index_sql(conn, "idx_tasks_idempotency")
+        remaining = conn.execute(
+            "SELECT COUNT(*) FROM tasks WHERE idempotency_key = 'dup-key'"
+        ).fetchone()[0]
+    assert sql2 is not None and "UNIQUE" in sql2.upper(), f"not UNIQUE: {sql2!r}"
+    assert remaining == 1

--- a/tests/hermes_cli/test_kanban_db_race.py
+++ b/tests/hermes_cli/test_kanban_db_race.py
@@ -1,0 +1,92 @@
+"""Race convergence for idempotent create_task (t_e548b1d2 slice of t_ec4b92fd).
+
+With the UNIQUE idx_tasks_idempotency (PR #95742) the historical
+"race is acceptable" comment is no longer true in the good direction:
+two concurrent same-key creators no longer both insert — instead the
+loser now RAISES sqlite3.IntegrityError (fail-loud interim behavior,
+documented in #95742). This slice makes racing creators CONVERGE:
+exactly one row persists and every caller gets that row's id.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import sqlite3
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def race_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an empty kanban DB (fresh = UNIQUE index)."""
+    from pathlib import Path
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def test_race_loser_converges_on_existing_row(race_home):
+    """Deterministic loser: pre-existing archived row with the same key.
+
+    Exercises the exact interleaving the pre-check cannot see: the row is
+    ARCHIVED (so the pre-check's historical status filter missed it) and the
+    UNIQUE index turns the would-be duplicate INSERT into IntegrityError.
+    create_task must converge on the archived row's id — admitted-once
+    means admitted-forever — instead of raising or duplicating.
+    """
+    key = "race-archived-key"
+    with kb.connect() as conn:
+        # Raw-SQL archived row: what a legacy estate looked like pre-purge.
+        conn.execute(
+            "INSERT INTO tasks (id, title, status, created_at, idempotency_key) "
+            "VALUES ('t_arch_1', 'archived original', 'archived', 1, ?)",
+            (key,),
+        )
+        conn.commit()
+
+        got = kb.create_task(conn, title="racing creator", idempotency_key=key)
+
+        assert got == "t_arch_1", (
+            "create_task racing an archived same-key row must return that "
+            "row's id (converge), not raise and not insert a duplicate"
+        )
+        count = conn.execute(
+            "SELECT COUNT(*) FROM tasks WHERE idempotency_key = ?", (key,)
+        ).fetchone()[0]
+        assert count == 1, f"expected exactly 1 row for key, found {count}"
+
+
+def test_concurrent_same_key_creates_produce_exactly_one_row(race_home):
+    """Real concurrency: 8 threads, separate connections, one key.
+
+    Every thread calls create_task with the same idempotency_key. Exactly
+    one row must persist and every caller must receive that row's id.
+    """
+    key = "race-concurrent-key"
+    n = 8
+
+    def create_one():
+        conn = kb.connect()
+        try:
+            return kb.create_task(conn, title="concurrent creator", idempotency_key=key)
+        finally:
+            conn.close()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=n) as pool:
+        ids = list(pool.map(lambda _: create_one(), range(n)))
+
+    assert len(set(ids)) == 1, f"callers diverged on id: {ids}"
+    with kb.connect() as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM tasks WHERE idempotency_key = ?", (key,)
+        ).fetchone()[0]
+        assert count == 1, f"expected exactly 1 row for key, found {count}"
+        assert conn.execute("SELECT id FROM tasks WHERE idempotency_key = ?", (key,)).fetchone()[
+            0
+        ] == ids[0]

--- a/tests/hermes_cli/test_kanban_db_race.py
+++ b/tests/hermes_cli/test_kanban_db_race.py
@@ -62,6 +62,25 @@ def test_race_loser_converges_on_existing_row(race_home):
         assert count == 1, f"expected exactly 1 row for key, found {count}"
 
 
+def test_empty_string_key_means_no_key(race_home):
+    """Regression: '' key must behave identically to None.
+
+    The guard historically treats '' as falsy (no idempotency), but the
+    INSERT stored '' as a value — under the UNIQUE index a second ''-key
+    create then crashed with IntegrityError ('' collided with the stored
+    ''). Normalizing '' to NULL at entry makes guard and storage agree:
+    each ''-key create is an ordinary independent task.
+    """
+    a = kb.create_task(kb.connect(), title="empty one", idempotency_key="")
+    b = kb.create_task(kb.connect(), title="empty two", idempotency_key="")
+    assert a != b, "'' key must not be idempotent — it means no key"
+    with kb.connect() as conn:
+        rows = conn.execute(
+            "SELECT COUNT(*) FROM tasks WHERE idempotency_key = ''"
+        ).fetchone()[0]
+    assert rows == 0, f"'' must be normalized to NULL, found {rows} stored '' keys"
+
+
 def test_concurrent_same_key_creates_produce_exactly_one_row(race_home):
     """Real concurrency: 8 threads, separate connections, one key.
 


### PR DESCRIPTION
## Summary

Makes racing same-key idempotent `create_task` calls **converge on exactly one row** instead of raising. Third slice of the issue #64 storage-layer fix:

| Slice | PR |
|---|---|
| Status-blind idempotency pre-check (AC1) | #95720 |
| UNIQUE `idx_tasks_idempotency` migration (AC2) | #95742 |
| **Race convergence (AC3 — this PR)** | this |

**Stacked on #95742** (branch is based on its head `ea8bedcd5d` — only the last commit is new; review that commit, #95742 carries the rest). Composes cleanly with #95720 (verified: all three applied together → 37 passed + 1 skip).

## Problem

#95742 replaced the "race is acceptable: two concurrent creators with the same key might both insert" blessing with a **fail-loud interim behavior**: a same-key creator that slips past the pre-check now hits the UNIQUE index and raises `sqlite3.IntegrityError`. Strictly better than the duplicate-row corruption it replaced, but retried webhooks / automation replaying a hot key can still crash their caller.

## Fix

In `create_task`'s existing `IntegrityError` handler: when an `idempotency_key` is set, re-select by key (status-blind — archived rows match, admitted-once means admitted-forever) and return the winning row's id. A miss falls through to the existing fresh-id retry (the constraint that fired was the task-id PK collision, not the key).

Why the re-select is guaranteed to find the row: `write_txn` serializes writers via `BEGIN IMMEDIATE`, so the loser's INSERT only fails *after* the winner's transaction committed; the SELECT runs on a post-rollback fresh WAL snapshot.

Design note: the task card suggested `INSERT OR IGNORE` + re-select; this uses the equivalent catch-`IntegrityError` + re-select deliberately — `INSERT OR IGNORE` would also swallow PK-collision errors on `task_id` (masking the existing fresh-id retry path) and any other constraint violation on that INSERT.

## Evidence

- TDD: RED reproduced first (both tests failed with `sqlite3.IntegrityError: UNIQUE constraint failed: tasks.idempotency_key` at the INSERT), then GREEN
- New tests: deterministic archived-row loser + real 8-thread concurrent same-key creates (separate connections) → exactly one row, all callers get the same id
- 10/10 stability loop on the race tests (concurrency-flake check)
- Full `tests/hermes_cli/test_kanban_db.py`: 34 passed + 1 windows-only skip
- Three-way composition (#95742 + #95720 + this): 37 passed + 1 skip
- Adjacent suites (core_functionality, db_init, goal_mode, db_repair, write_txn_busy_retry, swarm, decompose_db): 48 passed
