### PR TITLE
fix(kanban): treat review handoffs as terminal in the stop-guard

### DIFF
--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -17,7 +17,10 @@ import os
 from typing import Any, Iterable, Optional
 
 
-_TERMINAL_KANBAN_TOOLS = frozenset({"kanban_complete", "kanban_block"})
+_TERMINAL_KANBAN_TOOLS = frozenset({
+    "kanban_complete", "kanban_block",
+    "kanban_request_review", "kanban_request_changes",
+})
 
 _DEFAULT_MAX_ATTEMPTS = 2
 

--- a/tests/agent/test_kanban_stop.py
+++ b/tests/agent/test_kanban_stop.py
@@ -74,6 +74,27 @@ def test_no_nudge_after_kanban_complete(clear_kanban_env):
     assert build_kanban_stop_nudge(messages=messages) is None
 
 
+@pytest.mark.parametrize("tool", ["kanban_request_review", "kanban_request_changes"])
+def test_no_nudge_after_review_handoff(clear_kanban_env, tool):
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "1",
+                    "type": "function",
+                    "function": {"name": tool, "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "name": tool, "tool_call_id": "1", "content": "ok"},
+    ]
+    assert session_called_kanban_terminal(messages) is True
+    assert build_kanban_stop_nudge(messages=messages) is None
+
+
 
 
 


### PR DESCRIPTION
## What

When a dispatcher-spawned kanban worker exits its run by calling
`kanban_request_review` (or `kanban_request_changes`), the turn-end
stop-guard in `agent/kanban_stop.py` still emits its "task is still
running — call `kanban_complete`/`kanban_block`" nudge.

## Why

`_TERMINAL_KANBAN_TOOLS` at `agent/kanban_stop.py:20`
lists only `kanban_complete` and `kanban_block`. Both review transitions
were added later as first-class terminal transitions (they end the run
and move the task into the review column), but the stop-guard's allowlist
was never extended, and the guard decides "terminal?" purely by scanning
the conversation transcript for those two names — it never reads board
state. So a model that ends its final turn with plain text *after* calling
`kanban_request_review` gets prompted twice (bounded nudge budget,
`_DEFAULT_MAX_ATTEMPTS = 2`) to call `kanban_complete` on a task that is
already in review.

## Fix

Add both review tools to the terminal set. After this change the nudge
only fires when none of the four terminal tools was called, so the message
text remains accurate as written.

## Test

The new parametrized test (see diff) asserts `session_called_kanban_terminal`
is True for both tools and `build_kanban_stop_nudge` returns None. It fails
on `main` before this change.

## Notes

- No behavior change for `kanban_complete` / `kanban_block` / goal-loop
  (`goals.py` already handles review status via a live DB read).
- The goal loop already gates on live DB state; this only fixes the
  transcript-scan guard.