### PR TITLE
fix(desktop): stop finished todo lists from popping back up after the turn

### DIFF
--- a/apps/desktop/src/store/todos.test.ts
+++ b/apps/desktop/src/store/todos.test.ts
@@ -52,6 +52,15 @@ describe('setSessionTodos finished-list auto-clear', () => {
 
     expect($todosBySession.get().s1).toHaveLength(2)
   })
+
+  it('does not re-show a finished list when the same revision is read again', () => {
+    setSessionTodos('s1', [todo('a', 'completed')], 3)
+    vi.advanceTimersByTime(5_000)
+
+    setSessionTodos('s1', [todo('a', 'completed')], 3)
+
+    expect($todosBySession.get().s1).toBeUndefined()
+  })
 })
 
 describe('clearActiveSessionTodos (turn-end cleanup)', () => {
@@ -95,10 +104,10 @@ describe('todosForHydration (stale-active guard on restore)', () => {
     expect(todosForHydration([todo('a', 'pending')])).toBeNull()
   })
 
-  it('restores a finished list so its linger shows the final checkmarks', () => {
+  it('does not restore a finished list from an earlier turn', () => {
     const finished = [todo('a', 'completed'), todo('b', 'cancelled')]
 
-    expect(todosForHydration(finished)).toEqual(finished)
+    expect(todosForHydration(finished)).toBeNull()
   })
 
   it('returns null when there is nothing stored', () => {

--- a/apps/desktop/src/store/todos.ts
+++ b/apps/desktop/src/store/todos.ts
@@ -12,9 +12,8 @@ import { $sessionStates } from './session-states'
  * (the inline transcript panel is gone). Fed from two places:
  *
  * - live `todo` tool events (use-message-stream)
- * - stored-session hydration (desktop-controller) — but only when the list is
- *   still in flight, so reopening an old chat doesn't pin its finished plan
- *   above the composer forever.
+ * - stored-session hydration (desktop-controller) — only while a session is
+ *   still running, so reopening an old chat never re-pins its historic plan.
  */
 export const $todosBySession = atom<Record<string, TodoItem[]>>({})
 export const $todoRevisionsBySession = atom<Record<string, number>>({})
@@ -53,15 +52,12 @@ export const $todoProgressBySession = computed(
   }
 )
 
-// Decide which todo list to restore when rehydrating a session from stored
-// history. Rehydration runs *after* a turn completes, so an active list (last
-// item still pending/in_progress) is stale — the turn ended without a final
-// `todo` update — and must NOT be re-pinned (that would undo the turn-end
-// clear and, because it's read back from history, resurrect on restart). Only
-// a finished list is restored, so its short linger shows the last checkmark.
-// Returns null when there's nothing to restore (caller should clear).
-export function todosForHydration(todos: readonly TodoItem[] | null): TodoItem[] | null {
-  return todos && !todoListActive(todos) ? [...todos] : null
+// Stored todo snapshots are transcript history, not a new progress event. The
+// live event already shows the final checkmark, so restoring either an active
+// or completed list after the turn ends would make the composer pop back open.
+// Returns null so the caller clears the stale presentation state.
+export function todosForHydration(_todos: readonly TodoItem[] | null): TodoItem[] | null {
+  return null
 }
 
 // Once a list finishes (every item completed/cancelled), the final state
@@ -93,6 +89,22 @@ function acceptRevision(sid: string, revision?: null | number): boolean {
 
 export function setSessionTodos(sid: string, todos: TodoItem[], revision?: null | number) {
   if (!sid) {
+    return
+  }
+
+  const currentRevision = $todoRevisionsBySession.get()[sid]
+  const previous = $todosBySession.get()[sid]
+
+  // A completed list remains in the backend snapshot after its short UI linger.
+  // Reading it again must not reopen the composer status group or reset its timer.
+  // Keep a same-revision completion only when it replaces a still-visible active
+  // list, which is the final checkmark transition for that live plan.
+  if (
+    !todoListActive(todos) &&
+    revision != null &&
+    currentRevision === revision &&
+    !todoListActive(previous ?? [])
+  ) {
     return
   }
 


### PR DESCRIPTION
## What does this PR do?

Stops Hermes Desktop from replaying a finished task list above the composer after the turn has ended, while keeping the live plan display and the final-checkmark linger intact.

Two paths re-pinned historic plans:

1. **Post-turn hydration** (`todosForHydration`): after a turn completes, the app re-reads stored session history and restored any *finished* list. The live event had already shown the final checkmarks, so the group popped back open and restarted its linger on every subsequent exchange.
2. **Same-revision re-reads** (`setSessionTodos`): a completed snapshot stays in the backend state after its 4s UI linger; reading it again with the same revision restarted the linger and reopened the panel.

Stored todo snapshots are transcript history, not new progress events. `todosForHydration` now always returns `null` (the caller clears presentation state), and a same-revision completed write is ignored unless it is the live transition replacing a still-visible active list. Live `todo` tool events, running-session resume snapshots, and the final-checkmark linger are unchanged.

Note: #100665 fixed the adjacent idle resume/activate path in `restoreSessionTodosFromSnapshot` and intentionally kept the post-turn hydration linger; this PR covers that remaining path.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/src/store/todos.ts`: `todosForHydration` no longer restores stored finished lists (transcript history is not a progress event); `setSessionTodos` ignores a same-revision completed write unless it replaces a still-visible active list; ownership comments updated.
- `apps/desktop/src/store/todos.test.ts`: finished-hydration expectation changed to `null`; added a regression test that a same-revision re-read of a finished list does not re-show it.

## How to Test

1. In `apps/desktop`: `npx vitest run src/store/todos.test.ts src/app/session/hooks/use-message-stream/todo-cleanup.test.tsx` — 18 tests pass.
2. In `apps/desktop`: `npm run typecheck && npm run lint && npm run test:ui` — all pass.
3. Manual: finish a conversation that uses a task list, then keep chatting or switch away and back — the finished plan no longer re-opens above the composer; during a running turn the plan and final checkmarks still display, then linger-clear as before.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, desktop-only change (no Python touched)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.2 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A beyond updated store comments
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — logic is platform-independent; desktop UI tests pass
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
