### PR TITLE
feat(desktop): expose the complete slash command catalog

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -989,7 +989,11 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           try {
             const catalog = await requestGateway<CommandsCatalogLike>('commands.catalog', { session_id: sessionId })
 
-            renderSlashOutput(renderCommandsCatalog(catalog, copy))
+            renderSlashOutput(
+              renderCommandsCatalog(catalog, copy, {
+                includeUnavailable: ctx.arg.trim().toLowerCase() === 'all'
+              })
+            )
           } catch (err) {
             renderSlashOutput(`error: ${err instanceof Error ? err.message : String(err)}`)
           }

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.test.ts
@@ -2,6 +2,7 @@ import type { AppendMessage } from '@assistant-ui/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { ChatMessage } from '@/lib/chat-messages'
+import { rememberDesktopCommandsCatalog } from '@/lib/desktop-slash-commands'
 
 import {
   acquireSubmitInFlight,
@@ -23,6 +24,7 @@ import {
   readFileDataUrlForAttach,
   RECENT_INTERRUPT_COOLDOWN_MS,
   releaseSubmitInFlight,
+  renderCommandsCatalog,
   renderRpcResult,
   SessionRecoveryAborted,
   shouldInterruptBeforeRewind,
@@ -33,7 +35,108 @@ import {
   withSessionNotFoundResume
 } from './utils'
 
+describe('desktop command catalog', () => {
+  it('/help all includes unavailable commands omitted from backend categories', () => {
+    const catalog = {
+      categories: [
+        {
+          name: 'Commands',
+          pairs: [['/help', 'Show help']] as [string, string][]
+        }
+      ],
+      canon: {
+        '/remote-alias': '/remote-only'
+      },
+      commands: {
+        '/restart': { desktop: 'terminal' },
+        '/remote-only': { desktop: 'terminal' }
+      }
+    }
+
+    const copy = {} as Parameters<typeof renderCommandsCatalog>[1]
+
+    const all = renderCommandsCatalog(catalog, copy, { includeUnavailable: true })
+    const rowCount = (command: string) => all.match(new RegExp(`^${command}\\s`, 'gm'))?.length ?? 0
+
+    for (const command of [
+      '/restart',
+      '/approve',
+      '/deny',
+      '/sethome',
+      '/set-home',
+      '/remote-only',
+      '/model',
+      '/resume'
+    ]) {
+      expect(rowCount(command), command).toBe(1)
+    }
+
+    for (const alias of [
+      '/fork',
+      '/compact',
+      '/sessions',
+      '/switch',
+      '/reset',
+      '/commands',
+      '/learning',
+      '/memory-graph',
+      '/generate-pet',
+      '/remote-alias'
+    ]) {
+      expect(rowCount(alias), alias).toBe(1)
+    }
+
+    expect(all).toContain('/restart is only available in the terminal interface')
+    expect(all).toContain('/approve is only used from messaging platforms')
+    expect(all).toContain('/remote-only is only available in the terminal interface')
+    expect(all).toMatch(/^\/remote-alias\s+\/remote-only is only available in the terminal interface\.$/m)
+    expect(renderCommandsCatalog(catalog, copy)).not.toContain('/restart')
+    expect(renderCommandsCatalog(catalog, copy)).not.toContain('/commands')
+  })
+
+  it('merges categorized commands with pairs-only skills without duplicates', () => {
+    const copy = {
+      desktopCommands: 'Desktop commands',
+      skillCommandsAvailable: (count: number) => `${count} skill commands available`
+    } as Parameters<typeof renderCommandsCatalog>[1]
+
+    const output = renderCommandsCatalog(
+      {
+        categories: [{ name: 'Info', pairs: [['/help', 'Show help']] }],
+        pairs: [
+          ['/help', 'Show help'],
+          ['/docx', 'Work with Word documents']
+        ],
+        skills: { '/docx': { origin: 'bundled', usage: 1 } },
+        skill_count: 1
+      },
+      copy
+    )
+
+    expect(output.match(/^\/help\s/gm)).toHaveLength(1)
+    expect(output.match(/^\/docx\s/gm)).toHaveLength(1)
+    expect(output).toContain('Work with Word documents')
+  })
+
+  it('uses the exact catalog being rendered for dynamic availability guidance', () => {
+    rememberDesktopCommandsCatalog({ commands: { '/dynamic': { desktop: 'settings' } } })
+
+    const output = renderCommandsCatalog(
+      {
+        commands: { '/dynamic': { desktop: 'terminal' } },
+        pairs: [['/dynamic', 'Dynamic backend command']]
+      },
+      { desktopCommands: 'Desktop commands' } as Parameters<typeof renderCommandsCatalog>[1],
+      { includeUnavailable: true }
+    )
+
+    expect(output).toContain('/dynamic is only available in the terminal interface')
+    expect(output).not.toContain('/dynamic is managed from the desktop sidebar')
+  })
+})
+
 afterEach(() => {
+  rememberDesktopCommandsCatalog(undefined)
   clearSessionRecentlyInterrupted()
   clearSubmitInFlight()
 })

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -2,7 +2,14 @@ import type { AppendMessage } from '@assistant-ui/react'
 
 import { translateNow, type Translations } from '@/i18n'
 import type { ChatMessage } from '@/lib/chat-messages'
-import { type CommandsCatalogLike, filterDesktopCommandsCatalog } from '@/lib/desktop-slash-commands'
+import {
+  type CommandsCatalogLike,
+  desktopOmittedSlashCommands,
+  desktopSlashDescription,
+  desktopSlashUnavailableMessage,
+  filterDesktopCommandsCatalog,
+  rememberDesktopCommandsCatalog
+} from '@/lib/desktop-slash-commands'
 import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
 import type { ComposerAttachment } from '@/store/composer'
 
@@ -469,17 +476,47 @@ export function friendlyRemoteAttachError(err: unknown, label: string): Error {
   return new Error(`${label} is too large to upload to the remote gateway${cap}.`)
 }
 
-export function renderCommandsCatalog(catalog: CommandsCatalogLike, copy: Translations['desktop']): string {
-  const desktopCatalog = filterDesktopCommandsCatalog(catalog)
+export function renderCommandsCatalog(
+  catalog: CommandsCatalogLike,
+  copy: Translations['desktop'],
+  options: { includeUnavailable?: boolean } = {}
+): string {
+  rememberDesktopCommandsCatalog(catalog)
+  const desktopCatalog = options.includeUnavailable ? catalog : filterDesktopCommandsCatalog(catalog)
 
   const sections = desktopCatalog.categories?.length
-    ? desktopCatalog.categories
-    : [{ name: copy.desktopCommands, pairs: desktopCatalog.pairs ?? [] }]
+    ? desktopCatalog.categories.map(section => ({ ...section, pairs: [...section.pairs] }))
+    : []
+
+  const listed = new Set(sections.flatMap(section => section.pairs.map(([command]) => command.toLowerCase())))
+  const uncategorizedPairs = (desktopCatalog.pairs ?? []).filter(([command]) => !listed.has(command.toLowerCase()))
+
+  if (uncategorizedPairs.length > 0 || sections.length === 0) {
+    sections.push({ name: copy.desktopCommands, pairs: uncategorizedPairs })
+
+    for (const [command] of uncategorizedPairs) {
+      listed.add(command.toLowerCase())
+    }
+  }
+
+  if (options.includeUnavailable) {
+    const unavailablePairs = desktopOmittedSlashCommands(catalog)
+      .filter(command => !listed.has(command))
+      .map(command => [command, desktopSlashDescription(command)] as [string, string])
+
+    if (unavailablePairs.length > 0) {
+      sections.push({ name: 'Hidden aliases and unavailable commands', pairs: unavailablePairs })
+    }
+  }
 
   const body = sections
     .filter(section => section.pairs.length > 0)
     .map(section => {
-      const rows = section.pairs.map(([cmd, desc]) => `${cmd.padEnd(18)} ${desc}`)
+      const rows = section.pairs.map(([cmd, desc]) => {
+        const unavailable = options.includeUnavailable ? desktopSlashUnavailableMessage(cmd) : null
+
+        return `${cmd.padEnd(18)} ${desc}${desc && unavailable ? ' — ' : ''}${unavailable ?? ''}`.trimEnd()
+      })
 
       return [`${section.name}:`, ...rows].join('\n')
     })

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -206,7 +206,12 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
     argumentMode: 'options'
   },
   { name: '/title', description: 'Rename the current session', surface: action('title'), argumentMode: 'text' },
-  { name: '/help', description: 'Show desktop slash commands', aliases: ['/commands'], surface: action('help') },
+  {
+    name: '/help',
+    description: 'Show desktop slash commands (/help all includes unavailable commands)',
+    aliases: ['/commands'],
+    surface: action('help')
+  },
   {
     name: '/browser',
     description: 'Manage browser CDP connection [connect|disconnect|status] (local gateway only)',
@@ -583,6 +588,19 @@ export function desktopSlashUnavailableMessage(command: string): string | null {
   }
 
   return null
+}
+
+/** Commands deliberately omitted from Desktop suggestions, including aliases. */
+export function desktopOmittedSlashCommands(catalog: CommandsCatalogLike): string[] {
+  const candidates = [
+    ...Object.keys(catalog.commands ?? {}),
+    ...Object.keys(catalog.canon ?? {}),
+    ...ALL_SPECS.flatMap(spec => [spec.name, ...(spec.aliases ?? [])])
+  ]
+
+  return [...new Set(candidates.map(normalizeCommand))].filter(
+    command => !isDesktopSlashSuggestion(command) || resolveDesktopCommand(command)?.surface.kind === 'picker'
+  )
 }
 
 export function desktopSlashDescription(command: string, fallback = ''): string {


### PR DESCRIPTION
## Summary

Desktop currently filters unsupported slash commands out of both suggestions and `/help`, so users cannot discover roughly 40 backend, picker-owned, or alias commands or learn why they are unavailable.

This adds an explicit `/help all` view while preserving the existing concise `/help` output. The expanded catalog:

- merges categorized commands, top-level pairs, and pairs-only skill entries without duplicates;
- includes backend metadata omissions, Desktop-only unavailable commands, picker-owned commands, and static/catalog aliases;
- explains why a command is unavailable or which canonical command an alias resolves to;
- snapshots the exact catalog response before resolving dynamic availability guidance.

No command execution or availability rules are changed; this is a textual discoverability improvement rather than a new command palette.

Closes #101062.

## Verification

- Focused prompt-action suites: **89/89 passed**.
- Independent rerun of `utils.test.ts`: **57/57 passed**.
- Full Desktop UI suite: **7064/7064 passed**.
- TypeScript, targeted lint, Prettier, and `git diff --check`: **passed**.
- macOS DMG build: **passed**.
- Proof-of-bite: the three new catalog-contract tests fail on the base and pass with this commit.
- Fresh-context correctness review: **passed**.

The broader local Desktop check still has two unrelated environment/baseline Electron failures (`/bin/true` availability and an overlong profile-scoped Unix socket path); this PR does not claim those are fixed.
