### PR TITLE
test(browser): make the snapshot-threshold reload test hermetic

### DIFF
--- a/tests/tools/test_browser_snapshot_threshold.py
+++ b/tests/tools/test_browser_snapshot_threshold.py
@@ -68,6 +68,16 @@ def test_cleanup_reloads_updated_profile_config(isolated_snapshot_threshold):
     assert browser_tool.get_browser_snapshot_threshold() == 12000
 
     _write_threshold(isolated_snapshot_threshold, 15001)
+    # Same byte size ("12000" -> "15001"), and on a fast or coarse-mtime
+    # filesystem the rewrite can land in the same st_mtime_ns tick — so the
+    # raw-config cache key (mtime_ns, size) legitimately still matches the
+    # OLD content. Evict the raw-config cache entry for the isolated path so
+    # the post-cleanup read is hermetic: the assertions below then verify
+    # browser-cache invalidation against FRESH config content, independent
+    # of filesystem timing (#100988).
+    from hermes_cli.config import _RAW_CONFIG_CACHE, get_config_path
+
+    _RAW_CONFIG_CACHE.pop(str(get_config_path()), None)
     assert browser_tool.get_browser_snapshot_threshold() == 12000
 
     browser_tool.cleanup_all_browsers()


### PR DESCRIPTION
Fixes #100988

## Problem

`test_cleanup_reloads_updated_profile_config` rewrites `config.yaml` from `12000` to `15001` — **both same byte size** — then asserts `cleanup_all_browsers()` reloads the new value. But the raw-config cache keys on `(mtime_ns, size)` (`hermes_cli/config.py:3613`): on a sufficiently fast or coarse-mtime filesystem the rewrite lands in the same `st_mtime_ns` tick, the cache key legitimately matches the **old** content, and the post-cleanup read returns `12000`:

```
assert browser_tool.get_browser_snapshot_threshold() == 15001
E assert 12000 == 15001
```

Passes in isolation, fails in a full-file run — the classic order/timing signature the reporter identified.

## Fix

Exactly the reporter's suggested hermetic fix: after the same-size rewrite, evict the isolated path's entry from `_RAW_CONFIG_CACHE` before calling `cleanup_all_browsers()`. The test then verifies **browser-cache invalidation against fresh config content**, independent of filesystem mtime granularity.

The pre-cleanup assertion (`12000` still served while the browser-local cache is warm) is unchanged — so the test still covers **both** cache layers, each deterministically.

## Verification

- **The coarse-mtime case is real, not hypothetical**: backdated the second write's mtime via `os.utime` — the `(mtime_ns, size)` key collides exactly as reported (same size, same tick). On this NTFS box the two writes happen to get distinct ns values, which is why it passes here and only flakes on coarser filesystems.
- Suite: **9/9 pass** (`tests/tools/test_browser_snapshot_threshold.py`), full file and isolated.