### PR TITLE
Add bisque to the MCP catalog

### DIFF
--- a/optional-mcps/bisque/manifest.yaml
+++ b/optional-mcps/bisque/manifest.yaml
@@ -1,0 +1,38 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: bisque
+description: Author narrated presentations and publish them to a shareable watch URL.
+source: https://bisque.today/docs/mcp
+
+# Official vendor-hosted remote MCP (URL-only — Hermes never spawns a local
+# process for this entry). Native OAuth 2.1 + Dynamic Client Registration
+# (verified live: RFC 9728 protected-resource metadata -> AS metadata with
+# registration_endpoint); Hermes's MCP client + mcp_oauth_manager handle
+# discovery, PKCE, token exchange, and refresh.
+#
+# initialize, tools/list, resources/list, resources/read, prompts/list and
+# prompts/get answer with no credential; only tools/call needs one. So the
+# picker can introspect the server before a user signs in.
+
+transport:
+  type: http
+  url: https://bisque.cloud/presentations/mcp
+
+auth:
+  type: oauth
+
+# Composer-suggestion triggers (desktop brand pills).
+suggest:
+  keywords:
+    - bisque
+    - presentation
+  hosts:
+    - bisque.today
+
+post_install: |
+  Sign in the first time you call a tool — your browser opens and the client
+  registers itself; there is no API key to paste. Ask for a presentation and
+  you get back a watch URL: slides with synchronized narration that play in
+  any browser, published to your own channel.


### PR DESCRIPTION
Adds `optional-mcps/bisque/manifest.yaml` — Bisque's presentations server, a vendor-hosted remote MCP.

**What it does.** Your agent writes the slides and the narration script; Bisque narrates and hosts it, and hands back a watch URL — slides with synchronized narration that play in any browser. Useful for the things a Hermes agent already does unattended: a briefing on what an overnight run changed, a walkthrough of a pull request, a summary of a long document, handed to someone as a link instead of a wall of text. It reads presentations back too, so `get_presentation_context` returns the full transcript of any shared one for an agent to answer questions from.

**URL-only, no local process.**

```yaml
transport:
  type: http
  url: https://bisque.cloud/presentations/mcp

auth:
  type: oauth
```

**Auth verified live**, the same chain the canva entry documents:

- An unauthenticated `tools/call` returns `401` with `www-authenticate: Bearer resource_metadata="https://bisque.cloud/.well-known/oauth-protected-resource/presentations/mcp"` (RFC 9728).
- That document resolves, and `/.well-known/oauth-authorization-server` returns AS metadata carrying `registration_endpoint` (Dynamic Client Registration) and `code_challenge_methods_supported: ["S256"]`.

So `mcp_oauth_manager` handles discovery, PKCE, token exchange and refresh with nothing for the user to paste.

**The picker can introspect before sign-in.** `initialize`, `tools/list`, `resources/list`, `resources/read`, `prompts/list` and `prompts/get` all answer without a credential; only `tools/call` needs one.

**Tools (8):** `get_presentation_spec`, `create_presentation`, `publish_narrated_presentation`, `get_presentation_status`, `list_presentations`, `get_presentation_analytics`, `get_presentation_context`, `update_channel`.

`create_presentation` takes a `dryRun` flag that runs every check a real create runs — format, slug and org conflicts, tier cap, credit preflight — and writes nothing, which makes it safe to exercise during review.

**Provenance.** Published in the official MCP Registry as `cloud.bisque/presentations`. Docs at https://bisque.today/docs/mcp. The open-source skills that use it are at https://github.com/bisque-cloud/presenter (MIT).

No pins to age-check: this is a hosted URL, not a package launcher or a git install.