### PR TITLE
fix(desktop): render async completion output as Markdown

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -165,7 +165,10 @@ const COMPARED_FIELDS = [
   'completedAt',
   // Turn wall-clock duration — stamps the visible "⏱ 38s" badge, so a change
   // must re-render (set once at completion; stable afterwards).
-  'durationS'
+  'durationS',
+  // Async completion rows carry a separate Markdown body and rendering kind.
+  'displayContent',
+  'displayKind'
 ] as const
 
 const IGNORED_FIELDS = ['attachmentRefs', 'parts', 'rowId'] as const

--- a/apps/desktop/src/components/assistant-ui/thread/system-message.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/system-message.test.tsx
@@ -14,13 +14,13 @@ $displayTimestamps.set(true)
 const timestamp = new Date('2026-05-01T00:00:00.000Z')
 stubThreadEnvironment()
 
-function Harness({ text }: { text: string }) {
+function Harness({ custom = {}, text }: { custom?: Record<string, unknown>; text: string }) {
   const message = {
     id: 'system-1',
     role: 'system',
     content: [{ type: 'text', text }],
     createdAt: timestamp,
-    metadata: { custom: { timelineTimestamp: timestamp.getTime() / 1000 } }
+    metadata: { custom: { timelineTimestamp: timestamp.getTime() / 1000, ...custom } }
   } as unknown as ThreadMessage
 
   const runtime = useExternalStoreRuntime<ThreadMessage>({
@@ -45,6 +45,25 @@ function expectTimestampSeparated(container: HTMLElement, precedingText: string)
 }
 
 afterEach(cleanup)
+
+describe('async completion Markdown rendering', () => {
+  it('renders async completion bodies through the Markdown renderer', async () => {
+    const { container, findByRole } = render(
+      <Harness
+        custom={{
+          displayKind: 'async_delegation_complete',
+          displayContent: '# Report\n\n**Conclusion:** healthy\n\n| Strategy | Status |\n|---|---|\n| Alpha | running |'
+        }}
+        text="background agent work finished"
+      />
+    )
+
+    expect(await findByRole('heading', { name: 'Report' })).toBeTruthy()
+    expect(container.textContent).toContain('Conclusion:')
+    expect(container.textContent).toContain('Alpha')
+    expect(container.querySelector('table')).toBeTruthy()
+  })
+})
 
 describe('system message timestamp text separation', () => {
   it('separates an ordinary system row timestamp in accessible and copied text', () => {

--- a/apps/desktop/src/components/assistant-ui/thread/system-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/system-message.tsx
@@ -1,6 +1,7 @@
 import { MessagePrimitive, useAuiState } from '@assistant-ui/react'
 import { type FC } from 'react'
 
+import { MarkdownTextContent } from '@/components/assistant-ui/markdown-text'
 import { messageContentText } from '@/components/assistant-ui/thread/content'
 import { MessageTimelineTimestamp } from '@/components/assistant-ui/thread/timeline-timestamp'
 import { SCAFFOLD_LABEL_CLASS } from '@/components/chat/scaffold-row'
@@ -15,9 +16,28 @@ const REVIEW_NOTE_RE = /^review:(?<label>[^:\n]+):?\s*(?<detail>[\s\S]*)$/
 
 export const SystemMessage: FC = () => {
   const text = useAuiState(s => messageContentText(s.message.content))
+  const displayKind = useAuiState(s => s.message.metadata?.custom?.displayKind)
+  const displayContent = useAuiState(s => s.message.metadata?.custom?.displayContent)
 
   if (!text) {
     return null
+  }
+
+  // Async cron/delegation completions are persisted as system timeline rows
+  // to prevent them from starting an unsolicited agent turn. Their original
+  // body is nevertheless user-facing Markdown, so render it with the same
+  // pipeline as an assistant answer instead of treating it as plain text.
+  if (displayKind === 'async_delegation_complete' && typeof displayContent === 'string' && displayContent.trim()) {
+    return (
+      <MessagePrimitive.Root
+        className="w-full min-w-0 max-w-full self-start px-(--message-text-indent) py-0.5"
+        data-role="system"
+        data-slot="aui_system-message-root"
+      >
+        <MarkdownTextContent isRunning={false} text={displayContent} />
+        <MessageTimelineTimestamp className="mt-0.5 block" />
+      </MessagePrimitive.Root>
+    )
   }
 
   // The self-improvement review saved something to memory/skills — the same

--- a/apps/desktop/src/lib/chat-messages/hydration.ts
+++ b/apps/desktop/src/lib/chat-messages/hydration.ts
@@ -303,6 +303,10 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
       id: `${message.timestamp || Date.now()}-${index}-${displayRole}`,
       role: displayRole,
       parts,
+      ...(message.display_kind === 'async_delegation_complete'
+        ? { displayContent: displayContentForMessage(message.role, content) }
+        : {}),
+      ...(message.display_kind ? { displayKind: message.display_kind } : {}),
       timestamp: earliestTimestamp(message.timestamp, ...parts.map(part => part.timestamp)),
       ...(rowId !== undefined ? { rowId } : {}),
       ...(reactions.length ? { reactions } : {}),

--- a/apps/desktop/src/lib/chat-messages/types.ts
+++ b/apps/desktop/src/lib/chat-messages/types.ts
@@ -18,6 +18,10 @@ export type ChatMessage = {
   id: string
   role: SessionMessage['role']
   parts: ChatMessagePart[]
+  /** Original body for timeline rows whose compact label replaces the text. */
+  displayContent?: string
+  /** Durable display kind, retained for specialized timeline rendering. */
+  displayKind?: SessionMessage['display_kind']
   timestamp?: number
   completedAt?: number
   pending?: boolean

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -459,7 +459,13 @@ export function toRuntimeMessage(message: ChatMessage): ThreadMessage {
       role,
       content: [textPart(text)],
       createdAt,
-      metadata: { custom: timelineMeta }
+      metadata: {
+        custom: {
+          ...timelineMeta,
+          ...(message.displayKind ? { displayKind: message.displayKind } : {}),
+          ...(message.displayContent ? { displayContent: message.displayContent } : {})
+        }
+      }
     } as ThreadMessage
   }
 


### PR DESCRIPTION
## Summary
- Preserve async completion display kind and original body during Desktop message hydration.
- Render `async_delegation_complete` bodies through the existing `MarkdownTextContent` pipeline.
- Keep the outer timeline/system semantics intact so cron and delegation completions cannot trigger an unsolicited agent turn.
- Add regression coverage for headings, emphasis, and tables.

Fixes #101078

## Verification
- `npm run typecheck`
- `npm run test:ui -- --run src/components/assistant-ui/thread/system-message.test.tsx src/lib/chat-messages.test.ts`
