### PR TITLE
fix(desktop): escalate via sudo -n/pkexec so the sandbox helper configures without a TTY

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8244,17 +8244,79 @@ def _desktop_linux_sandbox_fixup(packaged_executable: Path) -> bool:
         print("✓ Using Chromium's user-namespace sandbox (setuid helper not needed).")
         return True
 
+    # The helper needs root:root 4755, which takes elevated privileges.
+    #
+    # A bare `sudo` can only prompt when a TTY is attached. Launched from the
+    # .desktop entry there is none, so sudo fails with "no tty present", the
+    # helper stays misconfigured, and the caller quietly downgrades the launch
+    # to --no-sandbox: the app starts, but unsandboxed, for a reason the user
+    # never sees (Terminal=false). Every rebuild resets the helper's mode, so
+    # this recurs on each update. Try the non-interactive and graphical paths
+    # before giving up.
     sudo = shutil.which("sudo")
-    if not sudo:
-        print("✗ Hermes Desktop requires sudo to configure Electron's Linux sandbox helper.")
+    pkexec = shutil.which("pkexec")
+    if not sudo and not pkexec:
+        print(
+            "✗ Hermes Desktop requires sudo or pkexec to configure "
+            "Electron's Linux sandbox helper."
+        )
         return False
 
-    print("→ Configuring Electron Linux sandbox helper (sudo required)...")
-    for command in ([sudo, "chown", "root:root", str(sandbox)], [sudo, "chmod", "4755", str(sandbox)]):
-        if subprocess.run(command, check=False).returncode != 0:
-            print(f"✗ Failed to configure Electron's Linux sandbox helper: {sandbox}")
-            return False
-    return True
+    shell = shutil.which("sh")
+    if not shell:
+        print("✗ Cannot configure Electron's Linux sandbox helper: sh not found.")
+        return False
+
+    # One elevated call does both changes, so the user is prompted once rather
+    # than twice. The path is shell-quoted; it is also already proven to be a
+    # regular file (not a symlink) by the lstat checks above.
+    quoted = shlex.quote(str(sandbox))
+    script = f"chown root:root {quoted} && chmod 4755 {quoted}"
+
+    try:
+        has_tty = sys.stdin is not None and sys.stdin.isatty()
+    except (AttributeError, ValueError):
+        has_tty = False
+
+    attempts: list[tuple[str, list[str]]] = []
+    if sudo:
+        # Cached credentials or a NOPASSWD rule: succeeds without prompting.
+        attempts.append(("sudo -n", [sudo, "-n", shell, "-c", script]))
+        if has_tty:
+            attempts.append(("sudo", [sudo, shell, "-c", script]))
+    if not has_tty and pkexec:
+        # No TTY, so let polkit raise its own graphical password prompt.
+        attempts.append(("pkexec", [pkexec, shell, "-c", script]))
+
+    if not attempts:
+        print(
+            "✗ Hermes Desktop requires sudo or pkexec to configure "
+            "Electron's Linux sandbox helper."
+        )
+        return False
+
+    print("→ Configuring Electron Linux sandbox helper (elevated privileges required)...")
+    for label, command in attempts:
+        if subprocess.run(command, check=False).returncode == 0:
+            return True
+        print(f"  … {label} did not succeed")
+
+    print(f"✗ Failed to configure Electron's Linux sandbox helper: {sandbox}")
+    if not has_tty:
+        # Nothing printed above reaches a launcher-started process; surface the
+        # reason where the user will see it, and name the command that fixes it.
+        notify = shutil.which("notify-send")
+        if notify:
+            subprocess.run(
+                [
+                    notify,
+                    "Hermes Desktop",
+                    "Could not configure the Electron sandbox helper. "
+                    "Run `hermes desktop` once from a terminal.",
+                ],
+                check=False,
+            )
+    return False
 
 
 def _desktop_linux_needs_disable_setuid_sandbox(packaged_executable: Path) -> bool:

--- a/tests/hermes_cli/test_linux_sandbox_fixup.py
+++ b/tests/hermes_cli/test_linux_sandbox_fixup.py
@@ -161,3 +161,97 @@ class TestDesktopLinuxNeedsDisableSetuidSandbox:
         exe = unpacked / "Hermes"
         exe.write_text("", encoding="utf-8")
         assert cli_main._desktop_linux_needs_disable_setuid_sandbox(exe) is False
+
+
+class TestDesktopLinuxSandboxFixupEscalation:
+    """The escalation path when userns is unavailable and the helper needs setuid.
+
+    On such hosts the fixup must still reach root, but a bare ``sudo`` can only
+    prompt with a TTY. Launched from the .desktop entry there is none, so it
+    must not be attempted; ``sudo -n`` (cached creds / NOPASSWD) and ``pkexec``
+    (graphical polkit prompt) are the paths that can succeed there.
+    """
+
+    def _fake_packaged_app(self, tmp_path):
+        unpacked = tmp_path / "linux-unpacked"
+        unpacked.mkdir()
+        exe = unpacked / "Hermes"
+        exe.write_text("", encoding="utf-8")
+        sandbox = unpacked / "chrome-sandbox"
+        sandbox.write_text("", encoding="utf-8")
+        sandbox.chmod(0o755)
+        return exe
+
+    def _which(self, available):
+        return lambda name: f"/usr/bin/{name}" if name in available else None
+
+    def test_no_tty_uses_pkexec_and_never_bare_sudo(self, monkeypatch, tmp_path):
+        """Without a TTY, bare sudo must never run — it can only fail there."""
+        monkeypatch.setattr(sys, "platform", "linux")
+        exe = self._fake_packaged_app(tmp_path)
+        with patch.object(
+                 cli_main, "_desktop_linux_userns_sandbox_available", return_value=False
+             ), \
+             patch.object(cli_main.shutil, "which",
+                          side_effect=self._which({"sh", "sudo", "pkexec"})), \
+             patch.object(cli_main.sys.stdin, "isatty", return_value=False), \
+             patch.object(cli_main.subprocess, "run") as run:
+            run.return_value = subprocess.CompletedProcess([], 1)
+            cli_main._desktop_linux_sandbox_fixup(exe)
+
+        argvs = [call.args[0] for call in run.call_args_list]
+        assert any(a[0].endswith("pkexec") for a in argvs), "pkexec must be attempted"
+        sudo_calls = [a for a in argvs if a[0].endswith("sudo")]
+        assert sudo_calls, "sudo -n must be attempted"
+        for a in sudo_calls:
+            assert a[1] == "-n", f"bare sudo must not run without a TTY: {a}"
+
+    def test_pkexec_success_returns_true(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(sys, "platform", "linux")
+        exe = self._fake_packaged_app(tmp_path)
+        with patch.object(
+                 cli_main, "_desktop_linux_userns_sandbox_available", return_value=False
+             ), \
+             patch.object(cli_main.shutil, "which",
+                          side_effect=self._which({"sh", "pkexec"})), \
+             patch.object(cli_main.sys.stdin, "isatty", return_value=False), \
+             patch.object(cli_main.subprocess, "run") as run:
+            run.return_value = subprocess.CompletedProcess([], 0)
+            assert cli_main._desktop_linux_sandbox_fixup(exe) is True
+
+    def test_tty_host_may_use_interactive_sudo(self, monkeypatch, tmp_path):
+        """With a TTY, bare sudo is a legitimate second attempt."""
+        monkeypatch.setattr(sys, "platform", "linux")
+        exe = self._fake_packaged_app(tmp_path)
+        with patch.object(
+                 cli_main, "_desktop_linux_userns_sandbox_available", return_value=False
+             ), \
+             patch.object(cli_main.shutil, "which",
+                          side_effect=self._which({"sh", "sudo"})), \
+             patch.object(cli_main.sys.stdin, "isatty", return_value=True), \
+             patch.object(cli_main.subprocess, "run") as run:
+            run.return_value = subprocess.CompletedProcess([], 1)
+            assert cli_main._desktop_linux_sandbox_fixup(exe) is False
+
+        argvs = [call.args[0] for call in run.call_args_list]
+        assert any(a[0].endswith("sudo") and a[1] == "-n" for a in argvs)
+        assert any(a[0].endswith("sudo") and a[1] != "-n" for a in argvs)
+
+    def test_headless_failure_notifies_the_user(self, monkeypatch, tmp_path):
+        """A launcher-started process shows no stdout — surface the reason."""
+        monkeypatch.setattr(sys, "platform", "linux")
+        exe = self._fake_packaged_app(tmp_path)
+        with patch.object(
+                 cli_main, "_desktop_linux_userns_sandbox_available", return_value=False
+             ), \
+             patch.object(cli_main.shutil, "which",
+                          side_effect=self._which({"sh", "pkexec", "notify-send"})), \
+             patch.object(cli_main.sys.stdin, "isatty", return_value=False), \
+             patch.object(cli_main.subprocess, "run") as run:
+            run.return_value = subprocess.CompletedProcess([], 1)
+            assert cli_main._desktop_linux_sandbox_fixup(exe) is False
+
+        argvs = [call.args[0] for call in run.call_args_list]
+        assert any(
+            a[0].endswith("notify-send") for a in argvs
+        ), "must notify on headless failure"


### PR DESCRIPTION
## Summary

On Linux hosts that restrict unprivileged user namespaces, `hermes desktop` launched from the `.desktop` entry still cannot configure Electron's setuid sandbox helper, and silently downgrades the launch to `--no-sandbox`. This adds the escalation paths that can actually succeed without a TTY.

## Root cause

`_desktop_linux_sandbox_fixup()` shells out to a bare `sudo`, which can only prompt when a TTY is attached. Launched from the desktop entry there is none, so `sudo` fails with "no tty present", the helper stays misconfigured, and the caller quietly falls back to `--no-sandbox`. The entry sets `Terminal=false`, so nothing printed on the failure path ever reaches the user. Each rebuild resets the helper's mode, so it recurs on every update.

The userns probe added for #88032 / #51327 fixed this for hosts where Chromium's namespace sandbox is usable — `_desktop_linux_userns_sandbox_available()` short-circuits before the sudo path. But on hosts that restrict unprivileged userns the probe returns `False` and execution falls through to the same bare `sudo` call, reproducing the original failure.

Reproduced on Ubuntu with `kernel.apparmor_restrict_unprivileged_userns=1`:

```
$ python -c "from hermes_cli.main import _desktop_linux_userns_sandbox_available as f; print(f())"
False
$ unshare --user --map-root-user true
unshare: write failed /proc/self/uid_map: Operation not permitted
```

Networking and the rest of the host are healthy; only the namespace path is blocked. The observable symptom is a desktop entry that launches an unsandboxed app, or — after the helper is configured interactively once — a launcher that stops passing `--no-sandbox` on a host where the sandbox cannot work at all.

## Changes

**`hermes_cli/main.py`** — in `_desktop_linux_sandbox_fixup()`, after the unchanged userns short-circuit:

- Escalate through `sudo -n` (cached credentials or a `NOPASSWD` rule, never prompts), then bare `sudo` **only when a TTY is present**, then `pkexec` when there is no TTY, so polkit can raise its own graphical prompt.
- `chown` and `chmod` are combined into one elevated call, so the user is prompted once rather than twice. The path is `shlex.quote`d; the pre-existing `lstat` symlink/regular-file guards still run before anything is elevated.
- If every attempt fails and there is no TTY, `notify-send` surfaces the reason and names the command that repairs it (`hermes desktop` from a terminal), since stdout is invisible to a launcher-started process.

**`tests/hermes_cli/test_linux_sandbox_fixup.py`** — four tests covering the escalation path:

- bare `sudo` is never attempted without a TTY, and `pkexec` is
- `pkexec` success returns `True`
- with a TTY, interactive `sudo` is a legitimate second attempt
- headless failure notifies the user

## Validation

| Check | Result |
|---|---|
| Existing 11 tests in the file | pass |
| New 4 tests | pass |
| Mutation check: prod file reverted to `origin/main`, new tests re-run | all 4 fail — they genuinely pin the behavior |
| `ruff check` on both touched files | clean |

On `ruff format`: both touched files already differ from `ruff format` output on `origin/main`, so I matched the surrounding style (the file's existing `with ... , \` form) rather than reformatting unrelated lines.

## Compatibility

- Hosts where userns works are unaffected — the probe still short-circuits before any escalation is considered.
- When neither `sudo` nor `pkexec` is present, the function fails exactly as before.
- No change to the caller's `--no-sandbox` fallback logic.
