### PR TITLE
feat(web): per-host request headers for web_extract

### DIFF
--- a/plugins/web/firecrawl/provider.py
+++ b/plugins/web/firecrawl/provider.py
@@ -210,11 +210,19 @@ class _KeylessFirecrawlClient:
     def __init__(self, api_url: str = _FIRECRAWL_CLOUD_API_URL):
         self.api_url = api_url.rstrip("/")
 
-    def _post(self, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    def _post(
+        self,
+        path: str,
+        payload: Dict[str, Any],
+        extra_headers: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, Any]:
+        headers = {"Content-Type": "application/json"}
+        if extra_headers:
+            headers.update(extra_headers)
         response = httpx.post(
             f"{self.api_url}{path}",
             json=payload,
-            headers={"Content-Type": "application/json"},
+            headers=headers,
             timeout=60.0,
         )
         response.raise_for_status()
@@ -223,8 +231,41 @@ class _KeylessFirecrawlClient:
     def search(self, *, query: str, limit: int = 5) -> Dict[str, Any]:
         return self._post("/v2/search", {"query": query, "limit": limit})
 
-    def scrape(self, *, url: str, formats: List[str]) -> Dict[str, Any]:
-        return self._post("/v2/scrape", {"url": url, "formats": formats})
+    def scrape(
+        self,
+        *,
+        url: str,
+        formats: List[str],
+        headers: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {"url": url, "formats": formats}
+        if headers:
+            # Forwarded to the target site by Firecrawl, NOT sent to the
+            # Firecrawl API itself.
+            payload["headers"] = headers
+        return self._post("/v2/scrape", payload)
+
+
+def _scrape_with_optional_headers(client: Any, scrape_kwargs: Dict[str, Any]) -> Any:
+    """Call ``client.scrape``, degrading gracefully when it rejects headers.
+
+    The Firecrawl SDK and the keyless REST client are duck-typed here, and
+    older SDK versions have no ``headers`` parameter. Rather than pin a
+    version, retry once without headers on TypeError so a stale SDK loses
+    the credential rather than the whole scrape.
+    """
+    if "headers" not in scrape_kwargs:
+        return client.scrape(**scrape_kwargs)
+    try:
+        return client.scrape(**scrape_kwargs)
+    except TypeError:
+        logger.warning(
+            "Firecrawl client rejected 'headers' — retrying without configured "
+            "request headers. Upgrade the firecrawl SDK for authenticated scrapes."
+        )
+        return client.scrape(
+            **{k: v for k, v in scrape_kwargs.items() if k != "headers"}
+        )
 
 
 def _get_firecrawl_gateway_url() -> str:
@@ -672,12 +713,25 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
 
             try:
                 logger.info("Firecrawl scraping: %s", url)
+                # Local import: tools.web_tools imports this module at
+                # module level, so a top-level import here is circular.
+                from tools.web_tools import resolve_request_headers
+
+                extra_headers = resolve_request_headers(url)
+                scrape_kwargs: Dict[str, Any] = {"url": url, "formats": formats}
+                if extra_headers:
+                    scrape_kwargs["headers"] = extra_headers
+                    logger.info(
+                        "Firecrawl: attaching %d configured request header(s) for %s",
+                        len(extra_headers),
+                        url,
+                    )
                 try:
                     scrape_result = await asyncio.wait_for(
                         asyncio.to_thread(
-                            _get_firecrawl_client().scrape,
-                            url=url,
-                            formats=formats,
+                            _scrape_with_optional_headers,
+                            _get_firecrawl_client(),
+                            scrape_kwargs,
                         ),
                         timeout=60,
                     )

--- a/tests/plugins/web/test_web_extract_request_headers.py
+++ b/tests/plugins/web/test_web_extract_request_headers.py
@@ -1,0 +1,211 @@
+"""Tests for config-driven per-host request headers on web_extract.
+
+Covers the ``web.request_headers`` resolution contract in
+``tools.web_tools`` and its wiring into the Firecrawl provider:
+
+  - host scoping (a credential configured for one host never leaks to
+    another),
+  - ``${VAR}`` expansion against the environment so secrets stay in
+    ``.env`` rather than ``config.yaml``,
+  - graceful degradation when the installed Firecrawl client predates the
+    ``headers`` parameter.
+"""
+
+import pytest
+
+import tools.web_tools as web_tools
+from plugins.web.firecrawl.provider import (
+    _KeylessFirecrawlClient,
+    _scrape_with_optional_headers,
+)
+
+
+@pytest.fixture
+def web_config(monkeypatch):
+    """Install a fake ``web:`` config section."""
+
+    def _install(cfg):
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: cfg)
+
+    return _install
+
+
+class TestHostMatching:
+    def test_exact_host_matches(self):
+        assert web_tools._host_matches("api.github.com", "api.github.com")
+
+    def test_different_host_does_not_match(self):
+        assert not web_tools._host_matches("api.github.com", "evil.com")
+
+    def test_dot_prefix_matches_subdomain_and_apex(self):
+        assert web_tools._host_matches(".example.com", "docs.example.com")
+        assert web_tools._host_matches(".example.com", "example.com")
+
+    def test_dot_prefix_does_not_match_suffix_impostor(self):
+        # notexample.com must not match .example.com
+        assert not web_tools._host_matches(".example.com", "notexample.com")
+
+    def test_bare_wildcard_is_not_a_glob(self):
+        # A bare "*" must not match everything — that would broadcast
+        # credentials to every scraped host.
+        assert not web_tools._host_matches("*", "api.github.com")
+
+    def test_empty_pattern_or_host_never_matches(self):
+        assert not web_tools._host_matches("", "api.github.com")
+        assert not web_tools._host_matches("api.github.com", "")
+
+
+class TestResolveRequestHeaders:
+    def test_returns_headers_for_matching_host(self, web_config, monkeypatch):
+        monkeypatch.setenv("TEST_GH_TOKEN", "ghp_secret")
+        web_config(
+            {
+                "request_headers": {
+                    "api.github.com": {"Authorization": "Bearer ${TEST_GH_TOKEN}"}
+                }
+            }
+        )
+        headers = web_tools.resolve_request_headers(
+            "https://api.github.com/repos/o/r/pulls/1"
+        )
+        assert headers == {"Authorization": "Bearer ghp_secret"}
+
+    def test_does_not_leak_headers_to_other_hosts(self, web_config, monkeypatch):
+        monkeypatch.setenv("TEST_GH_TOKEN", "ghp_secret")
+        web_config(
+            {
+                "request_headers": {
+                    "api.github.com": {"Authorization": "Bearer ${TEST_GH_TOKEN}"}
+                }
+            }
+        )
+        assert web_tools.resolve_request_headers("https://evil.example.com/") == {}
+
+    def test_unset_env_var_drops_header_rather_than_sending_literal(
+        self, web_config, monkeypatch
+    ):
+        monkeypatch.delenv("TEST_MISSING_TOKEN", raising=False)
+        web_config(
+            {
+                "request_headers": {
+                    "api.github.com": {
+                        "Authorization": "Bearer ${TEST_MISSING_TOKEN}"
+                    }
+                }
+            }
+        )
+        headers = web_tools.resolve_request_headers("https://api.github.com/x")
+        assert headers == {}
+
+    def test_literal_value_without_env_ref_is_passed_through(self, web_config):
+        web_config(
+            {"request_headers": {"api.github.com": {"X-Custom": "static-value"}}}
+        )
+        headers = web_tools.resolve_request_headers("https://api.github.com/x")
+        assert headers == {"X-Custom": "static-value"}
+
+    def test_absent_config_returns_empty(self, web_config):
+        web_config({})
+        assert web_tools.resolve_request_headers("https://api.github.com/x") == {}
+
+    def test_malformed_config_does_not_raise(self, web_config):
+        web_config({"request_headers": "not-a-dict"})
+        assert web_tools.resolve_request_headers("https://api.github.com/x") == {}
+
+    def test_unparseable_url_returns_empty(self, web_config):
+        web_config({"request_headers": {"api.github.com": {"X": "y"}}})
+        assert web_tools.resolve_request_headers("not a url") == {}
+
+
+class TestKeylessClientScrapePayload:
+    def test_headers_go_in_payload_not_to_firecrawl_api(self, monkeypatch):
+        captured = {}
+
+        def fake_post(self, path, payload, extra_headers=None):
+            captured["path"] = path
+            captured["payload"] = payload
+            captured["extra_headers"] = extra_headers
+            return {"data": {}}
+
+        monkeypatch.setattr(_KeylessFirecrawlClient, "_post", fake_post)
+        client = _KeylessFirecrawlClient()
+        client.scrape(
+            url="https://api.github.com/x",
+            formats=["markdown"],
+            headers={"Authorization": "Bearer tok"},
+        )
+
+        # Target-site headers ride in the request BODY; they must not be
+        # sent as headers to the Firecrawl API itself.
+        assert captured["payload"]["headers"] == {"Authorization": "Bearer tok"}
+        assert captured["extra_headers"] is None
+
+    def test_no_headers_key_when_none_configured(self, monkeypatch):
+        captured = {}
+
+        def fake_post(self, path, payload, extra_headers=None):
+            captured["payload"] = payload
+            return {"data": {}}
+
+        monkeypatch.setattr(_KeylessFirecrawlClient, "_post", fake_post)
+        _KeylessFirecrawlClient().scrape(
+            url="https://example.com", formats=["markdown"]
+        )
+        assert "headers" not in captured["payload"]
+
+
+class TestScrapeWithOptionalHeaders:
+    def test_passes_headers_when_client_accepts_them(self):
+        seen = {}
+
+        class Client:
+            def scrape(self, *, url, formats, headers=None):
+                seen["headers"] = headers
+                return {"ok": True}
+
+        result = _scrape_with_optional_headers(
+            Client(),
+            {
+                "url": "https://api.github.com/x",
+                "formats": ["markdown"],
+                "headers": {"Authorization": "Bearer tok"},
+            },
+        )
+        assert result == {"ok": True}
+        assert seen["headers"] == {"Authorization": "Bearer tok"}
+
+    def test_retries_without_headers_on_legacy_client(self):
+        calls = []
+
+        class LegacyClient:
+            def scrape(self, **kwargs):
+                calls.append(kwargs)
+                if "headers" in kwargs:
+                    raise TypeError("unexpected keyword argument 'headers'")
+                return {"ok": True}
+
+        result = _scrape_with_optional_headers(
+            LegacyClient(),
+            {
+                "url": "https://api.github.com/x",
+                "formats": ["markdown"],
+                "headers": {"Authorization": "Bearer tok"},
+            },
+        )
+        # Degrades to an unauthenticated scrape rather than failing outright.
+        assert result == {"ok": True}
+        assert len(calls) == 2
+        assert "headers" not in calls[1]
+
+    def test_typeerror_without_headers_is_not_swallowed(self):
+        class BrokenClient:
+            def scrape(self, **kwargs):
+                raise TypeError("genuine signature error")
+
+        # No headers configured: the TypeError is a real bug and must
+        # propagate rather than being masked by the retry path.
+        with pytest.raises(TypeError):
+            _scrape_with_optional_headers(
+                BrokenClient(),
+                {"url": "https://example.com", "formats": ["markdown"]},
+            )

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -156,6 +156,99 @@ def _load_web_config() -> dict:
         return {}
 
 
+def _host_of(url: str) -> str:
+    """Lowercased hostname for ``url``; ``""`` when unparseable.
+
+    ``urlparse`` raises ValueError on malformed authorities (e.g. an
+    unterminated IPv6 literal), which must not break extraction.
+    """
+    from urllib.parse import urlparse
+
+    try:
+        return (urlparse(url).hostname or "").lower()
+    except ValueError:
+        return ""
+
+
+def _host_matches(pattern: str, host: str) -> bool:
+    """Match a config host pattern against ``host``.
+
+    Exact match, or a leading-dot suffix pattern (``.example.com``) that
+    also matches the apex (``example.com``). Deliberately NOT a general
+    glob: a bare ``*`` would send credentials to every host scraped.
+    """
+    pattern = (pattern or "").strip().lower()
+    if not pattern or not host:
+        return False
+    if pattern.startswith("."):
+        return host == pattern[1:] or host.endswith(pattern)
+    return host == pattern
+
+
+def resolve_request_headers(url: str) -> Dict[str, str]:
+    """Return configured extra request headers for ``url``.
+
+    Reads ``web.request_headers`` from config.yaml — a mapping of host
+    pattern to header dict::
+
+        web:
+          request_headers:
+            api.github.com:
+              Authorization: "Bearer ${GITHUB_TOKEN}"
+
+    Header VALUES may reference environment variables as ``${VAR}`` so the
+    credential itself stays in ``.env`` and never lands in config.yaml
+    (repo convention: config.yaml carries behavior, .env carries secrets).
+    An unset variable drops that single header rather than sending the
+    literal ``${VAR}`` upstream.
+
+    Only headers whose host pattern matches are returned, so a token
+    configured for one host is never attached to another. Never raises.
+    """
+    try:
+        mapping = _load_web_config().get("request_headers") or {}
+        if not isinstance(mapping, dict):
+            return {}
+        host = _host_of(url)
+        if not host:
+            return {}
+
+        resolved: Dict[str, str] = {}
+        for pattern, headers in mapping.items():
+            if not isinstance(headers, dict):
+                continue
+            if not _host_matches(str(pattern), host):
+                continue
+            for name, raw in headers.items():
+                value = _expand_env_refs(str(raw))
+                if value:
+                    resolved[str(name)] = value
+        return resolved
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+def _expand_env_refs(value: str) -> str:
+    """Expand ``${VAR}`` refs; return ``""`` if any referenced var is unset.
+
+    Returning empty (rather than a partially expanded string) keeps an
+    unset credential from being sent as a literal ``${VAR}`` header.
+    """
+    import re as _re
+
+    missing = False
+
+    def _sub(match: "_re.Match[str]") -> str:
+        nonlocal missing
+        resolved = _env_value(match.group(1))
+        if not resolved:
+            missing = True
+        return resolved
+
+    expanded = _re.sub(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}", _sub, value)
+    return "" if missing else expanded
+
+
 # The built-in web backends whose availability is driven by hardcoded
 # env-var / package / OAuth probes below. Any name NOT in this set is a
 # candidate plugin-registered provider and must be resolved through the

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2402,6 +2402,36 @@ web:
 
 **Self-hosted Firecrawl:** Set `FIRECRAWL_API_URL` to point at your own instance. When a custom URL is set, the API key becomes optional (set `USE_DB_AUTHENTICATION=*** on the server to disable auth).
 
+### Authenticated extraction (`web.request_headers`)
+
+`web_extract` can attach extra request headers to specific hosts, so paywalled
+or private endpoints (a private GitHub repo's REST API, an internal wiki) can be
+read instead of returning a login or 404 page.
+
+```yaml
+web:
+  request_headers:
+    # Exact host, or a leading dot for "this domain and its subdomains".
+    api.github.com:
+      Authorization: "Bearer ${GITHUB_TOKEN}"
+      Accept: "application/vnd.github+json"
+    .internal.example.com:
+      X-Api-Key: "${INTERNAL_WIKI_KEY}"
+```
+
+- **Secrets stay in `.env`.** Header values may reference environment variables
+  as `${VAR}`; the credential itself never lands in `config.yaml`. If the
+  variable is unset, that header is dropped rather than sent as a literal
+  `${VAR}`.
+- **Headers are host-scoped.** A token configured for one host is never
+  attached to another. Patterns are exact-match, or `.example.com` to include
+  subdomains and the apex — a bare `*` is deliberately *not* a wildcard.
+- **Headers go to the target site**, not to the extraction provider's own API.
+
+Note that this only helps endpoints that accept token auth. `github.com`'s HTML
+pages are session-cookie only and return 404 to any token-bearing client — use
+`api.github.com` (or the `gh` CLI) for private repositories.
+
 **Parallel search modes:** Set `PARALLEL_SEARCH_MODE` to control search behavior — `fast`, `one-shot`, or `agentic` (default: `agentic`).
 
 **Exa:** Set `EXA_API_KEY` in `~/.hermes/.env`. Supports `category` filtering (`company`, `research paper`, `news`, `people`, `personal site`, `pdf`) and domain/date filters.


### PR DESCRIPTION
## Friction

Pasting a private GitHub PR URL into a session returns GitHub's **public 404 page**. Nothing signals that the failure was authentication — the model sees a "Page not found" document and reasonably concludes the PR does not exist. Same shape for any paywalled or internal endpoint.

## Gap

`web_extract` has no way to attach credentials to a request. In `plugins/web/firecrawl/provider.py` the scrape call was:

```python
_get_firecrawl_client().scrape(url=url, formats=formats)
```

No header path existed anywhere between the tool schema and the provider. Firecrawl itself supports per-request headers — Hermes just had no way to reach them.

## Change

`web.request_headers` in `config.yaml` — host pattern → headers, applied only on matching hosts:

```yaml
web:
  request_headers:
    api.github.com:
      Authorization: "Bearer ${GITHUB_TOKEN}"
      Accept: "application/vnd.github+json"
    .internal.example.com:
      X-Api-Key: "${INTERNAL_WIKI_KEY}"
```

Design decisions worth reviewing:

- **`${VAR}` expansion** keeps the credential in `.env` while `config.yaml` carries only behavior, per the repo rubric on secrets. An unset variable **drops the header** rather than sending a literal `${VAR}` upstream.
- **Host-scoped, not glob.** Exact match, or `.example.com` for subdomains plus apex. A bare `*` is intentionally *not* a wildcard — broadcasting a token to every scraped host is the failure mode worth designing out. `notexample.com` does not match `.example.com`.
- **Headers reach the target site**, riding in the scrape request body that Firecrawl forwards — they are not sent as headers on the Firecrawl API call.
- **Legacy clients degrade, not fail.** A client whose `scrape()` predates `headers` retries once without them, losing the credential rather than the whole scrape. A `TypeError` raised when no headers were configured still propagates, so real signature bugs are not masked.

No new tool, no new core surface, no new `HERMES_*` env var — one config key on an existing tool.

## Gate output

Repo gate, `bash scripts/run_tests.sh`:

```
=== Summary: 2 files, 50 tests passed, 0 failed (100% complete) in 2.7s ===
```

18 new tests; the 32 existing web-provider tests still pass. `ruff check` on all three changed files: `All checks passed!`

**Mutation-tested** — each mutation flips exactly one behavior and kills a test:

| Mutation | Result |
|---|---|
| Host scoping removed (headers leak to any host) | 1 failed |
| Unset `${VAR}` sends literal placeholder | 1 failed |
| Headers blanked in scrape payload | 1 failed |
| Legacy-client fallback removed | 1 failed |

**End-to-end against a real private repo** (self-hosted Firecrawl, real token):

- With `request_headers` configured → **30,475 chars**, correct PR title present
- Same URL, config removed → **120 chars**: `{"message":"Not Found",...,"status":"404"}`

That control is the point: the feature is what changes the outcome, not ambient auth.

## Note on scope

This works for endpoints that accept token auth. `github.com`'s **HTML** pages are session-cookie only and return 404 to any token-bearing client — verified directly (`Bearer` → 404, basic auth → 404, `api.github.com` → 200). The docs say so explicitly, so nobody burns an afternoon trying to make the web UI resolve.

Docs: new "Authenticated extraction" section under Web Search Backends in `configuration.md`.
