### PR TITLE
fix(gateway): route kanban notifications by profile

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -516,7 +516,11 @@ class GatewayKanbanWatchersMixin:
                             for route in (
                                 getattr(_config, "profile_routes", None) or []
                             )
-                            if getattr(route, "enabled", False)
+                            # Compatible route representations may omit an
+                            # explicit enabled field. Treat omission as active;
+                            # ``enabled: false`` still denies the route before
+                            # the exact authorization pass.
+                            if getattr(route, "enabled", True)
                             and str(getattr(route, "platform", "")).lower()
                             in active_platforms
                             and str(getattr(route, "profile", "")).strip()

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -219,11 +219,12 @@ class GatewayKanbanWatchersMixin:
     ) -> Any:
         """Authorize the primary transport for one stamped subscription.
 
-        A profile with any secondary-adapter registry entry owns its credential
-        boundary and can never fall back to the primary bot. Otherwise the
-        destination's best profile route is authoritative. A route match must
-        target the stamped, served profile; an unrouted destination may use the
-        primary adapter only for the active/default runtime profile.
+        A profile with any connected secondary adapter owns its credential
+        boundary and can never fall back to the primary bot. An empty registry
+        map is only a multiplex-startup placeholder, so the destination's exact
+        profile route remains authoritative. A route match must target the
+        stamped, served profile; an unrouted destination may use the primary
+        adapter only for the active/default runtime profile.
         """
         profile_name = str(owner_profile or "").strip()
         if not profile_name:
@@ -232,9 +233,13 @@ class GatewayKanbanWatchersMixin:
         adapter = adapters.get(platform)
         if adapter is None:
             return None
-        # An entry means this profile has its own credential boundary. Missing
-        # one platform is a denial, not permission to borrow the primary bot.
-        if profile_name in (getattr(self, "_profile_adapters", None) or {}):
+        # A non-empty entry means this profile has its own credential boundary.
+        # Multiplex startup also leaves empty maps for served profiles with no
+        # connected adapters; those may still use an exact primary route below.
+        profile_adapters = (getattr(self, "_profile_adapters", None) or {}).get(
+            profile_name
+        )
+        if profile_adapters:
             return None
 
         config = getattr(self, "config", None)

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -211,6 +211,166 @@ def _wake_scope_id(adapter: Any, sub: dict) -> Optional[str]:
 class GatewayKanbanWatchersMixin:
     """Kanban watcher / notifier / dispatcher loops for GatewayRunner."""
 
+    def _kanban_primary_adapter_for_routed_subscription(
+        self,
+        platform: Any,
+        sub: dict,
+        owner_profile: Optional[str],
+    ) -> Any:
+        """Authorize the primary transport for one stamped subscription.
+
+        A profile with any secondary-adapter registry entry owns its credential
+        boundary and can never fall back to the primary bot. Otherwise the
+        destination's best profile route is authoritative. A route match must
+        target the stamped, served profile; an unrouted destination may use the
+        primary adapter only for the active/default runtime profile.
+        """
+        profile_name = str(owner_profile or "").strip()
+        if not profile_name:
+            return None
+        adapters = getattr(self, "adapters", None) or {}
+        adapter = adapters.get(platform)
+        if adapter is None:
+            return None
+        # An entry means this profile has its own credential boundary. Missing
+        # one platform is a denial, not permission to borrow the primary bot.
+        if profile_name in (getattr(self, "_profile_adapters", None) or {}):
+            return None
+
+        config = getattr(self, "config", None)
+        routes = getattr(config, "profile_routes", None) or []
+        multiplex = bool(getattr(config, "multiplex_profiles", False))
+        active_profile = str(
+            getattr(self, "_kanban_notifier_profile", None)
+            or getattr(self, "_active_profile_name")()
+        ).strip()
+        if not multiplex or not routes:
+            return adapter if profile_name == active_profile else None
+
+        metadata = sub.get("delivery_metadata")
+        metadata = metadata if isinstance(metadata, dict) else {}
+        platform_name = getattr(platform, "value", str(platform)).lower()
+        guild_id = metadata.get("guild_id") or metadata.get("scope_id")
+        parent_chat_id = metadata.get("parent_chat_id")
+        try:
+            from gateway.profile_routing import match_profile_route
+
+            matched = match_profile_route(
+                routes,
+                platform=platform_name,
+                guild_id=str(guild_id) if guild_id else None,
+                chat_id=str(sub.get("chat_id") or "") or None,
+                thread_id=str(sub.get("thread_id") or "") or None,
+                parent_chat_id=(
+                    str(parent_chat_id) if parent_chat_id else None
+                ),
+            )
+        except Exception:
+            logger.warning(
+                "kanban notifier: profile-route resolution failed for %s/%s",
+                platform_name,
+                sub.get("chat_id"),
+                exc_info=True,
+            )
+            return None
+
+        # Persisted rows predating route-anchor metadata cannot safely prove
+        # that a more-specific route does not own this destination. Deny only
+        # when an otherwise-compatible route outranks the match we could make;
+        # known conflicting chat/thread/guild values still rule a route out.
+        chat_id = str(sub.get("chat_id") or "") or None
+        thread_id = str(sub.get("thread_id") or "") or None
+        chat_type = str(
+            metadata.get("chat_type") or sub.get("chat_type") or ""
+        ).lower()
+        thread_like = chat_type in {
+            "thread", "forum", "forum_post", "forum-post", "topic"
+        }
+        matched_specificity = matched.specificity if matched is not None else -1
+        for route in routes:
+            if not getattr(route, "enabled", True):
+                continue
+            if str(getattr(route, "platform", "")).lower() != platform_name:
+                continue
+            if getattr(route, "specificity", 0) <= matched_specificity:
+                continue
+            route_thread = getattr(route, "thread_id", None)
+            if route_thread and str(route_thread) != thread_id:
+                continue
+            missing_anchor = False
+            route_chat = getattr(route, "chat_id", None)
+            if route_chat:
+                route_chat = str(route_chat)
+                if route_chat == chat_id:
+                    pass
+                elif parent_chat_id:
+                    if route_chat != str(parent_chat_id):
+                        continue
+                elif thread_id or thread_like:
+                    missing_anchor = True
+                else:
+                    continue
+            route_guild = getattr(route, "guild_id", None)
+            if route_guild:
+                if guild_id:
+                    if str(route_guild) != str(guild_id):
+                        continue
+                else:
+                    missing_anchor = True
+            if missing_anchor:
+                return None
+
+        if matched is None:
+            return adapter if profile_name == active_profile else None
+        if matched.profile != profile_name:
+            return None
+
+        served_profiles = getattr(self, "_kanban_served_profiles", None)
+        if served_profiles is None:
+            try:
+                from hermes_cli.profiles import profiles_to_serve
+
+                served_profiles = frozenset(
+                    name
+                    for name, _home in profiles_to_serve(
+                        multiplex=True,
+                        profile_allowlist=getattr(
+                            config, "multiplex_profile_allowlist", None
+                        ),
+                    )
+                )
+            except Exception:
+                logger.warning(
+                    "kanban notifier: served-profile resolution failed; "
+                    "denying routed primary transport",
+                    exc_info=True,
+                )
+                served_profiles = frozenset()
+            setattr(self, "_kanban_served_profiles", served_profiles)
+        return adapter if profile_name in served_profiles else None
+
+    def _kanban_adapter_for_subscription(
+        self,
+        platform: Any,
+        sub: dict,
+        owner_profile: Optional[str],
+    ) -> Any:
+        """Resolve a subscription adapter without crossing profile credentials."""
+        authorized = getattr(self, "_authorization_adapter")(
+            platform, owner_profile
+        )
+        effective_profile = str(
+            owner_profile
+            or getattr(self, "_kanban_notifier_profile", None)
+            or getattr(self, "_active_profile_name")()
+        ).strip()
+        primary = (getattr(self, "adapters", None) or {}).get(platform)
+        if authorized is not None and authorized is not primary:
+            return authorized
+        return self._kanban_primary_adapter_for_routed_subscription(
+            platform, sub, effective_profile,
+        )
+
     def _owns_kanban_dispatcher_lock(self) -> bool:
         """Return whether this gateway currently owns the singleton lock."""
         return getattr(self, "_kanban_dispatcher_lock_handle", None) is not None
@@ -343,6 +503,24 @@ class GatewayKanbanWatchersMixin:
                         getattr(platform, "value", str(platform)).lower()
                         for platform in self.adapters.keys()
                     }
+                    # A primary credential can explicitly transport named
+                    # routed profiles without creating `_profile_adapters`
+                    # entries for them. Include only route targets on a live
+                    # primary platform in the coarse ownership query; the
+                    # subscription's exact destination is re-matched below
+                    # before any event is claimed.
+                    _config = getattr(self, "config", None)
+                    if getattr(_config, "multiplex_profiles", False):
+                        notifier_profiles.update(
+                            str(getattr(route, "profile", "")).strip()
+                            for route in (
+                                getattr(_config, "profile_routes", None) or []
+                            )
+                            if getattr(route, "enabled", False)
+                            and str(getattr(route, "platform", "")).lower()
+                            in active_platforms
+                            and str(getattr(route, "profile", "")).strip()
+                        )
                     # Widen to every platform any secondary profile has live,
                     # not just the default profile's. This is only a coarse
                     # pre-filter to skip claiming events for subs nobody can
@@ -463,15 +641,25 @@ class GatewayKanbanWatchersMixin:
                             for sub in subs:
                                 try:
                                     owner_profile = sub.get("notifier_profile") or None
-                                    if owner_profile and owner_profile != notifier_profile:
-                                        _owner_adapters = getattr(self, "_profile_adapters", {}).get(owner_profile)
-                                        if not _owner_adapters:
-                                            logger.debug(
-                                                "kanban notifier: subscription for %s owned by profile %s; current profile %s has no adapter for it, skipping",
-                                                sub.get("task_id"), owner_profile, notifier_profile,
-                                            )
-                                            continue
                                     platform = (sub.get("platform") or "").lower()
+                                    effective_owner = owner_profile or notifier_profile
+                                    try:
+                                        _sub_platform = _Platform(platform)
+                                    except ValueError:
+                                        _sub_platform = None
+                                    _owner_adapter = (
+                                        self._kanban_adapter_for_subscription(
+                                            _sub_platform, sub, effective_owner,
+                                        )
+                                        if _sub_platform is not None
+                                        else None
+                                    )
+                                    if _owner_adapter is None:
+                                        logger.debug(
+                                            "kanban notifier: subscription for %s owned by profile %s has no authorized adapter or exact route; skipping",
+                                            sub.get("task_id"), effective_owner,
+                                        )
+                                        continue
                                     if platform not in active_platforms:
                                         logger.debug(
                                             "kanban notifier: subscription for %s on %s skipped; adapter not connected",
@@ -538,7 +726,9 @@ class GatewayKanbanWatchersMixin:
                     # wrong bot (the cross-profile mis-delivery this whole change
                     # exists to fix). The helper returns None only when the profile
                     # (or default) genuinely has no adapter for the platform.
-                    adapter = self._authorization_adapter(plat, sub_profile or None)
+                    adapter = self._kanban_adapter_for_subscription(
+                        plat, sub, sub_profile or None,
+                    )
                     if adapter is None:
                         logger.debug(
                             "kanban notifier: adapter %s disconnected before delivery for %s; rewinding claim",
@@ -989,6 +1179,15 @@ class GatewayKanbanWatchersMixin:
                                         _delivery_meta.get("chat_type") or ""
                                     ).strip()
                             _chat_type = _chat_type or "group"
+                            _route_meta = sub.get("delivery_metadata")
+                            _route_meta = (
+                                _route_meta if isinstance(_route_meta, dict) else {}
+                            )
+                            _scope_id = (
+                                _route_meta.get("scope_id")
+                                or _route_meta.get("guild_id")
+                                or _wake_scope_id(adapter, sub)
+                            )
                             _source = SessionSource(
                                 platform=plat,
                                 chat_id=sub["chat_id"],
@@ -997,8 +1196,29 @@ class GatewayKanbanWatchersMixin:
                                 user_id=sub.get("user_id"),
                                 user_id_alt=sub.get("user_id_alt"),
                                 profile=sub_profile or None,
-                                scope_id=_wake_scope_id(adapter, sub),
+                                scope_id=str(_scope_id) if _scope_id else None,
+                                parent_chat_id=(
+                                    str(_route_meta["parent_chat_id"])
+                                    if _route_meta.get("parent_chat_id")
+                                    else None
+                                ),
                             )
+                            # Preserve the same in-process transport provenance
+                            # as BasePlatformAdapter.build_source(). A routed
+                            # runtime profile may intentionally have no
+                            # `_profile_adapters` entry; provenance keeps authz
+                            # and reply delivery on the primary credential that
+                            # the exact route authorized above.
+                            try:
+                                import weakref
+
+                                setattr(
+                                    _source,
+                                    "_transport_adapter_ref",
+                                    weakref.ref(adapter),
+                                )
+                            except TypeError:
+                                pass
                             # deliver_wake preserves the synthetic
                             # MessageEvent/handle_message path for
                             # push-capable adapters (the non-push /

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25741,6 +25741,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     metadata.setdefault("scope_id", str(team_id))
                 if user_id:
                     metadata.setdefault("user_id", str(user_id))
+        # Persist the exact routing anchors alongside synthetic/background
+        # delivery metadata. Kanban auto-subscriptions replay this dictionary
+        # after the originating MessageEvent is gone; without guild/scope and
+        # parent-channel identity, a guild or parent-channel profile route
+        # cannot be re-established safely and must fail closed.
+        for key in ("scope_id", "guild_id", "parent_chat_id"):
+            value = getattr(source, key, None)
+            if value:
+                metadata = dict(metadata or {})
+                metadata.setdefault(key, str(value))
         return metadata
 
     def _thread_metadata_for_target(
@@ -26502,6 +26512,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             user_id_alt=str(context.source.user_id_alt) if context.source.user_id_alt else "",
             user_name=str(context.source.user_name) if context.source.user_name else "",
             scope_id=str(getattr(context.source, "scope_id", "") or ""),
+            parent_chat_id=str(
+                getattr(context.source, "parent_chat_id", "") or ""
+            ),
             session_key=context.session_key,
             message_id=str(context.source.message_id) if context.source.message_id else "",
             profile=getattr(context.source, "profile", "") or "",

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -87,6 +87,12 @@ _SESSION_USER_NAME: ContextVar = ContextVar("HERMES_SESSION_USER_NAME", default=
 # the connector's fail-closed egress guard needs scope_id (or a user binding)
 # to resolve the tenant for a scoped reply after a restart.
 _SESSION_SCOPE_ID: ContextVar = ContextVar("HERMES_SESSION_SCOPE_ID", default=_UNSET)
+# Parent channel/chat for thread-like sources. This remains separate from
+# thread_id because some adapters use the thread itself as chat_id while
+# profile routes are configured against the containing channel.
+_SESSION_PARENT_CHAT_ID: ContextVar = ContextVar(
+    "HERMES_SESSION_PARENT_CHAT_ID", default=_UNSET
+)
 _SESSION_KEY: ContextVar = ContextVar("HERMES_SESSION_KEY", default=_UNSET)
 _SESSION_ID: ContextVar = ContextVar("HERMES_SESSION_ID", default=_UNSET)
 # In-process UI session/window id for multi-session desktop/TUI hosts. This is
@@ -152,6 +158,7 @@ _VAR_MAP = {
     "HERMES_SESSION_USER_ID_ALT": _SESSION_USER_ID_ALT,
     "HERMES_SESSION_USER_NAME": _SESSION_USER_NAME,
     "HERMES_SESSION_SCOPE_ID": _SESSION_SCOPE_ID,
+    "HERMES_SESSION_PARENT_CHAT_ID": _SESSION_PARENT_CHAT_ID,
     "HERMES_SESSION_KEY": _SESSION_KEY,
     "HERMES_SESSION_ID": _SESSION_ID,
     "HERMES_UI_SESSION_ID": _SESSION_UI_SESSION_ID,
@@ -232,6 +239,7 @@ def set_session_vars(
     user_id_alt: str = "",
     user_name: str = "",
     scope_id: str = "",
+    parent_chat_id: str = "",
     session_key: str = "",
     session_id: str = "",
     message_id: str = "",
@@ -278,6 +286,7 @@ def set_session_vars(
         _SESSION_USER_ID_ALT.set(user_id_alt),
         _SESSION_USER_NAME.set(user_name),
         _SESSION_SCOPE_ID.set(scope_id),
+        _SESSION_PARENT_CHAT_ID.set(parent_chat_id),
         _SESSION_KEY.set(session_key),
         _SESSION_ID.set(session_id),
         _SESSION_UI_SESSION_ID.set(ui_session_id),
@@ -319,6 +328,7 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_USER_ID_ALT,
         _SESSION_USER_NAME,
         _SESSION_SCOPE_ID,
+        _SESSION_PARENT_CHAT_ID,
         _SESSION_KEY,
         _SESSION_ID,
         _SESSION_UI_SESSION_ID,

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -550,7 +550,11 @@ class GatewaySlashCommandsMixin:
                                     thread_id=thread_id or None,
                                     user_id=user_id,
                                     user_id_alt=user_id_alt,
-                                    notifier_profile=getattr(self, "_kanban_notifier_profile", None) or self._active_profile_name(),
+                                    notifier_profile=(
+                                        str(getattr(source, "profile", "") or "")
+                                        or getattr(self, "_kanban_notifier_profile", None)
+                                        or getattr(self, "_active_profile_name")()
+                                    ),
                                     # Subscribing from chat: deliver the passive
                                     # message and wake the destination agent.
                                     delivery_mode="notify+wake",

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -830,6 +830,7 @@ def _make_routed_discord_runner(
     adapter,
     *,
     route_profile="yuki",
+    route_enabled=True,
     served_profiles=("default", "yuki"),
 ):
     from gateway.config import GatewayConfig
@@ -853,6 +854,7 @@ def _make_routed_discord_runner(
                     "guild_id": "engineering-guild",
                     "chat_id": "engineering-chat",
                     "profile": route_profile,
+                    "enabled": route_enabled,
                 }
             ]
         ),
@@ -947,6 +949,22 @@ def test_routed_profile_uses_primary_discord_adapter_on_secondary_board_once(
     asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
     assert len(adapter.sent) == 1
     assert len(adapter.handled) == 1
+
+
+def test_disabled_profile_route_is_not_a_primary_transport_target(
+    tmp_path, monkeypatch,
+):
+    """An explicitly disabled parsed route remains fail-closed."""
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    task_id = _create_routed_discord_completion(board=None)
+
+    adapter = RecordingAdapter()
+    runner = _make_routed_discord_runner(adapter, route_enabled=False)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert adapter.sent == []
+    assert adapter.handled == []
+    assert _unseen_routed_event_count(task_id) == 1
 
 
 def test_routed_profile_primary_adapter_denies_wrong_or_unmatched_route(

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -926,6 +926,10 @@ def test_routed_profile_uses_primary_discord_adapter_on_secondary_board_once(
 
     adapter = RecordingAdapter()
     runner = _make_routed_discord_runner(adapter)
+    # Multiplex startup creates an empty registry map even when a routed
+    # profile has no independently connected adapters.  An empty map is not a
+    # credential boundary and must not block its exact primary route.
+    runner._profile_adapters = {"yuki": {}}  # type: ignore[assignment]
     asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
 
     assert len(adapter.sent) == 1

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -745,3 +745,406 @@ def test_review_requested_does_not_wake_a_notify_only_subscription(
     assert adapter.handled == [], (
         "notify-only subscriptions must not be woken by a review handoff"
     )
+
+
+def test_kanban_subscription_metadata_keeps_profile_route_anchors():
+    """Auto-subscribe persists enough source identity to replay exact routing."""
+    from types import SimpleNamespace
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    source = SimpleNamespace(
+        platform=Platform.DISCORD,
+        chat_id="thread-7",
+        thread_id="thread-7",
+        chat_type="thread",
+        message_id="message-9",
+        scope_id="guild-3",
+        guild_id="guild-3",
+        parent_chat_id="engineering-chat",
+    )
+
+    metadata = runner._thread_metadata_for_source(source)
+
+    assert metadata == {
+        "thread_id": "thread-7",
+        "scope_id": "guild-3",
+        "guild_id": "guild-3",
+        "parent_chat_id": "engineering-chat",
+    }
+
+
+def test_gateway_kanban_create_subscription_uses_routed_source_profile(
+    tmp_path, monkeypatch,
+):
+    """Slash-created subscriptions belong to the routed conversation profile."""
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="slash routed", assignee="peer")
+    finally:
+        conn.close()
+
+    from types import SimpleNamespace
+    from gateway.run import GatewayRunner
+    import hermes_cli.kanban as kanban_cli
+
+    monkeypatch.setattr(
+        kanban_cli,
+        "run_slash",
+        lambda _text: f"Created {task_id}  (ready, assignee=peer)",
+    )
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._kanban_notifier_profile = "default"
+    runner._active_profile_name = lambda: "default"
+    source = SimpleNamespace(
+        platform=Platform.DISCORD,
+        chat_id="engineering-chat",
+        chat_type="channel",
+        thread_id=None,
+        user_id="user-1",
+        user_id_alt=None,
+        guild_id="engineering-guild",
+        scope_id="engineering-guild",
+        parent_chat_id=None,
+        profile="yuki",
+        message_id="message-1",
+    )
+    event = SimpleNamespace(text="/kanban create slash routed", source=source)
+
+    output = asyncio.run(
+        runner._handle_kanban_command(event)  # type: ignore[arg-type]
+    )
+
+    assert "Subscribed" in output or "subscribed" in output
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn, task_id=task_id)
+    finally:
+        conn.close()
+    assert len(subs) == 1
+    assert subs[0]["notifier_profile"] == "yuki"
+    assert subs[0]["delivery_metadata"]["guild_id"] == "engineering-guild"
+
+
+def _make_routed_discord_runner(
+    adapter,
+    *,
+    route_profile="yuki",
+    served_profiles=("default", "yuki"),
+):
+    from gateway.config import GatewayConfig
+    from gateway.profile_routing import parse_profile_routes
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._profile_adapters = {}
+    runner._kanban_sub_fail_counts = {}
+    runner._kanban_dispatcher_lock_handle = None
+    setattr(runner, "_kanban_served_profiles", frozenset(served_profiles))
+    runner._active_profile_name = lambda: "default"
+    runner.config = GatewayConfig(
+        multiplex_profiles=True,
+        profile_routes=parse_profile_routes(
+            [
+                {
+                    "name": "engineering-discord",
+                    "platform": "discord",
+                    "guild_id": "engineering-guild",
+                    "chat_id": "engineering-chat",
+                    "profile": route_profile,
+                }
+            ]
+        ),
+    )
+    return runner
+
+
+def _create_routed_discord_completion(
+    *,
+    board,
+    notifier_profile: str | None = "yuki",
+    chat_id="engineering-chat",
+    chat_type="group",
+    thread_id=None,
+    guild_id="engineering-guild",
+    include_guild_metadata=True,
+):
+    conn = kb.connect(board=board)
+    try:
+        tid = kb.create_task(
+            conn,
+            title="routed engineering task",
+            assignee="worker",
+            session_id=f"agent:yuki:discord:group:{chat_id}:creator",
+        )
+        kb.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform="discord",
+            chat_id=chat_id,
+            chat_type=chat_type,
+            thread_id=thread_id,
+            user_id="creator",
+            notifier_profile=notifier_profile,
+            delivery_mode="notify+wake",
+            delivery_metadata=(
+                {"guild_id": guild_id} if include_guild_metadata else None
+            ),
+        )
+        kb.complete_task(conn, tid, summary="route-aware completion")
+        return tid
+    finally:
+        conn.close()
+
+
+def _unseen_routed_event_count(task_id, chat_id="engineering-chat"):
+    conn = kb.connect()
+    try:
+        _, events = kb.unseen_events_for_sub(
+            conn,
+            task_id=task_id,
+            platform="discord",
+            chat_id=chat_id,
+            kinds=["completed"],
+        )
+        return len(events)
+    finally:
+        conn.close()
+
+
+def test_routed_profile_uses_primary_discord_adapter_on_secondary_board_once(
+    tmp_path, monkeypatch,
+):
+    """An exact profile route owns the primary transport for notify and wake."""
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    kb.create_board("engineering", name="Engineering")
+    tid = _create_routed_discord_completion(board="engineering")
+
+    adapter = RecordingAdapter()
+    runner = _make_routed_discord_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1
+    assert adapter.sent[0]["chat_id"] == "engineering-chat"
+    assert tid in adapter.sent[0]["text"]
+    assert len(adapter.handled) == 1
+    wake_source = adapter.handled[0].source
+    assert wake_source.profile == "yuki"
+    assert wake_source.guild_id == "engineering-guild"
+    assert runner._adapter_for_source(wake_source) is adapter
+
+    from gateway.session import build_session_key
+
+    assert build_session_key(wake_source, profile=wake_source.profile) == (
+        "agent:yuki:discord:group:engineering-chat:creator"
+    )
+
+    # The engineering-board cursor is the dedup boundary: a second tick neither
+    # re-sends the visible completion nor wakes the creator again.
+    runner = _make_routed_discord_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+    assert len(adapter.sent) == 1
+    assert len(adapter.handled) == 1
+
+
+def test_routed_profile_primary_adapter_denies_wrong_or_unmatched_route(
+    tmp_path, monkeypatch,
+):
+    """A primary credential is never a general secondary-profile fallback."""
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "route-denied.db"))
+    kb.init_db()
+    wrong_tid = _create_routed_discord_completion(
+        board=None,
+        notifier_profile="other-profile",
+    )
+    unmatched_tid = _create_routed_discord_completion(
+        board=None,
+        notifier_profile="yuki",
+        chat_id="unrouted-chat",
+    )
+
+    adapter = RecordingAdapter()
+    runner = _make_routed_discord_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert adapter.sent == []
+    assert adapter.handled == []
+    conn = kb.connect()
+    try:
+        for task_id, chat_id in (
+            (wrong_tid, "engineering-chat"),
+            (unmatched_tid, "unrouted-chat"),
+        ):
+            subs = kb.list_notify_subs(conn, task_id)
+            assert len(subs) == 1
+            _, events = kb.unseen_events_for_sub(
+                conn,
+                task_id=task_id,
+                platform="discord",
+                chat_id=chat_id,
+                kinds=["completed"],
+            )
+            assert len(events) == 1, "denied delivery must remain retryable"
+    finally:
+        conn.close()
+
+
+def test_primary_adapter_denies_ownerless_subscription_across_route(
+    tmp_path, monkeypatch,
+):
+    """Legacy ownerless rows cannot bypass a destination's profile route."""
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    task_id = _create_routed_discord_completion(
+        board=None,
+        notifier_profile=None,
+    )
+    adapter = RecordingAdapter()
+    runner = _make_routed_discord_runner(adapter)
+    runner._kanban_dispatcher_lock_handle = object()
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert adapter.sent == []
+    assert adapter.handled == []
+    assert _unseen_routed_event_count(task_id) == 1
+
+
+def test_primary_adapter_denies_route_with_missing_guild_anchor(
+    tmp_path, monkeypatch,
+):
+    """Legacy metadata cannot turn an ambiguous guild route into default ownership."""
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    task_id = _create_routed_discord_completion(
+        board=None,
+        notifier_profile="default",
+        include_guild_metadata=False,
+    )
+    adapter = RecordingAdapter()
+    runner = _make_routed_discord_runner(adapter)
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert adapter.sent == []
+    assert adapter.handled == []
+    assert _unseen_routed_event_count(task_id) == 1
+
+
+def test_primary_adapter_denies_thread_like_route_with_missing_parent_anchor(
+    tmp_path, monkeypatch,
+):
+    """A legacy forum row cannot bypass its unknown parent-channel route."""
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    task_id = _create_routed_discord_completion(
+        board=None,
+        notifier_profile="default",
+        chat_id="forum-post-1",
+        chat_type="forum",
+        thread_id=None,
+    )
+    adapter = RecordingAdapter()
+    runner = _make_routed_discord_runner(adapter)
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert adapter.sent == []
+    assert adapter.handled == []
+    assert _unseen_routed_event_count(task_id, chat_id="forum-post-1") == 1
+
+
+def test_primary_adapter_denies_default_subscription_reassigned_by_route(
+    tmp_path, monkeypatch,
+):
+    """A route to yuki prevents the default bot from delivering that destination."""
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    task_id = _create_routed_discord_completion(
+        board=None,
+        notifier_profile="default",
+    )
+    adapter = RecordingAdapter()
+    runner = _make_routed_discord_runner(adapter)
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert adapter.sent == []
+    assert adapter.handled == []
+    assert _unseen_routed_event_count(task_id) == 1
+
+
+def test_routed_primary_fallback_denies_profile_with_secondary_registry(
+    tmp_path, monkeypatch,
+):
+    """A partial secondary registry cannot silently fall back to the primary bot."""
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    task_id = _create_routed_discord_completion(board=None)
+    adapter = RecordingAdapter()
+    runner = _make_routed_discord_runner(adapter)
+    setattr(
+        runner,
+        "_profile_adapters",
+        {"yuki": {Platform.TELEGRAM: RecordingAdapter()}},
+    )
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert adapter.sent == []
+    assert adapter.handled == []
+    assert _unseen_routed_event_count(task_id) == 1
+
+
+def test_routed_profile_primary_adapter_denies_unserved_route_target(
+    tmp_path, monkeypatch,
+):
+    """A matching route cannot wake a profile this gateway does not serve."""
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "route-unserved.db"))
+    kb.init_db()
+    tid = _create_routed_discord_completion(board=None)
+
+    adapter = RecordingAdapter()
+    runner = _make_routed_discord_runner(
+        adapter,
+        served_profiles=("default",),
+    )
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert adapter.sent == []
+    assert adapter.handled == []
+    conn = kb.connect()
+    try:
+        _, events = kb.unseen_events_for_sub(
+            conn,
+            task_id=tid,
+            platform="discord",
+            chat_id="engineering-chat",
+            kinds=["completed"],
+        )
+    finally:
+        conn.close()
+    assert len(events) == 1
+
+
+def test_true_secondary_adapter_still_owns_its_profile_subscription(
+    tmp_path, monkeypatch,
+):
+    """A live secondary adapter wins; route-aware primary use is only fallback."""
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "secondary.db"))
+    kb.init_db()
+    tid = _create_routed_discord_completion(
+        board=None,
+        chat_id="secondary-only-chat",
+    )
+
+    primary_adapter = RecordingAdapter()
+    secondary_adapter = RecordingAdapter()
+    runner = _make_routed_discord_runner(primary_adapter)
+    runner._profile_adapters = {  # type: ignore[assignment]
+        "yuki": {Platform.DISCORD: secondary_adapter},
+    }
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert primary_adapter.sent == []
+    assert primary_adapter.handled == []
+    assert len(secondary_adapter.sent) == 1
+    assert tid in secondary_adapter.sent[0]["text"]
+    assert len(secondary_adapter.handled) == 1

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -849,6 +849,9 @@ def test_create_subscribes_gateway_session(monkeypatch, worker_env):
     monkeypatch.setenv("HERMES_SESSION_USER_ID", "user-9")
     monkeypatch.setenv("HERMES_SESSION_USER_ID_ALT", "alt-user-9")
     monkeypatch.setenv("HERMES_SESSION_CHAT_TYPE", "forum")
+    monkeypatch.setenv("HERMES_SESSION_PROFILE", "yuki")
+    monkeypatch.setenv("HERMES_SESSION_SCOPE_ID", "guild-3")
+    monkeypatch.setenv("HERMES_SESSION_PARENT_CHAT_ID", "parent-channel-2")
 
     out = kt._handle_create({
         "title": "auto-sub gateway",
@@ -868,6 +871,14 @@ def test_create_subscribes_gateway_session(monkeypatch, worker_env):
     assert s["user_id"] == "user-9"
     assert s["user_id_alt"] == "alt-user-9"
     assert s["chat_type"] == "forum"
+    assert s["notifier_profile"] == "yuki"
+    assert s["delivery_metadata"] == {
+        "thread_id": "thread-7",
+        "chat_type": "forum",
+        "scope_id": "guild-3",
+        "guild_id": "guild-3",
+        "parent_chat_id": "parent-channel-2",
+    }
     assert s["delivery_mode"] == "notify+wake"
 
 

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1578,6 +1578,16 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
             delivery_metadata["thread_id"] = thread_id
         if chat_type:
             delivery_metadata["chat_type"] = chat_type
+        scope_id = get_session_env("HERMES_SESSION_SCOPE_ID", "") or ""
+        if scope_id:
+            delivery_metadata["scope_id"] = scope_id
+            # Discord routes name this platform-neutral scope a guild.
+            delivery_metadata["guild_id"] = scope_id
+        parent_chat_id = (
+            get_session_env("HERMES_SESSION_PARENT_CHAT_ID", "") or ""
+        )
+        if parent_chat_id:
+            delivery_metadata["parent_chat_id"] = parent_chat_id
         if (
             platform.lower() == "telegram"
             and thread_id


### PR DESCRIPTION
## Summary
- authorize Kanban notifier delivery against the subscription destination's exact multiplex profile route
- preserve route anchors and routed profile identity through slash/tool auto-subscribe and synthetic wake sources
- fail closed for unserved profiles, partial secondary adapter registries, ownerless legacy rows, and ambiguous legacy route metadata
- preserve true secondary-profile adapters and per-board cursor deduplication

## Test plan
- `scripts/run_tests.sh tests/gateway/test_kanban_notifier.py tests/gateway/test_kanban_watchers_mixin.py tests/gateway/test_kanban_wake_scope.py tests/gateway/test_kanban_notifier_zero_sub_gate.py tests/gateway/test_multiplex_profile_authz.py tests/gateway/test_profile_routing.py tests/gateway/test_session_context_inheritance.py tests/tools/test_kanban_tools.py tests/tools/test_local_env_session_leak.py -q` (100 passed)
- `ruff check gateway/kanban_watchers.py gateway/run.py gateway/session_context.py gateway/slash_commands.py tools/kanban_tools.py tests/gateway/test_kanban_notifier.py tests/tools/test_kanban_tools.py`
- `git diff --check`