### PR TITLE
fix(gateway): keep multiplexed profile attachments reachable

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -35,6 +35,7 @@ import os
 import queue
 import re
 import shlex
+import shutil
 import site
 import sys
 import signal
@@ -2210,6 +2211,108 @@ def _multiplex_profile_homes(config: object) -> list[tuple[str, "Path"]]:
             profile_allowlist=getattr(config, "multiplex_profile_allowlist", None),
         )
     )
+
+
+def _cache_mounts_for_home(home: Path) -> list[dict[str, str]]:
+    """Resolve cache mounts against one explicit Hermes home."""
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+    from tools.credential_files import get_cache_directory_mounts
+
+    token = set_hermes_home_override(home)
+    try:
+        return get_cache_directory_mounts()
+    finally:
+        reset_hermes_home_override(token)
+
+
+def _relocate_inbound_media_for_active_profile(event: "MessageEvent") -> None:
+    """Move adapter-cached media into the active multiplex profile cache.
+
+    Platform adapters can download attachments before profile routing installs
+    its runtime scope. Match only files from the process cache, copy them into
+    the corresponding active-profile mount, and preserve whether ``media_urls``
+    originally used a host or sandbox path.
+    """
+    from hermes_constants import get_process_hermes_home
+
+    urls = list(getattr(event, "media_urls", None) or [])
+    if not urls:
+        return
+
+    source_home = get_process_hermes_home()
+    target_home = get_hermes_home()
+    if source_home == target_home or not target_home.is_dir():
+        return
+
+    source_mounts = _cache_mounts_for_home(source_home)
+    target_mounts = {
+        mount["container_path"]: mount for mount in _cache_mounts_for_home(target_home)
+    }
+    rewritten = list(urls)
+
+    for index, raw_path in enumerate(urls):
+        path = Path(raw_path)
+        for source_mount in source_mounts:
+            target_mount = target_mounts.get(source_mount["container_path"])
+            if target_mount is None:
+                continue
+
+            source_root = Path(source_mount["host_path"])
+            container_root = Path(source_mount["container_path"])
+            host_form = True
+            try:
+                relative = path.relative_to(source_root)
+            except ValueError:
+                host_form = False
+                try:
+                    relative = path.relative_to(container_root)
+                except ValueError:
+                    continue
+            if ".." in relative.parts:
+                continue
+
+            source_path = source_root / relative
+            target_path = Path(target_mount["host_path"]) / relative
+            try:
+                if target_path.is_file():
+                    if host_form:
+                        rewritten[index] = str(target_path)
+                    break
+                if not source_path.is_file():
+                    break
+            except OSError:
+                break
+
+            temporary = target_path.with_name(
+                f".{target_path.name}.{os.getpid()}.{threading.get_ident()}.{index}.tmp"
+            )
+            try:
+                target_path.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copyfile(source_path, temporary)
+                os.replace(temporary, target_path)
+            except OSError:
+                try:
+                    temporary.unlink(missing_ok=True)
+                except OSError:
+                    pass
+                logger.warning(
+                    "Failed to relocate inbound attachment into profile cache",
+                    exc_info=True,
+                )
+                break
+
+            try:
+                source_path.unlink()
+            except OSError:
+                logger.debug(
+                    "Copied inbound attachment but could not remove process-cache copy",
+                    exc_info=True,
+                )
+            if host_form:
+                rewritten[index] = str(target_path)
+            break
+
+    event.media_urls = rewritten
 
 
 @_contextmanager
@@ -18655,6 +18758,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         already run and images are represented in-text.
         """
         history = history or []
+        if getattr(self.config, "multiplex_profiles", False):
+            try:
+                _relocate_inbound_media_for_active_profile(event)
+            except Exception:
+                # Attachment relocation is a compatibility repair. If an
+                # unusual filesystem/backend rejects it, retain the original
+                # paths and let the established media pipeline handle them.
+                logger.warning(
+                    "Failed to scope inbound attachments to routed profile",
+                    exc_info=True,
+                )
         _pending_stt_prepared = hasattr(event, "_gateway_pending_stt_text")
         message_text = (
             getattr(event, "_gateway_pending_stt_text", None)

--- a/tests/gateway/test_multiplex_attachment_cache_scope.py
+++ b/tests/gateway/test_multiplex_attachment_cache_scope.py
@@ -1,0 +1,131 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner, _relocate_inbound_media_for_active_profile
+from gateway.session import SessionSource, build_session_key
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+def _scoped_relocate(event: MessageEvent, profile_home: Path) -> None:
+    token = set_hermes_home_override(profile_home)
+    try:
+        _relocate_inbound_media_for_active_profile(event)
+    finally:
+        reset_hermes_home_override(token)
+
+
+@pytest.mark.parametrize("path_form", ["host", "container"])
+def test_relocates_inbound_document_to_active_profile(
+    tmp_path, monkeypatch, path_form
+):
+    process_home = tmp_path / "root"
+    profile_home = process_home / "profiles" / "coder"
+    profile_home.mkdir(parents=True)
+    source = process_home / "cache" / "documents" / "report.pdf"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"%PDF-1.4 profile scoped")
+    monkeypatch.setenv("HERMES_HOME", str(process_home))
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+
+    original = (
+        str(source)
+        if path_form == "host"
+        else "/root/.hermes/cache/documents/report.pdf"
+    )
+    event = MessageEvent(text="inspect", media_urls=[original])
+
+    _scoped_relocate(event, profile_home)
+
+    target = profile_home / "cache" / "documents" / "report.pdf"
+    assert target.read_bytes() == b"%PDF-1.4 profile scoped"
+    assert not source.exists()
+    assert event.media_urls == ([str(target)] if path_form == "host" else [original])
+
+    _scoped_relocate(event, profile_home)
+    assert target.read_bytes() == b"%PDF-1.4 profile scoped"
+    assert event.media_urls == ([str(target)] if path_form == "host" else [original])
+
+
+def test_permission_error_keeps_original_path(tmp_path, monkeypatch):
+    process_home = tmp_path / "root"
+    profile_home = process_home / "profiles" / "coder"
+    profile_home.mkdir(parents=True)
+    source = process_home / "cache" / "documents" / "report.pdf"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"%PDF")
+    monkeypatch.setenv("HERMES_HOME", str(process_home))
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+
+    original_is_file = Path.is_file
+
+    def guarded_is_file(path):
+        if path == source:
+            raise PermissionError("not readable")
+        return original_is_file(path)
+
+    monkeypatch.setattr(Path, "is_file", guarded_is_file)
+    container_path = "/root/.hermes/cache/documents/report.pdf"
+    event = MessageEvent(text="inspect", media_urls=[container_path])
+
+    _scoped_relocate(event, profile_home)
+
+    assert event.media_urls == [container_path]
+    assert source.read_bytes() == b"%PDF"
+    assert not (profile_home / "cache" / "documents" / "report.pdf").exists()
+
+
+@pytest.mark.asyncio
+async def test_preprocessing_relocates_before_native_image_buffering(
+    tmp_path, monkeypatch
+):
+    process_home = tmp_path / "root"
+    profile_home = process_home / "profiles" / "coder"
+    profile_home.mkdir(parents=True)
+    source_path = process_home / "cache" / "images" / "photo.png"
+    source_path.parent.mkdir(parents=True)
+    source_path.write_bytes(b"\x89PNG\r\n\x1a\n")
+    monkeypatch.setenv("HERMES_HOME", str(process_home))
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner.adapters = {}
+    runner._model = "openai/gpt-4.1-mini"
+    runner._base_url = None
+    runner._decide_image_input_mode = lambda **_: "native"
+    runner._session_key_for_source = lambda source: build_session_key(source)
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="chat-a",
+        chat_type="private",
+        profile="coder",
+    )
+    event = MessageEvent(
+        text="inspect",
+        message_type=MessageType.PHOTO,
+        source=source,
+        media_urls=[str(source_path)],
+        media_types=["image/png"],
+    )
+
+    token = set_hermes_home_override(profile_home)
+    try:
+        await runner._prepare_inbound_message_text(
+            event=event,
+            source=source,
+            history=[],
+        )
+    finally:
+        reset_hermes_home_override(token)
+
+    target = profile_home / "cache" / "images" / "photo.png"
+    assert target.read_bytes() == b"\x89PNG\r\n\x1a\n"
+    assert event.media_urls == [str(target)]
+    assert runner._consume_pending_native_image_paths(build_session_key(source)) == [
+        str(target)
+    ]


### PR DESCRIPTION
## What does this PR do?

Inbound documents and images routed to a non-default profile no longer point at an empty sandbox cache. The gateway relocates adapter-cached files from the process cache into the routed profile's corresponding cache before vision, transcription, or document-note processing, while preserving each path's existing host or sandbox representation.

### Symptom

With gateway profile multiplexing and a Docker terminal backend, a PDF sent to a secondary profile is downloaded under the process-level cache while that profile's container mounts its own cache. The agent receives a valid-looking `/root/.hermes/cache/documents/...` path whose mounted directory does not contain the file and reports `File not found`. Host-form image paths also remain outside the profile cache authorized for vision reads.

### Impact

Documents and photos sent to non-default profiles can be unreachable even after the user resends them. The observed blast radius is multiplexed gateways whose adapters cache inbound media before the routed profile scope is active.

### Bug Cause

**Trigger:** `gateway/run.py:_prepare_inbound_message_text` when `gateway.multiplex_profiles` is enabled and `event.media_urls` contains an adapter-cached file.

**Causal chain:**
1. A platform adapter downloads an inbound attachment before per-turn profile routing installs the target profile's Hermes home.
2. The bytes land in the process cache, but cache mount discovery later resolves against the routed profile home.
3. The agent-visible path names the profile's mounted cache location without the bytes being present there.

**Why it is wrong:** The path translation and cache mount agree on a sandbox path but resolve different host directories, so a syntactically valid path points into an empty mount.

**Working sibling / contrast:** Single-profile gateways use the same process and active Hermes home, so the downloaded file and mounted directory already coincide.

**Ruled out:** Docker mount discovery is not omitting cache directories. `get_cache_directory_mounts()` creates and returns the active profile's cache mounts; the mismatch is where the adapter wrote the bytes before that profile became active.

### Fix

Resolve both process-cache and active-profile mount tables at preprocessing time, relocate only files proven to be under a known process cache root, and preserve host-form versus sandbox-form entries in `media_urls`. The copy uses an atomic destination replace, handles permission and filesystem failures without dropping the original path, rejects parent traversal, and is idempotent. The shared relocation covers images, documents, audio, video, and the other mounted cache classes without adapter-specific branches.

## Related Issue


N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` - relocate process-cached inbound media into the active multiplex profile before media consumers run.
- `tests/gateway/test_multiplex_attachment_cache_scope.py` - cover host and Docker path forms, idempotence, permission failures, and preprocessing order.

## How to Test

1. Run the focused gateway regression suite.
2. Confirm host-form paths are rewritten to the profile cache and Docker-form paths retain their sandbox coordinate.
3. Confirm native image buffering sees the relocated profile path.

```bash
scripts/run_tests.sh tests/gateway/test_multiplex_attachment_cache_scope.py -q --tb=short
```

Result: 4 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested the focused regression on Windows 11; Docker multiplex verification is delegated to the review environment

### Documentation & Housekeeping

- [x] Documentation update is N/A; behavior and rationale are documented in code and tests
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no workflow contract changed
- [x] Cross-platform impact was considered; path handling uses `pathlib` for host paths and preserves sandbox path coordinates
- [x] Tool descriptions and schemas are N/A; no model tool contract changed

## Screenshots / Logs

N/A - the focused regression suite provides the verification receipt above.
