### PR TITLE
Keep codex_responses mode on auxiliary fallback

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5331,6 +5331,25 @@ def _try_main_agent_model_fallback(
     """
     main_provider = (_read_main_provider() or "").strip()
     main_model = (_read_main_model() or "").strip()
+    if main_provider.lower() == "custom":
+        try:
+            from hermes_cli.runtime_provider import (
+                _get_named_custom_provider,
+                canonical_custom_identity,
+            )
+
+            named_provider = canonical_custom_identity(
+                base_url=_read_main_base_url(), model=main_model
+            )
+            named_entry = (
+                _get_named_custom_provider(named_provider)
+                if named_provider
+                else None
+            )
+            if named_entry and named_entry.get("api_mode") == "codex_responses":
+                main_provider = named_provider
+        except Exception:
+            pass
     if main_provider.lower() == "moa":
         # MoA virtual provider: fall back to the preset's aggregator — the
         # acting model — instead of the unreachable "moa"/<preset-name> pair.

--- a/tests/agent/test_auxiliary_fallback_codex_responses.py
+++ b/tests/agent/test_auxiliary_fallback_codex_responses.py
@@ -1,0 +1,63 @@
+"""Regression guard for the named custom Responses fallback."""
+
+from unittest.mock import MagicMock, patch
+
+
+def test_transport_failure_uses_named_custom_responses_client(tmp_path, monkeypatch):
+    """A bare runtime custom class must recover its named Responses route."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: custom:relay\n"
+        "  default: fallback-model\n"
+        "providers:\n"
+        "  relay:\n"
+        "    base_url: http://relay.test/backend-api/codex\n"
+        "    key_env: RELAY_API_KEY\n"
+        "    api_mode: codex_responses\n"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("RELAY_API_KEY", "test-key")
+
+    from agent import auxiliary_client as mod
+
+    class APIConnectionError(Exception):
+        pass
+
+    primary = MagicMock()
+    primary.base_url = "http://primary.test/v1"
+    primary.chat.completions.create.side_effect = APIConnectionError("transport down")
+    captured = []
+
+    def record_fallback(client, model, label, **_kwargs):
+        captured.append((client, model, label))
+        return {"fallback": True}
+
+    mod.clear_runtime_main()
+    mod.set_runtime_main(
+        "custom", "fallback-model",
+        base_url="http://relay.test/backend-api/codex",
+        api_key="test-key",
+    )
+    try:
+        with (
+            patch.object(
+                mod, "_resolve_task_provider_model",
+                return_value=("primary", "primary-model", None, None, None),
+            ),
+            patch.object(mod, "_get_cached_client", return_value=(primary, "primary-model")),
+            patch.object(mod, "_try_configured_fallback_chain", return_value=(None, None, "")),
+            patch.object(mod, "_call_fallback_candidate_sync", side_effect=record_fallback),
+        ):
+            assert mod.call_llm(
+                task="compression", messages=[{"role": "user", "content": "compress"}]
+            ) == {"fallback": True}
+    finally:
+        mod.clear_runtime_main()
+
+    client, model, label = captured.pop()
+    assert isinstance(client, mod.CodexAuxiliaryClient)
+    assert model == "fallback-model"
+    assert label == "main-agent(custom:relay)"
+    assert str(client.base_url).rstrip("/") == "http://relay.test/backend-api/codex"


### PR DESCRIPTION
## Summary

- preserve the named custom provider's `codex_responses` mode when the auxiliary safety-net falls back to the main model
- keep the fallback on the named Responses client and endpoint

## Problem

The fallback can lose `custom:codex-lb` and resolve only the bare `custom` billing class. That sends raw `/chat/completions` traffic to a Responses-only proxy, which returns HTTP 405 and leaves context compression failing on every fallback. The fix recovers the named identity only when its entry declares `api_mode: codex_responses`, then uses the existing named-provider client resolution.

With the primary auxiliary route forced invalid, the request reproduced `Error code: 405` before the fix and reaches `/responses` after it.

## Verification

- `pytest -q tests/agent/test_auxiliary_fallback_codex_responses.py tests/agent/test_auxiliary_named_custom_providers.py` — 21 passed
- `ruff check agent/auxiliary_client.py tests/agent/test_auxiliary_fallback_codex_responses.py` — passed
- `git diff --check upstream/main...HEAD` — passed

## Safety

- only bare-custom fallbacks whose named entry declares `api_mode: codex_responses` are affected
- every other provider and route is unchanged
- named-provider lookup is exception-guarded, so lookup failures retain the prior fallback behavior
