### PR TITLE
test(browser): update real-profile relaunch fixture

### DIFF
--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -983,6 +983,7 @@ class TestReviewRound3:
                    return_value=(str(tmp_path), None)) as snap, \
              patch("hermes_cli.browser_connect.chromium_executable",
                    return_value="/usr/bin/chrome"), \
+             patch.object(bt, "_real_profile_chrome_procs", []), \
              patch.object(bt.subprocess, "Popen", side_effect=fake_popen), \
              patch.object(bt, "_agent_browser_get_cdp",
                           side_effect=[None, "http://127.0.0.1:41000"]), \

--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -964,14 +964,28 @@ class TestReviewRound3:
         import tools.browser_tool as bt
         bt._real_profile_cdp_cache.clear()
         proc = Mock(returncode=0, stdout="", stderr="")
+
+        class FakeChrome:
+            def poll(self):
+                return None
+
+        def fake_popen(argv, **kw):
+            (tmp_path / "DevToolsActivePort").write_text(
+                "41000\n/devtools/browser/x\n"
+            )
+            return FakeChrome()
+
         with patch.object(bt, "_use_real_profile", return_value=True), \
              patch.object(bt, "_using_lightpanda_engine", return_value=False), \
              patch("hermes_cli.browser_connect.detect_default_chromium", return_value="chrome"), \
              patch("hermes_cli.browser_connect.real_profile_copy_dir", return_value=str(tmp_path)), \
              patch("hermes_cli.browser_connect.snapshot_real_profile",
                    return_value=(str(tmp_path), None)) as snap, \
+             patch("hermes_cli.browser_connect.chromium_executable",
+                   return_value="/usr/bin/chrome"), \
+             patch.object(bt.subprocess, "Popen", side_effect=fake_popen), \
              patch.object(bt, "_agent_browser_get_cdp",
-                          side_effect=[None, "http://127.0.0.1:9251"]), \
+                          side_effect=[None, "http://127.0.0.1:41000"]), \
              patch.object(bt, "_find_agent_browser", return_value="/usr/bin/agent-browser"), \
              patch.object(bt.subprocess, "run", return_value=proc), \
              patch.object(bt, "_is_headed_mode", return_value=False):


### PR DESCRIPTION
## What does this PR do?

Updates a stale real-profile relaunch unit test to exercise the direct Chrome launch path introduced on current `main`.

The test still verifies its original contract—when no reusable session exists, Hermes snapshots the real profile before relaunching—but now provides the browser binary, Chrome process, and `DevToolsActivePort` fixtures required by the production path. No production behavior changes.

## Related Issue

Fixes #100983

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tests/tools/test_browser_real_profile.py`: make `test_relaunch_path_does_snapshot` hermetic for direct Chrome launch by mocking `chromium_executable`, `Popen`, and `DevToolsActivePort` creation.

## How to Test

1. On base `c5c9aa8d44e03f4e8b5fe7f230cfd97ab2dde0bf`, run:
   ```bash
   python -m pytest -q tests/tools/test_browser_real_profile.py::TestReviewRound3::test_relaunch_path_does_snapshot
   ```
   It fails because the stale fixture does not provide a Chrome binary.
2. On this branch, run the same command.
3. Result: `1 passed`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.11

### Documentation & Housekeeping

- [x] Documentation update: N/A — test-only change
- [x] `cli-config.yaml.example` update: N/A — no config changes
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A — no architecture/workflow changes
- [x] Cross-platform impact considered: fixtures use Python mocks and `pathlib`, with no platform-specific production change
- [x] Tool descriptions/schemas update: N/A — no tool behavior changes

## Screenshots / Logs

```text
1 passed in 5.46s
```
