### PR TITLE
fix(bot-mode): hand off group tabs to remote bots

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/group-bot-handoff.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-bot-handoff.test.ts
@@ -76,6 +76,14 @@ async function loadRoom(): Promise<Room> {
 
 const BOT: RosterRow = { name: 'alpha', title: 'Alpha' }
 
+const REMOTE_BOT: RosterRow = {
+  connectionId: 'remote-1',
+  name: 'alpha',
+  remoteSource: true,
+  sourceScoped: true,
+  title: 'Alpha'
+}
+
 /** Seat a room and front it as a main-window tab, recording tab closes in
  *  the order they happen relative to the canonical open. */
 function registerGroup(room: Room, group: string, timeline: string[]) {
@@ -111,6 +119,22 @@ describe('opening a bot from a fronted room', () => {
     expect(room.panes.groupChatMainTabs.has('Core')).toBe(false)
   })
 
+  it('retires the group tab before opening a bot from another connection', async () => {
+    const timeline: string[] = []
+    const room = await loadRoom()
+    registerGroup(room, 'Core', timeline)
+    openBotCanonicalChat.mockImplementation(async () => {
+      timeline.push('canonicalOpen')
+
+      return { openedId: 'stored-chat', registryId: 'stored-chat' }
+    })
+
+    expect(await room.actions.openRosterBot(REMOTE_BOT)).toBe(true)
+    expect(timeline.filter(event => event.includes(':group:'))).toHaveLength(1)
+    expect(timeline.findIndex(event => event.includes(':group:'))).toBeLessThan(timeline.indexOf('canonicalOpen'))
+    expect(room.panes.groupChatMainTabs.has('Core')).toBe(false)
+  })
+
   it('is safe with no room fronted', async () => {
     const timeline: string[] = []
     const room = await loadRoom()
@@ -141,8 +165,9 @@ describe('a failed open must not steal the center', () => {
     registerGroup(room, 'Core', [])
     prepareBotSource.mockRejectedValue(new Error('source preparation failed'))
 
-    expect(await room.actions.openRosterBot({ ...BOT, connectionId: 'local', sourceScoped: true })).toBe(false)
+    expect(await room.actions.openRosterBot(REMOTE_BOT)).toBe(false)
     expect(room.chat.$groupChatWorkspace.get()).toBe('Core')
+    expect(room.panes.groupChatMainTabs.has('Core')).toBe(true)
   })
 
   it('restores the room by its immutable roomId, so a rename mid-open still finds it', async () => {

--- a/apps/desktop/src/plugins/hermes-bots/roster-actions.ts
+++ b/apps/desktop/src/plugins/hermes-bots/roster-actions.ts
@@ -178,7 +178,7 @@ export async function openRosterBot(bot: RosterRow, { canonical = false } = {}):
   haptic('tap')
   saveSelectedRosterBot(bot)
   setBotsWorkspaceOwner(botWorkspaceOwnerKey(bot), bot)
-  const dismissedGroup = bot.remoteSource ? null : dismissGroupChatForLocalBotOpen()
+  const dismissedGroup = dismissGroupChatForBotOpen()
 
   if (!dismissedGroup) {
     $groupChatWorkspace.set(null)
@@ -299,7 +299,7 @@ export async function openRosterBot(bot: RosterRow, { canonical = false } = {}):
 /** Bot-open handoff: capture the selected group and retire its registered
  * main tab (or clear the in-panel selection) before async source prep /
  * canonical open. */
-function dismissGroupChatForLocalBotOpen(): null | { group: string; roomId: string } {
+function dismissGroupChatForBotOpen(): null | { group: string; roomId: string } {
   const group = $groupChatWorkspace.get()
 
   if (!group) {


### PR DESCRIPTION
## What does this PR do?

When a Bot Mode group chat owned the center pane, selecting a bot from another registered connection skipped the existing group-to-bot handoff. The group tab remained registered while the canonical bot chat opened, so the center pane could keep showing the group transcript and make the selected bot appear out of sync.

This applies the same handoff to local and remote bot rows: retire the active group tab before opening the bot's canonical chat, then restore the group workspace if source preparation or the canonical open fails.

## Related Issue

No public issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Apply the existing group-chat handoff before opening any roster bot, including bots from remote connections.
- Add a regression test proving the group tab closes before a remote bot's canonical chat opens.
- Verify a failed remote source handoff restores the prior group tab and workspace selection.

## How to Test

1. Open a Bot Mode group chat so it owns the center pane.
2. Select a bot from another registered connection.
3. Confirm the group tab is retired before the bot's canonical `Bot Chat` opens, and confirm a failed open restores the group workspace.

Focused verification:

`vitest run --project ui src/plugins/hermes-bots/group-bot-handoff.test.ts` (7 passed)

`eslint src/plugins/hermes-bots/roster-actions.ts src/plugins/hermes-bots/group-bot-handoff.test.ts`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, focused UI tests and lint

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable. The regression is covered by the focused Bot Mode handoff test.
