### PR TITLE
fix(desktop): keep ignored nested repositories visible

### DIFF
--- a/apps/desktop/src/app/right-sidebar/files/ipc.test.ts
+++ b/apps/desktop/src/app/right-sidebar/files/ipc.test.ts
@@ -124,4 +124,90 @@ describe('readProjectDir', () => {
     expect(result.entries.map(entry => entry.name)).toEqual(['debug.log'])
     expect(readFileDataUrl).not.toHaveBeenCalled()
   })
+
+  it('keeps nested repository roots visible when the parent gitignores them', async () => {
+    gitRoot.mockResolvedValue('/repo')
+    readDir.mockImplementation(async path => {
+      if (path === '/repo') {
+        return ok([{ name: '.gitignore', path: '/repo/.gitignore', isDirectory: false }])
+      }
+
+      if (path === '/repo/dev') {
+        return ok([
+          { name: 'ownward-studio', path: '/repo/dev/ownward-studio', isDirectory: true },
+          { name: 'scratch', path: '/repo/dev/scratch', isDirectory: true },
+          { name: 'notes.txt', path: '/repo/dev/notes.txt', isDirectory: false },
+          { name: 'README.md', path: '/repo/dev/README.md', isDirectory: false }
+        ])
+      }
+
+      if (path === '/repo/dev/ownward-studio') {
+        return ok([{ name: '.git', path: '/repo/dev/ownward-studio/.git', isDirectory: true }])
+      }
+
+      return ok([])
+    })
+    readFileDataUrl.mockResolvedValue(dataUrl('dev/*\n!dev/README.md\n'))
+
+    const result = await readProjectDir('/repo/dev', '/repo')
+
+    expect(result.entries.map(entry => entry.name)).toEqual(['ownward-studio', 'README.md'])
+  })
+
+  it('keeps worktree roots with a .git file visible', async () => {
+    gitRoot.mockResolvedValue('/repo')
+    readDir.mockImplementation(async path => {
+      if (path === '/repo') {
+        return ok([{ name: '.gitignore', path: '/repo/.gitignore', isDirectory: false }])
+      }
+
+      if (path === '/repo/dev') {
+        return ok([{ name: 'wt-feature', path: '/repo/dev/wt-feature', isDirectory: true }])
+      }
+
+      if (path === '/repo/dev/wt-feature') {
+        return ok([{ name: '.git', path: '/repo/dev/wt-feature/.git', isDirectory: false }])
+      }
+
+      return ok([])
+    })
+    readFileDataUrl.mockResolvedValue(dataUrl('dev/*\n'))
+
+    const result = await readProjectDir('/repo/dev', '/repo')
+
+    expect(result.entries.map(entry => entry.name)).toEqual(['wt-feature'])
+  })
+
+  it('invalidates cached nested repository probes below a refreshed root', async () => {
+    let nestedRepoExists = false
+
+    gitRoot.mockResolvedValue('/repo')
+    readDir.mockImplementation(async path => {
+      if (path === '/repo') {
+        return ok([{ name: '.gitignore', path: '/repo/.gitignore', isDirectory: false }])
+      }
+
+      if (path === '/repo/dev') {
+        return ok([{ name: 'nested', path: '/repo/dev/nested', isDirectory: true }])
+      }
+
+      if (path === '/repo/dev/nested') {
+        return nestedRepoExists
+          ? ok([{ name: '.git', path: '/repo/dev/nested/.git', isDirectory: true }])
+          : ok([])
+      }
+
+      return ok([])
+    })
+    readFileDataUrl.mockResolvedValue(dataUrl('dev/*\n'))
+
+    const before = await readProjectDir('/repo/dev', '/repo')
+    expect(before.entries).toEqual([])
+
+    nestedRepoExists = true
+    clearProjectDirCache('/repo')
+
+    const after = await readProjectDir('/repo/dev', '/repo')
+    expect(after.entries.map(entry => entry.name)).toEqual(['nested'])
+  })
 })

--- a/apps/desktop/src/app/right-sidebar/files/ipc.ts
+++ b/apps/desktop/src/app/right-sidebar/files/ipc.ts
@@ -14,6 +14,7 @@ interface GitignoreRule {
 
 const gitRootCache = new Map<string, Promise<string | null>>()
 const gitignoreCache = new Map<string, Promise<GitignoreRule | null>>()
+const nestedRepoCache = new Map<string, Promise<boolean>>()
 
 function decodeDataUrl(dataUrl: string) {
   const match = dataUrl.match(/^data:[^,]*,(.*)$/)
@@ -104,6 +105,30 @@ async function gitignoreFor(dir: string) {
   return cached
 }
 
+async function isNestedRepoRoot(entry: HermesReadDirEntry): Promise<boolean> {
+  if (!entry.isDirectory) {
+    return false
+  }
+
+  const key = `${desktopFsCacheKey()}:${cleanPath(entry.path)}`
+  let cached = nestedRepoCache.get(key)
+
+  if (!cached) {
+    cached = (async () => {
+      try {
+        const listing = await readDesktopDir(entry.path)
+
+        return listing.entries.some(e => e.name === '.git')
+      } catch {
+        return false
+      }
+    })()
+    nestedRepoCache.set(key, cached)
+  }
+
+  return cached
+}
+
 function ignoredBy(rules: GitignoreRule[], entry: HermesReadDirEntry) {
   return rules.some(rule => {
     const rel = relativeTo(rule.base, entry.path)
@@ -127,7 +152,21 @@ async function filterIgnored(entries: HermesReadDirEntry[], rootPath: string, di
     Boolean(r)
   )
 
-  return rules.length > 0 ? entries.filter(entry => !ignoredBy(rules, entry)) : entries
+  if (rules.length === 0) {
+    return entries
+  }
+
+  const visible = await Promise.all(
+    entries.map(async entry => {
+      if (!ignoredBy(rules, entry)) {
+        return entry
+      }
+
+      return (await isNestedRepoRoot(entry)) ? entry : null
+    })
+  )
+
+  return visible.filter((entry): entry is HermesReadDirEntry => entry !== null)
 }
 
 export async function readProjectDir(dirPath: string, rootPath = dirPath): Promise<HermesReadDirResult> {
@@ -145,11 +184,21 @@ export function clearProjectDirCache(rootPath?: string) {
   if (!rootPath) {
     gitRootCache.clear()
     gitignoreCache.clear()
+    nestedRepoCache.clear()
 
     return
   }
 
-  const key = `${desktopFsCacheKey()}:${cleanPath(rootPath)}`
+  const normalizedRoot = cleanPath(rootPath)
+  const key = `${desktopFsCacheKey()}:${normalizedRoot}`
   gitRootCache.delete(key)
   gitignoreCache.delete(key)
+
+  const nestedPrefix = normalizedRoot === '/' ? key : `${key}/`
+
+  for (const nestedKey of nestedRepoCache.keys()) {
+    if (nestedKey === key || nestedKey.startsWith(nestedPrefix)) {
+      nestedRepoCache.delete(nestedKey)
+    }
+  }
 }


### PR DESCRIPTION
Fixes #99861.

The Desktop file browser applies the parent repository's `.gitignore` rules to nested repository roots, which can hide independently version-controlled projects and worktrees.

This keeps the existing ignore behavior for ordinary files/directories, but probes ignored directories for their own `.git` marker. Nested clones (`.git` directory) and linked worktrees (`.git` file) remain visible; ignored non-repository directories remain hidden. Probe results are cached with the existing file-browser caches.

Regression coverage includes both a nested repository root and a worktree-style `.git` file, plus cache invalidation below a refreshed root.

Refreshed directly onto current upstream `main` at `b94581315e14f0163aa6769f11adaf24fa121314`; upstream had not touched either changed file, so the focused two-file scope is unchanged.

Current head: `10dba428d63be37f4b1a47f2492d2c5077a47564`.

The previous rebased head passed CI, Docker Build/Test/Publish, and Nix flake check. Fresh hosted checks for this refreshed head are pending.