### PR TITLE
fix(acp): keep a named custom provider's credentials when a session resumes

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -390,8 +390,25 @@ class SessionManager:
             "enabled_toolsets": _expand_acp_enabled_toolsets(["hermes-acp"], mcp_server_names=configured_mcp_servers),
             "model": model or default_model,
         }
+        # ``requested_provider`` comes back from a resumed session's row, where
+        # it was stored as the agent's provider KIND (see ``_persist``). For a
+        # named custom provider that kind is the bare string "custom", which is
+        # not the name of anything under ``providers:`` — feeding it back in
+        # resolves some other endpoint and, crucially, no api_key, since only
+        # base_url and api_mode have a stored value to fall back on below. The
+        # session then sends its model somewhere that has never heard of it and
+        # every turn answers with that endpoint's rejection, for good.
+        #
+        # So the kind is not treated as a request: the configured provider is,
+        # with the session's own endpoint passed alongside it so a session
+        # pinned to a different one keeps it.
+        requested_runtime_provider = requested_provider or config_provider
+        if str(requested_runtime_provider or "").strip().lower() == "custom":
+            requested_runtime_provider = config_provider or None
+
         try:
-            runtime = resolve_runtime_provider(requested=requested_provider or config_provider)
+            runtime = resolve_runtime_provider(requested=requested_runtime_provider,
+                                               explicit_base_url=base_url or None)
             kwargs.update({
                 "provider": runtime.get("provider"), "api_mode": api_mode or runtime.get("api_mode"),
                 "base_url": base_url or runtime.get("base_url"), "api_key": runtime.get("api_key"),

--- a/tests/acp_adapter/test_acp_resume_provider.py
+++ b/tests/acp_adapter/test_acp_resume_provider.py
@@ -1,0 +1,112 @@
+"""Resuming an ACP session must not lose a named custom provider's credentials.
+
+``_persist`` records the agent's provider KIND ("custom"), not the name of the
+entry under ``providers:``. Feeding that kind back into ``resolve_runtime_provider``
+on restore resolves a different endpoint and no api_key — and only base_url and
+api_mode have a stored value to fall back on, so the resumed session sends its
+model somewhere that has never heard of it. Every turn then answers with that
+endpoint's rejection, as ordinary assistant text, for the life of the session.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from acp_adapter.session import SessionManager
+
+
+GATEWAY_URL = "https://gateway.example.com/v1"
+
+
+class RecordingAgent:
+    """Stand-in for AIAgent that keeps the kwargs it was built with."""
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.model = kwargs.get("model")
+        self.provider = kwargs.get("provider")
+        self.session_id = kwargs.get("session_id")
+
+
+@pytest.fixture
+def resolver_calls(monkeypatch):
+    """Patch the pieces ``_make_agent`` reaches for, and record the resolution."""
+    calls: list[dict] = []
+
+    def fake_resolve(*, requested=None, explicit_base_url=None, **_kw):
+        calls.append({"requested": requested, "explicit_base_url": explicit_base_url})
+        # Only the provider's own name resolves to its credentials. The bare
+        # kind resolves to whatever else is configured, without a key — this is
+        # what the real resolver does with a named custom provider.
+        if requested == "my-gateway":
+            return {
+                "provider": "custom",
+                "api_mode": "chat_completions",
+                "base_url": GATEWAY_URL,
+                "api_key": "gateway-key",
+            }
+        return {
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "base_url": "https://elsewhere.example.com/v1",
+            "api_key": "",
+        }
+
+    def fake_load_config():
+        return {"model": {"default": "some-model", "provider": "my-gateway"}}
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", fake_resolve)
+    monkeypatch.setattr("hermes_cli.config.load_config", fake_load_config)
+    monkeypatch.setattr("run_agent.AIAgent", RecordingAgent)
+    return calls
+
+
+def test_restore_does_not_feed_the_provider_kind_back_in(resolver_calls, tmp_path):
+    """A resumed session keeps the credentials it was created with."""
+    manager = SessionManager(db=None)
+
+    agent = manager._make_agent(
+        session_id="s-1",
+        cwd=str(tmp_path),
+        model="some-model",
+        # What _restore reads back out of the session row.
+        requested_provider="custom",
+        base_url=GATEWAY_URL,
+        api_mode="chat_completions",
+    )
+
+    assert resolver_calls, "the provider was never resolved"
+    assert resolver_calls[0]["requested"] == "my-gateway", (
+        '"custom" is a provider kind, not a configured provider name; resolving '
+        "it picks a different endpoint and no credentials"
+    )
+    assert resolver_calls[0]["explicit_base_url"] == GATEWAY_URL, (
+        "the session's own endpoint must be passed so a session pinned to one "
+        "other than the configured default keeps it"
+    )
+    assert agent.kwargs["api_key"] == "gateway-key"
+    assert agent.kwargs["base_url"] == GATEWAY_URL
+
+
+def test_a_fresh_session_still_uses_the_configured_provider(resolver_calls, tmp_path):
+    """The path that always worked keeps working: nothing stored, nothing forced."""
+    manager = SessionManager(db=None)
+
+    agent = manager._make_agent(session_id="s-2", cwd=str(tmp_path))
+
+    assert resolver_calls[0]["requested"] == "my-gateway"
+    assert agent.kwargs["api_key"] == "gateway-key"
+
+
+def test_an_explicitly_named_provider_is_still_honoured(resolver_calls, tmp_path):
+    """Only the ambiguous kind is overridden — a real provider name is a request."""
+    manager = SessionManager(db=None)
+
+    manager._make_agent(
+        session_id="s-3",
+        cwd=str(tmp_path),
+        requested_provider="my-gateway",
+        base_url=GATEWAY_URL,
+    )
+
+    assert resolver_calls[0]["requested"] == "my-gateway"


### PR DESCRIPTION
Fixes #101130.

## What

`_persist` records the agent's provider **kind** — the bare string `"custom"` — not the name of the `providers:` entry it came from:

https://github.com/NousResearch/hermes-agent/blob/main/acp_adapter/session.py#L436-L442

`_restore` reads that back as `requested_provider`, and `_make_agent` feeds it to `resolve_runtime_provider`. The kind cannot round-trip: it is not the name of anything configured, so it resolves to some other endpoint and, crucially, to **no api_key**. Only `base_url` and `api_mode` have a stored value to fall back on —

```python
"base_url": base_url or runtime.get("base_url"),   # stored value wins
"api_key":  runtime.get("api_key"),                # nothing to fall back on
```

— so the resumed session is built without credentials and its model is sent somewhere that has never heard of it.

## Why it matters

The failure is silent and permanent:

- it arrives as ordinary assistant text with `stopReason: end_turn`, so an ACP client cannot detect it;
- every new process resuming that session id repeats it, so the session never recovers.

What the user sees is the agent replying `HTTP 400: modelCode: does not exist` (or whatever the misrouted endpoint says) to everything, forever.

On the config this was found on:

```python
resolve_runtime_provider(requested="custom")
# -> base_url 'https://openrouter.ai/api/v1', api_key '', source 'env/config'

resolve_runtime_provider(requested=None)          # what a fresh session gets
# -> base_url '<the configured gateway>', api_key <set>, source 'custom_provider:<name>'
```

## The change

The stored kind is no longer treated as a request. The configured provider is, with the session's own endpoint passed alongside it so a session pinned to one other than the default keeps it:

```python
requested_runtime_provider = requested_provider or config_provider
if str(requested_runtime_provider or "").strip().lower() == "custom":
    requested_runtime_provider = config_provider or None

runtime = resolve_runtime_provider(
    requested=requested_runtime_provider,
    explicit_base_url=base_url or None,
)
```

An explicitly named provider is still honoured — only the ambiguous kind is overridden.

Persisting the provider *name* would be the more complete fix, but it would only help sessions created after the change. Fixing the restore side also repairs the sessions already in `state.db`.

## How to test

Config shape that triggers it — a named custom provider, plus at least one other provider configured (that is where the misrouted request lands):

```yaml
model:
  default: some-model
  provider: my-gateway
providers:
  my-gateway:
    base_url: https://gateway.example.com/v1
    key_env: MY_GATEWAY_KEY
```

1. `hermes acp` → `initialize` → `session/new` → `session/prompt` ("remember the codeword MANGO-9")
2. Kill the process
3. New `hermes acp` → `initialize` → `session/load` (or `session/resume`) with the same `sessionId` → `session/prompt` ("what was the codeword?")

Before: step 3 replies `HTTP 400: modelCode: does not exist`, and the log shows the agent built against a different `base_url` than step 1.
After: both `session/load` and `session/resume` come back on the right endpoint, and the agent answers `MANGO-9`.

New regression test: `tests/acp_adapter/test_acp_resume_provider.py` — asserts the resolver is asked for the configured provider rather than the kind, that the session's endpoint is passed through, and that a fresh session and an explicitly named provider are unaffected. Reverting the fix fails the first of the three.

```
scripts/run_tests.sh tests/acp_adapter/ tests/acp/ -q
=== Summary: 20 files, 154 tests passed, 0 failed ===
```

## Platforms

Tested on macOS 15 (Darwin 25.0.0), Python 3.11.16, against a real named custom provider. The change is pure provider resolution — no file I/O, process or terminal handling — so no platform-specific behaviour is involved.
