### PR TITLE
feat(gateway): add inject_observed_group_context option to opt out of observed message replay

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1202,10 +1202,13 @@ def _message_timestamps_enabled(user_config: Optional[dict]) -> bool:
 
 def _build_gateway_agent_history(
     history: List[Dict[str, Any]], *, channel_prompt: Optional[str] = None,
-    inject_timestamps: bool = False) -> tuple[List[Dict[str, Any]], Optional[str]]:
+    inject_timestamps: bool = False, inject_observed_context: bool = True,
+) -> tuple[List[Dict[str, Any]], Optional[str]]:
     """Convert stored gateway transcript rows into agent replay messages.
 
-    Observed context stays out of ``conversation_history`` so consecutive-user repair can't merge it in."""
+    Observed context stays out of ``conversation_history`` so consecutive-user repair can't merge it in.
+    With ``inject_observed_context=False`` observed rows are still withheld from replay (they stay stored
+    transcript rows, never model input) but no observed-context block is returned for the addressed turn."""
     from hermes_time import get_timezone as _get_msg_tz
     from gateway.message_timestamps import (
         render_user_content_with_timestamp as _render_msg_ts,
@@ -1225,9 +1228,10 @@ def _build_gateway_agent_history(
 
         content = msg.get("content")
         if separate_observed_context and msg.get("observed") and role == "user" and content:
-            if inject_timestamps and isinstance(content, str):
-                content = _render_msg_ts(content, msg.get("timestamp"), tz=_msg_tz)
-            observed_group_context.append(str(content).strip())
+            if inject_observed_context:
+                if inject_timestamps and isinstance(content, str):
+                    content = _render_msg_ts(content, msg.get("timestamp"), tz=_msg_tz)
+                observed_group_context.append(str(content).strip())
             continue
 
         # Rich tool_calls/tool-result rows pass through intact so the API sees valid assistant→tool sequences.

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -35,6 +35,28 @@ if TYPE_CHECKING:  # string annotations only; never imported at runtime (cycle)
 logger = logging.getLogger("gateway.run")
 
 
+def _telegram_inject_observed_group_context_enabled(user_config: Optional[dict]) -> bool:
+    """Resolve ``telegram.inject_observed_group_context`` from this turn's profile config.
+
+    Config-only by design: under ``gateway.multiplex_profiles`` a process-global env value would pin
+    the launch profile's setting for every routed profile, so the value is read from the active
+    profile's own config. The telegram section is located the way the gateway locates it for every
+    other platform setting, and the key may sit on the section or in its ``extra`` block.
+    """
+    if not isinstance(user_config, dict):
+        return True
+    from gateway.config_loader import platform_section
+    gateway_cfg = user_config.get("gateway")
+    gateway_platforms = gateway_cfg.get("platforms") if isinstance(gateway_cfg, dict) else None
+    section, _ = platform_section(user_config, "telegram", gateway_platforms)
+    if not isinstance(section, dict):
+        return True
+    for block in (section, section.get("extra")):
+        if isinstance(block, dict) and "inject_observed_group_context" in block:
+            return is_truthy_value(block["inject_observed_group_context"], default=True)
+    return True
+
+
 class _ExecApprovalDeclined(RuntimeError):
     """The connector refused the approval card's destination.
 
@@ -1393,7 +1415,10 @@ class TurnRunner:
         # sequences. Telegram observed=True rows are withheld from replayable history and attached to
         # the current addressed message as API-only context.
         agent_history, observed_group_context = _build_gateway_agent_history(
-            ctx.history, channel_prompt=ctx.channel_prompt, inject_timestamps=_message_timestamps_enabled(ctx.user_config),
+            ctx.history,
+            channel_prompt=ctx.channel_prompt,
+            inject_timestamps=_message_timestamps_enabled(ctx.user_config),
+            inject_observed_context=_telegram_inject_observed_group_context_enabled(ctx.user_config),
         )
         # FTS write-corruption guard: if persistence failed silently the reloaded transcript is stale
         # while the SAME cached agent still holds the live conversation (same-session amnesia). Only

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -621,6 +621,117 @@ def test_top_level_require_mention_bridges_to_telegram(monkeypatch, tmp_path):
         assert tg_cfg.extra.get("require_mention") is True
 
 
+def test_inject_observed_group_context_defaults_on_and_is_config_scoped():
+    """The turn runner reads the active profile's YAML, never a bridged process env."""
+    from gateway.run_turn_runner import _telegram_inject_observed_group_context_enabled
+
+    assert _telegram_inject_observed_group_context_enabled({}) is True
+    assert _telegram_inject_observed_group_context_enabled(None) is True
+    assert _telegram_inject_observed_group_context_enabled(
+        {"telegram": {"inject_observed_group_context": False}}
+    ) is False
+    assert _telegram_inject_observed_group_context_enabled(
+        {"telegram": {"inject_observed_group_context": "false"}}
+    ) is False
+    assert _telegram_inject_observed_group_context_enabled(
+        {"telegram": {"extra": {"inject_observed_group_context": False}}}
+    ) is False
+    # The gateway's own platform section is the other documented place a telegram setting lives.
+    assert _telegram_inject_observed_group_context_enabled(
+        {"gateway": {"platforms": {"telegram": {"inject_observed_group_context": False}}}}
+    ) is False
+    assert _telegram_inject_observed_group_context_enabled(
+        {"gateway": {"platforms": {"telegram": {"extra": {"inject_observed_group_context": False}}}}}
+    ) is False
+    # ``hermes gateway setup`` may write gateway.platforms as a list of names; a non-dict shape
+    # must fall back to the default instead of raising.
+    assert _telegram_inject_observed_group_context_enabled(
+        {"gateway": {"platforms": ["telegram"]}, "telegram": "not-a-mapping"}
+    ) is True
+
+
+def test_inject_observed_group_context_is_per_profile_and_never_process_global(tmp_path, monkeypatch):
+    """Two multiplexed profiles keep independent values and nothing lands in the process env."""
+    import os
+
+    from agent.secret_scope import set_multiplex_active
+    from gateway.run import _load_gateway_config, _profile_runtime_scope
+    from gateway.run_turn_runner import _telegram_inject_observed_group_context_enabled as enabled
+    from plugins.platforms.telegram.adapter import _apply_yaml_config
+
+    homes = {}
+    for name, value in (("optout", "false"), ("optin", "true")):
+        home = tmp_path / name
+        home.mkdir()
+        (home / "config.yaml").write_text(
+            f"telegram:\n  inject_observed_group_context: {value}\n", encoding="utf-8")
+        homes[name] = home
+
+    monkeypatch.delenv("TELEGRAM_INJECT_OBSERVED_GROUP_CONTEXT", raising=False)
+
+    with _profile_runtime_scope(homes["optout"], {}, hydrate_secrets=False):
+        # The adapter's YAML→env bridge is the multiplex leak surface (#72348): a secondary
+        # profile must not publish this setting where every other profile would read it.
+        set_multiplex_active(True)
+        try:
+            _apply_yaml_config({}, {"inject_observed_group_context": False})
+        finally:
+            set_multiplex_active(False)
+        assert enabled(_load_gateway_config()) is False
+        assert "TELEGRAM_INJECT_OBSERVED_GROUP_CONTEXT" not in os.environ
+
+    with _profile_runtime_scope(homes["optin"], {}, hydrate_secrets=False):
+        assert enabled(_load_gateway_config()) is True
+        assert "TELEGRAM_INJECT_OBSERVED_GROUP_CONTEXT" not in os.environ
+
+
+def test_build_gateway_agent_history_can_withhold_observed_prompt_context():
+    """Opting out still leaves observed rows persisted, but excludes them from the live prompt."""
+    from gateway.run import _build_gateway_agent_history
+
+    history = [
+        {"role": "user", "content": "[Alice|111] side chatter", "observed": True},
+        {"role": "assistant", "content": "Earlier reply"},
+    ]
+    channel_prompt = "observed Telegram group context"
+
+    injected_history, injected_context = _build_gateway_agent_history(
+        history, channel_prompt=channel_prompt, inject_observed_context=True,
+    )
+    withheld_history, withheld_context = _build_gateway_agent_history(
+        history, channel_prompt=channel_prompt, inject_observed_context=False,
+    )
+
+    assert injected_context == "[Alice|111] side chatter"
+    assert withheld_context is None
+    assert injected_history == withheld_history == [{"role": "assistant", "content": "Earlier reply"}]
+    assert history[0]["observed"] is True
+
+
+def test_turn_runner_loads_observed_context_according_to_the_profile_setting():
+    """The production caller must pass the profile's flag into the replay builder."""
+    from gateway.run_turn_runner import TurnRunner
+
+    runner = object.__new__(TurnRunner)
+    runner._ctx = SimpleNamespace(
+        history=[{"role": "user", "content": "[Alice|111] side chatter", "observed": True}],
+        channel_prompt="observed Telegram group context",
+        user_config={"telegram": {"inject_observed_group_context": False}},
+        session_id="telegram-group-session",
+        session_key="key",
+    )
+
+    agent_history, observed_group_context, _media = runner._load_turn_history(object(), False)
+
+    assert agent_history == []
+    assert observed_group_context is None
+
+    # Default (no setting): the observed row still rides the addressed turn's context block.
+    runner._ctx.user_config = {}
+    _history, observed_group_context, _media = runner._load_turn_history(object(), False)
+    assert observed_group_context == "[Alice|111] side chatter"
+
+
 # ---------------------------------------------------------------------------
 # Helpers for location / media observe+attribution tests
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -180,6 +180,18 @@ TELEGRAM_OBSERVE_UNMENTIONED_GROUP_MESSAGES=true
 
 This requires Telegram to deliver ordinary group messages to the gateway, so disable BotFather privacy mode or promote the bot to group admin as described above.
 
+### Keep observed group chatter out of the model's context
+
+Observed context is injected by default. To record group chatter in the transcript without feeding it to the model, set `inject_observed_group_context: false`:
+
+```yaml
+telegram:
+  observe_unmentioned_group_messages: true
+  inject_observed_group_context: false
+```
+
+Observed group messages are still appended to the shared session transcript, but an addressed turn no longer replays them as an observed-context block, so the model only sees the message that actually addressed it. Default is `true` (previous behavior). This is a `config.yaml` setting with no environment variable; the gateway resolves it from the active profile's own config, so multiplexed profiles can each choose their own value.
+
 ## Step 4: Find Your User ID
 
 Hermes Agent uses numeric Telegram user IDs to control access. Your user ID is **not** your username — it's a number like `123456789`.


### PR DESCRIPTION
## Background

When `observe_unmentioned_group_messages` is enabled (a common setup for group bots that store all chat traffic for search/RAG), every unmentioned group message is ingested into the session database **and** — on the next bot @mention — the accumulated observed messages are collected and prepended to the turn's prompt as "observed context".

In high-volume group chats with an **external RAG workflow** (messages are already retrieved via the RAG service), injecting all observed chatter into the prompt is redundant and expensive: ~180 messages/day of ambient conversation get replayed into context, driving frequent context compression and degraded latency — while the messages are already stored and searchable in the transcript/DB either way.

## Change

Adds a Telegram opt-out: `telegram.inject_observed_group_context: false`.

- `true` (default, unchanged behavior): observed messages are still collected and prepended to the prompt on @mention.
- `false`: observed messages keep being **stored/ingested as before** (search + RAG keep working), but are skipped when building the prompt replay — the turn starts clean with the actual @-mentioned message.

Config-only by design: the key is read from the active turn's own profile config, never bridged into the process environment. Under `gateway.multiplex_profiles` a process-global value would pin one profile's setting for every other routed profile, so no `TELEGRAM_*` env override exists for this key.

Files:
- `gateway/run_turn_runner.py` — `_telegram_inject_observed_group_context_enabled(user_config)` resolver (default `true`; key on the telegram section or in its `extra` block) + wiring into the turn's replay-history build
- `gateway/run.py` — `inject_observed_context` parameter on `_build_gateway_agent_history`; observed rows are still consumed/withheld from replay (they remain stored transcript rows), but no observed-context block is returned when disabled
- `tests/gateway/test_telegram_group_gating.py` — new tests: default-true preserves replay, false skips injection, config-shape resolution, dual-profile isolation (the key is never published to `os.environ` while multiplex is active), and the production wiring seam via `TurnRunner._load_turn_history`
- `website/docs/user-guide/messaging/telegram.md` — documents the config-only opt-out

No behavior change for existing setups (default remains `true`). Message storage/ingestion is untouched in both modes — only prompt injection is switchable.

Local: `scripts/run_tests.sh tests/gateway/` — 802 files, 7989 passed, 0 failed, 35 skipped (`windows_only`). Targeted `test_telegram_group_gating.py` + `test_config.py` — 85 passed. New tests verified red against `main` before the fix. Upstream CI runs the suite regardless.
