### PR TITLE
fix(kanban): reap notify subscriptions on abandoned tasks regardless of status

### DIFF
--- a/contributors/emails/itsflownium@users.noreply.github.com
+++ b/contributors/emails/itsflownium@users.noreply.github.com
@@ -1,0 +1,1 @@
+itsflownium

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -11685,20 +11685,28 @@ def purge_stale_done_notify_subs(
     *,
     max_age_days: int = 30,
 ) -> int:
-    """Delete notify subscriptions whose task has sat in ``done`` untouched
-    for longer than ``max_age_days``.
+    """Delete notify subscriptions whose task has sat **idle** untouched
+    for longer than ``max_age_days``, whatever its status.
 
     The notifier keeps subscriptions alive through ``done`` because a
     completed task can be reopened (review corrections, continuation) and
     the reopened cycle must still notify its origin session. On boards
     that never archive, that retention would otherwise accumulate
     subscription rows forever — each one scanned every notifier tick.
-    This GC bounds that: a task that has been ``done`` with no new events
-    for the retention window is treated as settled and its subscriptions
-    are purged. Age is measured from the task's most recent event
-    (falling back to ``completed_at`` then ``created_at``), so ANY
-    activity — including a reopen, which also moves the task off
-    ``done`` — resets or exempts it.
+    This GC bounds that on task idleness rather than status: a task that
+    has had no new events for the retention window — and no live-worker
+    heartbeat — is treated as abandoned and its subscriptions are
+    purged. That covers a stale ``done``, a stuck ``blocked``, an
+    abandoned ``review``, and a ``running`` task whose worker died
+    without a final state transition. Age is measured from the task's
+    most recent event (falling back to ``completed_at`` then
+    ``created_at``), so ANY activity — including a reopen, which also
+    moves the task off ``done`` — resets or exempts it.
+
+    A live worker is always exempt: ``heartbeat_worker`` refreshes
+    ``last_heartbeat_at`` (and appends a heartbeat event) at least once
+    a minute, so an actively running task never ages out no matter how
+    far back its other events reach.
 
     ``max_age_days <= 0`` disables the sweep entirely. Returns the number
     of subscription rows deleted.
@@ -11714,13 +11722,13 @@ def purge_stale_done_notify_subs(
         cur = conn.execute(
             "DELETE FROM kanban_notify_subs WHERE task_id IN ("
             " SELECT t.id FROM tasks t"
-            " WHERE t.status = 'done'"
-            " AND COALESCE("
+            " WHERE COALESCE("
             "  (SELECT MAX(e.created_at) FROM task_events e"
             "   WHERE e.task_id = t.id),"
             "  t.completed_at, t.created_at, 0"
-            " ) < ?)",
-            (cutoff,),
+            " ) < ?"
+            " AND COALESCE(t.last_heartbeat_at, 0) < ?)",
+            (cutoff, cutoff),
         )
     return int(cur.rowcount or 0)
 

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -1092,22 +1092,152 @@ def test_gc_honors_configured_retention_days(kanban_home):
         conn.close()
 
 
-def test_gc_spares_reopened_task_even_when_old(kanban_home):
+def test_gc_spares_fresh_reopen_even_when_history_old(kanban_home):
     import hermes_cli.kanban_db as kb
 
     conn = kb.connect()
     try:
         tid = _make_done_task_with_sub(kb, conn, title="reopened", chat_id="c-reopen")
         _backdate_task(kb, conn, tid, days=90)
-        # Reopen: the task leaves ``done``, so even with an ancient event
-        # history the GC must not touch its subscription.
+        # Reopen: the task leaves ``done``. The reopen itself is fresh
+        # activity, so even with an ancient done-era event history the
+        # GC must not touch its subscription — the reopened cycle still
+        # has to notify its origin session.
         with kb.write_txn(conn):
             conn.execute("UPDATE tasks SET status = 'ready' WHERE id = ?", (tid,))
             kb._append_event(conn, tid, "status", {"status": "ready"})
-        # Backdate the reopen event too — status alone must protect it.
-        _backdate_task(kb, conn, tid, days=90)
 
         assert kb.purge_stale_done_notify_subs(conn, max_age_days=30) == 0
+        assert len(kb.list_notify_subs(conn, tid)) == 1
+    finally:
+        conn.close()
+
+
+def test_gc_purges_reopened_task_abandoned_past_retention(kanban_home):
+    import hermes_cli.kanban_db as kb
+
+    conn = kb.connect()
+    try:
+        tid = _make_done_task_with_sub(kb, conn, title="reopened", chat_id="c-reopen")
+        _backdate_task(kb, conn, tid, days=90)
+        # Reopen, then nothing. Status alone must NOT protect the sub:
+        # total idleness past the retention window is the abandonment
+        # signal, whatever the task's status.
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status = 'ready' WHERE id = ?", (tid,))
+            kb._append_event(conn, tid, "status", {"status": "ready"})
+        # Backdate the reopen event too — the reopened cycle was never
+        # picked back up.
+        _backdate_task(kb, conn, tid, days=90)
+
+        assert kb.purge_stale_done_notify_subs(conn, max_age_days=30) == 1
+        assert kb.list_notify_subs(conn, tid) == []
+    finally:
+        conn.close()
+
+
+def _set_task_status(kb, conn, tid, status):
+    """Force a task into ``status`` with a matching status event."""
+    with kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET status = ? WHERE id = ?", (status, tid))
+        kb._append_event(conn, tid, "status", {"status": status})
+
+
+def test_gc_purges_blocked_task_that_never_done(kanban_home):
+    import hermes_cli.kanban_db as kb
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="stuck blocked", assignee="worker1")
+        kb.add_notify_sub(
+            conn, task_id=tid, platform="telegram", chat_id="c-blocked",
+            notifier_profile="default",
+        )
+        _set_task_status(kb, conn, tid, "blocked")
+        _backdate_task(kb, conn, tid, days=45)
+
+        purged = kb.purge_stale_done_notify_subs(conn, max_age_days=30)
+
+        assert purged == 1
+        assert kb.list_notify_subs(conn, tid) == []
+    finally:
+        conn.close()
+
+
+def test_gc_purges_running_task_with_dead_worker(kanban_home):
+    import hermes_cli.kanban_db as kb
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="orphaned running", assignee="worker1")
+        kb.add_notify_sub(
+            conn, task_id=tid, platform="telegram", chat_id="c-dead-run",
+            notifier_profile="default",
+        )
+        _set_task_status(kb, conn, tid, "running")
+        # Simulate a worker whose last heartbeat happened before it died:
+        # stale heartbeat + stale events => abandoned, must be reaped.
+        past = int(__import__("time").time()) - 45 * 86400
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET last_heartbeat_at = ? WHERE id = ?", (past, tid),
+            )
+        _backdate_task(kb, conn, tid, days=45)
+
+        purged = kb.purge_stale_done_notify_subs(conn, max_age_days=30)
+
+        assert purged == 1
+        assert kb.list_notify_subs(conn, tid) == []
+    finally:
+        conn.close()
+
+
+def test_gc_spares_running_task_with_live_worker(kanban_home):
+    import hermes_cli.kanban_db as kb
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="live running", assignee="worker1")
+        kb.add_notify_sub(
+            conn, task_id=tid, platform="telegram", chat_id="c-live-run",
+            notifier_profile="default",
+        )
+        _set_task_status(kb, conn, tid, "running")
+        _backdate_task(kb, conn, tid, days=45)
+        # heartbeat_worker refreshes last_heartbeat_at at least once a
+        # minute; the GC must exempt it even though the task's event
+        # history is far older than the retention window.
+        assert kb.heartbeat_worker(conn, tid)
+        # Age every event back out again — only the fresh
+        # last_heartbeat_at (touched above, untouched by the backdate)
+        # keeps this task out of the sweep.
+        _backdate_task(kb, conn, tid, days=45)
+
+        purged = kb.purge_stale_done_notify_subs(conn, max_age_days=30)
+
+        assert purged == 0
+        assert len(kb.list_notify_subs(conn, tid)) == 1
+    finally:
+        conn.close()
+
+
+def test_gc_spares_active_review_task(kanban_home):
+    import hermes_cli.kanban_db as kb
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="in review", assignee="worker1")
+        kb.add_notify_sub(
+            conn, task_id=tid, platform="telegram", chat_id="c-review",
+            notifier_profile="default",
+        )
+        # The review request itself is recent activity: an active review
+        # is NOT abandoned and must keep its subscription.
+        _set_task_status(kb, conn, tid, "review")
+
+        purged = kb.purge_stale_done_notify_subs(conn, max_age_days=30)
+
+        assert purged == 0
         assert len(kb.list_notify_subs(conn, tid)) == 1
     finally:
         conn.close()
@@ -1120,8 +1250,8 @@ def test_gc_archived_rows_already_removed_by_unsub(kanban_home):
     try:
         tid = _make_done_task_with_sub(kb, conn, title="archived", chat_id="c-arch")
         assert kb.archive_task(conn, tid)
-        # The notifier removes the sub at archive time; the GC targets only
-        # ``done`` tasks, so an archived task contributes nothing to purge.
+        # The notifier removes the sub at archive time; once removed the
+        # GC contributes nothing further for that task.
         kb.remove_notify_sub(
             conn, task_id=tid, platform="telegram", chat_id="c-arch",
         )


### PR DESCRIPTION
## Root cause
\`purge_stale_done_notify_subs\` gated reclamation on \`t.status = 'done'\`, so subscriptions on tasks that never reach \`done\` (blocked forever, abandoned review, running with a dead worker) were permanent by construction.

## Fix
Reclamation is now status-independent and keyed on task idleness: the task's most recent event timestamp (falling back to completed_at/created_at) must predate the retention window AND \`last_heartbeat_at\` must be stale — a live worker's sub-minute heartbeat always exempts its task. Any activity (including a reopen that is picked back up) restarts the idle clock, preserving the reopened-cycle notify contract.

## Tests
- \`tests/hermes_cli/test_kanban_notify.py\`: split the reopened-protection case into fresh-reopen (spared) and abandoned-reopen (purged); added blocked-never-done, dead-worker running, live-worker exempt, and active-review-spared cases.
\`uv run python -m pytest tests/hermes_cli/test_kanban_notify.py tests/hermes_cli/test_kanban_db.py -o 'addopts=' -q\` → **62 passed, 1 skipped**.

Closes #100955
