### PR TITLE
fix: fallback immediately on missing model

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5889,10 +5889,11 @@ def run_conversation(
                     # Fall through to normal error handling if compression
                     # is exhausted or didn't help.
 
-                # Eager fallback for rate-limit errors (429 or quota exhaustion)
-                # and transport errors (connection failure / timeout / provider
-                # overloaded).  Rate limits and billing: switch immediately —
-                # the primary provider won't recover within the retry window.
+                # Eager fallback for deterministic model availability failures,
+                # rate-limit errors (429 or quota exhaustion), and transport
+                # errors (connection failure / timeout / provider overloaded).
+                # Model-not-found, rate limits, and billing: switch immediately —
+                # the primary route won't recover within the retry window.
                 # Transport errors: allow 1 retry first (transient hiccups
                 # recover), then fall back if the provider is truly unreachable.
                 is_rate_limited = classified.reason in {
@@ -5919,6 +5920,7 @@ def run_conversation(
                     FailoverReason.timeout,
                     FailoverReason.overloaded,
                 }
+                _is_model_unavailable = classified.reason == FailoverReason.model_not_found
                 # Z.AI Coding Plan GLM-5.2 overload 429s classify as
                 # `overloaded` (to spare the credential pool), but `overloaded`
                 # is excluded from `is_rate_limited` — the gate for the adaptive
@@ -5932,7 +5934,8 @@ def run_conversation(
                 if _is_zai_coding_overload:
                     max_retries = max(max_retries, zai_coding_overload_retry_ceiling())
                 _should_fallback = (
-                    (is_rate_limited and _wrapped_output_cap_budget is None)
+                    _is_model_unavailable
+                    or (is_rate_limited and _wrapped_output_cap_budget is None)
                     or (_is_transport_failure and retry_count >= 2)
                 )
                 if _should_fallback and agent._fallback_index < len(agent._fallback_chain):
@@ -5972,6 +5975,10 @@ def run_conversation(
                                 agent._buffer_status(
                                     "⚠️ Billing or credits exhausted — switching to fallback provider..."
                                 )
+                        elif _is_model_unavailable:
+                            agent._buffer_status(
+                                "⚠️ Model unavailable — switching to fallback provider..."
+                            )
                         elif _is_transport_failure:
                             agent._buffer_status(
                                 "⚠️ Provider unreachable — switching to fallback provider..."

--- a/tests/agent/test_model_not_found_main_fallback.py
+++ b/tests/agent/test_model_not_found_main_fallback.py
@@ -1,0 +1,26 @@
+"""Regression coverage for main-turn model-not-found failover."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_main_turn_model_not_found_is_eager_fallback_reason():
+    """A stale Hermes model alias should switch to configured fallbacks immediately.
+
+    The classifier already marks model-not-found as non-retryable and
+    fallback-worthy. This pins the main conversation loop so it does not burn
+    generic retries before trying ``fallback_providers``.
+    """
+
+    source = (
+        Path(__file__).resolve().parent.parent.parent
+        / "agent"
+        / "conversation_loop.py"
+    ).read_text(encoding="utf-8")
+
+    assert "FailoverReason.model_not_found" in source
+    assert "_is_model_unavailable" in source
+    assert "_is_model_unavailable\n                    or (is_rate_limited" in source
+    assert "Model unavailable — switching to fallback provider" in source
+


### PR DESCRIPTION
## Summary
- Treat `model_not_found` as an eager main-turn fallback reason instead of retrying the unavailable primary model.
- Keep output-cap and credential-pool recovery guards intact.
- Add regression coverage so stale model aliases keep activating `fallback_providers` immediately.

## Test plan
- `scripts/run_tests.sh tests/agent/test_model_not_found_main_fallback.py tests/agent/test_error_classifier.py::TestClassifyApiError::test_404_model_not_found tests/gateway/test_fallback_chain_reload.py -q`

<!-- slack-request:begin -->
## Slack Request
- Requested by: <@U01DQ7KNDTP> / GitHub: @yuta-nakamura-dev
- Source thread: https://zen-jp.slack.com/archives/C091RB8LER3/p1788088714588369?thread_ts=1788088714.588369&cid=C091RB8LER3
- Related people:
  - <@U01DQ7KNDTP> / GitHub: @yuta-nakamura-dev / role: requester
- Agent: CodexOps
<!-- slack-request:end -->
