### PR TITLE
fix(delegate_task): exempt background spawn from sequential deadline

### DIFF
--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -44,6 +44,26 @@ logger = logging.getLogger(__name__)
 # When any of these appear in a batch, we fall back to sequential execution.
 _NEVER_PARALLEL_TOOLS = frozenset({"clarify"})
 
+# Tools whose dispatch is self-bounded and must NOT be preempted by the generic
+# per-call tool deadline (``timeouts.tools.sequential_call`` /
+# ``HERMES_CONCURRENT_TOOL_TIMEOUT_S``, default 420s). The generic deadline
+# exists to preempt a tool that genuinely wedges; these tools instead own their
+# own bound and can legitimately run longer than 420s without being stuck:
+#   * ``clarify``       — blocks on a human; bounded by ``agent.clarify_timeout``
+#                         (default 3600s, or unlimited when <= 0).
+#   * ``delegate_task`` — background spawn returns a handle almost immediately
+#                         and the children run detached past the return; the
+#                         forced-synchronous fallback (finite runtimes such as
+#                         Kanban workers / one-shot HTTP) joins its own children,
+#                         each bounded by ``delegation.max_iterations`` and its
+#                         own activity heartbeat. Applying the 420s deadline here
+#                         returned ``timed out after 420.0s`` to the parent turn
+#                         while the subagents were still alive in the background
+#                         (incident c4669b45...). ``list``/``steer``/``stop``
+#                         control actions return synchronously and fast, so the
+#                         exemption is harmless for them.
+_TOOL_DEADLINE_EXEMPT = _NEVER_PARALLEL_TOOLS | frozenset({"delegate_task"})
+
 # Read-only tools with no shared mutable session state.
 _PARALLEL_SAFE_TOOLS = frozenset({
     "ha_get_state",
@@ -833,6 +853,7 @@ def _maybe_wrap_untrusted(name: str, content: Any) -> Any:
 
 __all__ = [
     "_NEVER_PARALLEL_TOOLS",
+    "_TOOL_DEADLINE_EXEMPT",
     "_PARALLEL_SAFE_TOOLS",
     "_PATH_SCOPED_TOOLS",
     "_PATH_SCOPED_READERS",

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -34,7 +34,7 @@ from agent.display import (
 )
 from agent.message_sanitization import coalesce_tool_call_id
 from agent.tool_dispatch_helpers import (
-    _NEVER_PARALLEL_TOOLS,
+    _TOOL_DEADLINE_EXEMPT,
     _is_destructive_command,
     _is_multimodal_tool_result,
     _multimodal_text_summary,
@@ -834,6 +834,12 @@ def _run_sequential_tool_execution_middleware(
     timeout (``agent.clarify_timeout``: default 3600s, or unlimited when
     ``<= 0``) owns that wait. Applying the generic tool deadline here would
     return ``tool_timeout`` while the prompt and worker stay active.
+
+    ``delegate_task`` is exempt for the same reason (``_TOOL_DEADLINE_EXEMPT``):
+    background spawn returns a handle and the children run detached past the
+    return, and the forced-synchronous fallback joins its own children, each
+    bounded by ``delegation.max_iterations`` and an activity heartbeat — so the
+    generic 420s deadline must not fire against it (incident c4669b45...).
     """
     timeout_s = _resolve_sequential_tool_timeout()
     kwargs = {
@@ -846,7 +852,7 @@ def _run_sequential_tool_execution_middleware(
         "display_index": display_index,
         "middleware_trace": middleware_trace,
     }
-    if function_name in _NEVER_PARALLEL_TOOLS:
+    if function_name in _TOOL_DEADLINE_EXEMPT:
         return _run_agent_tool_execution_middleware(agent, **kwargs)
 
     from tools.daemon_pool import DaemonThreadPoolExecutor

--- a/tests/run_agent/test_sequential_tool_timeout.py
+++ b/tests/run_agent/test_sequential_tool_timeout.py
@@ -71,7 +71,15 @@ def _make_agent(tmp_path: Path) -> AIAgent:
                         "description": "test tool",
                         "parameters": {"type": "object", "properties": {}},
                     },
-                }
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "delegate_task",
+                        "description": "test delegate tool",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                },
             ],
         ),
         patch("run_agent.check_toolset_requirements", return_value={}),
@@ -287,6 +295,80 @@ def test_sequential_tool_interrupt_hides_lifecycle_cancel_detail(tmp_path, monke
     assert "user interrupt" not in messages[0]["content"]
     assert "PRIVATE_LIFECYCLE_REASON_DO_NOT_COPY" not in terminal_events[0]["error_message"]
     assert terminal_events[0]["error_type"] == "tool_interrupted"
+
+
+def _delegate_call(call_id: str = "delegate-1"):
+    return SimpleNamespace(
+        id=call_id,
+        type="function",
+        function=SimpleNamespace(
+            name="delegate_task",
+            arguments=(
+                '{"action": "spawn", "tasks": ['
+                '{"goal": "research A"}, {"goal": "research B"}]}'
+            ),
+        ),
+    )
+
+
+def test_sequential_timeout_does_not_cut_delegate_task_dispatch(
+    tmp_path, monkeypatch
+):
+    """delegate_task dispatch must not be preempted by the generic tool deadline.
+
+    delegate_task(background) hands children to a detached executor and returns
+    a handle; the children keep running past the return. The dispatch itself
+    (building N child agents, or the forced-synchronous fallback joining them on
+    finite runtimes such as Kanban workers) can outlast the 420s concurrent-tool
+    deadline, but that generic deadline must not fire against it — otherwise the
+    parent turn sees ``timed out after 420.0s`` while the subagents are still
+    alive in the background (incident c4669b45...). Mirrors the clarify
+    exemption via ``_TOOL_DEADLINE_EXEMPT``.
+    """
+    agent = _make_agent(tmp_path)
+    monkeypatch.setenv("HERMES_CONCURRENT_TOOL_TIMEOUT_S", "1.0")
+
+    dispatched_payload = {
+        "status": "dispatched",
+        "mode": "background",
+        "count": 2,
+        "delegation_id": "deleg-xyz",
+    }
+
+    def _dispatch_delegate(next_args):
+        # Dispatch outlasts the 1.0s generic deadline (child construction / the
+        # forced-sync join). It must still return its handle, not be cut.
+        time.sleep(1.3)
+        return json.dumps(dispatched_payload, ensure_ascii=False)
+
+    monkeypatch.setattr(agent, "_dispatch_delegate_task", _dispatch_delegate)
+    terminal_events: list[dict] = []
+
+    def _capture_terminal_event(*_args, **kwargs):
+        terminal_events.append(kwargs)
+
+    messages: list[dict] = []
+    started = time.monotonic()
+    with patch(
+        "agent.tool_executor._emit_terminal_post_tool_call",
+        side_effect=_capture_terminal_event,
+    ):
+        execute_tool_calls_sequential(
+            agent,
+            SimpleNamespace(tool_calls=[_delegate_call()]),
+            messages,
+            "task",
+        )
+
+    assert time.monotonic() - started < 10.0
+    assert [message["tool_call_id"] for message in messages] == ["delegate-1"]
+    assert "timed out" not in messages[0]["content"]
+    payload = json.loads(messages[0]["content"])
+    assert payload["status"] == "dispatched"
+    assert payload["delegation_id"] == "deleg-xyz"
+    assert not any(
+        event.get("error_type") == "tool_timeout" for event in terminal_events
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- exempt `delegate_task` from the generic sequential tool deadline, matching its documented background-spawn lifecycle
- keep the deadline unchanged for normal sequential tools
- add a regression test reproducing the parent timeout while delegated children remain alive

## Root cause
`delegate_task` is a barrier tool and always uses the sequential middleware. Its background-spawn setup can outlive the generic tool deadline, so the parent turn reported a timeout while child work continued.

## Verification
- targeted delegate/async tests: 252 passed
- full `tests/run_agent/`: 2,049 passed, 4 skipped
- `ruff check` on all changed files: passed

The same patch was independently reviewed before rebasing onto current `origin/main`; this branch was rebuilt from current upstream and re-tested.