### PR TITLE
fix(file-tools): route the cwd-override guard through _is_container_backend

### DIFF
--- a/tests/tools/test_container_cwd_sanitize.py
+++ b/tests/tools/test_container_cwd_sanitize.py
@@ -18,6 +18,29 @@ behaviour so neither path can regress.
 """
 
 import tools.terminal_tool as tt
+from agent import terminal_env_registry as reg
+from agent.terminal_env_provider import TerminalEnvironmentProvider
+
+
+class _RegistryBackedContainerProvider(TerminalEnvironmentProvider):
+    """Minimal registry-registered provider with ``is_container = True``.
+
+    Stands in for a plugin-registered container backend (e.g. a third-party
+    sandbox) so the cwd-guard regression can be pinned without depending on
+    any specific built-in backend.
+    """
+
+    name = "test_registry_container"
+    display_name = "Test Registry Container"
+    is_remote = True
+    is_container = True
+
+    def is_available(self):
+        return True
+
+    def create_environment(self, *, cwd, timeout, task_id="default",
+                            image=None, container_config=None, **kwargs):
+        raise NotImplementedError("not exercised: _create_environment is monkeypatched")
 
 
 class TestIsUnusableContainerCwd:
@@ -212,3 +235,34 @@ class TestFileOpsCwdSanitizedAtCallSite:
         cwd = self._run_and_capture_cwd(
             monkeypatch, "/Users/me/workspace", env_type="modal")
         assert cwd == "/workspace"
+
+    def test_registry_container_host_override_does_not_reach_container(self, monkeypatch):
+        """A plugin backend registered with ``is_container = True`` is only
+        classified via ``_is_container_backend()`` (the registry-aware
+        classifier), never via the built-in ``_CONTAINER_BACKENDS``
+        frozenset. If this call site reads the frozenset directly, the guard
+        silently stops firing for every registry-registered backend and a
+        host cwd override reaches the container builder unsanitized."""
+        provider = _RegistryBackedContainerProvider()
+        previous = reg.snapshot_registration(provider.name)
+        reg.register_provider(provider)
+        try:
+            cwd = self._run_and_capture_cwd(
+                monkeypatch, "/Users/me/workspace", env_type=provider.name)
+        finally:
+            reg.restore_registration(provider.name, provider, previous)
+        assert cwd == "/workspace", (
+            f"Host-path cwd override leaked to the container builder: {cwd!r}. "
+            "It must be sanitized back to config['cwd']."
+        )
+
+    def test_registry_container_valid_override_is_preserved(self, monkeypatch):
+        provider = _RegistryBackedContainerProvider()
+        previous = reg.snapshot_registration(provider.name)
+        reg.register_provider(provider)
+        try:
+            cwd = self._run_and_capture_cwd(
+                monkeypatch, "/workspace/task42", env_type=provider.name)
+        finally:
+            reg.restore_registration(provider.name, provider, previous)
+        assert cwd == "/workspace/task42"

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1416,7 +1416,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
         _resolve_container_task_id,
         _resolve_task_host_cwd,
         _is_unusable_container_cwd,
-        _CONTAINER_BACKENDS,
+        _is_container_backend,
     )
     import time
 
@@ -1510,7 +1510,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
             # bypass the guard.  Valid in-container override paths (RL/benchmark
             # sandboxes that set cwd to /workspace, /root, etc.) are absolute
             # non-host paths and pass through untouched.
-            if env_type in _CONTAINER_BACKENDS and _is_unusable_container_cwd(cwd):
+            if _is_container_backend(env_type) and _is_unusable_container_cwd(cwd):
                 if cwd != config["cwd"]:
                     logger.info(
                         "Ignoring host/relative cwd override %r for %s backend "
@@ -1521,9 +1521,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
             logger.info("Creating new %s environment for task %s...", env_type, task_id[:8])
 
             container_config = None
-            from tools.terminal_tool import _is_container_backend as _is_container
-
-            if _is_container(env_type):
+            if _is_container_backend(env_type):
                 container_config = {
                     "container_cpu": config.get("container_cpu", 1),
                     "container_memory": config.get("container_memory", 5120),


### PR DESCRIPTION
## What does this PR do?

`tools/file_tools.py`'s `_get_file_ops()` builds a per-task cwd override for a
new sandbox and runs a guard that discards a host-path override (e.g.
`/Users/<me>/workspace`, registered by a gateway/TUI session) so it can't
reach `docker run -w`. That guard classifies the backend by reading the
built-in `_CONTAINER_BACKENDS` frozenset directly:

```python
if env_type in _CONTAINER_BACKENDS and _is_unusable_container_cwd(cwd):
```

Eleven lines below, the *same function* classifies the backend a second time
for container-config construction, but through `_is_container_backend()`,
the classifier that also consults `agent/terminal_env_registry.py`'s
per-provider `is_container` flag for plugin-registered backends. The twin
guard in `tools/terminal_tool.py` (`_get_env_config()`) already uses
`_is_container_backend()` too. `file_tools.py`'s cwd-override guard is the one
site in this call path still reading the frozenset.

The practical effect: a terminal backend registered only through the plugin
registry (`agent.terminal_env_registry.register_provider`, `is_container =
True`) is invisible to the frozenset check, so the cwd-override guard never
fires for it. A host-path cwd override then reaches the container builder
unsanitized instead of being reset to the validated `config["cwd"]`.

This PR routes that one site through `_is_container_backend()`, so every
classification site in `_get_file_ops()` agrees, and removes the function's
redundant second import of `_is_container_backend` (it was already imported
once at the top of the function, then re-imported under an alias
(`_is_container`) a few lines later for the same check).

## Related Issue

Fixes #101013

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/file_tools.py`: `_get_file_ops()` now imports `_is_container_backend`
  once from `tools.terminal_tool` (replacing the `_CONTAINER_BACKENDS`
  import) and uses it at both classification sites in the function; dropped
  the redundant inline re-import of `_is_container_backend` under the
  `_is_container` alias.
- `tests/tools/test_container_cwd_sanitize.py`: added
  `_RegistryBackedContainerProvider`, a minimal `TerminalEnvironmentProvider`
  with `is_container = True` registered through
  `agent.terminal_env_registry`, plus two tests in
  `TestFileOpsCwdSanitizedAtCallSite` pinning the file-ops cwd path for a
  registry-only backend: a host-path override is discarded back to
  `config["cwd"]`, and a valid in-container override passes through
  unchanged. The provider is registered and unregistered per test via
  `snapshot_registration`/`restore_registration` so it never leaks into
  other tests.

## How to Test

1. `.venv/bin/python -m pytest tests/tools/test_container_cwd_sanitize.py -q`
, 11 passed (was 1 failed / 10 passed before the `tools/file_tools.py`
   fix, confirmed by reverting just that file).
2. `.venv/bin/python -m pytest tests/hermes_cli/test_mcp_config.py -q`, 38
   passed.
3. `.venv/bin/python -m pytest tests/hermes_cli/test_kanban_worker_terminal_cwd.py -q`
, 1 passed.
4. Full `scripts/run_tests.sh` on this branch (macOS 26, Apple Silicon): 43,403 passed, 114 failed in 37 files, all cloud-SDK / platform shaped and unrelated to this change; the only touched-file failures (`tests/tools/test_file_tools.py`: `test_writes_content`, `test_replace_mode_calls_patch_replace`) fail identically on the base commit `9514d354`.
5. `.venv/bin/python -m ruff check tools/file_tools.py tests/tools/test_container_cwd_sanitize.py`
, all checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass, run scoped per-file (see How to Test); this repo's own tooling avoids invoking `tests/hermes_cli` as one batched process.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6 (Apple Silicon), Python 3.11, per-file pytest + `scripts/run_tests.sh` parity against the base commit

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings), N/A, internal classification-site fix, no documented behavior changes.
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys, N/A, no config keys touched.
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows, N/A.
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility), N/A, no OS-specific paths changed; the guard's existing Windows-path handling is untouched.
- [ ] I've updated tool descriptions/schemas if I changed tool behavior, N/A, no tool schema changed.

## Screenshots / Logs

Not applicable, this is an internal classification-site fix with no
user-facing output to capture; the test run output above is the evidence.
