### PR TITLE
fix(gateway): cover counter retry format and noise-filter the final response

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -144,7 +144,11 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"|context\s+reduced\s+to\s+[\d,]+\s+tokens\s+\(was\s+[\d,]+\),\s+retrying"
     r"|session\s+compressed\s+\d+\s+times"
     r"|rate\s+limited\.\s+waiting\s+\d"
-    r"|retrying\s+in\s+\d"
+    # #101138: the empty-response retry emitter gained a counter, so the
+    # current format is "retrying (1/3) in 8s" — cover both generations.
+    r"|retrying\s+(?:\(\d+/\d+\)\s+)?in\s+\d"
+    r"|empty\s+response\s+from\s+model"
+    r"|no\s+reply:\s+the\s+model\s+returned\s+empty\s+content"
     r"|max\s+retries\s+\(\d+\).*(?:trying\s+fallback|exhausted|invalid\s+responses)"
     r"|stream\s+(?:drop|drop\s+mid\s+tool-call).+retry\s+\d"
     r"|stale\s+connections\s+from\s+a\s+previous\s+provider\s+issue"
@@ -990,6 +994,22 @@ def _looks_like_gateway_provider_error(text: str) -> bool:
     return bool(_GATEWAY_PROVIDER_ERROR_SHAPE_RE.search(body))
 
 
+def _final_response_is_noise(text: str) -> bool:
+    """True when a short final response is retry-chatter exhaustion text.
+
+    The turn-exit notice for exhausted retries ("⚠️ No reply: the model
+    returned empty content after retries... Try `continue`, switch
+    model/provider...") is infrastructure noise with CLI-only instructions,
+    not assistant prose (#101138). Same short-envelope guard as
+    ``_looks_like_gateway_provider_error`` so long assistant answers that
+    merely quote a noisy phrase pass through untouched.
+    """
+    body = str(text).strip()
+    if not body or len(body) > 400 or body.count("\n") > 4:
+        return False
+    return bool(_TELEGRAM_NOISY_STATUS_RE.search(body))
+
+
 def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
     """Sanitize final gateway replies before sending them to chat surfaces.
 
@@ -1025,6 +1045,12 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
 
     redacted = _redact_gateway_user_facing_secrets(str(text))
     if _looks_like_gateway_provider_error(redacted):
+        return _gateway_provider_error_reply(redacted)
+    # #101138: the retry-exhaustion notice never matched the provider-error
+    # shape, so it reached chats verbatim as the turn's final word. Replace
+    # it with the plain-language provider-failure reply instead of dropping
+    # it — silence after a user's message is its own failure mode.
+    if _final_response_is_noise(redacted):
         return _gateway_provider_error_reply(redacted)
     return redacted
 

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -343,3 +343,77 @@ def test_chat_gateways_redact_all_issue_23810_credential_shapes(platform, shape_
     # Prose around the secret is preserved — redaction is surgical.
     assert "here is the token you asked me to echo" in sanitized
     assert sanitized.endswith("done.")
+
+
+# #101138: the empty-response retry emitter reworded its status to
+# "Empty response from model — retrying (1/3) in 8s" (counter added), but
+# the noise filter only knew "retrying in Ns", so the chatter reached chat.
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS)
+def test_chat_gateways_suppress_counter_format_retry_chatter(platform):
+    """Both retry-status generations must stay out of chat surfaces."""
+    assert (
+        _prepare_gateway_status_message(
+            platform, "lifecycle", "⚠️ Empty response from model — retrying (1/3) in 8s"
+        )
+        is None
+    )
+    assert (
+        _prepare_gateway_status_message(
+            platform,
+            "lifecycle",
+            "⚠️ Empty response from model — retrying (3/5) in 12s"
+            " — high-cost request, reduced retry budget",
+        )
+        is None
+    )
+    # Pre-counter generation keeps being suppressed too.
+    assert _prepare_gateway_status_message(platform, "lifecycle", "⏳ Retrying in 4.2s...") is None
+
+
+# #101138 defect 2: the retry-exhaustion turn-exit notice leaves as the turn's
+# FINAL response, which never consulted the noise filter, so users got raw
+# CLI-only instructions ("Try `continue`, switch model/provider...") as the
+# last word. It must be replaced with a plain-language reply, not dropped.
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS)
+def test_chat_gateways_replace_retry_exhaustion_final_response(platform):
+    exhaustion_notice = (
+        "⚠️ No reply: the model returned empty content after retries and any "
+        "fallback providers. Try `continue`, switch model/provider, or "
+        "inspect the tool output above."
+    )
+
+    sanitized = _sanitize_gateway_final_response(platform, exhaustion_notice)
+
+    assert sanitized
+    assert "No reply:" not in sanitized
+    assert "switch model/provider" not in sanitized
+    assert "provider failed after retries" in sanitized.lower()
+
+
+def test_local_final_response_keeps_retry_exhaustion_notice():
+    """Local/CLI diagnostics keep the raw turn-exit notice verbatim."""
+    raw = (
+        "⚠️ No reply: the model returned empty content after retries and any "
+        "fallback providers. Try `continue`, switch model/provider, or "
+        "inspect the tool output above."
+    )
+
+    assert _sanitize_gateway_final_response("local", raw) == raw
+
+
+def test_final_response_noise_guard_skips_long_prose():
+    """Long assistant prose quoting a noisy phrase must pass through.
+
+    The noise rewrite is scoped to short envelopes; a full answer that
+    happens to mention "retrying (1/3) in 8s" must not be rewritten.
+    """
+    prose = (
+        "The provider logged 'Empty response from model — retrying (1/3) in "
+        "8s' during the outage, and here is the long post-mortem analysis of "
+        "what happened, why the retry ladder behaved the way it did, and what "
+        "we changed afterwards to make the empty-response budget easier to "
+        "tune. " + "Detail paragraph. " * 30
+    )
+    assert len(prose) > 400
+
+    assert _sanitize_gateway_final_response(Platform.TELEGRAM, prose) == prose


### PR DESCRIPTION
## What does this PR do?

Fixes both defects from #101138 in the gateway's suppression of provider retry chatter on chat surfaces:

1. **Stale pattern**: the empty-response retry emitter gained a retry counter ("Empty response from model — retrying (1/3) in 8s", asserted by `tests/run_agent/test_run_agent.py:3783`), but `_TELEGRAM_NOISY_STATUS_RE` still only knew "retrying in Ns", so the chatter reached chat. The pattern now covers both generations plus the "Empty response from model" anchor.
2. **Final-response bypass**: the turn-exit notice for exhausted retries ("⚠️ No reply: the model returned empty content after retries... Try `continue`, switch model/provider...") leaves through `_sanitize_gateway_final_response`, which never consulted the noise filter — so the last message, the one the user is most likely to read, was delivered raw with CLI-only instructions.

Per the reporter's suggestion, defect 2 is fixed by **replacing** the notice with the existing plain-language provider-failure reply (`_gateway_provider_error_reply`), not dropping it — silence after a user's message is its own failure mode. The check reuses the short-envelope guard (≤400 chars, ≤4 newlines) from `_looks_like_gateway_provider_error` so long assistant prose that merely quotes a noisy phrase passes through untouched.

## Related Issue

Fixes #101138

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` — `_TELEGRAM_NOISY_STATUS_RE`: widened `retrying in Ns` to also match the counter format `retrying (1/3) in 8s`, and added the "Empty response from model" / "No reply: the model returned empty content" anchors.
- `gateway/run.py` — new `_final_response_is_noise()` helper: short-envelope guard + noise-pattern match, mirroring `_looks_like_gateway_provider_error`'s shape constraints.
- `gateway/run.py` — `_sanitize_gateway_final_response`: route retry-chatter exhaustion notices to `_gateway_provider_error_reply` instead of delivering them verbatim.
- `tests/gateway/test_telegram_noise_filter.py` — regression tests: counter-format status suppression on all chat platforms (both generations + budget-note variant), final-response replacement, local/CLI passthrough, and a long-prose fail-safe guard.

## How to Test

1. `pytest tests/gateway/test_telegram_noise_filter.py -q` → **144 passed** (12 new test cases included).
2. `pytest tests/agent/test_turn_context_overflow_warning.py tests/agent/test_surrogate_chokepoints.py tests/gateway/test_compression_progress_notices.py -q` (the other suites touching these functions) → **54 passed**.
3. `pytest tests/run_agent/test_run_agent.py -q -k empty` (emitter side) → **16 passed**.
4. Observed result: before the fix, `_prepare_gateway_status_message('telegram', 'lifecycle', '⚠️ Empty response from model — retrying (1/3) in 8s')` returned the text (pattern miss) and the "⚠️ No reply: ... switch model/provider ..." final response passed through `_sanitize_gateway_final_response` verbatim; after the fix, the status is suppressed (`None`) and the final response is replaced with the plain-language "⚠️ The model provider failed after retries..." reply, while `local` keeps both verbatim.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.contributing-covenant.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] N/A (inline comments document the pattern generations and the guard; no docs/config keys touched)
- [x] N/A — no config keys changed
- [x] N/A — no architecture/workflow changes
- [x] N/A — no tool behavior changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the pattern and guard are pure-text logic with no platform-specific behavior

## Screenshots / Logs

```
$ pytest tests/gateway/test_telegram_noise_filter.py -q
144 passed, 6 warnings in 2.27s
```