### PR TITLE
fix(compression): start attempt clocks after setup

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -733,11 +733,13 @@ class CompressionCommitFence:
             self.set_total_ceiling_seconds(total_ceiling_seconds)
 
     def set_total_ceiling_seconds(self, seconds: float) -> None:
-        """Arm the wall-clock deadline shared by the host and worker."""
+        """Arm the wall-clock and no-progress clocks for a new attempt."""
         seconds = float(seconds)
         if seconds <= 0:
             raise ValueError("total compression ceiling must be positive")
-        self._deadline = time.monotonic() + seconds
+        now = time.monotonic()
+        self._last_progress = now
+        self._deadline = now + seconds
 
     def touch_progress(self) -> None:
         """Record forward progress (e.g. a streamed summary token arriving).
@@ -1520,7 +1522,6 @@ def run_compress_context_with_progress_timeout(
     ceiling = max(float(total_ceiling_seconds), float(idle_timeout_seconds))
     idle = float(idle_timeout_seconds)
     fence = fence if fence is not None else CompressionCommitFence()
-    fence.set_total_ceiling_seconds(ceiling)
     # Sync mirror of gateway session-hygiene's run_in_executor(None, ...) +
     # wait_for loop (gateway/run.py): offload compress_context onto the shared
     # daemon pool, poll with an inactivity budget + total ceiling, then
@@ -1571,12 +1572,13 @@ def run_compress_context_with_progress_timeout(
             return messages, ""
         return worker(worker_fence)
 
-    # Bare pool workers start with an empty ContextVar map; propagate the
-    # parent conversation/approval context into the worker.
+    # Capture the parent context before the attempt clocks start: this helper
+    # can lazily import approval plumbing, which is setup work rather than
+    # summary-model time. Every failure after admission must release the slot.
     try:
-        future = executor.submit(
-            propagate_context_to_thread(_fence_gated_worker), fence
-        )
+        wrapped_worker = propagate_context_to_thread(_fence_gated_worker)
+        fence.set_total_ceiling_seconds(ceiling)
+        future = executor.submit(wrapped_worker, fence)
     except BaseException:
         _release_compression_admission()
         raise

--- a/tests/agent/test_compression_review_76354.py
+++ b/tests/agent/test_compression_review_76354.py
@@ -183,7 +183,64 @@ class _InjectingExecutor:
         )
 
 
+class TestAttemptClockStart:
+    def test_parent_context_setup_does_not_consume_attempt_budget(self, monkeypatch):
+        """Only summary work, not wrapper setup, is charged to the attempt."""
+        real_propagate = __import__(
+            "tools.thread_context", fromlist=["propagate_context_to_thread"]
+        ).propagate_context_to_thread
+
+        def slow_setup(worker):
+            time.sleep(0.06)
+            return real_propagate(worker)
+
+        monkeypatch.setattr(
+            "tools.thread_context.propagate_context_to_thread", slow_setup
+        )
+        compressed = [{"role": "assistant", "content": "summary"}]
+        result = run_compress_context_with_progress_timeout(
+            worker=lambda _fence: (compressed, "summarized-prompt"),
+            messages=[{"role": "user", "content": "original"}],
+            system_prompt_fallback="fallback",
+            idle_timeout_seconds=0.05,
+            total_ceiling_seconds=0.05,
+        )
+        assert result == (compressed, "summarized-prompt")
+        _drain_admission_slots()
+
+
 class TestF2HostUnwindRevokesAdmission:
+    def test_wrapper_setup_failure_releases_admission(self, monkeypatch):
+        """Parent-side context setup can fail before a future exists."""
+        balance = 0
+
+        def admit():
+            nonlocal balance
+            balance += 1
+            return True
+
+        def release():
+            nonlocal balance
+            balance -= 1
+
+        def fail_setup(_worker):
+            raise RuntimeError("context setup failed")
+
+        monkeypatch.setattr(cc, "_try_admit_compression_job", admit)
+        monkeypatch.setattr(cc, "_release_compression_admission", release)
+        monkeypatch.setattr(
+            "tools.thread_context.propagate_context_to_thread", fail_setup
+        )
+        with pytest.raises(RuntimeError, match="context setup failed"):
+            run_compress_context_with_progress_timeout(
+                worker=lambda _fence: ([], ""),
+                messages=[],
+                system_prompt_fallback="fallback",
+                idle_timeout_seconds=1.0,
+                total_ceiling_seconds=1.0,
+            )
+        assert balance == 0
+
     @pytest.mark.parametrize(
         "exc_type", [KeyboardInterrupt, RuntimeError], ids=["ki", "generic"]
     )


### PR DESCRIPTION
## Summary
- start compression attempt timing after parent context wrapping
- reset the no-progress baseline whenever a fence is armed
- release bounded-pool admission if parent-side setup fails
- add deterministic regressions for setup latency and setup failure

## Root cause
`propagate_context_to_thread(...)` can perform lazy parent-side imports before the worker is submitted. The fence deadline and no-progress clock were armed before that setup, so setup latency could expire the attempt before the primary worker started.

## Test plan
- `uv run --extra dev pytest -q tests/agent/test_compression_stall_fallback_78981.py tests/agent/test_compression_attempt_lifecycle.py tests/agent/test_compression_attempt_ownership.py tests/agent/test_context_compressor.py tests/agent/test_compression_review_76354.py` (195 passed)
- `uv run --extra dev ruff check agent/conversation_compression.py tests/agent/test_compression_review_76354.py`
- `git diff --check`

Related: #98722, #99692
