### PR TITLE
feat(providers): add openzoo model provider (pay-per-call inference over x402, no API key)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -173,6 +173,17 @@
 # NEBIUS_BASE_URL=https://api.tokenfactory.nebius.com/v1
 
 # =============================================================================
+# LLM PROVIDER (openzoo)
+# =============================================================================
+# openzoo — local proxy that pays for inference per call over x402 (on-chain
+# micropayments from a burner wallet). No account, no API key: run `npx openzoo`
+# and it listens on http://localhost:8402/v1. The value below is a placeholder
+# Hermes needs to be non-empty; the proxy ignores it. https://openzoo.fun
+# OPENZOO_API_KEY=sk-openzoo
+# Optional base URL override (e.g. a proxy started with OPENZOO_PORT=8412):
+# OPENZOO_BASE_URL=http://localhost:8402/v1
+
+# =============================================================================
 # LLM PROVIDER (Tencent Hy — TokenHub & TokenPlan)
 # =============================================================================
 # Tencent TokenHub (OpenAI-compatible): https://tokenhub.tencentmaas.com

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -68,6 +68,7 @@ model:
   #   "ai-gateway"   - Vercel AI Gateway (requires: AI_GATEWAY_API_KEY)
   #   "azure-foundry" - Microsoft Foundry / Azure OpenAI (API key or Entra ID)
   #   "lmstudio"     - LM Studio local server (optional: LM_API_KEY, defaults to http://127.0.0.1:1234/v1)
+  #   "openzoo"      - openzoo local x402 proxy, pays per call (requires: OPENZOO_API_KEY=sk-openzoo — any value; run `npx openzoo`; defaults to http://localhost:8402/v1)
   #
   # Local servers (LM Studio, Ollama, vLLM, llama.cpp):
   #   "custom"       - Any other OpenAI-compatible endpoint. Set base_url below.

--- a/plugins/model-providers/openzoo/__init__.py
+++ b/plugins/model-providers/openzoo/__init__.py
@@ -1,0 +1,105 @@
+"""openzoo provider profile.
+
+openzoo (https://openzoo.fun, npm ``openzoo``) is a local proxy that pays for
+LLM inference per call over x402 — on-chain micropayments from a burner
+wallet the proxy holds. There is no account and no API key. The user runs
+``npx openzoo``; the proxy listens on ``http://localhost:8402/v1`` as an
+OpenAI-compatible endpoint and forwards each paid call to the public gateway
+(``https://x402-tokens.fly.dev/v1``), which answers HTTP 402 to anything
+unpaid. Only the local proxy can settle those 402s, so this profile's
+``base_url`` is the LOCAL proxy, never the gateway.
+
+The proxy ignores the bearer value (payment replaces the key), but Hermes'
+API-key resolver refuses to run a provider with an empty credential, so
+``OPENZOO_API_KEY`` must be set to any non-empty value — ``sk-openzoo`` is
+the documented placeholder.
+
+Model discovery: ``GET /v1/models`` is free and returns OpenRouter-shaped
+rows. Rows carrying a ``kind`` field (``image`` / ``video``) are media
+models and are skipped so the chat picker only lists chat-completions
+targets. Prices in that catalog are a ceiling (OpenRouter-direct basis);
+the gateway charges at most that. Receipts land in ``~/.openzoo/proxy.log``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.request
+
+from providers import register_provider
+from providers.base import ProviderProfile, _profile_user_agent
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_OPENZOO_BASE_URL = "http://localhost:8402/v1"
+
+# Any non-empty bearer satisfies the proxy; documented placeholder.
+OPENZOO_PLACEHOLDER_API_KEY = "sk-openzoo"
+
+
+class OpenZooProfile(ProviderProfile):
+    """openzoo — OpenAI-compatible local proxy that pays per call over x402."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Fetch the chat catalog from the local proxy, dropping media rows.
+
+        The catalog endpoint is free (no 402), so no bearer is sent. Rows
+        with a ``kind`` field are image/video generation models served on
+        other endpoints and must not appear in the chat-completions picker.
+        """
+        effective_base = (base_url or "").strip() or self.base_url
+        if not effective_base:
+            return None
+
+        req = urllib.request.Request(effective_base.rstrip("/") + "/models")
+        req.add_header("Accept", "application/json")
+        req.add_header("User-Agent", _profile_user_agent())
+
+        from hermes_cli.urllib_security import open_credentialed_url
+
+        try:
+            with open_credentialed_url(req, timeout=timeout) as resp:
+                data = json.loads(resp.read().decode())
+        except Exception as exc:
+            logger.debug("fetch_models(openzoo): %s", exc)
+            return None
+
+        items = data if isinstance(data, list) else data.get("data", [])
+        return [
+            m["id"]
+            for m in items
+            if isinstance(m, dict) and m.get("id") and not m.get("kind")
+        ]
+
+
+openzoo = OpenZooProfile(
+    name="openzoo",
+    aliases=("open-zoo", "zoo"),
+    display_name="openzoo",
+    description="openzoo — pay-per-call inference over x402 via the local proxy (no API key)",
+    signup_url="https://openzoo.fun",
+    env_vars=("OPENZOO_API_KEY", "OPENZOO_BASE_URL"),
+    base_url=DEFAULT_OPENZOO_BASE_URL,
+    auth_type="api_key",
+    # The gateway's own router; the cheapest sensible default for side tasks.
+    default_aux_model="openzoo/auto",
+    # Offline floor for the picker; the live /v1/models catalog is
+    # authoritative and is merged in when the proxy is reachable.
+    fallback_models=(
+        "openzoo/auto",
+        "anthropic/claude-sonnet-5",
+        "anthropic/claude-fable-5.1",
+        "x-ai/grok-4.6",
+        "deepseek/deepseek-v4-pro",
+        "nvidia/nemotron-3.5-lightning",
+    ),
+)
+
+register_provider(openzoo)

--- a/plugins/model-providers/openzoo/__init__.py
+++ b/plugins/model-providers/openzoo/__init__.py
@@ -12,7 +12,9 @@ unpaid. Only the local proxy can settle those 402s, so this profile's
 The proxy ignores the bearer value (payment replaces the key), but Hermes'
 API-key resolver refuses to run a provider with an empty credential, so
 ``OPENZOO_API_KEY`` must be set to any non-empty value — ``sk-openzoo`` is
-the documented placeholder.
+the documented placeholder. The value only ever travels to the loopback
+proxy (or, for a public tunnel, as the tunnel's own printed bearer over the
+tunnel's TLS); it is never forwarded to the upstream gateway.
 
 Model discovery: ``GET /v1/models`` is free and returns OpenRouter-shaped
 rows. Rows carrying a ``kind`` field (``image`` / ``video``) are media
@@ -91,14 +93,16 @@ openzoo = OpenZooProfile(
     # The gateway's own router; the cheapest sensible default for side tasks.
     default_aux_model="openzoo/auto",
     # Offline floor for the picker; the live /v1/models catalog is
-    # authoritative and is merged in when the proxy is reachable.
+    # authoritative and is merged in when the proxy is reachable. Every id
+    # below is verified against openzoo@0.50.84's published catalog — the
+    # proxy uses bare ids, not vendor-prefixed OpenRouter slugs.
     fallback_models=(
         "openzoo/auto",
-        "anthropic/claude-sonnet-5",
-        "anthropic/claude-fable-5.1",
-        "x-ai/grok-4.6",
-        "deepseek/deepseek-v4-pro",
-        "nvidia/nemotron-3.5-lightning",
+        "claude-sonnet-5",
+        "claude-fable-5",
+        "grok-4",
+        "deepseek-reasoner",
+        "gemini-2.5-pro",
     ),
 )
 

--- a/plugins/model-providers/openzoo/plugin.yaml
+++ b/plugins/model-providers/openzoo/plugin.yaml
@@ -1,0 +1,6 @@
+name: openzoo-provider
+kind: model-provider
+version: 1.0.0
+description: openzoo — pay-per-call inference over x402 via the local proxy (no API key)
+author: Jarett Dunn
+homepage: https://github.com/staccDOTsol/openzoo

--- a/tests/providers/test_openzoo_profile.py
+++ b/tests/providers/test_openzoo_profile.py
@@ -1,0 +1,103 @@
+"""Tests for the bundled openzoo provider plugin.
+
+openzoo is a local proxy (``npx openzoo``) that pays for inference per call
+over x402; Hermes talks to it as a plain OpenAI-compatible endpoint on
+localhost. No live network calls — the catalog fetch is exercised through a
+stubbed ``open_credentialed_url``.
+"""
+
+import io
+import json
+
+import pytest
+
+from providers import get_provider_profile
+
+
+def _profile():
+    p = get_provider_profile("openzoo")
+    assert p is not None
+    return p
+
+
+class TestOpenZooProfile:
+    def test_profile_registered(self):
+        p = _profile()
+        assert p.name == "openzoo"
+        assert p.base_url == "http://localhost:8402/v1"
+        assert p.auth_type == "api_key"
+        assert p.api_mode == "chat_completions"
+        assert p.env_vars == ("OPENZOO_API_KEY", "OPENZOO_BASE_URL")
+        assert p.default_aux_model == "openzoo/auto"
+        assert p.fallback_models[0] == "openzoo/auto"
+        assert "anthropic/claude-sonnet-5" in p.fallback_models
+
+    @pytest.mark.parametrize("alias", ["open-zoo", "zoo"])
+    def test_aliases_resolve(self, alias):
+        assert get_provider_profile(alias) is _profile()
+
+    def test_base_url_is_local_proxy_not_gateway(self):
+        """Only the local proxy can settle the gateway's 402s."""
+        assert get_provider_profile("openzoo").get_hostname() == "localhost"
+
+
+class _FakeResponse(io.BytesIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+        return False
+
+
+def _stub_catalog(monkeypatch, payload, *, seen=None):
+    import hermes_cli.urllib_security as sec
+
+    def fake_open(request, *, timeout, **kwargs):
+        if seen is not None:
+            seen.append(request)
+        return _FakeResponse(json.dumps(payload).encode())
+
+    monkeypatch.setattr(sec, "open_credentialed_url", fake_open)
+
+
+class TestFetchModels:
+    def test_skips_media_rows(self, monkeypatch):
+        seen = []
+        _stub_catalog(
+            monkeypatch,
+            {
+                "data": [
+                    {"id": "openzoo/auto", "name": None, "context_length": 128000000},
+                    {"id": "anthropic/claude-sonnet-5"},
+                    {"id": "black-forest-labs/flux-2", "kind": "image"},
+                    {"id": "google/veo-3.1", "kind": "video"},
+                    {"id": ""},
+                    "not-a-row",
+                ]
+            },
+            seen=seen,
+        )
+        models = _profile().fetch_models(api_key="sk-openzoo")
+        assert models == ["openzoo/auto", "anthropic/claude-sonnet-5"]
+        assert seen[0].full_url == "http://localhost:8402/v1/models"
+        # The catalog is free — no bearer is sent for it.
+        assert not seen[0].has_header("Authorization")
+
+    def test_honours_custom_base_url(self, monkeypatch):
+        seen = []
+        _stub_catalog(monkeypatch, {"data": [{"id": "x-ai/grok-4.6"}]}, seen=seen)
+        models = _profile().fetch_models(
+            api_key="sk-openzoo", base_url="http://127.0.0.1:8412/v1/"
+        )
+        assert models == ["x-ai/grok-4.6"]
+        assert seen[0].full_url == "http://127.0.0.1:8412/v1/models"
+
+    def test_fetch_failure_returns_none(self, monkeypatch):
+        import hermes_cli.urllib_security as sec
+
+        def boom(request, *, timeout, **kwargs):
+            raise ConnectionRefusedError("proxy not running")
+
+        monkeypatch.setattr(sec, "open_credentialed_url", boom)
+        assert _profile().fetch_models(api_key="sk-openzoo") is None

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -59,6 +59,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **MiniMax OAuth** | `hermes model` → "MiniMax (OAuth)" (provider: `minimax-oauth`; browser PKCE login) |
 | **StepFun** | `STEPFUN_API_KEY` in `~/.hermes/.env` (provider: `stepfun`) |
 | **LM Studio** | `hermes model` → "LM Studio" (provider: `lmstudio`, optional `LM_API_KEY`) |
+| **openzoo** | `OPENZOO_API_KEY=sk-openzoo` in `~/.hermes/.env` (any value — the local proxy pays per call over x402; no account, no key) (provider: `openzoo`; aliases: `open-zoo`, `zoo`). Run `npx openzoo` first; Hermes talks to it at `http://localhost:8402/v1` |
 | **Custom Endpoint** | `hermes model` → choose "Custom endpoint" (saved in `config.yaml`) |
 
 For the official API-key path, see the dedicated [Google Gemini guide](/guides/google-gemini).
@@ -313,6 +314,10 @@ hermes chat --provider gmi --model zai-org/GLM-5.1-FP8
 # Nebius Token Factory
 hermes chat --provider nebius --model deepseek-ai/DeepSeek-V4-Pro
 # Requires: NEBIUS_API_KEY in ~/.hermes/.env
+
+# openzoo (local x402 proxy — run `npx openzoo` first; it listens on http://localhost:8402/v1)
+hermes chat --provider openzoo --model openzoo/auto
+# Requires: OPENZOO_API_KEY=sk-openzoo in ~/.hermes/.env (any value; the proxy pays per call, not the key)
 ```
 
 Fireworks uses its native slash-form catalog IDs, such as `accounts/fireworks/models/kimi-k2p6`. Run `hermes model`, choose **Fireworks AI**, and select from the live catalog or enter another Fireworks model ID. The default endpoint is `https://api.fireworks.ai/inference/v1`; configure a different endpoint through `model.base_url` in `config.yaml`, not `.env`.
@@ -324,7 +329,7 @@ model:
   default: "zai-org/GLM-5.1-FP8"
 ```
 
-Base URLs can be overridden with `NOVITA_BASE_URL`, `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, `DASHSCOPE_BASE_URL`, `XIAOMI_BASE_URL`, `GMI_BASE_URL`, `META_BASE_URL`, or `TOKENHUB_BASE_URL` environment variables.
+Base URLs can be overridden with `NOVITA_BASE_URL`, `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, `DASHSCOPE_BASE_URL`, `XIAOMI_BASE_URL`, `GMI_BASE_URL`, `META_BASE_URL`, `OPENZOO_BASE_URL`, or `TOKENHUB_BASE_URL` environment variables.
 
 :::note Meta contributor tier
 `muse-spark-1.2-contributor` is Meta's discounted tier — Meta may train on your prompts and completions, so [interactive model selection asks for confirmation](../user-guide/configuring-models.md) before using it. Use `muse-spark-1.2` (standard pricing, no training) for confidential work.

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -99,6 +99,8 @@ Hermes reads environment variables from the process environment and, for user-ma
 | `RAMP_ROUTER_BASE_URL` | Override Ramp Router base URL (default: `https://api.router.com/v1`) |
 | `NEBIUS_API_KEY` | Nebius Token Factory API key ([tokenfactory.nebius.com](https://tokenfactory.nebius.com/)); `NEBIUS_TOKEN_FACTORY_API_KEY` also accepted |
 | `NEBIUS_BASE_URL` | Override Nebius Token Factory base URL (default: `https://api.tokenfactory.nebius.com/v1`) |
+| `OPENZOO_API_KEY` | openzoo placeholder key — any non-empty value (`sk-openzoo`); the local proxy pays per call over x402, no account needed ([openzoo.fun](https://openzoo.fun)) |
+| `OPENZOO_BASE_URL` | Override openzoo proxy base URL (default: `http://localhost:8402/v1`) |
 | `NVIDIA_API_KEY` | NVIDIA NIM API key — Nemotron and open models ([build.nvidia.com](https://build.nvidia.com)) |
 | `NVIDIA_BASE_URL` | Override NVIDIA base URL (default: `https://integrate.api.nvidia.com/v1`; set to `http://localhost:8000/v1` for a local NIM endpoint) |
 | `STEPFUN_API_KEY` | StepFun API key — Step-series models ([platform.stepfun.com](https://platform.stepfun.com)) |


### PR DESCRIPTION
## What does this PR do?

Adds a bundled model-provider plugin for **openzoo** (`plugins/model-providers/openzoo/`), provider id `openzoo`.

openzoo (npm `openzoo`, https://github.com/staccDOTsol/openzoo, https://openzoo.fun) is a local proxy that pays for LLM inference per call over x402 — on-chain micropayments from a burner wallet the proxy holds. There is no account and no API key. The user runs `npx openzoo`; it listens on `http://localhost:8402/v1` as an OpenAI-compatible endpoint and forwards each paid call to the public gateway, which answers HTTP 402 to anything unpaid. Only the local proxy can settle those 402s, so the profile's `base_url` is the local proxy, never the gateway.

Why a bundled profile rather than `provider: custom`: the custom path already works (a tested `config.yaml` snippet exists), but users have to type the base URL, a placeholder key and a model id by hand, and get no live catalog in `hermes model`. The profile gives the same "drop a directory" shape as `ollama-cloud` / `lmstudio` / `actual` (local or keyless-style endpoints), with:

- `fetch_models` override: the proxy's `GET /v1/models` is free and returns OpenRouter-shaped rows; rows carrying a `kind` field (`image` / `video`) are media models served on other endpoints and are dropped so the chat picker only lists chat-completions targets. No bearer is sent for the catalog.
- Static `fallback_models` floor (`openzoo/auto` first — the gateway's router — then a handful of well-known ids) so the picker is usable before the proxy is up; the live catalog is merged in when it is reachable.
- `default_aux_model="openzoo/auto"`.

**Key/env resolution.** The proxy ignores the bearer value, but Hermes' API-key resolver refuses to run a provider with an empty credential (`has_usable_secret` gate in `runtime_provider.py`). Rather than special-casing the provider in core (the `opencode-free` keyless path touches `auth.py`, `providers.py` overlays and `models.py`), this profile keeps the generic `auth_type="api_key"` contract and documents `OPENZOO_API_KEY=sk-openzoo` (any non-empty value). `OPENZOO_BASE_URL` is a real override for a proxy started on another port (`OPENZOO_PORT=8412`). Both env vars are wired only through `ProviderProfile.env_vars`; no core files change.

**On CONTRIBUTING's "third-party product integrations ship as standalone plugins" rule.** I read it and this PR is knowingly asking for an exception on the narrow grounds that apply to the other bundled inference endpoints: it is a `ProviderProfile` over a plain OpenAI-compatible localhost URL, with no account, no vendor SDK, no hooks into core, and the same 4-file shape as #88565 (Meta Model API) and #97916 (Nebius). The maintenance surface is the profile file itself. If the maintainers would rather it live out of tree, the identical directory works unchanged as a user plugin at `$HERMES_HOME/plugins/model-providers/openzoo/` — I will publish it that way and close this PR without argument.

Pricing shown by the catalog is a ceiling (OpenRouter-direct basis); the gateway charges at most that and usually less. Receipts: `~/.openzoo/proxy.log`. Nothing in this PR touches pricing or `model_cost_guard`.

This PR was written with AI assistance (Claude Code); I reviewed every line, ran the checks below, and verified the live catalog against a running proxy.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/model-providers/openzoo/__init__.py` — `OpenZooProfile(ProviderProfile)`: name `openzoo`, aliases `open-zoo` / `zoo`, `base_url=http://localhost:8402/v1`, `env_vars=("OPENZOO_API_KEY", "OPENZOO_BASE_URL")`, `auth_type="api_key"`, `api_mode="chat_completions"`, `default_aux_model="openzoo/auto"`, static `fallback_models`, and a `fetch_models` override that drops `kind`-tagged media rows and sends no bearer for the free catalog.
- `plugins/model-providers/openzoo/plugin.yaml` — manifest (`kind: model-provider`).
- `tests/providers/test_openzoo_profile.py` — registration/aliases/base-url assertions; `fetch_models` media filtering, custom base URL, no `Authorization` header, and failure → `None`, all through a stubbed `open_credentialed_url` (no network).
- `website/docs/integrations/providers.md` — provider table row, `hermes chat --provider openzoo` example, `OPENZOO_BASE_URL` in the base-URL override list.
- `website/docs/reference/environment-variables.md` — `OPENZOO_API_KEY`, `OPENZOO_BASE_URL` rows.
- `.env.example` — openzoo section.
- `cli-config.yaml.example` — `"openzoo"` line in the provider comment list.

No changes to `hermes_cli/`, `agent/`, or `providers/`.

## How to Test

1. `npx openzoo` (or `npm i -g openzoo && openzoo`) — the proxy prints its listen address (`http://localhost:8402/v1`).
2. `echo 'OPENZOO_API_KEY=sk-openzoo' >> ~/.hermes/.env`
3. `hermes model` → pick **openzoo** → the picker lists the live `/v1/models` catalog (chat models only; image/video rows are absent), or `hermes chat --provider openzoo --model openzoo/auto -q "Say hello"`.
4. `hermes doctor` shows `openzoo` under Provider Connectivity with a `/models` probe.
5. Unit tests: `scripts/run_tests.sh tests/providers/test_openzoo_profile.py -q`
6. Wiring suites: `scripts/run_tests.sh tests/providers/ tests/hermes_cli/test_runtime_provider_resolution.py tests/cli/test_cli_provider_resolution.py tests/hermes_cli/test_setup_model_provider.py tests/run_agent/test_provider_parity.py -q`

Verified locally (macOS 26.3, Python 3.12 venv via `uv sync --extra dev`): `resolve_runtime_provider(requested="openzoo")` returns `{provider: openzoo, api_mode: chat_completions, base_url: http://localhost:8402/v1, api_key: sk-openzoo, source: env:OPENZOO_API_KEY}`; with the env var unset it raises `AuthError: No usable credentials found for provider 'openzoo'. Set OPENZOO_API_KEY.`; `provider_model_ids("openzoo")` against a running proxy returned 397 live chat ids merged with the static floor. `ruff check` on the new files passes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — provider-scoped suites via `scripts/run_tests.sh` (see How to Test); full-suite run not performed locally
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3 (Darwin 25.3.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python profile, stdlib `urllib` via the existing `open_credentialed_url` helper; no file I/O or process handling
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ OPENZOO_API_KEY=sk-openzoo python -c "from hermes_cli.runtime_provider import resolve_runtime_provider as r; print(r(requested='openzoo'))"
{'provider': 'openzoo', 'api_mode': 'chat_completions', 'base_url': 'http://localhost:8402/v1', 'api_key': 'sk-openzoo', 'source': 'env:OPENZOO_API_KEY', ...}
```

Author: @STACCoverflow
