### PR TITLE
fix(matrix): harden required E2EE boundaries

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -875,8 +875,35 @@ async def _read_httpx_body_with_limit(response, *, media_type: str) -> bytes:
 def get_image_cache_dir() -> Path:
     """Return the image cache directory, creating it if it doesn't exist."""
     d = _resolve_cache_dir("IMAGE_CACHE_DIR", "cache/images", "image_cache")
-    d.mkdir(parents=True, exist_ok=True)
+    _ensure_private_cache_dir(d)
     return d
+
+
+def _ensure_private_cache_dir(path: Path) -> None:
+    """Create a decrypted-media cache directory with owner-only permissions."""
+    existed = path.exists()
+    path.mkdir(parents=True, exist_ok=True, mode=0o700)
+    # New directories honor ``mode`` only after umask masking. These caches may
+    # contain plaintext downloaded from encrypted messaging rooms, so do not
+    # inherit a permissive process umask. Existing paths are intentionally not
+    # repaired here; required Matrix startup rejects them for explicit operator
+    # remediation instead of mutating deployment state behind their back.
+    if not existed:
+        os.chmod(path, 0o700)
+
+
+def _write_private_cache_bytes(path: Path, data: bytes) -> None:
+    """Write a newly generated decrypted cache file without inheriting umask."""
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(data)
+    except BaseException:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+        raise
 
 
 def _looks_like_image(data: bytes) -> bool:
@@ -921,7 +948,7 @@ def cache_image_from_bytes(data: bytes, ext: str = ".jpg") -> str:
     cache_dir = get_image_cache_dir()
     filename = f"img_{uuid.uuid4().hex[:12]}{ext}"
     filepath = cache_dir / filename
-    filepath.write_bytes(data)
+    _write_private_cache_bytes(filepath, data)
     return str(filepath)
 
 
@@ -1031,7 +1058,7 @@ AUDIO_CACHE_DIR = get_hermes_dir("cache/audio", "audio_cache")
 def get_audio_cache_dir() -> Path:
     """Return the audio cache directory, creating it if it doesn't exist."""
     d = _resolve_cache_dir("AUDIO_CACHE_DIR", "cache/audio", "audio_cache")
-    d.mkdir(parents=True, exist_ok=True)
+    _ensure_private_cache_dir(d)
     return d
 
 
@@ -1063,7 +1090,7 @@ def cache_audio_from_bytes(data: bytes, ext: str = ".ogg") -> str:
     sniffed_ext = _sniff_audio_ext(data, ext)
     filename = f"audio_{uuid.uuid4().hex[:12]}{sniffed_ext}"
     filepath = cache_dir / filename
-    filepath.write_bytes(data)
+    _write_private_cache_bytes(filepath, data)
     return str(filepath)
 
 
@@ -1160,7 +1187,7 @@ SUPPORTED_VIDEO_TYPES = {
 def get_video_cache_dir() -> Path:
     """Return the video cache directory, creating it if it doesn't exist."""
     d = _resolve_cache_dir("VIDEO_CACHE_DIR", "cache/videos", "video_cache")
-    d.mkdir(parents=True, exist_ok=True)
+    _ensure_private_cache_dir(d)
     return d
 
 
@@ -1170,7 +1197,7 @@ def cache_video_from_bytes(data: bytes, ext: str = ".mp4") -> str:
     cache_dir = get_video_cache_dir()
     filename = f"video_{uuid.uuid4().hex[:12]}{ext}"
     filepath = cache_dir / filename
-    filepath.write_bytes(data)
+    _write_private_cache_bytes(filepath, data)
     return str(filepath)
 
 
@@ -2244,7 +2271,7 @@ def _strip_media_tag_directives(text: str) -> str:
 def get_document_cache_dir() -> Path:
     """Return the document cache directory, creating it if it doesn't exist."""
     d = _resolve_cache_dir("DOCUMENT_CACHE_DIR", "cache/documents", "document_cache")
-    d.mkdir(parents=True, exist_ok=True)
+    _ensure_private_cache_dir(d)
     return d
 
 
@@ -2276,7 +2303,7 @@ def cache_document_from_bytes(data: bytes, filename: str) -> str:
     # Final safety check: ensure path stays inside cache dir
     if not filepath.resolve().is_relative_to(cache_dir.resolve()):
         raise ValueError(f"Path traversal rejected: {filename!r}")
-    filepath.write_bytes(data)
+    _write_private_cache_bytes(filepath, data)
     return str(filepath)
 
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4065,6 +4065,7 @@ StartLimitIntervalSec=0
 Type={systemd_type}
 {systemd_watchdog_directives}User={username}
 Group={group_name}
+UMask=0077
 ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run
 WorkingDirectory={working_dir}
 Environment="HOME={home_dir}"
@@ -4107,7 +4108,8 @@ StartLimitIntervalSec=0
 
 [Service]
 Type={systemd_type}
-{systemd_watchdog_directives}ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run
+{systemd_watchdog_directives}UMask=0077
+ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run
 WorkingDirectory={working_dir}
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -59,6 +59,7 @@ import mimetypes
 import os
 import re
 import shutil
+import stat
 import subprocess
 import sys
 import time
@@ -599,6 +600,50 @@ from hermes_constants import get_hermes_dir as _get_hermes_dir
 
 _STORE_DIR = _get_hermes_dir("platforms/matrix/store", "matrix/store")
 _CRYPTO_DB_PATH = _STORE_DIR / "crypto.db"
+_REQUIRED_E2EE_ALGORITHM = "m.megolm.v1.aes-sha2"
+
+
+def _matrix_private_storage_preflight() -> bool:
+    """Create only new Matrix storage paths privately and reject weak existing ones."""
+    cache_root = _get_hermes_dir("cache", "cache")
+    required_dirs = (
+        _STORE_DIR.parent.parent,
+        _STORE_DIR.parent,
+        _STORE_DIR,
+    )
+    for directory in required_dirs:
+        existed = directory.exists()
+        try:
+            directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+            if not existed:
+                os.chmod(directory, 0o700)
+            if stat.S_IMODE(directory.stat().st_mode) != 0o700:
+                logger.error("Matrix: refusing insecure existing storage directory %s", directory)
+                return False
+        except OSError as exc:
+            logger.error("Matrix: cannot validate private storage directory %s: %s", directory, exc)
+            return False
+
+    for db_path in (_CRYPTO_DB_PATH, _CRYPTO_DB_PATH.with_name("crypto.db-wal"), _CRYPTO_DB_PATH.with_name("crypto.db-shm")):
+        if db_path.exists() and stat.S_IMODE(db_path.stat().st_mode) != 0o600:
+            logger.error("Matrix: refusing insecure existing crypto store file %s", db_path)
+            return False
+
+    for cache_dir in (cache_root / "images", cache_root / "audio", cache_root / "videos", cache_root / "documents"):
+        if not cache_dir.exists():
+            continue
+        try:
+            if stat.S_IMODE(cache_dir.stat().st_mode) != 0o700:
+                logger.error("Matrix: refusing insecure existing decrypted cache directory %s", cache_dir)
+                return False
+            for cached_file in cache_dir.iterdir():
+                if cached_file.is_file() and stat.S_IMODE(cached_file.stat().st_mode) != 0o600:
+                    logger.error("Matrix: refusing insecure existing decrypted cache file %s", cached_file)
+                    return False
+        except OSError as exc:
+            logger.error("Matrix: cannot validate decrypted cache %s: %s", cache_dir, exc)
+            return False
+    return True
 
 # Grace period: ignore messages older than this many seconds before startup.
 _STARTUP_GRACE_SECONDS = 5
@@ -1252,6 +1297,12 @@ class MatrixAdapter(BasePlatformAdapter):
 
         self._processed_events: deque = deque(maxlen=1000)
         self._processed_events_set: set = set()
+        # Required E2EE mode dispatches only entries recorded by
+        # _on_encrypted_event after crypto successfully decrypts the exact
+        # Matrix event. Room state alone is never enough provenance for an
+        # inbound command or approval control.
+        self._verified_decrypted_events: deque = deque(maxlen=1000)
+        self._verified_decrypted_events_set: set[tuple[str, str]] = set()
 
         # Buffer for undecrypted events pending key receipt.
         # Each entry: (room_id, event, timestamp)
@@ -1436,6 +1487,99 @@ class MatrixAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
     # E2EE helpers
     # ------------------------------------------------------------------
+
+    async def _required_e2ee_room_allowed(self, room_id: str) -> bool:
+        """Fail closed unless a required-mode room has the supported encryption state."""
+        if getattr(self, "_e2ee_mode", "off") != "required":
+            return True
+        client = self._client
+        if not client or not getattr(client, "crypto", None) or not room_id:
+            return False
+        if not hasattr(client, "get_state_event"):
+            return False
+        try:
+            event = await asyncio.wait_for(
+                client.get_state_event(RoomID(room_id), "m.room.encryption"),
+                timeout=5.0,
+            )
+        except Exception as exc:
+            logger.debug("Matrix: required E2EE state unavailable for %s: %s", room_id, exc)
+            return False
+        return self._state_event_value(event, "algorithm") == _REQUIRED_E2EE_ALGORITHM
+
+    async def _required_e2ee_local_room_encrypted(self, room_id: str) -> bool:
+        """Confirm local crypto state before required-mode media encryption.
+
+        The homeserver state query is authoritative about a room's configured
+        algorithm, but attachment encryption also depends on the local
+        StateStore. A stale, missing, or failing local result must deny instead
+        of falling through to a plaintext upload.
+        """
+        if getattr(self, "_e2ee_mode", "off") != "required":
+            return True
+        client = self._client
+        state_store = getattr(client, "state_store", None) if client else None
+        if state_store is None or not hasattr(state_store, "is_encrypted"):
+            return False
+        try:
+            return bool(await state_store.is_encrypted(RoomID(room_id)))
+        except Exception as exc:
+            logger.debug("Matrix: required local E2EE state unavailable for %s: %s", room_id, exc)
+            return False
+
+    def _record_verified_decrypted_event(self, room_id: str, event_id: str) -> None:
+        """Record bounded provenance for one successfully decrypted event."""
+        key = (room_id, event_id)
+        if not room_id or not event_id or key in self._verified_decrypted_events_set:
+            return
+        if len(self._verified_decrypted_events) == self._verified_decrypted_events.maxlen:
+            self._verified_decrypted_events_set.discard(self._verified_decrypted_events.popleft())
+        self._verified_decrypted_events.append(key)
+        self._verified_decrypted_events_set.add(key)
+
+    async def _required_e2ee_event_allowed(self, room_id: str, event: Any) -> bool:
+        """Require exact successful-decryption provenance for required intake."""
+        if getattr(self, "_e2ee_mode", "off") != "required":
+            return True
+        if not await self._required_e2ee_room_allowed(room_id):
+            return False
+        event_id = str(getattr(event, "event_id", ""))
+        return bool(event_id and (room_id, event_id) in self._verified_decrypted_events_set)
+
+    async def _on_encrypted_event(self, event: Any) -> None:
+        """Decrypt and dispatch one required-mode Matrix event with provenance.
+
+        TODO(verification-before-merge): exercise this handler against the
+        supported mautrix runtime and an encrypted test room. Offline tests
+        cover denial semantics only; they cannot prove SDK dispatcher ordering.
+        """
+        room_id = str(getattr(event, "room_id", ""))
+        event_id = str(getattr(event, "event_id", ""))
+        if not event_id or not await self._is_allowed_matrix_room_event(room_id):
+            return
+        if not await self._required_e2ee_room_allowed(room_id):
+            return
+        crypto = getattr(self._client, "crypto", None) if self._client else None
+        if crypto is None or not hasattr(crypto, "decrypt_megolm_event"):
+            return
+        try:
+            decrypted = await crypto.decrypt_megolm_event(event)
+        except Exception as exc:
+            logger.info("Matrix: denying encrypted event %s after decrypt failure: %s", event_id, exc)
+            return
+        decrypted_event_id = str(getattr(decrypted, "event_id", ""))
+        decrypted_room_id = str(getattr(decrypted, "room_id", ""))
+        if decrypted_event_id != event_id or decrypted_room_id != room_id:
+            logger.warning("Matrix: denying decrypted event with mismatched provenance")
+            return
+        self._record_verified_decrypted_event(room_id, event_id)
+        event_type = str(getattr(decrypted, "type", ""))
+        if event_type == EventType.ROOM_MESSAGE:
+            await self._on_room_message(decrypted)
+        elif event_type == EventType.REACTION:
+            await self._on_reaction(decrypted)
+        else:
+            logger.debug("Matrix: ignoring unsupported decrypted event type %s", event_type)
 
     @staticmethod
     def _extract_server_ed25519(device_keys_obj: Any) -> Optional[str]:
@@ -1728,7 +1872,13 @@ class MatrixAdapter(BasePlatformAdapter):
             logger.error("Matrix: homeserver URL not configured")
             return False
 
-        # Ensure store dir exists for E2EE key persistence.
+        # Required mode must never create or use a weak crypto/cache location.
+        # Existing paths are verified, not repaired, to avoid silently changing
+        # ownership-sensitive deployment state at startup.
+        if self._e2ee_mode == "required" and not _matrix_private_storage_preflight():
+            return False
+
+        # Ensure store dir exists for E2EE key persistence in non-required modes.
         _STORE_DIR.mkdir(parents=True, exist_ok=True)
 
         # Create the HTTP API layer.
@@ -1914,12 +2064,25 @@ class MatrixAdapter(BasePlatformAdapter):
                         )
                         legacy_pickle.unlink()
 
+                    if self._e2ee_mode == "required" and not _CRYPTO_DB_PATH.exists():
+                        fd = os.open(
+                            _CRYPTO_DB_PATH,
+                            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                            0o600,
+                        )
+                        os.close(fd)
+
                     crypto_db = Database.create(
                         f"sqlite:///{_CRYPTO_DB_PATH}",
                         upgrade_table=PgCryptoStore.upgrade_table,
                     )
                     await crypto_db.start()
                     self._crypto_db = crypto_db
+                    if self._e2ee_mode == "required" and not _matrix_private_storage_preflight():
+                        await crypto_db.stop()
+                        self._crypto_db = None
+                        await api.session.close()
+                        return False
 
                     _acct_id = self._user_id or "hermes"
                     # Use the resolved client.device_id (from whoami or password
@@ -2071,16 +2234,23 @@ class MatrixAdapter(BasePlatformAdapter):
         # Without this the INVITE handler below never fires.
         client.add_dispatcher(MembershipEventDispatcher)
 
-        client.add_event_handler(
-            EventType.ROOM_MESSAGE,
-            self._on_room_message,
-            wait_sync=True,
-        )
-        client.add_event_handler(
-            EventType.REACTION,
-            self._on_reaction,
-            wait_sync=True,
-        )
+        if self._e2ee_mode == "required":
+            client.add_event_handler(
+                EventType.ROOM_ENCRYPTED,
+                self._on_encrypted_event,
+                wait_sync=True,
+            )
+        else:
+            client.add_event_handler(
+                EventType.ROOM_MESSAGE,
+                self._on_room_message,
+                wait_sync=True,
+            )
+            client.add_event_handler(
+                EventType.REACTION,
+                self._on_reaction,
+                wait_sync=True,
+            )
         client.add_event_handler(
             IntEvt.INVITE,
             self._on_invite,
@@ -2200,6 +2370,8 @@ class MatrixAdapter(BasePlatformAdapter):
 
         if not content:
             return SendResult(success=True)
+        if not await self._required_e2ee_room_allowed(chat_id):
+            return SendResult(success=False, error="Required E2EE room state unavailable")
 
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted, self.max_message_length)
@@ -2336,6 +2508,8 @@ class MatrixAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Edit an existing message (via m.replace)."""
 
+        if not await self._required_e2ee_room_allowed(chat_id):
+            return SendResult(success=False, error="Required E2EE room state unavailable")
         formatted = self.format_message(content)
         new_content = self._build_text_message_content(formatted)
         msg_content: Dict[str, Any] = {
@@ -2883,6 +3057,10 @@ class MatrixAdapter(BasePlatformAdapter):
         voice_metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Upload bytes to Matrix and send as a media message."""
+        if not await self._required_e2ee_room_allowed(room_id):
+            return SendResult(success=False, error="Required E2EE room state unavailable")
+        if not await self._required_e2ee_local_room_encrypted(room_id):
+            return SendResult(success=False, error="Required local E2EE state unavailable")
         if len(data) > self._max_media_bytes:
             return SendResult(
                 success=False,
@@ -2891,7 +3069,20 @@ class MatrixAdapter(BasePlatformAdapter):
 
         upload_data = data
         encrypted_file = None
-        if self._encryption and getattr(self._client, "crypto", None):
+        required_file_payload = None
+        if self._e2ee_mode == "required":
+            try:
+                from mautrix.crypto.attachments import encrypt_attachment
+                upload_data, encrypted_file = encrypt_attachment(data)
+                required_file_payload = encrypted_file.serialize()
+                if not isinstance(required_file_payload, dict) or not all(
+                    required_file_payload.get(key) for key in ("key", "iv", "hashes", "v")
+                ):
+                    raise ValueError("attachment encryption returned incomplete Matrix file metadata")
+            except Exception as exc:
+                logger.error("Matrix: required attachment encryption failed: %s", exc)
+                return SendResult(success=False, error=str(exc))
+        elif self._encryption and getattr(self._client, "crypto", None):
             state_store = getattr(self._client, "state_store", None)
             if state_store:
                 try:
@@ -2927,7 +3118,10 @@ class MatrixAdapter(BasePlatformAdapter):
                 "size": len(data),
             },
         }
-        if encrypted_file is not None:
+        if required_file_payload is not None:
+            required_file_payload["url"] = str(mxc_url)
+            msg_content["file"] = required_file_payload
+        elif encrypted_file is not None:
             file_payload = encrypted_file.serialize()
             file_payload["url"] = str(mxc_url)
             msg_content["file"] = file_payload
@@ -3191,12 +3385,13 @@ class MatrixAdapter(BasePlatformAdapter):
     async def _is_allowed_matrix_room_event(self, room_id: str) -> bool:
         """Return True when a room event may proceed past intake filters.
 
-        MATRIX_ALLOWED_ROOMS constrains shared rooms. Matrix DMs are exempt so
-        personal chats still work when operators use a room allowlist for
-        project rooms.
+        MATRIX_ALLOWED_ROOMS constrains shared rooms. Required E2EE mode has no
+        DM exception because an unlisted DM cannot satisfy locked-down policy.
         """
         if self._is_allowed_matrix_room(room_id):
             return True
+        if self._e2ee_mode == "required":
+            return False
         try:
             return await self._is_dm_room(room_id)
         except Exception as exc:
@@ -3250,6 +3445,9 @@ class MatrixAdapter(BasePlatformAdapter):
                 "Matrix: ignoring message from unauthorized room %s",
                 room_id,
             )
+            return
+        if not await self._required_e2ee_event_allowed(room_id, event):
+            logger.info("Matrix: ignoring inbound event without required decrypt provenance in %s", room_id)
             return
 
         # Deduplicate by event ID.
@@ -3780,6 +3978,33 @@ class MatrixAdapter(BasePlatformAdapter):
 
         await self.handle_message(msg_event)
 
+    def _is_authorized_inviter(self, inviter: str) -> bool:
+        """Return whether an exact Matrix MXID is allowed to invite this bot."""
+        allow_all = os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {
+            "true",
+            "1",
+            "yes",
+        }
+        return allow_all or bool(inviter and self._allowed_user_ids and inviter in self._allowed_user_ids)
+
+    @staticmethod
+    def _pending_invite_details(invite_data: Any) -> tuple[str, bool]:
+        """Read the exact inviter and direct flag from a Matrix initial-sync invite."""
+        if not isinstance(invite_data, dict):
+            return "", False
+        events = (invite_data.get("invite_state") or {}).get("events") or []
+        if not isinstance(events, list):
+            return "", False
+        for event in events:
+            if not isinstance(event, dict) or event.get("type") != "m.room.member":
+                continue
+            content = event.get("content") or {}
+            if not isinstance(content, dict) or content.get("membership") != "invite":
+                continue
+            inviter = str(event.get("sender") or "")
+            return inviter, bool(content.get("is_direct"))
+        return "", False
+
     async def _on_invite(self, event: Any) -> None:
         """Auto-join rooms when invited, recording DM rooms in m.direct."""
 
@@ -3792,19 +4017,15 @@ class MatrixAdapter(BasePlatformAdapter):
         # federated Matrix user could invite the bot into arbitrary rooms,
         # exposing its presence and metadata. Mirrors the allow-list gate
         # used on the message/reaction paths.
-        allow_all = os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {
-            "true",
-            "1",
-            "yes",
-        }
-        if not allow_all and not (
-            self._allowed_user_ids and inviter in self._allowed_user_ids
-        ):
+        if not self._is_authorized_inviter(inviter):
             logger.warning(
                 "Matrix: rejecting invite to %s from unauthorized user %s",
                 room_id,
                 inviter,
             )
+            return
+        if not await self._required_e2ee_room_allowed(room_id):
+            logger.warning("Matrix: rejecting invite to %s without required E2EE state", room_id)
             return
 
         logger.info(
@@ -3869,6 +4090,9 @@ class MatrixAdapter(BasePlatformAdapter):
 
         async def _join_invite() -> None:
             try:
+                if not await self._required_e2ee_room_allowed(room_id):
+                    logger.warning("Matrix: declining invite to %s without required E2EE state", room_id)
+                    return
                 joined = await asyncio.wait_for(
                     self._join_room_by_id(room_id), timeout=45.0
                 )
@@ -3889,11 +4113,15 @@ class MatrixAdapter(BasePlatformAdapter):
         invites = rooms.get("invite", {})
         if not isinstance(invites, dict):
             return
-        for room_id in invites:
+        for room_id, invite_data in invites.items():
             if room_id in self._joined_rooms:
                 continue
+            inviter, is_direct = self._pending_invite_details(invite_data)
+            if not self._is_authorized_inviter(inviter):
+                logger.warning("Matrix: rejecting pending invite to %s without authorized inviter", room_id)
+                continue
             logger.info("Matrix: reconciling pending invite for %s", room_id)
-            self._schedule_invite_join(str(room_id))
+            self._schedule_invite_join(str(room_id), is_direct=is_direct, inviter=inviter)
 
     # ------------------------------------------------------------------
     # Reactions (send, receive, processing lifecycle)
@@ -3910,6 +4138,8 @@ class MatrixAdapter(BasePlatformAdapter):
         """
 
         if not self._client:
+            return None
+        if not await self._required_e2ee_room_allowed(room_id):
             return None
         content = {
             "m.relates_to": {
@@ -4017,6 +4247,10 @@ class MatrixAdapter(BasePlatformAdapter):
             return
 
         room_id = str(getattr(event, "room_id", ""))
+        if not await self._is_allowed_matrix_room_event(room_id):
+            return
+        if not await self._required_e2ee_event_allowed(room_id, event):
+            return
         content = getattr(event, "content", None)
         if content:
             relates_to = (
@@ -4384,6 +4618,8 @@ class MatrixAdapter(BasePlatformAdapter):
         """Redact (delete) a message or event from a room."""
         if not self._client:
             return False
+        if not await self._required_e2ee_room_allowed(room_id):
+            return False
         try:
             await self._client.redact(
                 RoomID(room_id),
@@ -4551,6 +4787,8 @@ class MatrixAdapter(BasePlatformAdapter):
         """Send a simple message (emote, notice) with optional HTML formatting."""
         if not self._client or not text:
             return SendResult(success=False, error="No client or empty text")
+        if not await self._required_e2ee_room_allowed(chat_id):
+            return SendResult(success=False, error="Required E2EE room state unavailable")
 
         msg_content = self._build_text_message_content(text, msgtype=msgtype)
 

--- a/tests/gateway/probe_matrix_e2ee_required_hardening.py
+++ b/tests/gateway/probe_matrix_e2ee_required_hardening.py
@@ -1,0 +1,186 @@
+"""Dependency-light executable contract for Matrix required E2EE hardening.
+
+TODO(verification-before-merge): this is a supplemental offline probe, not a
+replacement for the pytest, ruff, ty, gitleaks, and live-Matrix checks listed
+in ``MATRIX_E2EE_REQUIRED_HARDENING_DRAFT.md``.
+"""
+
+import asyncio
+import os
+import stat
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from gateway.config import PlatformConfig
+from gateway.platforms import base
+from hermes_cli.gateway import generate_systemd_unit
+from plugins.platforms.matrix.adapter import MatrixAdapter
+
+
+class FakeClient:
+    def __init__(self, encryption_state, *, crypto=True):
+        self.crypto = object() if crypto else None
+        self.get_state_event = AsyncMock(return_value=encryption_state)
+        self.send_message_event = AsyncMock(return_value="$event:example.org")
+        self.upload_media = AsyncMock(return_value="mxc://example.org/media")
+        self.state_store: object = None
+
+
+def make_adapter(mode="required"):
+    os.environ["MATRIX_ALLOWED_USERS"] = "@alice:example.org"
+    os.environ["MATRIX_ALLOWED_ROOMS"] = "!allowed:example.org"
+    os.environ.pop("GATEWAY_ALLOW_ALL_USERS", None)
+    return MatrixAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="synthetic-test-token",
+            extra={
+                "homeserver": "https://matrix.example.org",
+                "user_id": "@bot:example.org",
+                "e2ee_mode": mode,
+            },
+        )
+    )
+
+
+async def check_required_deny_and_positive_paths():
+    denied = make_adapter()
+    denied_client = FakeClient(None)
+    denied._client = denied_client
+    assert not (await denied.send("!allowed:example.org", "synthetic text")).success
+    assert not (await denied.edit_message("!allowed:example.org", "$old", "synthetic edit")).success
+    assert not (
+        await denied._upload_and_send(
+            "!allowed:example.org", b"synthetic", "probe.txt", "text/plain", "m.file"
+        )
+    ).success
+    assert await denied._send_reaction("!allowed:example.org", "$old", "✅") is None
+    denied_client.send_message_event.assert_not_awaited()
+    denied_client.upload_media.assert_not_awaited()
+
+    divergent = make_adapter()
+    divergent_client = FakeClient({"algorithm": "m.megolm.v1.aes-sha2"})
+    divergent_client.state_store = SimpleNamespace(is_encrypted=AsyncMock(return_value=False))
+    divergent._client = divergent_client
+    assert not (
+        await divergent._upload_and_send(
+            "!allowed:example.org", b"synthetic", "probe.txt", "text/plain", "m.file"
+        )
+    ).success
+    divergent_client.upload_media.assert_not_awaited()
+
+    inbound = make_adapter()
+    inbound._client = FakeClient({"algorithm": "m.megolm.v1.aes-sha2"}, crypto=False)
+    inbound.handle_message = AsyncMock()
+    await inbound._on_room_message(
+        SimpleNamespace(
+            room_id="!allowed:example.org",
+            sender="@alice:example.org",
+            event_id="$inbound",
+            timestamp=10**15,
+            content={"msgtype": "m.text", "body": "synthetic"},
+        )
+    )
+    inbound.handle_message.assert_not_awaited()
+
+    positive = make_adapter()
+    positive_client = FakeClient({"algorithm": "m.megolm.v1.aes-sha2"})
+    positive._client = positive_client
+    assert (await positive.send("!allowed:example.org", "encrypted text")).success
+    positive_client.send_message_event.assert_awaited_once()
+
+    unsupported = make_adapter()
+    unsupported._client = FakeClient({"algorithm": "m.unknown"})
+    assert not (await unsupported.send("!allowed:example.org", "wrong algorithm")).success
+
+    optional = make_adapter("optional")
+    optional_client = FakeClient(None)
+    optional._client = optional_client
+    assert (await optional.send("!allowed:example.org", "optional legacy path")).success
+    optional_client.send_message_event.assert_awaited_once()
+
+    plain_event = SimpleNamespace(room_id="!allowed:example.org", event_id="$plaintext")
+    assert not await positive._required_e2ee_event_allowed("!allowed:example.org", plain_event)
+    decrypted = SimpleNamespace(
+        room_id="!allowed:example.org",
+        event_id="$encrypted",
+        type="m.room.message",
+    )
+    provenance_client = FakeClient({"algorithm": "m.megolm.v1.aes-sha2"})
+    provenance_client.crypto = SimpleNamespace(
+        decrypt_megolm_event=AsyncMock(return_value=decrypted)
+    )
+    positive._client = provenance_client
+    positive._on_room_message = AsyncMock()
+    await positive._on_encrypted_event(
+        SimpleNamespace(room_id="!allowed:example.org", event_id="$encrypted")
+    )
+    positive._on_room_message.assert_awaited_once_with(decrypted)
+    assert await positive._required_e2ee_event_allowed("!allowed:example.org", decrypted)
+
+
+async def check_acl_and_invites():
+    adapter = make_adapter()
+    adapter._is_dm_room = AsyncMock(return_value=True)
+    assert not await adapter._is_allowed_matrix_room_event("!unlisted-dm:example.org")
+
+    scheduled = []
+    adapter._schedule_invite_join = lambda room_id, **kwargs: scheduled.append((room_id, kwargs))
+    adapter._schedule_pending_invite_joins(
+        {
+            "rooms": {
+                "invite": {
+                    "!missing:example.org": {"invite_state": {"events": []}},
+                    "!mallory:example.org": {
+                        "invite_state": {"events": [{"type": "m.room.member", "sender": "@mallory:example.org", "content": {"membership": "invite", "is_direct": True}}]}
+                    },
+                    "!alice:example.org": {
+                        "invite_state": {"events": [{"type": "m.room.member", "sender": "@alice:example.org", "content": {"membership": "invite", "is_direct": True}}]}
+                    },
+                }
+            }
+        }
+    )
+    assert scheduled == [("!alice:example.org", {"is_direct": True, "inviter": "@alice:example.org"})]
+
+
+def check_private_cache_and_systemd_contract():
+    with tempfile.TemporaryDirectory() as raw_tmp:
+        tmp = Path(raw_tmp)
+        old_dir = base.IMAGE_CACHE_DIR
+        old_document_dir = base.DOCUMENT_CACHE_DIR
+        old_video_dir = base.VIDEO_CACHE_DIR
+        old_umask = os.umask(0o022)
+        try:
+            base.IMAGE_CACHE_DIR = tmp / "images"
+            base.DOCUMENT_CACHE_DIR = tmp / "documents"
+            base.VIDEO_CACHE_DIR = tmp / "videos"
+            output = Path(base.cache_image_from_bytes(b"\x89PNG\r\n\x1a\nsynthetic", ext=".png"))
+            document = Path(base.cache_document_from_bytes(b"synthetic", "probe.txt"))
+            video = Path(base.cache_video_from_bytes(b"synthetic", ext=".mp4"))
+        finally:
+            base.IMAGE_CACHE_DIR = old_dir
+            base.DOCUMENT_CACHE_DIR = old_document_dir
+            base.VIDEO_CACHE_DIR = old_video_dir
+            os.umask(old_umask)
+        for cache_dir, cached_file in (
+            (tmp / "images", output),
+            (tmp / "documents", document),
+            (tmp / "videos", video),
+        ):
+            assert stat.S_IMODE(cache_dir.stat().st_mode) == 0o700
+            assert stat.S_IMODE(cached_file.stat().st_mode) == 0o600
+    assert "UMask=0077" in generate_systemd_unit(system=False)
+
+
+async def main():
+    await check_required_deny_and_positive_paths()
+    await check_acl_and_invites()
+    check_private_cache_and_systemd_contract()
+    print("matrix_e2ee_required_hardening=PASS")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/gateway/test_matrix_e2ee_required_hardening.py
+++ b/tests/gateway/test_matrix_e2ee_required_hardening.py
@@ -1,0 +1,285 @@
+"""Regression coverage for fail-closed Matrix E2EE required mode.
+
+TODO(verification-before-merge): run this module through
+``scripts/run_tests.sh`` with pytest available.  The isolated draft runner
+used for this candidate has no pytest, ruff, ty, or gitleaks; those controls
+remain UNKNOWN rather than passing by implication.
+"""
+
+import asyncio
+import os
+import stat
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+class _FakeClient:
+    def __init__(self, encryption_state=None):
+        self.crypto = object()
+        self.encryption_state = encryption_state
+        self.get_state_event = AsyncMock(return_value=encryption_state)
+        self.send_message_event = AsyncMock(return_value="$event:example.org")
+        self.upload_media = AsyncMock(return_value="mxc://example.org/media")
+        self.state_store: object = None
+
+
+def _adapter(monkeypatch, *, mode="required", allowed_rooms="!allowed:example.org"):
+    monkeypatch.setenv("MATRIX_ALLOWED_USERS", "@alice:example.org")
+    monkeypatch.setenv("MATRIX_ALLOWED_ROOMS", allowed_rooms)
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+    from plugins.platforms.matrix.adapter import MatrixAdapter
+
+    return MatrixAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="synthetic-test-token",
+            extra={
+                "homeserver": "https://matrix.example.org",
+                "user_id": "@bot:example.org",
+                "e2ee_mode": mode,
+            },
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_required_mode_blocks_all_outbound_paths_when_encryption_state_is_missing(monkeypatch, tmp_path):
+    """Required mode must not emit plaintext, edits, media, or reactions."""
+    adapter = _adapter(monkeypatch)
+    client = _FakeClient(encryption_state=None)
+    adapter._client = client
+
+    text = await adapter.send("!allowed:example.org", "synthetic content")
+    edit = await adapter.edit_message("!allowed:example.org", "$old", "synthetic edit")
+    media = await adapter._upload_and_send(
+        "!allowed:example.org", b"synthetic media", "probe.txt", "text/plain", "m.file"
+    )
+    reaction = await adapter._send_reaction("!allowed:example.org", "$old", "✅")
+
+    assert text.success is False
+    assert edit.success is False
+    assert media.success is False
+    assert reaction is None
+    client.send_message_event.assert_not_awaited()
+    client.upload_media.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_required_media_denies_when_remote_and_local_encryption_state_disagree(monkeypatch):
+    """A stale local room store must never turn a required-mode upload plaintext."""
+    adapter = _adapter(monkeypatch)
+    client = _FakeClient(encryption_state={"algorithm": "m.megolm.v1.aes-sha2"})
+    client.state_store = SimpleNamespace(is_encrypted=AsyncMock(return_value=False))
+    adapter._client = client
+
+    result = await adapter._upload_and_send(
+        "!allowed:example.org", b"synthetic plaintext", "probe.txt", "text/plain", "m.file"
+    )
+
+    assert result.success is False
+    client.upload_media.assert_not_awaited()
+    client.send_message_event.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_required_mode_allows_only_megolm_room_and_optional_mode_is_unchanged(monkeypatch):
+    """The strict algorithm applies only to required mode."""
+    required = _adapter(monkeypatch, mode="required")
+    required_client = _FakeClient(encryption_state={"algorithm": "m.megolm.v1.aes-sha2"})
+    required._client = required_client
+
+    required_result = await required.send("!allowed:example.org", "encrypted path")
+
+    optional = _adapter(monkeypatch, mode="optional")
+    optional_client = _FakeClient(encryption_state=None)
+    optional._client = optional_client
+    optional_result = await optional.send("!allowed:example.org", "legacy optional path")
+
+    assert required_result.success is True
+    assert optional_result.success is True
+    required_client.send_message_event.assert_awaited_once()
+    optional_client.send_message_event.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_required_mode_has_no_dm_bypass_for_locked_down_room_allowlist(monkeypatch):
+    """A DM outside MATRIX_ALLOWED_ROOMS remains denied in required mode."""
+    adapter = _adapter(monkeypatch)
+    adapter._is_dm_room = AsyncMock(return_value=True)
+
+    assert await adapter._is_allowed_matrix_room_event("!unlisted-dm:example.org") is False
+
+
+@pytest.mark.asyncio
+async def test_required_mode_drops_unencrypted_inbound_before_agent_turn(monkeypatch):
+    """Missing encryption state prevents inbound content from reaching the agent."""
+    adapter = _adapter(monkeypatch)
+    adapter._client = _FakeClient(encryption_state=None)
+    adapter.handle_message = AsyncMock()
+    event = SimpleNamespace(
+        room_id="!allowed:example.org",
+        sender="@alice:example.org",
+        event_id="$inbound",
+        timestamp=10**15,
+        content={"msgtype": "m.text", "body": "synthetic inbound"},
+    )
+
+    await adapter._on_room_message(event)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_required_mode_rejects_plain_inbound_event_without_decrypt_provenance(monkeypatch):
+    """Encrypted-room state alone is not proof that this concrete event decrypted."""
+    adapter = _adapter(monkeypatch)
+    adapter._client = _FakeClient(encryption_state={"algorithm": "m.megolm.v1.aes-sha2"})
+    event = SimpleNamespace(room_id="!allowed:example.org", event_id="$plaintext")
+
+    assert await adapter._required_e2ee_event_allowed("!allowed:example.org", event) is False
+
+
+@pytest.mark.asyncio
+async def test_required_mode_records_only_successfully_decrypted_event_provenance(monkeypatch):
+    """A raw encrypted event becomes eligible only after exact decrypt success."""
+    adapter = _adapter(monkeypatch)
+    decrypted = SimpleNamespace(
+        room_id="!allowed:example.org",
+        event_id="$encrypted",
+        type="m.room.message",
+    )
+    client = _FakeClient(encryption_state={"algorithm": "m.megolm.v1.aes-sha2"})
+    client.crypto = SimpleNamespace(decrypt_megolm_event=AsyncMock(return_value=decrypted))
+    adapter._client = client
+    adapter._on_room_message = AsyncMock()
+    encrypted = SimpleNamespace(room_id="!allowed:example.org", event_id="$encrypted")
+
+    await adapter._on_encrypted_event(encrypted)
+
+    adapter._on_room_message.assert_awaited_once_with(decrypted)
+    assert await adapter._required_e2ee_event_allowed("!allowed:example.org", decrypted) is True
+
+
+def test_pending_invites_require_exact_inviter_before_scheduling_join(monkeypatch):
+    """Initial-sync invite reconciliation must not bypass the live inviter gate."""
+    adapter = _adapter(monkeypatch)
+    scheduled = []
+    adapter._schedule_invite_join = lambda room_id, **kwargs: scheduled.append((room_id, kwargs))
+    sync_data = {
+        "rooms": {
+            "invite": {
+                "!missing:example.org": {"invite_state": {"events": []}},
+                "!mallory:example.org": {
+                    "invite_state": {
+                        "events": [
+                            {
+                                "type": "m.room.member",
+                                "sender": "@mallory:example.org",
+                                "content": {"membership": "invite", "is_direct": True},
+                            }
+                        ]
+                    }
+                },
+                "!alice:example.org": {
+                    "invite_state": {
+                        "events": [
+                            {
+                                "type": "m.room.member",
+                                "sender": "@alice:example.org",
+                                "content": {"membership": "invite", "is_direct": True},
+                            }
+                        ]
+                    }
+                },
+            }
+        }
+    }
+
+    adapter._schedule_pending_invite_joins(sync_data)
+
+    assert scheduled == [
+        ("!alice:example.org", {"is_direct": True, "inviter": "@alice:example.org"})
+    ]
+
+
+def test_decrypted_media_cache_is_private_despite_process_umask(monkeypatch, tmp_path):
+    """Cache parents and files use explicit private modes, not inherited umask."""
+    from gateway.platforms import base
+
+    cache_dir = tmp_path / "images"
+    monkeypatch.setattr(base, "IMAGE_CACHE_DIR", cache_dir)
+    old_umask = os.umask(0o022)
+    try:
+        path = base.cache_image_from_bytes(b"\x89PNG\r\n\x1a\nsynthetic", ext=".png")
+    finally:
+        os.umask(old_umask)
+
+    assert stat.S_IMODE(cache_dir.stat().st_mode) == 0o700
+    assert stat.S_IMODE(os.stat(path).st_mode) == 0o600
+
+
+def test_decrypted_document_and_video_cache_are_private_despite_process_umask(monkeypatch, tmp_path):
+    """Matrix document/video cache paths must use the owner-only shared helpers."""
+    from gateway.platforms import base
+
+    document_dir = tmp_path / "documents"
+    video_dir = tmp_path / "videos"
+    monkeypatch.setattr(base, "DOCUMENT_CACHE_DIR", document_dir)
+    monkeypatch.setattr(base, "VIDEO_CACHE_DIR", video_dir)
+    old_umask = os.umask(0o022)
+    try:
+        document = base.cache_document_from_bytes(b"synthetic document", "probe.txt")
+        video = base.cache_video_from_bytes(b"synthetic video", ext=".mp4")
+    finally:
+        os.umask(old_umask)
+
+    for cache_dir, cached_file in ((document_dir, document), (video_dir, video)):
+        assert stat.S_IMODE(cache_dir.stat().st_mode) == 0o700
+        assert stat.S_IMODE(os.stat(cached_file).st_mode) == 0o600
+
+
+@pytest.mark.asyncio
+async def test_required_live_invite_does_not_join_before_encryption_state_is_available(monkeypatch):
+    """Live invites share the required-room gate used by pending reconciliation."""
+    adapter = _adapter(monkeypatch)
+    adapter._client = _FakeClient(encryption_state=None)
+    adapter._schedule_invite_join = MagicMock()
+
+    await adapter._on_invite(
+        SimpleNamespace(
+            room_id="!allowed:example.org",
+            sender="@alice:example.org",
+            content=SimpleNamespace(is_direct=True),
+        )
+    )
+
+    adapter._schedule_invite_join.assert_not_called()
+
+
+def test_required_storage_preflight_rejects_existing_weak_crypto_db_without_repair(monkeypatch, tmp_path):
+    """An operator must repair pre-existing ACLs; startup never chmods them."""
+    from plugins.platforms.matrix import adapter as matrix_mod
+
+    store = tmp_path / "platforms" / "matrix" / "store"
+    store.mkdir(parents=True, mode=0o700)
+    for parent in (store.parent.parent, store.parent, store):
+        os.chmod(parent, 0o700)
+    crypto_db = store / "crypto.db"
+    crypto_db.touch(mode=0o644)
+    os.chmod(crypto_db, 0o644)
+    monkeypatch.setattr(matrix_mod, "_STORE_DIR", store)
+    monkeypatch.setattr(matrix_mod, "_CRYPTO_DB_PATH", crypto_db)
+
+    assert matrix_mod._matrix_private_storage_preflight() is False
+    assert stat.S_IMODE(crypto_db.stat().st_mode) == 0o644
+
+
+def test_gateway_systemd_units_set_private_umask():
+    """The generated user systemd service sets the deployment umask."""
+    from hermes_cli.gateway import generate_systemd_unit
+
+    assert "UMask=0077" in generate_systemd_unit(system=False)

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -393,7 +393,7 @@ MATRIX_E2EE_MODE=required
 |------|----------|
 | `off` | Do not initialize Matrix E2EE. |
 | `optional` | Try E2EE when dependencies are available, but keep unencrypted rooms working if crypto cannot initialize. |
-| `required` | Fail closed if E2EE dependencies or crypto setup are not available. |
+| `required` | Fail closed unless runtime room state is `m.megolm.v1.aes-sha2`; missing/unknown state, crypto failure, decrypt failure, or another algorithm blocks join, inbound processing, text, edits, media, reactions, approvals, and proactive delivery. |
 
 Optional mode may fall back to non-E2EE operation when crypto setup is unavailable. Required mode fails closed instead of silently downgrading.
 
@@ -405,6 +405,21 @@ When E2EE is enabled, Hermes:
 - Uploads device keys on first connection
 - Decrypts incoming messages and encrypts outgoing messages automatically
 - Auto-joins encrypted rooms when invited
+
+For a gateway installed through Hermes' systemd integration, generated units set
+`UMask=0077`. In `required` mode startup creates only new Matrix storage paths
+with owner-only modes and refuses to start if an existing crypto database,
+SQLite WAL/SHM, or decrypted cache has broader permissions; it does not repair
+existing files automatically.
+
+### Required-mode deployment verification
+
+TODO before merge or any live deployment: run the Matrix required-mode pytest
+module through `scripts/run_tests.sh`, the repository lint, type, and secret
+scans, then verify an invited encrypted room, an unencrypted room, an unknown
+algorithm, a missing inviter, an unlisted DM, outbound media, approvals, and
+restart persistence against a non-production Matrix homeserver. Offline source
+checks do not prove those runtime and live-service properties.
 
 ### Matrix Tools and Controls
 
@@ -521,7 +536,9 @@ MATRIX_HOME_ROOM=!abc123def456:matrix.example.org
 
 Restrict the bot to a fixed set of Matrix rooms. When set, the bot **only** responds in rooms whose ID appears in the list — messages from any other room are silently ignored, even if the bot is mentioned.
 
-**DMs (direct chat rooms) are exempt** from this filter, so authorized users can always reach the bot one-on-one.
+**DMs (direct chat rooms) are exempt** from this filter in `off` and `optional`
+mode. In `required` mode, a non-empty allowlist has no DM bypass: the DM room
+must be listed and satisfy the runtime encrypted-room gate.
 
 ```yaml
 matrix:


### PR DESCRIPTION
## Summary
- fail closed on required-mode remote/local E2EE disagreement before media upload
- keep document/video cache material owner-scoped
- require successful-decryption provenance for required inbound dispatch

## Verification
- `python3 -m py_compile ...`: PASS (pre-public candidate evidence)
- `git diff --check`: PASS before commit
- focused pytest and live Matrix runtime: not run in this runner; tracked as follow-up validation

No merge, deployment, or live configuration change is included.