### PR TITLE
fix(kanban): let kanban_attach take a local path, not just base64

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -996,6 +996,124 @@ def allow_private_urls(monkeypatch):
     url_safety._reset_allow_private_cache()
 
 
+def test_attach_from_source_path(worker_env, tmp_path):
+    """A file on disk is attached by path — the bytes never travel through
+    the model. This is the case base64 could not serve: a report only a few
+    KB long becomes an oversized single response once encoded."""
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    src = tmp_path / "report.md"
+    payload = ("# Report" + os.linesep + "x" * 7500).encode()
+    src.write_bytes(payload)
+
+    out = kt._handle_attach({"source_path": str(src)})
+    d = json.loads(out)
+    assert d.get("ok") is True, d
+    assert d["size"] == len(payload)
+
+    conn = kb.connect()
+    try:
+        rows = kb.list_attachments(conn, worker_env)
+    finally:
+        conn.close()
+    assert len(rows) == 1
+    row = rows[0]
+    # filename defaults to the path's leaf when not supplied
+    assert row.filename == "report.md"
+    # stored bytes are identical to the source, not a re-encode
+    with open(row.stored_path, "rb") as fh:
+        assert fh.read() == payload
+
+
+def test_attach_source_path_explicit_filename_wins(worker_env, tmp_path):
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    src = tmp_path / "scratch-name.md"
+    src.write_bytes(b"body")
+    out = kt._handle_attach({"source_path": str(src), "filename": "final.md"})
+    assert json.loads(out).get("ok") is True
+
+    conn = kb.connect()
+    try:
+        rows = kb.list_attachments(conn, worker_env)
+    finally:
+        conn.close()
+    assert rows[0].filename == "final.md"
+
+
+def test_attach_rejects_both_sources(worker_env, tmp_path):
+    """Supplying both is a caller bug, not something to resolve silently."""
+    import base64
+
+    from tools import kanban_tools as kt
+
+    src = tmp_path / "a.md"
+    src.write_bytes(b"body")
+    out = kt._handle_attach({
+        "source_path": str(src),
+        "content_base64": base64.b64encode(b"other").decode(),
+    })
+    d = json.loads(out)
+    assert "error" in d
+    assert "not both" in d["error"]
+
+
+def test_attach_requires_a_source(worker_env):
+    from tools import kanban_tools as kt
+
+    d = json.loads(kt._handle_attach({"filename": "a.md"}))
+    assert "error" in d
+    assert "source_path or content_base64" in d["error"]
+
+
+def test_attach_source_path_must_be_a_file(worker_env, tmp_path):
+    """A missing path and a directory both fail the same way — neither can
+    produce bytes, and the message names the offending value."""
+    from tools import kanban_tools as kt
+
+    missing = json.loads(
+        kt._handle_attach({"source_path": str(tmp_path / "nope.md")})
+    )
+    assert "error" in missing and "not a file" in missing["error"]
+
+    a_dir = json.loads(kt._handle_attach({"source_path": str(tmp_path)}))
+    assert "error" in a_dir and "not a file" in a_dir["error"]
+
+
+def test_attach_source_path_over_cap_is_rejected_before_read(
+    worker_env, tmp_path, monkeypatch
+):
+    """Size is checked from the stat, so an oversized file is refused without
+    being read into memory."""
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setattr(kb, "KANBAN_ATTACHMENT_MAX_BYTES", 16)
+    src = tmp_path / "big.bin"
+    src.write_bytes(b"z" * 64)
+
+    d = json.loads(kt._handle_attach({"source_path": str(src)}))
+    assert "error" in d
+    assert "cap" in d["error"]
+
+
+def test_attach_base64_still_works(worker_env):
+    """The inline path stays supported — existing callers must not break."""
+    import base64
+
+    from tools import kanban_tools as kt
+
+    out = kt._handle_attach({
+        "filename": "small.txt",
+        "content_base64": base64.b64encode(b"hello").decode(),
+    })
+    d = json.loads(out)
+    assert d.get("ok") is True
+    assert d["size"] == 5
+
+
 def test_attach_url_rejects_non_http_scheme(worker_env):
     from tools import kanban_tools as kt
 

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1116,12 +1116,21 @@ def _handle_comment(args: dict, **kw) -> str:
 
 
 def _handle_attach(args: dict, **kw) -> str:
-    """Attach an inline (base64) file to a task.
+    """Attach a file to a task, from a local path or inline base64.
 
-    Mirrors the dashboard's upload endpoint for the agent surface: decode
-    the payload, enforce the shared size cap, write it under the per-task
+    Mirrors the dashboard's upload endpoint for the agent surface: read the
+    bytes, enforce the shared size cap, write them under the per-task
     attachments dir, and record the metadata row — all via
     ``kanban_db.store_attachment_bytes`` so the three surfaces stay in lockstep.
+
+    ``source_path`` exists because base64 was the only accepted source, and
+    that makes the tool unusable for anything but small files: the agent has
+    to emit the whole encoded payload inside one response, so a ~7.5 KB
+    report becomes ~10 KB of base64 and hits the output-token limit. The
+    length-continuation retries then re-emit the same payload and truncate
+    again, and the turn is abandoned with a partial attachment written. The
+    CLI (``hermes kanban attach <task> <path>``) has always taken a path;
+    this closes the gap between the two surfaces.
     """
     from hermes_cli import kanban_db as kb
 
@@ -1137,17 +1146,55 @@ def _handle_attach(args: dict, **kw) -> str:
     if ownership_err:
         return ownership_err
     filename = args.get("filename")
+    if (not filename or not str(filename).strip()) and args.get("source_path"):
+        import os as _os
+
+        filename = _os.path.basename(str(args["source_path"]).rstrip("/\\"))
     if not filename or not str(filename).strip():
         return tool_error("filename is required")
     content_b64 = args.get("content_base64")
-    if not content_b64 or not str(content_b64).strip():
-        return tool_error("content_base64 is required")
-    import base64
-    import binascii
-    try:
-        data = base64.b64decode(str(content_b64), validate=True)
-    except (binascii.Error, ValueError) as e:
-        return tool_error(f"content_base64 is not valid base64: {e}")
+    source_path = args.get("source_path")
+    has_b64 = bool(content_b64 and str(content_b64).strip())
+    has_path = bool(source_path and str(source_path).strip())
+    if has_b64 and has_path:
+        return tool_error(
+            "pass either source_path or content_base64, not both"
+        )
+    if not has_b64 and not has_path:
+        return tool_error("source_path or content_base64 is required")
+
+    if has_path:
+        # Read locally rather than making the model carry the bytes. Size is
+        # checked here as well as in store_attachment_bytes so an oversized
+        # file is rejected before it is read into memory.
+        import os
+
+        raw_path = os.path.expanduser(str(source_path))
+        if not os.path.isabs(raw_path):
+            raw_path = os.path.abspath(raw_path)
+        if not os.path.isfile(raw_path):
+            return tool_error(f"source_path is not a file: {source_path}")
+        try:
+            actual = os.path.getsize(raw_path)
+        except OSError as e:
+            return tool_error(f"cannot stat source_path: {e}")
+        if actual > kb.KANBAN_ATTACHMENT_MAX_BYTES:
+            return tool_error(
+                f"source_path is {actual} bytes, over the "
+                f"{kb.KANBAN_ATTACHMENT_MAX_BYTES}-byte attachment cap"
+            )
+        try:
+            with open(raw_path, "rb") as fh:
+                data = fh.read()
+        except OSError as e:
+            return tool_error(f"cannot read source_path: {e}")
+    else:
+        import base64
+        import binascii
+        try:
+            data = base64.b64decode(str(content_b64), validate=True)
+        except (binascii.Error, ValueError) as e:
+            return tool_error(f"content_base64 is not valid base64: {e}")
     content_type = args.get("content_type")
     board = args.get("board")
     try:
@@ -2036,11 +2083,14 @@ KANBAN_COMMENT_SCHEMA = {
 KANBAN_ATTACH_SCHEMA = {
     "name": "kanban_attach",
     "description": (
-        "Attach a file to a task by passing its bytes inline (base64). "
+        "Attach a file to a task — pass source_path for a file already on "
+        "disk (preferred), or content_base64 to supply the bytes inline. "
         "Use for genuine file artifacts the next worker or a human should "
         "be able to download — generated reports, images, exports. The "
         "file is stored as a real attachment (not a comment link) under "
-        "the task's attachments dir, capped at 25 MB. Prefer "
+        "the task's attachments dir, capped at 25 MB. Write the file out "
+        "first and pass its path: base64 has to travel inside one model "
+        "response, so it only works for very small files. Prefer "
         "kanban_attach_url when you only have a URL."
     ),
     "parameters": {
@@ -2057,9 +2107,23 @@ KANBAN_ATTACH_SCHEMA = {
                     "Directory components are stripped; only the leaf is kept."
                 ),
             },
+            "source_path": {
+                "type": "string",
+                "description": (
+                    "Path to a local file to attach. Preferred over "
+                    "content_base64: Hermes reads the bytes itself, so the "
+                    "payload never has to fit in one model response. If "
+                    "filename is omitted it defaults to this path's leaf."
+                ),
+            },
             "content_base64": {
                 "type": "string",
-                "description": "The file contents, base64-encoded. Max 25 MB decoded.",
+                "description": (
+                    "The file contents, base64-encoded. Max 25 MB decoded. "
+                    "Use source_path instead when the file is on disk — "
+                    "anything more than a few KB will not fit in one "
+                    "response once encoded."
+                ),
             },
             "content_type": {
                 "type": "string",
@@ -2067,7 +2131,7 @@ KANBAN_ATTACH_SCHEMA = {
             },
             "board": _board_schema_prop(),
         },
-        "required": ["filename", "content_base64"],
+        "required": [],
     },
 }
 


### PR DESCRIPTION
`kanban_attach` accepts only `content_base64`, so the agent has to emit the entire encoded payload inside one response. A ~7.5 KB report becomes ~10 KB of base64 and hits the output-token limit; the length-continuation retries then re-emit the same payload and truncate again, and the turn is abandoned before the tool call lands.

This is not a theoretical limit — it produced three different failure shapes on one local board in a single day, all from this one cause:

| what was left behind | what happened |
|---|---|
| a 226-byte placeholder attachment | turn abandoned mid-upload after four continuation attempts |
| a duplicate `…_review (1).md` | a retry wrote a second copy alongside the first |
| an 11,160-byte attachment of mojibake | stored from a truncated base64 body; the real file on disk was 10,484 bytes of valid markdown |

The last one is the worst of the three: it succeeds, so nothing downstream knows the attachment is garbage.

Meanwhile the CLI has always taken a path — `hermes kanban attach <task> <path>` — so the two surfaces disagree about what an attachment source is.

### The change

`source_path` is added to `kanban_attach`. Hermes reads the bytes itself; they never travel through the model.

- Either `source_path` or `content_base64`, not both. Supplying neither, or both, is a clean tool error rather than a silent preference.
- `filename` becomes optional when `source_path` is given — it defaults to the path's leaf.
- Size is checked from the stat *before* the read, so an oversized file is refused without being pulled into memory.
- `content_base64` is untouched and still works. Existing callers are unaffected.

I chose a parameter over a third attach tool (`kanban_attach` / `kanban_attach_url` / …) because the recent core-tool deferral work is reducing the tool surface rather than growing it. Happy to split it out if you would rather keep one source per tool.

### Testing

7 new cases in `tests/tools/test_kanban_tools.py`:

- path happy path, including a byte-for-byte comparison of the stored file against the source
- `filename` defaulting to the leaf, and an explicit `filename` overriding it
- both-sources and no-source errors
- a missing path and a directory path (both must fail, and name the offending value)
- the over-cap refusal
- the base64 route still working

Full module passes 39/39 locally (`uv run --with pytest pytest tests/tools/test_kanban_tools.py`).

### Note

I have another PR open (#99234) that is unrelated to this one — different files, no overlap. This branch is cut from current `main` and can be reviewed on its own.
