### PR TITLE
fix(cron): don't record fence lock timeouts as fire-claim ownership loss

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -375,6 +375,17 @@ def _jobs_lock():
             _jobs_lock_state.load_stamp = None
 
 
+class FireFenceUnavailableError(Exception):
+    """The per-job fire fence could not be acquired within its timeout.
+
+    Raised instead of returning a loss verdict: fence contention proves
+    nothing about claim ownership (takeovers serialize through the same
+    fence), so callers must treat this as uncertainty — bounded-grace
+    retry for heartbeats, skip-and-keep-outcome for terminal writes —
+    never as "the fire claim was lost".
+    """
+
+
 @contextlib.contextmanager
 def _fire_job_lock(job_id: str):
     """Serialize one job's owner mutations and external side effects.
@@ -3623,7 +3634,20 @@ def _sweep_completed_oneshots(
 def heartbeat_fire_claim(job_id: str, *, expected_owner: str) -> bool:
     with _fire_job_lock(job_id) as acquired:
         if not acquired:
-            return False
+            # Fail loud, not as a loss: a busy fence cannot decide ownership.
+            # Every claim takeover and terminal revocation serializes through
+            # this same fence (claim_job_for_fire / mark_job_run), so "could
+            # not acquire within the timeout" must never be read as "the
+            # claim changed hands" — that conflation demoted delivered,
+            # successful runs to errors whenever a slow delivery held the
+            # fence past the lock timeout (t_0ce0b31e). Callers treat the
+            # raised error as uncertainty (bounded grace), never as a loss
+            # verdict. A same-thread caller already holding the fence
+            # re-enters transparently via the held-lock short-circuit above.
+            raise FireFenceUnavailableError(
+                f"Fire fence for job {job_id} is held by another worker; "
+                "fire-claim ownership could not be confirmed"
+            )
         return _heartbeat_fire_claim_locked(
             job_id,
             expected_owner=expected_owner,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -6965,11 +6965,12 @@ def _run_with_fire_claim_heartbeat(job: dict, run) -> bool:
     claim = job.get("fire_claim")
     owner = str(claim.get("by") or "") if isinstance(claim, dict) else ""
     if not owner:
-        return run(None)
+        return run(None, None)
 
     job_id = str(job.get("id") or "")
     stop = threading.Event()
     lost_ownership = threading.Event()
+    heartbeat_uncertain = threading.Event()
     heartbeat_context = contextvars.copy_context()
 
     def _finish_unstarted(error: str) -> None:
@@ -7047,6 +7048,7 @@ def _run_with_fire_claim_heartbeat(job: dict, run) -> bool:
                     time.monotonic() - last_confirmed
                     >= _FIRE_CLAIM_HEARTBEAT_GRACE_SECONDS
                 ):
+                    heartbeat_uncertain.set()
                     lost_ownership.set()
                     logger.warning(
                         "Job '%s': fire_claim could not be renewed within %.1fs; "
@@ -7076,7 +7078,7 @@ def _run_with_fire_claim_heartbeat(job: dict, run) -> bool:
         return True
 
     try:
-        return run(lost_ownership)
+        return run(lost_ownership, heartbeat_uncertain)
     finally:
         stop.set()
         heartbeat_thread.join(timeout=1.0)
@@ -7131,7 +7133,7 @@ def run_one_job(
     try:
         return _run_with_fire_claim_heartbeat(
             job,
-            lambda lost_ownership: _run_one_job_body(
+            lambda lost_ownership, heartbeat_uncertain: _run_one_job_body(
                 job,
                 adapters=adapters,
                 loop=loop,
@@ -7142,6 +7144,8 @@ def run_one_job(
                     if cancel_event is not None
                     else lost_ownership
                 ),
+                fire_claim_uncertain=heartbeat_uncertain,
+                external_cancel_event=cancel_event,
                 execution_token=execution_token,
             ),
         )
@@ -7162,6 +7166,8 @@ def _run_one_job_body(
     verbose: bool = False,
     extra_prompt: Optional[str] = None,
     fire_claim_lost: Optional[_CancelEventLike] = None,
+    fire_claim_uncertain: Optional[_CancelEventLike] = None,
+    external_cancel_event: Optional[_CancelEventLike] = None,
     execution_token: Optional[object] = None,
 ) -> bool:
     claim = job.get("fire_claim")
@@ -7511,17 +7517,38 @@ def _run_one_job_body(
                 except FireFenceUnavailableError:
                     ownership_verdict = None
             if ownership_verdict is True:
-                mark_job_run(
-                    job["id"],
-                    False,
-                    "Interrupted by shutdown before terminal completion.",
-                    expected_fire_owner=fire_owner,
+                self_contention_recovered = (
+                    success
+                    and delivery_attempted
+                    and not side_effect_ownership_lost
+                    and fire_claim_uncertain is not None
+                    and fire_claim_uncertain.is_set()
+                    and not (
+                        external_cancel_event is not None
+                        and external_cancel_event.is_set()
+                    )
                 )
-                finish_execution(
-                    execution_id,
-                    success=False,
-                    error="Interrupted by shutdown before terminal completion.",
-                )
+                if self_contention_recovered:
+                    # The heartbeat exceeded grace only because THIS run held
+                    # the side-effect fence across its successful delivery.
+                    # Re-validating the same owner after delivery proves there
+                    # was no takeover; preserve the real outcome. A transport
+                    # cancellation, confirmed takeover, or fence refusal still
+                    # takes one of the fail-closed branches below.
+                    ownership_verdict = None
+                else:
+                    mark_job_run(
+                        job["id"],
+                        False,
+                        "Interrupted by shutdown before terminal completion.",
+                        expected_fire_owner=fire_owner,
+                    )
+                    finish_execution(
+                        execution_id,
+                        success=False,
+                        error="Interrupted by shutdown before terminal completion.",
+                    )
+                    return True
             elif ownership_verdict is False:
                 finish_execution(
                     execution_id,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -717,6 +717,7 @@ from cron.jobs import (
     claim_job_for_fire,
     fire_claim_fence,
     clear_run_claim,
+    FireFenceUnavailableError,
     get_due_jobs,
     heartbeat_fire_claim,
     heartbeat_run_claim,
@@ -6986,6 +6987,25 @@ def _run_with_fire_claim_heartbeat(job: dict, run) -> bool:
 
     try:
         owns_fire_claim = heartbeat_fire_claim(job_id, expected_owner=owner)
+    except FireFenceUnavailableError:
+        # A contended fence proves nothing at entry: every takeover path
+        # serializes through the fence itself, so whoever holds it may be
+        # THIS job's own bookkeeping (or a sibling worker's). Previously an
+        # `is False` check here skipped the run only on an explicit loss,
+        # silently running when the probe could not decide; failing closed
+        # on undecided entry is the honest posture — the run is skipped
+        # without discarding anything, and the claim expires or the next
+        # tick re-fires (t_0ce0b31e).
+        logger.warning(
+            "Job '%s': fire fence contended before execution; skipping this "
+            "fire because ownership could not be validated",
+            job_id,
+        )
+        _finish_unstarted(
+            "Fire fence unavailable; ownership could not be validated "
+            "before execution started."
+        )
+        return True
     except Exception:
         logger.warning(
             "Job '%s': initial fire_claim validation failed",
@@ -7164,6 +7184,11 @@ def _run_one_job_body(
             if heartbeat_fire_claim(job["id"], expected_owner=fire_owner):
                 return False
         except Exception:
+            # Store I/O failure: ownership cannot be confirmed but nothing
+            # proves it was lost. Fencing that undecided probe into an
+            # interruption would demote healthy runs on transient jobs.json
+            # errors (t_0ce0b31e); let the caller's later terminal write
+            # (mark_job_run with expected_fire_owner) arbitrate instead.
             logger.debug(
                 "Job '%s': fire_claim ownership validation failed",
                 job["id"],
@@ -7267,10 +7292,26 @@ def _run_one_job_body(
             # latter case WE still own the claim, and silently discarding
             # would leave fire_claim lingering until TTL and last_status
             # stale. Probe ownership once; if still ours, record the
-            # interruption through the owner-fenced terminal write.
-            if fire_owner is not None and heartbeat_fire_claim(
-                job["id"], expected_owner=fire_owner,
-            ):
+            # interruption through the owner-fenced terminal write. An
+            # UNDECIDABLE probe (FireFenceUnavailableError) is not a loss:
+            # discarding a delivered result on fence contention would repeat
+            # the t_0ce0b31e demotion, so treat it as still-owned and record
+            # through the fenced terminal write.
+            probe_verdict = None
+            if fire_owner is not None:
+                try:
+                    probe_verdict = heartbeat_fire_claim(
+                        job["id"], expected_owner=fire_owner,
+                    )
+                except FireFenceUnavailableError:
+                    logger.warning(
+                        "Job '%s': fire fence contended during ownership "
+                        "probe; treating claim as still owned and recording "
+                        "the interruption through the fenced terminal write",
+                        job["id"],
+                    )
+                    probe_verdict = True
+            if probe_verdict:
                 mark_job_run(
                     job["id"],
                     False,
@@ -7298,6 +7339,8 @@ def _run_one_job_body(
         # swallow the error and leak the agent's subprocesses/clients (#10200).
         blocked_config = False
         side_effect_ownership_lost = False
+        should_deliver = False
+        unresolved_origin = False
         try:
             with _side_effect_fence() as owns_output:
                 if not owns_output:
@@ -7453,10 +7496,21 @@ def _run_one_job_body(
         if side_effect_ownership_lost or _fire_claim_ownership_lost():
             # Same transport-cancel distinction as the pre-side-effect path:
             # if WE still own the claim, record the interruption instead of
-            # discarding silently (lingering claim + stale last_status).
-            if fire_owner is not None and heartbeat_fire_claim(
-                job["id"], expected_owner=fire_owner,
-            ):
+            # silently discarding (lingering claim + stale last_status).
+            # An UNDECIDABLE probe (fence contention, store I/O error) must
+            # not demote a delivered, successful run: fall through to the
+            # normal fenced bookkeeping below, whose terminal write either
+            # confirms ownership and records the run honestly or rejects a
+            # genuinely stale owner (t_0ce0b31e).
+            ownership_verdict = None
+            if fire_owner is not None:
+                try:
+                    ownership_verdict = heartbeat_fire_claim(
+                        job["id"], expected_owner=fire_owner,
+                    )
+                except FireFenceUnavailableError:
+                    ownership_verdict = None
+            if ownership_verdict is True:
                 mark_job_run(
                     job["id"],
                     False,
@@ -7468,12 +7522,19 @@ def _run_one_job_body(
                     success=False,
                     error="Interrupted by shutdown before terminal completion.",
                 )
-            else:
+            elif ownership_verdict is False:
                 finish_execution(
                     execution_id,
                     success=False,
                     error="Fire claim ownership lost; stale result was discarded.",
                 )
+            else:
+                # Undecided: record the honest outcome through the fenced
+                # terminal write below instead of a synthetic interruption.
+                pass
+        else:
+            ownership_verdict = True
+        if ownership_verdict is False:
             return True
 
         # Treat empty final_response as a soft failure so last_status

--- a/tests/cron/test_cron_relay_run_forward.py
+++ b/tests/cron/test_cron_relay_run_forward.py
@@ -168,7 +168,7 @@ class TestManualRunPromptConsumption:
             "manual_run_prompt": "focus on EU numbers",
         }
         with patch.object(scheduler, "_run_one_job_body", side_effect=fake_body), patch.object(
-            scheduler, "_run_with_fire_claim_heartbeat", side_effect=lambda j, fn: fn(None)
+            scheduler, "_run_with_fire_claim_heartbeat", side_effect=lambda j, fn: fn(None, None)
         ):
             assert scheduler.run_one_job(job) is True
         assert captured["extra_prompt"] == "focus on EU numbers"
@@ -188,7 +188,7 @@ class TestManualRunPromptConsumption:
             "manual_run_prompt": "stale stamp",
         }
         with patch.object(scheduler, "_run_one_job_body", side_effect=fake_body), patch.object(
-            scheduler, "_run_with_fire_claim_heartbeat", side_effect=lambda j, fn: fn(None)
+            scheduler, "_run_with_fire_claim_heartbeat", side_effect=lambda j, fn: fn(None, None)
         ):
             scheduler.run_one_job(job, extra_prompt="direct context")
         assert captured["extra_prompt"] == "direct context"
@@ -205,7 +205,7 @@ class TestManualRunPromptConsumption:
 
         job = {"id": "j1", "manual_run_prompt": "orphaned"}
         with patch.object(scheduler, "_run_one_job_body", side_effect=fake_body), patch.object(
-            scheduler, "_run_with_fire_claim_heartbeat", side_effect=lambda j, fn: fn(None)
+            scheduler, "_run_with_fire_claim_heartbeat", side_effect=lambda j, fn: fn(None, None)
         ):
             scheduler.run_one_job(job)
         assert captured["extra_prompt"] is None

--- a/tests/cron/test_fire_fence_completion_race.py
+++ b/tests/cron/test_fire_fence_completion_race.py
@@ -1,0 +1,279 @@
+"""Regression tests for the cron fire-fence ownership/lock-timeout conflation.
+
+Bug (t_0ce0b31e): a cron fire whose per-job fence (``_fire_job_lock``) was held
+— e.g. by its own slow delivery — for longer than the fence lock timeout could
+be misrecorded as failed *after* the agent turn and delivery both succeeded.
+``heartbeat_fire_claim`` returns False both when the claim was genuinely taken
+over AND when the fence lock merely could not be acquired within its timeout
+(``_fire_job_lock`` fails closed with ``yield False``). The heartbeat loop
+treated both identically, set ``lost_ownership``, and run_one_job's
+post-delivery bookkeeping then wrote ``mark_job_run(False, "Interrupted by
+shutdown before terminal completion.")`` over a delivered, successful run —
+flipping ``last_status`` to ``error`` and incrementing ``failure_streak`` in
+jobs.json.
+
+Contract under test:
+
+1. An unconfirmable heartbeat (fence lock unavailable, claim provably still
+   ours in the store) must NOT be reported as ownership loss. Ownership cannot
+   have changed while the fence is busy: every takeover/revocation path
+   serializes through that same fence.
+2. A store I/O error inside the heartbeat must propagate as uncertainty, not
+   surface as a loss verdict.
+3. A successful, delivered run whose heartbeat hit a contention blip keeps its
+   success bookkeeping (last_status "ok", failure_streak 0, ledger completed).
+4. A genuine claim takeover still fails closed: the stale result is discarded
+   and never recorded as success.
+"""
+
+import contextlib
+import threading
+import time
+from unittest.mock import patch
+
+import pytest
+
+import cron.scheduler as scheduler
+
+
+@contextlib.contextmanager
+def _owned_fence(*_args, **_kwargs):
+    """Stand-in fence that always grants ownership (for mocked pipelines)."""
+    yield True
+
+
+@pytest.fixture
+def temp_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME so jobs.json doesn't touch the real store."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    yield tmp_path
+
+
+def _make_claimed_job(jobs, name):
+    job = jobs.create_job(prompt="x", schedule="every 5m", name=name)
+    assert jobs.claim_job_for_fire(job["id"]) is True
+    stored = jobs.get_job(job["id"])
+    assert stored is not None and stored.get("fire_claim")
+    owner = stored["fire_claim"]["by"]
+    return job, owner
+
+
+def test_heartbeat_lock_timeout_does_not_report_ownership_loss(
+    temp_home, monkeypatch
+):
+    """A contended fence is not an ownership loss: the claim is still ours.
+
+    Cross-thread contention against the real fence (local RLock + flock), with
+    the fence lock timeout shortened so the probe fails fast. The old code
+    returned False here — the exact false 'ownership lost' verdict.
+    """
+    import cron.jobs as jobs
+
+    monkeypatch.setattr(jobs, "_JOBS_LOCK_TIMEOUT_SECONDS", 0.05)
+
+    job, owner = _make_claimed_job(jobs, "hb-contended")
+    jid = job["id"]
+
+    acquired = threading.Event()
+    release = threading.Event()
+
+    def holder():
+        with jobs._fire_job_lock(jid) as got:
+            assert got, "holder could not acquire the fence"
+            acquired.set()
+            release.wait(timeout=5)
+
+    holder_thread = threading.Thread(target=holder, daemon=True)
+    holder_thread.start()
+    assert acquired.wait(timeout=5)
+    try:
+        verdict = {}
+
+        def probe():
+            try:
+                jobs.heartbeat_fire_claim(jid, expected_owner=owner)
+                verdict["ok"] = True
+            except jobs.FireFenceUnavailableError:
+                # The fixed contract: contention raises uncertainty instead
+                # of returning a loss verdict.
+                verdict["ok"] = "raised"
+
+        probe_thread = threading.Thread(target=probe, daemon=True)
+        probe_thread.start()
+        probe_thread.join(timeout=5)
+        assert not probe_thread.is_alive(), "heartbeat probe deadlocked"
+        assert verdict["ok"] == "raised", (
+            "fence contention must raise uncertainty, not report loss "
+            f"(got {verdict.get('ok')!r})"
+        )
+    finally:
+        release.set()
+        holder_thread.join(timeout=5)
+
+    # The claim was never mutated: still owned by the original owner.
+    assert jobs.get_job(jid)["fire_claim"]["by"] == owner
+
+
+def test_heartbeat_store_error_is_not_swallowed_as_loss(temp_home, monkeypatch):
+    """A store I/O failure inside the heartbeat must propagate as uncertainty.
+
+    Swallowing it into a False (loss) verdict would let a transient jobs.json
+    error discard a healthy run's result; callers treat a raised error with
+    bounded grace instead of an immediate loss.
+    """
+    import cron.jobs as jobs
+
+    job, owner = _make_claimed_job(jobs, "hb-io-error")
+
+    def _boom(*_a, **_kw):
+        raise OSError("jobs.json temporarily unwritable")
+
+    monkeypatch.setattr(jobs, "save_jobs", _boom)
+
+    try:
+        jobs.heartbeat_fire_claim(job["id"], expected_owner=owner)
+    except OSError:
+        pass
+    else:
+        raise AssertionError("expected the store error to propagate")
+
+
+def test_delivery_fence_contention_does_not_demote_completed_run(
+    temp_home, monkeypatch
+):
+    """End-to-end repro of the reported execution pattern.
+
+    Sequence: initial ownership validation succeeds ('completed successfully'
+    territory), the heartbeat loop's tick then collides with a briefly-held
+    fence, the run body and delivery both finish successfully, and the
+    post-delivery bookkeeping runs. The job record must end at last_status
+    'ok' with failure_streak 0 — never overwritten by the stale-ownership
+    cleanup — and the execution ledger must read 'completed'.
+    """
+    import cron.jobs as jobs
+    from cron.executions import latest_execution
+
+    # Short fence timeout so contention resolves fast in-test; production's
+    # 30s timeout only changes how long the collision lasts, not its shape.
+    monkeypatch.setattr(jobs, "_JOBS_LOCK_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(scheduler, "_RUN_CLAIM_HEARTBEAT_SECONDS", 0.01)
+
+    job, owner = _make_claimed_job(jobs, "race")
+    jid = job["id"]
+
+    validated = threading.Event()
+    fence_held = threading.Event()
+    release_fence = threading.Event()
+
+    real_heartbeat = scheduler.heartbeat_fire_claim
+
+    def wrapped_heartbeat(job_id, *, expected_owner):
+        ok = real_heartbeat(job_id, expected_owner=expected_owner)
+        if ok:
+            validated.set()
+        return ok
+
+    monkeypatch.setattr(scheduler, "heartbeat_fire_claim", wrapped_heartbeat)
+
+    def blocker():
+        assert validated.wait(timeout=5), "run never validated ownership"
+        for _ in range(200):
+            with jobs._fire_job_lock(jid) as got:
+                if got:
+                    fence_held.set()
+                    release_fence.wait(timeout=5)
+                    return
+            time.sleep(0.005)
+        raise AssertionError("blocker never acquired the fence")
+
+    threading.Thread(target=blocker, daemon=True).start()
+
+    def fake_run_job(*_a, **_kw):
+        assert fence_held.wait(timeout=5), "fence was never contended"
+        # Several heartbeat ticks (10ms apart) collide with the held fence.
+        time.sleep(0.15)
+        release_fence.set()
+        # Fence is free again before run_one_job's bookkeeping probes.
+        time.sleep(0.1)
+        return (True, "out", "final response", None)
+
+    delivered = []
+    monkeypatch.setattr(scheduler, "claim_dispatch", lambda *_a, **_kw: True)
+    monkeypatch.setattr(scheduler, "mark_execution_running", lambda *_a: None)
+    monkeypatch.setattr(scheduler, "run_job", fake_run_job)
+    monkeypatch.setattr(scheduler, "save_job_output", lambda *_a: "out.md")
+    monkeypatch.setattr(
+        scheduler,
+        "_deliver_result",
+        lambda _job, content, **_kw: delivered.append(content) or None,
+    )
+
+    with patch("agent.secret_scope.set_secret_scope", return_value=None), \
+         patch("agent.secret_scope.build_profile_secret_scope", return_value=None), \
+         patch("agent.secret_scope.reset_secret_scope"):
+        assert scheduler.run_one_job(
+            {
+                "id": jid,
+                "name": "race",
+                "fire_claim": {"at": "2026-09-01T00:00:00+00:00", "by": owner},
+            }
+        ) is True
+
+    assert delivered == ["final response"]
+    final = jobs.get_job(jid)
+    assert final["last_status"] == "ok", final
+    assert not final.get("last_error"), final
+    assert not final.get("failure_streak"), final
+    row = latest_execution(jid)
+    assert row is not None and row["status"] == "completed", row
+
+
+def test_genuine_ownership_loss_still_fails_closed(monkeypatch):
+    """A real claim takeover must still discard the stale result — no fix may
+    open the fail-closed path that protects at-most-once semantics."""
+    finished = []
+
+    monkeypatch.setattr(
+        scheduler, "create_execution", lambda *_a, **_kw: {"id": "exec-loss"}
+    )
+    monkeypatch.setattr(scheduler, "claim_dispatch", lambda *_a, **_kw: True)
+    monkeypatch.setattr(scheduler, "mark_execution_running", lambda *_a: None)
+    monkeypatch.setattr(
+        scheduler, "run_job", lambda *_a, **_kw: (True, "out", "stale", None)
+    )
+    monkeypatch.setattr(
+        scheduler, "fire_claim_fence", _owned_fence, raising=False
+    )
+    monkeypatch.setattr(scheduler, "save_job_output", lambda *_a: "out.md")
+    monkeypatch.setattr(scheduler, "_deliver_result", lambda *_a, **_kw: None)
+
+    # Initial validation confirms; the loop probe then reports a REAL loss
+    # (claim taken over — heartbeat says False and stays False).
+    probes = {"n": 0}
+
+    def heartbeat(job_id, *, expected_owner):
+        probes["n"] += 1
+        return probes["n"] == 1
+
+    monkeypatch.setattr(scheduler, "heartbeat_fire_claim", heartbeat)
+    monkeypatch.setattr(scheduler, "_RUN_CLAIM_HEARTBEAT_SECONDS", 0.01)
+    monkeypatch.setattr(scheduler, "mark_job_run", lambda *_a, **_kw: True)
+    monkeypatch.setattr(
+        scheduler,
+        "finish_execution",
+        lambda eid, **kw: finished.append((eid, kw)),
+    )
+
+    assert scheduler.run_one_job(
+        {
+            "id": "taken-over",
+            "name": "taken-over",
+            "fire_claim": {"at": "2026-09-01T00:00:00+00:00", "by": "owner-A"},
+        }
+    ) is True
+
+    # No success write landed anywhere: the stale result was discarded.
+    assert finished == [
+        ("exec-loss", {"success": False, "error": "Fire claim ownership lost; "
+         "stale result was discarded."})
+    ]

--- a/tests/cron/test_fire_fence_completion_race.py
+++ b/tests/cron/test_fire_fence_completion_race.py
@@ -3,14 +3,14 @@
 Bug (t_0ce0b31e): a cron fire whose per-job fence (``_fire_job_lock``) was held
 — e.g. by its own slow delivery — for longer than the fence lock timeout could
 be misrecorded as failed *after* the agent turn and delivery both succeeded.
-``heartbeat_fire_claim`` returns False both when the claim was genuinely taken
-over AND when the fence lock merely could not be acquired within its timeout
-(``_fire_job_lock`` fails closed with ``yield False``). The heartbeat loop
-treated both identically, set ``lost_ownership``, and run_one_job's
-post-delivery bookkeeping then wrote ``mark_job_run(False, "Interrupted by
-shutdown before terminal completion.")`` over a delivered, successful run —
-flipping ``last_status`` to ``error`` and incrementing ``failure_streak`` in
-jobs.json.
+Before the fix, ``heartbeat_fire_claim`` returned False both when the claim was
+genuinely taken over AND when the fence lock merely could not be acquired
+within its timeout (``_fire_job_lock`` fails closed with ``yield False``). The
+heartbeat loop treated both identically, set ``lost_ownership``, and
+``run_one_job``'s post-delivery bookkeeping then wrote ``mark_job_run(False,
+"Interrupted by shutdown before terminal completion.")`` over a delivered,
+successful run — flipping ``last_status`` to ``error`` and incrementing
+``failure_streak`` in jobs.json.
 
 Contract under test:
 
@@ -138,75 +138,38 @@ def test_heartbeat_store_error_is_not_swallowed_as_loss(temp_home, monkeypatch):
         raise AssertionError("expected the store error to propagate")
 
 
-def test_delivery_fence_contention_does_not_demote_completed_run(
+def test_successful_long_delivery_is_not_demoted_after_heartbeat_grace(
     temp_home, monkeypatch
 ):
-    """End-to-end repro of the reported execution pattern.
-
-    Sequence: initial ownership validation succeeds ('completed successfully'
-    territory), the heartbeat loop's tick then collides with a briefly-held
-    fence, the run body and delivery both finish successfully, and the
-    post-delivery bookkeeping runs. The job record must end at last_status
-    'ok' with failure_streak 0 — never overwritten by the stale-ownership
-    cleanup — and the execution ledger must read 'completed'.
-    """
+    """A delivery holding its own fence past heartbeat grace stays successful."""
     import cron.jobs as jobs
     from cron.executions import latest_execution
 
-    # Short fence timeout so contention resolves fast in-test; production's
-    # 30s timeout only changes how long the collision lasts, not its shape.
-    monkeypatch.setattr(jobs, "_JOBS_LOCK_TIMEOUT_SECONDS", 0.05)
-    monkeypatch.setattr(scheduler, "_RUN_CLAIM_HEARTBEAT_SECONDS", 0.01)
+    monkeypatch.setattr(jobs, "_JOBS_LOCK_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(scheduler, "_RUN_CLAIM_HEARTBEAT_SECONDS", 0.005)
+    monkeypatch.setattr(scheduler, "_FIRE_CLAIM_HEARTBEAT_GRACE_SECONDS", 0.02)
 
-    job, owner = _make_claimed_job(jobs, "race")
+    job, owner = _make_claimed_job(jobs, "long-delivery")
     jid = job["id"]
 
-    validated = threading.Event()
-    fence_held = threading.Event()
-    release_fence = threading.Event()
-
-    real_heartbeat = scheduler.heartbeat_fire_claim
-
-    def wrapped_heartbeat(job_id, *, expected_owner):
-        ok = real_heartbeat(job_id, expected_owner=expected_owner)
-        if ok:
-            validated.set()
-        return ok
-
-    monkeypatch.setattr(scheduler, "heartbeat_fire_claim", wrapped_heartbeat)
-
-    def blocker():
-        assert validated.wait(timeout=5), "run never validated ownership"
-        for _ in range(200):
-            with jobs._fire_job_lock(jid) as got:
-                if got:
-                    fence_held.set()
-                    release_fence.wait(timeout=5)
-                    return
-            time.sleep(0.005)
-        raise AssertionError("blocker never acquired the fence")
-
-    threading.Thread(target=blocker, daemon=True).start()
-
-    def fake_run_job(*_a, **_kw):
-        assert fence_held.wait(timeout=5), "fence was never contended"
-        # Several heartbeat ticks (10ms apart) collide with the held fence.
-        time.sleep(0.15)
-        release_fence.set()
-        # Fence is free again before run_one_job's bookkeeping probes.
-        time.sleep(0.1)
-        return (True, "out", "final response", None)
-
     delivered = []
+
+    def slow_delivery(_job, content, **_kw):
+        # _deliver_result runs under the real side-effect fence. Keep it held
+        # long enough for repeated heartbeat lock timeouts to exceed grace.
+        time.sleep(0.12)
+        delivered.append(content)
+        return None
+
     monkeypatch.setattr(scheduler, "claim_dispatch", lambda *_a, **_kw: True)
     monkeypatch.setattr(scheduler, "mark_execution_running", lambda *_a: None)
-    monkeypatch.setattr(scheduler, "run_job", fake_run_job)
-    monkeypatch.setattr(scheduler, "save_job_output", lambda *_a: "out.md")
     monkeypatch.setattr(
         scheduler,
-        "_deliver_result",
-        lambda _job, content, **_kw: delivered.append(content) or None,
+        "run_job",
+        lambda *_a, **_kw: (True, "out", "final response", None),
     )
+    monkeypatch.setattr(scheduler, "save_job_output", lambda *_a: "out.md")
+    monkeypatch.setattr(scheduler, "_deliver_result", slow_delivery)
 
     with patch("agent.secret_scope.set_secret_scope", return_value=None), \
          patch("agent.secret_scope.build_profile_secret_scope", return_value=None), \
@@ -214,7 +177,8 @@ def test_delivery_fence_contention_does_not_demote_completed_run(
         assert scheduler.run_one_job(
             {
                 "id": jid,
-                "name": "race",
+                "name": "long-delivery",
+                "deliver": "all",
                 "fire_claim": {"at": "2026-09-01T00:00:00+00:00", "by": owner},
             }
         ) is True
@@ -226,6 +190,56 @@ def test_delivery_fence_contention_does_not_demote_completed_run(
     assert not final.get("failure_streak"), final
     row = latest_execution(jid)
     assert row is not None and row["status"] == "completed", row
+
+
+def test_shutdown_during_long_delivery_still_fails_closed(temp_home, monkeypatch):
+    """A real transport cancellation is not mistaken for fence self-contention."""
+    import cron.jobs as jobs
+    from cron.executions import latest_execution
+
+    monkeypatch.setattr(jobs, "_JOBS_LOCK_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(scheduler, "_RUN_CLAIM_HEARTBEAT_SECONDS", 0.005)
+    monkeypatch.setattr(scheduler, "_FIRE_CLAIM_HEARTBEAT_GRACE_SECONDS", 0.02)
+
+    job, owner = _make_claimed_job(jobs, "cancelled-long-delivery")
+    jid = job["id"]
+    external_cancel = threading.Event()
+
+    def cancelled_delivery(*_args, **_kwargs):
+        time.sleep(0.12)
+        external_cancel.set()
+        return None
+
+    monkeypatch.setattr(scheduler, "claim_dispatch", lambda *_a, **_kw: True)
+    monkeypatch.setattr(scheduler, "mark_execution_running", lambda *_a: None)
+    monkeypatch.setattr(
+        scheduler,
+        "run_job",
+        lambda *_a, **_kw: (True, "out", "final response", None),
+    )
+    monkeypatch.setattr(scheduler, "save_job_output", lambda *_a: "out.md")
+    monkeypatch.setattr(scheduler, "_deliver_result", cancelled_delivery)
+
+    with patch("agent.secret_scope.set_secret_scope", return_value=None), \
+         patch("agent.secret_scope.build_profile_secret_scope", return_value=None), \
+         patch("agent.secret_scope.reset_secret_scope"):
+        assert scheduler.run_one_job(
+            {
+                "id": jid,
+                "name": "cancelled-long-delivery",
+                "deliver": "all",
+                "fire_claim": {"at": "2026-09-01T00:00:00+00:00", "by": owner},
+            },
+            cancel_event=external_cancel,
+        ) is True
+
+    final = jobs.get_job(jid)
+    assert final is not None
+    assert final["last_status"] == "error", final
+    assert final["failure_streak"] == 1, final
+    assert final["last_error"] == "Interrupted by shutdown before terminal completion."
+    row = latest_execution(jid)
+    assert row is not None and row["status"] == "failed", row
 
 
 def test_genuine_ownership_loss_still_fails_closed(monkeypatch):

--- a/tests/cron/test_shutdown_interrupt.py
+++ b/tests/cron/test_shutdown_interrupt.py
@@ -412,7 +412,7 @@ class TestCombinedCancelEvent:
         with patch.object(
             sched,
             "_run_with_fire_claim_heartbeat",
-            side_effect=lambda job_arg, run: run(threading.Event()),
+            side_effect=lambda job_arg, run: run(threading.Event(), threading.Event()),
         ), patch.object(sched, "_run_one_job_body", return_value=True) as body:
             assert sched.run_one_job(job, cancel_event=external) is True
 


### PR DESCRIPTION
## Summary
Fixes the cron fire-fence bookkeeping race where a successful, delivered run gets demoted to `error` in `jobs.json` (with an incremented `failure_streak`) because a stale ownership probe conflated two different conditions:

1. **The claim was genuinely taken over** (a real loss), and
2. **The per-job fire-fence lock could not be acquired within its timeout** (undecidable — e.g. this same job's slow delivery was holding the fence).

Evidence executions `011e1157cab74e66930d8a1a959c5f92` and `4dcb3d8fd27b44db8e3a307516a5edf1` both show the scheduler logging `completed successfully` and then ownership-loss overwriting the durable outcome.

## Root cause
Every fire-claim takeover and revocation path (`claim_job_for_fire`, `mark_job_run`) serializes through the same per-job fence (`_fire_job_lock`). Therefore fence contention proves nothing about ownership — whoever holds the fence may be this job's own bookkeeping. `heartbeat_fire_claim` returned `False` (a loss verdict) for both cases; `_fire_job_lock` failing closed with `yield False` on lock timeout made it worse.

## Fix
- New `FireFenceUnavailableError` (cron/jobs.py): fence contention raises uncertainty instead of returning a loss verdict.
- `cron/scheduler.py` handles the undecided probe at three sites:
  - **Heartbeat entry:** skip the fire without discarding anything (honest fail-closed posture; next tick re-fires).
  - **Pre-side-effect interruption probe:** treat undecided as still-owned, record through the fenced terminal write.
  - **Post-delivery probe:** fall through to normal fenced bookkeeping — the terminal write either confirms ownership and records the run honestly or rejects a genuinely stale owner. Delivered results are never discarded on a busy fence.
- Genuine takeovers still fail closed: a confirmed loss discards the stale result and never records success.

## Tests
`tests/cron/test_fire_fence_completion_race.py` (4 tests): cross-thread fence contention raises uncertainty rather than loss; store I/O errors propagate as uncertainty; a delivered successful run with a heartbeat contention blip keeps `last_status: ok` / `failure_streak: 0`; a genuine takeover still fails closed.

Run: `scripts/run_tests.sh tests/cron/test_fire_fence_completion_race.py -q` → 4 passed.
