### PR TITLE
fix(trajectory_compressor): handle empty input in single-file sample mode

### DIFF
--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -1523,7 +1523,7 @@ def main(
         if sample_percent is not None:
             random.seed(seed)
             sample_size = max(1, int(total_entries * sample_percent / 100))
-            entries = random.sample(entries, sample_size)
+            entries = random.sample(entries, min(sample_size, len(entries)))
             print(f"   Sampled {len(entries):,} trajectories ({sample_percent}% of {total_entries:,})")
         
         if dry_run:


### PR DESCRIPTION
## What does this PR do?

Fixes a crash in `trajectory_compressor.py` when running in single-file mode with `--sample_percent` on an empty JSONL file (or a file with only invalid JSON lines).

## Related Issue

Fixes #93737

## Type of Change

🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Clamped `random.sample` size to `min(sample_size, len(entries))` in the single-file branch (line 1526), mirroring the existing guard in the directory branch (line 1605).

## How to Test

```bash
echo -n  > empty.jsonl
python trajectory_compressor.py --input empty.jsonl --sample_percent 50 --dry_run
```

Before: `ValueError: Sample larger than population or is negative`
After: Prints "Sampled 0 trajectories (50% of 0)" and exits cleanly.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope): description`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've tested on my platform: Windows 11 (WSL2/git-bash)
- [x] I've considered cross-platform impact