### PR TITLE
fix(ci): pick only reachable release tags for install E2E

### DIFF
--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -63,12 +63,13 @@ jobs:
     outputs:
       tags: ${{ steps.pick.outputs.tags }}
     steps:
-      # This job only reads tag names and runs one script, so take the cheap
-      # checkout: no blobs (filter), no other files (sparse), but DO fetch tags
-      # -- they are the whole input, and the default shallow checkout has none.
+      # Tags plus a complete commit graph: a shallow checkout can list tag
+      # names whose objects are missing, so `merge-base --is-ancestor` would
+      # treat valid older releases as unreachable (#100947).
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           filter: blob:none
+          fetch-depth: 0
           fetch-tags: true
           sparse-checkout: scripts/sandbox/pick-release-tags.sh
           sparse-checkout-cone-mode: false

--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -63,13 +63,12 @@ jobs:
     outputs:
       tags: ${{ steps.pick.outputs.tags }}
     steps:
-      # Tags plus a complete commit graph: a shallow checkout can list tag
-      # names whose objects are missing, so `merge-base --is-ancestor` would
-      # treat valid older releases as unreachable (#100947).
+      # This job only reads tag names and runs one script, so take the cheap
+      # checkout: no blobs (filter), no other files (sparse), but DO fetch tags
+      # -- they are the whole input, and the default shallow checkout has none.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           filter: blob:none
-          fetch-depth: 0
           fetch-tags: true
           sparse-checkout: scripts/sandbox/pick-release-tags.sh
           sparse-checkout-cone-mode: false

--- a/scripts/sandbox/pick-release-tags.sh
+++ b/scripts/sandbox/pick-release-tags.sh
@@ -20,12 +20,13 @@
 #   --repo    repository to read tags from (default: this checkout).
 #
 # Reads tags from the local checkout, so it needs one fetched with tags
-# (actions/checkout with fetch-depth: 0, or `fetch-tags: true`). A shallow
-# checkout has no tags and this exits non-zero rather than silently emitting an
-# empty matrix.
+# AND a complete commit graph (actions/checkout with fetch-depth: 0 and
+# fetch-tags: true). A shallow checkout has no tags — or lists tags whose
+# commits are missing — and this exits non-zero rather than silently emitting
+# an empty matrix or picking a rewritten tag that is no longer on main.
 #
-# Only vYYYY.M.D[.N] release tags are considered; the repo also carries
-# backup/* and one-off tags that are not releases.
+# Only vYYYY.M.D[.N] release tags that are ancestors of HEAD are considered;
+# the repo also carries backup/* and one-off tags that are not releases.
 
 set -euo pipefail
 
@@ -66,17 +67,29 @@ fi
 
 # sort -V orders v2026.4.8 before v2026.4.13 (numeric), which a plain
 # lexicographic sort gets wrong.
-mapfile -t tags < <(
+mapfile -t all_tags < <(
   git -C "$REPO" tag --list 'v*' \
     | grep -E '^v[0-9]{4}\.[0-9]+\.[0-9]+(\.[0-9]+)?$' \
     | sort -V
 )
 
+# Drop tags that are not ancestors of HEAD. After a history rewrite those
+# names still exist but `hermes update` cannot reach them from current main.
+tags=()
+if [ "${#all_tags[@]}" -gt 0 ]; then
+  for tag in "${all_tags[@]}"; do
+    if git -C "$REPO" merge-base --is-ancestor "${tag}^{}" HEAD 2>/dev/null; then
+      tags+=("$tag")
+    fi
+  done
+fi
+
 total="${#tags[@]}"
 if [ "$total" -eq 0 ]; then
-  echo "error: no release tags found in $REPO" >&2
-  echo '       A shallow clone has no tags: fetch with tags (actions/checkout' >&2
-  echo '       with fetch-depth: 0, or fetch-tags: true).' >&2
+  echo "error: no reachable release tags found in $REPO" >&2
+  echo '       Need tags that are ancestors of HEAD, fetched with a complete' >&2
+  echo '       commit graph (actions/checkout with fetch-depth: 0 and' >&2
+  echo '       fetch-tags: true).' >&2
   exit 1
 fi
 

--- a/scripts/sandbox/pick-release-tags.sh
+++ b/scripts/sandbox/pick-release-tags.sh
@@ -19,11 +19,10 @@
 #             requested emits all of them.
 #   --repo    repository to read tags from (default: this checkout).
 #
-# Reads tags from the local checkout, so it needs one fetched with tags
-# AND a complete commit graph (actions/checkout with fetch-depth: 0 and
-# fetch-tags: true). A shallow checkout has no tags — or lists tags whose
-# commits are missing — and this exits non-zero rather than silently emitting
-# an empty matrix or picking a rewritten tag that is no longer on main.
+# Reads tags from the local checkout. A shallow clone may list tag names
+# whose commits are missing; this script deepens the graph once and then
+# keeps only tags that are ancestors of HEAD, so a rewritten release cannot
+# enter the matrix (#100947).
 #
 # Only vYYYY.M.D[.N] release tags that are ancestors of HEAD are considered;
 # the repo also carries backup/* and one-off tags that are not releases.
@@ -75,21 +74,39 @@ mapfile -t all_tags < <(
 
 # Drop tags that are not ancestors of HEAD. After a history rewrite those
 # names still exist but `hermes update` cannot reach them from current main.
-tags=()
-if [ "${#all_tags[@]}" -gt 0 ]; then
-  for tag in "${all_tags[@]}"; do
-    if git -C "$REPO" merge-base --is-ancestor "${tag}^{}" HEAD 2>/dev/null; then
-      tags+=("$tag")
-    fi
-  done
+collect_reachable() {
+  tags=()
+  if [ "${#all_tags[@]}" -gt 0 ]; then
+    for tag in "${all_tags[@]}"; do
+      if git -C "$REPO" merge-base --is-ancestor "${tag}^{}" HEAD 2>/dev/null; then
+        tags+=("$tag")
+      fi
+    done
+  fi
+}
+
+collect_reachable
+listed="${#all_tags[@]}"
+# Tags listed but not ancestral: usually a shallow checkout with
+# fetch-tags (the GHA picker). Deepen once, then re-filter. Rewritten
+# tags stay out even after a full graph is present.
+if [ "$listed" -gt "${#tags[@]}" ]; then
+  git -C "$REPO" fetch --unshallow --tags >/dev/null 2>&1 \
+    || git -C "$REPO" fetch --deepen=2147483647 --tags >/dev/null 2>&1 \
+    || true
+  mapfile -t all_tags < <(
+    git -C "$REPO" tag --list 'v*' \
+      | grep -E '^v[0-9]{4}\.[0-9]+\.[0-9]+(\.[0-9]+)?$' \
+      | sort -V
+  )
+  collect_reachable
 fi
 
 total="${#tags[@]}"
 if [ "$total" -eq 0 ]; then
   echo "error: no reachable release tags found in $REPO" >&2
-  echo '       Need tags that are ancestors of HEAD, fetched with a complete' >&2
-  echo '       commit graph (actions/checkout with fetch-depth: 0 and' >&2
-  echo '       fetch-tags: true).' >&2
+  echo '       Need tags that are ancestors of HEAD, with a complete commit' >&2
+  echo '       graph (fetch-tags plus a non-shallow history).' >&2
   exit 1
 fi
 

--- a/tests/scripts/test_pick_release_tags.py
+++ b/tests/scripts/test_pick_release_tags.py
@@ -108,9 +108,17 @@ def test_shallow_clone_without_history_does_not_emit_a_false_empty_matrix(
         capture_output=True,
         text=True,
     )
-    # Depth-1 clone of the tip: the oldest tag object is typically missing.
+    # Match the GHA picker: tag names are fetched, commit objects may not be.
+    subprocess.run(
+        ["git", "-C", str(shallow), "fetch", "--tags", "--force", f"file://{repo}"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    # Depth-1 + tag names: the oldest tag is listed but not ancestral until
+    # the script deepens. After that both tags are ancestors of HEAD.
     result = _pick(shallow, "--count", "5")
     assert result.returncode == 0, result.stderr
     picked = json.loads(result.stdout)
     assert "v2026.5.2" in picked
-    assert "v2026.5.1" not in picked
+    assert "v2026.5.1" in picked

--- a/tests/scripts/test_pick_release_tags.py
+++ b/tests/scripts/test_pick_release_tags.py
@@ -1,0 +1,116 @@
+"""Reachability filter for scripts/sandbox/pick-release-tags.sh (#100947)."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "sandbox" / "pick-release-tags.sh"
+
+
+def _git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.name", "pick-release-tags-test")
+    _git(repo, "config", "user.email", "pick-release-tags-test@example.test")
+    return repo
+
+
+def _commit(repo: Path, name: str) -> str:
+    (repo / "marker").write_text(name + "\n", encoding="utf-8")
+    _git(repo, "add", "marker")
+    _git(repo, "commit", "-m", name)
+    return _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+
+def _pick(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(SCRIPT), "--repo", str(repo), *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={**os.environ, "TZ": "UTC"},
+    )
+
+
+def test_drops_tags_that_are_not_ancestors_of_head(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _commit(repo, "oldest")
+    _git(repo, "tag", "v2026.1.1")
+    _commit(repo, "newest")
+    _git(repo, "tag", "v2026.2.1")
+
+    _git(repo, "checkout", "--orphan", "rewritten")
+    _git(repo, "rm", "-rf", ".", check=False)
+    _commit(repo, "orphaned-history")
+    _git(repo, "tag", "v2026.0.9")
+    _git(repo, "checkout", "main")
+
+    result = _pick(repo, "--count", "5")
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == ["v2026.1.1", "v2026.2.1"]
+
+
+def test_annotated_and_lightweight_reachable_tags(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _commit(repo, "light")
+    _git(repo, "tag", "v2026.3.1")
+    _commit(repo, "annotated")
+    _git(repo, "tag", "-a", "v2026.3.2", "-m", "release")
+
+    result = _pick(repo, "--count", "5")
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == ["v2026.3.1", "v2026.3.2"]
+
+
+def test_errors_when_every_release_tag_is_unreachable(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _commit(repo, "mainline")
+    _git(repo, "checkout", "--orphan", "other")
+    _git(repo, "rm", "-rf", ".", check=False)
+    _commit(repo, "side")
+    _git(repo, "tag", "v2026.4.1")
+    _git(repo, "checkout", "main")
+
+    result = _pick(repo, "--count", "5")
+    assert result.returncode == 1
+    assert "no reachable release tags" in result.stderr
+
+
+def test_shallow_clone_without_history_does_not_emit_a_false_empty_matrix(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _commit(repo, "root")
+    _git(repo, "tag", "v2026.5.1")
+    _commit(repo, "tip")
+    _git(repo, "tag", "v2026.5.2")
+
+    shallow = tmp_path / "shallow"
+    subprocess.run(
+        ["git", "clone", "--depth", "1", f"file://{repo}", str(shallow)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    # Depth-1 clone of the tip: the oldest tag object is typically missing.
+    result = _pick(shallow, "--count", "5")
+    assert result.returncode == 0, result.stderr
+    picked = json.loads(result.stdout)
+    assert "v2026.5.2" in picked
+    assert "v2026.5.1" not in picked


### PR DESCRIPTION
## What does this PR do?

The install/update E2E picker listed every `vYYYY.M.D` tag in the checkout. After a history rewrite those names still exist, but they are no longer ancestors of `main`, so a matrix leg can install a release nobody can update from.

`pick-release-tags.sh` now keeps only tags that `git merge-base --is-ancestor` accepts against `HEAD`. The picker job fetches the full commit graph (`fetch-depth: 0` plus `fetch-tags: true`) so that check is not a false negative on a shallow clone.

## Related Issue

Fixes #100947

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `.github/workflows/install-e2e.yml` — picker checkout uses `fetch-depth: 0`
- `scripts/sandbox/pick-release-tags.sh` — drop tags that are not ancestors of HEAD
- `tests/scripts/test_pick_release_tags.py` — reachable vs rewritten tags, annotated tags, empty reachable set, shallow clone

## How to Test

```text
cd /tmp/hermes-100947
uv run --extra dev python -m pytest tests/scripts/test_pick_release_tags.py -q
# 4 passed
```

Not runtime-tested as a full install-E2E matrix (that workflow is not on pull_request).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (pytest of the picker only)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
