### PR TITLE
feat: bind delegated runs to the live Git session

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3206,6 +3206,18 @@ logger = logging.getLogger(__name__)
 # must not wait on, and the caller clamps this to the watchdog leash anyway.
 _EXECUTOR_QUIESCE_TIMEOUT = 2.0
 
+def _format_delegation_binding_line(binding, delegation_status):
+    """Render server-owned delegation identity and terminal status once."""
+    if not isinstance(binding, dict):
+        return None
+    return (
+        "🔀 delegation "
+        f"{'completed' if delegation_status == 'completed' else 'failed'} · "
+        f"repo={binding.get('repo') or ''} "
+        f"branch={binding.get('branch') or 'HEAD'} "
+        f"sha={binding.get('sha') or ''}"
+    )
+
 
 _OWN_POLICY_OPEN_ENV = {
     Platform.WECOM: ("WECOM_DM_POLICY", "WECOM_GROUP_POLICY", "WECOM_ALLOW_ALL_USERS"),
@@ -7170,7 +7182,10 @@ class TurnRunner:
                     history_offset=len(agent_history),
                 )
             try:
-                from gateway.session_context import current_run_binding
+                from gateway.session_context import (
+                    current_delegation_status,
+                    current_run_binding,
+                )
 
                 _binding = current_run_binding()
                 if _binding is not None:
@@ -7179,6 +7194,9 @@ class TurnRunner:
                         "branch": _binding.branch or _binding.ref,
                         "sha": _binding.short_head,
                     }
+                _delegation_status = current_delegation_status()
+                if _delegation_status is not None:
+                    result["delegation_status"] = _delegation_status
             except Exception:
                 logger.debug("Could not attach run binding to gateway result", exc_info=True)
 
@@ -7379,6 +7397,7 @@ class TurnRunner:
                 "model": _resolved_model,
                 "context_length": _context_length,
                 "run_binding": result.get("run_binding"),
+                "delegation_status": result.get("delegation_status"),
             }
 
         # Scan tool results for MEDIA:<path> tags that need to be delivered
@@ -7469,6 +7488,7 @@ class TurnRunner:
             # True preserves the skip-db behaviour for the standard runtime.
             "agent_persisted": (ctx.result_holder[0].get("agent_persisted", True) if ctx.result_holder[0] else True),
             "run_binding": ctx.result_holder[0].get("run_binding") if ctx.result_holder[0] else None,
+            "delegation_status": ctx.result_holder[0].get("delegation_status") if ctx.result_holder[0] else None,
         }
 
 
@@ -23789,39 +23809,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 response = ""
 
-            # Keep the server-owned delegation identity on the existing final
-            # reply. This is independent of optional tool progress, so a
-            # normal messaging channel still receives the checkout and child
-            # outcome when progress display is disabled.
-            _binding_meta = agent_result.get("run_binding")
-            _binding_line = None
-            if isinstance(_binding_meta, dict) and not _intentional_silence:
-                _binding_line = (
-                    "🔀 delegation "
-                    f"{'failed' if agent_result.get('failed') else 'completed'} · "
-                    f"repo={_binding_meta.get('repo') or ''} "
-                    f"branch={_binding_meta.get('branch') or 'HEAD'} "
-                    f"sha={_binding_meta.get('sha') or ''}"
-                )
-                if response and not agent_result.get("already_sent"):
-                    response = f"{response}\n\n{_binding_line}"
-                elif not response and not agent_result.get("already_sent"):
-                    response = _binding_line
-
             # ``run_binding`` is returned by the server-owned gateway turn,
             # not by the model. Attach it to the existing final reply so
             # messaging surfaces still show the selected checkout when their
             # optional tool-progress queue is disabled.
             _binding_meta = agent_result.get("run_binding")
-            _binding_line = None
-            if isinstance(_binding_meta, dict) and not _intentional_silence:
-                _binding_line = (
-                    "🔀 delegation "
-                    f"{'failed' if agent_result.get('failed') else 'completed'} · "
-                    f"repo={_binding_meta.get('repo') or ''} "
-                    f"branch={_binding_meta.get('branch') or 'HEAD'} "
-                    f"sha={_binding_meta.get('sha') or ''}"
+            _binding_line = (
+                _format_delegation_binding_line(
+                    _binding_meta, agent_result.get("delegation_status")
                 )
+                if not _intentional_silence else None
+            )
+            if _binding_line:
                 if response and not agent_result.get("already_sent"):
                     response = f"{response}\n\n{_binding_line}"
                 elif not response and not agent_result.get("already_sent"):
@@ -23852,8 +23851,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # content the user hasn't seen (streaming only sent earlier
             # partial output before the failure).  Without this guard,
             # users see the agent "stop responding without explanation."
-            if agent_result.get("already_sent") and not agent_result.get("failed"):
-                if response:
+            if agent_result.get("already_sent"):
+                if response and not agent_result.get("failed"):
                     _media_adapter = self._adapter_for_source(source)
                     if _media_adapter:
                         await self._deliver_media_from_response(
@@ -23875,31 +23874,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     except Exception as _e:
                         logger.debug("trailing footer send failed: %s", _e)
                 if _binding_line:
-                    try:
-                        _binding_adapter = self._adapter_for_source(source)
-                        if _binding_adapter:
-                            await _binding_adapter.send(
-                                source.chat_id,
-                                _binding_line,
-                                metadata=self._thread_metadata_for_source(
-                                    source, self._reply_anchor_for_event(event)
-                                ),
-                            )
-                    except Exception as _e:
-                        logger.debug("trailing binding send failed: %s", _e)
-                if _binding_line:
-                    try:
-                        _binding_adapter = self._adapter_for_source(source)
-                        if _binding_adapter:
-                            await _binding_adapter.send(
-                                source.chat_id,
-                                _binding_line,
-                                metadata=self._thread_metadata_for_source(
-                                    source, self._reply_anchor_for_event(event)
-                                ),
-                            )
-                    except Exception as _e:
-                        logger.debug("trailing binding send failed: %s", _e)
+                    await self._send_delegation_binding_line(
+                        source, event, _binding_line
+                    )
                 # This branch returns None so the adapter does not send the
                 # body twice. /loop and /goal hooks in _handle_message read
                 # the return value, so stash the delivered text on the event
@@ -25422,6 +25399,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         except Exception as e:
             logger.warning("Post-stream media extraction failed: %s", e)
+
+    async def _send_delegation_binding_line(self, source, event, line):
+        """Send the one trailing binding line for an already-streamed turn."""
+        try:
+            adapter = self._adapter_for_source(source)
+            if adapter:
+                await adapter.send(
+                    source.chat_id,
+                    line,
+                    metadata=self._thread_metadata_for_source(
+                        source, self._reply_anchor_for_event(event)
+                    ),
+                )
+        except Exception as exc:
+            logger.debug("trailing binding send failed: %s", exc)
 
     async def _deliver_queued_first_response(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7169,6 +7169,18 @@ class TurnRunner:
                     result.get("messages", []),
                     history_offset=len(agent_history),
                 )
+            try:
+                from gateway.session_context import current_run_binding
+
+                _binding = current_run_binding()
+                if _binding is not None:
+                    result["run_binding"] = {
+                        "repo": _binding.repo_root,
+                        "branch": _binding.branch or _binding.ref,
+                        "sha": _binding.short_head,
+                    }
+            except Exception:
+                logger.debug("Could not attach run binding to gateway result", exc_info=True)
 
         ctx.result_holder[0] = result
 
@@ -7366,6 +7378,7 @@ class TurnRunner:
                 "output_tokens": _output_toks,
                 "model": _resolved_model,
                 "context_length": _context_length,
+                "run_binding": result.get("run_binding"),
             }
 
         # Scan tool results for MEDIA:<path> tags that need to be delivered
@@ -7455,6 +7468,7 @@ class TurnRunner:
             # self-persisted (it didn't — see codex_runtime.py).  Default
             # True preserves the skip-db behaviour for the standard runtime.
             "agent_persisted": (ctx.result_holder[0].get("agent_persisted", True) if ctx.result_holder[0] else True),
+            "run_binding": ctx.result_holder[0].get("run_binding") if ctx.result_holder[0] else None,
         }
 
 
@@ -23775,6 +23789,44 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 response = ""
 
+            # Keep the server-owned delegation identity on the existing final
+            # reply. This is independent of optional tool progress, so a
+            # normal messaging channel still receives the checkout and child
+            # outcome when progress display is disabled.
+            _binding_meta = agent_result.get("run_binding")
+            _binding_line = None
+            if isinstance(_binding_meta, dict) and not _intentional_silence:
+                _binding_line = (
+                    "🔀 delegation "
+                    f"{'failed' if agent_result.get('failed') else 'completed'} · "
+                    f"repo={_binding_meta.get('repo') or ''} "
+                    f"branch={_binding_meta.get('branch') or 'HEAD'} "
+                    f"sha={_binding_meta.get('sha') or ''}"
+                )
+                if response and not agent_result.get("already_sent"):
+                    response = f"{response}\n\n{_binding_line}"
+                elif not response and not agent_result.get("already_sent"):
+                    response = _binding_line
+
+            # ``run_binding`` is returned by the server-owned gateway turn,
+            # not by the model. Attach it to the existing final reply so
+            # messaging surfaces still show the selected checkout when their
+            # optional tool-progress queue is disabled.
+            _binding_meta = agent_result.get("run_binding")
+            _binding_line = None
+            if isinstance(_binding_meta, dict) and not _intentional_silence:
+                _binding_line = (
+                    "🔀 delegation "
+                    f"{'failed' if agent_result.get('failed') else 'completed'} · "
+                    f"repo={_binding_meta.get('repo') or ''} "
+                    f"branch={_binding_meta.get('branch') or 'HEAD'} "
+                    f"sha={_binding_meta.get('sha') or ''}"
+                )
+                if response and not agent_result.get("already_sent"):
+                    response = f"{response}\n\n{_binding_line}"
+                elif not response and not agent_result.get("already_sent"):
+                    response = _binding_line
+
             # Auto voice reply: send TTS audio before the text response
             _already_sent = bool(agent_result.get("already_sent"))
             # Skip when streaming TTS already delivered audio for this turn (#60671).
@@ -23822,6 +23874,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             )
                     except Exception as _e:
                         logger.debug("trailing footer send failed: %s", _e)
+                if _binding_line:
+                    try:
+                        _binding_adapter = self._adapter_for_source(source)
+                        if _binding_adapter:
+                            await _binding_adapter.send(
+                                source.chat_id,
+                                _binding_line,
+                                metadata=self._thread_metadata_for_source(
+                                    source, self._reply_anchor_for_event(event)
+                                ),
+                            )
+                    except Exception as _e:
+                        logger.debug("trailing binding send failed: %s", _e)
+                if _binding_line:
+                    try:
+                        _binding_adapter = self._adapter_for_source(source)
+                        if _binding_adapter:
+                            await _binding_adapter.send(
+                                source.chat_id,
+                                _binding_line,
+                                metadata=self._thread_metadata_for_source(
+                                    source, self._reply_anchor_for_event(event)
+                                ),
+                            )
+                    except Exception as _e:
+                        logger.debug("trailing binding send failed: %s", _e)
                 # This branch returns None so the adapter does not send the
                 # body twice. /loop and /goal hooks in _handle_message read
                 # the return value, so stash the delivered text on the event

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4845,6 +4845,29 @@ class TurnRunner:
     def progress_callback(self, event_type: str, tool_name: str = None, preview: str = None, args: dict = None, **kwargs):
         """Callback invoked by agent on tool lifecycle events."""
         ctx = self._ctx
+        # Delegation identity is server-derived metadata, not model text. Keep
+        # the compact repo/branch/SHA on the same gateway progress rail so a
+        # messaging user can tell which checkout the child is using.
+        _run_binding = kwargs.get("run_binding")
+        if (
+            _run_binding
+            and event_type in {"subagent.start", "subagent.complete"}
+            and ctx.progress_queue is not None
+            and ctx._run_still_current()
+        ):
+            try:
+                from tools.delegate_tool import SUBAGENT_FAILURE_STATUSES
+            except Exception:
+                SUBAGENT_FAILURE_STATUSES = frozenset()
+            _repo = str(_run_binding.get("repo") or "")
+            _branch = str(_run_binding.get("branch") or "HEAD")
+            _sha = str(_run_binding.get("sha") or "")
+            _label = "delegation started" if event_type == "subagent.start" else "delegation complete"
+            if kwargs.get("status") in SUBAGENT_FAILURE_STATUSES:
+                _label = "delegation failed"
+            ctx.progress_queue.put(
+                f"🔀 {_label} · repo={_repo} branch={_branch} sha={_sha}"
+            )
         # Failed subagent → one clean user-facing notice. Handled FIRST,
         # before every progress-queue gate: platforms that keep
         # tool_progress off (Telegram, Slack, ...) must still hear about a
@@ -27527,7 +27550,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         Returns a list of reset tokens; pass them to ``_clear_session_env``
         in a ``finally`` block.
         """
-        from gateway.session_context import set_session_vars
+        from gateway.session_context import (
+            GatewayRunAuthority,
+            set_gateway_run_authority,
+            set_session_vars,
+        )
         # Propagate the adapter's async-delivery capability so async tools
         # (terminal notify_on_complete / watch_patterns, delegate_task
         # background=True) know whether this channel can wake a later turn.
@@ -27537,8 +27564,48 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # don't blow up — they simply default to supported.
         _adapters = getattr(self, "adapters", None) or {}
         _adapter = _adapters.get(context.source.platform)
+        try:
+            _adapter = self._adapter_for_source(context.source) or _adapter
+        except Exception:
+            pass
         _async_delivery = getattr(_adapter, "supports_async_delivery", True)
-        return set_session_vars(
+        try:
+            from agent.runtime_cwd import resolve_agent_cwd
+            from tools.terminal_tool import get_session_cwd
+
+            _cwd = get_session_cwd(context.session_key) or str(resolve_agent_cwd())
+        except Exception:
+            _cwd = os.environ.get("TERMINAL_CWD", "") or os.getcwd()
+
+        _store = getattr(self, "session_store", None)
+        _record = None
+        if _store is not None and context.session_key:
+            try:
+                with _store._lock:
+                    _store._ensure_loaded_locked()
+                    _record = _store._entries.get(context.session_key)
+            except Exception:
+                logger.debug("gateway run authority capture failed", exc_info=True)
+
+        def _authority_is_current(authority: GatewayRunAuthority) -> bool:
+            if _store is None or _record is None:
+                return False
+            try:
+                with _store._lock:
+                    _store._ensure_loaded_locked()
+                    live_record = _store._entries.get(authority.session_key)
+                if live_record is not authority.record:
+                    return False
+                try:
+                    live_adapter = self._adapter_for_source(context.source)
+                except Exception:
+                    live_adapter = _adapter
+                return live_adapter is authority.transport
+            except Exception:
+                logger.debug("gateway run authority validation failed", exc_info=True)
+                return False
+
+        _tokens = set_session_vars(
             platform=context.source.platform.value,
             chat_id=context.source.chat_id,
             chat_type=(
@@ -27553,9 +27620,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             session_key=context.session_key,
             message_id=str(context.source.message_id) if context.source.message_id else "",
             profile=getattr(context.source, "profile", "") or "",
+            cwd=_cwd,
             async_delivery=_async_delivery,
             cron_session="",
         )
+        if _record is not None:
+            set_gateway_run_authority(
+                GatewayRunAuthority(
+                    validator=_authority_is_current,
+                    session_key=context.session_key,
+                    cwd=_cwd,
+                    profile=getattr(context.source, "profile", "") or "",
+                    record=_record,
+                    transport=_adapter,
+                    owner_generation=str(id(_record)),
+                    transport_generation=str(id(_adapter)),
+                )
+            )
+        return _tokens
 
     def _clear_session_env(self, tokens: list) -> None:
         """Restore session context variables to their pre-handler values."""

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -38,12 +38,59 @@ needs to replace the import + call site:
 
 from contextlib import contextmanager
 from contextvars import ContextVar
+from dataclasses import dataclass
 from typing import Any, Iterator
 
 # Sentinel to distinguish "never set in this context" from "explicitly set to empty".
 # When a contextvar holds _UNSET, we fall back to os.environ (CLI/cron compat).
 # When it holds "" (after clear_session_vars resets it), we return "" — no fallback.
 _UNSET: Any = object()
+
+
+@dataclass(frozen=True)
+class RunBinding:
+    """Immutable server-owned identity for one live conversation turn.
+
+    This is deliberately process-local state.  It is captured by the gateway
+    from the authenticated session and the live checkout, then inherited by
+    tools in that turn.  Model text and RPC parameters are never an authority
+    source for these fields.
+    """
+
+    cwd: str
+    repo_root: str
+    worktree_root: str
+    git_common_dir: str
+    branch: str
+    ref: str
+    head: str
+    session_key: str
+    ui_session_id: str
+    profile: str
+
+    @property
+    def short_head(self) -> str:
+        return self.head[:12]
+
+    def display(self) -> str:
+        repo = self.repo_root or self.worktree_root or self.cwd
+        return f"repo={repo} branch={self.branch or self.ref or 'HEAD'} sha={self.short_head}"
+
+    def differences(self, other: "RunBinding") -> tuple[str, ...]:
+        """Return changed identity fields in stable, user-readable order."""
+        fields = (
+            "cwd", "repo_root", "worktree_root", "git_common_dir", "branch",
+            "ref", "head", "session_key", "ui_session_id", "profile",
+        )
+        return tuple(name for name in fields if getattr(self, name) != getattr(other, name))
+
+    def matches(self, other: "RunBinding") -> bool:
+        return isinstance(other, RunBinding) and not self.differences(other)
+
+
+_CURRENT_RUN_BINDING: ContextVar[RunBinding | None] = ContextVar(
+    "HERMES_CURRENT_RUN_BINDING", default=None
+)
 
 # Process-level flag: has any code in this process bound a session via
 # set_session_vars()? Concurrent multi-session hosts (the messaging gateway, the
@@ -204,6 +251,23 @@ def set_current_session_id(session_id: str) -> None:
     os.environ["HERMES_SESSION_ID"] = session_id
 
 
+def set_run_binding(binding: RunBinding) -> object:
+    """Bind the server-derived run identity to the current turn context."""
+    if not isinstance(binding, RunBinding):
+        raise TypeError("binding must be a RunBinding")
+    return _CURRENT_RUN_BINDING.set(binding)
+
+
+def reset_run_binding(token: object) -> None:
+    """Restore the run identity that preceded this turn."""
+    _CURRENT_RUN_BINDING.reset(token)
+
+
+def current_run_binding() -> RunBinding | None:
+    """Return the immutable identity captured for this turn, if any."""
+    return _CURRENT_RUN_BINDING.get()
+
+
 @contextmanager
 def scoped_current_session_id(session_id: str | None = None) -> Iterator[None]:
     """Bind a task-local session id and restore the prior value on exit.
@@ -334,6 +398,7 @@ def clear_session_vars(tokens: list) -> None:
     # behavior (CLI / unaware paths), not be mistaken for an opted-out
     # stateless adapter.
     _SESSION_ASYNC_DELIVERY.set(_UNSET)
+    _CURRENT_RUN_BINDING.set(None)
     try:
         from agent.runtime_cwd import clear_session_cwd
 
@@ -382,6 +447,7 @@ def reset_session_vars() -> None:
     # same inheritance-leak reason as the mapped vars above — see clear_session_vars,
     # which resets this var on the handler-exit path for the symmetric concern.
     _SESSION_ASYNC_DELIVERY.set(_UNSET)
+    _CURRENT_RUN_BINDING.set(None)
     try:
         from agent.runtime_cwd import clear_session_cwd
 

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -67,6 +67,8 @@ class RunBinding:
     session_key: str
     ui_session_id: str
     profile: str
+    owner_generation: str = ""
+    transport_generation: str = ""
 
     @property
     def short_head(self) -> str:
@@ -81,6 +83,7 @@ class RunBinding:
         fields = (
             "cwd", "repo_root", "worktree_root", "git_common_dir", "branch",
             "ref", "head", "session_key", "ui_session_id", "profile",
+            "owner_generation", "transport_generation",
         )
         return tuple(name for name in fields if getattr(self, name) != getattr(other, name))
 

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -120,6 +120,9 @@ _CURRENT_RUN_BINDING: ContextVar[RunBinding | None] = ContextVar(
 _CURRENT_GATEWAY_RUN_AUTHORITY: ContextVar[GatewayRunAuthority | None] = ContextVar(
     "HERMES_CURRENT_GATEWAY_RUN_AUTHORITY", default=None
 )
+_CURRENT_DELEGATION_STATUS: ContextVar[str | None] = ContextVar(
+    "HERMES_CURRENT_DELEGATION_STATUS", default=None
+)
 
 # Process-level flag: has any code in this process bound a session via
 # set_session_vars()? Concurrent multi-session hosts (the messaging gateway, the
@@ -307,6 +310,17 @@ def current_gateway_run_authority() -> GatewayRunAuthority | None:
     return _CURRENT_GATEWAY_RUN_AUTHORITY.get()
 
 
+def set_delegation_status(status: str | None) -> object:
+    """Publish the server-owned terminal status for the current turn."""
+    if status not in (None, "completed", "failed"):
+        raise ValueError("delegation status must be completed, failed, or None")
+    return _CURRENT_DELEGATION_STATUS.set(status)
+
+
+def current_delegation_status() -> str | None:
+    return _CURRENT_DELEGATION_STATUS.get()
+
+
 @contextmanager
 def scoped_current_session_id(session_id: str | None = None) -> Iterator[None]:
     """Bind a task-local session id and restore the prior value on exit.
@@ -439,6 +453,7 @@ def clear_session_vars(tokens: list) -> None:
     _SESSION_ASYNC_DELIVERY.set(_UNSET)
     _CURRENT_RUN_BINDING.set(None)
     _CURRENT_GATEWAY_RUN_AUTHORITY.set(None)
+    _CURRENT_DELEGATION_STATUS.set(None)
     try:
         from agent.runtime_cwd import clear_session_cwd
 
@@ -489,6 +504,7 @@ def reset_session_vars() -> None:
     _SESSION_ASYNC_DELIVERY.set(_UNSET)
     _CURRENT_RUN_BINDING.set(None)
     _CURRENT_GATEWAY_RUN_AUTHORITY.set(None)
+    _CURRENT_DELEGATION_STATUS.set(None)
     try:
         from agent.runtime_cwd import clear_session_cwd
 

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -91,8 +91,34 @@ class RunBinding:
         return isinstance(other, RunBinding) and not self.differences(other)
 
 
+@dataclass(frozen=True)
+class GatewayRunAuthority:
+    """Live, process-local owner captured by the ordinary gateway turn.
+
+    The objects are intentionally not serializable.  ``validate`` is supplied
+    by the gateway runner so a delegate can re-check its live session registry
+    immediately before constructing a child rather than trusting copied
+    ContextVars.
+    """
+
+    validator: Any
+    session_key: str
+    cwd: str
+    profile: str
+    record: Any
+    transport: Any
+    owner_generation: str
+    transport_generation: str
+
+    def validate(self) -> bool:
+        return bool(self.validator(self))
+
+
 _CURRENT_RUN_BINDING: ContextVar[RunBinding | None] = ContextVar(
     "HERMES_CURRENT_RUN_BINDING", default=None
+)
+_CURRENT_GATEWAY_RUN_AUTHORITY: ContextVar[GatewayRunAuthority | None] = ContextVar(
+    "HERMES_CURRENT_GATEWAY_RUN_AUTHORITY", default=None
 )
 
 # Process-level flag: has any code in this process bound a session via
@@ -271,6 +297,16 @@ def current_run_binding() -> RunBinding | None:
     return _CURRENT_RUN_BINDING.get()
 
 
+def set_gateway_run_authority(authority: GatewayRunAuthority) -> object:
+    if not isinstance(authority, GatewayRunAuthority):
+        raise TypeError("authority must be a GatewayRunAuthority")
+    return _CURRENT_GATEWAY_RUN_AUTHORITY.set(authority)
+
+
+def current_gateway_run_authority() -> GatewayRunAuthority | None:
+    return _CURRENT_GATEWAY_RUN_AUTHORITY.get()
+
+
 @contextmanager
 def scoped_current_session_id(session_id: str | None = None) -> Iterator[None]:
     """Bind a task-local session id and restore the prior value on exit.
@@ -402,6 +438,7 @@ def clear_session_vars(tokens: list) -> None:
     # stateless adapter.
     _SESSION_ASYNC_DELIVERY.set(_UNSET)
     _CURRENT_RUN_BINDING.set(None)
+    _CURRENT_GATEWAY_RUN_AUTHORITY.set(None)
     try:
         from agent.runtime_cwd import clear_session_cwd
 
@@ -451,6 +488,7 @@ def reset_session_vars() -> None:
     # which resets this var on the handler-exit path for the symmetric concern.
     _SESSION_ASYNC_DELIVERY.set(_UNSET)
     _CURRENT_RUN_BINDING.set(None)
+    _CURRENT_GATEWAY_RUN_AUTHORITY.set(None)
     try:
         from agent.runtime_cwd import clear_session_cwd
 

--- a/tests/gateway/test_run_binding_messaging.py
+++ b/tests/gateway/test_run_binding_messaging.py
@@ -1,8 +1,9 @@
 """Focused ordinary-gateway turn to delegate binding coverage."""
 
 import queue
+import asyncio
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from gateway.config import Platform
 from gateway.run import GatewayRunner, TurnRunner
@@ -102,3 +103,29 @@ def test_gateway_progress_keeps_bound_checkout_visible():
     assert progress.get_nowait() == (
         "🔀 delegation started · repo=/workspace branch=main sha=abc123456789"
     )
+
+
+def test_final_adapter_delivery_keeps_binding_when_progress_is_off():
+    runner = object.__new__(GatewayRunner)
+    adapter = MagicMock()
+    adapter.extract_media.side_effect = lambda text: ([], text)
+    adapter.send = AsyncMock()
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="chat")
+    response = (
+        "The child completed the requested work.\n\n"
+        "🔀 delegation completed · repo=/workspace branch=main sha=abc123456789"
+    )
+
+    # This is the existing final adapter path. No progress queue is involved;
+    # progress display is off, but the final same-channel reply remains intact.
+    asyncio.run(
+        runner._deliver_queued_first_response(
+            response,
+            source,
+            adapter,
+            deliver_media=False,
+        )
+    )
+
+    adapter.send.assert_awaited_once()
+    assert response in adapter.send.await_args.args

--- a/tests/gateway/test_run_binding_messaging.py
+++ b/tests/gateway/test_run_binding_messaging.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from gateway.config import Platform
-from gateway.run import GatewayRunner, TurnRunner
+from gateway.run import GatewayRunner, TurnRunner, _format_delegation_binding_line
 from gateway.session import SessionContext, SessionSource
 from gateway.session_context import reset_session_vars
 from tools.delegate_tool import delegate_task
@@ -82,6 +82,7 @@ def test_gateway_turn_binds_lazily_at_delegate_boundary():
             result = delegate_task(goal="Inspect the selected repository", parent_agent=parent)
 
         assert '"status": "completed"' in result
+        assert '"delegation_status": "completed"' in result
         build.assert_called_once()
         assert build.call_args.kwargs["run_binding"] is binding
     finally:
@@ -111,10 +112,11 @@ def test_final_adapter_delivery_keeps_binding_when_progress_is_off():
     adapter.extract_media.side_effect = lambda text: ([], text)
     adapter.send = AsyncMock()
     source = SessionSource(platform=Platform.TELEGRAM, chat_id="chat")
-    response = (
-        "The child completed the requested work.\n\n"
-        "🔀 delegation completed · repo=/workspace branch=main sha=abc123456789"
+    line = _format_delegation_binding_line(
+        {"repo": "/workspace", "branch": "main", "sha": "abc123456789"},
+        "completed",
     )
+    response = f"The child completed the requested work.\n\n{line}"
 
     # This is the existing final adapter path. No progress queue is involved;
     # progress display is off, but the final same-channel reply remains intact.
@@ -129,3 +131,27 @@ def test_final_adapter_delivery_keeps_binding_when_progress_is_off():
 
     adapter.send.assert_awaited_once()
     assert response in adapter.send.await_args.args
+    assert adapter.send.await_args.args[1].count("🔀 delegation") == 1
+
+
+def test_streaming_binding_trailing_delivery_is_exactly_once_when_progress_is_off():
+    runner = object.__new__(GatewayRunner)
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    runner._adapter_for_source = lambda source: adapter
+    runner._thread_metadata_for_source = lambda source, anchor=None: {}
+    runner._reply_anchor_for_event = lambda event: None
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="chat")
+    event = SimpleNamespace()
+    line = _format_delegation_binding_line(
+        {"repo": "/workspace", "branch": "main", "sha": "abc123456789"},
+        "completed",
+    )
+
+    # This is the already_sent=True trailing adapter path.  There is no
+    # progress queue; the terminal binding is still delivered once.
+    asyncio.run(runner._send_delegation_binding_line(source, event, line))
+
+    adapter.send.assert_awaited_once()
+    assert adapter.send.await_args.args[1] == line
+    assert adapter.send.await_args.args[1].count("🔀 delegation") == 1

--- a/tests/gateway/test_run_binding_messaging.py
+++ b/tests/gateway/test_run_binding_messaging.py
@@ -1,0 +1,104 @@
+"""Focused ordinary-gateway turn to delegate binding coverage."""
+
+import queue
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from gateway.config import Platform
+from gateway.run import GatewayRunner, TurnRunner
+from gateway.session import SessionContext, SessionSource
+from gateway.session_context import reset_session_vars
+from tools.delegate_tool import delegate_task
+
+
+class _Store:
+    def __init__(self, key, record):
+        import threading
+
+        self._lock = threading.Lock()
+        self._entries = {key: record}
+
+    def _ensure_loaded_locked(self):
+        return None
+
+
+def test_gateway_turn_binds_lazily_at_delegate_boundary():
+    key = "agent:main:telegram:dm:chat:user"
+    record = object()
+    adapter = object()
+    runner = object.__new__(GatewayRunner)
+    runner.session_store = _Store(key, record)
+    runner._adapter_for_source = lambda source: adapter
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="chat",
+        user_id="user",
+        profile="default",
+    )
+    context = SessionContext(source=source, connected_platforms=[], home_channels={}, session_key=key)
+    tokens = runner._set_session_env(context)
+    try:
+        from gateway.session_context import current_gateway_run_authority
+
+        authority = current_gateway_run_authority()
+        assert authority is not None
+        assert authority.record is record
+        assert authority.transport is adapter
+
+        parent = SimpleNamespace(
+            _delegate_depth=0,
+            _active_children=[],
+            _active_children_lock=__import__("threading").Lock(),
+            tool_progress_callback=None,
+            _session_db=None,
+            platform="telegram",
+        )
+        binding = SimpleNamespace(
+            ui_session_id="",
+            owner_generation=str(id(record)),
+            transport_generation=str(id(adapter)),
+            session_key=key,
+            profile="default",
+            cwd="/workspace",
+            head="a" * 40,
+            repo_root="/workspace",
+            worktree_root="/workspace",
+            git_common_dir="/workspace/.git",
+            branch="main",
+            ref="refs/heads/main",
+            short_head="aaaaaaaaaaaa",
+            differences=lambda other: (),
+            display=lambda: "repo=/workspace branch=main sha=aaaaaaaaaaaa",
+        )
+        child = MagicMock()
+        with (
+            patch("tui_gateway.git_probe.capture_run_binding", return_value=binding),
+            patch("tui_gateway.git_probe.run_git", return_value=""),
+            patch("tools.delegate_tool._get_worktree_isolation", return_value=False),
+            patch("tools.delegate_tool._build_child_preserving_parent_tools", return_value=child) as build,
+            patch("tools.delegate_tool._run_single_child", return_value={"status": "completed"}),
+        ):
+            result = delegate_task(goal="Inspect the selected repository", parent_agent=parent)
+
+        assert '"status": "completed"' in result
+        build.assert_called_once()
+        assert build.call_args.kwargs["run_binding"] is binding
+    finally:
+        runner._clear_session_env(tokens)
+        reset_session_vars()
+
+
+def test_gateway_progress_keeps_bound_checkout_visible():
+    progress = queue.Queue()
+    ctx = MagicMock()
+    ctx.progress_queue = progress
+    ctx._run_still_current.return_value = True
+    runner = object.__new__(GatewayRunner)
+    TurnRunner(runner, ctx).progress_callback(
+        "subagent.start",
+        preview="Inspect the selected repository",
+        run_binding={"repo": "/workspace", "branch": "main", "sha": "abc123456789"},
+    )
+    assert progress.get_nowait() == (
+        "🔀 delegation started · repo=/workspace branch=main sha=abc123456789"
+    )

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -597,8 +597,13 @@ class TestDelegateTask(unittest.TestCase):
                 child_db = kwargs["session_db"]
                 self.assertIsInstance(child_db, SessionDB)
                 self.assertIsNot(child_db, parent_db)
+                # ``get_shared_session_db`` canonicalizes the path, while
+                # ``SessionDB`` preserves an explicitly supplied spelling
+                # (macOS commonly aliases ``/tmp`` to ``/private/tmp``).
+                # The invariant is the database file, not its spelling.
                 self.assertEqual(
-                    str(child_db.db_path), str(parent_db.db_path)
+                    Path(child_db.db_path).resolve(),
+                    Path(parent_db.db_path).resolve(),
                 )
             finally:
                 if child_db is not None:

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -274,8 +274,10 @@ class TestDelegateTask(unittest.TestCase):
     def test_live_owner_drift_refuses_before_child_construction(self):
         from gateway.session_context import RunBinding, reset_run_binding, set_run_binding
         from tui_gateway import server
+        from tui_gateway.transport import bind_transport, reset_transport
 
-        live_record = {"session_key": "session-live", "transport": None}
+        live_transport = object()
+        live_record = {"session_key": "session-live", "transport": live_transport}
         binding = RunBinding(
             cwd="/workspace",
             repo_root="/workspace",
@@ -288,10 +290,14 @@ class TestDelegateTask(unittest.TestCase):
             ui_session_id="ui-live",
             profile="default",
             owner_generation=str(id({})),
-            transport_generation=str(id(None)),
+            transport_generation=str(id(live_transport)),
         )
         binding_token = set_run_binding(binding)
         live_token = server._current_runtime_session_record.set(live_record)
+        transport_token = bind_transport(live_transport)
+        with server._sessions_lock:
+            previous = server._sessions.get("ui-live")
+            server._sessions["ui-live"] = live_record
         try:
             parent = _make_mock_parent()
             with patch("tools.delegate_tool._build_child_preserving_parent_tools") as build:
@@ -302,6 +308,60 @@ class TestDelegateTask(unittest.TestCase):
             self.assertIn("live session owner changed", result["error"])
             build.assert_not_called()
         finally:
+            with server._sessions_lock:
+                if previous is None:
+                    server._sessions.pop("ui-live", None)
+                else:
+                    server._sessions["ui-live"] = previous
+            server._current_runtime_session_record.reset(live_token)
+            reset_transport(transport_token)
+            reset_run_binding(binding_token)
+
+    def test_registry_replacement_rejects_stale_context_authority(self):
+        from gateway.session_context import RunBinding, reset_run_binding, set_run_binding
+        from tui_gateway import server
+        from tui_gateway.transport import bind_transport, reset_transport
+
+        old_transport = object()
+        new_transport = object()
+        old_record = {"session_key": "session-live", "transport": old_transport}
+        new_record = {"session_key": "session-live", "transport": new_transport}
+        binding = RunBinding(
+            cwd="/workspace",
+            repo_root="/workspace",
+            worktree_root="/workspace",
+            git_common_dir="/workspace/.git",
+            branch="main",
+            ref="refs/heads/main",
+            head="0" * 40,
+            session_key="session-live",
+            ui_session_id="ui-live",
+            profile="default",
+            owner_generation=str(id(old_record)),
+            transport_generation=str(id(old_transport)),
+        )
+        binding_token = set_run_binding(binding)
+        live_token = server._current_runtime_session_record.set(old_record)
+        transport_token = bind_transport(old_transport)
+        with server._sessions_lock:
+            previous = server._sessions.get("ui-live")
+            server._sessions["ui-live"] = new_record
+        try:
+            parent = _make_mock_parent()
+            with patch("tools.delegate_tool._build_child_preserving_parent_tools") as build:
+                result = json.loads(
+                    delegate_task(goal="Refuse replaced UI session", parent_agent=parent)
+                )
+            self.assertIn("error", result)
+            self.assertIn("replaced or rebound", result["error"])
+            build.assert_not_called()
+        finally:
+            with server._sessions_lock:
+                if previous is None:
+                    server._sessions.pop("ui-live", None)
+                else:
+                    server._sessions["ui-live"] = previous
+            reset_transport(transport_token)
             server._current_runtime_session_record.reset(live_token)
             reset_run_binding(binding_token)
 
@@ -315,6 +375,9 @@ class TestDelegateTask(unittest.TestCase):
             "transport": None,
         }
         live_token = server._current_runtime_session_record.set(live_record)
+        with server._sessions_lock:
+            previous = server._sessions.get("ui-live")
+            server._sessions["ui-live"] = live_record
         try:
             parent = _make_mock_parent()
             with patch("tools.delegate_tool._build_child_preserving_parent_tools") as build:
@@ -325,13 +388,20 @@ class TestDelegateTask(unittest.TestCase):
             self.assertIn("must be attached to a Git worktree", result["error"])
             build.assert_not_called()
         finally:
+            with server._sessions_lock:
+                if previous is None:
+                    server._sessions.pop("ui-live", None)
+                else:
+                    server._sessions["ui-live"] = previous
             server._current_runtime_session_record.reset(live_token)
 
     def test_bound_worktree_failure_refuses_before_child_construction(self):
         from gateway.session_context import RunBinding, reset_run_binding, set_run_binding
         from tui_gateway import server
+        from tui_gateway.transport import bind_transport, reset_transport
 
-        live_record = {"session_key": "session-live", "transport": None}
+        live_transport = object()
+        live_record = {"session_key": "session-live", "transport": live_transport}
         binding = RunBinding(
             cwd="/workspace",
             repo_root="/workspace",
@@ -344,10 +414,14 @@ class TestDelegateTask(unittest.TestCase):
             ui_session_id="ui-live",
             profile="default",
             owner_generation=str(id(live_record)),
-            transport_generation=str(id(None)),
+            transport_generation=str(id(live_transport)),
         )
         binding_token = set_run_binding(binding)
         live_token = server._current_runtime_session_record.set(live_record)
+        transport_token = bind_transport(live_transport)
+        with server._sessions_lock:
+            previous = server._sessions.get("ui-live")
+            server._sessions["ui-live"] = live_record
         try:
             parent = _make_mock_parent()
             with (
@@ -366,7 +440,13 @@ class TestDelegateTask(unittest.TestCase):
             self.assertIn("no child was spawned", result["error"])
             build.assert_not_called()
         finally:
+            with server._sessions_lock:
+                if previous is None:
+                    server._sessions.pop("ui-live", None)
+                else:
+                    server._sessions["ui-live"] = previous
             server._current_runtime_session_record.reset(live_token)
+            reset_transport(transport_token)
             reset_run_binding(binding_token)
 
 

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -271,6 +271,104 @@ class TestDelegateTask(unittest.TestCase):
         self.assertIn("error", result)
         self.assertIn("depth limit", result["error"].lower())
 
+    def test_live_owner_drift_refuses_before_child_construction(self):
+        from gateway.session_context import RunBinding, reset_run_binding, set_run_binding
+        from tui_gateway import server
+
+        live_record = {"session_key": "session-live", "transport": None}
+        binding = RunBinding(
+            cwd="/workspace",
+            repo_root="/workspace",
+            worktree_root="/workspace",
+            git_common_dir="/workspace/.git",
+            branch="main",
+            ref="refs/heads/main",
+            head="0" * 40,
+            session_key="session-live",
+            ui_session_id="ui-live",
+            profile="default",
+            owner_generation=str(id({})),
+            transport_generation=str(id(None)),
+        )
+        binding_token = set_run_binding(binding)
+        live_token = server._current_runtime_session_record.set(live_record)
+        try:
+            parent = _make_mock_parent()
+            with patch("tools.delegate_tool._build_child_preserving_parent_tools") as build:
+                result = json.loads(
+                    delegate_task(goal="Refuse stale live owner", parent_agent=parent)
+                )
+            self.assertIn("error", result)
+            self.assertIn("live session owner changed", result["error"])
+            build.assert_not_called()
+        finally:
+            server._current_runtime_session_record.reset(live_token)
+            reset_run_binding(binding_token)
+
+    def test_non_git_live_turn_allows_chat_but_refuses_delegation(self):
+        from tui_gateway import server
+
+        live_record = {
+            "session_key": "session-live",
+            "cwd": self._testMethodName,
+            "profile_home": None,
+            "transport": None,
+        }
+        live_token = server._current_runtime_session_record.set(live_record)
+        try:
+            parent = _make_mock_parent()
+            with patch("tools.delegate_tool._build_child_preserving_parent_tools") as build:
+                result = json.loads(
+                    delegate_task(goal="Refuse non Git delegation", parent_agent=parent)
+                )
+            self.assertIn("error", result)
+            self.assertIn("must be attached to a Git worktree", result["error"])
+            build.assert_not_called()
+        finally:
+            server._current_runtime_session_record.reset(live_token)
+
+    def test_bound_worktree_failure_refuses_before_child_construction(self):
+        from gateway.session_context import RunBinding, reset_run_binding, set_run_binding
+        from tui_gateway import server
+
+        live_record = {"session_key": "session-live", "transport": None}
+        binding = RunBinding(
+            cwd="/workspace",
+            repo_root="/workspace",
+            worktree_root="/workspace",
+            git_common_dir="/workspace/.git",
+            branch="main",
+            ref="refs/heads/main",
+            head="0" * 40,
+            session_key="session-live",
+            ui_session_id="ui-live",
+            profile="default",
+            owner_generation=str(id(live_record)),
+            transport_generation=str(id(None)),
+        )
+        binding_token = set_run_binding(binding)
+        live_token = server._current_runtime_session_record.set(live_record)
+        try:
+            parent = _make_mock_parent()
+            with (
+                patch("tui_gateway.git_probe.capture_run_binding", return_value=binding),
+                patch("tui_gateway.git_probe.run_git", return_value=""),
+                patch("tui_gateway.server._current_profile_name", return_value="default"),
+                patch("tools.delegate_tool._get_worktree_isolation", return_value=True),
+                patch("tools.subagent_worktree.local_backend_active", return_value=True),
+                patch("tools.subagent_worktree.create_subagent_worktree", return_value=None),
+                patch("tools.delegate_tool._build_child_preserving_parent_tools") as build,
+            ):
+                result = json.loads(
+                    delegate_task(goal="Refuse missing bound worktree", parent_agent=parent)
+                )
+            self.assertIn("error", result)
+            self.assertIn("no child was spawned", result["error"])
+            build.assert_not_called()
+        finally:
+            server._current_runtime_session_record.reset(live_token)
+            reset_run_binding(binding_token)
+
 
     def test_child_inherits_runtime_credentials(self):
         parent = _make_mock_parent(depth=0)

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -306,6 +306,8 @@ class TestDelegateTask(unittest.TestCase):
                 )
             self.assertIn("error", result)
             self.assertIn("live session owner changed", result["error"])
+            self.assertEqual(result["delegation_status"], "failed")
+            self.assertEqual(json.dumps(result).count('"delegation_status": "failed"'), 1)
             build.assert_not_called()
         finally:
             with server._sessions_lock:
@@ -354,6 +356,8 @@ class TestDelegateTask(unittest.TestCase):
                 )
             self.assertIn("error", result)
             self.assertIn("replaced or rebound", result["error"])
+            self.assertEqual(result["delegation_status"], "failed")
+            self.assertEqual(json.dumps(result).count('"delegation_status": "failed"'), 1)
             build.assert_not_called()
         finally:
             with server._sessions_lock:
@@ -438,6 +442,8 @@ class TestDelegateTask(unittest.TestCase):
                 )
             self.assertIn("error", result)
             self.assertIn("no child was spawned", result["error"])
+            self.assertEqual(result["delegation_status"], "failed")
+            self.assertEqual(json.dumps(result).count('"delegation_status": "failed"'), 1)
             build.assert_not_called()
         finally:
             with server._sessions_lock:

--- a/tests/tools/test_subagent_worktree.py
+++ b/tests/tools/test_subagent_worktree.py
@@ -94,6 +94,21 @@ class SubagentWorktreeTests(unittest.TestCase):
         (Path(info["path"]) / "child.txt").write_text("x", encoding="utf-8")
         self.assertFalse((repo / "child.txt").exists())
 
+    def test_create_can_start_from_bound_commit(self):
+        repo = _make_repo(self.tmp)
+        bound_head = _git(["rev-parse", "HEAD"], repo).stdout.strip()
+        (repo / "later.txt").write_text("later\n", encoding="utf-8")
+        _git(["add", "later.txt"], repo)
+        _git(["commit", "-q", "-m", "later"], repo)
+
+        info = sw.create_subagent_worktree(
+            str(repo), "bound1", base_commit=bound_head
+        )
+        self.assertIsNotNone(info)
+        assert info is not None
+        self.assertEqual(info["base_commit"], bound_head)
+        self.assertFalse((Path(info["path"]) / "later.txt").exists())
+
     def test_create_unborn_head_returns_none(self):
         repo = self.tmp / "empty"
         repo.mkdir()

--- a/tests/tui_gateway/test_run_binding.py
+++ b/tests/tui_gateway/test_run_binding.py
@@ -1,0 +1,72 @@
+"""Behavioral coverage for server-owned per-turn RunBinding identity."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from gateway.session_context import RunBinding, current_run_binding, reset_run_binding, set_run_binding
+from tui_gateway.git_probe import capture_run_binding
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=cwd, check=True, capture_output=True, text=True
+    )
+    return result.stdout.strip()
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+    (repo / "README.md").write_text("seed\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-q", "-m", "seed")
+    return repo
+
+
+def test_capture_is_server_owned_and_contains_full_checkout_identity(tmp_path):
+    repo = _repo(tmp_path)
+
+    binding = capture_run_binding(
+        str(repo), session_key="conversation-1", ui_session_id="window-1", profile="default"
+    )
+
+    assert binding.cwd == str(repo.resolve())
+    assert binding.worktree_root == str(repo.resolve())
+    assert binding.repo_root == str(repo.resolve())
+    assert binding.git_common_dir == str((repo / ".git").resolve())
+    assert binding.branch
+    assert binding.ref == "refs/heads/" + binding.branch
+    assert len(binding.head) == 40
+    assert binding.session_key == "conversation-1"
+    assert binding.ui_session_id == "window-1"
+    assert binding.profile == "default"
+    assert binding.short_head == binding.head[:12]
+
+
+def test_binding_differences_identify_owner_and_checkout_drift(tmp_path):
+    repo = _repo(tmp_path)
+    original = capture_run_binding(
+        str(repo), session_key="conversation-1", ui_session_id="window-1", profile="default"
+    )
+    changed = RunBinding(
+        **{**original.__dict__, "session_key": "conversation-2", "profile": "coder"}
+    )
+
+    assert original.differences(changed) == ("session_key", "profile")
+    assert not original.matches(changed)
+
+
+def test_run_binding_context_is_explicitly_scoped(tmp_path):
+    repo = _repo(tmp_path)
+    binding = capture_run_binding(str(repo), session_key="conversation-1")
+    token = set_run_binding(binding)
+    try:
+        assert current_run_binding() is binding
+    finally:
+        reset_run_binding(token)
+    assert current_run_binding() is None

--- a/tests/tui_gateway/test_subagent_child_mirror.py
+++ b/tests/tui_gateway/test_subagent_child_mirror.py
@@ -77,6 +77,28 @@ def test_no_live_child_session_no_mirror(server, emits):
     assert server._child_mirrors == {}
 
 
+def test_parent_progress_preserves_compact_run_binding(server, emits):
+    _relay(
+        server,
+        "subagent.tool",
+        tool_name="terminal",
+        preview="pwd",
+        child_session_id="child-1",
+        run_binding={
+            "repo": "/workspace/hermes",
+            "branch": "main",
+            "sha": "0123456789ab",
+        },
+    )
+
+    parent = next(payload for event, sid, payload in emits if sid == "parent-sid")
+    assert parent["run_binding"] == {
+        "repo": "/workspace/hermes",
+        "branch": "main",
+        "sha": "0123456789ab",
+    }
+
+
 def test_live_child_session_gets_native_stream(server, emits):
     # A window resumed the child session: live sid differs from the stored key.
     server._sessions["live-1"] = {"session_key": "child-1", "agent": None}
@@ -236,5 +258,4 @@ def test_text_mirrors_as_message_delta(server, emits):
         ("message.delta", {"text": "Here is "}),
         ("message.delta", {"text": "the answer."}),
     ]
-
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -4360,6 +4360,15 @@ def delegate_task(
                     "Start a new conversation turn after selecting the intended worktree."
                 )
         _bound_run_binding = _reprobed
+        try:
+            from gateway.session_context import set_run_binding
+
+            # Preserve the server-derived result for the enclosing gateway
+            # run. The event-loop final-reply path consumes only the compact
+            # projection; it never trusts model/RPC text for identity.
+            set_run_binding(_bound_run_binding)
+        except Exception:
+            logger.debug("Could not publish gateway run binding", exc_info=True)
         if run_git(_binding_cwd, "status", "--porcelain", "--untracked-files=all"):
             return tool_error(
                 "Delegation refused: the selected worktree has uncommitted changes. "

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1467,6 +1467,7 @@ def _build_child_progress_callback(
     model: Optional[str] = None,
     toolsets: Optional[List[str]] = None,
     session_ref: Optional[Dict[str, Any]] = None,
+    run_binding: Any = None,
 ) -> Optional[callable]:
     """Build a callback that relays child agent tool calls to the parent display.
 
@@ -1531,7 +1532,7 @@ def _build_child_progress_callback(
         try:
             from gateway.session_context import current_run_binding
 
-            binding = current_run_binding()
+            binding = run_binding or current_run_binding()
             if binding is not None:
                 kw["run_binding"] = {
                     "repo": binding.repo_root,
@@ -1777,6 +1778,7 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    run_binding: Any = None,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -1910,6 +1912,7 @@ def _build_child_agent(
         model=effective_model_for_cb,
         toolsets=child_toolsets,
         session_ref=child_session_ref,
+        run_binding=run_binding,
     )
 
     # Each subagent gets its own iteration budget capped at max_iterations
@@ -2853,7 +2856,12 @@ def _run_single_child(
 
     # Worktree-isolation state: populated inside the try once the child's
     # task id is known; the default no-op keeps every early error path safe.
-    _worktree_info: Optional[Dict[str, str]] = None
+    _bound_worktree_info = getattr(child, "_bound_worktree_info", None)
+    _worktree_info: Optional[Dict[str, str]] = (
+        _bound_worktree_info
+        if isinstance(_bound_worktree_info, dict)
+        else None
+    )
 
     def _attach_worktree(entry_dict: Dict[str, Any]) -> None:
         """Inspect + prune the child worktree, reporting into the entry."""
@@ -2937,8 +2945,9 @@ def _run_single_child(
         # Opt-in worktree isolation (delegation.worktree_isolation, inspired
         # by Muse Code's --subagent-worktree-isolation): give this child its
         # own git worktree branched from the parent repo's HEAD, and start its
-        # terminal there. Git-only and local-backend-only; any failure
-        # degrades silently to the shared-workspace behavior above.
+        # terminal there. Git-only and local-backend-only. Bound runs fail
+        # closed when isolation cannot be established; legacy unbound callers
+        # retain the historical best-effort behavior.
         if _get_worktree_isolation():
             try:
                 from tools import subagent_worktree
@@ -2962,11 +2971,30 @@ def _run_single_child(
                             run_binding.head if run_binding is not None else None
                         ),
                     )
+                    if run_binding is not None and _worktree_info is None:
+                        raise RuntimeError(
+                            "bound Git worktree creation failed; refusing shared-workspace fallback"
+                        )
                 else:
+                    if run_binding is not None:
+                        raise RuntimeError(
+                            "bound delegation requires a local isolated Git worktree"
+                        )
                     logger.debug(
                         "worktree isolation skipped: non-local terminal backend"
                     )
             except Exception as e:
+                if run_binding is not None:
+                    logger.warning("bound worktree isolation refused: %s", e)
+                    return {
+                        "status": "failed",
+                        "exit_reason": "error",
+                        "error": str(e),
+                        "summary": (
+                            "Delegation refused: the bound Git worktree could not "
+                            "be created; the parent workspace was not used."
+                        ),
+                    }
                 logger.debug("worktree isolation setup failed: %s", e)
             if _worktree_info is not None:
                 try:
@@ -4136,43 +4164,105 @@ def delegate_task(
             return tool_error(f"Task {i} output_schema invalid: {schema_err}")
         task_schemas.append(coerced_schema)
 
-    # A gateway/TUI turn carries a server-derived immutable RunBinding.  Before
-    # constructing even one child, reprobe the exact session-owned checkout
-    # and identity.  This closes the stale-session/worktree window without
-    # making CLI and legacy callers (which have no binding) fail unexpectedly.
-    from gateway.session_context import current_run_binding, get_session_env
+    # A gateway/TUI turn carries a server-derived immutable RunBinding. Before
+    # constructing even one child, read the live session record and transport
+    # generation, then reprobe the exact session-owned checkout. Legacy CLI
+    # callers have no live record and retain their existing behavior.
+    from gateway.session_context import current_run_binding
 
     _bound_run_binding = current_run_binding()
-    if _bound_run_binding is not None:
-        _binding_cwd = _bound_run_binding.cwd
-        _parent_task_id = getattr(parent_agent, "_current_task_id", None)
-        try:
-            from tools.terminal_tool import get_session_cwd
+    try:
+        from tui_gateway import server as _gateway_server
+        from tui_gateway.transport import current_transport as _current_transport
 
-            _binding_cwd = get_session_cwd(_parent_task_id) or _binding_cwd
-        except Exception:
-            pass
+        _live_session_record = _gateway_server._current_runtime_session_record.get()
+        _live_transport = _current_transport()
+    except Exception:
+        _live_session_record = None
+        _live_transport = None
+
+    if _bound_run_binding is not None or _live_session_record is not None:
+        if _live_session_record is None:
+            return tool_error(
+                "Delegation refused: the originating live session is no longer active."
+            )
+        _parent_task_id = getattr(parent_agent, "_current_task_id", None)
+        _binding_drift: list[str] = []
+        if (
+            _bound_run_binding is not None
+            and _bound_run_binding.owner_generation
+            and _bound_run_binding.owner_generation != str(id(_live_session_record))
+        ):
+            _binding_drift.append("owner_session")
+        if (
+            _bound_run_binding is not None
+            and _bound_run_binding.transport_generation
+            and _bound_run_binding.transport_generation != str(id(_live_transport))
+        ):
+            _binding_drift.append("transport_generation")
+        if _live_session_record.get("transport") is not _live_transport:
+            _binding_drift.append("transport")
+        _live_key = str(_live_session_record.get("session_key") or "")
+        _live_profile_home = _live_session_record.get("profile_home")
+        _live_profile = (
+            Path(str(_live_profile_home)).name
+            if _live_profile_home
+            else str(_gateway_server._current_profile_name())
+        )
+        if _bound_run_binding is not None:
+            if _bound_run_binding.session_key != _live_key:
+                _binding_drift.append("session_key")
+            if _bound_run_binding.profile != _live_profile:
+                _binding_drift.append("profile")
+        if _binding_drift:
+            return tool_error(
+                "Delegation refused: the live session owner changed after this "
+                f"turn was bound ({', '.join(dict.fromkeys(_binding_drift))})."
+            )
+
+        _binding_cwd = str(_live_session_record.get("cwd") or "")
+        if not _binding_cwd:
+            try:
+                from tools.terminal_tool import get_session_cwd
+
+                _binding_cwd = get_session_cwd(_parent_task_id) or ""
+            except Exception:
+                _binding_cwd = ""
         try:
-            from tui_gateway.git_probe import capture_run_binding
+            from tui_gateway.git_probe import capture_run_binding, run_git
 
             _reprobed = capture_run_binding(
                 _binding_cwd,
-                session_key=get_session_env("HERMES_SESSION_KEY", ""),
-                ui_session_id=get_session_env("HERMES_UI_SESSION_ID", ""),
-                profile=get_session_env("HERMES_SESSION_PROFILE", ""),
+                session_key=_live_key,
+                ui_session_id=(
+                    _bound_run_binding.ui_session_id
+                    if _bound_run_binding is not None
+                    else ""
+                ),
+                profile=_live_profile,
+                owner_generation=str(id(_live_session_record)),
+                transport_generation=str(id(_live_transport)),
             )
         except ValueError as exc:
             return tool_error(
-                "Delegation refused: the bound Git worktree is no longer available. "
+                "Delegation refused: the selected live session must be attached "
+                "to a Git worktree. "
                 f"{exc}"
             )
-        _binding_drift = _bound_run_binding.differences(_reprobed)
-        if _binding_drift:
+        if _bound_run_binding is not None:
+            _binding_drift = list(_bound_run_binding.differences(_reprobed))
+            if _binding_drift:
+                return tool_error(
+                    "Delegation refused: the live session/worktree changed after "
+                    f"this turn was bound ({', '.join(_binding_drift)}). "
+                    f"Bound {_bound_run_binding.display()}; current {_reprobed.display()}. "
+                    "Start a new conversation turn after selecting the intended worktree."
+                )
+        _bound_run_binding = _reprobed
+        if run_git(_binding_cwd, "status", "--porcelain", "--untracked-files=all"):
             return tool_error(
-                "Delegation refused: the live session/worktree changed after this "
-                f"turn was bound ({', '.join(_binding_drift)}). "
-                f"Bound {_bound_run_binding.display()}; current {_reprobed.display()}. "
-                "Start a new conversation turn after selecting the intended worktree."
+                "Delegation refused: the selected worktree has uncommitted changes. "
+                "Commit or clean it before delegating so the bound HEAD is complete."
             )
 
     overall_start = time.monotonic()
@@ -4230,6 +4320,40 @@ def delegate_task(
         _capture_gateway_steer_authority(_origin_ui_session_id)
     )
 
+    # Reserve every bound child worktree before constructing any child agent.
+    # This makes an isolation failure a true zero-child refusal instead of
+    # constructing a child and silently sending it into the parent workspace.
+    _precreated_worktrees: list[Optional[Dict[str, str]]] = []
+    if _bound_run_binding is not None and _get_worktree_isolation():
+        from tools import subagent_worktree
+
+        if not subagent_worktree.local_backend_active():
+            return tool_error(
+                "Delegation refused: bound runs require a local isolated Git "
+                "worktree, but the active terminal backend cannot create one."
+            )
+        import uuid as _uuid
+
+        _preflight_cwd = _bound_run_binding.cwd
+        for _preflight_index in range(len(task_list)):
+            _info = subagent_worktree.create_subagent_worktree(
+                _preflight_cwd,
+                subagent_id=(
+                    f"bound-{_preflight_index}-{_uuid.uuid4().hex[:8]}"
+                ),
+                base_commit=_bound_run_binding.head,
+            )
+            if _info is None:
+                for _created in _precreated_worktrees:
+                    if _created is not None:
+                        subagent_worktree.finalize_subagent_worktree(_created)
+                return tool_error(
+                    "Delegation refused: the bound Git worktree could not be "
+                    "created; no child was spawned and the parent workspace "
+                    "was not used as a fallback."
+                )
+            _precreated_worktrees.append(_info)
+
     # Build all child agents on the main thread (thread-safe construction).
     # _build_child_preserving_parent_tools saves/restores the parent's
     # resolved tool names around each construction under a lock, so child
@@ -4269,11 +4393,19 @@ def delegate_task(
                 override_acp_command=creds.get("command"),
                 override_acp_args=creds.get("args"),
                 role=effective_role,
+                run_binding=_bound_run_binding,
             )
         except ValueError as exc:
             # Explicit-pin preflight failures (e.g. pinned delegation.command
             # missing from PATH) refuse the spawn loudly (#80450).
+            from tools import subagent_worktree as _sw
+
+            for _created in _precreated_worktrees:
+                if _created is not None:
+                    _sw.finalize_subagent_worktree(_created)
             return tool_error(str(exc))
+        if i < len(_precreated_worktrees):
+            child._bound_worktree_info = _precreated_worktrees[i]
         # Attach the validated schema for the completion-side validation
         # hook in _run_single_child. Absent (None) on schema-less tasks.
         if _task_schema is not None:

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -4175,6 +4175,33 @@ def delegate_task(
 
     _bound_run_binding = current_run_binding()
     _gateway_run_authority = current_gateway_run_authority()
+
+    def _publish_delegation_status(status: str) -> None:
+        """Publish terminal delegation state on the server-owned turn rail."""
+        try:
+            from gateway.session_context import set_delegation_status
+
+            set_delegation_status(status)
+        except Exception:
+            logger.debug("Could not publish delegation status", exc_info=True)
+
+    def _binding_projection() -> Optional[Dict[str, str]]:
+        if _bound_run_binding is None:
+            return None
+        return {
+            "repo": _bound_run_binding.repo_root,
+            "branch": _bound_run_binding.branch or _bound_run_binding.ref,
+            "sha": _bound_run_binding.short_head,
+        }
+
+    def _binding_refusal(message: str) -> str:
+        _publish_delegation_status("failed")
+        extra: Dict[str, Any] = {"delegation_status": "failed"}
+        projection = _binding_projection()
+        if projection is not None:
+            extra["run_binding"] = projection
+        return tool_error(message, **extra)
+
     _gateway_server = None
     try:
         from tui_gateway import server as _gateway_server
@@ -4194,7 +4221,7 @@ def delegate_task(
         # helper so a replaced or rebound row cannot pass on stale context.
         if not _bound_run_binding.ui_session_id and _gateway_run_authority is not None:
             if not _gateway_run_authority.validate():
-                return tool_error(
+                return _binding_refusal(
                     "Delegation refused: the originating live gateway session was "
                     "replaced or rebound after this turn was bound. Start a new "
                     "conversation turn."
@@ -4208,7 +4235,7 @@ def delegate_task(
             }
             _live_transport = _gateway_run_authority.transport
         elif _gateway_server is None:
-            return tool_error(
+            return _binding_refusal(
                 "Delegation refused: the live UI session authority is unavailable."
             )
         else:
@@ -4221,7 +4248,7 @@ def delegate_task(
                 or _authority_record is not _context_session_record
                 or _authority_transport is not _context_transport
             ):
-                return tool_error(
+                return _binding_refusal(
                     "Delegation refused: the live UI session was replaced or "
                     "rebound after this turn was bound. Start a new conversation turn."
                 )
@@ -4238,7 +4265,7 @@ def delegate_task(
                 for record in list(_gateway_server._sessions.values())
             )
         if not _registered:
-            return tool_error(
+            return _binding_refusal(
                 "Delegation refused: the originating live UI session is no "
                 "longer registered. Start a new conversation turn."
             )
@@ -4247,7 +4274,7 @@ def delegate_task(
         # SessionStore/adapter authority is the live owner registry instead;
         # validate it now, while still keeping Git capture lazy.
         if not _gateway_run_authority.validate():
-            return tool_error(
+            return _binding_refusal(
                 "Delegation refused: the originating live gateway session is no "
                 "longer current. Start a new conversation turn."
             )
@@ -4262,7 +4289,7 @@ def delegate_task(
 
     if _bound_run_binding is not None or _live_session_record is not None:
         if _live_session_record is None:
-            return tool_error(
+            return _binding_refusal(
                 "Delegation refused: the originating live session is no longer active."
             )
         _parent_task_id = getattr(parent_agent, "_current_task_id", None)
@@ -4306,7 +4333,7 @@ def delegate_task(
             if _bound_run_binding.profile != _live_profile:
                 _binding_drift.append("profile")
         if _binding_drift:
-            return tool_error(
+            return _binding_refusal(
                 "Delegation refused: the live session owner changed after this "
                 f"turn was bound ({', '.join(dict.fromkeys(_binding_drift))})."
             )
@@ -4345,7 +4372,7 @@ def delegate_task(
                 ),
             )
         except ValueError as exc:
-            return tool_error(
+            return _binding_refusal(
                 "Delegation refused: the selected live session must be attached "
                 "to a Git worktree. "
                 f"{exc}"
@@ -4353,7 +4380,7 @@ def delegate_task(
         if _bound_run_binding is not None:
             _binding_drift = list(_bound_run_binding.differences(_reprobed))
             if _binding_drift:
-                return tool_error(
+                return _binding_refusal(
                     "Delegation refused: the live session/worktree changed after "
                     f"this turn was bound ({', '.join(_binding_drift)}). "
                     f"Bound {_bound_run_binding.display()}; current {_reprobed.display()}. "
@@ -4370,7 +4397,7 @@ def delegate_task(
         except Exception:
             logger.debug("Could not publish gateway run binding", exc_info=True)
         if run_git(_binding_cwd, "status", "--porcelain", "--untracked-files=all"):
-            return tool_error(
+            return _binding_refusal(
                 "Delegation refused: the selected worktree has uncommitted changes. "
                 "Commit or clean it before delegating so the bound HEAD is complete."
             )
@@ -4438,7 +4465,7 @@ def delegate_task(
         from tools import subagent_worktree
 
         if not subagent_worktree.local_backend_active():
-            return tool_error(
+            return _binding_refusal(
                 "Delegation refused: bound runs require a local isolated Git "
                 "worktree, but the active terminal backend cannot create one."
             )
@@ -4457,7 +4484,7 @@ def delegate_task(
                 for _created in _precreated_worktrees:
                     if _created is not None:
                         subagent_worktree.finalize_subagent_worktree(_created)
-                return tool_error(
+                return _binding_refusal(
                     "Delegation refused: the bound Git worktree could not be "
                     "created; no child was spawned and the parent workspace "
                     "was not used as a fallback."
@@ -4513,7 +4540,7 @@ def delegate_task(
             for _created in _precreated_worktrees:
                 if _created is not None:
                     _sw.finalize_subagent_worktree(_created)
-            return tool_error(str(exc))
+            return _binding_refusal(str(exc))
         if i < len(_precreated_worktrees):
             child._bound_worktree_info = _precreated_worktrees[i]
         # Attach the validated schema for the completion-side validation
@@ -4738,9 +4765,20 @@ def delegate_task(
                     entry["live_transcript"] = live_paths[_idx]
         update_manifest_statuses(live_deleg_id, results)
 
+        # The child lifecycle owns this outcome.  The parent agent's generic
+        # ``failed`` flag describes the enclosing model turn and is not a
+        # delegation result, so never use it for the user-facing binding line.
+        _delegation_status = (
+            "completed"
+            if results and all(entry.get("status") == "completed" for entry in results)
+            else "failed"
+        )
+        _publish_delegation_status(_delegation_status)
+
         combined: Dict[str, Any] = {
             "results": results,
             "total_duration_seconds": total_duration,
+            "delegation_status": _delegation_status,
         }
         if _bound_run_binding is not None:
             combined["run_binding"] = {

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -4171,15 +4171,57 @@ def delegate_task(
     from gateway.session_context import current_run_binding
 
     _bound_run_binding = current_run_binding()
+    _gateway_server = None
     try:
         from tui_gateway import server as _gateway_server
         from tui_gateway.transport import current_transport as _current_transport
 
-        _live_session_record = _gateway_server._current_runtime_session_record.get()
-        _live_transport = _current_transport()
+        _context_session_record = _gateway_server._current_runtime_session_record.get()
+        _context_transport = _current_transport()
     except Exception:
-        _live_session_record = None
-        _live_transport = None
+        _context_session_record = None
+        _context_transport = None
+
+    _live_session_record = _context_session_record
+    _live_transport = _context_transport
+    if _bound_run_binding is not None:
+        # The ContextVar is only the turn's captured expectation. Resolve the
+        # public UI id against the live registry under its existing authority
+        # helper so a replaced or rebound row cannot pass on stale context.
+        if _gateway_server is None:
+            return tool_error(
+                "Delegation refused: the live UI session authority is unavailable."
+            )
+        _authority = _gateway_server._current_session_steer_authority(
+            _bound_run_binding.ui_session_id
+        )
+        _authority_transport, _authority_record = _authority
+        if (
+            _authority_record is None
+            or _authority_record is not _context_session_record
+            or _authority_transport is not _context_transport
+        ):
+            return tool_error(
+                "Delegation refused: the live UI session was replaced or "
+                "rebound after this turn was bound. Start a new conversation turn."
+            )
+        _live_session_record = _authority_record
+        _live_transport = _authority_transport
+    elif _context_session_record is not None and _gateway_server is not None:
+        # Lazy capture still needs registry admission. There is no UI id in the
+        # ContextVar before the first delegation, so resolve the exact record
+        # and transport by identity under the same registry lock.
+        with _gateway_server._sessions_lock:
+            _registered = any(
+                record is _context_session_record
+                and record.get("transport") is _context_transport
+                for record in list(_gateway_server._sessions.values())
+            )
+        if not _registered:
+            return tool_error(
+                "Delegation refused: the originating live UI session is no "
+                "longer registered. Start a new conversation turn."
+            )
 
     if _bound_run_binding is not None or _live_session_record is not None:
         if _live_session_record is None:

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1528,6 +1528,18 @@ def _build_child_progress_callback(
         if session_ref and session_ref.get("delegation_id"):
             kw["delegation_id"] = str(session_ref["delegation_id"])
         kw["tool_count"] = _tool_count[0]
+        try:
+            from gateway.session_context import current_run_binding
+
+            binding = current_run_binding()
+            if binding is not None:
+                kw["run_binding"] = {
+                    "repo": binding.repo_root,
+                    "branch": binding.branch or binding.ref,
+                    "sha": binding.short_head,
+                }
+        except Exception:
+            pass
         return kw
 
     def _relay(
@@ -2622,6 +2634,7 @@ def _run_single_child(
     owner_session_id: Optional[str] = None,
     owner_transport: Any = None,
     owner_session_record: Any = None,
+    run_binding: Any = None,
     **_kwargs,
 ) -> Dict[str, Any]:
     """
@@ -2938,9 +2951,16 @@ def _run_single_child(
                         _parent_cwd = _gsc(parent_task_id)
                     except Exception:
                         pass
+                    if run_binding is None:
+                        from gateway.session_context import current_run_binding
+
+                        run_binding = current_run_binding()
                     _worktree_info = subagent_worktree.create_subagent_worktree(
                         _parent_cwd or _resolve_workspace_hint(parent_agent),
                         subagent_id=_subagent_id,
+                        base_commit=(
+                            run_binding.head if run_binding is not None else None
+                        ),
                     )
                 else:
                     logger.debug(
@@ -4116,6 +4136,45 @@ def delegate_task(
             return tool_error(f"Task {i} output_schema invalid: {schema_err}")
         task_schemas.append(coerced_schema)
 
+    # A gateway/TUI turn carries a server-derived immutable RunBinding.  Before
+    # constructing even one child, reprobe the exact session-owned checkout
+    # and identity.  This closes the stale-session/worktree window without
+    # making CLI and legacy callers (which have no binding) fail unexpectedly.
+    from gateway.session_context import current_run_binding, get_session_env
+
+    _bound_run_binding = current_run_binding()
+    if _bound_run_binding is not None:
+        _binding_cwd = _bound_run_binding.cwd
+        _parent_task_id = getattr(parent_agent, "_current_task_id", None)
+        try:
+            from tools.terminal_tool import get_session_cwd
+
+            _binding_cwd = get_session_cwd(_parent_task_id) or _binding_cwd
+        except Exception:
+            pass
+        try:
+            from tui_gateway.git_probe import capture_run_binding
+
+            _reprobed = capture_run_binding(
+                _binding_cwd,
+                session_key=get_session_env("HERMES_SESSION_KEY", ""),
+                ui_session_id=get_session_env("HERMES_UI_SESSION_ID", ""),
+                profile=get_session_env("HERMES_SESSION_PROFILE", ""),
+            )
+        except ValueError as exc:
+            return tool_error(
+                "Delegation refused: the bound Git worktree is no longer available. "
+                f"{exc}"
+            )
+        _binding_drift = _bound_run_binding.differences(_reprobed)
+        if _binding_drift:
+            return tool_error(
+                "Delegation refused: the live session/worktree changed after this "
+                f"turn was bound ({', '.join(_binding_drift)}). "
+                f"Bound {_bound_run_binding.display()}; current {_reprobed.display()}. "
+                "Start a new conversation turn after selecting the intended worktree."
+            )
+
     overall_start = time.monotonic()
     results = []
 
@@ -4263,6 +4322,7 @@ def delegate_task(
                 owner_session_id=_origin_ui_session_id or None,
                 owner_transport=_origin_owner_transport,
                 owner_session_record=_origin_owner_session_record,
+                run_binding=_bound_run_binding,
             )
             results.append(result)
         else:
@@ -4288,6 +4348,7 @@ def delegate_task(
                         owner_session_id=_origin_ui_session_id or None,
                         owner_transport=_origin_owner_transport,
                         owner_session_record=_origin_owner_session_record,
+                        run_binding=_bound_run_binding,
                     )
                     futures[future] = i
 
@@ -4439,6 +4500,12 @@ def delegate_task(
             "results": results,
             "total_duration_seconds": total_duration,
         }
+        if _bound_run_binding is not None:
+            combined["run_binding"] = {
+                "repo": _bound_run_binding.repo_root,
+                "branch": _bound_run_binding.branch or _bound_run_binding.ref,
+                "sha": _bound_run_binding.short_head,
+            }
         if live_paths:
             combined["live_transcripts"] = list(live_paths)
         return combined
@@ -4650,6 +4717,12 @@ def delegate_task(
                 "goals": _goals,
                 "note": note,
             }
+            if _bound_run_binding is not None:
+                payload["run_binding"] = {
+                    "repo": _bound_run_binding.repo_root,
+                    "branch": _bound_run_binding.branch or _bound_run_binding.ref,
+                    "sha": _bound_run_binding.short_head,
+                }
             _sids = [
                 getattr(_c, "_subagent_id", None) for _c in _child_agents
             ]

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -4168,9 +4168,13 @@ def delegate_task(
     # constructing even one child, read the live session record and transport
     # generation, then reprobe the exact session-owned checkout. Legacy CLI
     # callers have no live record and retain their existing behavior.
-    from gateway.session_context import current_run_binding
+    from gateway.session_context import (
+        current_gateway_run_authority,
+        current_run_binding,
+    )
 
     _bound_run_binding = current_run_binding()
+    _gateway_run_authority = current_gateway_run_authority()
     _gateway_server = None
     try:
         from tui_gateway import server as _gateway_server
@@ -4188,25 +4192,41 @@ def delegate_task(
         # The ContextVar is only the turn's captured expectation. Resolve the
         # public UI id against the live registry under its existing authority
         # helper so a replaced or rebound row cannot pass on stale context.
-        if _gateway_server is None:
+        if not _bound_run_binding.ui_session_id and _gateway_run_authority is not None:
+            if not _gateway_run_authority.validate():
+                return tool_error(
+                    "Delegation refused: the originating live gateway session was "
+                    "replaced or rebound after this turn was bound. Start a new "
+                    "conversation turn."
+                )
+            _live_session_record = {
+                "session_key": _gateway_run_authority.session_key,
+                "cwd": _gateway_run_authority.cwd,
+                "profile": _gateway_run_authority.profile,
+                "transport": _gateway_run_authority.transport,
+                "_record_identity": _gateway_run_authority.record,
+            }
+            _live_transport = _gateway_run_authority.transport
+        elif _gateway_server is None:
             return tool_error(
                 "Delegation refused: the live UI session authority is unavailable."
             )
-        _authority = _gateway_server._current_session_steer_authority(
-            _bound_run_binding.ui_session_id
-        )
-        _authority_transport, _authority_record = _authority
-        if (
-            _authority_record is None
-            or _authority_record is not _context_session_record
-            or _authority_transport is not _context_transport
-        ):
-            return tool_error(
-                "Delegation refused: the live UI session was replaced or "
-                "rebound after this turn was bound. Start a new conversation turn."
+        else:
+            _authority = _gateway_server._current_session_steer_authority(
+                _bound_run_binding.ui_session_id
             )
-        _live_session_record = _authority_record
-        _live_transport = _authority_transport
+            _authority_transport, _authority_record = _authority
+            if (
+                _authority_record is None
+                or _authority_record is not _context_session_record
+                or _authority_transport is not _context_transport
+            ):
+                return tool_error(
+                    "Delegation refused: the live UI session was replaced or "
+                    "rebound after this turn was bound. Start a new conversation turn."
+                )
+            _live_session_record = _authority_record
+            _live_transport = _authority_transport
     elif _context_session_record is not None and _gateway_server is not None:
         # Lazy capture still needs registry admission. There is no UI id in the
         # ContextVar before the first delegation, so resolve the exact record
@@ -4222,6 +4242,23 @@ def delegate_task(
                 "Delegation refused: the originating live UI session is no "
                 "longer registered. Start a new conversation turn."
             )
+    elif _gateway_run_authority is not None:
+        # Ordinary messaging has no TUI session registry. Its existing
+        # SessionStore/adapter authority is the live owner registry instead;
+        # validate it now, while still keeping Git capture lazy.
+        if not _gateway_run_authority.validate():
+            return tool_error(
+                "Delegation refused: the originating live gateway session is no "
+                "longer current. Start a new conversation turn."
+            )
+        _live_session_record = {
+            "session_key": _gateway_run_authority.session_key,
+            "cwd": _gateway_run_authority.cwd,
+            "profile": _gateway_run_authority.profile,
+            "transport": _gateway_run_authority.transport,
+            "_record_identity": _gateway_run_authority.record,
+        }
+        _live_transport = _gateway_run_authority.transport
 
     if _bound_run_binding is not None or _live_session_record is not None:
         if _live_session_record is None:
@@ -4230,10 +4267,17 @@ def delegate_task(
             )
         _parent_task_id = getattr(parent_agent, "_current_task_id", None)
         _binding_drift: list[str] = []
+        _record_identity = (
+            _live_session_record.get("_record_identity")
+            if isinstance(_live_session_record, dict)
+            else _live_session_record
+        )
+        if _record_identity is None:
+            _record_identity = _live_session_record
         if (
             _bound_run_binding is not None
             and _bound_run_binding.owner_generation
-            and _bound_run_binding.owner_generation != str(id(_live_session_record))
+            and _bound_run_binding.owner_generation != str(id(_record_identity))
         ):
             _binding_drift.append("owner_session")
         if (
@@ -4247,9 +4291,14 @@ def delegate_task(
         _live_key = str(_live_session_record.get("session_key") or "")
         _live_profile_home = _live_session_record.get("profile_home")
         _live_profile = (
-            Path(str(_live_profile_home)).name
-            if _live_profile_home
-            else str(_gateway_server._current_profile_name())
+            _live_session_record.get("profile", "")
+            if _gateway_run_authority is not None
+            and (_bound_run_binding is None or not _bound_run_binding.ui_session_id)
+            else (
+                Path(str(_live_profile_home)).name
+                if _live_profile_home
+                else str(_gateway_server._current_profile_name())
+            )
         )
         if _bound_run_binding is not None:
             if _bound_run_binding.session_key != _live_key:
@@ -4282,8 +4331,18 @@ def delegate_task(
                     else ""
                 ),
                 profile=_live_profile,
-                owner_generation=str(id(_live_session_record)),
-                transport_generation=str(id(_live_transport)),
+                owner_generation=(
+                    _gateway_run_authority.owner_generation
+                    if _gateway_run_authority is not None
+                    and not (_bound_run_binding and _bound_run_binding.ui_session_id)
+                    else str(id(_live_session_record))
+                ),
+                transport_generation=(
+                    _gateway_run_authority.transport_generation
+                    if _gateway_run_authority is not None
+                    and not (_bound_run_binding and _bound_run_binding.ui_session_id)
+                    else str(id(_live_transport))
+                ),
             )
         except ValueError as exc:
             return tool_error(

--- a/tools/subagent_worktree.py
+++ b/tools/subagent_worktree.py
@@ -131,6 +131,8 @@ def _ensure_gitignore_entry(repo_root: str) -> None:
 def create_subagent_worktree(
     parent_cwd: Optional[str],
     subagent_id: Optional[str] = None,
+    *,
+    base_commit: Optional[str] = None,
 ) -> Optional[Dict[str, str]]:
     """Create an isolated worktree for one child agent.
 
@@ -157,10 +159,15 @@ def create_subagent_worktree(
     _ensure_gitignore_entry(repo_root)
 
     try:
-        base = _run_git(["rev-parse", "HEAD"], cwd=repo_root)
-        base_commit = base.stdout.strip() if base.returncode == 0 else ""
+        if base_commit:
+            base = _run_git(["rev-parse", "--verify", f"{base_commit}^{{commit}}"], cwd=repo_root)
+        else:
+            base = _run_git(["rev-parse", "HEAD"], cwd=repo_root)
+        resolved_base_commit = base.stdout.strip() if base.returncode == 0 else ""
+        if not resolved_base_commit:
+            return None
         result = _run_git(
-            ["worktree", "add", str(wt_path), "-b", branch, "HEAD"],
+            ["worktree", "add", str(wt_path), "-b", branch, resolved_base_commit],
             cwd=repo_root,
         )
     except Exception as exc:
@@ -179,7 +186,7 @@ def create_subagent_worktree(
         "path": str(wt_path),
         "branch": branch,
         "repo_root": repo_root,
-        "base_commit": base_commit,
+        "base_commit": resolved_base_commit,
     }
 
 

--- a/tui_gateway/git_probe.py
+++ b/tui_gateway/git_probe.py
@@ -69,6 +69,8 @@ def capture_run_binding(
     session_key: str = "",
     ui_session_id: str = "",
     profile: str = "",
+    owner_generation: str = "",
+    transport_generation: str = "",
 ):
     """Capture immutable checkout and live-session identity for one turn.
 
@@ -111,6 +113,8 @@ def capture_run_binding(
         session_key=str(session_key or ""),
         ui_session_id=str(ui_session_id or ""),
         profile=str(profile or ""),
+        owner_generation=str(owner_generation or ""),
+        transport_generation=str(transport_generation or ""),
     )
 
 

--- a/tui_gateway/git_probe.py
+++ b/tui_gateway/git_probe.py
@@ -63,6 +63,57 @@ def branch(cwd: str) -> str:
     return run_git(cwd, "branch", "--show-current") or run_git(cwd, "rev-parse", "--short", "HEAD")
 
 
+def capture_run_binding(
+    cwd: str,
+    *,
+    session_key: str = "",
+    ui_session_id: str = "",
+    profile: str = "",
+):
+    """Capture immutable checkout and live-session identity for one turn.
+
+    The gateway is the authority for the session fields.  Git is probed here
+    at the moment of capture and again immediately before delegation; no
+    model-supplied path, branch, or SHA is accepted.
+    """
+    from gateway.session_context import RunBinding
+
+    try:
+        canonical_cwd = os.path.realpath(os.path.abspath(os.path.expanduser(cwd)))
+    except (TypeError, ValueError):
+        canonical_cwd = ""
+    if not canonical_cwd or not os.path.isdir(canonical_cwd):
+        raise ValueError("Unable to bind this conversation: working directory is unavailable.")
+
+    worktree = run_git(canonical_cwd, "rev-parse", "--show-toplevel")
+    head = run_git(canonical_cwd, "rev-parse", "HEAD")
+    common_dir = run_git(
+        canonical_cwd, "rev-parse", "--path-format=absolute", "--git-common-dir"
+    )
+    if not worktree or not head or not common_dir:
+        raise ValueError(
+            "Unable to bind this conversation: the selected working directory is not a complete Git worktree."
+        )
+    worktree = os.path.realpath(worktree)
+    common_dir = os.path.realpath(common_dir)
+    repo = os.path.dirname(common_dir) if os.path.basename(common_dir) == ".git" else common_repo_root(canonical_cwd)
+    repo = os.path.realpath(repo or worktree)
+    ref = run_git(canonical_cwd, "symbolic-ref", "--quiet", "HEAD") or "HEAD"
+    current_branch = run_git(canonical_cwd, "branch", "--show-current")
+    return RunBinding(
+        cwd=canonical_cwd,
+        repo_root=repo,
+        worktree_root=worktree,
+        git_common_dir=common_dir,
+        branch=current_branch or "HEAD",
+        ref=ref,
+        head=head.strip(),
+        session_key=str(session_key or ""),
+        ui_session_id=str(ui_session_id or ""),
+        profile=str(profile or ""),
+    )
+
+
 class _RootCache:
     """Thread-safe, single-flight cache of git-root probes. Positive results are
     cached for the process lifetime; negative ("not a repo") results are cached

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4793,6 +4793,7 @@ def _set_session_context(
         # it instead of falling back to the gateway launch dir.
         resolved = cwd if cwd is not None else _cwd_for_session_key(session_key)
         source = _resolve_session_platform()
+        profile = _current_profile_name()
         browser_control_principal = ""
         browser_control_transport_family = ""
         # Derive the live conversation id so terminal/execute_code subprocesses
@@ -4809,6 +4810,9 @@ def _set_session_context(
             for sess in list(_sessions.values()):
                 if sess.get("session_key") == session_key:
                     source = _session_source(sess)
+                    profile_home = sess.get("profile_home")
+                    if profile_home:
+                        profile = Path(str(profile_home)).name
                     session_id = (
                         getattr(sess.get("agent"), "session_id", None) or session_key
                     )
@@ -4830,6 +4834,7 @@ def _set_session_context(
             browser_control_transport_family=browser_control_transport_family,
             cwd=resolved,
             ui_session_id=ui_session_id,
+            profile=profile,
             cron_session="",
         )
     except Exception:
@@ -13253,6 +13258,7 @@ def _run_prompt_submit(
         agent = session["agent"]
         approval_token = None
         session_tokens = []
+        run_binding_token = None
         home_token = None  # per-turn HERMES_HOME override for a resumed remote profile
         secret_token = None
         goal_followup = None  # set by the post-turn goal hook below
@@ -13358,6 +13364,41 @@ def _run_prompt_submit(
                 history_version = int(session.get("history_version", 0))
             cwd = _session_cwd(session)
             _register_session_cwd(session)
+            # Capture checkout identity from the live session at turn start.
+            # The model and RPC payload are intentionally not inputs to this
+            # binding; delegate_task will re-probe it immediately before the
+            # first child is constructed.
+            try:
+                from gateway.session_context import set_run_binding
+
+                _profile = str(
+                    Path(str(session.get("profile_home"))).name
+                    if session.get("profile_home")
+                    else _current_profile_name()
+                )
+                _binding = git_probe.capture_run_binding(
+                    cwd,
+                    session_key=str(session.get("session_key") or ""),
+                    ui_session_id=sid,
+                    profile=_profile,
+                )
+                run_binding_token = set_run_binding(_binding)
+            except ValueError as binding_error:
+                # A conversation without a stable Git worktree cannot safely
+                # attribute a delegated run. Surface the refusal on the same
+                # conversation and spawn no child.
+                _emit(
+                    "message.complete",
+                    sid,
+                    {
+                        "text": str(binding_error),
+                        "status": "error",
+                        "error": str(binding_error),
+                        "failure_reason": "run_binding_refused",
+                        "recoverable": True,
+                    },
+                )
+                return
             cols = session.get("cols", 80)
             streamer = make_stream_renderer(cols)
             prompt = text
@@ -14105,6 +14146,13 @@ def _run_prompt_submit(
                 from tools.terminal_scope import reset_terminal_scope
 
                 reset_terminal_scope(_terminal_scope_token)
+            if run_binding_token is not None:
+                try:
+                    from gateway.session_context import reset_run_binding
+
+                    reset_run_binding(run_binding_token)
+                except Exception:
+                    pass
             _clear_session_context(session_tokens)
             _current_runtime_session_record.reset(runtime_session_token)
             reset_transport(transport_token)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8323,6 +8323,15 @@ def _on_tool_progress(
             payload["tool_count"] = int(_kwargs["tool_count"])
         if _kwargs.get("toolsets"):
             payload["toolsets"] = [str(t) for t in _kwargs["toolsets"]]
+        run_binding = _kwargs.get("run_binding")
+        if isinstance(run_binding, dict):
+            compact_binding = {
+                key: str(run_binding[key])
+                for key in ("repo", "branch", "sha")
+                if run_binding.get(key)
+            }
+            if compact_binding:
+                payload["run_binding"] = compact_binding
         # Per-branch rollups emitted on subagent.complete (features 1+2+4).
         for int_key in (
             "input_tokens",
@@ -13258,7 +13267,6 @@ def _run_prompt_submit(
         agent = session["agent"]
         approval_token = None
         session_tokens = []
-        run_binding_token = None
         home_token = None  # per-turn HERMES_HOME override for a resumed remote profile
         secret_token = None
         goal_followup = None  # set by the post-turn goal hook below
@@ -13364,41 +13372,6 @@ def _run_prompt_submit(
                 history_version = int(session.get("history_version", 0))
             cwd = _session_cwd(session)
             _register_session_cwd(session)
-            # Capture checkout identity from the live session at turn start.
-            # The model and RPC payload are intentionally not inputs to this
-            # binding; delegate_task will re-probe it immediately before the
-            # first child is constructed.
-            try:
-                from gateway.session_context import set_run_binding
-
-                _profile = str(
-                    Path(str(session.get("profile_home"))).name
-                    if session.get("profile_home")
-                    else _current_profile_name()
-                )
-                _binding = git_probe.capture_run_binding(
-                    cwd,
-                    session_key=str(session.get("session_key") or ""),
-                    ui_session_id=sid,
-                    profile=_profile,
-                )
-                run_binding_token = set_run_binding(_binding)
-            except ValueError as binding_error:
-                # A conversation without a stable Git worktree cannot safely
-                # attribute a delegated run. Surface the refusal on the same
-                # conversation and spawn no child.
-                _emit(
-                    "message.complete",
-                    sid,
-                    {
-                        "text": str(binding_error),
-                        "status": "error",
-                        "error": str(binding_error),
-                        "failure_reason": "run_binding_refused",
-                        "recoverable": True,
-                    },
-                )
-                return
             cols = session.get("cols", 80)
             streamer = make_stream_renderer(cols)
             prompt = text


### PR DESCRIPTION
## User-visible outcome (Desktop/TUI and ordinary messaging gateway slice)
A normal Hermes conversation keeps working when it starts outside Git or never delegates. When the same Desktop/TUI or messaging/Companion-capable gateway turn invokes `delegate_task`, the server binds the current live session to its canonical cwd, resolved Git worktree/common-dir identity, branch/ref, full HEAD, profile, and live owner/transport generations at the delegation boundary. The child starts from that bound HEAD. Compact `repo/branch/short-SHA` progress rides the existing same-channel gateway rail when progress is enabled, and the same existing final adapter reply includes the compact binding plus delegation outcome even when optional tool progress is disabled.

## Safety behavior
- Non-Git ordinary messages are not rejected at turn start.
- Delegation from a non-Git session is refused on the delegation surface.
- Current registry-backed session record and transport identity are revalidated immediately before child construction; replacement/rebind drift refuses with zero children.
- Dirty bound worktrees are refused so uncommitted changes are not silently omitted.
- Bound worktree creation failure refuses before child construction; the parent workspace is never used as a fallback.
- Legacy unbound CLI callers keep their existing behavior.

## Validation
Validated at rebased head `7909d55f85c54337d80983274ebdcb5edc4e2719` on `origin/main` `8cab422ab09332c1867af81ee4e910878ac1172b`.

- `scripts/run_tests.sh tests/gateway/test_run_binding_messaging.py tests/tools/test_delegate.py tests/tools/test_subagent_worktree.py tests/tui_gateway/test_run_binding.py tests/tui_gateway/test_subagent_child_mirror.py -q`
- 5 affected test files, 125 tests passed, 0 failed
- Changed-source byte compilation passed for the six production Python paths:
  - `gateway/run.py`
  - `gateway/session_context.py`
  - `tools/delegate_tool.py`
  - `tools/subagent_worktree.py`
  - `tui_gateway/git_probe.py`
  - `tui_gateway/server.py`
- `git diff --check origin/main...HEAD` passed

## Scope and nonclaims
This PR remains within existing gateway/session/delegate rails. It adds no service, database, durable schema, prompt/RPC identity assertion, command scanning, absolute filesystem-containment claim, second route, or runtime installation. The installed `orch` gateway is not claimed to contain this branch commit. No external provider/runtime/install/restart operation or natural end-to-end user acceptance run was performed; CI, runtime adoption, and user acceptance remain separate claims.

Related: #97226, #97227, #97228