### PR TITLE
fix(mcp): keepalive no longer respawns a healthy stdio server that silently drops ping (#97245, salvage #97258)

### DIFF
--- a/tests/tools/test_mcp_capability_gating.py
+++ b/tests/tools/test_mcp_capability_gating.py
@@ -295,4 +295,54 @@ class TestKeepaliveProbeFallback:
 
         assert task._ping_unsupported is False
 
+    async def test_silent_ping_drop_falls_back_to_list_tools(self):
+        """Regression for #97245: a server that silently drops ping (no
+        response at all) produces a TimeoutError. If list_tools succeeds,
+        the transport is alive — latch _ping_unsupported and return
+        normally instead of reconnect-looping."""
+        task = MCPServerTask("test")
+        task.initialize_result = _caps(tools=SimpleNamespace())
+        task.session = SimpleNamespace(
+            send_ping=AsyncMock(side_effect=asyncio.TimeoutError()),
+            list_tools=AsyncMock(return_value=SimpleNamespace(tools=[])),
+        )
+
+        # Should NOT raise — the server is alive.
+        await task._keepalive_probe()
+
+        task.session.send_ping.assert_awaited_once()
+        task.session.list_tools.assert_awaited_once()
+        assert task._ping_unsupported is True
+
+    async def test_silent_ping_drop_both_fail_propagates(self):
+        """When both ping AND list_tools time out, it is a genuine liveness
+        failure — propagate so the caller reconnects."""
+        task = MCPServerTask("test")
+        task.initialize_result = _caps(tools=SimpleNamespace())
+        task.session = SimpleNamespace(
+            send_ping=AsyncMock(side_effect=asyncio.TimeoutError()),
+            list_tools=AsyncMock(side_effect=asyncio.TimeoutError()),
+        )
+
+        with pytest.raises((TimeoutError, asyncio.TimeoutError)):
+            await task._keepalive_probe()
+
+        assert task._ping_unsupported is False
+
+    async def test_silent_ping_drop_no_tools_propagates(self):
+        """A server that has no tools capability and times out on ping has no
+        fallback probe — the timeout must propagate immediately."""
+        task = MCPServerTask("test")
+        task.initialize_result = _caps(prompts=SimpleNamespace())  # no tools
+        task.session = SimpleNamespace(
+            send_ping=AsyncMock(side_effect=asyncio.TimeoutError()),
+            list_tools=AsyncMock(),
+        )
+
+        with pytest.raises((TimeoutError, asyncio.TimeoutError)):
+            await task._keepalive_probe()
+
+        # list_tools must not be called — no tools capability advertised.
+        task.session.list_tools.assert_not_called()
+        assert task._ping_unsupported is False
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2871,21 +2871,44 @@ class MCPServerTask:
                 await asyncio.wait_for(self.session.send_ping(), timeout=30.0)
                 return
             except Exception as exc:
-                # Only a "method not found" means ping is unsupported. Any
-                # other error (timeout, closed transport, session expired) is
-                # a real liveness failure — propagate so we reconnect.
-                if not _is_method_not_found_error(exc):
+                if _is_method_not_found_error(exc):
+                    # Structural -32601 or "Unknown method" — ping is
+                    # definitively unsupported.
+                    if not self._advertises_tools():
+                        raise
+                    self._ping_unsupported = True
+                    logger.info(
+                        "MCP server '%s': does not implement the optional "
+                        "'ping' utility (-32601); using 'list_tools' for "
+                        "keepalive on this connection.",
+                        self.name,
+                    )
+                elif isinstance(exc, (TimeoutError, asyncio.TimeoutError)) and self._advertises_tools():
+                    # A server that silently drops ping (no response at all)
+                    # produces a TimeoutError indistinguishable from a dead
+                    # transport. Before declaring it dead, try list_tools as
+                    # a confirmation probe (#97245). If the transport is
+                    # genuinely broken, list_tools will also fail and we
+                    # propagate that failure.
+                    try:
+                        await asyncio.wait_for(self.session.list_tools(), timeout=30.0)
+                    except Exception:
+                        # Both probes failed — genuine liveness failure.
+                        raise exc from None
+                    # Transport alive, ping just isn't answered. Latch the
+                    # fallback so subsequent keepalives skip the 30s wait.
+                    self._ping_unsupported = True
+                    logger.info(
+                        "MCP server '%s': ping timed out but list_tools "
+                        "succeeded — server silently drops ping; using "
+                        "'list_tools' for keepalive on this connection.",
+                        self.name,
+                    )
+                    return
+                else:
+                    # Any other error (closed transport, session expired,
+                    # etc.) is a real liveness failure — propagate.
                     raise
-                if not self._advertises_tools():
-                    # No ping, no tools → no cheaper probe to fall back to.
-                    raise
-                self._ping_unsupported = True
-                logger.info(
-                    "MCP server '%s': does not implement the optional 'ping' "
-                    "utility (-32601); using 'list_tools' for keepalive on "
-                    "this connection.",
-                    self.name,
-                )
 
         # Fallback probe for servers without ping support.
         await asyncio.wait_for(self.session.list_tools(), timeout=30.0)


### PR DESCRIPTION
## Summary

A stdio MCP server that never answers the optional `ping` (no `-32601`, no response at all) is no longer torn down and respawned on every keepalive tick. On the first ping timeout, `_keepalive_probe()` confirms with `list_tools` before declaring the transport dead; if that answers, `_ping_unsupported` latches and `list_tools` is used from then on. Only when both probes fail does the reconnect fire.

Root cause: the `_ping_unsupported` latch was reachable only via `_is_method_not_found_error()`; a silent server yields a bare `TimeoutError`, indistinguishable from a real hang, so every tick reconnected — which for stdio closes the child's stdin and kills a healthy process (#97245: 362 respawns/day from one server).

Salvage of #97258 by @Synxneuos (authorship preserved), rebased onto current main.

## Changes

- `tools/mcp_tool.py` `_keepalive_probe()`: on `TimeoutError` with tools advertised, one `list_tools` confirmation; latch + log on success, `raise exc` on failure. `-32601` path unchanged.
- `tests/tools/test_mcp_capability_gating.py`: 3 tests (silent drop → fallback latches; both fail → propagates; no tools capability → propagates).

## Validation

**Live repro** — 10-line stdio server answering `initialize`/`tools/list` only (the issue's fixture), `keepalive_interval: 2`, observed 75s:

| | child respawned | `_ping_unsupported` | reconnect_retries |
|---|---|---|---|
| origin/main | yes (2 keepalive-failed → reconnect cycles) | False | 2 |
| this PR | no, same pid | True (after first tick) | 0 |

- `test_mcp_capability_gating.py` + `test_mcp_stability.py`: 36 passed; ruff clean.

## Credit

Fix and tests by @Synxneuos (#97258). Report with fixture and measurements by @WKassebaum (#97245). #96470 (@silverstein) proposes a different design for the same symptom (drop protocol probes for stdio entirely, use child liveness) — left open for separate review; #97267 (@salch-cred) was self-closed as overlapping.

Closes #97245. Closes #97258.

## Infographic

![MCP keepalive: silent ping](https://v3b.fal.media/files/b/0aa8c6f9/H-sHt-DTvpnMdTeHGHvMD_2qKq1QaA.png)
