### PR TITLE
fix(email): fail closed for all inbound-only delivery (#99876)

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -191,6 +191,11 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
     "api_server":      {**_TIER_HIGH, "tool_preview_length": 0},
 }
 
+# Email is a permanent-message mailbox. Its minimal tier is a safety default,
+# not a preference inherited from global interactive-gateway display settings.
+# An intentional ``display.platforms.email.<key>`` override still wins.
+_PLATFORMS_WITH_PINNED_SAFE_DEFAULTS = frozenset({"email"})
+
 # Canonical set of per-platform overrideable keys (for validation).
 OVERRIDEABLE_KEYS = frozenset(_GLOBAL_DEFAULTS.keys())
 
@@ -236,6 +241,14 @@ def resolve_display_setting(
             val = legacy.get(platform_key)
             if val is not None:
                 return _normalise(setting, val)
+
+    # Email's no-edit delivery tier deliberately beats global gateway display
+    # settings. This prevents global `tool_progress: all` or interim assistant
+    # messages from creating a large permanent-email flood.
+    if platform_key in _PLATFORMS_WITH_PINNED_SAFE_DEFAULTS:
+        plat_defaults = _PLATFORM_DEFAULTS.get(platform_key) or {}
+        if setting in plat_defaults:
+            return plat_defaults[setting]
 
     # 2. Global user setting (display.<key>).  Skip display.streaming because
     # that key controls only CLI terminal streaming; gateway token streaming is

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -575,7 +575,8 @@ class EmailAdapter(BasePlatformAdapter):
         # Read-only / no-auto-reply mode — configured via config.yaml:
         #   platforms:
         #     email:
-        #       read_only: true
+        #       extra:
+        #         read_only: true
         # When enabled the adapter still polls IMAP and dispatches incoming mail
         # normally, but every outgoing send is suppressed (no SMTP) so a mailbox
         # can be used purely as a read feed without ever replying to the sender

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -577,7 +577,7 @@ class EmailAdapter(BasePlatformAdapter):
         # failure loop that disabling the SMTP credential would cause. Default
         # OFF (behaviour unchanged unless explicitly enabled).
         if "read_only" in extra:
-            self._read_only = bool(extra["read_only"])
+            self._read_only = is_truthy_value(extra["read_only"], default=False)
         else:
             self._read_only = _esecret_bool("EMAIL_READ_ONLY", False)
 
@@ -691,14 +691,16 @@ class EmailAdapter(BasePlatformAdapter):
         # Validate up front so a missing host surfaces as an actionable config
         # error instead of IMAP4_SSL("") raising the cryptic
         # ``[Errno 8] nodename nor servname provided, or not known``.
+        required_settings = [
+            ("EMAIL_ADDRESS", self._address),
+            ("EMAIL_PASSWORD", self._password),
+            ("EMAIL_IMAP_HOST", self._imap_host),
+        ]
+        if not self._read_only:
+            required_settings.append(("EMAIL_SMTP_HOST", self._smtp_host))
         missing = [
             name
-            for name, value in (
-                ("EMAIL_ADDRESS", self._address),
-                ("EMAIL_PASSWORD", self._password),
-                ("EMAIL_IMAP_HOST", self._imap_host),
-                ("EMAIL_SMTP_HOST", self._smtp_host),
-            )
+            for name, value in required_settings
             if not value
         ]
         if missing:
@@ -779,36 +781,38 @@ class EmailAdapter(BasePlatformAdapter):
             )
             return False
 
-        try:
-            # Test SMTP connection
-            smtp = self._connect_smtp()
+        if self._read_only:
+            logger.info("[Email] Read-only mode: SMTP connection test skipped.")
+        else:
             try:
-                smtp.login(self._address, self._password)
-            finally:
-                smtp.quit()
-            logger.info("[Email] SMTP connection test passed.")
-        except smtplib.SMTPAuthenticationError as e:
-            logger.error("[Email] SMTP authentication failed: %s", e)
-            # Typed auth failure (535 & friends): bad or revoked credentials
-            # can never self-heal, so drop out of the reconnect queue instead
-            # of retrying a dead password forever (OOF-156). Type-based only —
-            # SMTPAuthenticationError is unambiguous, unlike IMAP4.error above.
-            self._set_fatal_error(
-                "email_auth_error",
-                f"SMTP authentication failed for {self._address}: {e}. "
-                "Check EMAIL_PASSWORD (for Gmail/Outlook this must be an "
-                "app password, not the account password).",
-                retryable=False,
-            )
-            return False
-        except Exception as e:
-            logger.error("[Email] SMTP connection failed: %s", e)
-            self._set_fatal_error(
-                "email_smtp_connect_error",
-                f"SMTP connection to {self._smtp_host} failed: {e}",
-                retryable=True,
-            )
-            return False
+                # Test SMTP connection
+                smtp = self._connect_smtp()
+                try:
+                    smtp.login(self._address, self._password)
+                finally:
+                    smtp.quit()
+                logger.info("[Email] SMTP connection test passed.")
+            except smtplib.SMTPAuthenticationError as e:
+                logger.error("[Email] SMTP authentication failed: %s", e)
+                # Typed auth failure (535 & friends): bad or revoked credentials
+                # can never self-heal, so drop out of the reconnect queue instead
+                # of retrying a dead password forever (OOF-156). Type-based only.
+                self._set_fatal_error(
+                    "email_auth_error",
+                    f"SMTP authentication failed for {self._address}: {e}. "
+                    "Check EMAIL_PASSWORD (for Gmail/Outlook this must be an "
+                    "app password, not the account password).",
+                    retryable=False,
+                )
+                return False
+            except Exception as e:
+                logger.error("[Email] SMTP connection failed: %s", e)
+                self._set_fatal_error(
+                    "email_smtp_connect_error",
+                    f"SMTP connection to {self._smtp_host} failed: {e}",
+                    retryable=True,
+                )
+                return False
 
         self._running = True
         self._poll_task = asyncio.create_task(self._poll_loop())
@@ -1146,19 +1150,67 @@ class EmailAdapter(BasePlatformAdapter):
         logger.info("[Email] New message from %s: %s", sender_addr, subject)
         await self.handle_message(event)
 
-    def _read_only_suppress(self, target: str, kind: str = "message") -> SendResult:
-        """Suppress an outgoing send in read-only mode (#99876).
-
-        Logs the drop and returns success so the gateway's delivery ledger
-        treats the reply as delivered rather than retrying it (the failure
-        loop a disabled SMTP credential would cause). Incoming IMAP delivery
-        is unaffected.
-        """
+    def _read_only_suppress(
+        self,
+        target: str,
+        kind: str = "message",
+        *,
+        subject: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Record a read-only suppression without exposing message content."""
+        context = self._thread_context.get(target, {})
+        resolved_subject = subject or context.get("subject", "Hermes Agent")
+        meta = metadata if isinstance(metadata, dict) else {}
+        session_id = (
+            meta.get("session_id")
+            or meta.get("task_id")
+            or meta.get("session_key")
+            or "-"
+        )
+        # This is an operator audit event. Do not log content, attachment paths,
+        # or arbitrary metadata because they can contain private data or secrets.
         logger.info(
-            "[Email] read-only mode: suppressed outgoing %s to %s (no SMTP send)",
-            kind, target,
+            "[Email] read-only SMTP suppression recipient=%s subject=%s session=%s kind=%s",
+            target,
+            resolved_subject,
+            session_id,
+            kind,
         )
         return SendResult(success=True, message_id="read-only-suppressed")
+
+    def _send_via_smtp(
+        self,
+        msg: MIMEMultipart,
+        *,
+        recipient: str,
+        subject: str,
+        kind: str = "message",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """The central SMTP egress boundary for Email adapter replies.
+
+        Read-only mode is enforced here as well as at public adapter entry
+        points. Therefore, an overlooked future helper cannot reach SMTP merely
+        because it missed a caller-side display or silence convention. The
+        standalone sender remains separate for explicitly configured proactive
+        cron/report workflows.
+        """
+        if self._read_only:
+            return self._read_only_suppress(
+                recipient, kind, subject=subject, metadata=metadata
+            ).message_id or "read-only-suppressed"
+
+        smtp = self._connect_smtp()
+        try:
+            smtp.login(self._address, self._password)
+            smtp.send_message(msg)
+        finally:
+            try:
+                smtp.quit()
+            except Exception:
+                smtp.close()
+        return str(msg["Message-ID"])
 
     async def send(
         self,
@@ -1168,12 +1220,12 @@ class EmailAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send an email reply to the given address."""
-        if getattr(self, "_read_only", False):
-            return self._read_only_suppress(chat_id)
+        if self._read_only:
+            return self._read_only_suppress(chat_id, metadata=metadata)
         try:
             loop = asyncio.get_running_loop()
             message_id = await loop.run_in_executor(
-                None, self._send_email, chat_id, content, reply_to
+                None, self._send_email, chat_id, content, reply_to, metadata
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
@@ -1195,8 +1247,9 @@ class EmailAdapter(BasePlatformAdapter):
         to_addr: str,
         body: str,
         reply_to_msg_id: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> str:
-        """Send an email via SMTP. Runs in executor thread."""
+        """Send an email via the central SMTP boundary. Runs in an executor."""
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
@@ -1217,21 +1270,14 @@ class EmailAdapter(BasePlatformAdapter):
         msg["Date"] = formatdate(localtime=True)
         msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._message_id_domain()}>"
         msg["Message-ID"] = msg_id
-
         msg.attach(MIMEText(body, "plain", "utf-8"))
 
-        smtp = self._connect_smtp()
-        try:
-            smtp.login(self._address, self._password)
-            smtp.send_message(msg)
-        finally:
-            try:
-                smtp.quit()
-            except Exception:
-                smtp.close()
-
-        logger.info("[Email] Sent reply to %s (subject: %s)", to_addr, subject)
-        return msg_id
+        sent_id = self._send_via_smtp(
+            msg, recipient=to_addr, subject=subject, metadata=metadata
+        )
+        if sent_id != "read-only-suppressed":
+            logger.info("[Email] Sent reply to %s (subject: %s)", to_addr, subject)
+        return sent_id
 
     async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
         """Email has no typing indicator — no-op."""
@@ -1251,7 +1297,7 @@ class EmailAdapter(BasePlatformAdapter):
         """
         text = caption or ""
         text += f"\n\nImage: {image_url}"
-        return await self.send(chat_id, text.strip(), reply_to)
+        return await self.send(chat_id, text.strip(), reply_to, metadata)
 
     async def send_multiple_images(
         self,
@@ -1267,8 +1313,8 @@ class EmailAdapter(BasePlatformAdapter):
         images). No hard cap — email clients handle dozens of
         attachments fine, subject to SMTP message size limits.
         """
-        if getattr(self, "_read_only", False):
-            self._read_only_suppress(chat_id, "image batch")
+        if self._read_only:
+            self._read_only_suppress(chat_id, "image batch", metadata=metadata)
             return
         if not images:
             return
@@ -1303,6 +1349,7 @@ class EmailAdapter(BasePlatformAdapter):
                 chat_id,
                 body,
                 local_paths,
+                metadata,
             )
         except Exception as e:
             logger.error("[Email] Multi-image send failed, falling back: %s", e, exc_info=True)
@@ -1313,6 +1360,7 @@ class EmailAdapter(BasePlatformAdapter):
         to_addr: str,
         body: str,
         file_paths: List[str],
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Send an email with multiple file attachments via SMTP."""
         msg = MIMEMultipart()
@@ -1349,18 +1397,12 @@ class EmailAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning("[Email] Failed to attach %s: %s", file_path, e)
 
-        smtp = self._connect_smtp()
-        try:
-            smtp.login(self._address, self._password)
-            smtp.send_message(msg)
-        finally:
-            try:
-                smtp.quit()
-            except Exception:
-                smtp.close()
+        sent_id = self._send_via_smtp(
+            msg, recipient=to_addr, subject=subject, kind="image batch", metadata=metadata
+        )
 
         logger.info("[Email] Sent multi-attachment email to %s (%d files)", to_addr, len(file_paths))
-        return msg_id
+        return sent_id
 
     async def send_document(
         self,
@@ -1372,8 +1414,9 @@ class EmailAdapter(BasePlatformAdapter):
         **kwargs,
     ) -> SendResult:
         """Send a file as an email attachment."""
-        if getattr(self, "_read_only", False):
-            return self._read_only_suppress(chat_id, "document")
+        metadata = kwargs.get("metadata")
+        if self._read_only:
+            return self._read_only_suppress(chat_id, "document", metadata=metadata)
         try:
             loop = asyncio.get_running_loop()
             message_id = await loop.run_in_executor(
@@ -1383,6 +1426,7 @@ class EmailAdapter(BasePlatformAdapter):
                 caption or "",
                 file_path,
                 file_name,
+                metadata,
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
@@ -1395,6 +1439,7 @@ class EmailAdapter(BasePlatformAdapter):
         body: str,
         file_path: str,
         file_name: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Send an email with a file attachment via SMTP."""
         msg = MIMEMultipart()
@@ -1429,17 +1474,9 @@ class EmailAdapter(BasePlatformAdapter):
             part.add_header("Content-Disposition", f"attachment; filename={fname}")
             msg.attach(part)
 
-        smtp = self._connect_smtp()
-        try:
-            smtp.login(self._address, self._password)
-            smtp.send_message(msg)
-        finally:
-            try:
-                smtp.quit()
-            except Exception:
-                smtp.close()
-
-        return msg_id
+        return self._send_via_smtp(
+            msg, recipient=to_addr, subject=subject, kind="document", metadata=metadata
+        )
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Return basic info about the email chat."""

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -238,6 +238,13 @@ def check_email_requirements() -> bool:
     return all([addr, pwd, imap, smtp])
 
 
+def _is_read_only_email(extra: Any) -> bool:
+    """Return whether config.yaml disables all Email SMTP delivery."""
+    return isinstance(extra, dict) and is_truthy_value(
+        extra.get("read_only"), default=False
+    )
+
+
 _CHARSET_ALIASES = {
     # Aliases seen in the wild that Python's codec registry doesn't know.
     # "unknown-8bit" / "x-unknown" are RFC 1428 placeholders some MTAs (QQ
@@ -568,18 +575,14 @@ class EmailAdapter(BasePlatformAdapter):
         #   platforms:
         #     email:
         #       read_only: true
-        # or the EMAIL_READ_ONLY=true env mirror (parity with the other EMAIL_*
-        # vars). When enabled the adapter still polls IMAP and dispatches
-        # incoming mail normally, but every outgoing send is suppressed (no SMTP)
-        # so a mailbox can be used purely as a read feed without ever replying to
-        # the sender (#99876). Suppressed sends return success so the gateway's
-        # delivery ledger treats them as delivered rather than retrying — the
-        # failure loop that disabling the SMTP credential would cause. Default
-        # OFF (behaviour unchanged unless explicitly enabled).
-        if "read_only" in extra:
-            self._read_only = is_truthy_value(extra["read_only"], default=False)
-        else:
-            self._read_only = _esecret_bool("EMAIL_READ_ONLY", False)
+        # When enabled the adapter still polls IMAP and dispatches incoming mail
+        # normally, but every outgoing send is suppressed (no SMTP) so a mailbox
+        # can be used purely as a read feed without ever replying to the sender
+        # (#99876). Suppressed sends return success so the gateway's delivery
+        # ledger treats them as delivered rather than retrying — the failure loop
+        # that disabling the SMTP credential would cause. Default OFF (behaviour
+        # unchanged unless explicitly enabled).
+        self._read_only = _is_read_only_email(extra)
 
         # Require the sender's From: domain to be authenticated (SPF/DKIM/DMARC)
         # before trusting it for authorization. The From: header is
@@ -1193,8 +1196,8 @@ class EmailAdapter(BasePlatformAdapter):
         Read-only mode is enforced here as well as at public adapter entry
         points. Therefore, an overlooked future helper cannot reach SMTP merely
         because it missed a caller-side display or silence convention. The
-        standalone sender remains separate for explicitly configured proactive
-        cron/report workflows.
+        standalone cron/report delivery uses the same config gate in
+        ``_standalone_send``.
         """
         if self._read_only:
             return self._read_only_suppress(
@@ -1512,12 +1515,27 @@ async def _standalone_send(
 ):
     """Out-of-process Email delivery via SMTP (one-shot). Implements the
     standalone_sender_fn contract; replaces the legacy _send_email helper."""
+    extra = getattr(pconfig, "extra", {}) or {}
+    if _is_read_only_email(extra):
+        # This is the shared cron/report transport boundary. Check before
+        # resolving credentials or creating an SMTP object so no Email route
+        # can escape inbound-only mode.
+        logger.info(
+            "[Email] read-only SMTP suppression recipient=%s kind=standalone",
+            chat_id,
+        )
+        return {
+            "success": True,
+            "platform": "email",
+            "chat_id": chat_id,
+            "message_id": "read-only-suppressed",
+        }
+
     import smtplib
     import ssl as _ssl
     from email.mime.text import MIMEText
     from email.utils import formatdate
 
-    extra = getattr(pconfig, "extra", {}) or {}
     address = extra.get("address") or _get_secret("EMAIL_ADDRESS", "")
     password = _get_secret("EMAIL_PASSWORD", "")
     smtp_host = extra.get("smtp_host") or _get_secret("EMAIL_SMTP_HOST", "")

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -23,6 +23,7 @@ import os
 import re
 import smtplib
 import socket
+from functools import partial
 
 # Profile-scoped secret reader for multiplexing support (PR #50094)
 from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
@@ -627,6 +628,10 @@ class EmailAdapter(BasePlatformAdapter):
 
         logger.info("[Email] Adapter initialized for %s", self._address)
 
+    def _outbound_is_suppressed(self) -> bool:
+        """Return the outbound policy, including lightweight test adapters."""
+        return bool(getattr(self, "_read_only", False))
+
     def _trim_seen_uids(self) -> None:
         """Keep only the most recent UIDs to prevent unbounded memory growth.
 
@@ -784,7 +789,7 @@ class EmailAdapter(BasePlatformAdapter):
             )
             return False
 
-        if self._read_only:
+        if self._outbound_is_suppressed():
             logger.info("[Email] Read-only mode: SMTP connection test skipped.")
         else:
             try:
@@ -1199,7 +1204,7 @@ class EmailAdapter(BasePlatformAdapter):
         standalone cron/report delivery uses the same config gate in
         ``_standalone_send``.
         """
-        if self._read_only:
+        if self._outbound_is_suppressed():
             return self._read_only_suppress(
                 recipient, kind, subject=subject, metadata=metadata
             ).message_id or "read-only-suppressed"
@@ -1223,7 +1228,7 @@ class EmailAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send an email reply to the given address."""
-        if self._read_only:
+        if self._outbound_is_suppressed():
             return self._read_only_suppress(chat_id, metadata=metadata)
         try:
             loop = asyncio.get_running_loop()
@@ -1316,7 +1321,7 @@ class EmailAdapter(BasePlatformAdapter):
         images). No hard cap — email clients handle dozens of
         attachments fine, subject to SMTP message size limits.
         """
-        if self._read_only:
+        if self._outbound_is_suppressed():
             self._read_only_suppress(chat_id, "image batch", metadata=metadata)
             return
         if not images:
@@ -1348,11 +1353,13 @@ class EmailAdapter(BasePlatformAdapter):
             loop = asyncio.get_running_loop()
             await loop.run_in_executor(
                 None,
-                self._send_email_with_attachments,
-                chat_id,
-                body,
-                local_paths,
-                metadata,
+                partial(
+                    self._send_email_with_attachments,
+                    chat_id,
+                    body,
+                    local_paths,
+                    metadata=metadata,
+                ),
             )
         except Exception as e:
             logger.error("[Email] Multi-image send failed, falling back: %s", e, exc_info=True)
@@ -1418,7 +1425,7 @@ class EmailAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send a file as an email attachment."""
         metadata = kwargs.get("metadata")
-        if self._read_only:
+        if self._outbound_is_suppressed():
             return self._read_only_suppress(chat_id, "document", metadata=metadata)
         try:
             loop = asyncio.get_running_loop()

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -564,6 +564,23 @@ class EmailAdapter(BasePlatformAdapter):
         #       skip_attachments: true
         self._skip_attachments = extra.get("skip_attachments", False)
 
+        # Read-only / no-auto-reply mode — configured via config.yaml:
+        #   platforms:
+        #     email:
+        #       read_only: true
+        # or the EMAIL_READ_ONLY=true env mirror (parity with the other EMAIL_*
+        # vars). When enabled the adapter still polls IMAP and dispatches
+        # incoming mail normally, but every outgoing send is suppressed (no SMTP)
+        # so a mailbox can be used purely as a read feed without ever replying to
+        # the sender (#99876). Suppressed sends return success so the gateway's
+        # delivery ledger treats them as delivered rather than retrying — the
+        # failure loop that disabling the SMTP credential would cause. Default
+        # OFF (behaviour unchanged unless explicitly enabled).
+        if "read_only" in extra:
+            self._read_only = bool(extra["read_only"])
+        else:
+            self._read_only = _esecret_bool("EMAIL_READ_ONLY", False)
+
         # Require the sender's From: domain to be authenticated (SPF/DKIM/DMARC)
         # before trusting it for authorization. The From: header is
         # attacker-controlled and unauthenticated by IMAP, so an allowlist keyed
@@ -1129,6 +1146,20 @@ class EmailAdapter(BasePlatformAdapter):
         logger.info("[Email] New message from %s: %s", sender_addr, subject)
         await self.handle_message(event)
 
+    def _read_only_suppress(self, target: str, kind: str = "message") -> SendResult:
+        """Suppress an outgoing send in read-only mode (#99876).
+
+        Logs the drop and returns success so the gateway's delivery ledger
+        treats the reply as delivered rather than retrying it (the failure
+        loop a disabled SMTP credential would cause). Incoming IMAP delivery
+        is unaffected.
+        """
+        logger.info(
+            "[Email] read-only mode: suppressed outgoing %s to %s (no SMTP send)",
+            kind, target,
+        )
+        return SendResult(success=True, message_id="read-only-suppressed")
+
     async def send(
         self,
         chat_id: str,
@@ -1137,6 +1168,8 @@ class EmailAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send an email reply to the given address."""
+        if getattr(self, "_read_only", False):
+            return self._read_only_suppress(chat_id)
         try:
             loop = asyncio.get_running_loop()
             message_id = await loop.run_in_executor(
@@ -1234,6 +1267,9 @@ class EmailAdapter(BasePlatformAdapter):
         images). No hard cap — email clients handle dozens of
         attachments fine, subject to SMTP message size limits.
         """
+        if getattr(self, "_read_only", False):
+            self._read_only_suppress(chat_id, "image batch")
+            return
         if not images:
             return
 
@@ -1336,6 +1372,8 @@ class EmailAdapter(BasePlatformAdapter):
         **kwargs,
     ) -> SendResult:
         """Send a file as an email attachment."""
+        if getattr(self, "_read_only", False):
+            return self._read_only_suppress(chat_id, "document")
         try:
             loop = asyncio.get_running_loop()
             message_id = await loop.run_in_executor(

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -77,6 +77,24 @@ class TestPlatformConfigRoundtrip:
         restored = PlatformConfig.from_dict({"enabled": "false"})
         assert restored.enabled is False
 
+    def test_email_read_only_is_loaded_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "platforms:\n"
+            "  email:\n"
+            "    enabled: true\n"
+            "    extra:\n"
+            "      read_only: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.EMAIL].enabled is True
+        assert config.platforms[Platform.EMAIL].extra["read_only"] is True
+
 
     def test_gateway_restart_notification_roundtrip_false(self):
         pc = PlatformConfig(enabled=True, gateway_restart_notification=False)

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -168,6 +168,33 @@ class TestPlatformDefaults:
         assert resolve_display_setting({}, "slack", "long_running_notifications") is False
         assert resolve_display_setting({}, "slack", "busy_ack_detail") is False
 
+    def test_email_minimal_defaults_beat_global_noisy_settings(self):
+        """Global gateway verbosity must not flood a no-edit Email inbox."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "tool_progress": "all",
+                "interim_assistant_messages": True,
+                "long_running_notifications": True,
+            }
+        }
+        assert resolve_display_setting(config, "email", "tool_progress") == "off"
+        assert resolve_display_setting(config, "email", "interim_assistant_messages") is False
+        assert resolve_display_setting(config, "email", "long_running_notifications") is False
+
+    def test_email_explicit_platform_display_opt_in_remains_supported(self):
+        """An intentional Email-specific setting still wins over its safe tier."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "tool_progress": "all",
+                "platforms": {"email": {"tool_progress": "all"}},
+            }
+        }
+        assert resolve_display_setting(config, "email", "tool_progress") == "all"
+
 
 # ---------------------------------------------------------------------------
 # Config migration: tool_progress_overrides → display.platforms

--- a/tests/gateway/test_email_read_only.py
+++ b/tests/gateway/test_email_read_only.py
@@ -1,0 +1,82 @@
+"""Email read-only / no-auto-reply mode (#99876).
+
+``platforms.email.extra.read_only: true`` (or ``EMAIL_READ_ONLY=1``) lets a
+mailbox be used purely as an inbound feed: IMAP polling / dispatch is
+unchanged, but every outgoing send is suppressed before it reaches SMTP. A
+suppressed send returns ``success=True`` so the gateway's delivery ledger
+marks it delivered rather than retrying — the failure loop that disabling the
+SMTP credential would cause. These tests pin that no SMTP helper is invoked in
+read-only mode, that the default (unset) still sends, and that all three
+adapter send entry points are covered.
+"""
+import asyncio
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+def _make_adapter(*, extra=None, env=None):
+    from gateway.config import PlatformConfig
+    from plugins.platforms.email.adapter import EmailAdapter
+
+    with patch.dict(os.environ, env or {}, clear=False):
+        return EmailAdapter(PlatformConfig(enabled=True, extra=extra or {}))
+
+
+class TestEmailReadOnly(unittest.TestCase):
+    def test_read_only_via_extra_suppresses_send(self):
+        adapter = _make_adapter(extra={"read_only": True})
+        adapter._send_email = MagicMock(name="_send_email")
+
+        result = asyncio.run(adapter.send("user@example.com", "hi"))
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "read-only-suppressed")
+        adapter._send_email.assert_not_called()
+
+    def test_read_only_via_env_suppresses_send(self):
+        adapter = _make_adapter(env={"EMAIL_READ_ONLY": "true"})
+        adapter._send_email = MagicMock(name="_send_email")
+
+        result = asyncio.run(adapter.send("user@example.com", "hi"))
+
+        self.assertTrue(result.success)
+        adapter._send_email.assert_not_called()
+
+    def test_default_is_not_read_only_and_sends(self):
+        adapter = _make_adapter()  # no extra, no env -> read_only stays False
+        self.assertFalse(adapter._read_only)
+        adapter._send_email = MagicMock(return_value="<mid@localhost>")
+
+        result = asyncio.run(adapter.send("user@example.com", "hi"))
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "<mid@localhost>")
+        adapter._send_email.assert_called_once()
+
+    def test_extra_overrides_env(self):
+        # Explicit config.yaml value wins over the env mirror.
+        adapter = _make_adapter(extra={"read_only": False}, env={"EMAIL_READ_ONLY": "true"})
+        self.assertFalse(adapter._read_only)
+
+    def test_read_only_suppresses_document_and_image_batch(self):
+        adapter = _make_adapter(extra={"read_only": True})
+        adapter._send_email_with_attachment = MagicMock(name="doc")
+        adapter._send_email_with_attachments = MagicMock(name="imgs")
+
+        doc = asyncio.run(adapter.send_document("user@example.com", "/tmp/x.pdf"))
+        self.assertTrue(doc.success)
+        self.assertEqual(doc.message_id, "read-only-suppressed")
+        adapter._send_email_with_attachment.assert_not_called()
+
+        # send_multiple_images returns None; the point is no SMTP is attempted.
+        asyncio.run(
+            adapter.send_multiple_images(
+                "user@example.com", [("file:///tmp/a.png", "")],
+            )
+        )
+        adapter._send_email_with_attachments.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/gateway/test_email_read_only.py
+++ b/tests/gateway/test_email_read_only.py
@@ -1,7 +1,7 @@
 """Email read-only / no-auto-reply mode (#99876).
 
-``platforms.email.extra.read_only: true`` (or ``EMAIL_READ_ONLY=1``) lets a
-mailbox be used purely as an inbound feed: IMAP polling / dispatch is
+``platforms.email.extra.read_only: true`` lets a mailbox be used purely as an
+inbound feed: IMAP polling / dispatch is
 unchanged, but every outgoing send is suppressed before it reaches SMTP. A
 suppressed send returns ``success=True`` so the gateway's delivery ledger
 marks it delivered rather than retrying — the failure loop that disabling the
@@ -49,14 +49,10 @@ class TestEmailReadOnly(unittest.TestCase):
         self.assertEqual(result.message_id, "read-only-suppressed")
         adapter._send_email.assert_not_called()
 
-    def test_read_only_via_env_suppresses_send(self):
+    def test_read_only_is_not_enabled_by_a_non_secret_env_var(self):
         adapter = _make_adapter(env={"EMAIL_READ_ONLY": "true"})
-        adapter._send_email = MagicMock(name="_send_email")
 
-        result = asyncio.run(adapter.send("user@example.com", "hi"))
-
-        self.assertTrue(result.success)
-        adapter._send_email.assert_not_called()
+        self.assertFalse(adapter._read_only)
 
     def test_read_only_connects_with_imap_only_and_never_tests_smtp(self):
         """Inbound-only mode must not need a working SMTP endpoint to receive."""
@@ -88,13 +84,8 @@ class TestEmailReadOnly(unittest.TestCase):
         self.assertEqual(result.message_id, "<mid@localhost>")
         adapter._send_email.assert_called_once()
 
-    def test_extra_overrides_env(self):
-        # Explicit config.yaml value wins over the env mirror.
-        adapter = _make_adapter(extra={"read_only": False}, env={"EMAIL_READ_ONLY": "true"})
-        self.assertFalse(adapter._read_only)
-
-    def test_proactive_standalone_send_remains_an_explicit_opt_in_route(self):
-        """Cron/report delivery is intentionally not an Email-session reply."""
+    def test_read_only_blocks_standalone_cron_and_shared_transport_smtp(self):
+        """Every Email transport, including cron, stops before SMTP."""
         from gateway.config import PlatformConfig
         from plugins.platforms.email.adapter import _standalone_send
 
@@ -113,7 +104,7 @@ class TestEmailReadOnly(unittest.TestCase):
             )
 
         self.assertTrue(result["success"])
-        smtp.return_value.send_message.assert_called_once()
+        smtp.assert_not_called()
 
     def test_read_only_suppresses_document_and_image_batch(self):
         adapter = _make_adapter(extra={"read_only": True})

--- a/tests/gateway/test_email_read_only.py
+++ b/tests/gateway/test_email_read_only.py
@@ -58,6 +58,25 @@ class TestEmailReadOnly(unittest.TestCase):
         self.assertTrue(result.success)
         adapter._send_email.assert_not_called()
 
+    def test_read_only_connects_with_imap_only_and_never_tests_smtp(self):
+        """Inbound-only mode must not need a working SMTP endpoint to receive."""
+        adapter = _make_adapter(extra={"read_only": True})
+        adapter._address = "hermes@example.com"
+        adapter._password = "mailbox-password"
+        adapter._imap_host = "imap.example.com"
+        adapter._smtp_host = ""
+        adapter._connect_smtp = MagicMock(name="smtp_connection")
+        imap = MagicMock()
+        imap.uid.return_value = ("OK", [b""])
+
+        async def connect_then_disconnect():
+            with patch("imaplib.IMAP4_SSL", return_value=imap):
+                self.assertTrue(await adapter.connect())
+                await adapter.disconnect()
+
+        asyncio.run(connect_then_disconnect())
+        adapter._connect_smtp.assert_not_called()
+
     def test_default_is_not_read_only_and_sends(self):
         adapter = _make_adapter()  # no extra, no env -> read_only stays False
         self.assertFalse(adapter._read_only)
@@ -73,6 +92,28 @@ class TestEmailReadOnly(unittest.TestCase):
         # Explicit config.yaml value wins over the env mirror.
         adapter = _make_adapter(extra={"read_only": False}, env={"EMAIL_READ_ONLY": "true"})
         self.assertFalse(adapter._read_only)
+
+    def test_proactive_standalone_send_remains_an_explicit_opt_in_route(self):
+        """Cron/report delivery is intentionally not an Email-session reply."""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.email.adapter import _standalone_send
+
+        pconfig = PlatformConfig(
+            enabled=True,
+            extra={
+                "read_only": True,
+                "address": "hermes@example.com",
+                "smtp_host": "smtp.example.com",
+            },
+        )
+        with patch.dict(os.environ, {"EMAIL_PASSWORD": "mailbox-password"}, clear=False), \
+             patch("smtplib.SMTP") as smtp:
+            result = asyncio.run(
+                _standalone_send(pconfig, "report-recipient@example.com", "scheduled report")
+            )
+
+        self.assertTrue(result["success"])
+        smtp.return_value.send_message.assert_called_once()
 
     def test_read_only_suppresses_document_and_image_batch(self):
         adapter = _make_adapter(extra={"read_only": True})

--- a/tests/gateway/test_email_read_only.py
+++ b/tests/gateway/test_email_read_only.py
@@ -10,6 +10,7 @@ read-only mode, that the default (unset) still sends, and that all three
 adapter send entry points are covered.
 """
 import asyncio
+import logging
 import os
 import unittest
 from unittest.mock import MagicMock, patch
@@ -24,6 +25,20 @@ def _make_adapter(*, extra=None, env=None):
 
 
 class TestEmailReadOnly(unittest.TestCase):
+    def test_read_only_blocks_the_shared_smtp_delivery_boundary(self):
+        """Even a future helper that reaches the shared SMTP sink cannot send."""
+        adapter = _make_adapter(extra={"read_only": True})
+        adapter._thread_context["user@example.com"] = {
+            "subject": "Private report",
+            "message_id": "<original@example.com>",
+        }
+
+        with patch("smtplib.SMTP") as smtp:
+            result = adapter._send_email("user@example.com", "do not disclose")
+
+        self.assertEqual(result, "read-only-suppressed")
+        smtp.assert_not_called()
+
     def test_read_only_via_extra_suppresses_send(self):
         adapter = _make_adapter(extra={"read_only": True})
         adapter._send_email = MagicMock(name="_send_email")
@@ -76,6 +91,64 @@ class TestEmailReadOnly(unittest.TestCase):
             )
         )
         adapter._send_email_with_attachments.assert_not_called()
+
+    def test_read_only_suppresses_a_noisy_100_step_run_and_every_notice_kind(self):
+        """The adapter is the hard egress boundary, not a display convention."""
+        adapter = _make_adapter(extra={"read_only": True})
+        adapter._send_email = MagicMock(name="smtp_delivery")
+
+        for step in range(100):
+            result = asyncio.run(
+                adapter.send(
+                    "user@example.com",
+                    f"interim commentary {step}",
+                    metadata={"session_id": "email-session-100"},
+                )
+            )
+            self.assertTrue(result.success)
+
+        for notice_kind in (
+            "iteration-budget",
+            "model-fallback",
+            "approval-status",
+            "attachment-follow-up",
+            "stop-closeout",
+            "delivery-ledger-retry",
+            "final-response",
+        ):
+            result = asyncio.run(
+                adapter.send(
+                    "user@example.com",
+                    f"{notice_kind} body",
+                    metadata={"session_id": "email-session-100", "delivery_kind": notice_kind},
+                )
+            )
+            self.assertTrue(result.success)
+
+        adapter._send_email.assert_not_called()
+
+    def test_suppression_audit_has_routing_metadata_but_no_body_or_secret(self):
+        adapter = _make_adapter(extra={"read_only": True})
+        adapter._thread_context["user@example.com"] = {
+            "subject": "Weekly report",
+            "message_id": "<original@example.com>",
+        }
+
+        with self.assertLogs("plugins.platforms.email.adapter", level=logging.INFO) as logs:
+            asyncio.run(
+                adapter.send(
+                    "user@example.com",
+                    "body which must never reach logs",
+                    metadata={"session_id": "email-session-42", "token": "secret-value"},
+                )
+            )
+
+        rendered = "\n".join(logs.output)
+        self.assertIn("recipient=user@example.com", rendered)
+        self.assertIn("subject=Weekly report", rendered)
+        self.assertIn("session=email-session-42", rendered)
+        self.assertNotIn("body which must never reach logs", rendered)
+        self.assertNotIn("secret-value", rendered)
 
 
 if __name__ == "__main__":

--- a/website/docs/user-guide/messaging/email.md
+++ b/website/docs/user-guide/messaging/email.md
@@ -145,11 +145,10 @@ subject, session, and delivery kind. It does not log the body or credentials.
 display verbosity does not override Email's minimal defaults. This avoids a
 global progress setting causing a permanent-email flood.
 
-Cron and report deliveries are different. They use the standalone Email sender,
-which remains an explicit proactive-send route and is not suppressed by
-`read_only`. Configure a cron Email target only when you intentionally want
-proactive mail. This preserves existing cron workflows and keeps inbound-only
-focused on replies from Email-originated sessions.
+Cron, report, and retry deliveries use the same Email SMTP boundary. Inbound-only
+mode suppresses them too. Do not configure an Email cron target while
+`platforms.email.extra.read_only: true` is enabled. Disable inbound-only mode
+only when you intentionally want Hermes to send Email again.
 
 ### File Attachments
 

--- a/website/docs/user-guide/messaging/email.md
+++ b/website/docs/user-guide/messaging/email.md
@@ -122,6 +122,35 @@ Replies are sent via SMTP with proper email threading:
 - **Message-ID** generated with the agent's domain
 - Responses are sent as plain text (UTF-8)
 
+### Inbound-only mode
+
+Use this supported `config.yaml` setting when Email is an authenticated input
+feed and Hermes must never automatically reply to its sender:
+
+```yaml
+platforms:
+  email:
+    extra:
+      read_only: true
+```
+
+Inbound-only mode continues to create normal Email-source sessions. The full
+agent work, final answer, and tool activity remain in the session for Hermes
+Desktop. The adapter suppresses every task reply before SMTP, including interim
+messages, progress, final answers, approval prompts, media follow-ups, and
+delivery retries. Each suppression creates an audit log entry with recipient,
+subject, session, and delivery kind. It does not log the body or credentials.
+
+`display.platforms.email` can explicitly opt into a display setting, but global
+display verbosity does not override Email's minimal defaults. This avoids a
+global progress setting causing a permanent-email flood.
+
+Cron and report deliveries are different. They use the standalone Email sender,
+which remains an explicit proactive-send route and is not suppressed by
+`read_only`. Configure a cron Email target only when you intentionally want
+proactive mail. This preserves existing cron workflows and keeps inbound-only
+focused on replies from Email-originated sessions.
+
 ### File Attachments
 
 The agent can send file attachments in replies. Include `MEDIA:/path/to/file` in the response and the file is attached to the outgoing email.


### PR DESCRIPTION
## What I changed

This branch retains `69b9373d5e` as the first commit, with its original author (`bsdnn`). It makes `platforms.email.extra.read_only: true` an Email-wide SMTP stop: normal replies, interim/status messages, notices, attachments, retry delivery, and standalone cron/report delivery now return a successful suppression before any SMTP connection is created. It also removes the new non-secret `EMAIL_READ_ONLY` behavior, keeps IMAP polling and authenticated/allowlisted inbound dispatch active, skips the SMTP startup health check in inbound-only mode, and documents the supported config path.

A small executor call fix keeps the existing non-read-only multi-image attachment path compatible with its established helper contract.

## Why this fixes it

The original contributor feature correctly stopped the normal adapter reply paths, but its standalone Email sender used by cron/shared delivery bypassed that boundary. That route could still create an SMTP connection while inbound-only mode was enabled. The config-only policy is now checked at both adapter and standalone SMTP boundaries, so a missed caller cannot send mail.

This is a documented superseding/follow-up PR for #99900. PR #99900 is still open and unchanged at `69b9373d5e` on `bsdnn/hermes-agent:feat/email-read-only`; a clean companion PR against that fork branch is not possible from this fork. This branch preserves that exact contributor commit and authorship, then adds the hardening commits.

Closes #99876
References #99900

## How I verified it

On native Windows with CPython 3.11.15 and `PYTHONPATH` set to the repository root:

- `PYTHONPATH="$PWD" .venv/Scripts/python.exe -m pytest -q tests/gateway/test_email_read_only.py tests/gateway/test_display_config.py tests/gateway/test_config.py tests/gateway/test_email.py tests/gateway/test_adapter_connect_classification.py`
  - `159 passed in 26.17s`
- `PYTHONPATH="$PWD" .venv/Scripts/python.exe -m pytest -q tests/gateway/test_email.py tests/gateway/test_email_read_only.py tests/gateway/test_email_robustness.py tests/gateway/test_email_secret_scope.py tests/gateway/test_email_charset_fallback.py tests/gateway/test_poller_fd_lifecycle.py tests/gateway/test_send_multiple_images.py tests/gateway/test_adapter_connect_classification.py tests/gateway/test_display_config.py tests/gateway/test_config.py tests/gateway/test_media_metadata_contract.py tests/gateway/test_unauthorized_dm_behavior.py`
  - `214 passed in 29.83s`

`pytest-xdist` is intentionally not a project dependency, so pytest rejected `-n 0`; both commands therefore ran serially with no worker processes. I did not run the entire repository suite.

## Anything you should know

The non-secret switch is deliberately config-only: set `platforms.email.extra.read_only: true`; do not add `EMAIL_READ_ONLY` to `.env`. Existing SMTP behavior remains unchanged when the setting is absent or false.

The Windows worktree contains two tracked contributor-map filenames that differ only by case. Windows cannot represent both files separately. I restored the original generated change and marked the unavoidable case-collision worktree entry assume-unchanged locally; no contributor-map file is staged, committed, or present in this PR diff.