### PR TITLE
fix(agent): aux fallback_chain ignored on aggregator 503 model_not_found

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4838,10 +4838,15 @@ def _is_model_not_found_error(exc: Exception) -> bool:
         Model 'gpt-5.4-mini' not found. The requested model does not exist
         in our configuration or OpenRouter catalog.
 
-    Distinct from :func:`_is_payment_error` (which also matches some 404s for
-    free-tier/credit language) — this one keys on "does not exist / not found /
-    not a valid model" phrasing, and explicitly excludes the billing keywords
-    that the payment path already owns so the two predicates don't overlap.
+    Billing/quota 404s belong to :func:`_is_payment_error` — don't claim them here.
+
+    Status gate: 404/400/None are the documented shapes, plus 5xx bodies that
+    carry the same phrasing. Aggregator gateways (new-api / one-api style
+    distributors) report an unroutable model as ``503 model_not_found``
+    ("No available channel for model X under group default") — the model is
+    genuinely unserviceable on that route, so classifying it by body rather
+    than by status keeps it out of the generic-5xx bucket where it would
+    otherwise abort the whole auxiliary task instead of failing over.
     """
     status = getattr(exc, "status_code", None)
     err_lower = str(exc).lower()
@@ -4852,7 +4857,9 @@ def _is_model_not_found_error(exc: Exception) -> bool:
         "not available on the free tier",
     )):
         return False
-    if status not in {404, 400, None}:
+    if status not in {404, 400, None} and not (
+        isinstance(status, int) and 500 <= status < 600
+    ):
         return False
     return any(kw in err_lower for kw in (
         "model does not exist",
@@ -10839,6 +10846,7 @@ def _call_llm_impl(
             or _is_connection_error(first_err)
             or _is_rate_limit_error(first_err)
             or _is_model_incompatible_error(first_err)
+            or _is_model_not_found_error(first_err)
             or _is_invalid_aux_response_error(first_err)
         )
         # Respect explicit provider choice for transient errors (auth, request
@@ -10862,6 +10870,7 @@ def _call_llm_impl(
             or _is_connection_error(first_err)
             or _is_rate_limit_error(first_err)
             or _is_model_incompatible_error(first_err)
+            or _is_model_not_found_error(first_err)
             or _is_invalid_aux_response_error(first_err)
         )
         if should_fallback and (is_auto or is_capacity_error):
@@ -10880,6 +10889,8 @@ def _call_llm_impl(
                 reason = "rate limit"
             elif _is_model_incompatible_error(first_err):
                 reason = "model incompatible with route"
+            elif _is_model_not_found_error(first_err):
+                reason = "model not served by route"
             elif _is_invalid_aux_response_error(first_err):
                 reason = "invalid provider response"
             else:
@@ -11600,6 +11611,7 @@ async def _async_call_llm_impl(
             or _is_connection_error(first_err)
             or _is_rate_limit_error(first_err)
             or _is_model_incompatible_error(first_err)
+            or _is_model_not_found_error(first_err)
             or _is_invalid_aux_response_error(first_err)
         )
         # Capacity errors (payment/quota/connection/rate-limit) bypass the
@@ -11615,6 +11627,7 @@ async def _async_call_llm_impl(
             or _is_connection_error(first_err)
             or _is_rate_limit_error(first_err)
             or _is_model_incompatible_error(first_err)
+            or _is_model_not_found_error(first_err)
             or _is_invalid_aux_response_error(first_err)
         )
         if should_fallback and (is_auto or is_capacity_error):
@@ -11629,6 +11642,8 @@ async def _async_call_llm_impl(
                 reason = "rate limit"
             elif _is_model_incompatible_error(first_err):
                 reason = "model incompatible with route"
+            elif _is_model_not_found_error(first_err):
+                reason = "model not served by route"
             elif _is_invalid_aux_response_error(first_err):
                 reason = "invalid provider response"
             else:

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4664,7 +4664,16 @@ def _is_transient_transport_error(exc: Exception) -> bool:
     same target once" gate, distinct from ``_is_payment_error`` /
     ``_is_auth_error`` / ``_is_rate_limit_error`` which the except-chain
     handles by switching provider, refreshing creds, or rotating the pool.
+
+    A body-confirmed model-not-found is excluded even when it arrives with a
+    5xx status: aggregator gateways answer ``503 model_not_found`` when no
+    channel can serve the model, which is a permanent property of that route,
+    not a blip. Retrying the same target burns the full backoff budget (and,
+    on the compression critical path, the user's wall clock) before the
+    fallback chain is reached, so send it straight to the except-chain.
     """
+    if _is_model_not_found_error(exc):
+        return False
     if _is_connection_error(exc):
         return True
     status = getattr(exc, "status_code", None) or getattr(
@@ -4849,6 +4858,11 @@ def _is_model_not_found_error(exc: Exception) -> bool:
     otherwise abort the whole auxiliary task instead of failing over.
     """
     status = getattr(exc, "status_code", None)
+    if status is None:
+        # httpx / OpenAI-SDK wrapping shapes carry the code on ``.response``
+        # only; read it too so classification is driven by a real status
+        # rather than silently falling into the status-is-None allowance.
+        status = getattr(getattr(exc, "response", None), "status_code", None)
     err_lower = str(exc).lower()
     # Billing/quota 404s belong to _is_payment_error — don't claim them here.
     if any(kw in err_lower for kw in (
@@ -9833,6 +9847,7 @@ def _create_with_progress_once(
         if (
             force_stream
             or _is_transient_transport_error(exc)
+            or _is_model_not_found_error(exc)
             or _is_auth_error(exc)
             or _is_payment_error(exc)
             or _is_rate_limit_error(exc)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1457,6 +1457,38 @@ class TestIsModelNotFoundError:
         # billing keyword wins — payment owns it
         assert _is_model_not_found_error(exc) is False
 
+    def test_aggregator_503_model_not_found(self):
+        """new-api / one-api style distributors report an unroutable model as
+        503 model_not_found, not 404. The model is genuinely unserviceable on
+        that route, so it must classify here and become fallback-worthy."""
+        exc = Exception(
+            "Error code: 503 - {'error': {'code': 'model_not_found', "
+            "'message': 'No available channel for model claude-opus-4-8 "
+            "under group default (distributor)', 'type': 'new_api_error'}}"
+        )
+        exc.status_code = 503
+        assert _is_model_not_found_error(exc) is True
+
+    def test_plain_5xx_is_not_model_not_found(self):
+        """Widening the status gate to 5xx must stay body-driven: a generic
+        upstream failure carries no model phrasing and must NOT be claimed,
+        or every transient 500 would be treated as a dead model."""
+        for status, body in (
+            (503, "Service Unavailable: upstream timeout"),
+            (500, "Internal server error"),
+            (502, "Bad gateway"),
+        ):
+            exc = Exception(body)
+            exc.status_code = status
+            assert _is_model_not_found_error(exc) is False, body
+
+    def test_billing_5xx_is_not_model_not_found(self):
+        """Billing language still routes to the payment path even on a 5xx
+        that also mentions model_not_found."""
+        exc = Exception("model_not_found but insufficient funds on this account")
+        exc.status_code = 503
+        assert _is_model_not_found_error(exc) is False
+
 
 
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -26,6 +26,7 @@ from agent.auxiliary_client import (
     _is_rate_limit_error,
     _is_model_not_found_error,
     _is_model_incompatible_error,
+    _is_transient_transport_error,
     _refresh_nous_recommended_model,
     _normalize_aux_provider,
     _try_payment_fallback,
@@ -1488,6 +1489,119 @@ class TestIsModelNotFoundError:
         exc = Exception("model_not_found but insufficient funds on this account")
         exc.status_code = 503
         assert _is_model_not_found_error(exc) is False
+
+    def test_status_read_from_response_attribute(self):
+        """httpx / OpenAI-SDK wrapping shapes carry the code on ``.response``
+        only. Structured status extraction must look there too, so the same
+        aggregator body classifies identically however the SDK wrapped it."""
+        exc = Exception(
+            "Error code: 503 - {'error': {'code': 'model_not_found', "
+            "'message': 'No available channel for model x'}}"
+        )
+        exc.response = SimpleNamespace(status_code=503)
+        assert _is_model_not_found_error(exc) is True
+
+    def test_response_attribute_status_still_gates_out_unrelated(self):
+        """The ``.response`` read must not become a bypass: an unrelated 401
+        carrying model phrasing is still rejected by the status gate."""
+        exc = Exception("model not found")
+        exc.response = SimpleNamespace(status_code=401)
+        assert _is_model_not_found_error(exc) is False
+
+
+class TestModelNotFoundNotTransient:
+    """A body-confirmed model-not-found is permanent for that route, so it must
+    not consume the same-provider transient retry budget on its way to the
+    fallback chain (the retries cost the full backoff, and on the compression
+    critical path that is user-visible wall clock)."""
+
+    def _agg_503(self):
+        exc = Exception(
+            "Error code: 503 - {'error': {'code': 'model_not_found', "
+            "'message': 'No available channel for model claude-opus-4-8 "
+            "under group default (distributor)', 'type': 'new_api_error'}}"
+        )
+        exc.status_code = 503
+        return exc
+
+    def test_aggregator_503_is_not_transient(self):
+        assert _is_transient_transport_error(self._agg_503()) is False
+
+    def test_plain_503_is_still_transient(self):
+        """The exclusion is body-driven — a generic 503 must keep its retry."""
+        exc = Exception("Service Unavailable")
+        exc.status_code = 503
+        assert _is_transient_transport_error(exc) is True
+
+    def test_no_wasted_same_provider_retries_before_fallback(self):
+        """End-to-end: primary answers 503 model_not_found, configured chain is
+        healthy. The primary must be attempted exactly once."""
+        primary = MagicMock()
+        primary.base_url = "https://aggregator.example.com/v1"
+        primary.chat.completions.create.side_effect = self._agg_503()
+
+        fb_client = MagicMock()
+        fb_client.base_url = "https://alt.example.com/v1"
+        fb_client.chat.completions.create.return_value = {"fallback": True}
+
+        with patch("agent.auxiliary_client._TRANSIENT_RETRY_BACKOFF_BASE", 0.0), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("aggregator", "claude-opus-4-8", None, None, None)), \
+             patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(primary, "claude-opus-4-8")), \
+             patch("agent.auxiliary_client._validate_llm_response",
+                   side_effect=lambda resp, _task, **_kw: resp), \
+             patch("agent.auxiliary_client._try_configured_fallback_chain",
+                   return_value=(fb_client, "alt-model",
+                                 "fallback_chain[0](alt)")) as mock_chain, \
+             patch("agent.auxiliary_client._try_main_agent_model_fallback",
+                   return_value=(None, None, "")):
+            result = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert result == {"fallback": True}
+        assert primary.chat.completions.create.call_count == 1, (
+            "A permanent model_not_found must not burn same-provider retries"
+        )
+        mock_chain.assert_called()
+        assert fb_client.chat.completions.create.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_async_no_wasted_retries_before_fallback(self):
+        """Async parity: same single-attempt-then-chain behaviour."""
+        primary = MagicMock()
+        primary.base_url = "https://aggregator.example.com/v1"
+        primary.chat.completions.create = AsyncMock(side_effect=self._agg_503())
+
+        fb_client = MagicMock()
+        fb_client.base_url = "https://alt.example.com/v1"
+        fb_client.chat.completions.create = AsyncMock(
+            return_value={"fallback": True})
+
+        with patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("aggregator", "claude-opus-4-8", None, None, None)), \
+             patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(primary, "claude-opus-4-8")), \
+             patch("agent.auxiliary_client._to_async_client",
+                   side_effect=lambda c, m, **_kw: (c, m)), \
+             patch("agent.auxiliary_client._validate_llm_response",
+                   side_effect=lambda resp, _task, **_kw: resp), \
+             patch("agent.auxiliary_client._try_configured_fallback_chain",
+                   return_value=(fb_client, "alt-model",
+                                 "fallback_chain[0](alt)")) as mock_chain, \
+             patch("agent.auxiliary_client._try_main_agent_model_fallback",
+                   return_value=(None, None, "")):
+            result = await async_call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert result == {"fallback": True}
+        assert primary.chat.completions.create.await_count == 1
+        mock_chain.assert_called()
+        assert fb_client.chat.completions.create.await_count == 1
 
 
 


### PR DESCRIPTION
## Summary

`_is_model_not_found_error()` is status-gated to `{404, 400, None}`. An aggregator
gateway that reports an unroutable model as **503 `model_not_found`** therefore falls
through to the generic-5xx path, which is not fallback-worthy — so `call_llm()` re-raises
the primary route's error and the configured `auxiliary.<task>.fallback_chain` is never
consulted.

Observed on a self-hosted new-api / one-api style distributor:

```
Error code: 503 - {'error': {'code': 'model_not_found',
  'message': 'No available channel for model claude-opus-4-8
  under group default (distributor)', 'type': 'new_api_error'}}
```

The model name is valid and the credential is fine — the route simply cannot serve it,
which is exactly the "try the next candidate" case.

For compression this is the worst place to give up: the attempt aborts, the transcript
stays over threshold, and the session grows until the model stops responding. The
user-visible symptom is the compression-blocked banner repeating while context climbs.

## Changes

- Widen the status gate in `_is_model_not_found_error()` to accept 5xx. Classification
  stays **body-driven**: a plain 500/502/503 with no model phrasing is still not claimed,
  and billing language still belongs to `_is_payment_error()` (guard runs first, unchanged).
- Add `_is_model_not_found_error` to `should_fallback` and `is_capacity_error` in **both**
  `_call_llm_impl` and `_async_call_llm_impl`, with `reason = "model not served by route"`.
  Capacity classification is what lets it bypass the explicit-provider gate: the provider
  cannot serve the request regardless of user intent.

## Relationship to prior work

Not a duplicate of #10093 (merged). That fix lives in `context_compressor.py` and retries
the **main model** when a distinct `summary_model` fails permanently. This one is a layer
lower, in `auxiliary_client.py`, and governs whether the configured `fallback_chain` is
consulted at all. With an explicit `auxiliary.compression.fallback_chain` set, the chain is
the intended recovery path and it was being skipped.

Same predicate as #48296 (410 Gone), #70496 (capability-404) and #74940 (generic proxy
404) — each widened a different unroutable shape. This adds the aggregator 5xx shape.

## Verification

Live aggregator endpoint, `auxiliary.compression.provider/model` pointed at the dead model,
healthy `fallback_chain[0]`:

```
before: RESULT: FAILED  InternalServerError 503
after:  RESULT: RESCUED by MiniMaxAI/MiniMax-M3
```

Also verified: primary dead **and** `chain[0]` dead **and** `chain[1]` healthy → rescued by
`chain[1]`.

Tests — 4 new cases in `TestIsModelNotFoundError`: aggregator 503 claimed, plain
500/502/503 not claimed, billing-language 5xx not claimed.

```
tests/agent/test_auxiliary_client.py              191 passed
-k "auxiliary or fallback or compression"          765 passed, 2 failed, 5 skipped
```

The 2 failures are `TestResolveVisionCustomProvider::test_custom_main_forwards_runtime_endpoint`
and `test_custom_prefixed_main_forwards_runtime_endpoint`. **They reproduce identically on
unpatched `origin/main`** with the same selection, and pass when that class runs alone —
pre-existing cross-test pollution, unrelated to this change.

Platform tested: Linux (Ubuntu 22.04, Python 3.11).

## Known limitation (not addressed here)

`_call_fallback_candidate_sync` re-raises any non-auth error, so if a chain entry itself
errors at request time the walk stops there rather than continuing to later entries.
Measured: `primary=dead, chain[0]=<different dead model>, chain[1]=healthy` still fails.
Left alone deliberately — widening that is a behaviour change with its own retry-budget
questions, and worth a separate PR.
