### PR TITLE
fix(pricing): add Claude 5-series rates and model 1h cache writes

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -26,6 +26,12 @@ _SUBCENT_THRESHOLD = Decimal("0.01")
 # distinguish "free because subscription" from "free because $0 pricing".
 _INCLUDED_NOTE = "subscription-included; no provider invoice for usage"
 
+# Cache for pricing.overrides read out of config.yaml, keyed on the file's
+# mtime so an operator editing rates mid-session takes effect without a
+# restart. None = not yet loaded.
+_PRICING_OVERRIDE_CACHE: Optional[Dict[tuple[str, str], "PricingEntry"]] = None
+_PRICING_OVERRIDE_MTIME: float = -1.0
+
 
 def format_cost_label(amount: Decimal) -> str:
     """Format a cost amount as a display label.
@@ -76,6 +82,10 @@ class CanonicalUsage:
     output_tokens: int = 0
     cache_read_tokens: int = 0
     cache_write_tokens: int = 0
+    # Subset of ``cache_write_tokens`` that Anthropic reports as 1h-TTL writes
+    # (``cache_creation.ephemeral_1h_input_tokens``). Billed at the higher 1h
+    # rate; the remainder bills at the 5m rate. Always <= cache_write_tokens.
+    cache_write_1h_tokens: int = 0
     reasoning_tokens: int = 0
     request_count: int = 1
     raw_usage: Optional[dict[str, Any]] = None
@@ -102,6 +112,7 @@ class CanonicalUsage:
             output_tokens=self.output_tokens + other.output_tokens,
             cache_read_tokens=self.cache_read_tokens + other.cache_read_tokens,
             cache_write_tokens=self.cache_write_tokens + other.cache_write_tokens,
+            cache_write_1h_tokens=self.cache_write_1h_tokens + other.cache_write_1h_tokens,
             reasoning_tokens=self.reasoning_tokens + other.reasoning_tokens,
             request_count=self.request_count + other.request_count,
             raw_usage=None,
@@ -122,6 +133,12 @@ class PricingEntry:
     output_cost_per_million: Optional[Decimal] = None
     cache_read_cost_per_million: Optional[Decimal] = None
     cache_write_cost_per_million: Optional[Decimal] = None
+    # Anthropic bills a longer cache TTL at a higher write rate: the 5m write
+    # carries a 1.25x premium over base input, the 1h write carries 2x. The
+    # field above is the 5m (default) rate; this one is the 1h rate and is only
+    # consulted for the token count the API reports as 1h writes. Left None for
+    # routes that do not offer a 1h tier — those fall back to the 5m rate.
+    cache_write_1h_cost_per_million: Optional[Decimal] = None
     request_cost: Optional[Decimal] = None
     source: CostSource = "none"
     source_url: Optional[str] = None
@@ -204,6 +221,93 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         source_url="https://openai.com/index/previewing-gpt-5-6-sol/",
         pricing_version="openai-gpt-5.6-2026-07",
     ),
+    # ── Anthropic Claude Opus 5 / Fable 5 / Mythos 5 (+ 5.1) ─────────────
+    # Opus 5 launched 2026-07-24 at the same $5/$25 base as Opus 4.8.
+    # Fable 5 / Mythos 5 sit at $10/$50. The 5.1 refresh keeps the same base
+    # rates but drops cache hits to 0.025x base input (vs the standard 0.1x)
+    # — that footnote is why 5.1 needs its own entries rather than an alias.
+    # 1h cache writes bill at 2x base input; 5m writes at 1.25x.
+    # Source: https://docs.claude.com/en/docs/about-claude/pricing
+    (
+        "anthropic",
+        "claude-opus-5",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("5.00"),
+        output_cost_per_million=Decimal("25.00"),
+        cache_read_cost_per_million=Decimal("0.50"),
+        cache_write_cost_per_million=Decimal("6.25"),
+        cache_write_1h_cost_per_million=Decimal("10.00"),
+        source="official_docs_snapshot",
+        source_url="https://docs.claude.com/en/docs/about-claude/pricing",
+        pricing_version="anthropic-pricing-2026-09",
+    ),
+    (
+        "anthropic",
+        "claude-opus-5-fast",
+    ): PricingEntry(
+        # Fast mode is a research-preview serving tier at exactly 2x standard.
+        input_cost_per_million=Decimal("10.00"),
+        output_cost_per_million=Decimal("50.00"),
+        cache_read_cost_per_million=Decimal("1.00"),
+        cache_write_cost_per_million=Decimal("12.50"),
+        cache_write_1h_cost_per_million=Decimal("20.00"),
+        source="official_docs_snapshot",
+        source_url="https://docs.claude.com/en/docs/about-claude/pricing",
+        pricing_version="anthropic-pricing-2026-09",
+    ),
+    (
+        "anthropic",
+        "claude-fable-5",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("10.00"),
+        output_cost_per_million=Decimal("50.00"),
+        cache_read_cost_per_million=Decimal("1.00"),
+        cache_write_cost_per_million=Decimal("12.50"),
+        cache_write_1h_cost_per_million=Decimal("20.00"),
+        source="official_docs_snapshot",
+        source_url="https://docs.claude.com/en/docs/about-claude/pricing",
+        pricing_version="anthropic-pricing-2026-09",
+    ),
+    (
+        "anthropic",
+        "claude-fable-5-1",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("10.00"),
+        output_cost_per_million=Decimal("50.00"),
+        # 0.025x base input on 5.1, not the standard 0.1x.
+        cache_read_cost_per_million=Decimal("0.25"),
+        cache_write_cost_per_million=Decimal("12.50"),
+        cache_write_1h_cost_per_million=Decimal("20.00"),
+        source="official_docs_snapshot",
+        source_url="https://docs.claude.com/en/docs/about-claude/pricing",
+        pricing_version="anthropic-pricing-2026-09",
+    ),
+    (
+        "anthropic",
+        "claude-mythos-5",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("10.00"),
+        output_cost_per_million=Decimal("50.00"),
+        cache_read_cost_per_million=Decimal("1.00"),
+        cache_write_cost_per_million=Decimal("12.50"),
+        cache_write_1h_cost_per_million=Decimal("20.00"),
+        source="official_docs_snapshot",
+        source_url="https://docs.claude.com/en/docs/about-claude/pricing",
+        pricing_version="anthropic-pricing-2026-09",
+    ),
+    (
+        "anthropic",
+        "claude-mythos-5-1",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("10.00"),
+        output_cost_per_million=Decimal("50.00"),
+        cache_read_cost_per_million=Decimal("0.25"),
+        cache_write_cost_per_million=Decimal("12.50"),
+        cache_write_1h_cost_per_million=Decimal("20.00"),
+        source="official_docs_snapshot",
+        source_url="https://docs.claude.com/en/docs/about-claude/pricing",
+        pricing_version="anthropic-pricing-2026-09",
+    ),
     # ── Anthropic Claude 4.8 ─────────────────────────────────────────────
     # Same $5/$25 base pricing as 4.6/4.7.  Fast-mode variant is a separate
     # model ID with 2x premium (vs the 6x premium on older Opus generations).
@@ -216,6 +320,7 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         output_cost_per_million=Decimal("25.00"),
         cache_read_cost_per_million=Decimal("0.50"),
         cache_write_cost_per_million=Decimal("6.25"),
+        cache_write_1h_cost_per_million=Decimal("10.00"),
         source="official_docs_snapshot",
         source_url="https://platform.claude.com/docs/en/about-claude/pricing",
         pricing_version="anthropic-pricing-2026-05",
@@ -228,15 +333,17 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         output_cost_per_million=Decimal("50.00"),
         cache_read_cost_per_million=Decimal("1.00"),
         cache_write_cost_per_million=Decimal("12.50"),
+        cache_write_1h_cost_per_million=Decimal("20.00"),
         source="official_docs_snapshot",
         source_url="https://openrouter.ai/anthropic/claude-opus-4.8-fast",
         pricing_version="anthropic-pricing-2026-05",
     ),
     # ── Anthropic Claude Sonnet 5 ────────────────────────────────────────
-    # Launched 2026-06-30. Introductory pricing ($2/$10 per MTok) runs
-    # through 2026-08-31, after which it reverts to $3/$15 (matching
-    # Sonnet 4.6). Update this entry when the intro window closes.
-    # Source: https://platform.claude.com/docs/en/about-claude/pricing
+    # Launched 2026-06-30 at $2/$10 per MTok, originally announced as
+    # introductory pricing through 2026-08-31. Anthropic has since confirmed
+    # this IS the standard price and the scheduled increase to $3/$15 on
+    # 2026-09-01 will NOT occur — do not "restore" the higher rates.
+    # Source: https://docs.claude.com/en/docs/about-claude/pricing
     (
         "anthropic",
         "claude-sonnet-5",
@@ -245,9 +352,10 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         output_cost_per_million=Decimal("10.00"),
         cache_read_cost_per_million=Decimal("0.20"),
         cache_write_cost_per_million=Decimal("2.50"),
+        cache_write_1h_cost_per_million=Decimal("4.00"),
         source="official_docs_snapshot",
-        source_url="https://platform.claude.com/docs/en/about-claude/pricing",
-        pricing_version="anthropic-pricing-2026-06-intro",
+        source_url="https://docs.claude.com/en/docs/about-claude/pricing",
+        pricing_version="anthropic-pricing-2026-09",
     ),
     # ── Anthropic Claude 4.7 ─────────────────────────────────────────────
     # Opus 4.5/4.6/4.7 share $5/$25 pricing (new tokenizer, up to 35% more
@@ -261,6 +369,7 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         output_cost_per_million=Decimal("25.00"),
         cache_read_cost_per_million=Decimal("0.50"),
         cache_write_cost_per_million=Decimal("6.25"),
+        cache_write_1h_cost_per_million=Decimal("10.00"),
         source="official_docs_snapshot",
         source_url="https://platform.claude.com/docs/en/about-claude/pricing",
         pricing_version="anthropic-pricing-2026-05",
@@ -273,6 +382,7 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         output_cost_per_million=Decimal("25.00"),
         cache_read_cost_per_million=Decimal("0.50"),
         cache_write_cost_per_million=Decimal("6.25"),
+        cache_write_1h_cost_per_million=Decimal("10.00"),
         source="official_docs_snapshot",
         source_url="https://platform.claude.com/docs/en/about-claude/pricing",
         pricing_version="anthropic-pricing-2026-05",
@@ -286,6 +396,7 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         output_cost_per_million=Decimal("25.00"),
         cache_read_cost_per_million=Decimal("0.50"),
         cache_write_cost_per_million=Decimal("6.25"),
+        cache_write_1h_cost_per_million=Decimal("10.00"),
         source="official_docs_snapshot",
         source_url="https://platform.claude.com/docs/en/about-claude/pricing",
         pricing_version="anthropic-pricing-2026-05",
@@ -298,6 +409,7 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         output_cost_per_million=Decimal("25.00"),
         cache_read_cost_per_million=Decimal("0.50"),
         cache_write_cost_per_million=Decimal("6.25"),
+        cache_write_1h_cost_per_million=Decimal("10.00"),
         source="official_docs_snapshot",
         source_url="https://platform.claude.com/docs/en/about-claude/pricing",
         pricing_version="anthropic-pricing-2026-05",
@@ -310,6 +422,7 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         output_cost_per_million=Decimal("15.00"),
         cache_read_cost_per_million=Decimal("0.30"),
         cache_write_cost_per_million=Decimal("3.75"),
+        cache_write_1h_cost_per_million=Decimal("6.00"),
         source="official_docs_snapshot",
         source_url="https://platform.claude.com/docs/en/about-claude/pricing",
         pricing_version="anthropic-pricing-2026-05",
@@ -322,6 +435,7 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         output_cost_per_million=Decimal("15.00"),
         cache_read_cost_per_million=Decimal("0.30"),
         cache_write_cost_per_million=Decimal("3.75"),
+        cache_write_1h_cost_per_million=Decimal("6.00"),
         source="official_docs_snapshot",
         source_url="https://platform.claude.com/docs/en/about-claude/pricing",
         pricing_version="anthropic-pricing-2026-05",
@@ -335,6 +449,7 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         output_cost_per_million=Decimal("25.00"),
         cache_read_cost_per_million=Decimal("0.50"),
         cache_write_cost_per_million=Decimal("6.25"),
+        cache_write_1h_cost_per_million=Decimal("10.00"),
         source="official_docs_snapshot",
         source_url="https://platform.claude.com/docs/en/about-claude/pricing",
         pricing_version="anthropic-pricing-2026-05",
@@ -347,6 +462,7 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         output_cost_per_million=Decimal("15.00"),
         cache_read_cost_per_million=Decimal("0.30"),
         cache_write_cost_per_million=Decimal("3.75"),
+        cache_write_1h_cost_per_million=Decimal("6.00"),
         source="official_docs_snapshot",
         source_url="https://platform.claude.com/docs/en/about-claude/pricing",
         pricing_version="anthropic-pricing-2026-05",
@@ -359,6 +475,7 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         output_cost_per_million=Decimal("5.00"),
         cache_read_cost_per_million=Decimal("0.10"),
         cache_write_cost_per_million=Decimal("1.25"),
+        cache_write_1h_cost_per_million=Decimal("2.00"),
         source="official_docs_snapshot",
         source_url="https://platform.claude.com/docs/en/about-claude/pricing",
         pricing_version="anthropic-pricing-2026-05",
@@ -372,6 +489,7 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         output_cost_per_million=Decimal("75.00"),
         cache_read_cost_per_million=Decimal("1.50"),
         cache_write_cost_per_million=Decimal("18.75"),
+        cache_write_1h_cost_per_million=Decimal("30.00"),
         source="official_docs_snapshot",
         source_url="https://platform.claude.com/docs/en/about-claude/pricing",
         pricing_version="anthropic-pricing-2026-05",
@@ -384,6 +502,7 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         output_cost_per_million=Decimal("15.00"),
         cache_read_cost_per_million=Decimal("0.30"),
         cache_write_cost_per_million=Decimal("3.75"),
+        cache_write_1h_cost_per_million=Decimal("6.00"),
         source="official_docs_snapshot",
         source_url="https://platform.claude.com/docs/en/about-claude/pricing",
         pricing_version="anthropic-pricing-2026-05",
@@ -475,6 +594,7 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         output_cost_per_million=Decimal("15.00"),
         cache_read_cost_per_million=Decimal("0.30"),
         cache_write_cost_per_million=Decimal("3.75"),
+        cache_write_1h_cost_per_million=Decimal("6.00"),
         source="official_docs_snapshot",
         source_url="https://platform.claude.com/docs/en/about-claude/pricing",
         pricing_version="anthropic-pricing-2026-05",
@@ -487,6 +607,7 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         output_cost_per_million=Decimal("4.00"),
         cache_read_cost_per_million=Decimal("0.08"),
         cache_write_cost_per_million=Decimal("1.00"),
+        cache_write_1h_cost_per_million=Decimal("1.60"),
         source="official_docs_snapshot",
         source_url="https://platform.claude.com/docs/en/about-claude/pricing",
         pricing_version="anthropic-pricing-2026-05",
@@ -499,6 +620,7 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         output_cost_per_million=Decimal("75.00"),
         cache_read_cost_per_million=Decimal("1.50"),
         cache_write_cost_per_million=Decimal("18.75"),
+        cache_write_1h_cost_per_million=Decimal("30.00"),
         source="official_docs_snapshot",
         source_url="https://platform.claude.com/docs/en/about-claude/pricing",
         pricing_version="anthropic-pricing-2026-05",
@@ -511,6 +633,7 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         output_cost_per_million=Decimal("1.25"),
         cache_read_cost_per_million=Decimal("0.03"),
         cache_write_cost_per_million=Decimal("0.30"),
+        cache_write_1h_cost_per_million=Decimal("0.50"),
         source="official_docs_snapshot",
         source_url="https://platform.claude.com/docs/en/about-claude/pricing",
         pricing_version="anthropic-pricing-2026-05",
@@ -1260,6 +1383,94 @@ def _pricing_entry_from_metadata(
     )
 
 
+def _config_pricing_overrides() -> Dict[tuple[str, str], PricingEntry]:
+    """Build pricing entries from ``pricing.overrides`` in config.yaml.
+
+    Lets an operator price a model the shipped table doesn't know about (a
+    same-day model launch) or correct a rate that changed after release,
+    without patching code. Shape:
+
+        pricing:
+          overrides:
+            "anthropic/claude-opus-9":
+              input: 5.00          # USD per MILLION tokens
+              output: 25.00
+              cache_read: 0.50
+              cache_write: 6.25
+              cache_write_1h: 10.00
+
+    The key is ``provider/model``; a bare ``model`` applies to any provider.
+    Rates are per MILLION tokens to match how vendors publish them. Result is
+    cached per config mtime so a live edit is picked up without a restart.
+    """
+    global _PRICING_OVERRIDE_CACHE, _PRICING_OVERRIDE_MTIME
+    try:
+        from hermes_constants import get_hermes_home
+
+        cfg_path = get_hermes_home() / "config.yaml"
+        mtime = cfg_path.stat().st_mtime if cfg_path.exists() else 0.0
+    except Exception:
+        return {}
+
+    if _PRICING_OVERRIDE_CACHE is not None and mtime == _PRICING_OVERRIDE_MTIME:
+        return _PRICING_OVERRIDE_CACHE
+
+    entries: Dict[tuple[str, str], PricingEntry] = {}
+    try:
+        if mtime:
+            import yaml
+
+            with open(cfg_path, "r", encoding="utf-8") as fh:
+                raw = yaml.safe_load(fh) or {}
+            overrides = ((raw.get("pricing") or {}).get("overrides") or {})
+            for key, spec in overrides.items():
+                if not isinstance(spec, dict):
+                    continue
+                key_s = str(key).strip().lower()
+                prov, _, model = key_s.rpartition("/")
+                entries[(prov, model)] = PricingEntry(
+                    input_cost_per_million=_to_decimal(spec.get("input")),
+                    output_cost_per_million=_to_decimal(spec.get("output")),
+                    cache_read_cost_per_million=_to_decimal(spec.get("cache_read")),
+                    cache_write_cost_per_million=_to_decimal(spec.get("cache_write")),
+                    cache_write_1h_cost_per_million=_to_decimal(
+                        spec.get("cache_write_1h")
+                    ),
+                    source="official_docs_snapshot",
+                    source_url=str(cfg_path),
+                    pricing_version="config-override",
+                )
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("pricing.overrides in config.yaml could not be read: %s", exc)
+        entries = {}
+
+    _PRICING_OVERRIDE_CACHE = entries
+    _PRICING_OVERRIDE_MTIME = mtime
+    return entries
+
+
+def _lookup_config_pricing(route: BillingRoute) -> Optional[PricingEntry]:
+    """Config override for this route, if any. Provider-specific wins."""
+    overrides = _config_pricing_overrides()
+    if not overrides:
+        return None
+    model = route.model.lower()
+    candidates = [model]
+    if route.provider == "anthropic":
+        normalized = _normalize_anthropic_model_name(model)
+        if normalized != model:
+            candidates.append(normalized)
+    for name in candidates:
+        entry = overrides.get((route.provider, name))
+        if entry:
+            return entry
+    for name in candidates:
+        entry = overrides.get(("", name))
+        if entry:
+            return entry
+    return None
+
+
 def get_pricing_entry(
     model_name: str,
     provider: Optional[str] = None,
@@ -1267,6 +1478,12 @@ def get_pricing_entry(
     api_key: Optional[str] = None,
 ) -> Optional[PricingEntry]:
     route = resolve_billing_route(model_name, provider=provider, base_url=base_url)
+    # Operator overrides win over every built-in source: they exist precisely
+    # to correct a shipped rate that has gone stale or to price a model the
+    # table has never heard of.
+    override = _lookup_config_pricing(route)
+    if override:
+        return override
     if route.billing_mode == "subscription_included":
         return PricingEntry(
             input_cost_per_million=_ZERO,
@@ -1312,6 +1529,9 @@ def normalize_usage(
 
     provider_name = (provider or "").strip().lower()
     mode = (api_mode or "").strip().lower()
+    # Only the Anthropic wire reports a TTL split today; other branches leave
+    # this at 0 so the whole write count bills at the single (5m) rate.
+    cache_write_1h_tokens = 0
 
     if mode == "anthropic_messages" or provider_name == "anthropic":
         input_tokens = _usage_count(_usage_get(response_usage, "input_tokens", 0))
@@ -1320,6 +1540,18 @@ def normalize_usage(
         cache_write_tokens = _usage_count(
             _usage_get(response_usage, "cache_creation_input_tokens", 0)
         )
+        # Anthropic breaks writes out by TTL under `cache_creation`. The 1h
+        # tier bills at 2x base input vs 1.25x for 5m, so the split has to
+        # survive into estimate_usage_cost — collapsing it undercounts any
+        # deployment running prompt_caching.cache_ttl: "1h".
+        _cache_creation = _usage_get(response_usage, "cache_creation", None)
+        cache_write_1h_tokens = _usage_count(
+            _usage_get(_cache_creation, "ephemeral_1h_input_tokens", 0)
+            if _cache_creation
+            else 0
+        )
+        if cache_write_1h_tokens > cache_write_tokens:
+            cache_write_1h_tokens = cache_write_tokens
     elif mode == "codex_responses":
         input_total = _usage_count(_usage_get(response_usage, "input_tokens", 0))
         output_tokens = _usage_count(_usage_get(response_usage, "output_tokens", 0))
@@ -1441,6 +1673,7 @@ def normalize_usage(
         output_tokens=output_tokens,
         cache_read_tokens=cache_read_tokens,
         cache_write_tokens=cache_write_tokens,
+        cache_write_1h_tokens=cache_write_1h_tokens,
         reasoning_tokens=reasoning_tokens,
     )
 
@@ -1519,7 +1752,17 @@ def estimate_usage_cost(
     if cache_read_rate is not None:
         amount += Decimal(usage.cache_read_tokens) * cache_read_rate / _ONE_MILLION
     if entry.cache_write_cost_per_million is not None:
-        amount += Decimal(usage.cache_write_tokens) * entry.cache_write_cost_per_million / _ONE_MILLION
+        # Split the write count by TTL: the 1h subset bills at the 1h rate
+        # (2x base input), the remainder at the 5m rate (1.25x). Routes with
+        # no published 1h rate fall back to the 5m rate for the whole count,
+        # which is the old behaviour.
+        _write_1h = min(usage.cache_write_1h_tokens, usage.cache_write_tokens)
+        _write_5m = usage.cache_write_tokens - _write_1h
+        _rate_1h = entry.cache_write_1h_cost_per_million
+        if _rate_1h is None:
+            _rate_1h = entry.cache_write_cost_per_million
+        amount += Decimal(_write_5m) * entry.cache_write_cost_per_million / _ONE_MILLION
+        amount += Decimal(_write_1h) * _rate_1h / _ONE_MILLION
     if entry.request_cost is not None and usage.request_count:
         amount += Decimal(usage.request_count) * entry.request_cost
 

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -867,3 +867,108 @@ def test_flat_entries_unaffected_by_tier_machinery():
     )
     # 250k * $0.25/M + 10k * $1.50/M
     assert result.amount_usd == Decimal("0.0775")
+
+
+def test_current_claude_5_series_models_are_priced():
+    """Models Hermes routes to must resolve to a price.
+
+    Not asserting the rate (that changes) — only that lookup succeeds.
+    An absent model books every call as $0.00 with cost_status="unknown",
+    which is indistinguishable from a genuinely free call.
+    """
+    for model in (
+        "claude-opus-5",
+        "claude-opus-5-fast",
+        "claude-fable-5",
+        "claude-fable-5-1",
+        "claude-mythos-5",
+        "claude-mythos-5-1",
+        "claude-sonnet-5",
+    ):
+        assert get_pricing_entry(model, provider="anthropic") is not None, (
+            f"{model} has no pricing entry - usage books as $0.00"
+        )
+
+
+def test_anthropic_1h_cache_write_is_twice_base_input():
+    """Anthropic prices 1h cache writes at 2x base input on every model.
+
+    A relationship rather than a frozen number, so it survives price
+    changes while still catching a mistyped rate.
+    """
+    from agent.usage_pricing import _OFFICIAL_DOCS_PRICING
+
+    checked = 0
+    for (provider, model), entry in _OFFICIAL_DOCS_PRICING.items():
+        if provider != "anthropic":
+            continue
+        if entry.cache_write_1h_cost_per_million is None:
+            continue
+        if entry.input_cost_per_million is None:
+            continue
+        checked += 1
+        assert entry.cache_write_1h_cost_per_million == entry.input_cost_per_million * Decimal("2"), (
+            f"{model}: 1h cache-write rate is not 2x base input"
+        )
+    assert checked > 0, "no Anthropic 1h rates found to check"
+
+
+def test_fable_5_1_cache_hits_use_the_reduced_multiplier():
+    """Fable 5.1 / Mythos 5.1 price cache hits at 0.025x base input.
+
+    Every other model uses 0.1x. Aliasing 5.1 to the 5.0 entry would
+    overcharge cache reads by 4x, so they need their own entries.
+    """
+    for model in ("claude-fable-5-1", "claude-mythos-5-1"):
+        entry = get_pricing_entry(model, provider="anthropic")
+        assert entry is not None
+        assert entry.cache_read_cost_per_million == entry.input_cost_per_million * Decimal("0.025")
+
+    base = get_pricing_entry("claude-fable-5", provider="anthropic")
+    assert base is not None
+    assert base.cache_read_cost_per_million == base.input_cost_per_million * Decimal("0.1")
+
+
+def test_1h_cache_writes_bill_more_than_5m_writes():
+    """The TTL split must reach the arithmetic, not just the table."""
+    all_5m = CanonicalUsage(cache_write_tokens=1_000_000)
+    all_1h = CanonicalUsage(cache_write_tokens=1_000_000, cache_write_1h_tokens=1_000_000)
+
+    cost_5m = estimate_usage_cost("claude-opus-5", all_5m, provider="anthropic")
+    cost_1h = estimate_usage_cost("claude-opus-5", all_1h, provider="anthropic")
+
+    # 5m writes bill at 1.25x base input, 1h writes at 2x.
+    assert cost_5m.amount_usd == Decimal("6.25")
+    assert cost_1h.amount_usd == Decimal("10.00")
+
+
+def test_normalize_usage_reads_anthropic_1h_cache_write_split():
+    """Anthropic reports the TTL split under cache_creation."""
+    usage = SimpleNamespace(
+        input_tokens=10,
+        output_tokens=5,
+        cache_creation_input_tokens=1000,
+        cache_creation=SimpleNamespace(
+            ephemeral_5m_input_tokens=400,
+            ephemeral_1h_input_tokens=600,
+        ),
+    )
+    canonical = normalize_usage(usage, provider="anthropic")
+    assert canonical.cache_write_tokens == 1000
+    assert canonical.cache_write_1h_tokens == 600
+
+
+def test_unknown_model_returns_no_pricing_rather_than_guessing():
+    """An unpriced model must resolve to None, never to a nearby entry.
+
+    Silently substituting another model's rate card produces a confident
+    wrong number; None lets callers report the cost as unknown.
+    """
+    assert get_pricing_entry("claude-opus-9", provider="anthropic") is None
+    result = estimate_usage_cost(
+        "claude-opus-9",
+        CanonicalUsage(input_tokens=1_000_000, output_tokens=1_000_000),
+        provider="anthropic",
+    )
+    assert result.amount_usd is None
+    assert result.status == "unknown"


### PR DESCRIPTION
## Summary

Two correctness bugs in cost accounting, both of which cause real spend to be reported as less than it was.

1. **The Claude 5 series is absent from `_OFFICIAL_DOCS_PRICING` entirely** — `claude-opus-5`, `claude-opus-5-fast`, `claude-fable-5`, `claude-fable-5-1`, `claude-mythos-5`, `claude-mythos-5-1`. Every call to these models books `$0.00` with `cost_status='unknown'`, so `hermes insights` and every other cost surface reports real spend as free.

2. **1h cache writes were never modelled.** `PricingEntry` carried only the 5m write rate. A deployment running `prompt_caching.cache_ttl: '1h'` is undercounted on *every cache write* — 1h writes bill at **2× base input**, not the 1.25× that was charged. This affects models that were *already* priced, so it is not fixed by adding table rows.

## Rates and their source lines

All from the Anthropic pricing table: https://docs.claude.com/en/docs/about-claude/pricing

| Model | Base input | 5m write | 1h write | Cache hits | Output |
|---|---|---|---|---|---|
| Claude Fable 5.1 | $10 | $12.50 | $20 | **$0.25**¹ | $50 |
| Claude Mythos 5.1 | $10 | $12.50 | $20 | **$0.25**¹ | $50 |
| Claude Fable 5 | $10 | $12.50 | $20 | $1 | $50 |
| Claude Mythos 5 | $10 | $12.50 | $20 | $1 | $50 |
| Claude Opus 5 | $5 | $6.25 | $10 | $0.50 | $25 |
| Claude Sonnet 5 | $2 | $2.50 | $4 | $0.20 | $10 |

Three footnotes on that page are load-bearing for this diff:

**¹ The 5.1 cache-hit multiplier.** Verbatim from the table's footnote:

> Cache hits and refreshes on Claude Fable 5.1 and Claude Mythos 5.1 are priced at 0.025x the base input price. All other models use the standard 0.1x multiplier.

This is why 5.1 gets its own entries instead of aliasing to 5.0 — aliasing would overcharge their cache reads by 4×.

**Sonnet 5 pricing is now permanent.** Verbatim:

> The $2/$10 per million input/output token pricing for Claude Sonnet 5, announced at launch as introductory pricing through August 31, 2026, is now the standard price. The previously scheduled increase […]

The existing in-tree comment says the opposite:

```python
# Launched 2026-06-30. Introductory pricing ($2/$10 per MTok) runs
# through 2026-08-31, after which it reverts to $3/$15 (matching
# Sonnet 4.6). Update this entry when the intro window closes.
```

That instruction is now actively harmful — following it raises Sonnet 5 rates by 50%. Corrected in this PR with a do-not-restore note.

**1h writes are 2× base input**, uniformly, per the `1h Cache Writes` column across every row.

## Implementation

- `PricingEntry.cache_write_1h_cost_per_million` — the 1h rate, optional.
- `CanonicalUsage.cache_write_1h_tokens` — the 1h subset of writes, read from Anthropic's `cache_creation.ephemeral_1h_input_tokens`.
- `estimate_usage_cost` bills the two tiers separately; the 5m remainder is `cache_write_tokens - cache_write_1h_tokens`.

Providers that report no TTL split are unaffected: the field stays `0` and everything bills at the 5m rate exactly as before. Existing `test_usage_pricing.py` passes unchanged (52 tests).

## On unknown models: return `None`, never guess

`get_pricing_entry` already returns `None` for an unpriced model rather than substituting a nearby rate card, and this PR adds a test pinning that behavior. It is worth stating explicitly because the failure mode is severe and silent.

Anthropic's legacy Opus 4.1 rates are exactly **3×** Opus 5's in every token class ($15/$75/$18.75/$1.50 vs $5/$25/$6.25/$0.50). Any consumer that reacts to a missing entry by falling back to an older Claude card — a dashboard, a report generator, a human reading the table — produces a figure that is wrong by a constant 3× and looks entirely plausible. In our case four sessions were reported at $459.66 / $351.06 / $322.40 / $191.61 when the true Opus 5 cost was $153.23 / $117.02 / $107.47 / $64.99; the ratio was exactly 2.9998–3.0000 across completely different token mixes, which is how the substitution was eventually spotted.

`None` + `cost_status='unknown'` is the right contract: a caller can render "unknown" honestly, while a guessed rate card produces a confident wrong number that nobody audits. Covered by `test_unknown_model_returns_no_pricing_rather_than_guessing`.

## Tests

Written as relationships rather than snapshots so they survive the next price change:

- `test_current_claude_5_series_models_are_priced` — lookup succeeds (no rate asserted)
- `test_anthropic_1h_cache_write_is_twice_base_input` — holds across every Anthropic entry
- `test_fable_5_1_cache_hits_use_the_reduced_multiplier` — 0.025× on 5.1, 0.1× on 5.0
- `test_1h_cache_writes_bill_more_than_5m_writes` — the split reaches the arithmetic
- `test_normalize_usage_reads_anthropic_1h_cache_write_split` — wire format parsing
- `test_unknown_model_returns_no_pricing_rather_than_guessing` — `None` + `status='unknown'`

```
scripts/run_tests.sh tests/agent/test_usage_pricing.py -q
=== Summary: 1 files, 52 tests passed, 0 failed (100% complete) in 2.8s ===
```

## Relationship to existing PRs

The missing-model rows overlap with #87942, #79426, #45238, and #43317, which have been sitting in competing scopes. I have no attachment to this PR's version of those rows — if any of those lands first, the model table here can be dropped and rebased.

**The 1h cache-write half does not overlap with any of them.** #43317 identified the gap and consciously left it:

> The docs also list a 1h cache-write tier, but PricingEntry currently models the standard 5m cache-write bucket used by usage normalization.

That is the part of this PR that is not duplicated elsewhere, and it under-reports cost on models that are already in the table.
