### PR TITLE
test(browser): make the snapshot-threshold reload test hermetic

### DIFF
--- a/tests/tools/test_browser_snapshot_threshold.py
+++ b/tests/tools/test_browser_snapshot_threshold.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from hermes_cli import config
 from hermes_cli.config import DEFAULT_CONFIG
 from tools import browser_camofox, browser_tool
 
@@ -69,6 +70,16 @@ def test_cleanup_reloads_updated_profile_config(isolated_snapshot_threshold):
 
     _write_threshold(isolated_snapshot_threshold, 15001)
     assert browser_tool.get_browser_snapshot_threshold() == 12000
+
+    # Evict the isolated path from the raw-config cache explicitly rather
+    # than relying on the filesystem mtime having advanced since the
+    # rewrite above -- read_raw_config() caches on (mtime_ns, size), and
+    # 12000 -> 15001 is a same-byte-size rewrite, so a fast enough or
+    # coarse-enough-mtime write can leave the cache key unchanged and this
+    # assertion would spuriously see the stale value even though
+    # cleanup_all_browsers() correctly reset the browser-local cache below
+    # (issue #100988).
+    config._RAW_CONFIG_CACHE.pop(str(config.get_config_path()), None)
 
     browser_tool.cleanup_all_browsers()
     assert browser_tool.get_browser_snapshot_threshold() == 15001


### PR DESCRIPTION
Fixes #100988.

## Root cause

`test_cleanup_reloads_updated_profile_config` rewrites `config.yaml` from `12000` to `15001` -- both same byte length. `read_raw_config()` keys its cache by `(mtime_ns, size)`, so a same-size rewrite can leave the cache key unchanged on a sufficiently fast or coarse-mtime write, letting the raw config cache return the stale `12000` even after `cleanup_all_browsers()` correctly reset the browser-local snapshot cache. Test order/filesystem-timing dependency, not a browser runtime failure -- the same test passes reliably in isolation.

## Fix

Evict the isolated path from `hermes_cli.config._RAW_CONFIG_CACHE` explicitly before calling `cleanup_all_browsers()`, matching the issue's own suggested fix -- removes the dependency on real filesystem mtime granularity/timing entirely.

## Verification

Verified the exact mechanism directly: forced a `_RAW_CONFIG_CACHE` entry whose `(mtime_ns, size)` key matches the config file's actual current stat but whose cached data holds the stale value -- precisely reproducing the race (a simple same-size double-write isn't reliably reproducible in a sandboxed run, since real mtime advances during normal execution speed). Confirmed `read_raw_config()` returns the stale value under that forced collision, and the fresh value once the fix's eviction line runs.

9/9 pass in the full test file (no regression).