### PR TITLE
fix(auth): configure key command timeout

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -7157,7 +7157,9 @@ def resolve_provider_client(
             if custom_key_cmd:
                 from agent.command_token_source import build_command_token_provider
                 custom_key = build_command_token_provider(
-                    custom_key_cmd, custom_entry.get("name") or provider
+                    custom_key_cmd,
+                    custom_entry.get("name") or provider,
+                    custom_entry.get("key_cmd_timeout_seconds"),
                 ) or custom_key
             if not custom_key:
                 try:

--- a/agent/command_token_source.py
+++ b/agent/command_token_source.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import subprocess
 import threading
 import time
@@ -59,11 +60,23 @@ _MINT_TIMEOUT_SECONDS = 15
 _NO_TTL_REFRESH_SECONDS = 900.0
 
 
+def _key_cmd_timeout_seconds(value: object) -> float:
+    """Return a safe key-command timeout, defaulting invalid config to 15s."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return float(_MINT_TIMEOUT_SECONDS)
+    timeout = float(value)
+    return timeout if math.isfinite(timeout) and timeout > 0 else float(_MINT_TIMEOUT_SECONDS)
+
+
 class CommandTokenError(RuntimeError):
     """A ``key_cmd`` failed to produce a usable token."""
 
 
-def _mint(command: str, label: str) -> tuple[str, Optional[float]]:
+def _mint(
+    command: str,
+    label: str,
+    timeout_seconds: float = _MINT_TIMEOUT_SECONDS,
+) -> tuple[str, Optional[float]]:
     """Run *command*, returning ``(token, ttl_seconds_or_None)``."""
     try:
         completed = subprocess.run(
@@ -71,12 +84,12 @@ def _mint(command: str, label: str) -> tuple[str, Optional[float]]:
             shell=True,
             capture_output=True,
             text=True,
-            timeout=_MINT_TIMEOUT_SECONDS,
+            timeout=timeout_seconds,
         )
     except subprocess.TimeoutExpired as exc:
         raise CommandTokenError(
             f"key_cmd for provider {label!r} timed out after "
-            f"{_MINT_TIMEOUT_SECONDS}s"
+            f"{timeout_seconds:g}s"
         ) from exc
     except OSError as exc:
         raise CommandTokenError(
@@ -152,9 +165,15 @@ def _mint(command: str, label: str) -> tuple[str, Optional[float]]:
 class CommandTokenSource:
     """Callable returning a bearer token, cached until shortly before expiry."""
 
-    def __init__(self, command: str, label: str = "custom") -> None:
+    def __init__(
+        self,
+        command: str,
+        label: str = "custom",
+        key_cmd_timeout_seconds: object = _MINT_TIMEOUT_SECONDS,
+    ) -> None:
         self._command = command
         self._label = label or "custom"
+        self._timeout_seconds = _key_cmd_timeout_seconds(key_cmd_timeout_seconds)
         self._lock = threading.Lock()
         self._token = ""
         self._expires_at: float = 0.0
@@ -163,7 +182,7 @@ class CommandTokenSource:
         with self._lock:
             if self._token and time.monotonic() < self._expires_at:
                 return self._token
-            token, ttl = _mint(self._command, self._label)
+            token, ttl = _mint(self._command, self._label, self._timeout_seconds)
             self._token = token
             self._expires_at = (
                 time.monotonic() + max(ttl - _TOKEN_REFRESH_LEEWAY_SECONDS, 5.0)
@@ -182,9 +201,14 @@ class CommandTokenSource:
 def build_command_token_provider(
     key_cmd: str,
     provider_label: str = "custom",
+    key_cmd_timeout_seconds: object = _MINT_TIMEOUT_SECONDS,
 ) -> Optional[Callable[[], str]]:
-    """A per-request token provider for *key_cmd*, or ``None`` when unset."""
+    """Build a token provider for *key_cmd*, or ``None`` when unset.
+
+    ``key_cmd_timeout_seconds`` is a positive finite per-provider timeout;
+    absent or invalid values use the 15-second default.
+    """
     command = str(key_cmd or "").strip()
     if not command:
         return None
-    return CommandTokenSource(command, provider_label)
+    return CommandTokenSource(command, provider_label, key_cmd_timeout_seconds)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1706,7 +1706,7 @@ def _normalize_custom_provider_entry(
         # configs don't warn on every load.
         "provider",
         "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
-        "key_cmd",
+        "key_cmd", "key_cmd_timeout_seconds",
         "api_mode", "transport", "model", "default_model", "models",
         "models_discovered",
         "context_length", "rate_limit_delay",
@@ -2349,9 +2349,11 @@ _VALID_CUSTOM_PROVIDER_FIELDS = {
     "name", "base_url", "api_key", "api_mode", "model", "models",
     "context_length", "rate_limit_delay", "extra_body",
     "ssl_ca_cert", "ssl_verify",
-    # key_env is read at runtime by runtime_provider.py and auxiliary_client.py
+    # key_env, key_cmd, and key_cmd_timeout_seconds are read at runtime by
+    # runtime_provider.py and auxiliary_client.py
     # — include it here so the set accurately describes the supported schema.
     "key_env",
+    "key_cmd", "key_cmd_timeout_seconds",
 }
 
 # Fields that look like they should be inside custom_providers, not at root

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -866,6 +866,9 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                     key_cmd = str(entry.get("key_cmd", "") or "").strip()
                     if key_cmd:
                         result["key_cmd"] = key_cmd
+                        result["key_cmd_timeout_seconds"] = entry.get(
+                            "key_cmd_timeout_seconds"
+                        )
                     # The v11→v12 migration writes the API mode under the new
                     # ``transport`` field, but hand-edited configs may still
                     # use the legacy ``api_mode`` spelling.  Accept both —
@@ -1392,6 +1395,7 @@ def _resolve_named_custom_runtime(
         token_provider = build_command_token_provider(
             key_cmd,
             str(custom_provider.get("name", requested_provider) or "custom"),
+            custom_provider.get("key_cmd_timeout_seconds"),
         )
         if token_provider is not None:
             api_key = token_provider

--- a/tests/agent/test_command_token_source.py
+++ b/tests/agent/test_command_token_source.py
@@ -153,6 +153,36 @@ class TestBuilder:
         assert callable(provider)
         assert provider() == "tok"
 
+    def test_configured_timeout_reaches_the_token_helper(self, monkeypatch):
+        """A provider may give a slow local token helper a larger budget."""
+        import agent.command_token_source as source_module
+
+        seen = {}
+
+        def _run(*_args, **kwargs):
+            seen["timeout"] = kwargs["timeout"]
+            return SimpleNamespace(returncode=0, stdout="token")
+
+        monkeypatch.setattr(source_module.subprocess, "run", _run)
+        provider = build_command_token_provider(
+            "ignored", "dbx", key_cmd_timeout_seconds=3.5
+        )
+
+        assert provider is not None
+        assert provider() == "token"
+        assert seen["timeout"] == 3.5
+
+    @pytest.mark.parametrize("invalid", [None, False, 0, -1, float("nan"), float("inf"), "slow"])
+    def test_invalid_configured_timeout_uses_the_safe_default(self, invalid):
+        from agent.command_token_source import _MINT_TIMEOUT_SECONDS
+
+        provider = build_command_token_provider(
+            "printf token", "dbx", key_cmd_timeout_seconds=invalid
+        )
+
+        assert provider is not None
+        assert provider._timeout_seconds == _MINT_TIMEOUT_SECONDS
+
 
 class TestResolutionYieldsACallable:
     """The integration contract: a callable reaches the wire client."""
@@ -177,6 +207,25 @@ class TestResolutionYieldsACallable:
         api_key = runtime["api_key"]
         assert callable(api_key), "key_cmd must resolve to a per-request callable"
         assert api_key() == "minted-token"
+
+    def test_runtime_provider_passes_the_configured_key_cmd_timeout(self, monkeypatch):
+        from hermes_cli import runtime_provider as rp
+
+        config = {
+            "providers": {
+                "dbx": {
+                    "base_url": "https://example.invalid/v1",
+                    "key_cmd": "printf minted-token",
+                    "key_cmd_timeout_seconds": 21,
+                }
+            }
+        }
+        monkeypatch.setattr(rp, "load_config", lambda *a, **k: config)
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda *a, **k: config)
+
+        runtime = rp.resolve_runtime_provider(requested="custom:dbx")
+
+        assert runtime["api_key"]._timeout_seconds == 21.0
 
     def test_explicit_api_key_still_wins(self, monkeypatch):
         """``--api-key`` stays the one-off recovery escape hatch."""
@@ -330,6 +379,18 @@ class TestAuxiliaryResolverHonoursKeyCmd:
         api_key = self._resolve(monkeypatch, {**self.BASE, "key_cmd": "printf minted-token"})
         assert callable(api_key), "auxiliary tasks must mint per request too"
         assert api_key() == "minted-token"
+
+    def test_auxiliary_provider_passes_the_configured_key_cmd_timeout(self, monkeypatch):
+        api_key = self._resolve(
+            monkeypatch,
+            {
+                **self.BASE,
+                "key_cmd": "printf minted-token",
+                "key_cmd_timeout_seconds": 21,
+            },
+        )
+
+        assert api_key._timeout_seconds == 21.0
 
     def test_key_cmd_beats_static_credentials(self, monkeypatch):
         """Precedence matches the runtime resolver, so both agree on one entry."""

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1232,6 +1232,12 @@ class TestProviderEntryApiKeyEnvAlias:
         from hermes_cli.config import _VALID_CUSTOM_PROVIDER_FIELDS
         assert "key_env" in _VALID_CUSTOM_PROVIDER_FIELDS
 
+    def test_valid_fields_set_lists_key_cmd_timeout_seconds(self):
+        """The documented provider timeout must survive config validation."""
+        from hermes_cli.config import _VALID_CUSTOM_PROVIDER_FIELDS
+
+        assert "key_cmd_timeout_seconds" in _VALID_CUSTOM_PROVIDER_FIELDS
+
     def test_extra_body_is_supported_schema(self):
         from hermes_cli.config import (
             _VALID_CUSTOM_PROVIDER_FIELDS,

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1309,11 +1309,14 @@ providers:
     base_url: "https://gateway.internal.example.com/v1"
     api_mode: chat_completions
     key_cmd: "my-auth-cli print-token --profile prod"
+    key_cmd_timeout_seconds: 30  # optional; defaults to 15
 ```
 
 Works with any helper that prints a token — `databricks auth token`, `gcloud auth print-access-token`, `az account get-access-token`, `vault read`, or Claude Code-style `apiKeyHelper` scripts.
 
 The command must print **only** the token on stdout: either bare, or as JSON with an `access_token` field (`expires_in` is honored; absolute `expiry`/`expiresOn` ISO timestamps too). Multi-line output is rejected rather than guessed at. If no expiry is advertised, the token is re-minted on a bounded window.
+
+`key_cmd_timeout_seconds` is an optional per-provider timeout for the command. It must be a finite positive number; omitted or invalid values safely use the default of 15 seconds.
 
 Precedence: an explicit `--api-key` flag still wins; otherwise `key_cmd` beats a static `api_key`/`key_env` on the same entry. The minted credential applies to the main agent turn and to auxiliary tasks (title generation, compression, vision, embedding) alike.
 


### PR DESCRIPTION
## Problem
Custom providers using `key_cmd` have a fixed 15-second helper deadline. Some valid credential helpers can exceed that budget, with no provider-level tuning.

## Change
- Add `key_cmd_timeout_seconds` to custom-provider configuration.
- Accept only positive finite numeric values; invalid or omitted values retain the 15-second default.
- Apply the value in both primary runtime and auxiliary provider resolution.

Example:
```yaml
providers:
  my-gateway:
    key_cmd: my-auth-cli print-token
    key_cmd_timeout_seconds: 30
```

## Verification
- Changed-path tests: `105 passed`
- Manual configured-timeout enforcement test passed.
- `git diff --check` passed.

## Compatibility
No configuration change is required; existing providers retain the 15-second default.