### PR TITLE
fix(cron): exempt OS error signatures from provider failure classification

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -292,6 +292,14 @@ def _log_tick_yield_once(reason: str) -> None:
     _last_yield_log = {"reason": reason, "at": now}
 
 
+# OSError repr signatures that embed user/script content in the message.
+# Provider errors from HTTP stacks never carry these tokens (#99988).
+_OS_ERROR_SIGNATURE_RE = re.compile(
+    r"^(?:[A-Za-z_][\w.]*:\s*)?\[(?:Errno|WinError)\s+\d+\]",
+    re.IGNORECASE,
+)
+
+
 def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     """Return a compact one-line failure message for chat delivery.
 
@@ -302,6 +310,9 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     job_name = job.get("name") or job.get("id") or "cron job"
     text = (error or "unknown error").strip()
     lower = text.lower()
+    first_line = text.splitlines()[0] if text else ""
+    first_lower = first_line.lower()
+    os_error_signature = bool(_OS_ERROR_SIGNATURE_RE.match(first_line))
 
     if "skipped to prevent unintended spend: global inference config drifted" in lower:
         if "finite one-shot job is consumed" in lower:
@@ -358,8 +369,8 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     # Match 429 as a whole token (#83188 @cation98): bare substring matching
     # let identifiers containing those digits (job ids, ports, hashes) trip
     # a false "provider rate limit" alert.
-    if provider_reachable and (
-        re.search(r"\b429\b", text) or "rate limit" in lower or "usage limit" in lower
+    if provider_reachable and not os_error_signature and (
+        re.search(r"\b429\b", first_line) or "rate limit" in first_lower or "usage limit" in first_lower
     ):
         reason = "rate limit"
         if "weekly usage limit" in lower:
@@ -396,8 +407,8 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
             "quiet. Full details saved in cron output."
         )
 
-    if provider_reachable and (
-        "readtimeout" in lower or "timed out" in lower or "timeout" in lower
+    if provider_reachable and not os_error_signature and (
+        "readtimeout" in first_lower or "timed out" in first_lower or "timeout" in first_lower
     ):
         return (
             f"⚠️ Cron '{job_name}' failed: provider timeout. "
@@ -408,8 +419,9 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     # Match authentication/authorization wording at a word boundary and the
     # 401/403 status codes as whole tokens, so "oauth", "4015" and similar do
     # not trip a misleading auth message.
-    if provider_reachable and (
-        re.search(r"authenticat|authoriz", lower) or re.search(r"\b(401|403)\b", text)
+    if provider_reachable and not os_error_signature and (
+        re.search(r"authenticat|authoriz", first_lower)
+        or re.search(r"\b(401|403)\b", first_line)
     ):
         return (
             f"⚠️ Cron '{job_name}' failed: provider authentication error. "

--- a/tests/cron/test_cron_failure_summarizer_embedded_payload.py
+++ b/tests/cron/test_cron_failure_summarizer_embedded_payload.py
@@ -1,0 +1,77 @@
+"""Regression tests for #99988: cron failure summarizer must not classify
+embedded payload text (script source, headers) as provider failures.
+
+OSError/WinError messages embed the entire "filename" on a single line, so
+first-line-only matching alone is insufficient — skip provider branches when
+the first line carries an OS error signature ([Errno N] or [WinError N]).
+"""
+
+from cron.scheduler import _summarize_cron_failure_for_delivery
+
+
+def _script_with_auth_header() -> str:
+    return (
+        "#!/bin/bash\n"
+        "TOKEN=$(curl ...)\n"
+        'MANIFEST=$(curl -s -H "Authorization: Bearer $TOKEN" ...)\n'
+    )
+
+
+def test_errno63_embedded_authorization_not_labeled_provider_auth():
+    script = _script_with_auth_header()
+    # Linux capture form: str(OSError) embeds the filename on one line (#99988).
+    error = (
+        "OSError: [Errno 63] File name too long: "
+        f"'{script.replace(chr(10), chr(92) + 'n')}'"
+    )
+    assert len(error.splitlines()) == 1
+
+    job = {"name": "monitor-job", "no_agent": False}
+    msg = _summarize_cron_failure_for_delivery(job, error)
+
+    assert "provider authentication error" not in msg.lower()
+    assert "monitor-job" in msg
+
+
+def test_winerror206_embedded_authorization_not_labeled_provider_auth():
+    script = _script_with_auth_header().replace("\n", "\\n")
+    error = (
+        "OSError: [WinError 206] The filename or extension is too long: "
+        f"'{script}'"
+    )
+    assert len(error.splitlines()) == 1
+
+    job = {"name": "monitor-job", "no_agent": False}
+    msg = _summarize_cron_failure_for_delivery(job, error)
+
+    assert "provider authentication error" not in msg.lower()
+    assert "WinError 206" in msg or "filename" in msg.lower()
+
+
+def test_flipping_authorization_to_xuthorization_does_not_change_classification():
+    script = _script_with_auth_header().replace("\n", "\\n")
+    script_x = script.replace("Authorization", "Xuthorization")
+    error_a = f"OSError: [Errno 63] File name too long: '{script_x}'"
+    error_b = f"OSError: [Errno 63] File name too long: '{script}'"
+
+    job = {"name": "monitor-job", "no_agent": False}
+    msg_a = _summarize_cron_failure_for_delivery(job, error_a)
+    msg_b = _summarize_cron_failure_for_delivery(job, error_b)
+    assert "provider authentication error" not in msg_a.lower()
+    assert "provider authentication error" not in msg_b.lower()
+
+
+def test_embedded_timeout_wording_not_labeled_provider_timeout():
+    error = (
+        "RuntimeError: job crashed\n"
+        "details: the upstream request timed out after 30s"
+    )
+    job = {"name": "digest", "no_agent": False}
+    msg = _summarize_cron_failure_for_delivery(job, error)
+    assert "provider timeout" not in msg.lower()
+
+
+def test_first_line_provider_auth_still_classifies():
+    job = {"name": "daily-digest", "no_agent": False}
+    msg = _summarize_cron_failure_for_delivery(job, "HTTP 401 authentication failed")
+    assert "provider authentication error" in msg


### PR DESCRIPTION
## What does this PR do?

`_summarize_cron_failure_for_delivery` matched provider signatures (auth/timeout/rate-limit) against the **full** error text, so failures whose payload embeds those words were misclassified. In #99988 a monitor job crashed with `[Errno 63] File name too long: '<whole bash script>'` — the script's own `Authorization:` header tripped the auth regex, delivering **provider authentication error** for a crash that never touched a provider.

This PR:
1. Matches provider branches against the error's **first line** only (the exception line).
2. Skips all provider branches when the first line carries an OS error signature — `[Errno N]` on Linux or `[WinError N]` on Windows — because OSError embeds user/script content in that line.

Review on #99993 noted the `[Errno N]` exemption but the published pattern did not cover Windows `[WinError N]`; this closes that gap.

## Related Issue

Fixes #99988

Related: #99993

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py` — add `_OS_ERROR_SIGNATURE_RE`; derive `first_line`/`first_lower`; gate provider rate-limit, timeout, and auth branches on first-line matching and OS-error exemption.
- `tests/cron/test_cron_failure_summarizer_embedded_payload.py` — regression tests for Errno 63 and WinError 206 embedded payloads, plus first-line provider auth guard.

## How to Test

1. `python -m pytest tests/cron/test_cron_failure_summarizer_embedded_payload.py -q` — 5 passed
2. `python -m pytest tests/cron/test_cron_no_agent.py::test_agent_job_provider_classification_unchanged -q` — 3 passed

## Checklist

- [x] Read CONTRIBUTING.md
- [x] Conventional Commits message
- [x] Searched for duplicate PRs (#99993 covers partial fix; this adds WinError + ships standalone)
- [x] PR contains only changes related to this fix
- [x] Added tests
- [x] Tested on Windows 11