### PR TITLE
fix(cron): deliver shared-token satellite jobs through routed bot

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2921,6 +2921,7 @@ def mark_job_run(
     status: Optional[str] = None,
     *,
     expected_fire_owner: Optional[str] = None,
+    preserve_delivery_error: bool = False,
 ) -> bool:
     with _fire_job_lock(job_id) as acquired:
         if not acquired:
@@ -2932,6 +2933,7 @@ def mark_job_run(
             delivery_error,
             status=status,
             expected_fire_owner=expected_fire_owner,
+            preserve_delivery_error=preserve_delivery_error,
         )
 
 
@@ -3026,6 +3028,7 @@ def _mark_job_run_locked(
     *,
     status: Optional[str] = None,
     expected_fire_owner: Optional[str] = None,
+    preserve_delivery_error: bool = False,
 ) -> bool:
     """
     Mark a job as having been run.
@@ -3104,8 +3107,11 @@ def _mark_job_run_locked(
                     job["failure_streak"] = 0
                 else:
                     job["failure_streak"] = int(job.get("failure_streak") or 0) + 1
-                # Track delivery failures separately — cleared on successful delivery
-                job["last_delivery_error"] = delivery_error
+                # A [SILENT] monitor tick does not attempt delivery, so it cannot
+                # prove that the previous transport failure healed. Other runs
+                # retain the historical clear-on-success behavior.
+                if not preserve_delivery_error:
+                    job["last_delivery_error"] = delivery_error
                 # Clear any external-fire claim so a re-armed recurring job can
                 # be claimed again on its next fire (Phase 4C CAS).
                 job["fire_claim"] = None

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -25,6 +25,7 @@ import sys
 import threading
 import time
 import uuid
+from dataclasses import dataclass
 from datetime import datetime, timezone
 
 # fcntl is Unix-only; on Windows use msvcrt for file locking
@@ -62,6 +63,20 @@ from agent.delegation_context import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ProfileRouteDeliveryContext:
+    """Primary transport available to one multiplexed satellite profile.
+
+    The job still executes under the satellite profile's home and secret scope.
+    This context only carries the already-connected primary gateway transport;
+    it never copies credentials into the satellite profile.
+    """
+
+    profile: str
+    config: Any
+    adapters: Any
 
 
 def _close_late_session_db_result(future: "concurrent.futures.Future") -> None:
@@ -3141,7 +3156,13 @@ def _record_delivery_verification(job: dict, unverified_targets: list) -> None:
         )
 
 
-def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
+def _deliver_result(
+    job: dict,
+    content: str,
+    adapters=None,
+    loop=None,
+    profile_route_context: Optional[ProfileRouteDeliveryContext] = None,
+) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
 
@@ -3354,6 +3375,41 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         from gateway.delivery import resolve_delivery_transport
 
         transport = resolve_delivery_transport(platform, config, adapters)
+        transport_config = config
+        transport_adapters = adapters
+        primary_route_owned = False
+        if transport is None and profile_route_context is not None and chat_id:
+            from gateway.profile_routing import match_profile_route
+
+            primary_config = profile_route_context.config
+            matched_route = match_profile_route(
+                getattr(primary_config, "profile_routes", None) or [],
+                platform=platform_name.lower(),
+                chat_id=str(chat_id),
+                thread_id=str(thread_id) if thread_id is not None else None,
+            )
+            # Only a concrete chat route proves that this exact cron target is
+            # owned by the satellite. Platform- and guild-only routes cannot be
+            # safely resolved from a platform:chat_id delivery token.
+            if (
+                matched_route is not None
+                and matched_route.profile == profile_route_context.profile
+                and matched_route.chat_id
+            ):
+                primary_route_owned = True
+                transport_config = primary_config
+                transport_adapters = profile_route_context.adapters
+                transport = resolve_delivery_transport(
+                    platform, transport_config, transport_adapters
+                )
+                if transport is None:
+                    msg = (
+                        f"profile-routed delivery to {platform_name}:{chat_id} "
+                        "has no primary live adapter"
+                    )
+                    logger.warning("Job '%s': %s", job["id"], msg)
+                    delivery_errors.append(msg)
+                    continue
         if transport is not None:
             pconfig = transport.config
             runtime_adapter = transport.adapter
@@ -3644,7 +3700,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 elif text_to_send:
                     from agent.async_utils import safe_schedule_threadsafe
 
-                    router = DeliveryRouter(config, adapters)
+                    router = DeliveryRouter(transport_config, transport_adapters)
                     route_target = DeliveryTarget(
                         platform=platform,
                         chat_id=str(chat_id),
@@ -3771,7 +3827,9 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                                     f"live adapter send to {platform_name}:{chat_id} "
                                     f"returned unconfirmed result ({shape}, error={err})"
                                 )
-                                if transport is not None and transport.is_relay:
+                                if primary_route_owned or (
+                                    transport is not None and transport.is_relay
+                                ):
                                     logger.warning("Job '%s': %s", job["id"], msg)
                                 else:
                                     logger.warning(
@@ -3806,7 +3864,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     routed_media_metadata = dict(media_metadata or {})
                     if transport is not None and transport.is_relay:
                         routed_media_metadata["_relay_logical_platform"] = platform.value
-                        logical_home = config.get_home_channel(platform)
+                        logical_home = transport_config.get_home_channel(platform)
                         if logical_home is not None and logical_home.chat_id == chat_id:
                             if logical_home.user_id:
                                 routed_media_metadata["user_id"] = logical_home.user_id
@@ -3928,7 +3986,9 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 err_msg = f"live adapter delivery to {platform_name}:{chat_id} failed: {e}"
                 if not any(err_msg in err for err in target_errors):
                     target_errors.append(err_msg)
-                if transport is not None and transport.is_relay:
+                if primary_route_owned or (
+                    transport is not None and transport.is_relay
+                ):
                     logger.warning("Job '%s': %s", job["id"], err_msg)
                 else:
                     logger.warning(
@@ -3937,13 +3997,15 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     )
 
         if not delivered:
-            if transport is not None and transport.is_relay:
-                # Relay owns the logical destination and its connector owns the
-                # platform credential. A native retry could duplicate delivery
-                # and cannot be authenticated correctly, so fail closed.
+            if primary_route_owned or (transport is not None and transport.is_relay):
+                # Relay and a primary profile-route transport own their logical
+                # destination credentials. Retrying under the satellite's
+                # standalone sender could duplicate delivery and cannot be
+                # authenticated correctly, so fail closed.
                 if not target_errors:
+                    owner = "primary profile-route" if primary_route_owned else "relay"
                     target_errors.append(
-                        f"relay delivery to {platform_name}:{chat_id} failed"
+                        f"{owner} delivery to {platform_name}:{chat_id} failed"
                     )
                 delivery_errors.extend(target_errors)
                 continue
@@ -7240,6 +7302,7 @@ def run_one_job(
     verbose: bool = False,
     extra_prompt: Optional[str] = None,
     cancel_event: Optional[_CancelEventLike] = None,
+    profile_route_context: Optional[ProfileRouteDeliveryContext] = None,
 ) -> bool:
     """Run ONE due job end-to-end: execute → save output → deliver → mark.
 
@@ -7293,6 +7356,7 @@ def run_one_job(
                     else lost_ownership
                 ),
                 execution_token=execution_token,
+                profile_route_context=profile_route_context,
             ),
         )
     finally:
@@ -7313,6 +7377,7 @@ def _run_one_job_body(
     extra_prompt: Optional[str] = None,
     fire_claim_lost: Optional[_CancelEventLike] = None,
     execution_token: Optional[object] = None,
+    profile_route_context: Optional[ProfileRouteDeliveryContext] = None,
 ) -> bool:
     claim = job.get("fire_claim")
     fire_owner = str(claim.get("by") or "") if isinstance(claim, dict) else None
@@ -7570,6 +7635,7 @@ def _run_one_job_body(
             # responses: do not deliver a blank message, and let the
             # empty-response guard below mark the run as a soft failure.
             should_deliver = bool(deliver_content.strip())
+            silent_success = False
             if blocked_config_silent or drift_skip_silent:
                 should_deliver = False
             unresolved_origin = False
@@ -7582,6 +7648,7 @@ def _run_one_job_body(
             if should_deliver and success and _is_cron_silence_response(deliver_content):
                 logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
                 should_deliver = False
+                silent_success = True
 
             if should_deliver and _fire_claim_ownership_lost():
                 should_deliver = False
@@ -7605,6 +7672,7 @@ def _run_one_job_body(
                             deliver_content,
                             adapters=adapters,
                             loop=loop,
+                            profile_route_context=profile_route_context,
                         )
                 except Exception as de:
                     if isinstance(de, _FireClaimLostDuringSideEffect):
@@ -7680,6 +7748,8 @@ def _run_one_job_body(
             return True
 
         mark_kwargs = {"delivery_error": delivery_error}
+        if silent_success:
+            mark_kwargs["preserve_delivery_error"] = True
         if fire_owner is not None:
             mark_kwargs["expected_fire_owner"] = fire_owner
         if blocked_config:
@@ -7775,6 +7845,7 @@ def _run_one_job_body(
                         + _failure_streak_nudge(job),
                         adapters=adapters,
                         loop=loop,
+                        profile_route_context=profile_route_context,
                     )
                 except Exception as delivery_exc:
                     delivery_error = str(delivery_exc)
@@ -8003,6 +8074,7 @@ def tick(
     sync: bool = True,
     *,
     can_dispatch=None,
+    profile_route_context: Optional[ProfileRouteDeliveryContext] = None,
 ):
     """
     Check and run all due jobs.
@@ -8246,6 +8318,7 @@ def tick(
                 adapters=adapters,
                 loop=loop,
                 verbose=verbose,
+                profile_route_context=profile_route_context,
             )
 
         # Workdir is task-scoped, so every job uses the normal parallel lane.

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -560,6 +560,7 @@ class InProcessCronScheduler(CronScheduler):
         profile_homes=None,
         profile_adapters=None,
         default_profile=None,
+        primary_gateway_config=None,
     ):
         import logging
         from cron.scheduler import CronTickYielded
@@ -590,6 +591,7 @@ class InProcessCronScheduler(CronScheduler):
                 can_dispatch=can_dispatch,
                 profile_adapters=profile_adapters,
                 default_profile=default_profile,
+                primary_gateway_config=primary_gateway_config,
             )
             return
 
@@ -670,6 +672,7 @@ class InProcessCronScheduler(CronScheduler):
         can_dispatch=None,
         profile_adapters=None,
         default_profile=None,
+        primary_gateway_config=None,
     ):
         """Tick every served profile's cron store when multiplex_profiles is on.
 
@@ -743,14 +746,27 @@ class InProcessCronScheduler(CronScheduler):
                                 # — it simply does not deliver this tick.
                                 if _pname is None or _pname == default_profile:
                                     _tick_adapters = adapters
+                                    _route_context = None
                                 else:
                                     _tick_adapters = (profile_adapters or {}).get(_pname) or {}
+                                    _route_context = None
+                                    if primary_gateway_config is not None:
+                                        from cron.scheduler import (
+                                            ProfileRouteDeliveryContext,
+                                        )
+
+                                        _route_context = ProfileRouteDeliveryContext(
+                                            profile=_pname,
+                                            config=primary_gateway_config,
+                                            adapters=adapters or {},
+                                        )
                                 cron_tick(
                                     verbose=False,
                                     adapters=_tick_adapters,
                                     loop=loop,
                                     sync=False,
                                     can_dispatch=can_dispatch,
+                                    profile_route_context=_route_context,
                                 )
                         except CronTickYielded as e:
                             # This profile is served stale and a fresh

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -33734,6 +33734,10 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 # cron through the default bot (even before its adapter connects,
                 # when profile_adapters[name] is still absent/empty).
                 cron_start_kwargs["default_profile"] = "default"
+                # The satellite still owns execution and secret scope. The
+                # primary config is carried only as a target-scoped transport
+                # authority for exact profile_routes matches during delivery.
+                cron_start_kwargs["primary_gateway_config"] = runner.config
                 logger.info(
                     "Cron scheduler will tick %d profile(s) under multiplex: %s",
                     len(profile_homes),

--- a/tests/cron/test_cron_multiplex_profile_route_delivery.py
+++ b/tests/cron/test_cron_multiplex_profile_route_delivery.py
@@ -1,0 +1,189 @@
+"""Live cron delivery through a primary adapter for exact profile routes."""
+
+import asyncio
+from concurrent.futures import Future
+from unittest.mock import MagicMock, patch
+
+from cron.scheduler import ProfileRouteDeliveryContext, _deliver_result
+from gateway.config import Platform, PlatformConfig
+from gateway.profile_routing import ProfileRoute
+
+
+CHAT_ID = "1543065293755256852"
+
+
+class _SendResult:
+    def __init__(self, *, success=True, message_id=None, error=None):
+        self.success = success
+        self.message_id = message_id
+        self.error = error
+        self.raw_response = None
+
+
+def _config(*, enabled=True, routes=None):
+    config = MagicMock()
+    config.platforms = (
+        {Platform.DISCORD: PlatformConfig(enabled=True)} if enabled else {}
+    )
+    config.profile_routes = list(routes or [])
+    config.get_home_channel.return_value = None
+    return config
+
+
+def _job(chat_id=CHAT_ID):
+    return {
+        "id": "shared-route-job",
+        "name": "Shared route",
+        "deliver": f"discord:{chat_id}",
+    }
+
+
+def _context(*, profile="fitness", chat_id=CHAT_ID, adapter=True, enabled=True):
+    routes = [
+        ProfileRoute(
+            name="fitness-channel",
+            platform="discord",
+            chat_id=chat_id,
+            profile=profile,
+            enabled=enabled,
+        )
+    ]
+    primary_adapter = MagicMock(name="primary-discord-adapter")
+    adapters = {Platform.DISCORD: primary_adapter} if adapter else {}
+    return (
+        ProfileRouteDeliveryContext(
+            profile="fitness",
+            config=_config(enabled=True, routes=routes),
+            adapters=adapters,
+        ),
+        primary_adapter,
+    )
+
+
+def _run(*, context, own_adapter=None, result=None, chat_id=CHAT_ID):
+    loop = MagicMock()
+    loop.is_running.return_value = True
+    router_calls = []
+    router_construction = []
+    standalone_calls = []
+
+    def fake_run_coro(coro, _loop):
+        future = Future()
+        try:
+            future.set_result(asyncio.run(coro))
+        except BaseException as exc:  # noqa: BLE001
+            future.set_exception(exc)
+        return future
+
+    class _Router:
+        def __init__(self, config, adapters):
+            router_construction.append((config, adapters))
+
+        async def _deliver_to_platform(self, target, text, metadata):
+            router_calls.append((target, text, metadata))
+            return result or _SendResult(message_id="discord-message-1")
+
+    async def _standalone(*args, **kwargs):
+        standalone_calls.append((args, kwargs))
+        return {}
+
+    satellite_config = _config(enabled=own_adapter is not None)
+    own_adapters = {Platform.DISCORD: own_adapter} if own_adapter is not None else {}
+    with patch("gateway.config.load_gateway_config", return_value=satellite_config), \
+         patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+         patch("gateway.delivery.DeliveryRouter", _Router), \
+         patch("tools.send_message_tool._send_to_platform", _standalone), \
+         patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
+        error = _deliver_result(
+            _job(chat_id),
+            "Scheduled report",
+            adapters=own_adapters,
+            loop=loop,
+            profile_route_context=context,
+        )
+    return error, router_calls, router_construction, standalone_calls
+
+
+def test_exact_route_uses_primary_live_adapter_with_positive_evidence():
+    context, primary_adapter = _context()
+
+    error, calls, constructed, standalone = _run(context=context)
+
+    assert error is None
+    assert len(calls) == 1
+    assert constructed == [(context.config, context.adapters)]
+    assert constructed[0][1][Platform.DISCORD] is primary_adapter
+    assert standalone == []
+
+
+def test_secondary_own_adapter_wins_over_primary_route():
+    context, _primary_adapter = _context()
+    own_adapter = MagicMock(name="own-discord-adapter")
+
+    error, calls, constructed, standalone = _run(
+        context=context, own_adapter=own_adapter
+    )
+
+    assert error is None
+    assert len(calls) == 1
+    assert constructed[0][1][Platform.DISCORD] is own_adapter
+    assert standalone == []
+
+
+def test_unmatched_target_does_not_use_primary_adapter():
+    context, _primary_adapter = _context(chat_id="different-channel")
+
+    error, calls, constructed, standalone = _run(context=context)
+
+    assert error is not None
+    assert calls == []
+    assert constructed == []
+    assert standalone == []
+
+
+def test_route_for_another_profile_does_not_use_primary_adapter():
+    context, _primary_adapter = _context(profile="other")
+
+    error, calls, constructed, standalone = _run(context=context)
+
+    assert error is not None
+    assert calls == []
+    assert constructed == []
+    assert standalone == []
+
+
+def test_disabled_route_does_not_use_primary_adapter():
+    context, _primary_adapter = _context(enabled=False)
+
+    error, calls, constructed, standalone = _run(context=context)
+
+    assert error is not None
+    assert calls == []
+    assert constructed == []
+    assert standalone == []
+
+
+def test_exact_route_without_primary_adapter_fails_without_standalone():
+    context, _primary_adapter = _context(adapter=False)
+
+    error, calls, constructed, standalone = _run(context=context)
+
+    assert error is not None
+    assert "primary live adapter" in error
+    assert calls == []
+    assert constructed == []
+    assert standalone == []
+
+
+def test_primary_route_send_failure_does_not_fall_back_to_satellite_standalone():
+    context, _primary_adapter = _context()
+
+    error, calls, _constructed, standalone = _run(
+        context=context,
+        result=_SendResult(success=False, error="Discord unavailable"),
+    )
+
+    assert len(calls) == 1
+    assert error is not None
+    assert "Discord unavailable" in error
+    assert standalone == []

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -699,6 +699,16 @@ class TestMarkJobRun:
         mark_job_run(job["id"], success=True, delivery_error="")
         assert get_job(job["id"])["last_status"] == "ok"
 
+    def test_silent_success_can_preserve_previous_delivery_error(self, tmp_cron_dir):
+        job = create_job(prompt="Monitor", schedule="every 1h")
+        mark_job_run(job["id"], True, delivery_error="send failed: 502")
+
+        mark_job_run(job["id"], True, preserve_delivery_error=True)
+
+        updated = get_job(job["id"])
+        assert updated["last_status"] == "ok"
+        assert updated["last_delivery_error"] == "send failed: 502"
+
     def test_agent_failure_still_error_with_delivery_error(self, tmp_cron_dir):
         """An agent failure outranks delivery: still "error", still a streak."""
         job = create_job(prompt="Report", schedule="every 1h")

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -29,7 +29,9 @@ def _patch_pipeline(monkeypatch, *, success=True, output="out", final="final res
         calls.append(("save", jid))
         return f"/tmp/{jid}.txt"
 
-    def fake_deliver(job, content, adapters=None, loop=None):
+    def fake_deliver(
+        job, content, adapters=None, loop=None, profile_route_context=None
+    ):
         calls.append(("deliver", job["id"]))
         return None
 
@@ -76,6 +78,32 @@ def test_run_one_job_success_sequence(monkeypatch):
     assert ok is True
     assert [c[0] for c in calls] == ["run_job", "save", "deliver", "mark"]
     assert calls[-1] == ("mark", "j2", True)
+
+
+def test_silent_success_preserves_previous_delivery_error(monkeypatch):
+    """A monitor's [SILENT] tick did not retry delivery and cannot heal it."""
+    marked = []
+    _patch_pipeline(monkeypatch, silent_marker_in="[SILENT]")
+    monkeypatch.setattr(
+        s,
+        "mark_job_run",
+        lambda *args, **kwargs: marked.append((args, kwargs)),
+    )
+
+    assert s.run_one_job(
+        {
+            "id": "silent-monitor",
+            "name": "monitor",
+            "last_delivery_error": "Discord standalone send failed",
+        }
+    ) is True
+
+    assert marked == [
+        (
+            ("silent-monitor", True, None),
+            {"delivery_error": None, "preserve_delivery_error": True},
+        )
+    ]
 
 
 def test_run_one_job_exception_delivers_failure_alert(monkeypatch):

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -786,3 +786,53 @@ def test_multiplex_missing_secondary_does_not_fall_back_to_shared(tmp_path):
     assert default_ad is shared
     assert sec_ad is not shared
     assert not sec_ad
+
+
+def test_multiplex_secondary_receives_target_scoped_primary_route_context(tmp_path):
+    """Primary transport stays separate from the satellite adapter map."""
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    default_home = tmp_path / "default"
+    satellite_home = tmp_path / "fitness"
+    for home in (default_home, satellite_home):
+        (home / "cron").mkdir(parents=True)
+
+    shared = {"kind": "primary"}
+    primary_config = object()
+    captured = []
+    stop = threading.Event()
+
+    def _capture(*_args, **kwargs):
+        captured.append(kwargs)
+        if len(captured) >= 2:
+            stop.set()
+        return 0
+
+    with patch("cron.scheduler.tick", side_effect=_capture), \
+         patch("cron.jobs.record_ticker_heartbeat", lambda **_kw: None):
+        thread = threading.Thread(
+            target=InProcessCronScheduler().start,
+            args=(stop,),
+            kwargs={
+                "interval": 0,
+                "profile_homes": [
+                    ("default", default_home),
+                    ("fitness", satellite_home),
+                ],
+                "adapters": shared,
+                "profile_adapters": {},
+                "default_profile": "default",
+                "primary_gateway_config": primary_config,
+            },
+            daemon=True,
+        )
+        thread.start()
+        thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert captured[0]["profile_route_context"] is None
+    context = captured[1]["profile_route_context"]
+    assert context.profile == "fitness"
+    assert context.config is primary_config
+    assert context.adapters is shared
+    assert captured[1]["adapters"] == {}


### PR DESCRIPTION
## What does this PR do?

Cron jobs owned by credentialless satellite profiles now deliver through the primary gateway's live adapter when the exact target is assigned to that satellite by an enabled `gateway.profile_routes` chat route. This keeps execution, state, and secret scope in the satellite profile while separating transport ownership from runtime ownership. Unmatched, disabled, wrong-profile, or unavailable primary transports fail closed without copying credentials or falling through to the satellite standalone sender.

### Symptom

A satellite profile's scheduled job completed successfully, but delivery failed with `Discord standalone send: DISCORD_BOT_TOKEN is not set` even though the primary gateway's connected Discord adapter owned the routed channel.

### Impact

Scheduled output from credentialless profiles using shared-token routing never reached the configured Discord channel. The same topology worked for normal gateway traffic, leaving cron delivery inconsistent and operator-visible job state in `delivery_failed`.

### Bug Cause

**Trigger:** `cron/scheduler_provider.py` / `InProcessCronScheduler._start_multiplex` selected an empty adapter map for a credentialless satellite profile.

**Causal chain:**
1. The primary gateway connected the shared Discord credential and routed an exact channel to a satellite profile.
2. The multiplex ticker correctly executed the job under the satellite home, but passed only that profile's empty adapter map into delivery.
3. `_deliver_result` could not resolve a live transport and attempted the satellite standalone sender, which had no token by design.

**Why it is wrong:** Runtime ownership and transport ownership are different for shared-token profile routes. Adapter selection represented only runtime ownership, so the exact route that authorized the primary transport was discarded before delivery.

**Working sibling / contrast:** Satellite profiles with their own connected adapters already receive their own adapter map and continue to prefer it. The primary profile continues to use the shared adapter map directly.

**Ruled out:** Missing credentials on the transport owner were ruled out because the primary live adapter was connected and had previously delivered to the same target. Copying the token into the satellite is not a valid fix because duplicate-token adapters violate profile isolation.

### Fix

The multiplex ticker now carries a separate primary-route delivery context alongside the satellite's own adapter map. Delivery first prefers the satellite's own live adapter, then authorizes the primary transport only when the most-specific enabled route matches the exact platform/chat/thread and names the running satellite profile. A matched route with no live primary transport, or a routed live-send failure, is reported without standalone fallback. A later successful `[SILENT]` monitor tick also preserves the earlier delivery error because it did not retry the failed transport.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler_provider.py` - carry target-scoped primary route transport context into satellite ticks.
- `cron/scheduler.py` - resolve exact profile routes after own-adapter selection and fail closed on routed transport failures.
- `cron/jobs.py` - preserve a prior delivery failure across successful `[SILENT]` monitor ticks.
- `gateway/run.py` - provide the connected primary gateway config to the multiplex cron scheduler.
- `tests/cron/` - cover exact routing, own-adapter precedence, failure boundaries, positive evidence, context isolation, and silent-state retention.

## How to Test

1. Configure `gateway.multiplex_profiles: true`, connect Discord only on the primary profile, and route one exact Discord channel to a credentialless satellite profile.
2. Run a satellite-owned cron job targeting that channel and verify the primary live adapter handles the send while the job runs under the satellite home.
3. Run the focused regression suite:

```bash
scripts/run_tests.sh tests/cron/test_cron_multiplex_profile_route_delivery.py tests/cron/test_run_one_job.py tests/cron/test_jobs.py tests/cron/test_scheduler_provider.py tests/cron/test_cron_multiplex_profile_route_preflight.py -q
```

Result: 175 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the focused repository test entry and all relevant tests pass
- [x] I've added tests for my changes
- [x] I've tested the in-process behavior on Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation and docstrings are updated, or N/A
- [x] `cli-config.yaml.example` is unchanged because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are unchanged because no workflow changed
- [x] Cross-platform impact was considered; the change uses platform-neutral Python and existing abstractions
- [x] Tool descriptions and schemas are unchanged because no tool behavior changed

## Screenshots / Logs

N/A - automated regression tests cover the routing and fail-closed behavior.
