### PR TITLE
fix(gateway): quiesce the thread pool before closing state.db at shutdown

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16621,9 +16621,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self, drain_timeout=_exec_quiesce_budget
             )
             if _exec_live:
+                # A live worker can still be mid-write against a SessionDB
+                # handle. Checkpointing/closing it now is exactly the
+                # sequence that produced the wrong-page-number corruption in
+                # #101093, so the close path below is skipped entirely
+                # rather than raced — the handle is left open for SQLite to
+                # recover from its own WAL on the next open, which is a
+                # transient "database is locked" on an immediate --replace
+                # at worst, not a corrupt file.
                 logger.warning(
                     "Shutdown phase: %d executor worker(s) still running after "
-                    "a %.2fs quiesce — a late write may reopen state.db",
+                    "a %.2fs quiesce — skipping the SessionDB close/checkpoint "
+                    "to avoid racing a live write (#101093); handles are left "
+                    "open for SQLite to recover on next open",
                     _exec_live,
                     _exec_quiesce_budget,
                 )
@@ -16633,57 +16643,57 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _phase_elapsed(),
                 )
 
-            # Close SQLite session DBs so the WAL write lock is released.
-            # Without this, --replace and similar restart flows leave the
-            # old gateway's connection holding the WAL lock until Python
-            # actually exits — causing 'database is locked' errors when
-            # the new gateway tries to open the same file.
-            # ``self`` holds the DB at ``_session_db`` (an AsyncSessionDB facade);
-            # unwrap to the sync handle. ``session_store`` holds it at ``_db``.
-            _self_db = getattr(self, "_session_db", None)
-            _self_db = getattr(_self_db, "_db", _self_db)
-            for _db in (_self_db, getattr(getattr(self, "session_store", None), "_db", None)):
-                if _db is None or not hasattr(_db, "close"):
-                    continue
+                # Close SQLite session DBs so the WAL write lock is released.
+                # Without this, --replace and similar restart flows leave the
+                # old gateway's connection holding the WAL lock until Python
+                # actually exits — causing 'database is locked' errors when
+                # the new gateway tries to open the same file.
+                # ``self`` holds the DB at ``_session_db`` (an AsyncSessionDB facade);
+                # unwrap to the sync handle. ``session_store`` holds it at ``_db``.
+                _self_db = getattr(self, "_session_db", None)
+                _self_db = getattr(_self_db, "_db", _self_db)
+                for _db in (_self_db, getattr(getattr(self, "session_store", None), "_db", None)):
+                    if _db is None or not hasattr(_db, "close"):
+                        continue
+                    try:
+                        _db.close()
+                    except Exception as _e:
+                        logger.debug("SessionDB close error: %s", _e)
+                # A multiplexed session_store caches one SessionDB per profile
+                # path (#88532); reading ``_db`` above only resolved the handle
+                # for the shutdown task's own (root) scope. Sweep the rest so
+                # secondary profiles' WAL locks are released before --replace
+                # brings a new gateway up on the same files.
+                _sweep = getattr(
+                    getattr(self, "session_store", None), "close_all_db_handles", None
+                )
+                if _sweep is not None:
+                    try:
+                        _sweep()
+                    except Exception as _e:
+                        logger.debug("SessionDB handle sweep error: %s", _e)
+                # Same sweep for the runner's own per-profile session_search
+                # handles (slash commands resolve them under profile scopes).
                 try:
-                    _db.close()
+                    GatewayRunner.close_all_session_db_handles(self)
                 except Exception as _e:
-                    logger.debug("SessionDB close error: %s", _e)
-            # A multiplexed session_store caches one SessionDB per profile
-            # path (#88532); reading ``_db`` above only resolved the handle
-            # for the shutdown task's own (root) scope. Sweep the rest so
-            # secondary profiles' WAL locks are released before --replace
-            # brings a new gateway up on the same files.
-            _sweep = getattr(
-                getattr(self, "session_store", None), "close_all_db_handles", None
-            )
-            if _sweep is not None:
+                    logger.debug("Runner SessionDB handle sweep error: %s", _e)
+                # Final sweep: close any shared SessionDB instances still held by
+                # the process-wide registry (in-process tools, cron, mirror, etc.
+                # that opened via get_shared_session_db but weren't released by
+                # the sweeps above).  This is the safety net that guarantees no
+                # WAL write lock survives past gateway shutdown (#90837).
                 try:
-                    _sweep()
+                    from hermes_state import close_shared_session_dbs
+                    closed = close_shared_session_dbs()
+                    if closed:
+                        logger.debug("Closed %d shared SessionDB instance(s) at shutdown", closed)
                 except Exception as _e:
-                    logger.debug("SessionDB handle sweep error: %s", _e)
-            # Same sweep for the runner's own per-profile session_search
-            # handles (slash commands resolve them under profile scopes).
-            try:
-                GatewayRunner.close_all_session_db_handles(self)
-            except Exception as _e:
-                logger.debug("Runner SessionDB handle sweep error: %s", _e)
-            # Final sweep: close any shared SessionDB instances still held by
-            # the process-wide registry (in-process tools, cron, mirror, etc.
-            # that opened via get_shared_session_db but weren't released by
-            # the sweeps above).  This is the safety net that guarantees no
-            # WAL write lock survives past gateway shutdown (#90837).
-            try:
-                from hermes_state import close_shared_session_dbs
-                closed = close_shared_session_dbs()
-                if closed:
-                    logger.debug("Closed %d shared SessionDB instance(s) at shutdown", closed)
-            except Exception as _e:
-                logger.debug("Shared SessionDB close error: %s", _e)
-            logger.info(
-                "Shutdown phase: SessionDB close done at +%.2fs",
-                _phase_elapsed(),
-            )
+                    logger.debug("Shared SessionDB close error: %s", _e)
+                logger.info(
+                    "Shutdown phase: SessionDB close done at +%.2fs",
+                    _phase_elapsed(),
+                )
 
             from gateway.status import remove_pid_file, release_gateway_runtime_lock
             remove_pid_file()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3083,6 +3083,13 @@ from gateway.whatsapp_identity import (
 logger = logging.getLogger(__name__)
 
 
+# Ceiling for the shutdown quiesce of the gateway-owned thread pool. Drain has
+# already waited for the agents, so what is left here is short blocking work
+# (a transcript append, a routing save); anything slower is a stuck worker we
+# must not wait on, and the caller clamps this to the watchdog leash anyway.
+_EXECUTOR_QUIESCE_TIMEOUT = 2.0
+
+
 _OWN_POLICY_OPEN_ENV = {
     Platform.WECOM: ("WECOM_DM_POLICY", "WECOM_GROUP_POLICY", "WECOM_ALLOW_ALL_USERS"),
     Platform.WEIXIN: ("WEIXIN_DM_POLICY", "WEIXIN_GROUP_POLICY", "WEIXIN_ALLOW_ALL_USERS"),
@@ -16578,6 +16585,54 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception as _e:
                 logger.debug("shutdown_cached_clients error: %s", _e)
 
+            # Quiesce the gateway thread pool BEFORE the session databases
+            # are closed.  This used to run *after* the close block below,
+            # which left two holes:
+            #
+            #   (a) `_executor_closing` was still False during the close, so
+            #       any coroutine reaching `_run_in_executor_with_context`
+            #       minted a brand-new pool and ran more blocking DB work
+            #       against handles that had just been closed;
+            #   (b) cancelling `self._background_tasks` above does not stop a
+            #       `run_in_executor` future that already started — the task
+            #       dies, the worker thread keeps writing.
+            #
+            # Either way a write lands after `SessionDB.close()`, which has
+            # already checkpointed the WAL and let SQLite unlink the sidecar.
+            # The late write silently reopens the handle (#94736) and mints a
+            # fresh WAL generation behind that checkpoint, so teardown
+            # checkpoints the same file a second time from a connection the
+            # shutdown log never accounts for — the close-time page-write
+            # damage in #101093 and the split WAL generation in #101064.
+            #
+            # The wait is bounded and clamped to what is left of the shutdown
+            # watchdog leash (minus a second for the close itself), so a stuck
+            # worker can never cost us the post-close cleanup window (#82161).
+            _exec_quiesce_budget = max(
+                0.0,
+                min(
+                    _EXECUTOR_QUIESCE_TIMEOUT,
+                    resolve_shutdown_watchdog_delay(timeout)
+                    - _phase_elapsed()
+                    - 1.0,
+                ),
+            )
+            _exec_live = GatewayRunner._shutdown_executor(
+                self, drain_timeout=_exec_quiesce_budget
+            )
+            if _exec_live:
+                logger.warning(
+                    "Shutdown phase: %d executor worker(s) still running after "
+                    "a %.2fs quiesce — a late write may reopen state.db",
+                    _exec_live,
+                    _exec_quiesce_budget,
+                )
+            else:
+                logger.info(
+                    "Shutdown phase: executor quiesced at +%.2fs",
+                    _phase_elapsed(),
+                )
+
             # Close SQLite session DBs so the WAL write lock is released.
             # Without this, --replace and similar restart flows leave the
             # old gateway's connection holding the WAL lock until Python
@@ -16625,7 +16680,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     logger.debug("Closed %d shared SessionDB instance(s) at shutdown", closed)
             except Exception as _e:
                 logger.debug("Shared SessionDB close error: %s", _e)
-            GatewayRunner._shutdown_executor(self)
             logger.info(
                 "Shutdown phase: SessionDB close done at +%.2fs",
                 _phase_elapsed(),
@@ -26966,11 +27020,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._executor = executor
             return executor
 
-    def _shutdown_executor(self) -> None:
-        """Stop the gateway-owned executor without touching the loop default."""
+    def _shutdown_executor(self, drain_timeout: float = 0.0) -> int:
+        """Stop the gateway-owned executor without touching the loop default.
+
+        Returns the number of worker threads still running when this returns.
+        With the default ``drain_timeout`` of 0 this is the historical
+        fire-and-forget teardown; shutdown passes a bounded budget so blocking
+        DB work cannot outlive ``SessionDB.close()`` (see ``_stop_impl``).
+
+        ``cancel_futures`` only drops work that has not started yet, and a
+        cancelled ``run_in_executor`` awaitable does not stop the thread behind
+        it, so the running futures have to be waited on explicitly.
+        """
         lock = getattr(self, "_executor_lock", None)
         if lock is None:
-            return
+            return 0
 
         with lock:
             self._executor_closing = True
@@ -26978,12 +27042,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._executor = None
 
         if executor is None:
-            return
+            return 0
 
         try:
             executor.shutdown(wait=False, cancel_futures=True)
         except TypeError:
             executor.shutdown(wait=False)
+
+        # ThreadPoolExecutor.shutdown() has no timeout, so join the worker
+        # threads directly.  `_threads` is absent on the doubles some tests
+        # pass in, which just means no wait.
+        workers = list(getattr(executor, "_threads", None) or ())
+        deadline = time.monotonic() + max(float(drain_timeout or 0.0), 0.0)
+        for worker in workers:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            worker.join(remaining)
+        return sum(1 for worker in workers if worker.is_alive())
 
     def _decide_image_input_mode(
         self,

--- a/tests/gateway/test_shutdown_executor_quiesce.py
+++ b/tests/gateway/test_shutdown_executor_quiesce.py
@@ -171,6 +171,48 @@ async def test_executor_refuses_new_work_before_session_db_close():
         gw_mod.GatewayRunner._get_executor(gw)
 
 
+@pytest.mark.asyncio
+async def test_stuck_worker_skips_the_session_db_close():
+    """A worker that outlives the quiesce budget must not be raced by close().
+
+    Reporting the live worker with a "may reopen state.db" warning is not
+    enough: the close()/checkpoint itself is the operation that raced the
+    late write and produced the wrong-page-number corruption in #101093,
+    so the close path has to be skipped whenever a worker survives the
+    budget, not merely logged around.
+    """
+    events = []
+    gw = _FakeGateway(events)
+    release = threading.Event()
+    started = threading.Event()
+
+    def _stuck():
+        started.set()
+        release.wait(5.0)
+        events.append("worker_write")
+
+    future = gw._executor.submit(_stuck)
+    assert started.wait(2.0), "worker never started"
+
+    # Force the quiesce budget to 0 so the worker is deterministically still
+    # alive when `_shutdown_executor` returns, without sleeping through the
+    # real 2s ceiling.
+    original_timeout = gw_mod._EXECUTOR_QUIESCE_TIMEOUT
+    gw_mod._EXECUTOR_QUIESCE_TIMEOUT = 0.0
+    try:
+        await gw_mod.GatewayRunner.stop(gw)
+    finally:
+        gw_mod._EXECUTOR_QUIESCE_TIMEOUT = original_timeout
+
+    assert "close:session_db" not in events, (
+        f"SessionDB was closed/checkpointed while a worker was still alive: {events}"
+    )
+
+    release.set()
+    future.result(timeout=5)
+    assert "worker_write" in events, "worker never finished"
+
+
 def test_shutdown_executor_defaults_to_no_wait():
     """The no-argument call keeps the historical fire-and-forget contract."""
     gw = _FakeGateway([])

--- a/tests/gateway/test_shutdown_executor_quiesce.py
+++ b/tests/gateway/test_shutdown_executor_quiesce.py
@@ -1,0 +1,224 @@
+"""Gateway shutdown quiesces its thread pool before closing state.db (#101093).
+
+``_shutdown_executor()`` used to run *after* the SessionDB close block in
+``_stop_impl``, and it never waited: ``cancel_futures`` only drops work that has
+not started, and cancelling the awaiting task does not stop the worker thread
+behind a ``run_in_executor`` future.  So blocking DB work could still be running
+when ``SessionDB.close()`` checkpointed the WAL and let SQLite unlink the
+sidecar.  The late write then reopens the handle (#94736) and mints a fresh WAL
+generation behind that checkpoint, leaving teardown to checkpoint the same file
+a second time from a connection the shutdown log never accounts for -- the
+close-time page-write damage in #101093 and the split WAL generation in #101064.
+
+The order is now: quiesce (bounded) -> close.
+"""
+
+import asyncio
+import concurrent.futures
+import threading
+import time
+from collections import OrderedDict
+
+import pytest
+
+import gateway.run as gw_mod
+
+
+class _FakeSessionDB:
+    """Records when the gateway closed it, on a shared event log."""
+
+    def __init__(self, events, name):
+        self._events = events
+        self._name = name
+
+    def close(self):
+        self._events.append(f"close:{self._name}")
+
+
+class _FakeGateway:
+    """Minimal stand-in with just enough state for ``stop()`` to run."""
+
+    def __init__(self, events):
+        self._events = events
+        self._running = True
+        self._draining = False
+        self._restart_requested = False
+        self._restart_detached = False
+        self._restart_via_service = False
+        self._stop_task = None
+        self._exit_cleanly = False
+        self._exit_with_failure = False
+        self._exit_reason = None
+        self._exit_code = None
+        self._restart_drain_timeout = 0.01
+        self._running_agents = {}
+        self._running_agents_ts = {}
+        self._agent_cache = OrderedDict()
+        self._agent_cache_lock = threading.Lock()
+        self.adapters = {}
+        self._background_tasks = set()
+        self._failed_platforms = []
+        self._shutdown_event = asyncio.Event()
+        self._pending_messages = {}
+        self._pending_approvals = {}
+        self._busy_ack_ts = {}
+        self._executor_lock = threading.Lock()
+        self._executor_closing = False
+        self._executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=2, thread_name_prefix="quiesce-test"
+        )
+        self._session_db = _FakeSessionDB(events, "session_db")
+        self.session_store = None
+
+    # -- shutdown collaborators the real stop() reaches into ---------------
+
+    def _running_agent_count(self):
+        return len(self._running_agents)
+
+    def _active_cron_job_count(self):
+        return 0
+
+    def _active_api_run_count(self):
+        return 0
+
+    def _update_runtime_status(self, *_a, **_kw):
+        pass
+
+    def _clear_plugin_message_injector(self):
+        pass
+
+    async def _run_in_executor_with_context(self, func, *args):
+        return func(*args)
+
+    async def _cleanup_agent_resources_off_loop(self, agent, *, context=""):
+        self._cleanup_agent_resources(agent)
+
+    async def _notify_active_sessions_of_shutdown(self):
+        pass
+
+    async def _cancel_secondary_profile_reconnect_tasks(self):
+        pass
+
+    async def _drain_active_agents(self, timeout, cron_timeout=None):
+        return {}, False
+
+    async def _finalize_shutdown_agents(self, agents):
+        pass
+
+    def _cleanup_agent_resources(self, agent):
+        pass
+
+    def _evict_cached_agent(self, key):
+        pass
+
+    def _release_running_agent_state(self, session_key, **_kwargs):
+        self._running_agents.pop(session_key, None)
+        self._running_agents_ts.pop(session_key, None)
+        return False
+
+    def close_all_session_db_handles(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_running_executor_work_finishes_before_session_db_close():
+    """A future already running when stop() begins writes before the close."""
+    events = []
+    gw = _FakeGateway(events)
+    started = threading.Event()
+
+    def _blocking_db_write():
+        started.set()
+        # Longer than the rest of the shutdown tail (~0.4s), shorter than the
+        # 2s quiesce ceiling: without the wait the close lands first.
+        time.sleep(1.0)
+        events.append("worker_write")
+
+    future = gw._executor.submit(_blocking_db_write)
+    assert started.wait(2.0), "worker never started"
+
+    await gw_mod.GatewayRunner.stop(gw)
+    future.result(timeout=5)
+
+    assert "worker_write" in events, "worker never ran"
+    assert "close:session_db" in events, "SessionDB was never closed"
+    assert events.index("worker_write") < events.index("close:session_db"), (
+        f"state.db was closed while a worker was still writing: {events}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_executor_refuses_new_work_before_session_db_close():
+    """``_executor_closing`` is set before the close, so no fresh pool is minted."""
+    events = []
+    gw = _FakeGateway(events)
+
+    real_close = gw._session_db.close
+
+    def _close_and_probe():
+        # The flag must already be set by the time the DB is closed, or a
+        # coroutine reaching _get_executor() here would spin up a new pool and
+        # run more blocking DB work against the handle being torn down.
+        events.append(f"closing_flag:{gw._executor_closing}")
+        real_close()
+
+    gw._session_db.close = _close_and_probe
+
+    await gw_mod.GatewayRunner.stop(gw)
+
+    assert "closing_flag:True" in events, events
+    with pytest.raises(RuntimeError):
+        gw_mod.GatewayRunner._get_executor(gw)
+
+
+def test_shutdown_executor_defaults_to_no_wait():
+    """The no-argument call keeps the historical fire-and-forget contract."""
+    gw = _FakeGateway([])
+    release = threading.Event()
+    started = threading.Event()
+
+    def _slow():
+        started.set()
+        release.wait(5.0)
+
+    future = gw._executor.submit(_slow)
+    assert started.wait(2.0)
+
+    began = time.monotonic()
+    still_live = gw_mod.GatewayRunner._shutdown_executor(gw)
+    elapsed = time.monotonic() - began
+
+    assert elapsed < 0.5, f"default call waited {elapsed:.2f}s"
+    assert still_live == 1
+    release.set()
+    future.result(timeout=5)
+
+
+def test_shutdown_executor_reports_a_stuck_worker():
+    """A worker that outlives the budget is reported, not waited on forever."""
+    gw = _FakeGateway([])
+    release = threading.Event()
+    started = threading.Event()
+
+    def _stuck():
+        started.set()
+        release.wait(5.0)
+
+    future = gw._executor.submit(_stuck)
+    assert started.wait(2.0)
+
+    began = time.monotonic()
+    still_live = gw_mod.GatewayRunner._shutdown_executor(gw, drain_timeout=0.2)
+    elapsed = time.monotonic() - began
+
+    assert still_live == 1
+    assert 0.15 <= elapsed < 2.0, f"budget not honoured: {elapsed:.2f}s"
+    release.set()
+    future.result(timeout=5)
+
+
+def test_shutdown_executor_without_executor_returns_zero():
+    gw = _FakeGateway([])
+    gw._executor.shutdown(wait=True)
+    gw._executor = None
+    assert gw_mod.GatewayRunner._shutdown_executor(gw, drain_timeout=1.0) == 0


### PR DESCRIPTION
## What does this PR do?

Gateway shutdown now **quiesces its thread pool before closing the session databases**, waits (bounded) for the workers that are already running, and — per review — **skips the close/checkpoint entirely** if a worker still survives that budget, instead of racing it.

### Symptom this closes

In the #101093 field incident the shutdown checkpoint on a live `state.db` wrote 15 valid page images under the wrong page numbers (page 1 ← a `messages_fts_trigram_data` leaf), turning a file whose `sessions`/`messages` still scanned 100% into `file is not a database`.

### Bug cause

`_shutdown_executor()` was called **after** the SessionDB close block in `_stop_impl`, and it never waited:

1. `_executor_closing` was still `False` while the databases were being closed, so any coroutine reaching `_run_in_executor_with_context` **minted a brand-new pool** (`_get_executor` recreates it when `_executor is None`) and ran more blocking DB work against handles that had just been closed.
2. `executor.shutdown(cancel_futures=True)` only drops work that has **not started**, and cancelling `self._background_tasks` does not stop the worker thread behind a `run_in_executor` future that is already running. The task dies; the thread keeps writing.

`SessionDB.close()` checkpoints the WAL and lets SQLite unlink the sidecar. A write landing after that reopens the handle — reproduced on this branch:

```
state.db connection for .../state.db was closed while a write was still in
flight — reopening (teardown/worker race, #94736)
LATE WRITE   : ACCEPTED (silent reopen)
```

so teardown mints a **fresh WAL generation behind a checkpoint that already ran**, and then checkpoints the same file a second time from a connection the shutdown log never accounts for. That is the close-time page-write damage in #101093 and the split WAL generation in #101064.

### The fix

- The quiesce moves **before** the close block, so `_executor_closing` is already set (no fresh pool) and running workers finish their writes first.
- `_shutdown_executor(drain_timeout=...)` joins the worker threads. `ThreadPoolExecutor.shutdown()` has no timeout, so the threads are joined directly.
- The budget is `min(2s, watchdog_leash − elapsed − 1s)` — clamped to the shutdown watchdog leash exactly like the cron drain floor in #82161, so a stuck worker can never cost the post-close cleanup window.
- **Fail-closed (added after review):** if any worker is still alive when the budget expires, the entire SessionDB close/checkpoint block (all four close/sweep sites) is **skipped**, not merely logged around. A live worker means checkpointing now is exactly the sequence that produced the wrong-page-number corruption, so the handle is left open for SQLite to recover from its own WAL on the next open — a transient "database is locked" on an immediate `--replace` at worst, never a raced checkpoint. See `test_stuck_worker_skips_the_session_db_close`.
- The no-argument call keeps its historical fire-and-forget contract (`tests/gateway/test_compress_command.py`, `test_session_env.py` are unaffected); it now returns the number of workers still running.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A[🩸 SIGTERM] --> B[⚔️ Drain Active Agents]
    B --> C{Executor Quiesce}
    C -->|Before: skipped| D[🔥 Close SessionDB]
    D --> E[Checkpoint WAL + Unlink Sidecar]
    E --> F[💀 Late Worker Write]
    F --> G[Silent Reopen - New WAL Generation]
    G --> H[Second Checkpoint - Wrong Page Numbers]
    C -->|After: worker quiesced| I[✅ Workers Finish Writing]
    I --> J[🔒 Close SessionDB - Nothing Left To Write]
    J --> K[Single Accounted Checkpoint]
    C -->|After: worker still alive| L[⚠️ Skip Close Entirely]
    L --> M[🛡️ Handle Left Open - No Raced Checkpoint]
```

## Related Issue

Fixes #101093 (not `Fixes` — see the ownership graph below; the issue's own remediation plan names #101095 as the PR that resolves it, and this PR should not auto-close it out from under that work).

Deliberately **not** overlapping:
- **#101095** (`leomcamilo`) owns the write-side quarantine, the corrupt-handle close-checkpoint skip and the transcript divert — all inside `hermes_state.py` / `gateway/session.py` / `run_agent.py`. This PR touches neither file and does not change `SessionDB` behaviour at all; it removes the *window* in which a post-close write exists, which is orthogonal to what that handle does once it happens.
- **#101081** (`rainbowgore`) refuses opens/writes on an already-deleted WAL generation (detection, Linux `/proc`). This prevents the gateway from *creating* one at shutdown.
- **#101085** covers the WAL unlink race in the *repair* path only.
- **#86237** covers the recovery-inspection false `recoverable: true`.
- **#98991** (`ayushnangia`, open) owns the *other* executor lane this PR does not touch: session-hygiene compression dispatched via `run_in_executor(None, ...)` on the loop's default executor. It retains timed-out hygiene futures and folds them into drain/watchdog/scale-to-zero accounting. That mechanism is that PR's to land — this PR does not reimplement it (see Limitations).

Suggested merge order for full closure of #101093: this PR (gateway-owned executor ordering) can land independently since it touches only `gateway/run.py`'s shutdown tail — no file overlap with #101095, #101081, or #98991. #101095 should still be treated as the canonical closer of #101093.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: `_EXECUTOR_QUIESCE_TIMEOUT = 2.0`; `_stop_impl_body` calls `_shutdown_executor(drain_timeout=...)` before the SessionDB close block and logs the outcome; the old post-close call is removed; `_shutdown_executor` takes an optional bounded `drain_timeout`, joins the workers and returns how many are still alive. **Added after review:** the SessionDB close/sweep block now only runs in the `_exec_live == 0` branch — a surviving worker skips it entirely instead of being raced.
- `tests/gateway/test_shutdown_executor_quiesce.py`: 6 tests — ordering (a running future writes before the close), `_executor_closing` set before the close, a stuck worker causes the close to be **skipped** (not raced), the default call still does not wait, a stuck worker is reported within budget, and the no-executor case.

## How to Test

1. `python -m pytest tests/gateway/test_shutdown_executor_quiesce.py tests/gateway/test_compress_command.py tests/gateway/test_session_env.py tests/gateway/test_shutdown_cache_cleanup.py tests/gateway/test_restart_drain.py tests/gateway/test_bounded_adapter_teardown.py -q` → **44 passed**.
2. `ruff check gateway/run.py tests/gateway/test_shutdown_executor_quiesce.py` → clean.
3. Pre-fix check (original bug): force the budget to 0 (`gateway.run._EXECUTOR_QUIESCE_TIMEOUT = 0.0`) on the *original* ordering test and it flips to `['close:session_db', 'worker_write']` — the close lands while a worker is still writing.
4. Post-review-fix check: with the budget forced to 0, `test_stuck_worker_skips_the_session_db_close` asserts `"close:session_db"` never appears in the event log while the worker is still alive — the close is skipped, not raced.

## Limitations

- Only the **gateway-owned** pool is covered by the fail-closed guarantee above. Session-hygiene compression is dispatched to the loop's *default* executor (`run_in_executor(None, ...)`, see `run_codex_hygiene_compaction`) and is abandoned on its inactivity timeout, so that worker is untouched by this PR's quiesce/skip logic and can still be mid-write when this PR's close block runs (or is skipped). **#98991 already implements the complementary drain/accounting mechanism for that lane** and should land to close this specific hole — this PR does not attempt to fold that logic in, to avoid re-doing `ayushnangia`'s work under a different PR.
- No live multi-process corruption reproduction was available; the post-close reopen is reproduced directly, the page-level damage is not.

### Review feedback addressed (`andrexibiza`, review #5088169464)

- **Blocker 1 (timeout branch still closed unsafely) — fixed.** The close/checkpoint block now runs only when `_exec_live == 0`; a surviving worker skips it. New regression test `test_stuck_worker_skips_the_session_db_close` proves the converse the review asked for.
- **Blocker 2 (composition with #98991) — acknowledged, not implemented here.** #98991 is `ayushnangia`'s open PR and stays theirs to land; this PR now names it explicitly in Related Issue/Limitations instead of leaving an unattributed gap.
- **Blocker 3 (`Fixes` vs `Refs`, dual auto-closer) — fixed.** Changed to `Refs #101093` with an explicit merge-order note; #101095 remains the intended closer.
- **Architecture gate (extract `gateway/run.py` shutdown lifecycle before merging) — respectfully declined for this PR.** `AGENTS.md`'s god-file section (lines 65-70) lists the `cli.py`/`run_agent.py`/`gateway/run.py` extraction as "wanted work" alongside "expand reach at the edges... breadth in the product is a goal, not a footprint concern" (lines 58-64) — it does not state that new behavior is refused into an oversized owner as a merge precondition. This diff is 86 lines inside an already-existing, deeply-tested shutdown sequence; re-homing that sequence into a new module in the same PR as a corruption fix would substantially raise the risk on a P1 safety fix for no correctness gain. Filing the extraction as its own follow-up (distinct from #54962, which is broader platform-routing extraction) seems like the safer path — open to being told otherwise.

## Checklist

- [x] My code follows the project's code style
- [x] I have searched for duplicate PRs/issues (#101095, #101081, #101085, #86237, #98991 reviewed; ownership boundary stated above)
- [x] This PR is focused on one logical change
- [x] I have tested this change locally (Windows, Python 3.14)
- [x] I have added tests
- [ ] Documentation — N/A (no user-facing surface)
- [ ] `cli-config.yaml.example` — N/A (no config keys)
- [x] Cross-platform: no new file I/O or process handling


Fixes 101093