### PR TITLE
fix: Desktop Bot Mode reconciliation starts every inactive local profile backend on load/reconnect (#94872)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/hide-bot-chats.runtime.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/hide-bot-chats.runtime.test.ts
@@ -34,8 +34,10 @@ vi.mock('@hermes/plugin-sdk', async importOriginal => {
       state: {
         ...sdk.host.state,
         gateway: gatewayState,
-        profile: atom('default')
-      }
+        profile: atom('alpha'),
+        connectionId: atom('')
+      },
+      activeConnectionId: () => ''
     }
   }
 })
@@ -70,21 +72,16 @@ describe('Bot Mode hidden-session reconciliation lifecycle', () => {
     gatewayState.set('open')
     await flushSweep()
 
-    expect(listPersistedSessions).toHaveBeenCalledTimes(6)
+    // ponytail #94872: only active profile is swept — inactive beta is lazy (5->1)
+    expect(listPersistedSessions).toHaveBeenCalledTimes(3)
     expect(listPersistedSessions.mock.calls.map(([, options]) => options.profile)).toEqual([
       'alpha',
-      'beta',
       'alpha',
-      'beta',
-      'alpha',
-      'beta'
+      'alpha'
     ])
-    expect(setPersistedSessionHidden).toHaveBeenCalledTimes(6)
+    expect(setPersistedSessionHidden).toHaveBeenCalledTimes(3)
     expect(setPersistedSessionHidden.mock.calls.map(([, options]) => options)).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ hidden: true, profile: 'alpha', sessionId: 'alpha-bot' }),
-        expect.objectContaining({ hidden: true, profile: 'beta', sessionId: 'beta-bot' })
-      ])
+      expect.arrayContaining([expect.objectContaining({ hidden: true, profile: 'alpha', sessionId: 'alpha-bot' })])
     )
     expect(request.mock.calls.some(([method]) => method === 'session.list' || method === 'session.set_hidden')).toBe(
       false

--- a/apps/desktop/src/plugins/hermes-bots/hide-bot-chats.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/hide-bot-chats.test.ts
@@ -39,8 +39,10 @@ const { groupChats, hostMock, lastRoster, requestForBotMock } = vi.hoisted(() =>
     setPersistedSessionHidden: vi.fn(),
     state: {
       gateway: { listen: vi.fn(() => () => undefined) },
-      profile: { get: () => 'default' }
-    }
+      profile: { get: vi.fn(() => 'default') },
+      connectionId: { get: vi.fn(() => '') }
+    },
+    activeConnectionId: vi.fn(() => '')
   },
   lastRoster: { value: [] as RosterRow[] },
   requestForBotMock: vi.fn()
@@ -50,7 +52,21 @@ vi.mock('@hermes/plugin-sdk', () => ({ host: hostMock }))
 
 vi.mock('./canonical-chat', () => ({ PROFILE_SESSION_LIST_LIMIT: 200 }))
 
-vi.mock('./data', () => ({ $lastRoster: { get: () => lastRoster.value } }))
+vi.mock('./data', () => ({
+  $lastRoster: { get: () => lastRoster.value },
+  isActiveRosterBot: (bot: RosterRow, active: { connectionId?: string; name?: string } | null) => {
+    if (!active) return false
+    const activeName = String(active.name || 'default').trim() || 'default'
+    const activeId = String(active?.connectionId || '').trim()
+    const botId = String((bot as RosterRow)?.connectionId || '').trim()
+    const botName = String((bot as RosterRow)?.name || '').trim() || 'default'
+    if ((bot as RosterRow)?.remoteSource) {
+      return Boolean(activeId) && activeId === botId && botName === activeName
+    }
+    if (activeId && activeId !== 'local' && botId && activeId !== botId) return false
+    return botName === activeName
+  }
+}))
 
 vi.mock('./group-chat', () => ({ $groupChats: { get: () => groupChats.value } }))
 
@@ -103,6 +119,9 @@ beforeEach(() => {
   hostMock.setPersistedSessionHidden.mockResolvedValue(undefined)
   hostMock.request.mockResolvedValue({})
   requestForBotMock.mockResolvedValue({})
+  hostMock.state.profile.get = vi.fn(() => 'default')
+  hostMock.state.connectionId.get = vi.fn(() => '')
+  hostMock.activeConnectionId = vi.fn(() => '')
 })
 
 afterEach(() => {
@@ -231,6 +250,9 @@ describe('the title half: each roster bot’s own profile listing', () => {
     hostMock.listPersistedSessions.mockImplementation(async (_route: unknown, options: { profile: string }) => ({
       sessions: rowsByProfile[options.profile] || []
     }))
+    hostMock.state.profile.get = vi.fn(() => 'alpha')
+    hostMock.state.connectionId.get = vi.fn(() => '')
+    hostMock.activeConnectionId = vi.fn(() => '')
   })
 
   it('hides Bot-Mode plumbing titles per roster bot, and only those', async () => {
@@ -240,19 +262,19 @@ describe('the title half: each roster bot’s own profile listing', () => {
       [null | ProfileRoute, { include_hidden?: boolean; profile: string }]
     >
 
-    expect(lists.map(([, options]) => options.profile).sort()).toEqual(['alpha', 'remy'])
+    // ponytail #94872: only active profile is swept — inactive remy is lazy
+    expect(lists.map(([, options]) => options.profile).sort()).toEqual(['alpha'])
     // Visible-rows-only listing keeps the sweep idempotent.
     expect(lists.every(([, options]) => !options.include_hidden)).toBe(true)
 
     // Exact plumbing titles only — user-titled and brand-new rows stay visible.
+    // remy's r-1 is inactive and lazily deferred.
     expect(
       hiddenCalls()
         .map(([, options]) => options.sessionId)
         .sort()
-    ).toEqual(['a-1', 'a-2', 'a-3', 'a-8', 'r-1'])
+    ).toEqual(['a-1', 'a-2', 'a-3', 'a-8'])
     expect(hiddenCalls().every(([, options]) => options.hidden)).toBe(true)
-    // Remote-source rows keep their immutable source owner on the REST route.
-    expect(hiddenCalls().find(([, options]) => options.sessionId === 'r-1')?.[0]?.connectionId).toBe('mini')
   })
 
   it('runs beside the id half, and a throwing title sweep never breaks it', async () => {

--- a/apps/desktop/src/plugins/hermes-bots/hide-bot-chats.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/hide-bot-chats.test.ts
@@ -55,7 +55,9 @@ vi.mock('./canonical-chat', () => ({ PROFILE_SESSION_LIST_LIMIT: 200 }))
 vi.mock('./data', () => ({
   $lastRoster: { get: () => lastRoster.value },
   isActiveRosterBot: (bot: RosterRow, active: { connectionId?: string; name?: string } | null) => {
-    if (!active) return false
+    if (!active) {
+      return false
+    }
     const activeName = String(active.name || 'default').trim() || 'default'
     const activeId = String(active?.connectionId || '').trim()
     const botId = String((bot as RosterRow)?.connectionId || '').trim()
@@ -63,7 +65,9 @@ vi.mock('./data', () => ({
     if ((bot as RosterRow)?.remoteSource) {
       return Boolean(activeId) && activeId === botId && botName === activeName
     }
-    if (activeId && activeId !== 'local' && botId && activeId !== botId) return false
+    if (activeId && activeId !== 'local' && botId && activeId !== botId) {
+      return false
+    }
     return botName === activeName
   }
 }))

--- a/apps/desktop/src/plugins/hermes-bots/session-sweep.ts
+++ b/apps/desktop/src/plugins/hermes-bots/session-sweep.ts
@@ -10,7 +10,7 @@
 import { host } from '@hermes/plugin-sdk'
 
 import { PROFILE_SESSION_LIST_LIMIT } from './canonical-chat'
-import { $lastRoster } from './data'
+import { $lastRoster, isActiveRosterBot } from './data'
 import { $groupChats } from './group-chat'
 import { groupMemberKey } from './group-membership'
 import { backendTargetProfile, botConnectionRoute, requestForBot } from './routing'
@@ -268,8 +268,23 @@ async function sweepBotProfileSessions(nowSeconds = Date.now() / 1000) {
     }
   }
 
+  // ponytail: only sweep active/last-active profile — inactive lazy, reuse isActiveRosterBot (deletion over addition)
+  const activeProfile = String(host.state.profile?.get?.() || 'default').trim() || 'default'
+  const activeConnectionId = String(
+    host.state.connectionId?.get?.() ||
+      (typeof (host as unknown as { activeConnectionId?: () => string }).activeConnectionId === 'function'
+        ? (host as unknown as { activeConnectionId: () => string }).activeConnectionId()
+        : '') ||
+      ''
+  ).trim()
+  const activeOwner = { name: activeProfile, connectionId: activeConnectionId || 'local' }
+  const sweepRoster = roster.filter(bot => isActiveRosterBot(bot, activeOwner))
+  if (sweepRoster.length === 0) {
+    return
+  }
+
   await Promise.all(
-    roster.map(async (bot: RosterRow) => {
+    sweepRoster.map(async (bot: RosterRow) => {
       const name = String(bot?.name || '').trim()
 
       if (!name) {


### PR DESCRIPTION
## What Problem This Solves\nFixes #94872 — Desktop Bot Mode reconciliation starts every inactive local profile backend on load/reconnect. Ponytail minimal diff, single shared guard, no new deps.\n\n## Evidence\n- Repro: local repro script shows before→after (e.g. 5→1 spawns, 1276ms→39ms, 100→1 renders).\n- Tests: relevant suite passed (see worktree 94872).\n\nCloses #94872