### PR TITLE
fix(telegram): allow inline-button callbacks to trigger gateway commands in-process

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -7409,6 +7409,17 @@ class TelegramAdapter(BasePlatformAdapter):
         "vip-domain":   ("vip-add.sh",         ["domain"], "✓ marked VIP domain",  True),
     }
 
+    # Gateway slash commands that a gmail-triage inline button may trigger
+    # in-process. Telegram never delivers a bot's own outgoing messages back to
+    # the bot, so a script that sends "/reset" cannot reach the command handler.
+    # These verbs instead reconstruct the caller's SessionSource from the
+    # callback metadata and route a synthetic MessageEvent straight into the
+    # runner's normal _handle_message pipeline (auth + command + busy-guard +
+    # session resolution all still apply).
+    _GT_COMMAND_DISPATCH = {
+        "reset": ("/reset", "✓ reset requested"),
+    }
+
     async def _handle_gmail_triage_callback(
         self,
         query,
@@ -7435,6 +7446,19 @@ class TelegramAdapter(BasePlatformAdapter):
             user_name=query_user_name,
         ):
             await query.answer(text="⛔ You are not authorized to act on this email.")
+            return
+
+        command_entry = self._GT_COMMAND_DISPATCH.get(verb)
+        if command_entry is not None:
+            await self._run_command_verb(
+                command_entry,
+                query,
+                caller_id=caller_id,
+                chat_id=query_chat_id,
+                chat_type=query_chat_type,
+                thread_id=query_thread_id,
+                user_name=query_user_name,
+            )
             return
 
         entry = self._GT_VERB_DISPATCH.get(verb)
@@ -7502,6 +7526,57 @@ class TelegramAdapter(BasePlatformAdapter):
                 await query.edit_message_text(text=appended, reply_markup=None)
         except Exception:
             pass
+
+    async def _run_command_verb(self, command_entry, query, *, caller_id, chat_id, chat_type, thread_id, user_name) -> None:
+        """Run a gateway slash command from a gmail-triage inline-button verb.
+
+        Reconstructs the caller's :class:`SessionSource` from the callback
+        metadata and routes a synthetic ``MessageEvent`` (text = the slash
+        command, e.g. ``/reset``) into the runner's normal
+        ``_handle_message`` pipeline, so authorization, command detection, the
+        busy-guard, and session-key resolution all apply exactly as they do for
+        a typed command. Script dispatch is untouched.
+        """
+        command_text, success_label = command_entry
+
+        runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+        handler = getattr(runner, "_handle_message", None)
+        if not callable(handler):
+            await query.answer(text="❌ gateway runner unavailable")
+            logger.error("[%s] command verb %s: no _handle_message on runner", self.name, command_text)
+            return
+
+        try:
+            from gateway.session import SessionSource
+
+            normalized_chat_type = str(chat_type or "dm").strip().lower() or "dm"
+            if normalized_chat_type == "private":
+                normalized_chat_type = "dm"
+            elif normalized_chat_type == "supergroup":
+                normalized_chat_type = "forum" if thread_id is not None else "group"
+
+            source = SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id=str(chat_id or caller_id),
+                chat_type=normalized_chat_type,
+                user_id=str(caller_id or "").strip(),
+                user_name=str(user_name).strip() if user_name else None,
+                thread_id=str(thread_id) if thread_id is not None else None,
+            )
+        except Exception as exc:
+            await query.answer(text="❌ could not build session source")
+            logger.error("[%s] command verb %s: SessionSource build failed: %s", self.name, command_text, exc, exc_info=True)
+            return
+
+        event = MessageEvent(text=command_text, source=source, user_id=source.user_id, user_name=source.user_name)
+
+        await query.answer(text=success_label)
+        try:
+            await handler(event)
+        except Exception as exc:
+            logger.error("[%s] command verb %s: _handle_message raised: %s", self.name, command_text, exc, exc_info=True)
+        # The runner's own send path reports the command's real result; nothing
+        # to echo back here beyond the ack already given.
 
     def _missing_media_path_error(self, label: str, path: str) -> str:
         """Build an actionable file-not-found error for gateway MEDIA delivery.

--- a/tests/gateway/test_telegram_command_verb.py
+++ b/tests/gateway/test_telegram_command_verb.py
@@ -1,0 +1,171 @@
+"""Tests for gmail-triage command-verb dispatch.
+
+Inline-button callbacks are limited to shelling out to scripts. A command verb
+(e.g. ``reset``) must instead reconstruct the caller's SessionSource from the
+callback metadata and route a synthetic MessageEvent into the runner's
+_handle_message pipeline, because Telegram never delivers a bot's own outgoing
+``/reset`` back to the bot.
+"""
+
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import PlatformConfig, Platform
+
+
+# -- Fake telegram modules (minimal stubs) --------------------------------
+
+_fake_telegram_error = types.ModuleType("telegram.error")
+
+
+class _TelegramError(Exception):
+    pass
+
+
+_fake_telegram_error.TelegramError = _TelegramError
+_fake_telegram_error.BadRequest = type("BadRequest", (_TelegramError,), {})
+_fake_telegram_error.NetworkError = type("NetworkError", (_TelegramError,), {})
+
+_fake_telegram_constants = types.ModuleType("telegram.constants")
+_fake_telegram_constants.ParseMode = SimpleNamespace(HTML="HTML")
+
+_fake_telegram_request = types.ModuleType("telegram.request")
+_fake_telegram_request.HTTPXRequest = type("HTTPXRequest", (), {"__init__": lambda *a, **kw: None})
+
+_fake_telegram_ext = types.ModuleType("telegram.ext")
+_fake_telegram_ext.ApplicationBuilder = type("ApplicationBuilder", (), {
+    "token": lambda self, *a: self,
+    "build": lambda self: None,
+})
+
+_fake_telegram = types.ModuleType("telegram")
+_fake_telegram.error = _fake_telegram_error
+_fake_telegram.constants = _fake_telegram_constants
+_fake_telegram.ext = _fake_telegram_ext
+_fake_telegram.request = _fake_telegram_request
+
+
+@pytest.fixture(autouse=True)
+def _inject_fake_telegram(monkeypatch):
+    monkeypatch.setitem(sys.modules, "telegram", _fake_telegram)
+    monkeypatch.setitem(sys.modules, "telegram.error", _fake_telegram_error)
+    monkeypatch.setitem(sys.modules, "telegram.constants", _fake_telegram_constants)
+    monkeypatch.setitem(sys.modules, "telegram.ext", _fake_telegram_ext)
+    monkeypatch.setitem(sys.modules, "telegram.request", _fake_telegram_request)
+
+
+def _make_adapter(monkeypatch, *, handler=None):
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    config = PlatformConfig(enabled=True, token="fake-token")
+    adapter = object.__new__(TelegramAdapter)
+    adapter.config = config
+    adapter._config = config
+    adapter._platform = Platform.TELEGRAM
+    adapter._connected = True
+    # NOTE: `name` is a read-only property on TelegramAdapter, so leave it out.
+
+    # Stub the runner back-pointer. The adapter resolves the runner via
+    # ``getattr(getattr(self, "_message_handler", None), "__self__", None)``,
+    # so give _message_handler a bound-method with a __self__ that carries the
+    # async _handle_message we want to observe.
+    captures = {}
+
+    async def _handle_message(event):
+        captures["event"] = event
+        return "ok"
+
+    class _Runner:
+        pass
+
+    runner = _Runner()
+    runner._handle_message = _handle_message
+
+    class _Bound:
+        __self__ = runner
+
+    adapter._message_handler = _Bound()
+    return adapter, captures
+
+
+def _fake_query():
+    async def _answer(**kw):
+        return None
+
+    async def _edit_text(**kw):
+        return None
+
+    return SimpleNamespace(
+        answer=_answer,
+        message=SimpleNamespace(text="original", edit_text=_edit_text),
+        from_user=SimpleNamespace(id=4242, first_name="Tester"),
+    )
+
+
+class TestCommandVerbDispatch:
+    """gmail-triage command verbs must route in-process through _handle_message."""
+
+    def test_reset_verb_routes_synthetic_event_to_runner(self, monkeypatch):
+        adapter, captures = _make_adapter(monkeypatch)
+        query = _fake_query()
+
+        command_entry = adapter._GT_COMMAND_DISPATCH["reset"]
+        assert command_entry[0] == "/reset"
+
+        import asyncio
+
+        asyncio.run(adapter._run_command_verb(
+            command_entry,
+            query,
+            caller_id="4242",
+            chat_id="4242",
+            chat_type="private",
+            thread_id=None,
+            user_name="tester",
+        ))
+
+        event = captures.get("event")
+        assert event is not None, "runner._handle_message was not called"
+        assert event.text == "/reset"
+        assert event.source.platform == Platform.TELEGRAM
+        assert event.source.chat_id == "4242"
+        # "private" must normalize to "dm" exactly as the auth path does.
+        assert event.source.chat_type == "dm"
+        assert event.source.user_id == "4242"
+        assert event.source.user_name == "tester"
+
+    def test_command_verb_normalizes_supergroup_to_group_without_thread(self, monkeypatch):
+        adapter, captures = _make_adapter(monkeypatch)
+        query = _fake_query()
+        import asyncio
+
+        asyncio.run(adapter._run_command_verb(
+            adapter._GT_COMMAND_DISPATCH["reset"],
+            query,
+            caller_id="4242",
+            chat_id="-100123",
+            chat_type="supergroup",
+            thread_id=None,
+            user_name="tester",
+        ))
+        assert captures["event"].source.chat_type == "group"
+
+    def test_command_verb_normalizes_supergroup_to_forum_with_thread(self, monkeypatch):
+        adapter, captures = _make_adapter(monkeypatch)
+        query = _fake_query()
+        import asyncio
+
+        asyncio.run(adapter._run_command_verb(
+            adapter._GT_COMMAND_DISPATCH["reset"],
+            query,
+            caller_id="4242",
+            chat_id="-100123",
+            chat_type="supergroup",
+            thread_id="7",
+            user_name="tester",
+        ))
+        assert captures["event"].source.chat_type == "forum"
+        assert captures["event"].source.thread_id == "7"


### PR DESCRIPTION
## Problem

Telegram inline-button callbacks (the `gt:<verb>:` dispatch in the Telegram adapter) can only run shell scripts — there is no way for a button to invoke a gateway slash-command handler directly. The common workaround of having the dispatched script send a `/command` message back into the chat is broken by design: Telegram never delivers a bot's own outgoing messages back to that same bot, so the command handler never receives it. The user taps the button, gets a success response, but the command (e.g. a session reset) never runs.

## Root cause

`_handle_gmail_triage_callback` in `plugins/platforms/telegram/adapter.py` is the sole dispatcher for these callbacks and it only ever does `asyncio.create_subprocess_exec(...)` against a script in `~/.hermes/scripts/gmail-triage/`. `_GT_VERB_DISPATCH` has no verb kind that maps to a gateway command handler, so there is no in-process route for the callback to reach it.

## Fix

Add a `_GT_COMMAND_DISPATCH` mapping (verb -> slash command) and a `_run_command_verb` path. When a callback resolves to a command verb, it reconstructs the caller's `SessionSource` from the callback metadata and routes a synthetic `MessageEvent` (text = the slash command) into the runner's existing `_handle_message` pipeline. Authorization, command detection, the busy-guard, and session-key resolution all apply exactly as they do for a typed command — so a `reset` button behaves identically to the user typing `/reset`. Script dispatch is untouched.

## Testing

- [x] New test `tests/gateway/test_telegram_command_verb.py` (3 cases): the reset verb routes a synthetic `/reset` event to the runner with a correctly-built source (chat_type normalization: private→dm, supergroup→group, supergroup+thread→forum).
- [x] Existing `test_telegram_callback_auth_fail_closed.py` still passes (5/5 total).

## Notes / open questions

- Decided to add a parallel `_GT_COMMAND_DISPATCH` rather than overload the existing 4-tuple `_GT_VERB_DISPATCH` shape, so existing script verbs are byte-for-byte unchanged.
- Which commands should be exposed via buttons is left to the caller; only `reset` is wired here as the concrete motivating case.