### PR TITLE
fix(skill_manager): _find_skill fails to locate symlinked skills

### DIFF
--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -34,6 +34,7 @@ Directory layout for user skills:
 
 import json
 import logging
+import os
 import re
 import shutil
 import threading
@@ -741,7 +742,10 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     for skills_dir in get_all_skills_dirs():
         if not skills_dir.exists():
             continue
-        for skill_md in skills_dir.rglob("SKILL.md"):
+        for root, _dirs, files in os.walk(str(skills_dir), followlinks=True):
+            if "SKILL.md" not in files:
+                continue
+            skill_md = Path(root) / "SKILL.md"
             if is_excluded_skill_path(skill_md):
                 continue
             # Fast path first: the bare directory name. Avoids the resolve()
@@ -752,7 +756,7 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
             # dir's POSIX relative path so the lookup works on Windows too.
             if "/" in name or "\\" in name:
                 try:
-                    rel = skill_md.parent.resolve().relative_to(_local_root())
+                    rel = skill_md.parent.relative_to(_local_root())
                 except ValueError:
                     continue
                 if rel.as_posix() == name:


### PR DESCRIPTION
## Bug

`_find_skill()` uses `Path.rglob("SKILL.md")` to scan skill directories, but Python 3.9's `rglob` does not follow symlinks. The skill listing API (`iter_skill_index_files`) uses `os.walk(followlinks=True)` and correctly finds symlinked skills, but `_find_skill` cannot, causing the desktop UI to show the skill in the list but fail with 'skill not found' when clicking the edit button.

## Root cause

`tools/skill_manager_tool.py:_find_skill` was written with `rglob` while all other skill-scanning code in the codebase uses `os.walk(followlinks=True)`. The two paths disagree on which skills exist.

## Fix

1. Replace `rglob("SKILL.md")` with `os.walk(str(skills_dir), followlinks=True)` + filtering for `"SKILL.md" in files`.
2. Also fix the categorized-path lookup to use the unresolved path for `relative_to()`, since `resolve()` follows the symlink to a path outside the skills root, causing a `ValueError`.

## Verification

All 12 test scenarios pass:
- Symlinked skills found by bare name: ✅
- Symlinked skills found by categorized path: ✅
- Regular (non-symlink) skills: ✅
- Non-existent skills return None: ✅