### PR TITLE
docs(skills): correct antigravity-cli print-mode output flags in SKILL.md

### DIFF
--- a/optional-skills/autonomous-ai-agents/antigravity-cli/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/antigravity-cli/SKILL.md
@@ -72,7 +72,7 @@ fixes, reviews, second opinions) to Antigravity rather than just smoke-testing.
 ### One-shot (preferred for scripted prompts and second opinions)
 
 ```
-terminal(command="agy -p 'Review this diff for bugs and security issues' --model 'Gemini 3.1 Pro (High)'", workdir="/path/to/repo", timeout=300)
+terminal(command="agy --model 'Gemini 3.1 Pro (High)' -p 'Review this diff for bugs and security issues'", workdir="/path/to/repo", timeout=300)
 ```
 
 `-p` is non-interactive: it runs the prompt and exits. Pick the engine with
@@ -85,7 +85,7 @@ roots with repeatable `--add-dir`.
 Background it and get notified on completion, the same as the `codex` skill:
 
 ```
-terminal(command="agy -p 'Implement the change described in TASK.md and run the tests' --dangerously-skip-permissions", workdir="/path/to/repo", background=true, notify_on_complete=true)
+terminal(command="agy --dangerously-skip-permissions -p 'Implement the change described in TASK.md and run the tests'", workdir="/path/to/repo", background=true, notify_on_complete=true)
 # then: process(action="poll"/"log"/"wait", session_id=<id>)
 ```
 
@@ -103,11 +103,13 @@ Create one git worktree per task and launch an independent `agy -p` in each
 uses for batch issue fixing. Bound concurrency to what the machine and your
 review capacity can absorb.
 
-### Output + bounding caveat (differs from Claude Code)
+### Output + bounding caveats
 
-- `agy -p` returns **plain text** — there is **no `--output-format json`** and
-  no result envelope with `session_id` / cost / turn count. Parse stdout
-  directly; don't expect a JSON object.
+- `agy -p` supports structured output: `--output-format json` prints one JSON
+  envelope on stdout (`conversation_id`, `status`, `response`, `num_turns`,
+  `duration_seconds`, `usage`), and `--json-schema <file>` adds a validated
+  `structured_output` object. The default (`text`) is plain stdout — parse it
+  directly only when you didn't request JSON.
 - There is **no `--max-turns`**. A print run is bounded by **`--print-timeout`**
   (default `5m`). Raise it for long tasks: `--print-timeout 20m`. Pair with the
   `terminal` `timeout=` so the outer call doesn't cut the run short.
@@ -149,6 +151,8 @@ another agent's plan or diff.
 - `--continue` / `-c`
 - `--conversation`
 - `--dangerously-skip-permissions`
+- `--json-schema`
+- `--output-format`
 - `--print` / `-p`
 - `--print-timeout`
 - `--prompt`
@@ -217,8 +221,11 @@ another agent's plan or diff.
   session-state problems, not browser-only problems.
 - Workspace identity can depend on launch directory and the `.antigravitycli`
   project marker.
-- `agy -p` prints plain text only — no `--output-format json`, no result
-  envelope. Don't try to parse a JSON object out of it (unlike `claude-code`).
+- `agy -p` takes the prompt as its value and must come last in the argv: a
+  positional prompt is ignored, and stdin is never read.
+- Without `--add-dir <repo>`, print runs that write files land them under
+  `~/.gemini/antigravity-cli/scratch/`, not the launch directory —
+  `workdir=` on the `terminal` tool is not enough.
 - Bound print runs with `--print-timeout` (default `5m`), not `--max-turns`
   (which does not exist on `agy`).
 

--- a/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-antigravity-cli.md
+++ b/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-antigravity-cli.md
@@ -90,7 +90,7 @@ fixes, reviews, second opinions) to Antigravity rather than just smoke-testing.
 ### One-shot (preferred for scripted prompts and second opinions)
 
 ```
-terminal(command="agy -p 'Review this diff for bugs and security issues' --model 'Gemini 3.1 Pro (High)'", workdir="/path/to/repo", timeout=300)
+terminal(command="agy --model 'Gemini 3.1 Pro (High)' -p 'Review this diff for bugs and security issues'", workdir="/path/to/repo", timeout=300)
 ```
 
 `-p` is non-interactive: it runs the prompt and exits. Pick the engine with
@@ -103,7 +103,7 @@ roots with repeatable `--add-dir`.
 Background it and get notified on completion, the same as the `codex` skill:
 
 ```
-terminal(command="agy -p 'Implement the change described in TASK.md and run the tests' --dangerously-skip-permissions", workdir="/path/to/repo", background=true, notify_on_complete=true)
+terminal(command="agy --dangerously-skip-permissions -p 'Implement the change described in TASK.md and run the tests'", workdir="/path/to/repo", background=true, notify_on_complete=true)
 # then: process(action="poll"/"log"/"wait", session_id=<id>)
 ```
 
@@ -121,11 +121,13 @@ Create one git worktree per task and launch an independent `agy -p` in each
 uses for batch issue fixing. Bound concurrency to what the machine and your
 review capacity can absorb.
 
-### Output + bounding caveat (differs from Claude Code)
+### Output + bounding caveats
 
-- `agy -p` returns **plain text** — there is **no `--output-format json`** and
-  no result envelope with `session_id` / cost / turn count. Parse stdout
-  directly; don't expect a JSON object.
+- `agy -p` supports structured output: `--output-format json` prints one JSON
+  envelope on stdout (`conversation_id`, `status`, `response`, `num_turns`,
+  `duration_seconds`, `usage`), and `--json-schema <file>` adds a validated
+  `structured_output` object. The default (`text`) is plain stdout — parse it
+  directly only when you didn't request JSON.
 - There is **no `--max-turns`**. A print run is bounded by **`--print-timeout`**
   (default `5m`). Raise it for long tasks: `--print-timeout 20m`. Pair with the
   `terminal` `timeout=` so the outer call doesn't cut the run short.
@@ -167,6 +169,8 @@ another agent's plan or diff.
 - `--continue` / `-c`
 - `--conversation`
 - `--dangerously-skip-permissions`
+- `--json-schema`
+- `--output-format`
 - `--print` / `-p`
 - `--print-timeout`
 - `--prompt`
@@ -235,8 +239,11 @@ another agent's plan or diff.
   session-state problems, not browser-only problems.
 - Workspace identity can depend on launch directory and the `.antigravitycli`
   project marker.
-- `agy -p` prints plain text only — no `--output-format json`, no result
-  envelope. Don't try to parse a JSON object out of it (unlike `claude-code`).
+- `agy -p` takes the prompt as its value and must come last in the argv: a
+  positional prompt is ignored, and stdin is never read.
+- Without `--add-dir <repo>`, print runs that write files land them under
+  `~/.gemini/antigravity-cli/scratch/`, not the launch directory —
+  `workdir=` on the `terminal` tool is not enough.
 - Bound print runs with `--print-timeout` (default `5m`), not `--max-turns`
   (which does not exist on `agy`).
 


### PR DESCRIPTION
## What does this PR do?

Corrects the `antigravity-cli` skill documentation, which claimed twice that `agy -p` (print mode) returns plain text only and has **no** `--output-format json` / result envelope. As verified on `agy 1.1.22` and `1.1.23` in #101073, print mode does support `--output-format json` (one JSON envelope on stdout: `conversation_id`, `status`, `response`, `num_turns`, `duration_seconds`, `usage`) and `--json-schema <file>` (adds a validated `structured_output` object). The old claims would make an agent avoid structured output that actually exists.

While fixing those two spots, the same verified observations from the issue are folded in:

- `-p` takes the prompt as its value and must come **last** in the argv (a positional prompt is ignored; stdin is never read) — the two delegation examples previously placed `--model` / `--dangerously-skip-permissions` after `-p`, so their flag order is corrected.
- Without `--add-dir <repo>`, print runs that write files land them under `~/.gemini/antigravity-cli/scratch/`, not the launch directory — `workdir=` on the `terminal` tool is not enough.

The website page `website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-antigravity-cli.md` is auto-generated from the SKILL.md, so the identical content edits are mirrored there (no generator re-run, to avoid platform-specific noise from a local regeneration).

## Related Issue

Fixes #101073

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `optional-skills/autonomous-ai-agents/antigravity-cli/SKILL.md`
  - "Output + bounding caveat" section: replaced the "plain text only, no `--output-format json`" bullet with the actual JSON envelope / `--json-schema` behavior (default `text` stays plain stdout).
  - Pitfalls: replaced the stale "don't try to parse a JSON object" bullet with the two real pitfalls reported in the issue (`-p` value/last-position requirement; scratch-dir writes without `--add-dir`).
  - Quick Reference flags list: added `--json-schema` and `--output-format`.
  - Fixed flag order in the One-shot and Long-runs examples so `-p` comes last.
- `website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-antigravity-cli.md`: mirrored the identical content edits (generated page).

## How to Test

1. `grep -n "no \`--output-format json\`" optional-skills/autonomous-ai-agents/antigravity-cli/SKILL.md website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-antigravity-cli.md` — should return no matches (observed result: no matches on both files).
2. Confirm the source and generated page stay in sync: the added/removed lines of both diffs should be identical (observed result: `diff` of both `git diff` added-line sets reports no difference).
3. `pytest tests/skills/ tests/website/ -q` (docs-adjacent suites for skills + website) — should pass (observed result: 1630 passed).
4. Manual cross-check against the probe output in #101073 (`agy --help` on 1.1.22/1.1.23 lists `--output-format` and `--json-schema`; the JSON envelope fields match the documented list).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — documentation-only change.
