### PR TITLE
fix(desktop): serialize Desktop E2E runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -128,14 +128,13 @@ jobs:
     # Tests-only PRs (~17% of commits) skip this 5-minute job — the longest
     # single job in the workflow — while still running the full pytest lanes.
     #
-    # Re-disabled (Sep 2026): the Sep 1 re-enable is still incredibly flaky.
-    # Keep this a bare `if: false`. The earlier
-    # `${{ false && (... || ...) }}` form on this reusable-workflow job made
-    # GitHub's workflow parser fail at startup ("An unexpected error has
-    # occurred") — every ci.yaml run repo-wide dispatched 0 jobs from
-    # 24f5a60ed1 until this line changed. To re-enable, restore:
-    #   if: ${{ needs.detect.outputs.python_prod == 'true' || needs.detect.outputs.frontend == 'true' }}
-    if: false
+    # The mock-backend E2E suite launches a real Electron app and `hermes
+    # serve` for each spec. Its Playwright config explicitly serializes those
+    # stacks, avoiding the concurrent startup race that made the Sep 1
+    # re-enable flaky. Keep this expression intact: an earlier disabled form
+    # with a malformed `${{ false && (...) }}` expression prevented the entire
+    # reusable workflow graph from dispatching.
+    if: ${{ needs.detect.outputs.python_prod == 'true' || needs.detect.outputs.frontend == 'true' }}
     uses: ./.github/workflows/e2e-desktop.yml
 
   docs-site:

--- a/apps/desktop/e2e/playwright-config.unit.test.ts
+++ b/apps/desktop/e2e/playwright-config.unit.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest'
+
+import config from '../playwright.config'
+
+describe('desktop Playwright configuration', () => {
+  it('runs real Electron stacks serially', () => {
+    expect(config.workers).toBe(1)
+    expect(config.fullyParallel).toBe(false)
+  })
+})

--- a/apps/desktop/playwright.config.ts
+++ b/apps/desktop/playwright.config.ts
@@ -36,7 +36,14 @@ export default defineConfig({
    * per test gives us headroom without masking real hangs. */
   timeout: 90_000,
   retries: process.env.CI ? 1 : 0,
-  /* Each test gets its own worker so the Electron process is fully isolated. */
+  /*
+   * Every spec launches a real Electron renderer and `hermes serve` backend.
+   * Letting Playwright use its default CI worker count starts a large burst of
+   * those stacks on the 32-core runner, which races application startup and
+   * makes the suite flaky. Keep the actual integration lane serial; each
+   * spec still gets a fresh app and sandbox from its fixtures.
+   */
+  workers: 1,
   fullyParallel: false,
   reporter: reporters,
   use: {


### PR DESCRIPTION
Serialize the Desktop E2E runner so each real Electron and `hermes serve` stack starts in isolation, then re-enable the lane.

## What changed and why
- Set the Desktop Playwright suite to one worker. The suite launches a full Electron app and backend for each spec; CI's default worker count launches those stacks concurrently and makes startup flaky.
- Restore the normal `e2e-desktop` workflow condition so production or frontend changes run the Desktop E2E lane again.
- Add a configuration test that protects the single-worker contract.

## Addressing maintainer feedback
- #100453 (merged): its re-enable exposed the remaining intermittent harness failure. This change addresses that concurrency source before enabling the lane again.

## How to test
1. Run `npm ci` from the repository root.
2. Run `cd apps/desktop && npm run build && npm run typecheck`.
3. Run `cd apps/desktop && npx vitest run --project electron e2e/playwright-config.unit.test.ts`.
4. On Linux with Xvfb available, run `cd apps/desktop && CI=true xvfb-run -a --server-args="-screen 0 1280x1024x24" npx playwright test e2e/ --reporter=list` and confirm it reports one worker.

## What platforms tested on
- macOS (darwin-arm64): desktop build, TypeScript type-check, and the focused Vitest configuration test passed.
- macOS sandbox: the full Electron suite was attempted and confirmed the one-worker scheduler, but cannot bind loopback sockets (`listen EPERM`); CI's Linux/Xvfb lane exercises the full suite.

Refs #76627

test verification unavailable: the recorded local test command exited 3

<!-- autocontrib:worker-id=issue-new-46d51c74 kind=pr-open -->