### PR TITLE
docs(delegation): document that a provider pin clears inherited OpenRouter routing

### DIFF
--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2708,6 +2708,8 @@ delegation:
 
 **Per-child request settings (`request_overrides`):** `delegation.request_overrides` is a dict of request settings sent on every subagent API call. Top-level keys are API kwargs (e.g. `service_tier`); an `extra_body` sub-dict is merged into the request's `extra_body`. It is honored on **all three** resolution branches — direct `base_url`, named `provider`, and pure inherit — so the key always takes effect. Precedence: explicit `request_overrides` values merge **over** any runtime- or parent-derived overrides — top-level explicit keys win, and `extra_body` is deep-merged one level so runtime `extra_body` keys (e.g. a provider's `thinking: {type: disabled}` personality) survive unless your key redefines them. The canonical use case is OpenRouter routing hints for delegation children:
 
+> **Gotcha:** when `delegation.provider` is set, children do **not** inherit the parent's `provider_routing` preferences (they are cleared so the pin is honored) — so for OpenRouter delegation you must restate sub-provider routing here via `request_overrides.extra_body.provider`. See [Delegation → Model Override](../features/delegation.md#model-override) for the worked example.
+
 ```yaml
 delegation:
   model: "deepseek/deepseek-v4-flash-0731"

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -227,6 +227,23 @@ delegation:
 
 Resolution order: `delegation.base_url` (direct endpoint) takes precedence, then `delegation.provider` (full credential bundle resolved via the runtime provider system), and when neither is set children inherit the parent's provider and credentials; `delegation.model` applies in all cases, and when it is empty children inherit the parent's model. Setting `delegation.provider` alongside `delegation.base_url` keeps the explicit endpoint but carries that provider's request overrides and max output tokens into the child. An explicit `delegation.request_overrides` dict is honored on every branch and merges over those runtime-derived values (see [Configuration](#configuration) below).
 
+:::warning
+**Provider override clears inherited routing.** An explicit `delegation.provider` is treated as "children run on a different provider," so children do **not** inherit the parent's OpenRouter routing preferences (`provider_routing.only` / `ignore` / `order` / `sort`) — those are cleared so the override isn't silently fought by parent-level filters. The parent's fallback provider chain is also not inherited (a pinned child fails loudly instead of silently rerouting mid-run). If you pin `delegation.provider: openrouter` and want children to land on a specific sub-provider, restate the routing in `delegation.request_overrides`:
+
+```yaml
+delegation:
+  model: "deepseek/deepseek-v4-flash-0731"
+  provider: "openrouter"
+  request_overrides:
+    extra_body:
+      provider:
+        only:
+          - deepinfra   # children pin to one OpenRouter sub-provider
+```
+
+`extra_body` is deep-merged one level into the request's `extra_body`, so this `provider` object reaches the OpenRouter wire payload even though the inherited `provider_routing` preferences were cleared. Note the pin replaces the profile's default provider preferences wholesale (the one-level `extra_body` deep-merge covers the `extra_body` dict itself, not sub-keys within `provider`).
+:::
+
 Note that the pin is global: `delegate_task` has no per-task model parameter, so every child in a batch runs on the configured delegation model. For quality-sensitive subtasks that need a stronger model, either leave `delegation.model` unset for that session or hand the task to the [kanban board](kanban.md#per-task-model-override), which does support a per-task model override.
 
 ## The `/review` Command
@@ -487,7 +504,7 @@ For **durable execution** that must survive session closure or process restart, 
 - Leaf subagents **cannot** call: `delegate_task`, `clarify`, `memory`, `send_message`, `cronjob`. Orchestrator subagents retain `delegate_task` but keep the other blocks. Both roles retain `execute_code` (programmatic tool calling) so children can batch mechanical work instead of burning reasoning iterations.
 - **Cancellation follows ownership** — `/stop` or closing/resetting the owning session cancels its background children; synchronous descendants under orchestrators follow their parent's interrupt state
 - Only the final summary enters the parent's context, keeping token usage efficient
-- Subagents inherit the parent's **API key, provider configuration, and credential pool** (enabling key rotation on rate limits)
+- Subagents inherit the parent's **API key, provider configuration, and credential pool** (enabling key rotation on rate limits) — except when an explicit `delegation.provider` or `delegation.base_url` pin is configured, which routes children to a different provider and therefore clears the parent's OpenRouter routing preferences and fallback chain (see [Model Override](#model-override))
 
 ## Worktree Isolation
 


### PR DESCRIPTION
## What does this PR do?

Documents an undocumented and cost-relevant behavior in delegation provider pinning: setting `delegation.provider` (any value, even the same provider as the parent) makes children run on a *different provider*, so they do **not** inherit the parent's OpenRouter routing preferences (`provider_routing.only` / `ignore` / `order` / `sort`) or its fallback provider chain. Users who pin `delegation.provider: openrouter` and expect children to keep the parent's sub-provider whitelist get round-robined across sub-providers — full input price, cold prefix caches. The documented compensation (`delegation.request_overrides.extra_body.provider`) is already supported on every resolution branch but was only shown for the `base_url` case.

The behavior is intentional (an explicit pin must be honored; a pinned child fails loudly instead of silently rerouting via the parent's fallback chain) — this PR makes it *documented*. It also fixes the Key Properties bullet that currently claims children inherit "the parent's API key, provider configuration, and credential pool" unconditionally.

Source ground truth on current `main` (verified at `fbd40c907d`): the clearing block in `tools/delegate_tool.py::_build_child_agent` (`child_providers_allowed = None` under `override_provider`), the fallback-chain drop (`parent_fallback = None if override_provider ...`), and the `request_overrides.extra_body` merge in `agent/transports/chat_completions.py::_build_kwargs_from_profile`.

## Related Issue

Fixes # (no existing issue — verified via `gh search` that no open PR/issue covers this gap; #61870 covers service-tier inheritance, a different behavior)

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- `website/docs/user-guide/features/delegation.md`: warning box under **Model Override** explaining the routing-clear + fallback-drop and the worked `request_overrides.extra_body.provider.only` sub-provider pin example; Key Properties inherit bullet now states the exception and links to it.
- `website/docs/user-guide/configuration.md`: gotcha note in the `request_overrides` section cross-linking the worked example (the section previously showed the `extra_body.provider` pattern only for the `base_url` case).

## How to Test

1. Docs-only change; render check: the two files are Docusaurus pages, no code paths touched.
2. To verify the documented behavior end-to-end (as done on a live install): set `delegation.provider: openrouter` + `delegation.model` alongside a parent `provider_routing.only` pin, spawn a subagent, and observe on the OpenRouter dashboard that the request carries no `provider.only` unless `delegation.request_overrides.extra_body.provider.only` is also set — with the override set, the child request lands on the pinned sub-provider.

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`docs(delegation): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] `pytest tests/ -q` — N/A (no code changed)
- [x] Tests added — N/A (docs only)
- [x] Tested on my platform: Linux (Raspberry Pi 5, aarch64, user-scope systemd gateway)

### Documentation & Housekeeping
- [x] I've updated relevant documentation
- [x] cli-config.yaml.example — N/A (no config keys added/changed)
- [x] CONTRIBUTING.md / AGENTS.md — N/A
- [x] Cross-platform impact — N/A (docs only)
- [x] Tool descriptions/schemas — N/A

---

## Rebase Note

Rebased onto current `main` tip (`869228cab4`, per GitHub PR base SHA) on 2026-09-07. No conflicts during rebase; the single docs commit (`2169d9861`) now sits directly on `main` with a clean, mergeable tree. Checked upstream `main` docs (`provider_routing` in `user-guide/configuration.md`, `features/provider-routing.md`, `features/delegation.md`, `integrations/providers.md`): no existing section documents that a `delegation.provider` pin clears inherited OpenRouter routing — this PR remains complementary, not duplicative. Docs-only sanity check passed (balanced `:::warning` callout & code fences; `#model-override` cross-link resolves; full Docusaurus build not run — no node/npm toolchain in this environment).
