### PR TITLE
feat(image_gen): add Meta Model API (muse-image) provider plugin (salvages #97283)

### DIFF
--- a/plugins/image_gen/meta-ai/__init__.py
+++ b/plugins/image_gen/meta-ai/__init__.py
@@ -1,0 +1,287 @@
+"""Meta Model API image generation backend.
+
+Exposes Meta's ``muse-image`` model(s) as an :class:`ImageGenProvider`.
+The Meta Model API (https://api.meta.ai/v1) is OpenAI-compatible, so we reuse
+the OpenAI Python SDK pointed at Meta's base URL and authenticate with
+``META_MODEL_API_KEY``.
+
+Output is base64 JSON (WebP) -> saved under ``$HERMES_HOME/cache/images/``.
+
+Selection precedence (first hit wins):
+  1. ``META_IMAGE_MODEL`` env var (escape hatch for scripts / tests)
+  2. ``image_gen.meta-ai.model`` in ``config.yaml``
+  3. ``image_gen.model`` in ``config.yaml`` (when it's one of our IDs)
+  4. :data:`DEFAULT_MODEL`
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+from agent.secret_scope import get_secret
+from agent.image_gen_provider import (
+    DEFAULT_ASPECT_RATIO,
+    ImageGenProvider,
+    error_response,
+    normalize_reference_images,
+    resolve_aspect_ratio,
+    save_b64_image,
+    save_url_image,
+    success_response,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BASE_URL = "https://api.meta.ai/v1"
+# Auth env vars, in priority order. Mirrors the bundled ``meta-ai`` chat
+# provider (plugins/model-providers/meta-ai): MODEL_API_KEY is Meta's
+# documented var; the rest are accepted aliases.
+API_KEY_ENVS = ("MODEL_API_KEY", "META_API_KEY", "META_MODEL_API_KEY")
+# Primary key shown in setup prompts / error messages.
+API_KEY_ENV = "META_MODEL_API_KEY"
+# Optional base-url override (same var the chat provider honors).
+BASE_URL_ENV = "META_BASE_URL"
+
+
+def _resolve_api_key() -> Optional[str]:
+    """First non-empty auth env var, checked in priority order."""
+    for env in API_KEY_ENVS:
+        val = get_secret(env)
+        if val:
+            return val
+    return None
+
+
+def _resolve_base_url() -> str:
+    return (os.environ.get(BASE_URL_ENV) or "").strip() or DEFAULT_BASE_URL
+
+
+# ---------------------------------------------------------------------------
+# Model catalog
+# ---------------------------------------------------------------------------
+# Catalog shown in `hermes tools` and matched against `image_gen.model`.
+# The model id is sent verbatim to the Meta Model API (`/v1/images/generations`).
+_MODELS: Dict[str, Dict[str, Any]] = {
+    "muse-image-1.0": {
+        "display": "Muse Image 1.0",
+        "speed": "~10s",
+        "strengths": "Meta Model API image generation",
+        "price": "$0.01/image",
+    },
+}
+DEFAULT_MODEL = "muse-image-1.0"
+
+# aspect_ratio -> OpenAI-style size string
+_SIZES: Dict[str, str] = {
+    "square": "1024x1024",
+    "landscape": "1536x1024",
+    "portrait": "1024x1536",
+}
+
+
+def _resolve_model() -> Tuple[str, Dict[str, Any]]:
+    """Return (model_id, metadata) using the documented precedence chain."""
+    env_model = os.environ.get("META_IMAGE_MODEL")
+    if env_model and env_model in _MODELS:
+        return env_model, _MODELS[env_model]
+
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        ig = cfg.get("image_gen") or {}
+        scoped = (ig.get("meta-ai") or {}).get("model")
+        if scoped and scoped in _MODELS:
+            return scoped, _MODELS[scoped]
+        top = ig.get("model")
+        if top and top in _MODELS:
+            return top, _MODELS[top]
+    except Exception:
+        logger.debug("Could not read image_gen model from config", exc_info=True)
+
+    return DEFAULT_MODEL, _MODELS[DEFAULT_MODEL]
+
+
+class MetaImageGenProvider(ImageGenProvider):
+    """Meta Model API ``images.generate`` backend (muse-image)."""
+
+    @property
+    def name(self) -> str:
+        return "meta-ai"
+
+    @property
+    def display_name(self) -> str:
+        return "Meta Model API"
+
+    def is_available(self) -> bool:
+        if not _resolve_api_key():
+            return False
+        try:
+            import openai  # noqa: F401
+        except ImportError:
+            return False
+        return True
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "id": mid,
+                "display": m["display"],
+                "speed": m["speed"],
+                "strengths": m["strengths"],
+                "price": m["price"],
+            }
+            for mid, m in _MODELS.items()
+        ]
+
+    def default_model(self) -> Optional[str]:
+        return DEFAULT_MODEL
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Meta Model API",
+            "badge": "internal",
+            "tag": "Muse Image via Meta Model API (api.meta.ai)",
+            "env_vars": [
+                {
+                    "key": API_KEY_ENV,
+                    "prompt": "Meta Model API key (LLM|... token)",
+                    "url": "https://api.meta.ai",
+                },
+            ],
+        }
+
+    def capabilities(self) -> Dict[str, Any]:
+        # Text-to-image only for now. Bump this once image-to-image is verified
+        # against the Meta endpoint.
+        return {"modalities": ["text"], "max_reference_images": 0}
+
+    def generate(
+        self,
+        prompt: str,
+        aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+        *,
+        image_url: Optional[str] = None,
+        reference_image_urls: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        prompt = (prompt or "").strip()
+        aspect = resolve_aspect_ratio(aspect_ratio)
+
+        if not prompt:
+            return error_response(
+                error="Prompt is required and must be a non-empty string",
+                error_type="invalid_argument",
+                provider="meta-ai",
+                aspect_ratio=aspect,
+            )
+
+        api_key = _resolve_api_key()
+        if not api_key:
+            return error_response(
+                error=(
+                    f"{API_KEY_ENV} not set. Run `hermes tools` -> Image "
+                    "Generation -> Meta Model API to configure."
+                ),
+                error_type="auth_required",
+                provider="meta-ai",
+                aspect_ratio=aspect,
+            )
+
+        try:
+            import openai
+        except ImportError:
+            return error_response(
+                error="openai Python package not installed (pip install openai)",
+                error_type="missing_dependency",
+                provider="meta-ai",
+                aspect_ratio=aspect,
+            )
+
+        model_id, _meta = _resolve_model()
+        size = _SIZES.get(aspect, _SIZES["square"])
+
+        client = openai.OpenAI(api_key=api_key, base_url=_resolve_base_url())
+
+        payload: Dict[str, Any] = {
+            "model": model_id,
+            "prompt": prompt,
+            "size": size,
+            "n": 1,
+        }
+
+        try:
+            response = client.images.generate(**payload)
+        except Exception as exc:
+            logger.debug("Meta image generation failed", exc_info=True)
+            return error_response(
+                error=f"Meta image generation failed: {exc}",
+                error_type="api_error",
+                provider="meta-ai",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        try:
+            first = response.data[0]
+        except (AttributeError, IndexError, TypeError):
+            return error_response(
+                error="Meta response contained no image data",
+                error_type="empty_response",
+                provider="meta-ai",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        b64 = getattr(first, "b64_json", None)
+        url = getattr(first, "url", None)
+
+        try:
+            if b64:
+                path = save_b64_image(b64, prefix="meta", extension="webp")
+                image_ref = str(path)
+            elif url:
+                path = save_url_image(url, prefix="meta")
+                image_ref = str(path)
+            else:
+                return error_response(
+                    error="Meta response contained neither b64_json nor URL",
+                    error_type="empty_response",
+                    provider="meta-ai",
+                    model=model_id,
+                    prompt=prompt,
+                    aspect_ratio=aspect,
+                )
+        except Exception as exc:
+            return error_response(
+                error=f"Failed to save Meta image: {exc}",
+                error_type="io_error",
+                provider="meta-ai",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        revised_prompt = getattr(first, "revised_prompt", None)
+        extra: Dict[str, Any] = {"size": size}
+        if revised_prompt:
+            extra["revised_prompt"] = revised_prompt
+
+        return success_response(
+            image=image_ref,
+            model=model_id,
+            prompt=prompt,
+            aspect_ratio=aspect,
+            provider="meta-ai",
+            modality="text",
+            extra=extra,
+        )
+
+
+def register(ctx) -> None:
+    """Plugin entry point -- wire ``MetaImageGenProvider`` into the registry."""
+    ctx.register_image_gen_provider(MetaImageGenProvider())

--- a/plugins/image_gen/meta-ai/__init__.py
+++ b/plugins/image_gen/meta-ai/__init__.py
@@ -8,10 +8,11 @@ the OpenAI Python SDK pointed at Meta's base URL and authenticate with
 Output is base64 JSON (WebP) -> saved under ``$HERMES_HOME/cache/images/``.
 
 Selection precedence (first hit wins):
-  1. ``META_IMAGE_MODEL`` env var (escape hatch for scripts / tests)
-  2. ``image_gen.meta-ai.model`` in ``config.yaml``
-  3. ``image_gen.model`` in ``config.yaml`` (when it's one of our IDs)
-  4. :data:`DEFAULT_MODEL`
+  1. ``model`` kwarg forwarded by the dispatcher (the ``hermes tools`` pick)
+  2. ``META_IMAGE_MODEL`` env var (escape hatch for scripts / tests)
+  3. ``image_gen.meta-ai.model`` in ``config.yaml``
+  4. ``image_gen.model`` in ``config.yaml`` (when it's one of our IDs)
+  5. :data:`DEFAULT_MODEL`
 """
 
 from __future__ import annotations
@@ -81,8 +82,17 @@ _SIZES: Dict[str, str] = {
 }
 
 
-def _resolve_model() -> Tuple[str, Dict[str, Any]]:
-    """Return (model_id, metadata) using the documented precedence chain."""
+def _resolve_model(caller_model: Optional[str] = None) -> Tuple[str, Dict[str, Any]]:
+    """Return (model_id, metadata) using the documented precedence chain.
+
+    ``caller_model`` is the ``model`` kwarg the dispatcher forwards from the
+    top-level ``image_gen.model`` config key (what ``hermes tools`` writes).
+    It wins when it names one of our models, mirroring the xai/krea/openrouter
+    providers, so a user's picker choice is never silently dropped.
+    """
+    if caller_model and caller_model in _MODELS:
+        return caller_model, _MODELS[caller_model]
+
     env_model = os.environ.get("META_IMAGE_MODEL")
     if env_model and env_model in _MODELS:
         return env_model, _MODELS[env_model]
@@ -142,7 +152,7 @@ class MetaImageGenProvider(ImageGenProvider):
     def get_setup_schema(self) -> Dict[str, Any]:
         return {
             "name": "Meta Model API",
-            "badge": "internal",
+            "badge": "paid",
             "tag": "Muse Image via Meta Model API (api.meta.ai)",
             "env_vars": [
                 {
@@ -200,7 +210,7 @@ class MetaImageGenProvider(ImageGenProvider):
                 aspect_ratio=aspect,
             )
 
-        model_id, _meta = _resolve_model()
+        model_id, _meta = _resolve_model(kwargs.get("model"))
         size = _SIZES.get(aspect, _SIZES["square"])
 
         client = openai.OpenAI(api_key=api_key, base_url=_resolve_base_url())

--- a/plugins/image_gen/meta-ai/plugin.yaml
+++ b/plugins/image_gen/meta-ai/plugin.yaml
@@ -1,0 +1,7 @@
+name: meta-ai-image-gen
+version: 1.0.0
+description: "Meta Model API image generation backend (muse-image). OpenAI-compatible /v1/images/generations. Saves images to $HERMES_HOME/cache/images/."
+author: Meta Platforms, Inc.
+kind: backend
+requires_env:
+  - META_MODEL_API_KEY

--- a/tests/plugins/image_gen/test_meta_ai_provider.py
+++ b/tests/plugins/image_gen/test_meta_ai_provider.py
@@ -25,6 +25,7 @@ _PNG_HEX = (
 
 def _b64_png() -> str:
     import base64
+
     return base64.b64encode(bytes.fromhex(_PNG_HEX)).decode()
 
 
@@ -37,8 +38,13 @@ def _fake_response(*, b64=None, url=None, revised_prompt=None):
 def _tmp_hermes_home(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     # Clear every auth + override env var so tests start from a clean slate.
-    for env in ("MODEL_API_KEY", "META_API_KEY", "META_MODEL_API_KEY",
-                "META_BASE_URL", "META_IMAGE_MODEL"):
+    for env in (
+        "MODEL_API_KEY",
+        "META_API_KEY",
+        "META_MODEL_API_KEY",
+        "META_BASE_URL",
+        "META_IMAGE_MODEL",
+    ):
         monkeypatch.delenv(env, raising=False)
     yield tmp_path
 
@@ -133,11 +139,45 @@ class TestModelResolution:
         # Unknown id is ignored; falls through to the default.
         assert model_id == "muse-image-1.0"
 
+    def test_caller_model_kwarg_wins(self, monkeypatch):
+        # The dispatcher forwards top-level image_gen.model as the `model`
+        # kwarg; it must beat the env override (#55893 bug class).
+        monkeypatch.setitem(
+            meta_plugin._MODELS,
+            "muse-image-test",
+            dict(meta_plugin._MODELS["muse-image-1.0"]),
+        )
+        monkeypatch.setenv("META_IMAGE_MODEL", "muse-image-1.0")
+        model_id, _meta = meta_plugin._resolve_model("muse-image-test")
+        assert model_id == "muse-image-test"
+
+    def test_caller_model_unknown_falls_through(self):
+        model_id, _meta = meta_plugin._resolve_model("not-a-real-model")
+        assert model_id == "muse-image-1.0"
+
 
 # ── Generate ──────────────────────────────────────────────────────────────────
 
 
 class TestGenerate:
+    def test_model_kwarg_reaches_payload(self, provider, monkeypatch):
+        monkeypatch.setitem(
+            meta_plugin._MODELS,
+            "muse-image-test",
+            dict(meta_plugin._MODELS["muse-image-1.0"]),
+        )
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
+        with _patched_openai(fake_client):
+            result = provider.generate("a cat", model="muse-image-test")
+        assert result["success"] is True
+        assert (
+            fake_client.images.generate.call_args.kwargs["model"] == "muse-image-test"
+        )
+
+    def test_badge_is_standard_paid(self, provider):
+        assert provider.get_setup_schema()["badge"] == "paid"
+
     def test_empty_prompt_rejected(self, provider):
         result = provider.generate("", aspect_ratio="square")
         assert result["success"] is False
@@ -182,7 +222,9 @@ class TestGenerate:
         with patch.dict("sys.modules", {"openai": fake_openai}):
             provider.generate("a cat")
 
-        assert fake_openai.OpenAI.call_args.kwargs["base_url"] == "https://api.meta.ai/v1"
+        assert (
+            fake_openai.OpenAI.call_args.kwargs["base_url"] == "https://api.meta.ai/v1"
+        )
 
     def test_base_url_override_reaches_client(self, provider, monkeypatch):
         monkeypatch.setenv("META_BASE_URL", "https://proxy.internal/v1")
@@ -194,13 +236,19 @@ class TestGenerate:
         with patch.dict("sys.modules", {"openai": fake_openai}):
             provider.generate("a cat")
 
-        assert fake_openai.OpenAI.call_args.kwargs["base_url"] == "https://proxy.internal/v1"
+        assert (
+            fake_openai.OpenAI.call_args.kwargs["base_url"]
+            == "https://proxy.internal/v1"
+        )
 
-    @pytest.mark.parametrize("aspect,expected_size", [
-        ("landscape", "1536x1024"),
-        ("square", "1024x1024"),
-        ("portrait", "1024x1536"),
-    ])
+    @pytest.mark.parametrize(
+        "aspect,expected_size",
+        [
+            ("landscape", "1536x1024"),
+            ("square", "1024x1024"),
+            ("portrait", "1024x1536"),
+        ],
+    )
     def test_aspect_ratio_mapping(self, provider, aspect, expected_size):
         fake_client = MagicMock()
         fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
@@ -213,7 +261,8 @@ class TestGenerate:
     def test_revised_prompt_passed_through(self, provider):
         fake_client = MagicMock()
         fake_client.images.generate.return_value = _fake_response(
-            b64=_b64_png(), revised_prompt="A photo of a cat",
+            b64=_b64_png(),
+            revised_prompt="A photo of a cat",
         )
 
         with _patched_openai(fake_client):
@@ -226,13 +275,18 @@ class TestGenerate:
         providers) so ephemeral signed URLs can't expire mid-flight."""
         fake_client = MagicMock()
         fake_client.images.generate.return_value = _fake_response(
-            b64=None, url="https://example.com/img.webp",
+            b64=None,
+            url="https://example.com/img.webp",
         )
 
-        with _patched_openai(fake_client), patch.object(
-            meta_plugin, "save_url_image",
-            return_value=Path("/tmp/meta_20260524_000000_deadbeef.webp"),
-        ) as mock_save_url:
+        with (
+            _patched_openai(fake_client),
+            patch.object(
+                meta_plugin,
+                "save_url_image",
+                return_value=Path("/tmp/meta_20260524_000000_deadbeef.webp"),
+            ) as mock_save_url,
+        ):
             result = provider.generate("a cat")
 
         assert result["success"] is True

--- a/tests/plugins/image_gen/test_meta_ai_provider.py
+++ b/tests/plugins/image_gen/test_meta_ai_provider.py
@@ -1,0 +1,262 @@
+"""Tests for the bundled Meta Model API image_gen plugin (muse-image)."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# The plugin directory uses a hyphen, which is not a valid Python identifier
+# for the dotted-import form. Load it via importlib so tests don't need to
+# touch sys.path or rename the directory.
+meta_plugin = importlib.import_module("plugins.image_gen.meta-ai")
+
+
+# 1×1 transparent PNG — valid bytes for save_b64_image()
+_PNG_HEX = (
+    "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4"
+    "890000000d49444154789c6300010000000500010d0a2db40000000049454e44"
+    "ae426082"
+)
+
+
+def _b64_png() -> str:
+    import base64
+    return base64.b64encode(bytes.fromhex(_PNG_HEX)).decode()
+
+
+def _fake_response(*, b64=None, url=None, revised_prompt=None):
+    item = SimpleNamespace(b64_json=b64, url=url, revised_prompt=revised_prompt)
+    return SimpleNamespace(data=[item])
+
+
+@pytest.fixture(autouse=True)
+def _tmp_hermes_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    # Clear every auth + override env var so tests start from a clean slate.
+    for env in ("MODEL_API_KEY", "META_API_KEY", "META_MODEL_API_KEY",
+                "META_BASE_URL", "META_IMAGE_MODEL"):
+        monkeypatch.delenv(env, raising=False)
+    yield tmp_path
+
+
+@pytest.fixture
+def provider(monkeypatch):
+    monkeypatch.setenv("META_MODEL_API_KEY", "test-key")
+    return meta_plugin.MetaImageGenProvider()
+
+
+def _patched_openai(fake_client: MagicMock):
+    fake_openai = MagicMock()
+    fake_openai.OpenAI.return_value = fake_client
+    return patch.dict("sys.modules", {"openai": fake_openai})
+
+
+# ── Metadata ────────────────────────────────────────────────────────────────
+
+
+class TestMetadata:
+    def test_name(self, provider):
+        assert provider.name == "meta-ai"
+
+    def test_display_name(self, provider):
+        assert provider.display_name == "Meta Model API"
+
+    def test_default_model(self, provider):
+        assert provider.default_model() == "muse-image-1.0"
+
+    def test_list_models(self, provider):
+        ids = [m["id"] for m in provider.list_models()]
+        assert ids == ["muse-image-1.0"]
+
+    def test_catalog_entries_have_display_speed_strengths_price(self, provider):
+        for entry in provider.list_models():
+            assert entry["display"]
+            assert entry["speed"]
+            assert entry["strengths"]
+            assert entry["price"]
+
+    def test_text_only_capabilities(self, provider):
+        caps = provider.capabilities()
+        assert caps["modalities"] == ["text"]
+        assert caps["max_reference_images"] == 0
+
+
+# ── Availability ────────────────────────────────────────────────────────────
+
+
+class TestAvailability:
+    def test_no_api_key_unavailable(self):
+        assert meta_plugin.MetaImageGenProvider().is_available() is False
+
+    @pytest.mark.parametrize(
+        "env", ["MODEL_API_KEY", "META_API_KEY", "META_MODEL_API_KEY"]
+    )
+    def test_each_auth_alias_makes_available(self, monkeypatch, env):
+        monkeypatch.setenv(env, "test")
+        assert meta_plugin.MetaImageGenProvider().is_available() is True
+
+
+# ── Auth / base-url resolution ────────────────────────────────────────────────
+
+
+class TestResolution:
+    def test_api_key_priority_order(self, monkeypatch):
+        # MODEL_API_KEY wins over the aliases.
+        monkeypatch.setenv("META_MODEL_API_KEY", "third")
+        monkeypatch.setenv("META_API_KEY", "second")
+        monkeypatch.setenv("MODEL_API_KEY", "first")
+        assert meta_plugin._resolve_api_key() == "first"
+
+    def test_default_base_url(self):
+        assert meta_plugin._resolve_base_url() == "https://api.meta.ai/v1"
+
+    def test_base_url_override(self, monkeypatch):
+        monkeypatch.setenv("META_BASE_URL", "https://proxy.internal/v1")
+        assert meta_plugin._resolve_base_url() == "https://proxy.internal/v1"
+
+
+# ── Model resolution ──────────────────────────────────────────────────────────
+
+
+class TestModelResolution:
+    def test_default(self):
+        model_id, _meta = meta_plugin._resolve_model()
+        assert model_id == "muse-image-1.0"
+
+    def test_env_var_override_ignores_unknown(self, monkeypatch):
+        monkeypatch.setenv("META_IMAGE_MODEL", "not-a-real-model")
+        model_id, _meta = meta_plugin._resolve_model()
+        # Unknown id is ignored; falls through to the default.
+        assert model_id == "muse-image-1.0"
+
+
+# ── Generate ──────────────────────────────────────────────────────────────────
+
+
+class TestGenerate:
+    def test_empty_prompt_rejected(self, provider):
+        result = provider.generate("", aspect_ratio="square")
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_argument"
+        assert result["provider"] == "meta-ai"
+
+    def test_missing_api_key(self):
+        result = meta_plugin.MetaImageGenProvider().generate("a cat")
+        assert result["success"] is False
+        assert result["error_type"] == "auth_required"
+
+    def test_b64_saves_to_cache(self, provider, tmp_path):
+        png_bytes = bytes.fromhex(_PNG_HEX)
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
+
+        with _patched_openai(fake_client):
+            result = provider.generate("a cat", aspect_ratio="landscape")
+
+        assert result["success"] is True
+        assert result["model"] == "muse-image-1.0"
+        assert result["aspect_ratio"] == "landscape"
+        assert result["provider"] == "meta-ai"
+        assert result["modality"] == "text"
+
+        saved = Path(result["image"])
+        assert saved.exists()
+        assert saved.parent == tmp_path / "cache" / "images"
+        assert saved.read_bytes() == png_bytes
+
+        call_kwargs = fake_client.images.generate.call_args.kwargs
+        assert call_kwargs["model"] == "muse-image-1.0"
+        assert call_kwargs["size"] == "1536x1024"
+        assert call_kwargs["n"] == 1
+
+    def test_client_uses_meta_base_url(self, provider):
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
+        fake_openai = MagicMock()
+        fake_openai.OpenAI.return_value = fake_client
+
+        with patch.dict("sys.modules", {"openai": fake_openai}):
+            provider.generate("a cat")
+
+        assert fake_openai.OpenAI.call_args.kwargs["base_url"] == "https://api.meta.ai/v1"
+
+    def test_base_url_override_reaches_client(self, provider, monkeypatch):
+        monkeypatch.setenv("META_BASE_URL", "https://proxy.internal/v1")
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
+        fake_openai = MagicMock()
+        fake_openai.OpenAI.return_value = fake_client
+
+        with patch.dict("sys.modules", {"openai": fake_openai}):
+            provider.generate("a cat")
+
+        assert fake_openai.OpenAI.call_args.kwargs["base_url"] == "https://proxy.internal/v1"
+
+    @pytest.mark.parametrize("aspect,expected_size", [
+        ("landscape", "1536x1024"),
+        ("square", "1024x1024"),
+        ("portrait", "1024x1536"),
+    ])
+    def test_aspect_ratio_mapping(self, provider, aspect, expected_size):
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
+
+        with _patched_openai(fake_client):
+            provider.generate("a cat", aspect_ratio=aspect)
+
+        assert fake_client.images.generate.call_args.kwargs["size"] == expected_size
+
+    def test_revised_prompt_passed_through(self, provider):
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(
+            b64=_b64_png(), revised_prompt="A photo of a cat",
+        )
+
+        with _patched_openai(fake_client):
+            result = provider.generate("a cat")
+
+        assert result["revised_prompt"] == "A photo of a cat"
+
+    def test_url_response_is_cached_locally(self, provider):
+        """A URL response is materialized locally (symmetric to the openai/xai
+        providers) so ephemeral signed URLs can't expire mid-flight."""
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(
+            b64=None, url="https://example.com/img.webp",
+        )
+
+        with _patched_openai(fake_client), patch.object(
+            meta_plugin, "save_url_image",
+            return_value=Path("/tmp/meta_20260524_000000_deadbeef.webp"),
+        ) as mock_save_url:
+            result = provider.generate("a cat")
+
+        assert result["success"] is True
+        assert result["image"].startswith("/")
+        assert "example.com" not in result["image"]
+        mock_save_url.assert_called_once()
+
+    def test_empty_response_errors(self, provider):
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(b64=None, url=None)
+
+        with _patched_openai(fake_client):
+            result = provider.generate("a cat")
+
+        assert result["success"] is False
+        assert result["error_type"] == "empty_response"
+
+    def test_api_error_surfaced(self, provider):
+        fake_client = MagicMock()
+        fake_client.images.generate.side_effect = RuntimeError("boom")
+
+        with _patched_openai(fake_client):
+            result = provider.generate("a cat")
+
+        assert result["success"] is False
+        assert result["error_type"] == "api_error"
+        assert "boom" in result["error"]

--- a/website/docs/developer-guide/image-gen-provider-plugin.md
+++ b/website/docs/developer-guide/image-gen-provider-plugin.md
@@ -6,7 +6,7 @@ description: "How to build an image-generation backend plugin for Hermes Agent"
 
 # Building an Image Generation Provider Plugin
 
-Image-gen provider plugins register a backend that services every `image_generate` tool call — DALL·E, gpt-image, Grok, Flux, Imagen, Stable Diffusion, fal, Replicate, a local ComfyUI rig, anything. Built-in providers (OpenAI, OpenAI-Codex, xAI, FAL, Krea, DeepInfra, OpenRouter) all ship as plugins. You can add a new one, or override a bundled one, by dropping a directory into `plugins/image_gen/<name>/`.
+Image-gen provider plugins register a backend that services every `image_generate` tool call — DALL·E, gpt-image, Grok, Flux, Imagen, Stable Diffusion, fal, Replicate, a local ComfyUI rig, anything. Built-in providers (OpenAI, OpenAI-Codex, xAI, FAL, Krea, DeepInfra, OpenRouter, Meta Model API) all ship as plugins. You can add a new one, or override a bundled one, by dropping a directory into `plugins/image_gen/<name>/`.
 
 :::tip
 Image-gen is one of several **backend plugins** Hermes supports. The others (with more specialized ABCs) are [Memory Provider Plugins](/developer-guide/memory-provider-plugin), [Context Engine Plugins](/developer-guide/context-engine-plugin), and [Model Provider Plugins](/developer-guide/model-provider-plugin). General tool/hook/CLI plugins live in [Build a Hermes Plugin](/developer-guide/plugins).

--- a/website/docs/user-guide/features/image-generation.md
+++ b/website/docs/user-guide/features/image-generation.md
@@ -104,6 +104,28 @@ image_gen:
 
 The `fal-ai/gpt-image-1.5` and `fal-ai/gpt-image-2` request quality is pinned to `medium` (~$0.034–$0.06/image at 1024×1024). We don't expose the `low` / `high` tiers as a user-facing option so that Nous Portal billing stays predictable across all users — the cost spread between tiers is 3–22×. If you want a cheaper option, pick Klein 9B or Z-Image Turbo; if you want higher quality, use Nano Banana Pro or Recraft V4 Pro.
 
+### Meta Model API: Muse Image
+
+With `image_gen.provider: meta-ai`, images are generated through the
+[Meta Model API](https://api.meta.ai) (`https://api.meta.ai/v1`), the same
+OpenAI-compatible endpoint that serves the Muse Spark chat models. It is the
+image-gen companion to the bundled `meta-ai` chat provider.
+
+| Model | Speed | Strengths | Price |
+|---|---|---|---|
+| `muse-image-1.0` *(default)* | ~10s | Meta Model API image generation | $0.01/image |
+
+```yaml
+image_gen:
+  provider: meta-ai
+  model: muse-image-1.0
+```
+
+Auth reuses the same env vars as the Meta chat provider — `MODEL_API_KEY`
+(Meta's documented name), with `META_API_KEY` / `META_MODEL_API_KEY` accepted
+as aliases. Set `META_BASE_URL` to point at a proxy or alternate host. Text-to-image
+only for now; responses are saved to `$HERMES_HOME/cache/images/`.
+
 ## Usage
 
 The agent-facing schema is intentionally minimal — the model picks up whatever you've configured:


### PR DESCRIPTION
## Summary
Bundles a `meta-ai` image-generation backend for the **Meta Model API** (`https://api.meta.ai/v1`, OpenAI-compatible), exposing `muse-image-1.0` through the standard `image_generate` tool. Companion to the already-bundled `meta-ai` chat provider (#88565): same provider id, same auth env vars (`MODEL_API_KEY` / `META_API_KEY` / `META_MODEL_API_KEY`, `META_BASE_URL` override).

Salvages #97283 by @mreso (Meta) — his commit cherry-picked with authorship preserved, plus one follow-up commit from us.

## Follow-up fixes on top of #97283
1. **Honor the dispatcher's `model` kwarg.** `_dispatch_to_plugin_provider` forwards top-level `image_gen.model` (what `hermes tools` writes) as `kwargs["model"]`; the plugin ignored it. Harmless with a single model, silently drops the user's pick the moment Meta ships a second image model (#55893 bug class; xai/krea/openrouter already honor it).
2. Setup-schema badge `"internal"` → `"paid"`, consistent with every other paid image backend in the picker.

## Validation
| Check | Result |
|---|---|
| `tests/plugins/image_gen` + `tests/tools/test_image_generation.py` | 258 passed locally — 27 contributor tests + 4 new |
| ruff check / format on touched files | clean |
| Plugin discovery on temp `HERMES_HOME` | `meta-ai` registered alongside deepinfra/fal/krea/nous/openai/openai-codex/openrouter/xai; `is_available()` True with key; badge `paid` |
| Full E2E via `_handle_image_generate` (real config + real dispatcher + real plugin, only `openai.OpenAI` mocked) | `success=True, provider=meta-ai, model=muse-image-1.0`; client built with `base_url=https://api.meta.ai/v1`; payload `{model, prompt, size: 1536x1024, n: 1}` for landscape; WebP saved under `$HERMES_HOME/cache/images/` |
| Live endpoint probe | `POST https://api.meta.ai/v1/images/generations` with invalid key → `401 invalid_api_key` (route exists, auth path correct). No Meta key on the review box, so no real generation; @mreso verified end-to-end against api.meta.ai per #97283. |

Distinct from #100010 (same model via FAL credentials); both should land.

Closes #97283