### PR TITLE
feat(delegation): add fallback chain for subagents with backward compat

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1246,6 +1246,20 @@ DEFAULT_CONFIG = {
         # notifications to the PARENT; false suppresses them (the child's result is the
         # deliverable). Async-delegation results are NEVER suppressed.
         "surface_child_process_notifications": False,
+        # Fallback providers for delegation subagents — tried when the pinned
+        # delegation provider fails with rate-limit/overload/auth errors.
+        # Empty (default) preserves the legacy behavior: a pinned
+        # delegation.provider disables the parent's fallback_providers chain
+        # (no silent reroute). When set, this list is passed as the child's
+        # fallback_model, exactly like the top-level fallback_providers chain
+        # but scoped to delegation. Each entry needs provider + model;
+        # base_url / api_mode / key_env are optional.
+        # Aliases fallback_chain / fallback_model are also honored (parsed
+        # locally for the delegation block; top-level fallback semantics are
+        # unchanged — see _get_delegation_fallback_chain).
+        "fallback_providers": [],
+        "fallback_chain": [],
+        "fallback_model": None,
     },
     # Ephemeral prefill messages file — JSON list of {role, content} dicts injected at the start of
     # every API call for few-shot priming. Never saved to sessions/logs/trajectories.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1254,9 +1254,9 @@ DEFAULT_CONFIG = {
         # fallback_model, exactly like the top-level fallback_providers chain
         # but scoped to delegation. Each entry needs provider + model;
         # base_url / api_mode / key_env are optional.
-        # Aliases fallback_chain / fallback_model are also honored (parsed
-        # locally for the delegation block; top-level fallback semantics are
-        # unchanged — see _get_delegation_fallback_chain).
+        # Aliases fallback_chain / fallback_model are also honored (merged via
+        # the shared merge_fallback_keys() helper with delegation's key set;
+        # top-level fallback semantics are unchanged).
         "fallback_providers": [],
         "fallback_chain": [],
         "fallback_model": None,

--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -54,6 +54,30 @@ def _entry_identity(entry: dict[str, Any]) -> tuple[str, str, str]:
     )
 
 
+def merge_fallback_keys(
+    config: dict[str, Any] | None, keys: tuple[str, ...]
+) -> list[dict[str, Any]]:
+    """Merge fallback entries across a caller-selected ordered set of config keys.
+
+    Entries keep key-priority order with per-route dedup (provider/model/
+    base_url); the returned list always contains fresh dict copies. Callers
+    choose which keys participate: the top-level chain uses
+    (``fallback_providers``, ``fallback_model``), delegation additionally
+    honors its ``fallback_chain`` alias — without making that alias a
+    recognized top-level key.
+    """
+    config = config or {}
+    chain: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for key in keys:
+        for entry in _iter_fallback_entries(config.get(key)):
+            identity = _entry_identity(entry)
+            if identity not in seen:
+                seen.add(identity)
+                chain.append(entry)
+    return chain
+
+
 def get_fallback_chain(config: dict[str, Any] | None) -> list[dict[str, Any]]:
     """Return the effective fallback chain merged across old and new config keys.
 
@@ -62,13 +86,4 @@ def get_fallback_chain(config: dict[str, Any] | None) -> list[dict[str, Any]]:
     provider/model/base_url route as an earlier entry. The returned list always contains fresh dict
     copies.
     """
-    config = config or {}
-    chain: list[dict[str, Any]] = []
-    seen: set[tuple[str, str, str]] = set()
-    for key in ("fallback_providers", "fallback_model"):
-        for entry in _iter_fallback_entries(config.get(key)):
-            identity = _entry_identity(entry)
-            if identity not in seen:
-                seen.add(identity)
-                chain.append(entry)
-    return chain
+    return merge_fallback_keys(config, ("fallback_providers", "fallback_model"))

--- a/tests/hermes_cli/test_delegation_fallback_chain.py
+++ b/tests/hermes_cli/test_delegation_fallback_chain.py
@@ -1,0 +1,59 @@
+"""Tests for the delegation fallback chain config helper.
+
+These tests cover tools.delegate_tool_config._get_delegation_fallback_chain
+(re-exported through tools.delegate_tool) applied to the delegation block
+(delegation.fallback_providers / fallback_chain / fallback_model). The helper
+is parsed locally for the delegation block on purpose: the shared top-level
+get_fallback_chain() is left untouched.
+"""
+
+from tools.delegate_tool import _get_delegation_fallback_chain
+
+
+class TestDelegationFallbackChainConfig:
+    def test_empty_delegation_returns_none(self):
+        assert _get_delegation_fallback_chain({}) is None
+        assert _get_delegation_fallback_chain({"fallback_providers": []}) is None
+        assert _get_delegation_fallback_chain(None) is None
+
+    def test_fallback_providers_list_preserved(self):
+        chain = [
+            {"provider": "openrouter", "model": "gpt-4o-mini"},
+            {"provider": "nous", "model": "hermes-4-405b"},
+        ]
+        assert _get_delegation_fallback_chain({"fallback_providers": chain}) == chain
+
+    def test_fallback_model_single_dict_normalized(self):
+        entry = {"provider": "nous", "model": "hermes-4-405b"}
+        assert _get_delegation_fallback_chain({"fallback_model": entry}) == [entry]
+
+    def test_fallback_chain_alias_honoured(self):
+        chain = [{"provider": "nous", "model": "hermes-4-405b"}]
+        assert _get_delegation_fallback_chain({"fallback_chain": chain}) == chain
+
+    def test_fallback_providers_take_precedence_over_aliases(self):
+        providers_chain = [{"provider": "openrouter", "model": "gpt-4o-mini"}]
+        alias_chain = [{"provider": "nous", "model": "hermes-4-405b"}]
+        cfg = {"fallback_providers": providers_chain, "fallback_chain": alias_chain}
+        assert _get_delegation_fallback_chain(cfg) == providers_chain + alias_chain
+
+    def test_invalid_entries_filtered(self):
+        cfg = {"fallback_providers": [
+            {"provider": "", "model": "x"},
+            {"provider": "nous", "model": ""},
+            {"provider": "nous", "model": "hermes-4-405b"},
+        ]}
+        assert _get_delegation_fallback_chain(cfg) == [
+            {"provider": "nous", "model": "hermes-4-405b"}
+        ]
+
+    def test_duplicate_routes_deduped(self):
+        entry = {"provider": "nous", "model": "hermes-4-405b"}
+        cfg = {"fallback_providers": [entry], "fallback_model": dict(entry)}
+        assert _get_delegation_fallback_chain(cfg) == [entry]
+
+    def test_pinned_keys_coexist_with_chain(self):
+        chain = [{"provider": "openrouter", "model": "gpt-4o-mini"}]
+        cfg = {"provider": "minimax", "model": "minimax/m2", "fallback_providers": chain}
+        assert _get_delegation_fallback_chain(cfg) == chain
+        assert cfg["provider"] == "minimax"

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -2233,5 +2233,124 @@ class TestFallbackModelInheritance(unittest.TestCase):
         self.assertIn("missing-acp-binary", str(ctx.exception))
 
 
+class TestDelegationFallbackChain(unittest.TestCase):
+    """Delegation fallback chain: delegation.fallback_providers overrides parent inheritance.
+
+    Mirrors the auxiliary fallback pattern: the delegation config's fallback
+    chain takes precedence over the parent's _fallback_chain. When empty, the
+    legacy pinned-vs-inherit rules apply (#80450).
+    """
+
+    def _capture_fallback(self, parent, delegation_cfg, override_provider=None):
+        """Helper: build child and return captured fallback_model kwarg."""
+        patch_target = "tools.delegate_tool._load_config"
+        with patch(patch_target, return_value=delegation_cfg):
+            with patch("run_agent.AIAgent") as MockAgent:
+                MockAgent.return_value = MagicMock()
+                kwargs = {}
+                if override_provider is not None:
+                    kwargs["override_provider"] = override_provider
+                _build_child_agent(
+                    task_index=0,
+                    goal="test delegation fallback",
+                    context=None,
+                    toolsets=None,
+                    model=None,
+                    max_iterations=10,
+                    parent_agent=parent,
+                    task_count=1,
+                    **kwargs,
+                )
+                return MockAgent.call_args[1].get("fallback_model")
+
+    def test_pinned_provider_empty_delegation_fallback_is_none(self):
+        """Backward compat: pinned provider + empty delegation fallback => None."""
+        parent = _make_mock_parent(depth=0)
+        parent._fallback_chain = [{"provider": "openrouter", "model": "gpt-4o-mini"}]
+        delegation_cfg = {"provider": "minimax", "fallback_providers": []}
+        fb = self._capture_fallback(parent, delegation_cfg, override_provider="minimax")
+        self.assertIsNone(fb)
+
+    def test_pinned_provider_delegation_fallback_chain_used(self):
+        """Pinned provider + delegation chain => child fallback equals delegation chain."""
+        parent = _make_mock_parent(depth=0)
+        parent._fallback_chain = [{"provider": "openrouter", "model": "gpt-4o-mini"}]
+        delegation_chain = [
+            {"provider": "openrouter", "model": "gpt-4o-mini"},
+            {"provider": "nous", "model": "hermes-4-405b"},
+        ]
+        delegation_cfg = {"provider": "minimax", "fallback_providers": delegation_chain}
+        fb = self._capture_fallback(parent, delegation_cfg, override_provider="minimax")
+        self.assertEqual(fb, delegation_chain)
+
+    def test_unpinned_inherits_parent_when_delegation_fallback_empty(self):
+        """Unpinned (inherit) + parent chain + empty delegation fallback => parent chain."""
+        parent = _make_mock_parent(depth=0)
+        parent_chain = [{"provider": "openrouter", "model": "gpt-4o-mini"}]
+        parent._fallback_chain = parent_chain
+        delegation_cfg = {"fallback_providers": []}
+        fb = self._capture_fallback(parent, delegation_cfg)
+        self.assertEqual(fb, parent_chain)
+
+    def test_unpinned_inherits_none_when_both_empty(self):
+        """Unpinned + no parent chain + empty delegation => None."""
+        parent = _make_mock_parent(depth=0)
+        parent._fallback_chain = []
+        delegation_cfg = {}
+        fb = self._capture_fallback(parent, delegation_cfg)
+        self.assertIsNone(fb)
+
+    def test_delegation_fallback_precedence_over_parent(self):
+        """Delegation fallback takes precedence when both delegation and parent have chains."""
+        parent = _make_mock_parent(depth=0)
+        parent._fallback_chain = [{"provider": "openrouter", "model": "gpt-4o-mini"}]
+        delegation_chain = [{"provider": "nous", "model": "hermes-4-405b"}]
+        delegation_cfg = {"fallback_providers": delegation_chain}
+        fb = self._capture_fallback(parent, delegation_cfg)
+        self.assertEqual(fb, delegation_chain)
+        self.assertNotEqual(fb, parent._fallback_chain)
+
+    def test_delegation_fallback_precedence_when_pinned_and_both_present(self):
+        """Pinned + both present => delegation chain wins (not None, not parent)."""
+        parent = _make_mock_parent(depth=0)
+        parent._fallback_chain = [{"provider": "openrouter", "model": "gpt-4o-mini"}]
+        delegation_chain = [{"provider": "nous", "model": "hermes-4-405b"}]
+        delegation_cfg = {"provider": "minimax", "fallback_providers": delegation_chain}
+        fb = self._capture_fallback(parent, delegation_cfg, override_provider="minimax")
+        self.assertEqual(fb, delegation_chain)
+
+    def test_delegation_fallback_chain_alias(self):
+        """delegation.fallback_chain (list) is honoured."""
+        parent = _make_mock_parent(depth=0)
+        parent._fallback_chain = []
+        delegation_chain = [{"provider": "nous", "model": "hermes-4-405b"}]
+        delegation_cfg = {"fallback_chain": delegation_chain}
+        fb = self._capture_fallback(parent, delegation_cfg)
+        self.assertEqual(fb, delegation_chain)
+
+    def test_delegation_fallback_model_legacy_dict(self):
+        """Legacy single-dict fallback_model inside delegation is honoured."""
+        parent = _make_mock_parent(depth=0)
+        parent._fallback_chain = []
+        delegation_cfg = {"fallback_model": {"provider": "nous", "model": "hermes-4-405b"}}
+        fb = self._capture_fallback(parent, delegation_cfg)
+        self.assertEqual(fb, [{"provider": "nous", "model": "hermes-4-405b"}])
+
+    def test_get_delegation_fallback_chain_helper_empty(self):
+        """_get_delegation_fallback_chain returns None for empty/missing config."""
+        from tools.delegate_tool import _get_delegation_fallback_chain
+        self.assertIsNone(_get_delegation_fallback_chain({}))
+        self.assertIsNone(_get_delegation_fallback_chain({"fallback_providers": []}))
+        self.assertIsNone(_get_delegation_fallback_chain(None))
+
+    def test_get_delegation_fallback_chain_normalizes(self):
+        """_get_delegation_fallback_chain normalizes provider/model entries."""
+        from tools.delegate_tool import _get_delegation_fallback_chain
+        chain = _get_delegation_fallback_chain(
+            {"fallback_providers": [{"provider": "nous", "model": "hermes-4-405b"}]}
+        )
+        self.assertEqual(chain, [{"provider": "nous", "model": "hermes-4-405b"}])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -28,7 +28,7 @@ from tools.delegate_tool_child_run import (  # noqa: F401
     _lease_child_credential, _merge_late_steer, _register_child, _start_heartbeat, _validate_child_output_schema,
 )
 from tools.delegate_tool_config import (  # noqa: F401
-    _DEFAULT_MAX_CONCURRENT_CHILDREN, _get_child_timeout, _get_max_async_children, _get_max_concurrent_children,
+    _DEFAULT_MAX_CONCURRENT_CHILDREN, _get_child_timeout, _get_delegation_fallback_chain, _get_max_async_children, _get_max_concurrent_children,
     _get_max_spawn_depth, _get_orchestrator_enabled, _get_subagent_approval_callback, _get_worktree_isolation,
     _inherit_parent_capabilities, _load_config, _merge_request_overrides, _resolve_child_credential_pool,
     _resolve_child_runtime, _resolve_delegation_credentials, _subagent_auto_approve, _subagent_auto_deny,

--- a/tools/delegate_tool_config.py
+++ b/tools/delegate_tool_config.py
@@ -408,6 +408,34 @@ _ROUTING_FILTER_DEFAULTS = (
 
 _NOUS_PROVIDERS = frozenset({"nous", "nous-portal", "nousresearch"})
 
+def _get_delegation_fallback_chain(delegation_cfg: dict | None) -> list | None:
+    """Resolve the delegation-scoped fallback chain with backward compat.
+
+    Merges ``delegation.fallback_providers`` -> ``fallback_chain`` ->
+    ``fallback_model`` (in that priority order) with dedup, reusing the
+    shared entry parser/identity from ``hermes_cli.fallback_config``. Parsed
+    LOCALLY for the delegation block on purpose: the shared top-level
+    ``get_fallback_chain()`` is left untouched so top-level config semantics
+    (which keys activate a fallback) do not change. Empty chain normalizes
+    to None so callers can distinguish "no delegation fallback configured"
+    from "explicit chain".
+    """
+    if not isinstance(delegation_cfg, dict):
+        return None
+    try:
+        from hermes_cli.fallback_config import _entry_identity, _iter_fallback_entries
+    except Exception:
+        return None
+    chain: list = []
+    seen: set = set()
+    for key in ("fallback_providers", "fallback_chain", "fallback_model"):
+        for entry in _iter_fallback_entries(delegation_cfg.get(key)):
+            identity = _entry_identity(entry)
+            if identity not in seen:
+                seen.add(identity)
+                chain.append(entry)
+    return chain or None
+
 def _resolve_child_runtime(
     parent_agent, delegation_cfg: dict, parent_api_key: Any, *, model: Optional[str], override_provider: Optional[str],
     override_base_url: Optional[str], override_api_key: Optional[str], override_api_mode: Optional[str],
@@ -485,9 +513,16 @@ def _resolve_child_runtime(
         "capabilities": _inherit_parent_capabilities(parent_agent, override_provider, override_base_url),
         "api_mode": effective_api_mode, "acp_command": effective_acp_command, "acp_args": effective_acp_args,
         "reasoning_config": child_reasoning,
-        # Inherit the parent's fallback chain EXCEPT under a pinned provider: a mid-run 429/auth failure must not
-        # silently reroute the quiet child onto the parent's fallbacks. Predictability > liveness for explicit pins.
-        "fallback_model": None if override_provider else (getattr(parent_agent, "_fallback_chain", None) or None),
+        # Delegation fallback takes precedence over parent inheritance: when
+        # delegation.fallback_providers (or the fallback_chain/fallback_model
+        # aliases) is configured it fully replaces the parent chain (mirrors
+        # the auxiliary fallback pattern). Otherwise the legacy rules apply:
+        # a pinned provider disables inheritance (predictability > liveness
+        # for explicit pins, #80450), unpinned inherits the parent chain.
+        "fallback_model": (
+            _get_delegation_fallback_chain(delegation_cfg)
+            or (None if override_provider else (getattr(parent_agent, "_fallback_chain", None) or None))
+        ),
         "openrouter_min_coding_score": getattr(parent_agent, "openrouter_min_coding_score", None),
         # Routing filters reset to their defaults under a pinned provider (see _ROUTING_FILTER_DEFAULTS).
         **{a: d if override_provider else getattr(parent_agent, a, d) for a, d in _ROUTING_FILTER_DEFAULTS},

--- a/tools/delegate_tool_config.py
+++ b/tools/delegate_tool_config.py
@@ -412,28 +412,22 @@ def _get_delegation_fallback_chain(delegation_cfg: dict | None) -> list | None:
     """Resolve the delegation-scoped fallback chain with backward compat.
 
     Merges ``delegation.fallback_providers`` -> ``fallback_chain`` ->
-    ``fallback_model`` (in that priority order) with dedup, reusing the
-    shared entry parser/identity from ``hermes_cli.fallback_config``. Parsed
-    LOCALLY for the delegation block on purpose: the shared top-level
-    ``get_fallback_chain()`` is left untouched so top-level config semantics
-    (which keys activate a fallback) do not change. Empty chain normalizes
-    to None so callers can distinguish "no delegation fallback configured"
-    from "explicit chain".
+    ``fallback_model`` (in that priority order) through the shared public
+    ``merge_fallback_keys()`` helper. Parsed with delegation's key set on
+    purpose: the shared top-level ``get_fallback_chain()`` is left untouched
+    so top-level config semantics (which keys activate a fallback) do not
+    change. Empty chain normalizes to None so callers can distinguish "no
+    delegation fallback configured" from "explicit chain".
     """
     if not isinstance(delegation_cfg, dict):
         return None
     try:
-        from hermes_cli.fallback_config import _entry_identity, _iter_fallback_entries
+        from hermes_cli.fallback_config import merge_fallback_keys
     except Exception:
         return None
-    chain: list = []
-    seen: set = set()
-    for key in ("fallback_providers", "fallback_chain", "fallback_model"):
-        for entry in _iter_fallback_entries(delegation_cfg.get(key)):
-            identity = _entry_identity(entry)
-            if identity not in seen:
-                seen.add(identity)
-                chain.append(entry)
+    chain = merge_fallback_keys(
+        delegation_cfg, ("fallback_providers", "fallback_chain", "fallback_model")
+    )
     return chain or None
 
 def _resolve_child_runtime(


### PR DESCRIPTION
## Summary

Subagents spawned via `delegate_task` previously had no configurable failover. A pinned `delegation.provider` intentionally disabled the parent `fallback_providers` chain (#80450), and there was no delegation-scoped alternative. This adds an explicit `delegation.fallback_providers` chain (aliases: `fallback_chain` / `fallback_model`) that is passed as the child's `fallback_model` when configured, regardless of pin. When empty, legacy behavior is preserved.

## Root cause

Delegation accepted a single provider/model. On capacity errors the only recovery was an external proxy. The auxiliary tasks already had a per-task `fallback_chain`; delegation lacked the same pattern, forcing users to route through a litellm-style proxy to get any fallback for subagents.

## Changes (current owner modules, post-#102117)

- `hermes_cli/config_defaults.py` — `delegation.fallback_providers: []`, `fallback_chain: []`, `fallback_model: None` (empty defaults preserve legacy: pinned => no fallback, unpinned => inherit parent)
- `tools/delegate_tool_config.py` — new `_get_delegation_fallback_chain()` helper plus one-line precedence in `_resolve_child_runtime()`: configured delegation chain wins, else legacy pinned-vs-inherit rules; flows to the child through the normal `AIAgent(fallback_model=...)` path (no `_build_child_agent` signature change needed)
- `hermes_cli/fallback_config.py` — new public `merge_fallback_keys(config, keys)` helper; `get_fallback_chain()` is reimplemented through it with its exact current keys, so top-level behavior and precedence are byte-identical. Delegation passes its own key set including the `fallback_chain` alias. The alias is NOT a newly recognized top-level config key.
- `tools/delegate_tool.py` — one-line re-export of the helper through the facade (tests import it from there)

Backward compat: existing installs with empty `delegation.fallback_*` keep current behavior (pinned still fails loudly, unpinned still inherits parent). Only explicit configuration opts into the new path.

## Semantic note for reviewers (competing PRs, no action taken on them)

Three open PRs now offer a delegation fallback with different empty/unset contracts — only one can land:

* This PR (#101017): empty = legacy (#80450 preserved: pinned => None, unpinned => inherit parent); a configured chain works even when pinned; a pinned provider never silently inherits the parent chain.
* #81072: unset/`"inherit"` = inherit parent (even when pinned); explicit `[]` = disable all fallback.
* #85290: empty = inherit parent chain.

If the project prefers inherit-by-default, #81072/#85290 carry that semantic; this PR is the conservative choice that cannot change behavior for any existing install.

## How to test

```bash
pytest tests/hermes_cli/test_delegation_fallback_chain.py  # 8 passed (helper unit tests)
pytest tests/tools/test_delegate.py::TestDelegationFallbackChain  # 10 passed
pytest tests/tools/test_delegate.py::TestFallbackModelInheritance  # 5 passed (legacy pinned/inherit rules green)
pytest tests/hermes_cli/test_fallback_config.py  # top-level fallback behavior unchanged
python3 scripts/check-windows-footguns.py --all  # clean
```

(Broader `tests/tools/test_delegate.py` run: 95 passed + 1 pre-existing failure in `TestSubagentCostRollup` that reproduces identically on pristine upstream main — environment issue, unrelated.)

Platforms: Linux (WSL2).
