### PR TITLE
fix(kanban): enforce worker authority boundaries

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -64,6 +64,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "assignee": t.assignee,
         "status": t.status,
         "priority": t.priority,
+        "completion_policy": t.completion_policy,
         "tenant": t.tenant,
         "workspace_kind": t.workspace_kind,
         "workspace_path": t.workspace_path,
@@ -394,6 +395,16 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                                "and re-queues the task.")
     p_create.add_argument("--created-by", default="user",
                           help="Author name recorded on the task (default: user)")
+    p_create.add_argument(
+        "--completion-policy",
+        choices=sorted(kb.VALID_COMPLETION_POLICIES),
+        default="independent",
+        help=(
+            "Who may close the card: independent (default) requires another "
+            "profile or completed approval parent; worker allows self-completion; "
+            "approval marks a reviewer/verifier parent"
+        ),
+    )
     p_create.add_argument("--skill", action="append", default=[], dest="skills",
                           help="Skill to force-load into the worker "
                                "(repeatable). The kanban lifecycle is already "
@@ -1669,6 +1680,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             body=args.body,
             assignee=args.assignee,
             created_by=args.created_by or _profile_author(),
+            completion_policy=args.completion_policy,
             workspace_kind=ws_kind,
             workspace_path=ws_path,
             branch_name=branch_name,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -101,6 +101,7 @@ _log = logging.getLogger(__name__)
 
 VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done", "archived"}
 VALID_INITIAL_STATUSES = {"running", "blocked"}
+VALID_COMPLETION_POLICIES = {"worker", "independent", "approval"}
 
 # Typed block reasons. Distinguishes the two fundamentally different things a
 # worker (or human) means by "blocked", so each can be routed differently
@@ -1141,6 +1142,9 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    # Completion authority. Kept at the end with a default so older tests and
+    # plugins that construct Task directly remain source-compatible.
+    completion_policy: str = "worker"
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -1162,6 +1166,11 @@ class Task:
             status=row["status"],
             priority=row["priority"],
             created_by=row["created_by"],
+            completion_policy=(
+                row["completion_policy"]
+                if "completion_policy" in keys
+                else "worker"
+            ),
             created_at=row["created_at"],
             started_at=row["started_at"],
             completed_at=row["completed_at"],
@@ -1338,6 +1347,8 @@ CREATE TABLE IF NOT EXISTS tasks (
     status               TEXT NOT NULL,
     priority             INTEGER DEFAULT 0,
     created_by           TEXT,
+    -- ``approval`` is worker-completable and may approve an independent child.
+    completion_policy    TEXT NOT NULL DEFAULT 'worker',
     created_at           INTEGER NOT NULL,
     started_at           INTEGER,
     completed_at         INTEGER,
@@ -2557,6 +2568,15 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         _add_column_if_missing(
             conn, "tasks", "idempotency_key", "idempotency_key TEXT"
         )
+    if "completion_policy" not in cols:
+        # Legacy rows retain assigned-worker completion. User-created cards
+        # opt into independent approval at the CLI ingress.
+        _add_column_if_missing(
+            conn,
+            "tasks",
+            "completion_policy",
+            "completion_policy TEXT NOT NULL DEFAULT 'worker'",
+        )
     # ``idx_tasks_idempotency`` is created unconditionally below alongside
     # the other additive-column indexes — see the block after the
     # legacy-column migration. Creating it here too would be redundant.
@@ -3173,6 +3193,7 @@ def create_task(
     body: Optional[str] = None,
     assignee: Optional[str] = None,
     created_by: Optional[str] = None,
+    completion_policy: str = "worker",
     workspace_kind: str = "scratch",
     workspace_path: Optional[str] = None,
     branch_name: Optional[str] = None,
@@ -3236,6 +3257,12 @@ def create_task(
     """
     model_override = (model_override or "").strip() or None
     provider_override = (provider_override or "").strip() or None
+    completion_policy = str(completion_policy or "").strip().lower()
+    if completion_policy not in VALID_COMPLETION_POLICIES:
+        raise ValueError(
+            "completion_policy must be one of "
+            f"{sorted(VALID_COMPLETION_POLICIES)}"
+        )
     reasoning_effort = normalize_reasoning_effort(reasoning_effort)
     if provider_override and not model_override:
         raise ValueError("provider_override requires a model_override")
@@ -3503,13 +3530,14 @@ def create_task(
                     """
                     INSERT INTO tasks (
                         id, title, body, assignee, status, priority,
-                        created_by, created_at, workspace_kind, workspace_path,
+                        created_by, completion_policy, created_at,
+                        workspace_kind, workspace_path,
                         branch_name, project_id, tenant, idempotency_key,
                         max_runtime_seconds,
                         skills, max_retries, model_override, provider_override,
                         reasoning_effort,
                         goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -3519,6 +3547,7 @@ def create_task(
                         task_status,
                         priority,
                         created_by,
+                        completion_policy,
                         now,
                         workspace_kind,
                         workspace_path,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -11087,6 +11087,7 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
     lines.append("")
     lines.append(f"Assignee: {task.assignee or '(unassigned)'}")
     lines.append(f"Status:   {task.status}")
+    lines.append(f"Completion policy: {task.completion_policy}")
     if task.tenant:
         lines.append(f"Tenant:   {task.tenant}")
     lines.append(f"Workspace: {task.workspace_kind} @ {task.workspace_path or '(unresolved)'}")

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -822,6 +822,8 @@ async def test_notifier_artifact_delivery_skips_missing_files(kanban_home, tmp_p
 
     import os
     os.environ["HERMES_KANBAN_TASK"] = tid
+    old_profile = os.environ.get("HERMES_PROFILE")
+    os.environ["HERMES_PROFILE"] = "reviewer"
     try:
         kt._handle_complete({
             "summary": "one real, one ghost",
@@ -829,6 +831,10 @@ async def test_notifier_artifact_delivery_skips_missing_files(kanban_home, tmp_p
         })
     finally:
         os.environ.pop("HERMES_KANBAN_TASK", None)
+        if old_profile is None:
+            os.environ.pop("HERMES_PROFILE", None)
+        else:
+            os.environ["HERMES_PROFILE"] = old_profile
 
     runner = object.__new__(GatewayRunner)
     runner._owns_kanban_dispatcher_lock = lambda: True

--- a/tests/tools/test_kanban_redaction.py
+++ b/tests/tools/test_kanban_redaction.py
@@ -126,12 +126,14 @@ def test_scrub_respects_force_flag_regardless_of_config(worker_env, monkeypatch)
 # Negative test — legacy result field is also scrubbed
 # ---------------------------------------------------------------------------
 
-def test_kanban_complete_result_field_scrubbed(worker_env):
+def test_kanban_complete_result_field_scrubbed(monkeypatch, worker_env):
     """Legacy result field must be scrubbed just like summary."""
     from tools import kanban_tools as kt
     from hermes_cli import kanban_db as kb
     secret = "sk-" + "D" * 48
-    kt._handle_complete({"result": f"finished with key={secret}"})
+    monkeypatch.setenv("HERMES_PROFILE", "reviewer")
+    result = json.loads(kt._handle_complete({"result": f"finished with key={secret}"}))
+    assert result["ok"] is True
     conn = kb.connect()
     try:
         run = kb.latest_run(conn, worker_env)

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -84,8 +84,32 @@ def test_show_defaults_to_env_task_id(worker_env):
     assert "task" in d
     assert d["task"]["id"] == worker_env
     assert d["task"]["status"] == "running"
+    assert d["task"]["completion_policy"] == "independent"
     assert "worker_context" in d
+    assert "Completion policy: independent" in d["worker_context"]
     assert "runs" in d
+
+
+def test_show_exposes_worker_completion_policy(monkeypatch, worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        ordinary = kb.create_task(
+            conn,
+            title="ordinary worker card",
+            assignee="test-worker",
+            completion_policy="worker",
+        )
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", ordinary)
+
+    shown = json.loads(kt._handle_show({}))
+
+    assert shown["task"]["completion_policy"] == "worker"
+    assert "Completion policy: worker" in shown["worker_context"]
 
 
 def test_list_filters_tasks(monkeypatch, worker_env):

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -55,13 +55,21 @@ def worker_env(monkeypatch, tmp_path):
     monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
     from pathlib import Path as _Path
     monkeypatch.setattr(_Path, "home", lambda: tmp_path)
+    profiles = home / "profiles"
+    for name in ("test-worker", "dev", "reviewer", "qa"):
+        (profiles / name).mkdir(parents=True, exist_ok=True)
 
     from hermes_cli import kanban_db as kb
     kb._INITIALIZED_PATHS.clear()
     kb.init_db()
     conn = kb.connect()
     try:
-        tid = kb.create_task(conn, title="worker-test", assignee="test-worker")
+        tid = kb.create_task(
+            conn,
+            title="worker-test",
+            assignee="test-worker",
+            completion_policy="independent",
+        )
         kb.claim_task(conn, tid)
     finally:
         conn.close()
@@ -133,6 +141,51 @@ def test_distinct_worker_can_complete_scoped_task(monkeypatch, worker_env):
         conn.close()
 
 
+def test_assigned_worker_can_complete_worker_policy_task(monkeypatch, worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        ordinary = kb.create_task(
+            conn,
+            title="ordinary worker card",
+            assignee="test-worker",
+            completion_policy="worker",
+        )
+        kb.claim_task(conn, ordinary)
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", ordinary)
+
+    completed = json.loads(kt._handle_complete({"summary": "ordinary done"}))
+
+    assert completed.get("ok") is True
+
+
+def test_independent_same_card_reviewer_can_complete(monkeypatch, worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, worker_env)
+        assert kb.request_review(
+            conn,
+            worker_env,
+            reviewer="reviewer",
+            expected_run_id=task.current_run_id,
+        )
+        kb.claim_task(conn, worker_env)
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_PROFILE", "reviewer")
+
+    completed = json.loads(kt._handle_complete({"summary": "approved"}))
+
+    assert completed.get("ok") is True
+
+
 def test_worker_cannot_complete_own_assigned_task(worker_env):
     from hermes_cli import kanban_db as kb
     from tools import kanban_tools as kt
@@ -140,7 +193,7 @@ def test_worker_cannot_complete_own_assigned_task(worker_env):
     rejected = json.loads(kt._handle_complete({"summary": "self-attested"}))
 
     assert rejected.get("ok") is not True
-    assert "distinct actor" in rejected.get("error", "")
+    assert "independent completion policy" in rejected.get("error", "")
     conn = kb.connect()
     try:
         assert kb.get_task(conn, worker_env).status == "running"
@@ -429,11 +482,11 @@ def test_comment_ignores_caller_supplied_author(worker_env):
         conn.close()
 
 
-def test_worker_create_same_profile_happy_path(worker_env):
+def test_worker_create_linked_specialist_happy_path(worker_env):
     from tools import kanban_tools as kt
     out = kt._handle_create({
         "title": "child task",
-        "assignee": "test-worker",
+        "assignee": "reviewer",
         "parents": [worker_env],
     })
     d = json.loads(out)
@@ -445,7 +498,7 @@ def test_worker_create_same_profile_happy_path(worker_env):
     try:
         child = kb.get_task(conn, d["task_id"])
         assert child.title == "child task"
-        assert child.assignee == "test-worker"
+        assert child.assignee == "reviewer"
     finally:
         conn.close()
 
@@ -460,7 +513,7 @@ def test_worker_create_rejects_cross_profile_assignee(worker_env):
     }))
 
     assert rejected.get("ok") is not True
-    assert "own profile" in rejected.get("error", "")
+    assert "must either be linked" in rejected.get("error", "")
     conn = kb.connect()
     try:
         assert all(
@@ -490,6 +543,31 @@ def test_worker_create_fails_closed_without_profile(monkeypatch, worker_env):
         conn.close()
 
 
+def test_worker_create_rejects_unknown_linked_profile(worker_env):
+    from tools import kanban_tools as kt
+
+    rejected = json.loads(kt._handle_create({
+        "title": "unknown specialist",
+        "assignee": "missing-profile",
+        "parents": [worker_env],
+    }))
+
+    assert rejected.get("ok") is not True
+    assert "unknown assignee profile" in rejected.get("error", "")
+
+
+def test_worker_create_allows_explicit_unlinked_approval_card(worker_env):
+    from tools import kanban_tools as kt
+
+    created = json.loads(kt._handle_create({
+        "title": "review this work",
+        "assignee": "reviewer",
+        "completion_policy": "approval",
+    }))
+
+    assert created.get("ok") is True
+
+
 def test_orchestrator_create_cross_profile_allowed(monkeypatch, worker_env):
     from hermes_cli import kanban_db as kb
     from tools import kanban_tools as kt
@@ -506,6 +584,56 @@ def test_orchestrator_create_cross_profile_allowed(monkeypatch, worker_env):
         assert kb.get_task(conn, created["task_id"]).assignee == "peer"
     finally:
         conn.close()
+
+
+def test_independent_task_graph_releases_after_review_approval(monkeypatch, worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        review = kb.create_task(
+            conn,
+            title="review implementation",
+            assignee="reviewer",
+            created_by="dev",
+            completion_policy="approval",
+        )
+        implementation = kb.create_task(
+            conn,
+            title="implementation",
+            assignee="dev",
+            completion_policy="independent",
+            parents=[review],
+        )
+    finally:
+        conn.close()
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", implementation)
+    monkeypatch.setenv("HERMES_PROFILE", "dev")
+    denied = json.loads(kt._handle_complete({"summary": "self-attested"}))
+    assert denied.get("ok") is not True
+
+    conn = kb.connect()
+    try:
+        kb.claim_task(conn, review)
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", review)
+    monkeypatch.setenv("HERMES_PROFILE", "reviewer")
+    approved = json.loads(kt._handle_complete({"summary": "review passed"}))
+    assert approved.get("ok") is True
+
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, implementation).status == "ready"
+        kb.claim_task(conn, implementation)
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", implementation)
+    monkeypatch.setenv("HERMES_PROFILE", "dev")
+    completed = json.loads(kt._handle_complete({"summary": "approved work"}))
+    assert completed.get("ok") is True
 
 
 def test_link_happy_path(worker_env):
@@ -601,7 +729,7 @@ def test_worker_lifecycle_through_tools(monkeypatch, worker_env):
     # 4. spawn a child task for follow-up
     child_out = json.loads(kt._handle_create({
         "title": "write integration test",
-        "assignee": "test-worker",
+        "assignee": "qa",
         "parents": [worker_env],
     }))
     assert child_out["ok"]

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -111,8 +111,9 @@ def test_list_filters_tasks(monkeypatch, worker_env):
     assert tenant_ids == [c]
 
 
-def test_complete_happy_path(worker_env):
+def test_distinct_worker_can_complete_scoped_task(monkeypatch, worker_env):
     from tools import kanban_tools as kt
+    monkeypatch.setenv("HERMES_PROFILE", "reviewer")
     out = kt._handle_complete({
         "summary": "got the thing done",
         "metadata": {"files": 2},
@@ -132,12 +133,44 @@ def test_complete_happy_path(worker_env):
         conn.close()
 
 
-def test_complete_retry_with_empty_created_cards_succeeds(worker_env):
+def test_worker_cannot_complete_own_assigned_task(worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    rejected = json.loads(kt._handle_complete({"summary": "self-attested"}))
+
+    assert rejected.get("ok") is not True
+    assert "distinct actor" in rejected.get("error", "")
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, worker_env).status == "running"
+    finally:
+        conn.close()
+
+
+def test_worker_completion_fails_closed_without_profile(monkeypatch, worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    monkeypatch.delenv("HERMES_PROFILE")
+    rejected = json.loads(kt._handle_complete({"summary": "anonymous"}))
+
+    assert rejected.get("ok") is not True
+    assert "HERMES_PROFILE" in rejected.get("error", "")
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, worker_env).status == "running"
+    finally:
+        conn.close()
+
+
+def test_complete_retry_with_empty_created_cards_succeeds(monkeypatch, worker_env):
     """After a phantom rejection, retrying kanban_complete with
     created_cards=[] (the documented escape hatch) must complete the
     task. Regression for #22923."""
     from hermes_cli import kanban_db as kb
     from tools import kanban_tools as kt
+    monkeypatch.setenv("HERMES_PROFILE", "reviewer")
 
     # Hit the gate first.
     rejected = json.loads(kt._handle_complete({
@@ -187,6 +220,7 @@ def test_complete_goal_mode_rejected_by_judge(monkeypatch, tmp_path):
     finally:
         conn.close()
     monkeypatch.setenv("HERMES_KANBAN_TASK", goal_task_id)
+    monkeypatch.setenv("HERMES_PROFILE", "reviewer")
 
     # Mock the judge to reject the completion. The gate only runs when a
     # judge is reachable, so force the availability probe True as well.
@@ -395,11 +429,11 @@ def test_comment_ignores_caller_supplied_author(worker_env):
         conn.close()
 
 
-def test_create_happy_path(worker_env):
+def test_worker_create_same_profile_happy_path(worker_env):
     from tools import kanban_tools as kt
     out = kt._handle_create({
         "title": "child task",
-        "assignee": "peer",
+        "assignee": "test-worker",
         "parents": [worker_env],
     })
     d = json.loads(out)
@@ -411,7 +445,65 @@ def test_create_happy_path(worker_env):
     try:
         child = kb.get_task(conn, d["task_id"])
         assert child.title == "child task"
-        assert child.assignee == "peer"
+        assert child.assignee == "test-worker"
+    finally:
+        conn.close()
+
+
+def test_worker_create_rejects_cross_profile_assignee(worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    rejected = json.loads(kt._handle_create({
+        "title": "cross-queue injection",
+        "assignee": "privileged-profile",
+    }))
+
+    assert rejected.get("ok") is not True
+    assert "own profile" in rejected.get("error", "")
+    conn = kb.connect()
+    try:
+        assert all(
+            task.title != "cross-queue injection"
+            for task in kb.list_tasks(conn)
+        )
+    finally:
+        conn.close()
+
+
+def test_worker_create_fails_closed_without_profile(monkeypatch, worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    monkeypatch.delenv("HERMES_PROFILE")
+    rejected = json.loads(kt._handle_create({
+        "title": "anonymous injection",
+        "assignee": "any-profile",
+    }))
+
+    assert rejected.get("ok") is not True
+    assert "HERMES_PROFILE" in rejected.get("error", "")
+    conn = kb.connect()
+    try:
+        assert all(task.title != "anonymous injection" for task in kb.list_tasks(conn))
+    finally:
+        conn.close()
+
+
+def test_orchestrator_create_cross_profile_allowed(monkeypatch, worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    monkeypatch.delenv("HERMES_KANBAN_TASK")
+    created = json.loads(kt._handle_create({
+        "title": "orchestrated work",
+        "assignee": "peer",
+    }))
+
+    assert created.get("ok") is True
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, created["task_id"]).assignee == "peer"
     finally:
         conn.close()
 
@@ -487,7 +579,7 @@ def test_unblock_with_pending_parents_returns_todo(monkeypatch, tmp_path):
         conn.close()
 
 
-def test_worker_lifecycle_through_tools(worker_env):
+def test_worker_lifecycle_through_tools(monkeypatch, worker_env):
     """Drive the full claim -> heartbeat -> comment -> complete lifecycle
     exclusively through the tools, then verify the DB state matches what
     the dispatcher/notifier expect."""
@@ -509,12 +601,13 @@ def test_worker_lifecycle_through_tools(worker_env):
     # 4. spawn a child task for follow-up
     child_out = json.loads(kt._handle_create({
         "title": "write integration test",
-        "assignee": "qa",
+        "assignee": "test-worker",
         "parents": [worker_env],
     }))
     assert child_out["ok"]
 
-    # 5. complete with structured handoff
+    # 5. a distinct actor completes with the worker's structured handoff
+    monkeypatch.setenv("HERMES_PROFILE", "reviewer")
     comp = json.loads(kt._handle_complete({
         "summary": "implemented + spawned QA follow-up",
         "metadata": {"child_task": child_out["task_id"]},
@@ -588,8 +681,8 @@ def test_kanban_guidance_orchestrator_decision_ownership():
 # kanban_unblock) must refuse to operate
 # on any OTHER task id, even if the caller supplies an explicit `task_id`
 # argument. Workers legitimately call kanban_show / kanban_list /
-# kanban_comment / kanban_create / kanban_link on other tasks, so those
-# are unrestricted.
+# kanban_comment / kanban_link on other tasks. kanban_create is separately
+# limited to the worker's own profile so it cannot inject another queue.
 #
 # Orchestrator profiles (no HERMES_KANBAN_TASK in env) are intentionally
 # exempt — their job is routing, and they sometimes close out child
@@ -852,7 +945,7 @@ def test_create_subscribes_gateway_session(monkeypatch, worker_env):
 
     out = kt._handle_create({
         "title": "auto-sub gateway",
-        "assignee": "peer",
+        "assignee": "test-worker",
     })
     d = json.loads(out)
     assert d["ok"] is True
@@ -886,7 +979,7 @@ def test_create_subscribes_tui_session_via_session_key(monkeypatch, worker_env):
 
     out = kt._handle_create({
         "title": "auto-sub tui",
-        "assignee": "peer",
+        "assignee": "test-worker",
     })
     d = json.loads(out)
     assert d["ok"] is True
@@ -912,7 +1005,7 @@ def test_create_does_not_subscribe_in_cli_session(monkeypatch, worker_env):
 
     out = kt._handle_create({
         "title": "no sub cli",
-        "assignee": "peer",
+        "assignee": "test-worker",
     })
     d = json.loads(out)
     assert d["ok"] is True
@@ -941,7 +1034,7 @@ def test_create_respects_auto_subscribe_on_create_false(monkeypatch, worker_env,
     from tools import kanban_tools as kt
     out = kt._handle_create({
         "title": "no sub gated",
-        "assignee": "peer",
+        "assignee": "test-worker",
     })
     d = json.loads(out)
     assert d["ok"] is True
@@ -968,7 +1061,7 @@ def test_maybe_auto_subscribe_swallows_add_notify_sub_failure(monkeypatch, worke
 
     out = kt._handle_create({
         "title": "auto-sub tolerates add_notify_sub failure",
-        "assignee": "peer",
+        "assignee": "test-worker",
     })
     d = json.loads(out)
     assert d["ok"] is True, d

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -212,6 +212,43 @@ def _enforce_worker_task_ownership(tid: str) -> Optional[str]:
     return None
 
 
+def _enforce_distinct_completion_actor(task: Any) -> Optional[str]:
+    """Require task-scoped completion to come from a distinct profile."""
+    if not os.environ.get("HERMES_KANBAN_TASK"):
+        return None
+    profile = (os.environ.get("HERMES_PROFILE") or "").strip()
+    if not profile:
+        return tool_error(
+            "task-scoped kanban_complete requires HERMES_PROFILE to verify "
+            "a distinct completion actor"
+        )
+    assignee = (getattr(task, "assignee", None) or "").strip()
+    if assignee and profile == assignee:
+        return tool_error(
+            f"profile {profile} is assigned to this task and cannot complete "
+            "its own work; a distinct actor must complete the handoff"
+        )
+    return None
+
+
+def _enforce_worker_create_assignee(assignee: str) -> Optional[str]:
+    """Keep task-scoped workers from injecting work into another queue."""
+    if not os.environ.get("HERMES_KANBAN_TASK"):
+        return None
+    profile = (os.environ.get("HERMES_PROFILE") or "").strip()
+    if not profile:
+        return tool_error(
+            "task-scoped kanban_create requires HERMES_PROFILE to verify "
+            "the target assignee"
+        )
+    if assignee != profile:
+        return tool_error(
+            f"task-scoped workers may only create cards assigned to their own "
+            f"profile ({profile}); refusing assignee {assignee}"
+        )
+    return None
+
+
 def _connect(board: Optional[str] = None):
     """Import + connect lazily so the module imports cleanly in non-kanban
     contexts (e.g. test rigs that import every tool module).
@@ -752,6 +789,9 @@ def _handle_complete(args: dict, **kw) -> str:
             # Only enforce when a judge is actually reachable — see
             # _goal_judge_available for why an unavailable judge fails open.
             task = kb.get_task(conn, tid)
+            actor_err = _enforce_distinct_completion_actor(task)
+            if actor_err:
+                return actor_err
             rejection = _goal_mode_handoff_rejection(
                 task,
                 (summary or result or "").strip(),
@@ -1358,6 +1398,10 @@ def _handle_create(args: dict, **kw) -> str:
             "assignee is required — name the profile that should execute this "
             "task (the dispatcher will only spawn tasks with an assignee)"
         )
+    assignee = str(assignee).strip()
+    assignee_err = _enforce_worker_create_assignee(assignee)
+    if assignee_err:
+        return assignee_err
     body = args.get("body")
     parents = args.get("parents") or []
     tenant = args.get("tenant") or os.environ.get("HERMES_TENANT")
@@ -1437,7 +1481,7 @@ def _handle_create(args: dict, **kw) -> str:
                 conn,
                 title=str(title).strip(),
                 body=body,
-                assignee=str(assignee),
+                assignee=assignee,
                 parents=tuple(parents),
                 tenant=tenant,
                 priority=int(priority) if priority is not None else 0,

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -212,27 +212,58 @@ def _enforce_worker_task_ownership(tid: str) -> Optional[str]:
     return None
 
 
-def _enforce_distinct_completion_actor(task: Any) -> Optional[str]:
-    """Require task-scoped completion to come from a distinct profile."""
+def _enforce_completion_policy(conn: Any, task: Any) -> Optional[str]:
+    """Enforce explicit independent approval without breaking worker cards."""
     if not os.environ.get("HERMES_KANBAN_TASK"):
         return None
     profile = (os.environ.get("HERMES_PROFILE") or "").strip()
     if not profile:
         return tool_error(
             "task-scoped kanban_complete requires HERMES_PROFILE to verify "
-            "a distinct completion actor"
+            "the completion actor"
         )
+    if getattr(task, "completion_policy", "worker") != "independent":
+        return None
     assignee = (getattr(task, "assignee", None) or "").strip()
-    if assignee and profile == assignee:
-        return tool_error(
-            f"profile {profile} is assigned to this task and cannot complete "
-            "its own work; a distinct actor must complete the handoff"
-        )
-    return None
+    if not assignee or profile != assignee:
+        return None
+
+    review_event = conn.execute(
+        "SELECT payload FROM task_events WHERE task_id = ? "
+        "AND kind = 'review_requested' ORDER BY id DESC LIMIT 1",
+        (task.id,),
+    ).fetchone()
+    if review_event and review_event["payload"]:
+        try:
+            implementer = json.loads(review_event["payload"]).get("implementer")
+        except (TypeError, json.JSONDecodeError):
+            implementer = None
+        if implementer and profile != implementer:
+            return None
+
+    approval = conn.execute(
+        "SELECT 1 FROM task_links l JOIN tasks p ON p.id = l.parent_id "
+        "WHERE l.child_id = ? AND p.status = 'done' "
+        "AND p.completion_policy = 'approval' "
+        "AND COALESCE(p.assignee, '') <> ? LIMIT 1",
+        (task.id, profile),
+    ).fetchone()
+    if approval:
+        return None
+    return tool_error(
+        f"profile {profile} cannot self-complete task {task.id}; its independent "
+        "completion policy requires another profile or a completed approval parent"
+    )
 
 
-def _enforce_worker_create_assignee(assignee: str) -> Optional[str]:
-    """Keep task-scoped workers from injecting work into another queue."""
+def _enforce_worker_create_scope(
+    conn: Any,
+    assignee: str,
+    parents: list[str],
+    tenant: Optional[str],
+    completion_policy: str,
+) -> Optional[str]:
+    """Allow linked specialist delegation, but reject cross-queue injection."""
     if not os.environ.get("HERMES_KANBAN_TASK"):
         return None
     profile = (os.environ.get("HERMES_PROFILE") or "").strip()
@@ -241,12 +272,26 @@ def _enforce_worker_create_assignee(assignee: str) -> Optional[str]:
             "task-scoped kanban_create requires HERMES_PROFILE to verify "
             "the target assignee"
         )
-    if assignee != profile:
+    if assignee == profile:
+        return None
+    current_tid = os.environ.get("HERMES_KANBAN_TASK")
+    current = conn.execute(
+        "SELECT tenant FROM tasks WHERE id = ?", (current_tid,)
+    ).fetchone()
+    same_tenant = current is not None and current["tenant"] == tenant
+    from hermes_cli.profiles import list_profile_names
+    known_profile = assignee in set(list_profile_names())
+    explicit_delegate = current_tid in parents or completion_policy == "approval"
+    if explicit_delegate and same_tenant and known_profile:
+        return None
+    if not explicit_delegate:
         return tool_error(
-            f"task-scoped workers may only create cards assigned to their own "
-            f"profile ({profile}); refusing assignee {assignee}"
+            "task-scoped cross-profile delegation must either be linked with "
+            f"parents=[{current_tid}] or use completion_policy='approval'"
         )
-    return None
+    if not same_tenant:
+        return tool_error("task-scoped delegation cannot cross tenant boundaries")
+    return tool_error(f"unknown assignee profile {assignee}")
 
 
 def _connect(board: Optional[str] = None):
@@ -529,6 +574,7 @@ def _task_summary_dict(kb, conn, task) -> dict[str, Any]:
         "assignee": task.assignee,
         "status": task.status,
         "priority": task.priority,
+        "completion_policy": task.completion_policy,
         "tenant": task.tenant,
         "workspace_kind": task.workspace_kind,
         "workspace_path": task.workspace_path,
@@ -789,7 +835,7 @@ def _handle_complete(args: dict, **kw) -> str:
             # Only enforce when a judge is actually reachable — see
             # _goal_judge_available for why an unavailable judge fails open.
             task = kb.get_task(conn, tid)
-            actor_err = _enforce_distinct_completion_actor(task)
+            actor_err = _enforce_completion_policy(conn, task)
             if actor_err:
                 return actor_err
             rejection = _goal_mode_handoff_rejection(
@@ -1398,10 +1444,11 @@ def _handle_create(args: dict, **kw) -> str:
             "assignee is required — name the profile that should execute this "
             "task (the dispatcher will only spawn tasks with an assignee)"
         )
-    assignee = str(assignee).strip()
-    assignee_err = _enforce_worker_create_assignee(assignee)
-    if assignee_err:
-        return assignee_err
+    from hermes_cli.profiles import normalize_profile_name
+    try:
+        assignee = normalize_profile_name(str(assignee).strip())
+    except ValueError as e:
+        return tool_error(f"kanban_create: {e}")
     body = args.get("body")
     parents = args.get("parents") or []
     tenant = args.get("tenant") or os.environ.get("HERMES_TENANT")
@@ -1441,6 +1488,7 @@ def _handle_create(args: dict, **kw) -> str:
     idempotency_key = args.get("idempotency_key")
     max_runtime_seconds = args.get("max_runtime_seconds")
     initial_status = args.get("initial_status") or "running"
+    completion_policy = args.get("completion_policy") or "worker"
     skills = args.get("skills")
     if isinstance(skills, str):
         # Accept a single skill name as a string for convenience.
@@ -1467,6 +1515,11 @@ def _handle_create(args: dict, **kw) -> str:
     try:
         kb, conn = _connect(board=board)
         try:
+            assignee_err = _enforce_worker_create_scope(
+                conn, assignee, list(parents), tenant, str(completion_policy)
+            )
+            if assignee_err:
+                return assignee_err
             # A project link is safe to inherit because ``create_task`` turns
             # it into a fresh per-task worktree. Never inherit the parent's
             # literal workspace kind/path; directory sharing must be explicit.
@@ -1503,6 +1556,7 @@ def _handle_create(args: dict, **kw) -> str:
                     int(goal_max_turns) if goal_max_turns is not None else None
                 ),
                 initial_status=str(initial_status),
+                completion_policy=str(completion_policy),
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
                 session_id=session_id,
             )
@@ -2289,6 +2343,16 @@ KANBAN_CREATE_SCHEMA = {
                     "require immediate human ops (R3 gate) to skip the "
                     "brief running-to-blocked transition. Defaults to "
                     "'running', which preserves the usual dispatch path."
+                ),
+            },
+            "completion_policy": {
+                "type": "string",
+                "enum": ["worker", "independent", "approval"],
+                "description": (
+                    "Completion authority. 'worker' (default) lets the assigned "
+                    "worker close the card; 'independent' requires another "
+                    "profile or a completed 'approval' parent; 'approval' marks "
+                    "a reviewer/verifier card that may release such a child."
                 ),
             },
             "skills": {

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -622,6 +622,7 @@ def _handle_show(args: dict, **kw) -> str:
                 return {
                     "id": t.id, "title": t.title, "body": t.body,
                     "assignee": t.assignee, "status": t.status,
+                    "completion_policy": t.completion_policy,
                     "tenant": t.tenant, "priority": t.priority,
                     "workspace_kind": t.workspace_kind,
                     "workspace_path": t.workspace_path,


### PR DESCRIPTION
## Summary

- require task-scoped completion to come from a profile distinct from the task assignee
- fail closed when worker profile identity is unavailable
- restrict task-scoped card creation to the worker's own profile while preserving orchestrator fan-out
- add regression coverage for self-completion, cross-profile creation, identity failures, and unaffected orchestrator paths

## Root cause

The existing worker ownership guard only compared task IDs, so a dispatcher-scoped worker was authorized to complete its own card. The create handler did not bind the requested assignee to the worker's server-derived profile at all, allowing cross-queue injection.

## Testing

- `scripts/run_tests.sh tests/tools/test_kanban_tools.py tests/tools/test_kanban_redaction.py tests/tools/test_delegate_kanban_isolation.py tests/hermes_cli/test_kanban_notify.py tests/hermes_cli/test_kanban_goal_mode.py tests/cron/test_cron_kanban_env_isolation.py -q` (96 passed)

## Related Issue

Closes #100948
