### PR TITLE
fix(cron): keep manual completions on final output

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -6742,10 +6742,6 @@ def run_job(
 **Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}
 **Schedule:** {job.get('schedule_display', 'N/A')}
 
-## Prompt
-
-{prompt}
-
 ## Response
 
 {logged_response}
@@ -6798,10 +6794,6 @@ def run_job(
 **Job ID:** {job_id}
 **Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}
 **Schedule:** {job.get('schedule_display', 'N/A')}
-
-## Prompt
-
-{prompt}
 
 ## Error
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -589,6 +589,46 @@ class TestRunJobSessionPersistence:
         fake_db.close.assert_called_once()
         mock_agent.close.assert_called_once()
 
+    def test_run_job_persists_final_response_without_assembled_prompt(self, tmp_path):
+        job = {
+            "id": "silent-monitor",
+            "name": "silent monitor",
+            "prompt": "assembled prompt\n" + ("loaded skill content\n" * 100),
+        }
+        with self._run_job_patches(tmp_path) as (_fake_db, mock_agent_cls):
+            mock_agent_cls.return_value.run_conversation.return_value = {
+                "final_response": "[SILENT]"
+            }
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "[SILENT]"
+        assert "## Response\n\n[SILENT]" in output
+        assert "assembled prompt" not in output
+        assert "loaded skill content" not in output
+
+    def test_run_job_persists_error_without_assembled_prompt(self, tmp_path):
+        job = {
+            "id": "failed-monitor",
+            "name": "failed monitor",
+            "prompt": "assembled prompt\n" + ("loaded skill content\n" * 100),
+        }
+        with self._run_job_patches(tmp_path) as (_fake_db, mock_agent_cls):
+            mock_agent_cls.return_value.run_conversation.side_effect = RuntimeError(
+                "provider unavailable"
+            )
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is False
+        assert final_response == ""
+        assert error == "RuntimeError: provider unavailable"
+        assert "## Error\n\n```\nRuntimeError: provider unavailable" in output
+        assert "assembled prompt" not in output
+        assert "loaded skill content" not in output
+
 
     @contextlib.contextmanager
     def _run_job_patches(self, tmp_path, extra=()):

--- a/tests/tools/test_cronjob_run_background.py
+++ b/tests/tools/test_cronjob_run_background.py
@@ -17,6 +17,7 @@ import threading
 from unittest.mock import patch
 
 from tools.cronjob_tools import (
+    _latest_job_output_excerpt,
     _try_dispatch_background_run,
     cronjob,
 )
@@ -92,15 +93,16 @@ class TestBackgroundDispatch:
 
         from tools.process_registry import process_registry
 
+        job = {**_job("job-bg-02"), "deliver": "telegram"}
         # The runner executes on a daemon thread — the patches must stay
         # active until the completion event lands, so poll INSIDE the blocks.
         with _bound_session_key("agent:main:telegram:dm:777"):
-            with patch("tools.cronjob_tools.claim_job_for_fire", side_effect=lambda jid, **kw: {**_job(jid), "fire_claim": {"by": "bg-owner"}}), \
+            with patch("tools.cronjob_tools.claim_job_for_fire", return_value={**job, "fire_claim": {"by": "bg-owner"}}), \
                  patch("cron.scheduler.run_one_job", return_value=True), \
                  patch("tools.cronjob_tools.get_job",
                        return_value={"last_status": "ok", "last_error": None,
                                      "next_run_at": "2026-08-07T09:00:00"}):
-                res = _try_dispatch_background_run(_job('job-bg-02'))
+                res = _try_dispatch_background_run(job)
                 assert res["dispatched"] is True
 
                 found = None
@@ -121,6 +123,152 @@ class TestBackgroundDispatch:
         assert found["status"] == "completed"
         assert "bg run" in (found.get("summary") or "")
         assert "Next scheduled run" in found["summary"]
+        assert "output was delivered" not in found["summary"]
+
+
+class TestBackgroundCompletionOutput:
+    def test_ambiguous_legacy_prompt_heading_is_not_excerpted(
+        self, tmp_path, monkeypatch
+    ):
+        from cron import jobs
+
+        monkeypatch.setattr(jobs, "OUTPUT_DIR", tmp_path / "output")
+        out_dir = jobs.OUTPUT_DIR / "job-final-00"
+        out_dir.mkdir(parents=True)
+        (out_dir / "2026-09-01_22-08-23.md").write_text(
+            "# Cron Job: monitor\n\n"
+            "**Job ID:** job-final-00\n\n"
+            "## Prompt\n\n"
+            "Review this example output:\n\n"
+            "## Response\n\n"
+            "prompt content that must not reenter the parent session\n",
+            encoding="utf-8",
+        )
+
+        assert _latest_job_output_excerpt("job-final-00") is None
+
+    def test_legacy_document_with_output_heading_is_not_excerpted(
+        self, tmp_path, monkeypatch
+    ):
+        from cron import jobs
+
+        monkeypatch.setattr(jobs, "OUTPUT_DIR", tmp_path / "output")
+        out_dir = jobs.OUTPUT_DIR / "job-final-01"
+        out_dir.mkdir(parents=True)
+        (out_dir / "2026-09-01_22-08-23.md").write_text(
+            "# Cron Job: monitor\n\n"
+            "**Job ID:** job-final-01\n\n"
+            "## Prompt\n\n"
+            + "assembled prompt and loaded skill content\n" * 100
+            + "\n## Response\n\nexample response heading inside the prompt\n"
+            + "\n## Error\n\nexample error heading inside the prompt\n"
+            + "\n## Response\n\nMaterial change found.\n",
+            encoding="utf-8",
+        )
+
+        assert _latest_job_output_excerpt("job-final-01") is None
+
+    def test_silent_final_response_does_not_reenter_parent_session(
+        self, tmp_path, monkeypatch
+    ):
+        from cron import jobs
+
+        monkeypatch.setattr(jobs, "OUTPUT_DIR", tmp_path / "output")
+        out_dir = jobs.OUTPUT_DIR / "job-final-02"
+        out_dir.mkdir(parents=True)
+        (out_dir / "2026-09-01_22-08-23.md").write_text(
+            "# Cron Job: monitor\n\n"
+            "## Prompt\n\nassembled prompt and loaded skills\n\n"
+            "## Response\n\n[SILENT]\n",
+            encoding="utf-8",
+        )
+
+        assert _latest_job_output_excerpt("job-final-02") is None
+
+    def test_monitor_no_change_document_remains_visible(
+        self, tmp_path, monkeypatch
+    ):
+        from cron import jobs
+
+        monkeypatch.setattr(jobs, "OUTPUT_DIR", tmp_path / "output")
+        out_dir = jobs.OUTPUT_DIR / "job-final-03"
+        out_dir.mkdir(parents=True)
+        no_change = (
+            "# Cron Job: monitor\n\n"
+            "**Job ID:** job-final-03\n"
+            "**Status:** no_change (monitor output unchanged)\n"
+        )
+        (out_dir / "2026-09-01_22-08-23.md").write_text(
+            no_change, encoding="utf-8"
+        )
+
+        assert _latest_job_output_excerpt("job-final-03") == no_change.strip()
+
+    def test_prompt_free_error_keeps_nested_response_heading(
+        self, tmp_path, monkeypatch
+    ):
+        from cron import jobs
+
+        monkeypatch.setattr(jobs, "OUTPUT_DIR", tmp_path / "output")
+        out_dir = jobs.OUTPUT_DIR / "job-final-04"
+        out_dir.mkdir(parents=True)
+        error_detail = (
+            "RuntimeError: provider returned malformed output\n\n"
+            "## Response\n\n"
+            "This heading is part of the error detail."
+        )
+        (out_dir / "2026-09-01_22-08-23.md").write_text(
+            "# Cron Job: monitor (FAILED)\n\n"
+            "**Job ID:** job-final-04\n\n"
+            "## Error\n\n"
+            + error_detail,
+            encoding="utf-8",
+        )
+
+        assert _latest_job_output_excerpt("job-final-04") == error_detail
+
+    def test_prompt_free_response_keeps_nested_prompt_and_response_headings(
+        self, tmp_path, monkeypatch
+    ):
+        from cron import jobs
+
+        monkeypatch.setattr(jobs, "OUTPUT_DIR", tmp_path / "output")
+        out_dir = jobs.OUTPUT_DIR / "job-final-05"
+        out_dir.mkdir(parents=True)
+        response = (
+            "Lead finding.\n\n"
+            "## Prompt\n\n"
+            "Quoted prompt text.\n\n"
+            "## Response\n\n"
+            "Quoted response text."
+        )
+        (out_dir / "2026-09-01_22-08-23.md").write_text(
+            "# Cron Job: report\n\n"
+            "**Job ID:** job-final-05\n\n"
+            "## Response\n\n"
+            + response,
+            encoding="utf-8",
+        )
+
+        assert _latest_job_output_excerpt("job-final-05") == response
+
+    def test_malformed_legacy_document_without_final_heading_is_not_excerpted(
+        self, tmp_path, monkeypatch
+    ):
+        from cron import jobs
+
+        monkeypatch.setattr(jobs, "OUTPUT_DIR", tmp_path / "output")
+        out_dir = jobs.OUTPUT_DIR / "job-final-06"
+        out_dir.mkdir(parents=True)
+        (out_dir / "2026-09-01_22-08-23.md").write_text(
+            "# Cron Job: monitor\n\n"
+            "**Job ID:** job-final-06\n\n"
+            "## Prompt\n\n"
+            "assembled prompt and loaded skill content\n",
+            encoding="utf-8",
+        )
+
+        assert _latest_job_output_excerpt("job-final-06") is None
 
     def test_failed_run_reports_error_status_in_event(self):
         import time

--- a/tests/tools/test_cronjob_run_delivery_notice.py
+++ b/tests/tools/test_cronjob_run_delivery_notice.py
@@ -137,8 +137,11 @@ class TestDeliveryNote:
             == expected
         )
 
-    def test_remote_without_error_keeps_legacy_wording(self):
-        expected = " (output was delivered there by the job itself)"
+    def test_remote_without_error_does_not_claim_delivery(self):
+        expected = (
+            " (delivery is handled separately by the job and may be "
+            "suppressed for silent output)"
+        )
         assert _manual_run_delivery_note("telegram", {}) == expected
         assert (
             _manual_run_delivery_note("telegram", {"last_delivery_error": None})
@@ -247,7 +250,7 @@ class TestRunnerSummaryWiring:
         assert "Delivery target: local (output saved locally only)" in summary
         assert "delivered there by the job itself" not in summary
 
-    def test_delivery_success_wording_unchanged_in_completion_summary(self):
+    def test_delivery_success_does_not_overclaim_in_completion_summary(self):
         from tools.cronjob_tools import _try_dispatch_background_run
 
         job = _job("job-dn-02", "telegram")
@@ -268,7 +271,7 @@ class TestRunnerSummaryWiring:
                 evt = _drain_completion_event(res["delegation_id"])
         assert evt is not None, "completion event never reached the queue"
         summary = evt.get("summary") or ""
-        assert (
-            "Delivery target: telegram (output was delivered there by the job itself)"
-        ) in summary
+        assert "Delivery target: telegram" in summary
+        assert "output was delivered" not in summary
+        assert "may be suppressed for silent output" in summary
         assert "delivery FAILED" not in summary

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -927,8 +927,8 @@ def _manual_run_delivery_note(deliver: str, refreshed: Dict[str, Any]) -> str:
     ``last_delivery_error`` via ``mark_job_run`` when the post-run delivery
     (telegram/discord/…) failed, and the summary must not claim success over
     that record — the calling agent relays this line to the user. Local jobs
-    never deliver; an empty/missing error keeps the legacy wording
-    byte-for-byte.
+    never deliver. An empty/missing error is not proof of delivery because
+    intentional silence suppresses the send without recording an error.
     """
     # Falsy deliver ("", stored JSON null) means no delivery target — the
     # fire-time path normalizes it to "local" (no delivery, output persisted
@@ -940,7 +940,10 @@ def _manual_run_delivery_note(deliver: str, refreshed: Dict[str, Any]) -> str:
         return " (output saved locally only)"
     err = str(refreshed.get("last_delivery_error") or "").strip()
     if not err:
-        return " (output was delivered there by the job itself)"
+        return (
+            " (delivery is handled separately by the job and may be "
+            "suppressed for silent output)"
+        )
     return f" (⚠ delivery FAILED: {err[:200]})"
 
 
@@ -1171,11 +1174,15 @@ def _run_claimed_job(
 
 
 def _latest_job_output_excerpt(job_id: str, max_chars: int = 2000) -> Optional[str]:
-    """Best-effort excerpt of the job's most recent saved output file.
+    """Best-effort excerpt of the job's most recent final output.
 
     Included in the background-run completion block so the parent agent sees
     what the job actually produced without having to dig through
-    ``~/.hermes/cron/output/``. Never raises.
+    ``~/.hermes/cron/output/``. Legacy output documents include an arbitrary
+    assembled prompt before ``## Response`` / ``## Error`` and therefore have
+    no unambiguous output delimiter; omit them so a manual-run completion
+    cannot re-inject prompt text into its parent session. Canonical silent
+    responses produce no excerpt. Never raises.
     """
     try:
         from cron.jobs import get_cron_output_dir
@@ -1186,6 +1193,26 @@ def _latest_job_output_excerpt(job_id: str, max_chars: int = 2000) -> Optional[s
             return None
         text = files[-1].read_text(encoding="utf-8", errors="replace").strip()
         if not text:
+            return None
+        headings = ("\n## Response\n", "\n## Error\n")
+        matches = [
+            (text.find(heading), heading)
+            for heading in headings
+            if heading in text
+        ]
+        prompt_position = text.find("\n## Prompt\n")
+        legacy_document = prompt_position >= 0 and (
+            not matches or prompt_position < min(position for position, _ in matches)
+        )
+        if legacy_document:
+            return None
+        else:
+            if matches:
+                position, heading = min(matches, key=lambda match: match[0])
+                text = text[position + len(heading):].strip()
+        from gateway.response_filters import is_autonomous_silence_response
+
+        if is_autonomous_silence_response(text):
             return None
         if len(text) > max_chars:
             text = text[:max_chars] + f"\n… (truncated; full output: {files[-1]})"


### PR DESCRIPTION
## Summary

Manual cron completion artifacts could persist the fully assembled prompt before `## Response` / `## Error`. The background completion then excerpted that artifact, allowing prompt and loaded-skill text to re-enter the parent session.

This patch:

- persists only the final response/error sections for successful and failed agent runs;
- fails closed for legacy output documents whose first section is `## Prompt`, because arbitrary Markdown inside the prompt makes the old grammar ambiguous;
- extracts prompt-free documents from the first outer `## Response` or `## Error`, preserving nested headings in the actual output;
- suppresses `[SILENT]` excerpts;
- stops the manual-run completion from claiming delivery merely because a remote target is configured.

No routing, retry, or silence semantics are changed. This is complementary to #94926 and does not claim to implement its broader typed delivery-result scope.

## Verification

- RED proof: `test_ambiguous_legacy_prompt_heading_is_not_excerpted` fails on the vulnerable `e9c4b9ce74fe431f2cdc52647c5804c09e81191e` candidate and passes with the fix.
- Candidate base `df4b3733baa5534bec1e6e888e5ba86a0a6f9c3b`: focused scheduler/background/delivery suites **134/134 passed**.
- Fresh `origin/main` `fbd40c907d75e6b5cb0037845f06228ac1aa594f`: clean cherry-pick `ec4281cb05c676ae0ec5d41a67b44aa4cf2a6648`; same focused suites **134/134 passed**.
- Post-full-run background regression: **20/20 passed**.
- Independent privacy/correctness review: **PASS**; `git diff --check`: **PASS**.
- The repository-wide canonical runner remains red in this environment (**141 failures across 44 files**), all outside the two recovery-touched production/test areas; this PR does not claim a globally green suite.

Authored by Jakub Nitka; no generated/private prompt contents are included.
