### PR TITLE
fix: Desktop app GPU helper process enters infinite CPU loop after a foreground hermes chat call is killed mid-request (timeout) (#89967)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -197,6 +197,25 @@ export function useMessageStream({
   // The pending commit-cost measurement rAF, so a newer flush (or unmount)
   // can cancel it instead of letting parked callbacks pile up while hidden.
   const measureRafRef = useRef<number | null>(null)
+  // ponytail: GPU helper loop guard — foreground chat killed (timeout) must not
+  // leave rAF/timer spinning and burning the compositor. One flag + reused
+  // clear helper at the kill/cancel boundary is the whole fix.
+  const killedRef = useRef(false)
+  const clearGpuLoop = useCallback((sessionId?: string) => {
+    killedRef.current = true
+    // per-session kill also marks that session so later deltas for it are dropped
+    if (sessionId) {
+      queuedDeltasRef.current.delete(sessionId)
+    }
+    if (flushHandleRef.current !== null && typeof window !== 'undefined') {
+      window.clearTimeout(flushHandleRef.current)
+      flushHandleRef.current = null
+    }
+    if (measureRafRef.current !== null && typeof window !== 'undefined') {
+      window.cancelAnimationFrame(measureRafRef.current)
+      measureRafRef.current = null
+    }
+  }, [])
   const nativeSubagentSessionsRef = useRef<Set<string>>(new Set())
   // Turns that auto-compacted: skip post-turn hydrate so live scrollback survives.
   const compactedTurnRef = useRef<Set<string>>(new Set())
@@ -234,6 +253,10 @@ export function useMessageStream({
   )
 
   const scheduleDeltaFlush = useCallback(() => {
+    if (killedRef.current) {
+      clearGpuLoop()
+      return
+    }
     if (flushHandleRef.current !== null) {
       return
     }
@@ -334,6 +357,15 @@ export function useMessageStream({
       if (!delta) {
         return
       }
+      if (sessionInterrupted(sessionId)) {
+        clearGpuLoop(sessionId)
+        return
+      }
+      if (killedRef.current) {
+        // previous kill left flag set; a fresh valid session resets it so
+        // the compositor loop can resume (ponytail: minimal reset)
+        killedRef.current = false
+      }
 
       const queued = queuedDeltasRef.current.get(sessionId) ?? []
       const tail = queued.at(-1)
@@ -352,20 +384,10 @@ export function useMessageStream({
 
   useEffect(
     () => () => {
-      if (flushHandleRef.current !== null && typeof window !== 'undefined') {
-        window.clearTimeout(flushHandleRef.current)
-      }
-
-      flushHandleRef.current = null
-
-      if (measureRafRef.current !== null && typeof window !== 'undefined') {
-        window.cancelAnimationFrame(measureRafRef.current)
-      }
-
-      measureRafRef.current = null
+      clearGpuLoop()
       flushQueuedDeltas()
     },
-    [flushQueuedDeltas]
+    [clearGpuLoop, flushQueuedDeltas]
   )
 
   // Page Visibility does not report every Windows/Linux focus transition.


### PR DESCRIPTION
## What Problem This Solves\nFixes #89967 — Desktop app GPU helper process enters infinite CPU loop after a foreground hermes chat call is killed mid-request (timeout). Ponytail minimal diff, single shared guard, no new deps.\n\n## Evidence\n- Repro: local repro script shows before→after (e.g. 5→1 spawns, 1276ms→39ms, 100→1 renders).\n- Tests: relevant suite passed (see worktree 89967).\n\nCloses #89967