### PR TITLE
fix(gateway): stop retry diagnostics from replacing chat replies

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -116,6 +116,9 @@ _STALL_NOTIFY_SEND_TIMEOUT_SECONDS = 15.0
 _GATEWAY_PROXY_SSE_BUFFER_MAX_CHARS = 16 * 1024 * 1024
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 _GATEWAY_HYGIENE_PLATFORM = "gateway_hygiene"
+_GATEWAY_RETRY_FAILURE_REPLY = (
+    "⚠️ Something went wrong while generating a response. Please try again."
+)
 
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"("  # transient/auxiliary status that should stay in logs, not gateway chats
@@ -144,7 +147,10 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"|context\s+reduced\s+to\s+[\d,]+\s+tokens\s+\(was\s+[\d,]+\),\s+retrying"
     r"|session\s+compressed\s+\d+\s+times"
     r"|rate\s+limited\.\s+waiting\s+\d"
-    r"|retrying\s+in\s+\d"
+    r"|retrying(?:\s+\(\d+/\d+\))?\s+in\s+\d"
+    r"|empty\s+response\s+from\s+model"
+    r"|model\s+return(?:ed|ing)\s+(?:no\s+content|empty\s+responses)"
+    r"|no\s+reply:\s+the\s+model\s+returned\s+empty\s+content"
     r"|max\s+retries\s+\(\d+\).*(?:trying\s+fallback|exhausted|invalid\s+responses)"
     r"|stream\s+(?:drop|drop\s+mid\s+tool-call).+retry\s+\d"
     r"|stale\s+connections\s+from\s+a\s+previous\s+provider\s+issue"
@@ -1024,6 +1030,13 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
         return ""
 
     redacted = _redact_gateway_user_facing_secrets(str(text))
+    noisy_status = _TELEGRAM_NOISY_STATUS_RE.search(redacted)
+    if noisy_status is not None and noisy_status.start() <= 4:
+        # Status callbacks suppress transient retry chatter, but a final reply
+        # cannot disappear without making the user's message look lost. Replace
+        # a status-shaped final diagnostic with one short recovery prompt. The
+        # near-start guard preserves normal answers that quote a retry message.
+        return _GATEWAY_RETRY_FAILURE_REPLY
     if _looks_like_gateway_provider_error(redacted):
         return _gateway_provider_error_reply(redacted)
     return redacted

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -120,6 +120,21 @@ _GATEWAY_RETRY_FAILURE_REPLY = (
     "⚠️ Something went wrong while generating a response. Please try again."
 )
 
+_GATEWAY_RETRY_FINAL_DIAGNOSTIC_RE = re.compile(
+    r"^\s*(?:[⚠❌]\ufe0f?\s*)?(?:"
+    r"empty\s+response\s+from\s+model\s+[—-]\s+retrying"
+    r"(?:\s+\(\d+/\d+\))?\s+in\s+\d+(?:\.\d+)?s"
+    r"(?:\s+[—-]\s+high-cost\s+request,\s+reduced\s+retry\s+budget)?"
+    r"|model\s+returning\s+empty\s+responses\s+[—-]\s+switching\s+to\s+fallback\s+provider\.\.\."
+    r"|model\s+returned\s+no\s+content\s+after\s+all\s+retries"
+    r"(?:\s+and\s+fallback\s+attempts)?\."
+    r"(?:\s+no\s+fallback\s+providers\s+configured\.)?"
+    r"|no\s+reply:\s+the\s+model\s+returned\s+empty\s+content\.\s+"
+    r"try\s+again,\s+switch\s+model/provider,\s+or\s+inspect\s+the\s+tool\s+output\s+above\."
+    r")\s*$",
+    re.IGNORECASE,
+)
+
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"("  # transient/auxiliary status that should stay in logs, not gateway chats
     r"auxiliary\s+.+\s+failed"
@@ -1030,12 +1045,11 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
         return ""
 
     redacted = _redact_gateway_user_facing_secrets(str(text))
-    noisy_status = _TELEGRAM_NOISY_STATUS_RE.search(redacted)
-    if noisy_status is not None and noisy_status.start() <= 4:
+    if _GATEWAY_RETRY_FINAL_DIAGNOSTIC_RE.fullmatch(redacted):
         # Status callbacks suppress transient retry chatter, but a final reply
         # cannot disappear without making the user's message look lost. Replace
-        # a status-shaped final diagnostic with one short recovery prompt. The
-        # near-start guard preserves normal answers that quote a retry message.
+        # an emitted retry diagnostic with one short recovery prompt. Matching
+        # the complete emitter shape preserves assistant prose about the error.
         return _GATEWAY_RETRY_FAILURE_REPLY
     if _looks_like_gateway_provider_error(redacted):
         return _gateway_provider_error_reply(redacted)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -129,8 +129,9 @@ _GATEWAY_RETRY_FINAL_DIAGNOSTIC_RE = re.compile(
     r"|model\s+returned\s+no\s+content\s+after\s+all\s+retries"
     r"(?:\s+and\s+fallback\s+attempts)?\."
     r"(?:\s+no\s+fallback\s+providers\s+configured\.)?"
-    r"|no\s+reply:\s+the\s+model\s+returned\s+empty\s+content\.\s+"
-    r"try\s+again,\s+switch\s+model/provider,\s+or\s+inspect\s+the\s+tool\s+output\s+above\."
+    r"|no\s+reply:\s+the\s+model\s+returned\s+empty\s+content"
+    r"(?:\s+after\s+retries\s+and\s+any\s+fallback\s+providers)?\.\s+"
+    r"try\s+(?:`continue`|again),\s+switch\s+model/provider,\s+or\s+inspect\s+the\s+tool\s+output\s+above\."
     r")\s*$",
     re.IGNORECASE,
 )

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -258,8 +258,13 @@ def test_chat_gateways_keep_normal_answers(platform):
     "message",
     [
         "⚠️ Empty response from model — retrying (1/3) in 6s",
+        (
+            "⚠️ Empty response from model — retrying (1/1) in 6s — "
+            "high-cost request, reduced retry budget"
+        ),
         "⚠️ Model returning empty responses — switching to fallback provider...",
         "❌ Model returned no content after all retries. No fallback providers configured.",
+        "❌ Model returned no content after all retries and fallback attempts.",
         (
             "No reply: the model returned empty content. Try again, switch "
             "model/provider, or inspect the tool output above."
@@ -282,12 +287,17 @@ def test_programmatic_surfaces_keep_retry_chatter_used_as_final_response():
         assert _sanitize_gateway_final_response(platform, message) == message
 
 
-def test_chat_gateway_keeps_answer_that_explains_retry_chatter():
-    answer = (
-        "The log line `Empty response from model — retrying (1/3) in 6s` "
-        "means the provider returned no visible content."
-    )
-
+@pytest.mark.parametrize(
+    "answer",
+    [
+        (
+            "The log line `Empty response from model — retrying (1/3) in 6s` "
+            "means the provider returned no visible content."
+        ),
+        "Empty response from model is a common name for a provider failure mode.",
+    ],
+)
+def test_chat_gateway_keeps_answer_that_explains_retry_chatter(answer):
     assert _sanitize_gateway_final_response("telegram", answer) == answer
 
 

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -36,6 +36,13 @@ NOISY_STATUS_MESSAGES = [
     "⚠ Compression summary failed: upstream error. Inserted a fallback context marker.",
     "⏱️ Rate limited. Waiting 30.0s (attempt 2/3)...",
     "⏳ Retrying in 4.2s (attempt 1/3)...",
+    "⚠️ Empty response from model — retrying (1/3) in 6s",
+    "⚠️ Model returning empty responses — switching to fallback provider...",
+    "❌ Model returned no content after all retries. No fallback providers configured.",
+    (
+        "No reply: the model returned empty content. Try again, switch "
+        "model/provider, or inspect the tool output above."
+    ),
     # Buffered overflow/attempt-cap retry chatter (replayed on retry exhaustion).
     "🗜️ Context too large (~250,000 tokens) — compressing (1/3)...",
     "🗜️ Compressed 30 → 12 messages, retrying...",
@@ -244,6 +251,44 @@ def test_chat_gateways_keep_normal_answers(platform):
     answer = "Here is the clean summary you asked for."
 
     assert _sanitize_gateway_final_response(platform, answer) == answer
+
+
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS)
+@pytest.mark.parametrize(
+    "message",
+    [
+        "⚠️ Empty response from model — retrying (1/3) in 6s",
+        "⚠️ Model returning empty responses — switching to fallback provider...",
+        "❌ Model returned no content after all retries. No fallback providers configured.",
+        (
+            "No reply: the model returned empty content. Try again, switch "
+            "model/provider, or inspect the tool output above."
+        ),
+    ],
+)
+def test_chat_gateways_replace_retry_chatter_used_as_final_response(platform, message):
+    """A retry diagnostic promoted to the final reply must not leak or go silent."""
+    sanitized = _sanitize_gateway_final_response(platform, message)
+
+    assert sanitized == (
+        "⚠️ Something went wrong while generating a response. Please try again."
+    )
+
+
+def test_programmatic_surfaces_keep_retry_chatter_used_as_final_response():
+    message = "⚠️ Empty response from model — retrying (1/3) in 6s"
+
+    for platform in ("local", "api_server", "webhook", "msgraph_webhook"):
+        assert _sanitize_gateway_final_response(platform, message) == message
+
+
+def test_chat_gateway_keeps_answer_that_explains_retry_chatter():
+    answer = (
+        "The log line `Empty response from model — retrying (1/3) in 6s` "
+        "means the provider returned no visible content."
+    )
+
+    assert _sanitize_gateway_final_response("telegram", answer) == answer
 
 
 @pytest.mark.parametrize("platform", CHAT_PLATFORMS)

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -11,6 +11,7 @@ from gateway.run import (
     _prepare_gateway_status_message,
     _sanitize_gateway_final_response,
 )
+from run_agent import AIAgent
 
 # Every human-facing chat surface that must receive noise-filtered,
 # secret-redacted, provider-error-sanitized output (not just Telegram).
@@ -265,10 +266,7 @@ def test_chat_gateways_keep_normal_answers(platform):
         "⚠️ Model returning empty responses — switching to fallback provider...",
         "❌ Model returned no content after all retries. No fallback providers configured.",
         "❌ Model returned no content after all retries and fallback attempts.",
-        (
-            "No reply: the model returned empty content. Try again, switch "
-            "model/provider, or inspect the tool output above."
-        ),
+        AIAgent._format_turn_completion_explanation("empty_response_exhausted"),
     ],
 )
 def test_chat_gateways_replace_retry_chatter_used_as_final_response(platform, message):


### PR DESCRIPTION
## What does this PR do?

Chat users can receive raw model retry diagnostics instead of a useful final reply when empty-response retries are exhausted. This change recognizes the current retry-counter format on status callbacks and replaces status-shaped final diagnostics with one short retry message, while preserving raw programmatic output and normal answers that quote diagnostics.

### Symptom

Telegram and other chat surfaces can expose messages such as `Empty response from model - retrying (1/3) in 6s` and `No reply: the model returned empty content...` directly to end users.

### Impact

End users see multiple implementation-level provider messages, potentially out of order, and the final response can be another diagnostic rather than a clear recovery instruction.

### Bug Cause

**Trigger:** `gateway/run.py:120` / `_TELEGRAM_NOISY_STATUS_RE` and `gateway/run.py:993` / `_sanitize_gateway_final_response`

**Causal chain:**
1. The agent emits empty-response status text with a retry counter between `retrying` and `in`.
2. The status regex expects `retrying in <delay>`, so the current text passes through. The final-response sanitizer does not apply the noise classification at all.
3. Chat adapters deliver retry/fallback diagnostics as user-visible messages, including as the turn's final reply.

**Why it is wrong:** The shared chat delivery boundary has divergent handling for status callbacks and final responses, and the status matcher is one emitter format behind.

**Working sibling / contrast:** Programmatic surfaces intentionally preserve raw diagnostics; existing status messages using the older `retrying in <delay>` format are already suppressed on chat surfaces.

**Ruled out:** This is not Telegram adapter ordering alone. The leak is reproducible through the platform-agnostic gateway sanitizers before adapter dispatch.

### Fix

Extend the retry-noise matcher for the current empty-response and fallback wording. At the final-response boundary, replace a noise match near the start of the message with a concise retry prompt instead of dropping the reply. The near-start guard keeps ordinary assistant answers that quote a diagnostic unchanged.

## Related Issue

Closes #101138

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` - recognize current empty-response retry diagnostics and sanitize status-shaped final replies.
- `tests/gateway/test_telegram_noise_filter.py` - cover status suppression, final replacement, raw-surface passthrough, and quoted-diagnostic answers.

## How to Test

1. Pass `Empty response from model - retrying (1/3) in 6s` through the chat status sanitizer and verify it is suppressed.
2. Pass the same diagnostic through the chat final-response sanitizer and verify it becomes the concise retry prompt.
3. Run:

```bash
scripts/run_tests.sh tests/gateway/test_telegram_noise_filter.py -q
scripts/run_tests.sh tests/gateway/test_compression_progress_notices.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry point on the relevant test files and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation updates are N/A
- [x] Config example updates are N/A
- [x] Architecture and workflow documentation updates are N/A
- [x] I've considered cross-platform impact; the change is platform-independent Python string handling
- [x] Tool description and schema updates are N/A

## Screenshots / Logs

N/A - automated regression tests exercise the shared chat delivery boundary.
