### PR TITLE
fix(browser): reap orphaned real-profile Chrome processes

### DIFF
--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -193,6 +193,7 @@ class TestRealProfileCdpLaunch:
     def _reset(self):
         import tools.browser_tool as bt
         bt._real_profile_cdp_cache.clear()
+        bt._real_profile_chrome_procs.clear()
 
     def test_consent_off_is_noop(self):
         import tools.browser_tool as bt
@@ -215,6 +216,7 @@ class TestRealProfileCdpLaunch:
         self._reset()
         with patch.object(bt, "_use_real_profile", return_value=True), \
              patch("hermes_cli.browser_connect.detect_default_chromium", return_value="chrome"), \
+             patch.object(bt, "_agent_browser_get_cdp", return_value=None), \
              patch("hermes_cli.browser_connect.snapshot_real_profile", return_value=(None, "boom")):
             cdp, err = bt._real_profile_cdp()
         assert cdp is None
@@ -950,9 +952,12 @@ class TestReviewRound3:
              patch.object(bt, "_using_lightpanda_engine", return_value=False), \
              patch("hermes_cli.browser_connect.detect_default_chromium", return_value="chrome"), \
              patch("hermes_cli.browser_connect.real_profile_copy_dir", return_value=str(tmp_path)), \
+             patch("hermes_cli.browser_connect.chromium_executable", return_value="/usr/bin/chrome"), \
              patch.object(bt, "_agent_browser_get_cdp", return_value="http://127.0.0.1:9251"), \
              patch.object(bt, "_cdp_http_ready", return_value=True), \
              patch.object(bt, "_cdp_on_data_dir", return_value=True), \
+             patch("tools.real_profile_lifecycle.claim_real_profile_chrome",
+                   return_value={"pid": 4321}), \
              patch("hermes_cli.browser_connect.snapshot_real_profile") as snap:
             cdp, err = bt._real_profile_cdp()
         assert cdp == "http://127.0.0.1:9251" and err is None
@@ -964,21 +969,64 @@ class TestReviewRound3:
         import tools.browser_tool as bt
         bt._real_profile_cdp_cache.clear()
         proc = Mock(returncode=0, stdout="", stderr="")
+
+        class FakeChrome:
+            def poll(self):
+                return None
+
+        def fake_popen(argv, **kw):
+            (tmp_path / "DevToolsActivePort").write_text("9251\n/devtools/browser/x\n")
+            return FakeChrome()
+
         with patch.object(bt, "_use_real_profile", return_value=True), \
              patch.object(bt, "_using_lightpanda_engine", return_value=False), \
              patch("hermes_cli.browser_connect.detect_default_chromium", return_value="chrome"), \
              patch("hermes_cli.browser_connect.real_profile_copy_dir", return_value=str(tmp_path)), \
+             patch("hermes_cli.browser_connect.chromium_executable", return_value="/usr/bin/chrome"), \
              patch("hermes_cli.browser_connect.snapshot_real_profile",
                    return_value=(str(tmp_path), None)) as snap, \
              patch.object(bt, "_agent_browser_get_cdp",
                           side_effect=[None, "http://127.0.0.1:9251"]), \
              patch.object(bt, "_find_agent_browser", return_value="/usr/bin/agent-browser"), \
+             patch.object(bt.subprocess, "Popen", side_effect=fake_popen), \
              patch.object(bt.subprocess, "run", return_value=proc), \
              patch.object(bt, "_is_headed_mode", return_value=False):
             cdp, err = bt._real_profile_cdp()
         assert err is None
         snap.assert_called_once()
         bt._real_profile_cdp_cache.clear()
+
+    def test_attach_failure_terminates_direct_chrome(self, tmp_path):
+        """A failed agent-browser attach must not leave Chrome behind."""
+        import tools.browser_tool as bt
+
+        chrome = Mock()
+        chrome.pid = None
+        chrome.poll.return_value = None
+        proc = Mock(returncode=1, stdout="", stderr="attach failed")
+
+        def fake_popen(argv, **kw):
+            (tmp_path / "DevToolsActivePort").write_text("9251\n/devtools/browser/x\n")
+            return chrome
+
+        with patch.object(bt, "_use_real_profile", return_value=True), \
+             patch.object(bt, "_using_lightpanda_engine", return_value=False), \
+             patch("hermes_cli.browser_connect.detect_default_chromium", return_value="chrome"), \
+             patch("hermes_cli.browser_connect.real_profile_copy_dir", return_value=str(tmp_path)), \
+             patch("hermes_cli.browser_connect.snapshot_real_profile",
+                   return_value=(str(tmp_path), None)), \
+             patch("hermes_cli.browser_connect.chromium_executable", return_value="/usr/bin/chrome"), \
+             patch.object(bt, "_agent_browser_get_cdp", return_value=None), \
+             patch.object(bt, "_find_agent_browser", return_value="/usr/bin/agent-browser"), \
+             patch.object(bt.subprocess, "Popen", side_effect=fake_popen), \
+             patch.object(bt.subprocess, "run", return_value=proc), \
+             patch.object(bt, "_is_headed_mode", return_value=False):
+            cdp, err = bt._real_profile_cdp()
+
+        assert cdp is None
+        assert err and "failed to start" in err
+        chrome.terminate.assert_called_once_with()
+        bt._real_profile_chrome_procs.clear()
 
 
 class TestWindowsLockedProfileCopy:

--- a/tests/tools/test_real_profile_lifecycle.py
+++ b/tests/tools/test_real_profile_lifecycle.py
@@ -1,0 +1,217 @@
+"""Tests for persistent ownership of directly-launched real-profile Chrome."""
+
+import json
+import os
+from unittest.mock import Mock, patch
+
+
+def _setup_home(tmp_path, monkeypatch):
+    import tools.real_profile_lifecycle as lifecycle
+
+    home = tmp_path / "hermes-home"
+    monkeypatch.setattr(lifecycle, "_hermes_home", lambda: home)
+    return lifecycle, home, home / "browser-profile" / "chrome"
+
+
+def _record(lifecycle, home, *, pid=4321, target_start=99, owners=None):
+    profile = home / "browser-profile" / "chrome"
+    binary = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+    record = lifecycle._base_record(
+        "chrome", profile.resolve(), lifecycle._canonical_path(binary), pid, target_start
+    )
+    record = lifecycle._with_owner_fields(record, owners or [])
+    assert lifecycle._write_record("chrome", record)
+    return record
+
+
+def test_register_persists_exact_target_and_owner(tmp_path, monkeypatch):
+    lifecycle, home, profile = _setup_home(tmp_path, monkeypatch)
+    binary = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+    target_pid = 4321
+    monkeypatch.setattr(
+        lifecycle,
+        "_safe_start_time",
+        lambda pid: 222 if pid == target_pid else 333,
+    )
+
+    record = lifecycle.register_real_profile_chrome(
+        "chrome", str(profile), binary, target_pid
+    )
+
+    assert record is not None
+    stored = json.loads(
+        (home / "cache" / "browser-use" / "real-profile" / "chrome.json").read_text()
+    )
+    assert stored["pid"] == target_pid
+    assert stored["target_start_time"] == 222
+    assert stored["profile_dir"] == str(profile.resolve())
+    assert stored["binary"] == binary
+    assert stored["owners"] == [{"pid": os.getpid(), "start_time": 333}]
+    if os.name != "nt":
+        assert (home / "cache" / "browser-use" / "real-profile").stat().st_mode & 0o077 == 0
+
+
+def test_register_does_not_replace_another_live_target(tmp_path, monkeypatch):
+    lifecycle, home, profile = _setup_home(tmp_path, monkeypatch)
+    binary = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+    _record(lifecycle, home, pid=1111, target_start=10)
+    monkeypatch.setattr(lifecycle, "_safe_start_time", lambda pid: 20)
+    monkeypatch.setattr(lifecycle, "_target_matches", lambda *args: True)
+
+    result = lifecycle.register_real_profile_chrome("chrome", str(profile), binary, 2222)
+
+    assert result is None
+    stored = json.loads(
+        (home / "cache" / "browser-use" / "real-profile" / "chrome.json").read_text()
+    )
+    assert stored["pid"] == 1111
+
+
+def test_claim_adds_a_second_live_owner(tmp_path, monkeypatch):
+    lifecycle, home, profile = _setup_home(tmp_path, monkeypatch)
+    binary = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+    other_owner = {"pid": 7777, "start_time": 70}
+    _record(lifecycle, home, pid=4321, target_start=99, owners=[other_owner])
+    monkeypatch.setattr(lifecycle, "_target_matches", lambda *args: True)
+    monkeypatch.setattr(
+        lifecycle,
+        "_safe_start_time",
+        lambda pid: 88 if pid == os.getpid() else 70,
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "_owner_is_alive",
+        lambda owner: owner == other_owner or owner["pid"] == os.getpid(),
+    )
+
+    result = lifecycle.claim_real_profile_chrome("chrome", str(profile), binary)
+
+    assert result and result["pid"] == 4321
+    stored = json.loads(
+        (home / "cache" / "browser-use" / "real-profile" / "chrome.json").read_text()
+    )
+    assert stored["owners"] == [other_owner, {"pid": os.getpid(), "start_time": 88}]
+
+
+def test_retire_releases_only_current_owner_when_browser_is_shared(tmp_path, monkeypatch):
+    lifecycle, home, profile = _setup_home(tmp_path, monkeypatch)
+    binary = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+    current_owner = {"pid": os.getpid(), "start_time": 88}
+    other_owner = {"pid": 7777, "start_time": 70}
+    _record(lifecycle, home, pid=4321, target_start=99, owners=[other_owner, current_owner])
+    monkeypatch.setattr(lifecycle, "_safe_start_time", lambda pid: 88)
+    monkeypatch.setattr(
+        lifecycle,
+        "_owner_is_alive",
+        lambda owner: owner == other_owner,
+    )
+    terminate = Mock()
+
+    with patch(
+        "tools.process_registry.ProcessRegistry._terminate_host_pid",
+        terminate,
+    ):
+        result = lifecycle.retire_real_profile_chrome(
+            "chrome", str(profile), binary, 4321
+        )
+
+    assert result is False
+    terminate.assert_not_called()
+    stored = json.loads(
+        (home / "cache" / "browser-use" / "real-profile" / "chrome.json").read_text()
+    )
+    assert stored["owners"] == [other_owner]
+
+
+def test_retire_last_owner_tree_kills_exact_target(tmp_path, monkeypatch):
+    lifecycle, home, profile = _setup_home(tmp_path, monkeypatch)
+    binary = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+    current_owner = {"pid": os.getpid(), "start_time": 88}
+    _record(lifecycle, home, pid=4321, target_start=99, owners=[current_owner])
+    monkeypatch.setattr(lifecycle, "_safe_start_time", lambda pid: 88)
+    monkeypatch.setattr(lifecycle, "_target_matches", lambda *args: True)
+    terminate = Mock()
+
+    with patch(
+        "tools.process_registry.ProcessRegistry._terminate_host_pid",
+        terminate,
+    ):
+        result = lifecycle.retire_real_profile_chrome(
+            "chrome", str(profile), binary, 4321
+        )
+
+    assert result is True
+    terminate.assert_called_once_with(4321, expected_start=99)
+    assert not (home / "cache" / "browser-use" / "real-profile" / "chrome.json").exists()
+
+
+def test_reaper_kills_exact_orphan_and_removes_record(tmp_path, monkeypatch):
+    lifecycle, home, _profile = _setup_home(tmp_path, monkeypatch)
+    _record(lifecycle, home, owners=[])
+    monkeypatch.setattr(lifecycle, "_live_owners", lambda record: [])
+    monkeypatch.setattr(lifecycle, "_target_matches", side_effect := Mock(side_effect=[True, False]))
+    terminate = Mock()
+
+    with patch(
+        "tools.process_registry.ProcessRegistry._terminate_host_pid",
+        terminate,
+    ):
+        reaped = lifecycle.reap_orphaned_real_profile_chrome()
+
+    assert reaped == 1
+    terminate.assert_called_once_with(4321, expected_start=99)
+    assert not (home / "cache" / "browser-use" / "real-profile" / "chrome.json").exists()
+    assert side_effect.call_count == 2
+
+
+def test_reaper_spares_live_owner(tmp_path, monkeypatch):
+    lifecycle, home, _profile = _setup_home(tmp_path, monkeypatch)
+    _record(lifecycle, home, owners=[{"pid": os.getpid(), "start_time": 1}])
+    monkeypatch.setattr(lifecycle, "_live_owners", lambda record: [{"pid": os.getpid()}])
+    matches = Mock(return_value=True)
+    monkeypatch.setattr(lifecycle, "_target_matches", matches)
+    terminate = Mock()
+
+    with patch(
+        "tools.process_registry.ProcessRegistry._terminate_host_pid",
+        terminate,
+    ):
+        assert lifecycle.reap_orphaned_real_profile_chrome() == 0
+
+    matches.assert_not_called()
+    terminate.assert_not_called()
+
+
+def test_reaper_removes_recycled_pid_without_signalling(tmp_path, monkeypatch):
+    lifecycle, home, _profile = _setup_home(tmp_path, monkeypatch)
+    _record(lifecycle, home, owners=[])
+    monkeypatch.setattr(lifecycle, "_live_owners", lambda record: [])
+    monkeypatch.setattr(lifecycle, "_target_matches", lambda *args: False)
+    terminate = Mock()
+
+    with patch(
+        "tools.process_registry.ProcessRegistry._terminate_host_pid",
+        terminate,
+    ):
+        assert lifecycle.reap_orphaned_real_profile_chrome() == 0
+
+    terminate.assert_not_called()
+    assert not (home / "cache" / "browser-use" / "real-profile" / "chrome.json").exists()
+
+
+def test_reaper_leaves_malformed_record_without_signalling(tmp_path, monkeypatch):
+    lifecycle, home, _profile = _setup_home(tmp_path, monkeypatch)
+    state_dir = home / "cache" / "browser-use" / "real-profile"
+    state_dir.mkdir(parents=True)
+    record_path = state_dir / "chrome.json"
+    record_path.write_text("{not-json")
+    terminate = Mock()
+
+    with patch(
+        "tools.process_registry.ProcessRegistry._terminate_host_pid",
+        terminate,
+    ):
+        assert lifecycle.reap_orphaned_real_profile_chrome() == 0
+
+    terminate.assert_not_called()
+    assert record_path.exists()

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1530,7 +1530,67 @@ def _use_real_profile() -> bool:
 _REAL_PROFILE_SESSION = "hermes-real-profile"
 _real_profile_cdp_lock = threading.Lock()
 _real_profile_cdp_cache: dict = {}
-_real_profile_chrome_procs: list = []  # Popen handles of directly-launched real browsers
+_real_profile_chrome_procs: list = []  # owned real-profile browser entries
+
+
+def _terminate_real_profile_popen(proc: Any) -> None:
+    """Best-effort fallback for a process without persistent lifecycle state."""
+    try:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except Exception:
+                proc.kill()
+    except Exception as e:
+        logger.debug("real-profile chrome terminate failed: %s", e)
+
+
+def _terminate_real_profile_entry(entry: dict[str, Any]) -> None:
+    """Release one real-profile owner without killing a shared browser."""
+    # Keep compatibility with pre-persistence in-process callers/tests that
+    # may still have placed a bare Popen handle in this list.
+    if not isinstance(entry, dict):
+        _terminate_real_profile_popen(entry)
+        return
+    proc = entry.get("proc")
+    browser = entry.get("browser")
+    profile_dir = entry.get("profile_dir")
+    binary = entry.get("binary")
+    pid = entry.get("pid")
+
+    if browser and profile_dir and binary and pid:
+        try:
+            from tools.real_profile_lifecycle import retire_real_profile_chrome
+
+            lifecycle_result = retire_real_profile_chrome(
+                browser, profile_dir, binary, pid
+            )
+            if lifecycle_result is not None:
+                # False means another live Hermes process adopted this
+                # browser.  Its Popen handle may belong to the old launcher,
+                # but it must not terminate the shared target.
+                if lifecycle_result is False:
+                    try:
+                        from tools.real_profile_lifecycle import has_live_real_profile_owner
+
+                        if has_live_real_profile_owner(browser):
+                            return
+                    except Exception:
+                        # If ownership cannot be checked, fail closed and
+                        # leave a shared browser alive for the other owner.
+                        return
+                if lifecycle_result is True:
+                    return
+        except Exception as e:
+            logger.debug("real-profile lifecycle release failed: %s", e)
+
+    # Test doubles and legacy/partially-started processes may have no
+    # persistent identity.  Only the process handle that this Hermes process
+    # received is eligible for this fallback; cross-process cleanup is always
+    # identity-checked by tools.real_profile_lifecycle.
+    if proc is not None:
+        _terminate_real_profile_popen(proc)
 
 
 def _terminate_real_profile_chrome() -> None:
@@ -1542,16 +1602,8 @@ def _terminate_real_profile_chrome() -> None:
     own session cleanup never kills them. Idempotent; safe from atexit.
     """
     while _real_profile_chrome_procs:
-        proc = _real_profile_chrome_procs.pop()
-        try:
-            if proc.poll() is None:
-                proc.terminate()
-                try:
-                    proc.wait(timeout=5)
-                except Exception:
-                    proc.kill()
-        except Exception as e:
-            logger.debug("real-profile chrome terminate failed: %s", e)
+        entry = _real_profile_chrome_procs.pop()
+        _terminate_real_profile_entry(entry)
 
 
 def _agent_browser_argv(browser_cmd: str) -> list:
@@ -1654,6 +1706,7 @@ def _real_profile_cdp() -> tuple:
         # still on disk, it holds copies of the user's cookies/logins — delete
         # it so revoking consent actually removes the credential copies. Cheap
         # (one isdir check) and idempotent.
+        _terminate_real_profile_chrome()
         try:
             from hermes_cli.browser_connect import cleanup_real_profile_snapshots
 
@@ -1723,8 +1776,42 @@ def _real_profile_cdp() -> tuple:
         # snapshot/overlay happens solely on the relaunch path below, when no
         # live browser owns the dir.
         copy_dir = real_profile_copy_dir(browser)
+        from hermes_cli.browser_connect import chromium_executable
+
+        real_binary = chromium_executable(browser)
+        if real_binary is None:
+            return None, (
+                "browser.use_real_profile is on, but the real browser binary for "
+                f"'{browser}' could not be found. Reinstall it or turn the toggle off."
+            )
         existing = _agent_browser_get_cdp(_REAL_PROFILE_SESSION)
         if existing and _cdp_http_ready(existing) and _cdp_on_data_dir(existing, copy_dir):
+            try:
+                from tools.real_profile_lifecycle import claim_real_profile_chrome
+
+                claimed = claim_real_profile_chrome(browser, copy_dir, real_binary)
+            except Exception as e:
+                logger.debug("real-profile ownership claim failed: %s", e)
+                claimed = None
+            if not claimed:
+                return None, (
+                    "browser.use_real_profile is on, but an existing real-profile "
+                    "browser could not be safely claimed. Close the stale Hermes "
+                    "browser session and retry."
+                )
+            claim_entry = {
+                "proc": None,
+                "browser": browser,
+                "profile_dir": copy_dir,
+                "binary": real_binary,
+                "pid": claimed.get("pid"),
+            }
+            if not any(
+                entry.get("pid") == claim_entry["pid"]
+                and entry.get("profile_dir") == copy_dir
+                for entry in _real_profile_chrome_procs
+            ):
+                _real_profile_chrome_procs.append(claim_entry)
             _real_profile_cdp_cache["cdp"] = existing
             return existing, None
         if existing:
@@ -1760,15 +1847,6 @@ def _real_profile_cdp() -> tuple:
         # NO mock-keychain switches keeps the OS keychain path intact, exactly
         # as the snapshot design intends; agent-browser attaches to it after
         # via --auto-connect (--cdp <port>).
-        from hermes_cli.browser_connect import chromium_executable
-
-        real_binary = chromium_executable(browser)
-        if real_binary is None:
-            return None, (
-                "browser.use_real_profile is on, but the real browser binary for "
-                f"'{browser}' could not be found. Reinstall it or turn the toggle off."
-            )
-
         port_file = os.path.join(copy_dir, "DevToolsActivePort")
         try:
             os.unlink(port_file)  # stale port from a previous launch confuses reuse probes
@@ -1823,7 +1901,33 @@ def _real_profile_cdp() -> tuple:
             )
         except (subprocess.SubprocessError, OSError) as e:
             return None, f"browser.use_real_profile is on, but the launch failed: {e}"
-        _real_profile_chrome_procs.append(chrome_proc)
+        chrome_entry = {
+            "proc": chrome_proc,
+            "browser": browser,
+            "profile_dir": copy_dir,
+            "binary": real_binary,
+            "pid": getattr(chrome_proc, "pid", None),
+        }
+        _real_profile_chrome_procs.append(chrome_entry)
+        chrome_pid = chrome_entry["pid"]
+        if chrome_pid:
+            try:
+                from tools.real_profile_lifecycle import register_real_profile_chrome
+
+                registered = register_real_profile_chrome(
+                    browser, copy_dir, real_binary, chrome_pid
+                )
+            except Exception as e:
+                logger.debug("real-profile ownership registration failed: %s", e)
+                registered = None
+            if not registered:
+                _real_profile_chrome_procs.remove(chrome_entry)
+                _terminate_real_profile_entry(chrome_entry)
+                return None, (
+                    "browser.use_real_profile is on, but Hermes could not persist "
+                    "ownership of the real-profile browser. The process was stopped; "
+                    "retry after checking the Hermes home is writable."
+                )
 
         # Wait for DevToolsActivePort to appear (Chrome picks a free port).
         import time as _time
@@ -1840,14 +1944,18 @@ def _real_profile_cdp() -> tuple:
             except OSError:
                 pass
             if chrome_proc.poll() is not None:
-                _terminate_real_profile_chrome()
+                if chrome_entry in _real_profile_chrome_procs:
+                    _real_profile_chrome_procs.remove(chrome_entry)
+                _terminate_real_profile_entry(chrome_entry)
                 return None, (
                     "browser.use_real_profile is on, but Chrome exited during "
                     "startup (another instance may hold the profile copy)."
                 )
             _time.sleep(0.25)
         if port is None:
-            _terminate_real_profile_chrome()
+            if chrome_entry in _real_profile_chrome_procs:
+                _real_profile_chrome_procs.remove(chrome_entry)
+            _terminate_real_profile_entry(chrome_entry)
             return None, (
                 "browser.use_real_profile is on, but the real-profile browser "
                 "did not expose a debug port in time. Retry, or turn the toggle off."
@@ -1858,6 +1966,9 @@ def _real_profile_cdp() -> tuple:
         try:
             browser_cmd = _find_agent_browser()
         except FileNotFoundError as e:
+            if chrome_entry in _real_profile_chrome_procs:
+                _real_profile_chrome_procs.remove(chrome_entry)
+            _terminate_real_profile_entry(chrome_entry)
             return None, (
                 "browser.use_real_profile is on, but the local browser engine "
                 f"(agent-browser) is not installed: {e}"
@@ -1875,13 +1986,22 @@ def _real_profile_cdp() -> tuple:
                 env=_build_browser_env(),
             )
         except subprocess.TimeoutExpired:
+            if chrome_entry in _real_profile_chrome_procs:
+                _real_profile_chrome_procs.remove(chrome_entry)
+            _terminate_real_profile_entry(chrome_entry)
             return None, (
                 "browser.use_real_profile is on, but the real-profile browser "
                 "took too long to start. Retry, or turn the toggle off."
             )
         except (subprocess.SubprocessError, OSError) as e:
+            if chrome_entry in _real_profile_chrome_procs:
+                _real_profile_chrome_procs.remove(chrome_entry)
+            _terminate_real_profile_entry(chrome_entry)
             return None, f"browser.use_real_profile is on, but the launch failed: {e}"
         if proc.returncode != 0:
+            if chrome_entry in _real_profile_chrome_procs:
+                _real_profile_chrome_procs.remove(chrome_entry)
+            _terminate_real_profile_entry(chrome_entry)
             tail = (proc.stderr or proc.stdout or "").strip().splitlines()
             reason = tail[-1] if tail else f"exit {proc.returncode}"
             return None, (
@@ -1904,6 +2024,9 @@ def _real_profile_cdp() -> tuple:
         except (OSError, ValueError):
             pass
         if not cdp:
+            if chrome_entry in _real_profile_chrome_procs:
+                _real_profile_chrome_procs.remove(chrome_entry)
+            _terminate_real_profile_entry(chrome_entry)
             return None, (
                 "browser.use_real_profile is on, but the real-profile browser "
                 "started without exposing a devtools endpoint. Retry, or turn "
@@ -2568,6 +2691,18 @@ def _reap_orphaned_browser_sessions():
         reap_orphaned_lightpanda()
     except Exception as e:
         logger.debug("Lightpanda orphan reap failed: %s", e)
+
+    # Real-profile browsing launches the signed browser binary directly on a
+    # Hermes-owned profile copy, so there is no agent-browser socket directory
+    # for the generic daemon sweep below to discover.  Its persistent records
+    # carry an exact PID/start-time/executable/profile identity and are
+    # reaped before the early ``no socket dirs`` return.
+    try:
+        from tools.real_profile_lifecycle import reap_orphaned_real_profile_chrome
+
+        reap_orphaned_real_profile_chrome()
+    except Exception as e:
+        logger.debug("Real-profile Chrome orphan reap failed: %s", e)
 
     tmpdir = _socket_safe_tmpdir()
     pattern = os.path.join(tmpdir, "agent-browser-h_*")

--- a/tools/real_profile_lifecycle.py
+++ b/tools/real_profile_lifecycle.py
@@ -1,0 +1,642 @@
+"""Persistent lifecycle tracking for real-profile Chromium processes.
+
+The real-profile browser path launches the user's signed browser binary
+directly on a Hermes-owned profile copy.  Unlike an ``agent-browser`` daemon,
+that child is not discoverable from a socket directory after the owning Hermes
+process crashes.  This module records enough identity to reap only the exact
+process we launched, while allowing several live Hermes processes to share the
+same copy-browser safely.
+
+Records are deliberately narrow: only the managed profile path and the exact
+browser binary are accepted.  Every destructive operation revalidates the
+PID, process start time, executable, and ``--user-data-dir`` argument before
+delegating to the shared process-tree terminator.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+_RECORD_VERSION = 1
+_BROWSER_NAME = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+_RECORD_DIRNAME = "real-profile"
+
+
+def _browser_name_is_safe(browser: str) -> bool:
+    return isinstance(browser, str) and bool(_BROWSER_NAME.fullmatch(browser))
+
+
+def _hermes_home() -> Path:
+    from hermes_constants import get_hermes_home
+
+    return Path(get_hermes_home()).expanduser()
+
+
+def _managed_profile_dir(browser: str) -> Path:
+    return (_hermes_home() / "browser-profile" / browser).resolve(strict=False)
+
+
+def _canonical_path(value: Any) -> Optional[Path]:
+    if not isinstance(value, str) or not value or not os.path.isabs(value):
+        return None
+    try:
+        return Path(value).expanduser().resolve(strict=False)
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+
+def _state_dir(*, create: bool = True) -> Optional[Path]:
+    try:
+        path = _hermes_home() / "cache" / "browser-use" / _RECORD_DIRNAME
+    except (OSError, RuntimeError, ValueError) as exc:
+        logger.debug("Could not resolve real-profile lifecycle state: %s", exc)
+        return None
+    if not create:
+        return path if path.is_dir() else None
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+        os.chmod(path, 0o700)
+        return path
+    except (OSError, RuntimeError, ValueError) as exc:
+        logger.warning("Could not create real-profile lifecycle state: %s", exc)
+        return None
+
+
+def _record_path(browser: str, *, create: bool = False) -> Optional[Path]:
+    if not _browser_name_is_safe(browser):
+        return None
+    state_dir = _state_dir(create=create)
+    return state_dir / f"{browser}.json" if state_dir else None
+
+
+def _safe_start_time(pid: Optional[int]) -> Optional[int]:
+    if not pid:
+        return None
+    try:
+        from tools.process_registry import ProcessRegistry
+
+        return ProcessRegistry._safe_host_start_time(int(pid))
+    except Exception:
+        return None
+
+
+def _owner_entry(pid: int) -> dict[str, Optional[int]]:
+    return {"pid": int(pid), "start_time": _safe_start_time(int(pid))}
+
+
+def _normalize_owner_entries(record: dict[str, Any]) -> list[dict[str, Optional[int]]]:
+    """Read current and legacy owner fields into a de-duplicated list."""
+    raw = record.get("owners")
+    candidates: list[Any] = raw if isinstance(raw, list) else []
+    if not candidates and record.get("owner_pid") is not None:
+        candidates = [
+            {
+                "pid": record.get("owner_pid"),
+                "start_time": record.get("owner_start_time"),
+            }
+        ]
+
+    owners: list[dict[str, Optional[int]]] = []
+    seen: set[tuple[int, Optional[int]]] = set()
+    for item in candidates:
+        if not isinstance(item, dict):
+            continue
+        try:
+            pid = int(item.get("pid"))
+        except (TypeError, ValueError):
+            continue
+        if pid <= 0:
+            continue
+        raw_start = item.get("start_time")
+        try:
+            start_time = int(raw_start) if raw_start is not None else None
+        except (TypeError, ValueError):
+            start_time = None
+        key = (pid, start_time)
+        if key in seen:
+            continue
+        seen.add(key)
+        owners.append({"pid": pid, "start_time": start_time})
+    return owners
+
+
+def _with_owner_fields(
+    record: dict[str, Any], owners: list[dict[str, Optional[int]]]
+) -> dict[str, Any]:
+    """Return a record with the multi-owner list and legacy primary fields."""
+    updated = dict(record)
+    updated["owners"] = owners
+    if owners:
+        primary = owners[-1]
+        updated["owner_pid"] = primary["pid"]
+        updated["owner_start_time"] = primary["start_time"]
+    else:
+        updated.pop("owner_pid", None)
+        updated.pop("owner_start_time", None)
+    return updated
+
+
+def _write_record(browser: str, record: dict[str, Any]) -> bool:
+    path = _record_path(browser, create=True)
+    if path is None:
+        return False
+    temp_name: Optional[str] = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{browser}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temp_name = handle.name
+            os.chmod(handle.name, 0o600)
+            json.dump(record, handle, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_name, path)
+        os.chmod(path, 0o600)
+        return True
+    except (OSError, TypeError, ValueError) as exc:
+        logger.warning(
+            "Could not persist real-profile lifecycle state for %s: %s", browser, exc
+        )
+        if temp_name:
+            try:
+                Path(temp_name).unlink(missing_ok=True)
+            except OSError:
+                pass
+        return False
+
+
+def _read_record(browser: str) -> Optional[dict[str, Any]]:
+    path = _record_path(browser, create=False)
+    if path is None:
+        return None
+    try:
+        record = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return None
+    return record if isinstance(record, dict) else None
+
+
+def _unlink_record(browser: str) -> None:
+    path = _record_path(browser, create=False)
+    if path is None:
+        return
+    try:
+        path.unlink(missing_ok=True)
+    except OSError as exc:
+        logger.debug(
+            "Could not remove real-profile lifecycle state for %s: %s", browser, exc
+        )
+
+
+def _record_target(
+    record: dict[str, Any],
+) -> Optional[tuple[str, Path, Path, int, Optional[int]]]:
+    browser_value = record.get("browser")
+    if not isinstance(browser_value, str) or not _browser_name_is_safe(browser_value):
+        return None
+    browser = browser_value
+    profile_dir = _canonical_path(record.get("profile_dir"))
+    binary = _canonical_path(record.get("binary"))
+    raw_pid = record.get("pid")
+    if isinstance(raw_pid, bool) or not isinstance(raw_pid, (int, str)):
+        return None
+    try:
+        expected_pid = int(raw_pid)
+    except (TypeError, ValueError):
+        return None
+    if expected_pid <= 0 or profile_dir is None or binary is None:
+        return None
+    try:
+        managed_profile = _managed_profile_dir(browser)
+    except (OSError, RuntimeError, ValueError):
+        return None
+    if profile_dir != managed_profile:
+        return None
+    raw_start = record.get("target_start_time", record.get("start_time"))
+    try:
+        target_start = int(raw_start) if raw_start is not None else None
+    except (TypeError, ValueError):
+        return None
+    return browser, profile_dir, binary, expected_pid, target_start
+
+
+def _process_is_alive(proc: Any) -> bool:
+    try:
+        import psutil
+
+        return proc.is_running() and proc.status() != psutil.STATUS_ZOMBIE
+    except Exception:
+        return False
+
+
+def _process_user_data_dir(cmdline: list[str]) -> Optional[Path]:
+    for index, arg in enumerate(cmdline):
+        if not isinstance(arg, str):
+            continue
+        if arg.startswith("--user-data-dir="):
+            return _canonical_path(arg.split("=", 1)[1])
+        if arg == "--user-data-dir" and index + 1 < len(cmdline):
+            return _canonical_path(cmdline[index + 1])
+    return None
+
+
+def _process_binary(proc: Any, cmdline: list[str]) -> Optional[Path]:
+    try:
+        executable = proc.exe()
+    except Exception:
+        executable = cmdline[0] if cmdline else None
+    return _canonical_path(executable)
+
+
+def _target_matches(
+    pid: int,
+    profile_dir: Path,
+    binary: Path,
+    expected_start: Optional[int],
+) -> bool:
+    """Verify a recorded PID is the exact direct browser incarnation."""
+    if expected_start is None:
+        # A target without an identity fingerprint cannot be safely killed
+        # after a restart.  A current Popen handle may still be cleaned up by
+        # its owner, but the cross-process reaper must leave this record alone.
+        return False
+    try:
+        import psutil
+
+        proc = psutil.Process(int(pid))
+        if not _process_is_alive(proc):
+            return False
+        if _safe_start_time(int(pid)) != expected_start:
+            return False
+        cmdline = proc.cmdline()
+        # Renderer/GPU children can inherit the profile argument.  The main
+        # process is the only exact executable/profile match without a
+        # Chromium process-type switch.
+        if any(arg.startswith("--type=") for arg in cmdline):
+            return False
+        if _process_binary(proc, cmdline) != binary:
+            return False
+        return _process_user_data_dir(cmdline) == profile_dir
+    except Exception:
+        return False
+
+
+def _matching_browser_processes(
+    profile_dir: Path, binary: Path
+) -> list[tuple[int, int]]:
+    """Find uniquely identifiable main Chromium processes for a profile copy."""
+    matches: list[tuple[int, int]] = []
+    try:
+        import psutil
+
+        for proc in psutil.process_iter(["pid", "cmdline"]):
+            try:
+                pid = int(proc.info["pid"])
+                cmdline = [
+                    arg for arg in (proc.info.get("cmdline") or [])
+                    if isinstance(arg, str)
+                ]
+                if not cmdline or any(arg.startswith("--type=") for arg in cmdline):
+                    continue
+                if _process_binary(proc, cmdline) != binary:
+                    continue
+                if _process_user_data_dir(cmdline) != profile_dir:
+                    continue
+                start_time = _safe_start_time(pid)
+                if start_time is not None and _process_is_alive(proc):
+                    matches.append((pid, start_time))
+            except (psutil.NoSuchProcess, psutil.AccessDenied, OSError, ValueError):
+                continue
+    except Exception:
+        return []
+    return matches
+
+
+def _owner_is_alive(owner: dict[str, Optional[int]]) -> bool:
+    pid = owner.get("pid")
+    if not pid:
+        return False
+    try:
+        from gateway.status import _pid_exists
+
+        if not _pid_exists(int(pid)):
+            return False
+    except Exception:
+        return False
+    expected_start = owner.get("start_time")
+    if expected_start is None:
+        # Legacy records have no owner fingerprint.  Treat a live PID as live
+        # to avoid killing an unrelated process; this may leak until the
+        # record is manually removed, which is safer than a false kill.
+        return True
+    return _safe_start_time(int(pid)) == expected_start
+
+
+def _live_owners(record: dict[str, Any]) -> list[dict[str, Optional[int]]]:
+    return [
+        owner for owner in _normalize_owner_entries(record) if _owner_is_alive(owner)
+    ]
+
+
+def _base_record(
+    browser: str,
+    profile_dir: Path,
+    binary: Path,
+    pid: int,
+    target_start: Optional[int],
+) -> dict[str, Any]:
+    now = time.time()
+    return {
+        "version": _RECORD_VERSION,
+        "browser": browser,
+        "pid": int(pid),
+        "profile_dir": str(profile_dir),
+        "binary": str(binary),
+        "target_start_time": target_start,
+        # Keep the old field name for operators/scripts that already inspect
+        # real-profile records, while the new field is more explicit.
+        "start_time": target_start,
+        "started_at": now,
+    }
+
+
+def register_real_profile_chrome(
+    browser: str,
+    profile_dir: str,
+    binary: str,
+    pid: int,
+) -> Optional[dict[str, Any]]:
+    """Persist ownership for a just-launched real-profile browser.
+
+    Returns the normalized target record on success.  ``None`` means the
+    profile/binary was not a managed target or state could not be persisted;
+    callers must terminate the just-launched process in that case.
+    """
+    if not _browser_name_is_safe(browser):
+        return None
+    profile = _canonical_path(profile_dir)
+    executable = _canonical_path(binary)
+    if (
+        profile is None
+        or executable is None
+        or profile != _managed_profile_dir(browser)
+    ):
+        return None
+    try:
+        pid = int(pid)
+    except (TypeError, ValueError):
+        return None
+    if pid <= 0:
+        return None
+
+    target_start = _safe_start_time(pid)
+    record = _base_record(browser, profile, executable, pid, target_start)
+    current = _read_record(browser)
+    current_target_matches = False
+    if current:
+        parsed = _record_target(current)
+        if parsed and parsed[1:] == (profile, executable, pid, target_start):
+            current_target_matches = True
+        elif parsed:
+            old_browser, old_profile, old_binary, old_pid, old_start = parsed
+            if _target_matches(old_pid, old_profile, old_binary, old_start):
+                logger.warning(
+                    "Refusing to replace live real-profile %s browser pid %d with pid %d",
+                    old_browser,
+                    old_pid,
+                    pid,
+                )
+                return None
+
+    owners = _normalize_owner_entries(current or {}) if current_target_matches else []
+    owners = [owner for owner in owners if _owner_is_alive(owner)]
+    owners.append(_owner_entry(os.getpid()))
+    record = _with_owner_fields(record, owners)
+    if not _write_record(browser, record):
+        return None
+    return record
+
+
+def claim_real_profile_chrome(
+    browser: str,
+    profile_dir: str,
+    binary: str,
+) -> Optional[dict[str, Any]]:
+    """Claim a browser already serving the managed profile copy.
+
+    This is used when a new Hermes process reuses an existing shared
+    agent-browser session.  If no record exists (for example, a browser was
+    launched by a Hermes build before persistent tracking), the exact process
+    is discovered from its executable/profile arguments and recorded.  The
+    function fails closed when the process identity is ambiguous.
+    """
+    if not _browser_name_is_safe(browser):
+        return None
+    profile = _canonical_path(profile_dir)
+    executable = _canonical_path(binary)
+    if (
+        profile is None
+        or executable is None
+        or profile != _managed_profile_dir(browser)
+    ):
+        return None
+
+    current = _read_record(browser)
+    target: Optional[tuple[int, int]] = None
+    if current:
+        parsed = _record_target(current)
+        if parsed is None:
+            current = None
+        else:
+            _, current_profile, current_binary, pid, start_time = parsed
+            if (
+                current_profile == profile
+                and current_binary == executable
+                and start_time is not None
+                and _target_matches(pid, profile, executable, start_time)
+            ):
+                target = (pid, start_time)
+            elif not _target_matches(pid, current_profile, current_binary, start_time):
+                # The record is stale; replace it below after discovering the
+                # live process.  Never kill or overwrite a live mismatched one.
+                current = None
+            else:
+                return None
+
+    if target is None:
+        matches = _matching_browser_processes(profile, executable)
+        if len(matches) != 1:
+            return None
+        target = matches[0]
+        current = None
+
+    pid, target_start = target
+    record = _base_record(browser, profile, executable, pid, target_start)
+    if current:
+        # Preserve the original launch timestamp and existing owners when the
+        # record already describes this exact target.
+        record["started_at"] = current.get("started_at", record["started_at"])
+        owners = [
+            owner
+            for owner in _normalize_owner_entries(current)
+            if _owner_is_alive(owner)
+        ]
+    else:
+        owners = []
+    current_owner = _owner_entry(os.getpid())
+    owners = [owner for owner in owners if owner != current_owner]
+    owners.append(current_owner)
+    record = _with_owner_fields(record, owners)
+    if not _write_record(browser, record):
+        return None
+    return record
+
+
+def _remove_current_owner(record: dict[str, Any]) -> list[dict[str, Optional[int]]]:
+    current_pid = os.getpid()
+    current_start = _safe_start_time(current_pid)
+    owners = _normalize_owner_entries(record)
+    remaining = []
+    for owner in owners:
+        if owner.get("pid") != current_pid:
+            remaining.append(owner)
+            continue
+        if current_start is None or owner.get("start_time") in (None, current_start):
+            continue
+        remaining.append(owner)
+    return [owner for owner in remaining if _owner_is_alive(owner)]
+
+
+def retire_real_profile_chrome(
+    browser: str,
+    profile_dir: str,
+    binary: str,
+    pid: Optional[int],
+) -> Optional[bool]:
+    """Release this Hermes owner and stop the target when no owner remains.
+
+    Returns ``True`` when the target was stopped or was already gone,
+    ``False`` when another live Hermes owner still uses it, and ``None`` when
+    no trustworthy record describes the supplied process.
+    """
+    if not _browser_name_is_safe(browser):
+        return None
+    record = _read_record(browser)
+    if not record:
+        return None
+    parsed = _record_target(record)
+    profile = _canonical_path(profile_dir)
+    executable = _canonical_path(binary)
+    if not parsed or profile is None or executable is None:
+        return None
+    _, recorded_profile, recorded_binary, recorded_pid, recorded_start = parsed
+    if recorded_profile != profile or recorded_binary != executable:
+        return None
+    if pid is not None and int(pid) != recorded_pid:
+        return None
+
+    owners = _remove_current_owner(record)
+    if owners:
+        updated = _with_owner_fields(record, owners)
+        return False if _write_record(browser, updated) else False
+
+    if recorded_start is None:
+        # The current owner can still use its Popen handle as a last-resort
+        # cleanup path, but a cross-process caller must not unlink this record
+        # or signal a PID without an incarnation fingerprint.
+        return False
+
+    if _target_matches(recorded_pid, recorded_profile, recorded_binary, recorded_start):
+        try:
+            from tools.process_registry import ProcessRegistry
+
+            ProcessRegistry._terminate_host_pid(
+                recorded_pid, expected_start=recorded_start
+            )
+        except Exception as exc:
+            logger.debug(
+                "Could not stop real-profile Chrome pid %d: %s", recorded_pid, exc
+            )
+            return False
+    _unlink_record(browser)
+    return True
+
+
+def has_live_real_profile_owner(browser: str) -> bool:
+    """Return whether a tracked real-profile browser still has a live owner."""
+    record = _read_record(browser)
+    return bool(record and _live_owners(record))
+
+
+def reap_orphaned_real_profile_chrome() -> int:
+    """Reap direct real-profile Chrome processes whose owners are gone."""
+    state_dir = _state_dir(create=False)
+    if state_dir is None:
+        return 0
+    reaped = 0
+    for record_path in sorted(state_dir.glob("*.json")):
+        try:
+            record = json.loads(record_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError, TypeError):
+            # A partially-written/malformed record is not evidence that a
+            # process is ours.  Leave it for inspection; never guess a PID.
+            continue
+        if not isinstance(record, dict):
+            continue
+        parsed = _record_target(record)
+        if parsed is None:
+            continue
+        browser, profile_dir, binary, pid, target_start = parsed
+        if _live_owners(record):
+            continue
+        if target_start is None:
+            logger.warning(
+                "Refusing to reap real-profile Chrome pid %d (%s): "
+                "no process start-time fingerprint",
+                pid,
+                browser,
+            )
+            continue
+        if not _target_matches(pid, profile_dir, binary, target_start):
+            # The target already exited or the PID was recycled.  Removing a
+            # stale record is safe because no process was signalled.
+            try:
+                record_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            continue
+        try:
+            from tools.process_registry import ProcessRegistry
+
+            ProcessRegistry._terminate_host_pid(pid, expected_start=target_start)
+        except Exception as exc:
+            logger.debug(
+                "Could not reap orphaned real-profile Chrome pid %d: %s", pid, exc
+            )
+            continue
+
+        # Do not discard a record if the exact process is still alive after a
+        # failed/denied tree-kill; the next sweep can retry safely.
+        if not _target_matches(pid, profile_dir, binary, target_start):
+            try:
+                record_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            reaped += 1
+            logger.info("Reaped orphaned real-profile Chrome pid %d (%s)", pid, browser)
+    return reaped


### PR DESCRIPTION
## Summary

- Persist ownership for the directly-launched real-profile Chromium process, including its PID, start-time fingerprint, exact executable, and exact Hermes-owned profile copy.
- Track multiple live Hermes owners when a shared real-profile browser is reused, so one gateway cannot terminate a browser still used by another.
- Reap orphaned real-profile Chrome processes from the existing browser cleanup worker and atexit sweep, with PID-reuse and process-identity checks before tree termination.
- Release or terminate the direct browser on agent-browser attach failures and when real-profile consent is revoked.

## Why

Hermes real-profile mode launches the signed Chrome binary directly so macOS Keychain-encrypted cookies remain usable. That process is not represented by an agent-browser socket directory, so an unclean Hermes exit can leave a headless `com.google.Chrome` process behind. On macOS, that stale process can collide with normal Chrome LaunchServices and leave duplicate Dock entries or prevent the normal Chrome window from opening.

This is a focused companion to #100865: that change covers persistent agent-browser daemons, while this change covers the directly-launched signed Chrome child.

## Testing

- `./scripts/run_tests.sh tests/tools/test_real_profile_lifecycle.py tests/tools/test_browser_real_profile.py tests/tools/test_browser_orphan_reaper.py -q` — 111 passed.
- `ruff check` — passed.
- `ty check tools/real_profile_lifecycle.py` — passed.
- `scripts/check-windows-footguns.py` — passed for changed production files.
- Manual macOS subprocess check — register, exact identity match, and tree termination passed.

Related: #33155, #100855.
