### PR TITLE
fix(cli): honour config model.base_url before the managed llamacpp guard

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1232,8 +1232,20 @@ def _resolve_named_custom_runtime(
     # Managed llama.cpp runtime: a llamacpp-flavored alias with no explicit
     # base_url resolves to the supervised server (or a detected external
     # one) before the generic custom fallthrough. Explicit base_url always
-    # wins — a user pointing at a specific server means that server.
-    if requested_norm in ("llamacpp", "llama.cpp", "llama-cpp") and not explicit_base_url:
+    # wins — a user pointing at a specific server means that server. A
+    # config-level model.base_url is that same explicit pointer (#101120):
+    # the managed-runtime guard must not intercept it, or a self-managed
+    # llama.cpp server configured via `hermes config set model.base_url`
+    # stops resolving and the CLI falls back to "no provider configured".
+    try:
+        _cfg_base_url = str(_get_model_config().get("base_url") or "").strip()
+    except Exception:  # noqa: BLE001 — config read is best-effort here
+        _cfg_base_url = ""
+    if (
+        requested_norm in ("llamacpp", "llama.cpp", "llama-cpp")
+        and not explicit_base_url
+        and not _cfg_base_url
+    ):
         try:
             from hermes_cli.local_runtime.endpoint import resolve_llamacpp_endpoint
 

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1340,6 +1340,56 @@ def test_minimax_oauth_pool_forces_anthropic_messages_despite_stale_config(monke
 
 
 
+# ----------------------------------------------------------------------
+# GitHub #101120 — the managed llama.cpp runtime guard must not intercept
+# a llamacpp alias when a config-level model.base_url points at the
+# user's own server. That base_url is as explicit as a flag-level one;
+# without the check, `hermes config set model.provider llamacpp` +
+# `model.base_url http://127.0.0.1:9931/v1` raises "The local model
+# server is turned off", the startup credential probe swallows it, and
+# the CLI reports "No inference provider is configured yet".
+# ----------------------------------------------------------------------
+
+def test_llamacpp_alias_with_config_base_url_skips_managed_runtime(monkeypatch):
+    """A config model.base_url keeps llamacpp on the generic custom path."""
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "llamacpp",
+            "base_url": "http://127.0.0.1:9931/v1",
+        },
+    )
+    def _must_not_resolve():
+        raise AssertionError("managed endpoint resolver must not be consulted")
+
+    monkeypatch.setattr(
+        "hermes_cli.local_runtime.endpoint.resolve_llamacpp_endpoint",
+        _must_not_resolve,
+    )
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "custom")
+
+    resolved = rp.resolve_runtime_provider(requested="llamacpp")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["base_url"] == "http://127.0.0.1:9931/v1"
+
+
+def test_llamacpp_alias_without_config_base_url_keeps_managed_runtime(monkeypatch):
+    """No base_url anywhere: the managed-runtime guard still owns the alias."""
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {"provider": "llamacpp"},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.local_runtime.endpoint.resolve_llamacpp_endpoint",
+        lambda: None,
+    )
+
+    with pytest.raises(ValueError, match="local model server"):
+        rp.resolve_runtime_provider(requested="llamacpp")
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

The managed llama.cpp runtime guard introduced in 43e67d872f intercepts a llamacpp-flavored alias whenever the flag-level `explicit_base_url` is empty. But a config-level `model.base_url` is that same explicit pointer — as the guard's own comment puts it, "a user pointing at a specific server means that server". With `model.provider: llamacpp` plus `model.base_url` aimed at a self-managed llama.cpp server, the guard finds no supervised/detected endpoint and raises `ValueError("The local model server is turned off…")`; the CLI startup credential probe (`_runtime_credentials_ready`) swallows that exception, returns False, and the session opens with "No inference provider is configured yet".

The fix reads `model.base_url` inside the guard, so a configured base URL falls through to the generic custom path — the same trust rules #27132 established for the ollama/vllm/llamacpp aliases — and the alias keeps resolving to the user's own server.

## Related Issue

Fixes #101120

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/runtime_provider.py`: the managed-llamacpp guard in `_resolve_named_custom_runtime` now also checks the config-level `model.base_url` (best-effort read, fail-open to the previous behavior on config errors) and skips the managed-runtime resolution when one is set.
- `tests/hermes_cli/test_runtime_provider_resolution.py`: regression tests — a llamacpp alias with a config `model.base_url` resolves to the configured endpoint without ever consulting the managed endpoint resolver, and a llamacpp alias with no base URL anywhere still goes through the managed guard.

## How to Test

1. `HERMES_HOME=$(mktemp -d)` with a `config.yaml` containing `model: {provider: llamacpp, base_url: http://127.0.0.1:9931/v1}` (the reporter's setup, no managed runtime installed).
2. Before the fix: `resolve_runtime_provider(requested="llamacpp")` raises `ValueError: The local model server is turned off…`, which the startup probe turns into "No inference provider is configured yet". Observed result: reproduced locally.
3. After the fix: the same call resolves to `{'provider': 'custom', 'base_url': 'http://127.0.0.1:9931/v1', …}`. Observed result: verified locally.
4. `pytest tests/hermes_cli/test_runtime_provider_resolution.py -q` — 67 passed. Also ran `tests/hermes_cli/test_setup_summary_provider_warning.py` and `tests/hermes_cli/test_local_runtime_updates.py` (7 passed) plus `ruff check` on both touched files (clean).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64); the reporter's repro is Windows 11 and the fix is platform-neutral config-read logic

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
