### PR TITLE
test(cli): keep cmd_update tests off live gateways and un-poison the pytest session

### DIFF
--- a/tests/hermes_cli/conftest.py
+++ b/tests/hermes_cli/conftest.py
@@ -2,7 +2,188 @@
 
 from __future__ import annotations
 
+import functools
+import sys
+
 import pytest
+
+#: Package prefixes that ``update_cmd._purge_stale_hermes_modules`` evicts from
+#: ``sys.modules``. Mirrors ``_STALE_PURGE_PREFIXES`` — kept as a literal so the
+#: fixture below stays usable even when the purge itself dropped ``update_cmd``.
+_HERMES_MODULE_PREFIXES = (
+    "hermes_cli",
+    "gateway",
+    "tools",
+    "tui_gateway",
+    "agent",
+)
+
+
+@pytest.fixture(autouse=True)
+def _restore_purged_hermes_modules():
+    """Undo ``sys.modules`` eviction performed by ``cmd_update`` under test.
+
+    ``hermes update`` keeps running in the pre-pull interpreter, so
+    ``update_cmd._purge_stale_hermes_modules`` drops every cached
+    ``hermes_cli``/``gateway``/``tools``/``agent`` module to force later
+    imports to rebuild from the new checkout. In production that process is
+    about to exit; inside pytest it poisons the rest of the session.
+
+    A test module that did ``from hermes_cli.curses_ui import curses_radiolist``
+    at import time keeps the OLD module's function, while any later
+    ``import hermes_cli.curses_ui`` builds a SECOND module object with its own
+    ``ContextVar`` instances. A menu navigation handler installed through one
+    copy is then invisible to the other, ``allow_back`` reads ``False``, Left
+    arrow is dropped, and ``curses_radiolist`` loops on ``getch() == -1``
+    forever while appending to the fake screen's write log.
+
+    That is not hypothetical: running ``tests/hermes_cli/`` as a whole,
+    ``test_cmd_update.py`` sorts before ``test_curses_arrow_keys.py``, and the
+    resulting spin grew one pytest process to 47 GB before the kernel's OOM
+    killer took the machine down.
+
+    Restoring only entries whose object identity changed keeps genuinely new
+    imports made by the test, and costs one dict copy per test.
+    """
+    snapshot = {
+        name: module
+        for name, module in sys.modules.items()
+        if name.split(".", 1)[0] in _HERMES_MODULE_PREFIXES
+    }
+    yield
+    _restore_module_snapshot(snapshot)
+
+
+def _restore_module_snapshot(snapshot: dict) -> None:
+    """Put back the snapshotted modules — through BOTH names each one has.
+
+    A submodule is reachable two ways: ``sys.modules["pkg.mod"]`` and the
+    ``pkg.mod`` attribute the import system binds on the parent package.
+    Rewriting only the dict re-creates the very split identity this fixture
+    exists to prevent — just one level up. Observed in this suite: after
+    ``test_state_db_guard`` deletes ``hermes_cli.config*`` and re-imports it
+    under a temporary ``HERMES_HOME``, restoring the dict alone leaves
+    ``from hermes_cli import config`` on the tmp-era copy with its own
+    module-level locks and caches, while ``hermes_cli.config`` as a target of
+    ``monkeypatch.setattr`` resolves to the original — so a later test patches
+    a copy the code under test never looks at.
+
+    Kept as a module-level function rather than an inline loop so the contract
+    is directly testable; see ``test_update_stale_module_purge``.
+    """
+    for name, module in snapshot.items():
+        if sys.modules.get(name) is module:
+            continue
+        sys.modules[name] = module
+        parent_name, _, child = name.rpartition(".")
+        parent = sys.modules.get(parent_name) if parent_name else None
+        # `getattr` first: a package whose attribute already agrees needs no
+        # write, and some parents (namespace shims, mocks) reject setattr.
+        if parent is not None and getattr(parent, child, None) is not module:
+            try:
+                setattr(parent, child, module)
+            except (AttributeError, TypeError):
+                pass
+
+
+@functools.lru_cache(maxsize=None)
+def _module_drives_cmd_update(path: str) -> bool:
+    """True when a test module's source calls ``cmd_update(``.
+
+    Deliberately a source scan and not a hand-written list of module names. A
+    list is a thing that goes stale silently: the next ``test_update_*`` module
+    to grow one step further down ``cmd_update`` loses the seat belt without
+    anybody noticing, and it stays green in CI because CI has no gateways to
+    kill. The predicate that actually matters — "does this module drive
+    ``cmd_update``" — is right there in the source, so read it.
+
+    The two modules that must NOT be patched (``test_update_launchd_*``
+    exercises the real ``find_gateway_pids``, ``test_update_stale_module_purge``
+    asserts ``hermes_cli.gateway`` IS evicted) fall out for free: neither calls
+    ``cmd_update``. So this needs no opt-out list either.
+
+    Cached per file path — 13 modules match today, each read once per session.
+    """
+    try:
+        with open(path, encoding="utf-8") as handle:
+            return "cmd_update(" in handle.read()
+    except OSError:
+        # Unreadable module: fail SAFE (patch it) rather than let an
+        # end-to-end update test loose on this machine's gateways.
+        return True
+
+
+@pytest.fixture(autouse=True)
+def _guard_live_gateway_discovery(request):
+    """Give every module that drives ``cmd_update`` the discovery seat belt.
+
+    Lives here rather than as a ``pytestmark`` in each test module so that a
+    new ``test_update_*`` module gets the seat belt automatically instead of
+    having to remember to opt in.
+    """
+    path = getattr(request.module, "__file__", None)
+    if path and _module_drives_cmd_update(path):
+        request.getfixturevalue("patch_gateway_discovery")
+
+
+@pytest.fixture
+def patch_gateway_discovery(monkeypatch):
+    """Keep ``cmd_update``'s gateway auto-restart phase off this machine's fleet.
+
+    Since the restart phase was surfaced (#78574: an aborted restart fails the
+    update), any end-to-end ``cmd_update`` test that leaves gateway discovery
+    unmocked finds the developer's REAL gateways, tries to ``os.kill`` them,
+    trips the ``tests/conftest.py`` live-system guard and turns into a spurious
+    ``sys.exit(1)``. Discovery returning nothing makes the phase a clean no-op.
+
+    Patching the module attributes is not enough on its own — and that is why
+    the upstream per-module attempts at this (``test_update_head_moved_gate``,
+    ``test_update_fleet_restart_pending``, ``test_update_autostash`` each
+    already mock all three functions "to keep the phase away from this
+    machine's real gateways") still shipped SIGTERM at the live fleet.
+    Right before the restart phase does its function-level ``from
+    hermes_cli.gateway import ...``, ``cmd_update`` calls
+    ``_purge_stale_hermes_modules()``, which drops ``hermes_cli.gateway`` out
+    of ``sys.modules``. The import then re-executes the module from disk and
+    binds the REAL functions; the patches are still attached to the evicted
+    module object, so they no longer apply. Pinning ``hermes_cli.gateway`` into
+    the purge's protected set keeps the mocked module object in ``sys.modules``
+    so the re-import resolves to it, while leaving the purge itself running for
+    every other module (its own behaviour is covered by
+    ``test_update_stale_module_purge.py``, which asserts ``hermes_cli.gateway``
+    IS evicted — hence this pin is opt-in per module, not autouse here).
+
+    A test that wants the restart phase to see gateways re-patches these three
+    inside its own body; the inner patch wins for its duration.
+
+    ``monkeypatch`` — not ``mock.patch`` — on purpose, and it is not a style
+    preference. Three of the covered modules ``monkeypatch.setattr`` these same
+    three names inside their own bodies. ``monkeypatch`` is function-scoped, so
+    this fixture and the test body get the SAME ``MonkeyPatch`` object: both
+    sets of writes land on one undo stack and unwind in LIFO order, which is
+    what makes the nesting compose. Two INDEPENDENT undo stacks do not compose
+    — whichever unwinds last wins — and a ``mock.patch`` version of this
+    fixture did exactly that: it left a live ``MagicMock`` on
+    ``hermes_cli.gateway.find_gateway_pids`` for the rest of the session, so
+    ``test_update_launchd_fleet_restart``'s own ``monkeypatch.setattr``
+    silently did nothing. It failed only when it ran after
+    ``test_update_head_moved_gate`` and passed on its own.
+    """
+    import hermes_cli.gateway as hermes_gateway
+    import hermes_cli.update_cmd as update_cmd
+
+    monkeypatch.setattr(
+        update_cmd,
+        "_STALE_PURGE_PROTECTED",
+        frozenset(update_cmd._STALE_PURGE_PROTECTED | {"hermes_cli.gateway"}),
+    )
+    monkeypatch.setattr(hermes_gateway, "find_gateway_pids", lambda *a, **k: [])
+    monkeypatch.setattr(
+        hermes_gateway, "supports_systemd_services", lambda *a, **k: False
+    )
+    monkeypatch.setattr(
+        hermes_gateway, "find_profile_gateway_processes", lambda *a, **k: []
+    )
 
 
 @pytest.fixture

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -75,22 +75,12 @@ def _patch_managed_uv(request):
         yield
 
 
-@pytest.fixture(autouse=True)
-def _patch_gateway_discovery():
-    """Keep cmd_update's gateway auto-restart phase off this machine's gateways.
-
-    The restart phase used to swallow every exception at debug level, so these
-    end-to-end tests never noticed it touching real gateway discovery. Since
-    the phase is surfaced (#78574: an aborted restart now fails the update),
-    an unmocked ``find_gateway_pids`` on a box with a live gateway reaches the
-    conftest live-system guard and turns into a spurious ``sys.exit(1)``.
-    Discovery returning nothing makes the phase a clean no-op for every test
-    in this module (none of them assert on gateway restarts).
-    """
-    with patch("hermes_cli.gateway.find_gateway_pids", return_value=[]), \
-         patch("hermes_cli.gateway.supports_systemd_services", return_value=False), \
-         patch("hermes_cli.gateway.find_profile_gateway_processes", return_value=[]):
-        yield
+# The gateway-discovery mocking that used to live here as a local
+# ``_patch_gateway_discovery`` autouse fixture now comes from
+# ``tests/hermes_cli/conftest.py`` — it is needed by four sibling
+# ``test_update_*`` modules too, and the local copy was both duplicated and
+# incomplete (it did not survive ``cmd_update``'s ``sys.modules`` purge, so the
+# real fleet got discovered anyway). See ``patch_gateway_discovery`` there.
 
 
 class TestCmdUpdateNpmLockfileCache:

--- a/tests/hermes_cli/test_update_stale_module_purge.py
+++ b/tests/hermes_cli/test_update_stale_module_purge.py
@@ -134,3 +134,86 @@ def test_stale_symbol_scenario_end_to_end():
         sys.modules.pop(name, None)
         if real is not None:
             sys.modules[name] = real
+
+
+# --- the pytest-side antidote to the purge -------------------------------
+#
+# The purge is correct in production (the interpreter is about to exec the new
+# checkout) and poisonous inside pytest, where the session continues. The
+# antidote is `conftest._restore_purged_hermes_modules`; these tests pin its
+# CONTRACT, because the first version of it restored `sys.modules` only and so
+# rebuilt the same split identity one level up — a later test's
+# `monkeypatch.setattr("pkg.sub.thing", ...)` then patched a copy the code under
+# test never reached. Reproduced in this suite with `hermes_cli.config` after
+# `test_state_db_guard` deletes and re-imports it.
+
+
+def _install_fake_package(monkeypatch):
+    """A parent package with one submodule, wired the way import wires it."""
+    pkg = types.ModuleType("hermes_cli_fakepkg")
+    sub = types.ModuleType("hermes_cli_fakepkg.sub")
+    pkg.sub = sub
+    monkeypatch.setitem(sys.modules, "hermes_cli_fakepkg", pkg)
+    monkeypatch.setitem(sys.modules, "hermes_cli_fakepkg.sub", sub)
+    return pkg, sub
+
+
+def test_restore_snapshot_rebinds_the_parent_attribute(monkeypatch):
+    """Restoring must fix BOTH names a submodule answers to."""
+    from tests.hermes_cli.conftest import _restore_module_snapshot
+
+    pkg, sub = _install_fake_package(monkeypatch)
+    snapshot = {"hermes_cli_fakepkg.sub": sub}
+
+    # What a partial purge + re-import leaves behind, and the shape that
+    # actually bit: only the SUBMODULE was evicted, so the import system
+    # rebound the fresh copy onto the SAME, still-cached parent package.
+    new_sub = types.ModuleType("hermes_cli_fakepkg.sub")
+    sys.modules["hermes_cli_fakepkg.sub"] = new_sub
+    pkg.sub = new_sub
+
+    _restore_module_snapshot(snapshot)
+
+    assert sys.modules["hermes_cli_fakepkg.sub"] is sub
+    # The regression: without rebinding, this is still `new_sub`, so
+    # `from hermes_cli_fakepkg import sub` hands out the copy the test built.
+    assert pkg.sub is sub, "parent package still points at the post-purge copy"
+
+
+def test_restore_snapshot_leaves_untouched_modules_alone(monkeypatch):
+    """Identity already correct ⇒ no write, so a legitimately shared object
+    is never clobbered and a read-only parent never raises."""
+    pkg, sub = _install_fake_package(monkeypatch)
+
+    class Frozen(types.ModuleType):
+        def __setattr__(self, name, value):  # pragma: no cover - guard only
+            raise AttributeError("read-only parent")
+
+    frozen = Frozen("hermes_cli_fakepkg")
+    monkeypatch.setitem(sys.modules, "hermes_cli_fakepkg", frozen)
+
+    from tests.hermes_cli.conftest import _restore_module_snapshot
+
+    # `sub` is unchanged in sys.modules, so restore must not touch the parent.
+    _restore_module_snapshot({"hermes_cli_fakepkg.sub": sub})
+    assert sys.modules["hermes_cli_fakepkg.sub"] is sub
+
+
+def test_restore_snapshot_survives_a_parent_that_refuses_setattr(monkeypatch):
+    """A parent that rejects attribute writes must not fail the whole run:
+    the dict entry is the load-bearing half, the attribute is best-effort."""
+    from tests.hermes_cli.conftest import _restore_module_snapshot
+
+    class Frozen(types.ModuleType):
+        def __setattr__(self, name, value):
+            raise AttributeError("read-only parent")
+
+    frozen = Frozen("hermes_cli_fakepkg")
+    sub = types.ModuleType("hermes_cli_fakepkg.sub")
+    monkeypatch.setitem(sys.modules, "hermes_cli_fakepkg", frozen)
+    monkeypatch.setitem(sys.modules, "hermes_cli_fakepkg.sub",
+                        types.ModuleType("hermes_cli_fakepkg.sub"))
+
+    _restore_module_snapshot({"hermes_cli_fakepkg.sub": sub})
+
+    assert sys.modules["hermes_cli_fakepkg.sub"] is sub


### PR DESCRIPTION
## Problem

Two things go wrong when the `cmd_update` end-to-end tests run on a developer machine that has real gateways running.

**1. The tests reach the developer's live gateways.** Since the gateway auto-restart phase of `hermes update` was surfaced (#78574), an end-to-end `cmd_update` test that leaves gateway discovery unmocked finds the real gateways, tries to `os.kill` them, trips the live-system guard in `tests/conftest.py` and turns into a spurious `sys.exit(1)`. Several modules already mock `find_gateway_pids` and friends "to keep the phase away from this machine's real gateways", but the mocks did not hold: right before the restart phase does its function-level `from hermes_cli.gateway import ...`, `cmd_update` calls `_purge_stale_hermes_modules()`, which evicts `hermes_cli.gateway` from `sys.modules`. The import re-executes the module from disk and binds the real functions, while the patches stay attached to the evicted module object. We measured SIGTERM being sent to a live gateway from the test suite.

**2. The purge poisons the rest of the pytest session.** The purge is correct in production, where the process is about to exec the new checkout. Inside pytest the session continues with two copies of every `hermes_cli` / `gateway` / `tools` / `agent` module: test modules that imported names at collection time hold the old objects, later imports build new ones. A `ContextVar` created in one copy is invisible to the other. Concretely, `test_curses_arrow_keys` running after `test_cmd_update` lost its Left-arrow handler and `curses_radiolist` spun forever on `getch() == -1` while appending to the fake screen's write log; that spin grew one pytest process to 47 GB before the OOM killer took the machine down.

## Fix

All in `tests/hermes_cli/conftest.py`:

- `patch_gateway_discovery` fixture: mocks the three discovery functions **and** pins `hermes_cli.gateway` into `_STALE_PURGE_PROTECTED`, so the re-import after the purge resolves to the mocked module. It uses `monkeypatch` rather than `mock.patch` on purpose: tests that re-patch the same names in their own bodies then share one undo stack with the fixture, so the nesting composes. (A `mock.patch` version left a live `MagicMock` on `find_gateway_pids` for the rest of the session and broke `test_update_launchd_fleet_restart` depending on test order.)
- `_guard_live_gateway_discovery` (autouse): applies that fixture to every test module whose source calls `cmd_update(`. A source scan instead of a hand-written module list, so the next `test_update_*` module gets the seat belt without opting in. The modules that must not be patched (`test_update_launchd_*` exercise the real discovery, `test_update_stale_module_purge` asserts `hermes_cli.gateway` **is** evicted) fall out for free because they never call `cmd_update`.
- `_restore_purged_hermes_modules` (autouse): snapshots the Hermes modules before each test and restores any whose identity changed, through **both** names a submodule has (`sys.modules["pkg.mod"]` and the `pkg.mod` attribute on the parent). Restoring only the dict re-creates the same split identity one level up.
- `test_cmd_update.py` drops its local `_patch_gateway_discovery` fixture, which was both duplicated and incomplete for the reason above.
- `test_update_stale_module_purge.py` gains three tests pinning the restore contract (parent attribute rebound, untouched modules left alone, a parent that refuses `setattr` does not fail the run).

## Tests

Run on Linux, Python from the repo venv, `HERMES_HOME` pointed at a throwaway directory so the suite cannot see a real Hermes home. Baseline is `main` at `1802911`, the commit this branch forks from.

- Directly affected modules — `test_update_stale_module_purge.py`, `test_cmd_update.py`, `test_update_autostash.py`, `test_update_head_moved_gate.py`, `test_update_fleet_restart_pending.py`, `test_curses_arrow_keys.py`: **122 passed** in 72s.
- Full `tests/hermes_cli` on this branch: **104 failed, 8582 passed, 127 skipped in 14:59**, 1.4 GB peak RSS.
- Full `tests/hermes_cli` on `main`, same base, same environment: **does not finish.** The kernel OOM killer took it at ~17% of the session after 9m42s and a 28 GB peak. That is problem 2 above reproducing, so there is no whole-session `main` baseline to diff against — the run this PR is meant to make possible is exactly the run that cannot be produced without it.
- Instead, the 104 failing ids from the branch run were replayed as their own session, in identical order, on both branches. Both give **71 failed, 33 passed**, and the two failure sets are byte-identical (`md5 34b6f2c3…`). The 33 that pass in isolation are order-dependent in the full session and behave the same on both branches. So the fixtures in this PR add no failures of their own; the 104 are pre-existing, environment-dependent failures of this suite on this machine.
- Among them, `test_auth_commands.py::test_seed_from_singletons_respects_hermes_pkce_suppression` fails identically on `main` and is unrelated to this change.
