### PR TITLE
fix(cron): let long-running scripts opt out of deadlines

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3930,6 +3930,8 @@ _FIRE_CLAIM_HEARTBEAT_GRACE_SECONDS = _RUN_CLAIM_HEARTBEAT_SECONDS * 3
 def _parse_script_timeout(value: Any, source: str) -> tuple[bool, Optional[int]]:
     """Parse one timeout source, distinguishing unlimited from invalid."""
     try:
+        if isinstance(value, bool):
+            raise TypeError
         numeric = float(value)
         if numeric == 0:
             return True, None

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3927,32 +3927,44 @@ _RUN_CLAIM_HEARTBEAT_SECONDS = 60.0
 _FIRE_CLAIM_HEARTBEAT_GRACE_SECONDS = _RUN_CLAIM_HEARTBEAT_SECONDS * 3
 
 
-def _get_script_timeout() -> int:
-    """Resolve cron pre-run script timeout from module/env/config with a safe default."""
+def _parse_script_timeout(value: Any, source: str) -> tuple[bool, Optional[int]]:
+    """Parse one timeout source, distinguishing unlimited from invalid."""
+    try:
+        numeric = float(value)
+        if numeric == 0:
+            return True, None
+        timeout = int(numeric)
+        if timeout > 0:
+            return True, timeout
+    except (TypeError, ValueError, OverflowError):
+        pass
+
+    logger.warning("Invalid %s=%r; expected 0 or at least 1 second", source, value)
+    return False, None
+
+
+def _get_script_timeout() -> Optional[int]:
+    """Resolve the cron script timeout; ``None`` means no deadline."""
     if _SCRIPT_TIMEOUT != _DEFAULT_SCRIPT_TIMEOUT:
-        try:
-            timeout = int(float(_SCRIPT_TIMEOUT))
-            if timeout > 0:
-                return timeout
-        except Exception:
-            logger.warning("Invalid patched _SCRIPT_TIMEOUT=%r; using env/config/default", _SCRIPT_TIMEOUT)
+        valid, timeout = _parse_script_timeout(_SCRIPT_TIMEOUT, "patched _SCRIPT_TIMEOUT")
+        if valid:
+            return timeout
 
     env_value = os.getenv("HERMES_CRON_SCRIPT_TIMEOUT", "").strip()
     if env_value:
-        try:
-            timeout = int(float(env_value))
-            if timeout > 0:
-                return timeout
-        except Exception:
-            logger.warning("Invalid HERMES_CRON_SCRIPT_TIMEOUT=%r; using config/default", env_value)
+        valid, timeout = _parse_script_timeout(env_value, "HERMES_CRON_SCRIPT_TIMEOUT")
+        if valid:
+            return timeout
 
     try:
         cfg = load_config() or {}
         cron_cfg = cfg.get("cron", {}) if isinstance(cfg, dict) else {}
         configured = cron_cfg.get("script_timeout_seconds")
         if configured is not None:
-            timeout = int(float(configured))
-            if timeout > 0:
+            valid, timeout = _parse_script_timeout(
+                configured, "cron.script_timeout_seconds"
+            )
+            if valid:
                 return timeout
     except Exception as exc:
         logger.debug("Failed to load cron script timeout from config: %s", exc)
@@ -4412,7 +4424,9 @@ def _run_job_script(
             env=env,
             **popen_kwargs,
         )
-        deadline = time.monotonic() + script_timeout
+        deadline = (
+            None if script_timeout is None else time.monotonic() + script_timeout
+        )
         while True:
             if cancel_event is not None and cancel_event.is_set():
                 # Same bug class as the timeout site below: a cancelled fire
@@ -4420,8 +4434,8 @@ def _run_job_script(
                 _terminate_cron_script_tree(proc)
                 _drain_script_pipes(proc)
                 return False, "Script cancelled because cron fire ownership was lost"
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
+            remaining = None if deadline is None else deadline - time.monotonic()
+            if remaining is not None and remaining <= 0:
                 # Phase 4a (#85125): a script timeout must leave ZERO living
                 # descendants. killpg only reaches the script's own process
                 # group — a grandchild that called setsid (backgrounded
@@ -4435,7 +4449,8 @@ def _run_job_script(
                 _drain_script_pipes(proc)
                 return False, f"Script timed out after {script_timeout}s: {path}"
             try:
-                stdout_raw, stderr_raw = proc.communicate(timeout=min(0.1, remaining))
+                poll_timeout = 0.1 if remaining is None else min(0.1, remaining)
+                stdout_raw, stderr_raw = proc.communicate(timeout=poll_timeout)
                 break
             except subprocess.TimeoutExpired:
                 continue

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -108,24 +108,41 @@ class TestRunJobScript:
 
         assert sched._get_script_timeout() is None
 
-    @pytest.mark.parametrize("configured", [-1, "not-a-number"])
+    @pytest.mark.parametrize(
+        ("source", "configured"),
+        [
+            ("config", -1),
+            ("config", "not-a-number"),
+            ("config", False),
+            ("module", False),
+        ],
+    )
     def test_invalid_config_timeout_warns_and_uses_default(
-        self, cron_env, monkeypatch, caplog, configured,
+        self, cron_env, monkeypatch, caplog, source, configured,
     ):
         from cron import scheduler as sched
 
         monkeypatch.setattr(sched, "_SCRIPT_TIMEOUT", sched._DEFAULT_SCRIPT_TIMEOUT)
         monkeypatch.delenv("HERMES_CRON_SCRIPT_TIMEOUT", raising=False)
-        monkeypatch.setattr(
-            sched,
-            "load_config",
-            lambda: {"cron": {"script_timeout_seconds": configured}},
-        )
+        if source == "module":
+            monkeypatch.setattr(sched, "_SCRIPT_TIMEOUT", configured)
+            monkeypatch.setattr(sched, "load_config", lambda: {})
+        else:
+            monkeypatch.setattr(
+                sched,
+                "load_config",
+                lambda: {"cron": {"script_timeout_seconds": configured}},
+            )
 
         with caplog.at_level("WARNING", logger=sched.__name__):
             assert sched._get_script_timeout() == sched._DEFAULT_SCRIPT_TIMEOUT
 
-        assert "script_timeout_seconds" in caplog.text
+        expected_source = (
+            "patched _SCRIPT_TIMEOUT"
+            if source == "module"
+            else "cron.script_timeout_seconds"
+        )
+        assert expected_source in caplog.text
 
     def test_unlimited_script_can_finish_without_deadline(self, cron_env, monkeypatch):
         from cron import scheduler as sched

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -87,6 +87,61 @@ def test_cronjob_tool_rejects_stale_past_one_shot(cron_env, monkeypatch):
 class TestRunJobScript:
     """Test the _run_job_script() function."""
 
+    @pytest.mark.parametrize("source", ["module", "env", "config"])
+    def test_zero_timeout_resolves_to_unlimited(self, cron_env, monkeypatch, source):
+        from cron import scheduler as sched
+
+        monkeypatch.setattr(sched, "_SCRIPT_TIMEOUT", sched._DEFAULT_SCRIPT_TIMEOUT)
+        monkeypatch.delenv("HERMES_CRON_SCRIPT_TIMEOUT", raising=False)
+        monkeypatch.setattr(sched, "load_config", lambda: {})
+
+        if source == "module":
+            monkeypatch.setattr(sched, "_SCRIPT_TIMEOUT", 0)
+        elif source == "env":
+            monkeypatch.setenv("HERMES_CRON_SCRIPT_TIMEOUT", "0")
+        else:
+            monkeypatch.setattr(
+                sched,
+                "load_config",
+                lambda: {"cron": {"script_timeout_seconds": 0}},
+            )
+
+        assert sched._get_script_timeout() is None
+
+    @pytest.mark.parametrize("configured", [-1, "not-a-number"])
+    def test_invalid_config_timeout_warns_and_uses_default(
+        self, cron_env, monkeypatch, caplog, configured,
+    ):
+        from cron import scheduler as sched
+
+        monkeypatch.setattr(sched, "_SCRIPT_TIMEOUT", sched._DEFAULT_SCRIPT_TIMEOUT)
+        monkeypatch.delenv("HERMES_CRON_SCRIPT_TIMEOUT", raising=False)
+        monkeypatch.setattr(
+            sched,
+            "load_config",
+            lambda: {"cron": {"script_timeout_seconds": configured}},
+        )
+
+        with caplog.at_level("WARNING", logger=sched.__name__):
+            assert sched._get_script_timeout() == sched._DEFAULT_SCRIPT_TIMEOUT
+
+        assert "script_timeout_seconds" in caplog.text
+
+    def test_unlimited_script_can_finish_without_deadline(self, cron_env, monkeypatch):
+        from cron import scheduler as sched
+
+        script = cron_env / "scripts" / "slow_success.py"
+        script.write_text(
+            'import time\ntime.sleep(0.2)\nprint("finished")\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(sched, "_get_script_timeout", lambda: None)
+
+        success, output = sched._run_job_script(str(script))
+
+        assert success is True
+        assert output == "finished"
+
     def test_successful_script(self, cron_env):
         from cron.scheduler import _run_job_script
 
@@ -719,6 +774,7 @@ class TestScriptTimeoutTreeKill:
             proc.kill()
 
         monkeypatch.setattr(sched, "_terminate_cron_script_tree", _record_and_kill)
+        monkeypatch.setattr(sched, "_get_script_timeout", lambda: None)
 
         class _Cancelled:
             def is_set(self):


### PR DESCRIPTION
## What does this PR do?

Cron scripts can now set `cron.script_timeout_seconds` to `0` to run without an arbitrary framework deadline while still responding to cancellation. Positive timeout behavior remains bounded, and invalid or negative values warn before falling back to the safe default.

### Symptom

An explicit timeout of `0` was ignored and silently replaced with the 3600-second default, so healthy long-running scripts could be terminated after one hour.

### Impact

Operators cannot opt deterministic scripts out of the framework deadline even when those scripts own their own checkpointing and lease behavior.

### Bug Cause

**Trigger:** `cron/scheduler.py::_get_script_timeout` when a module, environment, or config timeout resolves to numeric zero.

**Causal chain:**
1. The resolver converts the configured value and only returns it when it is greater than zero.
2. Numeric zero falls through every source and returns `_DEFAULT_SCRIPT_TIMEOUT`.
3. `_run_job_script` always creates a fixed deadline, so the script is terminated after 3600 seconds instead of running without a deadline.

**Why it is wrong:** Zero is a valid sentinel for unlimited execution, but the resolver treated it like an absent or invalid value.

**Working sibling / contrast:** Positive timeout values already resolve to a fixed integer deadline and retain that behavior.

**Ruled out:** Process cancellation was not the cause. The existing polling loop handles cancellation correctly; only unconditional deadline resolution and arithmetic prevented unlimited execution.

### Fix

The timeout resolver now distinguishes valid unlimited zero from invalid input, returns `None` for unlimited execution, and warns for invalid or negative values. The process loop skips deadline arithmetic and timeout checks only when unlimited, while continuing its 100 ms polling cadence for completion and cancellation.

## Related Issue

Fixes #100943

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py` - parse exact zero as unlimited and make deadline checks optional without disabling cancellation polling.
- `tests/cron/test_cron_script.py` - cover all timeout sources, invalid fallback warnings, unlimited completion, and unlimited cancellation.

## How to Test

1. Set each timeout source to `0` and confirm the resolver returns unlimited.
2. Run a script past a short test interval and confirm it completes with no deadline.
3. Cancel an unlimited script and confirm its process tree is terminated.
4. Run the related suites:

```bash
scripts/run_tests.sh tests/cron/test_cron_script.py tests/cron/test_cron_no_agent.py -q
```

Result: 55 passed, 2 skipped.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repo test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation update is N/A; the existing config key is unchanged
- [x] `cli-config.yaml.example` update is N/A; no config key was added or renamed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; architecture and workflows are unchanged
- [x] I've considered cross-platform impact; the polling and timeout logic is platform-independent
- [x] Tool description and schema updates are N/A; no model tool behavior changed

## Screenshots / Logs

N/A - this is scheduler behavior covered by automated process tests.
