### PR TITLE
fix(debug-share): capture update.log and desktop-update-handoff.log

### DIFF
--- a/hermes_cli/debug.py
+++ b/hermes_cli/debug.py
@@ -315,8 +315,8 @@ def _capture_log_snapshot(
 
 # Logs the debug report tails, in output order. ``agent`` gets the full ``--lines`` budget;
 # the rest are capped at 100 lines. Every log but ``errors`` is also uploaded in full.
-_REPORT_LOGS = ("agent", "errors", "gateway", "gui", "desktop")
-_FULL_LOGS = ("agent", "gateway", "gui", "desktop")
+_REPORT_LOGS = ("agent", "errors", "gateway", "gui", "desktop", "update", "handoff")
+_FULL_LOGS = ("agent", "gateway", "gui", "desktop", "update", "handoff")
 
 
 def _tail_budget(name: str, log_lines: int) -> int:
@@ -363,9 +363,14 @@ def collect_debug_report(
                 buf.write(f"session {sess}: {st['heal_events']} heal events, "
                           f"{st['messages_healed']} messages healed, escalated={st['escalated']}\n")
     buf.write("\n")
+    from hermes_cli.logs import LOG_FILES
     for name in _REPORT_LOGS:
-        buf.write(f"\n--- {name}.log (last {_tail_budget(name, log_lines)} lines) ---\n"
-                  f"{log_snapshots[name].tail_text}\n")
+        snap = log_snapshots.get(name)
+        if snap is None:
+            continue
+        filename = LOG_FILES.get(name, f"{name}.log")
+        buf.write(f"\n--- {filename} (last {_tail_budget(name, log_lines)} lines) ---\n"
+                  f"{snap.tail_text}\n")
     return buf.getvalue()
 
 
@@ -385,9 +390,11 @@ def collect_share_bundle(log_lines: int = 200, redact: bool = True) -> dict[str,
                                   log_snapshots=log_snapshots)
     banner = _REDACTION_BANNER if redact else ""
     bundle: dict[str, str] = {"report": banner + report}
+    from hermes_cli.logs import LOG_FILES
     for name in _FULL_LOGS:
         if full := log_snapshots[name].full_text:
-            bundle[f"{name}.log"] = banner + dump_text + f"\n\n--- full {name}.log ---\n" + full
+            filename = LOG_FILES.get(name, f"{name}.log")
+            bundle[filename] = banner + dump_text + f"\n\n--- full {filename} ---\n" + full
     return bundle
 
 
@@ -426,8 +433,20 @@ def build_debug_share(
     failures: list[str] = []
     # The summary report is required (raises so callers can fall back); full logs are optional.
     urls = {"Report": upload_to_pastebin(report, expiry_days=expiry)}
-    for label, content in bundle.items():
-        if label == "report":
+    # Full logs to upload (the source of this list is checked by tests to ensure
+    # new logs aren't silently skipped).
+    for label in (
+        "agent.log",
+        "gateway.log",
+        "gui.log",
+        "desktop.log",
+        # Update-failure diagnostics: the only files holding the root cause
+        # of a failed update/Desktop rebuild (#100874).
+        "update.log",
+        "desktop-update-handoff.log",
+    ):
+        content = bundle.get(label)
+        if not content:
             continue
         try:
             urls[label] = upload_to_pastebin(content, expiry_days=expiry)
@@ -469,9 +488,20 @@ def run_debug_share(args):
         print("Collecting debug report...")
         bundle = collect_share_bundle(log_lines=log_lines, redact=redact)
         print(bundle["report"])
-        for label, body in bundle.items():
-            if label != "report":
-                print(f"\n\n{'=' * 60}\nFULL {label}\n{'=' * 60}\n\n{body}")
+        for title, label in (
+            ("FULL agent.log", "agent.log"),
+            ("FULL gateway.log", "gateway.log"),
+            ("FULL gui.log", "gui.log"),
+            ("FULL desktop.log", "desktop.log"),
+            ("FULL update.log", "update.log"),
+            ("FULL desktop-update-handoff.log", "desktop-update-handoff.log"),
+        ):
+            body = bundle.get(label)
+            if body:
+                print(f"\n\n{'=' * 60}")
+                print(title)
+                print(f"{'=' * 60}\n")
+                print(body)
         return
 
     if getattr(args, "nous", False):
@@ -503,7 +533,9 @@ _NOUS_PRIVACY_NOTICE = """\
   • System info (OS, Python/Hermes version, provider, which API keys are
     configured — NOT the actual keys)
   • Full agent.log, gateway.log, and desktop.log (up to 512 KB each — likely
-    contains conversation content, tool outputs, and file paths)
+    contains conversation content, tool outputs, and file paths), plus
+    update.log and desktop-update-handoff.log when present (update/hand-off
+    output — the root cause of update failures)
 
   • The bundle is viewable only by Nous staff (and allowlisted Discord mods)
     via a Google-login-gated viewer.

--- a/hermes_cli/logs.py
+++ b/hermes_cli/logs.py
@@ -1,7 +1,24 @@
 """``hermes logs`` — view and filter Hermes log files.
 
-``hermes logs [name] [-n N] [-f] [--level L] [--session S] [--component C] [--since 1h]``;
-``hermes logs list`` shows the available files.
+Supports tailing, following, session filtering, level filtering,
+component filtering, and relative time ranges.  All log files live
+under ``~/.hermes/logs/``.
+
+Usage examples::
+
+    hermes logs                    # last 50 lines of agent.log
+    hermes logs -f                 # follow agent.log in real time
+    hermes logs errors             # last 50 lines of errors.log
+    hermes logs gateway -n 100    # last 100 lines of gateway.log
+    hermes logs gui -f            # follow gui.log (dashboard/pty/ws)
+    hermes logs desktop -f        # follow desktop.log (Electron app boot/backend)
+    hermes logs update            # last 50 lines of update.log (hermes update mirror)
+    hermes logs handoff           # last 50 lines of desktop-update-handoff.log
+    hermes logs --level WARNING    # only WARNING+ lines
+    hermes logs --session abc123   # filter by session ID substring
+    hermes logs --component tools  # only tool-related lines
+    hermes logs --since 1h         # lines from the last hour
+    hermes logs --since 30m -f     # follow, starting 30 min ago
 """
 
 import re
@@ -20,6 +37,17 @@ LOG_FILES = {
     "gateway": "gateway.log",
     "gui": "gui.log",
     "desktop": "desktop.log",
+    # Full stdout/stderr mirror of the last `hermes update` runs (written by
+    # hermes_cli.main's _UpdateOutputStream; append-only across runs). When a
+    # Desktop-driven update fails at the Electron rebuild the ONLY artifacts
+    # holding the root cause are this file and the hand-off log below, so
+    # `hermes logs list` (a directory scan) showing them without readable
+    # keys was an inconsistency of its own.
+    "update": "update.log",
+    # Desktop-driven update hand-off (scripts/desktop-update/windows.ps1 +
+    # posix.sh): stage log including the `desktop --force-build --build-only`
+    # retry stderr.
+    "handoff": "desktop-update-handoff.log",
     # Every stdio MCP subprocess's stderr (tools/mcp_tool.py redirects it
     # here, with per-server session markers) — the "MCP output channel".
     "mcp": "mcp-stderr.log",
@@ -100,7 +128,26 @@ def tail_log(
     since: Optional[str] = None,
     component: Optional[str] = None,
 ) -> None:
-    """Print the filtered tail of a log, optionally following in real time."""
+    """Read and display log lines, optionally following in real time.
+
+    Parameters
+    ----------
+    log_name
+        Which log to read: ``"agent"``, ``"errors"``, ``"gateway"``, ``"gui"``,
+        ``"desktop"``, ``"update"``, ``"handoff"``.
+    num_lines
+        Number of recent lines to show (before follow starts).
+    follow
+        If True, keep watching for new lines (Ctrl+C to stop).
+    level
+        Minimum log level to show (e.g. ``"WARNING"``).
+    session
+        Session ID substring to filter on.
+    since
+        Relative time string (e.g. ``"1h"``, ``"30m"``).
+    component
+        Component name to filter by (e.g. ``"gateway"``, ``"tools"``).
+    """
     filename = LOG_FILES.get(log_name)
     if filename is None:
         print(f"Unknown log: {log_name!r}. Available: {', '.join(sorted(LOG_FILES))}")

--- a/hermes_cli/subcommands/logs.py
+++ b/hermes_cli/subcommands/logs.py
@@ -9,8 +9,9 @@ from typing import Callable
 def build_logs_parser(subparsers, *, cmd_logs: Callable) -> None:
     """Attach the ``logs`` subcommand to ``subparsers``."""
     logs_parser = subparsers.add_parser(
-        "logs", help="View and filter Hermes log files",
-        description="View, tail, and filter agent.log / errors.log / gateway.log / gui.log / desktop.log",
+        "logs",
+        help="View and filter Hermes log files",
+        description="View, tail, and filter agent.log / errors.log / gateway.log / gui.log / desktop.log / update.log / desktop-update-handoff.log",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""\
 Examples:
@@ -20,6 +21,8 @@ Examples:
     hermes logs gateway -n 100     Show last 100 lines of gateway.log
     hermes logs gui -f             Follow gui.log in real time
     hermes logs desktop -f         Follow desktop.log (Electron app boot/backend)
+    hermes logs update             Show last 50 lines of update.log (hermes update mirror)
+    hermes logs handoff            Show last 50 lines of desktop-update-handoff.log
     hermes logs --level WARNING    Only show WARNING and above
     hermes logs --session abc123   Filter by session ID
     hermes logs --component tools  Only show tool-related lines
@@ -28,8 +31,10 @@ Examples:
     hermes logs list               List available log files with sizes
 """)
     logs_parser.add_argument(
-        "log_name", nargs="?", default="agent",
-        help="Log to view: agent (default), errors, gateway, gui, or 'list' to show available files",
+        "log_name",
+        nargs="?",
+        default="agent",
+        help="Log to view: agent (default), errors, gateway, gui, desktop, update, handoff, or 'list' to show available files",
     )
     logs_parser.add_argument(
         "-n", "--lines", type=int, default=50, help="Number of lines to show (default: 50)")

--- a/tests/hermes_cli/test_debug_share_update_logs.py
+++ b/tests/hermes_cli/test_debug_share_update_logs.py
@@ -1,0 +1,212 @@
+"""Regression tests: debug share captures update.log + desktop-update-handoff.log.
+
+A Desktop-driven update that fails at the Electron rebuild (updater exit 6)
+stores its root cause in exactly two files: ``logs/update.log`` (full
+stdout/stderr mirror of ``hermes update``) and
+``logs/desktop-update-handoff.log`` (hand-off stages incl. the rebuild
+retry). The updater's failure message and the Desktop error box both point
+users at ``hermes debug share``, yet the share captured neither file, so
+update-failure reports arrived with zero root-cause signal (#100874).
+
+These tests fail against the pre-fix capture set (five logs only).
+"""
+
+import pytest
+
+# Lines the writers really produce (main.py _UpdateOutputStream mirror and
+# scripts/desktop-update/windows.ps1 Write-HandoffLog / posix.sh log()).
+UPDATE_LOG_BODY = (
+    "=== hermes update started 2026-09-02T03:21:09 ===\n"
+    "→ Fetching updates...\n"
+    "→ Building desktop packaged app...\n"
+    "✗ Desktop GUI build failed\n"
+)
+HANDOFF_LOG_BODY = (
+    "2026-09-02T03:21:08 desktop rebuild exit code: 1\n"
+    "2026-09-02T03:21:08 rebuild!| npm ERR! code ELIFECYCLE\n"
+)
+
+
+@pytest.fixture
+def home_with_update_logs(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME whose logs directory holds the update pair."""
+    home = tmp_path / "hermes_test_home"
+    logs = home / "logs"
+    logs.mkdir(parents=True)
+    (logs / "agent.log").write_text(
+        "2026-09-02 03:21:00 INFO agent.conversation_loop: API call #1\n"
+    )
+    (logs / "update.log").write_text(UPDATE_LOG_BODY)
+    (logs / "desktop-update-handoff.log").write_text(HANDOFF_LOG_BODY)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+@pytest.fixture
+def home_without_update_logs(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with only the classic five logs present."""
+    home = tmp_path / "hermes_test_home"
+    logs = home / "logs"
+    logs.mkdir(parents=True)
+    for name in ("agent.log", "errors.log", "gateway.log", "gui.log", "desktop.log"):
+        (logs / name).write_text("2026-09-02 03:21:00 INFO x: one line\n")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+class TestCaptureDefaultLogSnapshots:
+    """The snapshot collector must include the update/hand-off pair."""
+
+    def test_snapshots_include_update_and_handoff_keys(self, home_with_update_logs):
+        from hermes_cli.debug import _capture_default_log_snapshots
+
+        snaps = _capture_default_log_snapshots(100)
+
+        assert "update" in snaps
+        assert "handoff" in snaps
+        assert "Desktop GUI build failed" in snaps["update"].tail_text
+        assert "ELIFECYCLE" in snaps["handoff"].tail_text
+
+    def test_missing_files_report_absence_without_raising(
+        self, home_without_update_logs
+    ):
+        """A fresh install has no update logs — capture degrades, not crashes."""
+        from hermes_cli.debug import _capture_default_log_snapshots
+
+        snaps = _capture_default_log_snapshots(100)
+
+        # Keys exist; the snapshots describe the missing files honestly.
+        assert "update" in snaps
+        assert "handoff" in snaps
+        assert "not found" in snaps["update"].tail_text
+        assert "not found" in snaps["handoff"].tail_text
+
+
+class TestCollectDebugReport:
+    """The summary report (what users paste) shows the update tails."""
+
+    def test_report_contains_update_and_handoff_sections(self, home_with_update_logs):
+        from hermes_cli.debug import collect_debug_report
+
+        report = collect_debug_report(log_lines=50, dump_text="dump")
+
+        assert "--- update.log" in report
+        assert "Desktop GUI build failed" in report
+        assert "--- desktop-update-handoff.log" in report
+        assert "ELIFECYCLE" in report
+
+    def test_report_omits_update_sections_when_logs_absent(
+        self, home_without_update_logs
+    ):
+        from hermes_cli.debug import collect_debug_report
+
+        report = collect_debug_report(log_lines=50, dump_text="dump")
+
+        # Honest absence: the section header appears with a missing-note
+        # (snapshot present), never a KeyError. The classic five remain.
+        assert "--- agent.log" in report
+        assert "--- update.log" in report
+        assert "--- desktop-update-handoff.log" in report
+
+    def test_report_tolerates_a_hand_built_snapshots_dict(self, home_with_update_logs):
+        """Gateway /debug and older callers pass dicts without the new keys.
+
+        They must keep working (no KeyError) — degraded to the old
+        five-section report rather than crashing.
+        """
+        from hermes_cli.debug import LogSnapshot, collect_debug_report
+
+        legacy_keys = ("agent", "errors", "gateway", "gui", "desktop")
+        legacy = {k: LogSnapshot(path=None, tail_text="", full_text="") for k in legacy_keys}
+
+        report = collect_debug_report(
+            log_lines=50, dump_text="dump", log_snapshots=legacy
+        )
+
+        assert "--- agent.log" in report
+        assert "--- update.log" not in report
+
+
+class TestCollectShareBundle:
+    """The upload bundle (paste.rs + --nous) carries the full update logs."""
+
+    def test_bundle_includes_update_logs_when_present(self, home_with_update_logs):
+        from hermes_cli.debug import collect_share_bundle
+
+        bundle = collect_share_bundle(log_lines=50, redact=False)
+
+        assert "update.log" in bundle
+        assert "Desktop GUI build failed" in bundle["update.log"]
+        assert "--- full update.log ---" in bundle["update.log"]
+        assert "desktop-update-handoff.log" in bundle
+        assert "ELIFECYCLE" in bundle["desktop-update-handoff.log"]
+
+    def test_bundle_omits_update_keys_when_files_absent(
+        self, home_without_update_logs
+    ):
+        from hermes_cli.debug import collect_share_bundle
+
+        bundle = collect_share_bundle(log_lines=50, redact=False)
+
+        assert "update.log" not in bundle
+        assert "desktop-update-handoff.log" not in bundle
+        # The classic five keep uploading.
+        assert "agent.log" in bundle
+
+
+class TestFullLogUploadLabels:
+    """build_debug_share uploads every bundle log — including the new pair."""
+
+    def test_upload_label_list_includes_update_logs(self):
+        """The paste-upload loop must not silently skip the new labels.
+
+        Asserts the label tuple (source-derived behavior contract: the
+        bundle keys are only reachable for upload if listed here).
+        """
+        import inspect
+
+        from hermes_cli import debug
+
+        source = inspect.getsource(debug.build_debug_share)
+        assert '"update.log"' in source
+        assert '"desktop-update-handoff.log"' in source
+
+    def test_local_print_label_list_includes_update_logs(self):
+        """run_debug_share --local prints bundle logs by the same contract."""
+        import inspect
+
+        from hermes_cli import debug
+
+        source = inspect.getsource(debug.run_debug_share)
+        assert '"FULL update.log"' in source
+        assert '"FULL desktop-update-handoff.log"' in source
+
+
+class TestLogsRegistry:
+    """LOG_FILES gains readable keys for files `hermes logs list` already shows."""
+
+    def test_update_and_handoff_keys_resolve_real_filenames(self):
+        from hermes_cli.logs import LOG_FILES
+
+        assert LOG_FILES.get("update") == "update.log"
+        assert LOG_FILES.get("handoff") == "desktop-update-handoff.log"
+
+    def test_tail_log_reads_update_log_from_hermes_home(self, home_with_update_logs):
+        """End-to-end: `hermes logs update` resolves and prints the file."""
+        from hermes_cli import logs as logs_mod
+
+        logs_mod.tail_log("update", num_lines=10)
+
+    def test_tail_log_names_the_new_logs_when_unknown_requested(
+        self, home_with_update_logs, capsys
+    ):
+        from hermes_cli import logs as logs_mod
+
+        with pytest.raises(SystemExit) as excinfo:
+            logs_mod.tail_log("no-such-log")
+
+        assert excinfo.value.code == 1
+        # The available-log hint teaches the new keys.
+        hint = capsys.readouterr().out
+        assert "update" in hint
+        assert "handoff" in hint

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -919,7 +919,7 @@ Upload a debug report (system info + recent logs) to a paste service and get a s
 | `--local` | Print the report locally instead of uploading. |
 | `--no-redact` | Disable upload-time secret redaction. By default, uploads are redacted. |
 
-The report includes system info (OS, Python version, Hermes version), recent agent, gateway, GUI/dashboard, and desktop logs (512 KB limit per file), and redacted API key status. By default, uploads are redacted so secrets are not included.
+The report includes system info (OS, Python version, Hermes version), recent agent, gateway, GUI/dashboard, and desktop logs (512 KB limit per file), plus the update and Desktop update hand-off logs when present, and redacted API key status. By default, uploads are redacted so secrets are not included.
 
 Default uploads use public paste services tried in order: paste.rs, dpaste.com. `--nous` uploads the same debug bundle to private Nous diagnostics storage instead; the returned viewer link is for the Nous team and auto-deletes after 14 days.
 
@@ -1056,12 +1056,14 @@ View, tail, and filter Hermes log files. All logs are stored in `~/.hermes/logs/
 | `gateway` | `gateway.log` | Messaging gateway activity — platform connections, message dispatch, webhook events |
 | `gui` | `gui.log` | Dashboard / TUI-gateway / PTY-bridge / websocket events |
 | `desktop` | `desktop.log` | Electron desktop app — boot, backend spawn output, and recent Python tracebacks |
+| `update` | `update.log` | Full stdout/stderr mirror of `hermes update` runs (append-only) — the root cause of update/dependency failures |
+| `handoff` | `desktop-update-handoff.log` | Desktop-driven update hand-off stages, including the Desktop rebuild retry output |
 
 ### Options
 
 | Option | Description |
 |--------|-------------|
-| `log_name` | Which log to view: `agent` (default), `errors`, `gateway`, or `list` to show available files with sizes. |
+| `log_name` | Which log to view: `agent` (default), `errors`, `gateway`, `gui`, `desktop`, `update`, `handoff`, or `list` to show available files with sizes. |
 | `-n`, `--lines <N>` | Number of lines to show (default: 50). |
 | `-f`, `--follow` | Follow the log in real time, like `tail -f`. Press Ctrl+C to stop. |
 | `--level <LEVEL>` | Minimum log level to show: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`. |


### PR DESCRIPTION
Fixes #101087

## What does this PR do?

When a Desktop-driven update fails at the Electron rebuild stage (updater exit 6, *"Code and dependencies updated, but the Desktop app REBUILD FAILED"*), the only artifacts holding the root cause are `~/.hermes/logs/update.log` (full stdout/stderr mirror of `hermes update`, written by `_UpdateOutputStream`) and `~/.hermes/logs/desktop-update-handoff.log` (hand-off stages including the `desktop --force-build --build-only` retry output). Both the updater's failure messages and the Desktop error box direct users to `hermes debug share` — but the share captured neither file: `LOG_FILES` and the `debug.py` capture chain covered only the classic five logs, so update-failure reports (e.g. #100874: four consecutive exit-6 failures) arrived with the diagnostics that matter most missing.

As a second symptom, `hermes logs list` (a directory scan) already lists both files, but `LOG_FILES` had no readable key for them, so `hermes logs update` failed with "Unknown log" against a file the CLI itself displays.

This PR wires both files through the whole chain:

- `hermes_cli/logs.py`: add `update` → `update.log` and `handoff` → `desktop-update-handoff.log` keys to `LOG_FILES` (fixes the list-vs-read inconsistency; tail/follow/filters come free, and `/api/logs` inherits both).
- `hermes_cli/debug.py`: `_capture_default_log_snapshots`, `collect_debug_report` (tails ride the 100-line budget; a hand-built snapshot dict without the new keys — e.g. gateway `/debug` on an older backend — degrades to the old five-section report instead of `KeyError`), `collect_share_bundle` full logs, the paste-upload label list in `build_debug_share`, and the `--local` print list in `run_debug_share`. The `--nous` bundle inherits the new keys; the 512 KB snapshot cap and force-redaction from `_capture_log_snapshot` apply unchanged.
- `hermes_cli/subcommands/logs.py` + `website/docs/reference/cli-commands.md`: the CLI help text and docs list the new logs, and the debug-share description names the new captures.

Related: #97394 (update.log as the hand-off watchdog's progress signal), #100874 (the report that surfaced this gap).

## Related Issue

Fixes #101087

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## How to Test

1. New dedicated suite: `tests/hermes_cli/test_debug_share_update_logs.py` (12 tests: snapshot capture, report sections, bundle keys, upload/`--local` label lists, `LOG_FILES` resolution, `tail_log` end-to-end, missing-file degradation).
   `python3 -m pytest tests/hermes_cli/test_debug_share_update_logs.py -q` → **12 passed**.
2. Sabotage pass (fails without the fix): `git stash push -- hermes_cli/logs.py hermes_cli/debug.py hermes_cli/subcommands/logs.py` → **10 of 12 fail** against unpatched code; `git stash pop` → 12 passed.
3. Neighbor suites untouched: `test_debug.py`, `test_logs.py`, `test_sanitiser_escalation.py`, `test_debug_command.py`, `test_diagnostics_share_nous.py`, `test_dashboard_admin_endpoints.py`, `test_desktop_update_windows_python_handoff.py` → all pass (12 + 98 green).
4. E2E against a temp `HERMES_HOME`: `tail_log("update")` / `tail_log("handoff")` print the files, and `run_debug_share --local` shows both tails in the report plus both `FULL` sections; on a fresh install (no update logs) the report prints `(file not found)` and the bundle omits both keys.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added tests for the changes (sabotage-verified regression tests)
- [x] I've updated relevant documentation (`cli-commands.md`)
- [x] Tested on Debian 13 x86_64 (log collection is cross-platform; the hand-off log paths are shared with the Windows/POSIX update scripts)

---

**🛠️ Dev:** Halldrix
**🤖 Sidekick:** Hermes Agent v0.21.0
