### PR TITLE
fix(pricing): resolve dated Anthropic snapshot ids to their family entry

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1196,6 +1196,16 @@ def _lookup_official_docs_pricing(route: BillingRoute) -> Optional[PricingEntry]
             entry = _OFFICIAL_DOCS_PRICING.get((route.provider, normalized))
             if entry:
                 return entry
+        # Dated snapshot ids (claude-haiku-4-5-20251001) are the API-returned
+        # spelling of the same model as their undated family entry and bill
+        # identically, so an exact miss falls back to the family id (#101145).
+        # This is a resolution fallback, not a rate guess: an unknown family
+        # id still falls through to None below.
+        family = re.sub(r"-\d{8}$", "", normalized)
+        if family != normalized:
+            entry = _OFFICIAL_DOCS_PRICING.get((route.provider, family))
+            if entry:
+                return entry
     # Bedrock cross-region inference profiles carry a region prefix
     # (us./global./eu./...) that the bare pricing keys don't have.
     if route.provider == "bedrock":

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -1,3 +1,4 @@
+import re
 from types import SimpleNamespace
 
 from agent.usage_pricing import (
@@ -8,6 +9,7 @@ from agent.usage_pricing import (
     normalize_usage,
     resolve_billing_route,
 )
+from agent.usage_pricing import _OFFICIAL_DOCS_PRICING
 from decimal import Decimal
 
 
@@ -867,3 +869,52 @@ def test_flat_entries_unaffected_by_tier_machinery():
     )
     # 250k * $0.25/M + 10k * $1.50/M
     assert result.amount_usd == Decimal("0.0775")
+
+
+def test_dated_anthropic_snapshot_resolves_to_family_entry():
+    """Regression test: a dated snapshot id is the same model as its undated
+    family entry and bills identically, so it must resolve to the family's
+    rates. Before this fix, sessions pinned to a dated snapshot (the form the
+    API returns and persists) silently booked $0.00 as unknown cost (#101145).
+    """
+    entry = get_pricing_entry("claude-haiku-4-5-20251001", provider="anthropic")
+    family = get_pricing_entry("claude-haiku-4-5", provider="anthropic")
+
+    assert entry is not None
+    assert family is not None
+    assert entry.input_cost_per_million == family.input_cost_per_million
+    assert entry.output_cost_per_million == family.output_cost_per_million
+
+
+def test_dotted_and_dated_anthropic_id_resolves():
+    """Dot-notation and a dated suffix compose: claude-opus-4.5-20251001 must
+    normalize to claude-opus-4-5-20251001 and then strip to the family id."""
+    entry = get_pricing_entry("claude-opus-4.5-20251001", provider="anthropic")
+
+    assert entry is not None
+    assert entry.input_cost_per_million == Decimal("5.00")
+
+
+def test_dated_strip_does_not_invent_rates_for_unknown_families():
+    """The dated fallback is a resolution, not a guess: when the family id is
+    not in the table, the lookup must still return None so callers report the
+    cost as unknown instead of silently booking $0.00 from a wrong card."""
+    assert get_pricing_entry("claude-opus-9-20251001", provider="anthropic") is None
+
+
+def test_every_undated_anthropic_entry_resolves_with_dated_suffix():
+    """Every undated Anthropic family entry must keep pricing when the caller
+    pins a dated snapshot of it, so the two spellings cannot drift apart as
+    entries are added to the table."""
+    dated_suffix = "-20251001"
+    undated = [
+        model
+        for provider, model in _OFFICIAL_DOCS_PRICING
+        if provider == "anthropic" and not re.search(r"-\d{8}$", model)
+    ]
+    assert undated  # sanity: the table still has undated family entries
+
+    for model in undated:
+        entry = get_pricing_entry(model + dated_suffix, provider="anthropic")
+        assert entry is not None, f"{model}{dated_suffix} prices as unknown"
+        assert entry is _OFFICIAL_DOCS_PRICING[("anthropic", model)]


### PR DESCRIPTION
## What does this PR do?

A dated Anthropic snapshot id (`claude-haiku-4-5-20251001`) is the API-returned spelling of the same model as its undated family entry and bills identically — but `_lookup_official_docs_pricing` only tried the exact id and the dot-notation normalization, so any session pinned to a dated snapshot priced as unknown and booked `estimated_cost_usd = 0.00`.

This adds one resolution fallback on an exact miss: strip the trailing `-YYYYMMDD` and look up the family id. The fallback happens **after** the existing dot-notation normalization, so the two compose (`claude-opus-4.5-20251001` → `claude-opus-4-5`). It is a resolution fallback, not a rate guess: when the family id is not in the table the lookup still returns `None`, so unknown models keep reporting unknown cost instead of silently substituting a wrong card (per the #101068 note on why nearest-model substitution is dangerous).

Bedrock ids already strip trailing dates via `_normalize_bedrock_model_name`; this closes the same gap for the direct `anthropic` route, whose table entries mix dated and undated spellings (`claude-opus-4-6-20250414` vs `claude-haiku-4-5`).

## Related Issue

Fixes #101145

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/usage_pricing.py` (~10 lines): in `_lookup_official_docs_pricing`'s anthropic branch, after the existing exact/dot-notation lookups miss, strip a trailing `-YYYYMMDD` date and retry the family id before falling through to `None`.
- `tests/agent/test_usage_pricing.py`: four regression tests — dated→family price resolution, dotted+dated composition, unknown-family-stays-`None`, and an anti-drift sweep asserting every undated anthropic table entry still resolves when a dated suffix is appended.

## How to Test

1. `python -m pytest tests/agent/test_usage_pricing.py -q` — Observed result: 50 passed (46 pre-existing + 4 new).
2. Direct check of the issue reproduction:
   ```python
   from agent.usage_pricing import get_pricing_entry
   get_pricing_entry("claude-haiku-4-5", provider="anthropic")           # entry, $1.00/$5.00
   get_pricing_entry("claude-haiku-4-5-20251001", provider="anthropic")  # same entry (was None before)
   get_pricing_entry("claude-opus-9-20251001", provider="anthropic")     # still None — no invented rates
   ```
   Observed result: all three behave as commented.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ python -m pytest tests/agent/test_usage_pricing.py -q
50 passed in 7.93s
```