### PR TITLE
feat(slack): allowlist user-token Web API posts as human senders

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1277,6 +1277,13 @@ platform_toolsets:
 #       # Render live tool calls as Slack-native plan/task cards. This explicit
 #       # opt-in works even though Slack text tool_progress defaults to off.
 #       native_task_cards: false
+#       # Treat Web-API posts from these senders as human-authored. Posts made
+#       # with a user token still carry the posting app's bot_id/app_id, so by
+#       # default they are dropped as bot traffic — allowlist your own
+#       # front-end (dashboard, mobile shell) here instead of allow_bots: all.
+#       # Env equivalents: SLACK_API_HUMAN_USERS / SLACK_API_HUMAN_APPS.
+#       api_human_users: "U0AAAAAAA,U0BBBBBBB"
+#       api_human_apps: "A0CCCCCCC"
 #       # Suppress automatic link-preview cards without removing clickable links.
 #       # Omit either key to preserve Slack's default for that preview type.
 #       unfurl_links: false

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3838,8 +3838,53 @@ class SlackAdapter(BasePlatformAdapter):
             return "none"
         return value
 
+    def _slack_api_human_allowlists(self) -> tuple:
+        """Return (user_ids, app_ids) whose Web-API posts count as human.
+
+        Messages posted through the Web API with a *user* token carry the
+        posting app's ``bot_id``/``app_id`` even though the author is a real
+        person — Slack stamps every API post with the app that made it.
+        Operators running their own front-ends on top of Hermes (an internal
+        dashboard, a mobile shell) can allowlist those senders here so their
+        posts are not dropped as bot traffic. Configured via
+        ``platforms.slack.extra.api_human_users`` / ``.api_human_apps`` or the
+        ``SLACK_API_HUMAN_USERS`` / ``SLACK_API_HUMAN_APPS`` env vars
+        (comma-separated; the config keys win when both are set).
+        """
+
+        def _parse(value) -> set:
+            if value is None:
+                return set()
+            if isinstance(value, (list, tuple, set)):
+                return {str(v).strip() for v in value if str(v).strip()}
+            return {p.strip() for p in str(value).split(",") if p.strip()}
+
+        users = self.config.extra.get("api_human_users")
+        if users is None:
+            users = os.getenv("SLACK_API_HUMAN_USERS", "")
+        apps = self.config.extra.get("api_human_apps")
+        if apps is None:
+            apps = os.getenv("SLACK_API_HUMAN_APPS", "")
+        return _parse(users), _parse(apps)
+
     def _event_declares_bot_sender(self, event: dict) -> bool:
         """Return True when the Slack event itself identifies a bot sender."""
+        # Allowlisted Web-API posts from real users are human, not bot,
+        # traffic (see _slack_api_human_allowlists). Scoped to events that
+        # name a real user and are not subtype=bot_message, so genuine bot
+        # posts (which carry no ``user``) can never match.
+        sender_user = event.get("user")
+        if sender_user and event.get("subtype") != "bot_message":
+            allow_users, allow_apps = self._slack_api_human_allowlists()
+            if sender_user in allow_users or (
+                event.get("app_id") and event.get("app_id") in allow_apps
+            ):
+                logger.info(
+                    "[Slack] Treating API-posted message as human: user=%s app=%s",
+                    sender_user,
+                    event.get("app_id"),
+                )
+                return False
         if event.get("bot_id") or event.get("bot_profile"):
             return True
         if event.get("subtype") == "bot_message":
@@ -9830,6 +9875,15 @@ def _apply_yaml_config(yaml_cfg: dict, slack_cfg: dict) -> dict | None:
         ).lower()
     if "allow_bots" in slack_cfg and not os.getenv("SLACK_ALLOW_BOTS"):
         os.environ["SLACK_ALLOW_BOTS"] = str(slack_cfg["allow_bots"]).lower()
+    for _key, _env in (
+        ("api_human_users", "SLACK_API_HUMAN_USERS"),
+        ("api_human_apps", "SLACK_API_HUMAN_APPS"),
+    ):
+        _val = slack_cfg.get(_key)
+        if _val is not None and not os.getenv(_env):
+            if isinstance(_val, (list, tuple, set)):
+                _val = ",".join(str(v) for v in _val)
+            os.environ[_env] = str(_val)
     frc = slack_cfg.get("free_response_channels")
     if frc is not None and not os.getenv("SLACK_FREE_RESPONSE_CHANNELS"):
         if isinstance(frc, list):

--- a/tests/gateway/test_slack_api_human_senders.py
+++ b/tests/gateway/test_slack_api_human_senders.py
@@ -1,0 +1,136 @@
+"""Tests for the Slack ``api_human_users`` / ``api_human_apps`` allowlists.
+
+A message posted through the Web API with a *user* token is authored by a
+real person, but Slack stamps it with the posting app's ``bot_id``/``app_id``
+so ``_event_declares_bot_sender`` classifies it as bot traffic and the
+message is dropped. Operators running their own front-ends (dashboards,
+mobile shells) can allowlist those senders via
+``platforms.slack.extra.api_human_users`` / ``.api_human_apps`` or the
+``SLACK_API_HUMAN_USERS`` / ``SLACK_API_HUMAN_APPS`` env vars.
+
+These tests pin the allowlist scope: only events that name a real ``user``
+and are not ``subtype: bot_message`` may match, so classic bot posts (which
+carry no ``user``) can never ride the allowlist.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# Mock slack-bolt / slack-sdk the same way test_slack_mention.py does.
+def _ensure_slack_mock():
+    if "slack_bolt" in sys.modules and hasattr(sys.modules["slack_bolt"], "__file__"):
+        return
+    slack_bolt = MagicMock()
+    slack_bolt.async_app.AsyncApp = MagicMock
+    slack_bolt.adapter.socket_mode.async_handler.AsyncSocketModeHandler = MagicMock
+    slack_sdk = MagicMock()
+    slack_sdk.web.async_client.AsyncWebClient = MagicMock
+    for name, mod in [
+        ("slack_bolt", slack_bolt),
+        ("slack_bolt.async_app", slack_bolt.async_app),
+        ("slack_bolt.adapter", slack_bolt.adapter),
+        ("slack_bolt.adapter.socket_mode", slack_bolt.adapter.socket_mode),
+        (
+            "slack_bolt.adapter.socket_mode.async_handler",
+            slack_bolt.adapter.socket_mode.async_handler,
+        ),
+        ("slack_sdk", slack_sdk),
+        ("slack_sdk.web", slack_sdk.web),
+        ("slack_sdk.web.async_client", slack_sdk.web.async_client),
+    ]:
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("aiohttp", MagicMock())
+
+
+_ensure_slack_mock()
+
+import plugins.platforms.slack.adapter as _slack_mod  # noqa: E402
+
+_slack_mod.SLACK_AVAILABLE = True
+
+from plugins.platforms.slack.adapter import SlackAdapter  # noqa: E402
+
+from gateway.config import Platform, PlatformConfig  # noqa: E402
+
+
+HUMAN_ID = "U_human"
+FRONTEND_APP_ID = "A_frontend"
+
+
+def _make_adapter(extra=None):
+    adapter = object.__new__(SlackAdapter)
+    adapter.platform = Platform.SLACK
+    adapter.config = PlatformConfig(enabled=True, extra=dict(extra or {}))
+    return adapter
+
+
+def _api_post(**overrides):
+    """A user-token chat.postMessage as delivered over Socket Mode:
+    real ``user``, no ``client_msg_id``, stamped with the app's ids."""
+    event = {
+        "type": "message",
+        "user": HUMAN_ID,
+        "bot_id": "B_stamp",
+        "app_id": FRONTEND_APP_ID,
+        "text": "build the lunch app",
+    }
+    event.update(overrides)
+    return event
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("SLACK_API_HUMAN_USERS", raising=False)
+    monkeypatch.delenv("SLACK_API_HUMAN_APPS", raising=False)
+
+
+def test_api_post_is_bot_by_default():
+    assert _make_adapter()._event_declares_bot_sender(_api_post()) is True
+
+
+def test_config_user_allowlist_admits_api_post():
+    adapter = _make_adapter({"api_human_users": HUMAN_ID})
+    assert adapter._event_declares_bot_sender(_api_post()) is False
+
+
+def test_config_user_allowlist_accepts_list_form():
+    adapter = _make_adapter({"api_human_users": ["U_other", HUMAN_ID]})
+    assert adapter._event_declares_bot_sender(_api_post()) is False
+
+
+def test_env_app_allowlist_admits_api_post(monkeypatch):
+    monkeypatch.setenv("SLACK_API_HUMAN_APPS", FRONTEND_APP_ID)
+    assert _make_adapter()._event_declares_bot_sender(_api_post()) is False
+
+
+def test_config_key_wins_over_env(monkeypatch):
+    monkeypatch.setenv("SLACK_API_HUMAN_USERS", HUMAN_ID)
+    adapter = _make_adapter({"api_human_users": "U_someone_else"})
+    assert adapter._event_declares_bot_sender(_api_post()) is True
+
+
+def test_unlisted_sender_stays_bot():
+    adapter = _make_adapter({"api_human_users": "U_other", "api_human_apps": "A_other"})
+    assert adapter._event_declares_bot_sender(_api_post()) is True
+
+
+def test_bot_message_subtype_never_matches():
+    adapter = _make_adapter({"api_human_users": HUMAN_ID})
+    event = _api_post(subtype="bot_message")
+    assert adapter._event_declares_bot_sender(event) is True
+
+
+def test_event_without_user_never_matches():
+    """Classic bot posts carry no ``user`` — the app allowlist must not admit them."""
+    adapter = _make_adapter({"api_human_apps": FRONTEND_APP_ID})
+    event = _api_post()
+    del event["user"]
+    assert adapter._event_declares_bot_sender(event) is True
+
+
+def test_plain_human_message_unaffected():
+    event = {"type": "message", "user": HUMAN_ID, "client_msg_id": "x-1", "text": "hi"}
+    assert _make_adapter()._event_declares_bot_sender(event) is False

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -472,6 +472,7 @@ platforms:
 | `platforms.slack.extra.suggested_prompts` | `[]` | Up to four `{title, message}` prompts for Agent/Assistant DM entry points; accepts either a list or `{title, prompts}`. |
 | `platforms.slack.extra.assistant_thread_titles` | `true` | When `true`, names Agent/Assistant DM threads from the first user message. |
 | `platforms.slack.extra.allow_bots` | `"none"` | Controls messages from other Slack bots: `"none"` ignores them, `"mentions"` accepts a bot message only when **that message itself** @mentions Hermes, and `"all"` accepts all of them. Use `"mentions"` for the safest bot-to-bot collaboration mode. See [Accepting messages from other bots](#accepting-messages-from-other-bots-allow_bots). |
+| `platforms.slack.extra.api_human_users` / `.api_human_apps` | *(empty)* | Comma-separated Slack user IDs / app IDs whose **Web-API posts count as human**. Posts made with a *user* token still carry the posting app's `bot_id`/`app_id`, so by default they are dropped as bot traffic; allowlist your own front-end here instead of reaching for `allow_bots: all`. See [Treating your own app's user-token posts as human](#treating-your-own-apps-user-token-posts-as-human-api_human_users). |
 | `platforms.slack.extra.cron_continuable_surface` | `"thread"` | Delivery surface for [continuable cron jobs](../features/cron.md#flat-in-channel-continuation-slack). `"thread"` opens a dedicated thread per delivery (default); `"in_channel"` delivers flat into the channel timeline. Pair `in_channel` with `reply_in_thread: false` (and `require_mention: false`) so a plain channel reply continues the job. |
 
 The equivalent environment variable is `SLACK_ALLOW_BOTS=none|mentions|all`.
@@ -700,6 +701,43 @@ How `mentions` mode gates:
 `mentions` is the recommended mode for bot-to-bot collaboration: each agent must explicitly summon the other per turn. Avoid `all` unless every peer bot's own reply policy is loop-safe — two bots that answer everything will answer each other forever. Detection covers labeled bot messages (`bot_id`, `subtype: bot_message`), app-originated events, and unlabeled bot *users* (probed via `users.info`), so peer Hermes agents are filtered consistently across workspaces.
 
 For strict multi-bot deployments, pair with `require_mention: true` and `strict_mention: true` — see the smoke-check profile below.
+
+### Treating your own app's user-token posts as human (`api_human_users`)
+
+A message posted through the Web API with a **user token** (`xoxp-`) is
+authored by a real person, but Slack still stamps it with the posting app's
+`bot_id`/`app_id` — so Hermes's bot-sender detection drops it like any other
+app post. This blocks a common pattern: a custom front-end (an internal
+dashboard, a mobile shell, a kiosk) that sends messages to Hermes *as* the
+logged-in user.
+
+`allow_bots: all` would let those posts through, but it opens the door to every
+bot in the channel and weakens the loop protections. Instead, allowlist just
+your own senders:
+
+```yaml
+platforms:
+  slack:
+    extra:
+      # Slack user IDs whose API posts are treated as human-authored
+      api_human_users: "U0AAAAAAA,U0BBBBBBB"
+      # ...or trust every user posting through this app ID
+      api_human_apps: "A0CCCCCCC"
+```
+
+Env equivalents: `SLACK_API_HUMAN_USERS` / `SLACK_API_HUMAN_APPS`
+(comma-separated; the config keys win when both are set).
+
+Scope and safety:
+
+- Only events that carry a real `user` id and are **not** `subtype:
+  bot_message` can match — classic bot posts carry no `user`, so a peer bot
+  can never ride this allowlist.
+- The rest of the pipeline is unchanged: mention gating, `allowed_channels`,
+  and `SLACK_ALLOWED_USERS` still apply to the (now human) sender.
+- Prefer `api_human_users` when a fixed set of people uses the front-end;
+  use `api_human_apps` when the app manages its own logins and any workspace
+  member may post through it.
 
 ### Reaction Triggers (`reaction_triggers`)
 


### PR DESCRIPTION
## Summary
Adds narrow allowlists — `platforms.slack.extra.api_human_users` / `.api_human_apps` (env: `SLACK_API_HUMAN_USERS` / `SLACK_API_HUMAN_APPS`) — so operators can mark specific senders whose **Web-API posts are treated as human-authored**.

A message posted through the Web API with a **user token** (`xoxp-`) is authored by a real person, but Slack stamps it with the posting app's `bot_id`/`app_id`, so `_event_declares_bot_sender` classifies it as bot traffic and the gateway drops it. That blocks a common pattern: a custom front-end (internal dashboard, mobile shell, kiosk) posting to Hermes *as* the logged-in user via their own OAuth token. The existing escape hatch, `allow_bots: all` (#26191, #70198), admits **every** bot in the channel and weakens the agent-loop protections the default policy exists for.

```yaml
platforms:
  slack:
    extra:
      api_human_users: "U0AAAAAAA,U0BBBBBBB"  # these people's API posts are human
      api_human_apps: "A0CCCCCCC"             # ...or trust posts made through this app
```

**Scope and safety:** only events that carry a real `user` id and are **not** `subtype: bot_message` can match — classic bot posts carry no `user`, so a peer bot can never ride the allowlist. Everything downstream is unchanged: mention gating, `allowed_channels`, and `SLACK_ALLOWED_USERS` still apply to the admitted sender. With the keys unset, behavior is byte-for-byte identical to today.

Same allowlist spirit as `SLACK_ALLOWED_USERS` / `SLACK_ALLOWED_CHANNELS`; config `extra` wins over env, list and comma-string forms both accepted, config→env export sits beside the existing `allow_bots` export. No existing issue or PR covers this — searched open/closed for `allow_bots` / user-token / `bot_id` false-positives; only the coarse `allow_bots` knob exists.

We run this in production for a multi-agent office dashboard where teammates log in with Slack OAuth and message their PM agent from the web UI under their own identity — the gateway logs `[Slack] Treating API-posted message as human: user=U… app=A…` and processes the DM normally.

## Changes
- `plugins/platforms/slack/adapter.py` — `_slack_api_human_allowlists()` helper (config `extra` → env fallback); allowlist check at the top of `_event_declares_bot_sender`, scoped to real-`user`, non-`bot_message` events; config→env export beside `allow_bots`.
- `tests/gateway/test_slack_api_human_senders.py` — 9 new tests: default unchanged, config/env/list forms, config-over-env precedence, `bot_message` subtype and user-less events never match, plain human messages unaffected.
- `website/docs/user-guide/messaging/slack.md` — config-table row + "Treating your own app's user-token posts as human" section next to the `allow_bots` docs.
- `cli-config.yaml.example` — the two new keys documented under `platforms.slack.extra`.

## Validation
| Check | Result |
|---|---|
| `tests/gateway/test_slack_api_human_senders.py -q` | 9 passed |
| Full Slack gateway suite, `tests/gateway -k slack -q` | **651 passed, 2 skipped** (platform skips), macOS 12.7 Intel / Python 3.11 |
| Neighboring detection suites (`wake_external_bot_messages`, `peer_agent_smoke`, `bot_auth_bypass`, `mention`) | 35 passed |
| Live | Bot-less Slack app with user scopes posting a DM: dropped by default; with `SLACK_API_HUMAN_USERS=<member id>` set, processed and logged as human. Running in production on our team workspace. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N32iaJ73C6KLEK6GrAL2JW
