### PR TITLE
fix(buzz): keep quiet healthy WebSocket connections alive

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1967,10 +1967,6 @@ class BuzzAdapter(BasePlatformAdapter):
                                     # A clean close racing the liveness probe is
                                     # normal relay lifecycle, not a failure.
                                     break
-                                except asyncio.TimeoutError:
-                                    raise ConnectionError(
-                                        "WebSocket liveness probe timed out"
-                                    ) from None
                                 try:
                                     message = json.loads(raw)
                                 except (ValueError, TypeError):

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -308,24 +308,11 @@ _WS_AUTH_TIMEOUT = 20.0
 # never completes, so a manual ping round-trip times out and forces the
 # normal reconnect path. A quiet-but-healthy relay answers the ping and the
 # connection is kept — silence alone is not death.
-_WS_LIVENESS_INTERVAL = 60.0
-_WS_LIVENESS_TIMEOUT = 45.0
+_WS_LIVENESS_INTERVAL = 300.0
+_WS_LIVENESS_TIMEOUT = 15.0
 _WS_MAX_MESSAGE_BYTES = 2_000_000
 _WS_MEMBERSHIP_KIND = 44100
 _WS_MEMBERSHIP_SUB_ID = "hermes-buzz-membership"
-
-
-def _ws_clean_close_error():
-    """The websockets clean-close exception class (version-portable).
-
-    websockets 15.x raises ``ConnectionClosedOK`` when the server closes
-    cleanly — normally surfaced as the iterator ending, but a close racing
-    the liveness ping instead raises it from ``ping()``/``recv()``.
-    Resolved lazily so adapter import never needs websockets present.
-    """
-    from websockets.exceptions import ConnectionClosedOK
-
-    return ConnectionClosedOK
 
 # Where to look for a credentials JSON (keys: nsec / private_key_hex) when
 # BUZZ_PRIVATE_KEY is not set.  Module-level so tests can point it at a tmpdir.
@@ -1891,36 +1878,62 @@ class BuzzAdapter(BasePlatformAdapter):
 
     async def _probe_liveness(self, websocket) -> None:
         """Require proof of transport life via a ping/pong round-trip."""
-        ping_fn = getattr(websocket, "ping", None)
-        if not callable(ping_fn):
-            return
-        pong_waiter = await ping_fn()
+        pong_waiter = await websocket.ping()
         if pong_waiter is not None:
             await pong_waiter
 
     async def _read_frame_or_probe(self, frame_iter, websocket) -> str:
-        """Read a frame, probing the connection while it remains quiet."""
+        """Read a frame, probing the connection while it remains quiet.
+
+        The pending read is kept across idle/probe cycles — cancelling and
+        re-creating it per cycle would drop frames that arrive while the
+        probe is in flight.
+        """
         read_task = asyncio.ensure_future(frame_iter.__anext__())
+        probe_task = None
         try:
             while True:
-                done, _ = await asyncio.wait({read_task}, timeout=_WS_LIVENESS_INTERVAL)
+                done, _ = await asyncio.wait(
+                    {read_task}, timeout=_WS_LIVENESS_INTERVAL
+                )
                 if done:
                     return read_task.result()
-                try:
-                    await asyncio.wait_for(
-                        self._probe_liveness(websocket), timeout=_WS_LIVENESS_TIMEOUT
-                    )
-                except asyncio.TimeoutError:
+                probe_task = asyncio.ensure_future(
+                    self._probe_liveness(websocket)
+                )
+                done, _ = await asyncio.wait(
+                    {read_task, probe_task},
+                    timeout=_WS_LIVENESS_TIMEOUT,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if not done:
                     raise ConnectionError(
                         "relay did not answer a liveness ping within "
                         f"{_WS_LIVENESS_TIMEOUT:.0f}s; assuming the connection went silent"
                     ) from None
+                if probe_task in done:
+                    # A failed probe wins even when a frame also completed:
+                    # the transport error must reach the reconnect path.
+                    probe_task.result()
+                    if read_task in done:
+                        return read_task.result()
+                    probe_task = None
+                    continue
+                # Only the frame is ready: return it without waiting for the
+                # pong; the finally block cancels and settles the probe.
+                return read_task.result()
         finally:
-            read_task.cancel()
-            try:
-                await read_task
-            except (asyncio.CancelledError, Exception):
-                pass
+            for task in (read_task, probe_task):
+                if task is None or task.done():
+                    continue
+                task.cancel()
+                try:
+                    await task
+                except (asyncio.CancelledError, Exception):
+                    pass
+            for task in (read_task, probe_task):
+                if task is not None and not task.cancelled():
+                    task.exception()  # retrieve, so nothing is left un-retrieved
 
     async def _websocket_loop(self) -> None:
         """Persistent authenticated subscription with bounded reconnect
@@ -1929,6 +1942,7 @@ class BuzzAdapter(BasePlatformAdapter):
         from the last observed timestamps (same-second overlap de-duped by
         event id)."""
         import websockets
+        from websockets.exceptions import ConnectionClosedOK
 
         backoff = 1.0
         try:
@@ -1963,9 +1977,9 @@ class BuzzAdapter(BasePlatformAdapter):
                                     )
                                 except StopAsyncIteration:
                                     break
-                                except _ws_clean_close_error():
-                                    # A clean close racing the liveness probe is
-                                    # normal relay lifecycle, not a failure.
+                                # A clean close racing the liveness probe is
+                                # normal relay lifecycle, not a failure.
+                                except ConnectionClosedOK:
                                     break
                                 try:
                                     message = json.loads(raw)

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -300,16 +300,32 @@ def _attachment_origin(value: str) -> Optional[tuple[str, int]]:
 # WebSocket transport (NIP-42 authenticated Nostr subscription).
 # kind 44100 is Buzz's channel-membership event — used for live DM discovery.
 _WS_AUTH_TIMEOUT = 20.0
-# Last-resort bound on how long the read loop may wait for a frame. The
-# library keepalive (ping_interval/ping_timeout below) should catch a dead
-# relay first, but a relay-side close the transport never surfaces (observed
-# as a CLOSE_WAIT socket with the loop parked on recv, #98097) leaves the
-# gateway "connected" while inbound stops; this timeout forces the normal
-# reconnect path instead.
-_WS_READ_IDLE_TIMEOUT = 300.0
+# Last-resort liveness probe for the read loop. The library keepalive
+# (ping_interval/ping_timeout below) should catch a dead relay first, but a
+# relay-side close the transport never surfaces (observed as a CLOSE_WAIT
+# socket with the loop parked on recv, #98097) leaves the gateway
+# "connected" while inbound stops: in that state the pending pong waiter
+# never completes, so a manual ping round-trip times out and forces the
+# normal reconnect path. A quiet-but-healthy relay answers the ping and the
+# connection is kept — silence alone is not death.
+_WS_LIVENESS_INTERVAL = 60.0
+_WS_LIVENESS_TIMEOUT = 45.0
 _WS_MAX_MESSAGE_BYTES = 2_000_000
 _WS_MEMBERSHIP_KIND = 44100
 _WS_MEMBERSHIP_SUB_ID = "hermes-buzz-membership"
+
+
+def _ws_clean_close_error():
+    """The websockets clean-close exception class (version-portable).
+
+    websockets 15.x raises ``ConnectionClosedOK`` when the server closes
+    cleanly — normally surfaced as the iterator ending, but a close racing
+    the liveness ping instead raises it from ``ping()``/``recv()``.
+    Resolved lazily so adapter import never needs websockets present.
+    """
+    from websockets.exceptions import ConnectionClosedOK
+
+    return ConnectionClosedOK
 
 # Where to look for a credentials JSON (keys: nsec / private_key_hex) when
 # BUZZ_PRIVATE_KEY is not set.  Module-level so tests can point it at a tmpdir.
@@ -1873,6 +1889,39 @@ class BuzzAdapter(BasePlatformAdapter):
             except Exception:
                 logger.warning("Buzz: WebSocket discovery sweep failed", exc_info=True)
 
+    async def _probe_liveness(self, websocket) -> None:
+        """Require proof of transport life via a ping/pong round-trip."""
+        ping_fn = getattr(websocket, "ping", None)
+        if not callable(ping_fn):
+            return
+        pong_waiter = await ping_fn()
+        if pong_waiter is not None:
+            await pong_waiter
+
+    async def _read_frame_or_probe(self, frame_iter, websocket) -> str:
+        """Read a frame, probing the connection while it remains quiet."""
+        read_task = asyncio.ensure_future(frame_iter.__anext__())
+        try:
+            while True:
+                done, _ = await asyncio.wait({read_task}, timeout=_WS_LIVENESS_INTERVAL)
+                if done:
+                    return read_task.result()
+                try:
+                    await asyncio.wait_for(
+                        self._probe_liveness(websocket), timeout=_WS_LIVENESS_TIMEOUT
+                    )
+                except asyncio.TimeoutError:
+                    raise ConnectionError(
+                        "relay did not answer a liveness ping within "
+                        f"{_WS_LIVENESS_TIMEOUT:.0f}s; assuming the connection went silent"
+                    ) from None
+        finally:
+            read_task.cancel()
+            try:
+                await read_task
+            except (asyncio.CancelledError, Exception):
+                pass
+
     async def _websocket_loop(self) -> None:
         """Persistent authenticated subscription with bounded reconnect
         backoff. Events route through _handle_event() — identical semantics
@@ -1909,16 +1958,18 @@ class BuzzAdapter(BasePlatformAdapter):
                             frame_iter = websocket.__aiter__()
                             while True:
                                 try:
-                                    raw = await asyncio.wait_for(
-                                        frame_iter.__anext__(),
-                                        timeout=_WS_READ_IDLE_TIMEOUT,
+                                    raw = await self._read_frame_or_probe(
+                                        frame_iter, websocket
                                     )
                                 except StopAsyncIteration:
                                     break
+                                except _ws_clean_close_error():
+                                    # A clean close racing the liveness probe is
+                                    # normal relay lifecycle, not a failure.
+                                    break
                                 except asyncio.TimeoutError:
                                     raise ConnectionError(
-                                        f"no WebSocket frame for {_WS_READ_IDLE_TIMEOUT:.0f}s; "
-                                        "assuming the connection went silent"
+                                        "WebSocket liveness probe timed out"
                                     ) from None
                                 try:
                                     message = json.loads(raw)

--- a/tests/gateway/test_buzz_websocket.py
+++ b/tests/gateway/test_buzz_websocket.py
@@ -161,6 +161,93 @@ async def _unresolved_pong():
 
 
 @pytest.mark.asyncio
+async def test_frame_wins_over_pending_liveness_probe(monkeypatch):
+    monkeypatch.setattr(_buzz_mod, "_WS_LIVENESS_INTERVAL", 0.01)
+    monkeypatch.setattr(_buzz_mod, "_WS_LIVENESS_TIMEOUT", 1)
+    frame_ready = asyncio.Event()
+    pong_started = asyncio.Event()
+    pong_waiter = None
+
+    async def anext_behavior():
+        await frame_ready.wait()
+        return "frame"
+
+    async def ping_behavior():
+        nonlocal pong_waiter
+        pong_waiter = asyncio.get_running_loop().create_future()
+        pong_started.set()
+        return pong_waiter
+
+    websocket = _ScriptedWebSocket(anext_behavior, ping_behavior)
+    frame_task = asyncio.create_task(
+        BuzzAdapter._read_frame_or_probe(_make_adapter(), websocket.__aiter__(), websocket)
+    )
+    await asyncio.wait_for(pong_started.wait(), 1)
+    frame_ready.set()
+
+    assert await asyncio.wait_for(frame_task, 1) == "frame"
+    assert pong_waiter.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_failed_probe_wins_simultaneous_frame_completion(monkeypatch):
+    monkeypatch.setattr(_buzz_mod, "_WS_LIVENESS_INTERVAL", 0.01)
+    monkeypatch.setattr(_buzz_mod, "_WS_LIVENESS_TIMEOUT", 1)
+    frame_ready = asyncio.Event()
+    probe_started = asyncio.Event()
+    probe_failed = asyncio.Event()
+
+    async def anext_behavior():
+        await frame_ready.wait()
+        return "frame"
+
+    async def ping_behavior():
+        probe_started.set()
+        await asyncio.sleep(0)
+        probe_failed.set()
+        raise ConnectionError("transport failed")
+
+    websocket = _ScriptedWebSocket(anext_behavior, ping_behavior)
+    frame_task = asyncio.create_task(
+        BuzzAdapter._read_frame_or_probe(_make_adapter(), websocket.__aiter__(), websocket)
+    )
+    await asyncio.wait_for(probe_started.wait(), 1)
+    frame_ready.set()
+    await asyncio.wait_for(probe_failed.wait(), 1)
+    await asyncio.sleep(0)
+
+    with pytest.raises(ConnectionError, match="transport failed"):
+        await asyncio.wait_for(frame_task, 1)
+
+
+@pytest.mark.asyncio
+async def test_liveness_race_cancellation_settles_pending_tasks(monkeypatch):
+    monkeypatch.setattr(_buzz_mod, "_WS_LIVENESS_INTERVAL", 0.01)
+    monkeypatch.setattr(_buzz_mod, "_WS_LIVENESS_TIMEOUT", 1)
+    pong_waiter = None
+    probe_started = asyncio.Event()
+
+    async def anext_behavior():
+        await asyncio.Event().wait()
+
+    async def ping_behavior():
+        nonlocal pong_waiter
+        pong_waiter = asyncio.get_running_loop().create_future()
+        probe_started.set()
+        return pong_waiter
+
+    websocket = _ScriptedWebSocket(anext_behavior, ping_behavior)
+    task = asyncio.create_task(
+        BuzzAdapter._read_frame_or_probe(_make_adapter(), websocket.__aiter__(), websocket)
+    )
+    await asyncio.wait_for(probe_started.wait(), 1)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(task, 1)
+    assert pong_waiter.cancelled()
+
+
+@pytest.mark.asyncio
 async def test_websocket_loop_keeps_a_quiet_healthy_connection(monkeypatch):
     adapter = _make_adapter()
     monkeypatch.setattr(_buzz_mod, "_WS_LIVENESS_INTERVAL", 0.02)

--- a/tests/gateway/test_buzz_websocket.py
+++ b/tests/gateway/test_buzz_websocket.py
@@ -116,10 +116,12 @@ class _ScriptedWebSocket(_FakeWebSocket):
     a clean close.
     """
 
-    def __init__(self, anext_behavior):
+    def __init__(self, anext_behavior, ping_behavior):
         super().__init__()
         self._anext_behavior = anext_behavior
+        self._ping_behavior = ping_behavior
         self.exited = False
+        self.ping_count = 0
 
     async def __aenter__(self):
         return self
@@ -128,40 +130,88 @@ class _ScriptedWebSocket(_FakeWebSocket):
         self.exited = True
 
     def __aiter__(self):
+        # Match websockets 15.x: the frame iterator is distinct from the
+        # connection and does not expose ping().
+        return _ScriptedFrameIterator(self._anext_behavior)
+
+    async def ping(self):
+        self.ping_count += 1
+        return await self._ping_behavior()
+
+
+class _ScriptedFrameIterator:
+    def __init__(self, anext_behavior):
+        self._anext_behavior = anext_behavior
+
+    def __aiter__(self):
         return self
 
     async def __anext__(self):
         return await self._anext_behavior()
 
 
+async def _resolved_pong():
+    waiter = asyncio.get_running_loop().create_future()
+    waiter.set_result(0.0)
+    return waiter
+
+
+async def _unresolved_pong():
+    return asyncio.get_running_loop().create_future()
+
+
 @pytest.mark.asyncio
-async def test_websocket_loop_reconnects_when_read_goes_silent(monkeypatch, caplog):
-    """A relay close the transport never surfaces must not park the loop.
-
-    Reproduces the #98097 shape: a socket stuck in CLOSE_WAIT yields no
-    frame and no error, so without a read-side bound the loop would wait
-    forever while the gateway keeps reporting "connected".
-    """
-    import logging
-
+async def test_websocket_loop_keeps_a_quiet_healthy_connection(monkeypatch):
     adapter = _make_adapter()
-    monkeypatch.setattr(_buzz_mod, "_WS_READ_IDLE_TIMEOUT", 0.05)
-    caplog.set_level(logging.WARNING)
+    monkeypatch.setattr(_buzz_mod, "_WS_LIVENESS_INTERVAL", 0.02)
+    monkeypatch.setattr(_buzz_mod, "_WS_LIVENESS_TIMEOUT", 0.02)
 
     sockets = []
 
-    async def dead_anext():
-        await asyncio.Event().wait()  # never yields, never raises
+    async def quiet_anext():
+        await asyncio.Event().wait()
 
     def fake_connect(*args, **kwargs):
-        ws = _ScriptedWebSocket(dead_anext)
+        ws = _ScriptedWebSocket(quiet_anext, _resolved_pong)
         sockets.append(ws)
         return ws
 
     import websockets as _ws_mod
 
     monkeypatch.setattr(_ws_mod, "connect", fake_connect)
+    task = asyncio.create_task(adapter._websocket_loop())
+    await asyncio.sleep(0.2)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(task, 5.0)
 
+    assert len(sockets) == 1
+    assert sockets[0].ping_count >= 2
+    assert sockets[0].exited
+
+
+@pytest.mark.asyncio
+async def test_websocket_loop_reconnects_when_liveness_ping_goes_silent(monkeypatch, caplog):
+    import logging
+
+    adapter = _make_adapter()
+    monkeypatch.setattr(_buzz_mod, "_WS_LIVENESS_INTERVAL", 0.02)
+    monkeypatch.setattr(_buzz_mod, "_WS_LIVENESS_TIMEOUT", 0.02)
+    caplog.set_level(logging.WARNING)
+
+    sockets = []
+
+    async def dead_anext():
+        await asyncio.Event().wait()
+
+    def fake_connect(*args, **kwargs):
+        ws = _ScriptedWebSocket(dead_anext, _unresolved_pong)
+        sockets.append(ws)
+        return ws
+
+    import websockets as _ws_mod
+
+    monkeypatch.setattr(_ws_mod, "connect", fake_connect)
     task = asyncio.create_task(adapter._websocket_loop())
     try:
         deadline = time.monotonic() + 5.0
@@ -174,9 +224,52 @@ async def test_websocket_loop_reconnects_when_read_goes_silent(monkeypatch, capl
         except (asyncio.CancelledError, asyncio.TimeoutError):
             pass
 
-    assert len(sockets) >= 2, "idle read watchdog did not force a reconnect"
-    assert sockets[0].exited, "the silent connection was not closed before reconnecting"
+    assert len(sockets) >= 2
+    assert sockets[0].exited
     assert any("went silent" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_websocket_loop_clean_close_during_liveness_ping_is_quiet(
+    monkeypatch, caplog
+):
+    import logging
+
+    from websockets.exceptions import ConnectionClosedOK
+    from websockets.frames import Close
+
+    adapter = _make_adapter()
+    monkeypatch.setattr(_buzz_mod, "_WS_LIVENESS_INTERVAL", 0.01)
+    monkeypatch.setattr(_buzz_mod, "_WS_LIVENESS_TIMEOUT", 0.01)
+    caplog.set_level(logging.WARNING)
+
+    async def quiet_anext():
+        await asyncio.Event().wait()
+
+    async def clean_ping_close():
+        raise ConnectionClosedOK(Close(1000, "normal closure"), None)
+
+    sockets = []
+    connects = []
+
+    def fake_connect(*args, **kwargs):
+        connects.append(1)
+        if len(connects) == 2:
+            raise asyncio.CancelledError()
+        ws = _ScriptedWebSocket(quiet_anext, clean_ping_close)
+        sockets.append(ws)
+        return ws
+
+    import websockets as _ws_mod
+
+    monkeypatch.setattr(_ws_mod, "connect", fake_connect)
+    task = asyncio.create_task(adapter._websocket_loop())
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(task, 5.0)
+
+    assert len(connects) == 2
+    assert sockets[0].exited
+    assert not any("WebSocket disconnected" in record.message for record in caplog.records)
 
 
 @pytest.mark.asyncio
@@ -215,7 +308,7 @@ async def test_websocket_loop_dispatches_frames_and_closes_cleanly(monkeypatch):
         # loop's except-order, unlike a regular Exception which would retry.
         if len(sockets) == 1:
             raise asyncio.CancelledError()
-        ws = _ScriptedWebSocket(scripted_anext)
+        ws = _ScriptedWebSocket(scripted_anext, _resolved_pong)
         sockets.append(ws)
         return ws
 
@@ -666,7 +759,7 @@ async def test_ws_discovery_task_cancelled_when_connection_exits(monkeypatch):
     def fake_connect(*args, **kwargs):
         if sockets:
             raise asyncio.CancelledError()
-        ws = _ScriptedWebSocket(closed_anext)
+        ws = _ScriptedWebSocket(closed_anext, _resolved_pong)
         sockets.append(ws)
         return ws
 


### PR DESCRIPTION
## Infographic

![Buzz WebSocket liveness](https://files.catbox.moe/grzwap.png)

## Summary

- Fix the Buzz WebSocket false reconnect loop on healthy quiet relays.
- Replace the application-frame idle timeout with bounded transport ping/pong probes: resolved pong keeps the connection; an unanswered probe enters the existing reconnect path.
- Race the persistent frame read against the two-stage websockets 15.0.1 ping/pong probe so frames are dispatched immediately.
- Treat clean closure, including `ConnectionClosedOK` racing a probe, as quiet lifecycle rather than warning noise.
- Cancel, await, and retrieve pending read/probe task outcomes on every exit.

Closes #101160

<details>
<summary>Testing evidence</summary>

On exact head `89b266fa5984975138376a4208b6c89c6b85d975`:

- `scripts/run_tests.sh tests/gateway/test_buzz_websocket.py` — 23 passed, 0 failed.
- `scripts/run_tests.sh tests/gateway/test_buzz_*.py tests/plugins/platforms/buzz/` — 270 passed, 0 failed across 8 files.
- `ruff check plugins/platforms/buzz/adapter.py tests/gateway/test_buzz_websocket.py` — clean.
- `python -m py_compile plugins/platforms/buzz/adapter.py tests/gateway/test_buzz_websocket.py` — clean.
- `git diff --check` — clean.
- Red-first regression verification: the frame-versus-probe regression timed out on starting head `01aeae275bd5ed879768cfc55a6e2169a45c0bc6` because the pending frame was not returned while the pong remained unresolved; it passed after the fix.

</details>

## Scope and residuals

Only `plugins/platforms/buzz/adapter.py` and `tests/gateway/test_buzz_websocket.py` are changed. Reaction lifecycle, presence, startup/config-gate, and loader work are intentionally excluded; PR #99451 is untouched. Upstream PR CI reports no checks yet for this fork branch (maintainer workflow approval gate), so CI is not claimed green.
