### PR TITLE
fix(web): add accessible labels to skill switches

### DIFF
--- a/web/src/pages/SkillsPage.test.tsx
+++ b/web/src/pages/SkillsPage.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { act, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const apiMocks = vi.hoisted(() => ({
+  getSkills: vi.fn(),
+  getToolsets: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: apiMocks,
+}));
+
+vi.mock("@/contexts/useProfileScope", () => ({
+  useProfileScope: () => ({ profile: "" }),
+}));
+
+vi.mock("@/contexts/usePageHeader", () => ({
+  usePageHeader: () => ({ setAfterTitle: vi.fn(), setEnd: vi.fn() }),
+}));
+
+vi.mock("@/components/ToolsetConfigDrawer", () => ({
+  ToolsetConfigDrawer: () => null,
+}));
+
+vi.mock("@/components/SkillEditorDialog", () => ({
+  SkillEditorDialog: () => null,
+}));
+
+vi.mock("@/plugins", () => ({
+  PluginSlot: () => null,
+}));
+
+vi.mock("@nous-research/ui/hooks/use-toast", () => ({
+  useToast: () => ({ toast: null, showToast: vi.fn() }),
+}));
+
+vi.mock("@/i18n", () => {
+  const labels = new Proxy(
+    {},
+    { get: (_target, key: string | symbol) => String(key) },
+  );
+  return {
+    useI18n: () => ({ t: { common: labels, skills: labels } }),
+  };
+});
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function render(ui: ReactNode) {
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  await act(async () => {
+    root.render(ui);
+  });
+}
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  vi.clearAllMocks();
+});
+
+describe("SkillsPage accessibility", () => {
+  it("names an enabled skill switch with the skill name", async () => {
+    apiMocks.getSkills.mockResolvedValue([
+      {
+        name: "airtable",
+        description: "Manage Airtable data",
+        enabled: true,
+        category: null,
+      },
+    ]);
+    apiMocks.getToolsets.mockResolvedValue([]);
+
+    const { default: SkillsPage } = await import("./SkillsPage");
+    await render(
+      <MemoryRouter>
+        <SkillsPage />
+      </MemoryRouter>,
+    );
+
+    const skillSwitch = container.querySelector('[role="switch"]');
+    expect(skillSwitch).not.toBeNull();
+    expect(skillSwitch?.getAttribute("aria-label")).toBe("Disable airtable");
+    expect(skillSwitch?.getAttribute("aria-checked")).toBe("true");
+  });
+});

--- a/web/src/pages/SkillsPage.tsx
+++ b/web/src/pages/SkillsPage.tsx
@@ -747,6 +747,7 @@ function SkillRow({
           checked={skill.enabled}
           onCheckedChange={onToggle}
           disabled={toggling}
+          aria-label={`${skill.enabled ? "Disable" : "Enable"} ${skill.name}`}
         />
       </div>
       <div className="flex-1 min-w-0">


### PR DESCRIPTION
## What does this PR do?

Adds accessible names to the enable/disable switches on the Skills page.

Previously, the switches exposed their checked state but had no accessible name, making them difficult to identify with screen readers and other accessibility tools.

Each switch now receives a state-aware `aria-label`, for example:

- `Disable airtable` when the skill is enabled
- `Enable airtable` when the skill is disabled

This keeps the visual UI unchanged while making each switch identifiable to assistive technology.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `web/src/pages/SkillsPage.tsx`
  - Added a state-aware accessible label to each skill switch:
    - `Disable <skill>` when enabled
    - `Enable <skill>` when disabled

- `web/src/pages/SkillsPage.test.tsx`
  - Added regression coverage verifying the switch:
    - exists
    - exposes `aria-label="Disable airtable"`
    - exposes `aria-checked="true"`

## How to Test

1. Run the SkillsPage test.
2. Run the full web Vitest suite.
3. Open the Skills page and inspect its accessibility tree. An enabled Airtable skill should be exposed as `switch "Disable airtable"` with `checked=true`.

Verification performed locally:

- Focused SkillsPage test passed
- Full Vitest suite passed: 38 files / 282 tests
- TypeScript `tsc -p . --noEmit` passed
- TypeScript `tsc -b` passed
- Vite production build passed
- Live accessibility snapshot verified `switch "Disable airtable"` with `checked=true`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Accessibility verification exposed the enabled Airtable switch as:

`switch "Disable airtable"` — `checked=true`

### Notes

ESLint could not be run locally because dependency resolution is currently blocked by the repository's `min-release-age` policy for `blobatar@2.0.0`. The dependency policy was not bypassed or modified.