### PR TITLE
fix(bot-mode): stop api server Bot Chats from losing agent replies

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -27542,8 +27542,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     adapter_supports_push,
                     deliver_wake,
                     persist_delegation_delivery,
+                    persist_message_agent_delivery,
                 )
                 if adapter is not None and not adapter_supports_push(adapter):
+                    if evt.get("completion_delivery") == "message_agent":
+                        try:
+                            await persist_message_agent_delivery(
+                                adapter,
+                                text=synth_text,
+                                session_id=raw_sid,
+                                profile_home=str(
+                                    evt.get("completion_delivery_home") or ""
+                                ),
+                                evt=evt,
+                            )
+                            return True
+                        except Exception as e:
+                            logger.warning(
+                                "message_agent delivery persist failed for "
+                                "session %s: %s",
+                                raw_sid,
+                                e,
+                            )
+                            return False
                     if evt.get("type") == "async_delegation":
                         # #85957: after the parent turn's event.complete the
                         # CLIENT owns the next turn on this stateless surface.
@@ -27633,8 +27654,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # which binds chat_id = session_id). handle_message would run the
             # wake under a build_session_key()-derived key that never matches
             # the raw X-Hermes-Session-Id session — self-post instead.
-            from gateway.wake import deliver_wake, persist_delegation_delivery
+            from gateway.wake import (
+                deliver_wake,
+                persist_delegation_delivery,
+                persist_message_agent_delivery,
+            )
             raw_sid = str(evt.get("origin_session_id") or "").strip() or str(source.chat_id or "")
+            if evt.get("completion_delivery") == "message_agent":
+                try:
+                    await persist_message_agent_delivery(
+                        adapter,
+                        text=synth_text,
+                        session_id=raw_sid,
+                        profile_home=str(
+                            evt.get("completion_delivery_home") or ""
+                        ),
+                        evt=evt,
+                    )
+                    return True
+                except Exception as e:
+                    logger.warning(
+                        "message_agent delivery persist failed for session %s: %s",
+                        raw_sid,
+                        e,
+                    )
+                    return False
             if evt.get("type") == "async_delegation":
                 # #85957: same client-owns-the-turn rule as the raw-key branch
                 # above — persist the completion as a delivery row, never
@@ -27959,6 +28003,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "chat_id",
             "thread_id",
             "user_id",
+            "completion_delivery_home",
         ))
 
     @staticmethod
@@ -28465,6 +28510,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "parent_session_id": (
                             watcher.get("parent_session_id")
                             or getattr(session, "parent_session_id", "")
+                            or ""
+                        ),
+                        "completion_delivery": (
+                            watcher.get("completion_delivery")
+                            or getattr(session, "completion_delivery", "")
+                            or ""
+                        ),
+                        "completion_delivery_home": (
+                            watcher.get("completion_delivery_home")
+                            or getattr(session, "completion_delivery_home", "")
                             or ""
                         ),
                     }

--- a/gateway/wake.py
+++ b/gateway/wake.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from pathlib import Path
 from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
@@ -178,6 +179,49 @@ async def persist_delegation_delivery(
     logger.info(
         "async delegation completion persisted as delivery row for "
         "api_server session %s (no wake turn)",
+        session_id,
+    )
+
+
+async def persist_message_agent_delivery(
+    adapter: Any,
+    *,
+    text: str,
+    session_id: str,
+    profile_home: str,
+    evt: Optional[dict] = None,
+) -> None:
+    """Persist a message_agent subprocess reply into its sender Bot Chat."""
+    if not session_id or not profile_home:
+        raise ValueError(
+            "persist_message_agent_delivery: sender session and profile home required"
+        )
+    open_db = getattr(adapter, "_open_and_cache_session_db", None)
+    db: Any = (
+        await asyncio.to_thread(open_db, Path(profile_home))
+        if callable(open_db)
+        else None
+    )
+    if db is None:
+        raise RuntimeError(
+            "persist_message_agent_delivery: sender SessionDB unavailable — "
+            f"cannot persist completion for session {session_id}"
+        )
+    event = evt or {}
+    await asyncio.to_thread(
+        db.append_message,
+        session_id,
+        "user",
+        content=text,
+        display_kind="internal_notification",
+        display_metadata={
+            "delivery_kind": "message_agent",
+            "process_id": str(event.get("session_id") or ""),
+            "exit_code": event.get("exit_code"),
+        },
+    )
+    logger.info(
+        "message_agent completion persisted for api_server session %s",
         session_id,
     )
 

--- a/tests/gateway/test_async_delivery_capability.py
+++ b/tests/gateway/test_async_delivery_capability.py
@@ -186,11 +186,16 @@ class TestTerminalNotifyGate:
         yield
         process_registry.pending_watchers = []
 
-    def _run_bg(self, command):
+    def _run_bg(self, command, **kwargs):
         from tools.terminal_tool import terminal_tool
 
         return json.loads(
-            terminal_tool(command=command, background=True, notify_on_complete=True)
+            terminal_tool(
+                command=command,
+                background=True,
+                notify_on_complete=True,
+                **kwargs,
+            )
         )
 
     def test_api_server_skips_watcher_and_notes(self):
@@ -208,5 +213,34 @@ class TestTerminalNotifyGate:
         assert d.get("notify_unsupported"), "must explain the limitation"
         assert "poll" in d["notify_unsupported"].lower()
         assert len(process_registry.pending_watchers) == 0
+
+    def test_api_server_retains_private_message_agent_persist_watcher(self, tmp_path):
+        from tools.process_registry import process_registry
+
+        tokens = set_session_vars(
+            platform="api_server",
+            chat_id="sender-sid",
+            session_key="sender-sid",
+            session_id="sender-sid",
+            async_delivery=False,
+        )
+        try:
+            d = self._run_bg(
+                "sleep 30",
+                _completion_delivery="message_agent",
+                _completion_delivery_home=str(tmp_path),
+            )
+        finally:
+            clear_session_vars(tokens)
+
+        try:
+            assert d.get("notify_on_complete") is True
+            assert "notify_unsupported" not in d
+            watcher = process_registry.pending_watchers[-1]
+            assert watcher["parent_session_id"] == "sender-sid"
+            assert watcher["completion_delivery"] == "message_agent"
+            assert watcher["completion_delivery_home"] == str(tmp_path)
+        finally:
+            process_registry.kill_process(d["session_id"])
 
 

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -581,6 +581,51 @@ async def test_inject_watch_notification_origin_session_id_wins(monkeypatch, tmp
 
 
 @pytest.mark.asyncio
+async def test_message_agent_completion_apiserver_persists_without_self_post(
+    monkeypatch, tmp_path,
+):
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    api_adapter = SimpleNamespace(supports_async_delivery=False)
+    runner.adapters[Platform.API_SERVER] = api_adapter
+
+    import gateway.wake as wake_mod
+
+    posts = []
+    persisted = []
+
+    async def fake_self_post(adapter, *, text, session_id):
+        posts.append(session_id)
+
+    async def fake_persist(adapter, *, text, session_id, profile_home, evt=None):
+        persisted.append((text, session_id, profile_home, evt))
+
+    monkeypatch.setattr(wake_mod, "_self_post_chat_completion", fake_self_post)
+    monkeypatch.setattr(wake_mod, "persist_message_agent_delivery", fake_persist)
+
+    evt = {
+        "type": "completion",
+        "session_id": "proc_reply",
+        "session_key": "raw-sender-sid",
+        "platform": "api_server",
+        "chat_type": "dm",
+        "chat_id": "raw-sender-sid",
+        "parent_session_id": "raw-sender-sid",
+        "completion_delivery": "message_agent",
+        "completion_delivery_home": str(tmp_path / "profiles" / "sender"),
+    }
+    result = await runner._inject_watch_notification("reply", evt)
+
+    assert result is True
+    assert posts == []
+    assert persisted == [(
+        "reply",
+        "raw-sender-sid",
+        str(tmp_path / "profiles" / "sender"),
+        evt,
+    )]
+
+
+@pytest.mark.asyncio
 async def test_async_delegation_apiserver_persists_delivery_not_self_post(
     monkeypatch, tmp_path,
 ):

--- a/tests/gateway/test_completion_delivery.py
+++ b/tests/gateway/test_completion_delivery.py
@@ -420,6 +420,23 @@ def test_completion_batches_do_not_cross_conversation_routes():
     assert adapter.handle_message.await_count == 2
 
 
+def test_message_agent_batches_do_not_cross_profile_homes():
+    first = _completion_event(started_at=1.0, session_id="proc_profile_a")
+    second = _completion_event(started_at=2.0, session_id="proc_profile_b")
+    first.update(
+        completion_delivery="message_agent",
+        completion_delivery_home="/hermes/profiles/a",
+    )
+    second.update(
+        completion_delivery="message_agent",
+        completion_delivery_home="/hermes/profiles/b",
+    )
+
+    assert GatewayRunner._completion_notification_batch_key(
+        first
+    ) != GatewayRunner._completion_notification_batch_key(second)
+
+
 def test_failed_coalesced_delivery_retries_all_entries():
     attempts = 0
 

--- a/tests/gateway/test_wake_delivery.py
+++ b/tests/gateway/test_wake_delivery.py
@@ -182,3 +182,40 @@ def test_persist_delegation_delivery_raises_without_db():
         ))
 
 
+def test_persist_message_agent_delivery_targets_sender_profile_db(tmp_path):
+    from gateway.wake import persist_message_agent_delivery
+    from hermes_state import SessionDB
+
+    home = tmp_path / "profiles" / "sender"
+    home.mkdir(parents=True)
+    db = SessionDB(db_path=home / "state.db")
+    sid = "sender-bot-chat"
+    db.create_session(sid, source="api_server")
+
+    class DbAdapter(ApiServerLikeAdapter):
+        def _open_and_cache_session_db(self, requested_home):
+            assert requested_home == home
+            return db
+
+    evt = {"session_id": "proc_reply", "exit_code": 0}
+    asyncio.run(
+        persist_message_agent_delivery(
+            DbAdapter(),
+            text="[Background process completed]\nreply from teammate",
+            session_id=sid,
+            profile_home=str(home),
+            evt=evt,
+        )
+    )
+
+    delivery = db.get_messages(sid)[-1]
+    assert delivery["role"] == "user"
+    assert delivery["content"].endswith("reply from teammate")
+    assert delivery["display_kind"] == "internal_notification"
+    assert delivery["display_metadata"] == {
+        "delivery_kind": "message_agent",
+        "process_id": "proc_reply",
+        "exit_code": 0,
+    }
+
+

--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -619,6 +619,30 @@ def test_successful_spawn_transfers_cleanup_to_runner(tmp_path, monkeypatch):
     assert dm_file.exists(), "the parent must not delete before the background runner reads"
 
 
+def test_spawn_marks_message_agent_completion_for_durable_delivery(tmp_path, monkeypatch):
+    home = _managed_home(tmp_path)
+    agent = _FakeAgent(home)
+    captured = {}
+
+    import tools.terminal_tool as terminal_tool_module
+
+    def launched(command, **kwargs):
+        captured.update(kwargs)
+        return json.dumps({"session_id": "proc_durable"})
+
+    monkeypatch.setattr(terminal_tool_module, "terminal_tool", launched)
+
+    result = json.loads(
+        bot_mode_dm._spawn_delivery(
+            "unused", "@researcher", task_id=None, agent=agent
+        )
+    )
+
+    assert result["status"] == "sent"
+    assert captured["_completion_delivery"] == "message_agent"
+    assert captured["_completion_delivery_home"] == str(home)
+
+
 def test_write_dm_file_unlinks_partial_file_on_write_exception(tmp_path, monkeypatch):
     dm_file = tmp_path / "partial.txt"
     real_mkstemp = bot_mode_dm.tempfile.mkstemp

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1049,6 +1049,25 @@ class TestCheckpoint:
             assert secret not in data[0]["command"]
             assert data[0]["command"] != command
 
+    def test_checkpoint_preserves_durable_completion_route(self, registry, tmp_path):
+        checkpoint = tmp_path / "procs.json"
+        with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
+            s = _make_session(sid="proc_message_agent", command="deliver")
+            s.pid = 12345
+            s.parent_session_id = "sender-sid"
+            s.completion_delivery = "message_agent"
+            s.completion_delivery_home = str(tmp_path / "profiles" / "sender")
+            registry._running[s.id] = s
+
+            registry._write_checkpoint()
+
+        entry = json.loads(checkpoint.read_text())[0]
+        assert entry["parent_session_id"] == "sender-sid"
+        assert entry["completion_delivery"] == "message_agent"
+        assert entry["completion_delivery_home"] == str(
+            tmp_path / "profiles" / "sender"
+        )
+
 # =========================================================================
 # Kill process
 # =========================================================================

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -33,9 +33,10 @@ The transports themselves are unchanged and proven:
   --create-if-missing -Q --query-file <tmp>`` (one turn, reply on stdout)
 - peer teammate   → ``hermes peer dm <peer>[/<name>] < <tmp>``
 
-Both run through ``terminal_tool(background=True, notify_on_complete=True)``
-so the reply lands as a completion notification on the sender's NEXT turn —
-the same wake shape every Bot Mode agent already knows.
+Both run through ``terminal_tool(background=True, notify_on_complete=True)``.
+Push-capable surfaces receive the established completion wake; stateless
+``api_server`` sessions retain the same watcher but persist its completion as
+a durable transcript row, ready for the next client-owned turn.
 """
 
 from __future__ import annotations
@@ -689,6 +690,8 @@ def _spawn_delivery(
             task_id=task_id,
             workdir=str(Path(__file__).resolve().parent.parent),
             _host_local=True,
+            _completion_delivery="message_agent",
+            _completion_delivery_home=_agent_home(agent),
         )
         try:
             parsed = json.loads(raw)

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -417,6 +417,8 @@ class ProcessSession:
     # boundary (/new), instead of injecting them into the chat's NEW session.
     parent_session_id: str = ""
     notify_on_complete: bool = False             # Queue agent notification on exit
+    completion_delivery: str = ""                # Private durable-delivery kind
+    completion_delivery_home: str = ""           # Exact sender profile home
     # Watch patterns — trigger agent notification when output matches any pattern
     watch_patterns: List[str] = field(default_factory=list)
     _watch_hits: int = field(default=0, repr=False)          # total matches delivered
@@ -2839,6 +2841,8 @@ class ProcessRegistry:
                             "watcher_interval": s.watcher_interval,
                             "parent_session_id": s.parent_session_id,
                             "notify_on_complete": s.notify_on_complete,
+                            "completion_delivery": s.completion_delivery,
+                            "completion_delivery_home": s.completion_delivery_home,
                             "watch_patterns": s.watch_patterns,
                         })
                 if extra_entries:
@@ -2937,6 +2941,8 @@ class ProcessRegistry:
                 watcher_interval=entry.get("watcher_interval", 0),
                 parent_session_id=entry.get("parent_session_id", ""),
                 notify_on_complete=entry.get("notify_on_complete", False),
+                completion_delivery=entry.get("completion_delivery", ""),
+                completion_delivery_home=entry.get("completion_delivery_home", ""),
                 watch_patterns=entry.get("watch_patterns", []),
             )
             with self._lock:
@@ -2958,6 +2964,8 @@ class ProcessRegistry:
                     "message_id": session.watcher_message_id,
                     "notify_on_complete": session.notify_on_complete,
                     "parent_session_id": session.parent_session_id,
+                    "completion_delivery": session.completion_delivery,
+                    "completion_delivery_home": session.completion_delivery_home,
                 })
 
         self._write_checkpoint(extra_entries=unresolved_scope_entries)

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2828,6 +2828,8 @@ def terminal_tool(
     notify_on_complete: bool = False,
     watch_patterns: Optional[List[str]] = None,
     _host_local: bool = False,
+    _completion_delivery: str = "",
+    _completion_delivery_home: str = "",
 ) -> str:
     """
     Execute a command in the configured terminal environment.
@@ -3458,7 +3460,15 @@ def terminal_tool(
                     # Kanban workers) cannot route a completion back to the
                     # agent after the turn/process ends. Refuse the promise:
                     # drop the flags and tell the agent to poll.
-                    if not _async_ok():
+                    _gw_platform = _gse("HERMES_SESSION_PLATFORM", "")
+                    _parent_session_id = _gse("HERMES_SESSION_ID", "")
+                    _durable_message_agent = (
+                        _completion_delivery == "message_agent"
+                        and bool(_completion_delivery_home)
+                        and _gw_platform == "api_server"
+                        and bool(_parent_session_id)
+                    )
+                    if not _async_ok() and not _durable_message_agent:
                         notify_on_complete = False
                         watch_patterns = None
                         result_data["notify_on_complete"] = False
@@ -3477,7 +3487,6 @@ def terminal_tool(
                             proc_session.id,
                         )
                     else:
-                        _gw_platform = _gse("HERMES_SESSION_PLATFORM", "")
                         if _gw_platform:
                             _gw_chat_id = _gse("HERMES_SESSION_CHAT_ID", "")
                             _gw_thread_id = _gse("HERMES_SESSION_THREAD_ID", "")
@@ -3496,9 +3505,12 @@ def terminal_tool(
                             # notification when the user closes this session
                             # (/new) before the process finishes, instead of
                             # injecting it into the chat's NEW session.
-                            proc_session.parent_session_id = _gse(
-                                "HERMES_SESSION_ID", ""
-                            )
+                            proc_session.parent_session_id = _parent_session_id
+                            if _durable_message_agent:
+                                proc_session.completion_delivery = "message_agent"
+                                proc_session.completion_delivery_home = str(
+                                    _completion_delivery_home
+                                )
 
                 # Mutual exclusion: if both notify_on_complete and watch_patterns
                 # are set, drop watch_patterns. The combination produces duplicate
@@ -3538,6 +3550,8 @@ def terminal_tool(
                             "message_id": proc_session.watcher_message_id,
                             "notify_on_complete": True,
                             "parent_session_id": proc_session.parent_session_id,
+                            "completion_delivery": proc_session.completion_delivery,
+                            "completion_delivery_home": proc_session.completion_delivery_home,
                         })
 
                 # Set watch patterns for output monitoring


### PR DESCRIPTION
## What does this PR do?

Bot Mode agents using an `api_server` canonical Bot Chat can no longer silently lose completed `message_agent` replies after the sender turn ends. The delivery subprocess now retains an internal completion watcher on this stateless surface and persists its redacted completion into the exact sender profile and session instead of attempting an unsupported post-turn push.

### Symptom

`message_agent` can return `status: sent`, the recipient can complete with exit code 0 and full stdout, but the sender's `api_server` Bot Chat never receives that reply.

### Impact

The sending agent can lose completed teammate work without an error or retry signal. The affected blast radius is Bot Mode canonical chats served through the stateless API server surface.

### Bug Cause

**Trigger:** `tools/terminal_tool.py:3461` disabled `notify_on_complete` whenever `supports_async_delivery` was false.

**Causal chain:**
1. `tools/bot_mode_dm.py::_spawn_delivery` starts a bounded recipient transport with `notify_on_complete=True`.
2. The API server session capability gate removes that flag and registers no process watcher because the HTTP response has no later push channel.
3. The subprocess still starts and `message_agent` reports success, but its completed stdout has no route back into the sender transcript.

**Why it is wrong:** `message_agent` treated a process-start acknowledgement as end-to-end delivery even though its only return path had been disabled by the stateless channel gate.

**Working sibling / contrast:** Push-capable messaging adapters keep their existing synthetic completion wake. API server async delegation already uses a durable transcript delivery row rather than a client-unrequested wake turn.

**Ruled out:** Recipient execution failure is not the cause: reported lost cases exited successfully with the complete reply captured in process output. Burst contention is also not sufficient because sequential loss was observed.

### Fix

- Mark only Hermes-owned `message_agent` subprocesses with a private durable completion route and exact sender profile home.
- Allow that private route through the API server's generic async-delivery refusal while leaving ordinary terminal notifications unsupported.
- Carry the route through process checkpoints and completion events.
- Persist API server completions as `internal_notification` transcript rows in the sender's exact SessionDB, without starting a model turn; failed persistence remains retryable.
- Include the profile home in completion batching identity so multiplexed profiles cannot coalesce replies across databases.

## Related Issue

Closes #101142

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/bot_mode_dm.py` - identify message-agent subprocess completions as durable deliveries.
- `tools/terminal_tool.py` - retain the private API server watcher while preserving the public stateless-channel refusal.
- `tools/process_registry.py` - checkpoint and restore the durable delivery route.
- `gateway/run.py` - carry completion metadata, isolate profile batches, and route API server replies to persistence.
- `gateway/wake.py` - append replies to the exact sender profile and session without a synthetic agent turn.
- `tests/` - cover the terminal capability exception, sender-profile persistence, no-self-post routing, batch isolation, and checkpoint metadata.

## How to Test

1. Run the focused delivery and Bot Mode suites:

```bash
scripts/run_tests.sh tests/gateway/test_completion_delivery.py tests/gateway/test_async_delivery_capability.py tests/gateway/test_wake_delivery.py tests/gateway/test_background_process_notifications.py tests/tools/test_bot_mode_dm.py -q -k 'not dm_dir_is_private_and_uid_scoped_on_posix and not dm_dir_repairs_restrictive_owner_mode'
```

2. Run the checkpoint regression:

```bash
scripts/run_tests.sh tests/tools/test_process_registry.py -q -k checkpoint_preserves_durable_completion_route
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant suites
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant docstrings
- [x] Config example changes are N/A because no config keys changed
- [x] Architecture guide changes are N/A because the existing delivery architecture is extended
- [x] I've considered cross-platform impact; the added route uses existing pathlib and process-registry abstractions
- [x] Tool schema changes are N/A because the new terminal parameters are private and not model-exposed

## Screenshots / Logs

N/A - automated behavior tests cover the non-visual delivery contract.
