### PR TITLE
fix(dashboard): live-view gateway sessions without spawning a second TUI

### DIFF
--- a/web/src/components/ChatSessionList.tsx
+++ b/web/src/components/ChatSessionList.tsx
@@ -19,6 +19,14 @@
  */
 
 import { Button } from "@nous-research/ui/ui/components/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@nous-research/ui/ui/components/dialog";
 import { ListItem } from "@nous-research/ui/ui/components/list-item";
 import { Spinner } from "@nous-research/ui/ui/components/spinner";
 import { AlertCircle, MessageSquarePlus, RefreshCw } from "lucide-react";
@@ -27,6 +35,7 @@ import { useSearchParams } from "react-router";
 
 import { useI18n } from "@/i18n";
 import { api, type SessionInfo } from "@/lib/api";
+import { shouldConfirmResumeOwnership } from "@/lib/session-ownership";
 import { cn, timeAgo } from "@/lib/utils";
 
 const SESSION_LIMIT = 30;
@@ -69,6 +78,9 @@ export function ChatSessionList({
   const [error, setError] = useState<string | null>(null);
   // Bumped to force a refetch (after switching, on Refresh, on mount).
   const [reloadNonce, setReloadNonce] = useState(0);
+  const [handoffSession, setHandoffSession] = useState<SessionInfo | null>(
+    null,
+  );
 
   // `profile` is read inside the fetch; it's part of the scope key so a
   // profile switch refetches. The empty-string fallback keeps the dep
@@ -110,22 +122,50 @@ export function ChatSessionList({
 
   const reload = useCallback(() => setReloadNonce((n) => n + 1), []);
 
-  // Picking a row sets `/chat?resume=<id>`. Re-picking the row already in
-  // the terminal is a no-op (avoids a needless PTY teardown).
-  const pick = useCallback(
+  const navigateResume = useCallback(
     (id: string) => {
-      onPicked?.();
-      if (id === activeSessionId) return;
       setSearchParams(
         (prev) => {
           const next = new URLSearchParams(prev);
+          next.delete("live");
           next.set("resume", id);
           return next;
         },
         { replace: false },
       );
     },
-    [activeSessionId, onPicked, setSearchParams],
+    [setSearchParams],
+  );
+
+  const navigateLive = useCallback(
+    (id: string) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.delete("resume");
+          next.set("live", id);
+          return next;
+        },
+        { replace: false },
+      );
+    },
+    [setSearchParams],
+  );
+
+  // Picking a row resumes that conversation in the TUI — unless the session
+  // still looks gateway-owned, in which case we require an explicit handoff
+  // (same contract as SessionsPage Resume) and offer Live view instead.
+  const pick = useCallback(
+    (session: SessionInfo) => {
+      onPicked?.();
+      if (session.id === activeSessionId) return;
+      if (shouldConfirmResumeOwnership(session)) {
+        setHandoffSession(session);
+        return;
+      }
+      navigateResume(session.id);
+    },
+    [activeSessionId, navigateResume, onPicked],
   );
 
   // "New chat" prefers ChatPage's robust handler (clears resume + forces a
@@ -143,6 +183,7 @@ export function ChatSessionList({
       (prev) => {
         const next = new URLSearchParams(prev);
         next.delete("resume");
+        next.delete("live");
         return next;
       },
       { replace: false },
@@ -184,7 +225,7 @@ export function ChatSessionList({
           return (
             <ListItem
               key={s.id}
-              onClick={() => pick(s.id)}
+              onClick={() => pick(s)}
               aria-current={isActive ? "true" : undefined}
               className={cn(
                 "flex-col items-start gap-0.5 rounded px-2 py-1.5",
@@ -255,6 +296,50 @@ export function ChatSessionList({
       <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden px-1 pb-1">
         {content}
       </div>
+
+      <Dialog
+        open={handoffSession !== null}
+        onOpenChange={(open) => {
+          if (!open) setHandoffSession(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {t.sessions.resumeOwnershipTitle ??
+                "Take ownership of this session?"}
+            </DialogTitle>
+            <DialogDescription>
+              {t.sessions.resumeOwnershipDescription ??
+                "This session still looks active on a messaging gateway. Resume starts a separate writable TUI and can create a second writer. Prefer Live view to watch without taking ownership."}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="gap-2">
+            <Button
+              outlined
+              onClick={() => {
+                const id = handoffSession?.id;
+                setHandoffSession(null);
+                if (id) navigateLive(id);
+              }}
+            >
+              {t.sessions.liveView ?? "Live view"}
+            </Button>
+            <Button outlined onClick={() => setHandoffSession(null)}>
+              {t.common.cancel}
+            </Button>
+            <Button
+              onClick={() => {
+                const id = handoffSession?.id;
+                setHandoffSession(null);
+                if (id) navigateResume(id);
+              }}
+            >
+              {t.sessions.resumeInChat}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </aside>
   );
 }

--- a/web/src/components/LiveSessionView.tsx
+++ b/web/src/components/LiveSessionView.tsx
@@ -1,0 +1,205 @@
+/**
+ * Read-only Live view for a gateway-owned (or any) session.
+ *
+ * Unlike `/chat?resume=<id>`, this path never opens a PTY / ui-tui runtime.
+ * It polls persisted messages (and follows valid compression continuations)
+ * so the dashboard can observe externally written turns without becoming a
+ * second writer.
+ */
+
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Typography } from "@nous-research/ui/ui/components/typography/index";
+import { Eye, Play, RefreshCw } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router";
+
+import { usePageHeader } from "@/contexts/usePageHeader";
+import { useProfileScope } from "@/contexts/useProfileScope";
+import { useI18n } from "@/i18n";
+import { api, type SessionMessage } from "@/lib/api";
+import { normalizeSessionTitle } from "@/lib/chat-title";
+import { cn } from "@/lib/utils";
+
+const LIVE_POLL_MS = 2500;
+
+interface LiveSessionViewProps {
+  sessionId: string;
+  isActive: boolean;
+}
+
+export function LiveSessionView({ sessionId, isActive }: LiveSessionViewProps) {
+  const { t } = useI18n();
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { setTitle } = usePageHeader();
+  const { profile: scopedProfile } = useProfileScope();
+
+  const [messages, setMessages] = useState<SessionMessage[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [title, setLocalTitle] = useState<string | null>(null);
+  const [revision, setRevision] = useState<{
+    messageCount: number | null;
+    lastActive: number | null;
+  }>({ messageCount: null, lastActive: null });
+  const bottomRef = useRef<HTMLDivElement | null>(null);
+  const targetIdRef = useRef(sessionId);
+
+  useEffect(() => {
+    targetIdRef.current = sessionId;
+  }, [sessionId]);
+
+  const liveViewLabel = t.sessions.liveView ?? "Live view";
+  const readOnlyHint =
+    t.sessions.liveViewReadOnlyHint ??
+    "Read-only. New turns from the gateway appear here without starting a TUI.";
+  const resumeLabel = t.sessions.resumeInChat ?? "Resume in Chat";
+
+  const load = useCallback(
+    async (silent = false) => {
+      const id = targetIdRef.current;
+      if (!silent) setLoading(true);
+      try {
+        // Follow compression continuations only — latest-descendant is already
+        // constrained server-side to valid continuations (#98690 family).
+        const descendant = await api.getSessionLatestDescendant(
+          id,
+          scopedProfile,
+        );
+        if (
+          descendant.session_id &&
+          descendant.session_id !== id &&
+          descendant.changed
+        ) {
+          const next = new URLSearchParams(searchParams);
+          next.set("live", descendant.session_id);
+          setSearchParams(next, { replace: true });
+          targetIdRef.current = descendant.session_id;
+        }
+        const liveId = targetIdRef.current;
+        const [detail, msgs] = await Promise.all([
+          api.getSessionDetail(liveId, scopedProfile),
+          api.getSessionMessages(liveId, scopedProfile),
+        ]);
+        setLocalTitle(normalizeSessionTitle(detail.title));
+        setRevision({
+          messageCount: detail.message_count ?? null,
+          lastActive: detail.last_active ?? null,
+        });
+        setMessages(msgs.messages);
+        setError(null);
+      } catch (err) {
+        setError(String(err));
+      } finally {
+        if (!silent) setLoading(false);
+      }
+    },
+    [scopedProfile, searchParams, setSearchParams],
+  );
+
+  useEffect(() => {
+    void load(false);
+  }, [sessionId, load]);
+
+  useEffect(() => {
+    if (!isActive) return;
+    const timer = setInterval(() => {
+      void load(true);
+    }, LIVE_POLL_MS);
+    return () => clearInterval(timer);
+  }, [isActive, load]);
+
+  useEffect(() => {
+    if (!isActive) {
+      setTitle(null);
+      return;
+    }
+    setTitle(title ? `${liveViewLabel}: ${title}` : liveViewLabel);
+    return () => setTitle(null);
+  }, [isActive, title, liveViewLabel, setTitle]);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+  }, [messages.length]);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-background">
+      <div className="flex flex-wrap items-center gap-2 border-b border-border px-3 py-2">
+        <Eye className="h-4 w-4 text-muted-foreground" aria-hidden />
+        <Typography variant="small" className="text-muted-foreground">
+          {readOnlyHint}
+        </Typography>
+        <div className="ml-auto flex items-center gap-2">
+          <Button
+            ghost
+            size="sm"
+            onClick={() => void load(false)}
+            aria-label="Refresh live view"
+            title="Refresh"
+          >
+            <RefreshCw className="h-4 w-4" />
+          </Button>
+          <Button
+            outlined
+            size="sm"
+            onClick={() =>
+              navigate(`/chat?resume=${encodeURIComponent(sessionId)}`)
+            }
+            aria-label={resumeLabel}
+            title={
+              t.sessions.resumeWritableHint ??
+              "Starts a writable TUI runtime for this session"
+            }
+          >
+            <Play className="mr-1 h-4 w-4" />
+            {resumeLabel}
+          </Button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="border-b border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
+        {loading && messages.length === 0 ? (
+          <Typography variant="small" className="text-muted-foreground">
+            Loading…
+          </Typography>
+        ) : messages.length === 0 ? (
+          <Typography variant="small" className="text-muted-foreground">
+            No messages yet.
+          </Typography>
+        ) : (
+          <ul className="flex flex-col gap-3">
+            {messages.map((m, idx) => (
+              <li
+                key={`${m.timestamp ?? idx}-${m.role}-${idx}`}
+                className={cn(
+                  "rounded border border-border px-3 py-2 text-sm whitespace-pre-wrap break-words",
+                  m.role === "user" && "bg-primary/5",
+                  m.role === "assistant" && "bg-background-base/40",
+                  m.role === "tool" && "bg-muted/30 font-mono text-xs",
+                  m.role === "system" && "text-muted-foreground",
+                )}
+              >
+                <div className="mb-1 text-[11px] uppercase tracking-wide text-muted-foreground">
+                  {m.role}
+                  {revision.messageCount != null && idx === messages.length - 1
+                    ? ` · ${revision.messageCount} msgs`
+                    : null}
+                </div>
+                {m.content || ""}
+              </li>
+            ))}
+            <div ref={bottomRef} />
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default LiveSessionView;

--- a/web/src/components/LiveSessionView.tsx
+++ b/web/src/components/LiveSessionView.tsx
@@ -126,7 +126,7 @@ export function LiveSessionView({ sessionId, isActive }: LiveSessionViewProps) {
     <div className="flex h-full min-h-0 flex-col bg-background">
       <div className="flex flex-wrap items-center gap-2 border-b border-border px-3 py-2">
         <Eye className="h-4 w-4 text-muted-foreground" aria-hidden />
-        <Typography variant="small" className="text-muted-foreground">
+        <Typography variant="sm" className="text-muted-foreground">
           {readOnlyHint}
         </Typography>
         <div className="ml-auto flex items-center gap-2">
@@ -165,11 +165,11 @@ export function LiveSessionView({ sessionId, isActive }: LiveSessionViewProps) {
 
       <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
         {loading && messages.length === 0 ? (
-          <Typography variant="small" className="text-muted-foreground">
+          <Typography variant="sm" className="text-muted-foreground">
             Loading…
           </Typography>
         ) : messages.length === 0 ? (
-          <Typography variant="small" className="text-muted-foreground">
+          <Typography variant="sm" className="text-muted-foreground">
             No messages yet.
           </Typography>
         ) : (

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -189,6 +189,14 @@ export const en: Translations = {
     selectedSessionsDeleted: "{count} sessions deleted",
     failedToDeleteSelected: "Failed to delete selected sessions",
     resumeInChat: "Resume in Chat",
+    liveView: "Live view",
+    liveViewReadOnlyHint:
+      "Read-only view of persisted turns — does not start a TUI",
+    resumeWritableHint:
+      "Starts a writable TUI runtime — not a live gateway viewer",
+    resumeOwnershipTitle: "Take ownership of this session?",
+    resumeOwnershipDescription:
+      "This session still looks active on a messaging gateway. Resume starts a separate writable TUI and can create a second writer. Prefer Live view to watch without taking ownership.",
     newChat: "New chat",
     previousPage: "Previous page",
     nextPage: "Next page",

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -202,6 +202,12 @@ export interface Translations {
     selectedSessionsDeleted: string;
     failedToDeleteSelected: string;
     resumeInChat: string;
+    /** Optional — fall back to English until translated. */
+    liveView?: string;
+    liveViewReadOnlyHint?: string;
+    resumeWritableHint?: string;
+    resumeOwnershipTitle?: string;
+    resumeOwnershipDescription?: string;
     newChat: string;
     previousPage: string;
     nextPage: string;

--- a/web/src/lib/session-ownership.test.ts
+++ b/web/src/lib/session-ownership.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  isGatewayOwnedSession,
+  shouldConfirmResumeOwnership,
+  sessionSourceFamily,
+} from "./session-ownership";
+
+describe("session-ownership", () => {
+  it("detects gateway-owned active messaging sessions", () => {
+    expect(
+      isGatewayOwnedSession({ is_active: true, source: "discord" }),
+    ).toBe(true);
+    expect(
+      isGatewayOwnedSession({ is_active: true, source: "api_server" }),
+    ).toBe(true);
+    expect(
+      isGatewayOwnedSession({ is_active: true, source: "cli" }),
+    ).toBe(false);
+    expect(
+      isGatewayOwnedSession({ is_active: false, source: "discord" }),
+    ).toBe(false);
+  });
+
+  it("requires an explicit Resume handoff only for gateway-owned sessions", () => {
+    expect(
+      shouldConfirmResumeOwnership({ is_active: true, source: "feishu" }),
+    ).toBe(true);
+    expect(
+      shouldConfirmResumeOwnership({ is_active: true, source: "desktop" }),
+    ).toBe(false);
+  });
+
+  it("parses source families", () => {
+    expect(sessionSourceFamily("discord:guild")).toBe("discord");
+  });
+});

--- a/web/src/lib/session-ownership.ts
+++ b/web/src/lib/session-ownership.ts
@@ -1,0 +1,50 @@
+/**
+ * Decide whether Resuming a session needs an explicit ownership handoff.
+ *
+ * Live view is always read-only. Resume starts a writable TUI. When the
+ * session still looks gateway-owned (active messaging source), require the
+ * user to confirm they are taking over as a second writer.
+ */
+
+const GATEWAY_SESSION_SOURCES = new Set([
+  "discord",
+  "telegram",
+  "slack",
+  "feishu",
+  "whatsapp",
+  "signal",
+  "matrix",
+  "mattermost",
+  "email",
+  "sms",
+  "api_server",
+  "webhook",
+  "qqbot",
+  "dingtalk",
+  "wecom",
+  "weixin",
+  "yuanbao",
+  "bluebubbles",
+  "homeassistant",
+]);
+
+export function sessionSourceFamily(source: string | null | undefined): string {
+  if (!source) return "";
+  return source.split(":")[0].trim().toLowerCase();
+}
+
+export function isGatewayOwnedSession(session: {
+  is_active?: boolean | null;
+  source?: string | null;
+}): boolean {
+  if (!session.is_active) return false;
+  const family = sessionSourceFamily(session.source);
+  return GATEWAY_SESSION_SOURCES.has(family);
+}
+
+export function shouldConfirmResumeOwnership(session: {
+  is_active?: boolean | null;
+  source?: string | null;
+}): boolean {
+  return isGatewayOwnedSession(session);
+}

--- a/web/src/lib/session-refresh.test.ts
+++ b/web/src/lib/session-refresh.test.ts
@@ -1,9 +1,20 @@
 import { describe, it, expect } from "vitest";
-import { shouldRefreshSessions } from "./session-refresh";
+import {
+  shouldRefreshExpandedTranscript,
+  shouldRefreshSessions,
+  sessionListRevisionKey,
+} from "./session-refresh";
 
 describe("shouldRefreshSessions", () => {
   it("returns false on the first poll (no baseline yet)", () => {
     expect(shouldRefreshSessions(null, "s2")).toBe(false);
+    expect(
+      shouldRefreshSessions(null, {
+        newestId: "s2",
+        messageCount: 3,
+        lastActive: 10,
+      }),
+    ).toBe(false);
   });
 
   it("returns false when the current response has no sessions", () => {
@@ -11,11 +22,69 @@ describe("shouldRefreshSessions", () => {
     expect(shouldRefreshSessions(null, null)).toBe(false);
   });
 
-  it("returns false when the newest session id is unchanged", () => {
+  it("returns false when the newest session id is unchanged (legacy id-only)", () => {
     expect(shouldRefreshSessions("s1", "s1")).toBe(false);
   });
 
   it("returns true when a new session appears at the head of the list", () => {
     expect(shouldRefreshSessions("s1", "s2")).toBe(true);
+    expect(
+      shouldRefreshSessions(
+        { newestId: "s1", messageCount: 2, lastActive: 1 },
+        { newestId: "s2", messageCount: 1, lastActive: 2 },
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true when the same newest id gains messages or activity", () => {
+    expect(
+      shouldRefreshSessions(
+        { newestId: "s1", messageCount: 2, lastActive: 100 },
+        { newestId: "s1", messageCount: 4, lastActive: 100 },
+      ),
+    ).toBe(true);
+    expect(
+      shouldRefreshSessions(
+        { newestId: "s1", messageCount: 2, lastActive: 100 },
+        { newestId: "s1", messageCount: 2, lastActive: 200 },
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false when the richer revision is unchanged", () => {
+    expect(
+      shouldRefreshSessions(
+        { newestId: "s1", messageCount: 2, lastActive: 100 },
+        { newestId: "s1", messageCount: 2, lastActive: 100 },
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("sessionListRevisionKey", () => {
+  it("encodes id plus optional count/activity", () => {
+    expect(sessionListRevisionKey("abc")).toBe("abc");
+    expect(
+      sessionListRevisionKey({
+        newestId: "abc",
+        messageCount: 4,
+        lastActive: 9,
+      }),
+    ).toBe("abc\u00004\u00009");
+  });
+});
+
+describe("shouldRefreshExpandedTranscript", () => {
+  it("returns false until a baseline exists", () => {
+    expect(shouldRefreshExpandedTranscript(null, null, 2, 10)).toBe(false);
+  });
+
+  it("returns true when message_count or last_active advances", () => {
+    expect(shouldRefreshExpandedTranscript(2, 10, 4, 10)).toBe(true);
+    expect(shouldRefreshExpandedTranscript(2, 10, 2, 20)).toBe(true);
+  });
+
+  it("returns false when the revision is unchanged", () => {
+    expect(shouldRefreshExpandedTranscript(2, 10, 2, 10)).toBe(false);
   });
 });

--- a/web/src/lib/session-refresh.ts
+++ b/web/src/lib/session-refresh.ts
@@ -2,25 +2,83 @@
  * Decide whether the paginated sessions list should be silently
  * re-fetched after an overview poll.
  *
- * The dashboard's FastAPI server and a terminal CLI are separate
- * processes that share the same SQLite session DB. There is no
- * inter-process push channel, so the Sessions page polls the 50 newest
- * sessions every few seconds (the "overview" poll). When that poll
- * surfaces a session id at the head of the list that we have not seen
- * before, a new session was created in another process and the
- * paginated list is stale — refresh it.
+ * The dashboard's FastAPI server and messaging gateways (Discord, Feishu,
+ * Telegram, api_server, …) are separate processes that share the same
+ * SQLite session DB. There is no inter-process push channel, so the
+ * Sessions page polls the 50 newest sessions every few seconds (the
+ * "overview" poll).
  *
- * Returns false on the very first poll (no baseline yet) and when
- * either id is null (empty DB / transient empty response), so we never
- * trigger a spurious reload on mount or while the DB is empty.
+ * A refresh is needed when:
+ * - a different session appears at the head of the list (new session), or
+ * - the head session's ``message_count`` / ``last_active`` advances while
+ *   the newest id is unchanged (external append to the same conversation).
+ *
+ * Returns false on the very first poll (no baseline yet) and when either
+ * side lacks a newest id (empty DB / transient empty response), so we
+ * never trigger a spurious reload on mount or while the DB is empty.
  */
+
+export interface SessionListRevision {
+  newestId: string;
+  messageCount?: number | null;
+  lastActive?: number | null;
+}
+
+/** Accept legacy id-only strings or a richer head-session revision. */
+export type SessionRefreshSignal = string | SessionListRevision | null;
+
+export function sessionListRevisionKey(
+  signal: SessionRefreshSignal,
+): string | null {
+  if (signal == null) return null;
+  if (typeof signal === "string") return signal;
+  if (!signal.newestId) return null;
+  const count =
+    signal.messageCount === undefined || signal.messageCount === null
+      ? ""
+      : String(signal.messageCount);
+  const active =
+    signal.lastActive === undefined || signal.lastActive === null
+      ? ""
+      : String(signal.lastActive);
+  return `${signal.newestId}\0${count}\0${active}`;
+}
+
 export function shouldRefreshSessions(
-  prevNewestId: string | null,
-  currentNewestId: string | null,
+  prev: SessionRefreshSignal,
+  current: SessionRefreshSignal,
 ): boolean {
+  const prevKey = sessionListRevisionKey(prev);
+  const currentKey = sessionListRevisionKey(current);
   return (
-    prevNewestId !== null &&
-    currentNewestId !== null &&
-    prevNewestId !== currentNewestId
+    prevKey !== null && currentKey !== null && prevKey !== currentKey
   );
+}
+
+/**
+ * Whether an expanded Sessions-row transcript should be re-fetched after
+ * the parent list/overview updates the same session's revision.
+ */
+export function shouldRefreshExpandedTranscript(
+  prevMessageCount: number | null | undefined,
+  prevLastActive: number | null | undefined,
+  nextMessageCount: number | null | undefined,
+  nextLastActive: number | null | undefined,
+): boolean {
+  if (prevMessageCount == null && prevLastActive == null) return false;
+  if (
+    nextMessageCount != null &&
+    prevMessageCount != null &&
+    nextMessageCount !== prevMessageCount
+  ) {
+    return true;
+  }
+  if (
+    nextLastActive != null &&
+    prevLastActive != null &&
+    nextLastActive !== prevLastActive
+  ) {
+    return true;
+  }
+  return false;
 }

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -32,6 +32,7 @@ import { useSearchParams } from "react-router";
 
 import { ChatSidebar } from "@/components/ChatSidebar";
 import { ChatSessionList } from "@/components/ChatSessionList";
+import { LiveSessionView } from "@/components/LiveSessionView";
 import { usePageHeader } from "@/contexts/usePageHeader";
 import { useI18n } from "@/i18n";
 import { api } from "@/lib/api";
@@ -175,6 +176,17 @@ function terminalLineHeightForWidth(layoutWidthPx: number): number {
 }
 
 export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
+  // Live view is a read-only subscription to persisted turns. It must not
+  // fall through into the embedded TUI / PTY path (that is Resume).
+  const [liveSearchParams] = useSearchParams();
+  const liveSessionId = (liveSearchParams.get("live") || "").trim();
+  if (liveSessionId) {
+    return <LiveSessionView sessionId={liveSessionId} isActive={isActive} />;
+  }
+  return <EmbeddedTuiChatPage isActive={isActive} />;
+}
+
+function EmbeddedTuiChatPage({ isActive = true }: { isActive?: boolean }) {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const termWrapRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<Terminal | null>(null);
@@ -284,6 +296,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     const next = new URLSearchParams(searchParams);
 
     next.delete("resume");
+    next.delete("live");
     forceFreshPtyRef.current = true;
     reconnectAttemptRef.current = 0;
     clearReconnectTimer();

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -25,6 +25,7 @@ import {
   Hash,
   X,
   Play,
+  Eye,
   Eraser,
   Download,
   Upload,
@@ -34,7 +35,12 @@ import {
 } from "lucide-react";
 import { api } from "@/lib/api";
 import { formatSessionPruneResult } from "@/lib/session-prune";
-import { shouldRefreshSessions } from "@/lib/session-refresh";
+import {
+  shouldRefreshExpandedTranscript,
+  shouldRefreshSessions,
+  type SessionListRevision,
+} from "@/lib/session-refresh";
+import { shouldConfirmResumeOwnership } from "@/lib/session-ownership";
 import {
   importSummary,
   parseImportSessions,
@@ -480,24 +486,104 @@ function SessionRow({
   const [renaming, setRenaming] = useState(false);
   const [renameValue, setRenameValue] = useState(session.title ?? "");
   const [renameSaving, setRenameSaving] = useState(false);
+  const [transcriptTargetId, setTranscriptTargetId] = useState(session.id);
+  const [resumeHandoffOpen, setResumeHandoffOpen] = useState(false);
+  const loadedRevisionRef = useRef<{
+    messageCount: number;
+    lastActive: number;
+  } | null>(null);
   const { t } = useI18n();
   const navigate = useNavigate();
+  const liveViewLabel = t.sessions.liveView ?? "Live view";
+  const resumeWritableHint =
+    t.sessions.resumeWritableHint ??
+    "Starts a writable TUI runtime — not a live gateway viewer";
+  const resumeHandoffTitle =
+    t.sessions.resumeOwnershipTitle ?? "Take ownership of this session?";
+  const resumeHandoffDescription =
+    t.sessions.resumeOwnershipDescription ??
+    "This session still looks active on a messaging gateway. Resume starts a separate writable TUI and can create a second writer. Prefer Live view to watch without taking ownership.";
+
+  const goResume = () => {
+    navigate(
+      `/chat?resume=${encodeURIComponent(transcriptTargetId || session.id)}`,
+    );
+  };
+
+  const requestResume = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (shouldConfirmResumeOwnership(session)) {
+      setResumeHandoffOpen(true);
+      return;
+    }
+    goResume();
+  };
 
   useEffect(() => {
-    if (!isExpanded || messages !== null) return;
+    setTranscriptTargetId(session.id);
+    setMessages(null);
+    loadedRevisionRef.current = null;
+  }, [session.id]);
+
+  useEffect(() => {
+    if (!isExpanded) return;
+    const prev = loadedRevisionRef.current;
+    const needsFetch =
+      messages === null ||
+      (prev != null &&
+        shouldRefreshExpandedTranscript(
+          prev.messageCount,
+          prev.lastActive,
+          session.message_count,
+          session.last_active,
+        ));
+    if (!needsFetch) return;
+
     let cancelled = false;
+    const loadId = session.id;
     api
-      .getSessionMessages(session.id)
+      .getSessionLatestDescendant(loadId)
+      .then((descendant) => {
+        if (cancelled) return null;
+        const target =
+          descendant.session_id && descendant.changed
+            ? descendant.session_id
+            : loadId;
+        if (target !== loadId) {
+          setTranscriptTargetId(target);
+        }
+        return api.getSessionMessages(target);
+      })
       .then((resp) => {
-        if (!cancelled) setMessages(resp.messages);
+        if (cancelled || !resp) return;
+        setMessages(resp.messages);
+        loadedRevisionRef.current = {
+          messageCount: session.message_count,
+          lastActive: session.last_active,
+        };
+        setError(null);
       })
       .catch((err) => {
-        if (!cancelled) setError(String(err));
+        if (!cancelled) {
+          setError(String(err));
+          // Avoid a null→retry storm when the messages endpoint fails.
+          setMessages([]);
+          loadedRevisionRef.current = {
+            messageCount: session.message_count,
+            lastActive: session.last_active,
+          };
+        }
       });
     return () => {
       cancelled = true;
     };
-  }, [isExpanded, session.id, messages]);
+  }, [
+    isExpanded,
+    session.id,
+    session.message_count,
+    session.last_active,
+    messages,
+  ]);
 
   const sourceKey = session.source?.split(":")[0];
   const sourceInfo = (session.source
@@ -529,19 +615,36 @@ function SessionRow({
       </Badge>
 
       {resumeInChatEnabled && (
-        <Button
-          ghost
-          size="icon"
-          className="text-muted-foreground hover:text-success"
-          aria-label={t.sessions.resumeInChat}
-          title={t.sessions.resumeInChat}
-          onClick={(e) => {
-            e.stopPropagation();
-            navigate(`/chat?resume=${encodeURIComponent(session.id)}`);
-          }}
-        >
-          <Play />
-        </Button>
+        <>
+          <Button
+            ghost
+            size="icon"
+            className="text-muted-foreground hover:text-foreground"
+            aria-label={liveViewLabel}
+            title={
+              t.sessions.liveViewReadOnlyHint ??
+              "Read-only live view of persisted turns (no TUI)"
+            }
+            onClick={(e) => {
+              e.stopPropagation();
+              navigate(
+                `/chat?live=${encodeURIComponent(transcriptTargetId || session.id)}`,
+              );
+            }}
+          >
+            <Eye />
+          </Button>
+          <Button
+            ghost
+            size="icon"
+            className="text-muted-foreground hover:text-success"
+            aria-label={t.sessions.resumeInChat}
+            title={`${t.sessions.resumeInChat} — ${resumeWritableHint}`}
+            onClick={requestResume}
+          >
+            <Play />
+          </Button>
+        </>
       )}
 
       <Button
@@ -756,6 +859,52 @@ function SessionRow({
           )}
         </div>
       )}
+
+      <Dialog
+        open={resumeHandoffOpen}
+        onOpenChange={(open) => {
+          if (!open) setResumeHandoffOpen(false);
+        }}
+      >
+        <DialogContent onClick={(e) => e.stopPropagation()}>
+          <DialogHeader>
+            <DialogTitle>{resumeHandoffTitle}</DialogTitle>
+            <DialogDescription>{resumeHandoffDescription}</DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="gap-2">
+            <Button
+              outlined
+              onClick={(e) => {
+                e.stopPropagation();
+                setResumeHandoffOpen(false);
+                navigate(
+                  `/chat?live=${encodeURIComponent(transcriptTargetId || session.id)}`,
+                );
+              }}
+            >
+              {liveViewLabel}
+            </Button>
+            <Button
+              outlined
+              onClick={(e) => {
+                e.stopPropagation();
+                setResumeHandoffOpen(false);
+              }}
+            >
+              {t.common.cancel}
+            </Button>
+            <Button
+              onClick={(e) => {
+                e.stopPropagation();
+                setResumeHandoffOpen(false);
+                goResume();
+              }}
+            >
+              {t.sessions.resumeInChat}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }
@@ -1049,7 +1198,7 @@ export default function SessionsPage() {
     if (!silent) sessionsRequestRef.current = requestId;
     if (!silent) setLoading(true);
     api
-      .getSessions(PAGE_SIZE, p * PAGE_SIZE, sessionQueryOptions)
+      .getSessions(PAGE_SIZE, p * PAGE_SIZE, sessionQueryOptions, "recent")
       .then((resp) => {
         if (requestId !== sessionsRequestRef.current) return;
         setSessions(resp.sessions);
@@ -1104,12 +1253,12 @@ export default function SessionsPage() {
     loadStats();
   }, [loadStats]);
 
-  // Refs for the overview poll's new-session detection. The poll effect
-  // below is mounted once with stable deps, so it reads the current page
-  // and the last-seen newest session id through refs instead of capturing
-  // stale values. ``newestSeenRef`` starts null so the first poll sets a
-  // baseline without triggering a redundant reload (mount already loads).
-  const newestSeenRef = useRef<string | null>(null);
+  // Refs for the overview poll's change detection. The poll effect below is
+  // mounted once with stable deps, so it reads the current page and the
+  // last-seen head revision through refs instead of capturing stale values.
+  // ``newestSeenRef`` starts null so the first poll sets a baseline without
+  // triggering a redundant reload (mount already loads).
+  const newestSeenRef = useRef<SessionListRevision | null>(null);
   const pageRef = useRef(page);
 
   useEffect(() => {
@@ -1138,22 +1287,27 @@ export default function SessionsPage() {
         })
         .catch(() => {});
       api
-        .getSessions(50, 0, sessionQueryOptions)
+        .getSessions(50, 0, sessionQueryOptions, "recent")
         .then((r) => {
           if (cancelled) return;
           setOverviewSessions(r.sessions);
-          // The dashboard server and a terminal CLI are separate
+          // The dashboard server and messaging gateways are separate
           // processes sharing one session DB — there is no push channel,
-          // so we detect sessions created in another process here. The
-          // overview poll already fetches the 50 newest sessions, so we
-          // reuse its head id as a cheap change signal: when it changes,
-          // silently refresh the paginated list so the new session shows
-          // up in real time without a visible loading flicker.
-          const newest = r.sessions[0]?.id ?? null;
-          if (shouldRefreshSessions(newestSeenRef.current, newest)) {
+          // so we detect externally written turns here. Refresh when the
+          // head session id changes OR when the same head session's
+          // message_count / last_active advances.
+          const head = r.sessions[0];
+          const current: SessionListRevision | null = head
+            ? {
+                newestId: head.id,
+                messageCount: head.message_count,
+                lastActive: head.last_active,
+              }
+            : null;
+          if (shouldRefreshSessions(newestSeenRef.current, current)) {
             loadSessions(pageRef.current, true);
           }
-          newestSeenRef.current = newest;
+          newestSeenRef.current = current;
         })
         .catch(() => {});
     };


### PR DESCRIPTION
## What does this PR do?

Dashboard `/chat?resume=` was acting like a live view of an active messaging session, but it actually spawned an independent `ui-tui` PTY (`HERMES_TUI_RESUME`). That PTY stayed on a historical snapshot while the gateway kept writing new turns (and could create a second writer for the same conversation).

This change splits the UX into two explicit operations:

- **Live view** (`/chat?live=<id>`) — read-only polling of persisted messages; never opens a PTY; follows valid compression continuations via `latest-descendant`.
- **Resume** (`/chat?resume=<id>`) — writable TUI as before, but when the session still looks gateway-owned, Sessions and the chat session list require an explicit ownership handoff (prefer Live view, cancel, or confirm Resume).

Sessions overview/expanded rows also refresh when `message_count` / `last_active` advance on the same session id, and list ordering defaults to recent activity so long-lived conversations stay discoverable.

## Related Issue

Fixes #101084

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `web/src/pages/ChatPage.tsx` — route `?live=` to `LiveSessionView` before the embedded TUI/PTY path.
- `web/src/components/LiveSessionView.tsx` — read-only poll (~2.5s), continuation retarget, no PTY.
- `web/src/pages/SessionsPage.tsx` — `order=recent`; revision-aware overview + expanded-row refetch; Live + Resume actions; Resume ownership dialog.
- `web/src/components/ChatSessionList.tsx` — same ownership handoff before silent Resume; Live navigation clears `resume` and vice versa.
- `web/src/lib/session-refresh.ts` (+ tests) — refresh when newest id **or** head `message_count` / `last_active` changes; expanded-transcript revision helper.
- `web/src/lib/session-ownership.ts` (+ tests) — gateway-owned session detection + `shouldConfirmResumeOwnership`.
- `web/src/i18n/en.ts`, `web/src/i18n/types.ts` — Live view / ownership copy.

## How to Test

1. Start (or use) an active messaging/gateway session and open the dashboard Sessions page.
2. Expand the session: continue the conversation on the gateway and confirm the expanded transcript updates without collapsing/reopening.
3. Click **Live view** → `/chat?live=<id>` shows new turns without spawning `/api/pty` / a TUI child.
4. From Sessions or the chat session list, click **Resume** on an active gateway session → ownership dialog appears; **Live view** / Cancel / confirm Resume behave as labeled.
5. Confirm a non-gateway / inactive session still Resumes without the dialog.
6. Unit: `npm --prefix web test -- --run src/lib/session-refresh.test.ts src/lib/session-ownership.test.ts` (13 passed).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (darwin 25)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
Test Files  2 passed (2)
Tests  13 passed (13)
```

Live view path does not call `/api/pty`. Resume still uses the existing PTY attach/spawn path after an explicit handoff when the session is gateway-owned.