### PR TITLE
fix(mcp): treat ttl_ms of 0 as no-hint so lazy mode engages (#101007)

### DIFF
--- a/tests/tools/test_mcp_schema_cache_ttl.py
+++ b/tests/tools/test_mcp_schema_cache_ttl.py
@@ -18,6 +18,36 @@ def test_entry_without_ttl_never_expires():
     assert sc.get_cached_entry("srv", "fp") is not None
 
 
+def test_entry_with_zero_ttl_never_expires(monkeypatch):
+    """A ``ttl_ms`` of 0 is SEP-2549's "no hint" and must not expire the
+    entry on every read — every current server reports 0, so expiring would
+    defeat ``lazy`` mode entirely (#101007)."""
+    sc.write_cache_entry("srv", "fp", tools=[{"name": "t"}], ttl_ms=0)
+    entry = sc.get_cached_entry("srv", "fp")
+    assert entry is not None
+    assert "written_at" not in entry, "0-TTL hints should not be persisted"
+    real_time = time.time
+    monkeypatch.setattr(sc.time, "time", lambda: real_time() + 3600.0)
+    assert sc.get_cached_entry("srv", "fp") is not None
+
+
+def test_legacy_zero_ttl_cache_row_still_served(tmp_path, monkeypatch):
+    """Caches written before the fix persist ``ttl_ms: 0`` with a
+    ``written_at``; those rows must read back as hits, not expire."""
+    monkeypatch.setattr(sc, "_cache_path", lambda: tmp_path / "cache.json")
+    sc._save_all(
+        {
+            "srv": {
+                "fingerprint": "fp",
+                "tools": [{"name": "t"}],
+                "ttl_ms": 0,
+                "written_at": 1.0,
+            }
+        }
+    )
+    assert sc.get_cached_entry("srv", "fp") is not None
+
+
 def test_entry_within_ttl_served():
     sc.write_cache_entry("srv", "fp", tools=[{"name": "t"}], ttl_ms=60_000)
     entry = sc.get_cached_entry("srv", "fp")

--- a/tools/mcp_schema_cache.py
+++ b/tools/mcp_schema_cache.py
@@ -70,8 +70,11 @@ def get_cached_entry(server_name: str, fingerprint: str) -> Optional[dict]:
     MCP 2026-07-28 (SEP-2549): ``tools/list`` results carry ``ttlMs`` as a
     freshness hint. When the live discovery path recorded one, an entry
     older than its TTL is treated as a miss so the next startup re-probes
-    the server instead of serving a stale manifest forever. Entries without
-    a recorded TTL (pre-2026 servers) keep the old never-expires behavior.
+    the server instead of serving a stale manifest forever. A ``ttl_ms`` of
+    ``0`` (or absent) means the server sent no hint — such entries keep the
+    old never-expires behavior (SEP-2549 makes the hint optional; every
+    current server reports ``0``, so treating it as "expire immediately"
+    silently defeats ``lazy`` mode on all of them, #101007).
     ``cacheScope`` is irrelevant here: this cache is per-user local disk,
     which satisfies even ``private``.
     """
@@ -83,7 +86,11 @@ def get_cached_entry(server_name: str, fingerprint: str) -> Optional[dict]:
         return None
     ttl_ms = entry.get("ttl_ms")
     written_at = entry.get("written_at")
-    if isinstance(ttl_ms, (int, float)) and isinstance(written_at, (int, float)):
+    if (
+        isinstance(ttl_ms, (int, float))
+        and ttl_ms > 0
+        and isinstance(written_at, (int, float))
+    ):
         if (time.time() - written_at) * 1000.0 >= float(ttl_ms):
             return None
     return entry
@@ -113,7 +120,7 @@ def write_cache_entry(
         "tools": tools,
         "utility_tools": utility_tools or [],
     }
-    if isinstance(ttl_ms, (int, float)):
+    if isinstance(ttl_ms, (int, float)) and ttl_ms > 0:
         entry["ttl_ms"] = ttl_ms
         entry["written_at"] = time.time()
     if cache_scope:


### PR DESCRIPTION
## What does this PR do?

Fixes #101007: with `mcp_servers.<name>.lazy: true`, the schema-cache entry was a miss on every startup, so the lazy branch in `discover_mcp_tools()` silently fell through to the eager connect and every MCP server was spawned/connected on every CLI start.

Root cause: `tools/mcp_tool.py` persists the server's SEP-2549 `ttlMs` hint as `ttl_ms`, and every current server reports `0`. `get_cached_entry()` then applied the expiry check unconditionally — `(elapsed_ms) >= float(0)` is always true — so a fresh entry was treated as already expired.

SEP-2549 makes the freshness hint optional: a `ttl_ms` of `0` (or absent) means the server sent no hint and should keep the old never-expire behavior.

## Related Issue

Fixes #101007

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_schema_cache.py`
  - `get_cached_entry()`: apply the expiry check only when `ttl_ms > 0`. A `0`-TTL row (including rows written before this fix) reads back as a hit, restoring `lazy` mode for every server that reports `ttlMs: 0`.
  - `write_cache_entry()`: persist `ttl_ms`/`written_at` only when `ttl_ms > 0`, so fresh writes stop producing unusable `0`-TTL rows. A missing `written_at` also restores the byte-identical short-circuit for those entries (consistent with pre-TTL behavior).
- `tests/tools/test_mcp_schema_cache_ttl.py`: two new tests —
  - `ttl_ms=0` write is served (and `written_at` is not persisted), including after time advances;
  - a legacy cache row (written before the fix with `ttl_ms: 0` + `written_at`) still reads back as a hit.

## How to Test

1. Set `lazy: true` on any MCP server, run `hermes chat -q hi --oneshot -Q` twice.
2. Before: second run logs `MCP server '<name>' (HTTP): registered N tool(s)` (eager connect). After: it logs `registered N lazy tool(s) from schema cache`.

Automated: `scripts/run_tests.sh tests/tools/test_mcp_schema_cache_ttl.py tests/tools/test_mcp_schema_cache.py tests/tools/test_mcp_dynamic_discovery.py -q` — 24 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring in `get_cached_entry` updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure cache-expiry logic)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- N/A — logic change with automated coverage. -->
