### PR TITLE
feat(teams): send from stored conversation refs

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -31,7 +31,8 @@ import os
 import sys
 from contextlib import contextmanager
 from typing import Any, Dict, Iterator, Optional
-from urllib.parse import quote
+from pathlib import Path
+from urllib.parse import quote, urlparse
 
 # httpx is imported lazily — only the ``_write_summary_via_incoming_webhook``
 # code path actually constructs an ``AsyncClient``. Top-level import here
@@ -821,6 +822,9 @@ class TeamsAdapter(BasePlatformAdapter):
         # Maps chat_id → ConversationReference captured from incoming messages.
         # Used to send cards with the correct conversation type (personal/group/channel).
         self._conv_refs: Dict[str, Any] = {}
+        # Disk-backed slim refs (teams/conversation_refs/*.json) for proactive
+        # send after restart — in-memory conv refs do not survive (#1218).
+        self._stored_refs: Dict[str, Dict[str, Any]] = {}
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         # Defensive re-check: create_adapter() already ran the installer
@@ -900,6 +904,7 @@ class TeamsAdapter(BasePlatformAdapter):
             await site.start()
 
             self._running = True
+            self._load_stored_refs()
             self._mark_connected()
             logger.info(
                 "[teams] Webhook server listening on %s:%d%s",
@@ -926,6 +931,62 @@ class TeamsAdapter(BasePlatformAdapter):
         self._app = None
         self._mark_disconnected()
         logger.info("[teams] Disconnected")
+
+    def _stored_ref_dir(self) -> Path:
+        from hermes_constants import get_hermes_home
+
+        return Path(get_hermes_home()) / "teams" / "conversation_refs"
+
+    def _load_stored_refs(self) -> None:
+        from plugins.platforms.teams.stored_ref import load_stored_refs
+
+        self._stored_refs = load_stored_refs(self._stored_ref_dir())
+        if self._stored_refs:
+            logger.info("[teams] loaded %d stored conversation ref(s)", len(self._stored_refs))
+
+    def _persist_inbound_stored_ref(self, activity: Any, conv: Any, from_account: Any) -> None:
+        if not self._client_id:
+            return
+        conv_type = getattr(conv, "conversation_type", None) or ""
+        if conv_type != "personal":
+            return
+        conv_id = getattr(conv, "id", None)
+        service_url = getattr(activity, "service_url", None) or ""
+        if not conv_id or not service_url:
+            return
+        from plugins.platforms.teams.stored_ref import StoredRefError, persist_inbound_ref
+
+        try:
+            persist_inbound_ref(
+                self._stored_ref_dir(),
+                conversation_id=str(conv_id),
+                conversation_type="personal",
+                service_url=str(service_url),
+                tenant_id=str(getattr(conv, "tenant_id", None) or self._tenant_id or ""),
+                bot_app_id=self._client_id,
+                aad_object_id=getattr(from_account, "aad_object_id", None),
+                user_id=getattr(from_account, "id", None),
+                person=getattr(from_account, "name", None),
+            )
+            self._load_stored_refs()
+        except StoredRefError as exc:
+            logger.info("[teams] stored-ref persist skipped: %s", exc)
+        except OSError as exc:
+            logger.warning("[teams] stored-ref persist failed: %s", exc)
+
+    async def _post_stored_activity(self, url: str, headers: Any, body: Dict[str, Any]):
+        parsed = urlparse(url)
+        if parsed.scheme != "https" or parsed.hostname not in _ALLOWED_TEAMS_SERVICE_HOSTS:
+            return 0, {"error": "stored-ref send: service host is not allowlisted"}
+        import httpx
+
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.post(url, headers=dict(headers), json=body)
+            try:
+                payload = resp.json()
+            except Exception:
+                payload = {}
+            return resp.status_code, payload
 
     async def _get_botframework_token(self) -> str:
         """Acquire a Bot Framework bearer token via client credentials.
@@ -1055,6 +1116,7 @@ class TeamsAdapter(BasePlatformAdapter):
         from_account = activity.from_
         user_id = getattr(from_account, "aad_object_id", None) or getattr(from_account, "id", "")
         user_name = getattr(from_account, "name", None) or ""
+        self._persist_inbound_stored_ref(activity, conv, from_account)
 
         source = self.build_source(
             chat_id=conv.id,
@@ -1362,6 +1424,32 @@ class TeamsAdapter(BasePlatformAdapter):
 
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted)
+        stored = self._stored_refs.get(chat_id)
+        if stored:
+            from plugins.platforms.teams.stored_ref import send_from_stored_ref
+
+            try:
+                token = await self._get_botframework_token()
+            except Exception as e:
+                return SendResult(success=False, error=str(e), retryable=True)
+            last_message_id = None
+            for chunk in chunks:
+                result = await send_from_stored_ref(
+                    stored,
+                    chunk,
+                    poster=self._post_stored_activity,
+                    expected_bot_app_id=self._client_id,
+                    token=token,
+                )
+                if not result.get("success"):
+                    return SendResult(
+                        success=False,
+                        error=str(result.get("error") or "stored-ref send failed"),
+                        retryable=True,
+                    )
+                last_message_id = result.get("message_id")
+            return SendResult(success=True, message_id=last_message_id)
+
         last_message_id = None
 
         for chunk in chunks:

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -980,13 +980,18 @@ class TeamsAdapter(BasePlatformAdapter):
             return 0, {"error": "stored-ref send: service host is not allowlisted"}
         import httpx
 
-        async with httpx.AsyncClient(timeout=15.0) as client:
-            resp = await client.post(url, headers=dict(headers), json=body)
-            try:
-                payload = resp.json()
-            except Exception:
-                payload = {}
-            return resp.status_code, payload
+        try:
+            async with httpx.AsyncClient(timeout=15.0) as client:
+                resp = await client.post(url, headers=dict(headers), json=body)
+                try:
+                    payload = resp.json()
+                except Exception:
+                    payload = {}
+                return resp.status_code, payload
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            return 0, {"error": "stored-ref send: network error"}
 
     async def _get_botframework_token(self) -> str:
         """Acquire a Bot Framework bearer token via client credentials.

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -826,7 +826,8 @@ class TeamsAdapter(BasePlatformAdapter):
         # send after restart — in-memory conv refs do not survive (#1218).
         self._stored_refs: Dict[str, Dict[str, Any]] = {}
         # Activity ids this bot sent, keyed by conversation id. Group inbound
-        # is addressed only via @mention or reply-to-one-of-these.
+        # is heard always; a send replies on @mention or reply-to-own, and
+        # unmentioned lines default silent.
         self._own_activity_ids: Dict[str, set[str]] = {}
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
@@ -973,12 +974,7 @@ class TeamsAdapter(BasePlatformAdapter):
                 entities=getattr(activity, "entities", None),
                 reply_to_id=reply_to,
                 own_activity_ids=self._own_activity_ids.get(str(conv_id)),
-            )
-            if not addressed_via:
-                logger.info(
-                    "[teams] stored-ref persist skipped: group inbound did not address this bot"
-                )
-                return
+            ) or "unmentioned"
 
         try:
             persist_inbound_ref(

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -827,7 +827,8 @@ class TeamsAdapter(BasePlatformAdapter):
         self._stored_refs: Dict[str, Dict[str, Any]] = {}
         # Activity ids this bot sent, keyed by conversation id. Group inbound
         # is heard always; a send replies on @mention or reply-to-own, and
-        # unmentioned lines default silent.
+        # unmentioned lines default silent unless this turn's decide_speak
+        # opts in.
         self._own_activity_ids: Dict[str, set[str]] = {}
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
@@ -947,6 +948,23 @@ class TeamsAdapter(BasePlatformAdapter):
         self._stored_refs = load_stored_refs(self._stored_ref_dir())
         if self._stored_refs:
             logger.info("[teams] loaded %d stored conversation ref(s)", len(self._stored_refs))
+
+    def _decide_speak_for_turn(self, metadata: Optional[Dict[str, Any]]):
+        """Speak decision bound to this inbound send, not adapter-wide state.
+
+        Unmentioned group turns run through this callable. Default is
+        silent; a per-send ``metadata['decide_speak']`` bool or callable
+        may opt in. Exceptions fail closed in ``group_inbound_should_reply``.
+        """
+        snapshot = dict(metadata or {})
+
+        def _decide() -> bool:
+            raw = snapshot.get("decide_speak", False)
+            if callable(raw):
+                return bool(raw())
+            return bool(raw)
+
+        return _decide
 
     def _persist_inbound_stored_ref(self, activity: Any, conv: Any, from_account: Any) -> None:
         if not self._client_id:
@@ -1459,6 +1477,7 @@ class TeamsAdapter(BasePlatformAdapter):
                 token = await self._get_botframework_token()
             except Exception as e:
                 return SendResult(success=False, error=str(e), retryable=True)
+            decide_speak = self._decide_speak_for_turn(metadata)
             last_message_id = None
             for chunk in chunks:
                 result = await send_from_stored_ref(
@@ -1468,7 +1487,10 @@ class TeamsAdapter(BasePlatformAdapter):
                     expected_bot_app_id=self._client_id,
                     token=token,
                     reply_to=reply_to,
+                    decide_speak=decide_speak,
                 )
+                if result.get("silent"):
+                    return SendResult(success=True, message_id=None)
                 if not result.get("success"):
                     return SendResult(
                         success=False,

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -825,6 +825,9 @@ class TeamsAdapter(BasePlatformAdapter):
         # Disk-backed slim refs (teams/conversation_refs/*.json) for proactive
         # send after restart — in-memory conv refs do not survive (#1218).
         self._stored_refs: Dict[str, Dict[str, Any]] = {}
+        # Activity ids this bot sent, keyed by conversation id. Group inbound
+        # is addressed only via @mention or reply-to-one-of-these.
+        self._own_activity_ids: Dict[str, set[str]] = {}
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         # Defensive re-check: create_adapter() already ran the installer
@@ -954,7 +957,28 @@ class TeamsAdapter(BasePlatformAdapter):
         service_url = getattr(activity, "service_url", None) or ""
         if not conv_id or not service_url:
             return
-        from plugins.platforms.teams.stored_ref import StoredRefError, persist_inbound_ref
+        from plugins.platforms.teams.stored_ref import (
+            StoredRefError,
+            group_inbound_addresses_bot,
+            persist_inbound_ref,
+        )
+
+        addressed_via = None
+        if conv_type in ("groupChat", "group"):
+            reply_to = getattr(activity, "reply_to_id", None) or getattr(
+                activity, "replyToId", None
+            )
+            addressed_via = group_inbound_addresses_bot(
+                bot_app_id=self._client_id,
+                entities=getattr(activity, "entities", None),
+                reply_to_id=reply_to,
+                own_activity_ids=self._own_activity_ids.get(str(conv_id)),
+            )
+            if not addressed_via:
+                logger.info(
+                    "[teams] stored-ref persist skipped: group inbound did not address this bot"
+                )
+                return
 
         try:
             persist_inbound_ref(
@@ -968,6 +992,7 @@ class TeamsAdapter(BasePlatformAdapter):
                 user_id=getattr(from_account, "id", None),
                 person=getattr(from_account, "name", None),
                 inbound_activity_id=getattr(activity, "id", None),
+                addressed_via=addressed_via,
             )
             self._load_stored_refs()
         except StoredRefError as exc:
@@ -1455,6 +1480,8 @@ class TeamsAdapter(BasePlatformAdapter):
                         retryable=True,
                     )
                 last_message_id = result.get("message_id")
+            if last_message_id:
+                self._own_activity_ids.setdefault(chat_id, set()).add(str(last_message_id))
             return SendResult(success=True, message_id=last_message_id)
 
         last_message_id = None
@@ -1479,6 +1506,8 @@ class TeamsAdapter(BasePlatformAdapter):
             except Exception as e:
                 return SendResult(success=False, error=str(e), retryable=True)
 
+        if last_message_id:
+            self._own_activity_ids.setdefault(chat_id, set()).add(str(last_message_id))
         return SendResult(success=True, message_id=last_message_id)
 
     async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -948,7 +948,7 @@ class TeamsAdapter(BasePlatformAdapter):
         if not self._client_id:
             return
         conv_type = getattr(conv, "conversation_type", None) or ""
-        if conv_type != "personal":
+        if conv_type not in ("personal", "groupChat", "group"):
             return
         conv_id = getattr(conv, "id", None)
         service_url = getattr(activity, "service_url", None) or ""
@@ -960,13 +960,14 @@ class TeamsAdapter(BasePlatformAdapter):
             persist_inbound_ref(
                 self._stored_ref_dir(),
                 conversation_id=str(conv_id),
-                conversation_type="personal",
+                conversation_type=str(conv_type),
                 service_url=str(service_url),
                 tenant_id=str(getattr(conv, "tenant_id", None) or self._tenant_id or ""),
                 bot_app_id=self._client_id,
                 aad_object_id=getattr(from_account, "aad_object_id", None),
                 user_id=getattr(from_account, "id", None),
                 person=getattr(from_account, "name", None),
+                inbound_activity_id=getattr(activity, "id", None),
             )
             self._load_stored_refs()
         except StoredRefError as exc:
@@ -1445,6 +1446,7 @@ class TeamsAdapter(BasePlatformAdapter):
                     poster=self._post_stored_activity,
                     expected_bot_app_id=self._client_id,
                     token=token,
+                    reply_to=reply_to,
                 )
                 if not result.get("success"):
                     return SendResult(

--- a/plugins/platforms/teams/plugin.yaml
+++ b/plugins/platforms/teams/plugin.yaml
@@ -1,7 +1,7 @@
 name: teams-platform
 label: Microsoft Teams
 kind: platform
-version: 1.0.0
+version: 1.0.1
 description: >
   Microsoft Teams gateway adapter for Hermes Agent.
   Connects to Microsoft Teams via the Bot Framework and relays messages

--- a/plugins/platforms/teams/stored_ref.py
+++ b/plugins/platforms/teams/stored_ref.py
@@ -1,0 +1,165 @@
+"""Disk-backed Teams conversation references for proactive send.
+
+Bot Framework proactive send is
+``POST {serviceUrl}v3/conversations/{id}/activities`` with the bot's own
+app token. The live adapter only kept ConversationReferences in memory,
+so a restart (or never-seen inbound) had no send path.
+
+This module loads, classifies, and persists slim personal refs and POSTs
+from the bot app identity. Callers inject ``poster`` so tests never
+touch a live host. Live sends still go through the adapter's Bot
+Framework allowlist.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Dict, Mapping, Optional
+from urllib.parse import quote, urlparse
+
+
+Poster = Callable[[str, Mapping[str, str], Dict[str, Any]], Awaitable[tuple[int, Any]]]
+
+_REQUIRED = ("kind", "bot_app_id", "service_url", "conversation_id", "tenant_id")
+_CONV_ID_RE = re.compile(r"^[A-Za-z0-9:@\-_.]+$")
+_STEM_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+class StoredRefError(ValueError):
+    """Stored reference is missing, the wrong kind, or policy-blocked."""
+
+
+def classify_stored_ref(
+    ref: Mapping[str, Any],
+    *,
+    expected_bot_app_id: Optional[str] = None,
+) -> None:
+    missing = [k for k in _REQUIRED if not str(ref.get(k) or "").strip()]
+    if missing:
+        raise StoredRefError(f"stored ref missing fields: {', '.join(missing)}")
+    kind = str(ref.get("kind") or "").strip()
+    if kind != "personal":
+        raise StoredRefError(f"stored ref kind must be personal, got {kind!r}")
+    conv_id = str(ref["conversation_id"])
+    if not _CONV_ID_RE.match(conv_id):
+        raise StoredRefError("stored ref conversation_id is not a Bot Framework id")
+    bot = str(ref["bot_app_id"]).strip()
+    if expected_bot_app_id and bot != expected_bot_app_id:
+        raise StoredRefError("stored ref bot_app_id does not match this adapter")
+    policy = str(ref.get("outbound_policy") or "")
+    if "reply_only" in policy:
+        raise StoredRefError("stored ref outbound_policy is reply_only")
+    parsed = urlparse(str(ref["service_url"]))
+    if not parsed.scheme or not parsed.netloc:
+        raise StoredRefError("stored ref service_url is not an absolute URL")
+
+
+def activity_post_url(ref: Mapping[str, Any]) -> str:
+    classify_stored_ref(ref)
+    base = str(ref["service_url"]).rstrip("/") + "/"
+    conv = quote(str(ref["conversation_id"]), safe=":@-_.")
+    return f"{base}v3/conversations/{conv}/activities"
+
+
+def load_stored_refs(directory: Path) -> Dict[str, Dict[str, Any]]:
+    loaded: Dict[str, Dict[str, Any]] = {}
+    if not directory.is_dir():
+        return loaded
+    for path in sorted(directory.glob("*.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        try:
+            classify_stored_ref(data)
+        except StoredRefError:
+            continue
+        loaded[str(data["conversation_id"])] = data
+    return loaded
+
+
+def persist_inbound_ref(
+    directory: Path,
+    *,
+    conversation_id: str,
+    conversation_type: str,
+    service_url: str,
+    tenant_id: str,
+    bot_app_id: str,
+    aad_object_id: Optional[str] = None,
+    user_id: Optional[str] = None,
+    person: Optional[str] = None,
+    filename_stem: Optional[str] = None,
+) -> Path:
+    kind = "personal" if conversation_type == "personal" else conversation_type
+    ref: Dict[str, Any] = {
+        "kind": kind,
+        "conversation_id": conversation_id,
+        "service_url": service_url if service_url.endswith("/") else service_url + "/",
+        "tenant_id": tenant_id,
+        "bot_app_id": bot_app_id,
+    }
+    if person:
+        ref["person"] = person
+    if aad_object_id:
+        ref["aad_object_id"] = aad_object_id
+    if user_id:
+        ref["user_id"] = user_id
+    classify_stored_ref(ref, expected_bot_app_id=bot_app_id)
+    directory.mkdir(parents=True, exist_ok=True)
+    for existing in directory.glob("*.json"):
+        try:
+            prev = json.loads(existing.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(prev, dict):
+            continue
+        if prev.get("conversation_id") != conversation_id:
+            continue
+        if "reply_only" in str(prev.get("outbound_policy") or ""):
+            raise StoredRefError("will not unlock reply_only ref")
+    stem = filename_stem or person or aad_object_id or conversation_id[:12]
+    stem = _STEM_RE.sub("-", stem).strip("-._") or "personal"
+    dest = directory / f"{stem}.json"
+    dest.write_text(json.dumps(ref, indent=2) + "\n", encoding="utf-8")
+    dest.chmod(0o600)
+    return dest
+
+
+async def send_from_stored_ref(
+    ref: Mapping[str, Any],
+    text: str,
+    *,
+    poster: Poster,
+    expected_bot_app_id: Optional[str] = None,
+    token: str,
+) -> Dict[str, Any]:
+    if not text or not str(text).strip():
+        return {"error": "stored-ref send: empty text"}
+    if not token:
+        return {"error": "stored-ref send: missing token"}
+    try:
+        classify_stored_ref(ref, expected_bot_app_id=expected_bot_app_id)
+    except StoredRefError as exc:
+        return {"error": f"stored-ref send: {exc}"}
+    url = activity_post_url(ref)
+    bot = str(ref["bot_app_id"]).strip()
+    body: Dict[str, Any] = {
+        "type": "message",
+        "text": text,
+        "textFormat": "markdown",
+        "from": {"id": f"28:{bot}"},
+    }
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+    status, payload = await poster(url, headers, body)
+    if status >= 400:
+        return {"error": f"stored-ref send: activity post failed ({status})"}
+    if not isinstance(payload, dict) or not payload.get("id"):
+        return {"error": "stored-ref send: connector accepted without activity id"}
+    return {"success": True, "message_id": payload["id"], "http_status": status}

--- a/plugins/platforms/teams/stored_ref.py
+++ b/plugins/platforms/teams/stored_ref.py
@@ -25,10 +25,50 @@ Poster = Callable[[str, Mapping[str, str], Dict[str, Any]], Awaitable[tuple[int,
 _REQUIRED = ("kind", "bot_app_id", "service_url", "conversation_id", "tenant_id")
 _CONV_ID_RE = re.compile(r"^[A-Za-z0-9:@\-_.]+$")
 _STEM_RE = re.compile(r"[^A-Za-z0-9._-]+")
+_GROUP_ADDRESSED_VIA = frozenset({"mention", "reply_to_own"})
 
 
 class StoredRefError(ValueError):
     """Stored reference is missing, the wrong kind, or policy-blocked."""
+
+
+def group_inbound_addresses_bot(
+    *,
+    bot_app_id: str,
+    entities: Any = None,
+    reply_to_id: Optional[str] = None,
+    own_activity_ids: Any = None,
+) -> Optional[str]:
+    """Return how a group inbound addressed this bot, or None.
+
+    A group message addresses the bot only when it @mentions the bot app
+    id (``28:{bot_app_id}``) or replies to one of this bot's own
+    activity ids. Any other group message must not unlock a send.
+    """
+    bot = str(bot_app_id or "").strip()
+    if not bot:
+        return None
+    bot_ids = {bot, f"28:{bot}"}
+    for ent in entities or []:
+        if isinstance(ent, Mapping):
+            typ = ent.get("type")
+            mentioned = ent.get("mentioned")
+        else:
+            typ = getattr(ent, "type", None)
+            mentioned = getattr(ent, "mentioned", None)
+        if str(typ or "").lower() != "mention":
+            continue
+        if isinstance(mentioned, Mapping):
+            mid = mentioned.get("id")
+        else:
+            mid = getattr(mentioned, "id", None) if mentioned is not None else None
+        if str(mid or "") in bot_ids:
+            return "mention"
+    reply = str(reply_to_id or "").strip()
+    own = {str(x) for x in (own_activity_ids or []) if str(x).strip()}
+    if reply and reply in own:
+        return "reply_to_own"
+    return None
 
 
 def classify_stored_ref(
@@ -41,6 +81,11 @@ def classify_stored_ref(
         raise StoredRefError(f"stored ref missing fields: {', '.join(missing)}")
     kind = str(ref.get("kind") or "").strip()
     if kind in ("group", "groupChat"):
+        via = str(ref.get("addressed_via") or "").strip()
+        if via not in _GROUP_ADDRESSED_VIA:
+            raise StoredRefError(
+                "group inbound must mention this bot or reply to this bot"
+            )
         if not str(ref.get("addressed_by") or "").strip():
             raise StoredRefError("group ref requires inbound addresser")
     elif kind != "personal":
@@ -98,6 +143,7 @@ def persist_inbound_ref(
     person: Optional[str] = None,
     filename_stem: Optional[str] = None,
     inbound_activity_id: Optional[str] = None,
+    addressed_via: Optional[str] = None,
 ) -> Path:
     if conversation_type == "personal":
         kind = "personal"
@@ -119,9 +165,15 @@ def persist_inbound_ref(
     if user_id:
         ref["user_id"] = user_id
     if kind == "groupChat":
+        via = str(addressed_via or "").strip()
+        if via not in _GROUP_ADDRESSED_VIA:
+            raise StoredRefError(
+                "group inbound must mention this bot or reply to this bot"
+            )
         addresser = user_id or aad_object_id
         if not addresser:
             raise StoredRefError("group ref requires inbound addresser")
+        ref["addressed_via"] = via
         ref["addressed_by"] = str(addresser)
         if inbound_activity_id:
             ref["last_inbound_activity_id"] = str(inbound_activity_id)

--- a/plugins/platforms/teams/stored_ref.py
+++ b/plugins/platforms/teams/stored_ref.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import asyncio
 import json
 import re
+import time
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, Mapping, Optional
 from urllib.parse import quote, urlparse
@@ -134,11 +135,24 @@ def activity_post_url(ref: Mapping[str, Any]) -> str:
     return f"{base}v3/conversations/{conv}/activities"
 
 
+def _ref_recency(path: Path, data: Mapping[str, Any]) -> int:
+    stamp = data.get("persisted_at")
+    if isinstance(stamp, bool):
+        stamp = None
+    if isinstance(stamp, (int, float)):
+        return int(stamp)
+    try:
+        return path.stat().st_mtime_ns
+    except OSError:
+        return 0
+
+
 def load_stored_refs(directory: Path) -> Dict[str, Dict[str, Any]]:
     loaded: Dict[str, Dict[str, Any]] = {}
+    recency: Dict[str, int] = {}
     if not directory.is_dir():
         return loaded
-    for path in sorted(directory.glob("*.json")):
+    for path in directory.glob("*.json"):
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
@@ -149,7 +163,12 @@ def load_stored_refs(directory: Path) -> Dict[str, Dict[str, Any]]:
             classify_stored_ref(data)
         except StoredRefError:
             continue
-        loaded[str(data["conversation_id"])] = data
+        conv = str(data["conversation_id"])
+        rank = _ref_recency(path, data)
+        if conv in recency and recency[conv] >= rank:
+            continue
+        recency[conv] = rank
+        loaded[conv] = data
     return loaded
 
 
@@ -200,6 +219,7 @@ def persist_inbound_ref(
         ref["addressed_by"] = str(addresser)
         if inbound_activity_id:
             ref["last_inbound_activity_id"] = str(inbound_activity_id)
+    ref["persisted_at"] = time.time_ns()
     classify_stored_ref(ref, expected_bot_app_id=bot_app_id)
     directory.mkdir(parents=True, exist_ok=True)
     for existing in directory.glob("*.json"):

--- a/plugins/platforms/teams/stored_ref.py
+++ b/plugins/platforms/teams/stored_ref.py
@@ -26,6 +26,7 @@ _REQUIRED = ("kind", "bot_app_id", "service_url", "conversation_id", "tenant_id"
 _CONV_ID_RE = re.compile(r"^[A-Za-z0-9:@\-_.]+$")
 _STEM_RE = re.compile(r"[^A-Za-z0-9._-]+")
 _GROUP_ADDRESSED_VIA = frozenset({"mention", "reply_to_own"})
+_GROUP_HEARD_VIA = frozenset({"mention", "reply_to_own", "unmentioned"})
 
 
 class StoredRefError(ValueError):
@@ -43,7 +44,8 @@ def group_inbound_addresses_bot(
 
     A group message addresses the bot only when it @mentions the bot app
     id (``28:{bot_app_id}``) or replies to one of this bot's own
-    activity ids. Any other group message must not unlock a send.
+    activity ids. Unmentioned lines are still heard; they do not count
+    as an address.
     """
     bot = str(bot_app_id or "").strip()
     if not bot:
@@ -71,6 +73,27 @@ def group_inbound_addresses_bot(
     return None
 
 
+def group_inbound_should_reply(
+    addressed_via: Optional[str] = None,
+    *,
+    decide_speak: Optional[Callable[[], bool]] = None,
+) -> bool:
+    """Whether a delivered group inbound should produce a send.
+
+    Mention or reply-to-own always replies. Unmentioned lines default
+    silent; ``decide_speak`` may opt in (fail closed on exception).
+    """
+    via = str(addressed_via or "").strip()
+    if via in _GROUP_ADDRESSED_VIA:
+        return True
+    if decide_speak is None:
+        return False
+    try:
+        return bool(decide_speak())
+    except Exception:
+        return False
+
+
 def classify_stored_ref(
     ref: Mapping[str, Any],
     *,
@@ -82,9 +105,9 @@ def classify_stored_ref(
     kind = str(ref.get("kind") or "").strip()
     if kind in ("group", "groupChat"):
         via = str(ref.get("addressed_via") or "").strip()
-        if via not in _GROUP_ADDRESSED_VIA:
+        if via not in _GROUP_HEARD_VIA:
             raise StoredRefError(
-                "group inbound must mention this bot or reply to this bot"
+                "group inbound must record mention, reply-to-own, or unmentioned"
             )
         if not str(ref.get("addressed_by") or "").strip():
             raise StoredRefError("group ref requires inbound addresser")
@@ -165,10 +188,10 @@ def persist_inbound_ref(
     if user_id:
         ref["user_id"] = user_id
     if kind == "groupChat":
-        via = str(addressed_via or "").strip()
-        if via not in _GROUP_ADDRESSED_VIA:
+        via = str(addressed_via or "").strip() or "unmentioned"
+        if via not in _GROUP_HEARD_VIA:
             raise StoredRefError(
-                "group inbound must mention this bot or reply to this bot"
+                "group inbound must record mention, reply-to-own, or unmentioned"
             )
         addresser = user_id or aad_object_id
         if not addresser:
@@ -206,6 +229,7 @@ async def send_from_stored_ref(
     expected_bot_app_id: Optional[str] = None,
     token: str,
     reply_to: Optional[str] = None,
+    decide_speak: Optional[Callable[[], bool]] = None,
 ) -> Dict[str, Any]:
     if not text or not str(text).strip():
         return {"error": "stored-ref send: empty text"}
@@ -228,6 +252,12 @@ async def send_from_stored_ref(
     if kind in ("group", "groupChat"):
         if not thread_id:
             return {"error": "stored-ref send: group send is never a first post"}
+        via = str(ref.get("addressed_via") or "").strip()
+        if not group_inbound_should_reply(via, decide_speak=decide_speak):
+            return {
+                "silent": True,
+                "error": "stored-ref send: unmentioned group inbound is silent by default",
+            }
         body["replyToId"] = thread_id
     headers = {
         "Authorization": f"Bearer {token}",

--- a/plugins/platforms/teams/stored_ref.py
+++ b/plugins/platforms/teams/stored_ref.py
@@ -12,6 +12,7 @@ Framework allowlist.
 """
 from __future__ import annotations
 
+import asyncio
 import json
 import re
 from pathlib import Path
@@ -157,8 +158,13 @@ async def send_from_stored_ref(
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",
     }
-    status, payload = await poster(url, headers, body)
-    if status >= 400:
+    try:
+        status, payload = await poster(url, headers, body)
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        return {"error": f"stored-ref send failed: {type(exc).__name__}"}
+    if status not in (200, 201, 202):
         return {"error": f"stored-ref send: activity post failed ({status})"}
     if not isinstance(payload, dict) or not payload.get("id"):
         return {"error": "stored-ref send: connector accepted without activity id"}

--- a/plugins/platforms/teams/stored_ref.py
+++ b/plugins/platforms/teams/stored_ref.py
@@ -40,8 +40,11 @@ def classify_stored_ref(
     if missing:
         raise StoredRefError(f"stored ref missing fields: {', '.join(missing)}")
     kind = str(ref.get("kind") or "").strip()
-    if kind != "personal":
-        raise StoredRefError(f"stored ref kind must be personal, got {kind!r}")
+    if kind in ("group", "groupChat"):
+        if not str(ref.get("addressed_by") or "").strip():
+            raise StoredRefError("group ref requires inbound addresser")
+    elif kind != "personal":
+        raise StoredRefError(f"stored ref kind must be personal or groupChat, got {kind!r}")
     conv_id = str(ref["conversation_id"])
     if not _CONV_ID_RE.match(conv_id):
         raise StoredRefError("stored ref conversation_id is not a Bot Framework id")
@@ -94,8 +97,14 @@ def persist_inbound_ref(
     user_id: Optional[str] = None,
     person: Optional[str] = None,
     filename_stem: Optional[str] = None,
+    inbound_activity_id: Optional[str] = None,
 ) -> Path:
-    kind = "personal" if conversation_type == "personal" else conversation_type
+    if conversation_type == "personal":
+        kind = "personal"
+    elif conversation_type in ("group", "groupChat"):
+        kind = "groupChat"
+    else:
+        raise StoredRefError(f"cannot persist kind {conversation_type!r}")
     ref: Dict[str, Any] = {
         "kind": kind,
         "conversation_id": conversation_id,
@@ -109,6 +118,13 @@ def persist_inbound_ref(
         ref["aad_object_id"] = aad_object_id
     if user_id:
         ref["user_id"] = user_id
+    if kind == "groupChat":
+        addresser = user_id or aad_object_id
+        if not addresser:
+            raise StoredRefError("group ref requires inbound addresser")
+        ref["addressed_by"] = str(addresser)
+        if inbound_activity_id:
+            ref["last_inbound_activity_id"] = str(inbound_activity_id)
     classify_stored_ref(ref, expected_bot_app_id=bot_app_id)
     directory.mkdir(parents=True, exist_ok=True)
     for existing in directory.glob("*.json"):
@@ -137,6 +153,7 @@ async def send_from_stored_ref(
     poster: Poster,
     expected_bot_app_id: Optional[str] = None,
     token: str,
+    reply_to: Optional[str] = None,
 ) -> Dict[str, Any]:
     if not text or not str(text).strip():
         return {"error": "stored-ref send: empty text"}
@@ -154,6 +171,12 @@ async def send_from_stored_ref(
         "textFormat": "markdown",
         "from": {"id": f"28:{bot}"},
     }
+    kind = str(ref.get("kind") or "").strip()
+    thread_id = str(reply_to or ref.get("last_inbound_activity_id") or "").strip()
+    if kind in ("group", "groupChat"):
+        if not thread_id:
+            return {"error": "stored-ref send: group send is never a first post"}
+        body["replyToId"] = thread_id
     headers = {
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",

--- a/plugins/platforms/teams/stored_ref.py
+++ b/plugins/platforms/teams/stored_ref.py
@@ -172,6 +172,22 @@ def load_stored_refs(directory: Path) -> Dict[str, Dict[str, Any]]:
     return loaded
 
 
+def _ref_filename_stem(
+    *,
+    conversation_id: str,
+    kind: str,
+    filename_stem: Optional[str],
+    person: Optional[str],
+    aad_object_id: Optional[str],
+    user_id: Optional[str],
+) -> str:
+    """Conversation-qualified stem. Never key on person alone."""
+    label = filename_stem or person or aad_object_id or user_id or "ref"
+    raw = f"{label}-{kind}-{conversation_id}"
+    stem = _STEM_RE.sub("-", raw).strip("-._") or "ref"
+    return stem[:180]
+
+
 def persist_inbound_ref(
     directory: Path,
     *,
@@ -233,8 +249,14 @@ def persist_inbound_ref(
             continue
         if "reply_only" in str(prev.get("outbound_policy") or ""):
             raise StoredRefError("will not unlock reply_only ref")
-    stem = filename_stem or person or aad_object_id or conversation_id[:12]
-    stem = _STEM_RE.sub("-", stem).strip("-._") or "personal"
+    stem = _ref_filename_stem(
+        conversation_id=conversation_id,
+        kind=kind,
+        filename_stem=filename_stem,
+        person=person,
+        aad_object_id=aad_object_id,
+        user_id=user_id,
+    )
     dest = directory / f"{stem}.json"
     dest.write_text(json.dumps(ref, indent=2) + "\n", encoding="utf-8")
     dest.chmod(0o600)

--- a/tests/plugins/platforms/test_teams_stored_ref_send.py
+++ b/tests/plugins/platforms/test_teams_stored_ref_send.py
@@ -1,0 +1,159 @@
+"""Stored conversation-ref send for Teams (governance #1218).
+
+Throwaway HTTP only — never a live Bot Framework host.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from plugins.platforms.teams.stored_ref import (
+    StoredRefError,
+    activity_post_url,
+    classify_stored_ref,
+    load_stored_refs,
+    persist_inbound_ref,
+    send_from_stored_ref,
+)
+
+
+BOT = "00000000-0000-4000-8000-0000000000aa"
+
+
+def _throwaway(**overrides):
+    ref = {
+        "kind": "personal",
+        "person": "Throwaway",
+        "aad_object_id": "00000000-0000-0000-0000-000000000001",
+        "tenant_id": "00000000-0000-0000-0000-000000000002",
+        "bot_app_id": BOT,
+        "service_url": "http://127.0.0.1:9/",
+        "conversation_id": "throwaway-1218",
+        "user_id": "29:throwaway-roster",
+    }
+    ref.update(overrides)
+    return ref
+
+
+def test_classify_accepts_personal_matching_bot():
+    classify_stored_ref(_throwaway(), expected_bot_app_id=BOT)
+
+
+def test_classify_rejects_group():
+    with pytest.raises(StoredRefError, match="personal"):
+        classify_stored_ref(_throwaway(kind="groupChat"), expected_bot_app_id=BOT)
+
+
+def test_classify_rejects_wrong_bot():
+    with pytest.raises(StoredRefError, match="bot"):
+        classify_stored_ref(_throwaway(), expected_bot_app_id="00000000-0000-0000-0000-000000000099")
+
+
+def test_classify_rejects_reply_only_policy():
+    with pytest.raises(StoredRefError, match="reply_only"):
+        classify_stored_ref(
+            _throwaway(outbound_policy="reply_only_until_customer_writes"),
+            expected_bot_app_id=BOT,
+        )
+
+
+def test_activity_url_uses_service_url_and_conversation_id():
+    url = activity_post_url(_throwaway())
+    assert url == "http://127.0.0.1:9/v3/conversations/throwaway-1218/activities"
+
+
+def test_load_stored_refs_indexes_by_conversation_id(tmp_path: Path):
+    path = tmp_path / "throwaway.json"
+    path.write_text(json.dumps(_throwaway()), encoding="utf-8")
+    loaded = load_stored_refs(tmp_path)
+    assert "throwaway-1218" in loaded
+    assert loaded["throwaway-1218"]["user_id"] == "29:throwaway-roster"
+
+
+def test_persist_inbound_ref_writes_personal_json(tmp_path: Path):
+    dest = persist_inbound_ref(
+        tmp_path,
+        conversation_id="a:owner-chat",
+        conversation_type="personal",
+        service_url="https://smba.trafficmanager.net/teams/",
+        tenant_id="00000000-0000-0000-0000-000000000002",
+        bot_app_id=BOT,
+        aad_object_id="00000000-0000-4000-8000-0000000000bb",
+        user_id="29:owner-roster",
+        person="Owner",
+        filename_stem="owner",
+    )
+    data = json.loads(dest.read_text(encoding="utf-8"))
+    assert data["kind"] == "personal"
+    assert data["conversation_id"] == "a:owner-chat"
+    assert data["user_id"] == "29:owner-roster"
+    assert data["bot_app_id"] == BOT
+    assert "outbound_policy" not in data
+
+
+def test_persist_inbound_ref_does_not_unlock_reply_only(tmp_path: Path):
+    locked = _throwaway(
+        conversation_id="a:locked",
+        outbound_policy="reply_only_until_customer_writes",
+    )
+    (tmp_path / "customer.json").write_text(json.dumps(locked), encoding="utf-8")
+    with pytest.raises(StoredRefError, match="reply_only"):
+        persist_inbound_ref(
+            tmp_path,
+            conversation_id="a:locked",
+            conversation_type="personal",
+            service_url="https://smba.trafficmanager.net/teams/",
+            tenant_id=locked["tenant_id"],
+            bot_app_id=BOT,
+            filename_stem="unlocked",
+        )
+    assert not (tmp_path / "unlocked.json").exists()
+
+
+def test_send_from_stored_ref_returns_activity_id_on_201():
+    posted = {}
+
+    async def poster(url, headers, body):
+        posted["url"] = url
+        posted["body"] = body
+        posted["auth_prefix"] = str(headers.get("Authorization", ""))[:7]
+        return 201, {"id": "activity-throwaway-1218"}
+
+    async def run():
+        return await send_from_stored_ref(
+            _throwaway(),
+            "STORED-REF-OWN-SEND",
+            poster=poster,
+            expected_bot_app_id=BOT,
+            token="not-a-secret-for-test",
+        )
+
+    result = asyncio.run(run())
+    assert result["success"] is True
+    assert result["message_id"] == "activity-throwaway-1218"
+    assert posted["url"].endswith("/v3/conversations/throwaway-1218/activities")
+    assert posted["body"]["text"] == "STORED-REF-OWN-SEND"
+    assert posted["body"]["from"]["id"] == f"28:{BOT}"
+    assert posted["auth_prefix"] == "Bearer "
+
+
+def test_send_from_stored_ref_http_400_is_not_success():
+    async def poster(url, headers, body):
+        return 400, {"error": {"message": "Invalid or unencrypted user ID"}}
+
+    async def run():
+        return await send_from_stored_ref(
+            _throwaway(),
+            "STORED-REF-OWN-SEND",
+            poster=poster,
+            expected_bot_app_id=BOT,
+            token="not-a-secret-for-test",
+        )
+
+    result = asyncio.run(run())
+    assert result.get("success") is not True
+    assert "error" in result
+    assert "400" in result["error"]

--- a/tests/plugins/platforms/test_teams_stored_ref_send.py
+++ b/tests/plugins/platforms/test_teams_stored_ref_send.py
@@ -614,8 +614,14 @@ def test_two_senders_keep_own_refs_latest_unmentioned_not_older_mention(
         inbound_activity_id="latest-unmentioned",
         addressed_via="unmentioned",
     )
-    zulu = json.loads((tmp_path / "Zulu.json").read_text(encoding="utf-8"))
-    alpha = json.loads((tmp_path / "Alpha.json").read_text(encoding="utf-8"))
+    by_person = {
+        json.loads(path.read_text(encoding="utf-8"))["person"]: json.loads(
+            path.read_text(encoding="utf-8")
+        )
+        for path in tmp_path.glob("*.json")
+    }
+    zulu = by_person["Zulu"]
+    alpha = by_person["Alpha"]
     assert zulu["addressed_via"] == "mention"
     assert zulu["last_inbound_activity_id"] == "old-mentioned"
     assert zulu["addressed_by"] == "29:zulu-roster"
@@ -626,3 +632,49 @@ def test_two_senders_keep_own_refs_latest_unmentioned_not_older_mention(
     assert loaded["addressed_via"] == "unmentioned"
     assert loaded["last_inbound_activity_id"] == "latest-unmentioned"
     assert loaded["addressed_by"] == "29:alpha-roster"
+
+
+def _persist_same_person(tmp_path: Path, *, personal_first: bool) -> None:
+    person = "Pat"
+    user_id = "29:same-roster"
+    common = dict(
+        service_url="https://smba.trafficmanager.net/teams/",
+        tenant_id="00000000-0000-0000-0000-000000000002",
+        bot_app_id=BOT,
+        user_id=user_id,
+        person=person,
+    )
+    personal = dict(
+        conversation_id="19:personal-throwaway",
+        conversation_type="personal",
+        **common,
+    )
+    group = dict(
+        conversation_id="19:group-throwaway",
+        conversation_type="groupChat",
+        inbound_activity_id="group-line",
+        addressed_via="unmentioned",
+        **common,
+    )
+    first, second = (personal, group) if personal_first else (group, personal)
+    persist_inbound_ref(tmp_path, **first)
+    persist_inbound_ref(tmp_path, **second)
+
+
+@pytest.mark.parametrize("personal_first", [True, False])
+def test_same_person_personal_and_group_keep_separate_refs(
+    tmp_path: Path, personal_first: bool
+):
+    _persist_same_person(tmp_path, personal_first=personal_first)
+    loaded = load_stored_refs(tmp_path)
+    personal = loaded["19:personal-throwaway"]
+    group = loaded["19:group-throwaway"]
+    assert personal["kind"] == "personal"
+    assert personal["person"] == "Pat"
+    assert personal["user_id"] == "29:same-roster"
+    assert group["kind"] == "groupChat"
+    assert group["person"] == "Pat"
+    assert group["conversation_id"] == "19:group-throwaway"
+    assert personal["conversation_id"] == "19:personal-throwaway"
+    names = {path.name for path in tmp_path.glob("*.json")}
+    assert len(names) == 2

--- a/tests/plugins/platforms/test_teams_stored_ref_send.py
+++ b/tests/plugins/platforms/test_teams_stored_ref_send.py
@@ -14,6 +14,7 @@ from plugins.platforms.teams.stored_ref import (
     StoredRefError,
     activity_post_url,
     classify_stored_ref,
+    group_inbound_addresses_bot,
     load_stored_refs,
     persist_inbound_ref,
     send_from_stored_ref,
@@ -43,13 +44,36 @@ def test_classify_accepts_personal_matching_bot():
 
 
 def test_classify_rejects_group_without_inbound_addresser():
-    with pytest.raises(StoredRefError, match="addresser"):
+    with pytest.raises(StoredRefError, match="mention this bot or reply"):
         classify_stored_ref(_throwaway(kind="groupChat"), expected_bot_app_id=BOT)
 
 
-def test_classify_accepts_group_after_inbound_addresser():
+def test_classify_rejects_group_with_sender_but_no_bot_address():
+    with pytest.raises(StoredRefError, match="mention this bot or reply"):
+        classify_stored_ref(
+            _throwaway(kind="groupChat", addressed_by="29:customer-roster"),
+            expected_bot_app_id=BOT,
+        )
+
+
+def test_classify_accepts_group_after_mention():
     classify_stored_ref(
-        _throwaway(kind="groupChat", addressed_by="29:customer-roster"),
+        _throwaway(
+            kind="groupChat",
+            addressed_by="29:customer-roster",
+            addressed_via="mention",
+        ),
+        expected_bot_app_id=BOT,
+    )
+
+
+def test_classify_accepts_group_after_reply_to_own():
+    classify_stored_ref(
+        _throwaway(
+            kind="groupChat",
+            addressed_by="29:customer-roster",
+            addressed_via="reply_to_own",
+        ),
         expected_bot_app_id=BOT,
     )
 
@@ -227,6 +251,7 @@ def _group_ref(**overrides):
         kind="groupChat",
         conversation_id="19:group-throwaway",
         addressed_by="29:customer-roster",
+        addressed_via="mention",
         last_inbound_activity_id="activity-inbound-1",
     )
     ref.update(overrides)
@@ -272,3 +297,82 @@ def test_group_send_replies_in_addressed_thread():
     assert result["success"] is True
     assert result["message_id"] == "activity-group-reply"
     assert posted["body"]["replyToId"] == "activity-inbound-1"
+
+
+def test_group_inbound_mention_addresses_bot():
+    assert (
+        group_inbound_addresses_bot(
+            bot_app_id=BOT,
+            entities=[{"type": "mention", "mentioned": {"id": f"28:{BOT}"}}],
+        )
+        == "mention"
+    )
+
+
+def test_group_inbound_reply_to_own_addresses_bot():
+    assert (
+        group_inbound_addresses_bot(
+            bot_app_id=BOT,
+            reply_to_id="activity-own-1",
+            own_activity_ids=["activity-own-1"],
+        )
+        == "reply_to_own"
+    )
+
+
+def test_group_inbound_ambient_does_not_address_bot():
+    assert (
+        group_inbound_addresses_bot(
+            bot_app_id=BOT,
+            entities=[],
+            reply_to_id="activity-someone-else",
+            own_activity_ids=["activity-own-1"],
+        )
+        is None
+    )
+
+
+def test_persist_rejects_unmentioned_group(tmp_path: Path):
+    with pytest.raises(StoredRefError, match="mention this bot or reply"):
+        persist_inbound_ref(
+            tmp_path,
+            conversation_id="19:group-throwaway",
+            conversation_type="groupChat",
+            service_url="https://smba.trafficmanager.net/teams/",
+            tenant_id="00000000-0000-0000-0000-000000000002",
+            bot_app_id=BOT,
+            user_id="29:customer-roster",
+            inbound_activity_id="activity-ambient",
+        )
+    assert list(tmp_path.glob("*.json")) == []
+
+
+def test_adapter_does_not_persist_unmentioned_group(tmp_path: Path, monkeypatch):
+    from plugins.platforms.teams.adapter import TeamsAdapter
+
+    adapter = object.__new__(TeamsAdapter)
+    adapter._client_id = BOT
+    adapter._tenant_id = "00000000-0000-0000-0000-000000000002"
+    adapter._stored_refs = {}
+    adapter._own_activity_ids = {}
+    monkeypatch.setattr(adapter, "_stored_ref_dir", lambda: tmp_path)
+
+    class _Conv:
+        conversation_type = "groupChat"
+        id = "19:group-throwaway"
+        tenant_id = "00000000-0000-0000-0000-000000000002"
+
+    class _Activity:
+        service_url = "https://smba.trafficmanager.net/teams/"
+        id = "activity-ambient"
+        entities = []
+        reply_to_id = None
+
+    class _From:
+        aad_object_id = "00000000-0000-0000-0000-000000000001"
+        id = "29:customer-roster"
+        name = "Customer"
+
+    adapter._persist_inbound_stored_ref(_Activity(), _Conv(), _From())
+    assert list(tmp_path.glob("*.json")) == []
+    assert adapter._stored_refs == {}

--- a/tests/plugins/platforms/test_teams_stored_ref_send.py
+++ b/tests/plugins/platforms/test_teams_stored_ref_send.py
@@ -157,3 +157,59 @@ def test_send_from_stored_ref_http_400_is_not_success():
     assert result.get("success") is not True
     assert "error" in result
     assert "400" in result["error"]
+
+
+def test_send_from_stored_ref_missing_activity_id_is_not_success():
+    async def poster(url, headers, body):
+        return 201, {}
+
+    async def run():
+        return await send_from_stored_ref(
+            _throwaway(),
+            "STORED-REF-OWN-SEND",
+            poster=poster,
+            expected_bot_app_id=BOT,
+            token="not-a-secret-for-test",
+        )
+
+    result = asyncio.run(run())
+    assert result.get("success") is not True
+    assert "activity id" in result["error"]
+
+
+def test_send_from_stored_ref_poster_exception_is_not_success():
+    async def poster(url, headers, body):
+        raise TimeoutError("connector timeout")
+
+    async def run():
+        return await send_from_stored_ref(
+            _throwaway(),
+            "STORED-REF-OWN-SEND",
+            poster=poster,
+            expected_bot_app_id=BOT,
+            token="not-a-secret-for-test",
+        )
+
+    result = asyncio.run(run())
+    assert result.get("success") is not True
+    assert "error" in result
+    assert "TimeoutError" in result["error"] or "timeout" in result["error"].lower()
+
+
+def test_send_from_stored_ref_status_zero_is_not_missing_activity_id():
+    async def poster(url, headers, body):
+        return 0, {"error": "stored-ref send: service host is not allowlisted"}
+
+    async def run():
+        return await send_from_stored_ref(
+            _throwaway(),
+            "STORED-REF-OWN-SEND",
+            poster=poster,
+            expected_bot_app_id=BOT,
+            token="not-a-secret-for-test",
+        )
+
+    result = asyncio.run(run())
+    assert result.get("success") is not True
+    assert "activity id" not in result["error"]
+    assert "failed (0)" in result["error"]

--- a/tests/plugins/platforms/test_teams_stored_ref_send.py
+++ b/tests/plugins/platforms/test_teams_stored_ref_send.py
@@ -42,9 +42,16 @@ def test_classify_accepts_personal_matching_bot():
     classify_stored_ref(_throwaway(), expected_bot_app_id=BOT)
 
 
-def test_classify_rejects_group():
-    with pytest.raises(StoredRefError, match="personal"):
+def test_classify_rejects_group_without_inbound_addresser():
+    with pytest.raises(StoredRefError, match="addresser"):
         classify_stored_ref(_throwaway(kind="groupChat"), expected_bot_app_id=BOT)
+
+
+def test_classify_accepts_group_after_inbound_addresser():
+    classify_stored_ref(
+        _throwaway(kind="groupChat", addressed_by="29:customer-roster"),
+        expected_bot_app_id=BOT,
+    )
 
 
 def test_classify_rejects_wrong_bot():
@@ -213,3 +220,55 @@ def test_send_from_stored_ref_status_zero_is_not_missing_activity_id():
     assert result.get("success") is not True
     assert "activity id" not in result["error"]
     assert "failed (0)" in result["error"]
+
+
+def _group_ref(**overrides):
+    ref = _throwaway(
+        kind="groupChat",
+        conversation_id="19:group-throwaway",
+        addressed_by="29:customer-roster",
+        last_inbound_activity_id="activity-inbound-1",
+    )
+    ref.update(overrides)
+    return ref
+
+
+def test_group_send_without_reply_is_not_a_first_post():
+    async def poster(url, headers, body):
+        raise AssertionError("must not POST a group first post")
+
+    async def run():
+        return await send_from_stored_ref(
+            _group_ref(last_inbound_activity_id=""),
+            "STORED-REF-OWN-SEND",
+            poster=poster,
+            expected_bot_app_id=BOT,
+            token="not-a-secret-for-test",
+        )
+
+    result = asyncio.run(run())
+    assert result.get("success") is not True
+    assert "first post" in result["error"]
+
+
+def test_group_send_replies_in_addressed_thread():
+    posted = {}
+
+    async def poster(url, headers, body):
+        posted["body"] = body
+        return 201, {"id": "activity-group-reply"}
+
+    async def run():
+        return await send_from_stored_ref(
+            _group_ref(),
+            "STORED-REF-OWN-SEND",
+            poster=poster,
+            expected_bot_app_id=BOT,
+            token="not-a-secret-for-test",
+            reply_to="activity-inbound-1",
+        )
+
+    result = asyncio.run(run())
+    assert result["success"] is True
+    assert result["message_id"] == "activity-group-reply"
+    assert posted["body"]["replyToId"] == "activity-inbound-1"

--- a/tests/plugins/platforms/test_teams_stored_ref_send.py
+++ b/tests/plugins/platforms/test_teams_stored_ref_send.py
@@ -477,3 +477,109 @@ def test_unmentioned_decide_speak_exception_is_silent():
     result = asyncio.run(run())
     assert result.get("success") is not True
     assert result.get("silent") is True
+
+
+def _adapter_for_stored_send(poster, ref):
+    from plugins.platforms.teams.adapter import TeamsAdapter
+
+    adapter = object.__new__(TeamsAdapter)
+    adapter._app = object()
+    adapter._client_id = BOT
+    adapter._own_activity_ids = {}
+    adapter._stored_refs = {ref["conversation_id"]: ref}
+    adapter.format_message = lambda content: content
+    adapter.truncate_message = lambda content, max_length=4096, len_fn=None: [content]
+
+    async def _token():
+        return "not-a-secret-for-test"
+
+    adapter._get_botframework_token = _token
+    adapter._post_stored_activity = poster
+    return adapter
+
+
+def test_adapter_send_unmentioned_decide_speak_false_does_not_post():
+    posted = []
+
+    async def poster(url, headers, body):
+        posted.append(body)
+        raise AssertionError("must not POST when decide_speak is false")
+
+    adapter = _adapter_for_stored_send(
+        poster, _group_ref(addressed_via="unmentioned")
+    )
+
+    async def run():
+        return await adapter.send(
+            "19:group-throwaway",
+            "STORED-REF-OWN-SEND",
+            reply_to="activity-inbound-1",
+            metadata={"decide_speak": False},
+        )
+
+    result = asyncio.run(run())
+    assert posted == []
+    assert result.success is True
+    assert result.message_id is None
+
+
+def test_adapter_send_unmentioned_decide_speak_true_posts_once():
+    posted = []
+
+    async def poster(url, headers, body):
+        posted.append(body)
+        return 201, {"id": "activity-adapter-spoken"}
+
+    adapter = _adapter_for_stored_send(
+        poster, _group_ref(addressed_via="unmentioned")
+    )
+
+    async def run():
+        return await adapter.send(
+            "19:group-throwaway",
+            "STORED-REF-OWN-SEND",
+            reply_to="activity-inbound-1",
+            metadata={"decide_speak": True},
+        )
+
+    result = asyncio.run(run())
+    assert len(posted) == 1
+    assert posted[0]["replyToId"] == "activity-inbound-1"
+    assert result.success is True
+    assert result.message_id == "activity-adapter-spoken"
+
+
+def test_adapter_send_unmentioned_default_and_error_are_silent():
+    posted = []
+
+    async def poster(url, headers, body):
+        posted.append(body)
+        raise AssertionError("must not POST on default or decision-error")
+
+    ref = _group_ref(addressed_via="unmentioned")
+
+    async def default_send():
+        adapter = _adapter_for_stored_send(poster, ref)
+        return await adapter.send(
+            "19:group-throwaway",
+            "STORED-REF-OWN-SEND",
+            reply_to="activity-inbound-1",
+        )
+
+    def boom():
+        raise RuntimeError("classifier failed")
+
+    async def error_send():
+        adapter = _adapter_for_stored_send(poster, ref)
+        return await adapter.send(
+            "19:group-throwaway",
+            "STORED-REF-OWN-SEND",
+            reply_to="activity-inbound-1",
+            metadata={"decide_speak": boom},
+        )
+
+    default = asyncio.run(default_send())
+    error = asyncio.run(error_send())
+    assert posted == []
+    assert default.success is True and default.message_id is None
+    assert error.success is True and error.message_id is None

--- a/tests/plugins/platforms/test_teams_stored_ref_send.py
+++ b/tests/plugins/platforms/test_teams_stored_ref_send.py
@@ -583,3 +583,46 @@ def test_adapter_send_unmentioned_default_and_error_are_silent():
     assert posted == []
     assert default.success is True and default.message_id is None
     assert error.success is True and error.message_id is None
+
+
+def test_two_senders_keep_own_refs_latest_unmentioned_not_older_mention(
+    tmp_path: Path,
+):
+    conv = "19:group-throwaway"
+    common = dict(
+        conversation_id=conv,
+        conversation_type="groupChat",
+        service_url="https://smba.trafficmanager.net/teams/",
+        tenant_id="00000000-0000-0000-0000-000000000002",
+        bot_app_id=BOT,
+    )
+    persist_inbound_ref(
+        tmp_path,
+        **common,
+        user_id="29:zulu-roster",
+        person="Zulu",
+        filename_stem="Zulu",
+        inbound_activity_id="old-mentioned",
+        addressed_via="mention",
+    )
+    persist_inbound_ref(
+        tmp_path,
+        **common,
+        user_id="29:alpha-roster",
+        person="Alpha",
+        filename_stem="Alpha",
+        inbound_activity_id="latest-unmentioned",
+        addressed_via="unmentioned",
+    )
+    zulu = json.loads((tmp_path / "Zulu.json").read_text(encoding="utf-8"))
+    alpha = json.loads((tmp_path / "Alpha.json").read_text(encoding="utf-8"))
+    assert zulu["addressed_via"] == "mention"
+    assert zulu["last_inbound_activity_id"] == "old-mentioned"
+    assert zulu["addressed_by"] == "29:zulu-roster"
+    assert alpha["addressed_via"] == "unmentioned"
+    assert alpha["last_inbound_activity_id"] == "latest-unmentioned"
+    assert alpha["addressed_by"] == "29:alpha-roster"
+    loaded = load_stored_refs(tmp_path)[conv]
+    assert loaded["addressed_via"] == "unmentioned"
+    assert loaded["last_inbound_activity_id"] == "latest-unmentioned"
+    assert loaded["addressed_by"] == "29:alpha-roster"

--- a/tests/plugins/platforms/test_teams_stored_ref_send.py
+++ b/tests/plugins/platforms/test_teams_stored_ref_send.py
@@ -15,6 +15,7 @@ from plugins.platforms.teams.stored_ref import (
     activity_post_url,
     classify_stored_ref,
     group_inbound_addresses_bot,
+    group_inbound_should_reply,
     load_stored_refs,
     persist_inbound_ref,
     send_from_stored_ref,
@@ -44,12 +45,12 @@ def test_classify_accepts_personal_matching_bot():
 
 
 def test_classify_rejects_group_without_inbound_addresser():
-    with pytest.raises(StoredRefError, match="mention this bot or reply"):
+    with pytest.raises(StoredRefError, match="mention, reply-to-own, or unmentioned"):
         classify_stored_ref(_throwaway(kind="groupChat"), expected_bot_app_id=BOT)
 
 
-def test_classify_rejects_group_with_sender_but_no_bot_address():
-    with pytest.raises(StoredRefError, match="mention this bot or reply"):
+def test_classify_rejects_group_with_sender_but_no_heard_via():
+    with pytest.raises(StoredRefError, match="mention, reply-to-own, or unmentioned"):
         classify_stored_ref(
             _throwaway(kind="groupChat", addressed_by="29:customer-roster"),
             expected_bot_app_id=BOT,
@@ -73,6 +74,17 @@ def test_classify_accepts_group_after_reply_to_own():
             kind="groupChat",
             addressed_by="29:customer-roster",
             addressed_via="reply_to_own",
+        ),
+        expected_bot_app_id=BOT,
+    )
+
+
+def test_classify_accepts_heard_unmentioned_group():
+    classify_stored_ref(
+        _throwaway(
+            kind="groupChat",
+            addressed_by="29:customer-roster",
+            addressed_via="unmentioned",
         ),
         expected_bot_app_id=BOT,
     )
@@ -332,22 +344,23 @@ def test_group_inbound_ambient_does_not_address_bot():
     )
 
 
-def test_persist_rejects_unmentioned_group(tmp_path: Path):
-    with pytest.raises(StoredRefError, match="mention this bot or reply"):
-        persist_inbound_ref(
-            tmp_path,
-            conversation_id="19:group-throwaway",
-            conversation_type="groupChat",
-            service_url="https://smba.trafficmanager.net/teams/",
-            tenant_id="00000000-0000-0000-0000-000000000002",
-            bot_app_id=BOT,
-            user_id="29:customer-roster",
-            inbound_activity_id="activity-ambient",
-        )
-    assert list(tmp_path.glob("*.json")) == []
+def test_persist_hears_unmentioned_group(tmp_path: Path):
+    dest = persist_inbound_ref(
+        tmp_path,
+        conversation_id="19:group-throwaway",
+        conversation_type="groupChat",
+        service_url="https://smba.trafficmanager.net/teams/",
+        tenant_id="00000000-0000-0000-0000-000000000002",
+        bot_app_id=BOT,
+        user_id="29:customer-roster",
+        inbound_activity_id="activity-ambient",
+    )
+    data = json.loads(dest.read_text(encoding="utf-8"))
+    assert data["addressed_via"] == "unmentioned"
+    assert data["last_inbound_activity_id"] == "activity-ambient"
 
 
-def test_adapter_does_not_persist_unmentioned_group(tmp_path: Path, monkeypatch):
+def test_adapter_hears_unmentioned_group(tmp_path: Path, monkeypatch):
     from plugins.platforms.teams.adapter import TeamsAdapter
 
     adapter = object.__new__(TeamsAdapter)
@@ -371,8 +384,96 @@ def test_adapter_does_not_persist_unmentioned_group(tmp_path: Path, monkeypatch)
     class _From:
         aad_object_id = "00000000-0000-0000-0000-000000000001"
         id = "29:customer-roster"
-        name = "Customer"
+        name = "Peer"
 
     adapter._persist_inbound_stored_ref(_Activity(), _Conv(), _From())
-    assert list(tmp_path.glob("*.json")) == []
-    assert adapter._stored_refs == {}
+    files = list(tmp_path.glob("*.json"))
+    assert len(files) == 1
+    data = json.loads(files[0].read_text(encoding="utf-8"))
+    assert data["addressed_via"] == "unmentioned"
+    assert data["conversation_id"] == "19:group-throwaway"
+    assert adapter._stored_refs["19:group-throwaway"]["addressed_via"] == "unmentioned"
+
+
+def test_mentioned_group_should_reply():
+    assert group_inbound_should_reply("mention") is True
+
+
+def test_replied_to_group_should_reply():
+    assert group_inbound_should_reply("reply_to_own") is True
+
+
+def test_unmentioned_group_default_silent():
+    assert group_inbound_should_reply("unmentioned") is False
+    assert group_inbound_should_reply(None) is False
+
+
+def test_unmentioned_group_spoken_when_decided():
+    assert group_inbound_should_reply("unmentioned", decide_speak=lambda: True) is True
+
+
+def test_unmentioned_silent_does_not_post():
+    async def poster(url, headers, body):
+        raise AssertionError("must not POST when unmentioned default silent")
+
+    async def run():
+        return await send_from_stored_ref(
+            _group_ref(addressed_via="unmentioned"),
+            "STORED-REF-OWN-SEND",
+            poster=poster,
+            expected_bot_app_id=BOT,
+            token="not-a-secret-for-test",
+            reply_to="activity-inbound-1",
+        )
+
+    result = asyncio.run(run())
+    assert result.get("success") is not True
+    assert result.get("silent") is True
+    assert "silent" in result["error"]
+
+
+def test_unmentioned_spoken_posts_reply():
+    posted = {}
+
+    async def poster(url, headers, body):
+        posted["body"] = body
+        return 201, {"id": "activity-unmentioned-spoken"}
+
+    async def run():
+        return await send_from_stored_ref(
+            _group_ref(addressed_via="unmentioned"),
+            "STORED-REF-OWN-SEND",
+            poster=poster,
+            expected_bot_app_id=BOT,
+            token="not-a-secret-for-test",
+            reply_to="activity-inbound-1",
+            decide_speak=lambda: True,
+        )
+
+    result = asyncio.run(run())
+    assert result["success"] is True
+    assert result["message_id"] == "activity-unmentioned-spoken"
+    assert posted["body"]["replyToId"] == "activity-inbound-1"
+
+
+def test_unmentioned_decide_speak_exception_is_silent():
+    async def poster(url, headers, body):
+        raise AssertionError("must not POST when decide_speak fails closed")
+
+    def boom():
+        raise RuntimeError("classifier failed")
+
+    async def run():
+        return await send_from_stored_ref(
+            _group_ref(addressed_via="unmentioned"),
+            "STORED-REF-OWN-SEND",
+            poster=poster,
+            expected_bot_app_id=BOT,
+            token="not-a-secret-for-test",
+            reply_to="activity-inbound-1",
+            decide_speak=boom,
+        )
+
+    result = asyncio.run(run())
+    assert result.get("success") is not True
+    assert result.get("silent") is True


### PR DESCRIPTION
## Summary
Disk-backed Teams personal conversation refs so a gateway can POST from the bot's own app identity after restart (`POST {serviceUrl}v3/conversations/{id}/activities` as `28:{bot_app_id}`).

Fail-closed on group, wrong bot, and `reply_only` (will not unlock a locked ref). Inbound personal activities persist the ref including the `29:` user id.

Thrownaway self-test only — no live Teams send in this PR.

House context: runi-services/governance#1218. Hermes reviews before any real message. Gateway bounce is a separate named-minute act.

## Test plan
- [x] `python -m pytest tests/plugins/platforms/test_teams_stored_ref_send.py -q -n 0` → 10 passed
- [ ] Hermes review
- [ ] No gateway bounce in this PR