### PR TITLE
fix(gateway): keep Dashboard from killing gateways during state migration

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -32982,7 +32982,46 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         if _stderr_level < logging.getLogger().level:
             logging.getLogger().setLevel(_stderr_level)
 
-    runner = GatewayRunner(config)
+    # Claim the runtime identity BEFORE constructing GatewayRunner.  Its
+    # constructor opens SessionStore/SessionDB and may spend minutes in a
+    # large schema migration.  Until the PID file exists, the dashboard's
+    # orphan sweep cannot distinguish that live startup from an abandoned
+    # gateway and may terminate it, leaving the successor blocked in the same
+    # migration path (#100968).
+    import atexit
+    from gateway.status import write_pid_file, remove_pid_file, get_running_pid
+    _current_pid = get_running_pid()
+    if _current_pid is not None and _current_pid != os.getpid():
+        logger.error(
+            "Another gateway instance (PID %d) started during our startup. "
+            "Exiting to avoid double-running.", _current_pid
+        )
+        return False
+    if not acquire_gateway_runtime_lock():
+        logger.error(
+            "Gateway runtime lock is already held by another instance. Exiting."
+        )
+        return False
+    try:
+        write_pid_file()
+    except FileExistsError:
+        release_gateway_runtime_lock()
+        logger.error(
+            "PID file race lost to another gateway instance. Exiting."
+        )
+        return False
+    atexit.register(remove_pid_file)
+    atexit.register(release_gateway_runtime_lock)
+
+    try:
+        runner = GatewayRunner(config)
+    except BaseException:
+        # Construction can fail after opening config/state resources but
+        # before runner.stop() exists to own cleanup.  Do not leave the early
+        # identity claim behind for a healthy retry.
+        remove_pid_file()
+        release_gateway_runtime_lock()
+        raise
     # ``--replace`` is explicit startup authority, not a durable reconnect
     # policy. GatewayRunner scopes this bit to cold adapter connects and clears
     # it before the background reconnect watcher starts.
@@ -33143,37 +33182,6 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         name="planned-stop-watcher",
     )
     _planned_stop_watcher_thread.start()
-
-    # Claim the PID file BEFORE bringing up any platform adapters.
-    # This closes the --replace race window: two concurrent `gateway run
-    # --replace` invocations both pass the termination-wait above, but
-    # only the winner of the O_CREAT|O_EXCL race below will ever open
-    # Telegram polling, Discord gateway sockets, etc. The loser exits
-    # cleanly before touching any external service.
-    import atexit
-    from gateway.status import write_pid_file, remove_pid_file, get_running_pid
-    _current_pid = get_running_pid()
-    if _current_pid is not None and _current_pid != os.getpid():
-        logger.error(
-            "Another gateway instance (PID %d) started during our startup. "
-            "Exiting to avoid double-running.", _current_pid
-        )
-        return False
-    if not acquire_gateway_runtime_lock():
-        logger.error(
-            "Gateway runtime lock is already held by another instance. Exiting."
-        )
-        return False
-    try:
-        write_pid_file()
-    except FileExistsError:
-        release_gateway_runtime_lock()
-        logger.error(
-            "PID file race lost to another gateway instance. Exiting."
-        )
-        return False
-    atexit.register(remove_pid_file)
-    atexit.register(release_gateway_runtime_lock)
 
     # Control socket (#92091 step 1) — the gateway-owned identify/status
     # surface. Started immediately after the PID-file claim: winning that

--- a/tests/gateway/test_startup_restart_race.py
+++ b/tests/gateway/test_startup_restart_race.py
@@ -216,3 +216,58 @@ async def test_start_gateway_does_not_start_cron_after_aborted_startup(tmp_path,
     assert exc.value.code == GATEWAY_SERVICE_RESTART_EXIT_CODE
     assert cron_started is False
     assert export_shutdown_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_start_gateway_claims_identity_before_runner_opens_state_db(
+    tmp_path, monkeypatch
+):
+    """A slow SessionDB migration must already be visible as the live gateway.
+
+    Dashboard orphan reaping runs concurrently with gateway startup.  The
+    runner constructor opens state.db, so delaying the PID/runtime-lock claim
+    until after construction lets the dashboard misclassify a migrating
+    gateway as an orphan and terminate it.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    events = []
+
+    class StopAfterConstructor(RuntimeError):
+        pass
+
+    class MigrationProbeRunner:
+        def __init__(self, config):
+            events.append("runner")
+            raise StopAfterConstructor
+
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr(
+        "gateway.status.acquire_gateway_runtime_lock",
+        lambda: events.append("runtime-lock") or True,
+    )
+    monkeypatch.setattr(
+        "gateway.status.write_pid_file", lambda: events.append("pid-file")
+    )
+    monkeypatch.setattr(
+        "gateway.status.remove_pid_file", lambda: events.append("remove-pid")
+    )
+    monkeypatch.setattr(
+        "gateway.status.release_gateway_runtime_lock",
+        lambda: events.append("release-lock"),
+    )
+    monkeypatch.setattr("tools.skills_sync.sync_skills", lambda quiet=True: None)
+    monkeypatch.setattr("hermes_logging.setup_logging", lambda hermes_home, mode: None)
+    monkeypatch.setattr("gateway.run.GatewayRunner", MigrationProbeRunner)
+
+    with pytest.raises(StopAfterConstructor):
+        await gateway_run.start_gateway(
+            config=GatewayConfig(), replace=False, verbosity=None
+        )
+
+    assert events == [
+        "runtime-lock",
+        "pid-file",
+        "runner",
+        "remove-pid",
+        "release-lock",
+    ]


### PR DESCRIPTION
## What does this PR do?

Prevents a gateway that is still opening or migrating `state.db` from being mistaken for an abandoned process by the Web Dashboard orphan sweep. The gateway now publishes its PID and holds the runtime lock before constructing `GatewayRunner`, so dashboard startup can recognize and preserve the active startup instead of terminating it and triggering another migration attempt.

### Symptom

Opening the Web Dashboard while a CLI gateway is still in `state_db_data_migrations` can terminate that gateway. A replacement then enters the same startup phase, while the startup watchdog reports that the migration progress lease is still being honored.

### Impact

Affected gateways can fail to reach the live event loop and can enter repeated startup attempts until the lingering process metadata is manually cleaned up.

### Bug Cause

**Trigger:** `gateway/run.py:start_gateway` constructed `GatewayRunner` before claiming the gateway runtime lock and writing `gateway.pid`.

**Causal chain:**
1. Gateway startup constructs `GatewayRunner`, whose `SessionStore` opens `SessionDB` and may perform a long schema or data migration.
2. During that unregistered window, the Dashboard orphan sweep cannot find the startup in the PID/runtime records and classifies its process-scan match as abandoned.
3. The sweep terminates the live startup, and the successor enters the same database initialization path instead of allowing the original startup to finish.

**Why it is wrong:** The runtime identity was claimed only after the state database had already been opened, even though the identity is the exclusion evidence used by concurrent lifecycle management.

**Working sibling / contrast:** Once `gateway.pid` and the runtime lock exist, the orphan reaper includes the recorded gateway in its exclusion set and leaves it running.

**Ruled out:** Startup progress leases are process-local monotonic state and do not survive SIGKILL or transfer to a successor. The warning identifies the replacement process's current migration lease; it is not a persisted lease left by the previous process.

### Fix

Claim the runtime lock and PID file before `GatewayRunner` construction, and release both claims if construction raises before normal runner shutdown can own cleanup. A regression test verifies the claim order and constructor-failure cleanup.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` - claim gateway identity before `SessionStore` can open or migrate `state.db`, with failure cleanup.
- `tests/gateway/test_startup_restart_race.py` - cover claim ordering and cleanup when runner construction aborts.

## How to Test

1. Run the gateway startup/restart race tests.
2. Run the Dashboard gateway restart/reaper tests.
3. Run the startup watchdog tests.

```bash
scripts/run_tests.sh tests/gateway/test_startup_restart_race.py -q
scripts/run_tests.sh tests/hermes_cli/test_spawn_gateway_restart_reap.py tests/hermes_cli/test_gateway.py -q
scripts/run_tests.sh tests/gateway/test_startup_watchdog.py -q
```

Local result: 93 tests passed, 5 skipped.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant suites and all selected tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; behavior is covered by focused code comments and tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A - verified with automated lifecycle and startup tests.
