### PR TITLE
feat(desktop): per-project toggle for gitignored files in the file tree

### DIFF
--- a/apps/desktop/src/app/right-sidebar/files/ipc.test.ts
+++ b/apps/desktop/src/app/right-sidebar/files/ipc.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { HermesReadDirEntry, HermesReadDirResult } from '@/global'
 
 import { clearProjectDirCache, readProjectDir } from './ipc'
+import { $showIgnoredRoots, setShowIgnoredFiles } from './prefs'
 
 const readDir = vi.fn<(path: string) => Promise<HermesReadDirResult>>()
 const readFileDataUrl = vi.fn<(path: string) => Promise<string>>()
@@ -43,6 +44,7 @@ describe('readProjectDir', () => {
 
   afterEach(() => {
     clearProjectDirCache()
+    $showIgnoredRoots.set([])
     delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
   })
 
@@ -123,5 +125,70 @@ describe('readProjectDir', () => {
 
     expect(result.entries.map(entry => entry.name)).toEqual(['debug.log'])
     expect(readFileDataUrl).not.toHaveBeenCalled()
+  })
+
+  it('keeps gitignored entries — and skips the gitignore reads — when the root opted in', async () => {
+    setShowIgnoredFiles('/repo', true)
+    gitRoot.mockResolvedValue('/repo')
+    readDir.mockImplementation(async path => {
+      if (path === '/repo/src') {
+        return ok([
+          { name: 'debug.log', path: '/repo/src/debug.log', isDirectory: false },
+          { name: 'keep.ts', path: '/repo/src/keep.ts', isDirectory: false }
+        ])
+      }
+
+      if (path === '/repo') {
+        return ok([{ name: '.gitignore', path: '/repo/.gitignore', isDirectory: false }])
+      }
+
+      return ok([])
+    })
+    readFileDataUrl.mockResolvedValue(dataUrl('src/*.log\n'))
+
+    const result = await readProjectDir('/repo/src', '/repo')
+
+    expect(result.entries.map(entry => entry.name)).toEqual(['debug.log', 'keep.ts'])
+    expect(gitRoot).not.toHaveBeenCalled()
+    expect(readFileDataUrl).not.toHaveBeenCalled()
+  })
+
+  it('still excludes ALWAYS_EXCLUDED entries when the root opted in', async () => {
+    setShowIgnoredFiles('/repo', true)
+    readDir.mockResolvedValue(
+      ok([
+        { name: '.git', path: '/repo/.git', isDirectory: true },
+        { name: 'node_modules', path: '/repo/node_modules', isDirectory: true },
+        { name: 'src', path: '/repo/src', isDirectory: true }
+      ])
+    )
+
+    const result = await readProjectDir('/repo', '/repo')
+
+    expect(result.entries.map(entry => entry.name)).toEqual(['src'])
+  })
+
+  it('opting one root in leaves other roots filtered', async () => {
+    setShowIgnoredFiles('/repo', true)
+    gitRoot.mockResolvedValue('/other')
+    readDir.mockImplementation(async path => {
+      if (path === '/other/src') {
+        return ok([
+          { name: 'debug.log', path: '/other/src/debug.log', isDirectory: false },
+          { name: 'keep.ts', path: '/other/src/keep.ts', isDirectory: false }
+        ])
+      }
+
+      if (path === '/other') {
+        return ok([{ name: '.gitignore', path: '/other/.gitignore', isDirectory: false }])
+      }
+
+      return ok([])
+    })
+    readFileDataUrl.mockResolvedValue(dataUrl('src/*.log\n'))
+
+    const result = await readProjectDir('/other/src', '/other')
+
+    expect(result.entries.map(entry => entry.name)).toEqual(['keep.ts'])
   })
 })

--- a/apps/desktop/src/app/right-sidebar/files/ipc.ts
+++ b/apps/desktop/src/app/right-sidebar/files/ipc.ts
@@ -5,6 +5,8 @@ import { desktopFsCacheKey, desktopGitRoot, readDesktopDir, readDesktopFileDataU
 import { ALWAYS_EXCLUDED } from '@/lib/excluded-paths'
 import { cleanPath, comparisonPath } from '@/lib/path-compare'
 
+import { showsIgnoredFiles } from './prefs'
+
 export type ProjectTreeEntry = HermesReadDirEntry
 
 interface GitignoreRule {
@@ -117,6 +119,13 @@ function ignoredBy(rules: GitignoreRule[], entry: HermesReadDirEntry) {
 }
 
 async function filterIgnored(entries: HermesReadDirEntry[], rootPath: string, dirPath: string) {
+  // Opting a project into its ignored files skips the gitignore pass entirely —
+  // no git-root probe, no .gitignore reads. ALWAYS_EXCLUDED still applies: `.git`
+  // internals and dependency/build dirs are never worth browsing, in any repo.
+  if (showsIgnoredFiles(rootPath)) {
+    return entries
+  }
+
   const root = await gitRootFor(rootPath)
 
   if (!root) {

--- a/apps/desktop/src/app/right-sidebar/files/prefs.test.ts
+++ b/apps/desktop/src/app/right-sidebar/files/prefs.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { $showIgnoredRoots, setShowIgnoredFiles, showsIgnoredFiles } from './prefs'
+
+describe('files show-ignored preference', () => {
+  beforeEach(() => {
+    $showIgnoredRoots.set([])
+  })
+
+  it('defaults to filtering and only opts in the root it was told about', () => {
+    expect(showsIgnoredFiles('/repo')).toBe(false)
+
+    setShowIgnoredFiles('/repo', true)
+
+    expect(showsIgnoredFiles('/repo')).toBe(true)
+    expect(showsIgnoredFiles('/other')).toBe(false)
+  })
+
+  it('round-trips off again', () => {
+    setShowIgnoredFiles('/repo', true)
+    setShowIgnoredFiles('/repo', false)
+
+    expect(showsIgnoredFiles('/repo')).toBe(false)
+    expect($showIgnoredRoots.get()).toEqual([])
+  })
+
+  it('treats host spellings of one root as the same project', () => {
+    setShowIgnoredFiles('C:\\Repo\\', true)
+
+    expect(showsIgnoredFiles('c:/repo')).toBe(true)
+  })
+
+  it('does not distinguish a trailing separator on POSIX roots', () => {
+    setShowIgnoredFiles('/repo/', true)
+
+    expect(showsIgnoredFiles('/repo')).toBe(true)
+  })
+
+  it('keeps POSIX roots case-sensitive', () => {
+    setShowIgnoredFiles('/Repo', true)
+
+    expect(showsIgnoredFiles('/repo')).toBe(false)
+  })
+
+  it('ignores an empty root instead of storing a blank entry', () => {
+    setShowIgnoredFiles('', true)
+
+    expect(showsIgnoredFiles('')).toBe(false)
+    expect($showIgnoredRoots.get()).toEqual([])
+  })
+
+  it('never records a root twice', () => {
+    setShowIgnoredFiles('/repo', true)
+    setShowIgnoredFiles('/repo/', true)
+
+    expect($showIgnoredRoots.get()).toHaveLength(1)
+  })
+})

--- a/apps/desktop/src/app/right-sidebar/files/prefs.ts
+++ b/apps/desktop/src/app/right-sidebar/files/prefs.ts
@@ -1,0 +1,53 @@
+import { connectionScopedAtom } from '@/lib/connection-scoped'
+import { cleanPath, comparisonPath } from '@/lib/path-compare'
+import { Codecs } from '@/lib/persisted'
+
+// "Show gitignored files" is a per-project preference: a repo that keeps a
+// second checkout, a build output or an env-specific folder out of git is
+// exactly the repo whose owner wants to browse it, while every other project
+// should stay clean. Storing one global flag makes that choice leak across
+// projects, so the roots opted in are persisted as a list.
+//
+// The scope is CONNECTION + project root: the same absolute path can name two
+// different repos on two backends, and the connection scope keeps those apart
+// (see lib/connection-scoped). Presence in the list means "show"; absence is
+// the default, so an untouched install persists nothing at all.
+const SHOW_IGNORED_KEY = 'hermes.desktop.files.showIgnored'
+
+export const $showIgnoredRoots = connectionScopedAtom<string[]>(SHOW_IGNORED_KEY, [], Codecs.stringArray)
+
+/** Storage/comparison spelling for a project root — backends, pickers and
+ *  session rows disagree on separator and drive-letter case. */
+function rootKey(root: string): string {
+  return comparisonPath(cleanPath(root))
+}
+
+/** The single resolver every reader goes through, so the tree, its lazy child
+ *  reads and its revalidations always agree on one answer for a root. */
+export function showsIgnoredFiles(root: string): boolean {
+  if (!root) {
+    return false
+  }
+
+  return $showIgnoredRoots.get().includes(rootKey(root))
+}
+
+/** Set the preference for one project root. Returns whether it actually
+ *  changed, so the caller can skip an expensive reload on a no-op. */
+export function setShowIgnoredFiles(root: string, show: boolean): boolean {
+  if (!root) {
+    return false
+  }
+
+  const key = rootKey(root)
+  const current = $showIgnoredRoots.get()
+  const has = current.includes(key)
+
+  if (has === show) {
+    return false
+  }
+
+  $showIgnoredRoots.set(show ? [...current, key] : current.filter(item => item !== key))
+
+  return true
+}

--- a/apps/desktop/src/app/right-sidebar/files/use-project-tree.test.ts
+++ b/apps/desktop/src/app/right-sidebar/files/use-project-tree.test.ts
@@ -6,6 +6,7 @@ import { $connection } from '@/store/session'
 import { notifyWorkspaceChanged } from '@/store/workspace-events'
 
 import { clearProjectDirCache, readProjectDir } from './ipc'
+import { $showIgnoredRoots } from './prefs'
 import { resetProjectTreeState, useProjectTree } from './use-project-tree'
 
 const readDir = vi.fn<(path: string) => Promise<HermesReadDirResult>>()
@@ -13,6 +14,7 @@ const readDir = vi.fn<(path: string) => Promise<HermesReadDirResult>>()
 beforeEach(() => {
   $connection.set(null)
   resetProjectTreeState()
+  $showIgnoredRoots.set([])
   readDir.mockReset()
   ;(window as unknown as { hermesDesktop: { readDir: typeof readDir } }).hermesDesktop = { readDir }
 })
@@ -21,6 +23,7 @@ afterEach(() => {
   cleanup()
   $connection.set(null)
   resetProjectTreeState()
+  $showIgnoredRoots.set([])
   delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
 })
 
@@ -554,5 +557,124 @@ describe('useProjectTree', () => {
     })
 
     await waitFor(() => expect(result.current.data.map(node => node.name)).toEqual(['from-b']))
+  })
+
+  // The whole point of the toggle is "show me more files", so the folder the
+  // user is looking at must gain rows, not lose them. loadRoot(force) rebuilds
+  // `data` from the root listing alone, which drops every loaded subtree's
+  // children while arborist keeps the row open — an expanded folder rendering
+  // empty, with nothing left to re-fetch it.
+  it('keeps expanded folders populated when the show-ignored preference flips', async () => {
+    const gitRoot = vi.fn(async () => '/p')
+    const readFileDataUrl = vi.fn(async () => `data:text/plain;base64,${btoa('*.log\n')}`)
+
+    readDir.mockImplementation(async path => {
+      if (path === '/p') {
+        return ok([
+          { name: '.gitignore', path: '/p/.gitignore', isDirectory: false },
+          { name: 'src', path: '/p/src', isDirectory: true }
+        ])
+      }
+
+      if (path === '/p/src') {
+        return ok([
+          { name: 'app.ts', path: '/p/src/app.ts', isDirectory: false },
+          { name: 'debug.log', path: '/p/src/debug.log', isDirectory: false }
+        ])
+      }
+
+      return ok([])
+    })
+    ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = { gitRoot, readDir, readFileDataUrl }
+
+    const { result } = renderHook(() => useProjectTree('/p'))
+
+    await waitFor(() => expect(result.current.rootLoading).toBe(false))
+
+    // Mirror the real expand flow: arborist records the open state, then the
+    // hook lazy-loads that folder's children.
+    act(() => {
+      result.current.setNodeOpen('/p/src', true)
+    })
+
+    await act(async () => {
+      await result.current.loadChildren('/p/src')
+    })
+
+    expect(result.current.showIgnored).toBe(false)
+    expect(result.current.data.find(n => n.name === 'src')?.children?.map(c => c.name)).toEqual(['app.ts'])
+
+    await act(async () => {
+      result.current.setShowIgnored(true)
+    })
+
+    await waitFor(() =>
+      expect(result.current.data.find(n => n.name === 'src')?.children?.map(c => c.name)).toEqual([
+        'app.ts',
+        'debug.log'
+      ])
+    )
+    expect(result.current.showIgnored).toBe(true)
+    expect(result.current.openState['/p/src']).toBe(true)
+
+    await act(async () => {
+      result.current.setShowIgnored(false)
+    })
+
+    await waitFor(() =>
+      expect(result.current.data.find(n => n.name === 'src')?.children?.map(c => c.name)).toEqual(['app.ts'])
+    )
+    expect(result.current.showIgnored).toBe(false)
+  })
+
+  // A listing read under the old preference must never be committed after a
+  // toggle flipped it, or it re-hides the rows the toggle just revealed.
+  it('drops a child listing that was read before the preference flipped', async () => {
+    const gitRoot = vi.fn(async () => '/p')
+    const readFileDataUrl = vi.fn(async () => `data:text/plain;base64,${btoa('*.log\n')}`)
+    let releaseChild: ((value: HermesReadDirResult) => void) | undefined
+
+    readDir.mockImplementation(async path => {
+      if (path === '/p') {
+        return ok([
+          { name: '.gitignore', path: '/p/.gitignore', isDirectory: false },
+          { name: 'src', path: '/p/src', isDirectory: true }
+        ])
+      }
+
+      if (path === '/p/src') {
+        return new Promise<HermesReadDirResult>(resolve => {
+          releaseChild = resolve
+        })
+      }
+
+      return ok([])
+    })
+    ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = { gitRoot, readDir, readFileDataUrl }
+
+    const { result } = renderHook(() => useProjectTree('/p'))
+
+    await waitFor(() => expect(result.current.rootLoading).toBe(false))
+
+    let pendingChild: Promise<void> | undefined
+
+    act(() => {
+      pendingChild = result.current.loadChildren('/p/src')
+    })
+
+    await waitFor(() => expect(releaseChild).toBeTypeOf('function'))
+
+    act(() => {
+      result.current.setShowIgnored(true)
+    })
+
+    await act(async () => {
+      releaseChild?.(ok([{ name: 'app.ts', path: '/p/src/app.ts', isDirectory: false }]))
+      await pendingChild
+    })
+
+    // The stale read carried only the filtered row; committing it would have
+    // replaced the placeholder with a listing the new preference disagrees with.
+    expect(result.current.data.find(n => n.name === 'src')?.children?.map(c => c.name)).not.toEqual(['app.ts'])
   })
 })

--- a/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
+++ b/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
@@ -7,6 +7,7 @@ import { $connection } from '@/store/session'
 import { $workspaceChangeTick, consumeWorkspaceChange } from '@/store/workspace-events'
 
 import { clearProjectDirCache, type ProjectTreeEntry, readProjectDir } from './ipc'
+import { $showIgnoredRoots, setShowIgnoredFiles, showsIgnoredFiles } from './prefs'
 
 export interface TreeNode {
   /** Absolute filesystem path. Doubles as react-arborist node id. */
@@ -104,10 +105,13 @@ export interface UseProjectTreeResult {
   openState: Record<string, boolean>
   rootError: string | null
   rootLoading: boolean
+  /** True while this project's gitignored entries are displayed. */
+  showIgnored: boolean
   collapseAll: () => void
   loadChildren: (id: string) => Promise<void>
   refreshRoot: () => Promise<void>
   setNodeOpen: (id: string, open: boolean) => void
+  setShowIgnored: (show: boolean) => void
 }
 
 interface ProjectTreeState {
@@ -295,6 +299,11 @@ async function revalidateTree(
   }
 
   const rootPath = state.resolvedCwd || cwd
+  // The gitignore filter is user-switchable, so a listing read under the old
+  // preference must not be committed after a toggle flipped it — it would
+  // re-hide entries the toggle just revealed. Snapshot the policy, re-check it
+  // on commit, same shape as the requestId / connectionKey guards.
+  const filterAtRead = showsIgnoredFiles(rootPath)
 
   if (!change.full && change.dirs.length) {
     // Only re-read changed dirs that are actually loaded (root, or an expanded
@@ -308,7 +317,12 @@ async function revalidateTree(
     const reads = await Promise.all(targets.map(async dir => ({ dir, ...(await readProjectDir(dir, rootPath)) })))
 
     setProjectTree(latest => {
-      if (latest.cwd !== cwd || !latest.loaded || desktopFsCacheKey() !== connectionKey) {
+      if (
+        latest.cwd !== cwd ||
+        !latest.loaded ||
+        desktopFsCacheKey() !== connectionKey ||
+        showsIgnoredFiles(rootPath) !== filterAtRead
+      ) {
         return latest
       }
 
@@ -360,7 +374,10 @@ async function revalidateTree(
   const nextData = await reconcile(rootPath, state.data)
 
   setProjectTree(latest =>
-    latest.cwd === cwd && latest.loaded && desktopFsCacheKey() === connectionKey
+    latest.cwd === cwd &&
+    latest.loaded &&
+    desktopFsCacheKey() === connectionKey &&
+    showsIgnoredFiles(rootPath) === filterAtRead
       ? { ...latest, data: nextData }
       : latest
   )
@@ -378,8 +395,32 @@ export function useProjectTree(cwd: string): UseProjectTreeResult {
   const connection = useStore($connection)
   const workspaceTick = useStore($workspaceChangeTick)
   const connectionKey = desktopFsCacheKey(connection)
+  // Subscribed so a toggle re-renders the header; the roots list itself is read
+  // through showsIgnoredFiles so every caller shares one resolver.
+  useStore($showIgnoredRoots)
+
+  const effectiveCwd = state.cwd === cwd && state.resolvedCwd ? state.resolvedCwd : cwd
+  const showIgnored = showsIgnoredFiles(effectiveCwd)
 
   const refreshRoot = useCallback(() => loadRoot(cwd, { connectionKey, force: true }), [connectionKey, cwd])
+
+  // Flipping the filter changes what every already-read directory contains, so
+  // every loaded listing is stale by construction. `loadRoot(force)` is the
+  // wrong instrument: it rebuilds `data` from the root listing alone, so an
+  // expanded subtree loses its children while arborist keeps the row open —
+  // the folder renders empty and nothing re-fetches it. The full reconcile
+  // re-reads every loaded dir recursively and merges by path id, so expansion
+  // and the subtrees on screen both survive.
+  const setShowIgnored = useCallback(
+    (show: boolean) => {
+      if (!setShowIgnoredFiles(effectiveCwd, show)) {
+        return
+      }
+
+      void revalidateTree(cwd, { dirs: [], full: true }, connectionKey)
+    },
+    [connectionKey, cwd, effectiveCwd]
+  )
 
   const setNodeOpen = useCallback(
     (id: string, open: boolean) => {
@@ -435,6 +476,7 @@ export function useProjectTree(cwd: string): UseProjectTreeResult {
       })
 
       const rootPath = $projectTree.get().resolvedCwd || cwd
+      const filterAtRead = showsIgnoredFiles(rootPath)
       let entries: ProjectTreeEntry[] = []
       let error: string | undefined
 
@@ -447,7 +489,13 @@ export function useProjectTree(cwd: string): UseProjectTreeResult {
       }
 
       setProjectTree(current => {
-        if (current.cwd !== cwd || desktopFsCacheKey() !== connectionKey) {
+        // Same filter guard as revalidateTree: a child listing read before a
+        // show-ignored toggle must not land after it.
+        if (
+          current.cwd !== cwd ||
+          desktopFsCacheKey() !== connectionKey ||
+          showsIgnoredFiles(rootPath) !== filterAtRead
+        ) {
           return current
         }
 
@@ -535,25 +583,29 @@ export function useProjectTree(cwd: string): UseProjectTreeResult {
       collapseAll,
       collapseNonce: state.cwd === cwd ? state.collapseNonce : 0,
       data: state.cwd === cwd ? state.data : [],
-      effectiveCwd: state.cwd === cwd && state.resolvedCwd ? state.resolvedCwd : cwd,
+      effectiveCwd,
       loadChildren,
       openState: state.cwd === cwd ? state.openState : {},
       refreshRoot,
       rootError: state.cwd === cwd ? state.rootError : null,
       rootLoading: state.cwd === cwd ? state.rootLoading : Boolean(cwd),
-      setNodeOpen
+      setNodeOpen,
+      setShowIgnored,
+      showIgnored
     }),
     [
       collapseAll,
       cwd,
+      effectiveCwd,
       loadChildren,
       refreshRoot,
       setNodeOpen,
+      setShowIgnored,
+      showIgnored,
       state.collapseNonce,
       state.cwd,
       state.data,
       state.openState,
-      state.resolvedCwd,
       state.rootError,
       state.rootLoading
     ]

--- a/apps/desktop/src/app/right-sidebar/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.tsx
@@ -48,7 +48,9 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder }: RightSide
     refreshRoot,
     rootError,
     rootLoading,
-    setNodeOpen
+    setNodeOpen,
+    setShowIgnored,
+    showIgnored
   } = useProjectTree(hasWorkspace ? currentCwd : '')
 
   const cwdName =
@@ -99,7 +101,9 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder }: RightSide
         onNodeOpenChange={setNodeOpen}
         onPreviewFile={previewFile}
         onRefresh={() => void refreshRoot()}
+        onToggleShowIgnored={() => setShowIgnored(!showIgnored)}
         openState={openState}
+        showIgnored={showIgnored}
       />
     </aside>
   )
@@ -111,6 +115,8 @@ interface FilesystemTabProps extends FileTreeBodyProps {
   hasWorkspace: boolean
   onCollapseAll: () => void
   onRefresh: () => void
+  onToggleShowIgnored: () => void
+  showIgnored: boolean
 }
 
 // Sidebar palette + hover-reveal: header actions stay reachable while moving
@@ -136,7 +142,9 @@ function FilesystemTab({
   onNodeOpenChange,
   onPreviewFile,
   onRefresh,
-  openState
+  onToggleShowIgnored,
+  openState,
+  showIgnored
 }: FilesystemTabProps) {
   const { t } = useI18n()
   const r = t.rightSidebar
@@ -153,6 +161,20 @@ function FilesystemTab({
         <div className="flex min-w-0 flex-1">
           <SidebarPanelLabel>{cwdName}</SidebarPanelLabel>
         </div>
+        <Tip label={showIgnored ? r.hideIgnored : r.showIgnored}>
+          <Button
+            aria-label={showIgnored ? r.hideIgnored : r.showIgnored}
+            aria-pressed={showIgnored}
+            // Stays visible while active: the tree is showing more than the
+            // repo does, and that has to be legible without hovering.
+            className={showIgnored ? HEADER_ACTION_CLASS : HEADER_ACTION_LABEL_REVEAL}
+            onClick={onToggleShowIgnored}
+            size="icon-xs"
+            variant="ghost"
+          >
+            <Codicon name={showIgnored ? 'eye' : 'eye-closed'} size="0.8125rem" />
+          </Button>
+        </Tip>
         <Tip label={r.refreshTree}>
           <Button
             aria-label={r.refreshTree}

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2323,6 +2323,8 @@ export const ar = defineLocale({
     openFolder: 'فتح مجلد',
     refreshTree: 'تحديث الشجرة',
     collapseAll: 'طي الكل',
+    showIgnored: 'إظهار الملفات المتجاهلة في git',
+    hideIgnored: 'إخفاء الملفات المتجاهلة في git',
     previewUnavailable: 'المعاينة غير متاحة',
     couldNotPreview: path => `تعذرت معاينة ${path}`,
     noProjectTitle: 'لا يوجد مشروع',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -3139,6 +3139,8 @@ export const en: Translations = {
     openFolder: 'Open folder',
     refreshTree: 'Refresh tree',
     collapseAll: 'Collapse all folders',
+    showIgnored: 'Show gitignored files',
+    hideIgnored: 'Hide gitignored files',
     previewUnavailable: 'Preview unavailable',
     couldNotPreview: path => `Could not preview ${path}`,
     noProjectTitle: 'No project',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2753,6 +2753,8 @@ export const ja = defineLocale({
     openFolder: 'フォルダーを開く',
     refreshTree: 'ツリーを更新',
     collapseAll: 'すべてのフォルダーを折りたたむ',
+    showIgnored: 'gitignore されたファイルを表示',
+    hideIgnored: 'gitignore されたファイルを非表示',
     previewUnavailable: 'プレビューは利用できません',
     couldNotPreview: path => `${path} をプレビューできませんでした`,
     noProjectTitle: 'プロジェクトなし',

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -3159,6 +3159,8 @@ export const ru = defineLocale({
     openFolder: 'Открыть папку',
     refreshTree: 'Обновить дерево',
     collapseAll: 'Свернуть все папки',
+    showIgnored: 'Показать файлы из gitignore',
+    hideIgnored: 'Скрыть файлы из gitignore',
     previewUnavailable: 'Предпросмотр недоступен',
     couldNotPreview: path => `Не удалось предпросмотреть ${path}`,
     noProjectTitle: 'Проект не открыт',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2689,6 +2689,8 @@ export interface Translations {
     openFolder: string
     refreshTree: string
     collapseAll: string
+    showIgnored: string
+    hideIgnored: string
     previewUnavailable: string
     couldNotPreview: (path: string) => string
     noProjectTitle: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2655,6 +2655,8 @@ export const zhHant = defineLocale({
     openFolder: '開啟資料夾',
     refreshTree: '重新整理檔案樹',
     collapseAll: '收合所有資料夾',
+    showIgnored: '顯示 gitignore 的檔案',
+    hideIgnored: '隱藏 gitignore 的檔案',
     previewUnavailable: '預覽不可用',
     couldNotPreview: path => `無法預覽 ${path}`,
     noProjectTitle: '沒有專案',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3291,6 +3291,8 @@ export const zh: Translations = {
     openFolder: '打开文件夹',
     refreshTree: '刷新文件树',
     collapseAll: '折叠所有文件夹',
+    showIgnored: '显示 gitignore 的文件',
+    hideIgnored: '隐藏 gitignore 的文件',
     previewUnavailable: '预览不可用',
     couldNotPreview: path => `无法预览 ${path}`,
     noProjectTitle: '没有项目',


### PR DESCRIPTION
## Problem

The desktop right-sidebar file tree filters every entry through `.gitignore`, and there is no way to turn that off.

That is the right default for a repo that gitignores noise. It is the wrong one for a repo that uses `.gitignore` for *ownership*: a deny-by-default allowlist, a nested checkout with its own history, an environment-specific folder. Those directories vanish from the tree while they still exist on disk and stay reachable by the agent's own tools, so the workspace looks like it lost data.

Closes #45286, where the reporter's `.gitignore` starts `*` + `!`-allowlist and their real workspace folders disappeared from the tree.

## Solution

An eye toggle in the file-tree header, next to refresh and collapse-all.

**The preference is per project root and it persists.** A repo whose layout needs ignored files stays opted in across restarts; every other project stays clean. The scope is CONNECTION + root (`connectionScopedAtom`), so the same absolute path on two backends does not share one answer — the `#77318` rationale in `lib/connection-scoped.ts`. Roots are normalized through `comparisonPath(cleanPath(...))`, so Windows casing and trailing separators resolve to one project.

**One resolver owns the policy.** `filterIgnored()` reads `showsIgnoredFiles(rootPath)` directly instead of taking a threaded boolean. There are six `readProjectDir` call sites — two inside `revalidateTree`'s branches, and `loadRoot`'s fallback retry, which swaps the root mid-call. Threading a flag means six sites each deciding which root to ask about, the scatter `apps/desktop/AGENTS.md` names: *"One resolver owns each policy so every caller gets the same answer."* `filterIgnored` was never pure anyway — it already does IPC and reads two module-level caches.

Opting in also returns before the git-root probe and the `.gitignore` reads, which saves O(depth) IPC round-trips per directory read rather than one probe.

**`ALWAYS_EXCLUDED` still applies with the toggle on.** `.git` internals and dependency/build directories are not what this feature is about, and the main-process `FS_READDIR_HIDDEN` filter drops several of them before the renderer ever sees an entry, so relaxing the renderer list alone would not work. Pinned by a test.

## The bug this went through before it worked

The first implementation reloaded via `loadRoot(force: true)`. That rebuilds `data` from the root listing alone, so every loaded subtree's `children` reverts to `undefined` — while `collapseNonce` and `cwd` are unchanged, so arborist does not remount and keeps the row open. `childrenAccessor` maps `undefined → []`.

The result: expand `src/`, hit the eye, and `src/` renders **expanded and empty**. Nothing re-fetches it — `loadChildren` only fires on a user toggle, and both of `revalidateTree`'s paths skip nodes whose `children` is `undefined`. A feature whose entire purpose is "show me more files" made the folder you were looking at show none.

Toggling now runs `revalidateTree(cwd, { dirs: [], full: true }, connectionKey)`, the full-reconcile primitive already in the file: it re-reads every loaded dir recursively, merges by stable path id, and keeps expansion and the subtrees on screen.

Second issue, from making a previously-immutable filter runtime-mutable: a listing read issued *before* a flip could commit *after* it and re-hide the rows the toggle just revealed. `loadChildren` and `revalidateTree` now snapshot the preference and re-check it on commit, the same shape as the existing `requestId` / `connectionKey` guards. (`loadRoot`'s own `requestId` already covered it.)

Both are covered by hook-level tests, and I verified each one **fails against the earlier implementation** — reverting the reconcile fails the expanded-folder test, dropping the guard fails the stale-read test.

## Relationship to #45355

@arimu1 opened #45355 for this same issue in June. It is currently `CONFLICTING` against `main` and has not moved since July, so this is not an attempt to race it — credit for getting to the problem first is theirs, and the eye/eye-closed affordance is the same obvious answer we both landed on.

Two deliberate differences, offered for comparison rather than as a verdict on that PR:

| | #45355 | here |
|---|---|---|
| Scope | one global in-memory flag, all projects | per project root, persisted, connection-scoped |
| Lifetime | resets when the app closes | survives restart |
| Policy | `showIgnored` threaded through 5+ call sites | one resolver read inside `filterIgnored` |

Worth stating plainly: **the expanded-folders bug is design-independent and #45355 has it too**, so it is not an argument for this shape over that one. If maintainers prefer that PR's approach, the reconcile fix and the two regression tests here apply to it unchanged and I am happy to hand them over.

## Not in scope

- **The review (git diff) tree** deliberately gets no toggle. `store/review.ts:153` documents why: it lists changed files from `git status`, which drops gitignored paths upstream, so there is no filter of its own to flip. The two trees share only `ALWAYS_EXCLUDED`.
- **Unifying `ALWAYS_EXCLUDED`.** The same policy exists in three drifted copies — `electron/fs-read-dir.ts` `FS_READDIR_HIDDEN` (13 entries), `hermes_cli/web_server.py` `_FS_READDIR_HIDDEN` (13), and the renderer's `ALWAYS_EXCLUDED` (34). A deny-by-default repo whose real workspace folder is named `out/`, `vendor/` or `coverage/` is still hidden with the toggle on — the residual of this bug class. The fix crosses two process boundaries and the Python backend, so it belongs in its own PR, not as a rider here. Happy to file the issue.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (the 124 warnings are pre-existing, none in touched files)
- [x] `npx vitest run --project ui` — 710 files / 7047 tests pass
- [x] New tests fail against the pre-fix implementation (verified by reverting each fix in turn)
- [ ] Manual: open a repo with a deny-by-default `.gitignore`, confirm folders are hidden; click the eye, confirm they appear; expand a folder first and confirm it stays populated across a toggle; restart the app and confirm the preference held; open a second project and confirm it is unaffected

Tested on macOS. The Windows path-casing behavior is covered by tests mirroring `89490ae373`, but I have not exercised it on a Windows host.

## Files

| File | Change |
|---|---|
| `files/prefs.ts` | New. Connection-scoped persisted roots list + `showsIgnoredFiles` / `setShowIgnoredFiles` |
| `files/ipc.ts` | `filterIgnored` returns early for an opted-in root, before the git-root probe |
| `files/use-project-tree.ts` | `showIgnored` / `setShowIgnored` on the hook; full reconcile on toggle; filter guards on `loadChildren` and `revalidateTree` |
| `right-sidebar/index.tsx` | Header toggle button, visible while active |
| `i18n/*` | `showIgnored` / `hideIgnored` in `types.ts` and all 6 locales |
| `files/prefs.test.ts`, `files/ipc.test.ts`, `files/use-project-tree.test.ts` | Coverage for the store, the filter, and the two failure modes above |
