### PR TITLE
fix(providers): give alibaba-coding-plan-cn its own API key env var

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -423,6 +423,20 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("ALIBABA_CODING_PLAN_API_KEY", "DASHSCOPE_API_KEY"),
         base_url_env_var="ALIBABA_CODING_PLAN_BASE_URL",
     ),
+    # China endpoint (#101122): a dedicated, non-overlapping key var --
+    # mirroring kimi-coding / kimi-coding-cn (#10526) -- so setting the intl
+    # key above doesn't also light up this entry in the provider picker.
+    # Without an explicit registry entry here, this slug used to fall back to
+    # the plugin's ProviderProfile.env_vars, which shared both
+    # ALIBABA_CODING_PLAN_API_KEY and DASHSCOPE_API_KEY with the intl entry.
+    "alibaba-coding-plan-cn": ProviderConfig(
+        id="alibaba-coding-plan-cn",
+        name="Alibaba Cloud (Coding Plan, China)",
+        auth_type="api_key",
+        inference_base_url="https://coding.dashscope.aliyuncs.com/v1",
+        api_key_env_vars=("ALIBABA_CODING_PLAN_CN_API_KEY",),
+        base_url_env_var="ALIBABA_CODING_PLAN_CN_BASE_URL",
+    ),
     "minimax-cn": ProviderConfig(
         id="minimax-cn",
         name="MiniMax (China)",

--- a/plugins/model-providers/alibaba-coding-plan/__init__.py
+++ b/plugins/model-providers/alibaba-coding-plan/__init__.py
@@ -9,6 +9,13 @@ Region split, mirroring the base DashScope pair (#73265):
 
 Profile names match the models.dev catalog keys exactly so model metadata
 lines up and ``model.provider: alibaba-coding-plan-cn`` resolves at runtime.
+
+The two profiles use non-overlapping API-key env vars (#101122) -- mirroring
+kimi-coding / kimi-coding-cn (#10526) -- so setting only the intl key doesn't
+also make the CN entry appear "configured" in the provider picker, and vice
+versa. ``hermes_cli.auth.PROVIDER_REGISTRY`` carries a matching pair of
+entries and takes priority over these ``env_vars`` for picker/auth purposes;
+keep both in sync when changing either.
 """
 
 from providers import register_provider
@@ -31,7 +38,7 @@ alibaba_coding_plan_cn = ProviderProfile(
     display_name="Alibaba Cloud (Coding Plan, China)",
     description="Alibaba Cloud Coding Plan, mainland-China endpoint",
     signup_url="https://help.aliyun.com/zh/model-studio/",
-    env_vars=("ALIBABA_CODING_PLAN_API_KEY", "DASHSCOPE_API_KEY", "ALIBABA_CODING_PLAN_CN_BASE_URL"),
+    env_vars=("ALIBABA_CODING_PLAN_CN_API_KEY", "ALIBABA_CODING_PLAN_CN_BASE_URL"),
     base_url="https://coding.dashscope.aliyuncs.com/v1",
     auth_type="api_key",
 )

--- a/tests/hermes_cli/test_alibaba_coding_plan_cn_provider_listing.py
+++ b/tests/hermes_cli/test_alibaba_coding_plan_cn_provider_listing.py
@@ -1,0 +1,90 @@
+"""Test that alibaba-coding-plan and alibaba-coding-plan-cn don't both appear
+in the /model picker off a single shared key.
+
+Regression (#101122): both profiles listened to the same
+ALIBABA_CODING_PLAN_API_KEY / DASHSCOPE_API_KEY env vars, so setting either
+made *both* providers show up in the picker even though the user only has one
+endpoint's key. Fixed the same way as kimi-coding / kimi-coding-cn (#10526):
+give the China entry its own, non-overlapping env var
+(ALIBABA_CODING_PLAN_CN_API_KEY) in both the plugin's ProviderProfile and the
+hermes_cli.auth.PROVIDER_REGISTRY entry that takes priority over it.
+"""
+
+import os
+from unittest.mock import patch
+
+from hermes_cli.model_switch import list_authenticated_providers
+from hermes_cli.providers import resolve_provider_full
+
+
+# -- Only the CN key set ------------------------------------------------------
+
+
+@patch.dict(os.environ, {"ALIBABA_CODING_PLAN_CN_API_KEY": "sk-cn-fake"}, clear=False)
+def test_alibaba_cn_appears_when_only_cn_key_set():
+    """alibaba-coding-plan-cn should appear when only its own key is set."""
+    providers = list_authenticated_providers(current_provider="alibaba-coding-plan-cn")
+
+    cn = next((p for p in providers if p["slug"] == "alibaba-coding-plan-cn"), None)
+    assert cn is not None, (
+        "alibaba-coding-plan-cn should appear when ALIBABA_CODING_PLAN_CN_API_KEY is set"
+    )
+    assert cn["is_current"] is True
+
+    intl = next((p for p in providers if p["slug"] == "alibaba-coding-plan"), None)
+    assert intl is None, (
+        "alibaba-coding-plan should NOT appear when only the CN key is set"
+    )
+
+
+# -- Only the intl key set (the original bug) --------------------------------
+
+
+@patch.dict(os.environ, {"ALIBABA_CODING_PLAN_API_KEY": "sk-intl-fake"}, clear=False)
+def test_alibaba_cn_does_not_appear_when_only_intl_key_set():
+    """#101122: alibaba-coding-plan-cn must NOT appear off the intl-only key."""
+    providers = list_authenticated_providers(current_provider="alibaba-coding-plan")
+
+    intl = next((p for p in providers if p["slug"] == "alibaba-coding-plan"), None)
+    assert intl is not None, (
+        "alibaba-coding-plan should appear when ALIBABA_CODING_PLAN_API_KEY is set"
+    )
+    assert intl["is_current"] is True
+
+    cn = next((p for p in providers if p["slug"] == "alibaba-coding-plan-cn"), None)
+    assert cn is None, (
+        "alibaba-coding-plan-cn should NOT appear when only the shared intl key "
+        "(ALIBABA_CODING_PLAN_API_KEY) is set -- this was the duplicate-entry bug"
+    )
+
+
+@patch.dict(os.environ, {"DASHSCOPE_API_KEY": "sk-dashscope-fake"}, clear=False)
+def test_alibaba_cn_does_not_appear_when_only_shared_dashscope_key_set():
+    """The other half of the shared pair (#101122): DASHSCOPE_API_KEY alone
+    must not surface the CN entry either."""
+    providers = list_authenticated_providers(current_provider="alibaba-coding-plan")
+
+    intl = next((p for p in providers if p["slug"] == "alibaba-coding-plan"), None)
+    assert intl is not None
+
+    cn = next((p for p in providers if p["slug"] == "alibaba-coding-plan-cn"), None)
+    assert cn is None, (
+        "alibaba-coding-plan-cn should NOT appear when only DASHSCOPE_API_KEY is set"
+    )
+
+
+# -- Provider identity preserved ----------------------------------------------
+
+
+@patch.dict(os.environ, {
+    "ALIBABA_CODING_PLAN_API_KEY": "sk-intl-fake",
+    "ALIBABA_CODING_PLAN_CN_API_KEY": "sk-cn-fake",
+}, clear=False)
+def test_resolve_provider_full_preserves_alibaba_cn_provider_identity():
+    """Explicit alibaba-coding-plan-cn must resolve to its own endpoint/key,
+    not fall back to the intl one."""
+    pdef = resolve_provider_full("alibaba-coding-plan-cn", None, None)
+    assert pdef is not None
+    assert pdef.id == "alibaba-coding-plan-cn"
+    assert pdef.base_url == "https://coding.dashscope.aliyuncs.com/v1"
+    assert pdef.api_key_env_vars == ("ALIBABA_CODING_PLAN_CN_API_KEY", "ALIBABA_CODING_PLAN_CN_BASE_URL")

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -1234,13 +1234,17 @@ class TestRuntimeAlibabaRegionalAndTokenPlan:
         assert result["base_url"] == "https://dashscope.aliyuncs.com/compatible-mode/v1"
 
     def test_runtime_alibaba_coding_plan_cn(self, monkeypatch):
-        monkeypatch.setenv("ALIBABA_CODING_PLAN_API_KEY", "acp-key")
+        # #101122: the CN provider now has its own, non-overlapping key var
+        # (mirroring kimi-coding / kimi-coding-cn) -- it no longer resolves
+        # off the shared intl ALIBABA_CODING_PLAN_API_KEY / DASHSCOPE_API_KEY.
+        monkeypatch.setenv("ALIBABA_CODING_PLAN_CN_API_KEY", "acp-cn-key")
+        monkeypatch.delenv("ALIBABA_CODING_PLAN_API_KEY", raising=False)
         monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
         from hermes_cli.runtime_provider import resolve_runtime_provider
         result = resolve_runtime_provider(requested="alibaba-coding-plan-cn")
         assert result["provider"] == "alibaba-coding-plan-cn"
         assert result["api_mode"] == "chat_completions"
-        assert result["api_key"] == "acp-key"
+        assert result["api_key"] == "acp-cn-key"
         assert result["base_url"] == "https://coding.dashscope.aliyuncs.com/v1"
 
     def test_runtime_alibaba_token_plan(self, monkeypatch):

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -279,7 +279,14 @@ class TestAlibabaRegionalAndTokenPlanProfiles:
         p = get_provider_profile("alibaba-coding-plan-cn")
         assert p is not None and p.name == "alibaba-coding-plan-cn"
         assert p.base_url == "https://coding.dashscope.aliyuncs.com/v1"
-        assert "ALIBABA_CODING_PLAN_API_KEY" in p.env_vars
+        # #101122: the CN profile has its own, non-overlapping key var --
+        # mirroring kimi-coding / kimi-coding-cn (#10526) and the
+        # alibaba-token-plan / alibaba-token-plan-cn pair -- so it no longer
+        # shares ALIBABA_CODING_PLAN_API_KEY (or DASHSCOPE_API_KEY) with the
+        # intl profile and both stop appearing together off a single key.
+        assert "ALIBABA_CODING_PLAN_CN_API_KEY" in p.env_vars
+        assert "ALIBABA_CODING_PLAN_API_KEY" not in p.env_vars
+        assert "DASHSCOPE_API_KEY" not in p.env_vars
 
     def test_alibaba_token_plan_registered(self):
         p = get_provider_profile("alibaba-token-plan")


### PR DESCRIPTION
The "Alibaba Cloud (Coding Plan)" (intl) and "Alibaba Cloud (Coding Plan, China)" providers shared the same env vars (ALIBABA_CODING_PLAN_API_KEY / DASHSCOPE_API_KEY), both in the plugin's ProviderProfile and via the lack of a dedicated hermes_cli.auth.PROVIDER_REGISTRY entry for the CN slug (which fell back to the plugin's shared vars). Setting only one key made both entries show up in the /model picker at once, even though the user only has credentials for one endpoint.

Fixed the same way as kimi-coding / kimi-coding-cn (#10526): give the CN profile its own, non-overlapping ALIBABA_CODING_PLAN_CN_API_KEY, in both the plugin profile and a new matching PROVIDER_REGISTRY entry (the latter takes priority for picker/auth purposes, and was the actual root cause). The intl profile and its env vars are left untouched for backward compatibility with existing users.

Updated the tests that encoded the old shared-key behavior (test_provider_profiles.py, test_api_key_providers.py) and added tests/hermes_cli/test_alibaba_coding_plan_cn_provider_listing.py, modeled on the kimi-cn precedent, to cover the picker behavior directly.

Fixes #101122

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

