### PR TITLE
docs(email): document inbound-only mode + draft-only approval roadmap

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -191,6 +191,11 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
     "api_server":      {**_TIER_HIGH, "tool_preview_length": 0},
 }
 
+# Email is a permanent-message mailbox. Its minimal tier is a safety default,
+# not a preference inherited from global interactive-gateway display settings.
+# An intentional ``display.platforms.email.<key>`` override still wins.
+_PLATFORMS_WITH_PINNED_SAFE_DEFAULTS = frozenset({"email"})
+
 # Canonical set of per-platform overrideable keys (for validation).
 OVERRIDEABLE_KEYS = frozenset(_GLOBAL_DEFAULTS.keys())
 
@@ -236,6 +241,14 @@ def resolve_display_setting(
             val = legacy.get(platform_key)
             if val is not None:
                 return _normalise(setting, val)
+
+    # Email's no-edit delivery tier deliberately beats global gateway display
+    # settings. This prevents global `tool_progress: all` or interim assistant
+    # messages from creating a large permanent-email flood.
+    if platform_key in _PLATFORMS_WITH_PINNED_SAFE_DEFAULTS:
+        plat_defaults = _PLATFORM_DEFAULTS.get(platform_key) or {}
+        if setting in plat_defaults:
+            return plat_defaults[setting]
 
     # 2. Global user setting (display.<key>).  Skip display.streaming because
     # that key controls only CLI terminal streaming; gateway token streaming is

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -575,7 +575,8 @@ class EmailAdapter(BasePlatformAdapter):
         # Read-only / no-auto-reply mode — configured via config.yaml:
         #   platforms:
         #     email:
-        #       read_only: true
+        #       extra:
+        #         read_only: true
         # When enabled the adapter still polls IMAP and dispatches incoming mail
         # normally, but every outgoing send is suppressed (no SMTP) so a mailbox
         # can be used purely as a read feed without ever replying to the sender

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -577,7 +577,7 @@ class EmailAdapter(BasePlatformAdapter):
         # failure loop that disabling the SMTP credential would cause. Default
         # OFF (behaviour unchanged unless explicitly enabled).
         if "read_only" in extra:
-            self._read_only = bool(extra["read_only"])
+            self._read_only = is_truthy_value(extra["read_only"], default=False)
         else:
             self._read_only = _esecret_bool("EMAIL_READ_ONLY", False)
 
@@ -691,14 +691,16 @@ class EmailAdapter(BasePlatformAdapter):
         # Validate up front so a missing host surfaces as an actionable config
         # error instead of IMAP4_SSL("") raising the cryptic
         # ``[Errno 8] nodename nor servname provided, or not known``.
+        required_settings = [
+            ("EMAIL_ADDRESS", self._address),
+            ("EMAIL_PASSWORD", self._password),
+            ("EMAIL_IMAP_HOST", self._imap_host),
+        ]
+        if not self._read_only:
+            required_settings.append(("EMAIL_SMTP_HOST", self._smtp_host))
         missing = [
             name
-            for name, value in (
-                ("EMAIL_ADDRESS", self._address),
-                ("EMAIL_PASSWORD", self._password),
-                ("EMAIL_IMAP_HOST", self._imap_host),
-                ("EMAIL_SMTP_HOST", self._smtp_host),
-            )
+            for name, value in required_settings
             if not value
         ]
         if missing:
@@ -779,36 +781,38 @@ class EmailAdapter(BasePlatformAdapter):
             )
             return False
 
-        try:
-            # Test SMTP connection
-            smtp = self._connect_smtp()
+        if self._read_only:
+            logger.info("[Email] Read-only mode: SMTP connection test skipped.")
+        else:
             try:
-                smtp.login(self._address, self._password)
-            finally:
-                smtp.quit()
-            logger.info("[Email] SMTP connection test passed.")
-        except smtplib.SMTPAuthenticationError as e:
-            logger.error("[Email] SMTP authentication failed: %s", e)
-            # Typed auth failure (535 & friends): bad or revoked credentials
-            # can never self-heal, so drop out of the reconnect queue instead
-            # of retrying a dead password forever (OOF-156). Type-based only —
-            # SMTPAuthenticationError is unambiguous, unlike IMAP4.error above.
-            self._set_fatal_error(
-                "email_auth_error",
-                f"SMTP authentication failed for {self._address}: {e}. "
-                "Check EMAIL_PASSWORD (for Gmail/Outlook this must be an "
-                "app password, not the account password).",
-                retryable=False,
-            )
-            return False
-        except Exception as e:
-            logger.error("[Email] SMTP connection failed: %s", e)
-            self._set_fatal_error(
-                "email_smtp_connect_error",
-                f"SMTP connection to {self._smtp_host} failed: {e}",
-                retryable=True,
-            )
-            return False
+                # Test SMTP connection
+                smtp = self._connect_smtp()
+                try:
+                    smtp.login(self._address, self._password)
+                finally:
+                    smtp.quit()
+                logger.info("[Email] SMTP connection test passed.")
+            except smtplib.SMTPAuthenticationError as e:
+                logger.error("[Email] SMTP authentication failed: %s", e)
+                # Typed auth failure (535 & friends): bad or revoked credentials
+                # can never self-heal, so drop out of the reconnect queue instead
+                # of retrying a dead password forever (OOF-156). Type-based only.
+                self._set_fatal_error(
+                    "email_auth_error",
+                    f"SMTP authentication failed for {self._address}: {e}. "
+                    "Check EMAIL_PASSWORD (for Gmail/Outlook this must be an "
+                    "app password, not the account password).",
+                    retryable=False,
+                )
+                return False
+            except Exception as e:
+                logger.error("[Email] SMTP connection failed: %s", e)
+                self._set_fatal_error(
+                    "email_smtp_connect_error",
+                    f"SMTP connection to {self._smtp_host} failed: {e}",
+                    retryable=True,
+                )
+                return False
 
         self._running = True
         self._poll_task = asyncio.create_task(self._poll_loop())
@@ -1146,19 +1150,67 @@ class EmailAdapter(BasePlatformAdapter):
         logger.info("[Email] New message from %s: %s", sender_addr, subject)
         await self.handle_message(event)
 
-    def _read_only_suppress(self, target: str, kind: str = "message") -> SendResult:
-        """Suppress an outgoing send in read-only mode (#99876).
-
-        Logs the drop and returns success so the gateway's delivery ledger
-        treats the reply as delivered rather than retrying it (the failure
-        loop a disabled SMTP credential would cause). Incoming IMAP delivery
-        is unaffected.
-        """
+    def _read_only_suppress(
+        self,
+        target: str,
+        kind: str = "message",
+        *,
+        subject: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Record a read-only suppression without exposing message content."""
+        context = self._thread_context.get(target, {})
+        resolved_subject = subject or context.get("subject", "Hermes Agent")
+        meta = metadata if isinstance(metadata, dict) else {}
+        session_id = (
+            meta.get("session_id")
+            or meta.get("task_id")
+            or meta.get("session_key")
+            or "-"
+        )
+        # This is an operator audit event. Do not log content, attachment paths,
+        # or arbitrary metadata because they can contain private data or secrets.
         logger.info(
-            "[Email] read-only mode: suppressed outgoing %s to %s (no SMTP send)",
-            kind, target,
+            "[Email] read-only SMTP suppression recipient=%s subject=%s session=%s kind=%s",
+            target,
+            resolved_subject,
+            session_id,
+            kind,
         )
         return SendResult(success=True, message_id="read-only-suppressed")
+
+    def _send_via_smtp(
+        self,
+        msg: MIMEMultipart,
+        *,
+        recipient: str,
+        subject: str,
+        kind: str = "message",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """The central SMTP egress boundary for Email adapter replies.
+
+        Read-only mode is enforced here as well as at public adapter entry
+        points. Therefore, an overlooked future helper cannot reach SMTP merely
+        because it missed a caller-side display or silence convention. The
+        standalone sender remains separate for explicitly configured proactive
+        cron/report workflows.
+        """
+        if self._read_only:
+            return self._read_only_suppress(
+                recipient, kind, subject=subject, metadata=metadata
+            ).message_id or "read-only-suppressed"
+
+        smtp = self._connect_smtp()
+        try:
+            smtp.login(self._address, self._password)
+            smtp.send_message(msg)
+        finally:
+            try:
+                smtp.quit()
+            except Exception:
+                smtp.close()
+        return str(msg["Message-ID"])
 
     async def send(
         self,
@@ -1168,12 +1220,12 @@ class EmailAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send an email reply to the given address."""
-        if getattr(self, "_read_only", False):
-            return self._read_only_suppress(chat_id)
+        if self._read_only:
+            return self._read_only_suppress(chat_id, metadata=metadata)
         try:
             loop = asyncio.get_running_loop()
             message_id = await loop.run_in_executor(
-                None, self._send_email, chat_id, content, reply_to
+                None, self._send_email, chat_id, content, reply_to, metadata
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
@@ -1195,8 +1247,9 @@ class EmailAdapter(BasePlatformAdapter):
         to_addr: str,
         body: str,
         reply_to_msg_id: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> str:
-        """Send an email via SMTP. Runs in executor thread."""
+        """Send an email via the central SMTP boundary. Runs in an executor."""
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
@@ -1217,21 +1270,14 @@ class EmailAdapter(BasePlatformAdapter):
         msg["Date"] = formatdate(localtime=True)
         msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._message_id_domain()}>"
         msg["Message-ID"] = msg_id
-
         msg.attach(MIMEText(body, "plain", "utf-8"))
 
-        smtp = self._connect_smtp()
-        try:
-            smtp.login(self._address, self._password)
-            smtp.send_message(msg)
-        finally:
-            try:
-                smtp.quit()
-            except Exception:
-                smtp.close()
-
-        logger.info("[Email] Sent reply to %s (subject: %s)", to_addr, subject)
-        return msg_id
+        sent_id = self._send_via_smtp(
+            msg, recipient=to_addr, subject=subject, metadata=metadata
+        )
+        if sent_id != "read-only-suppressed":
+            logger.info("[Email] Sent reply to %s (subject: %s)", to_addr, subject)
+        return sent_id
 
     async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
         """Email has no typing indicator — no-op."""
@@ -1251,7 +1297,7 @@ class EmailAdapter(BasePlatformAdapter):
         """
         text = caption or ""
         text += f"\n\nImage: {image_url}"
-        return await self.send(chat_id, text.strip(), reply_to)
+        return await self.send(chat_id, text.strip(), reply_to, metadata)
 
     async def send_multiple_images(
         self,
@@ -1267,8 +1313,8 @@ class EmailAdapter(BasePlatformAdapter):
         images). No hard cap — email clients handle dozens of
         attachments fine, subject to SMTP message size limits.
         """
-        if getattr(self, "_read_only", False):
-            self._read_only_suppress(chat_id, "image batch")
+        if self._read_only:
+            self._read_only_suppress(chat_id, "image batch", metadata=metadata)
             return
         if not images:
             return
@@ -1303,6 +1349,7 @@ class EmailAdapter(BasePlatformAdapter):
                 chat_id,
                 body,
                 local_paths,
+                metadata,
             )
         except Exception as e:
             logger.error("[Email] Multi-image send failed, falling back: %s", e, exc_info=True)
@@ -1313,6 +1360,7 @@ class EmailAdapter(BasePlatformAdapter):
         to_addr: str,
         body: str,
         file_paths: List[str],
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Send an email with multiple file attachments via SMTP."""
         msg = MIMEMultipart()
@@ -1349,18 +1397,12 @@ class EmailAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning("[Email] Failed to attach %s: %s", file_path, e)
 
-        smtp = self._connect_smtp()
-        try:
-            smtp.login(self._address, self._password)
-            smtp.send_message(msg)
-        finally:
-            try:
-                smtp.quit()
-            except Exception:
-                smtp.close()
+        sent_id = self._send_via_smtp(
+            msg, recipient=to_addr, subject=subject, kind="image batch", metadata=metadata
+        )
 
         logger.info("[Email] Sent multi-attachment email to %s (%d files)", to_addr, len(file_paths))
-        return msg_id
+        return sent_id
 
     async def send_document(
         self,
@@ -1372,8 +1414,9 @@ class EmailAdapter(BasePlatformAdapter):
         **kwargs,
     ) -> SendResult:
         """Send a file as an email attachment."""
-        if getattr(self, "_read_only", False):
-            return self._read_only_suppress(chat_id, "document")
+        metadata = kwargs.get("metadata")
+        if self._read_only:
+            return self._read_only_suppress(chat_id, "document", metadata=metadata)
         try:
             loop = asyncio.get_running_loop()
             message_id = await loop.run_in_executor(
@@ -1383,6 +1426,7 @@ class EmailAdapter(BasePlatformAdapter):
                 caption or "",
                 file_path,
                 file_name,
+                metadata,
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
@@ -1395,6 +1439,7 @@ class EmailAdapter(BasePlatformAdapter):
         body: str,
         file_path: str,
         file_name: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Send an email with a file attachment via SMTP."""
         msg = MIMEMultipart()
@@ -1429,17 +1474,9 @@ class EmailAdapter(BasePlatformAdapter):
             part.add_header("Content-Disposition", f"attachment; filename={fname}")
             msg.attach(part)
 
-        smtp = self._connect_smtp()
-        try:
-            smtp.login(self._address, self._password)
-            smtp.send_message(msg)
-        finally:
-            try:
-                smtp.quit()
-            except Exception:
-                smtp.close()
-
-        return msg_id
+        return self._send_via_smtp(
+            msg, recipient=to_addr, subject=subject, kind="document", metadata=metadata
+        )
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Return basic info about the email chat."""

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -238,6 +238,13 @@ def check_email_requirements() -> bool:
     return all([addr, pwd, imap, smtp])
 
 
+def _is_read_only_email(extra: Any) -> bool:
+    """Return whether config.yaml disables all Email SMTP delivery."""
+    return isinstance(extra, dict) and is_truthy_value(
+        extra.get("read_only"), default=False
+    )
+
+
 _CHARSET_ALIASES = {
     # Aliases seen in the wild that Python's codec registry doesn't know.
     # "unknown-8bit" / "x-unknown" are RFC 1428 placeholders some MTAs (QQ
@@ -568,18 +575,14 @@ class EmailAdapter(BasePlatformAdapter):
         #   platforms:
         #     email:
         #       read_only: true
-        # or the EMAIL_READ_ONLY=true env mirror (parity with the other EMAIL_*
-        # vars). When enabled the adapter still polls IMAP and dispatches
-        # incoming mail normally, but every outgoing send is suppressed (no SMTP)
-        # so a mailbox can be used purely as a read feed without ever replying to
-        # the sender (#99876). Suppressed sends return success so the gateway's
-        # delivery ledger treats them as delivered rather than retrying — the
-        # failure loop that disabling the SMTP credential would cause. Default
-        # OFF (behaviour unchanged unless explicitly enabled).
-        if "read_only" in extra:
-            self._read_only = is_truthy_value(extra["read_only"], default=False)
-        else:
-            self._read_only = _esecret_bool("EMAIL_READ_ONLY", False)
+        # When enabled the adapter still polls IMAP and dispatches incoming mail
+        # normally, but every outgoing send is suppressed (no SMTP) so a mailbox
+        # can be used purely as a read feed without ever replying to the sender
+        # (#99876). Suppressed sends return success so the gateway's delivery
+        # ledger treats them as delivered rather than retrying — the failure loop
+        # that disabling the SMTP credential would cause. Default OFF (behaviour
+        # unchanged unless explicitly enabled).
+        self._read_only = _is_read_only_email(extra)
 
         # Require the sender's From: domain to be authenticated (SPF/DKIM/DMARC)
         # before trusting it for authorization. The From: header is
@@ -1193,8 +1196,8 @@ class EmailAdapter(BasePlatformAdapter):
         Read-only mode is enforced here as well as at public adapter entry
         points. Therefore, an overlooked future helper cannot reach SMTP merely
         because it missed a caller-side display or silence convention. The
-        standalone sender remains separate for explicitly configured proactive
-        cron/report workflows.
+        standalone cron/report delivery uses the same config gate in
+        ``_standalone_send``.
         """
         if self._read_only:
             return self._read_only_suppress(
@@ -1512,12 +1515,27 @@ async def _standalone_send(
 ):
     """Out-of-process Email delivery via SMTP (one-shot). Implements the
     standalone_sender_fn contract; replaces the legacy _send_email helper."""
+    extra = getattr(pconfig, "extra", {}) or {}
+    if _is_read_only_email(extra):
+        # This is the shared cron/report transport boundary. Check before
+        # resolving credentials or creating an SMTP object so no Email route
+        # can escape inbound-only mode.
+        logger.info(
+            "[Email] read-only SMTP suppression recipient=%s kind=standalone",
+            chat_id,
+        )
+        return {
+            "success": True,
+            "platform": "email",
+            "chat_id": chat_id,
+            "message_id": "read-only-suppressed",
+        }
+
     import smtplib
     import ssl as _ssl
     from email.mime.text import MIMEText
     from email.utils import formatdate
 
-    extra = getattr(pconfig, "extra", {}) or {}
     address = extra.get("address") or _get_secret("EMAIL_ADDRESS", "")
     password = _get_secret("EMAIL_PASSWORD", "")
     smtp_host = extra.get("smtp_host") or _get_secret("EMAIL_SMTP_HOST", "")

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -23,6 +23,7 @@ import os
 import re
 import smtplib
 import socket
+from functools import partial
 
 # Profile-scoped secret reader for multiplexing support (PR #50094)
 from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
@@ -627,6 +628,10 @@ class EmailAdapter(BasePlatformAdapter):
 
         logger.info("[Email] Adapter initialized for %s", self._address)
 
+    def _outbound_is_suppressed(self) -> bool:
+        """Return the outbound policy, including lightweight test adapters."""
+        return bool(getattr(self, "_read_only", False))
+
     def _trim_seen_uids(self) -> None:
         """Keep only the most recent UIDs to prevent unbounded memory growth.
 
@@ -784,7 +789,7 @@ class EmailAdapter(BasePlatformAdapter):
             )
             return False
 
-        if self._read_only:
+        if self._outbound_is_suppressed():
             logger.info("[Email] Read-only mode: SMTP connection test skipped.")
         else:
             try:
@@ -1199,7 +1204,7 @@ class EmailAdapter(BasePlatformAdapter):
         standalone cron/report delivery uses the same config gate in
         ``_standalone_send``.
         """
-        if self._read_only:
+        if self._outbound_is_suppressed():
             return self._read_only_suppress(
                 recipient, kind, subject=subject, metadata=metadata
             ).message_id or "read-only-suppressed"
@@ -1223,7 +1228,7 @@ class EmailAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send an email reply to the given address."""
-        if self._read_only:
+        if self._outbound_is_suppressed():
             return self._read_only_suppress(chat_id, metadata=metadata)
         try:
             loop = asyncio.get_running_loop()
@@ -1316,7 +1321,7 @@ class EmailAdapter(BasePlatformAdapter):
         images). No hard cap — email clients handle dozens of
         attachments fine, subject to SMTP message size limits.
         """
-        if self._read_only:
+        if self._outbound_is_suppressed():
             self._read_only_suppress(chat_id, "image batch", metadata=metadata)
             return
         if not images:
@@ -1348,11 +1353,13 @@ class EmailAdapter(BasePlatformAdapter):
             loop = asyncio.get_running_loop()
             await loop.run_in_executor(
                 None,
-                self._send_email_with_attachments,
-                chat_id,
-                body,
-                local_paths,
-                metadata,
+                partial(
+                    self._send_email_with_attachments,
+                    chat_id,
+                    body,
+                    local_paths,
+                    metadata=metadata,
+                ),
             )
         except Exception as e:
             logger.error("[Email] Multi-image send failed, falling back: %s", e, exc_info=True)
@@ -1418,7 +1425,7 @@ class EmailAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send a file as an email attachment."""
         metadata = kwargs.get("metadata")
-        if self._read_only:
+        if self._outbound_is_suppressed():
             return self._read_only_suppress(chat_id, "document", metadata=metadata)
         try:
             loop = asyncio.get_running_loop()

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -564,6 +564,23 @@ class EmailAdapter(BasePlatformAdapter):
         #       skip_attachments: true
         self._skip_attachments = extra.get("skip_attachments", False)
 
+        # Read-only / no-auto-reply mode — configured via config.yaml:
+        #   platforms:
+        #     email:
+        #       read_only: true
+        # or the EMAIL_READ_ONLY=true env mirror (parity with the other EMAIL_*
+        # vars). When enabled the adapter still polls IMAP and dispatches
+        # incoming mail normally, but every outgoing send is suppressed (no SMTP)
+        # so a mailbox can be used purely as a read feed without ever replying to
+        # the sender (#99876). Suppressed sends return success so the gateway's
+        # delivery ledger treats them as delivered rather than retrying — the
+        # failure loop that disabling the SMTP credential would cause. Default
+        # OFF (behaviour unchanged unless explicitly enabled).
+        if "read_only" in extra:
+            self._read_only = bool(extra["read_only"])
+        else:
+            self._read_only = _esecret_bool("EMAIL_READ_ONLY", False)
+
         # Require the sender's From: domain to be authenticated (SPF/DKIM/DMARC)
         # before trusting it for authorization. The From: header is
         # attacker-controlled and unauthenticated by IMAP, so an allowlist keyed
@@ -1129,6 +1146,20 @@ class EmailAdapter(BasePlatformAdapter):
         logger.info("[Email] New message from %s: %s", sender_addr, subject)
         await self.handle_message(event)
 
+    def _read_only_suppress(self, target: str, kind: str = "message") -> SendResult:
+        """Suppress an outgoing send in read-only mode (#99876).
+
+        Logs the drop and returns success so the gateway's delivery ledger
+        treats the reply as delivered rather than retrying it (the failure
+        loop a disabled SMTP credential would cause). Incoming IMAP delivery
+        is unaffected.
+        """
+        logger.info(
+            "[Email] read-only mode: suppressed outgoing %s to %s (no SMTP send)",
+            kind, target,
+        )
+        return SendResult(success=True, message_id="read-only-suppressed")
+
     async def send(
         self,
         chat_id: str,
@@ -1137,6 +1168,8 @@ class EmailAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send an email reply to the given address."""
+        if getattr(self, "_read_only", False):
+            return self._read_only_suppress(chat_id)
         try:
             loop = asyncio.get_running_loop()
             message_id = await loop.run_in_executor(
@@ -1234,6 +1267,9 @@ class EmailAdapter(BasePlatformAdapter):
         images). No hard cap — email clients handle dozens of
         attachments fine, subject to SMTP message size limits.
         """
+        if getattr(self, "_read_only", False):
+            self._read_only_suppress(chat_id, "image batch")
+            return
         if not images:
             return
 
@@ -1336,6 +1372,8 @@ class EmailAdapter(BasePlatformAdapter):
         **kwargs,
     ) -> SendResult:
         """Send a file as an email attachment."""
+        if getattr(self, "_read_only", False):
+            return self._read_only_suppress(chat_id, "document")
         try:
             loop = asyncio.get_running_loop()
             message_id = await loop.run_in_executor(

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -77,6 +77,24 @@ class TestPlatformConfigRoundtrip:
         restored = PlatformConfig.from_dict({"enabled": "false"})
         assert restored.enabled is False
 
+    def test_email_read_only_is_loaded_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "platforms:\n"
+            "  email:\n"
+            "    enabled: true\n"
+            "    extra:\n"
+            "      read_only: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.EMAIL].enabled is True
+        assert config.platforms[Platform.EMAIL].extra["read_only"] is True
+
 
     def test_gateway_restart_notification_roundtrip_false(self):
         pc = PlatformConfig(enabled=True, gateway_restart_notification=False)

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -168,6 +168,33 @@ class TestPlatformDefaults:
         assert resolve_display_setting({}, "slack", "long_running_notifications") is False
         assert resolve_display_setting({}, "slack", "busy_ack_detail") is False
 
+    def test_email_minimal_defaults_beat_global_noisy_settings(self):
+        """Global gateway verbosity must not flood a no-edit Email inbox."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "tool_progress": "all",
+                "interim_assistant_messages": True,
+                "long_running_notifications": True,
+            }
+        }
+        assert resolve_display_setting(config, "email", "tool_progress") == "off"
+        assert resolve_display_setting(config, "email", "interim_assistant_messages") is False
+        assert resolve_display_setting(config, "email", "long_running_notifications") is False
+
+    def test_email_explicit_platform_display_opt_in_remains_supported(self):
+        """An intentional Email-specific setting still wins over its safe tier."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "tool_progress": "all",
+                "platforms": {"email": {"tool_progress": "all"}},
+            }
+        }
+        assert resolve_display_setting(config, "email", "tool_progress") == "all"
+
 
 # ---------------------------------------------------------------------------
 # Config migration: tool_progress_overrides → display.platforms

--- a/tests/gateway/test_email_read_only.py
+++ b/tests/gateway/test_email_read_only.py
@@ -1,0 +1,82 @@
+"""Email read-only / no-auto-reply mode (#99876).
+
+``platforms.email.extra.read_only: true`` (or ``EMAIL_READ_ONLY=1``) lets a
+mailbox be used purely as an inbound feed: IMAP polling / dispatch is
+unchanged, but every outgoing send is suppressed before it reaches SMTP. A
+suppressed send returns ``success=True`` so the gateway's delivery ledger
+marks it delivered rather than retrying — the failure loop that disabling the
+SMTP credential would cause. These tests pin that no SMTP helper is invoked in
+read-only mode, that the default (unset) still sends, and that all three
+adapter send entry points are covered.
+"""
+import asyncio
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+def _make_adapter(*, extra=None, env=None):
+    from gateway.config import PlatformConfig
+    from plugins.platforms.email.adapter import EmailAdapter
+
+    with patch.dict(os.environ, env or {}, clear=False):
+        return EmailAdapter(PlatformConfig(enabled=True, extra=extra or {}))
+
+
+class TestEmailReadOnly(unittest.TestCase):
+    def test_read_only_via_extra_suppresses_send(self):
+        adapter = _make_adapter(extra={"read_only": True})
+        adapter._send_email = MagicMock(name="_send_email")
+
+        result = asyncio.run(adapter.send("user@example.com", "hi"))
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "read-only-suppressed")
+        adapter._send_email.assert_not_called()
+
+    def test_read_only_via_env_suppresses_send(self):
+        adapter = _make_adapter(env={"EMAIL_READ_ONLY": "true"})
+        adapter._send_email = MagicMock(name="_send_email")
+
+        result = asyncio.run(adapter.send("user@example.com", "hi"))
+
+        self.assertTrue(result.success)
+        adapter._send_email.assert_not_called()
+
+    def test_default_is_not_read_only_and_sends(self):
+        adapter = _make_adapter()  # no extra, no env -> read_only stays False
+        self.assertFalse(adapter._read_only)
+        adapter._send_email = MagicMock(return_value="<mid@localhost>")
+
+        result = asyncio.run(adapter.send("user@example.com", "hi"))
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "<mid@localhost>")
+        adapter._send_email.assert_called_once()
+
+    def test_extra_overrides_env(self):
+        # Explicit config.yaml value wins over the env mirror.
+        adapter = _make_adapter(extra={"read_only": False}, env={"EMAIL_READ_ONLY": "true"})
+        self.assertFalse(adapter._read_only)
+
+    def test_read_only_suppresses_document_and_image_batch(self):
+        adapter = _make_adapter(extra={"read_only": True})
+        adapter._send_email_with_attachment = MagicMock(name="doc")
+        adapter._send_email_with_attachments = MagicMock(name="imgs")
+
+        doc = asyncio.run(adapter.send_document("user@example.com", "/tmp/x.pdf"))
+        self.assertTrue(doc.success)
+        self.assertEqual(doc.message_id, "read-only-suppressed")
+        adapter._send_email_with_attachment.assert_not_called()
+
+        # send_multiple_images returns None; the point is no SMTP is attempted.
+        asyncio.run(
+            adapter.send_multiple_images(
+                "user@example.com", [("file:///tmp/a.png", "")],
+            )
+        )
+        adapter._send_email_with_attachments.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/gateway/test_email_read_only.py
+++ b/tests/gateway/test_email_read_only.py
@@ -1,7 +1,7 @@
 """Email read-only / no-auto-reply mode (#99876).
 
-``platforms.email.extra.read_only: true`` (or ``EMAIL_READ_ONLY=1``) lets a
-mailbox be used purely as an inbound feed: IMAP polling / dispatch is
+``platforms.email.extra.read_only: true`` lets a mailbox be used purely as an
+inbound feed: IMAP polling / dispatch is
 unchanged, but every outgoing send is suppressed before it reaches SMTP. A
 suppressed send returns ``success=True`` so the gateway's delivery ledger
 marks it delivered rather than retrying — the failure loop that disabling the
@@ -49,14 +49,10 @@ class TestEmailReadOnly(unittest.TestCase):
         self.assertEqual(result.message_id, "read-only-suppressed")
         adapter._send_email.assert_not_called()
 
-    def test_read_only_via_env_suppresses_send(self):
+    def test_read_only_is_not_enabled_by_a_non_secret_env_var(self):
         adapter = _make_adapter(env={"EMAIL_READ_ONLY": "true"})
-        adapter._send_email = MagicMock(name="_send_email")
 
-        result = asyncio.run(adapter.send("user@example.com", "hi"))
-
-        self.assertTrue(result.success)
-        adapter._send_email.assert_not_called()
+        self.assertFalse(adapter._read_only)
 
     def test_read_only_connects_with_imap_only_and_never_tests_smtp(self):
         """Inbound-only mode must not need a working SMTP endpoint to receive."""
@@ -88,13 +84,8 @@ class TestEmailReadOnly(unittest.TestCase):
         self.assertEqual(result.message_id, "<mid@localhost>")
         adapter._send_email.assert_called_once()
 
-    def test_extra_overrides_env(self):
-        # Explicit config.yaml value wins over the env mirror.
-        adapter = _make_adapter(extra={"read_only": False}, env={"EMAIL_READ_ONLY": "true"})
-        self.assertFalse(adapter._read_only)
-
-    def test_proactive_standalone_send_remains_an_explicit_opt_in_route(self):
-        """Cron/report delivery is intentionally not an Email-session reply."""
+    def test_read_only_blocks_standalone_cron_and_shared_transport_smtp(self):
+        """Every Email transport, including cron, stops before SMTP."""
         from gateway.config import PlatformConfig
         from plugins.platforms.email.adapter import _standalone_send
 
@@ -113,7 +104,7 @@ class TestEmailReadOnly(unittest.TestCase):
             )
 
         self.assertTrue(result["success"])
-        smtp.return_value.send_message.assert_called_once()
+        smtp.assert_not_called()
 
     def test_read_only_suppresses_document_and_image_batch(self):
         adapter = _make_adapter(extra={"read_only": True})

--- a/tests/gateway/test_email_read_only.py
+++ b/tests/gateway/test_email_read_only.py
@@ -58,6 +58,25 @@ class TestEmailReadOnly(unittest.TestCase):
         self.assertTrue(result.success)
         adapter._send_email.assert_not_called()
 
+    def test_read_only_connects_with_imap_only_and_never_tests_smtp(self):
+        """Inbound-only mode must not need a working SMTP endpoint to receive."""
+        adapter = _make_adapter(extra={"read_only": True})
+        adapter._address = "hermes@example.com"
+        adapter._password = "mailbox-password"
+        adapter._imap_host = "imap.example.com"
+        adapter._smtp_host = ""
+        adapter._connect_smtp = MagicMock(name="smtp_connection")
+        imap = MagicMock()
+        imap.uid.return_value = ("OK", [b""])
+
+        async def connect_then_disconnect():
+            with patch("imaplib.IMAP4_SSL", return_value=imap):
+                self.assertTrue(await adapter.connect())
+                await adapter.disconnect()
+
+        asyncio.run(connect_then_disconnect())
+        adapter._connect_smtp.assert_not_called()
+
     def test_default_is_not_read_only_and_sends(self):
         adapter = _make_adapter()  # no extra, no env -> read_only stays False
         self.assertFalse(adapter._read_only)
@@ -73,6 +92,28 @@ class TestEmailReadOnly(unittest.TestCase):
         # Explicit config.yaml value wins over the env mirror.
         adapter = _make_adapter(extra={"read_only": False}, env={"EMAIL_READ_ONLY": "true"})
         self.assertFalse(adapter._read_only)
+
+    def test_proactive_standalone_send_remains_an_explicit_opt_in_route(self):
+        """Cron/report delivery is intentionally not an Email-session reply."""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.email.adapter import _standalone_send
+
+        pconfig = PlatformConfig(
+            enabled=True,
+            extra={
+                "read_only": True,
+                "address": "hermes@example.com",
+                "smtp_host": "smtp.example.com",
+            },
+        )
+        with patch.dict(os.environ, {"EMAIL_PASSWORD": "mailbox-password"}, clear=False), \
+             patch("smtplib.SMTP") as smtp:
+            result = asyncio.run(
+                _standalone_send(pconfig, "report-recipient@example.com", "scheduled report")
+            )
+
+        self.assertTrue(result["success"])
+        smtp.return_value.send_message.assert_called_once()
 
     def test_read_only_suppresses_document_and_image_batch(self):
         adapter = _make_adapter(extra={"read_only": True})

--- a/tests/gateway/test_email_read_only.py
+++ b/tests/gateway/test_email_read_only.py
@@ -10,6 +10,7 @@ read-only mode, that the default (unset) still sends, and that all three
 adapter send entry points are covered.
 """
 import asyncio
+import logging
 import os
 import unittest
 from unittest.mock import MagicMock, patch
@@ -24,6 +25,20 @@ def _make_adapter(*, extra=None, env=None):
 
 
 class TestEmailReadOnly(unittest.TestCase):
+    def test_read_only_blocks_the_shared_smtp_delivery_boundary(self):
+        """Even a future helper that reaches the shared SMTP sink cannot send."""
+        adapter = _make_adapter(extra={"read_only": True})
+        adapter._thread_context["user@example.com"] = {
+            "subject": "Private report",
+            "message_id": "<original@example.com>",
+        }
+
+        with patch("smtplib.SMTP") as smtp:
+            result = adapter._send_email("user@example.com", "do not disclose")
+
+        self.assertEqual(result, "read-only-suppressed")
+        smtp.assert_not_called()
+
     def test_read_only_via_extra_suppresses_send(self):
         adapter = _make_adapter(extra={"read_only": True})
         adapter._send_email = MagicMock(name="_send_email")
@@ -76,6 +91,64 @@ class TestEmailReadOnly(unittest.TestCase):
             )
         )
         adapter._send_email_with_attachments.assert_not_called()
+
+    def test_read_only_suppresses_a_noisy_100_step_run_and_every_notice_kind(self):
+        """The adapter is the hard egress boundary, not a display convention."""
+        adapter = _make_adapter(extra={"read_only": True})
+        adapter._send_email = MagicMock(name="smtp_delivery")
+
+        for step in range(100):
+            result = asyncio.run(
+                adapter.send(
+                    "user@example.com",
+                    f"interim commentary {step}",
+                    metadata={"session_id": "email-session-100"},
+                )
+            )
+            self.assertTrue(result.success)
+
+        for notice_kind in (
+            "iteration-budget",
+            "model-fallback",
+            "approval-status",
+            "attachment-follow-up",
+            "stop-closeout",
+            "delivery-ledger-retry",
+            "final-response",
+        ):
+            result = asyncio.run(
+                adapter.send(
+                    "user@example.com",
+                    f"{notice_kind} body",
+                    metadata={"session_id": "email-session-100", "delivery_kind": notice_kind},
+                )
+            )
+            self.assertTrue(result.success)
+
+        adapter._send_email.assert_not_called()
+
+    def test_suppression_audit_has_routing_metadata_but_no_body_or_secret(self):
+        adapter = _make_adapter(extra={"read_only": True})
+        adapter._thread_context["user@example.com"] = {
+            "subject": "Weekly report",
+            "message_id": "<original@example.com>",
+        }
+
+        with self.assertLogs("plugins.platforms.email.adapter", level=logging.INFO) as logs:
+            asyncio.run(
+                adapter.send(
+                    "user@example.com",
+                    "body which must never reach logs",
+                    metadata={"session_id": "email-session-42", "token": "secret-value"},
+                )
+            )
+
+        rendered = "\n".join(logs.output)
+        self.assertIn("recipient=user@example.com", rendered)
+        self.assertIn("subject=Weekly report", rendered)
+        self.assertIn("session=email-session-42", rendered)
+        self.assertNotIn("body which must never reach logs", rendered)
+        self.assertNotIn("secret-value", rendered)
 
 
 if __name__ == "__main__":

--- a/website/docs/user-guide/messaging/email.md
+++ b/website/docs/user-guide/messaging/email.md
@@ -145,11 +145,10 @@ subject, session, and delivery kind. It does not log the body or credentials.
 display verbosity does not override Email's minimal defaults. This avoids a
 global progress setting causing a permanent-email flood.
 
-Cron and report deliveries are different. They use the standalone Email sender,
-which remains an explicit proactive-send route and is not suppressed by
-`read_only`. Configure a cron Email target only when you intentionally want
-proactive mail. This preserves existing cron workflows and keeps inbound-only
-focused on replies from Email-originated sessions.
+Cron, report, and retry deliveries use the same Email SMTP boundary. Inbound-only
+mode suppresses them too. Do not configure an Email cron target while
+`platforms.email.extra.read_only: true` is enabled. Disable inbound-only mode
+only when you intentionally want Hermes to send Email again.
 
 ### File Attachments
 

--- a/website/docs/user-guide/messaging/email.md
+++ b/website/docs/user-guide/messaging/email.md
@@ -19,6 +19,8 @@ This is separate from the bundled [Himalaya email skill](/docs/user-guide/skills
 | Let people email the Hermes agent and receive replies | Email gateway adapter on this page | None beyond an IMAP/SMTP email account |
 | Let the agent inspect, compose, move, and manage mailbox messages from terminal tools | Himalaya email skill | `himalaya` CLI and `~/.config/himalaya/config.toml` |
 
+**Email is an externally reachable, prompt-injection surface.** Before relying on it, read [Access Control](#access-control) (who can reach the agent) and [Threat model](#threat-model) below. By default every sender is denied, and an allowlisted sender is trusted only after the receiving mail server's SPF/DKIM/DMARC verdicts validate the `From:` domain.
+
 ---
 
 ## Prerequisites
@@ -79,7 +81,10 @@ EMAIL_IMAP_PORT=993                    # Default: 993 (IMAP SSL)
 EMAIL_SMTP_PORT=587                    # Default: 587 (SMTP STARTTLS)
 EMAIL_POLL_INTERVAL=15                 # Seconds between inbox checks (default: 15)
 EMAIL_HOME_ADDRESS=your@email.com      # Default delivery target for cron jobs
+EMAIL_AUTHSERV_ID=mx.google.com        # Pin trusted Authentication-Results server (see Access Control)
 ```
+
+Almost all access-control and outbound-safety settings live in `config.yaml` under `platforms.email.extra` — most importantly `read_only` for an inbound-only feed, `require_authenticated_sender`, and `authserv_id`. See [Access Control](#access-control) and [Inbound-only mode](#inbound-only-mode).
 
 ---
 
@@ -92,7 +97,7 @@ sudo hermes gateway install --system   # Linux only: boot-time system service
 ```
 
 On startup, the adapter:
-1. Tests IMAP and SMTP connections
+1. Tests IMAP and SMTP connections (the SMTP connection test is **skipped** in [inbound-only mode](#inbound-only-mode))
 2. Marks all existing inbox messages as "seen" (only processes new emails)
 3. Starts polling for new messages
 
@@ -111,7 +116,8 @@ The adapter polls the IMAP inbox for UNSEEN messages at a configurable interval 
   - Documents (PDF, ZIP, etc.) → available for file access
 - **HTML-only emails** have tags stripped for plain text extraction
 - **Self-messages** are filtered out to prevent reply loops
-- **Automated/noreply senders** are silently ignored — `noreply@`, `mailer-daemon@`, `bounce@`, `no-reply@`, and emails with `Auto-Submitted`, `Precedence: bulk`, or `List-Unsubscribe` headers
+- **Automated/noreply senders** are silently ignored — addresses matching `noreply`, `no-reply`, `no_reply`, `donotreply`, `do-not-reply`, `mailer-daemon`, `postmaster`, `bounce`, `notifications@`, `automated@`, `auto-confirm`, `auto-reply`, or `automailer`, and emails carrying `Auto-Submitted` (anything but `no`), `Precedence: bulk|list|junk`, `X-Auto-Response-Suppress`, or `List-Unsubscribe` headers
+- **Sender `From:` authentication is checked before the allowlist is matched.** SPF/DKIM/DMARC verdicts are read from the `Authentication-Results` header stamped by the receiving mail server (see [Access Control](#access-control)). An allowlisted address whose `From:` domain is not authenticated is dropped, because the `From:` header is attacker-controlled and never authenticated by IMAP delivery.
 
 ### Sending Replies
 
@@ -122,10 +128,32 @@ Replies are sent via SMTP with proper email threading:
 - **Message-ID** generated with the agent's domain
 - Responses are sent as plain text (UTF-8)
 
+### Quiet email sessions (display overrides)
+
+Email is a permanent-message mailbox — there is no editing, deleting, or streaming a message after it's sent. A single email-triggered session can otherwise churn out dozens of SMTP sends from ordinary live-work events: interim assistant commentary, tool-progress updates, heartbeats, long-running notifications, and busy-ack detail would each become their own email.
+
+To prevent that, Email uses a **minimal display tier**: `tool_progress: off`, `streaming: false`, `interim_assistant_messages: false`, `long_running_notifications: false`, `busy_ack_detail: false`. Since the inbound-only hardenings, Email's minimal defaults are **pinned**: a global `display.<key>` setting no longer cascades into Email and silently raises its verbosity. Only an explicit `display.platforms.email.<key>` override beats the minimal tier.
+
+To keep intent visible to other operators (and to stay protected even if default tiers change), set them explicitly in `config.yaml`:
+
+```yaml
+display:
+  platforms:
+    email:
+      interim_assistant_messages: false
+      tool_progress: off          # off | new | all | verbose | log
+      streaming: false
+      long_running_notifications: false
+      busy_ack_detail: false
+```
+
+`tool_progress` accepts the same values as the global setting; `off` and `false` both normalize to `off`.
+
+These settings are complementary to — **not a substitute for** — [inbound-only mode](#inbound-only-mode). Display overrides reduce *which* events are produced in the first place. `read_only` gate-keeps *every* outbound send at the SMTP boundary regardless of verbosity.
+
 ### Inbound-only mode
 
-Use this supported `config.yaml` setting when Email is an authenticated input
-feed and Hermes must never automatically reply to its sender:
+Use this supported `config.yaml` setting when Email is an authenticated input feed and Hermes must **never** automatically reply to its sender:
 
 ```yaml
 platforms:
@@ -134,21 +162,21 @@ platforms:
       read_only: true
 ```
 
-Inbound-only mode continues to create normal Email-source sessions. The full
-agent work, final answer, and tool activity remain in the session for Hermes
-Desktop. The adapter suppresses every task reply before SMTP, including interim
-messages, progress, final answers, approval prompts, media follow-ups, and
-delivery retries. Each suppression creates an audit log entry with recipient,
-subject, session, and delivery kind. It does not log the body or credentials.
+`read_only` is a **config.yaml-only** switch (the derived `EMAIL_READ_ONLY` environment variable is **not honored** — setting it has no effect). This keeps inbound-only mode explicit and deliberate in the machine's config rather than a silent env flag.
 
-`display.platforms.email` can explicitly opt into a display setting, but global
-display verbosity does not override Email's minimal defaults. This avoids a
-global progress setting causing a permanent-email flood.
+With `read_only: true`, the adapter:
 
-Cron, report, and retry deliveries use the same Email SMTP boundary. Inbound-only
-mode suppresses them too. Do not configure an Email cron target while
-`platforms.email.extra.read_only: true` is enabled. Disable inbound-only mode
-only when you intentionally want Hermes to send Email again.
+- **Keeps all inbound behavior unchanged** — it still connects over IMAP, polls, dispatches new messages, creates normal Email-source sessions, and the full agent work, final answer, and tool activity still appear in the session for Hermes Desktop.
+- **Skips the SMTP connection test at startup** and does **not require `EMAIL_SMTP_HOST`** — the mailbox is a pure read feed.
+- **Suppresses every outbound send before SMTP** — task replies, interim commentary, progress, final answers, approval prompts, media follow-ups, image batches, document sends, and delivery retries. Each suppressed send returns `success` with message id `read-only-suppressed`, so the gateway's delivery ledger marks it delivered and never enters a retry loop.
+- **Applies the same suppression at the standalone SMTP boundary** used by cron, report, and one-shot deliveries — no Email route can escape inbound-only mode.
+- **Logs an audit line per suppressed send** (INFO) with recipient, subject, session, and delivery kind. It does **not** log the body, attachment paths, or credentials.
+
+**Interplay with display overrides:** `read_only` is the enforce-at-egress control; the [quiet display settings](#quiet-email-sessions-display-overrides) are the reduce-what's-produced control. Use both. `read_only` guarantees no email is sent even if verbosity is raised; quiet display keeps the session transcript clean and avoids hundreds of pointless suppression audit lines.
+
+:::warning
+Do **not** configure an Email cron/report target while `platforms.email.extra.read_only: true` is enabled — those deliveries are suppressed too and will silently never arrive. Disable inbound-only mode only when you intentionally want Hermes to send Email again. The planned [draft approval (P1)](#draft-approval-p1--planned) removes the need to pick one or the other.
+:::
 
 ### File Attachments
 
@@ -161,7 +189,8 @@ To ignore all incoming attachments (for malware protection or bandwidth savings)
 ```yaml
 platforms:
   email:
-    skip_attachments: true
+    extra:
+      skip_attachments: true
 ```
 
 When enabled, attachment and inline parts are skipped before payload decoding. The email body text is still processed normally.
@@ -170,16 +199,88 @@ When enabled, attachment and inline parts are skipped before payload decoding. T
 
 ## Access Control
 
-Email access is stricter by default than chat-style platforms:
+Email follows a **default-deny** model: a message is admitted and dispatched only when it satisfies the allowlist (or an explicit open-access opt-in) **and** — when the allowlist is what grants access — the sender's `From:` domain passes mail authentication. The logic is checked in two layers and BOTH must agree for a sender to reach the agent.
 
-1. **`EMAIL_ALLOWED_USERS` set** → only emails from those addresses are processed
-2. **No allowlist set** → unknown senders are ignored silently
-3. **`EMAIL_ALLOW_ALL_USERS=true`** → any sender is accepted (use with caution)
-4. **`platforms.email.unauthorized_dm_behavior: pair`** → unknown senders receive a pairing code
+### 1. Adapter intake gate (per-message)
+
+The adapter drops a message before it ever becomes a session event if:
+
+- it is a **self-message**, or
+- it matches the **automated/noreply** patterns, or
+- the sender is **not in `EMAIL_ALLOWED_USERS`** and open access (`EMAIL_ALLOW_ALL_USERS` / `GATEWAY_ALLOW_ALL_USERS`) is not enabled. With no allowlist and no allow-all, **every** sender is silently dropped — default-deny at the intake boundary. (This gate keys on the per-platform `EMAIL_ALLOWED_USERS`; see the **global-allowlist nuance** note below.)
+
+### 2. Gateway authorization
+
+A dispatched event is authorized by the gateway if the sender is allowlisted (`EMAIL_ALLOWED_USERS` or the global `GATEWAY_ALLOWED_USERS`), DM-paired, or covered by an allow-all flag; otherwise it is denied (default `ignore` for unexpected Email senders).
+
+:::note Global-allowlist nuance for Email
+The gateway itself also honors `GATEWAY_ALLOWED_USERS`. However, because the adapter's **intake gate is keyed on `EMAIL_ALLOWED_USERS` only**, a sender listed in `GATEWAY_ALLOWED_USERS` but not in `EMAIL_ALLOWED_USERS` is dropped at intake and never reaches the gateway. In practice, **`EMAIL_ALLOWED_USERS` is the operative allowlist for Email** — keep your email senders there.
+:::
+
+### Decision table
+
+| Configuration | Who can reach the agent |
+|---|---|
+| No `EMAIL_ALLOWED_USERS`, no allow-all | **No one.** All senders silently dropped (default-deny). |
+| `EMAIL_ALLOWED_USERS=alice@x.com,bob@y.com` | Only those addresses — **and** each must pass mail authentication (below) unless you explicitly disable it. |
+| `EMAIL_ALLOW_ALL_USERS=true` (or `GATEWAY_ALLOW_ALL_USERS=true`) | **Any** sender on the internet — opens the whole world to a terminal-capable agent. Not recommended; use only deliberately. |
+| `platforms.email.extra.unauthorized_dm_behavior: pair` | Opts Email into the pairing flow instead of ignoring unknown senders. Because Email's intake gate rejects unknown senders first unless the mailbox is effectively open (allow-all), pairing for Email in practice requires opening intake — **an explicit allowlist is the supported and recommended control.** |
 
 :::warning
-**Use a dedicated inbox and configure `EMAIL_ALLOWED_USERS` for normal operation.** Email pairing is opt-in because shared inboxes often contain unrelated unread messages, and Hermes should not reply to those contacts by default.
+**Do not set `EMAIL_ALLOW_ALL_USERS` or `EMAIL_TRUST_FROM_HEADER` on an inbound-only (or any externally reachable) mailbox.** `EMAIL_ALLOW_ALL_USERS` opens the mailbox to every sender. `EMAIL_TRUST_FROM_HEADER` disables the mail-authentication gate below and lets an allowlist be keyed on a forged `From:` header.
 :::
+
+### Sender authentication (`require_authenticated_sender` + `authserv_id`)
+
+The `From:` header is **attacker-controlled and is never authenticated by IMAP delivery**. Mail applications connect to inboxes over TLS, but TLS authenticates the *transport*, not the authorship of the `From:` address. An allowlist keyed on `From:` alone is therefore spoofable — the fix that drove this design is tracked as GHSA-rxqh-5572-8m77.
+
+Hermes closes this by reading the `Authentication-Results` header that your **receiving mail server** (the one you IMAP into) stamps after running SPF/DKIM/DMARC. A sender is trusted only when that header records a **pass** for the `From:` domain:
+
+- `dmarc=pass`, **or**
+- `spf=pass` aligned with the `From:` domain, **or**
+- `dkim=pass` aligned with the `From:` domain (via `header.d`)
+
+Configuration:
+
+- `platforms.email.extra.require_authenticated_sender: true` — **default on** when it matters (an allowlist is actively granting access). When on, an allowlisted sender whose `From:` domain does not carry a pass verdict is dropped with a warning that includes the failure reason.
+- `platforms.email.extra.authserv_id: mx.google.com` (or the env mirror `EMAIL_AUTHSERV_ID`) — **pins** the trusted `Authentication-Results` instance to your own receiving server (e.g. `mx.google.com` for Gmail). Use this when you know your provider's receiving hostname. Default (unpinned) trusts the topmost `Authentication-Results` header, which protects against forged `From:` but not against a malformed message whose forged header sorts first — pinning closes that last gap.
+
+**Fail-closed:** a message with no `Authentication-Results` header, no instance from the pinned `authserv_id`, or non-pass verdicts is not admitted. If your mail server does not stamp `Authentication-Results` at all, your realistic options are to fix the delivery/verdicts at the server, or explicitly disable the check and accept the spoofing risk (`platforms.email.extra.require_authenticated_sender: false`, or the env mirror `EMAIL_TRUST_FROM_HEADER=true`). The auth gate is deliberately **skipped** when allow-all is active, because an operator who opted into any-sender access has already chosen to accept that risk.
+
+---
+
+## Threat model
+
+Treat an email-only mailbox as a **remote, unauthenticated command surface with credential exposure baked in**. Understand these before exposing the agent by email.
+
+**Who can command the mailbox.** Only the senders that survive the two-layer check above: allowlisted addresses whose `From:` domain passes SPF/DKIM/DMARC (or an explicit open-access opt-in, which should never be used for an externally reachable mailbox). An attacker forging an allowlisted `From:` is dropped because the mail-authentication verdicts won't validate the forged domain — unless you disabled `require_authenticated_sender` or the receiving server stamps no verdicts at all.
+
+**Quoted/forwarded content is data, not authority.** Anything inside an email body — a quote from a third party, a forwarding chain, an attachment, a copied salesperson — is **untrusted content** to the agent, never a directive. The allowlist gates *who may transmit*; it does not make the transmission trustworthy. A human in the allowlist can still be socially engineered into forwarding an attack. Bake that separation into standing instructions and require explicit operator confirmation for consequential actions. (The [dedicated-address guide](/docs/guides/agent-email-address) applies the same rule to the Himalaya skill path.)
+
+**A compromised owner mailbox is a control credential — not just a confidentiality leak.** The `.env` App Password grants full IMAP read access to every inbound request and send authority over the account. Worse, the agent holding that credential also has terminal access to the machine: gaining the mailbox can be a foothold toward that. Protect `~/.hermes/.env` (`chmod 600`), use a dedicated mailbox, rotate the App Password if you suspect exposure, and never reuse the agent's account for password resets, account recovery, or 2FA on other services.
+
+**Provider quotas are a backstop, not a control.** Gmail-class providers cap outbound SMTP volume per account per day and limit concurrent IMAP connections. These bound the blast radius of a runaway send loop (the historical incident that shaped this page produced 74 outbound emails from a single session), but a flood that stays under the quota still happens. Gate sends at the adapter — with [inbound-only mode](#inbound-only-mode) or the planned [draft approval](#draft-approval-p1--planned) — rather than relying on the provider to stop you. Similarly, keep only **one** gateway instance polling the mailbox so the provider's concurrent-IMAP limit isn't tripped and replies aren't duplicated.
+
+---
+
+## Draft approval (P1) — planned
+
+:::info Status: planned / in progress — not yet released
+This section describes the **P1 design intent** (issue #99876 family, branch `feat/email-draft-approval`). It is **not merged** at the base of these docs. Config keys, storage paths, and behavior below are subject to change before release — verify against the merged release notes before relying on them.
+:::
+
+Inbound-only mode solves "never send", but it is binary: there is no supported way to let the agent *compose* email yet still gate the *sending* on human review. P1's goal is review-then-send — kill the "send fast, regret later" class while keeping outbound available.
+
+Planned building blocks:
+
+- **Durable draft store.** Every outbound email is first written as a draft to disk, surviving restarts. Nothing touches SMTP until explicitly approved.
+- **One-shot atomic approval.** Approving a draft authorizes exactly **that** draft, sent exactly **once**. Approval is atomic and immediate: there are no standing "always allow this sender / this session" grants implied.
+- **Expiry.** Drafts carry a time-to-live; untouched drafts are dropped unapproved, so no pending send lingers indefinitely.
+- **Budgets / circuit breaker.** A per-period send budget and a tripwire that halts further sends until an explicit reset — bounding recurrence of a flood even with outbound enabled.
+- **Interrupt fence.** A pending approval is isolated from concurrent activity: inbound mail, `/steer`, interrupts, or a new turn cannot amend, approve, or bypass a pending draft once it has been submitted.
+- **Desktop surface.** The Hermes Desktop app is the approval surface — a draft renders as an approvable card (recipient, subject, body summary) with approve/deny that commits the one-shot decision.
+
+Until P1 lands, the supported way to prevent automatic outbound is [inbound-only mode](#inbound-only-mode).
 
 ---
 
@@ -188,23 +289,26 @@ Email access is stricter by default than chat-style platforms:
 | Problem | Solution |
 |---------|----------|
 | **"IMAP connection failed"** at startup | Verify `EMAIL_IMAP_HOST` and `EMAIL_IMAP_PORT`. Ensure IMAP is enabled on the account. For Gmail, enable it in Settings → Forwarding and POP/IMAP. |
-| **"SMTP connection failed"** at startup | Verify `EMAIL_SMTP_HOST` and `EMAIL_SMTP_PORT`. Check that your password is correct (use App Password for Gmail). |
+| **"SMTP connection failed"** at startup | Verify `EMAIL_SMTP_HOST` and `EMAIL_SMTP_PORT`. Check that your password is correct (use App Password for Gmail). If you intend an inbound-only mailbox, set `platforms.email.extra.read_only: true` so the SMTP test is skipped. |
 | **Messages not received** | Check `EMAIL_ALLOWED_USERS` includes the sender's email. Check spam folder — some providers flag automated replies. |
 | **"Authentication failed"** | For Gmail, you must use an App Password, not your regular password. Ensure 2FA is enabled first. |
+| **Agent reads mail but never replies** | Confirm `platforms.email.extra.read_only` is not set. Confirm the sender is in `EMAIL_ALLOWED_USERS`. If the log shows `Dropping sender with unauthenticated From:`, the sender's mail authentication failed or the receiving server stamps no verdicts — see [Access Control](#access-control). |
 | **Duplicate replies** | Ensure only one gateway instance is running. Check `hermes gateway status`. |
 | **Slow response** | The default poll interval is 15 seconds. Reduce with `EMAIL_POLL_INTERVAL=5` for faster response (but more IMAP connections). |
 | **Replies not threading** | The adapter uses In-Reply-To headers. Some email clients (especially web-based) may not thread correctly with automated messages. |
+| **Many outbound emails from one task** | Set the [quiet display overrides](#quiet-email-sessions-display-overrides) so progress/interim events aren't emailed, and/or use [inbound-only mode](#inbound-only-mode). |
 
 ---
 
 ## Security
 
 :::warning
-**Use a dedicated email account.** Don't use your personal email — the agent stores the password in `.env` and has full inbox access via IMAP.
+**Use a dedicated email account.** Don't use your personal email — the agent stores the password in `.env` and has full inbox access via IMAP. A compromised mailbox doubles as a control credential; see [Threat model](#threat-model).
 :::
 
 - Use **App Passwords** instead of your main password (required for Gmail with 2FA)
-- Set `EMAIL_ALLOWED_USERS` to restrict who can interact with the agent
+- Set `EMAIL_ALLOWED_USERS` to restrict who can interact with the agent, and keep `require_authenticated_sender` on (do not set `EMAIL_TRUST_FROM_HEADER`)
+- **Do not** set `EMAIL_ALLOW_ALL_USERS` / `GATEWAY_ALLOW_ALL_USERS` for a mailbox reachable from the internet
 - The password is stored in `~/.hermes/.env` — protect this file (`chmod 600`)
 - IMAP uses SSL (port 993) and SMTP uses STARTTLS (port 587) by default — connections are encrypted
 
@@ -217,10 +321,15 @@ Email access is stricter by default than chat-style platforms:
 | `EMAIL_ADDRESS` | Yes | — | Agent's email address |
 | `EMAIL_PASSWORD` | Yes | — | Email password or app password |
 | `EMAIL_IMAP_HOST` | Yes | — | IMAP server host (e.g., `imap.gmail.com`) |
-| `EMAIL_SMTP_HOST` | Yes | — | SMTP server host (e.g., `smtp.gmail.com`) |
+| `EMAIL_SMTP_HOST` | Yes* | — | SMTP server host (e.g., `smtp.gmail.com`). *Not required when `platforms.email.extra.read_only: true`. |
 | `EMAIL_IMAP_PORT` | No | `993` | IMAP server port |
 | `EMAIL_SMTP_PORT` | No | `587` | SMTP server port |
 | `EMAIL_POLL_INTERVAL` | No | `15` | Seconds between inbox checks |
-| `EMAIL_ALLOWED_USERS` | No | — | Comma-separated allowed sender addresses |
-| `EMAIL_HOME_ADDRESS` | No | — | Default delivery target for cron jobs |
-| `EMAIL_ALLOW_ALL_USERS` | No | `false` | Allow all senders (not recommended) |
+| `EMAIL_ALLOWED_USERS` | No | — | Comma-separated allowed sender addresses — the operative Email allowlist |
+| `EMAIL_HOME_ADDRESS` | No | — | Default delivery target for cron jobs (not used while inbound-only mode is on) |
+| `EMAIL_ALLOW_ALL_USERS` | No | `false` | Accept **any** sender — open access, not recommended |
+| `EMAIL_AUTHSERV_ID` | No | — | Pin the trusted `Authentication-Results` server (e.g. `mx.google.com`); mirror of `platforms.email.extra.authserv_id` |
+| `EMAIL_TRUST_FROM_HEADER` | No | `false` | Skip sender mail-authentication entirely — trust the `From:` header unauthenticated (spoofable, not recommended); mirror of `platforms.email.extra.require_authenticated_sender: false` |
+| `EMAIL_READ_ONLY` | No | — | **Not honored.** Inbound-only mode is config.yaml-only: `platforms.email.extra.read_only: true` |
+
+The access-control and outbound-safety switches below are configured in `config.yaml` under `platforms.email.extra`: `read_only`, `require_authenticated_sender`, `authserv_id`, `skip_attachments`, `unauthorized_dm_behavior`.

--- a/website/docs/user-guide/messaging/email.md
+++ b/website/docs/user-guide/messaging/email.md
@@ -122,6 +122,35 @@ Replies are sent via SMTP with proper email threading:
 - **Message-ID** generated with the agent's domain
 - Responses are sent as plain text (UTF-8)
 
+### Inbound-only mode
+
+Use this supported `config.yaml` setting when Email is an authenticated input
+feed and Hermes must never automatically reply to its sender:
+
+```yaml
+platforms:
+  email:
+    extra:
+      read_only: true
+```
+
+Inbound-only mode continues to create normal Email-source sessions. The full
+agent work, final answer, and tool activity remain in the session for Hermes
+Desktop. The adapter suppresses every task reply before SMTP, including interim
+messages, progress, final answers, approval prompts, media follow-ups, and
+delivery retries. Each suppression creates an audit log entry with recipient,
+subject, session, and delivery kind. It does not log the body or credentials.
+
+`display.platforms.email` can explicitly opt into a display setting, but global
+display verbosity does not override Email's minimal defaults. This avoids a
+global progress setting causing a permanent-email flood.
+
+Cron and report deliveries are different. They use the standalone Email sender,
+which remains an explicit proactive-send route and is not suppressed by
+`read_only`. Configure a cron Email target only when you intentionally want
+proactive mail. This preserves existing cron workflows and keeps inbound-only
+focused on replies from Email-originated sessions.
+
 ### File Attachments
 
 The agent can send file attachments in replies. Include `MEDIA:/path/to/file` in the response and the file is attached to the outgoing email.


### PR DESCRIPTION
## Summary

Maintainer-grade update to the **Email gateway** docs page (`website/docs/user-guide/messaging/email.md`) so it matches the **implemented code**, not the pre-incident mental model. Motivated by the 2026-09-01 incident (74 SMTP emails from one email-triggered session) and the P0 inbound-only hardenings (#99876).

This branch is based at the P0 tip (`b5fca867d8`, which already contains the P0 code + docs). No code, config, tests, or gateway state are touched — docs only.

## What changed

- **Sender intake + authentication** — documents the exact decision tree: default-deny; `EMAIL_ALLOWED_USERS` as the operative allowlist (with the `GATEWAY_ALLOWED_USERS` nuance — the adapter's intake gate keys on the per-platform var only); `require_authenticated_sender` (SPF/DKIM/DMARC pass verdicts, fail-closed); `authserv_id` pinning; and the two escape hatches (`EMAIL_ALLOW_ALL_USERS`, `EMAIL_TRUST_FROM_HEADER`) with explicit "do not set" guidance.
- **Inbound-only mode** — full contract for `platforms.email.extra.read_only: true`: config.yaml-only (the `EMAIL_READ_ONLY` env var is **not honored** — pinned by `tests/gateway/test_email_read_only.py`), SMTP connect test skipped, `EMAIL_SMTP_HOST` not required, every send kind suppressed at the SMTP boundary (incl. standalone cron/report), audit log without body/credentials, interplay with display overrides.
- **Quiet-work recommendations** — the `display.platforms.email.*` overrides and why (the 74-email incident); documents that Email's minimal display tier is pinned so global `display.*` no longer cascades in.
- **Threat model** — who can command the mailbox; quoted/forwarded content is data, not authority; compromised owner mailbox = control credential; provider quotas as backstop, not control.
- **Draft approval (P1) roadmap** — durable draft store, one-shot atomic approval, expiry, budgets/circuit breaker, interrupt fence, Desktop surface. Clearly marked **planned / not merged** (P1 branch `feat/email-draft-approval` is not in this base).
- **Fixes** — `skip_attachments` example moved under `platforms.email.extra` (code reads `extra.get("skip_attachments")`; the old platform-level example was dead config); automated-sender pattern list completed to match `_NOREPLY_PATTERNS`/`_AUTOMATED_HEADERS`.

## Key sections

- `### Inbound-only mode` — read_only contract + cron warning
- `### Quiet email sessions (display overrides)` — incident rationale + recommended YAML
- `## Access Control` — two-layer model, decision table, auth gate, authserv pinning, fail-closed
- `## Threat model` — mailbox as remote command surface
- `## Draft approval (P1) — planned` — roadmap, explicitly marked unreleased

## Grounding (code anchors)

- `plugins/platforms/email/adapter.py`: read_only init/`_outbound_is_suppressed` (L575-587, 632-634); auth config (L589-615); intake gate + auth enforcement (L1047-1106); suppression + audit (L1162-1242, 1326, 1430); standalone boundary (L1527-1540); SMTP test skip (L793-794); SMTP host not required (L708-709)
- `gateway/display_config.py`: `_PLATFORMS_WITH_PINNED_SAFE_DEFAULTS = {"email"}` (P0 `ce567c1b78`), `_PLATFORM_DEFAULTS["email"] = _TIER_MINIMAL`
- `tests/gateway/test_email_read_only.py`: env var not honored (L52-55), suppression semantics
- `gateway/config.py`: `extra` passthrough (L689); no bridge for `require_authenticated_sender`/`authserv_id`/`skip_attachments` (platform-level placement is dead config — documented under `extra`)

## CI state (honest)

**Not run.** Docs-only change (single markdown file) — no tests/build needed per repo policy. Link targets verified to exist (`user-guide/skills/bundled/email/email-himalaya.md`, `guides/agent-email-address.md`); in-page anchors verified against Docusaurus heading-anchor generation.

## Remaining gaps / follow-ups

- P1 (`feat/email-draft-approval`) is not merged into this base — the roadmap section will need updating to the real contract when the PR lands.
- `contributors/emails/agent@Agents-Mac-mini.local` in the worktree is an unrelated local artifact — deliberately **not** included.
- Source comments at `adapter.py:594-599` and `adapter.py:1101` suggest platform-level placement for `require_authenticated_sender`; the code reads it from `extra` (L603-604). Docs follow the code; consider fixing the comments/log string in a follow-up.

Closes/relates: #99876 (issue), PR #101053 (P0).