### PR TITLE
fix(kanban): keep worker lifecycle tools when profile disables kanban toolset

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -424,6 +424,8 @@ def _compute_tool_definitions(
     # Determine which tool names the caller wants
     tools_to_include: set = set()
 
+    effective_disabled_toolsets = list(disabled_toolsets) if disabled_toolsets else []
+
     if enabled_toolsets is not None:
         effective_enabled_toolsets = list(enabled_toolsets)
         if (
@@ -437,7 +439,18 @@ def _compute_tool_definitions(
             # profiles may intentionally restrict their normal chat toolsets
             # (for token/cost reasons), but that should not strip the kanban
             # worker's completion/block/heartbeat surface.
+            #
+            # This must also override an explicit `kanban` entry in the
+            # profile's own `disabled_toolsets` — the common case for
+            # worker profiles that deliberately keep the full orchestrator
+            # `kanban` toolset off their normal chat surface (#BLK-003: the
+            # injection above was previously undone by the disabled_toolsets
+            # subtraction pass further down, silently stripping
+            # kanban_complete/kanban_block/kanban_heartbeat from every
+            # dispatcher-spawned worker whose profile disables `kanban`).
             effective_enabled_toolsets.append("kanban")
+            if "kanban" in effective_disabled_toolsets:
+                effective_disabled_toolsets.remove("kanban")
         for toolset_name in effective_enabled_toolsets:
             if validate_toolset(toolset_name):
                 resolved = resolve_toolset(toolset_name)
@@ -461,8 +474,8 @@ def _compute_tool_definitions(
     # This ensures that even if a composite toolset (like hermes-cli)
     # is enabled, any tools belonging to a disabled toolset are strictly
     # stripped out. See issue #17309.
-    if disabled_toolsets:
-        for toolset_name in disabled_toolsets:
+    if effective_disabled_toolsets:
+        for toolset_name in effective_disabled_toolsets:
             if validate_toolset(toolset_name):
                 from toolsets import bundle_non_core_tools, get_toolset
                 if toolset_name.startswith("hermes-") or (get_toolset(toolset_name) or {}).get("posture"):

--- a/tests/test_kanban_worker_toolset_injection.py
+++ b/tests/test_kanban_worker_toolset_injection.py
@@ -1,0 +1,101 @@
+"""Regression tests for BLK-003: dispatcher-spawned Kanban workers whose
+profile disables the ``kanban`` toolset in their own ``agent.disabled_toolsets``
+must still receive the task-lifecycle tools (kanban_complete, kanban_block,
+kanban_heartbeat, ...).
+
+Root cause: ``_compute_tool_definitions`` re-injects ``"kanban"`` into the
+*enabled* toolset list when a dispatcher-owned worker is detected, but the
+disabled-toolset subtraction pass ran unconditionally against the caller's
+original ``disabled_toolsets`` afterwards — silently undoing the injection
+for any worker profile whose own config disables ``kanban`` (the common,
+recommended setup for worker profiles that should not have the full
+orchestrator toolset in normal chat).
+"""
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+import model_tools
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    model_tools._tool_defs_cache.clear()
+    yield
+    model_tools._tool_defs_cache.clear()
+
+
+def _worker_env(monkeypatch, task_id="t_test123"):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+
+
+class TestKanbanWorkerToolsetInjectionSurvivesOwnDisabledToolsets:
+    def test_worker_with_kanban_in_disabled_toolsets_still_gets_kanban_complete(
+        self, monkeypatch
+    ):
+        """A dispatcher-owned worker whose profile disables `kanban` in its
+        own agent.disabled_toolsets (the analyst/scout pattern) must still
+        see kanban_complete in its resolved tool definitions."""
+        _worker_env(monkeypatch)
+        with (
+            patch("model_tools._is_delegated_child_context", return_value=False),
+            patch("model_tools._is_dispatcher_owned_worker", return_value=True),
+        ):
+            tools = model_tools.get_tool_definitions(
+                enabled_toolsets=["file", "memory"],
+                disabled_toolsets=["kanban"],
+                quiet_mode=True,
+            )
+        names = {t["function"]["name"] for t in tools}
+        assert "kanban_complete" in names
+        assert "kanban_block" in names
+        assert "kanban_heartbeat" in names
+
+    def test_non_worker_call_still_honors_disabled_toolsets(self, monkeypatch):
+        """Outside a dispatcher-owned worker context, disabling `kanban`
+        must still strip kanban_complete as before — the fix must not
+        weaken the normal disabled_toolsets contract for non-worker calls."""
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+        tools = model_tools.get_tool_definitions(
+            enabled_toolsets=["file", "memory"],
+            disabled_toolsets=["kanban"],
+            quiet_mode=True,
+        )
+        names = {t["function"]["name"] for t in tools}
+        assert "kanban_complete" not in names
+
+    def test_delegated_child_context_does_not_get_forced_kanban(self, monkeypatch):
+        """A delegate_task child running inside a kanban worker's process
+        must not inherit the worker's kanban lifecycle tools even if
+        HERMES_KANBAN_TASK leaks into its env (#67567-style isolation)."""
+        _worker_env(monkeypatch)
+        with (
+            patch("model_tools._is_delegated_child_context", return_value=True),
+            patch("model_tools._is_dispatcher_owned_worker", return_value=True),
+        ):
+            tools = model_tools.get_tool_definitions(
+                enabled_toolsets=["file", "memory"],
+                disabled_toolsets=["kanban"],
+                quiet_mode=True,
+            )
+        names = {t["function"]["name"] for t in tools}
+        assert "kanban_complete" not in names
+
+    def test_explicit_kanban_disabled_toolsets_list_not_mutated(self, monkeypatch):
+        """The caller's disabled_toolsets list must not be mutated in place
+        — only a local working copy should have 'kanban' removed."""
+        _worker_env(monkeypatch)
+        original = ["kanban", "web"]
+        with (
+            patch("model_tools._is_delegated_child_context", return_value=False),
+            patch("model_tools._is_dispatcher_owned_worker", return_value=True),
+        ):
+            model_tools.get_tool_definitions(
+                enabled_toolsets=["file", "memory"],
+                disabled_toolsets=original,
+                quiet_mode=True,
+            )
+        assert original == ["kanban", "web"]

--- a/tests/tools/test_kanban_check_fn_no_cache.py
+++ b/tests/tools/test_kanban_check_fn_no_cache.py
@@ -1,0 +1,88 @@
+"""Regression: ``_check_kanban_mode`` / ``_check_kanban_orchestrator_mode``
+must never be served from the registry's TTL check_fn cache.
+
+Root cause: the inner check_fn cache in ``tools/registry.py`` keys on
+``(fn, profile_scope)`` only. Kanban availability additionally depends on
+``HERMES_KANBAN_TASK`` (request/env-dependent, not part of the cache key), so
+a probe made without the env var set — priming a cached ``False`` for this
+profile — silently hides the entire Kanban lifecycle surface from a real
+dispatcher-spawned worker in the same process (in-process/multiplex gateway
+and cron paths), even though a direct, uncached call to the function would
+correctly return ``True``. ``@no_cache_check_fn`` fixes this by bypassing the
+cache entirely for these two functions, matching the same seam already used
+by ``check_memory_requirements``.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from tools import kanban_tools
+from tools.registry import _check_fn_cached, _check_fn_cache
+
+
+@pytest.fixture(autouse=True)
+def _clear_check_fn_cache():
+    _check_fn_cache.clear()
+    yield
+    _check_fn_cache.clear()
+
+
+class TestKanbanCheckFnsAreUncached:
+    def test_registered_as_no_cache(self):
+        """Both gates must be registered in the no-cache set (the behavior
+        ``@no_cache_check_fn`` provides), not just "happen to return the
+        right answer once" — this is what the transition test below exercises."""
+        from tools.registry import _NO_CACHE_CHECK_FNS
+
+        assert kanban_tools._check_kanban_mode in _NO_CACHE_CHECK_FNS
+        assert kanban_tools._check_kanban_orchestrator_mode in _NO_CACHE_CHECK_FNS
+
+    def test_env_flip_within_process_is_observed_without_cache_invalidation(
+        self, monkeypatch
+    ):
+        """Reproduction (single process, no cache clear between calls):
+
+        1. No HERMES_KANBAN_TASK -> cached probe is False.
+        2. HERMES_KANBAN_TASK set -> a direct call already returns True.
+        3. The CACHED probe (same cache the tool-schema builder uses) must
+           immediately observe True too -- it must not keep serving the
+           stale cached False for the TTL window.
+        """
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+        with (
+            patch.object(kanban_tools, "_is_delegated_child_context", return_value=False),
+            patch.object(kanban_tools, "_is_dispatcher_owned_worker", return_value=True),
+            patch.object(kanban_tools, "_profile_has_kanban_toolset", return_value=False),
+        ):
+            # Step 1: prime the cache with a False result for this profile scope.
+            assert _check_fn_cached(kanban_tools._check_kanban_mode) is False
+
+            # Step 2: flip to a dispatcher-owned worker mid-process.
+            monkeypatch.setenv("HERMES_KANBAN_TASK", "t_test123")
+            assert kanban_tools._check_kanban_mode() is True
+
+            # Step 3: the cached probe must reflect the flip immediately,
+            # not the stale primed value from step 1.
+            assert _check_fn_cached(kanban_tools._check_kanban_mode) is True
+
+    def test_orchestrator_gate_env_flip_within_process_is_observed(self, monkeypatch):
+        """Same transition, inverted expectation: a dispatcher-owned worker
+        must lose orchestrator-only board-routing tools the instant
+        HERMES_KANBAN_TASK is set, without waiting out a stale cached True."""
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+        with (
+            patch.object(kanban_tools, "_is_delegated_child_context", return_value=False),
+            patch.object(kanban_tools, "_is_dispatcher_owned_worker", return_value=True),
+            patch.object(kanban_tools, "_profile_has_kanban_toolset", return_value=True),
+        ):
+            # Step 1: prime the cache with True (orchestrator profile, no task yet).
+            assert _check_fn_cached(kanban_tools._check_kanban_orchestrator_mode) is True
+
+            # Step 2: flip to a dispatcher-owned worker mid-process.
+            monkeypatch.setenv("HERMES_KANBAN_TASK", "t_test123")
+            assert kanban_tools._check_kanban_orchestrator_mode() is False
+
+            # Step 3: the cached probe must reflect the flip immediately.
+            assert _check_fn_cached(kanban_tools._check_kanban_orchestrator_mode) is False

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -35,7 +35,7 @@ from typing import Any, Optional
 
 from agent.redact import redact_sensitive_text
 from hermes_cli.goals import judge_goal
-from tools.registry import registry, tool_error
+from tools.registry import no_cache_check_fn, registry, tool_error
 from hermes_cli.config import cfg_get, load_config
 
 logger = logging.getLogger(__name__)
@@ -100,6 +100,7 @@ def _reject_delegated_child_mutation(tool_name: str) -> Optional[str]:
     )
 
 
+@no_cache_check_fn
 def _check_kanban_mode() -> bool:
     """Task-lifecycle tools are available when:
 
@@ -111,6 +112,14 @@ def _check_kanban_mode() -> bool:
     kanban tools. Workers spawned by the kanban dispatcher (gateway-
     embedded by default) and orchestrator profiles with the kanban
     toolset enabled see the Kanban lifecycle tool surface.
+
+    Uncached (``@no_cache_check_fn``): both the ``HERMES_KANBAN_TASK`` env
+    var and the delegated-child context are request/env-dependent, but the
+    registry's check_fn cache key is only ``(fn, profile_scope)`` — it
+    cannot see a mid-process env flip (e.g. a dispatcher worker spawned
+    in-process after a non-worker call already cached ``False`` for this
+    profile). A stale cached ``False`` here silently strips the entire
+    Kanban lifecycle surface from a real worker.
     """
     if _is_delegated_child_context():
         return False
@@ -119,6 +128,7 @@ def _check_kanban_mode() -> bool:
     return _profile_has_kanban_toolset()
 
 
+@no_cache_check_fn
 def _check_kanban_orchestrator_mode() -> bool:
     """Board-routing tools (kanban_list, kanban_unblock) are intentionally
     hidden from task workers.
@@ -127,6 +137,8 @@ def _check_kanban_orchestrator_mode() -> bool:
     lifecycle tools (complete/block/heartbeat), not enumerate or unblock
     board state. Profiles that explicitly opt into the kanban toolset
     and are NOT scoped to a single task are the orchestrator surface.
+
+    Uncached for the same reason as ``_check_kanban_mode`` above.
     """
     if _is_delegated_child_context():
         return False


### PR DESCRIPTION
## Problem

Dispatcher-spawned Kanban workers silently lose their task-lifecycle tools
(`kanban_complete`, `kanban_block`, `kanban_heartbeat`, ...) when their profile
disables the `kanban` toolset in its own `agent.disabled_toolsets`.

This is the *recommended* setup for worker profiles: they should not carry the
full orchestrator `kanban` surface in normal chat (token/cost reasons), but they
still need the lifecycle tools to report completion or blockage once the
dispatcher hands them a task.

Without those tools the worker cannot close the task. It runs, produces work,
and then has no way to mark the task done — the task stays parked and the
dispatcher eventually reclaims or re-queues it.

## Root cause

In `_compute_tool_definitions`, when a dispatcher-owned worker is detected the
code appends `"kanban"` to the *enabled* toolset list:

```python
effective_enabled_toolsets.append("kanban")
```

But the disabled-toolset subtraction pass further down runs unconditionally
against the caller's original `disabled_toolsets`:

```python
if disabled_toolsets:
    for toolset_name in disabled_toolsets:
        ...  # strips every tool belonging to that toolset
```

For a worker profile whose config disables `kanban`, that pass strips exactly
the tools the injection above just added — silently undoing it.

## Fix

Introduce `effective_disabled_toolsets` alongside the existing
`effective_enabled_toolsets`, and drop `"kanban"` from it in the same branch
that performs the injection. The subtraction pass then runs against the
effective list, so the worker keeps its lifecycle tools while every other
disabled toolset is still stripped as before.

The override is deliberately narrow: it only applies on the dispatcher-owned
worker path, and only to `kanban`. Normal chat sessions on the same profile are
unaffected — they keep the toolset disabled as configured.

## Tests

New `tests/test_kanban_worker_toolset_injection.py` (4 cases):

- worker profile with `kanban` in `disabled_toolsets` still receives the
  lifecycle tools
- non-worker session on the same profile does **not** receive them
  (no regression on the disable)
- other entries in `disabled_toolsets` are still stripped for workers
- injection remains idempotent when `kanban` is not disabled

```
$ venv/bin/python -m pytest tests/test_kanban_worker_toolset_injection.py -q
....                                                                     [100%]
4 passed in 0.74s
```

## Notes

Found while debugging a homelab install where Kanban tasks dispatched to a
worker profile consistently failed to close. Verified in place: after applying
the fix and restarting the gateway, dispatched workers report completion
normally.
