### PR TITLE
fix(terminal): infer background for omitted PTY dependency

### DIFF
--- a/tests/tools/test_terminal_tool_pty_fallback.py
+++ b/tests/tools/test_terminal_tool_pty_fallback.py
@@ -56,3 +56,50 @@ def test_terminal_background_keeps_pty_for_regular_interactive_commands(monkeypa
 
     assert captured["use_pty"] is True
     assert "pty_note" not in result
+
+
+def test_terminal_handler_infers_background_when_pty_dependency_is_omitted(monkeypatch):
+    captured = {}
+
+    def fake_terminal_tool(**kwargs):
+        captured.update(kwargs)
+        return '{"ok":true}'
+
+    monkeypatch.setattr(terminal_tool_module, "terminal_tool", fake_terminal_tool)
+
+    result = json.loads(
+        terminal_tool_module._handle_terminal(
+            {
+                "command": "hermes auth add openai-codex --type oauth --no-browser",
+                "pty": True,
+                "timeout": 900,
+            },
+            task_id="test",
+        )
+    )
+
+    assert result == {"ok": True}
+    assert captured["background"] is True
+    assert captured["pty"] is True
+    assert captured["timeout"] == 900
+
+
+def test_terminal_handler_rejects_explicit_foreground_pty(monkeypatch):
+    called = False
+
+    def fake_terminal_tool(**_kwargs):
+        nonlocal called
+        called = True
+        return '{"ok":true}'
+
+    monkeypatch.setattr(terminal_tool_module, "terminal_tool", fake_terminal_tool)
+
+    result = json.loads(
+        terminal_tool_module._handle_terminal(
+            {"command": "python3", "background": False, "pty": True},
+            task_id="test",
+        )
+    )
+
+    assert "background=true" in result["error"]
+    assert called is False

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -4134,7 +4134,7 @@ TERMINAL_SCHEMA = {
             },
             "pty": {
                 "type": "boolean",
-                "description": "With background=true: run in a pseudo-terminal for interactive CLI tools (Codex, Claude Code, Python REPL). Local backend only. Default: false.",
+                "description": "Run in a tracked background pseudo-terminal for interactive CLIs. Implies background=true when omitted; explicit false is rejected. Local backend only. Default: false.",
                 "default": False
             },
             "notify": {
@@ -4171,9 +4171,14 @@ def _handle_terminal(args, **kw):
     notify = args.get("notify")
     notify_on_complete = args.get("notify_on_complete", False)
     watch_patterns = args.get("watch_patterns")
+    # A PTY is only useful as a tracked session. Recover the common dependent-
+    # argument omission without overriding an explicit foreground request.
+    background = args.get("background", False)
+    if args.get("pty", False) and "background" not in args:
+        background = True
     # Background-only modifiers on a foreground call were silently ignored;
     # fail with the corrected call instead (poka-yoke, no schema cost).
-    if not args.get("background", False):
+    if not background:
         if notify or watch_patterns or notify_on_complete:
             return tool_error(
                 "notify only applies to background commands (foreground "
@@ -4201,7 +4206,7 @@ def _handle_terminal(args, **kw):
             )
     return terminal_tool(
         command=args.get("command"),
-        background=args.get("background", False),
+        background=background,
         timeout=args.get("timeout"),
         task_id=kw.get("task_id"),
         session_id=kw.get("session_id"),


### PR DESCRIPTION
## What does this PR do?

Models can correctly request `pty=true` and a long timeout while omitting the dependent `background=true` argument. The terminal handler currently rejects that call before the command starts, which can trap headless interactive flows in repeated identical errors.

This change treats an omitted dependency differently from an explicit contradiction:

- `pty=true` with no `background` key infers a tracked background session.
- `pty=true, background=false` still returns the existing teaching error.

That preserves the fail-loud invariant introduced in #95937 while recovering a common dependent-argument omission. The advertised PTY schema now documents the behavior.

## Related Issue

No existing issue or PR matched this failure mode.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Infer `background=true` in `_handle_terminal()` only when `pty=true` and the `background` key is absent.
- Preserve rejection when callers explicitly pass `background=false`.
- Add regression coverage for both paths and update the PTY schema description.

## How to Test

1. Run `scripts/run_tests.sh tests/tools/test_terminal_tool_pty_fallback.py`.
2. Call the handler with `{"command": "hermes auth add openai-codex --type oauth --no-browser", "pty": true, "timeout": 900}` and verify the terminal backend receives `background=true`.
3. Add `"background": false` to the same shape and verify the handler returns the existing `pty requires background=true` error without invoking the backend.

Results:

- Focused regression file: 4/4 passed.
- Terminal, notify, and watch-pattern neighbors: 57/57 passed.
- Broader local `test_code_execution.py`: 43/44 passed; its unrelated schema-drift test could not import `httpx` from the available local Python environment. The changed terminal path was not involved.
- Full GitHub CI passed, including Python tests, Windows and macOS suites, ruff, ty, supply-chain checks, Nix, and amd64/arm64 Docker builds.
- Live gateway validation: the previously rejected omitted-dependency shape started a tracked process, completed a device-code login, and the authenticated provider completed a real model request.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched for existing PRs and issues.
- [x] My PR contains only changes related to this fix.
- [x] The full GitHub CI matrix passes.
- [x] I've added tests for the bug.
- [x] I've tested on macOS and a Linux gateway deployment.

### Documentation & Housekeeping

- [x] Relevant tool schema documentation is updated.
- [x] `cli-config.yaml.example` is N/A because no config key changed.
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no architecture or workflow changed.
- [x] Cross-platform impact was considered; inference happens before backend dispatch and does not alter backend-specific PTY support.
