### PR TITLE
fix(gateway): prehydrate multiplex secrets off event loop

### DIFF
--- a/agent/secret_sources/onepassword.py
+++ b/agent/secret_sources/onepassword.py
@@ -39,9 +39,11 @@ material is fingerprinted, never stored.
 
 from __future__ import annotations
 
+import concurrent.futures
 import hashlib
 import logging
 import os
+import random
 import shutil
 import subprocess
 import time
@@ -64,8 +66,11 @@ logger = logging.getLogger(__name__)
 # Configuration constants
 # ---------------------------------------------------------------------------
 
-# How long to wait for a single `op read`, in seconds.
-_OP_RUN_TIMEOUT = 30
+# Independent reads share one bounded startup budget. A first attempt can use
+# at most 30 seconds globally; transport failures get one retry inside the
+# 45-second total source-resolution budget.
+_FIRST_ATTEMPT_BUDGET_SECONDS = 30.0
+_TOTAL_FETCH_BUDGET_SECONDS = 45.0
 
 # Default env var the official `op` CLI reads for service-account auth.  Users
 # can point `service_account_token_env` at a different name; we always export
@@ -157,15 +162,20 @@ def _validate_references(
     warnings: List[str] = []
     for name, ref in (references or {}).items():
         if not is_valid_env_name(name):
-            warnings.append(f"Skipping {name!r}: not a valid env-var name")
+            warnings.append(
+                f"Skipping {name!r}: not a valid env-var name (kind=ref_invalid)"
+            )
             continue
         if not isinstance(ref, str):
-            warnings.append(f"Skipping {name!r}: reference is not a string")
+            warnings.append(
+                f"Skipping {name!r}: reference is not a string (kind=ref_invalid)"
+            )
             continue
         cleaned = ref.strip()
         if not cleaned.startswith("op://"):
             warnings.append(
-                f"Skipping {name!r}: {ref!r} is not an op:// secret reference"
+                f"Skipping {name!r}: value is not an op:// secret reference "
+                "(kind=ref_invalid)"
             )
             continue
         valid[name] = cleaned
@@ -258,12 +268,22 @@ def _op_child_env(token_value: str) -> Dict[str, str]:
     return env
 
 
+class _OpReadError(RuntimeError):
+    """A classified, reference-free failure safe to surface in logs."""
+
+    def __init__(self, kind: ErrorKind, message: str) -> None:
+        super().__init__(message)
+        self.kind = kind
+
+
 def _run_op_read(
     op: Path,
     reference: str,
     *,
     account: str = "",
     token_value: str = "",
+    child_env: Optional[Dict[str, str]] = None,
+    timeout: float = _FIRST_ATTEMPT_BUDGET_SECONDS,
 ) -> str:
     """Resolve a single ``op://`` reference to its value.
 
@@ -281,27 +301,24 @@ def _run_op_read(
     try:
         proc = subprocess.run(  # noqa: S603 — op path is user-trusted, argv list
             cmd,
-            env=_op_child_env(token_value),
+            env=dict(child_env) if child_env is not None else _op_child_env(token_value),
             capture_output=True,
             text=True,
             encoding="utf-8",
             errors="replace",
-            timeout=_OP_RUN_TIMEOUT,
+            timeout=max(0.01, timeout),
         )
     except subprocess.TimeoutExpired as exc:
-        raise RuntimeError(
-            f"op read timed out after {_OP_RUN_TIMEOUT}s for {reference!r}"
-        ) from exc
+        raise _OpReadError(ErrorKind.TIMEOUT, "op read timed out") from exc
     except OSError as exc:
-        raise RuntimeError(f"failed to invoke op: {exc}") from exc
+        raise _OpReadError(
+            ErrorKind.BINARY_MISSING, f"failed to invoke op: {exc}"
+        ) from exc
 
     if proc.returncode != 0:
         err = _scrub(proc.stderr or "")[:200]
-        if err:
-            raise RuntimeError(f"op read failed for {reference!r}: {err}")
-        raise RuntimeError(
-            f"op read exited {proc.returncode} for {reference!r}"
-        )
+        kind = _classify_op_error(err or f"op read exited {proc.returncode}")
+        raise _OpReadError(kind, f"op read failed (kind={kind.value})")
 
     # `op` appends a trailing newline; strip only that so a value with
     # intentional internal/edge spaces survives.  But a value that is empty or
@@ -309,8 +326,67 @@ def _run_op_read(
     # good .env/shell credential with effectively nothing.
     value = (proc.stdout or "").rstrip("\r\n")
     if not value.strip():
-        raise RuntimeError(f"op read returned an empty value for {reference!r}")
+        raise _OpReadError(ErrorKind.EMPTY_VALUE, "op read returned an empty value")
     return value
+
+
+def _retry_jitter_seconds() -> float:
+    return random.uniform(0.1, 0.5)
+
+
+def _run_read_batch(
+    *,
+    op: Path,
+    references: Dict[str, str],
+    account: str,
+    token_value: str,
+    deadline: float,
+) -> Tuple[Dict[str, str], Dict[str, ErrorKind]]:
+    """Resolve refs concurrently without waiting beyond ``deadline``."""
+    if not references:
+        return {}, {}
+    remaining = max(0.0, deadline - time.monotonic())
+    if remaining <= 0:
+        return {}, {name: ErrorKind.TIMEOUT for name in references}
+
+    # Capture the active source environment before entering worker threads:
+    # ContextVars do not propagate into ThreadPoolExecutor workers.
+    child_env = _op_child_env(token_value)
+    executor = concurrent.futures.ThreadPoolExecutor(
+        max_workers=min(len(references), 32), thread_name_prefix="op-read"
+    )
+    futures = {
+        executor.submit(
+            _run_op_read,
+            op,
+            ref,
+            account=account,
+            token_value=token_value,
+            child_env=child_env,
+            timeout=remaining,
+        ): name
+        for name, ref in references.items()
+    }
+    values: Dict[str, str] = {}
+    failures: Dict[str, ErrorKind] = {}
+    try:
+        done, pending = concurrent.futures.wait(
+            futures, timeout=max(0.0, deadline - time.monotonic())
+        )
+        for future in done:
+            name = futures[future]
+            try:
+                values[name] = future.result()
+            except _OpReadError as exc:
+                failures[name] = exc.kind
+            except Exception:
+                failures[name] = ErrorKind.INTERNAL
+        for future in pending:
+            failures[futures[future]] = ErrorKind.TIMEOUT
+            future.cancel()
+    finally:
+        executor.shutdown(wait=False, cancel_futures=True)
+    return values, failures
 
 
 # ---------------------------------------------------------------------------
@@ -327,7 +403,9 @@ def fetch_onepassword_secrets(
     binary_path: str = "",
     use_cache: bool = True,
     cache_ttl_seconds: float = 300,
+    stale_if_error_seconds: float = 900,
     home_path: Optional[Path] = None,
+    _failure_kinds: Optional[Dict[str, ErrorKind]] = None,
 ) -> Tuple[Dict[str, str], List[str]]:
     """Resolve ``references`` (name → ``op://…``) to ``(secrets, warnings)``.
 
@@ -351,15 +429,28 @@ def fetch_onepassword_secrets(
         _refs_fingerprint(valid),
     )
 
-    if use_cache:
+    stale_candidate: Optional[CachedFetch] = None
+    cache_enabled = use_cache and cache_ttl_seconds > 0
+    if cache_enabled:
         cached = _CACHE.get(cache_key)
         if cached and cached.is_fresh(cache_ttl_seconds):
+            logger.info("1Password source cache decision=fresh layer=memory")
             return dict(cached.secrets), warnings
         disk_cached = _DISK_CACHE.read(cache_key, cache_ttl_seconds, home_path)
         if disk_cached is not None:
             # Promote into L1 so later fetches in this process skip the disk read.
             _CACHE[cache_key] = disk_cached
+            logger.info("1Password source cache decision=fresh layer=disk")
             return dict(disk_cached.secrets), warnings
+        if stale_if_error_seconds > 0:
+            stale_candidate = cached
+            if stale_candidate is None:
+                stale_candidate = _DISK_CACHE.read(cache_key, float("inf"), home_path)
+            if stale_candidate is not None and (
+                set(stale_candidate.secrets) != set(valid)
+                or (time.time() - stale_candidate.fetched_at) > stale_if_error_seconds
+            ):
+                stale_candidate = None
 
     op = binary or find_op(binary_path)
     if op is None:
@@ -369,21 +460,93 @@ def fetch_onepassword_secrets(
             "secrets.onepassword.binary_path to its absolute location."
         )
 
-    secrets: Dict[str, str] = {}
-    read_errors = 0
-    for name in sorted(valid):
-        try:
-            secrets[name] = _run_op_read(
-                op, valid[name], account=account, token_value=token_value
-            )
-        except RuntimeError as exc:
-            warnings.append(str(exc))
-            read_errors += 1
+    started = time.monotonic()
+    total_deadline = started + _TOTAL_FETCH_BUDGET_SECONDS
+    first_deadline = min(total_deadline, started + _FIRST_ATTEMPT_BUDGET_SECONDS)
+    secrets, failures = _run_read_batch(
+        op=op,
+        references=valid,
+        account=account,
+        token_value=token_value,
+        deadline=first_deadline,
+    )
+    retryable = {
+        name: valid[name]
+        for name, kind in failures.items()
+        if kind in (ErrorKind.TIMEOUT, ErrorKind.NETWORK)
+    }
+    if retryable and time.monotonic() < total_deadline:
+        jitter = min(
+            _retry_jitter_seconds(),
+            max(0.0, total_deadline - time.monotonic()),
+        )
+        if jitter > 0:
+            time.sleep(jitter)
+        retried, retry_failures = _run_read_batch(
+            op=op,
+            references=retryable,
+            account=account,
+            token_value=token_value,
+            deadline=total_deadline,
+        )
+        secrets.update(retried)
+        for name in retryable:
+            if name in retried:
+                failures.pop(name, None)
+            else:
+                failures[name] = retry_failures.get(name, ErrorKind.TIMEOUT)
 
-    if use_cache and not read_errors and secrets:
+    elapsed = time.monotonic() - started
+    if failures:
+        kinds = sorted({kind.value for kind in failures.values()})
+        logger.warning(
+            "1Password source live resolution incomplete resolved=%d unresolved=%d "
+            "kinds=%s elapsed=%.2fs",
+            len(secrets),
+            len(failures),
+            ",".join(kinds),
+            elapsed,
+        )
+    else:
+        logger.info(
+            "1Password source live resolution complete resolved=%d elapsed=%.2fs",
+            len(secrets),
+            elapsed,
+        )
+
+    if _failure_kinds is not None:
+        _failure_kinds.update(failures)
+
+    if (
+        failures
+        and stale_candidate is not None
+        and all(
+            kind in (ErrorKind.TIMEOUT, ErrorKind.NETWORK)
+            for kind in failures.values()
+        )
+    ):
+        age = max(0.0, time.time() - stale_candidate.fetched_at)
+        logger.warning(
+            "1Password source cache decision=stale-if-error age=%ds unresolved=%d",
+            int(age),
+            len(failures),
+        )
+        warnings.append(
+            f"live resolution had {len(failures)} transport failure(s); "
+            f"using complete stale cache ({int(age)}s old)"
+        )
+        if _failure_kinds is not None:
+            _failure_kinds.clear()
+        return dict(stale_candidate.secrets), warnings
+
+    for name in sorted(failures):
+        warnings.append(f"{name} unresolved (kind={failures[name].value})")
+
+    if cache_enabled and not failures and secrets:
         entry = CachedFetch(secrets=dict(secrets), fetched_at=time.time())
+        persistence_seconds = max(cache_ttl_seconds, stale_if_error_seconds)
         _CACHE[cache_key] = entry
-        _DISK_CACHE.write(cache_key, entry, cache_ttl_seconds, home_path)
+        _DISK_CACHE.write(cache_key, entry, persistence_seconds, home_path)
 
     return secrets, warnings
 
@@ -402,6 +565,7 @@ def apply_onepassword_secrets(
     binary_path: str = "",
     override_existing: bool = True,
     cache_ttl_seconds: float = 300,
+    stale_if_error_seconds: float = 900,
     home_path: Optional[Path] = None,
 ) -> FetchResult:
     """Resolve configured ``op://`` references and set them on ``os.environ``.
@@ -463,6 +627,7 @@ def apply_onepassword_secrets(
             token_env=service_account_token_env,
             binary=binary,
             cache_ttl_seconds=cache_ttl_seconds,
+            stale_if_error_seconds=stale_if_error_seconds,
             home_path=home_path,
         )
     except RuntimeError as exc:
@@ -550,6 +715,10 @@ class OnePasswordSource(SecretSource):
                 "description": "Disk+memory cache TTL; 0 disables",
                 "default": 300,
             },
+            "stale_if_error_seconds": {
+                "description": "Use a complete last-good cache after transport failures",
+                "default": 900,
+            },
             "override_existing": {
                 "description": "Resolved values overwrite .env/shell values",
                 "default": True,
@@ -566,7 +735,10 @@ class OnePasswordSource(SecretSource):
         )
         result.warnings.extend(warnings)
         if not valid:
-            if not warnings:
+            if warnings:
+                result.error = "1Password source has no valid mapped references"
+                result.error_kind = ErrorKind.REF_INVALID
+            else:
                 result.error = (
                     "secrets.onepassword.enabled is true but the env: map is "
                     "empty.  Add ENV_VAR: op://vault/item/field entries."
@@ -597,7 +769,12 @@ class OnePasswordSource(SecretSource):
             ttl = float(cfg.get("cache_ttl_seconds", 300))
         except (TypeError, ValueError):
             ttl = 300.0
+        try:
+            stale_if_error = float(cfg.get("stale_if_error_seconds", 900))
+        except (TypeError, ValueError):
+            stale_if_error = 900.0
 
+        failure_kinds: Dict[str, ErrorKind] = {}
         try:
             secrets, fetch_warnings = fetch_onepassword_secrets(
                 references=valid,
@@ -607,7 +784,9 @@ class OnePasswordSource(SecretSource):
                 ),
                 binary=binary,
                 cache_ttl_seconds=ttl,
+                stale_if_error_seconds=stale_if_error,
                 home_path=home_path,
+                _failure_kinds=failure_kinds,
             )
         except RuntimeError as exc:
             result.error = str(exc)
@@ -616,6 +795,18 @@ class OnePasswordSource(SecretSource):
 
         result.secrets = secrets
         result.warnings.extend(fetch_warnings)
+        if failure_kinds and not secrets:
+            kinds = sorted({kind.value for kind in failure_kinds.values()})
+            result.error = (
+                f"1Password source unresolved {len(failure_kinds)} mapped "
+                f"secret(s) (kinds: {','.join(kinds)})"
+            )
+            unique_kinds = set(failure_kinds.values())
+            result.error_kind = (
+                next(iter(unique_kinds))
+                if len(unique_kinds) == 1
+                else ErrorKind.INTERNAL
+            )
         return result
 
     def remediation(self, kind, cfg: dict) -> str:
@@ -645,15 +836,22 @@ def _classify_op_error(message: str) -> ErrorKind:
     if "not found on path" in lowered or "not an executable" in lowered \
             or "failed to invoke" in lowered:
         return ErrorKind.BINARY_MISSING
+    if any(tok in lowered for tok in ("session expired", "token expired",
+                                      "expired session")):
+        return ErrorKind.AUTH_EXPIRED
     if any(tok in lowered for tok in ("unauthorized", "not signed in",
-                                      "session expired", "authentication",
-                                      "401", "403")):
+                                      "authentication", "permission denied",
+                                      "forbidden", "401", "403")):
         return ErrorKind.AUTH_FAILED
     if "empty value" in lowered:
         return ErrorKind.EMPTY_VALUE
     if any(tok in lowered for tok in ("network", "connection", "resolve host",
                                       "dns")):
         return ErrorKind.NETWORK
+    if any(tok in lowered for tok in ("invalid secret reference",
+                                      "isn't a valid secret reference",
+                                      "could not find item", "could not find field")):
+        return ErrorKind.REF_INVALID
     return ErrorKind.INTERNAL
 
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -88,6 +88,37 @@ def _normalize_multiplex_profile_allowlist(value: Any) -> Optional[List[str]]:
     return normalized
 
 
+def _normalize_required_platforms(value: Any) -> List[str]:
+    """Normalize gateway.required_platforms to unique known platform names."""
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        logger.warning(
+            "Invalid gateway.required_platforms (expected a list, got %s); "
+            "gateway startup will fail until corrected",
+            type(value).__name__,
+        )
+        return ["<invalid-config>"]
+    known = {platform.value for platform in Platform}
+    normalized: List[str] = []
+    for index, entry in enumerate(value):
+        name = str(entry).strip().lower() if isinstance(entry, str) else ""
+        if not name:
+            logger.warning("Skipping invalid gateway.required_platforms entry %r", entry)
+            name = f"<invalid-entry-{index}>"
+        elif name.startswith("<invalid-"):
+            pass
+        elif name not in known:
+            logger.warning(
+                "Unknown gateway.required_platforms entry %r; gateway startup "
+                "will fail until corrected",
+                entry,
+            )
+        if name not in normalized:
+            normalized.append(name)
+    return normalized
+
+
 # Recognized truthy / falsy tokens for the GATEWAY_MULTIPLEX_PROFILES operator
 # override. Anything not in either set — and a blank/whitespace value — is
 # treated as "unset" so it falls through to config.yaml rather than silently
@@ -981,6 +1012,9 @@ class GatewayConfig:
     # Optional named-profile allowlist for multiplex mode. None preserves the
     # historical serve-all behavior; [] serves only the default profile.
     multiplex_profile_allowlist: Optional[List[str]] = None
+    # Platforms that must resolve their bootstrap credential before startup.
+    # Empty preserves the historical cron-only fail-open behavior.
+    required_platforms: List[str] = field(default_factory=list)
 
     # Opt-in systemd event-loop watchdog. Zero preserves Type=simple and
     # disables sd_notify at runtime.
@@ -1033,6 +1067,7 @@ class GatewayConfig:
         self.multiplex_profile_allowlist = _normalize_multiplex_profile_allowlist(
             self.multiplex_profile_allowlist
         )
+        self.required_platforms = _normalize_required_platforms(self.required_platforms)
         self.systemd_watchdog_seconds = coerce_systemd_watchdog_seconds(
             self.systemd_watchdog_seconds
         )
@@ -1148,6 +1183,7 @@ class GatewayConfig:
             "max_concurrent_sessions": self.max_concurrent_sessions,
             "multiplex_profiles": self.multiplex_profiles,
             "multiplex_profile_allowlist": self.multiplex_profile_allowlist,
+            "required_platforms": self.required_platforms,
             "systemd_watchdog_seconds": self.systemd_watchdog_seconds,
             "loop_watchdog": self.loop_watchdog,
             "loop_watchdog_probe_interval_s": self.loop_watchdog_probe_interval_s,
@@ -1222,6 +1258,10 @@ class GatewayConfig:
             multiplex_profile_allowlist = nested_gateway.get(
                 "multiplex_profile_allowlist"
             )
+        if "required_platforms" in data:
+            required_platforms = data.get("required_platforms")
+        else:
+            required_platforms = nested_gateway.get("required_platforms")
         if "systemd_watchdog_seconds" in data:
             systemd_watchdog_raw = data.get("systemd_watchdog_seconds")
             systemd_watchdog_key = "systemd_watchdog_seconds"
@@ -1328,6 +1368,7 @@ class GatewayConfig:
             thread_sessions_per_user=_coerce_bool(thread_sessions_per_user, False),
             multiplex_profiles=_coerce_bool(multiplex_profiles, False),
             multiplex_profile_allowlist=multiplex_profile_allowlist,
+            required_platforms=_normalize_required_platforms(required_platforms),
             systemd_watchdog_seconds=systemd_watchdog_seconds,
             loop_watchdog=loop_watchdog,
             loop_watchdog_probe_interval_s=loop_watchdog_probe_interval_s,
@@ -1485,6 +1526,14 @@ def load_gateway_config() -> GatewayConfig:
                 gw_data["multiplex_profile_allowlist"] = gateway_section[
                     "multiplex_profile_allowlist"
                 ]
+
+            if "required_platforms" in yaml_cfg:
+                gw_data["required_platforms"] = yaml_cfg["required_platforms"]
+            elif (
+                isinstance(gateway_section, dict)
+                and "required_platforms" in gateway_section
+            ):
+                gw_data["required_platforms"] = gateway_section["required_platforms"]
 
             # Profile-based routing rules: accept either top-level
             # ``profile_routes`` or the nested ``gateway.profile_routes`` form

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13340,6 +13340,77 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         startup_retryable_errors: list[str] = []
         _multiplex_on = bool(getattr(self.config, "multiplex_profiles", False))
         _multiplex_skipped_platforms: list[Platform] = []
+        _required_platforms: set[Platform] = set()
+        self._required_platforms = _required_platforms
+        self._required_platform_credentials_ready: set[Platform] = set()
+
+        def _fail_required_startup(
+            names: list[str], *, invalid_config: bool = False
+        ) -> bool:
+            if invalid_config:
+                readiness = ", ".join(f"{name}=invalid_config" for name in sorted(names))
+                reason = f"Invalid gateway.required_platforms configuration: {readiness}"
+            else:
+                readiness = ", ".join(
+                    f"{name}=missing_credential" for name in sorted(names)
+                )
+                reason = f"Required platform bootstrap credential unresolved: {readiness}"
+            logger.error("Required platform readiness: %s", readiness)
+            try:
+                from gateway.status import write_runtime_status
+
+                write_runtime_status(gateway_state="startup_failed", exit_reason=reason)
+            except Exception:
+                pass
+            self._exit_code = (
+                GATEWAY_FATAL_CONFIG_EXIT_CODE
+                if invalid_config
+                else GATEWAY_SERVICE_RESTART_EXIT_CODE
+            )
+            self._request_clean_exit(reason)
+            self._startup_restore_in_progress = False
+            return True
+
+        # Operators may opt specific messaging surfaces into fail-fast bootstrap
+        # readiness. This check is intentionally credential-only: transient
+        # connect failures still use the existing in-process reconnect path, and
+        # the default empty list preserves fleet/cron-only fail-open behavior.
+        from gateway.config import PLATFORM_TOKEN_ENV_NAMES
+
+        _required_invalid: list[str] = []
+        for _required_name in getattr(self.config, "required_platforms", []):
+            try:
+                _required_platform = Platform(_required_name)
+            except ValueError:
+                _required_invalid.append(_required_name)
+                continue
+            if _required_platform not in PLATFORM_TOKEN_ENV_NAMES:
+                _required_invalid.append(_required_name)
+                continue
+            _required_platforms.add(_required_platform)
+            _required_cfg = self.config.platforms.get(_required_platform)
+            if (
+                _required_cfg is not None
+                and _required_cfg.enabled
+                and _platform_has_bot_credential(_required_platform, _required_cfg)
+            ):
+                self._required_platform_credentials_ready.add(_required_platform)
+
+        if _required_invalid:
+            return _fail_required_startup(_required_invalid, invalid_config=True)
+        _required_missing = _required_platforms - self._required_platform_credentials_ready
+        if _required_missing and not _multiplex_on:
+            return _fail_required_startup(
+                [platform.value for platform in _required_missing]
+            )
+        if _required_platforms and not _required_missing:
+            logger.info(
+                "Required platform readiness: %s",
+                ", ".join(
+                    f"{platform.value}=credential_ready"
+                    for platform in sorted(_required_platforms, key=lambda item: item.value)
+                ),
+            )
         # Initialize and connect each configured platform.
         #
         # Parallel startup connect (#83791): the original code ran a serial for-loop,
@@ -13600,6 +13671,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Startup authority is one phase, not a persistent runner mode.
             # From this point onward every adapter retry is non-evicting.
             self._platform_lock_takeover_on_start = False
+
+        # In multiplex mode a required credential may intentionally live only
+        # in a secondary profile. Defer the decision until those profile configs
+        # have been hydrated, but still distinguish missing bootstrap material
+        # from transient adapter connection failures.
+        if _multiplex_on and _required_platforms:
+            _required_missing = (
+                _required_platforms - self._required_platform_credentials_ready
+            )
+            if _required_missing:
+                return _fail_required_startup(
+                    [platform.value for platform in _required_missing]
+                )
+            logger.info(
+                "Required platform readiness: %s",
+                ", ".join(
+                    f"{platform.value}=credential_ready"
+                    for platform in sorted(
+                        _required_platforms, key=lambda item: item.value
+                    )
+                ),
+            )
 
         # A platform we skipped on the primary for a missing credential was
         # supposed to be picked up by a secondary profile that owns the token.
@@ -16159,6 +16252,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         for platform, platform_config in profile_cfg.platforms.items():
             if not platform_config.enabled:
                 continue
+            if platform in getattr(
+                self, "_required_platforms", set()
+            ) and _platform_has_bot_credential(platform, platform_config):
+                self._required_platform_credentials_ready.add(platform)
             # Relay is shared process-level ingress in multiplex mode. The
             # active profile owns the one connection; connector-stamped
             # source.profile routes inbound turns to secondary profiles.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2320,6 +2320,13 @@ def _profile_runtime_scope(profile_home: "Path"):
     ``.env`` here does NOT mutate ``os.environ`` — ``build_profile_secret_scope``
     returns an isolated dict — which is what keeps subprocesses (MCP, kanban)
     from inheriting cross-profile secrets.
+
+    Scope-only: this never resolves external secret sources (1Password,
+    Bitwarden, ...). Those fetches block, and this scope runs synchronously on
+    the inbound path, so a cold profile must be hydrated beforehand — via
+    ``_prehydrate_profile_secret_sources`` at secondary startup, or the
+    process-global dotenv path for the active profile. The scope only reads
+    the already-recorded per-home snapshot.
     """
     from hermes_constants import set_hermes_home_override, reset_hermes_home_override
     from agent.secret_scope import (
@@ -2327,16 +2334,26 @@ def _profile_runtime_scope(profile_home: "Path"):
         set_secret_scope,
         reset_secret_scope,
     )
-    from hermes_cli.env_loader import hydrate_profile_secret_sources
 
     home_token = set_hermes_home_override(str(profile_home))
-    hydrate_profile_secret_sources(Path(profile_home))
     secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
     try:
         yield
     finally:
         reset_secret_scope(secret_token)
         reset_hermes_home_override(home_token)
+
+
+async def _prehydrate_profile_secret_sources(profile_home: "Path") -> None:
+    """Resolve one profile's external secret sources off the event loop.
+
+    ``hydrate_profile_secret_sources`` can block on a network/CLI backend, so
+    it runs in a worker thread. Must complete before the profile first enters
+    ``_profile_runtime_scope``, which is scope-only and never hydrates.
+    """
+    from hermes_cli.env_loader import hydrate_profile_secret_sources
+
+    await asyncio.to_thread(hydrate_profile_secret_sources, Path(profile_home))
 
 
 def load_gateway_config_for_runner() -> "GatewayConfig":
@@ -16160,9 +16177,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     claimed[retry_claim] = active
 
         profile_homes = _multiplex_profile_homes(self.config)
-        for profile_name, profile_home in profile_homes:
-            if profile_name == active:
-                continue  # handled by the primary startup loop
+        # The active profile is handled by the primary startup loop.
+        secondary = [(n, h) for n, h in profile_homes if n != active]
+        # Hydrate every secondary's external secret sources off-loop BEFORE any
+        # profile enters _profile_runtime_scope: the scope is synchronous and
+        # scope-only, so a cold source must be resolved here, never on the
+        # first inbound turn. Sequential on purpose — one blocking fetch at a
+        # time keeps backend rate limits and lock contention predictable.
+        for _profile_name, profile_home in secondary:
+            await _prehydrate_profile_secret_sources(profile_home)
+
+        for profile_name, profile_home in secondary:
             try:
                 connected += await self._start_one_profile_adapters(
                     profile_name, profile_home, claimed

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3154,6 +3154,10 @@ DEFAULT_CONFIG = {
         # the historical serve-all behavior; [] serves only the default.
         "multiplex_profile_allowlist": None,
 
+        # Messaging platforms that must have bootstrap credentials at startup.
+        # Empty preserves fail-open cron-only behavior for existing installs.
+        "required_platforms": [],
+
         # Durable delivery-obligation ledger: final agent responses are
         # recorded in state.db around the platform send, and a gateway that
         # died between finalize and platform ACK redelivers the stored
@@ -3718,6 +3722,10 @@ DEFAULT_CONFIG = {
             # Seconds to cache resolved values in-process and on disk.  0
             # disables BOTH cache layers (no values are written to disk).
             "cache_ttl_seconds": 300,
+            # Complete last-good cache may bridge only NETWORK/TIMEOUT failures
+            # within this age window. Auth/permission/invalid-ref failures never
+            # use stale values. 0 disables stale-if-error.
+            "stale_if_error_seconds": 900,
             # When True (default), resolved values overwrite existing env
             # vars so rotating a secret in 1Password takes effect on next
             # start.  Flip to false to let .env / shell exports win locally.

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -514,7 +514,11 @@ def load_hermes_dotenv(
     # in their gateway unit, which takes precedence (override=False below
     # ensures .op.env never clobbers a token already in the environment).
     op_env = home_path / ".op.env"
-    if op_env.exists() and not os.environ.get("OP_SERVICE_ACCOUNT_TOKEN"):
+    if op_env.exists():
+        # Always load the protected bootstrap file so headless op flags reach
+        # child processes even when .env or the service manager already
+        # supplied the token. override=False preserves those higher-priority
+        # values, including OP_SERVICE_ACCOUNT_TOKEN.
         _load_dotenv_with_fallback(op_env, override=False)
 
     if project_env_path and project_env_path.exists():

--- a/hermes_cli/onepassword_secrets_cli.py
+++ b/hermes_cli/onepassword_secrets_cli.py
@@ -181,6 +181,7 @@ def cmd_setup(args: argparse.Namespace) -> int:
     op_cfg["enabled"] = True
     op_cfg.setdefault("env", {})
     op_cfg.setdefault("cache_ttl_seconds", 300)
+    op_cfg.setdefault("stale_if_error_seconds", 900)
     op_cfg.setdefault("override_existing", True)
     save_config(cfg)
 
@@ -218,6 +219,9 @@ def cmd_status(args: argparse.Namespace) -> int:
     table.add_row("Token in env", _yn(token_set))
     table.add_row("Override existing", _yn(bool(op_cfg.get("override_existing", True))))
     table.add_row("Cache TTL (s)", str(op_cfg.get("cache_ttl_seconds", 300)))
+    table.add_row(
+        "Stale-if-error (s)", str(op_cfg.get("stale_if_error_seconds", 900))
+    )
     if binary:
         table.add_row("op binary", f"{binary} ({_op_version(binary)})")
     else:
@@ -395,6 +399,7 @@ def cmd_sync(args: argparse.Namespace) -> int:
             binary_path=binary_path,
             override_existing=bool(op_cfg.get("override_existing", True)),
             cache_ttl_seconds=0,  # an explicit sync always resolves fresh
+            stale_if_error_seconds=0,
         )
         if result.error:
             console.print(f"[red]{result.error}[/red]")

--- a/tests/gateway/test_multiplex_credential_isolation.py
+++ b/tests/gateway/test_multiplex_credential_isolation.py
@@ -5,6 +5,8 @@ interpolation) rather than mocking it, proving the property that matters: two
 profiles with different keys never see each other's, and an unscoped read in
 multiplex mode fails closed instead of leaking.
 """
+import asyncio
+
 import pytest
 
 from pathlib import Path
@@ -88,10 +90,10 @@ class TestProfilePathResolutionUnderMultiplexScope:
         assert b_seen == prof_b / "skills"
 
 
-def test_cold_profile_hydrates_external_source_without_global_env(
+def test_profile_scope_uses_prehydrated_external_source_without_global_env(
     tmp_path, monkeypatch
 ):
-    """The first routed secondary turn must resolve its own source locally."""
+    """Startup hydration supplies one profile without mutating global env."""
     import os
 
     from agent.secret_sources.base import FetchResult
@@ -150,6 +152,28 @@ def test_cold_profile_hydrates_external_source_without_global_env(
     monkeypatch.setattr(registry, "apply_all", _fake_apply_all)
     env_loader.reset_secret_source_cache()
 
+    # Scope-only: entering a cold profile's scope sees its .env but never
+    # triggers the (blocking) external fetch.
+    with _profile_runtime_scope(profile):
+        assert get_secret("EXPLICIT_API_KEY") == "dotenv-wins"
+        assert get_secret("TEST_PROVIDER_API_KEY") is None
+    assert calls["count"] == 0
+
+    # Explicit hydration — what secondary startup does off-loop.
+    assert env_loader.hydrate_profile_secret_sources(profile) == {
+        "TEST_PROVIDER_API_KEY": "profile-only"
+    }
+    assert calls["count"] == 1
+
+    # From here on any hydration attempt inside the scope is a failure, even
+    # one re-introduced via a function-local import.
+    def _forbidden_hydrate(_home):
+        raise AssertionError("_profile_runtime_scope must not hydrate")
+
+    monkeypatch.setattr(
+        env_loader, "hydrate_profile_secret_sources", _forbidden_hydrate
+    )
+
     with _profile_runtime_scope(profile):
         assert get_secret("TEST_PROVIDER_API_KEY") == "profile-only"
         assert get_secret("EXPLICIT_API_KEY") == "dotenv-wins"
@@ -164,5 +188,135 @@ def test_cold_profile_hydrates_external_source_without_global_env(
     assert calls["count"] == 1
     assert "TEST_PROVIDER_API_KEY" not in os.environ
     assert "EXPLICIT_API_KEY" not in os.environ
+
+
+@pytest.mark.asyncio
+async def test_secondary_startup_prehydrates_sequentially_off_loop(
+    tmp_path, monkeypatch
+):
+    """Secondary startup hydrates each cold profile off-loop, one at a time,
+    and only starts a profile's adapters after every hydration is done.
+
+    Each fake hydration blocks its worker thread until the event loop has
+    ticked a few more times. If hydration ran on the loop thread the ticker
+    could never advance and the hydration would stall (flagged, not hung).
+    """
+    import threading
+    import time
+    from unittest.mock import MagicMock
+
+    from agent.secret_scope import get_secret
+    from gateway.config import GatewayConfig
+    from gateway.run import GatewayRunner, _profile_runtime_scope
+    from hermes_cli import env_loader
+
+    ticks = 0
+    events: list = []
+    stalled: list = []
+    hydrated: dict[Path, dict[str, str]] = {}
+    seen_credentials: dict[str, str | None] = {}
+    lock = threading.Lock()
+
+    def slow_hydrate(home):
+        with lock:
+            events.append(("hydrate-start", home.name, ticks))
+        target = ticks + 3
+        deadline = time.monotonic() + 0.5
+        while ticks < target:
+            if time.monotonic() > deadline:
+                stalled.append(home.name)
+                break
+            time.sleep(0.001)
+        with lock:
+            hydrated[home.resolve()] = {
+                "TEST_PROVIDER_API_KEY": f"{home.name}-credential"
+            }
+            events.append(("hydrate-end", home.name, ticks))
+        return {}
+
+    monkeypatch.setattr(
+        "hermes_cli.env_loader.hydrate_profile_secret_sources", slow_hydrate
+    )
+    monkeypatch.setattr(
+        env_loader,
+        "get_secret_source_values",
+        lambda home: dict(hydrated.get(Path(home).resolve(), {})),
+    )
+
+    homes = {
+        name: tmp_path / name for name in ("default", "a", "b", "c")
+    }
+    for home in homes.values():
+        home.mkdir()
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        multiplex_profiles=True,
+        multiplex_profile_allowlist=["a", "b", "c"],
+    )
+    runner.adapters = {}
+    runner._profile_adapters = {}
+    runner.pairing_stores = {n: MagicMock() for n in ("default", "a", "b", "c")}
+    runner.pairing_store = runner.pairing_stores["default"]
+
+    async def fake_start_one(profile_name, profile_home, claimed):
+        events.append(("start", profile_name, ticks))
+        with _profile_runtime_scope(profile_home):
+            seen_credentials[profile_name] = get_secret("TEST_PROVIDER_API_KEY")
+        runner._profile_adapters[profile_name] = {}
+        return 1
+
+    monkeypatch.setattr(runner, "_start_one_profile_adapters", fake_start_one)
+    monkeypatch.setattr(
+        "hermes_cli.profiles.profiles_to_serve",
+        lambda multiplex, profile_allowlist=None: [
+            ("default", homes["default"]),
+            ("a", homes["a"]),
+            ("b", homes["b"]),
+            ("c", homes["c"]),
+        ],
+    )
+    monkeypatch.setattr("hermes_cli.profiles.get_active_profile_name", lambda: "default")
+    monkeypatch.setattr("gateway.status.write_runtime_status", lambda **kwargs: None)
+
+    async def ticker():
+        nonlocal ticks
+        while True:
+            ticks += 1
+            await asyncio.sleep(0)
+
+    ticker_task = asyncio.create_task(ticker())
+    try:
+        connected = await runner._start_secondary_profile_adapters()
+    finally:
+        ticker_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await ticker_task
+
+    assert connected == 3
+    assert stalled == [], f"event loop stalled during hydration of {stalled}"
+
+    hydrate_events = [(kind, name) for kind, name, _ in events if kind != "start"]
+    # Sequential: start/end pairs never interleave; active profile skipped.
+    assert hydrate_events == [
+        ("hydrate-start", "a"), ("hydrate-end", "a"),
+        ("hydrate-start", "b"), ("hydrate-end", "b"),
+        ("hydrate-start", "c"), ("hydrate-end", "c"),
+    ]
+    # Loop kept ticking while each hydration blocked its thread.
+    by_name = {(kind, name): tick for kind, name, tick in events}
+    for name in ("a", "b", "c"):
+        assert by_name[("hydrate-end", name)] > by_name[("hydrate-start", name)]
+    # Every hydration finishes before any profile starts; starts stay ordered.
+    kinds = [kind for kind, _, _ in events]
+    assert kinds.index("start") > max(
+        i for i, k in enumerate(kinds) if k == "hydrate-end"
+    )
+    assert [name for kind, name, _ in events if kind == "start"] == ["a", "b", "c"]
+    assert seen_credentials == {
+        "a": "a-credential",
+        "b": "b-credential",
+        "c": "c-credential",
+    }
 
 

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -3,7 +3,10 @@ from unittest.mock import AsyncMock
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter
-from gateway.restart import GATEWAY_FATAL_CONFIG_EXIT_CODE
+from gateway.restart import (
+    GATEWAY_FATAL_CONFIG_EXIT_CODE,
+    GATEWAY_SERVICE_RESTART_EXIT_CODE,
+)
 from gateway.run import GatewayRunner
 from gateway.status import read_runtime_status
 
@@ -355,6 +358,89 @@ async def test_runner_degrades_gracefully_when_all_adapters_missing(monkeypatch,
         "No adapter could be created" in record.message
         for record in caplog.records
     ), "Expected degraded-mode warning when all adapters are missing"
+
+
+@pytest.mark.asyncio
+async def test_required_telegram_without_resolved_token_exits_for_supervisor_retry(
+    monkeypatch, tmp_path, caplog
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="")},
+        required_platforms=["telegram"],
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+
+    ok = await runner.start()
+
+    assert ok is True
+    assert runner.should_exit_cleanly is True
+    assert runner.exit_code == GATEWAY_SERVICE_RESTART_EXIT_CODE
+    assert runner.adapters == {}
+    state = read_runtime_status()
+    assert state["gateway_state"] == "startup_failed"
+    assert any(
+        "Required platform readiness: telegram=missing_credential" in record.message
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_required_telegram_may_resolve_from_secondary_multiplex_profile(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="")},
+        required_platforms=["telegram"],
+        multiplex_profiles=True,
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+
+    async def _start_secondary():
+        runner._required_platform_credentials_ready.add(Platform.TELEGRAM)
+        return 1
+
+    monkeypatch.setattr(runner, "_start_secondary_profile_adapters", _start_secondary)
+
+    ok = await runner.start()
+
+    assert ok is True
+    assert runner.should_exit_cleanly is False
+    assert runner.exit_code is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("required", ["telegrm", "whatsapp"])
+async def test_invalid_or_unsupported_required_platform_exits_as_fatal_config(
+    monkeypatch, tmp_path, required
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = GatewayConfig(
+        required_platforms=[required],
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+
+    ok = await runner.start()
+
+    assert ok is True
+    assert runner.should_exit_cleanly is True
+    assert runner.exit_code == GATEWAY_FATAL_CONFIG_EXIT_CODE
+
+
+def test_required_platforms_default_fail_open_and_roundtrip():
+    assert GatewayConfig.from_dict({}).required_platforms == []
+    config = GatewayConfig.from_dict(
+        {"gateway": {"required_platforms": ["telegram", "telegram"]}}
+    )
+    assert config.required_platforms == ["telegram"]
+    assert config.to_dict()["required_platforms"] == ["telegram"]
+    assert GatewayConfig.from_dict(
+        {"gateway": {"required_platforms": ["telegrm"]}}
+    ).required_platforms == ["telegrm"]
 
 
 class _NonRetryableFailureAdapter(BasePlatformAdapter):

--- a/tests/test_env_loader_op_bootstrap.py
+++ b/tests/test_env_loader_op_bootstrap.py
@@ -41,6 +41,7 @@ import agent.credential_pool as credential_pool  # noqa: E402
 def _isolate_op_token(monkeypatch):
     """Each test starts with OP_SERVICE_ACCOUNT_TOKEN unset and a clean cache."""
     monkeypatch.delenv("OP_SERVICE_ACCOUNT_TOKEN", raising=False)
+    monkeypatch.delenv("OP_LOAD_DESKTOP_APP_SETTINGS", raising=False)
     env_loader.reset_secret_source_cache()
     yield
     env_loader.reset_secret_source_cache()
@@ -64,9 +65,57 @@ def test_op_env_autoloads_bootstrap_token_in_cron_context(tmp_path, monkeypatch)
 
     assert os.environ.get("OP_SERVICE_ACCOUNT_TOKEN") is None
 
+    seen_at_source_resolution = {}
+
+    def capture_source_environment(_home):
+        seen_at_source_resolution["token"] = os.environ.get(
+            "OP_SERVICE_ACCOUNT_TOKEN"
+        )
+
+    monkeypatch.setattr(
+        env_loader, "_apply_external_secret_sources", capture_source_environment
+    )
+
     env_loader.load_hermes_dotenv(hermes_home=home)
 
     assert os.environ["OP_SERVICE_ACCOUNT_TOKEN"] == "test-token"
+    assert seen_at_source_resolution["token"] == "test-token"
+
+
+def test_op_env_loads_headless_flags_when_dotenv_already_supplies_token(
+    tmp_path, monkeypatch
+):
+    """Protected op flags load without clobbering the existing bootstrap token."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / ".env").write_text(
+        "OP_SERVICE_ACCOUNT_TOKEN=dotenv-token\n", encoding="utf-8"
+    )
+    (home / ".op.env").write_text(
+        "OP_SERVICE_ACCOUNT_TOKEN=op-env-token\n"
+        "OP_LOAD_DESKTOP_APP_SETTINGS=false\n",
+        encoding="utf-8",
+    )
+    seen_at_source_resolution = {}
+
+    def capture_source_environment(_home):
+        seen_at_source_resolution["token"] = os.environ.get(
+            "OP_SERVICE_ACCOUNT_TOKEN"
+        )
+        seen_at_source_resolution["desktop"] = os.environ.get(
+            "OP_LOAD_DESKTOP_APP_SETTINGS"
+        )
+
+    monkeypatch.setattr(
+        env_loader, "_apply_external_secret_sources", capture_source_environment
+    )
+
+    env_loader.load_hermes_dotenv(hermes_home=home)
+
+    assert seen_at_source_resolution == {
+        "token": "dotenv-token",
+        "desktop": "false",
+    }
 
 
 

--- a/tests/test_onepassword_secrets.py
+++ b/tests/test_onepassword_secrets.py
@@ -11,6 +11,7 @@ import json
 import os
 import subprocess
 import sys
+import threading
 import time
 from pathlib import Path
 from unittest import mock
@@ -108,6 +109,94 @@ def test_fetch_happy_path(monkeypatch, tmp_path):
     assert warnings == []
 
 
+def test_op_child_receives_headless_desktop_flag(monkeypatch, tmp_path):
+    fake_op = tmp_path / "op"
+    fake_op.write_text("")
+    monkeypatch.setenv("OP_LOAD_DESKTOP_APP_SETTINGS", "false")
+    seen = {}
+
+    def fake_run(cmd, **kwargs):
+        seen.update(kwargs["env"])
+        return _ok("resolved")
+
+    monkeypatch.setattr(op.subprocess, "run", fake_run)
+    op.fetch_onepassword_secrets(
+        references={"K": "op://V/I/F"}, binary=fake_op, use_cache=False
+    )
+
+    assert seen["OP_LOAD_DESKTOP_APP_SETTINGS"] == "false"
+
+
+def test_four_hung_reads_share_one_global_deadline(monkeypatch, tmp_path):
+    fake_op = tmp_path / "op"
+    fake_op.write_text("")
+    release = threading.Event()
+
+    def hung(*args, **kwargs):
+        release.wait(0.5)
+        raise op._OpReadError(op.ErrorKind.TIMEOUT, "op read timed out")
+
+    monkeypatch.setattr(op, "_run_op_read", hung)
+    monkeypatch.setattr(op, "_FIRST_ATTEMPT_BUDGET_SECONDS", 0.05)
+    monkeypatch.setattr(op, "_TOTAL_FETCH_BUDGET_SECONDS", 0.10)
+    monkeypatch.setattr(op, "_retry_jitter_seconds", lambda: 0.0)
+
+    started = time.monotonic()
+    try:
+        secrets, warnings = op.fetch_onepassword_secrets(
+            references={f"K{i}": f"op://V/I/F{i}" for i in range(4)},
+            binary=fake_op,
+            use_cache=False,
+        )
+    finally:
+        release.set()
+
+    assert time.monotonic() - started < 0.25
+    assert secrets == {}
+    assert len(warnings) == 4
+    assert all("kind=timeout" in warning for warning in warnings)
+
+
+def test_retry_only_timeout_and_network(monkeypatch, tmp_path):
+    fake_op = tmp_path / "op"
+    fake_op.write_text("")
+    first_kinds = {
+        "op://V/I/timeout": op.ErrorKind.TIMEOUT,
+        "op://V/I/network": op.ErrorKind.NETWORK,
+        "op://V/I/auth": op.ErrorKind.AUTH_FAILED,
+        "op://V/I/invalid": op.ErrorKind.REF_INVALID,
+    }
+    calls = {ref: 0 for ref in first_kinds}
+
+    def fake_read(_binary, reference, **kwargs):
+        calls[reference] += 1
+        if calls[reference] == 1:
+            raise op._OpReadError(first_kinds[reference], "redacted failure")
+        return "recovered"
+
+    monkeypatch.setattr(op, "_run_op_read", fake_read)
+    monkeypatch.setattr(op, "_retry_jitter_seconds", lambda: 0.0)
+    secrets, warnings = op.fetch_onepassword_secrets(
+        references={
+            "TIMEOUT": "op://V/I/timeout",
+            "NETWORK": "op://V/I/network",
+            "AUTH": "op://V/I/auth",
+            "INVALID": "op://V/I/invalid",
+        },
+        binary=fake_op,
+        use_cache=False,
+    )
+
+    assert secrets == {"TIMEOUT": "recovered", "NETWORK": "recovered"}
+    assert calls == {
+        "op://V/I/timeout": 2,
+        "op://V/I/network": 2,
+        "op://V/I/auth": 1,
+        "op://V/I/invalid": 1,
+    }
+    assert {warning.split()[0] for warning in warnings} == {"AUTH", "INVALID"}
+
+
 
 
 
@@ -127,7 +216,7 @@ def test_fetch_read_failure_becomes_warning(monkeypatch, tmp_path):
     # ANSI control sequences are fully scrubbed from the surfaced message.
     assert "\x1b" not in warnings[0]
     assert "[31m" not in warnings[0]
-    assert "not signed in" in warnings[0]
+    assert "kind=auth_failed" in warnings[0]
 
 
 
@@ -195,6 +284,121 @@ def test_connect_credential_change_invalidates_cache(monkeypatch, tmp_path):
         binary=fake_op, home_path=tmp_path,
     )
     assert calls["n"] == 2  # cache key changed → refetch
+
+
+def _seed_stale_cache(tmp_path, refs, *, age_seconds=100):
+    key = (
+        op._auth_fingerprint("OP_SERVICE_ACCOUNT_TOKEN"),
+        "",
+        str(tmp_path),
+        op._refs_fingerprint(refs),
+    )
+    op._CACHE[key] = op.CachedFetch(
+        secrets={name: f"cached-{name}" for name in refs},
+        fetched_at=time.time() - age_seconds,
+    )
+
+
+@pytest.mark.parametrize("kind", [op.ErrorKind.TIMEOUT, op.ErrorKind.NETWORK])
+def test_complete_stale_cache_allowed_for_transport_errors(monkeypatch, tmp_path, kind):
+    fake_op = tmp_path / "op"
+    fake_op.write_text("")
+    refs = {"A": "op://V/I/A", "B": "op://V/I/B"}
+    _seed_stale_cache(tmp_path, refs)
+
+    def fail(*args, **kwargs):
+        raise op._OpReadError(kind, "redacted failure")
+
+    monkeypatch.setattr(op, "_run_op_read", fail)
+    monkeypatch.setattr(op, "_retry_jitter_seconds", lambda: 0.0)
+    secrets, warnings = op.fetch_onepassword_secrets(
+        references=refs,
+        binary=fake_op,
+        cache_ttl_seconds=1,
+        stale_if_error_seconds=900,
+        home_path=tmp_path,
+    )
+
+    assert secrets == {"A": "cached-A", "B": "cached-B"}
+    assert any("stale cache" in warning for warning in warnings)
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [
+        op.ErrorKind.AUTH_FAILED,
+        op.ErrorKind.AUTH_EXPIRED,
+        op.ErrorKind.REF_INVALID,
+        op.ErrorKind.EMPTY_VALUE,
+    ],
+)
+def test_stale_cache_never_used_for_nontransport_errors(monkeypatch, tmp_path, kind):
+    fake_op = tmp_path / "op"
+    fake_op.write_text("")
+    refs = {"A": "op://V/I/A"}
+    _seed_stale_cache(tmp_path, refs)
+
+    def fail(*args, **kwargs):
+        raise op._OpReadError(kind, "redacted failure")
+
+    monkeypatch.setattr(op, "_run_op_read", fail)
+    secrets, warnings = op.fetch_onepassword_secrets(
+        references=refs,
+        binary=fake_op,
+        cache_ttl_seconds=1,
+        stale_if_error_seconds=900,
+        home_path=tmp_path,
+    )
+
+    assert secrets == {}
+    assert not any("stale cache" in warning for warning in warnings)
+
+
+def test_permission_failure_is_classified_as_nonretryable_auth_failure():
+    assert (
+        op._classify_op_error("permission denied for this vault")
+        == op.ErrorKind.AUTH_FAILED
+    )
+
+
+def test_cache_ttl_zero_still_disables_all_cache_persistence(monkeypatch, tmp_path):
+    fake_op = tmp_path / "op"
+    fake_op.write_text("")
+    monkeypatch.setattr(op.subprocess, "run", lambda *a, **k: _ok("resolved"))
+
+    op.fetch_onepassword_secrets(
+        references={"A": "op://V/I/A"},
+        binary=fake_op,
+        cache_ttl_seconds=0,
+        stale_if_error_seconds=900,
+        home_path=tmp_path,
+    )
+
+    assert op._CACHE == {}
+    assert not op._disk_cache_path(tmp_path).exists()
+
+
+def test_incomplete_or_too_old_stale_cache_is_rejected(monkeypatch, tmp_path):
+    fake_op = tmp_path / "op"
+    fake_op.write_text("")
+    refs = {"A": "op://V/I/A", "B": "op://V/I/B"}
+    _seed_stale_cache(tmp_path, refs, age_seconds=901)
+
+    def fail(*args, **kwargs):
+        raise op._OpReadError(op.ErrorKind.NETWORK, "redacted failure")
+
+    monkeypatch.setattr(op, "_run_op_read", fail)
+    monkeypatch.setattr(op, "_retry_jitter_seconds", lambda: 0.0)
+    secrets, warnings = op.fetch_onepassword_secrets(
+        references=refs,
+        binary=fake_op,
+        cache_ttl_seconds=1,
+        stale_if_error_seconds=900,
+        home_path=tmp_path,
+    )
+
+    assert secrets == {}
+    assert not any("stale cache" in warning for warning in warnings)
 
 
 


### PR DESCRIPTION
## Summary

- resolve every secondary profile secret source sequentially with `asyncio.to_thread` before any multiplex runtime scope is entered
- make `_profile_runtime_scope` scope-only so inbound message paths can never trigger a first blocking external-secret fetch
- add a deterministic multi-profile event-loop witness and verify each adapter startup sees only its prehydrated profile credential

The liveness watchdog and its exit-75 behavior are unchanged. Hydration remains sequential because the env-loader cache and secret-source registry use process-global mutable state and a global lock.

## Verification

- `scripts/run_tests.sh tests/gateway/test_multiplex_credential_isolation.py -q` — 5 passed
- `scripts/run_tests.sh tests/gateway/test_multiplex_adapter_registry.py tests/gateway/test_adapter_startup_secret_scope.py tests/test_env_loader_secret_sources.py tests/test_env_loader_op_bootstrap.py tests/secret_sources/test_profile_secrets.py -q` — 126 passed
- `scripts/run_tests.sh tests/gateway/*multiplex*.py -q` — 136 passed
- `scripts/run_tests.sh tests/gateway/test_loop_liveness_watchdog.py tests/gateway/test_watchdog_review_76354.py -q` — 18 passed
- `.venv/bin/ruff check gateway/run.py tests/gateway/test_multiplex_credential_isolation.py` — passed
- `git diff --check` — passed

A broader `scripts/run_tests.sh tests/gateway/ -q` run completed 6,652 passing tests with 6 unrelated host/environment failures: macOS AF_UNIX path length in `test_scale_to_zero.py` (2), POSIX diagnostic spawn in `test_shutdown_forensics.py` (1), Linux abstract socket semantics in `test_systemd_notify.py` (1), and missing optional XML parser behavior in `test_wecom_callback.py` (2). All multiplex and watchdog files passed in that run.

## Tradeoff / residual risk

This keeps the event loop responsive but does not reduce worst-case secondary startup wall time: N unhealthy profiles can still take N times the source timeout. Parallel hydration remains intentionally out of scope until registry/cache state is profile-isolated.