### PR TITLE
fix(desktop): stop installing a hybrid plugin's desktop half twice

### DIFF
--- a/apps/desktop/electron/desktop-plugin-install.test.ts
+++ b/apps/desktop/electron/desktop-plugin-install.test.ts
@@ -9,6 +9,7 @@ import {
   desktopPluginFolderName,
   detectPluginComponents,
   findDesktopEntry,
+  manifestNameFromYaml,
   repoNameFromUrl,
   resolvePluginGitUrl,
   resolveSubdirWithin
@@ -110,6 +111,21 @@ describe('detectPluginComponents', () => {
     })
   })
 
+  it('names a manifest without `name:` after the caller fallback, not the clone folder', async () => {
+    // A probe clone lives in a mkdtemp folder; the backend would install this
+    // package under the repo name, so that is the name a caller can look up.
+    const root = mkdtemp('hermes-plugin-noname-')
+    roots.push(root)
+    fs.writeFileSync(path.join(root, 'plugin.yaml'), 'version: 1\n')
+    fs.writeFileSync(path.join(root, '__init__.py'), 'def register(ctx): pass\n')
+
+    await expect(detectPluginComponents(root, 'from-repo-url')).resolves.toMatchObject({
+      agent: true,
+      agentName: 'from-repo-url'
+    })
+    await expect(detectPluginComponents(root)).resolves.toMatchObject({ agentName: path.basename(root) })
+  })
+
   it('detects dual layout', async () => {
     const root = mkdtemp('hermes-plugin-dual-')
     roots.push(root)
@@ -122,7 +138,59 @@ describe('detectPluginComponents', () => {
       agent: true,
       desktop: true,
       agentName: 'dual',
-      desktopName: 'desktop'
+      desktopName: 'desktop',
+      desktopSourceSubdir: 'desktop'
     })
+  })
+
+  it('drops an unquoted trailing YAML comment from the agent name (matches yaml.safe_load)', async () => {
+    const root = mkdtemp('hermes-plugin-comment-')
+    roots.push(root)
+    fs.writeFileSync(path.join(root, 'plugin.yaml'), 'name: dual # the folder the backend creates\n')
+    fs.writeFileSync(path.join(root, '__init__.py'), 'def register(ctx): pass\n')
+
+    await expect(detectPluginComponents(root)).resolves.toMatchObject({ agent: true, agentName: 'dual' })
+  })
+
+  it('keeps a quoted agent name verbatim, hash included (matches yaml.safe_load)', async () => {
+    const root = mkdtemp('hermes-plugin-quoted-')
+    roots.push(root)
+    fs.writeFileSync(path.join(root, 'plugin.yaml'), 'name: "dual # two"\n')
+    fs.writeFileSync(path.join(root, '__init__.py'), 'def register(ctx): pass\n')
+
+    await expect(detectPluginComponents(root)).resolves.toMatchObject({ agent: true, agentName: 'dual # two' })
+  })
+
+  it('reports a root plugin.js desktop half as sourceSubdir "."', async () => {
+    // The unified plugins/<name>/desktop/ door never serves this shape, so
+    // the install modal must keep copying it to desktop-plugins/ (#100412).
+    const root = mkdtemp('hermes-plugin-dual-root-')
+    roots.push(root)
+    fs.writeFileSync(path.join(root, 'plugin.yaml'), 'name: dual-root\n')
+    fs.writeFileSync(path.join(root, '__init__.py'), 'def register(ctx): pass\n')
+    fs.writeFileSync(path.join(root, 'plugin.js'), 'export default { id: "dual-root-ui" }')
+
+    await expect(detectPluginComponents(root)).resolves.toMatchObject({
+      agent: true,
+      desktop: true,
+      desktopSourceSubdir: '.'
+    })
+  })
+})
+
+describe('manifestNameFromYaml', () => {
+  it.each([
+    ['name: dual\n', 'dual'],
+    ['name: dual # the folder the backend creates\n', 'dual'],
+    ['name: "dual" # comment after the quotes\n', 'dual'],
+    ["name: 'dual # two'\n", 'dual # two'],
+    ['name: foo#bar\n', 'foo#bar'],
+    ['version: 1\r\nname: dual # c\r\nfoo: 1\r\n', 'dual'],
+    ['name: "dual" # c\r\n', 'dual'],
+    ['version: 1\nname:   spaced   \n', 'spaced'],
+    ['name: ""\n', null],
+    ['version: 1\n', null]
+  ])('%j -> %j', (text, expected) => {
+    expect(manifestNameFromYaml(text)).toBe(expected)
   })
 })

--- a/apps/desktop/electron/desktop-plugin-install.ts
+++ b/apps/desktop/electron/desktop-plugin-install.ts
@@ -22,8 +22,11 @@ export interface PluginComponentDetection {
   desktop: boolean
   agentName: string | null
   desktopName: string | null
-  desktopSourceSubdir: string | null
+  desktopSourceSubdir: DesktopSourceSubdir | null
 }
+
+/** Where a repo keeps its desktop half: a root `plugin.js` or `desktop/plugin.js`. */
+export type DesktopSourceSubdir = '.' | 'desktop'
 
 export interface PluginProbeResult {
   ok: boolean
@@ -31,6 +34,11 @@ export interface PluginProbeResult {
   desktop: boolean
   agentName?: string | null
   desktopName?: string | null
+  /** Where the desktop half lives in the repo: '.' (root plugin.js) or
+   *  'desktop' (desktop/plugin.js). Only the nested shape is also served by
+   *  the unified `plugins/<name>/desktop/` door, so the install modal needs
+   *  to know which one it is looking at. */
+  desktopSourceSubdir?: DesktopSourceSubdir | null
   warnings: string[]
   insecure: boolean
   error?: string
@@ -175,7 +183,27 @@ async function pathIsFile(filePath: string): Promise<boolean> {
   }
 }
 
-export function findDesktopEntry(pluginRoot: string): { entryFile: string; sourceSubdir: string } | null {
+/**
+ * The top-level `name:` of a plugin manifest, read the way `yaml.safe_load`
+ * would for the plain scalars manifests use: a quoted value verbatim (a `#`
+ * inside the quotes is part of the name, a comment may follow the closing
+ * quote), an unquoted value up to a ` #` comment. The backend names the
+ * install folder after this value, so a caller can locate that folder (#100412).
+ */
+export function manifestNameFromYaml(text: string): string | null {
+  // `[^\r\n]` so a CRLF manifest does not smuggle the \r into the value.
+  const quoted = text.match(/^name:[ \t]*(?:"([^"\r\n]*)"|'([^'\r\n]*)')[ \t]*(?:#[^\r\n]*)?\r?$/m)
+
+  if (quoted) {
+    return (quoted[1] ?? quoted[2] ?? '').trim() || null
+  }
+
+  const plain = text.match(/^name:[ \t]*([^\r\n]*)\r?$/m)
+
+  return plain?.[1].replace(/\s+#.*$/, '').trim() || null
+}
+
+export function findDesktopEntry(pluginRoot: string): { entryFile: string; sourceSubdir: DesktopSourceSubdir } | null {
   const rootPlugin = path.join(pluginRoot, 'plugin.js')
 
   if (pathExistsSync(rootPlugin)) {
@@ -191,7 +219,16 @@ export function findDesktopEntry(pluginRoot: string): { entryFile: string; sourc
   return null
 }
 
-export async function detectPluginComponents(pluginRoot: string): Promise<PluginComponentDetection> {
+/**
+ * `fallbackName` is what an agent half is called when its manifest carries no
+ * `name:` — the backend uses the install subdir's last segment or the repo
+ * name, never the folder we happened to clone into. Defaults to the folder
+ * name for callers that resolved a real subdir.
+ */
+export async function detectPluginComponents(
+  pluginRoot: string,
+  fallbackName: string = path.basename(pluginRoot)
+): Promise<PluginComponentDetection> {
   const hasYaml =
     pathExistsSync(path.join(pluginRoot, 'plugin.yaml')) || pathExistsSync(path.join(pluginRoot, 'plugin.yml'))
 
@@ -205,7 +242,7 @@ export async function detectPluginComponents(pluginRoot: string): Promise<Plugin
   let agentName: string | null = null
 
   if (agent) {
-    agentName = path.basename(pluginRoot)
+    agentName = fallbackName
 
     if (hasYaml) {
       try {
@@ -214,10 +251,10 @@ export async function detectPluginComponents(pluginRoot: string): Promise<Plugin
           : path.join(pluginRoot, 'plugin.yml')
 
         const text = await fsp.readFile(yamlPath, 'utf8')
-        const match = text.match(/^name:\s*['"]?([^'"\n]+)['"]?\s*$/m)
+        const name = manifestNameFromYaml(text)
 
-        if (match?.[1]) {
-          agentName = match[1].trim()
+        if (name) {
+          agentName = name
         }
       } catch {
         // Fall back to directory name.
@@ -342,8 +379,11 @@ export async function probePluginRepo(gitBin: string, identifier: string): Promi
 
     try {
       const pluginRoot = await resolvePluginRoot(cloneRoot, subdir)
-      const detected = await detectPluginComponents(pluginRoot)
       const repoFallback = repoNameFromUrl(gitUrl)
+      // Without a subdir the plugin root IS the mkdtemp clone folder, whose
+      // basename means nothing — the backend would name the install after the
+      // repo instead.
+      const detected = await detectPluginComponents(pluginRoot, subdir ? undefined : repoFallback)
 
       if (!detected.agent && !detected.desktop) {
         return {
@@ -362,6 +402,7 @@ export async function probePluginRepo(gitBin: string, identifier: string): Promi
         desktop: detected.desktop,
         agentName: detected.agentName ?? (detected.agent ? repoFallback : null),
         desktopName: detected.desktop ? desktopPluginFolderName(gitUrl, subdir) : null,
+        desktopSourceSubdir: detected.desktopSourceSubdir,
         warnings,
         insecure
       }

--- a/apps/desktop/src/app/settings/plugin-install-modal.test.tsx
+++ b/apps/desktop/src/app/settings/plugin-install-modal.test.tsx
@@ -1,0 +1,452 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { requestGateway, installAgentPlugin, loadAgentPlugins, discoverRuntimePlugins, notify } = vi.hoisted(() => ({
+  requestGateway: vi.fn(),
+  installAgentPlugin: vi.fn(),
+  loadAgentPlugins: vi.fn(async () => undefined),
+  discoverRuntimePlugins: vi.fn<() => Promise<void>>(async () => undefined),
+  notify: vi.fn()
+}))
+
+vi.mock('@/app/gateway/hooks/use-gateway-request', () => ({
+  useGatewayRequest: () => ({ requestGateway })
+}))
+
+vi.mock('@/store/agent-plugins', () => ({ installAgentPlugin, loadAgentPlugins }))
+vi.mock('@/contrib/runtime-loader', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  discoverRuntimePlugins
+}))
+vi.mock('@/store/notifications', () => ({ notify, notifyError: vi.fn() }))
+// Same rounds, short waits: the real 3 × 2 s outlast an in-flight scan; here
+// they would only slow the "rescan dropped" and "never published" cases.
+vi.mock('./plugin-install-plan', async importOriginal => {
+  const plan = await importOriginal<typeof Plan>()
+
+  return {
+    ...plan,
+    settleUnifiedDesktopPluginId: (
+      rescan: () => Promise<void>,
+      records: Parameters<typeof plan.settleUnifiedDesktopPluginId>[1],
+      entryFile: string
+    ) => plan.settleUnifiedDesktopPluginId(rescan, records, entryFile, plan.UNIFIED_RECORD_ATTEMPTS, 40)
+  }
+})
+
+import { $pluginDecisions, $pluginRecords, publishPlugin } from '@/contrib/plugins-store'
+import { I18nProvider } from '@/i18n'
+import { closePluginInstallRequest, openPluginInstallRequest } from '@/store/plugin-install-request'
+import { $connection } from '@/store/session'
+
+import { PluginInstallModal } from './plugin-install-modal'
+import type * as Plan from './plugin-install-plan'
+
+const REPO = 'https://github.com/example/word-count'
+const PLUGINS_ROOT = '/home/u/.hermes/plugins'
+const DESKTOP_ROOT = '/home/u/.hermes/desktop-plugins'
+const UNIFIED_ENTRY = `${PLUGINS_ROOT}/word-count/desktop/plugin.js`
+
+const hybridProbe = {
+  ok: true,
+  agent: true,
+  desktop: true,
+  agentName: 'word-count',
+  desktopName: 'word-count',
+  desktopSourceSubdir: 'desktop' as '.' | 'desktop' | null,
+  warnings: [] as string[],
+  insecure: false
+}
+
+const probePluginRepo = vi.fn(async () => hybridProbe)
+const installDesktopPlugin = vi.fn(async () => ({ ok: true, pluginName: 'word-count' }))
+
+/** What the agent install leaves under plugins/ — the unified desktop half is
+ *  present only after a successful (or "already installed") agent install. */
+let unifiedHalfOnDisk = false
+
+/** A desktop-plugins/word-count/plugin.js left by an install made before this fix. */
+let standaloneOnDisk = false
+
+const readDir = vi.fn(async (dirPath: string) => {
+  const entry = (name: string, isDirectory: boolean) => ({ name, path: `${dirPath}/${name}`, isDirectory })
+
+  if (dirPath === DESKTOP_ROOT) {
+    return { entries: standaloneOnDisk ? [entry('word-count', true)] : [] }
+  }
+
+  if (dirPath === `${DESKTOP_ROOT}/word-count`) {
+    return { entries: [entry('plugin.js', false)] }
+  }
+
+  if (dirPath === PLUGINS_ROOT) {
+    return { entries: unifiedHalfOnDisk ? [entry('word-count', true)] : [] }
+  }
+
+  if (dirPath === `${PLUGINS_ROOT}/word-count`) {
+    return { entries: [entry('plugin.yaml', false), entry('desktop', true)] }
+  }
+
+  if (dirPath === `${PLUGINS_ROOT}/word-count/desktop`) {
+    return { entries: [entry('plugin.js', false)] }
+  }
+
+  return { entries: [], error: 'ENOENT' }
+})
+
+/** What the disk door publishes once it has scanned the unified half. */
+function publishUnifiedHalf() {
+  publishPlugin({
+    id: 'word-count',
+    name: 'Word count',
+    kind: 'disk',
+    status: 'disabled',
+    file: UNIFIED_ENTRY
+  })
+}
+
+function setConnection(mode: 'local' | 'remote' | undefined) {
+  $connection.set({
+    baseUrl: 'http://127.0.0.1:8642',
+    isFullscreen: false,
+    logs: [],
+    mode,
+    nativeOverlayWidth: 0,
+    token: 't',
+    windowButtonPosition: null,
+    wsUrl: 'ws://127.0.0.1:8642'
+  })
+}
+
+function renderModal() {
+  return render(
+    <MemoryRouter initialEntries={['/']}>
+      <I18nProvider configClient={null} initialLocale="en">
+        <PluginInstallModal />
+      </I18nProvider>
+    </MemoryRouter>
+  )
+}
+
+async function openModal() {
+  renderModal()
+
+  await act(async () => {
+    openPluginInstallRequest({ repo: REPO })
+  })
+
+  const install = await screen.findByRole('button', { name: 'Install' })
+
+  await waitFor(() => expect(install.hasAttribute('disabled')).toBe(false))
+
+  return install
+}
+
+async function clickInstall(install: HTMLElement) {
+  fireEvent.click(install)
+
+  await waitFor(() => expect(loadAgentPlugins).toHaveBeenCalled())
+}
+
+const successToast = (fragment: string) =>
+  expect.objectContaining({ kind: 'success', message: expect.stringContaining(fragment) })
+
+beforeEach(() => {
+  requestGateway.mockReset()
+  installAgentPlugin.mockReset()
+  installAgentPlugin.mockImplementation(async () => {
+    unifiedHalfOnDisk = true
+
+    return { ok: true, pluginName: 'word-count' }
+  })
+  loadAgentPlugins.mockClear()
+  discoverRuntimePlugins.mockReset()
+  discoverRuntimePlugins.mockImplementation(async () => {
+    publishUnifiedHalf()
+  })
+  notify.mockClear()
+  probePluginRepo.mockReset()
+  probePluginRepo.mockImplementation(async () => hybridProbe)
+  installDesktopPlugin.mockClear()
+  readDir.mockClear()
+  unifiedHalfOnDisk = false
+  standaloneOnDisk = false
+  $pluginRecords.set({})
+  $pluginDecisions.set({})
+  ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
+    probePluginRepo,
+    installDesktopPlugin,
+    readDir,
+    agentPluginsRoot: async () => PLUGINS_ROOT,
+    desktopPluginsRoot: async () => DESKTOP_ROOT
+  }
+})
+
+afterEach(() => {
+  cleanup()
+  closePluginInstallRequest()
+  $connection.set(null)
+  delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+  vi.restoreAllMocks()
+})
+
+describe('PluginInstallModal hybrid install (#100412)', () => {
+  it('serves the desktop half from the unified package on a local backend instead of copying it', async () => {
+    setConnection('local')
+
+    await clickInstall(await openModal())
+
+    expect(installAgentPlugin).toHaveBeenCalledTimes(1)
+    expect(installDesktopPlugin).not.toHaveBeenCalled()
+    expect(discoverRuntimePlugins).toHaveBeenCalledTimes(1)
+  })
+
+  it('enables the opt-in unified half because the user ticked "Desktop UI"', async () => {
+    setConnection('local')
+
+    await clickInstall(await openModal())
+
+    expect($pluginDecisions.get()['word-count']).toBe(true)
+    expect(notify).toHaveBeenCalledWith(successToast('enabled from the agent plugin package'))
+  })
+
+  it('rescans again when the first rescan was dropped by the loader lock, then enables it', async () => {
+    // discoverRuntimePlugins() is a no-op while another scan holds its lock
+    // (and a watched root has no poll to catch up); the next round lands.
+    setConnection('local')
+    discoverRuntimePlugins.mockReset()
+    discoverRuntimePlugins.mockResolvedValueOnce(undefined).mockImplementationOnce(async () => {
+      publishUnifiedHalf()
+    })
+
+    await clickInstall(await openModal())
+
+    expect(discoverRuntimePlugins).toHaveBeenCalledTimes(2)
+    expect(installDesktopPlugin).not.toHaveBeenCalled()
+    expect($pluginDecisions.get()['word-count']).toBe(true)
+    expect(notify).toHaveBeenCalledWith(successToast('enabled from the agent plugin package'))
+  })
+
+  it('leaves the unified half opt-in and says where to enable it when no scan publishes it', async () => {
+    setConnection('local')
+    discoverRuntimePlugins.mockImplementation(async () => undefined)
+
+    await clickInstall(await openModal())
+
+    expect(discoverRuntimePlugins).toHaveBeenCalledTimes(3)
+    expect(installDesktopPlugin).not.toHaveBeenCalled()
+    expect($pluginDecisions.get()).toEqual({})
+    expect(notify).toHaveBeenCalledWith(successToast('enable it under Settings'))
+  })
+
+  it('skips the copy when the agent install fails as "already installed" (the unified half is on disk)', async () => {
+    setConnection('local')
+    unifiedHalfOnDisk = true
+    installAgentPlugin.mockImplementation(async () => ({ ok: false, error: 'Plugin word-count is already installed' }))
+
+    await clickInstall(await openModal())
+
+    expect(installDesktopPlugin).not.toHaveBeenCalled()
+    expect($pluginDecisions.get()['word-count']).toBe(true)
+  })
+
+  it('falls back to copying when the local agent install fails and nothing landed under plugins/', async () => {
+    // Otherwise a clone failure would leave the user with no desktop half at
+    // all — a wrong guess must cost a duplicate, never the loss.
+    setConnection('local')
+    installAgentPlugin.mockImplementation(async () => ({ ok: false, error: 'clone failed' }))
+
+    await clickInstall(await openModal())
+
+    expect(installDesktopPlugin).toHaveBeenCalledTimes(1)
+    expect($pluginDecisions.get()).toEqual({})
+  })
+
+  it('copies when the backend installed into a root this app does not scan', async () => {
+    // e.g. a profile-scoped hermes home: the agent install succeeded but
+    // plugins/<name>/desktop/plugin.js is not in the scanned root.
+    setConnection('local')
+    installAgentPlugin.mockImplementation(async () => ({ ok: true, pluginName: 'word-count' }))
+
+    await clickInstall(await openModal())
+
+    expect(installDesktopPlugin).toHaveBeenCalledTimes(1)
+    expect(discoverRuntimePlugins).toHaveBeenCalledTimes(1)
+  })
+
+  it('copies a root-level plugin.js desktop half (the unified door does not serve that shape)', async () => {
+    setConnection('local')
+    unifiedHalfOnDisk = true
+    probePluginRepo.mockImplementation(async () => ({ ...hybridProbe, desktopSourceSubdir: '.' }))
+
+    const install = await openModal()
+
+    expect(screen.queryByText(/Uses the desktop half inside the agent plugin package/)).toBeNull()
+
+    await clickInstall(install)
+
+    expect(installDesktopPlugin).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports an enable failure instead of swallowing it', async () => {
+    setConnection('local')
+    discoverRuntimePlugins.mockImplementation(async () => {
+      publishPlugin(
+        { id: 'word-count', name: 'Word count', kind: 'disk', status: 'disabled', file: UNIFIED_ENTRY },
+        {
+          activate: () => {
+            throw new Error('register exploded')
+          },
+          deactivate: () => undefined
+        }
+      )
+    })
+
+    await clickInstall(await openModal())
+
+    expect(notify).not.toHaveBeenCalledWith(successToast('enabled from the agent plugin package'))
+    expect(await screen.findByText(/register exploded/)).toBeTruthy()
+    // The enable decision was persisted before activation threw; it is rolled back.
+    expect($pluginDecisions.get()['word-count']).toBe(false)
+  })
+
+  it('keeps refreshing an existing standalone copy: it is the one the loader serves', async () => {
+    // An install made before this fix left desktop-plugins/word-count/. The
+    // unified half must not silently win over it (and once the scan-time
+    // dedupe lands, that stale copy would be the only one served).
+    setConnection('local')
+    standaloneOnDisk = true
+
+    const install = await openModal()
+
+    expect(screen.queryByText(/Uses the desktop half inside the agent plugin package/)).toBeNull()
+    expect(screen.getByText(/Installs into this app's local desktop-plugins folder/)).toBeTruthy()
+
+    await clickInstall(install)
+
+    expect(installDesktopPlugin).toHaveBeenCalledWith({ identifier: REPO, force: false })
+    expect($pluginDecisions.get()).toEqual({})
+    expect(readDir).not.toHaveBeenCalledWith(PLUGINS_ROOT)
+  })
+
+  it('Force-reinstall refreshes an existing standalone copy instead of leaving it stale', async () => {
+    setConnection('local')
+    standaloneOnDisk = true
+    renderModal()
+
+    await act(async () => {
+      openPluginInstallRequest({ repo: REPO, force: true })
+    })
+
+    const install = await screen.findByRole('button', { name: 'Install' })
+
+    await waitFor(() => expect(install.hasAttribute('disabled')).toBe(false))
+    await clickInstall(install)
+
+    expect(installDesktopPlugin).toHaveBeenCalledWith({ identifier: REPO, force: true })
+  })
+
+  it('reports a unified half that failed to load right away instead of waiting every round', async () => {
+    setConnection('local')
+    discoverRuntimePlugins.mockImplementation(async () => {
+      publishPlugin({
+        id: 'word-count',
+        name: 'word-count',
+        kind: 'disk',
+        status: 'error',
+        error: 'syntax exploded',
+        file: UNIFIED_ENTRY
+      })
+    })
+
+    await clickInstall(await openModal())
+
+    expect(discoverRuntimePlugins).toHaveBeenCalledTimes(1)
+    expect(installDesktopPlugin).not.toHaveBeenCalled()
+    expect($pluginDecisions.get()).toEqual({})
+    expect(notify).not.toHaveBeenCalledWith(successToast('agent plugin package'))
+    expect(await screen.findByText(/syntax exploded/)).toBeTruthy()
+  })
+
+  it('never enables the loader\'s "<id>:disk-shadowed" row for a plugin that ships bundled', async () => {
+    setConnection('local')
+    discoverRuntimePlugins.mockImplementation(async () => {
+      publishPlugin({
+        id: 'word-count:disk-shadowed',
+        name: 'Word count (stale disk copy)',
+        description: 'Shadowed by the bundled "word-count" plugin — this folder is no longer used and can be deleted.',
+        kind: 'disk',
+        status: 'disabled',
+        file: UNIFIED_ENTRY
+      })
+    })
+
+    await clickInstall(await openModal())
+
+    expect($pluginDecisions.get()).toEqual({})
+    expect(await screen.findByText(/Shadowed by the bundled/)).toBeTruthy()
+  })
+
+  it('leaves an already-running unified plugin alone on an "already exists" retry', async () => {
+    // The user enabled it earlier; reinstalling must neither reload it nor
+    // let a failing reload flip its persisted decision to false.
+    setConnection('local')
+    unifiedHalfOnDisk = true
+    installAgentPlugin.mockImplementation(async () => ({ ok: false, error: "Plugin 'word-count' already exists" }))
+    $pluginDecisions.set({ 'word-count': true })
+
+    const activate = vi.fn(() => {
+      throw new Error('must not be called')
+    })
+
+    discoverRuntimePlugins.mockImplementation(async () => {
+      publishPlugin(
+        { id: 'word-count', name: 'Word count', kind: 'disk', status: 'loaded', file: UNIFIED_ENTRY },
+        { activate, deactivate: () => undefined }
+      )
+    })
+
+    await clickInstall(await openModal())
+
+    expect(installDesktopPlugin).not.toHaveBeenCalled()
+    expect(activate).not.toHaveBeenCalled()
+    expect($pluginDecisions.get()['word-count']).toBe(true)
+    expect(notify).toHaveBeenCalledWith(successToast('enabled from the agent plugin package'))
+    expect(screen.queryByText(/must not be called/)).toBeNull()
+  })
+
+  it('tells the user up front that no separate desktop copy will be made', async () => {
+    setConnection('local')
+
+    await openModal()
+
+    expect(screen.getByText(/Uses the desktop half inside the agent plugin package/)).toBeTruthy()
+  })
+
+  it('still copies the desktop half when the agent half targets a remote backend', async () => {
+    setConnection('remote')
+
+    await clickInstall(await openModal())
+
+    expect(installAgentPlugin).toHaveBeenCalledTimes(1)
+    expect(installDesktopPlugin).toHaveBeenCalledTimes(1)
+    expect(readDir).not.toHaveBeenCalledWith(PLUGINS_ROOT)
+    expect(screen.queryByText(/Uses the desktop half inside the agent plugin package/)).toBeNull()
+  })
+
+  it('copies when the user unticks the agent half on a local backend', async () => {
+    setConnection('local')
+
+    const install = await openModal()
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /Agent plugin/ }))
+
+    expect(screen.queryByText(/Uses the desktop half inside the agent plugin package/)).toBeNull()
+
+    await clickInstall(install)
+
+    expect(installAgentPlugin).not.toHaveBeenCalled()
+    expect(installDesktopPlugin).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/app/settings/plugin-install-modal.tsx
+++ b/apps/desktop/src/app/settings/plugin-install-modal.tsx
@@ -16,6 +16,7 @@ import {
   preventCloseButtonAutoFocus
 } from '@/components/ui/dialog'
 import { Switch } from '@/components/ui/switch'
+import { $pluginRecords, setPluginEnabled } from '@/contrib/plugins-store'
 import { discoverRuntimePlugins } from '@/contrib/runtime-loader'
 import { useI18n } from '@/i18n'
 import { ExternalLink } from '@/lib/external-link'
@@ -30,6 +31,13 @@ import {
 } from '@/store/plugin-install-request'
 import { $activeGatewayProfile, $profileScope } from '@/store/profile'
 import { $connection } from '@/store/session'
+
+import {
+  desktopHalfMayShareLocalRoot,
+  findStandaloneDesktopEntry,
+  findUnifiedDesktopEntry,
+  settleUnifiedDesktopPluginId
+} from './plugin-install-plan'
 
 type ProbeResult = Awaited<ReturnType<NonNullable<NonNullable<Window['hermesDesktop']>['probePluginRepo']>>>
 
@@ -55,11 +63,15 @@ export function PluginInstallModal() {
   const [forceReinstall, setForceReinstall] = useState(false)
   const [installing, setInstalling] = useState(false)
   const [installError, setInstallError] = useState<string | null>(null)
+  // An existing desktop-plugins/<name>/plugin.js from an earlier install. The
+  // loader serves that copy, so the install keeps refreshing it (#100412).
+  const [standaloneEntry, setStandaloneEntry] = useState<string | null>(null)
   const probeToken = useRef(0)
 
   const resetState = useCallback(() => {
     setPhase('idle')
     setProbe(null)
+    setStandaloneEntry(null)
     setInstallAgent(true)
     setInstallDesktop(true)
     setEnableAgent(true)
@@ -123,6 +135,16 @@ export function PluginInstallModal() {
         return
       }
 
+      const standalone =
+        result.desktop && result.desktopName
+          ? await findStandaloneDesktopEntry(window.hermesDesktop, result.desktopName)
+          : null
+
+      if (token !== probeToken.current) {
+        return
+      }
+
+      setStandaloneEntry(standalone)
       applyLegacyHint(payload, result)
       setPhase('ready')
     },
@@ -149,6 +171,26 @@ export function PluginInstallModal() {
 
   const agentTargetHint =
     connection?.mode === 'remote' ? m.agentTargetRemote(profileLabel) : m.agentTargetLocal(profileLabel)
+
+  // A hybrid repo installed into a local backend lands its desktop half at
+  // plugins/<name>/desktop/ too; a second copy under desktop-plugins/ would
+  // load the same plugin id twice (#100412). This is the cheap pre-check for
+  // the caption — the install itself only skips the copy once that unified
+  // entry is actually on disk. An existing standalone copy keeps today's
+  // path: the loader serves it, so Force must keep refreshing it.
+  const desktopMayShareLocalRoot = desktopHalfMayShareLocalRoot({
+    connectionMode: connection?.mode,
+    probeAgent: probe?.agent === true,
+    probeDesktop: probe?.desktop === true,
+    desktopSourceSubdir: probe?.desktopSourceSubdir ?? null,
+    standaloneCopy: standaloneEntry !== null,
+    installAgent,
+    installDesktop
+  })
+
+  const desktopTargetHint = desktopMayShareLocalRoot ? m.desktopTargetUnified : m.desktopTarget
+  // The unified half lives under the agent package's folder, not desktopName.
+  const desktopTargetName = desktopMayShareLocalRoot ? (probe?.agentName ?? probe?.desktopName) : probe?.desktopName
 
   const sourceLinks = useMemo(() => (request ? resolvePluginSourceLinks(request.repo) : null), [request])
 
@@ -177,6 +219,9 @@ export function PluginInstallModal() {
 
     const errors: string[] = []
     const successes: string[] = []
+    // The backend names the install folder after the manifest `name`, which is
+    // what both `pluginName` and the probe's `agentName` report.
+    let agentPluginName: null | string = probe.agentName ?? null
 
     try {
       if (installAgent && probe.agent) {
@@ -187,6 +232,7 @@ export function PluginInstallModal() {
         })
 
         if (result.ok) {
+          agentPluginName = result.pluginName ?? agentPluginName
           successes.push(m.agentSuccess(result.pluginName ?? request.repo))
 
           if (result.missingEnv?.length) {
@@ -204,7 +250,51 @@ export function PluginInstallModal() {
         }
       }
 
-      if (installDesktop && probe.desktop) {
+      // Skip the desktop-plugins/ copy only on hard evidence: the unified
+      // entry plugins/<name>/desktop/plugin.js exists in the root this app
+      // scans. That covers an agent install that just landed it AND one that
+      // failed as "already exists"; a clone failure, a backend on another
+      // hermes home, a root-level plugin.js, or an existing standalone copy
+      // (desktopMayShareLocalRoot is false then) all fall through to the copy
+      // — a wrong guess costs a duplicate, never the loss of the desktop half.
+      const unifiedEntry =
+        installDesktop && probe.desktop && desktopMayShareLocalRoot && agentPluginName
+          ? await findUnifiedDesktopEntry(window.hermesDesktop, agentPluginName)
+          : null
+
+      if (unifiedEntry) {
+        // That root loads opt-in, but the user ticked "Desktop UI" — honour
+        // it the way `enable` honours the agent half. A rescan is dropped
+        // while another scan holds the lock (and watched roots have no poll
+        // to catch up), so rescan-and-wait a few times; if the record never
+        // shows, leave it opt-in and say where to turn it on.
+        const outcome = await settleUnifiedDesktopPluginId(discoverRuntimePlugins, $pluginRecords, unifiedEntry)
+        const desktopName = agentPluginName ?? request.repo
+
+        if (!outcome) {
+          successes.push(m.desktopUnified(desktopName))
+        } else if ('error' in outcome) {
+          // The loader already inventoried it as broken or shadowed; that is
+          // final, not "not yet".
+          errors.push(`${m.desktopFailed}: ${outcome.error}`)
+        } else if ($pluginRecords.get()[outcome.id]?.status === 'loaded') {
+          // Already running (an "already exists" retry of a plugin the user
+          // enabled earlier) — nothing to change, and never risk its state.
+          successes.push(m.desktopUnifiedEnabled(desktopName))
+        } else {
+          try {
+            await setPluginEnabled(outcome.id, true)
+            successes.push(m.desktopUnifiedEnabled(desktopName))
+          } catch (error) {
+            // setPluginEnabled persists the decision before it activates, so
+            // a throw leaves a dangling "on". The record was disabled before
+            // (no decision, or an explicit off); an explicit off is the
+            // closest state the store can express, and renders the same.
+            await setPluginEnabled(outcome.id, false).catch(() => undefined)
+            errors.push(`${m.desktopFailed}: ${error instanceof Error ? error.message : String(error)}`)
+          }
+        }
+      } else if (installDesktop && probe.desktop) {
         const installFn = window.hermesDesktop?.installDesktopPlugin
 
         if (!installFn) {
@@ -348,8 +438,8 @@ export function PluginInstallModal() {
                     <span className="min-w-0">
                       <span className="block font-medium text-foreground">{m.desktopLabel}</span>
                       <span className="block text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
-                        {m.desktopTarget}
-                        {probe.desktopName ? ` · ${probe.desktopName}` : ''}
+                        {desktopTargetHint}
+                        {desktopTargetName ? ` · ${desktopTargetName}` : ''}
                       </span>
                     </span>
                   </label>

--- a/apps/desktop/src/app/settings/plugin-install-plan.test.ts
+++ b/apps/desktop/src/app/settings/plugin-install-plan.test.ts
@@ -1,0 +1,286 @@
+import { atom } from 'nanostores'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { PluginRecord } from '@/contrib/plugins-store'
+
+import {
+  desktopHalfMayShareLocalRoot,
+  findStandaloneDesktopEntry,
+  findUnifiedDesktopEntry,
+  findUnifiedDesktopPluginId,
+  type HybridInstallPlanInput,
+  type PluginRootsFs,
+  settleUnifiedDesktopPluginId,
+  waitForUnifiedDesktopPluginId
+} from './plugin-install-plan'
+
+const hybridOnLocal: HybridInstallPlanInput = {
+  connectionMode: 'local',
+  probeAgent: true,
+  probeDesktop: true,
+  desktopSourceSubdir: 'desktop',
+  standaloneCopy: false,
+  installAgent: true,
+  installDesktop: true
+}
+
+const ROOT = '/home/u/.hermes/plugins'
+const DESKTOP_ROOT = '/home/u/.hermes/desktop-plugins'
+const FILE = `${ROOT}/word-count/desktop/plugin.js`
+
+const record = (id: string, file: string | undefined, patch: Partial<PluginRecord> = {}): PluginRecord => ({
+  id,
+  name: id,
+  kind: 'disk',
+  status: 'disabled',
+  file,
+  ...patch
+})
+
+/** In-memory `readDir` over a posix tree: dir path -> child names ('x/' = directory). */
+function fakeFs(
+  tree: Record<string, string[]>,
+  roots: Partial<Record<'agent' | 'desktop', string>> = {}
+): PluginRootsFs {
+  return {
+    agentPluginsRoot: async () => roots.agent ?? ROOT,
+    desktopPluginsRoot: async () => roots.desktop ?? DESKTOP_ROOT,
+    readDir: async dirPath => {
+      const children = tree[dirPath]
+
+      if (!children) {
+        throw new Error(`ENOENT ${dirPath}`)
+      }
+
+      return {
+        entries: children.map(child => {
+          const isDirectory = child.endsWith('/')
+          const name = isDirectory ? child.slice(0, -1) : child
+
+          return { name, path: `${dirPath}/${name}`, isDirectory }
+        })
+      }
+    }
+  }
+}
+
+describe('desktopHalfMayShareLocalRoot (#100412)', () => {
+  it('rules in a hybrid repo with a nested desktop half installed into a local backend', () => {
+    expect(desktopHalfMayShareLocalRoot(hybridOnLocal)).toBe(true)
+  })
+
+  it('still copies when the agent half targets a remote backend', () => {
+    // The remote backend's plugins/ tree is not on this machine, so the
+    // desktop-plugins/ copy is the only local one (#97005 dual-target flow).
+    expect(desktopHalfMayShareLocalRoot({ ...hybridOnLocal, connectionMode: 'remote' })).toBe(false)
+  })
+
+  it('fails toward copying when the connection mode is unknown', () => {
+    expect(desktopHalfMayShareLocalRoot({ ...hybridOnLocal, connectionMode: undefined })).toBe(false)
+  })
+
+  it('copies a root-level plugin.js desktop half (the unified door only serves desktop/plugin.js)', () => {
+    expect(desktopHalfMayShareLocalRoot({ ...hybridOnLocal, desktopSourceSubdir: '.' })).toBe(false)
+    expect(desktopHalfMayShareLocalRoot({ ...hybridOnLocal, desktopSourceSubdir: null })).toBe(false)
+  })
+
+  it('keeps refreshing an existing standalone copy (the one the loader serves)', () => {
+    expect(desktopHalfMayShareLocalRoot({ ...hybridOnLocal, standaloneCopy: true })).toBe(false)
+  })
+
+  it('copies a desktop-only package (nothing lands in plugins/)', () => {
+    expect(desktopHalfMayShareLocalRoot({ ...hybridOnLocal, probeAgent: false })).toBe(false)
+  })
+
+  it('copies when the user unticked the agent half', () => {
+    expect(desktopHalfMayShareLocalRoot({ ...hybridOnLocal, installAgent: false })).toBe(false)
+  })
+
+  it('is moot when the desktop half is unticked', () => {
+    expect(desktopHalfMayShareLocalRoot({ ...hybridOnLocal, installDesktop: false })).toBe(false)
+  })
+})
+
+describe('findUnifiedDesktopEntry (#100412)', () => {
+  it('returns the entry path when plugins/<name>/desktop/plugin.js exists', async () => {
+    const fs = fakeFs({
+      [ROOT]: ['word-count/', 'other/'],
+      [`${ROOT}/word-count`]: ['plugin.yaml', '__init__.py', 'desktop/'],
+      [`${ROOT}/word-count/desktop`]: ['plugin.js']
+    })
+
+    await expect(findUnifiedDesktopEntry(fs, 'word-count')).resolves.toBe(FILE)
+  })
+
+  it('is null for an agent-only install (no desktop folder) or a missing plugin', async () => {
+    const fs = fakeFs({
+      [ROOT]: ['word-count/'],
+      [`${ROOT}/word-count`]: ['plugin.yaml', '__init__.py']
+    })
+
+    await expect(findUnifiedDesktopEntry(fs, 'word-count')).resolves.toBeNull()
+    await expect(findUnifiedDesktopEntry(fs, 'absent')).resolves.toBeNull()
+  })
+
+  it('is null when a segment has the wrong kind (a "desktop" file, a "plugin.js" folder)', async () => {
+    const fileNotDir = fakeFs({
+      [ROOT]: ['word-count/'],
+      [`${ROOT}/word-count`]: ['desktop']
+    })
+
+    const dirNotFile = fakeFs({
+      [ROOT]: ['word-count/'],
+      [`${ROOT}/word-count`]: ['desktop/'],
+      [`${ROOT}/word-count/desktop`]: ['plugin.js/']
+    })
+
+    await expect(findUnifiedDesktopEntry(fileNotDir, 'word-count')).resolves.toBeNull()
+    await expect(findUnifiedDesktopEntry(dirNotFile, 'word-count')).resolves.toBeNull()
+  })
+
+  it('is null (copy) when the root is unreadable, the bridge is missing, or the shell predates agentPluginsRoot', async () => {
+    await expect(findUnifiedDesktopEntry(fakeFs({}), 'word-count')).resolves.toBeNull()
+    await expect(findUnifiedDesktopEntry(undefined, 'word-count')).resolves.toBeNull()
+    await expect(
+      findUnifiedDesktopEntry({ readDir: vi.fn(async () => ({ entries: [] })) }, 'word-count')
+    ).resolves.toBeNull()
+  })
+})
+
+describe('findStandaloneDesktopEntry (#100412)', () => {
+  it('returns desktop-plugins/<name>/plugin.js from an earlier install', async () => {
+    const fs = fakeFs({
+      [DESKTOP_ROOT]: ['word-count/'],
+      [`${DESKTOP_ROOT}/word-count`]: ['plugin.js', 'README.md']
+    })
+
+    await expect(findStandaloneDesktopEntry(fs, 'word-count')).resolves.toBe(`${DESKTOP_ROOT}/word-count/plugin.js`)
+  })
+
+  it('is null when absent, when the folder has no plugin.js, or on an older shell', async () => {
+    const fs = fakeFs({ [DESKTOP_ROOT]: ['other/'], [`${DESKTOP_ROOT}/other`]: ['plugin.js'] })
+
+    await expect(findStandaloneDesktopEntry(fs, 'word-count')).resolves.toBeNull()
+    await expect(
+      findStandaloneDesktopEntry(
+        fakeFs({ [DESKTOP_ROOT]: ['word-count/'], [`${DESKTOP_ROOT}/word-count`]: [] }),
+        'word-count'
+      )
+    ).resolves.toBeNull()
+    await expect(
+      findStandaloneDesktopEntry({ readDir: vi.fn(async () => ({ entries: [] })) }, 'word-count')
+    ).resolves.toBeNull()
+  })
+})
+
+describe('findUnifiedDesktopPluginId (#100412)', () => {
+  it('finds the disk record published for the entry file', () => {
+    const records = {
+      other: record('other', '/home/u/.hermes/plugins/other/desktop/plugin.js'),
+      'word-count': record('word-count', FILE)
+    }
+
+    expect(findUnifiedDesktopPluginId(records, FILE)).toEqual({ id: 'word-count' })
+  })
+
+  it('never matches the standalone desktop-plugins/<name>/plugin.js copy', () => {
+    const records = {
+      'word-count': record('word-count', '/home/u/.hermes/desktop-plugins/word-count/plugin.js')
+    }
+
+    expect(findUnifiedDesktopPluginId(records, FILE)).toBeNull()
+  })
+
+  it('reports a broken load as a terminal error, not "not yet"', () => {
+    const records = { 'word-count': record('word-count', FILE, { status: 'error', error: 'syntax' }) }
+
+    expect(findUnifiedDesktopPluginId(records, FILE)).toEqual({ error: 'syntax' })
+  })
+
+  it('reports a bundled-shadowed row as terminal instead of enabling the phantom id', () => {
+    const records = {
+      'word-count:disk-shadowed': record('word-count:disk-shadowed', FILE, {
+        name: 'Word count (stale disk copy)',
+        description: 'Shadowed by the bundled "word-count" plugin'
+      })
+    }
+
+    expect(findUnifiedDesktopPluginId(records, FILE)).toEqual({ error: 'Shadowed by the bundled "word-count" plugin' })
+  })
+
+  it('ignores bundled records and records without a file', () => {
+    const records = {
+      bundled: record('bundled', FILE, { kind: 'bundled' }),
+      nofile: record('nofile', undefined)
+    }
+
+    expect(findUnifiedDesktopPluginId(records, FILE)).toBeNull()
+  })
+})
+
+describe('waitForUnifiedDesktopPluginId (#100412)', () => {
+  it('resolves at once when the record is already published, and releases its listener', async () => {
+    const records = atom<Record<string, PluginRecord>>({ 'word-count': record('word-count', FILE) })
+
+    await expect(waitForUnifiedDesktopPluginId(records, FILE, 50)).resolves.toEqual({ id: 'word-count' })
+    expect(records.lc).toBe(0)
+  })
+
+  it('resolves when an in-flight scan publishes the record later', async () => {
+    const records = atom<Record<string, PluginRecord>>({})
+    const pending = waitForUnifiedDesktopPluginId(records, FILE, 500)
+
+    setTimeout(() => records.set({ 'word-count': record('word-count', FILE) }), 20)
+
+    await expect(pending).resolves.toEqual({ id: 'word-count' })
+    expect(records.lc).toBe(0)
+  })
+
+  it('gives up with null after the timeout and stops listening', async () => {
+    const records = atom<Record<string, PluginRecord>>({})
+
+    await expect(waitForUnifiedDesktopPluginId(records, FILE, 30)).resolves.toBeNull()
+
+    records.set({ 'word-count': record('word-count', FILE) })
+
+    expect(records.lc).toBe(0)
+  })
+})
+
+describe('settleUnifiedDesktopPluginId (#100412)', () => {
+  it('rescans again when the first rescan was dropped by the loader lock', async () => {
+    // Round 1: scanDiskPlugins() returns at once because a watch/poll scan
+    // holds its lock and nothing else publishes. Round 2 lands.
+    const records = atom<Record<string, PluginRecord>>({})
+
+    const rescan = vi
+      .fn<() => Promise<void>>()
+      .mockResolvedValueOnce(undefined)
+      .mockImplementationOnce(async () => {
+        records.set({ 'word-count': record('word-count', FILE) })
+      })
+
+    await expect(settleUnifiedDesktopPluginId(rescan, records, FILE, 3, 30)).resolves.toEqual({ id: 'word-count' })
+    expect(rescan).toHaveBeenCalledTimes(2)
+  })
+
+  it('stops at once on a terminal outcome (broken load) instead of burning every round', async () => {
+    const records = atom<Record<string, PluginRecord>>({})
+
+    const rescan = vi.fn<() => Promise<void>>(async () => {
+      records.set({ 'word-count': record('word-count', FILE, { status: 'error', error: 'syntax' }) })
+    })
+
+    await expect(settleUnifiedDesktopPluginId(rescan, records, FILE, 3, 30)).resolves.toEqual({ error: 'syntax' })
+    expect(rescan).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops after the last round with null', async () => {
+    const records = atom<Record<string, PluginRecord>>({})
+    const rescan = vi.fn<() => Promise<void>>(async () => undefined)
+
+    await expect(settleUnifiedDesktopPluginId(rescan, records, FILE, 3, 10)).resolves.toBeNull()
+    expect(rescan).toHaveBeenCalledTimes(3)
+    expect(records.lc).toBe(0)
+  })
+})

--- a/apps/desktop/src/app/settings/plugin-install-plan.ts
+++ b/apps/desktop/src/app/settings/plugin-install-plan.ts
@@ -1,0 +1,196 @@
+import type { ReadableAtom } from 'nanostores'
+
+import type { PluginRecord } from '@/contrib/plugins-store'
+import { resolveDiskPluginEntry } from '@/contrib/runtime-loader'
+
+/**
+ * Cheap pre-check: could a hybrid repo's desktop half be served by the unified
+ * `plugins/<name>/desktop/plugin.js` the agent install lands, instead of a
+ * second copy under `desktop-plugins/<name>/`? Two copies load the same plugin
+ * id twice (#100412).
+ *
+ * This only rules the case IN; the install itself skips the copy on hard
+ * evidence (`findUnifiedDesktopEntry`). Everything here fails toward copying:
+ * a remote backend's `plugins/` tree is not on this machine, an unknown mode
+ * proves nothing, the unified door only serves the nested `desktop/plugin.js`
+ * shape (a root-level `plugin.js` would never load), and an existing
+ * standalone copy is the one the loader serves — Force must keep refreshing
+ * it rather than leave it stale behind a newer unified half.
+ */
+export interface HybridInstallPlanInput {
+  connectionMode: 'local' | 'remote' | undefined
+  probeAgent: boolean
+  probeDesktop: boolean
+  /** Where the repo keeps its desktop half: '.' (root plugin.js) or 'desktop'. */
+  desktopSourceSubdir: '.' | 'desktop' | null
+  /** `desktop-plugins/<name>/plugin.js` already exists from an earlier install. */
+  standaloneCopy: boolean
+  installAgent: boolean
+  installDesktop: boolean
+}
+
+export function desktopHalfMayShareLocalRoot(input: HybridInstallPlanInput): boolean {
+  return (
+    input.connectionMode === 'local' &&
+    input.probeAgent &&
+    input.probeDesktop &&
+    input.desktopSourceSubdir === 'desktop' &&
+    !input.standaloneCopy &&
+    input.installAgent &&
+    input.installDesktop
+  )
+}
+
+/** The slice of the Electron bridge the entry walks need (injectable for tests). */
+export type PluginRootsFs = Pick<NonNullable<Window['hermesDesktop']>, 'readDir'> &
+  Partial<Pick<NonNullable<Window['hermesDesktop']>, 'agentPluginsRoot' | 'desktopPluginsRoot'>>
+
+async function resolveEntryUnder(
+  desktop: PluginRootsFs | undefined,
+  root: 'agentPluginsRoot' | 'desktopPluginsRoot',
+  segments: readonly string[]
+): Promise<null | string> {
+  const rootFn = desktop?.[root]
+
+  if (!desktop || !rootFn) {
+    return null
+  }
+
+  try {
+    return await resolveDiskPluginEntry(desktop as Window['hermesDesktop'], await rootFn(), segments)
+  } catch {
+    return null // Root unreadable / IPC failure — no evidence, so copy.
+  }
+}
+
+/**
+ * Hard evidence for skipping the copy: resolve `<agentPluginsRoot>/<name>/
+ * desktop/plugin.js` with the loader's own entry resolver, so the answer is
+ * exactly "would the disk door pick this up" and the two can't drift. Returns
+ * the entry's absolute path (as the loader records it) or null.
+ */
+export function findUnifiedDesktopEntry(
+  desktop: PluginRootsFs | undefined,
+  pluginName: string
+): Promise<null | string> {
+  return resolveEntryUnder(desktop, 'agentPluginsRoot', [pluginName, 'desktop', 'plugin.js'])
+}
+
+/**
+ * An earlier install's `<desktopPluginsRoot>/<desktopName>/plugin.js` (the
+ * folder `installDesktopPlugin` writes). While it exists the loader serves it,
+ * so the install must keep going through `installDesktopPlugin` — Force
+ * refreshes that copy, no-Force reports it as already installed.
+ */
+export function findStandaloneDesktopEntry(
+  desktop: PluginRootsFs | undefined,
+  desktopName: string
+): Promise<null | string> {
+  return resolveEntryUnder(desktop, 'desktopPluginsRoot', [desktopName, 'plugin.js'])
+}
+
+/** Rescan-and-wait rounds for the unified record. A rescan is dropped while
+ *  another scan holds the loader's lock, and fully watched roots have no
+ *  fallback poll to catch up, so one round is not enough; three rounds of 2 s
+ *  outlast any in-flight scan without holding the modal open for long. In the
+ *  happy path the record is already published when round 1 looks. */
+export const UNIFIED_RECORD_ATTEMPTS = 3
+export const UNIFIED_RECORD_WAIT_MS = 2_000
+
+/** What the disk door said about the entry file: a live record to enable, or
+ *  a terminal reason it never will be (failed to load, shadowed by a bundled
+ *  copy). */
+export type UnifiedRecordOutcome = { id: string } | { error: string }
+
+/**
+ * The unified half loads OPT-IN (`defaultEnabled: false` on the `plugins/`
+ * root). Once the disk door publishes the record for the entry file, the
+ * modal can honour the ticked "Desktop UI" box the way `enable` honours the
+ * agent half. Null when no round produced any record — the plugin then stays
+ * opt-in.
+ */
+export async function settleUnifiedDesktopPluginId(
+  rescan: () => Promise<void>,
+  records: ReadableAtom<Record<string, PluginRecord>>,
+  entryFile: string,
+  attempts = UNIFIED_RECORD_ATTEMPTS,
+  waitMs = UNIFIED_RECORD_WAIT_MS
+): Promise<null | UnifiedRecordOutcome> {
+  for (let round = 0; round < attempts; round += 1) {
+    await rescan()
+
+    const outcome = await waitForUnifiedDesktopPluginId(records, entryFile, waitMs)
+
+    if (outcome) {
+      return outcome
+    }
+  }
+
+  return null
+}
+
+/** Resolve as soon as the disk door publishes anything for the entry file, or null after `timeoutMs`. */
+export function waitForUnifiedDesktopPluginId(
+  records: ReadableAtom<Record<string, PluginRecord>>,
+  entryFile: string,
+  timeoutMs: number
+): Promise<null | UnifiedRecordOutcome> {
+  return new Promise(resolve => {
+    let settled = false
+    let unsubscribe: (() => void) | null = null
+
+    const timer = setTimeout(() => finish(null), timeoutMs)
+
+    function finish(outcome: null | UnifiedRecordOutcome) {
+      if (settled) {
+        return
+      }
+
+      settled = true
+      clearTimeout(timer)
+      unsubscribe?.()
+      resolve(outcome)
+    }
+
+    // `subscribe` fires with the current value BEFORE returning the
+    // unsubscriber, so an already-published record settles here and the
+    // listener is released right after.
+    unsubscribe = records.subscribe(current => {
+      const outcome = findUnifiedDesktopPluginId(current, entryFile)
+
+      if (outcome) {
+        finish(outcome)
+      }
+    })
+
+    if (settled) {
+      unsubscribe()
+    }
+  })
+}
+
+const SHADOWED_SUFFIX = ':disk-shadowed'
+
+export function findUnifiedDesktopPluginId(
+  records: Record<string, PluginRecord>,
+  entryFile: string
+): null | UnifiedRecordOutcome {
+  for (const record of Object.values(records)) {
+    if (record.kind !== 'disk' || record.file !== entryFile) {
+      continue
+    }
+
+    // The loader's "a bundled copy of this id already ships" inventory row.
+    if (record.id.endsWith(SHADOWED_SUFFIX)) {
+      return { error: record.description ?? record.name }
+    }
+
+    if (record.status === 'error') {
+      return { error: record.error ?? record.name }
+    }
+
+    return { id: record.id }
+  }
+
+  return null
+}

--- a/apps/desktop/src/contrib/runtime-loader.ts
+++ b/apps/desktop/src/contrib/runtime-loader.ts
@@ -381,7 +381,7 @@ async function loadDiskPlugin(entry: DiskPlugin): Promise<boolean> {
   }
 }
 
-async function resolveDiskPluginEntry(
+export async function resolveDiskPluginEntry(
   desktop: Window['hermesDesktop'],
   folderPath: string,
   segments: readonly string[]

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -469,6 +469,7 @@ declare global {
         desktop: boolean
         agentName?: string | null
         desktopName?: string | null
+        desktopSourceSubdir?: '.' | 'desktop' | null
         warnings?: string[]
         insecure?: boolean
         error?: string

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -364,7 +364,12 @@ export const ar = defineLocale({
       disable: 'تعطيل',
       failed: 'فشل',
       empty: 'لا توجد إضافات سطح مكتب مثبتة بعد.',
-      kinds: { bundled: 'مضمّنة', disk: 'على القرص', runtime: 'وقت التشغيل' }
+      kinds: { bundled: 'مضمّنة', disk: 'على القرص', runtime: 'وقت التشغيل' },
+      installModal: {
+        desktopTargetUnified: 'يستخدم جزء سطح المكتب المضمّن في حزمة إضافة الوكيل — لا حاجة لنسخة منفصلة',
+        desktopUnifiedEnabled: name => `تم تفعيل واجهة سطح المكتب لـ ${name} من حزمة إضافة الوكيل`,
+        desktopUnified: name => `واجهة سطح المكتب لـ ${name} تأتي من حزمة إضافة الوكيل — فعّلها من الإعدادات ← الإضافات`
+      }
     },
     notifications: {
       title: 'الإشعارات',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -444,6 +444,7 @@ export const en: Translations = {
         agentTargetLocal: profile => `Installs into the ${profile} backend (~/.hermes/plugins/)`,
         agentTargetRemote: profile => `Installs into the connected ${profile} backend`,
         desktopTarget: "Installs into this app's local desktop-plugins folder",
+        desktopTargetUnified: 'Uses the desktop half inside the agent plugin package — no separate copy needed',
         desktopOnlyNote: 'Desktop-only packages do not install a backend agent plugin.',
         insecureWarning: 'This URL uses an insecure or local scheme. Prefer https:// or git@ for production installs.',
         securityHeading: 'Before you install',
@@ -463,6 +464,9 @@ export const en: Translations = {
         selectComponent: 'Select at least one component to install.',
         agentSuccess: name => `Agent plugin ${name} installed`,
         desktopSuccess: name => `Desktop plugin ${name} installed`,
+        desktopUnifiedEnabled: name => `Desktop UI for ${name} enabled from the agent plugin package`,
+        desktopUnified: name =>
+          `Desktop UI for ${name} is served from the agent plugin package — enable it under Settings → Plugins`,
         agentFailed: 'Agent plugin install failed',
         desktopFailed: 'Desktop plugin install failed',
         missingEnv: vars => `Missing env vars: ${vars}. Add them in Settings → Keys.`

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -290,6 +290,15 @@ export const ja = defineLocale({
       billing: '請求',
       notifications: '通知'
     },
+    plugins: {
+      installModal: {
+        desktopTargetUnified:
+          'エージェントプラグインパッケージに含まれるデスクトップ部分を使用します — 別途コピーは不要です',
+        desktopUnifiedEnabled: name => `${name} のデスクトップ UI をエージェントプラグインパッケージから有効にしました`,
+        desktopUnified: name =>
+          `${name} のデスクトップ UI はエージェントプラグインパッケージから提供されます — 設定 → プラグインで有効にしてください`
+      }
+    },
     notifications: {
       title: '通知',
       intro: 'アプリ内トーストとは別の、ネイティブのデスクトップ通知です。設定は端末ごとに保存されます。',

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -433,6 +433,7 @@ export const ru = defineLocale({
         agentTargetLocal: profile => `Устанавливается в локальный бэкенд ${profile} (~/.hermes/plugins/)`,
         agentTargetRemote: profile => `Устанавливается в подключённый бэкенд ${profile}`,
         desktopTarget: 'Устанавливается в локальную папку desktop-plugins этого приложения',
+        desktopTargetUnified: 'Использует часть для приложения из пакета плагина агента — отдельная копия не нужна',
         desktopOnlyNote: 'Пакеты только для приложения не устанавливают плагин агента.',
         insecureWarning:
           'Этот URL использует небезопасную или локальную схему. Для боевой установки предпочитайте https:// или git@.',
@@ -453,6 +454,9 @@ export const ru = defineLocale({
         selectComponent: 'Выберите хотя бы один компонент для установки.',
         agentSuccess: name => `Плагин агента ${name} установлен`,
         desktopSuccess: name => `Плагин приложения ${name} установлен`,
+        desktopUnifiedEnabled: name => `Интерфейс приложения для ${name} включён из пакета плагина агента`,
+        desktopUnified: name =>
+          `Интерфейс приложения для ${name} берётся из пакета плагина агента — включите его в Настройки → Плагины`,
         agentFailed: 'Не удалось установить плагин агента',
         desktopFailed: 'Не удалось установить плагин приложения',
         missingEnv: vars => `Не хватает переменных окружения: ${vars}. Добавьте их в Настройки → Ключи.`

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -386,6 +386,7 @@ export interface Translations {
         agentTargetLocal: (profile: string) => string
         agentTargetRemote: (profile: string) => string
         desktopTarget: string
+        desktopTargetUnified: string
         desktopOnlyNote: string
         insecureWarning: string
         securityHeading: string
@@ -404,6 +405,8 @@ export interface Translations {
         selectComponent: string
         agentSuccess: (name: string) => string
         desktopSuccess: (name: string) => string
+        desktopUnifiedEnabled: (name: string) => string
+        desktopUnified: (name: string) => string
         agentFailed: string
         desktopFailed: string
         missingEnv: (vars: string) => string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -281,6 +281,13 @@ export const zhHant = defineLocale({
       billing: '帳單',
       notifications: '通知'
     },
+    plugins: {
+      installModal: {
+        desktopTargetUnified: '使用智慧代理外掛套件內建的桌面部分 — 無需另外複製',
+        desktopUnifiedEnabled: name => `已從智慧代理外掛套件啟用 ${name} 的桌面 UI`,
+        desktopUnified: name => `${name} 的桌面 UI 由智慧代理外掛套件提供 — 請在設定 → 外掛中啟用`
+      }
+    },
     notifications: {
       title: '通知',
       intro: '原生桌面通知，與應用程式內提示不同。設定會依裝置保存，每台電腦各自獨立。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -432,6 +432,7 @@ export const zh: Translations = {
         agentTargetLocal: profile => `安装到 ${profile} 后端（~/.hermes/plugins/）`,
         agentTargetRemote: profile => `安装到已连接的 ${profile} 后端`,
         desktopTarget: '安装到此应用的本地 desktop-plugins 文件夹',
+        desktopTargetUnified: '使用智能体插件包内置的桌面部分 — 无需单独复制',
         desktopOnlyNote: '仅桌面包不会安装后端智能体插件。',
         insecureWarning: '此 URL 使用了不安全的本地 scheme。生产环境请优先使用 https:// 或 git@。',
         securityHeading: '安装前须知',
@@ -450,6 +451,8 @@ export const zh: Translations = {
         selectComponent: '请至少选择一个要安装的组件。',
         agentSuccess: name => `智能体插件 ${name} 已安装`,
         desktopSuccess: name => `桌面插件 ${name} 已安装`,
+        desktopUnifiedEnabled: name => `已从智能体插件包启用 ${name} 的桌面 UI`,
+        desktopUnified: name => `${name} 的桌面 UI 由智能体插件包提供 — 请在设置 → 插件中启用`,
         agentFailed: '智能体插件安装失败',
         desktopFailed: '桌面插件安装失败',
         missingEnv: vars => `缺少环境变量：${vars}。请在设置 → 密钥中添加。`

--- a/website/docs/developer-guide/desktop-plugin-sdk.md
+++ b/website/docs/developer-guide/desktop-plugin-sdk.md
@@ -715,8 +715,11 @@ Installing, sharing, or removing the feature is one folder.
 
 Two enable switches still apply, on purpose, and both default to **off**: the
 desktop half ships opt-in — it inventories in **Settings → Plugins** but stays
-disabled until the user toggles it — matching the Python half's
-`plugins.enabled` gate in `config.yaml` (the security boundary below). Dropping
+disabled until the user toggles it, or ticks **Desktop UI** when installing the
+package from **Settings → Plugins**, which counts as that toggle the same way the
+install modal's **Enable agent plugin** switch does for the Python half — matching
+the Python half's `plugins.enabled` gate in `config.yaml` (the security boundary
+below). Dropping
 a package into `~/.hermes/plugins` is inert on every surface until the user
 says otherwise. The desktop half degrades gracefully when the backend half is
 off — `ctx.rest` returns errors, not crashes.


### PR DESCRIPTION
## What does this PR do?

Companion to #100485 (scan-time dedupe by folder name); lands independently, touches different code, rebases cleanly in either order.

**What still breaks with #100485 alone:** every hybrid install on a local backend still writes a redundant `desktop-plugins/<name>/` copy; the git-managed `plugins/<name>/desktop/plugin.js` never takes effect because the standalone copy wins; the ticked **Desktop UI** box never reaches the opt-in unified half; and a repo whose git name differs from its manifest `name:` (folder claim keyed on the git name, backend folder named after the manifest) still loads twice. This PR fixes the install side so new installs stop creating the second copy in the first place.

**How:** the install modal skips the `desktop-plugins/` copy **only on hard evidence** — after the agent install it resolves `<agentPluginsRoot>/<name>/desktop/plugin.js` with the loader's own `resolveDiskPluginEntry` (now exported), so the question is exactly "would the disk door pick this up". Present means the unified door serves it, including an agent install that failed as "already exists". Absent means copy as before, so a clone failure, a backend on a different hermes home, or an older shell without `agentPluginsRoot` never lose the desktop half. A wrong guess costs a duplicate, never the loss.

**Existing dual installs keep today's behaviour.** If `desktop-plugins/<name>/plugin.js` already exists from an earlier install, the modal keeps going through `installDesktopPlugin`: Force refreshes that copy (the one the loader — and #100485's folder claim — serves), no-Force reports "already installed" as it does now. Nothing is deleted or migrated.

**Guards:** the pre-check only runs on a **local** connection with both boxes ticked; the probe now reports `desktopSourceSubdir` so a repo whose desktop half is a root-level `plugin.js` (which the unified door does not serve) keeps copying; and the probe's agent name now matches `yaml.safe_load` for the plain scalars manifests use (quoted verbatim, unquoted ` # comment` dropped, CRLF-safe) and falls back to the repo name instead of the temp clone folder — so the folder lookup agrees with the name the backend used. That parser is the reason `manifestNameFromYaml()` rides along: the "already exists" retry has no backend name to key off.

**Why the unified half gets enabled:** the `plugins/` root loads opt-in on purpose (`defaultEnabled: false`), and this PR keeps that. Ticking **Desktop UI** in the install modal is the user's explicit consent — the same consent the standalone door already gets, and the same shape as the modal's **Enable agent plugin** switch for the Python half — so the modal enables the record the disk door publishes for that entry file. Dropping a folder into `~/.hermes/plugins` by hand stays inert. One sentence added to the desktop plugin SDK doc.

**Why the rescan-and-wait loop lives in the modal:** `discoverRuntimePlugins()` is a no-op while another scan holds the loader lock, and fully watched roots have no fallback poll, so the modal rescans-and-waits up to three rounds of 2 s. The happy path settles in round 1 (the record is already published when it looks); 6 s is only the failure bound. A record that loaded broken or is shadowed by a bundled copy ends the wait at once and is reported. If nothing is ever published the plugin stays opt-in and the toast says where to turn it on. Coalescing concurrent scans inside `scanDiskPlugins` would remove the loop entirely; I kept it out of this PR because that hunk sits next to #100485's change, and I'm happy to send it as a follow-up.

An already-running plugin (an "already exists" retry of one the user enabled earlier) is left untouched; otherwise an activation error surfaces in the modal and the persisted enable decision is rolled back. The caption says up front when no separate copy will be made.

Known limit: the on-disk check proves the entry is loadable from this app's `plugins/` root, not that the backend wrote it there. Both sides resolve the same profile-scoped root in the supported local configuration (`localPluginsRoot` is profile-aware), so a mismatch needs a hand-built layout.

## Related Issue

Part of #100412 (Fix B in that report; #100485 is the scan-time folder-name dedupe)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/settings/plugin-install-plan.ts` (new): `desktopHalfMayShareLocalRoot()` — the pre-check (local + both ticked + nested desktop half + no existing standalone copy); `findUnifiedDesktopEntry()` / `findStandaloneDesktopEntry()` — on-disk resolution via the loader's resolver, null on any failure; `settleUnifiedDesktopPluginId()` — rescan-and-wait rounds over a nanostores subscription (listener released on settle) returning `{id}` or a terminal `{error}`
- `apps/desktop/src/app/settings/plugin-install-modal.tsx`: probe-time check for an existing standalone copy; skip `installDesktopPlugin` when the unified entry exists; rescan-and-wait, `setPluginEnabled(id, true)` with rollback on activation error; caption swaps to `desktopTargetUnified` and names the agent package folder; toasts `desktopUnifiedEnabled` / `desktopUnified`
- `apps/desktop/src/contrib/runtime-loader.ts`: `export` on `resolveDiskPluginEntry` (no behavior change)
- `apps/desktop/electron/desktop-plugin-install.ts` + `src/global.d.ts`: probe result gains `desktopSourceSubdir: '.' | 'desktop' | null` (already computed internally); `manifestNameFromYaml()`; `detectPluginComponents()` takes a fallback name so a probe clone names the package after the repo, not the temp folder
- `apps/desktop/src/i18n/{types,en,ja,zh,zh-hant,ru,ar}.ts`: three new strings in every locale (`ja`/`zh-hant`/`ar` get a partial `plugins.installModal` block; `defineLocale` deep-merges over `en`)
- `website/docs/developer-guide/desktop-plugin-sdk.md`: one sentence on the install modal's **Desktop UI** tick counting as the opt-in toggle
- `plugin-install-plan.test.ts` (new, 24 cases): decision matrix (remote / unknown mode / root-level plugin.js / existing standalone copy / desktop-only / unticked halves all copy); unified and standalone entry resolution over a fake `readDir`; record matching (standalone copy rejected; error and `:disk-shadowed` rows are terminal; bundled / no-file ignored); the wait (already published releases its listener / published later / timeout stops listening); the rounds (dropped first rescan retried / terminal outcome stops at once / gives up after the last round)
- `plugin-install-modal.test.tsx` (new, 17 cases): renders the modal end to end — local hybrid install never calls `installDesktopPlugin`, rescans and enables; a dropped first rescan is retried; never published stays opt-in with the Settings hint; "already exists" agent failure still skips; existing standalone copy keeps copying, and Force refreshes it; broken unified half is reported at once; `:disk-shadowed` row is never enabled; already-running plugin is neither reloaded nor disabled on retry; activation error shown and decision rolled back; clone failure / unscanned root / root-level `plugin.js` copy; caption up front and hidden when the agent box is unticked; remote copies without walking `plugins/`; unticked agent half copies
- `electron/desktop-plugin-install.test.ts`: `desktopSourceSubdir` for dual and root layouts; fallback name; a `manifestNameFromYaml` table (10 shapes incl. CRLF and quoted-then-comment)

## How to Test

```text
cd apps/desktop
npx vitest run --project ui src/app/settings/plugin-install-plan.test.ts src/app/settings/plugin-install-modal.test.tsx
# 2 files, 42 passed
npx vitest run --project electron electron/desktop-plugin-install.test.ts
# 25 passed
npm run typecheck   # renderer + electron + e2e tsconfigs
npm run lint        # 0 errors
```

Also run locally: the full `ui` project (709 files) and the full `electron` project (two files need the Electron binary, unrelated to this change).

Manual recipe (Settings → Plugins → install from Git, local backend, both boxes ticked, e.g. the `word-count` shape from #85078): the Desktop UI row reads "Uses the desktop half inside the agent plugin package…", `~/.hermes/desktop-plugins/<name>/` is not created, and the plugin appears once in the inventory, enabled. Reinstall without Force: the agent half reports "already exists" and still no copy is made. With a pre-existing `desktop-plugins/<name>/` from an older install: the row reads "Installs into this app's local desktop-plugins folder" and Force refreshes that copy. Against a remote profile: the copy is still made.

Not runtime-tested against a live hybrid Git install in Desktop; the packaged-app (`test:desktop:all`) and Playwright legs were left to CI.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — #100485 is the scan-time half of the same issue; this is the install-time half
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A, desktop-only change (vitest suites above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (Node 22, vitest + tsc + eslint; full `ui` and `electron` vitest projects)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — `website/docs/developer-guide/desktop-plugin-sdk.md`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the renderer walks paths through the existing `readDir` IPC and never joins them itself; the manifest parser is CRLF-safe (tested)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
$ npx vitest run --project ui src/app/settings/plugin-install-plan.test.ts src/app/settings/plugin-install-modal.test.tsx
 Test Files  2 passed (2)
      Tests  42 passed (42)
$ npx vitest run --project electron electron/desktop-plugin-install.test.ts
 Test Files  1 passed (1)
      Tests  25 passed (25)
$ npm run typecheck   # renderer + electron + e2e tsconfigs
$ npm run lint        # 0 errors (pre-existing warnings only)
```
