### PR TITLE
fix(kanban): let reviewer-requested rework resume an active PR

### DIFF
--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -1122,6 +1122,88 @@ def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
         )
 
 
+def _authenticated_review_rework_after_comment(
+    conn: sqlite3.Connection,
+    task_id: str,
+    comment_id: int,
+    comment_created_at: int,
+) -> bool:
+    """Whether durable reviewer-requested rework causally follows a PR comment.
+
+    ``created_at`` has one-second resolution, so equal timestamps are ordered
+    by the task event stream: ``add_comment`` emits ``commented`` before any
+    later lifecycle event. Legacy comments without that event fail closed for
+    an equal-second comparison. The run/event provenance checks mirror
+    ``request_changes`` so arbitrary operator mutations or forged task-scoped
+    events cannot turn an active PR into dispatch authority.
+    """
+    comment_count = conn.execute(
+        "SELECT COUNT(*) AS count FROM task_comments "
+        "WHERE task_id = ? AND created_at = ?",
+        (task_id, comment_created_at),
+    ).fetchone()["count"]
+    comment_rank = conn.execute(
+        "SELECT COUNT(*) AS count FROM task_comments "
+        "WHERE task_id = ? AND created_at = ? AND id <= ?",
+        (task_id, comment_created_at, comment_id),
+    ).fetchone()["count"]
+    comment_events = conn.execute(
+        "SELECT id FROM task_events "
+        "WHERE task_id = ? AND kind = 'commented' AND created_at = ? "
+        "ORDER BY id ASC",
+        (task_id, comment_created_at),
+    ).fetchall()
+    # Comment rows and their audit events are inserted in the same serialized
+    # transaction. Match them by ordinal within the second; if legacy/raw SQL
+    # left either stream incomplete, equal-second causality cannot be proven.
+    comment_boundary = None
+    if len(comment_events) == int(comment_count) and comment_rank:
+        comment_boundary = comment_events[int(comment_rank) - 1]["id"]
+    candidates = conn.execute(
+        "SELECT e.id, e.created_at, e.run_id, e.payload, r.profile "
+        "FROM task_events e JOIN task_runs r "
+        "ON r.id = e.run_id AND r.task_id = e.task_id "
+        "WHERE e.task_id = ? AND e.kind = 'changes_requested' "
+        "AND e.created_at >= ? AND r.outcome = 'changes_requested' "
+        "AND r.ended_at IS NOT NULL ORDER BY e.created_at DESC, e.id DESC",
+        (task_id, comment_created_at),
+    ).fetchall()
+    for event in candidates:
+        if int(event["created_at"]) == comment_created_at:
+            if comment_boundary is None or int(event["id"]) <= int(comment_boundary):
+                continue
+        payload = _kb._json_dict(event["payload"])
+        reviewer = payload.get("reviewer")
+        implementer = payload.get("implementer")
+        if not isinstance(reviewer, str) or not reviewer.strip():
+            continue
+        if not isinstance(implementer, str) or not implementer.strip():
+            continue
+        if event["profile"] != reviewer:
+            continue
+        claimed = conn.execute(
+            "SELECT id, payload FROM task_events "
+            "WHERE task_id = ? AND run_id = ? AND kind = 'claimed' AND id < ? "
+            "ORDER BY id DESC LIMIT 1",
+            (task_id, event["run_id"], event["id"]),
+        ).fetchone()
+        if claimed is None or _kb._json_dict(claimed["payload"]).get("source_status") != "review":
+            continue
+        handoff = conn.execute(
+            "SELECT payload FROM task_events "
+            "WHERE task_id = ? AND kind = 'review_requested' AND id < ? "
+            "ORDER BY id DESC LIMIT 1",
+            (task_id, claimed["id"]),
+        ).fetchone()
+        handoff_payload = _kb._json_dict(handoff["payload"] if handoff else None)
+        if handoff_payload.get("implementer") != implementer:
+            continue
+        if handoff_payload.get("reviewer") not in (None, reviewer):
+            continue
+        return True
+    return False
+
+
 def check_respawn_guard(
     conn: sqlite3.Connection, task_id: str, *, lane: str = "ready",
 ) -> Optional[str]:
@@ -1135,9 +1217,11 @@ def check_respawn_guard(
     (quota/auth pattern; the breaker still trips eventually), then for the
     ready lane only ``"recent_success"`` (completed run within the window, unless
     a re-queue event arrived after it — a deliberate re-run) and ``"active_pr"``
-    (PR URL in a recent comment; re-spawning risks a duplicate PR). The review
-    lane skips the last two: they are the *inputs* to a review handoff. Stale /
-    dead claim locks are NOT a guard reason — the reclaim passes own those.
+    (PR URL in a recent comment; re-spawning risks a duplicate PR unless a
+    durable, authenticated reviewer ``changes_requested`` lifecycle later
+    returned this same task to its implementer). The review lane skips the last
+    two: they are the *inputs* to a review handoff. Stale / dead claim locks are
+    NOT a guard reason — the reclaim passes own those.
     """
     row = conn.execute(
         "SELECT last_failure_error FROM tasks WHERE id = ?",
@@ -1203,14 +1287,29 @@ def check_respawn_guard(
         if not requeued_after:
             return "recent_success"
 
-    # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
+    # 4. A fresh PR comment normally proves another implementation already
+    #    exists. The sole exception is a later, authenticated request_changes
+    #    lifecycle on this same task: that is authority to resume the artifact,
+    #    not to create a second one. Use the freshest PR comment and durable
+    #    event ids for same-second ordering so a newer replacement PR wins.
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
-    for c in conn.execute(
-        "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
+    pr_comment = None
+    for comment in conn.execute(
+        "SELECT body, created_at, id FROM task_comments "
+        "WHERE task_id = ? AND created_at >= ? "
+        "ORDER BY created_at DESC, id DESC",
         (task_id, pr_cutoff),
     ).fetchall():
-        if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
-            return "active_pr"
+        if comment["body"] and _RESPAWN_GUARD_PR_URL_RE.search(comment["body"]):
+            pr_comment = comment
+            break
+    if pr_comment is not None and not _authenticated_review_rework_after_comment(
+        conn,
+        task_id,
+        int(pr_comment["id"]),
+        int(pr_comment["created_at"] or 0),
+    ):
+        return "active_pr"
 
     return None
 

--- a/tests/hermes_cli/test_kanban_review_lifecycle.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle.py
@@ -478,6 +478,194 @@ def test_active_pr_guard_skipped_for_review_lane_but_defers_ready_lane(
         ) == "rate_limit_cooldown"
 
 
+def test_reviewer_requested_rework_resumes_the_existing_worktree_once(
+    kanban_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A durable reviewer handoff resumes the same task artifact at spawn."""
+    import hermes_cli.profiles as profmod
+
+    fixed_now = 1_800_000_000
+    existing_workspace = tmp_path / "existing-worktree"
+    existing_workspace.mkdir()
+    captured: list[tuple[str, str, str | None]] = []
+
+    monkeypatch.setattr(kb.time, "time", lambda: fixed_now)
+    monkeypatch.setattr(profmod, "profile_exists", lambda name: True)
+    monkeypatch.setattr(kbd, "_memory_pressure_level", lambda: "unknown")
+    monkeypatch.setattr(
+        kbd._kbw,
+        "_resolve_worktree_workspace",
+        lambda task, board=None: (existing_workspace, task.branch_name),
+    )
+
+    def spawn(task, workspace):
+        captured.append((task.id, workspace, task.branch_name))
+        return 4321
+
+    with kbc.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="update the existing candidate",
+            assignee="coder",
+            workspace_kind="worktree",
+            workspace_path=str(existing_workspace),
+            branch_name="fix/existing-candidate",
+        )
+        implementation = kb.claim_task(conn, task_id, claimer="coder:implementation")
+        assert implementation is not None
+        kb.add_comment(
+            conn,
+            task_id,
+            author="coder",
+            body="PR: https://github.com/example/repo/pull/456",
+        )
+        assert kb.request_review(
+            conn,
+            task_id,
+            summary="candidate ready",
+            reviewer="reviewer",
+            expected_run_id=implementation.current_run_id,
+        )
+        review = kb.claim_review_task(conn, task_id, claimer="reviewer:independent")
+        assert review is not None
+        ok, implementer = kb.request_changes(
+            conn,
+            task_id,
+            reason="address finding 1",
+            expected_run_id=review.current_run_id,
+        )
+        assert (ok, implementer) == (True, "coder")
+        assert kb.get_task(conn, task_id).status == "ready"
+
+        result = kbd.dispatch_once(
+            conn,
+            spawn_fn=spawn,
+            max_in_progress=4,
+            max_in_progress_per_profile=2,
+            reconcile_orphans=False,
+        )
+        assert result.respawn_guarded == []
+        assert result.spawned == [(task_id, "coder", str(existing_workspace))]
+        assert captured == [
+            (task_id, str(existing_workspace), "fix/existing-candidate")
+        ]
+        resumed = kb.get_task(conn, task_id)
+        assert resumed.status == "running"
+        assert resumed.workspace_path == str(existing_workspace)
+        assert resumed.branch_name == "fix/existing-candidate"
+
+        # A later tick cannot create a second implementation while the resumed
+        # run owns the active claim.
+        again = kbd.dispatch_once(
+            conn,
+            spawn_fn=spawn,
+            max_in_progress=4,
+            max_in_progress_per_profile=2,
+            reconcile_orphans=False,
+        )
+        assert again.spawned == []
+        assert captured == [
+            (task_id, str(existing_workspace), "fix/existing-candidate")
+        ]
+
+
+def test_active_pr_bypass_requires_authenticated_same_task_reviewer_rework(
+    kanban_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Forged/non-review signals and newer PR comments stay guarded."""
+    fixed_now = 1_800_000_000
+    pr_url = "https://github.com/example/repo/pull/789"
+    monkeypatch.setattr(kb.time, "time", lambda: fixed_now)
+
+    def commented_task(conn, title: str) -> str:
+        task_id = kb.create_task(conn, title=title, assignee="coder")
+        kb.add_comment(conn, task_id, author="coder", body=f"PR: {pr_url}")
+        return task_id
+
+    def request_valid_rework(conn, task_id: str) -> None:
+        claimed = kb.claim_task(conn, task_id, claimer="coder:implementation")
+        assert claimed is not None
+        assert kb.request_review(
+            conn,
+            task_id,
+            summary="ready",
+            reviewer="reviewer",
+            expected_run_id=claimed.current_run_id,
+        )
+        review = kb.claim_review_task(conn, task_id, claimer="reviewer:independent")
+        assert review is not None
+        assert kb.request_changes(
+            conn,
+            task_id,
+            reason="fix it",
+            expected_run_id=review.current_run_id,
+        )[0]
+
+    with kbc.connect() as conn:
+        unchanged = commented_task(conn, "ordinary duplicate")
+        assert kbd.check_respawn_guard(conn, unchanged) == "active_pr"
+
+        failed = commented_task(conn, "failed transition")
+        assert kb.request_changes(conn, failed, reason="not a reviewer")[0] is False
+        assert kbd.check_respawn_guard(conn, failed) == "active_pr"
+
+        forged = commented_task(conn, "forged event")
+        with kb.write_txn(conn):
+            kb._append_event(
+                conn,
+                forged,
+                "changes_requested",
+                {"reviewer": "reviewer", "implementer": "coder", "status": "ready"},
+            )
+        assert kbd.check_respawn_guard(conn, forged) == "active_pr"
+
+        non_review = commented_task(conn, "non-review run")
+        run = kb.claim_task(conn, non_review, claimer="coder:ordinary")
+        assert run is not None
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE task_runs SET status = 'changes_requested', "
+                "outcome = 'changes_requested', ended_at = ? WHERE id = ?",
+                (fixed_now, run.current_run_id),
+            )
+            conn.execute(
+                "UPDATE tasks SET status = 'ready', current_run_id = NULL, "
+                "claim_lock = NULL, claim_expires = NULL WHERE id = ?",
+                (non_review,),
+            )
+            kb._append_event(
+                conn,
+                non_review,
+                "changes_requested",
+                {"reviewer": "reviewer", "implementer": "coder", "status": "ready"},
+                run_id=run.current_run_id,
+            )
+        assert kbd.check_respawn_guard(conn, non_review) == "active_pr"
+
+        stale = commented_task(conn, "stale claim")
+        assert kb.claim_task(conn, stale, claimer="dead") is not None
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET claim_expires = ? WHERE id = ?",
+                (fixed_now - 1, stale),
+            )
+        assert kb.release_stale_claims(conn) == 1
+        assert kbd.check_respawn_guard(conn, stale) == "active_pr"
+
+        sibling = commented_task(conn, "reviewer card isolation")
+        reviewed_elsewhere = commented_task(conn, "different task")
+        request_valid_rework(conn, reviewed_elsewhere)
+        assert kbd.check_respawn_guard(conn, sibling) == "active_pr"
+
+        newest_pr = commented_task(conn, "newest PR wins")
+        request_valid_rework(conn, newest_pr)
+        assert kbd.check_respawn_guard(conn, newest_pr) is None
+        kb.add_comment(conn, newest_pr, author="reviewer", body="rework acknowledged")
+        assert kbd.check_respawn_guard(conn, newest_pr) is None
+        kb.add_comment(conn, newest_pr, author="coder", body=f"replacement {pr_url}")
+        assert kbd.check_respawn_guard(conn, newest_pr) == "active_pr"
+
+
 def test_review_dispatch_preserves_task_skills_and_adds_reviewer_skill(
     kanban_home: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Problem

A recent PR-URL comment makes the ready-lane dispatcher return `active_pr` for 24 hours. That correctly prevents duplicate implementations, but it also stranded the same task after an independent reviewer used the durable `request_changes` lifecycle to return it to its implementer.

## Forward-port

This updates the existing candidate onto current split-dispatcher `main` (`79445a496c`), preserving the same PR and fork branch.

`check_respawn_guard` now bypasses `active_pr` only when the same task has a later `changes_requested` event that is tied to:

- a completed `changes_requested` task run,
- that run's durable `claimed(source_status="review")` event,
- matching reviewer profile/provenance, and
- the matching prior `review_requested` implementer handoff.

Arbitrary comments, status/promote/unblock/reclaim events, failed transitions, task-scoped forged events, non-review runs, stale-claim reclaim, and reviewer activity on another card do not bypass the guard. The freshest PR comment remains authoritative. Equal-second comparisons use the ordered task event stream rather than timestamp alone; a later non-PR acknowledgment does not revoke legitimate rework, while a later replacement PR comment does.

## TDD and verification

RED was observed on current `main` before production changes: both new lifecycle tests failed because the guard returned `active_pr`. A second RED was observed for same-second non-PR acknowledgment ordering before the ordinal event-boundary fix.

GREEN at exact head `967758eb07a4305e802307246154ea79d33ae4e6`:

- `scripts/run_tests.sh tests/hermes_cli/test_kanban*.py` — 322 passed, 0 failed, 2 host-skipped Windows tests
- `ruff check hermes_cli/kanban_db_dispatch.py tests/hermes_cli/test_kanban_review_lifecycle.py` — passed
- `python3 scripts/check_compat_pointers.py` — passed
- `git diff --check` and `py_compile` — passed
- static added-line scan — no secret, shell-injection, eval/exec, pickle, or formatted-SQL matches

The real spawn-boundary test runs request-review → reviewer claim → request-changes → ordinary dispatch, and asserts exactly one spawn of the same task/workspace/branch; a subsequent tick cannot spawn a second implementation while its claim is active. Existing dispatch-lock, host-cap, per-profile-cap, failure, and review-lifecycle suites are included in the full kanban sweep.

## CI

GitHub created CI, Nix, and Docker workflow runs for this exact head, but all are `action_required` pending upstream approval for a fork PR. The fork owner cannot approve them (`403 Must have admin rights`). This is reported as pending, not passing.

No merge, service restart, live-source edit, model/fallback/cap change, duplicate PR, or lifecycle-candidate mutation is part of this update.
