### PR TITLE
fix(bedrock): tick the aux progress hook per ConverseStream event

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2691,7 +2691,7 @@ class _BedrockCompletionsAdapter:
         self._model = model
 
     def create(self, **kwargs) -> Any:
-        from agent.bedrock_adapter import call_converse
+        from agent.bedrock_adapter import call_converse, call_converse_stream
 
         messages = kwargs.get("messages", [])
         model = kwargs.get("model", self._model)
@@ -2718,7 +2718,7 @@ class _BedrockCompletionsAdapter:
                 "stream); caller downgrades to non-streaming.",
                 model,
             )
-        response = call_converse(
+        converse_kwargs = dict(
             region=self._region,
             model=model,
             messages=messages,
@@ -2736,9 +2736,22 @@ class _BedrockCompletionsAdapter:
             top_p=kwargs.get("top_p"),
             stop_sequences=stop,
         )
-        # Converse is a complete-response API in this shim. Mark provider
-        # progress only after the response returns so TTFP reflects real
-        # Bedrock latency rather than dispatch/setup activity.
+        if _aux_progress_active():
+            # An active progress hook means an inactivity watchdog (e.g.
+            # CompressionCommitFence) is timing this call. A long Converse
+            # call must tick it per stream event or the watchdog cannot
+            # distinguish slow-but-alive from hung and kills the call with
+            # the tokens already billed. Streaming-denied IAM sessions fall
+            # back to non-streaming converse() inside call_converse_stream
+            # and stay unticked mid-call, exactly as before.
+            response = call_converse_stream(
+                **converse_kwargs, on_event=_notify_aux_provider_response,
+            )
+        else:
+            response = call_converse(**converse_kwargs)
+        # Terminal tick: TTFP still reflects real Bedrock latency on the
+        # non-streaming path (and after the final stream event), not
+        # dispatch/setup activity.
         _notify_aux_provider_response()
         return response
 
@@ -9660,8 +9673,9 @@ def _aux_stream_total_ceiling(effective_timeout: Optional[float]) -> float:
 def _client_streams_internally(client: Any) -> bool:
     """Wire adapters that consume a stream inside .create() already tick the
     progress hook themselves (Codex per SSE event, Anthropic per stream
-    event); Bedrock's Converse shim cannot stream at all. None of them
-    accept chat-completions ``stream=True`` semantics from us."""
+    event, Bedrock per ConverseStream event when a hook is active — see
+    _BedrockCompletionsAdapter.create). None of them accept
+    chat-completions ``stream=True`` semantics from us."""
     return isinstance(client, (
         CodexAuxiliaryClient,
         AnthropicAuxiliaryClient,

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -33,7 +33,7 @@ import logging
 import os
 import re
 from types import SimpleNamespace
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
 import httpx
@@ -1625,11 +1625,18 @@ def call_converse_stream(
     top_p: Optional[float] = None,
     stop_sequences: Optional[List[str]] = None,
     guardrail_config: Optional[Dict] = None,
+    on_event: Optional[Callable[[], None]] = None,
 ) -> SimpleNamespace:
     """Call Bedrock ConverseStream API and return an OpenAI-compatible response.
 
     Consumes the full stream and returns the assembled response. For true
     streaming with delta callbacks, use ``iter_converse_stream()`` instead.
+
+    ``on_event`` is called with no arguments once per yielded ConverseStream
+    event (see :func:`stream_converse_with_callbacks`) — a wire-level liveness
+    signal for external inactivity watchdogs. The streaming-denied IAM
+    fallback path never invokes it: a non-streaming converse() has no
+    intermediate events to report.
     """
     client = _get_bedrock_runtime_client(region)
     kwargs = build_converse_kwargs(
@@ -1648,8 +1655,8 @@ def call_converse_stream(
     except Exception as exc:
         retry_kwargs = recover_from_cache_point_rejection(exc, kwargs)
         if retry_kwargs is not None:
-            return normalize_converse_stream_events(
-                client.converse_stream(**retry_kwargs)
+            return stream_converse_with_callbacks(
+                client.converse_stream(**retry_kwargs), on_event=on_event
             )
         if is_streaming_access_denied_error(exc):
             # IAM allows bedrock:InvokeModel but not
@@ -1669,7 +1676,7 @@ def call_converse_stream(
             )
             invalidate_runtime_client(region)
         raise
-    return normalize_converse_stream_events(response)
+    return stream_converse_with_callbacks(response, on_event=on_event)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_aux_progress_streaming.py
+++ b/tests/agent/test_aux_progress_streaming.py
@@ -551,6 +551,95 @@ class TestFenceProgress:
 
 
 # ---------------------------------------------------------------------------
+# Bedrock auxiliary progress wiring (#101088)
+# ---------------------------------------------------------------------------
+
+class TestBedrockAuxProgress:
+    """The Bedrock adapter sits on _client_streams_internally's list, so no
+    outer wrapper can supply its liveness signal: with a hook installed the
+    adapter itself must stream and tick per ConverseStream event, or an
+    inactivity watchdog (CompressionCommitFence) kills every long summary as
+    hung with the tokens already billed."""
+
+    @staticmethod
+    def _client():
+        from agent.auxiliary_client import BedrockAuxiliaryClient
+        return BedrockAuxiliaryClient("us-east-1", "amazon.nova-lite-v1:0")
+
+    def test_end_to_end_ticks_per_stream_event(self):
+        client = self._client()
+        streamed_response = SimpleNamespace(
+            choices=[SimpleNamespace(
+                index=0,
+                message=SimpleNamespace(role="assistant", content="summary"),
+                finish_reason="stop",
+            )],
+            usage=None,
+        )
+
+        def _fake_stream(**kwargs):
+            # Emit exactly three wire events through the captured callback.
+            on_event = kwargs["on_event"]
+            for _ in range(3):
+                on_event()
+            return streamed_response
+
+        ticks = []
+        with (
+            patch(
+                "agent.bedrock_adapter.call_converse_stream",
+                side_effect=_fake_stream,
+            ),
+            patch("agent.bedrock_adapter.call_converse") as plain_converse,
+        ):
+            with aux_progress_hook(lambda: ticks.append(1)):
+                result = _create_with_progress(
+                    client, {"model": "amazon.nova-lite-v1:0", "messages": []},
+                )
+
+        assert result.choices[0].message.content == "summary"
+        assert plain_converse.call_count == 0
+        # 1 dispatch tick (the watchdog's historical liveness signal) + one
+        # per stream event + 1 terminal provider-response tick.
+        assert ticks == [1] * 5
+
+    def test_no_hook_keeps_the_nonstreaming_path(self):
+        completions = self._client().chat.completions
+        plain_response = SimpleNamespace(choices=["as-is"], usage=None)
+        with (
+            patch(
+                "agent.bedrock_adapter.call_converse",
+                return_value=plain_response,
+            ) as plain_converse,
+            patch("agent.bedrock_adapter.call_converse_stream") as streamed,
+        ):
+            result = completions.create(messages=[{"role": "user", "content": "hi"}])
+        assert result is plain_response
+        assert streamed.call_count == 0
+        assert plain_converse.call_count == 1
+
+    def test_on_event_carries_the_provider_response_signal(self):
+        # Per-event ticks must be _notify_aux_provider_response (timing +
+        # progress), matching the Codex adapter's substantive-payload
+        # notification, so latency_info callers see time_to_first_progress_ms
+        # at the first stream event.
+        from agent.auxiliary_client import _notify_aux_provider_response
+        completions = self._client().chat.completions
+        seen = {}
+
+        def _fake_stream(**kwargs):
+            seen["on_event"] = kwargs.get("on_event")
+            return SimpleNamespace(choices=[], usage=None)
+
+        with patch(
+            "agent.bedrock_adapter.call_converse_stream", side_effect=_fake_stream,
+        ):
+            with aux_progress_hook(lambda: None):
+                completions.create(messages=[])
+        assert seen["on_event"] is _notify_aux_provider_response
+
+
+# ---------------------------------------------------------------------------
 # Stream-only providers (credit @kudi88, PR #60686)
 # ---------------------------------------------------------------------------
 

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -595,6 +595,66 @@ class TestBuildConverseKwargs:
         wire_kwargs = boto3_client.converse_stream.call_args.kwargs
         assert "maxTokens" not in wire_kwargs.get("inferenceConfig", {})
 
+    def test_call_converse_stream_forwards_on_event(self):
+        """on_event must fire once per yielded ConverseStream event so an
+        external inactivity watchdog can tell a slow-but-alive call from a
+        hung one (#101088), while the assembled response stays unchanged."""
+        from unittest.mock import MagicMock, patch as mock_patch
+        from agent.bedrock_adapter import call_converse_stream
+        boto3_client = MagicMock()
+        boto3_client.converse_stream.return_value = {"stream": [
+            {"messageStart": {"role": "assistant"}},
+            {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {"text": "Hi"}}},
+            {"messageStop": {"stopReason": "end_turn"}},
+        ]}
+        ticks = []
+        with mock_patch(
+            "agent.bedrock_adapter._get_bedrock_runtime_client",
+            return_value=boto3_client,
+        ):
+            result = call_converse_stream(
+                region="us-east-1",
+                model="test-model",
+                messages=[{"role": "user", "content": "Hi"}],
+                max_tokens=None,
+                on_event=lambda: ticks.append(1),
+            )
+        assert result.choices[0].message.content == "Hi"
+        assert result.choices[0].finish_reason == "stop"
+        assert ticks == [1, 1, 1]
+
+    def test_call_converse_stream_denied_fallback_never_ticks_on_event(self):
+        """Streaming-denied IAM sessions fall back to non-streaming
+        converse(); that path has no intermediate events, so on_event must
+        stay silent and the plain response must still come back (#101088)."""
+        from unittest.mock import MagicMock, patch as mock_patch
+        from agent.bedrock_adapter import call_converse_stream
+        boto3_client = MagicMock()
+        boto3_client.converse_stream.side_effect = RuntimeError(
+            "User: arn:aws:iam::1:user/x is not authorized to perform: "
+            "bedrock:InvokeModelWithResponseStream on resource: y"
+        )
+        boto3_client.converse.return_value = {
+            "output": {"message": {"role": "assistant", "content": [{"text": "ok"}]}},
+            "stopReason": "end_turn",
+            "usage": {"inputTokens": 3, "outputTokens": 1},
+        }
+        ticks = []
+        with mock_patch(
+            "agent.bedrock_adapter._get_bedrock_runtime_client",
+            return_value=boto3_client,
+        ):
+            result = call_converse_stream(
+                region="us-east-1",
+                model="test-model",
+                messages=[{"role": "user", "content": "Hi"}],
+                max_tokens=None,
+                on_event=lambda: ticks.append(1),
+            )
+        assert ticks == []
+        assert boto3_client.converse.call_count == 1
+        assert result.choices[0].message.content == "ok"
+
 
 
 

--- a/tests/agent/test_fast_compression_lane.py
+++ b/tests/agent/test_fast_compression_lane.py
@@ -252,7 +252,7 @@ def test_boolean_cap_drift_stays_uncapped_and_preserves_existing_reasoning():
     assert request["extra_body"]["reasoning"] == {"enabled": False}
 
 
-def test_bedrock_converse_ttfp_waits_for_the_nonstreaming_response():
+def test_bedrock_converse_ttfp_waits_for_the_provider_response():
     from agent.auxiliary_client import BedrockAuxiliaryClient, call_llm
 
     config = {
@@ -276,13 +276,20 @@ def test_bedrock_converse_ttfp_waits_for_the_nonstreaming_response():
         time.sleep(0.02)
         return response
 
+    # latency_info installs a (no-op) progress hook, which routes the Bedrock
+    # adapter onto the streamed Converse path (#101088); the mock below emits
+    # no intermediate events, so the terminal provider-response tick after
+    # the call returns is still the first TTFP sample.
     with (
         patch("agent.auxiliary_client._get_auxiliary_task_config", return_value=config),
         patch(
             "agent.auxiliary_client._get_cached_client",
             return_value=(client, "amazon.nova-lite-v1:0"),
         ),
-        patch("agent.bedrock_adapter.call_converse", side_effect=_delayed_converse),
+        patch(
+            "agent.bedrock_adapter.call_converse_stream",
+            side_effect=_delayed_converse,
+        ),
     ):
         assert call_llm(
             task="compression",


### PR DESCRIPTION
## What does this PR do?

`_BedrockCompletionsAdapter.create()` only ever called the non-streaming `call_converse()`, while `_client_streams_internally()` lists `BedrockAuxiliaryClient` among the clients that "already tick the progress hook themselves". Both halves are needed for the bug: the outer streaming wrapper skips Bedrock because it trusts that claim, and the shim then never ticks. Net effect — the aux progress hook fired exactly once, at dispatch, and never again for the rest of the call.

`CompressionCommitFence` measures liveness with `seconds_since_progress()` precisely so "a slow-but-alive summary model is not killed by a fixed wall-clock deadline while tokens are moving". On Bedrock that signal was flat, so every compression looked motionless from the first second and died at the idle window (`commit_fence_cancelled`) — after the auxiliary tokens had already been billed.

This wires the missing seam. When a progress hook is active, `create()` routes through `call_converse_stream()` with `_notify_aux_provider_response` (timing + forward progress) as the per-event callback — matching the Codex adapter's substantive-payload notification and the main conversation path's wire-level liveness signal (`on_event` in `chat_completion_helpers.py`). The plumbing already existed in `agent/bedrock_adapter.py`; only the wire was missing.

Deliberately conservative edges:

- **Streaming-denied IAM keeps working.** `call_converse_stream()` already falls back to non-streaming `converse()` on `AccessDenied` for `InvokeModelWithResponseStream` via `is_streaming_access_denied_error()`; that path has no intermediate events and stays unticked mid-call, exactly as before.
- **No hook → byte-for-byte the old path.** Callers without a progress hook keep the exact non-streaming `call_converse()` call.
- **Response shape unchanged.** `call_converse_stream()` returns `stream_converse_with_callbacks(response, on_event=...)`, and `normalize_converse_stream_events()` is that same function's zero-argument alias — the assembled response comes from one code path.
- The per-event callback is `_notify_aux_provider_response` rather than bare `_notify_aux_progress` so `latency_info` callers see `time_to_first_progress_ms` at the first stream event.

## Related Issue

Fixes #101088

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/bedrock_adapter.py` — `call_converse_stream()` gains an optional `on_event` callback, forwarded to `stream_converse_with_callbacks()` (including on the cache-point-rejection retry); the IAM streaming-denied fallback deliberately never invokes it.
- `agent/auxiliary_client.py` — `_BedrockCompletionsAdapter.create()`: with a progress hook active, call `call_converse_stream(..., on_event=_notify_aux_provider_response)` instead of `call_converse()`; terminal `_notify_aux_provider_response()` retained after the response returns. `_client_streams_internally()` docstring updated (the "Converse shim cannot stream at all" note no longer held on the hook-active path).
- `tests/agent/test_bedrock_adapter.py` — pin `on_event` forwarding (3 events → 3 ticks, response assembled as before) and the denied-fallback path staying silent.
- `tests/agent/test_aux_progress_streaming.py` — end-to-end: hook + Bedrock client through `_create_with_progress` ticks dispatch + per-event + terminal; no hook keeps the non-streaming path; the forwarded callback is `_notify_aux_provider_response`.
- `tests/agent/test_fast_compression_lane.py` — the Bedrock TTFP test now patches `call_converse_stream` (a `latency_info` call installs a no-op hook, which is what switches the adapter to the streamed path); TTFP assertions unchanged.

## How to Test

1. `python -m pytest tests/agent/test_bedrock_adapter.py tests/agent/test_aux_progress_streaming.py tests/agent/test_fast_compression_lane.py -q` → 152 passed (observed result: `152 passed`).
2. `python -m pytest tests/agent/test_bedrock_integration.py tests/agent/test_bedrock_empty_text_blocks.py tests/agent/test_bedrock_1m_context.py tests/agent/test_auxiliary_explicit_cancellation.py tests/agent/test_compress_context_progress_timeout.py tests/agent/test_compression_worker_isolation_76354.py tests/agent/test_aux_stream_host_deadline.py tests/agent/test_aux_stream_host_deadline_sibling_wires.py tests/agent/test_auxiliary_client.py tests/agent/test_auxiliary_compression_timeout_floor.py -q` → 286 passed (observed result: all green, no regressions).
3. `python -m ruff check <changed files>` → All checks passed (observed result: pass); `scripts/check-windows-footguns.py` on the two source files → no footguns (observed result: pass).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
