### PR TITLE
fix(agent): tick aux progress per Bedrock Converse event (#101088)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2718,7 +2718,7 @@ class _BedrockCompletionsAdapter:
                 "stream); caller downgrades to non-streaming.",
                 model,
             )
-        response = call_converse(
+        converse_args = dict(
             region=self._region,
             model=model,
             messages=messages,
@@ -2736,11 +2736,69 @@ class _BedrockCompletionsAdapter:
             top_p=kwargs.get("top_p"),
             stop_sequences=stop,
         )
+        if not kwargs.get("stream") and _aux_progress_active():
+            return self._create_streaming_with_progress(converse_args)
+        response = call_converse(**converse_args)
         # Converse is a complete-response API in this shim. Mark provider
         # progress only after the response returns so TTFP reflects real
         # Bedrock latency rather than dispatch/setup activity.
         _notify_aux_provider_response()
         return response
+
+    def _create_streaming_with_progress(self, converse_args: Dict[str, Any]) -> Any:
+        """Drive Bedrock Converse streaming so the aux forward-progress hook
+        ticks per event.
+
+        The non-streaming :func:`call_converse` only signals once, after the
+        response returns — a compression inactivity fence watching
+        ``_notify_aux_progress`` would see a flat signal for the whole call
+        and cancel a slow-but-alive summary at the idle window (#101088).
+        Streaming over ``converse_stream`` requires the
+        ``InvokeModelWithResponseStream`` IAM permission; when Bedrock
+        denies the stream, fall back to the non-streaming call (unticked,
+        exactly today's behavior) so a minimal ``InvokeModel``-only policy
+        keeps working.
+        """
+        from agent.bedrock_adapter import (
+            _get_bedrock_runtime_client,
+            build_converse_kwargs,
+            call_converse,
+            is_streaming_access_denied_error,
+            stream_converse_with_callbacks,
+        )
+
+        client = _get_bedrock_runtime_client(converse_args["region"])
+        kwargs = build_converse_kwargs(
+            model=converse_args["model"],
+            messages=converse_args["messages"],
+            tools=converse_args.get("tools"),
+            max_tokens=converse_args.get("max_tokens"),
+            temperature=converse_args.get("temperature"),
+            top_p=converse_args.get("top_p"),
+            stop_sequences=converse_args.get("stop_sequences"),
+        )
+        try:
+            resp = client.converse_stream(**kwargs)
+        except Exception as exc:
+            if is_streaming_access_denied_error(exc):
+                logger.info(
+                    "BedrockAuxiliaryClient: converse_stream denied by IAM on "
+                    "(region=%s, model=%s) — falling back to non-streaming "
+                    "converse (no progress ticks)",
+                    converse_args["region"], converse_args["model"],
+                )
+                response = call_converse(**converse_args)
+                _notify_aux_provider_response()
+                return response
+            raise
+        result = stream_converse_with_callbacks(
+            resp,
+            # Wire-level liveness: fires on every yielded event, so the
+            # compression fence sees the stream moving while tokens flow.
+            on_event=lambda: _notify_aux_progress(),
+        )
+        _notify_aux_provider_response()
+        return result
 
 
 class _BedrockChatShim:
@@ -9660,8 +9718,9 @@ def _aux_stream_total_ceiling(effective_timeout: Optional[float]) -> float:
 def _client_streams_internally(client: Any) -> bool:
     """Wire adapters that consume a stream inside .create() already tick the
     progress hook themselves (Codex per SSE event, Anthropic per stream
-    event); Bedrock's Converse shim cannot stream at all. None of them
-    accept chat-completions ``stream=True`` semantics from us."""
+    event, Bedrock per Converse stream event when the hook is active
+    — #101088). None of them accept chat-completions ``stream=True``
+    semantics from us."""
     return isinstance(client, (
         CodexAuxiliaryClient,
         AnthropicAuxiliaryClient,

--- a/tests/agent/test_aux_progress_streaming.py
+++ b/tests/agent/test_aux_progress_streaming.py
@@ -16,6 +16,7 @@ import pytest
 
 from agent.auxiliary_client import (
     _AnthropicCompletionsAdapter,
+    _BedrockCompletionsAdapter,
     _ChatStreamAccumulator,
     _CodexCompletionsAdapter,
     _acreate_with_stream,
@@ -677,3 +678,90 @@ class TestAsyncStreamAggregation:
         )
         assert calls[0]["stream"] is True
         assert result.choices[0].message.content == "ok"
+
+
+# ---------------------------------------------------------------------------
+# _BedrockCompletionsAdapter progress ticking (#101088)
+# ---------------------------------------------------------------------------
+
+_BEDROCK_STREAM_EVENTS = [
+    {"contentBlockDelta": {"contentBlockIndex": 0,
+                           "delta": {"text": "Hello "}}},
+    {"contentBlockDelta": {"contentBlockIndex": 0,
+                           "delta": {"text": "world"}}},
+    {"messageStop": {"stopReason": "end_turn"}},
+    {"metadata": {"usage": {"inputTokens": 5, "outputTokens": 2}}},
+]
+
+
+class TestBedrockAuxProgress:
+    """Aux Bedrock calls must tick the progress hook while tokens move, not
+    once after the whole response returns (#101088)."""
+
+    def _make_client(self, stream_events=None, stream_error=None):
+        from unittest.mock import MagicMock
+
+        client = MagicMock()
+        if stream_error is not None:
+            client.converse_stream.side_effect = stream_error
+        elif stream_events is not None:
+            client.converse_stream.return_value = {"stream": iter(stream_events)}
+        return client
+
+    def test_hook_active_streams_and_ticks_per_event(self):
+        ticks = []
+        client = self._make_client(stream_events=_BEDROCK_STREAM_EVENTS)
+        adapter = _BedrockCompletionsAdapter("us-east-1", "bedrock-model")
+        with patch(
+            "agent.bedrock_adapter._get_bedrock_runtime_client",
+            return_value=client,
+        ), aux_progress_hook(lambda: ticks.append(1)):
+            result = adapter.create(
+                messages=[{"role": "user", "content": "summarize"}],
+                max_tokens=500,
+            )
+        client.converse_stream.assert_called_once()
+        assert result.choices[0].message.content == "Hello world"
+        assert result.choices[0].finish_reason == "stop"
+        # one tick per streamed event + the terminal provider-response tick.
+        assert len(ticks) >= len(_BEDROCK_STREAM_EVENTS)
+
+    def test_no_hook_keeps_plain_converse(self):
+        response = SimpleNamespace(choices=[], usage=None)
+        client = self._make_client()
+        adapter = _BedrockCompletionsAdapter("us-east-1", "bedrock-model")
+        with patch(
+            "agent.bedrock_adapter._get_bedrock_runtime_client",
+            return_value=client,
+        ), patch(
+            "agent.bedrock_adapter.call_converse", return_value=response,
+        ) as call_converse:
+            result = adapter.create(
+                messages=[{"role": "user", "content": "summarize"}],
+            )
+        assert result is response
+        call_converse.assert_called_once()
+        client.converse_stream.assert_not_called()
+
+    def test_stream_denied_falls_back_to_plain_converse(self):
+        ticks = []
+        denied = Exception(
+            "User: arn:aws:iam::123456789012:user/x is not authorized to "
+            "perform: bedrock:InvokeModelWithResponseStream on resource: ..."
+        )
+        client = self._make_client(stream_error=denied)
+        response = SimpleNamespace(choices=[], usage=None)
+        adapter = _BedrockCompletionsAdapter("us-east-1", "bedrock-model")
+        with patch(
+            "agent.bedrock_adapter._get_bedrock_runtime_client",
+            return_value=client,
+        ), patch(
+            "agent.bedrock_adapter.call_converse", return_value=response,
+        ) as call_converse, aux_progress_hook(lambda: ticks.append(1)):
+            result = adapter.create(
+                messages=[{"role": "user", "content": "summarize"}],
+            )
+        assert result is response
+        call_converse.assert_called_once()
+        # IAM-scoped fallback ticks once (response arrived), never streams.
+        assert ticks == [1]


### PR DESCRIPTION
## What does this PR do?

Fixes #101088: Bedrock auxiliary calls never ticked the aux forward-progress hook, so a `CompressionCommitFence` watching `seconds_since_progress()` saw a flat signal and cancelled every Bedrock compression at the idle window — after the auxiliary tokens had already been billed (measured: 124s survived unticked vs 900s when ticked on the same session/`/compress`).

Root cause: `_BedrockCompletionsAdapter.create()` only ever called the non-streaming `call_converse()`, while `_client_streams_internally()` listed `BedrockAuxiliaryClient` among adapters that "already tick the progress hook themselves". Codex and Anthropic really do tick per event; Bedrock satisfied neither half of the contract — the hook fired once at dispatch and never again.

## Related Issue

Fixes #101088

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py`
  - `_BedrockCompletionsAdapter.create()`: when the aux progress hook is active (and the caller did not explicitly request a downgraded stream), route through a new streaming path instead of the one-shot non-streaming call.
  - New `_create_streaming_with_progress()`: drives `converse_stream` through the existing `stream_converse_with_callbacks()` and ticks `_notify_aux_progress()` on every yielded event (its documented wire-level liveness signal). When Bedrock denies the stream (IAM grants `InvokeModel` but not `InvokeModelWithResponseStream`), falls back to the plain non-streaming `call_converse()` — unticked, exactly today's behavior — so a minimal IAM policy keeps working.
  - No hook installed keeps the existing single non-streaming call path.
  - `_client_streams_internally()` docstring updated (Bedrock now genuinely ticks internally when the hook is active).
- `tests/agent/test_aux_progress_streaming.py`: new `TestBedrockAuxProgress` — hook active → streams and ticks ≥ once per event with the response assembled; no hook → plain `call_converse` (no `converse_stream`); IAM stream denial → non-streaming fallback with the terminal tick only.

## How to Test

1. Reproduce the issue's scenario: a Bedrock profile, `/compress` on a session long enough that the summary takes > the idle window.
2. Before: compression dies at the idle window with `failure_class: commit_fence_cancelled` (flat progress). After: the fence observes continuous progress (`last progress 0.0–4.5s ago`) and the compression survives to its configured ceiling.

Automated: `scripts/run_tests.sh tests/agent/test_aux_progress_streaming.py tests/agent/test_auxiliary_client.py tests/agent/test_bedrock_adapter.py -q` — 317 passed (5 skipped).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring in `_client_streams_internally`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- N/A — wire behavior with automated coverage. -->
