### PR TITLE
fix(install): preflight core utilities and prefer .tar.gz node tarballs without xz

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1085,7 +1085,7 @@ install_node_line() {
         prefer_gz=true
         log_info "xz not found — preferring .tar.gz tarballs (GNU tar needs xz for .tar.xz)"
     fi
-    local tarball_name
+    local tarball_name=""
     if [ "$prefer_gz" = true ]; then
         tarball_name=$(curl -fsSL "$index_url" \
             | grep -oE "node-v${node_line}\.[0-9]+\.[0-9]+-${node_os}-${node_arch}\.tar\.gz" \

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -552,6 +552,38 @@ detect_os() {
 # Dependency checks
 # ============================================================================
 
+# The installer shells out to a handful of POSIX utilities without proving
+# they exist first. On stripped-down Linux a missing utility surfaces far
+# from its cause: without awk the uv installer stalls with no error at all,
+# and a missing sed/tar only breaks later stages with opaque messages
+# (#101164). Fail fast with per-distro install instructions instead.
+check_core_utilities() {
+    local missing=""
+    local util
+    for util in awk sed tar; do
+        command -v "$util" >/dev/null 2>&1 || missing="$missing $util"
+    done
+    if [ -z "$missing" ]; then
+        return 0
+    fi
+
+    log_error "Missing required utilities:$missing"
+    log_info "Install them, then re-run this script:"
+    case "$OS" in
+        linux)
+            case "$DISTRO" in
+                ubuntu|debian) log_info "  sudo apt install gawk sed tar" ;;
+                fedora)        log_info "  sudo dnf install gawk sed tar" ;;
+                arch)          log_info "  sudo pacman -S gawk sed tar" ;;
+                *)             log_info "  Use your package manager to install awk, sed, and tar" ;;
+            esac
+            ;;
+        android) log_info "  pkg install gawk sed tar" ;;
+        macos)   log_info "  xcode-select --install (provides awk, sed, and tar)" ;;
+    esac
+    exit 1
+}
+
 install_uv() {
     if [ "$DISTRO" = "termux" ]; then
         log_info "Termux detected — using Python's stdlib venv + pip instead of uv"
@@ -1040,12 +1072,30 @@ install_node_line() {
     local node_os="$2"
     local node_arch="$3"
 
-    # Resolve the latest v${node_line}.x.x tarball name from the index page
+    # Resolve the latest v${node_line}.x.x tarball name from the index page.
+    # GNU tar shells out to the xz binary for .tar.xz, and stripped-down
+    # Linux systems (a fresh Fedora WSL install ships without xz) fail with
+    # "tar (child): xz: Cannot exec" and burn through every release line.
+    # nodejs.org publishes a .tar.gz alongside every .tar.xz, so when xz is
+    # missing prefer the gz tarball instead (#101164). macOS bsdtar
+    # decompresses xz natively and keeps the (smaller) xz preference.
     local index_url="https://nodejs.org/dist/latest-v${node_line}.x/"
+    local prefer_gz=false
+    if [ "$OS" = "linux" ] && ! command -v xz >/dev/null 2>&1; then
+        prefer_gz=true
+        log_info "xz not found — preferring .tar.gz tarballs (GNU tar needs xz for .tar.xz)"
+    fi
     local tarball_name
-    tarball_name=$(curl -fsSL "$index_url" \
-        | grep -oE "node-v${node_line}\.[0-9]+\.[0-9]+-${node_os}-${node_arch}\.tar\.xz" \
-        | head -1)
+    if [ "$prefer_gz" = true ]; then
+        tarball_name=$(curl -fsSL "$index_url" \
+            | grep -oE "node-v${node_line}\.[0-9]+\.[0-9]+-${node_os}-${node_arch}\.tar\.gz" \
+            | head -1)
+    fi
+    if [ -z "$tarball_name" ]; then
+        tarball_name=$(curl -fsSL "$index_url" \
+            | grep -oE "node-v${node_line}\.[0-9]+\.[0-9]+-${node_os}-${node_arch}\.tar\.xz" \
+            | head -1)
+    fi
 
     # Fallback to .tar.gz if .tar.xz not available
     if [ -z "$tarball_name" ]; then
@@ -3700,6 +3750,7 @@ run_stage_body() {
             print_banner
             detect_os
             resolve_install_layout
+            check_core_utilities
             install_uv
             check_python
             check_git
@@ -3843,6 +3894,7 @@ main() {
 
     detect_os
     resolve_install_layout
+    check_core_utilities
     install_uv
     check_python
     check_git

--- a/tests/test_install_sh_core_utility_checks.py
+++ b/tests/test_install_sh_core_utility_checks.py
@@ -1,0 +1,132 @@
+"""Regression tests for install.sh core-utility preflight (#101164).
+
+The installer implicitly relied on awk/sed/tar (and on xz for extracting
+Node .tar.xz tarballs) without proving they exist. On a fresh Fedora WSL
+install a missing xz made GNU tar fail with "xz: Cannot exec" through
+every Node release line, and a missing awk stalled the uv installer with
+no error at all. The installer must fail fast on missing core utilities
+with actionable hints, and prefer .tar.gz Node tarballs when xz is
+unavailable.
+"""
+
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def _extract_function(text: str, name: str) -> str:
+    start = text.index(f"{name}() {{")
+    end = text.index("\n}\n", start) + len("\n}\n")
+    return text[start:end]
+
+
+def test_core_utilities_checked_before_uv_and_git() -> None:
+    """check_core_utilities must run before install_uv/check_git.
+
+    check_git parses `git --version` through awk and the uv installer needs
+    awk too — without the preflight, a missing awk kills the installer deep
+    inside those steps instead of with an actionable message (#101164).
+    """
+    text = INSTALL_SH.read_text()
+    assert "check_core_utilities" in text
+
+    main_body = _extract_function(text, "main")
+    assert main_body.index("check_core_utilities") < main_body.index("install_uv")
+    assert main_body.index("check_core_utilities") < main_body.index("check_git")
+
+    # The desktop bootstrap prerequisites stage keeps the same ordering.
+    prereq = text[text.index("        prerequisites)") : text.index("        repository)")]
+    assert prereq.index("check_core_utilities") < prereq.index("install_uv")
+
+
+def test_core_utilities_cover_awk_sed_tar() -> None:
+    text = INSTALL_SH.read_text()
+    func = _extract_function(text, "check_core_utilities")
+    assert "for util in awk sed tar; do" in func
+
+
+def _run_check_core_utilities(tmp_path: Path, tools: list[str]) -> subprocess.CompletedProcess:
+    """Extract check_core_utilities and run it against a stub PATH.
+
+    Only the utilities named in `tools` resolve; everything else (notably
+    awk when absent) is invisible to `command -v`.
+    """
+    text = INSTALL_SH.read_text()
+    func = _extract_function(text, "check_core_utilities")
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for util in tools:
+        stub = bin_dir / util
+        stub.write_text("#!/bin/sh\nexit 0\n")
+        stub.chmod(0o755)
+
+    harness = tmp_path / "harness.sh"
+    harness.write_text(
+        "#!/bin/bash\n"
+        "log_error() { printf 'ERR: %s\\n' \"$1\"; }\n"
+        "log_info() { printf 'INFO: %s\\n' \"$1\"; }\n"
+        "OS=linux\n"
+        "DISTRO=fedora\n"
+        + func
+        + "\ncheck_core_utilities\n"
+        + "echo UNREACHABLE\n"
+    )
+
+    env = {"PATH": str(bin_dir), "HOME": str(tmp_path)}
+    return subprocess.run(
+        # Absolute path: the stub PATH intentionally lacks bash, and exec
+        # resolves the command against the *child* env's PATH.
+        ["/bin/bash", str(harness)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_missing_awk_fails_fast_with_hint(tmp_path: Path) -> None:
+    """A missing awk must abort before any dependent step, with a hint.
+
+    Before the fix the script ran on and stalled inside the uv installer
+    (which requires awk) with nothing actionable printed (#101164).
+    """
+    result = _run_check_core_utilities(tmp_path, tools=["sed", "tar"])
+
+    assert result.returncode != 0
+    assert "awk" in result.stdout
+    assert "UNREACHABLE" not in result.stdout
+    # Fedora gets a concrete dnf command.
+    assert "dnf install gawk" in result.stdout
+
+
+def test_all_core_utilities_present_passes(tmp_path: Path) -> None:
+    """With awk/sed/tar all resolvable the preflight is a silent no-op."""
+    result = _run_check_core_utilities(tmp_path, tools=["awk", "sed", "tar"])
+
+    assert result.returncode == 0
+    assert "UNREACHABLE" in result.stdout
+
+
+def test_node_tarball_prefers_gz_when_xz_missing() -> None:
+    """Without xz, the Node download must resolve .tar.gz before .tar.xz.
+
+    GNU tar shells out to the xz binary for .tar.xz; nodejs.org publishes a
+    .tar.gz alongside every .tar.xz, so preferring gz keeps the Node install
+    working on stripped-down Linux (fresh Fedora WSL) without requiring the
+    user to install xz first (#101164).
+    """
+    text = INSTALL_SH.read_text()
+    func = _extract_function(text, "install_node_line")
+
+    # The gz preference is gated to Linux (macOS bsdtar decompresses xz
+    # natively and keeps the smaller xz tarballs).
+    assert '[ "$OS" = "linux" ] && ! command -v xz >/dev/null 2>&1' in func
+
+    # Under prefer_gz the .tar.gz resolution must come before the .tar.xz one.
+    prefer_gz_start = func.index("prefer_gz=true")
+    fallback_marker = func.index("# Fallback to .tar.gz")
+    prefer_block = func[prefer_gz_start:fallback_marker]
+    assert prefer_block.index(".tar\\.gz") < prefer_block.index(".tar\\.xz")


### PR DESCRIPTION
## What does this PR do?

The installer implicitly relied on `awk`, `sed`, `tar`, and `xz` without proving they exist first, which produced opaque failures on stripped-down Linux systems (#101164):

- Without `xz`, GNU tar fails with `tar (child): xz: Cannot exec` inside the Node install and the installer burns through every release line before giving up.
- Without `awk`, the uv installer (astral.sh) stalls with no error at all, and `check_git`'s version parsing dies under `set -e`.

Two changes fix this:

1. **`check_core_utilities()` fail-fast preflight** — runs right after `detect_os` in both `main()` and the desktop-bootstrap `prerequisites` stage. A missing `awk`/`sed`/`tar` aborts immediately with a per-distro install command (apt/dnf/pacman/pkg) instead of an opaque failure deep inside a later step.
2. **`.tar.gz` preference when `xz` is missing** — `install_node_line()` checks `command -v xz` on Linux and, when absent, resolves the `.tar.gz` tarball that nodejs.org publishes alongside every `.tar.xz` before trying the xz variant. A fresh Fedora WSL install (which ships without `xz`) now completes the Node install with zero user action. `xz` is deliberately **not** part of the hard preflight gate: it is only needed when a Node tarball must be downloaded, and the gz fallback makes even that case work. macOS bsdtar decompresses xz natively and keeps the smaller tarballs.

## Related Issue

Fixes #101164

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/install.sh` — new `check_core_utilities()` (awk/sed/tar preflight, per-distro install hints) called in `main()` and the `prerequisites` stage before `install_uv`/`check_git` (both consume awk before this gate)
- `scripts/install.sh` — `install_node_line()` now prefers `.tar.gz` over `.tar.xz` when Linux lacks `xz` (macOS unaffected)
- `tests/test_install_sh_core_utility_checks.py` — new regression tests: ordering of the preflight vs `install_uv`/`check_git`, coverage of the checked tool list, behavioral tests that extract and execute `check_core_utilities` against a stub PATH (missing-awk aborts with the dnf hint; all-present passes), and the gz-preference ordering inside `install_node_line`

## How to Test

1. `pytest tests/test_install_sh_core_utility_checks.py -v` — Observed result: 5 passed.
2. Whole `test_install_sh_*` family — Observed result: 51 passed (46 pre-existing + 5 new), no regressions.
3. Live normal path: `HERMES_HOME=$(mktemp -d) bash scripts/install.sh --stage prerequisites --json --non-interactive` — Observed result: `{"ok":true,"stage":"prerequisites","skipped":false}`, exit 0; the preflight is silent when all utilities are present (no false positives on a stock macOS host).
4. Live gz-availability check: `curl -fsSL https://nodejs.org/dist/latest-v26.x/ | grep -oE "node-v26\.[0-9]+\.[0-9]+-linux-x64\.tar\.gz"` — Observed result: `node-v26.8.1-linux-x64.tar.gz` resolves (same for latest-v22.x), confirming the fallback's data prerequisite.
5. Fedora-WSL repro from the issue (fresh system, no `xz`): previously three download attempts each dying at `tar (child): xz: Cannot exec`; with this change the installer logs `xz not found — preferring .tar.gz tarballs` and proceeds via the gz tarball.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64); Fedora-WSL scenario covered via PATH-stub behavioral tests and nodejs.org tarball verification

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A
