### PR TITLE
Gateway follow-ups queued during a busy/compression window no longer vanish; overflow survives shutdown (#99882, salvage #99912)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9765,8 +9765,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             depth += 1
         return depth
 
-    def _rescue_orphaned_overflow(self, session_key: str, adapter: Any) -> int:
-        """Stage any orphaned FIFO overflow into the pending slot (#99882).
+    def _rescue_orphaned_overflow(
+        self, session_key: str, adapter: Any
+    ) -> Optional["MessageEvent"]:
+        """Pop the oldest orphaned FIFO overflow event for an idle session (#99882).
 
         The FIFO overflow (``queued_events``) drains only at the post-turn
         promotion site (``_promote_queued_event`` inside the ``_run_agent``
@@ -9781,29 +9783,36 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         This rescue runs at the point where a NEW event arrives for a
         session that is NOT busy (the idle entry in
         ``_process_message_priority``).  If the session went idle with a
-        populated overflow, the orphaned events are re-staged in FIFO
-        order ahead of the incoming event's own enqueue, so arrival order
-        (#28503) is preserved: the orphaned follow-ups run first, then the
-        new message.  The slot must be empty at this point (the session is
-        idle), so staging is a plain slot assignment.
+        populated overflow, the oldest orphan is returned so the caller runs
+        it as THIS turn, and the next orphan (if any) is staged into the
+        slot so the post-turn drain continues the chain in arrival order
+        (#28503).  The caller then enqueues the incoming event behind the
+        chain via ``_enqueue_fifo``.
 
-        Returns the number of orphaned events re-staged (0 when none).
+        The returned event is REMOVED from both stores: leaving it in the
+        slot while it also runs as the current turn would make the post-turn
+        ``_dequeue_pending_event`` run it a second time.
+
+        Returns the orphaned event to run now, or ``None`` when there is
+        nothing to rescue (no overflow, slot occupied, or no slot storage).
         """
         try:
             _q_state = self._peek_session_state(session_key)
             overflow = _q_state.conversation.queued_events if _q_state else None
             if not overflow:
-                return 0
+                return None
             pending_slot = getattr(adapter, "_pending_messages", None)
             if not isinstance(pending_slot, dict) or pending_slot.get(session_key):
                 # Slot occupied (busy) or no slot storage — promotion owns
                 # this; do not fight it from the idle path.
-                return 0
-            # Only stage ONE orphan into the slot — the remaining overflow
-            # stays queued and will drain via the normal
-            # _promote_queued_event post-turn promotion.  Staging more than
-            # one would clobber the slot (single-slot design).
-            pending_slot[session_key] = overflow.pop(0)
+                return None
+            head = overflow.pop(0)
+            # Keep the slot occupied for the rest of the chain so the drain
+            # promotes in order and any mid-chain arrival routes to overflow
+            # instead of jumping the queue (same invariant as the drain's
+            # own _promote_queued_event).  Only ONE event fits the slot.
+            if overflow:
+                pending_slot[session_key] = overflow.pop(0)
             logger.warning(
                 "Rescued orphaned FIFO overflow event for idle session "
                 "%s — it was queued during a busy window but the post-turn "
@@ -9817,10 +9826,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     len(overflow),
                     session_key,
                 )
-            return 1
+            return head
         except Exception:
             logger.debug("FIFO overflow rescue failed for %s", session_key, exc_info=True)
-            return 0
+            return None
 
     @staticmethod
     def _is_goal_continuation_event(event_or_text: Any) -> bool:
@@ -19787,27 +19796,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _orphan_adapter is not None
                 and not bool(getattr(event, "internal", False))
                 and not event.get_command()
-                and self._queue_depth(
-                    _quick_key, adapter=_orphan_adapter
-                ) >= 1
-                and not _orphan_adapter._pending_messages.get(_quick_key)
             ):
                 _rescued = self._rescue_orphaned_overflow(
                     _quick_key, _orphan_adapter
                 )
-                if _rescued:
-                    # Orphans staged in the slot; park the incoming event
-                    # behind them in the overflow so it runs AFTER the
-                    # rescued chain (FIFO).
-                    _head = _orphan_adapter._pending_messages.get(_quick_key)
-                    if _head is not None:
-                        # The slot head runs as this turn via the loop
-                        # below; enqueue the incoming event into overflow.
-                        self._session_state(_quick_key).conversation.queued_events.append(
-                            event
-                        )
-                        # Swap: this turn now processes the oldest orphan.
-                        event = _head
+                if _rescued is not None:
+                    # The oldest orphan runs as THIS turn.  Park the
+                    # incoming event behind the rest of the chain: into the
+                    # slot when the chain was a single orphan (so the
+                    # post-turn drain picks it up), otherwise into overflow
+                    # behind the already-staged next orphan (FIFO).
+                    self._enqueue_fifo(_quick_key, event, _orphan_adapter)
+                    event = _rescued
+                    # Same session key by construction; carry the orphan's
+                    # own source so reply anchors / thread metadata point
+                    # at the message that is actually being answered.
+                    _rescued_source = getattr(_rescued, "source", None)
+                    if _rescued_source is not None:
+                        source = _rescued_source
+                    is_internal = bool(getattr(_rescued, "internal", False))
         except Exception:
             logger.debug(
                 "FIFO orphan rescue pre-claim failed for %s",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9804,23 +9804,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # _promote_queued_event post-turn promotion.  Staging more than
             # one would clobber the slot (single-slot design).
             pending_slot[session_key] = overflow.pop(0)
-            rescued = 1
-            if rescued:
+            logger.warning(
+                "Rescued orphaned FIFO overflow event for idle session "
+                "%s — it was queued during a busy window but the post-turn "
+                "drain never promoted it (#99882)",
+                session_key,
+            )
+            if overflow:
                 logger.warning(
-                    "Rescued %d orphaned FIFO overflow event(s) for idle session "
-                    "%s — they were queued during a busy window but the post-turn "
-                    "drain never promoted them (#99882)",
-                    rescued,
+                    "%d overflow event(s) still queued for session %s after "
+                    "rescue staging (will drain via normal promotion)",
+                    len(overflow),
                     session_key,
                 )
-                if overflow:
-                    logger.warning(
-                        "%d overflow event(s) still queued for session %s after "
-                        "rescue staging (will drain via normal promotion)",
-                        len(overflow),
-                        session_key,
-                    )
-            return rescued
+            return 1
         except Exception:
             logger.debug("FIFO overflow rescue failed for %s", session_key, exc_info=True)
             return 0

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9765,6 +9765,66 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             depth += 1
         return depth
 
+    def _rescue_orphaned_overflow(self, session_key: str, adapter: Any) -> int:
+        """Stage any orphaned FIFO overflow into the pending slot (#99882).
+
+        The FIFO overflow (``queued_events``) drains only at the post-turn
+        promotion site (``_promote_queued_event`` inside the ``_run_agent``
+        drain).  When a busy window ends without that drain running — the
+        #99882 shape: a follow-up queued during compression-in-flight lands
+        in overflow, compression finishes, the slot event's turn runs, but
+        the drain recursion exits before promoting (or the busy window ends
+        through an exception / interrupt / generation-bump exit that never
+        reaches the promotion site) — the overflow entries are silently
+        orphaned: never dispatched, never persisted, never logged.
+
+        This rescue runs at the point where a NEW event arrives for a
+        session that is NOT busy (the idle entry in
+        ``_process_message_priority``).  If the session went idle with a
+        populated overflow, the orphaned events are re-staged in FIFO
+        order ahead of the incoming event's own enqueue, so arrival order
+        (#28503) is preserved: the orphaned follow-ups run first, then the
+        new message.  The slot must be empty at this point (the session is
+        idle), so staging is a plain slot assignment.
+
+        Returns the number of orphaned events re-staged (0 when none).
+        """
+        try:
+            _q_state = self._peek_session_state(session_key)
+            overflow = _q_state.conversation.queued_events if _q_state else None
+            if not overflow:
+                return 0
+            pending_slot = getattr(adapter, "_pending_messages", None)
+            if not isinstance(pending_slot, dict) or pending_slot.get(session_key):
+                # Slot occupied (busy) or no slot storage — promotion owns
+                # this; do not fight it from the idle path.
+                return 0
+            # Only stage ONE orphan into the slot — the remaining overflow
+            # stays queued and will drain via the normal
+            # _promote_queued_event post-turn promotion.  Staging more than
+            # one would clobber the slot (single-slot design).
+            pending_slot[session_key] = overflow.pop(0)
+            rescued = 1
+            if rescued:
+                logger.warning(
+                    "Rescued %d orphaned FIFO overflow event(s) for idle session "
+                    "%s — they were queued during a busy window but the post-turn "
+                    "drain never promoted them (#99882)",
+                    rescued,
+                    session_key,
+                )
+                if overflow:
+                    logger.warning(
+                        "%d overflow event(s) still queued for session %s after "
+                        "rescue staging (will drain via normal promotion)",
+                        len(overflow),
+                        session_key,
+                    )
+            return rescued
+        except Exception:
+            logger.debug("FIFO overflow rescue failed for %s", session_key, exc_info=True)
+            return 0
+
     @staticmethod
     def _is_goal_continuation_event(event_or_text: Any) -> bool:
         """Return True for synthetic /goal continuation turns.
@@ -19712,6 +19772,52 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _quick_key,
             )
             return _limit_message
+
+        # ── FIFO orphan rescue (#99882) ────────────────────────────────
+        # If this session went idle with a populated overflow (queued
+        # during a busy window whose post-turn drain never promoted —
+        # e.g. a compression-demoted follow-up after the compression
+        # window ended through an exit that skipped the promotion site),
+        # those events were silently orphaned.  We are starting the next
+        # turn for this session NOW: re-stage the orphans in FIFO order
+        # and enqueue the incoming event behind them, so arrival order
+        # (#28503) holds: oldest orphan runs as this turn, the rest drain
+        # in order, the new message last.  Skipped for control commands
+        # (/stop etc. own their own semantics) and internal events.
+        try:
+            _orphan_adapter = self._adapter_for_source(source)
+            if (
+                _orphan_adapter is not None
+                and not bool(getattr(event, "internal", False))
+                and not event.get_command()
+                and self._queue_depth(
+                    _quick_key, adapter=_orphan_adapter
+                ) >= 1
+                and not _orphan_adapter._pending_messages.get(_quick_key)
+            ):
+                _rescued = self._rescue_orphaned_overflow(
+                    _quick_key, _orphan_adapter
+                )
+                if _rescued:
+                    # Orphans staged in the slot; park the incoming event
+                    # behind them in the overflow so it runs AFTER the
+                    # rescued chain (FIFO).
+                    _head = _orphan_adapter._pending_messages.get(_quick_key)
+                    if _head is not None:
+                        # The slot head runs as this turn via the loop
+                        # below; enqueue the incoming event into overflow.
+                        self._session_state(_quick_key).conversation.queued_events.append(
+                            event
+                        )
+                        # Swap: this turn now processes the oldest orphan.
+                        event = _head
+        except Exception:
+            logger.debug(
+                "FIFO orphan rescue pre-claim failed for %s",
+                _quick_key,
+                exc_info=True,
+            )
+
         _claim_state = self._session_state(_quick_key)
         if _active_session_lease is not None:
             _claim_state.turn.lease = _active_session_lease

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16523,6 +16523,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 flush_pending_to_file(dict(self._pending_messages), reason="shutdown")
             except Exception:
                 pass
+            # The FIFO tail lives in SessionState.conversation.queued_events,
+            # not in the slot dict above — flush it too or every follow-up
+            # parked in overflow at restart time is lost (#99882).
+            try:
+                from gateway.shutdown_flush import flush_overflow_to_file
+                flush_overflow_to_file(
+                    {
+                        _k: list(_v)
+                        for _k, _v in dict(getattr(self, "_queued_events", None) or {}).items()
+                        if _v
+                    },
+                    reason="shutdown",
+                )
+            except Exception:
+                pass
             # On the real runner these are live SessionState views whose
             # clear() resets one field per session — never a wholesale dict
             # swap, so a concurrent writer on another session can't lose its

--- a/gateway/shutdown_flush.py
+++ b/gateway/shutdown_flush.py
@@ -142,6 +142,66 @@ def flush_pending_to_file(
     return flushed
 
 
+def flush_overflow_to_file(
+    overflow_by_session: Dict[str, Any],
+    *,
+    reason: str = "shutdown",
+) -> int:
+    """Serialise the FIFO overflow tails (``queued_events``) to disk.
+
+    Sibling of :func:`flush_pending_to_file` for the second half of the
+    gateway FIFO (#99882): the adapter slot holds the queue head, and the
+    per-session ``SessionState.conversation.queued_events`` list holds the
+    tail.  Shutdown flushed only the slot, so every follow-up parked in
+    overflow at restart time vanished with the process.  Each overflow
+    event is written as its own payload in the same shape as a slot flush
+    so ``recover_pending_to_db`` replays them unchanged; a ``seq`` field
+    preserves arrival order within a session.
+
+    Returns the number of events flushed.
+    """
+    if not overflow_by_session:
+        return 0
+
+    flush_dir = _get_flush_dir()
+    ts = int(time.time())
+    flushed = 0
+
+    for session_key, events in list(overflow_by_session.items()):
+        if not session_key or not events:
+            continue
+        for seq, value in enumerate(list(events)):
+            if value is None:
+                continue
+            try:
+                serialised = _serialise_value(value)
+                if serialised is None:
+                    continue
+                _write_payload(
+                    flush_dir,
+                    {
+                        "session_key": session_key,
+                        "reason": reason,
+                        "ts": ts,
+                        "seq": seq,
+                        "data": serialised,
+                    },
+                )
+                flushed += 1
+            except Exception as exc:
+                logger.debug(
+                    "Failed to flush overflow message for %s: %s",
+                    session_key, exc,
+                )
+
+    if flushed:
+        logger.info(
+            "Flushed %d queued overflow message(s) to %s (reason=%s)",
+            flushed, flush_dir, reason,
+        )
+    return flushed
+
+
 # Reason tag for transcript messages dropped by the in-memory pending cap
 # during live operation (#78182). These payloads carry the full transcript
 # message dict so they can be replayed verbatim once the DB recovers.

--- a/tests/gateway/test_fifo_overflow_rescue.py
+++ b/tests/gateway/test_fifo_overflow_rescue.py
@@ -1,0 +1,132 @@
+"""Regression tests for #99882: FIFO overflow orphan rescue.
+
+When a follow-up is demoted to /queue during compression-in-flight,
+it lands in SessionState.conversation.queued_events (overflow) with
+the current turn's event occupying adapter._pending_messages[session_key]
+(slot).  After the slot's turn completes, _promote_queued_event moves
+the overflow head into the slot.  When that drain never runs — the
+compression window ended through an exit that skipped the promotion
+site — the overflow is silently orphaned: never dispatched, never
+persisted, never logged.
+
+The rescue in GatewayRunner._rescue_orphaned_overflow stages one orphan
+into the slot on the next idle arrival, so FIFO order (#28503) holds.
+"""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    Platform,
+    PlatformConfig,
+)
+from gateway.run import GatewayRunner
+
+
+class _StubAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="test"), Platform.TELEGRAM)
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        self._mark_disconnected()
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        from gateway.platforms.base import SendResult
+
+        return SendResult(success=True, message_id="msg-1")
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id, "type": "dm"}
+
+
+def _text_event(text: str, msg_id: str) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=MagicMock(chat_id="123", platform=Platform.TELEGRAM, profile=None),
+        message_id=msg_id,
+    )
+
+
+class TestRescueOrphanedOverflow:
+    def test_moves_overflow_head_to_empty_slot(self):
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner._queued_events = {}
+        # Minimal session_state with queued_events
+        adapter = _StubAdapter()
+        session_key = "telegram:user:1"
+        # Two overflow items orphaned after slot turn completed
+        runner._session_state(session_key).conversation.queued_events.extend(
+            [_text_event("orphan-1", "o1"), _text_event("orphan-2", "o2")]
+        )
+        # Slot empty (session went idle)
+        assert session_key not in adapter._pending_messages
+
+        rescued = runner._rescue_orphaned_overflow(session_key, adapter)
+
+        assert rescued == 1
+        # Slot now holds the oldest orphan
+        assert adapter._pending_messages[session_key].text == "orphan-1"
+        # Remaining orphan stays in overflow
+        overflow = runner._session_state(session_key).conversation.queued_events
+        assert len(overflow) == 1
+        assert overflow[0].text == "orphan-2"
+
+    def test_noop_when_slot_occupied(self):
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner._queued_events = {}
+        adapter = _StubAdapter()
+        session_key = "telegram:user:2"
+        runner._session_state(session_key).conversation.queued_events.append(
+            _text_event("orphan", "o1")
+        )
+        adapter._pending_messages[session_key] = _text_event("busy-slot", "slot")
+
+        rescued = runner._rescue_orphaned_overflow(session_key, adapter)
+
+        assert rescued == 0
+        assert adapter._pending_messages[session_key].text == "busy-slot"
+        assert len(runner._session_state(session_key).conversation.queued_events) == 1
+
+    def test_noop_when_no_overflow(self):
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner._queued_events = {}
+        adapter = _StubAdapter()
+        session_key = "telegram:user:3"
+
+        rescued = runner._rescue_orphaned_overflow(session_key, adapter)
+
+        assert rescued == 0
+        assert session_key not in adapter._pending_messages
+
+    def test_fifo_order_preserved_across_rescue_and_new_message(self):
+        """Oldest orphan runs first, new arrival last — FIFO (#28503)."""
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner._queued_events = {}
+        adapter = _StubAdapter()
+        session_key = "telegram:user:4"
+
+        # Two orphans from the lost window
+        runner._session_state(session_key).conversation.queued_events.extend(
+            [_text_event("orphan-1", "o1"), _text_event("orphan-2", "o2")]
+        )
+
+        # New message arrives for idle session — rescue stages orphan-1
+        rescued = runner._rescue_orphaned_overflow(session_key, adapter)
+        assert rescued == 1
+        # Simulate the caller enqueueing the new message behind the rescued chain
+        new_event = _text_event("new-msg", "new1")
+        runner._session_state(session_key).conversation.queued_events.append(new_event)
+
+        # Drain order: slot (orphan-1), then overflow[0] (orphan-2), then new-msg
+        assert adapter._pending_messages[session_key].text == "orphan-1"
+        overflow_texts = [e.text for e in runner._session_state(session_key).conversation.queued_events]
+        assert overflow_texts == ["orphan-2", "new-msg"]

--- a/tests/gateway/test_fifo_overflow_rescue.py
+++ b/tests/gateway/test_fifo_overflow_rescue.py
@@ -5,18 +5,16 @@ it lands in SessionState.conversation.queued_events (overflow) with
 the current turn's event occupying adapter._pending_messages[session_key]
 (slot).  After the slot's turn completes, _promote_queued_event moves
 the overflow head into the slot.  When that drain never runs — the
-compression window ended through an exit that skipped the promotion
-site — the overflow is silently orphaned: never dispatched, never
-persisted, never logged.
+busy window ended through an exit that skipped the promotion site
+(/stop, turn exception, generation bump) — the overflow is silently
+orphaned: never dispatched, never persisted, never logged.
 
-The rescue in GatewayRunner._rescue_orphaned_overflow stages one orphan
-into the slot on the next idle arrival, so FIFO order (#28503) holds.
+The rescue in GatewayRunner._rescue_orphaned_overflow pops the oldest
+orphan for the caller to run as the current turn and stages the next
+orphan in the slot, so FIFO order (#28503) holds and nothing runs twice.
 """
 
-import asyncio
 from unittest.mock import MagicMock
-
-import pytest
 
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -56,33 +54,47 @@ def _text_event(text: str, msg_id: str) -> MessageEvent:
     )
 
 
+def _runner() -> GatewayRunner:
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._queued_events = {}
+    return runner
+
+
 class TestRescueOrphanedOverflow:
-    def test_moves_overflow_head_to_empty_slot(self):
-        runner = GatewayRunner.__new__(GatewayRunner)
-        runner._queued_events = {}
-        # Minimal session_state with queued_events
+    def test_single_orphan_is_returned_and_removed_from_both_stores(self):
+        runner = _runner()
         adapter = _StubAdapter()
         session_key = "telegram:user:1"
-        # Two overflow items orphaned after slot turn completed
-        runner._session_state(session_key).conversation.queued_events.extend(
-            [_text_event("orphan-1", "o1"), _text_event("orphan-2", "o2")]
+        runner._session_state(session_key).conversation.queued_events.append(
+            _text_event("orphan-1", "o1")
         )
-        # Slot empty (session went idle)
         assert session_key not in adapter._pending_messages
 
         rescued = runner._rescue_orphaned_overflow(session_key, adapter)
 
-        assert rescued == 1
-        # Slot now holds the oldest orphan
-        assert adapter._pending_messages[session_key].text == "orphan-1"
-        # Remaining orphan stays in overflow
-        overflow = runner._session_state(session_key).conversation.queued_events
-        assert len(overflow) == 1
-        assert overflow[0].text == "orphan-2"
+        assert rescued is not None and rescued.text == "orphan-1"
+        # The rescued event runs as the current turn, so it must NOT also
+        # sit in the slot — the post-turn drain would run it a second time.
+        assert session_key not in adapter._pending_messages
+        assert runner._session_state(session_key).conversation.queued_events == []
+
+    def test_two_orphans_return_oldest_and_stage_next_in_slot(self):
+        runner = _runner()
+        adapter = _StubAdapter()
+        session_key = "telegram:user:1b"
+        runner._session_state(session_key).conversation.queued_events.extend(
+            [_text_event("orphan-1", "o1"), _text_event("orphan-2", "o2")]
+        )
+
+        rescued = runner._rescue_orphaned_overflow(session_key, adapter)
+
+        assert rescued is not None and rescued.text == "orphan-1"
+        # Slot now holds the NEXT orphan so the drain continues the chain.
+        assert adapter._pending_messages[session_key].text == "orphan-2"
+        assert runner._session_state(session_key).conversation.queued_events == []
 
     def test_noop_when_slot_occupied(self):
-        runner = GatewayRunner.__new__(GatewayRunner)
-        runner._queued_events = {}
+        runner = _runner()
         adapter = _StubAdapter()
         session_key = "telegram:user:2"
         runner._session_state(session_key).conversation.queued_events.append(
@@ -92,41 +104,56 @@ class TestRescueOrphanedOverflow:
 
         rescued = runner._rescue_orphaned_overflow(session_key, adapter)
 
-        assert rescued == 0
+        assert rescued is None
         assert adapter._pending_messages[session_key].text == "busy-slot"
         assert len(runner._session_state(session_key).conversation.queued_events) == 1
 
     def test_noop_when_no_overflow(self):
-        runner = GatewayRunner.__new__(GatewayRunner)
-        runner._queued_events = {}
+        runner = _runner()
         adapter = _StubAdapter()
         session_key = "telegram:user:3"
 
         rescued = runner._rescue_orphaned_overflow(session_key, adapter)
 
-        assert rescued == 0
+        assert rescued is None
         assert session_key not in adapter._pending_messages
 
     def test_fifo_order_preserved_across_rescue_and_new_message(self):
-        """Oldest orphan runs first, new arrival last — FIFO (#28503)."""
-        runner = GatewayRunner.__new__(GatewayRunner)
-        runner._queued_events = {}
+        """Oldest orphan runs first, new arrival last — FIFO (#28503).
+
+        Mirrors the idle-arrival call site: rescue → _enqueue_fifo(new).
+        """
+        runner = _runner()
         adapter = _StubAdapter()
         session_key = "telegram:user:4"
-
-        # Two orphans from the lost window
         runner._session_state(session_key).conversation.queued_events.extend(
             [_text_event("orphan-1", "o1"), _text_event("orphan-2", "o2")]
         )
 
-        # New message arrives for idle session — rescue stages orphan-1
         rescued = runner._rescue_orphaned_overflow(session_key, adapter)
-        assert rescued == 1
-        # Simulate the caller enqueueing the new message behind the rescued chain
-        new_event = _text_event("new-msg", "new1")
-        runner._session_state(session_key).conversation.queued_events.append(new_event)
+        assert rescued is not None and rescued.text == "orphan-1"
+        runner._enqueue_fifo(session_key, _text_event("new-msg", "new1"), adapter)
 
-        # Drain order: slot (orphan-1), then overflow[0] (orphan-2), then new-msg
-        assert adapter._pending_messages[session_key].text == "orphan-1"
-        overflow_texts = [e.text for e in runner._session_state(session_key).conversation.queued_events]
-        assert overflow_texts == ["orphan-2", "new-msg"]
+        # Drain order after this turn: slot (orphan-2), then overflow (new-msg)
+        assert adapter._pending_messages[session_key].text == "orphan-2"
+        overflow_texts = [
+            e.text for e in runner._session_state(session_key).conversation.queued_events
+        ]
+        assert overflow_texts == ["new-msg"]
+
+    def test_single_orphan_then_new_message_lands_in_slot(self):
+        """With one orphan the slot is free after rescue, so the incoming
+        message must go to the slot (not overflow) or the drain never sees it."""
+        runner = _runner()
+        adapter = _StubAdapter()
+        session_key = "telegram:user:5"
+        runner._session_state(session_key).conversation.queued_events.append(
+            _text_event("orphan-1", "o1")
+        )
+
+        rescued = runner._rescue_orphaned_overflow(session_key, adapter)
+        assert rescued is not None and rescued.text == "orphan-1"
+        runner._enqueue_fifo(session_key, _text_event("new-msg", "new1"), adapter)
+
+        assert adapter._pending_messages[session_key].text == "new-msg"
+        assert runner._session_state(session_key).conversation.queued_events == []

--- a/tests/gateway/test_shutdown_flush.py
+++ b/tests/gateway/test_shutdown_flush.py
@@ -11,6 +11,7 @@ import pytest
 
 from gateway.shutdown_flush import (
     _serialise_value,
+    flush_overflow_to_file,
     flush_pending_to_file,
     recover_pending_to_db,
 )
@@ -168,3 +169,72 @@ def test_get_flush_dir_uses_get_hermes_home(tmp_path, monkeypatch):
     assert result == tmp_path / "pending_messages"
 
 
+
+
+# ── FIFO overflow tail durability (#99882) ─────────────────────────────
+
+
+def _overflow_event(text: str, session_id: str = "20260901_120000_fifo"):
+    event = MagicMock()
+    event.text = text
+    event.session_id = session_id
+    event.platform = "telegram"
+    event.sender_id = "1572286605"
+    event.sender_name = "tester"
+    event.reply_to = None
+    event.media = None
+    event.raw_event = None
+    return event
+
+
+def test_flush_overflow_writes_one_payload_per_event_in_arrival_order(tmp_path, monkeypatch):
+    """The FIFO tail (queued_events) must survive shutdown like the slot does.
+
+    Each overflow entry is its own recover_pending_to_db-compatible payload,
+    with ``seq`` recording arrival order inside the session.
+    """
+    flush_dir = _make_flush_dir(tmp_path)
+    monkeypatch.setattr("gateway.shutdown_flush._get_flush_dir", lambda: flush_dir)
+
+    count = flush_overflow_to_file(
+        {
+            "agent:main:telegram:dm:1": [
+                _overflow_event("follow-up B"),
+                _overflow_event("follow-up C"),
+            ],
+            "agent:main:telegram:dm:2": [],
+            "": [_overflow_event("keyless — skipped")],
+        },
+        reason="shutdown",
+    )
+    assert count == 2
+    payloads = sorted(
+        (json.loads(f.read_text(encoding="utf-8")) for f in flush_dir.glob("*.json")),
+        key=lambda p: p["seq"],
+    )
+    assert [p["data"]["text"] for p in payloads] == ["follow-up B", "follow-up C"]
+    assert {p["session_key"] for p in payloads} == {"agent:main:telegram:dm:1"}
+    assert all(p["reason"] == "shutdown" for p in payloads)
+
+
+def test_flushed_overflow_is_replayed_by_recover_pending_to_db(tmp_path, monkeypatch):
+    """Round-trip: overflow payloads use the slot-flush shape, so the existing
+    startup recovery inserts them as user rows without any new reader."""
+    flush_dir = _make_flush_dir(tmp_path)
+    monkeypatch.setattr("gateway.shutdown_flush._get_flush_dir", lambda: flush_dir)
+    flush_overflow_to_file({"agent:main:telegram:dm:1": [_overflow_event("orphan-1")]})
+
+    db = MagicMock()
+    recovered = recover_pending_to_db(session_db=db)
+    assert recovered == 1
+    db.append_message.assert_called_once()
+    kwargs = db.append_message.call_args.kwargs
+    assert kwargs["session_id"] == "20260901_120000_fifo"
+    assert kwargs["role"] == "user"
+    assert kwargs["content"] == "orphan-1"
+    assert list(flush_dir.glob("*.json")) == []
+
+
+def test_flush_overflow_noop_on_empty():
+    assert flush_overflow_to_file({}) == 0
+    assert flush_overflow_to_file({"k": []}) == 0


### PR DESCRIPTION
## Summary
Gateway follow-ups that were queued into the FIFO overflow while a turn was busy (e.g. demoted `interrupt → queue` during in-flight compression) are no longer silently lost when the busy window ends without the post-turn promotion running: the next idle arrival rescues the orphaned chain and runs it first, in arrival order, exactly once — and the overflow tail now survives gateway shutdown alongside the slot.

Root cause: the overflow list (`SessionState.conversation.queued_events`) is only drained by `_promote_queued_event` at the `_run_agent` post-turn site. Any exit that skips that site (`/stop`, generation bump, turn exception, drain) left the tail populated on an idle session, and the fresh `_process_message` path never looked at it.

## Changes
- `gateway/run.py` — `_rescue_orphaned_overflow` (new, from #99912) + rescue at the idle claim site in `_handle_message` before `_claim_active_session_slot`. Follow-up on top of the salvaged commits: the helper now **pops** the oldest orphan and returns it as the current turn (the original left it in the slot too, so the post-turn `_dequeue_pending_event` ran it a second time), stages the next orphan in the slot so the drain continues the chain, and the call site parks the incoming event via `_enqueue_fifo` (slot when free, overflow otherwise). The rescued event's own `source` drives the turn.
- `gateway/run.py` `_stop_impl` + `gateway/shutdown_flush.py` — sibling site of the same loss class: shutdown flushed only the adapter slot (#72680); `flush_overflow_to_file` now writes each overflow event in the slot-flush payload shape (+`seq`), so the existing `recover_pending_to_db` replays them on restart with no new reader.
- `tests/gateway/test_fifo_overflow_rescue.py` (from #99912, contract updated) — single-orphan removal from both stores, 2-orphan chain staging, occupied-slot / empty no-ops, FIFO across rescue + new arrival, single-orphan-then-new-message lands in slot.
- `tests/gateway/test_shutdown_flush.py` — overflow flush ordering/skip cases, round-trip through `recover_pending_to_db`, empty no-op.

## Validation
| | Before (origin/main) | After |
|---|---|---|
| Live repro `/tmp/c1b_repro_fifo.py` (real `GatewayRunner`, real `BasePlatformAdapter.handle_message`, real `SessionStore`+`SessionDB` in temp HERMES_HOME, real compression lock; only the LLM scripted) | `ORPHAN STATE ... True`; `FINAL turns=['Sent', 'new idle message D', 'follow-up C (re-sent)']` → C ran only after D's full turn (FIFO violated; any boundary in that window drops it) | `Rescued orphaned FIFO overflow event ... (#99882)` WARNING; `FINAL turns=['Sent', 'follow-up C (re-sent)', 'new idle message D']`; `CLEAN: dispatched exactly once, before D` |
| Original #99912 shape under the same repro | — | `TURNS=['Sent','C','C','D']` (double dispatch) → fixed by the follow-up commit |
| Sabotage (restore original helper shape) | — | 4/6 rescue tests fail |
| `pytest tests/gateway/test_fifo_overflow_rescue.py test_shutdown_flush.py test_pending_queue_spool.py test_queue_consumption.py test_queue_command.py test_steer_fifo_overwrite.py test_priority_path_compression_demotion_56391.py test_session_race_guard.py test_restart_drain.py test_goal_continuation_drain.py test_session_stall_watchdog.py test_busy_session_ack.py test_max_concurrent_sessions.py` | — | 93 passed, 2 skipped |
| `ruff check` on touched files | — | clean |

**Live repro:** real gateway runner + adapter dispatch, compression lock held during the busy window, `/stop` ends the window — before: follow-up C orphaned in `queued_events` on an idle session, dispatched only after unrelated message D; after: C rescued on D's arrival, runs exactly once before D, overflow empty.

Closes #99882
Salvages #99912 — commits by @salch-cred cherry-picked with authorship preserved.

## Infographic
![fifo-orphan-rescue](https://v3b.fal.media/files/b/0aa8c526/IPXmOu50ZwvNuCofWT-R5_b9jktoVl.png)
