### PR TITLE
feat(tui_gateway): allow public HTTPS MCP OAuth client redirect URIs

### DIFF
--- a/tests/tui_gateway/test_mcp_oauth_client_callback.py
+++ b/tests/tui_gateway/test_mcp_oauth_client_callback.py
@@ -1,10 +1,10 @@
 """Tests for the client-side callback (remote-backend) variant of the
 session-backed MCP OAuth flow (tui_gateway/mcp_oauth_sessions.py).
 
-Covers the three seams added for remote Desktop backends:
-  - _validate_client_redirect_uri: loopback-only allowlist for the
-    client-supplied redirect URI (rejects public hosts/schemes so a gateway
-    never pins an attacker-controlled redirect into a DCR registration);
+Covers the three seams added for remote Desktop / SaaS backends:
+  - _validate_client_redirect_uri: loopback HTTP for native clients, plus
+    absolute public HTTPS (no credentials/fragment) for SaaS backends that
+    relay through mcp.servers.oauth.callback;
   - start_flow(client_redirect_uri=...): no gateway-side listener is bound and
     the flow's redirect_uri is pinned to the client's listener;
   - deliver_callback_flow: relays a client-captured code/state into the flow
@@ -45,13 +45,41 @@ def test_validate_accepts_loopback_http(uri, expected):
 
 
 @pytest.mark.parametrize(
+    "uri,expected",
+    [
+        (
+            "https://demo.one.immo/api/agent/mcp/oauth/callback",
+            "https://demo.one.immo/api/agent/mcp/oauth/callback",
+        ),
+        (
+            "https://saas.example.com:8443/oauth/callback",
+            "https://saas.example.com:8443/oauth/callback",
+        ),
+        # Empty path becomes /
+        ("https://saas.example.com", "https://saas.example.com/"),
+        # Query is preserved; host is lowercased
+        (
+            "https://SaaS.Example.com/cb?next=mcp",
+            "https://saas.example.com/cb?next=mcp",
+        ),
+        ("  https://saas.example.com/cb  ", "https://saas.example.com/cb"),
+    ],
+)
+def test_validate_accepts_public_https(uri, expected):
+    assert _validate_client_redirect_uri(uri) == expected
+
+
+@pytest.mark.parametrize(
     "uri",
     [
         "https://127.0.0.1:8412/callback",  # https is not a native loopback
-        "http://evil.example.com:8412/callback",  # public host
-        "http://192.168.1.10:8412/callback",  # LAN host
+        "https://localhost:8412/callback",
+        "http://evil.example.com:8412/callback",  # public host over http
+        "http://192.168.1.10:8412/callback",  # LAN host over http
         "http://127.0.0.1/callback",  # no port
         "http://user:pass@127.0.0.1:8412/callback",  # credentials
+        "https://user:pass@saas.example.com/cb",  # credentials
+        "https://saas.example.com/cb#frag",  # fragment
         "javascript:alert(1)",
         "",
         "not a url",
@@ -134,12 +162,44 @@ def test_start_flow_rejects_bad_client_redirect(monkeypatch):
             "/tmp/hermes-test-home",
             "clicky2",
             {"url": "https://mcp.example.com/mcp", "auth": "oauth"},
-            client_redirect_uri="https://evil.example.com/callback",
+            client_redirect_uri="http://evil.example.com/callback",
         )
     # No session must be left behind by a rejected start.
     assert all(
         r["server_name"] != "clicky2" for r in mcp_oauth_sessions._sessions.values()
     )
+
+
+def test_start_flow_public_https_skips_gateway_listener(monkeypatch):
+    _fake_worker_publishes_url(monkeypatch)
+
+    bound = []
+    real_listener = mcp_oauth_sessions._start_loopback_listener
+    monkeypatch.setattr(
+        mcp_oauth_sessions,
+        "_start_loopback_listener",
+        lambda flow: bound.append(flow) or real_listener(flow),
+    )
+
+    public = "https://demo.one.immo/api/agent/mcp/oauth/callback"
+    result = mcp_oauth_sessions.start_flow(
+        "/tmp/hermes-test-home",
+        "saas-relay",
+        {"url": "https://mcp.example.com/mcp", "auth": "oauth"},
+        client_redirect_uri=public,
+    )
+
+    assert result["session_id"]
+    assert bound == [], "gateway listener must NOT be bound with a public HTTPS redirect"
+
+    rec = mcp_oauth_sessions._sessions[result["session_id"]]
+    assert rec["httpd"] is None
+    assert rec["flow"].redirect_uri == public
+
+    deliver_callback_flow(
+        result["session_id"], "saas-relay", code="authcode", state="teststate123"
+    )
+    rec["flow"]._worker_done.wait(5)
 
 
 # ---------------------------------------------------------------------------

--- a/tui_gateway/mcp_oauth_sessions.py
+++ b/tui_gateway/mcp_oauth_sessions.py
@@ -39,6 +39,12 @@ provider redirect back via ``deliver_callback_flow`` /
 ``mcp.servers.oauth.callback``. State verification stays server-side in
 ``DashboardOAuthFlow.deliver_callback`` — a relayed code with the wrong
 ``state`` is rejected exactly like a forged loopback hit.
+
+A browser-based SaaS frontend cannot bind ``127.0.0.1``. That topology uses
+the same relay: ``client_redirect_uri`` is the backend's public HTTPS
+callback route, the provider redirects there, and the backend forwards
+``code`` / ``state`` / ``error`` through ``mcp.servers.oauth.callback``.
+The gateway still does not expose a public HTTP listener.
 """
 
 from __future__ import annotations
@@ -87,29 +93,65 @@ def _shutdown_listener(rec: Dict[str, Any]) -> None:
         rec["httpd"] = None
 
 
-def _validate_client_redirect_uri(uri: str) -> str:
-    """Validate a client-supplied loopback redirect URI.
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
 
-    Only plain-http loopback URLs are accepted (``http://127.0.0.1:<port>/...``
-    or ``http://localhost:<port>/...``), mirroring RFC 8252 native-app rules —
-    the client hosts a one-shot listener on ITS machine, so anything else
-    (public hosts, https proxies, schemes) is rejected to keep the gateway from
-    pinning an attacker-controlled redirect into a DCR registration.
+_CLIENT_REDIRECT_URI_ERROR = (
+    "client_redirect_uri must be a loopback http URL like "
+    "http://127.0.0.1:<port>/callback, or an absolute https URL "
+    "with no credentials or fragment"
+)
+
+
+def _format_netloc(host: str, port: int | None) -> str:
+    hostname = f"[{host}]" if ":" in host else host
+    return f"{hostname}:{port}" if port is not None else hostname
+
+
+def _validate_client_redirect_uri(uri: str) -> str:
+    """Validate a client-supplied OAuth redirect URI.
+
+    Two shapes are accepted:
+
+    * Loopback HTTP for native clients (RFC 8252):
+      ``http://127.0.0.1:<port>/...``, ``http://localhost:<port>/...``,
+      or ``http://[::1]:<port>/...``.
+    * Public HTTPS for remote/SaaS backends that own a callback route and
+      relay ``code``/``state`` through ``mcp.servers.oauth.callback``:
+      an absolute ``https`` URL with a non-loopback host, no URL credentials,
+      and no fragment.
+
+    State verification and one-shot delivery stay server-side on
+    ``DashboardOAuthFlow.deliver_callback``.
     """
     parsed = urlparse(str(uri or "").strip())
     host = (parsed.hostname or "").lower()
-    if (
-        parsed.scheme != "http"
-        or host not in ("127.0.0.1", "localhost", "::1")
-        or not parsed.port
-        or parsed.username is not None
-        or parsed.password is not None
-    ):
-        raise ValueError(
-            "client_redirect_uri must be a loopback http URL like "
-            "http://127.0.0.1:<port>/callback"
+    has_userinfo = parsed.username is not None or parsed.password is not None
+
+    if parsed.scheme == "http":
+        if (
+            host not in _LOOPBACK_HOSTS
+            or not parsed.port
+            or has_userinfo
+        ):
+            raise ValueError(_CLIENT_REDIRECT_URI_ERROR)
+        return (
+            f"http://{_format_netloc(host, parsed.port)}"
+            f"{parsed.path or '/callback'}"
         )
-    return f"http://{'[' + host + ']' if ':' in host else host}:{parsed.port}{parsed.path or '/callback'}"
+
+    if parsed.scheme == "https":
+        if (
+            not host
+            or host in _LOOPBACK_HOSTS
+            or has_userinfo
+            or parsed.fragment
+        ):
+            raise ValueError(_CLIENT_REDIRECT_URI_ERROR)
+        path = parsed.path or "/"
+        query = f"?{parsed.query}" if parsed.query else ""
+        return f"https://{_format_netloc(host, parsed.port)}{path}{query}"
+
+    raise ValueError(_CLIENT_REDIRECT_URI_ERROR)
 
 
 def _start_loopback_listener(flow) -> "http.server.HTTPServer":
@@ -263,11 +305,14 @@ def start_flow(
     string. Blocks up to ``url_timeout`` for the worker to publish the browser
     authorization URL, then returns it.
 
-    ``client_redirect_uri`` (remote-backend variant): a loopback callback URL
-    the CLIENT hosts on its own machine. When set (and valid), no gateway-side
-    listener is bound — the OAuth ``redirect_uri`` is pinned to the client's
-    listener, and the client relays the redirect's ``code``/``state`` back via
-    ``deliver_callback_flow``. Invalid values raise ``ValueError``.
+    ``client_redirect_uri`` (remote-backend variant): a callback URL the
+    CLIENT owns. Native clients pass a loopback HTTP listener
+    (``http://127.0.0.1:<port>/callback``). Browser-based SaaS backends
+    pass their public HTTPS callback route. When set (and valid), no
+    gateway-side listener is bound — the OAuth ``redirect_uri`` is pinned
+    to the client's URL, and the client relays the redirect's
+    ``code``/``state`` back via ``deliver_callback_flow``. Invalid values
+    raise ``ValueError``.
     """
     from tools.mcp_dashboard_oauth import DashboardOAuthFlow
 

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -2335,13 +2335,16 @@ def _(rid, params: dict) -> dict:
     (``_probe_single_server`` under ``force_interactive_oauth``), and a loopback
     listener captures the browser redirect — no FastAPI request object needed.
 
-    ``client_redirect_uri`` (remote backends): a loopback URL the CLIENT hosts
-    on its own machine (``http://127.0.0.1:<port>/callback``). When supplied,
-    the gateway binds NO listener — the provider redirects to the client's
-    listener and the client relays the code via ``mcp.servers.oauth.callback``.
-    This is the only flow that works when the desktop app and the gateway run
-    on different machines (SSH/Tailscale remote backend), where the gateway's
-    own 127.0.0.1 listener is unreachable from the user's browser.
+    ``client_redirect_uri`` (remote backends): a callback URL the CLIENT
+    owns. Native clients pass a loopback listener
+    (``http://127.0.0.1:<port>/callback``). Browser-based SaaS backends
+    pass an absolute public HTTPS callback route (no URL credentials or
+    fragment). When supplied, the gateway binds NO listener — the provider
+    redirects to the client's URL and the client relays the code via
+    ``mcp.servers.oauth.callback``. State verification stays server-side.
+    This is the flow that works when the client and the gateway run on
+    different machines (SSH/Tailscale remote backend, or a SaaS frontend
+    that cannot bind 127.0.0.1).
 
     Runs on the RPC thread pool (see _LONG_HANDLERS): start blocks briefly for
     the authorization URL to be published.


### PR DESCRIPTION
## What does this PR do?

`mcp.servers.oauth.start` already supports a remote-backend relay through `client_redirect_uri` and `mcp.servers.oauth.callback`, but `_validate_client_redirect_uri` only accepted loopback HTTP. That works for a native desktop listener. A browser-based SaaS frontend cannot bind `127.0.0.1`, so its backend needs to receive the provider redirect on a public HTTPS route and relay `code`, `state`, and `error` through the existing RPC.

This change accepts an absolute public HTTPS callback URL for that relay variant:

- scheme `https`, non-loopback host
- no URL credentials or fragment
- existing loopback HTTP allowance for native clients is unchanged
- `DashboardOAuthFlow.deliver_callback` still owns state verification and one-shot delivery

The gateway still does not expose a public HTTP listener. The SaaS backend owns the callback route and relays only the OAuth result.

## Related Issue

Fixes #101041

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/mcp_oauth_sessions.py` — `_validate_client_redirect_uri` now accepts absolute public HTTPS URLs (no credentials/fragment) in addition to loopback HTTP; `start_flow` still pins the validated URI and binds no gateway-side listener.
- `tui_gateway/methods_tools.py` — document the HTTPS relay variant on `mcp.servers.oauth.start`.
- `tests/tui_gateway/test_mcp_oauth_client_callback.py` — accept the reported `https://demo.one.immo/api/agent/mcp/oauth/callback` URL, reject credentials/fragments/http-on-public-hosts, and assert `start_flow` pins a public HTTPS URI without binding a listener.

## How to Test

1. Confirm the reported public HTTPS callback is accepted:
   `python -c "from tui_gateway.mcp_oauth_sessions import _validate_client_redirect_uri; print(_validate_client_redirect_uri('https://demo.one.immo/api/agent/mcp/oauth/callback'))"`
   Expected: `https://demo.one.immo/api/agent/mcp/oauth/callback`
2. Confirm loopback HTTP still works:
   `python -c "from tui_gateway.mcp_oauth_sessions import _validate_client_redirect_uri; print(_validate_client_redirect_uri('http://127.0.0.1:49152/callback'))"`
   Expected: `http://127.0.0.1:49152/callback`
3. Run `scripts/run_tests.sh tests/tui_gateway/test_mcp_oauth_client_callback.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
▶ launching test runner
Discovered 1 test files under tests/tui_gateway/test_mcp_oauth_client_callback.py
[100.0%] ✓ tests/tui_gateway/test_mcp_oauth_client_callback.py (28 passed, 0 failed)

https://demo.one.immo/api/agent/mcp/oauth/callback ACCEPTED
http://127.0.0.1:49152/callback ACCEPTED
http://evil.example.com:8412/callback REJECTED ValueError
```
