### PR TITLE
fix(agent): drop duplicate Codex tool calls

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -1584,6 +1584,7 @@ def _normalize_codex_response(
     reasoning_items_raw: List[Dict[str, Any]] = []
     message_items_raw: List[Dict[str, Any]] = []
     tool_calls: List[Any] = []
+    seen_tool_call_ids: set[str] = set()
     has_incomplete_items = response_status in {"queued", "in_progress", "incomplete"}
     saw_streaming_or_item_incomplete = response_status in {"queued", "in_progress"}
     saw_commentary_phase = False
@@ -1736,6 +1737,13 @@ def _normalize_codex_response(
             if not isinstance(call_id, str) or not call_id.strip():
                 call_id = _deterministic_call_id(fn_name, arguments, len(tool_calls))
             call_id = call_id.strip()
+            if call_id in seen_tool_call_ids:
+                logger.warning(
+                    "Skipping duplicate Codex function_call item with call_id=%s",
+                    call_id,
+                )
+                continue
+            seen_tool_call_ids.add(call_id)
             response_item_id = raw_item_id if isinstance(raw_item_id, str) else None
             response_item_id = _derive_responses_function_call_id(call_id, response_item_id)
             tool_calls.append(SimpleNamespace(
@@ -1757,6 +1765,13 @@ def _normalize_codex_response(
             if not isinstance(call_id, str) or not call_id.strip():
                 call_id = _deterministic_call_id(fn_name, arguments, len(tool_calls))
             call_id = call_id.strip()
+            if call_id in seen_tool_call_ids:
+                logger.warning(
+                    "Skipping duplicate Codex custom_tool_call item with call_id=%s",
+                    call_id,
+                )
+                continue
+            seen_tool_call_ids.add(call_id)
             response_item_id = raw_item_id if isinstance(raw_item_id, str) else None
             response_item_id = _derive_responses_function_call_id(call_id, response_item_id)
             tool_calls.append(SimpleNamespace(

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -452,6 +452,35 @@ def test_chat_messages_to_responses_input_canonicalizes_fc_only_pair():
         assert len(call["call_id"]) <= 64
 
 
+def test_normalize_codex_response_deduplicates_repeated_function_call_item_ids():
+    response = SimpleNamespace(
+        status="completed",
+        output=[
+            SimpleNamespace(
+                type="function_call",
+                id="call_1",
+                call_id="call_1",
+                name="terminal",
+                arguments='{"command":"echo hi"}',
+            ),
+            SimpleNamespace(
+                type="function_call",
+                id="call_1",
+                call_id="call_1",
+                name="terminal",
+                arguments="{}",
+            ),
+        ],
+    )
+
+    assistant_message, finish_reason = _normalize_codex_response(response)
+
+    assert finish_reason == "tool_calls"
+    assert assistant_message.tool_calls is not None
+    assert len(assistant_message.tool_calls) == 1
+    assert assistant_message.tool_calls[0].function.arguments == '{"command":"echo hi"}'
+
+
 def test_preflight_codex_input_items_sanitizes_replayed_fn_name():
     """The preflight choke-point also coerces invalid replayed names
     (covers callers that build input items without the chat converter)."""


### PR DESCRIPTION
## Summary
- Prevent duplicate Codex function calls with repeated `call_id`s from reaching normalization output.
- Add regression coverage for repeated `call_id` handling.

## Testing
- `HERMES_PYTHON=/home/cc/miniconda3/bin/python scripts/run_tests.sh tests/agent/test_codex_responses_adapter.py -q`
- `HERMES_PYTHON=/home/cc/miniconda3/bin/python scripts/run_tests.sh tests/run_agent/test_run_agent_codex_responses.py -q -k 'normalize_codex_response or chat_messages_to_responses_input'`
- `git diff --check`

Closes #96925