### PR TITLE
fix(codex): use Windows native roots for app server

### DIFF
--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -20,6 +20,7 @@ import json
 import os
 import queue
 import subprocess
+import sys
 import threading
 import time
 from dataclasses import dataclass, field
@@ -88,6 +89,23 @@ class CodexAppServerClient:
         # stripped while provider creds still flow, matching copilot_acp_client
         # (#29157 sibling spawn-site gap).
         spawn_env = hermes_subprocess_env(inherit_credentials=True)
+        if sys.platform == "win32":
+            # gateway._ensure_ssl_certs exports certifi's Mozilla bundle for
+            # Python clients on Windows. Rust Codex otherwise inherits that
+            # override instead of using the native Windows root store; valid
+            # chains can then fail with UnknownIssuer. Drop only the automatic
+            # certifi value. A distinct user/corporate CA bundle is preserved,
+            # and an explicit per-spawn env below can still override this.
+            try:
+                import certifi
+
+                inherited_ca = spawn_env.get("SSL_CERT_FILE")
+                if inherited_ca and os.path.normcase(os.path.abspath(inherited_ca)) == (
+                    os.path.normcase(os.path.abspath(certifi.where()))
+                ):
+                    spawn_env.pop("SSL_CERT_FILE", None)
+            except ImportError:
+                pass
         if env:
             spawn_env.update(env)
         if codex_home:

--- a/tests/agent/transports/test_codex_app_server_runtime.py
+++ b/tests/agent/transports/test_codex_app_server_runtime.py
@@ -168,6 +168,49 @@ class TestSpawnEnvIsolation:
             "subprocesses (gh, git, aws, npm) need the user's real HOME."
         )
 
+    def test_spawn_env_drops_auto_certifi_bundle_on_windows(self, monkeypatch):
+        """Rust Codex must use the Windows native root store by default.
+
+        The gateway exports certifi's bundle for Python HTTP clients.  Codex's
+        rustls client can reject otherwise-valid new chains when it inherits
+        that override, while the same request succeeds through Windows roots.
+        """
+        import certifi
+        import subprocess
+        from agent.transports import codex_app_server as cas
+
+        captured = {}
+
+        class FakePopen:
+            def __init__(self, cmd, *args, **kwargs):
+                captured["env"] = kwargs.get("env", {}).copy()
+                self.stdin = None
+                self.stdout = None
+                self.stderr = None
+                self.pid = 1
+                self.returncode = None
+
+            def poll(self):
+                return None
+
+            def terminate(self):
+                pass
+
+            def wait(self, timeout=None):
+                return 0
+
+            def kill(self):
+                pass
+
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+        monkeypatch.setattr(cas.sys, "platform", "win32")
+        monkeypatch.setenv("SSL_CERT_FILE", certifi.where())
+
+        client = cas.CodexAppServerClient(codex_bin="codex")
+        client._closed = True
+
+        assert "SSL_CERT_FILE" not in captured["env"]
+
     def test_spawn_env_sets_CODEX_HOME_when_provided(self, monkeypatch):
         """CODEX_HOME isolation must still work — that's the whole point
         of the codex_home arg."""


### PR DESCRIPTION
## Summary
- drop only Hermes' automatically exported certifi `SSL_CERT_FILE` when spawning Codex app-server on Windows
- preserve explicit/custom CA bundle overrides
- add a regression test for the Windows spawn environment

## Root cause
Hermes gateway exports certifi's Mozilla CA bundle for Python clients. The Rust Codex CLI inherits that process override and can fail an otherwise valid ChatGPT/Codex TLS chain with `UnknownIssuer`, while the same command succeeds immediately when `SSL_CERT_FILE` is absent and Windows native roots are used.

The fix is intentionally scoped to `codex_app_server` on Windows and only removes the value when it exactly matches `certifi.where()`. It does not disable TLS verification or modify other providers.

## Verification
- `tests/agent/transports/test_codex_app_server_runtime.py`: 24 passed
- default profile: four successful one-shot Codex calls
- delegated subagent: one call, completed in 4.81s
- three isolated OpenAI Codex profiles: one successful one-shot each, one API call each
- `hermes config check`: passed for default and all three profiles
- `git diff --check`: passed

Related to #13834, but does not claim to close that broader transport issue.