### PR TITLE
fix: Use stdenv.hostPlatform.isLinux in packages.nix

### DIFF
--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -43,7 +43,7 @@
           "voice"
         ]
         # matrix is Linux-only (oqs/liboqs lacks aarch64-darwin wheels).
-        ++ lib.optionals pkgs.stdenv.isLinux [ "matrix" ];
+        ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [ "matrix" ];
       };
     in
     {


### PR DESCRIPTION
## What does this PR do?

Fixes a Nix deprecation warning.

## Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

nix/packages.nix: `pkgs.stdenv.hostPlatform.isLinux` instead of `pkgs.stdenv.isLinux`

## How to Test

Nix build.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [X] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [X] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [X] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [X] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [X] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

N/A

## For New Skills

N/A

## Screenshots / Logs

N/A