### PR TITLE
fix: continue interactive tasks after gateway restart

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1541,13 +1541,11 @@ def build_resume_recovery_note(
     startup auto-resume turn synthesized by
     ``_schedule_resume_pending_sessions`` with no human message attached.
 
-    ``interactive`` selects the empty-message guidance: on interactive
-    platforms a human is present, so "report the restore and ask what next"
-    is right.  On non-interactive event platforms (webhook, API server —
-    adapters with ``interactive_resume = False``) nobody can answer; the
-    resumed turn must instead complete the interrupted work, or the task is
-    silently abandoned behind a "restored" acknowledgement that goes
-    nowhere (#57056).
+    ``interactive`` selects the empty-message guidance. Interactive platforms
+    report the restore before continuing; non-interactive event platforms
+    (webhook, API server — adapters with ``interactive_resume = False``)
+    continue silently. In both cases the resumed turn must complete the
+    interrupted work rather than abandoning it behind a generic question.
     """
     reason_phrase = (
         "a gateway restart"
@@ -1567,12 +1565,17 @@ def build_resume_recovery_note(
         )
     elif interactive:
         resume_guidance = (
-            "Report to the user that the session was restored "
-            "successfully and ask what they would like to do next."
+            "Report to the user that the session was restored successfully, "
+            "then review the conversation history and CONTINUE the interrupted "
+            "task to completion. Do not ask a generic question about what to "
+            "do next."
         )
         tail_guidance = (
-            "Do NOT re-execute old tool calls — skip any "
-            "unfinished work from the conversation history."
+            "Do NOT re-run tool calls whose results already appear in the "
+            "history. If a tool call has no recorded result, its effect is "
+            "UNKNOWN. Inspect current state before retrying. If the effect "
+            "cannot be verified and retrying could duplicate an external or "
+            "irreversible action, stop and ask one specific safety question."
         )
     else:
         resume_guidance = (

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -314,6 +314,17 @@ class TestResumePendingSystemNote:
         # But still guards against re-running already-recorded tool calls.
         assert "already appear in the history" in note
 
+    def test_empty_message_interactive_note_continues_task_safely(self):
+        """Interactive startup auto-resume must continue without asking a
+        generic question, while preserving ambiguous-side-effect safety."""
+        note = build_resume_recovery_note("restart_timeout", "", interactive=True)
+        assert "CONTINUE the interrupted task" in note
+        assert "ask what they would like to do next" not in note
+        assert "skip any unfinished work" not in note
+        assert "already appear in the history" in note
+        assert "effect is UNKNOWN" in note
+        assert "Inspect current state before retrying" in note
+
 
     def test_resume_note_is_persisted_instead_of_original_empty_message(self):
         """The auto-resume note must not leave an empty row in state.db."""


### PR DESCRIPTION
## Summary
- continue interrupted interactive turns instead of asking a generic what-next question
- avoid repeating recorded tool calls
- require state inspection before retrying calls with unknown external effects

## Test plan
- `scripts/run_tests.sh tests/gateway/test_restart_resume_pending.py tests/gateway/test_auto_continue.py -q` (44 passed)
