### PR TITLE
fix(preview): stop idle windows from rejecting active session actions

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { $gateway } from '@/store/gateway'
+
+import { handleDesktopBridgeEvent } from './desktop-bridge'
+import type { GatewayEventContext } from './types'
+
+function previewActContext({
+  explicitSid,
+  isActiveEvent
+}: {
+  explicitSid: string
+  isActiveEvent: boolean
+}): GatewayEventContext {
+  return {
+    event: { session_id: explicitSid || undefined, type: 'preview.act.request' },
+    explicitSid,
+    isActiveEvent,
+    payload: { action: 'elements', request_id: 'request-1' }
+  } as GatewayEventContext
+}
+
+describe('preview action bridge routing', () => {
+  afterEach(() => {
+    $gateway.set(null)
+  })
+
+  it('leaves a scoped action request unanswered in a window showing another session', () => {
+    const request = vi.fn()
+    $gateway.set({ request } as never)
+
+    expect(handleDesktopBridgeEvent(previewActContext({ explicitSid: 'session-a', isActiveEvent: false }))).toBe(true)
+    expect(request).not.toHaveBeenCalled()
+  })
+
+  it('keeps the legacy fail-fast response for an unscoped inactive request', () => {
+    const request = vi.fn()
+    $gateway.set({ request } as never)
+
+    expect(handleDesktopBridgeEvent(previewActContext({ explicitSid: '', isActiveEvent: false }))).toBe(true)
+    expect(request).toHaveBeenCalledWith('preview.act.respond', {
+      request_id: 'request-1',
+      text: JSON.stringify({
+        error: 'The in-app browser only takes actions in the session the user is looking at.',
+        success: false
+      })
+    })
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { $gateway } from '@/store/gateway'
+import { $toursEnabled } from '@/store/tours'
 
 import { handleDesktopBridgeEvent } from './desktop-bridge'
 import type { GatewayEventContext } from './types'
@@ -42,6 +43,51 @@ describe('preview action bridge routing', () => {
       request_id: 'request-1',
       text: JSON.stringify({
         error: 'The in-app browser only takes actions in the session the user is looking at.',
+        success: false
+      })
+    })
+  })
+})
+
+function tourContext({
+  explicitSid,
+  isActiveEvent
+}: {
+  explicitSid: string
+  isActiveEvent: boolean
+}): GatewayEventContext {
+  return {
+    event: { session_id: explicitSid || undefined, type: 'tour.request' },
+    explicitSid,
+    isActiveEvent,
+    payload: { action: 'discover', request_id: 'tour-request-1' }
+  } as GatewayEventContext
+}
+
+describe('tour bridge routing', () => {
+  afterEach(() => {
+    $gateway.set(null)
+    $toursEnabled.set(true)
+  })
+
+  it('leaves a scoped request unanswered in another session even when tours are disabled', () => {
+    const request = vi.fn()
+    $gateway.set({ request } as never)
+    $toursEnabled.set(false)
+
+    expect(handleDesktopBridgeEvent(tourContext({ explicitSid: 'session-a', isActiveEvent: false }))).toBe(true)
+    expect(request).not.toHaveBeenCalled()
+  })
+
+  it('keeps the legacy fail-fast response for an unscoped inactive request', () => {
+    const request = vi.fn()
+    $gateway.set({ request } as never)
+
+    expect(handleDesktopBridgeEvent(tourContext({ explicitSid: '', isActiveEvent: false }))).toBe(true)
+    expect(request).toHaveBeenCalledWith('tour.respond', {
+      request_id: 'tour-request-1',
+      text: JSON.stringify({
+        error: 'Tours only run in the session the user is looking at.',
         success: false
       })
     })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts
@@ -45,7 +45,7 @@ const loadPreviewEngine = () => {
  *  (terminal/preview/window), agent terminal streaming, pane reveal, and
  *  message reactions. */
 export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
-  const { event, payload, isActiveEvent } = ctx
+  const { event, payload, explicitSid, isActiveEvent } = ctx
 
   if (event.type === 'terminal.read.request') {
     // read_terminal tool: serialize the renderer's xterm buffer and answer
@@ -95,6 +95,13 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
     const requestId = typeof payload?.request_id === 'string' ? payload.request_id : ''
 
     if (requestId) {
+      // Every mounted desktop window can observe the same gateway event. A
+      // scoped mismatch belongs to another window, so answering here would race
+      // the owning window and could make this refusal win before its real result.
+      if (explicitSid && !isActiveEvent) {
+        return true
+      }
+
       const answer = (result: unknown) =>
         $gateway.get()?.request('preview.act.respond', {
           request_id: requestId,

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts
@@ -186,6 +186,13 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
     const requestId = typeof payload?.request_id === 'string' ? payload.request_id : ''
 
     if (requestId) {
+      // As with preview actions, only the renderer that owns an explicitly
+      // scoped request may answer. Inactive windows must stay silent even when
+      // tours are disabled locally, or their refusal can beat the owner.
+      if (explicitSid && !isActiveEvent) {
+        return true
+      }
+
       const answer = (result: unknown) =>
         $gateway.get()?.request('tour.respond', {
           request_id: requestId,


### PR DESCRIPTION
## What does this PR do?

Desktop preview actions now wait for the renderer that is showing the action's session instead of letting an idle HUD or popout window reject the request first. This prevents `drive_preview` and `annotate_preview` from failing whenever another mounted desktop window observes the same gateway event.

### Symptom

With a preview open in the active session and a second Hermes window alive, `drive_preview` can immediately return `The in-app browser only takes actions in the session the user is looking at.` Closing the second window makes the same action succeed.

### Impact

Users with HUD, session popout, or browser popout windows can be unable to drive the preview from the session they are actively viewing.

### Bug Cause

**Trigger:** `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts` in `handleDesktopBridgeEvent` when a scoped `preview.act.request` reaches a renderer whose active session differs.

**Causal chain:**
1. Multiple mounted desktop renderers observe the session-scoped preview action event.
2. A renderer showing another session enters the inactive branch and sends `preview.act.respond` with a refusal.
3. The backend accepts the first response for the request id, so the non-owning window can beat the owning window's real result.

**Why it is wrong:** An explicit session mismatch identifies the request as belonging to another renderer. Responding is not a valid authorization decision for that renderer and creates a cross-window response race.

**Working sibling / contrast:** `preview.read.request` has no active-session refusal branch, so an idle window does not win this specific rejection race. Closing the extra window also removes the competing responder.

**Ruled out:** The gateway event already carries `session_id` on current main and on the reported build. The missing behavior is in the renderer response gate, not the backend event frame.

### Fix

A renderer now consumes but does not answer explicitly scoped preview action requests for another active session. Unscoped legacy requests retain the existing fail-fast refusal, while the matching active renderer keeps the existing action path. A focused regression test covers both cases.

## Related Issue

Closes #101016

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts` - leave explicitly scoped action requests unanswered in non-owning windows.
- `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts` - cover scoped multi-window routing and the unscoped compatibility path.

## How to Test

1. Open a preview in one desktop session and keep a second HUD or popout window mounted on another session.
2. Run `drive_preview(action='elements')` from the preview-owning session and confirm the owning window returns the result.
3. Run the focused automated checks:

```bash
cd apps/desktop
npx vitest run src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts
npm run typecheck
npx eslint src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant desktop tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested the automated regression on Windows 11

### Documentation & Housekeeping

- [x] Documentation update is not applicable
- [x] Config example update is not applicable
- [x] Architecture or workflow documentation update is not applicable
- [x] Cross-platform impact was considered; the change is renderer-only TypeScript
- [x] Tool description or schema updates are not applicable

## Screenshots / Logs

Not applicable; the focused regression test captures the competing-response behavior.
