### PR TITLE
fix(cron): stop overlap losers from inflating failure history

### DIFF
--- a/cron/executions.py
+++ b/cron/executions.py
@@ -160,6 +160,18 @@ def create_execution(job_id: str, *, source: str) -> Dict[str, Any]:
     return record  # type: ignore[return-value]
 
 
+def discard_unstarted_execution(execution_id: str) -> bool:
+    """Delete this process's exact claimed placeholder before work starts."""
+    with _transaction() as conn:
+        cur = conn.execute(
+            """DELETE FROM executions
+               WHERE id=? AND process_id=? AND status='claimed'
+                 AND started_at IS NULL""",
+            (execution_id, _PROCESS_ID),
+        )
+    return cur.rowcount == 1
+
+
 def mark_execution_running(execution_id: str) -> Optional[Dict[str, Any]]:
     """Transition one claimed attempt to running exactly once."""
     now = _hermes_now().isoformat()

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -725,7 +725,12 @@ from cron.jobs import (
     save_job_output,
     use_cron_store,
 )
-from cron.executions import create_execution, finish_execution, mark_execution_running
+from cron.executions import (
+    create_execution,
+    discard_unstarted_execution,
+    finish_execution,
+    mark_execution_running,
+)
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
 # response with this marker to suppress delivery.  Output is still saved
@@ -8080,11 +8085,12 @@ def tick(
             # This prevents a queued lease from expiring before execution.
             claimed = claim_job_for_fire(job["id"], return_job=True)
             if not claimed:
-                finish_execution(
-                    job["execution_id"],
-                    success=False,
-                    error="Fire claim lost; execution was not started.",
-                )
+                if not discard_unstarted_execution(job["execution_id"]):
+                    logger.error(
+                        "Job '%s': refused to discard fire-claim loser because "
+                        "its execution placeholder was no longer owned and unstarted",
+                        job["id"],
+                    )
                 return True
             # Production CAS returns the exact persisted record with its unique
             # owner. Bool fallback keeps older test doubles/API overrides

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -39,6 +39,44 @@ def test_execution_transitions_are_durable(monkeypatch, tmp_path):
     assert persisted == [completed]
 
 
+def test_discard_unstarted_execution_removes_owned_claim(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    claimed = executions.create_execution("overlap-loser", source="builtin")
+
+    assert executions.discard_unstarted_execution(claimed["id"]) is True
+    assert executions.list_executions(job_id="overlap-loser") == []
+
+
+def test_discard_unstarted_execution_preserves_nonmatching_rows(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    foreign = executions.create_execution("foreign", source="builtin")
+    started = executions.create_execution("started", source="builtin")
+    running = executions.create_execution("running", source="builtin")
+    completed = executions.create_execution("completed", source="builtin")
+    with executions._transaction() as conn:
+        conn.execute(
+            "UPDATE executions SET process_id='another-process' WHERE id=?",
+            (foreign["id"],),
+        )
+        conn.execute(
+            "UPDATE executions SET started_at='already-started' WHERE id=?",
+            (started["id"],),
+        )
+    executions.mark_execution_running(running["id"])
+    executions.finish_execution(completed["id"], success=True)
+    before = {
+        row["id"]: row for row in executions.list_executions(limit=100)
+    }
+
+    for execution_id in (foreign["id"], started["id"], running["id"], completed["id"]):
+        assert executions.discard_unstarted_execution(execution_id) is False
+
+    after = {
+        row["id"]: row for row in executions.list_executions(limit=100)
+    }
+    assert after == before
+
+
 def test_execution_ledger_follows_the_current_profile_home(monkeypatch, tmp_path):
     import cron.executions as executions
 
@@ -211,6 +249,51 @@ def test_generic_submit_failure_finishes_attempt_and_releases_guard(monkeypatch)
         })
     ]
     assert "submit-fail" not in scheduler.get_running_job_ids()
+
+
+def test_builtin_tick_lost_fire_claim_discards_only_its_placeholder(
+    monkeypatch, tmp_path
+):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    winner = executions.create_execution("overlap-job", source="manual")
+    winner = executions.mark_execution_running(winner["id"])
+
+    import cron.scheduler as scheduler
+
+    job = {
+        "id": "overlap-job",
+        "name": "overlap",
+        "prompt": "test",
+        "schedule": "every 5m",
+        "enabled": True,
+        "next_run_at": "2020-01-01T00:00:00",
+        "deliver": "local",
+    }
+    job_run_updates = []
+    scheduler._shutdown_parallel_pool()
+    scheduler._running_job_ids.clear()
+    monkeypatch.setattr(scheduler, "get_due_jobs", lambda: [job])
+    monkeypatch.setattr(scheduler, "advance_next_runs", lambda _ids: 0)
+    monkeypatch.setattr(scheduler, "load_config", lambda: {})
+    monkeypatch.setattr(scheduler, "claim_job_for_fire", lambda *_a, **_kw: False)
+    monkeypatch.setattr(
+        scheduler,
+        "run_one_job",
+        lambda *_a, **_kw: (_ for _ in ()).throw(AssertionError("must not run")),
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "mark_job_run",
+        lambda *_a, **_kw: job_run_updates.append((_a, _kw)),
+    )
+
+    try:
+        assert scheduler.tick(verbose=False) == 1
+    finally:
+        scheduler._shutdown_parallel_pool()
+
+    assert executions.list_executions(job_id="overlap-job") == [winner]
+    assert job_run_updates == []
 
 
 def test_run_one_job_records_running_then_terminal(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Built-in Cron ticks that lose the durable fire claim before execution now discard only their own never-started audit placeholder instead of recording a failed run. The cleanup is a compare-and-swap delete over the exact execution ID, process owner, claimed state, and null start time, so concurrent winners and rows that advanced state remain untouched.

### Symptom

A built-in tick can create an execution placeholder and then lose `claim_job_for_fire` to an overlapping invocation. The placeholder is currently finalized as `failed` with `Fire claim lost; execution was not started.` even though no job work ran.

### Impact

Expected overlap losers inflate execution failure history and can make operators interpret serialization as a job failure. The winning execution remains valid, but the extra failed ledger row corrupts run reporting for the job.

### Bug Cause

**Trigger:** `cron/scheduler.py:tick` / `_process_job` when `claim_job_for_fire(..., return_job=True)` returns false.

**Causal chain:**
1. `_submit_with_guard` creates a `claimed` execution placeholder before executor dispatch.
2. The worker loses the durable fire claim to another invocation.
3. `_process_job` calls `finish_execution(..., success=False)`, converting work that never started into a failed terminal attempt.

**Why it is wrong:** A fire-claim conflict is an admission outcome, not an execution failure. Finalizing the placeholder also loses the distinction between a claim loser and a job that actually started and failed.

**Working sibling / contrast:** Real runs transition the ledger row through `mark_execution_running` before execution and continue to record terminal success or failure. External and manual fire paths keep their existing history semantics.

**Ruled out:** The in-process running guard is not the cause. The false failure is created after that guard admits the worker, specifically when the separate durable fire-claim compare-and-set loses.

### Fix

Add an execution-ledger cleanup operation that deletes only the exact row owned by the current process while it is still `claimed` with `started_at IS NULL`. Use it only for the built-in tick's initial fire-claim conflict; if the compare-and-swap no longer matches, preserve the row and log the diagnostic instead of rewriting foreign or advanced state.

## Related Issue

Fixes #100946

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/executions.py` - add owner- and state-fenced cleanup for never-started placeholders.
- `cron/scheduler.py` - neutralize only the built-in tick's initial fire-claim loser.
- `tests/cron/test_execution_ledger.py` - cover neutral overlap history, winner preservation, failure-streak isolation, and CAS rejection boundaries.

## How to Test

1. Run the execution-ledger regressions:

```bash
scripts/run_tests.sh tests/cron/test_execution_ledger.py -q
```

2. Run the adjacent scheduler suites:

```bash
scripts/run_tests.sh tests/cron/test_parallel_pool.py tests/cron/test_scheduler_provider.py -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A - no user-facing workflow changed
- [x] `cli-config.yaml.example` update: N/A - no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered: the cleanup uses SQLite transaction semantics shared across supported platforms
- [x] Tool descriptions/schemas update: N/A - no tool contract changed
