### PR TITLE
fix(hooks): stop non-TTY fail-closed policy bypasses

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -77,6 +77,8 @@ with ``hook <command> failed closed: <reason>``.  Use this for
 security-gating hooks (secret scanners, policy checks) where a crashed
 hook must not silently allow the action.  On non-blocking events
 ``fail_closed`` is ignored with a warning.
+If that hook is not yet allowlisted, Hermes installs a non-executing blocker
+for matching tool calls until the command is approved.
 
 Per-event ``extra`` keys
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -262,8 +264,10 @@ def register_from_config(
     pick them up.
 
     Returns the list of :class:`ShellHookSpec` entries that ended up wired
-    up on the plugin manager.  Skipped entries (unknown events, malformed,
-    not allowlisted, already registered) are logged but not returned.
+    up on the plugin manager.  An unapproved fail-closed blocking hook is
+    wired as a non-executing blocker so its matcher cannot silently fail
+    open.  Other skipped entries (unknown events, malformed, not allowlisted,
+    already registered) are logged but not returned.
     """
     if not isinstance(cfg, dict):
         return []
@@ -296,6 +300,7 @@ def register_from_config(
     # re-check in case two callers ever race through the prompt.
     for spec in specs:
         key = (spec.event, spec.matcher, spec.command)
+        callback = _make_callback(spec)
         with _registered_lock:
             if key in _registered:
                 continue
@@ -305,19 +310,30 @@ def register_from_config(
             if not _prompt_and_record(
                 spec.event, spec.command, accept_hooks=effective_accept,
             ):
-                logger.warning(
-                    "shell hook for %s (%s) not allowlisted — skipped. "
-                    "Use --accept-hooks / HERMES_ACCEPT_HOOKS=1 / "
-                    "hooks_auto_accept: true, or approve at the TTY "
-                    "prompt next run.",
-                    spec.event, spec.command,
-                )
-                continue
+                if spec.fail_closed and spec.event in _BLOCKING_EVENTS:
+                    callback = _make_unapproved_callback(spec)
+                    logger.error(
+                        "fail-closed shell hook for %s (%s) is not "
+                        "allowlisted — matching actions will be blocked "
+                        "without executing the hook. Use --accept-hooks / "
+                        "HERMES_ACCEPT_HOOKS=1 / hooks_auto_accept: true, "
+                        "or approve at the TTY prompt next run.",
+                        spec.event, spec.command,
+                    )
+                else:
+                    logger.warning(
+                        "shell hook for %s (%s) not allowlisted — skipped. "
+                        "Use --accept-hooks / HERMES_ACCEPT_HOOKS=1 / "
+                        "hooks_auto_accept: true, or approve at the TTY "
+                        "prompt next run.",
+                        spec.event, spec.command,
+                    )
+                    continue
 
         with _registered_lock:
             if key in _registered:
                 continue
-            manager._hooks.setdefault(spec.event, []).append(_make_callback(spec))
+            manager._hooks.setdefault(spec.event, []).append(callback)
             _registered.add(key)
             registered.append(spec)
             logger.info(
@@ -634,6 +650,21 @@ def _make_callback(spec: ShellHookSpec) -> Callable[..., Optional[Dict[str, Any]
         return _evaluate_result(spec, r)
 
     _callback.__name__ = f"shell_hook[{spec.event}:{spec.command}]"
+    _callback.__qualname__ = _callback.__name__
+    return _callback
+
+
+def _make_unapproved_callback(
+    spec: ShellHookSpec,
+) -> Callable[..., Optional[Dict[str, Any]]]:
+    """Block matching actions without executing an unapproved hook."""
+
+    def _callback(**kwargs: Any) -> Optional[Dict[str, Any]]:
+        if not spec.matches_tool(kwargs.get("tool_name")):
+            return None
+        return _fail_closed_block(spec, "not allowlisted")
+
+    _callback.__name__ = f"shell_hook_unapproved[{spec.event}:{spec.command}]"
     _callback.__qualname__ = _callback.__name__
     return _callback
 

--- a/tests/agent/test_shell_hooks_consent.py
+++ b/tests/agent/test_shell_hooks_consent.py
@@ -119,6 +119,45 @@ class TestNonTTYFlow:
             )
         assert registered == []
 
+    def test_no_tty_fail_closed_hook_blocks_without_running_unapproved_command(
+        self, tmp_path,
+    ):
+        from hermes_cli import plugins
+
+        marker = tmp_path / "hook-ran"
+        script = tmp_path / "hook.sh"
+        script.write_text(
+            "#!/usr/bin/env bash\n"
+            f"touch {marker}\n"
+            "printf '{}\\n'\n"
+        )
+        script.chmod(0o755)
+        plugins._plugin_manager = plugins.PluginManager()
+
+        cfg = {
+            "hooks": {
+                "pre_tool_call": [{
+                    "matcher": "terminal",
+                    "command": str(script),
+                    "fail_closed": True,
+                }],
+            },
+        }
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.isatty.return_value = False
+            registered = shell_hooks.register_from_config(
+                cfg, accept_hooks=False,
+            )
+
+        assert len(registered) == 1
+        assert plugins.get_pre_tool_call_block_message(
+            tool_name="terminal", args={"command": "echo unsafe"},
+        ) == f"hook {script} failed closed: not allowlisted"
+        assert plugins.get_pre_tool_call_block_message(
+            tool_name="web_search", args={"query": "safe"},
+        ) is None
+        assert not marker.exists()
+
 
     def test_no_tty_with_env_accepts(self, tmp_path, monkeypatch):
         from hermes_cli import plugins


### PR DESCRIPTION
## What does this PR do?

A fail-closed `pre_tool_call` shell hook can no longer disappear when a non-TTY gateway has not approved its command yet. Hermes now installs a non-executing blocker for matching tool calls, preserving the configured policy boundary without running an untrusted command.

### Symptom

A gateway with `hooks_auto_accept: false` and no profile-local allowlist entry logs that the hook was skipped, registers no callback, and continues processing matching tool calls.

### Impact

New or separately configured profiles can run tools that operators intended a `fail_closed: true` hook to gate. The affected deployment count is unknown beyond the profiles documented in the issue.

### Bug Cause

**Trigger:** `agent/shell_hooks.py:306` / `register_from_config()` when `_prompt_and_record()` rejects an unseen command in a non-TTY process.

**Causal chain:**
1. A profile configures a `fail_closed: true` `pre_tool_call` hook but has no matching allowlist record.
2. Non-TTY consent returns false, and registration continues before any callback is added to the plugin manager.
3. Because `fail_closed` is only evaluated by the missing callback, matching tool calls proceed without the configured policy check.

**Why it is wrong:** Registration failure sits outside the hook callback that enforces fail-closed behavior, so the strongest configured failure policy is unreachable at the exact point where it is needed.

**Working sibling / contrast:** An allowlisted hook registers its normal callback and evaluates command failures through `_evaluate_result()`, where `fail_closed` already blocks correctly.

**Ruled out:** The hook command does not need to be missing or inaccessible. The regression test uses an existing command and shows that consent state alone determines whether the policy callback exists.

### Fix

When consent is unavailable for a fail-closed blocking hook, registration now adds a matcher-aware callback that blocks without executing the unapproved command. Default fail-open hooks retain the existing skip behavior, and unrelated tools remain unaffected.

## Related Issue

Fixes #100942

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Security fix

## Changes Made

- `agent/shell_hooks.py` - register a non-executing fail-closed callback when a blocking hook is not allowlisted.
- `tests/agent/test_shell_hooks_consent.py` - cover non-TTY registration, matcher behavior, blocking, and non-execution of the unapproved command.

## How to Test

1. Configure a `fail_closed: true` `pre_tool_call` hook without an allowlist entry and run registration with a non-TTY stdin.
2. Confirm a matching tool call is blocked, a non-matching tool call is allowed, and the hook command is not executed.
3. Run the focused suites:

```bash
scripts/run_tests.sh tests/agent/test_shell_hooks_consent.py -k 'no_tty_fail_closed or no_tty_no_flag or no_tty_with_env' -q
scripts/run_tests.sh tests/agent/test_shell_hooks.py -k 'IdempotentRegistration or FailClosedParsing or EvaluateResult' -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the repository test entry on the relevant tests and all selected tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated the relevant module documentation
- [x] `cli-config.yaml.example` changes are N/A because no config key changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` changes are N/A because no workflow changed
- [x] I've considered cross-platform impact; the callback is pure Python and does not execute the unapproved command
- [x] Tool description and schema changes are N/A
