### PR TITLE
fix(tool-search): tool_call refuses spread arguments instead of silently dropping them

### DIFF
--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -413,6 +413,42 @@ class TestBridgeDispatch:
         assert "bridge tool" in err.lower()
 
 
+    def test_resolve_underlying_call_refuses_spread_tool_arguments(self):
+        """Arguments spread beside 'arguments' are refused, not dropped.
+
+        A model that emits some of the tool's own parameters as siblings of
+        'arguments' used to have them silently discarded, so the underlying
+        tool ran with an incomplete payload. When the lost parameters were
+        optional, nothing downstream could tell — the call simply did the
+        wrong thing.
+        """
+        from tools.tool_search import resolve_underlying_call
+        name, args, err = resolve_underlying_call({
+            "name": "some_mcp_tool",
+            "arguments": {"argv": ["/usr/bin/sqlite3", "chat.db", "select 1;"]},
+            "cwd": "~/Library/Messages",
+            "read_paths": ["~/Library/Messages"],
+        })
+        assert name is None
+        assert args == {}
+        assert err is not None
+        # The message has to name the keys, or the model cannot act on it.
+        assert "cwd" in err
+        assert "read_paths" in err
+        assert "arguments" in err
+
+    def test_resolve_underlying_call_allows_the_bare_envelope(self):
+        """The two envelope keys alone are not mistaken for stray arguments."""
+        from tools.tool_search import resolve_underlying_call
+        _, _, err = resolve_underlying_call({
+            "name": "unknown_xxx",
+            "arguments": {"foo": "bar"},
+        })
+        # Still an error (unknown_xxx is not deferrable), but not the new one.
+        assert err is not None
+        assert "alongside" not in err
+
+
 # ---------------------------------------------------------------------------
 # End-to-end via the real handle_function_call (smoke test).
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -400,6 +400,8 @@ class TestBridgeDispatch:
         })
         # Will fail classification because unknown_xxx isn't deferrable.
         assert err is not None
+        # ...and NOT because the bare envelope was mistaken for stray keys.
+        assert "alongside" not in err
 
 
     def test_resolve_underlying_call_rejects_recursion(self):
@@ -436,17 +438,6 @@ class TestBridgeDispatch:
         assert "cwd" in err
         assert "read_paths" in err
         assert "arguments" in err
-
-    def test_resolve_underlying_call_allows_the_bare_envelope(self):
-        """The two envelope keys alone are not mistaken for stray arguments."""
-        from tools.tool_search import resolve_underlying_call
-        _, _, err = resolve_underlying_call({
-            "name": "unknown_xxx",
-            "arguments": {"foo": "bar"},
-        })
-        # Still an error (unknown_xxx is not deferrable), but not the new one.
-        assert err is not None
-        assert "alongside" not in err
 
 
 # ---------------------------------------------------------------------------

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -67,6 +67,11 @@ TOOL_CALL_NAME = "tool_call"
 
 BRIDGE_TOOL_NAMES = frozenset({TOOL_SEARCH_NAME, TOOL_DESCRIBE_NAME, TOOL_CALL_NAME})
 
+# The only keys ``tool_call`` itself accepts. Anything else in the invocation is
+# a tool argument that was spread instead of nested — see
+# ``resolve_underlying_call``, which refuses rather than dropping it.
+_TOOL_CALL_ENVELOPE_KEYS = frozenset({"name", "arguments"})
+
 # When estimating tokens from char count without a real tokenizer, this is
 # the cheap rule of thumb that's stable across providers. Roughly 4 chars
 # per token for English+JSON. Underestimating leads to false negatives
@@ -1336,6 +1341,28 @@ def resolve_underlying_call(args: Dict[str, Any]) -> Tuple[Optional[str], Dict[s
         return None, {}, "tool_call requires a 'name' argument"
     if name in BRIDGE_TOOL_NAMES:
         return None, {}, f"tool_call cannot invoke '{name}' (it is itself a bridge tool)"
+    # Everything the tool actually receives travels inside ``arguments``. A
+    # model that spreads some of the tool's own parameters alongside it —
+    # ``{"name": ..., "arguments": {"argv": [...]}, "cwd": "...")`` — used to
+    # have those keys silently dropped here, and the call went out missing
+    # them. Nothing downstream can notice: the underlying tool's schema sees a
+    # payload that is merely incomplete, and if the lost parameters were
+    # OPTIONAL it validates clean and runs with the wrong inputs.
+    #
+    # That is a silent-wrong-answer bug, and an expensive one — a real MCP tool
+    # lost its `cwd`, ran in the wrong directory, and the resulting
+    # file-not-found error was misread by the agent as a permissions failure it
+    # then reported to the user. Refuse instead, and name the keys: the model
+    # gets a turn back and re-sends them nested.
+    stray = sorted(k for k in args if k not in _TOOL_CALL_ENVELOPE_KEYS)
+    if stray:
+        return None, {}, (
+            "tool_call got " + ", ".join(repr(k) for k in stray) + " alongside "
+            "'arguments'. Every argument for the tool being invoked belongs "
+            "INSIDE the 'arguments' object; tool_call itself takes only 'name' "
+            "and 'arguments'. Re-send with " + ", ".join(repr(k) for k in stray) +
+            " nested inside 'arguments'."
+        )
     raw_args = args.get("arguments")
     if raw_args is None:
         raw_args = {}


### PR DESCRIPTION
## What does this PR do?

`resolve_underlying_call` reads `arguments` and ignores every other key in the invocation. A model that spreads some of the invoked tool's own parameters alongside `arguments` —

```json
{"name": "some_mcp_tool",
 "arguments": {"argv": ["/usr/bin/sqlite3", "-readonly", "chat.db", "select 1;"]},
 "cwd": "~/Library/Messages",
 "read_paths": ["~/Library/Messages"]}
```

— has `cwd` and `read_paths` silently discarded, and the call is dispatched without them.

**Nothing downstream can catch this.** The invoked tool's schema sees a payload that is merely *incomplete*, not malformed. If the dropped parameters were **optional**, it validates clean and the tool runs with the wrong inputs. `validate_deferred_call_args()` doesn't help either — it only checks for missing *required* keys. And the `tool_call` bridge schema declares `{name, arguments}` without setting `additionalProperties: false`, so JSON Schema's default (`true`) means the model-facing schema doesn't forbid the extra keys. This function is the only enforcement point.

The result is a silent wrong answer, which is the worst failure mode available here: the model gets no signal that it did anything wrong, so it can't self-correct.

**Why refuse rather than merge the stray keys into `arguments`:** merging would paper over a real model mistake and would silently resolve key collisions against the caller's intent. A refusal costs one turn and is self-correcting — the message names the offending keys so the model can re-send them nested.

## Related Issue

Related to #73175, which documents the adjacent gap ("`validate_deferred_call_args()` ... deliberately checks only top-level `required` key absence"). This PR is **not** a duplicate of it, and the two are complementary:

- #73175 (and #100979 implementing it) validates the **contents** of `arguments` against the invoked tool's schema.
- This PR validates the **envelope** — that nothing was dropped on the way *into* `arguments`.

Ordering matters: envelope enforcement has to happen *before* the payload is extracted. By the time schema validation runs, the dropped key is already gone and the remaining payload is schema-valid, so a contents validator structurally cannot see this class. Notably, #73175's own reproduction places its stray key (`"unexpected": "accepted"`) *inside* `arguments`, which is the blind spot in miniature.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/tool_search.py` — added `_TOOL_CALL_ENVELOPE_KEYS = frozenset({"name", "arguments"})` next to `BRIDGE_TOOL_NAMES`, mirroring the declared schema properties so the two can't drift. `resolve_underlying_call` now returns a refusal naming any stray top-level keys, before `arguments` is extracted.
- `tests/tools/test_tool_search.py` — added `test_resolve_underlying_call_refuses_spread_tool_arguments`, asserting the stray keys are *named* in the message (an unactionable refusal is nearly as bad as the silent drop). The bare-envelope case is asserted inside the existing `test_resolve_underlying_call_parses_object_args` rather than as a separate near-duplicate test.

The refusal reads:

```
tool_call got 'cwd', 'read_paths' alongside 'arguments'. Every argument for the
tool being invoked belongs INSIDE the 'arguments' object; tool_call itself takes
only 'name' and 'arguments'. Re-send with 'cwd', 'read_paths' nested inside
'arguments'.
```

+54 / −0 across two files. All three call sites of `resolve_underlying_call` (`model_tools.handle_function_call`, the display layer, the trajectory recorder) pass the model's raw `function_args`, so none of them trips the new check.

## How to Test

1. Reproduce the drop on `main`:

```python
from tools.tool_search import resolve_underlying_call
name, args, err = resolve_underlying_call({
    "name": "some_deferred_tool",
    "arguments": {"argv": ["ls"]},
    "cwd": "/tmp",
})
# on main: `cwd` is gone from `args`, `err` is unrelated to the drop
```

2. With this PR, the same call returns `(None, {}, "<refusal naming 'cwd'>")`.
3. `pytest tests/tools/test_tool_search.py tests/tools/test_deferral_fixes.py tests/agent/test_tool_dispatch_helpers.py -q` → **89 passed**.

### How this was found

Observed in production against an MCP tool whose optional `cwd` selects the working directory. `cwd` was dropped, the command ran in the caller's scratch directory instead, and the resulting file-not-found surfaced as `unable to open database file` — a string byte-identical to a permissions failure. The agent diagnosed it as a missing OS permission grant and told the user to go into their system settings and enable disk access for the wrong process. The permission was already granted. Two wasted retry turns and one confidently wrong diagnosis delivered to a human, from a malformed call that nothing rejected.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate (nearest are #73175 / #100979 — different layer, see *Related Issue*; also reviewed #83953, #83949, #81765, #80594, #89246, all of which operate on the *contents* of `arguments`)
- [x] My PR contains **only** changes related to this fix (2 commits, rebased on current `main`)
- [ ] I've run `pytest tests/ -q` and all tests pass — **partially**: I ran the modules covering this change and its call sites (89 passed, listed above). The full `tests/` run does not complete in my environment — `tests/tools/test_mcp_oauth_metadata.py`, `test_mcp_tool.py` and `test_slack_send_message_media.py` fail at collection on a missing `mcp` module, which is unrelated to this diff (it touches neither those modules nor `tools/mcp_tool.py`). Happy to have CI confirm.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 14.5 (Darwin 23.5.0), Python 3.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (behavior is a refusal path; the refusal message is self-documenting and the new constant carries a comment explaining why it mirrors the schema)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture or workflow change)
- [x] I've considered cross-platform impact — N/A (pure dict-key comparison, no platform-specific behavior)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — the `tool_call` schema is unchanged; the new constant mirrors its existing `properties` so the two stay in sync. Setting `additionalProperties: false` on the bridge schema would be a reasonable belt-and-braces addition, but provider-side enforcement of that keyword is inconsistent, so the runtime check is the load-bearing half. Glad to add the schema flag too if you'd prefer both.
