### PR TITLE
fix(discord): play auto-TTS in voice channel instead of skipping

### DIFF
--- a/gateway/run_voice.py
+++ b/gateway/run_voice.py
@@ -308,7 +308,22 @@ class GatewayVoiceMixin:
             return False
         # Dedup: base adapter auto-TTS already handles voice input (play_tts plays in VC when
         # connected) — unless streaming consumed the text (already_sent): then the runner must.
-        return not (is_voice_input and not already_sent)
+        #
+        # Exception: when the bot is in a Discord voice channel, the runner's
+        # _send_voice_reply() is the only path that reliably calls
+        # play_in_voice_channel(). The base adapter's play_tts() override routes
+        # to the VC too, but this dedup skip prevents _send_voice_reply from
+        # running, and the base adapter path can fail silently when the
+        # response was already sent via streaming. So for VC-connected Discord,
+        # let the runner handle it. (#101185)
+        if is_voice_input and not already_sent:
+            guild_id = self._get_guild_id(event)
+            is_in_vc = getattr(adapter, "is_in_voice_channel", None)
+            if guild_id and callable(is_in_vc) and is_in_vc(guild_id):
+                pass  # Don't skip — let _send_voice_reply play in VC
+            else:
+                return False
+        return True
 
     def _should_echo_stt_transcripts(self) -> bool:
         return bool(getattr(self.config, "stt_echo_transcripts", True))


### PR DESCRIPTION
# Summary

When a user speaks in a Discord voice channel (`/voice join`), the bot transcribes correctly but **never plays its TTS reply back in the voice channel**. The text reply is sent, but no audio is played in the VC.

Fixes #101185

## Root cause

`_should_send_voice_reply()` in `gateway/run.py` skips auto-TTS for `MessageType.VOICE` when `already_sent=False`:

```python
if is_voice_input and not already_sent:
    return False
```

The comment says *"base adapter auto-TTS already handles voice input (play_tts plays in VC when connected, so runner can skip)"*. But:

1. The runner's `_send_voice_reply()` is the only path that reliably checks `is_in_voice_channel()` and calls `play_in_voice_channel()` — and it's being skipped.
2. The base adapter's auto-TTS does fire and calls `play_tts()`, but this path can fail silently for voice channel input (e.g., when streaming already delivered the response).

## Fix

Before skipping, check if the bot is currently connected to a Discord voice channel for this guild. If it is, **don't skip** — let `_send_voice_reply()` handle the TTS reply so it plays audio directly in the channel:

```python
if is_voice_input and not already_sent:
    adapter = self._adapter_for_source(event.source)
    guild_id = self._get_guild_id(event)
    is_in_vc = getattr(adapter, "is_in_voice_channel", None)
    if (guild_id and callable(is_in_vc) and is_in_vc(guild_id)):
        pass  # Don't skip — let _send_voice_reply play in VC
    else:
        return False
```

This preserves the original dedup behavior for non-VC scenarios (voice message attachments on Telegram, etc.) while fixing the Discord voice channel case.

## Testing

- **Before fix**: Speak in Discord VC -> bot transcribes (Mistral Voxtral) and responds in text, but **no audio in VC**
- **After fix**: Speak in Discord VC -> bot transcribes and **plays TTS reply in the voice channel**
- Non-VC voice messages (attachments): behavior unchanged (still handled by base adapter auto-TTS)

## Environment tested

- Hermes Agent (latest main)
- Discord platform adapter
- STT: Mistral Voxtral (`stt.provider: mistral`)
- TTS: Mistral Voxtral (`tts.provider: mistral`)
- `voice.auto_tts: true`, voice mode: `all`
