### PR TITLE
feat(models): OpenRouter, Nous Portal, and Alibaba Token Plan pickers carry Qwen3.8-Max-0902

### DIFF
--- a/hermes_cli/models_catalog_static.py
+++ b/hermes_cli/models_catalog_static.py
@@ -36,7 +36,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
         "openai/gpt-5.5", "openai/gpt-5.5-pro", "openai/gpt-5.4-mini", "google/gemini-3.1-pro-preview",
         "google/gemini-3.8-flash", "google/gemini-3.7-flash", "x-ai/grok-4.6", "deepseek/deepseek-v4-pro",
         "deepseek/deepseek-v4-pro-0813", "deepseek/deepseek-v4-flash", "deepseek/deepseek-v4-flash-0731",
-        "qwen/qwen3.8-max", "qwen/qwen3.8-flash", "moonshotai/kimi-k3", "minimax/minimax-m3", "z-ai/glm-5.3",
+        "qwen/qwen3.8-max-0902", "qwen/qwen3.8-flash", "moonshotai/kimi-k3", "minimax/minimax-m3", "z-ai/glm-5.3",
         "z-ai/glm-5.3-flash", "z-ai/glm-5.2", "xiaomi/mimo-v2.5-pro", "tencent/hy4-preview", "tencent/hy3",
         "stepfun/step-3.7-flash", "nvidia/nemotron-3-super-120b-a12b", "meta/muse-spark-1.2",
         "meta/muse-spark-1.2-contributor", "meta/muse-spark-1.3", "meta/muse-spark-1.3-contributor", "sakana/fugu-ultra",
@@ -146,7 +146,7 @@ _ALIBABA_CODING_PLAN_MODELS = [
 ]
 # Verified against a live Token Plan subscription (key tier ``sk-sp-...``).
 _ALIBABA_TOKEN_PLAN_MODELS = [
-    "qwen3.8-max-preview", "qwen3.7-max", "qwen3.7-plus", "qwen3.6-plus", "qwen3.6-flash", "deepseek-v4-pro",
+    "qwen3.8-max-0902", "qwen3.7-max", "qwen3.7-plus", "qwen3.6-plus", "qwen3.6-flash", "deepseek-v4-pro",
     "deepseek-v4-flash", "deepseek-v3.2", "kimi-k2.7-code", "kimi-k2.6", "kimi-k2.5", "glm-5.2", "glm-5.1", "glm-5",
 ]
 _XAI_MODELS = _xai_curated_models()

--- a/tests/test_empty_model_fallback.py
+++ b/tests/test_empty_model_fallback.py
@@ -27,16 +27,16 @@ class TestGetDefaultModelForProvider:
 
         with patch(
             "hermes_cli.model_catalog.get_default_model_from_cache",
-            return_value="qwen/qwen3.8-max",
+            return_value="qwen/qwen3.8-max-0902",
         ):
             assert (
                 models_mod.get_preferred_silent_default_model("nous")
-                == "qwen/qwen3.8-max"
+                == "qwen/qwen3.8-max-0902"
             )
-            # nous catalog carries qwen3.8-max, so the full resolver follows.
+            # nous catalog carries qwen3.8-max-0902, so the full resolver follows.
             assert (
                 models_mod.get_default_model_for_provider("nous")
-                == "qwen/qwen3.8-max"
+                == "qwen/qwen3.8-max-0902"
             )
 
 

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-09-04T22:47:22Z",
+  "updated_at": "2026-09-05T06:42:02Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -137,7 +137,7 @@
           "description": "dated snapshot of v4-flash"
         },
         {
-          "id": "qwen/qwen3.8-max",
+          "id": "qwen/qwen3.8-max-0902",
           "description": ""
         },
         {
@@ -341,7 +341,7 @@
           "id": "deepseek/deepseek-v4-flash-0731"
         },
         {
-          "id": "qwen/qwen3.8-max"
+          "id": "qwen/qwen3.8-max-0902"
         },
         {
           "id": "qwen/qwen3.8-flash"


### PR DESCRIPTION
## Summary
`qwen3.8-max-0902` (Alibaba's upgraded snapshot of Qwen3.8-Max, alias `qwen3.8-max-2026-09-02`) REPLACES `qwen3.8-max` in the OpenRouter and Nous Portal pickers, and `qwen3.8-max-preview` on Alibaba Token Plan.

Scoped rollout per request (openrouter / nous / qwen plan) — `alibaba`, `alibaba-cn`, `alibaba-coding-plan`, `opencode-go`, and `setup.py` defaults were deliberately left untouched.

## Changes
Rebuilt as ONE commit on current main after #97354-era catalog refactor moved the curated tables into `hermes_cli/models_catalog_static.py` (the earlier CI-green version conflicted; retrigger commits dropped in the rebuild).
- `hermes_cli/models_catalog_static.py`
  - `OPENROUTER_MODELS` (which also derives `_PROVIDER_MODELS["nous"]`): `qwen/qwen3.8-max` → `qwen/qwen3.8-max-0902` (hard swap, Teknium's call).
  - `_ALIBABA_TOKEN_PLAN_MODELS` (feeds `alibaba-token-plan` + `-cn`): `qwen3.8-max-preview` → `qwen3.8-max-0902`.
- `tests/test_empty_model_fallback.py`: fixture follows the nous catalog slug.
- `website/static/api/model-catalog.json`: regenerated via `scripts/build_model_catalog.py`.

## Verified skips (no new metadata entries)
| Surface | Result |
|---|---|
| `DEFAULT_CONTEXT_LENGTHS` | substring-matches `qwen3.8-max` → 1,000,000 (QwenCloud: 1M context, 131K output) |
| `reasoning_timeouts.py` floor | prefix fires, 180s for both slugs |
| Pricing snapshot | skipped — openrouter + nous both resolve to `official_models_api` |
| Plugin `fallback_models` / docs | repo-wide grep: no other sites carry `qwen3.8-max-preview` or need the new slug |

## Liveness (re-probed 2026-09-02 ~08:00 UTC — LIVE)
| Provider | `qwen/qwen3.8-max-0902` |
|---|---|
| OpenRouter | `/v1/models` lists it (1M ctx, 131K out, $2/$6, $0.25 cache read); completion 200, echoes slug, cost $0.000288 for 66+26 tok. Bare `qwen/qwen3.8-max` is GONE from the catalog. |
| Nous Portal | `/v1/models` lists it; bare `qwen/qwen3.8-max` GONE. (Completion probe 401'd on my key — out of funds, not a model issue.) |
| QwenCloud / DashScope | live since launch |

Both aggregators dropped the base slug in favor of -0902, so the hard swap matches what they serve.

## Validation
- `tests/hermes_cli/test_models.py test_anthropic_picker_curated.py test_gmi_provider.py test_model_catalog.py tests/agent/test_usage_pricing.py test_minimax_provider.py tests/test_empty_model_fallback.py tests/hermes_cli/test_context_switch_guard.py` (+ test_gmi_provider) → 178 passed on the rebuilt branch.
- E2E curated fallback (temp HERMES_HOME, keys stripped, socket connect denied after import): all four providers list `qwen3.8-max-0902`, no dupes.

Cluster sweep: no existing PRs or issues reference `qwen3.8-max-0902` / `0902` — this is the first.

## Infographic

![Qwen3.8-Max-0902 rollout](https://v3b.fal.media/files/b/0aa8c51b/9-S3jvXc9GWJBmjMYzPmn_YVfpyg1U.png)
