### PR TITLE
fix: add hermes_state_registry to py-modules list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -574,6 +574,7 @@ py-modules = [
   "hermes_state",
   "hermes_state_common",
   "hermes_state_portability",
+  "hermes_state_registry",
   "hermes_state_schema",
   "hermes_state_search",
   "hermes_startup_watchdog",


### PR DESCRIPTION
## Problem

`hermes_state_registry` exists in the source tree but is absent from the `py-modules` entry in `pyproject.toml`, so the module is omitted from the packaged build.

## Change

Add `"hermes_state_registry"` to the `py-modules` list, between `hermes_state_portability` and `hermes_state_schema`.

## Verification

One-line addition to `pyproject.toml`; the module file is present in the tree: `hermes_state_registry.py`.
