### PR TITLE
fix(packaging): ship hermes_state_registry in sealed installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -574,6 +574,7 @@ py-modules = [
   "hermes_state",
   "hermes_state_common",
   "hermes_state_portability",
+  "hermes_state_registry",
   "hermes_state_schema",
   "hermes_state_search",
   "hermes_startup_watchdog",

--- a/tests/test_pymodules_completeness.py
+++ b/tests/test_pymodules_completeness.py
@@ -1,0 +1,54 @@
+"""py-modules must cover every top-level hermes_state* module (#101147).
+
+hermes_state.py unconditionally re-exports from hermes_state_registry at
+import time. A sealed venv that ships hermes_state.py without
+hermes_state_registry.py dies on import — sessions silently stop being
+indexed. This pins the packaging list against exactly that regression.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+PYPROJECT = REPO / "pyproject.toml"
+
+
+def _py_modules() -> list[str]:
+    src = PYPROJECT.read_text(encoding="utf-8")
+    m = re.search(r"py-modules\s*=\s*\[", src)
+    assert m, "py-modules list must exist in pyproject.toml"
+    end = src.index("]", m.end())
+    return re.findall(r'"([a-z_0-9]+)"', src[m.start():end])
+
+
+def test_hermes_state_registry_is_declared():
+    """The #101147 one-liner: the registry module must ship in wheels."""
+    assert "hermes_state_registry" in _py_modules()
+
+
+def test_every_hermes_state_sibling_module_is_declared():
+    """Guard against the whole class: every top-level hermes_state*.py in the
+    source tree must appear in py-modules — a sibling added by a future
+    split without a packaging line reproduces #101147 silently."""
+    declared = set(_py_modules())
+    tree_top = {
+        p.stem
+        for p in REPO.glob("hermes_state*.py")
+        if p.is_file()
+    }
+    missing = sorted(tree_top - declared)
+    assert not missing, (
+        f"top-level hermes_state* modules missing from py-modules: {missing}"
+    )
+
+
+def test_declared_modules_exist_in_the_tree():
+    """The inverse direction: a py-modules entry pointing at a file that no
+    longer exists breaks the wheel build (setuptools fails hard)."""
+    declared = set(_py_modules())
+    for name in sorted(n for n in declared if n.startswith("hermes_")):
+        assert (REPO / f"{name}.py").is_file(), (
+            f"py-modules declares {name!r} but {name}.py is absent from the tree"
+        )


### PR DESCRIPTION
Fixes #101147

## Problem

`hermes_state_registry.py` was never added to `[tool.setuptools] py-modules` when the shared-`SessionDB` registry was split out of `hermes_state.py` (#90837). Every sibling `hermes_state*` module is declared — this one was not.

A sealed install built from the wheel (uv2nix/Nix store venv, `pip wheel`, the Docker image) therefore ships `hermes_state.py` **without** `hermes_state_registry.py`, and since `hermes_state.py:4357` re-exports from it unconditionally at import time:

```
ModuleNotFoundError: No module named 'hermes_state_registry'
```

Source checkouts and editable installs see the file on disk — which is why CI never caught it.

The failure is mostly **silent and lossy** rather than fatal:

- sessions never get indexed into `state.db` — the live chat still works while history silently stops growing
- `hermes sessions list` / `stats` / `browse` / `prune` fail outright
- async delegation completions can no longer be restored across restarts

Reproduced in isolation: a minimal site dir carrying `hermes_state.py`'s registry re-export, without the registry module, raises **exactly** the reporter's `ModuleNotFoundError`.

## Fix

The reporter's one-liner — add the module next to its siblings in `py-modules`.

Plus a **class-of-bug guard** (`tests/test_pymodules_completeness.py`, 3 tests):

1. `hermes_state_registry` is declared (the regression itself)
2. **every** top-level `hermes_state*.py` in the tree appears in `py-modules` — a future split without a packaging line fails CI instead of shipping broken wheels
3. every declared `hermes_*` entry exists in the tree — a stale entry after a module merge fails the wheel build at test time instead of at build time

The reporter notes this is **the second packaging miss of this class**; the completeness test closes both directions.