### PR TITLE
feat(cli): add Daybreak to OpenAI model pickers

### DIFF
--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -16,6 +16,7 @@ DEFAULT_CODEX_MODELS: List[str] = [
     # GPT-5.6 series (Sol/Terra/Luna). The public API exposes "-pro"
     # variants, but the ChatGPT Codex OAuth backend rejects them with HTTP 400,
     # so the curated offline fallback must not surface those dead choices.
+    "gpt-daybreak-blue-latest",
     "gpt-5.6-sol",
     "gpt-5.6-terra",
     "gpt-5.6-luna",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -329,6 +329,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gpt-4o-mini",
     ],
     "openai-api": [
+        "gpt-daybreak-blue-latest",
         "gpt-5.6-sol",
         "gpt-5.6-sol-pro",
         "gpt-5.6-terra",

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -15,6 +15,26 @@ CHATGPT_REJECTED_CODEX_PRO_SLUGS = {
 }
 
 
+def _fetch_live_models(monkeypatch, entries):
+    import sys
+
+    from hermes_cli import codex_models
+
+    class _FakeResp:
+        status_code = 200
+
+        def json(self):
+            return {"models": entries}
+
+    class _FakeHttpx:
+        @staticmethod
+        def get(url, headers=None, timeout=None):
+            return _FakeResp()
+
+    monkeypatch.setitem(sys.modules, "httpx", _FakeHttpx)
+    return codex_models._fetch_models_from_api(access_token="tok")
+
+
 def test_curated_codex_fallback_excludes_chatgpt_rejected_pro_slugs(monkeypatch):
     """OAuth fallback retains real models but never synthesizes rejected ones."""
     retained_models = {"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"}
@@ -35,14 +55,21 @@ def test_curated_codex_fallback_excludes_chatgpt_rejected_pro_slugs(monkeypatch)
     assert CHATGPT_REJECTED_CODEX_PRO_SLUGS.isdisjoint(model_ids)
 
 
-def test_picker_synthesizes_900k_variants_for_verified_slugs():
+def test_picker_synthesizes_900k_variants_for_verified_slugs(monkeypatch, tmp_path):
     """Every live-verified large-context slug gets an explicit ``-900k``
     picker variant directly after its base entry; slugs that genuinely
     enforce 272K (gpt-5.5, gpt-5.4-mini) never get one. Base slugs stay
     in the list as the cheaper 272K default."""
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
     model_ids = get_codex_model_ids()  # offline curated path
 
-    for base in ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.4"):
+    for base in (
+        "gpt-daybreak-blue-latest",
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
+        "gpt-5.4",
+    ):
         assert base in model_ids
         assert f"{base}-900k" in model_ids
         assert model_ids.index(f"{base}-900k") == model_ids.index(base) + 1
@@ -76,6 +103,16 @@ def test_setup_wizard_codex_import_resolves():
 
 
 
+def test_live_picker_synthesizes_daybreak_900k_variant(monkeypatch):
+    models = _fetch_live_models(
+        monkeypatch,
+        [{"slug": "gpt-daybreak-blue-latest", "priority": 0}],
+    )
+
+    assert "gpt-daybreak-blue-latest" in models
+    assert "gpt-daybreak-blue-latest-900k" in models
+
+
 def test_fetch_from_api_keeps_supported_in_api_false_models(monkeypatch):
     """Regression: gpt-5.3-codex-spark is returned by the live Codex backend
     with ``supported_in_api: false`` because it isn't in the public OpenAI
@@ -83,29 +120,18 @@ def test_fetch_from_api_keeps_supported_in_api_false_models(monkeypatch):
     accounts, so we must not drop it on that flag. visibility=hidden is
     the separate signal that *should* still filter entries out.
     """
-    import sys
-    from hermes_cli import codex_models
-
-    class _FakeResp:
-        status_code = 200
-
-        def json(self):
-            return {
-                "models": [
-                    {"slug": "gpt-5.5", "priority": 0, "supported_in_api": True},
-                    {"slug": "gpt-5.3-codex-spark", "priority": 7, "supported_in_api": False},
-                    {"slug": "gpt-5-internal", "priority": 99, "visibility": "hidden"},
-                ]
-            }
-
-    class _FakeHttpx:
-        @staticmethod
-        def get(url, headers=None, timeout=None):
-            return _FakeResp()
-
-    monkeypatch.setitem(sys.modules, "httpx", _FakeHttpx)
-
-    models = codex_models._fetch_models_from_api(access_token="tok")
+    models = _fetch_live_models(
+        monkeypatch,
+        [
+            {"slug": "gpt-5.5", "priority": 0, "supported_in_api": True},
+            {
+                "slug": "gpt-5.3-codex-spark",
+                "priority": 7,
+                "supported_in_api": False,
+            },
+            {"slug": "gpt-5-internal", "priority": 99, "visibility": "hidden"},
+        ],
+    )
 
     assert "gpt-5.5" in models
     assert "gpt-5.3-codex-spark" in models
@@ -238,4 +264,3 @@ class TestNormalizeModelForProvider:
         assert changed is True
         # Uses first from available list
         assert cli.model == "gpt-5.3-codex"
-

--- a/tests/hermes_cli/test_openai_picker_curated.py
+++ b/tests/hermes_cli/test_openai_picker_curated.py
@@ -61,12 +61,10 @@ def test_default_openai_endpoint_intersects_account_access(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "sk-fake")
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
 
-    curated = M._PROVIDER_MODELS["openai-api"]
-    # Account only serves the first two curated models.
-    live = list(curated[:2]) + ["text-embedding-3-large", "whisper-1"]
+    daybreak = "gpt-daybreak-blue-latest"
+    # Account serves two curated models plus unrelated API products.
+    live = ["gpt-5.6-sol", daybreak, "text-embedding-3-large", "whisper-1"]
     with patch.object(M, "fetch_api_models", return_value=live):
         result = M.provider_model_ids("openai-api", force_refresh=True)
 
-    assert result == list(curated[:2])
-
-
+    assert result == [daybreak, "gpt-5.6-sol"]


### PR DESCRIPTION
## What does this PR do?

Hermes users with approved access can select `gpt-daybreak-blue-latest` from both existing OpenAI picker paths. The ChatGPT or Codex Subscription path also exposes the existing `-900k` context option, while the OpenAI API path keeps its current live catalogue and fallback policies.

## Related Issue

Fixes #101111.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added Daybreak to the Codex subscription fallback catalogue and reused the verified 900K variant path.
- Added Daybreak to the curated OpenAI API catalogue without changing provider grouping or entitlement handling.
- Added relationship-based regression coverage for offline, live-discovery, and account-intersection behaviour.

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_codex_models.py tests/hermes_cli/test_codex_cli_model_picker.py tests/hermes_cli/test_model_catalog.py tests/hermes_cli/test_models.py tests/hermes_cli/test_openai_picker_curated.py tests/hermes_cli/test_openai_listing_authority.py tests/hermes_cli/test_official_openai_host.py -q`.
2. Open `/model`, choose ChatGPT or Codex Subscription, and confirm the Daybreak base and `-900k` options are available under the current account rules.
3. Choose OpenAI API and confirm the approved base model appears without a synthetic `-900k` option.

Local verification on Ubuntu 24.04.4 LTS: 138 related tests passed, Ruff passed, the Windows footgun scan passed, and a credential-free picker smoke check returned the expected three catalogue entries. A credentialed live entitlement response was not exercised locally.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04.4 LTS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A, picker catalogue correction only
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A. This changes CLI picker catalogue data and has no visual web surface.
