### PR TITLE
fix(browser): close stale real-profile agent-browser session before relaunch

### DIFF
--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -336,6 +336,45 @@ class TestRealProfileCdpLaunch:
         assert cdp == "http://127.0.0.1:41000"
         self._reset()
 
+    def test_closes_stale_session_when_daemon_reports_no_cdp(self, tmp_path):
+        """A daemon whose browser died answers get cdp-url with an error (None).
+
+        The daemon still owns the session name and ignores a fresh ``--cdp``,
+        so it must be closed before relaunch — otherwise every later launch
+        fails against the dead port.
+        """
+        import tools.browser_tool as bt
+        self._reset()
+        proc = Mock(return_value=None, returncode=0, stdout="", stderr="")
+        closed = {"n": 0}
+
+        class FakeChrome:
+            def poll(self):
+                return None
+
+        def fake_popen(argv, **kw):
+            (tmp_path / "DevToolsActivePort").write_text("41000\n/devtools/browser/x\n")
+            return FakeChrome()
+
+        with patch.object(bt, "_use_real_profile", return_value=True), \
+             patch("hermes_cli.browser_connect.detect_default_chromium", return_value="chrome"), \
+             patch("hermes_cli.browser_connect.snapshot_real_profile", return_value=(str(tmp_path), None)), \
+             patch("hermes_cli.browser_connect.chromium_executable", return_value="/usr/bin/chrome"), \
+             patch.object(bt.subprocess, "Popen", side_effect=fake_popen), \
+             patch.object(bt, "_agent_browser_get_cdp",
+                          side_effect=[None, "http://127.0.0.1:41000"]), \
+             patch.object(bt, "_cdp_http_ready", return_value=True), \
+             patch.object(bt, "_cdp_on_data_dir", return_value=False), \
+             patch.object(bt, "_agent_browser_close_session",
+                          side_effect=lambda s: closed.__setitem__("n", closed["n"] + 1)), \
+             patch.object(bt, "_find_agent_browser", return_value="/usr/bin/agent-browser"), \
+             patch.object(bt.subprocess, "run", return_value=proc), \
+             patch.object(bt, "_is_headed_mode", return_value=False):
+            cdp, err = bt._real_profile_cdp()
+        assert closed["n"] == 1  # dead-browser daemon was closed before relaunch
+        assert cdp == "http://127.0.0.1:41000"
+        self._reset()
+
     def test_cdp_on_data_dir_matches_devtoolsactiveport(self, tmp_path):
         import tools.browser_tool as bt
         (tmp_path / "DevToolsActivePort").write_text("41000\n/devtools/browser/x\n")

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1723,10 +1723,14 @@ def _real_profile_cdp() -> tuple:
         if existing and _cdp_http_ready(existing) and _cdp_on_data_dir(existing, copy_dir):
             _real_profile_cdp_cache["cdp"] = existing
             return existing, None
-        if existing:
-            # Stale/wrong-dir session (throwaway-temp fallback, or an old copy):
-            # close it so nothing holds the dir open before we overlay + relaunch.
-            _agent_browser_close_session(_REAL_PROFILE_SESSION)
+        # Not reusable: close the session unconditionally, not only when the
+        # daemon still reports an endpoint. A daemon whose browser died (e.g.
+        # the previous hermes process terminated its Chrome at exit) answers
+        # ``get cdp-url`` with an error, so ``existing`` is None — yet it still
+        # owns the session name and ignores a fresh ``--cdp`` on the attach
+        # below, failing every later launch against the dead port. Closing a
+        # non-existent session is a cheap no-op (~0.1s).
+        _agent_browser_close_session(_REAL_PROFILE_SESSION)
 
         # No live browser owns the dir now — safe to (re)snapshot + overlay.
         snap_dir, err = snapshot_real_profile(browser)


### PR DESCRIPTION
## What does this PR do?

Fixes a permanent failure of real-profile browsing (`browser.use_real_profile: true`) after the real-profile Chrome dies while the `hermes-real-profile` agent-browser daemon survives — which happens after every one-shot `hermes chat -q ...` run (Hermes terminates its Chrome at exit) and after every gateway restart.

In `_real_profile_cdp`, the stale-session close was guarded by `if existing:`. But a daemon whose browser is dead answers `get cdp-url` with an error, so `_agent_browser_get_cdp` returns `None`, the close is skipped, and the dead daemon keeps owning the session name. It then ignores the fresh `--cdp <port>` on the attach, and every later launch fails with `Auto-launch failed: All CDP discovery methods failed for 127.0.0.1:<dead port>`.

The fix closes the session unconditionally whenever it is not reusable. Closing a non-existent session is a ~0.1 s no-op (`✓ Browser closed`, exit 0).

## Related Issue

Fixes #101029

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/browser_tool.py` — `_real_profile_cdp`: drop the `if existing:` guard around `_agent_browser_close_session(_REAL_PROFILE_SESSION)` on the relaunch path; comment explains why.
- `tests/tools/test_browser_real_profile.py` — new `TestRealProfileCdpLaunch::test_closes_stale_session_when_daemon_reports_no_cdp`: `_agent_browser_get_cdp` returns `None` first (dead daemon), asserts the session is closed once and the relaunched browser's CDP is returned. Fails on `main`, passes with the fix.

## How to Test

1. `browser.use_real_profile: true`, Chromium default browser. Run `hermes chat -Q --oneshot -q "Use browser_exec to open https://example.com and print the H1"` twice in a row.
2. On `main` the second run fails with the "All CDP discovery methods failed for 127.0.0.1:<old port>" error (the daemon in `~/.agent-browser/hermes-real-profile.*` is still bound to the terminated Chrome).
3. With this PR both runs succeed; the log shows the second run closing the stale session and `real-profile browser ready for <browser> at http://127.0.0.1:<new port>`.
4. `pytest tests/tools/test_browser_real_profile.py -q` — the new test goes RED→GREEN.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the affected test file: 78 tests, 77 pass; the one failure, `TestReviewRound3::test_relaunch_path_does_snapshot`, fails identically on unpatched `main` (pre-existing, unrelated)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.6.2 (Apple Silicon), Brave 152, agent-browser 0.26.0, Python 3.11.16

### Documentation & Housekeeping

- [x] Docs — N/A (internal behavior only; the docstring/comment at the change site is updated)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered: the added call is the same `agent-browser --session <name> close` already used on the wrong-dir path; no platform-specific code
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

Before (second run, `main`):
```
Tool browser_exec returned error: {"error": "browser.use_real_profile is on, but the real-profile browser failed to start: ✗ Auto-launch failed: All CDP discovery methods failed for 127.0.0.1:60779: ... Connection refused (os error 61)"}
```
After (two consecutive runs):
```
09:45:57 real-profile browser ready for brave at http://127.0.0.1:61842 (.../browser-profile/brave)
09:45:58 tool browser_exec completed (6.56s, 199 chars)
09:46:10 real-profile browser ready for brave at http://127.0.0.1:61905 (.../browser-profile/brave)
09:46:11 tool browser_exec completed (5.98s, 199 chars)
```
