### PR TITLE
fix(gateway): prehydrate multiplex secrets off event loop

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2564,6 +2564,13 @@ def _profile_runtime_scope(profile_home: "Path"):
     ``.env`` here does NOT mutate ``os.environ`` — ``build_profile_secret_scope``
     returns an isolated dict — which is what keeps subprocesses (MCP, kanban)
     from inheriting cross-profile secrets.
+
+    Scope-only: this never resolves external secret sources (1Password,
+    Bitwarden, ...). Those fetches block, and this scope runs synchronously on
+    the inbound path, so a cold profile must be hydrated beforehand — via
+    ``_prehydrate_profile_secret_sources`` at secondary startup, or the
+    process-global dotenv path for the active profile. The scope only reads
+    the already-recorded per-home snapshot.
     """
     from hermes_constants import set_hermes_home_override, reset_hermes_home_override
     from agent.secret_scope import (
@@ -2571,16 +2578,26 @@ def _profile_runtime_scope(profile_home: "Path"):
         set_secret_scope,
         reset_secret_scope,
     )
-    from hermes_cli.env_loader import hydrate_profile_secret_sources
 
     home_token = set_hermes_home_override(str(profile_home))
-    hydrate_profile_secret_sources(Path(profile_home))
     secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
     try:
         yield
     finally:
         reset_secret_scope(secret_token)
         reset_hermes_home_override(home_token)
+
+
+async def _prehydrate_profile_secret_sources(profile_home: "Path") -> None:
+    """Resolve one profile's external secret sources off the event loop.
+
+    ``hydrate_profile_secret_sources`` can block on a network/CLI backend, so
+    it runs in a worker thread. Must complete before the profile first enters
+    ``_profile_runtime_scope``, which is scope-only and never hydrates.
+    """
+    from hermes_cli.env_loader import hydrate_profile_secret_sources
+
+    await asyncio.to_thread(hydrate_profile_secret_sources, Path(profile_home))
 
 
 def load_gateway_config_for_runner() -> "GatewayConfig":
@@ -16661,9 +16678,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     claimed[retry_claim] = active
 
         profile_homes = _multiplex_profile_homes(self.config)
-        for profile_name, profile_home in profile_homes:
-            if profile_name == active:
-                continue  # handled by the primary startup loop
+        # The active profile is handled by the primary startup loop.
+        secondary = [(n, h) for n, h in profile_homes if n != active]
+        # Hydrate every secondary's external secret sources off-loop BEFORE any
+        # profile enters _profile_runtime_scope: the scope is synchronous and
+        # scope-only, so a cold source must be resolved here, never on the
+        # first inbound turn. Sequential on purpose — one blocking fetch at a
+        # time keeps backend rate limits and lock contention predictable.
+        for _profile_name, profile_home in secondary:
+            await _prehydrate_profile_secret_sources(profile_home)
+
+        for profile_name, profile_home in secondary:
             try:
                 connected += await self._start_one_profile_adapters(
                     profile_name, profile_home, claimed

--- a/tests/gateway/test_multiplex_credential_isolation.py
+++ b/tests/gateway/test_multiplex_credential_isolation.py
@@ -5,6 +5,8 @@ interpolation) rather than mocking it, proving the property that matters: two
 profiles with different keys never see each other's, and an unscoped read in
 multiplex mode fails closed instead of leaking.
 """
+import asyncio
+
 import pytest
 
 from pathlib import Path
@@ -88,10 +90,10 @@ class TestProfilePathResolutionUnderMultiplexScope:
         assert b_seen == prof_b / "skills"
 
 
-def test_cold_profile_hydrates_external_source_without_global_env(
+def test_profile_scope_uses_prehydrated_external_source_without_global_env(
     tmp_path, monkeypatch
 ):
-    """The first routed secondary turn must resolve its own source locally."""
+    """Startup hydration supplies one profile without mutating global env."""
     import os
 
     from agent.secret_sources.base import FetchResult
@@ -150,6 +152,28 @@ def test_cold_profile_hydrates_external_source_without_global_env(
     monkeypatch.setattr(registry, "apply_all", _fake_apply_all)
     env_loader.reset_secret_source_cache()
 
+    # Scope-only: entering a cold profile's scope sees its .env but never
+    # triggers the (blocking) external fetch.
+    with _profile_runtime_scope(profile):
+        assert get_secret("EXPLICIT_API_KEY") == "dotenv-wins"
+        assert get_secret("TEST_PROVIDER_API_KEY") is None
+    assert calls["count"] == 0
+
+    # Explicit hydration — what secondary startup does off-loop.
+    assert env_loader.hydrate_profile_secret_sources(profile) == {
+        "TEST_PROVIDER_API_KEY": "profile-only"
+    }
+    assert calls["count"] == 1
+
+    # From here on any hydration attempt inside the scope is a failure, even
+    # one re-introduced via a function-local import.
+    def _forbidden_hydrate(_home):
+        raise AssertionError("_profile_runtime_scope must not hydrate")
+
+    monkeypatch.setattr(
+        env_loader, "hydrate_profile_secret_sources", _forbidden_hydrate
+    )
+
     with _profile_runtime_scope(profile):
         assert get_secret("TEST_PROVIDER_API_KEY") == "profile-only"
         assert get_secret("EXPLICIT_API_KEY") == "dotenv-wins"
@@ -164,5 +188,135 @@ def test_cold_profile_hydrates_external_source_without_global_env(
     assert calls["count"] == 1
     assert "TEST_PROVIDER_API_KEY" not in os.environ
     assert "EXPLICIT_API_KEY" not in os.environ
+
+
+@pytest.mark.asyncio
+async def test_secondary_startup_prehydrates_sequentially_off_loop(
+    tmp_path, monkeypatch
+):
+    """Secondary startup hydrates each cold profile off-loop, one at a time,
+    and only starts a profile's adapters after every hydration is done.
+
+    Each fake hydration blocks its worker thread until the event loop has
+    ticked a few more times. If hydration ran on the loop thread the ticker
+    could never advance and the hydration would stall (flagged, not hung).
+    """
+    import threading
+    import time
+    from unittest.mock import MagicMock
+
+    from agent.secret_scope import get_secret
+    from gateway.config import GatewayConfig
+    from gateway.run import GatewayRunner, _profile_runtime_scope
+    from hermes_cli import env_loader
+
+    ticks = 0
+    events: list = []
+    stalled: list = []
+    hydrated: dict[Path, dict[str, str]] = {}
+    seen_credentials: dict[str, str | None] = {}
+    lock = threading.Lock()
+
+    def slow_hydrate(home):
+        with lock:
+            events.append(("hydrate-start", home.name, ticks))
+        target = ticks + 3
+        deadline = time.monotonic() + 0.5
+        while ticks < target:
+            if time.monotonic() > deadline:
+                stalled.append(home.name)
+                break
+            time.sleep(0.001)
+        with lock:
+            hydrated[home.resolve()] = {
+                "TEST_PROVIDER_API_KEY": f"{home.name}-credential"
+            }
+            events.append(("hydrate-end", home.name, ticks))
+        return {}
+
+    monkeypatch.setattr(
+        "hermes_cli.env_loader.hydrate_profile_secret_sources", slow_hydrate
+    )
+    monkeypatch.setattr(
+        env_loader,
+        "get_secret_source_values",
+        lambda home: dict(hydrated.get(Path(home).resolve(), {})),
+    )
+
+    homes = {
+        name: tmp_path / name for name in ("default", "a", "b", "c")
+    }
+    for home in homes.values():
+        home.mkdir()
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        multiplex_profiles=True,
+        multiplex_profile_allowlist=["a", "b", "c"],
+    )
+    runner.adapters = {}
+    runner._profile_adapters = {}
+    runner.pairing_stores = {n: MagicMock() for n in ("default", "a", "b", "c")}
+    runner.pairing_store = runner.pairing_stores["default"]
+
+    async def fake_start_one(profile_name, profile_home, claimed):
+        events.append(("start", profile_name, ticks))
+        with _profile_runtime_scope(profile_home):
+            seen_credentials[profile_name] = get_secret("TEST_PROVIDER_API_KEY")
+        runner._profile_adapters[profile_name] = {}
+        return 1
+
+    monkeypatch.setattr(runner, "_start_one_profile_adapters", fake_start_one)
+    monkeypatch.setattr(
+        "hermes_cli.profiles.profiles_to_serve",
+        lambda multiplex, profile_allowlist=None: [
+            ("default", homes["default"]),
+            ("a", homes["a"]),
+            ("b", homes["b"]),
+            ("c", homes["c"]),
+        ],
+    )
+    monkeypatch.setattr("hermes_cli.profiles.get_active_profile_name", lambda: "default")
+    monkeypatch.setattr("gateway.status.write_runtime_status", lambda **kwargs: None)
+
+    async def ticker():
+        nonlocal ticks
+        while True:
+            ticks += 1
+            await asyncio.sleep(0)
+
+    ticker_task = asyncio.create_task(ticker())
+    try:
+        connected = await runner._start_secondary_profile_adapters()
+    finally:
+        ticker_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await ticker_task
+
+    assert connected == 3
+    assert stalled == [], f"event loop stalled during hydration of {stalled}"
+
+    hydrate_events = [(kind, name) for kind, name, _ in events if kind != "start"]
+    # Sequential: start/end pairs never interleave; active profile skipped.
+    assert hydrate_events == [
+        ("hydrate-start", "a"), ("hydrate-end", "a"),
+        ("hydrate-start", "b"), ("hydrate-end", "b"),
+        ("hydrate-start", "c"), ("hydrate-end", "c"),
+    ]
+    # Loop kept ticking while each hydration blocked its thread.
+    by_name = {(kind, name): tick for kind, name, tick in events}
+    for name in ("a", "b", "c"):
+        assert by_name[("hydrate-end", name)] > by_name[("hydrate-start", name)]
+    # Every hydration finishes before any profile starts; starts stay ordered.
+    kinds = [kind for kind, _, _ in events]
+    assert kinds.index("start") > max(
+        i for i, k in enumerate(kinds) if k == "hydrate-end"
+    )
+    assert [name for kind, name, _ in events if kind == "start"] == ["a", "b", "c"]
+    assert seen_credentials == {
+        "a": "a-credential",
+        "b": "b-credential",
+        "c": "c-credential",
+    }
 
 


### PR DESCRIPTION
## Summary

- resolve every secondary profile secret source sequentially with `asyncio.to_thread` before any multiplex runtime scope is entered
- make `_profile_runtime_scope` scope-only so inbound message paths can never trigger a first blocking external-secret fetch
- add a deterministic multi-profile event-loop witness and verify each adapter startup sees only its prehydrated profile credential

The liveness watchdog and its exit-75 behavior are unchanged. Hydration remains sequential because the env-loader cache and secret-source registry use process-global mutable state and a global lock.

## Verification

- `scripts/run_tests.sh tests/gateway/test_multiplex_credential_isolation.py tests/gateway/test_multiplex_adapter_registry.py tests/gateway/test_loop_liveness_watchdog.py tests/gateway/test_watchdog_review_76354.py tests/gateway/test_adapter_startup_secret_scope.py tests/test_env_loader_secret_sources.py tests/test_env_loader_op_bootstrap.py tests/secret_sources/test_profile_secrets.py -q` — 148 passed
- `scripts/run_tests.sh tests/gateway/*multiplex*.py -q` — 155 passed
- `.venv/bin/ruff check gateway/run.py tests/gateway/test_multiplex_credential_isolation.py` — passed
- `git diff --check` — passed

Before rebasing this two-file change onto current main, a broad `scripts/run_tests.sh tests/gateway/ -q` run completed 6,652 passing tests with 6 unrelated host/environment failures: macOS AF_UNIX path length in `test_scale_to_zero.py` (2), POSIX diagnostic spawn in `test_shutdown_forensics.py` (1), Linux abstract socket semantics in `test_systemd_notify.py` (1), and missing optional XML parser behavior in `test_wecom_callback.py` (2). All multiplex and watchdog files passed. The focused 148-test and complete 155-test multiplex runs above were repeated after rebasing onto current main.

## Tradeoff / residual risk

This keeps the event loop responsive but does not reduce worst-case secondary startup wall time: N unhealthy profiles can still take N times the source timeout. Parallel hydration remains intentionally out of scope until registry/cache state is profile-isolated.

Supersedes #101019, whose original head accidentally included an unpublished local base commit.