### PR TITLE
fix(backup): exit non-zero when a full backup is incomplete (salvage of #68866)

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -906,8 +906,16 @@ def _safe_restore_db(src: Path, dst: Path) -> bool:
 # Backup
 # ---------------------------------------------------------------------------
 
-def run_backup(args) -> None:
-    """Create a zip backup of the Hermes home directory."""
+def run_backup(args) -> bool:
+    """Create a zip backup of the Hermes home directory.
+
+    Returns True when every selected file landed in the archive (or there
+    was nothing to back up), False when the archive was written but is
+    incomplete — the summary lists what is missing and the zip is kept so
+    the operator can still restore the rest. Hard failures (no Hermes home,
+    unusable output path, another backup already running) keep raising
+    ``SystemExit(1)`` / ``SystemExit(2)``.
+    """
     hermes_root = get_default_hermes_root()
 
     if not hermes_root.is_dir():
@@ -916,13 +924,13 @@ def run_backup(args) -> None:
 
     try:
         with _backup_operation_lock(hermes_root):
-            _run_backup_locked(args, hermes_root)
+            return _run_backup_locked(args, hermes_root)
     except BackupInProgressError as exc:
         print(f"Error: {exc}")
         raise SystemExit(2) from exc
 
 
-def _run_backup_locked(args, hermes_root: Path) -> None:
+def _run_backup_locked(args, hermes_root: Path) -> bool:
     """Write a full backup while the cross-process backup slot is held."""
 
     # Determine output path
@@ -990,7 +998,7 @@ def _run_backup_locked(args, hermes_root: Path) -> None:
             (time.monotonic() - scan_started) * 1000,
         )
         print("No files to back up.")
-        return
+        return True
 
     # Create the zip
     file_count = len(files_to_add) + len(external_to_add)
@@ -1097,7 +1105,10 @@ def _run_backup_locked(args, hermes_root: Path) -> None:
             print(f"    {d}/")
 
     if errors:
-        print(f"\n  Warnings ({len(errors)} files skipped):")
+        print(
+            f"\n  Archive kept, but {len(errors)} file(s) could not be added "
+            "(exit status 1):"
+        )
         for e in errors[:10]:
             print(e)
         if len(errors) > 10:
@@ -1105,6 +1116,8 @@ def _run_backup_locked(args, hermes_root: Path) -> None:
 
     if not errors:
         print(f"\nRestore with: hermes import {out_path.name}")
+
+    return not errors
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5995,7 +5995,11 @@ def cmd_backup(args):
     else:
         from hermes_cli.backup import run_backup
 
-        run_backup(args)
+        # A written-but-incomplete archive must not report shell success:
+        # cron/systemd timers would otherwise publish zips missing state.db
+        # for months. The archive is kept; only the exit status changes.
+        if run_backup(args) is False:
+            raise SystemExit(1)
 
 
 def cmd_import(args):

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -697,7 +697,7 @@ class TestBackupEdgeCases:
         args = Namespace(output=str(tmp_path / "out.zip"))
 
         from hermes_cli.backup import run_backup
-        run_backup(args)
+        assert run_backup(args) is True
 
         # No zip should be created
         assert not (tmp_path / "out.zip").exists()
@@ -721,7 +721,8 @@ class TestBackupEdgeCases:
         args = Namespace(output=str(out_zip))
 
         from hermes_cli.backup import run_backup
-        run_backup(args)
+        # The archive is kept, but a skipped file makes the run incomplete.
+        assert run_backup(args) is False
 
         # Zip should still be created with the valid files
         assert out_zip.exists()
@@ -2225,3 +2226,112 @@ class TestImportHonorsHermesHomeOverride:
         backup_mod.run_import(args)
 
         assert calls and calls[0].get("context") == "import"
+
+
+class TestBackupExitStatus:
+    """A written-but-incomplete archive must not report shell success.
+
+    ``hermes backup`` recorded per-file failures, printed ``Backup incomplete``
+    and still exited 0, so cron/systemd timers could publish archives missing
+    ``state.db`` indefinitely. ``run_backup`` now reports completeness and
+    ``cmd_backup`` maps an incomplete archive to exit status 1; the archive is
+    kept. Lock contention keeps exit status 2.
+    """
+
+    def _home(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        _make_hermes_tree(hermes_home)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        return hermes_home
+
+    def test_run_backup_returns_false_and_keeps_archive_when_db_snapshot_fails(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        self._home(tmp_path, monkeypatch)
+        import hermes_cli.backup as backup_mod
+
+        monkeypatch.setattr(backup_mod, "_safe_copy_db", lambda *a, **kw: False)
+        out_zip = tmp_path / "out.zip"
+
+        assert backup_mod.run_backup(Namespace(output=str(out_zip))) is False
+
+        assert out_zip.exists()
+        with zipfile.ZipFile(out_zip, "r") as zf:
+            names = zf.namelist()
+        assert "config.yaml" in names
+        assert not any(name.endswith(".db") for name in names)
+        out = capsys.readouterr().out
+        assert "Backup incomplete" in out
+        assert "Archive kept" in out
+        assert "SQLite safe copy failed" in out
+        assert "Restore with:" not in out
+
+    def test_run_backup_returns_false_when_regular_file_unreadable(
+        self, tmp_path, monkeypatch
+    ):
+        if os.name != "posix" or os.geteuid() == 0:
+            pytest.skip("needs POSIX permissions and a non-root user")
+        hermes_home = self._home(tmp_path, monkeypatch)
+        secret = hermes_home / "unreadable.txt"
+        secret.write_text("x", encoding="utf-8")
+        secret.chmod(0)
+        out_zip = tmp_path / "out.zip"
+        try:
+            from hermes_cli.backup import run_backup
+
+            assert run_backup(Namespace(output=str(out_zip))) is False
+            assert out_zip.exists()
+        finally:
+            secret.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+    def test_run_backup_returns_true_when_complete(self, tmp_path, monkeypatch, capsys):
+        self._home(tmp_path, monkeypatch)
+        from hermes_cli.backup import run_backup
+
+        assert run_backup(Namespace(output=str(tmp_path / "out.zip"))) is True
+        out = capsys.readouterr().out
+        assert "Backup complete" in out
+        assert "Restore with:" in out
+
+    def test_run_backup_exits_2_when_another_backup_is_running(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = self._home(tmp_path, monkeypatch)
+        from hermes_cli.backup import _backup_operation_lock, run_backup
+
+        with _backup_operation_lock(hermes_home):
+            with pytest.raises(SystemExit) as exc:
+                run_backup(Namespace(output=str(tmp_path / "out.zip")))
+        assert exc.value.code == 2
+
+    def test_cmd_backup_exits_1_when_full_backup_incomplete(self, monkeypatch):
+        import hermes_cli.backup as backup_mod
+        from hermes_cli.main import cmd_backup
+
+        monkeypatch.setattr(backup_mod, "run_backup", lambda args: False)
+        with pytest.raises(SystemExit) as exc:
+            cmd_backup(Namespace(quick=False, output=None))
+        assert exc.value.code == 1
+
+    def test_cmd_backup_returns_normally_when_complete(self, monkeypatch):
+        import hermes_cli.backup as backup_mod
+        from hermes_cli.main import cmd_backup
+
+        monkeypatch.setattr(backup_mod, "run_backup", lambda args: True)
+        assert cmd_backup(Namespace(quick=False, output=None)) is None
+
+    def test_cmd_backup_quick_path_untouched(self, monkeypatch):
+        import hermes_cli.backup as backup_mod
+        from hermes_cli.main import cmd_backup
+
+        calls = []
+        monkeypatch.setattr(backup_mod, "run_quick_backup", lambda args: calls.append(args))
+
+        def _not_expected(args):
+            raise AssertionError("full backup must not run for --quick")
+
+        monkeypatch.setattr(backup_mod, "run_backup", _not_expected)
+        cmd_backup(Namespace(quick=True, output=None, label=None))
+        assert len(calls) == 1

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -955,6 +955,8 @@ The backup uses SQLite's `backup()` API for safe copying, so it works correctly 
 - `checkpoints/` — per-session trajectory caches. Hash-keyed and regenerated per session; wouldn't port cleanly to another install anyway.
 - The `hermes-agent` code itself (this is a user-data backup, not a repo snapshot).
 
+**Exit codes.** `0` when every selected file was archived (or there was nothing to back up); `1` when the archive was written but is incomplete — for example a SQLite database stayed locked past the snapshot deadline or a file could not be read; the summary lists what is missing and the zip is kept — or when the Hermes home / output path is unusable; `2` when another Hermes backup is already running. Scheduled backups (cron, systemd timers) should treat any non-zero status as a failed run.
+
 ### Examples
 
 ```bash


### PR DESCRIPTION
## What does this PR do?

`hermes backup` recorded per-file failures, printed `Backup incomplete: <path>` and still returned shell status 0. A cron job or systemd timer running it would therefore publish "successful" archives missing `state.db` (SQLite snapshot past its busy deadline, unreadable file) indefinitely — I found this while setting up a scheduled backup after a `state.db` corruption (#101093).

`run_backup()` now returns whether the archive is complete and `cmd_backup()` maps `False` to exit status 1. The partial archive is **kept** (it may still be the best copy available); the summary says so and lists the missing paths. Lock contention keeps exit status 2, and `--quick` is untouched.

Salvage of #68866 by @jbryce onto current `main` — the original diff predates the `run_backup`/`_run_backup_locked` split and the cross-process backup lock, so its hunks no longer apply. Authorship preserved via `Co-authored-by`. Supersedes #68866.

## Related Issue

Supersedes #68866. Related: #93347 / #93374 (non-regular files such as `gateway.sock` currently land in the error list; once #93374 merges they stop surfacing as exit 1), #82042 (transient files).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/backup.py`: `run_backup()` / `_run_backup_locked()` return `bool` (`True` for a complete archive or nothing to back up, `False` when files were skipped); the warnings header now reads `Archive kept, but N file(s) could not be added (exit status 1):`.
- `hermes_cli/main.py`: `cmd_backup()` raises `SystemExit(1)` when `run_backup()` returns `False`.
- `website/docs/reference/cli-commands.md`: exit codes documented for `hermes backup`.
- `tests/hermes_cli/test_backup.py`: new `TestBackupExitStatus` (7 tests: incomplete-because-SQLite, incomplete-because-unreadable-file, complete, lock contention exit 2, `cmd_backup` exit 1 / normal return / `--quick` untouched) and completeness assertions added to `test_empty_hermes_home` and `test_pre1980_timestamp_skipped`.

**Compatibility note:** scripts that relied on exit 0 for an incomplete archive will now see 1. Known false-positive sources that will surface as exit 1 until they land: `gateway.sock` on POSIX with a running gateway (#93347 / #93374) and transient chrome-debug files (#82042). If reviewers prefer a smaller blast radius, gating exit 1 only on SQLite snapshot failures is a one-line change in the final condition — happy to switch.

## How to Test

1. `hermes backup -o /tmp/hermes-test.zip; echo $?` → `Backup complete`, `0`.
2. Hold `BEGIN EXCLUSIVE` on `~/.hermes/state.db` from another process (e.g. the snippet in `tests/hermes_cli/test_backup.py::TestSafeCopyDb::test_locked_source_fails_fast_not_hang`), run the same command → `Backup incomplete`, `Archive kept, but 1 file(s) could not be added (exit status 1):`, `$?` = `1`, zip exists without `state.db`.
3. `scripts/run_tests.sh tests/hermes_cli/test_backup.py tests/hermes_cli/test_backup_stability.py tests/hermes_cli/test_backup_path_errors.py tests/hermes_cli/test_backup_all_profiles.py tests/hermes_cli/test_subcommands_batch.py -q` → 96 passed; `ruff check hermes_cli/backup.py hermes_cli/main.py tests/hermes_cli/test_backup.py` clean.

## Checklist

- [x] My code follows the project's code style
- [x] I have searched for duplicate PRs/issues (#68866 is the original; this rebases it)
- [x] This PR is focused on one logical change
- [x] I have tested this change locally (Linux, Python 3.12)
- [x] I have added/updated tests
- [x] Documentation updated
- [ ] `cli-config.yaml.example` — N/A
- [x] Cross-platform: no new I/O; the unreadable-file test is skipped on Windows/root

This change was developed with AI assistance (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNX8rNYHqA5pT4tAGSzXtb
