### PR TITLE
feat(gateway): accept the richer cron job fields on /api/jobs

### DIFF
--- a/contributors/emails/nate@gravillecapital.com
+++ b/contributors/emails/nate@gravillecapital.com
@@ -1,0 +1,1 @@
+NateGraville

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1469,6 +1469,22 @@ try:
 except Exception:  # pragma: no cover - scanner is optional hardening
     _scan_cron_prompt = None
 
+# Same-parity imports for the richer job fields below.  These are the exact
+# helpers `hermes cron create/edit` runs through (tools/cronjob_tools.py), so a
+# job created over REST is validated identically to one created from the CLI.
+# Imported defensively like the scanner above — but unlike the scanner, a
+# missing helper FAILS THE REQUEST that needs it rather than skipping the
+# check: these fields select scripts and credential routing, so silently
+# accepting them unvalidated would be worse than rejecting them.
+try:
+    from tools.cronjob_tools import (
+        _apply_continuity as _cron_apply_continuity,
+        _validate_cron_script_path as _cron_validate_script_path,
+    )
+except Exception:  # pragma: no cover - helpers are optional at import time
+    _cron_apply_continuity = None
+    _cron_validate_script_path = None
+
 
 class _ProviderAuthResolutionError(RuntimeError):
     """Raised only when gateway.run._resolve_runtime_agent_kwargs() fails
@@ -6716,8 +6732,31 @@ class APIServerAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     _JOB_ID_RE = __import__("re").compile(r"[a-f0-9]{12}")
+    # Job fields beyond the basic create/update set that `hermes cron
+    # create/edit` and the `cronjob` tool have always been able to set.  They
+    # are accepted here so a REST client (dashboard, external control plane)
+    # does not have to shell out to the CLI to configure change detection,
+    # run-to-run continuity, a narrowed toolset, or a per-job model pin.
+    #
+    # Deliberately NOT included: `base_url`, `script`, `workdir`, `no_agent`
+    # and `attach_to_session`.  Those select a host filesystem path, a
+    # credential-routing endpoint, or a non-agent execution mode; the REST
+    # surface stays narrower than the CLI there on purpose.
+    _RICH_JOB_FIELDS = (
+        "enabled_toolsets",
+        "continuity",
+        "context_from",
+        "monitor_script",
+        "monitor_url",
+        "model",
+        "provider",
+        "reasoning_effort",
+    )
     # Allowed fields for update — prevents clients injecting arbitrary keys
-    _UPDATE_ALLOWED_FIELDS = {"name", "schedule", "prompt", "deliver", "skills", "skill", "repeat", "enabled"}
+    _UPDATE_ALLOWED_FIELDS = {
+        "name", "schedule", "prompt", "deliver", "skills", "skill", "repeat", "enabled",
+        *_RICH_JOB_FIELDS,
+    }
     _MAX_NAME_LENGTH = 200
     _MAX_PROMPT_LENGTH = 5000
 
@@ -6743,6 +6782,97 @@ class APIServerAdapter(BasePlatformAdapter):
                 {"error": "Invalid job ID format"}, status=400,
             )
         return job_id, None
+
+    @staticmethod
+    def _coerce_job_string_list(value: Any, field: str) -> tuple:
+        """Normalize a str-or-list-of-str job field. Returns (items, error)."""
+        if isinstance(value, str):
+            return ([value.strip()] if value.strip() else []), None
+        if isinstance(value, list):
+            if not all(isinstance(item, str) for item in value):
+                return None, f"{field} entries must be strings"
+            return [item.strip() for item in value if item.strip()], None
+        return None, f"{field} must be a string or a list of strings"
+
+    def _normalize_rich_job_fields(
+        self,
+        body: Dict[str, Any],
+        existing: Optional[Dict[str, Any]] = None,
+    ) -> tuple:
+        """Validate the richer job fields from a REST body.
+
+        Returns ``(fields, error_message)``. ``fields`` is ready to pass to
+        ``create_job`` (``existing is None``) or to merge into an
+        ``update_job`` payload. Every rule here mirrors the create/update
+        branches of ``tools/cronjob_tools.py`` so the REST and CLI surfaces
+        cannot drift: same script-path containment, same context_from
+        existence check, same ``continuity`` → reserved ``"self"`` ref
+        translation, same "empty string clears the field" semantics.
+        """
+        fields: Dict[str, Any] = {}
+
+        for name in ("model", "provider", "reasoning_effort"):
+            value = body.get(name)
+            if value is None:
+                continue
+            if not isinstance(value, str):
+                return None, f"{name} must be a string"
+            # reasoning_effort spelling is validated at the storage choke
+            # point (cron.jobs._normalize_reasoning_effort), which raises
+            # ValueError — surfaced as a 400 by the handlers below.
+            fields[name] = value.strip() or None
+
+        for name in ("monitor_script", "monitor_url"):
+            value = body.get(name)
+            if value is None:
+                continue
+            if not isinstance(value, str):
+                return None, f"{name} must be a string"
+            value = value.strip()
+            if name == "monitor_script" and value:
+                if _cron_validate_script_path is None:
+                    return None, "monitor_script validation is unavailable"
+                script_error = _cron_validate_script_path(value)
+                if script_error:
+                    return None, script_error
+            fields[name] = value or None
+
+        if body.get("enabled_toolsets") is not None:
+            toolsets, error = self._coerce_job_string_list(
+                body["enabled_toolsets"], "enabled_toolsets",
+            )
+            if error:
+                return None, error
+            fields["enabled_toolsets"] = toolsets or None
+
+        continuity = body.get("continuity")
+        if continuity is not None and not isinstance(continuity, bool):
+            return None, "continuity must be a boolean"
+        context_from = body.get("context_from")
+        if context_from is not None or continuity is not None:
+            if context_from is None:
+                # continuity-only update: start from the job's stored refs so
+                # external chaining survives the toggle.
+                stored = (existing or {}).get("context_from") or []
+                refs = [str(item).strip() for item in stored if str(item).strip()]
+            else:
+                refs, error = self._coerce_job_string_list(context_from, "context_from")
+                if error:
+                    return None, error
+            if continuity is not None:
+                if _cron_apply_continuity is None:
+                    return None, "continuity is unavailable"
+                refs = _cron_apply_continuity(refs, continuity) or []
+            for ref_id in refs:
+                # "self" resolves to the job's own id at run time and cannot be
+                # looked up — on create the job does not exist yet.
+                if ref_id.lower() == "self":
+                    continue
+                if _cron_get is None or not _cron_get(ref_id):
+                    return None, f"context_from job '{ref_id}' not found"
+            fields["context_from"] = refs or None
+
+        return fields, None
 
     async def _handle_list_jobs(self, request: "web.Request") -> "web.Response":
         """GET /api/jobs — list all cron jobs."""
@@ -6795,6 +6925,10 @@ class APIServerAdapter(BasePlatformAdapter):
             if repeat is not None and (not isinstance(repeat, int) or repeat < 1):
                 return web.json_response({"error": "Repeat must be a positive integer"}, status=400)
 
+            rich_fields, rich_error = self._normalize_rich_job_fields(body)
+            if rich_error:
+                return web.json_response({"error": rich_error}, status=400)
+
             kwargs = {
                 "prompt": prompt,
                 "schedule": schedule,
@@ -6806,11 +6940,17 @@ class APIServerAdapter(BasePlatformAdapter):
                 kwargs["skills"] = skills
             if repeat is not None:
                 kwargs["repeat"] = repeat
+            kwargs.update(rich_fields)
 
             job = _cron_create(**kwargs)
             return web.json_response({"job": job})
         except _CronSchedulerRegistrationError as e:
             return web.json_response(e.to_dict(), status=424)
+        except ValueError as e:
+            # create_job raises ValueError for spelling-level rejections it owns
+            # (reasoning_effort grammar, monitor_script/monitor_url mutual
+            # exclusion). Those are client mistakes, not server faults.
+            return web.json_response({"error": _redact_api_error_text(e)}, status=400)
         except Exception as e:
             return web.json_response({"error": _redact_api_error_text(e)}, status=500)
 
@@ -6863,11 +7003,46 @@ class APIServerAdapter(BasePlatformAdapter):
                 scan_error = _scan_cron_prompt(sanitized["prompt"])
                 if scan_error:
                     return web.json_response({"error": scan_error}, status=400)
+            if set(self._RICH_JOB_FIELDS) & set(sanitized):
+                existing = _cron_get(job_id)
+                if not existing:
+                    return web.json_response({"error": "Job not found"}, status=404)
+                rich_fields, rich_error = self._normalize_rich_job_fields(
+                    sanitized, existing=existing,
+                )
+                if rich_error:
+                    return web.json_response({"error": rich_error}, status=400)
+                # `continuity` is REST/CLI sugar, not a stored field: it has
+                # already been folded into context_from. Drop every raw rich
+                # key and replace it with the normalized value.
+                for key in self._RICH_JOB_FIELDS:
+                    sanitized.pop(key, None)
+                sanitized.update(rich_fields)
+                # update_job() does not own the monitor mutual-exclusion rule
+                # that create_job() enforces, so check the EFFECTIVE pair here
+                # exactly as the cronjob tool does.
+                effective_script = sanitized.get(
+                    "monitor_script", existing.get("monitor_script"),
+                )
+                effective_url = sanitized.get(
+                    "monitor_url", existing.get("monitor_url"),
+                )
+                if effective_script and effective_url:
+                    return web.json_response({"error": (
+                        "monitor_script and monitor_url are mutually exclusive "
+                        "— clear one before setting the other."
+                    )}, status=400)
+                if not sanitized:
+                    return web.json_response({"error": "No valid fields to update"}, status=400)
             job = _cron_update(job_id, sanitized)
             if not job:
                 return web.json_response({"error": "Job not found"}, status=404)
             _notify_cron_provider_jobs_changed()
             return web.json_response({"job": job})
+        except ValueError as e:
+            # update_job raises ValueError for immutable-field and
+            # reasoning_effort rejections — client mistakes, not server faults.
+            return web.json_response({"error": _redact_api_error_text(e)}, status=400)
         except Exception as e:
             return web.json_response({"error": _redact_api_error_text(e)}, status=500)
 

--- a/tests/gateway/test_api_server_jobs_rich_fields.py
+++ b/tests/gateway/test_api_server_jobs_rich_fields.py
@@ -1,0 +1,395 @@
+"""
+Tests for the richer cron-job fields on the API server's /api/jobs surface.
+
+The CLI (`hermes cron create/edit`) and the `cronjob` tool have always been able
+to set change detection, run-to-run continuity, a narrowed toolset and a per-job
+model pin. These tests cover accepting the same fields over REST, and — the
+point of the change — that they are validated the SAME way, so a job created
+over REST is indistinguishable from one created from the CLI.
+
+Covers:
+- create passes enabled_toolsets / continuity / context_from / monitor_* /
+  model / provider / reasoning_effort through to create_job
+- continuity is translated to the reserved "self" context_from ref
+- context_from references are checked for existence ("self" excepted)
+- monitor_script goes through the same path-containment validator as the CLI
+- type errors return 400, not 500
+- create_job's own ValueErrors (reasoning_effort grammar, monitor mutual
+  exclusion) surface as 400
+- update accepts the same fields, merges continuity onto the STORED
+  context_from, and rejects a monitor_script + monitor_url pair
+- the update allowlist still rejects unknown keys
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter, cors_middleware
+
+_MOD = "gateway.platforms.api_server"
+
+SAMPLE_JOB = {
+    "id": "aabbccddeeff",
+    "name": "test-job",
+    "schedule": "*/5 * * * *",
+    "prompt": "do something",
+    "deliver": "local",
+    "enabled": True,
+}
+
+OTHER_JOB = {"id": "112233445566", "name": "upstream-job"}
+
+VALID_JOB_ID = "aabbccddeeff"
+OTHER_JOB_ID = "112233445566"
+
+
+def _make_adapter() -> APIServerAdapter:
+    return APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+
+
+def _create_app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application(middlewares=[cors_middleware])
+    app["api_server_adapter"] = adapter
+    app.router.add_post("/api/jobs", adapter._handle_create_job)
+    app.router.add_patch("/api/jobs/{job_id}", adapter._handle_update_job)
+    return app
+
+
+@pytest.fixture
+def adapter():
+    return _make_adapter()
+
+
+def _get_job_stub(job_id):
+    return {VALID_JOB_ID: SAMPLE_JOB, OTHER_JOB_ID: OTHER_JOB}.get(job_id)
+
+
+# ---------------------------------------------------------------------------
+# create
+# ---------------------------------------------------------------------------
+
+class TestCreateJobRichFields:
+    @pytest.mark.asyncio
+    async def test_create_passes_rich_fields_through(self, adapter):
+        """Every widened field reaches create_job with the CLI's shape."""
+        app = _create_app(adapter)
+        mock_create = MagicMock(return_value=SAMPLE_JOB)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+                f"{_MOD}._cron_create", mock_create
+            ), patch(f"{_MOD}._cron_get", MagicMock(side_effect=_get_job_stub)):
+                resp = await cli.post("/api/jobs", json={
+                    "name": "test-job",
+                    "schedule": "*/5 * * * *",
+                    "prompt": "do something",
+                    "enabled_toolsets": ["web", "files"],
+                    "context_from": [OTHER_JOB_ID],
+                    "monitor_url": "https://example.invalid/feed",
+                    "model": "claude-sonnet-4-6",
+                    "provider": "anthropic",
+                    "reasoning_effort": "low",
+                })
+                assert resp.status == 200
+                kwargs = mock_create.call_args[1]
+                assert kwargs["enabled_toolsets"] == ["web", "files"]
+                assert kwargs["context_from"] == [OTHER_JOB_ID]
+                assert kwargs["monitor_url"] == "https://example.invalid/feed"
+                assert kwargs["model"] == "claude-sonnet-4-6"
+                assert kwargs["provider"] == "anthropic"
+                assert kwargs["reasoning_effort"] == "low"
+
+    @pytest.mark.asyncio
+    async def test_continuity_becomes_the_self_context_ref(self, adapter):
+        """continuity=true is sugar for context_from including "self"."""
+        app = _create_app(adapter)
+        mock_create = MagicMock(return_value=SAMPLE_JOB)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+                f"{_MOD}._cron_create", mock_create
+            ), patch(f"{_MOD}._cron_get", MagicMock(side_effect=_get_job_stub)):
+                resp = await cli.post("/api/jobs", json={
+                    "name": "test-job",
+                    "schedule": "*/5 * * * *",
+                    "prompt": "do something",
+                    "continuity": True,
+                })
+                assert resp.status == 200
+                assert mock_create.call_args[1]["context_from"] == ["self"]
+                # "self" is never looked up — the job does not exist yet.
+
+    @pytest.mark.asyncio
+    async def test_continuity_false_leaves_external_refs(self, adapter):
+        app = _create_app(adapter)
+        mock_create = MagicMock(return_value=SAMPLE_JOB)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+                f"{_MOD}._cron_create", mock_create
+            ), patch(f"{_MOD}._cron_get", MagicMock(side_effect=_get_job_stub)):
+                resp = await cli.post("/api/jobs", json={
+                    "name": "test-job",
+                    "schedule": "*/5 * * * *",
+                    "prompt": "do something",
+                    "context_from": [OTHER_JOB_ID, "self"],
+                    "continuity": False,
+                })
+                assert resp.status == 200
+                assert mock_create.call_args[1]["context_from"] == [OTHER_JOB_ID]
+
+    @pytest.mark.asyncio
+    async def test_unknown_context_from_job_is_rejected(self, adapter):
+        app = _create_app(adapter)
+        mock_create = MagicMock(return_value=SAMPLE_JOB)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+                f"{_MOD}._cron_create", mock_create
+            ), patch(f"{_MOD}._cron_get", MagicMock(side_effect=_get_job_stub)):
+                resp = await cli.post("/api/jobs", json={
+                    "name": "test-job",
+                    "schedule": "*/5 * * * *",
+                    "prompt": "do something",
+                    "context_from": ["ffffffffffff"],
+                })
+                assert resp.status == 400
+                assert "not found" in (await resp.json())["error"]
+                mock_create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_monitor_script_uses_the_cli_path_validator(self, adapter):
+        """A traversal path is refused by the same helper the CLI runs."""
+        app = _create_app(adapter)
+        mock_create = MagicMock(return_value=SAMPLE_JOB)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+                f"{_MOD}._cron_create", mock_create
+            ), patch(
+                f"{_MOD}._cron_validate_script_path",
+                MagicMock(return_value="Script path escapes ~/.hermes/scripts/"),
+            ) as validator:
+                resp = await cli.post("/api/jobs", json={
+                    "name": "test-job",
+                    "schedule": "*/5 * * * *",
+                    "prompt": "do something",
+                    "monitor_script": "../../etc/passwd",
+                })
+                assert resp.status == 400
+                validator.assert_called_once_with("../../etc/passwd")
+                mock_create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_monitor_script_fails_closed_without_the_validator(self, adapter):
+        """A missing helper rejects the field rather than skipping the check."""
+        app = _create_app(adapter)
+        mock_create = MagicMock(return_value=SAMPLE_JOB)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+                f"{_MOD}._cron_create", mock_create
+            ), patch(f"{_MOD}._cron_validate_script_path", None):
+                resp = await cli.post("/api/jobs", json={
+                    "name": "test-job",
+                    "schedule": "*/5 * * * *",
+                    "prompt": "do something",
+                    "monitor_script": "watch.sh",
+                })
+                assert resp.status == 400
+                mock_create.assert_not_called()
+
+    @pytest.mark.parametrize("body_extra, expected", [
+        ({"enabled_toolsets": "web"}, ["web"]),
+        ({"enabled_toolsets": []}, None),
+        ({"monitor_url": ""}, None),
+    ])
+    @pytest.mark.asyncio
+    async def test_scalar_and_clearing_shapes(self, adapter, body_extra, expected):
+        """A bare string is a one-element list; an empty value clears."""
+        app = _create_app(adapter)
+        mock_create = MagicMock(return_value=SAMPLE_JOB)
+        field = next(iter(body_extra))
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+                f"{_MOD}._cron_create", mock_create
+            ):
+                resp = await cli.post("/api/jobs", json={
+                    "name": "test-job",
+                    "schedule": "*/5 * * * *",
+                    "prompt": "do something",
+                    **body_extra,
+                })
+                assert resp.status == 200
+                assert mock_create.call_args[1][field] == expected
+
+    @pytest.mark.parametrize("body_extra", [
+        {"continuity": "yes"},
+        {"enabled_toolsets": [1, 2]},
+        {"enabled_toolsets": 7},
+        {"model": 42},
+        {"monitor_url": ["a"]},
+        {"context_from": {"job": "x"}},
+    ])
+    @pytest.mark.asyncio
+    async def test_type_errors_are_400_not_500(self, adapter, body_extra):
+        app = _create_app(adapter)
+        mock_create = MagicMock(return_value=SAMPLE_JOB)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+                f"{_MOD}._cron_create", mock_create
+            ):
+                resp = await cli.post("/api/jobs", json={
+                    "name": "test-job",
+                    "schedule": "*/5 * * * *",
+                    "prompt": "do something",
+                    **body_extra,
+                })
+                assert resp.status == 400
+                mock_create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_create_job_value_error_is_400(self, adapter):
+        """reasoning_effort grammar and monitor exclusion are client errors."""
+        app = _create_app(adapter)
+        mock_create = MagicMock(
+            side_effect=ValueError("Invalid reasoning_effort 'turbo'."),
+        )
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+                f"{_MOD}._cron_create", mock_create
+            ):
+                resp = await cli.post("/api/jobs", json={
+                    "name": "test-job",
+                    "schedule": "*/5 * * * *",
+                    "prompt": "do something",
+                    "reasoning_effort": "turbo",
+                })
+                assert resp.status == 400
+                assert "reasoning_effort" in (await resp.json())["error"]
+
+    @pytest.mark.asyncio
+    async def test_basic_create_is_unchanged(self, adapter):
+        """A body with none of the new fields sends none of them."""
+        app = _create_app(adapter)
+        mock_create = MagicMock(return_value=SAMPLE_JOB)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+                f"{_MOD}._cron_create", mock_create
+            ):
+                resp = await cli.post("/api/jobs", json={
+                    "name": "test-job",
+                    "schedule": "*/5 * * * *",
+                    "prompt": "do something",
+                })
+                assert resp.status == 200
+                kwargs = mock_create.call_args[1]
+                for field in APIServerAdapter._RICH_JOB_FIELDS:
+                    assert field not in kwargs
+
+
+# ---------------------------------------------------------------------------
+# update
+# ---------------------------------------------------------------------------
+
+class TestUpdateJobRichFields:
+    @pytest.mark.asyncio
+    async def test_update_passes_rich_fields_through(self, adapter):
+        app = _create_app(adapter)
+        mock_update = MagicMock(return_value=SAMPLE_JOB)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+                f"{_MOD}._cron_update", mock_update
+            ), patch(f"{_MOD}._cron_get", MagicMock(side_effect=_get_job_stub)):
+                resp = await cli.patch(f"/api/jobs/{VALID_JOB_ID}", json={
+                    "enabled_toolsets": ["web"],
+                    "model": "claude-haiku-4-5",
+                })
+                assert resp.status == 200
+                updates = mock_update.call_args[0][1]
+                assert updates["enabled_toolsets"] == ["web"]
+                assert updates["model"] == "claude-haiku-4-5"
+
+    @pytest.mark.asyncio
+    async def test_continuity_only_update_keeps_stored_refs(self, adapter):
+        """Toggling continuity must not drop an external chaining ref."""
+        app = _create_app(adapter)
+        stored = dict(SAMPLE_JOB, context_from=[OTHER_JOB_ID])
+        mock_update = MagicMock(return_value=stored)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+                f"{_MOD}._cron_update", mock_update
+            ), patch(f"{_MOD}._cron_get", MagicMock(return_value=stored)):
+                resp = await cli.patch(
+                    f"/api/jobs/{VALID_JOB_ID}", json={"continuity": True},
+                )
+                assert resp.status == 200
+                updates = mock_update.call_args[0][1]
+                assert updates["context_from"] == [OTHER_JOB_ID, "self"]
+                # `continuity` is sugar, never a stored field.
+                assert "continuity" not in updates
+
+    @pytest.mark.asyncio
+    async def test_update_rejects_monitor_script_and_url_together(self, adapter):
+        app = _create_app(adapter)
+        stored = dict(SAMPLE_JOB, monitor_url="https://example.invalid/feed")
+        mock_update = MagicMock(return_value=stored)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+                f"{_MOD}._cron_update", mock_update
+            ), patch(f"{_MOD}._cron_get", MagicMock(return_value=stored)), patch(
+                f"{_MOD}._cron_validate_script_path", MagicMock(return_value=None)
+            ):
+                resp = await cli.patch(f"/api/jobs/{VALID_JOB_ID}", json={
+                    "monitor_script": "watch.sh",
+                })
+                assert resp.status == 400
+                assert "mutually exclusive" in (await resp.json())["error"]
+                mock_update.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_on_missing_job_is_404(self, adapter):
+        app = _create_app(adapter)
+        mock_update = MagicMock(return_value=None)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+                f"{_MOD}._cron_update", mock_update
+            ), patch(f"{_MOD}._cron_get", MagicMock(return_value=None)):
+                resp = await cli.patch(
+                    f"/api/jobs/{VALID_JOB_ID}", json={"continuity": True},
+                )
+                assert resp.status == 404
+                mock_update.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_still_rejects_unknown_fields(self, adapter):
+        """Widening the allowlist must not open it."""
+        app = _create_app(adapter)
+        mock_update = MagicMock(return_value=SAMPLE_JOB)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+                f"{_MOD}._cron_update", mock_update
+            ):
+                resp = await cli.patch(f"/api/jobs/{VALID_JOB_ID}", json={
+                    "id": "deadbeefcafe",
+                    "base_url": "https://attacker.invalid/v1",
+                    "script": "../../etc/passwd",
+                    "workdir": "/",
+                    "no_agent": True,
+                })
+                assert resp.status == 400
+                assert (await resp.json())["error"] == "No valid fields to update"
+                mock_update.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_job_value_error_is_400(self, adapter):
+        app = _create_app(adapter)
+        mock_update = MagicMock(
+            side_effect=ValueError("Cron job field(s) cannot be updated: id"),
+        )
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+                f"{_MOD}._cron_update", mock_update
+            ):
+                resp = await cli.patch(
+                    f"/api/jobs/{VALID_JOB_ID}", json={"name": "renamed"},
+                )
+                assert resp.status == 400

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -511,7 +511,28 @@ List all scheduled jobs.
 
 ### POST /api/jobs
 
-Create a new scheduled job. Body accepts the same shape as `hermes cron` — prompt, schedule, skills, provider override, delivery target.
+Create a new scheduled job. `name` and `schedule` are required; every other field is optional.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Job name (≤ 200 chars). Required. |
+| `schedule` | string | Cron expression or natural-language schedule. Required. |
+| `prompt` | string | Prompt for the run (≤ 5000 chars, scanned for prompt injection). |
+| `deliver` | string | Delivery target. Defaults to `local`. |
+| `skills` | string \| string[] | Skills to preload. |
+| `repeat` | integer | Positive repeat count. |
+| `enabled_toolsets` | string \| string[] | Narrow the tool schema to these toolsets — fewer tools means fewer tokens on every run. |
+| `continuity` | boolean | Feed the job its own previous run's output back in, so a recurring monitor stops re-reporting an unchanged condition. Stored as the reserved `self` entry in `context_from` — see [Cron](./cron.md). |
+| `context_from` | string \| string[] | Job IDs whose last output is prepended as context. `self` is reserved for continuity. Every other ID must already exist. |
+| `monitor_script` | string | Path to a script whose output gates the run — unchanged output skips the LLM entirely. Path containment is validated exactly as `hermes cron` validates it. |
+| `monitor_url` | string | URL whose content gates the run the same way. Mutually exclusive with `monitor_script`. |
+| `model` | string | Per-job model override. |
+| `provider` | string | Per-job provider override. |
+| `reasoning_effort` | string | Per-job reasoning-effort override. |
+
+Sending `""` (or `[]` for a list field) clears that field. Bodies that the jobs store rejects as malformed — a bad `reasoning_effort` spelling, both monitors set at once — return `400`.
+
+`base_url`, `script`, `workdir`, `no_agent` and `attach_to_session` are **not** accepted over REST: they select a host filesystem path, a credential-routing endpoint, or a non-agent execution mode, and stay CLI-only. Unknown fields are ignored.
 
 ### GET /api/jobs/\{job_id\}
 
@@ -519,7 +540,7 @@ Fetch a single job's definition and last-run state.
 
 ### PATCH /api/jobs/\{job_id\}
 
-Update fields on an existing job (prompt, schedule, etc.). Partial updates are merged.
+Update fields on an existing job. Partial updates are merged, and the body accepts the same fields as `POST /api/jobs` plus `enabled`. A `continuity`-only update is merged onto the job's stored `context_from`, so toggling it leaves any external chaining in place.
 
 ### DELETE /api/jobs/\{job_id\}
 


### PR DESCRIPTION

**Target:** `NousResearch/hermes-agent`, branch `main`
**Base:** `c5c9aa8d` (current `main`)
**Branch name:** `feat/api-server-rich-cron-job-fields`
**Files:**
- `gateway/platforms/api_server.py`
- `tests/gateway/test_api_server_jobs_rich_fields.py` (new, 23 tests)
- `website/docs/user-guide/features/api-server.md`



## Motivation

`hermes cron create` / `hermes cron edit` and the `cronjob` tool can set
`enabled_toolsets`, `continuity`, `context_from`, `monitor_script`,
`monitor_url`, `model`, `provider`, and `reasoning_effort`. The REST surface
cannot: `_handle_create_job` reads only `name`, `schedule`, `prompt`, `deliver`,
`skills`, and `repeat`, and `_UPDATE_ALLOWED_FIELDS` is the same set plus
`enabled`.

That gap costs the features that make a scheduled job cheap and quiet:

- **`continuity`** is the difference between a monitor that re-alerts on the
  same unchanged condition every morning and one that remembers what it already
  said. The docs describe it as the fix for exactly that amnesia
  (`user-guide/features/cron.md`, "Continuity: carry the previous run's output").
- **`monitor_script` / `monitor_url`** skip the LLM entirely when the watched
  output has not changed. Over a daily job that is most of the runs.
- **`enabled_toolsets`** narrows the tool schema for a job that needs two tools,
  which is a direct token saving on every run.
- **`model` / `provider` / `reasoning_effort`** let a cheap recurring job run on
  a cheap model instead of inheriting the interactive default.

Today a REST client that wants any of these has to shell out to the CLI on the
gateway host, or write to the jobs store directly. Both are worse than the API.

The endpoints already exist, are already bearer-authenticated
(`connect()` refuses to start without `API_SERVER_KEY`), and already forward to
`create_job` / `update_job`, which accept every one of these kwargs. This patch
only widens what the handlers are willing to read.

## What changed

**`_RICH_JOB_FIELDS`** — a new tuple naming the eight fields, folded into
`_UPDATE_ALLOWED_FIELDS` and read on create.

**`_normalize_rich_job_fields()`** — one normalizer used by both handlers. Every
rule mirrors the create/update branches of `tools/cronjob_tools.py`, so REST and
CLI cannot drift:

- `monitor_script` goes through `_validate_cron_script_path`, the same
  containment check the CLI runs.
- `context_from` accepts a string or a list; every referenced job must exist,
  with `"self"` excepted because it resolves to the job's own id at run time and
  cannot be looked up at create time.
- `continuity` is translated into the reserved `"self"` ref via
  `_apply_continuity` — the same sugar the tool applies — and is never stored as
  a field of its own. A continuity-only PATCH starts from the job's **stored**
  `context_from` so external chaining survives the toggle.
- Empty string / empty list clears a field, matching the tool's semantics.
- `reasoning_effort` spelling stays validated at the storage choke point
  (`cron.jobs._normalize_reasoning_effort`), which is the single grammar for
  every effort surface.

**Error mapping.** `create_job` and `update_job` raise `ValueError` for
client-side rejections they own — the `reasoning_effort` grammar, the
`monitor_script` / `monitor_url` mutual exclusion, immutable-field updates.
Those previously fell through to the generic handler and returned **500**. They
now return **400**. `_redact_api_error_text` still wraps the message.

**Monitor mutual exclusion on update.** `create_job` enforces it;
`update_job` does not, so the handler checks the *effective* pair (this
update merged over the stored job) exactly as `cronjob_tools` does.

**Docs.** `website/docs/user-guide/features/api-server.md` previously said the
jobs body "accepts the same shape as `hermes cron`", which was not true before
this patch and is only partly true after it. The Jobs API section now carries a
field table for `POST /api/jobs`, the clear-a-field semantics, the
continuity-merge behaviour of `PATCH`, and an explicit note that `base_url`,
`script`, `workdir`, `no_agent` and `attach_to_session` stay CLI-only.

**Deliberately not accepted:** `base_url`, `script`, `workdir`, `no_agent`,
`attach_to_session`. Those select a host filesystem path, a credential-routing
endpoint, or a non-agent execution mode. The CLI has additional guards for them
(`_validate_cron_base_url`, the effective-pair re-validation on every update);
rather than reimplement that policy on a second surface, this patch keeps REST
narrower than the CLI there. A `base_url` in a PATCH body is still dropped by
the allowlist, and `test_update_still_rejects_unknown_fields` pins that.

**Fail closed, not open.** The two new helper imports are defensive like the
existing `_scan_cron_prompt` import, but where the scanner *skips* when absent,
a missing `_validate_cron_script_path` or `_apply_continuity` **rejects** the
request that needs it. These fields select scripts and context; accepting them
unvalidated would be worse than refusing them.

## Related

#100459 (open) exposes `context_from`, `no_agent`, `script` and `reasoning_effort` on the same two handlers. This PR overlaps it on `context_from` and `reasoning_effort` and additionally covers `enabled_toolsets`, `continuity`, `monitor_script`, `monitor_url`, `model` and `provider`, routing all of them through one normalizer shared by create and update so REST and the `cronjob` tool cannot drift. Happy to rebase onto #100459 if it lands first, or to fold `no_agent`/`script` in here if maintainers prefer one PR.

## Compatibility

- **Purely additive on the wire.** A body with none of the new fields produces
  the same `create_job` kwargs as before — `test_basic_create_is_unchanged`
  asserts no new key is passed. No existing field changes meaning, no response
  shape changes, no route is added or removed.
- **The allowlist is widened, not opened.** Unknown keys are still dropped and
  an all-unknown PATCH still returns `400 No valid fields to update`.
- **The one behavior change is a status code**, and it is a correction: inputs
  that the storage layer rejects as malformed now return 400 instead of 500. A
  client that treated 500 as retryable would previously have retried a body that
  can never succeed.
- **Plugin compatibility contract.** No plugin-visible surface changes. The
  patch touches no hook name, no `ctx.*` API, no tool schema, and no plugin
  loading path — it stays inside two handlers and one new private method on
  `APIServerAdapter`. Plugins that register cron jobs continue to do so through
  `cron.jobs` unchanged, and the `cronjob` tool schema is untouched (in
  particular `reasoning_effort` remains CLI/REST-only and is still absent from
  `CRONJOB_SCHEMA`, preserving the standing "models do not make model-config
  decisions" policy).
- **Multi-profile routing is unaffected.** These handlers run inside the
  routed profile's scope like every other `/api/*` handler.
- **Cross-platform.** No new file I/O, subprocess, signal or path construction.
  `scripts/check-windows-footguns.py` reports clean on the touched files.

## Tests

New file `tests/gateway/test_api_server_jobs_rich_fields.py`, in the style of
the existing `tests/gateway/test_api_server_jobs.py` (aiohttp `TestClient`,
`_MOD`-scoped `patch`, per-handler app). 23 tests covering: pass-through of all
eight fields on create and update; `continuity` -> `"self"`; `continuity: false`
preserving external refs; continuity-only PATCH merging onto stored refs;
unknown `context_from` rejected; `monitor_script` routed through the CLI
validator; fail-closed when a validator is missing; scalar and clearing shapes;
six type errors returning 400 rather than 500; `ValueError` from create/update
returning 400; monitor mutual exclusion on update; 404 when the job is gone; the
allowlist still rejecting `id` / `base_url` / `script` / `workdir` / `no_agent`;
and a basic create being byte-for-byte unchanged.

**CI-parity runner** (`scripts/run_tests.sh`, per-file subprocess isolation,
`TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0`), run on the branch with the patch
applied:

```
$ scripts/run_tests.sh tests/gateway/test_api_server_jobs.py \
      tests/gateway/test_api_server_jobs_rich_fields.py \
      tests/gateway/test_api_server_runs.py -q

✓ tests/gateway/test_api_server_jobs.py             (20✓, 8.8s)
✓ tests/gateway/test_api_server_jobs_rich_fields.py (23✓, 9.6s)
✓ tests/gateway/test_api_server_runs.py             (57✓, 16.9s)

=== Summary: 3 files, 100 tests passed, 0 failed (100% complete) in 16.9s ===
```

Direct pytest, same result:

```
$ python -m pytest tests/gateway/test_api_server_jobs.py \
      tests/gateway/test_api_server_jobs_rich_fields.py -q
43 passed, 43 warnings in 9.16s

$ python -m pytest tests/gateway/test_api_server_runs.py -q
57 passed, 43 warnings in 15.75s

$ python -m pytest tests/gateway/test_api_server_toolset.py -q
5 passed in 2.84s
```

(The earlier draft of this PR reported 44 failures in
`test_api_server_runs.py` / `test_api_server_toolset.py`. Those were missing
optional dependencies in the environment that draft was written in — they
reproduce identically with the patch reverted. In a correctly provisioned
Python 3.11 environment both files pass, as above.)

## Lint

```
$ ruff check gateway/platforms/api_server.py \
      tests/gateway/test_api_server_jobs_rich_fields.py
All checks passed!

$ ruff check .            # the blocking gate in .github/workflows/lint.yml
All checks passed!

$ python scripts/check-windows-footguns.py
✓ No Windows footguns found (2 file(s) scanned).
```

`ruff format --check` reports the touched files would be reformatted, but so
does an untouched `gateway/platforms/api_server.py` at `aea2daee` — the repo is
not ruff-formatted and `lint.yml` does not run `ruff format`, so the patch
matches surrounding style instead of reformatting. `ty` could not be installed
in this offline environment; it is advisory-only in `lint.yml` (`--exit-zero`).
The Docusaurus build for the docs hunk was not run here (needs `npm ci`).

## Checklist (per `CONTRIBUTING.md` / `.github/PULL_REQUEST_TEMPLATE.md`)

**Type of change:** ✨ New feature (non-breaking change that adds functionality)

### Code

- [x] Read the Contributing Guide.
- [x] Commit message follows Conventional Commits with a valid scope:
      `feat(gateway): accept the richer cron job fields on /api/jobs`.
- [x] Searched open and closed PRs; #100459 overlaps on two of the eight fields (see Related).
- [x] Branch contains only this change — one commit, three files.
- [x] Tests run and passing (counts above); `scripts/run_tests.sh` used for
      CI parity, per `CONTRIBUTING.md` "Before Submitting" step 1.
- [x] Tests added for the change (23 new tests).
- [x] Tested on: macOS 15 (Darwin 25.4.0), Python 3.11.15.
- [ ] Manual exercise of the path (`CONTRIBUTING.md` step 2) not done on a live gateway yet —
      `hermes gateway` with `API_SERVER_KEY` set, then
      `curl -X POST localhost:<port>/api/jobs -H 'Authorization: Bearer $API_SERVER_KEY'
      -d '{"name":"t","schedule":"every 6h","prompt":"x","continuity":true}'`
      and confirm `hermes cron list` shows the `self` context ref.

### Documentation & housekeeping

- [x] Documentation updated — `website/docs/user-guide/features/api-server.md`
      Jobs API section.
- [x] `cli-config.yaml.example` — N/A, no config keys added.
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture or workflow change.
- [x] Cross-platform impact considered; `scripts/check-windows-footguns.py`
      clean.
- [x] Tool descriptions/schemas — N/A, `CRONJOB_SCHEMA` deliberately unchanged.
- [ ] **Known gap:** the zh-Hans mirror
      `website/i18n/zh-Hans/.../user-guide/features/api-server.md` still carries
      the old Jobs API text. Translations are synced separately upstream; flag
      it in the PR body rather than machine-translating it here.
- [x] `scripts/audit_pr_attribution.py` run on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012b4NZGPx3hwU6h5pmHA8ya
