### PR TITLE
feat(plugins): add post_transcription hook so plugins can annotate the stored transcript

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -260,6 +260,23 @@ VALID_HOOKS: Set[str] = {
     # read-only — attempts to change it are logged and dropped. The static
     # ``stt.prompt`` config value is the base; hook results mutate on top.
     "pre_transcription",
+    # Post-transcription transform hook — the symmetric partner of
+    # ``pre_transcription``. Fired by the STT dispatcher
+    # (tools.transcription_tools.transcribe_audio) AFTER a backend returned
+    # a successful, non-empty transcript and BEFORE that transcript is
+    # handed back to the caller (gateway message enrichment, voice mode,
+    # desktop upload), so a replacement reaches the persisted message text
+    # rather than only the model's per-turn context. Callbacks receive
+    # keyword args:
+    #   file_path, transcript, provider, source
+    # and may return a replacement ``str`` or None (unchanged). Results are
+    # applied in registration order, last-writer-wins — same composition
+    # rule as ``pre_transcription``. Non-string returns and strings that are
+    # empty after stripping are ignored, so a plugin cannot erase a
+    # transcript the backend actually produced. Never fired for failed or
+    # empty transcriptions: the gateway's "empty or inaudible" sentinel path
+    # (#41603) must keep seeing a genuinely empty transcript.
+    "post_transcription",
     # Kanban task lifecycle hooks. Fired by hermes_cli.kanban_db when a task
     # transitions state, AFTER the change is committed to the board DB (so the
     # hook always sees durable state and a slow plugin can never hold the

--- a/tests/tools/test_post_transcription_hook.py
+++ b/tests/tools/test_post_transcription_hook.py
@@ -1,0 +1,456 @@
+"""Tests for the ``post_transcription`` plugin hook wired into
+``tools.transcription_tools.transcribe_audio``.
+
+The symmetric partner of ``pre_transcription``: it fires after a backend
+returned a successful, non-empty transcript and may replace that transcript
+before it reaches the caller (gateway message enrichment, voice mode,
+desktop upload), so an annotation lands in the persisted message text.
+
+Covers the behavior contract:
+
+1. Registration surface — the hook name is accepted by the plugin system.
+2. A string return replaces the transcript; ``None`` leaves it unchanged.
+3. Two hooks → last-writer-wins in registration order (same composition
+   rule as ``pre_transcription``).
+4. Non-string and empty/whitespace-only returns are ignored: a plugin may
+   annotate a transcript but never erase one.
+5. Only ``transcript`` is replaced — every other result field passes
+   through untouched.
+6. Failed and empty-but-successful transcriptions never fire the hook, so
+   the gateway's "empty or inaudible" sentinel path keeps working.
+7. A raising callback leaves the transcript unchanged (fail-open).
+8. The kwargs contract, including the preprocessed ``file_path`` that is
+   still readable while the callback runs.
+9. No hook registered → ``invoke_hook`` is never called and the result is
+   identical to a control run.
+
+Mirrors the conventions of ``tests/tools/test_pre_transcription_hook.py``:
+hook plumbing is faked at the ``hermes_cli.plugins`` boundary and the STT
+backend is stubbed, so no model is loaded and no network call is made.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+import hermes_cli.plugins as plugins_mod
+from tools import transcription_tools
+
+
+TRANSCRIPT = "kannst du das bis heute abend fertig machen"
+MARKER = "[Voice: stressed, fast] "
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_audio(tmp_path):
+    audio = tmp_path / "voice.ogg"
+    audio.write_bytes(b"fake audio data")
+    return str(audio)
+
+
+def _fake_hooks(monkeypatch, results):
+    """Install fake has_hook/invoke_hook for ``post_transcription``.
+
+    ``transcribe_audio`` fires ``pre_transcription`` on the same dispatch,
+    so the fake is scoped by hook name: only ``post_transcription`` calls
+    are recorded and served *results*. ``captured`` stays empty when the
+    hook under test never fired.
+    """
+    captured = {}
+
+    def _invoke(hook_name, **kw):
+        if hook_name != "post_transcription":
+            return []
+        captured["hook_name"] = hook_name
+        captured["kwargs"] = kw
+        return [r(**kw) if callable(r) else r for r in results]
+
+    monkeypatch.setattr("hermes_cli.plugins.has_hook", lambda name: True)
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _invoke)
+    return captured
+
+
+def _no_hooks(monkeypatch):
+    """No hook registered: has_hook is False and invoke_hook must not fire."""
+    def _boom(hook_name, **kw):  # pragma: no cover - the assert is the point
+        raise AssertionError(
+            "invoke_hook must not be called when has_hook() is False"
+        )
+
+    monkeypatch.setattr("hermes_cli.plugins.has_hook", lambda name: False)
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _boom)
+
+
+def _dispatch_ctx(stt_config, provider):
+    """Patch config load + provider resolution around transcribe_audio."""
+    return (
+        patch("tools.transcription_tools._load_stt_config", return_value=stt_config),
+        patch("tools.transcription_tools._get_provider", return_value=provider),
+    )
+
+
+def _run(audio, backend_result, *, source=None):
+    """Transcribe *audio* with the openai backend stubbed to *backend_result*."""
+    backend = MagicMock(return_value=backend_result)
+    cfg_patch, prov_patch = _dispatch_ctx({"provider": "openai"}, "openai")
+    with cfg_patch, prov_patch, \
+         patch("tools.transcription_tools._transcribe_openai", backend):
+        return transcription_tools.transcribe_audio(audio, source=source)
+
+
+def _ok(transcript=TRANSCRIPT, **extra):
+    return {"success": True, "transcript": transcript, "provider": "openai", **extra}
+
+
+# ---------------------------------------------------------------------------
+# Hook registration surface
+# ---------------------------------------------------------------------------
+
+
+def test_post_transcription_in_valid_hooks():
+    assert "post_transcription" in plugins_mod.VALID_HOOKS
+
+
+def test_post_transcription_is_registerable_on_a_plugin_context():
+    """The registration surface actually accepts the name (not just the set)."""
+    manager = plugins_mod.PluginManager()
+    manifest = plugins_mod.PluginManifest(name="probe")
+    ctx = plugins_mod.PluginContext(manifest, manager)
+    ctx.register_hook("post_transcription", lambda **kw: None)
+
+    assert manager.has_hook("post_transcription")
+
+
+# ---------------------------------------------------------------------------
+# Replacement semantics
+# ---------------------------------------------------------------------------
+
+
+class TestReplacementSemantics:
+    def test_string_return_replaces_transcript(self, monkeypatch, tmp_path):
+        audio = _make_audio(tmp_path)
+        _fake_hooks(monkeypatch, [lambda transcript, **kw: MARKER + transcript])
+
+        result = _run(audio, _ok())
+
+        assert result["transcript"] == MARKER + TRANSCRIPT
+
+    def test_none_return_leaves_transcript_unchanged(self, monkeypatch, tmp_path):
+        audio = _make_audio(tmp_path)
+        _fake_hooks(monkeypatch, [lambda **kw: None])
+
+        result = _run(audio, _ok())
+
+        assert result["transcript"] == TRANSCRIPT
+
+    def test_two_hooks_last_writer_wins(self, monkeypatch, tmp_path):
+        """Registration order decides — same composition rule as
+        pre_transcription. Both callbacks see the ORIGINAL transcript."""
+        audio = _make_audio(tmp_path)
+        seen = []
+
+        def _first(transcript, **kw):
+            seen.append(transcript)
+            return "first"
+
+        def _second(transcript, **kw):
+            seen.append(transcript)
+            return "second"
+
+        _fake_hooks(monkeypatch, [_first, _second])
+
+        result = _run(audio, _ok())
+
+        assert result["transcript"] == "second"
+        assert seen == [TRANSCRIPT, TRANSCRIPT]
+
+    def test_non_string_return_ignored(self, monkeypatch, tmp_path):
+        audio = _make_audio(tmp_path)
+        _fake_hooks(monkeypatch, [{"transcript": "dict is not a string"}, 42])
+
+        result = _run(audio, _ok())
+
+        assert result["transcript"] == TRANSCRIPT
+
+    def test_empty_return_cannot_erase_transcript(self, monkeypatch, tmp_path):
+        """A plugin may annotate a transcript, never erase one: an empty
+        replacement would turn real speech into the gateway's inaudible
+        sentinel case."""
+        audio = _make_audio(tmp_path)
+        _fake_hooks(monkeypatch, [lambda **kw: ""])
+
+        result = _run(audio, _ok())
+
+        assert result["transcript"] == TRANSCRIPT
+
+    def test_whitespace_only_return_cannot_erase_transcript(
+        self, monkeypatch, tmp_path,
+    ):
+        audio = _make_audio(tmp_path)
+        _fake_hooks(monkeypatch, [lambda **kw: "   \n  "])
+
+        result = _run(audio, _ok())
+
+        assert result["transcript"] == TRANSCRIPT
+
+    def test_replacement_is_not_stripped_or_normalized(
+        self, monkeypatch, tmp_path,
+    ):
+        """Surrounding whitespace decides nothing but emptiness — a returned
+        string that survives the empty check is used verbatim, so a plugin
+        controls its own separator."""
+        audio = _make_audio(tmp_path)
+        _fake_hooks(monkeypatch, [lambda **kw: f"[Voice: calm]\n{TRANSCRIPT} "])
+
+        result = _run(audio, _ok())
+
+        assert result["transcript"] == f"[Voice: calm]\n{TRANSCRIPT} "
+
+    def test_ignored_return_after_valid_one_keeps_the_valid_one(
+        self, monkeypatch, tmp_path,
+    ):
+        """Last-writer-wins counts only usable returns — an ignored value from
+        a later hook does not undo an earlier valid replacement."""
+        audio = _make_audio(tmp_path)
+        _fake_hooks(monkeypatch, [lambda **kw: "annotated", lambda **kw: None])
+
+        result = _run(audio, _ok())
+
+        assert result["transcript"] == "annotated"
+
+
+# ---------------------------------------------------------------------------
+# Result envelope
+# ---------------------------------------------------------------------------
+
+
+class TestResultEnvelope:
+    def test_only_transcript_is_replaced(self, monkeypatch, tmp_path):
+        audio = _make_audio(tmp_path)
+        _fake_hooks(monkeypatch, [lambda **kw: "annotated"])
+
+        result = _run(
+            audio, _ok(language="de", duration=1.5),
+        )
+
+        assert result["transcript"] == "annotated"
+        assert result["success"] is True
+        assert result["provider"] == "openai"
+        assert result["language"] == "de"
+        assert result["duration"] == 1.5
+
+    def test_result_keys_unchanged_when_hook_replaces(
+        self, monkeypatch, tmp_path,
+    ):
+        """The envelope keeps exactly the keys the backend produced."""
+        audio = _make_audio(tmp_path)
+        _fake_hooks(monkeypatch, [lambda **kw: "annotated"])
+        backend_result = _ok(language="de")
+
+        result = _run(audio, dict(backend_result))
+
+        assert set(result) == set(backend_result)
+
+
+# ---------------------------------------------------------------------------
+# When the hook must NOT fire
+# ---------------------------------------------------------------------------
+
+
+class TestHookNotFired:
+    def test_failed_transcription_does_not_fire(self, monkeypatch, tmp_path):
+        audio = _make_audio(tmp_path)
+        captured = _fake_hooks(monkeypatch, [lambda **kw: "annotated"])
+
+        result = _run(
+            audio,
+            {"success": False, "transcript": "", "error": "boom",
+             "provider": "openai"},
+        )
+
+        assert captured == {}
+        assert result["transcript"] == ""
+        assert result["error"] == "boom"
+
+    def test_empty_successful_transcript_does_not_fire(
+        self, monkeypatch, tmp_path,
+    ):
+        """The gateway's 'empty or inaudible' sentinel path must keep seeing a
+        genuinely empty transcript — a plugin annotation would defeat it."""
+        audio = _make_audio(tmp_path)
+        captured = _fake_hooks(monkeypatch, [lambda **kw: "annotated"])
+
+        result = _run(audio, _ok(transcript=""))
+
+        assert captured == {}
+        assert result["transcript"] == ""
+
+    def test_whitespace_only_transcript_does_not_fire(
+        self, monkeypatch, tmp_path,
+    ):
+        audio = _make_audio(tmp_path)
+        captured = _fake_hooks(monkeypatch, [lambda **kw: "annotated"])
+
+        result = _run(audio, _ok(transcript="   \n "))
+
+        assert captured == {}
+        assert result["transcript"] == "   \n "
+
+
+# ---------------------------------------------------------------------------
+# Fail-open
+# ---------------------------------------------------------------------------
+
+
+class TestFailOpen:
+    def test_raising_callback_leaves_transcript_unchanged(
+        self, monkeypatch, tmp_path,
+    ):
+        audio = _make_audio(tmp_path)
+
+        def _explode(hook_name, **kw):
+            raise RuntimeError("plugin blew up")
+
+        monkeypatch.setattr("hermes_cli.plugins.has_hook", lambda name: True)
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _explode)
+
+        result = _run(audio, _ok())
+
+        assert result["success"] is True
+        assert result["transcript"] == TRANSCRIPT
+
+    def test_unimportable_hook_plumbing_leaves_transcript_unchanged(
+        self, monkeypatch, tmp_path,
+    ):
+        audio = _make_audio(tmp_path)
+
+        def _explode(name):
+            raise ImportError("plugins unavailable")
+
+        monkeypatch.setattr("hermes_cli.plugins.has_hook", _explode)
+
+        result = _run(audio, _ok())
+
+        assert result["transcript"] == TRANSCRIPT
+
+
+# ---------------------------------------------------------------------------
+# Kwargs contract
+# ---------------------------------------------------------------------------
+
+
+class TestKwargsContract:
+    def test_hook_receives_expected_kwargs(self, monkeypatch, tmp_path):
+        audio = _make_audio(tmp_path)
+        captured = _fake_hooks(monkeypatch, [])
+
+        _run(audio, _ok(), source="gateway")
+
+        assert captured["hook_name"] == "post_transcription"
+        kw = captured["kwargs"]
+        assert kw["file_path"] == audio
+        assert kw["transcript"] == TRANSCRIPT
+        assert kw["provider"] == "openai"
+        assert kw["source"] == "gateway"
+
+    def test_audio_file_is_still_readable_inside_the_callback(
+        self, monkeypatch, tmp_path,
+    ):
+        """The hook fires before any temp-file cleanup, so a callback that
+        wants to analyse the audio it was told about can still open it."""
+        audio = _make_audio(tmp_path)
+        observed = {}
+
+        def _read_audio(file_path, transcript, **kw):
+            observed["exists"] = os.path.exists(file_path)
+            observed["bytes"] = Path(file_path).read_bytes()
+            return None
+
+        _fake_hooks(monkeypatch, [_read_audio])
+
+        _run(audio, _ok())
+
+        assert observed["exists"] is True
+        assert observed["bytes"] == b"fake audio data"
+
+    def test_pre_and_post_hooks_agree_on_file_path(self, monkeypatch, tmp_path):
+        """The start-in-pre / join-in-post pattern depends on both hooks
+        naming the same file."""
+        audio = _make_audio(tmp_path)
+        seen = {}
+
+        def _invoke(hook_name, **kw):
+            seen[hook_name] = kw.get("file_path")
+            return []
+
+        monkeypatch.setattr("hermes_cli.plugins.has_hook", lambda name: True)
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _invoke)
+
+        _run(audio, _ok())
+
+        assert seen["pre_transcription"] == seen["post_transcription"]
+
+
+# ---------------------------------------------------------------------------
+# No-hook path stays identical
+# ---------------------------------------------------------------------------
+
+
+class TestNoHookPath:
+    def test_no_hook_result_identical_to_control(self, monkeypatch, tmp_path):
+        audio = _make_audio(tmp_path)
+        _no_hooks(monkeypatch)  # invoke_hook raises if ever called
+        backend_result = _ok(language="de")
+
+        result = _run(audio, dict(backend_result))
+
+        assert result == backend_result
+
+
+# ---------------------------------------------------------------------------
+# End-to-end with a real fixture plugin (real PluginManager mechanics)
+# ---------------------------------------------------------------------------
+
+
+def test_real_fixture_plugin_annotates_the_transcript(monkeypatch, tmp_path):
+    """Two callbacks registered by a real plugin through the real discovery
+    and dispatch path — last-writer-wins, verified on the returned result."""
+    hermes_home = Path(os.environ["HERMES_HOME"])
+    plugin_dir = hermes_home / "plugins" / "stt_marker"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.yaml").write_text("name: stt_marker\n", encoding="utf-8")
+    (plugin_dir / "__init__.py").write_text(
+        "def register(ctx):\n"
+        '    ctx.register_hook("post_transcription", lambda **kw: "loser")\n'
+        '    ctx.register_hook(\n'
+        '        "post_transcription",\n'
+        '        lambda transcript, **kw: "[Voice: calm] " + transcript,\n'
+        "    )\n",
+        encoding="utf-8",
+    )
+    cfg_path = hermes_home / "config.yaml"
+    cfg_path.write_text(
+        yaml.safe_dump({"plugins": {"enabled": ["stt_marker"]}}),
+        encoding="utf-8",
+    )
+
+    old_manager = plugins_mod._plugin_manager
+    plugins_mod._plugin_manager = plugins_mod.PluginManager()
+    try:
+        plugins_mod.discover_plugins()
+
+        audio = _make_audio(tmp_path)
+        result = _run(audio, _ok())
+    finally:
+        plugins_mod._plugin_manager = old_manager
+
+    assert result["success"] is True
+    assert result["transcript"] == f"[Voice: calm] {TRANSCRIPT}"

--- a/tests/tools/test_pre_transcription_hook.py
+++ b/tests/tools/test_pre_transcription_hook.py
@@ -50,10 +50,17 @@ def _make_audio(tmp_path):
 
 
 def _fake_hooks(monkeypatch, results):
-    """Install fake has_hook/invoke_hook returning *results* and capture kwargs."""
+    """Install fake has_hook/invoke_hook returning *results* and capture kwargs.
+
+    Scoped to ``pre_transcription``: the same dispatch also fires
+    ``post_transcription``, and an unscoped fake would overwrite the
+    captured payload with the later hook's kwargs.
+    """
     captured = {}
 
     def _invoke(hook_name, **kw):
+        if hook_name != "pre_transcription":
+            return []
         captured["hook_name"] = hook_name
         captured["kwargs"] = kw
         return list(results)

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1495,6 +1495,83 @@ def _apply_pre_transcription_hook(
 
 
 # ---------------------------------------------------------------------------
+# post_transcription plugin hook
+# ---------------------------------------------------------------------------
+
+
+def _apply_post_transcription_hook(
+    result: Dict[str, Any],
+    *,
+    file_path: str,
+    provider: str,
+    source: Optional[str],
+) -> Dict[str, Any]:
+    """Fire the ``post_transcription`` plugin hook and merge its result.
+
+    The symmetric partner of :func:`_apply_pre_transcription_hook`: same
+    ``has_hook`` gate (so the no-hook path never builds hook kwargs), same
+    fail-open contract (any hook-plumbing error returns the transcript
+    untouched), and the same last-writer-wins composition — ``invoke_hook``
+    returns results in registration order, so the last plugin to return a
+    usable string wins.
+
+    Only fires for a successful, non-empty transcript. A failed
+    transcription has no text to annotate, and the gateway's "empty or
+    inaudible" sentinel (#41603) must keep seeing a genuinely empty
+    transcript rather than a plugin's annotation of nothing.
+
+    Only ``transcript`` is replaced; every other key in *result*
+    (``success``, ``provider``, …) is passed through untouched.
+    """
+    try:
+        transcript = result.get("transcript")
+        if not result.get("success") or not isinstance(transcript, str):
+            return result
+        if not transcript.strip():
+            return result
+
+        from hermes_cli.plugins import has_hook, invoke_hook
+
+        # No-hook short-circuit: keep the no-plugin path free of any hook
+        # kwargs construction or dispatch.
+        if not has_hook("post_transcription"):
+            return result
+
+        hook_results = invoke_hook(
+            "post_transcription",
+            file_path=file_path,
+            transcript=transcript,
+            provider=provider,
+            source=source,
+        )
+        replacement: Optional[str] = None
+        for hook_result in hook_results:
+            if not isinstance(hook_result, str):
+                logger.debug(
+                    "post_transcription hook returned non-string value %r "
+                    "— ignoring.", hook_result,
+                )
+                continue
+            if not hook_result.strip():
+                # A plugin may annotate a transcript, never erase one: an
+                # empty replacement would turn a real utterance into the
+                # gateway's "inaudible" sentinel case.
+                logger.debug(
+                    "post_transcription hook returned an empty transcript "
+                    "— ignoring."
+                )
+                continue
+            replacement = hook_result
+
+        if replacement is None:
+            return result
+        return {**result, "transcript": replacement}
+    except Exception as _hook_err:  # noqa: BLE001 — hook plumbing is fail-open
+        logger.debug("post_transcription hook error: %s", _hook_err)
+        return result
+
+
+# ---------------------------------------------------------------------------
 # Shared validation
 # ---------------------------------------------------------------------------
 
@@ -2951,7 +3028,8 @@ def _transcribe_prepared_audio(
         model:     Override the model. If None, uses config or provider default.
         source:    Optional caller-surface label (e.g. ``"gateway"``,
                    ``"voice_mode"``) forwarded to the ``pre_transcription``
-                   plugin hook for observability. Not used for dispatch.
+                   and ``post_transcription`` plugin hooks for observability.
+                   Not used for dispatch.
 
     Returns:
         dict with keys:
@@ -3012,7 +3090,16 @@ def _transcribe_prepared_audio(
             trim_cleanup_dir = os.path.dirname(trimmed)
 
     try:
-        return _dispatch_stt_provider(file_path, provider, stt_config, model, source)
+        result = _dispatch_stt_provider(file_path, provider, stt_config, model, source)
+        # post_transcription plugin hook — fires after the backend returned
+        # and BEFORE the trim/convert temp dir is removed, so a callback can
+        # still read the exact file that was transcribed. ``file_path`` here
+        # is the preprocessed path the pre_transcription hook also saw, which
+        # is what lets a plugin start work in pre_transcription and join it
+        # here. The helper short-circuits on has_hook() and is fail-open.
+        return _apply_post_transcription_hook(
+            result, file_path=file_path, provider=provider, source=source,
+        )
     finally:
         if trim_cleanup_dir:
             shutil.rmtree(trim_cleanup_dir, ignore_errors=True)
@@ -3202,8 +3289,9 @@ def transcribe_audio(
     """Safely validate, preprocess supported inputs, and dispatch transcription.
 
     ``source`` is an optional caller-surface label (e.g. ``"gateway"``,
-    ``"voice_mode"``) forwarded to the ``pre_transcription`` plugin hook for
-    observability. Not used for dispatch.
+    ``"voice_mode"``) forwarded to the ``pre_transcription`` and
+    ``post_transcription`` plugin hooks for observability. Not used for
+    dispatch.
     """
     # Refuse to feed a credential / secret store (auth.json, .env, OAuth
     # tokens, mcp-tokens/, ...) to an STT provider — before ANY validation or

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -443,6 +443,7 @@ Payload fields below are the exact event-specific fields supplied by each call s
 | `transform_tool_result` | Transform | After `post_tool_call`, before conversation append; first string replaces the result. | `tool_name`, `args`, `result`, `task_id`, `session_id`, `tool_call_id`, `turn_id`, `api_request_id`, `duration_ms`, `status`, `error_type`, `error_message` | Exposes the full model-bound result and arguments. |
 | `transform_terminal_output` | Transform | After bounded foreground process capture, before final output limiting; first string replaces output. | `command`, `output`, `returncode`, `task_id`, `env_type` | Command/output may contain credentials. |
 | `pre_transcription` | Transform | Fired by the STT dispatcher after provider resolution and before any backend (built-in, command-type, or plugin-registered) is invoked; dict results are applied in registration order, last-writer-wins per field (`prompt`, `language`, `model`; `file_path` is read-only). | `file_path`, `provider`, `model`, `language`, `prompt`, `source` | The final prompt is uploaded to the configured STT provider with the audio — keep secrets out of hook returns. |
+| [`post_transcription`](#post_transcription) | Transform | Fired by the STT dispatcher after a backend returned a successful, non-empty transcript and before it reaches the caller; string results are applied in registration order, last-writer-wins. Not fired for failed or empty transcriptions. | `file_path`, `transcript`, `provider`, `source` | `transcript` is raw user speech; a replacement is persisted as the message text. |
 | `pre_llm_call` | Directive/control | Once per turn before the loop; all valid string/`{"context": ...}` returns are joined and injected into the user message. | `session_id`, `task_id`, `turn_id`, `user_message`, `conversation_history`, `is_first_turn`, `model`, `platform`, `parent_session_id`, `sender_id` | Full user message and conversation history. |
 | `post_llm_call` | Observer | Successful, non-interrupted turn finalization; return ignored. | `session_id`, `task_id`, `turn_id`, `user_message`, `assistant_response`, `conversation_history`, `model`, `platform` | Full prompt, response, and history. |
 | `transform_llm_output` | Transform | Before `post_llm_call` and final delivery; first non-empty string replaces the response. | `response_text`, `session_id`, `model`, `platform` | Full final assistant text. |
@@ -1404,6 +1405,51 @@ def register(ctx):
 ```
 
 Not every backend accepts a prompt. `local` maps it to faster-whisper's `initial_prompt`; `openai`, `groq`, `mistral`, and `deepinfra` send it as `prompt`; `xai`, `elevenlabs`, `local_command`, and `type: command` providers log at DEBUG and transcribe without it. See the [provider support table](/user-guide/configuration#transcription-prompt-vocabulary-hints) for the full matrix and the privacy boundary. Hook-plumbing errors are fail-open: the dispatch continues with the unmodified request.
+
+---
+
+### `post_transcription`
+
+The symmetric partner of [`pre_transcription`](#pre_transcription). Fires in the STT dispatcher **after** a backend returned a successful, non-empty transcript and **before** that transcript is handed back to the caller — so a replacement becomes the persisted message text, not just per-turn context the model sees once.
+
+**Callback signature:**
+
+```python
+def my_callback(
+    file_path: str,
+    transcript: str,
+    provider: str,
+    source: str | None,
+    **kwargs,
+) -> str | None:
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `file_path` | `str` | Absolute path to the audio file that was transcribed. This is the same preprocessed path `pre_transcription` saw (CAF→WAV conversion and silence trimming already applied), and the file still exists while the callback runs. |
+| `transcript` | `str` | The transcript returned by the backend. Never empty or whitespace-only. |
+| `provider` | `str` | The STT provider that produced it. |
+| `source` | `str \| None` | Caller surface label (`gateway`, `voice_mode`, …). Use it to scope your plugin — the hook fires for every transcription, including agent-initiated ones, not just inbound voice messages. |
+
+**Return value:** a `str` replacing the transcript, or `None` to leave it unchanged. Non-string returns are ignored, as are strings that are empty after stripping — a plugin may annotate a transcript but never erase one. Results are applied in **registration order, last-writer-wins**, matching `pre_transcription`. Only the transcript is replaced; every other field of the transcription result passes through untouched.
+
+**Not fired** when transcription failed, or when it succeeded with an empty transcript. The gateway has a dedicated "empty or inaudible" path for that case, and annotating silence would defeat it.
+
+**Use cases:** Prefix an audio-analysis result the transcript itself cannot carry (speaker/mood/emotion markers), tag the speaker on a multi-speaker recording, apply a domain-specific spelling correction pass, or redact a phrase class before the text is stored.
+
+```python
+def add_speaker_marker(transcript, source, **kwargs):
+    if source != "gateway":
+        return None
+    return f"[Speaker: Marius] {transcript}"
+
+def register(ctx):
+    ctx.register_hook("post_transcription", add_speaker_marker)
+```
+
+The callback runs **synchronously on the transcription path** — a slow callback delays the voice message. For an analysis that takes real time, start the work in `pre_transcription` (which returns immediately, and runs concurrently with the STT backend) and join the result here; `file_path` is identical across the two hooks, which is what makes that pairing reliable. Hook errors are fail-open: an exception leaves the transcript unchanged and never breaks transcription.
+
+This hook does not fire on `transcribe_audio_local_fallback`, the gateway's recovery path when the configured provider fails — the same limitation `pre_transcription` has, so a start/join pair stays consistent.
 
 ---
 

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -273,7 +273,7 @@ Plugins can register the 26 lifecycle events currently accepted by `hermes_cli.p
 | Descriptive category | Shipped hooks |
 |---|---|
 | **Directive/control** | `pre_tool_call`, `pre_llm_call`, `pre_verify`, `pre_gateway_dispatch` |
-| **Transform** | `transform_tool_result`, `transform_terminal_output`, `transform_llm_output`, `pre_transcription` |
+| **Transform** | `transform_tool_result`, `transform_terminal_output`, `transform_llm_output`, `pre_transcription`, `post_transcription` |
 | **Observer** | `post_tool_call`, `post_llm_call`, `pre_api_request`, `post_api_request`, `api_request_error`, `on_stream_start`, `on_stream_delta`, `on_stream_end`, `on_interim_message`, `on_session_start`, `on_session_end`, `on_session_finalize`, `on_session_reset`, `on_skill_lifecycle`, `subagent_start`, `subagent_stop`, `pre_approval_request`, `post_approval_response`, `pre_command`, `kanban_task_claimed`, `kanban_task_completed`, `kanban_task_blocked` |
 
 These categories describe current behavior rather than defining future naming rules. Plugin middleware remains a separate registry/surface.


### PR DESCRIPTION
## Summary

Adds a `post_transcription` plugin hook — the symmetric partner of the existing `pre_transcription`.

`pre_transcription` lets a plugin steer a transcription request (prompt, language, model) but it fires *before* the backend runs, so it never sees the result. A plugin whose entire purpose is to add something **derived from the audio itself** has nowhere to put that information.

## Concrete use case (the consumer exists)

I maintain a plugin that runs a fast audio analysis alongside STT and prefixes the transcript with how the speaker *sounds* — mood, energy, tone. Not what they said:

```
[Voice: stressed and tense, high, hurried] "can you get this done by tonight?"
```

The same shape covers speaker labels on multi-speaker recordings, or a domain-specific correction pass over the returned text.

Today the plugin registers `pre_transcription` (to start the analysis concurrently with Whisper) and then has to smuggle the marker in through `pre_llm_call` context injection. That reaches the model's per-turn context **only**: the marker is absent from the persisted message text, from the session export, and from the `🎙️ "…"` echo the gateway sends back to the user. There is no hook that can put it in the transcript, because `pre_transcription` fires too early to know it.

A transcription *provider* is the wrong lever here: it is selected via `stt.provider`, so it would hijack STT for every surface (voice mode, web uploads, Discord), rebuild core-private provider resolution, and — because providers are not given `source` — could not scope itself to the gateway.

## Design

The hook fires in `_transcribe_prepared_audio`, wrapped around the single `_dispatch_stt_provider(...)` call rather than at that function's dozen return points. That placement also puts it **inside** the existing `try/finally`, which matters twice:

- the callback still sees the exact preprocessed file (CAF→WAV converted, silence-trimmed) that `pre_transcription` was handed — same `file_path` in both hooks;
- it runs before the trim temp dir is removed, so a callback can still read the audio.

That shared `file_path` is what makes the useful pattern work: start slow work in `pre_transcription` (returns immediately, runs concurrently with the STT backend) and join it in `post_transcription`. In my plugin that keeps the added latency at ~0.5 s instead of serializing behind Whisper.

Contract, mirroring `pre_transcription` throughout:

| | |
|---|---|
| Kwargs | `file_path`, `transcript`, `provider`, `source` |
| Return | replacement `str`, or `None` for unchanged |
| Composition | registration order, **last-writer-wins** — same rule as `pre_transcription` |
| No-hook path | gated on `has_hook()`; no kwargs built, no dispatch |
| Errors | fail-open — any hook error returns the transcript untouched |
| Envelope | only `transcript` is replaced; every other result field passes through |

I went with a plain `str` return rather than `pre_transcription`'s dict because there is exactly one mutable field and inventing a dict schema for it would be speculative. Composition follows `pre_transcription` rather than `transform_llm_output`'s first-wins, because first-wins is wrong for annotations — with two annotating plugins it silently discards one.

### Where it deliberately does not fire

- **Failed transcription** — there is no text to annotate, and a hook that fires on failure invites plugins to invent transcripts.
- **Successful but empty transcript** — the gateway's "empty or inaudible" sentinel path (#41603) keys on exactly that, and annotating silence would defeat it. For the same reason an empty or whitespace-only *return* is ignored: a plugin may annotate a transcript, never erase one.
- **`transcribe_audio_local_fallback`** — the gateway's recovery path when the configured provider fails. `pre_transcription` does not fire there either; firing only the post half would hand a start/join plugin a join with no start. Happy to extend both hooks to that path in a follow-up if you'd prefer them there.

Because the hook fires for every transcription (including agent-initiated ones), the docs tell plugins to scope on `source` and note that the callback is synchronous on the transcription path.

## Test plan

New `tests/tools/test_post_transcription_hook.py` — 22 tests, behavior contracts rather than snapshots:

- replacement applied / `None` passes through
- two hooks → last-writer-wins, both seeing the original transcript
- non-string, empty, and whitespace-only returns ignored; an ignored later return does not undo an earlier valid one
- replacement used verbatim (not stripped or normalized)
- only `transcript` replaced — envelope keys and values preserved
- failed, empty, and whitespace-only transcripts never fire the hook
- fail-open: raising callback and unimportable hook plumbing both leave the transcript intact
- kwargs contract, including a callback that reads the audio file mid-hook (proves it still exists) and `pre`/`post` agreeing on `file_path`
- no hook registered → `invoke_hook` never called, result identical to a control run
- end-to-end through real plugin discovery with a fixture plugin registering two callbacks

```
scripts/run_tests.sh tests/tools/test_post_transcription_hook.py
  → 22 passed
```

Ran against the touched neighbours as well (`test_pre_transcription_hook`, `test_transcription*`, `test_plugins`, `test_plugin_guard`): **no new failures** — the failure set is byte-identical to a stashed `upstream/main` baseline on this machine. The 10 that do fail are pre-existing and environmental (no `openai` SDK in my test venv, plus one live-system-guard case), not related to this change.

One existing test helper needed a one-line fix: `test_pre_transcription_hook`'s `_fake_hooks` recorded whichever hook fired last, which is now `post_transcription`. It is scoped by hook name.

## Docs

- `website/docs/user-guide/features/hooks.md` — catalog row + full section (signature, parameter table, return semantics, the never-fires cases, the start-in-pre/join-in-post pattern, the synchronous-path warning, privacy note).
- `website/docs/user-guide/features/plugins.md` — added to the Transform category row.
