### PR TITLE
fix(weixin): recycle the send session after exhausted-retry failures

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1460,6 +1460,28 @@ class WeixinAdapter(BasePlatformAdapter):
             except Exception as exc:
                 logger.debug("[%s] old poll session close failed: %s", self.name, exc)
 
+    async def _recycle_send_session(self) -> None:
+        """Replace ``_send_session`` with a fresh one, closing the old.
+
+        A stalled poll connection (e.g. ``[WinError 121]``) can leave the
+        outbound connector's pooled sockets unusable, so every subsequent
+        ``sendmessage`` fails until the gateway is restarted (#101039).
+        Swap-then-close mirrors ``_recycle_poll_session`` so an in-flight
+        send on the old session finishes or fails independently.
+        """
+        if not self._running or aiohttp is None:
+            return
+        old = self._send_session
+        no_timeout = aiohttp.ClientTimeout(total=None, connect=None, sock_connect=None, sock_read=None)
+        self._send_session = aiohttp.ClientSession(
+            trust_env=True, connector=_make_ssl_connector(), timeout=no_timeout
+        )
+        if old is not None and not old.closed:
+            try:
+                await old.close()
+            except Exception as exc:
+                logger.debug("[%s] old send session close failed: %s", self.name, exc)
+
     async def _process_message_safe(self, message: Dict[str, Any]) -> None:
         try:
             await self._process_message(message)
@@ -1894,6 +1916,11 @@ class WeixinAdapter(BasePlatformAdapter):
             except Exception as exc:
                 last_error = exc
                 if attempt >= self._send_chunk_retries:
+                    # Every retry on this session failed — it is likely the
+                    # connection, not the message, so recycle it before
+                    # surfacing the error instead of leaving future sends
+                    # doomed to repeat the same failure (#101039).
+                    await self._recycle_send_session()
                     break
                 wait = self._send_chunk_retry_delay_seconds * (attempt + 1)
                 logger.warning(

--- a/tests/gateway/test_poller_fd_lifecycle.py
+++ b/tests/gateway/test_poller_fd_lifecycle.py
@@ -193,5 +193,98 @@ class TestWeixinPollSessionRecycle(unittest.TestCase):
         self.assertEqual(calls["recycled"], 1)
 
 
+class TestWeixinSendSessionRecycle(unittest.TestCase):
+    """The weixin send path must recycle its session once retries are
+    exhausted, mirroring the poll-session recycle above (#101039): a
+    stalled connection (e.g. a Windows ``[WinError 121]`` poll error) can
+    leave the send connector's pooled sockets unusable, so every
+    subsequent ``sendmessage`` keeps failing — misreported as a rate
+    limit — until the gateway is restarted.
+    """
+
+    def _make_adapter(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.weixin import WeixinAdapter
+
+        return WeixinAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="test-token",
+                extra={"account_id": "test-account"},
+            )
+        )
+
+    def test_recycle_closes_old_and_installs_fresh_session(self):
+        from gateway.platforms import weixin as weixin_mod
+
+        adapter = self._make_adapter()
+        adapter._running = True
+
+        closed = {"v": False}
+
+        async def _aclose():
+            closed["v"] = True
+
+        old_session = MagicMock()
+        old_session.closed = False
+        old_session.close = _aclose
+        adapter._send_session = old_session
+
+        new_session = MagicMock()
+        with patch.object(
+            weixin_mod.aiohttp, "ClientSession", return_value=new_session
+        ) as mk:
+            asyncio.run(adapter._recycle_send_session())
+
+        mk.assert_called_once()
+        self.assertIs(adapter._send_session, new_session)
+        self.assertTrue(closed["v"])
+
+    def test_recycle_noop_when_not_running(self):
+        adapter = self._make_adapter()
+        adapter._running = False
+        sentinel = MagicMock()
+        adapter._send_session = sentinel
+        asyncio.run(adapter._recycle_send_session())
+        self.assertIs(adapter._send_session, sentinel)
+
+    def test_send_chunk_recycles_session_after_retries_exhausted(self):
+        from gateway.platforms import weixin as weixin_mod
+
+        adapter = self._make_adapter()
+        adapter._running = True
+        adapter._send_session = MagicMock()
+        adapter._token = "test-token"
+        adapter._base_url = "https://weixin.example.com"
+        adapter._send_chunk_retries = 2
+        adapter._send_chunk_retry_delay_seconds = 0
+
+        async def _always_fails(*args, **kwargs):
+            raise ConnectionError("Cannot connect to host via proxy")
+
+        recycled = {"n": 0}
+
+        async def _fake_recycle():
+            recycled["n"] += 1
+
+        async def _no_sleep(_secs):
+            return None
+
+        with patch.object(weixin_mod, "_send_message", _always_fails), \
+                patch.object(weixin_mod.asyncio, "sleep", _no_sleep), \
+                patch.object(adapter, "_recycle_send_session", _fake_recycle):
+            with self.assertRaises(ConnectionError):
+                asyncio.run(
+                    adapter._send_text_chunk(
+                        chat_id="wxid_test123",
+                        chunk="hello",
+                        context_token="ctx",
+                        client_id="hermes-weixin-test",
+                    )
+                )
+
+        self.assertEqual(recycled["n"], 1)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What does this PR do?

Fixes a stuck-connection failure mode in the Weixin (iLink) adapter: once
the outbound send session's connection breaks, every subsequent send
fails on the same broken session — and gets misreported as "rate
limited" — until the gateway is manually restarted.

`gateway/platforms/weixin.py` already recycles `_poll_session` after a
consecutive-failure streak (`_recycle_poll_session`, added for #79889 —
failed connections through a proxy strand sockets in the aiohttp
connector). `_send_session` never got the same treatment: it is created
once in `connect()` and only ever closed in `disconnect()`. If a poll
error (e.g. a Windows `[WinError 121]` semaphore timeout) leaves the
underlying network path in a bad state, the send session's pooled
connections can become permanently unusable, and `_send_text_chunk_locked`
just keeps retrying the same broken session until its retry budget is
exhausted, then raises — with no path back to a healthy connection short
of a full gateway restart.

## Related Issue

Fixes #101039

`gateway/platforms/weixin.py` on current `main` already distinguishes
genuine iLink rate-limit responses (`ret`/`errcode == -2`) from other
protocol errors and from HTTP-level failures — so the issue's literal
"every non-200 response defaults to rate limited" no longer reproduces
verbatim. But the deeper root cause the report identifies — "iLink
connection breaks after a poll error, and all subsequent sendmessage
requests fail, recovered only by restarting the gateway" — is still real:
there is no reconnect/recycle path for the send session at all.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/weixin.py`: added `_recycle_send_session()` (mirrors
  the existing `_recycle_poll_session()`: swap-then-close so an in-flight
  send on the old session finishes or fails independently). Wired it into
  `_send_text_chunk_locked`'s connection-error retry path — called once
  the per-chunk retry budget (`_send_chunk_retries`) is exhausted, right
  before the error is raised, so the *next* send (this cron task's next
  tick, or any other outbound message) gets a fresh session instead of
  repeating the same failure.
- `tests/gateway/test_poller_fd_lifecycle.py`: added
  `TestWeixinSendSessionRecycle` (3 tests), following the existing
  `TestWeixinPollSessionRecycle` pattern in the same file.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_poller_fd_lifecycle.py tests/gateway/test_weixin.py tests/gateway/test_weixin_secret_scope.py tests/gateway/test_weixin_typing.py -v`
2. Confirmed the new tests fail without the fix: reverted just
   `gateway/platforms/weixin.py` to `HEAD~1` (keeping the new test file),
   reran — all 3 new tests fail with
   `AttributeError: 'WeixinAdapter' object has no attribute '_recycle_send_session'`.
   Restored the fix and reran — all pass.

### Test output (with fix)

```
▶ running per-file parallel test suite via run_tests_parallel.py
Discovered 4 test files (~54 tests)
[100.0% |    54/~54 | ✓54 | ✗0] ✓ tests/gateway/test_weixin.py (30✓, 3.0s)
[100.0% |    54/~54 | ✓54 | ✗0] ✓ tests/gateway/test_poller_fd_lifecycle.py (12✓, 1.6s)
[100.0% |    54/~54 | ✓54 | ✗0] ✓ tests/gateway/test_weixin_secret_scope.py (8✓, 1.5s)
[100.0% |    54/~54 | ✓54 | ✗0] ✓ tests/gateway/test_weixin_typing.py (4✓, 1.5s)

=== Summary: 4 files, 54 tests passed, 0 failed (100% complete) in 3.0s (8 workers) ===
```

### Test output (fix reverted, new tests only)

```
FAILED tests/gateway/test_poller_fd_lifecycle.py::TestWeixinSendSessionRecycle::test_recycle_closes_old_and_installs_fresh_session
FAILED tests/gateway/test_poller_fd_lifecycle.py::TestWeixinSendSessionRecycle::test_recycle_noop_when_not_running
FAILED tests/gateway/test_poller_fd_lifecycle.py::TestWeixinSendSessionRecycle::test_send_chunk_recycles_session_after_retries_exhausted
======================= 3 failed, 9 deselected in 0.64s ========================
```

`ruff check gateway/platforms/weixin.py tests/gateway/test_poller_fd_lifecycle.py` — all checks passed.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(weixin):`)
- [x] I searched for existing PRs (open) to make sure this isn't a duplicate — none reference #101039 or touch `_send_session` recycling; the closest related open PR (#94423) fixes different client-side false-success defects and explicitly does not address session recovery
- [x] My PR contains only changes related to this fix
- [x] I've run the test suite and all relevant tests pass
- [x] I've added tests for my changes
- [ ] I've tested on my platform — no Windows/macOS Weixin/iLink account available in this environment; covered by unit tests only

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or tool schemas changed

## Disclosure

This PR was written with AI assistance (Claude), with the diagnosis,
fix, and tests reviewed against the current `main` source before
submission.
