### PR TITLE
fix(docker): mount HERMES_HOME persona files into terminal container (#100900)

### DIFF
--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -434,6 +434,89 @@ _CACHE_DIRS: list[tuple[str, str]] = [
 ]
 
 
+# ---------------------------------------------------------------------------
+# HERMES_HOME context files (SOUL.md, persona, scripts) for Docker passthrough
+# ---------------------------------------------------------------------------
+
+# Persona / identity files that the agent loads from HERMES_HOME at prompt-
+# build time. When the terminal backend is Docker, the agent runs inside a
+# container whose filesystem is isolated from the host — without an explicit
+# bind mount these files are invisible and the agent falls back to a hard-
+# coded default or an empty persona (issue #100900). Mount each file that
+# exists on the host so the container sees the user's custom persona.
+_HERMES_CONTEXT_FILES: tuple[str, ...] = (
+    "SOUL.md",
+    "USER.md",
+    "MEMORY.md",
+    "IDENTITY.md",
+    "HEARTBEAT.md",
+    "BOOTSTRAP.md",
+    "AGENTS.md",
+)
+
+# Directories under HERMES_HOME that contain user-authored code referenced by
+# the agent at runtime (e.g. ~/.hermes/scripts/* invoked via run_script).
+_HERMES_CONTEXT_DIRS: tuple[str, ...] = (
+    "scripts",
+)
+
+
+def get_hermes_context_mounts(
+    container_base: str = "/root/.hermes",
+) -> List[Dict[str, str]]:
+    """Return bind-mount entries for HERMES_HOME context files/dirs.
+
+    Each entry has ``host_path`` and ``container_path`` keys. Only paths
+    that actually exist on the host are returned, so an empty default install
+    produces no extra mounts. Mounted read-only by the Docker backend.
+
+    When the active HERMES_HOME is a profile directory
+    (``~/.hermes/profiles/<name>``), the file is mounted to *both* the
+    default container location (``/root/.hermes/<name>``) and the
+    profile-specific location (``/root/.hermes/profiles/<name>/<name>``)
+    so the container sees it regardless of whether it resolves HERMES_HOME
+    to the default or profile path (the in-container HERMES_HOME can vary
+    depending on whether the session carries a profile-scoped override).
+    """
+    mounts: List[Dict[str, str]] = []
+    hermes_home = _resolve_hermes_home()
+    # Detect profile suffix for dual-mount
+    profile_suffix = None
+    try:
+        # hermes_home like /root/.hermes/profiles/<name>
+        parts = hermes_home.parts
+        if "profiles" in parts:
+            idx = parts.index("profiles")
+            profile_suffix = "/".join(parts[idx:])  # profiles/<name>
+    except Exception:
+        profile_suffix = None
+    for name in _HERMES_CONTEXT_FILES:
+        host_path = hermes_home / name
+        if host_path.is_file():
+            mounts.append({
+                "host_path": str(host_path),
+                "container_path": f"{container_base.rstrip('/')}/{name}",
+            })
+            if profile_suffix:
+                mounts.append({
+                    "host_path": str(host_path),
+                    "container_path": f"{container_base.rstrip('/')}/{profile_suffix}/{name}",
+                })
+    for name in _HERMES_CONTEXT_DIRS:
+        host_path = hermes_home / name
+        if host_path.is_dir():
+            mounts.append({
+                "host_path": str(host_path),
+                "container_path": f"{container_base.rstrip('/')}/{name}",
+            })
+            if profile_suffix:
+                mounts.append({
+                    "host_path": str(host_path),
+                    "container_path": f"{container_base.rstrip('/')}/{profile_suffix}/{name}",
+                })
+    return mounts
+
+
 def get_cache_directory_mounts(
     container_base: str = "/root/.hermes",
 ) -> List[Dict[str, str]]:

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -1121,6 +1121,28 @@ class DockerEnvironment(BaseEnvironment):
                     cache_mount["host_path"],
                     cache_mount["container_path"],
                 )
+
+            # Mount HERMES_HOME context files (SOUL.md, persona, scripts) so
+            # the agent inside the container sees the host's custom persona
+            # instead of a stale/empty default (#100900).
+            try:
+                from tools.credential_files import get_hermes_context_mounts
+
+                for ctx_mount in get_hermes_context_mounts():
+                    src = Path(ctx_mount["host_path"])
+                    if not src.exists():
+                        continue
+                    volume_args.extend([
+                        "-v",
+                        f"{ctx_mount['host_path']}:{ctx_mount['container_path']}:ro",
+                    ])
+                    logger.info(
+                        "Docker: mounting HERMES_HOME context %s -> %s",
+                        ctx_mount["host_path"],
+                        ctx_mount["container_path"],
+                    )
+            except Exception as ce:
+                logger.debug("Docker: could not load HERMES_HOME context mounts: %s", ce)
         except Exception as e:
             logger.debug("Docker: could not load credential file mounts: %s", e)
 


### PR DESCRIPTION
Fixes #100900

When `terminal.backend` is `docker`, the agent runs inside an isolated container that only bind-mounted individual subdirectories (skills, cache, credential files). Files at the `HERMES_HOME` root — `SOUL.md`, `USER.md`, `MEMORY.md` and `scripts/` — were invisible inside the container, so the agent fell back to a hard-coded default persona.

This PR adds `get_hermes_context_mounts()` in `tools/credential_files.py` and wires it into `tools/environments/docker.py` to mount all existing context files/directories read-only. For profile homes the file is dual-mounted to both the default and profile-specific container paths so it is visible regardless of how `HERMES_HOME` resolves inside the container.

**Tests:** docker session isolation, orphan reaper, terminal config sync and image source suites pass. Manual verification via `get_hermes_context_mounts()` shows correct mounts for the active profile.

Pre-run dedup confirmed no existing PR for this issue.