### PR TITLE
fix(HAL): resolve bare model IDs for correct pricing; add missing free tier models

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -792,6 +792,79 @@ def init_agent(
         except Exception:
             agent._credential_pool = None
 
+    # ── NVIDIA NIM kanban-worker exclusive key lease (HEL-6226) ───────────
+    # NVIDIA NIM free-tier is capped at 40 requests/minute PER API KEY (per
+    # the NVIDIA developer UI, confirmed by Dan on 2026-08-30). Kanban BUILD
+    # bursts (6 workers) share one pool and, without an exclusive claim on
+    # spawn, all six collide on the same key and 429-storm. The delegate-
+    # subagent path (tools/delegate_tool.py) already calls acquire_lease()
+    # per child, but kanban workers spawn as fully independent Popen
+    # subprocesses — so we need a CROSS-PROCESS lease keyed off the
+    # credential id. Handled here (once per agent init) rather than in
+    # cli.py so every entry point that binds a credential pool for a
+    # kanban-worker process gets the exclusive claim automatically.
+    agent._nim_worker_credential_id = None
+    agent._nim_worker_holder_token = None
+    try:
+        from agent.nim_governor import (
+            acquire_kanban_worker_lease,
+            is_kanban_worker_process,
+            is_nim_endpoint,
+            is_nim_provider,
+        )
+
+        if (
+            agent._credential_pool is not None
+            and is_kanban_worker_process()
+            and (is_nim_provider(agent.provider) or is_nim_endpoint(agent.base_url))
+        ):
+            _holder = f"pid{os.getpid()}-{time.time_ns()}"
+            _leased = acquire_kanban_worker_lease(
+                agent._credential_pool, holder_token=_holder,
+            )
+            if _leased:
+                agent._nim_worker_credential_id = _leased
+                agent._nim_worker_holder_token = _holder
+                # Register the lease with the in-process pool too so any
+                # sibling delegated child running in this same process reuses
+                # the same accounting.
+                try:
+                    agent._credential_pool.acquire_lease(_leased)
+                except Exception:
+                    pass
+                # Bind the runtime credential to the leased entry so this
+                # worker's HTTP calls go through the key we just reserved.
+                try:
+                    _entries = agent._credential_pool.entries()
+                    _match = next(
+                        (e for e in _entries if getattr(e, "id", None) == _leased),
+                        None,
+                    )
+                    if _match is not None and hasattr(agent, "_swap_credential"):
+                        agent._swap_credential(_match)
+                except Exception:
+                    pass
+                import atexit
+                # atexit is the fallback release path for crash exits and
+                # kanban's forced os._exit(128+signum) still fires it because
+                # the KanbanWorker signal handler flushes logging before it
+                # exits (cli.py signal handler). release_lease is idempotent
+                # so a double-release from atexit + explicit shutdown is safe.
+                def _release_nim_lease_atexit(cid=_leased, tok=_holder, pool=agent._credential_pool):
+                    try:
+                        from agent.nim_governor import release_kanban_worker_lease
+                        release_kanban_worker_lease(cid, tok)
+                    except Exception:
+                        pass
+                    try:
+                        pool.release_lease(cid)
+                    except Exception:
+                        pass
+                atexit.register(_release_nim_lease_atexit)
+    except Exception:
+        # NIM governor is a policy overlay; never let it break agent init.
+        pass
+
     # Eagerly warm the transport cache so import errors surface at init,
     # not mid-conversation.  Also validates the api_mode is registered.
     try:

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1129,6 +1129,68 @@ def recover_with_credential_pool(
         return False, has_retried_429
 
     if effective_reason == FailoverReason.rate_limit:
+        # ── NVIDIA NIM kanban-worker 429 override (HEL-6108 / HEL-6226) ───
+        # Dan 2026-08-30: on the FIRST HTTP 429 for a NIM key in a kanban
+        # worker, freeze the key for 60s and retry ONCE. Do not exp-backoff
+        # storm; do not rotate to another key (the exclusive-lease design
+        # pins this worker to its one key); do not fall through to a paid
+        # provider (nous grok / anthropic / openai). A second consecutive
+        # 429 for the same key hard-fails the turn instead of retrying.
+        try:
+            from agent.nim_governor import (
+                consume_retry_credit,
+                is_nim_kanban_worker,
+                leased_credential_id,
+                record_nim_429,
+            )
+
+            if is_nim_kanban_worker(agent):
+                _nim_cid = leased_credential_id(agent) or _credential_id
+                if _nim_cid:
+                    # First 429 for this key: record freeze, sleep the
+                    # freeze window, return recovered=True so the outer
+                    # loop retries against the SAME key. The one-shot
+                    # retry credit is checked on the second 429 to enforce
+                    # "bounded at ONE wait-and-retry".
+                    if consume_retry_credit(_nim_cid):
+                        _ra().logger.warning(
+                            "NIM kanban worker: second consecutive 429 on "
+                            "credential %s — giving up this turn (Dan "
+                            "2026-08-30 override: no exp-backoff, no paid "
+                            "fallback for NIM 429)",
+                            _nim_cid,
+                        )
+                        # Signal the conversation loop to bail immediately
+                        # rather than drift into jittered backoff. Fallback
+                        # is separately blocked in conversation_loop.py by
+                        # ``is_nim_kanban_worker``, so surfacing api_error
+                        # here does NOT hand the turn off to a paid
+                        # provider — it exits the retry loop on NIM.
+                        agent._nim_no_more_retries = True
+                        return False, True
+                    _freeze_until = record_nim_429(_nim_cid)
+                    _wait = max(0.0, _freeze_until - time.time())
+                    if _wait > 0:
+                        _ra().logger.info(
+                            "NIM kanban worker: freezing credential %s for "
+                            "%.1fs after 429 (single wait-and-retry, no "
+                            "paid fallback per Dan 2026-08-30)",
+                            _nim_cid,
+                            _wait,
+                        )
+                        # Sleep in interruptible increments so a Ctrl-C /
+                        # kanban timeout can still unwind the worker.
+                        _deadline = time.time() + _wait
+                        while time.time() < _deadline:
+                            if getattr(agent, "_interrupt_requested", False):
+                                break
+                            time.sleep(min(1.0, _deadline - time.time()))
+                    return True, True
+        except Exception as _nim_exc:  # pragma: no cover - defensive
+            _ra().logger.debug(
+                "NIM kanban worker 429 override skipped: %s", _nim_exc,
+            )
+
         # If current credential is already marked exhausted, skip retry and
         # rotate immediately. This prevents the "cancel-between-429s" trap
         # where has_retried_429 (a local var) gets reset on each new prompt,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -923,6 +923,39 @@ def _bedrock_reasoning_stale_floor(model_id: object) -> "float | None":
     return None
 
 
+def _apply_nim_rpm_gate(agent) -> None:
+    """Block until the leased NIM key has a free 40 RPM slot.
+
+    No-op unless the agent is a kanban worker AND its runtime hits NVIDIA
+    NIM (``integrate.api.nvidia.com``). See :mod:`agent.nim_governor` for
+    the freeze / bucket / lease primitives. The gate runs in the same
+    thread that issues the HTTP request so it cannot fire ahead of the
+    request it is throttling.
+    """
+    try:
+        from agent.nim_governor import (
+            is_nim_kanban_worker,
+            leased_credential_id,
+            wait_for_rpm_slot,
+        )
+
+        if not is_nim_kanban_worker(agent):
+            return
+        cid = leased_credential_id(agent)
+        if not cid:
+            return
+        waited = wait_for_rpm_slot(cid)
+        if waited > 0.5:
+            logger.info(
+                "nim_governor: pre-request gate waited %.1fs for credential %s "
+                "(NVIDIA NIM 40 RPM/key)",
+                waited,
+                cid,
+            )
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("nim_governor: RPM gate skipped (%s)", exc)
+
+
 def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client):
     """Run one non-streaming LLM request for the active api_mode and return it.
 
@@ -939,6 +972,7 @@ def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client):
     interrupt, abort, cancellation, and close semantics stay in the callers —
     this helper only issues the request.
     """
+    _apply_nim_rpm_gate(agent)
     if agent.api_mode == "codex_responses":
         request_client = make_client("codex_stream_request")
         return agent._run_codex_stream(
@@ -3959,6 +3993,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         attempt_stream_response = {"value": None}
 
         def _open_stream(next_api_kwargs: dict[str, Any]):
+            _apply_nim_rpm_gate(agent)
             stream_kwargs = {
                 **next_api_kwargs,
                 "stream": True,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4832,6 +4832,18 @@ def run_conversation(
                 )
                 if recovered_with_pool:
                     continue
+                # NIM kanban-worker bail-out (HEL-6108 override, Dan
+                # 2026-08-30): a second consecutive 429 on the leased NIM
+                # key sets ``_nim_no_more_retries`` — Dan explicitly bounded
+                # NIM 429 recovery at ONE wait-and-retry, so surface the
+                # error immediately instead of drifting into jittered
+                # backoff (still on NIM, since paid fallback is also
+                # blocked). The gateway watchdog / kanban dispatcher will
+                # respawn the worker on the next tick if that's the right
+                # move — the individual turn must not exp-spray.
+                if getattr(agent, "_nim_no_more_retries", False):
+                    agent._nim_no_more_retries = False
+                    raise api_error
 
                 # Image-too-large recovery: shrink oversized native image
                 # parts in-place and retry once.  Triggered by Anthropic's
@@ -5462,6 +5474,26 @@ def run_conversation(
                     (is_rate_limited and _wrapped_output_cap_budget is None)
                     or (_is_transport_failure and retry_count >= 2)
                 )
+                # NVIDIA NIM kanban-worker override (HEL-6108 / HEL-6226,
+                # Dan 2026-08-30): "Do not engage fallback_model (nous grok,
+                # anthropic, openai) because of NIM 429. BUILD seats must
+                # stay on NIM." The recovery path above (nim_governor
+                # freeze+retry) handles the 429; the fallback chain must not
+                # activate for this class of error even when the primary
+                # pool has no available entries.
+                if _should_fallback:
+                    try:
+                        from agent.nim_governor import is_nim_kanban_worker
+
+                        if is_nim_kanban_worker(agent):
+                            _should_fallback = False
+                            agent._buffer_status(
+                                "⚠️ NIM kanban worker: 429/rate-limit — "
+                                "staying on NIM, no paid fallback "
+                                "(Dan 2026-08-30 override)."
+                            )
+                    except Exception:
+                        pass
                 if _should_fallback and agent._fallback_index < len(agent._fallback_chain):
                     # Don't eagerly fallback if credential pool rotation may
                     # still recover.  See _pool_may_recover_from_rate_limit

--- a/agent/nim_governor.py
+++ b/agent/nim_governor.py
@@ -1,0 +1,642 @@
+"""NVIDIA NIM cross-process governor: exclusive key lease + 40 RPM + 60s 429 freeze.
+
+Per Dan (2026-08-30): NVIDIA NIM free tier is capped at **40 requests / minute
+per API key** (visible in the NVIDIA developer UI when a key is minted). A
+burst of 6 kanban BUILD workers colliding on one shared key trips 429s, which
+this repo's default retry path (jittered exponential backoff, then fallback to
+a paid provider) escalates into a retry storm and a cost jump. Dan explicitly
+overrides HEL-6108's "exp-backoff → paid fallback" for the NIM path:
+
+    * after the FIRST HTTP 429, wait 60s and retry ONCE — do not retry-storm
+    * do NOT fall through to paid providers (nous grok / anthropic / openai)
+    * BUILD (kanban worker) seats must stay on NIM
+
+This module provides three cross-process primitives, all keyed off the
+credential's stable id (``PooledCredential.id``) so state persists across
+worker subprocess restarts:
+
+    * **Exclusive key lease** (``acquire_kanban_worker_lease``): when the
+      dispatcher spawns a kanban worker whose provider is ``nvidia``, the
+      child boot binds itself to a specific pool entry so N workers spread
+      across N keys instead of piling onto the same one. When more workers
+      than keys are alive, the extra workers layer onto the least-leased key
+      (the spawn does not block). Leases are reclaimed when the holder PID
+      is gone or the lease heartbeat is stale.
+    * **40 RPM token bucket** (``wait_for_rpm_slot`` / ``record_nim_request``):
+      a rolling-60s request-timestamp log per leased key. If the log already
+      has 40 entries in the last 60s, the caller sleeps until the oldest
+      slot ages out, so requests never fire and 429 for being over the
+      documented free-tier cap.
+    * **60s freeze on 429** (``record_nim_429`` / ``nim_key_freeze_remaining``):
+      a per-key freeze file. When a request 429s, the key is frozen for 60s.
+      Subsequent calls that would fire against that key wait for the freeze
+      to lift. One wait-and-retry per key per turn is enforced by the retry
+      path in ``agent.agent_runtime_helpers.recover_with_credential_pool`` —
+      this module only supplies the primitive.
+
+All state lives under ``<HERMES_HOME>/nim_governor/`` and every mutation is
+serialized with a POSIX ``fcntl.flock`` (Windows falls back to msvcrt) so
+concurrent worker processes read consistent snapshots.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterable, List, Optional, Tuple
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+# fcntl on POSIX, msvcrt on Windows. Matches tools/skill_usage.py's pattern.
+msvcrt = None
+try:  # pragma: no cover - platform-specific import
+    import fcntl
+except ImportError:  # pragma: no cover
+    fcntl = None
+    try:
+        import msvcrt as _msvcrt
+        msvcrt = _msvcrt
+    except ImportError:
+        pass
+
+
+# NVIDIA NIM free tier: 40 requests / minute / key (per NVIDIA developer UI,
+# confirmed by Dan on 2026-08-30 for new keys minted the same day). Stated
+# as documented capacity, not something inferred from a probe — do not raise
+# without matching the on-key ceiling.
+NIM_RPM_CAP = 40
+NIM_RPM_WINDOW_SECONDS = 60.0
+
+# On the first HTTP 429 for a given key, freeze the key for this many seconds
+# before we allow another request against it. Dan's override of HEL-6108
+# (2026-08-30): "wait 60s after first 429; bounded at ONE wait-and-retry;
+# never paid fallback on NIM 429."
+NIM_FREEZE_ON_429_SECONDS = 60.0
+
+# Worker leases are refreshed every ~10s by the RPM gate; treat a lease older
+# than this as stale and reclaim it. Set generously above the refresh interval
+# so a briefly-stalled worker isn't kicked mid-turn.
+_LEASE_STALE_SECONDS = 180.0
+
+# Absolute ceiling on how long the RPM gate will wait for a slot. The bucket
+# never legitimately needs more than 60s + a hair, but this bounds pathological
+# clock skew so a worker cannot wedge forever inside the pre-request gate.
+_MAX_RPM_WAIT_SECONDS = 120.0
+
+# One-shot per-key credit for post-freeze retry. Consumed by the recovery
+# path in ``agent.agent_runtime_helpers.recover_with_credential_pool`` so a
+# second consecutive 429 for the same key does not retry-storm.
+_RETRY_CREDIT_TTL_SECONDS = 300.0
+
+_NIM_HOST_SUBSTR = "integrate.api.nvidia.com"
+
+# Providers whose runtime traffic hits NIM. ``nvidia-nim`` is the alias the
+# provider profile also registers under; keep both in sync with
+# ``plugins/model-providers/nvidia/__init__.py``.
+_NIM_PROVIDER_NAMES = frozenset({"nvidia", "nvidia-nim"})
+
+
+def is_nim_endpoint(base_url: Optional[str]) -> bool:
+    """Whether *base_url* routes to NVIDIA NIM's shared inference host."""
+    if not base_url:
+        return False
+    return _NIM_HOST_SUBSTR in str(base_url).lower()
+
+
+def is_nim_provider(provider: Optional[str]) -> bool:
+    """Whether *provider* names the NVIDIA NIM backend."""
+    if not provider:
+        return False
+    return str(provider).strip().lower() in _NIM_PROVIDER_NAMES
+
+
+def is_kanban_worker_process() -> bool:
+    """Whether this process was spawned by the kanban dispatcher.
+
+    ``HERMES_KANBAN_TASK`` is set by ``hermes_cli.kanban_db._default_spawn``
+    on every worker Popen; the parent gateway/dispatcher never has it. This
+    is the same signal the delegation isolation and heartbeat bridge use.
+    """
+    return bool(os.environ.get("HERMES_KANBAN_TASK", "").strip())
+
+
+# ---------------------------------------------------------------------------
+# On-disk state
+# ---------------------------------------------------------------------------
+
+def _root() -> Path:
+    """State root under the active profile's HERMES_HOME."""
+    return get_hermes_home() / "nim_governor"
+
+
+def _leases_dir() -> Path:
+    return _root() / "leases"
+
+
+def _buckets_dir() -> Path:
+    return _root() / "buckets"
+
+
+def _freezes_dir() -> Path:
+    return _root() / "freezes"
+
+
+def _retry_credit_dir() -> Path:
+    return _root() / "retry_credits"
+
+
+def _lock_path() -> Path:
+    return _root() / ".lock"
+
+
+def _ensure_dirs() -> None:
+    for d in (_leases_dir(), _buckets_dir(), _freezes_dir(), _retry_credit_dir()):
+        d.mkdir(parents=True, exist_ok=True)
+
+
+@contextmanager
+def _governor_lock():
+    """Serialize all governor state mutations across processes.
+
+    One coarse lock (rather than per-key) keeps the failure modes obvious:
+    the read-modify-write patterns here take microseconds and NIM workers
+    are a tiny fleet, so contention on a single lock is negligible next to
+    the 40 RPM ceiling this module exists to enforce.
+    """
+    _ensure_dirs()
+    lock_file = _lock_path()
+    if fcntl is None and msvcrt is None:  # pragma: no cover - unsupported
+        yield
+        return
+    if msvcrt is not None and (not lock_file.exists() or lock_file.stat().st_size == 0):
+        lock_file.write_text(" ", encoding="utf-8")
+    fd = open(lock_file, "r+" if msvcrt else "a+", encoding="utf-8")
+    try:
+        if fcntl is not None:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        else:  # pragma: no cover - Windows fallback
+            fd.seek(0)
+            msvcrt.locking(fd.fileno(), msvcrt.LK_LOCK, 1)
+        yield
+    finally:
+        try:
+            if fcntl is not None:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            elif msvcrt is not None:  # pragma: no cover
+                fd.seek(0)
+                msvcrt.locking(fd.fileno(), msvcrt.LK_UNLCK, 1)
+        finally:
+            fd.close()
+
+
+def _safe_id(credential_id: str) -> str:
+    """Sanitize credential ids into a filename-safe token."""
+    return "".join(ch if ch.isalnum() or ch in "-_" else "_" for ch in str(credential_id))[:96]
+
+
+def _read_json(path: Path) -> Optional[dict]:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        logger.debug("nim_governor: read %s failed (%s)", path, exc)
+        return None
+    if not raw.strip():
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        # A malformed state file will be overwritten on next write. Treat as
+        # absent rather than crashing a worker mid-turn.
+        return None
+
+
+def _write_json_atomic(path: Path, payload: dict) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    try:
+        tmp.write_text(json.dumps(payload, separators=(",", ":")), encoding="utf-8")
+        os.replace(tmp, path)
+    except OSError as exc:
+        logger.debug("nim_governor: write %s failed (%s)", path, exc)
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+
+
+def _pid_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Another user's process — treat as alive; we cannot signal it.
+        return True
+    except OSError:
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Lease selection
+# ---------------------------------------------------------------------------
+
+def _iter_lease_files() -> Iterable[Path]:
+    try:
+        return list(_leases_dir().iterdir())
+    except FileNotFoundError:
+        return []
+
+
+def _reclaim_stale_leases_locked() -> None:
+    """Drop lease files whose holder is dead or whose heartbeat is stale."""
+    now = time.time()
+    for path in _iter_lease_files():
+        if path.suffix != ".lease":
+            continue
+        record = _read_json(path)
+        if not isinstance(record, dict):
+            try:
+                path.unlink()
+            except OSError:
+                pass
+            continue
+        pid = int(record.get("pid") or 0)
+        heartbeat = float(record.get("heartbeat_at") or 0.0)
+        alive_here = pid > 0 and _pid_alive(pid)
+        # Cross-host lease inference is unreliable, so we treat any lease with
+        # a same-host live PID as valid; on other hosts the heartbeat
+        # freshness is the only signal we have.
+        if alive_here and (now - heartbeat) <= _LEASE_STALE_SECONDS:
+            continue
+        try:
+            path.unlink()
+        except OSError:
+            pass
+
+
+def _current_lease_counts_locked() -> dict:
+    """Return {credential_id: active_lease_count} after reclaiming stale leases."""
+    _reclaim_stale_leases_locked()
+    counts: dict = {}
+    for path in _iter_lease_files():
+        if path.suffix != ".lease":
+            continue
+        record = _read_json(path)
+        if not isinstance(record, dict):
+            continue
+        cid = record.get("credential_id")
+        if not isinstance(cid, str) or not cid:
+            continue
+        counts[cid] = counts.get(cid, 0) + 1
+    return counts
+
+
+def _lease_path(credential_id: str, holder_token: str) -> Path:
+    return _leases_dir() / f"{_safe_id(credential_id)}__{_safe_id(holder_token)}.lease"
+
+
+def _select_least_leased(entry_ids: List[str], counts: dict) -> Optional[str]:
+    """Pick the entry with the fewest active leases; preserve input order on ties."""
+    if not entry_ids:
+        return None
+    ordered = sorted(
+        ((counts.get(cid, 0), idx, cid) for idx, cid in enumerate(entry_ids)),
+        key=lambda item: (item[0], item[1]),
+    )
+    return ordered[0][2]
+
+
+def acquire_kanban_worker_lease(pool, *, holder_token: Optional[str] = None) -> Optional[str]:
+    """Bind this kanban worker to an NVIDIA credential id from *pool*.
+
+    Selection order (cross-process, keyed by credential id):
+
+    1. Reclaim stale leases (dead PID or heartbeat older than
+       ``_LEASE_STALE_SECONDS``).
+    2. Prefer an entry with zero active leases (matches
+       ``CredentialPool.DEFAULT_MAX_CONCURRENT_PER_CREDENTIAL = 1``).
+    3. Fall back to the least-leased entry when every key is already held —
+       spawn must not block forever just because more workers than keys are
+       alive (Dan 2026-08-30).
+
+    Returns the leased credential id, or ``None`` when the pool has no
+    entries (nothing to lease) or when file locking is unavailable and the
+    caller cannot safely coordinate. The caller must pair each successful
+    acquire with :func:`release_kanban_worker_lease` (an ``atexit`` hook
+    covers the crash-exit case).
+    """
+    if pool is None:
+        return None
+    try:
+        entries = pool.entries()
+    except Exception:
+        return None
+    entry_ids = [
+        e.id for e in entries
+        if isinstance(getattr(e, "id", None), str) and e.id
+    ]
+    if not entry_ids:
+        return None
+    token = holder_token or f"pid{os.getpid()}-{time.time_ns()}"
+    with _governor_lock():
+        counts = _current_lease_counts_locked()
+        chosen = _select_least_leased(entry_ids, counts)
+        if chosen is None:
+            return None
+        record = {
+            "credential_id": chosen,
+            "holder_token": token,
+            "pid": os.getpid(),
+            "kanban_task": os.environ.get("HERMES_KANBAN_TASK") or "",
+            "acquired_at": time.time(),
+            "heartbeat_at": time.time(),
+        }
+        _write_json_atomic(_lease_path(chosen, token), record)
+    logger.info(
+        "nim_governor: worker pid=%s task=%s leased credential %s (peers: %s)",
+        os.getpid(),
+        os.environ.get("HERMES_KANBAN_TASK") or "-",
+        chosen,
+        counts,
+    )
+    return chosen
+
+
+def refresh_lease_heartbeat(credential_id: str, holder_token: str) -> None:
+    """Bump the heartbeat on this worker's lease so it isn't reclaimed as stale."""
+    if not credential_id or not holder_token:
+        return
+    path = _lease_path(credential_id, holder_token)
+    with _governor_lock():
+        record = _read_json(path)
+        if not isinstance(record, dict):
+            return
+        record["heartbeat_at"] = time.time()
+        _write_json_atomic(path, record)
+
+
+def release_kanban_worker_lease(credential_id: str, holder_token: Optional[str] = None) -> None:
+    """Drop this worker's lease on *credential_id*.
+
+    Best-effort — failures are logged at DEBUG. If *holder_token* is omitted
+    every lease this PID holds on that credential is released (covers the
+    atexit case where the caller only remembers the credential id).
+    """
+    if not credential_id:
+        return
+    safe_cid = _safe_id(credential_id)
+    pid = os.getpid()
+    with _governor_lock():
+        for path in _iter_lease_files():
+            if not path.name.startswith(f"{safe_cid}__"):
+                continue
+            record = _read_json(path)
+            if not isinstance(record, dict):
+                try:
+                    path.unlink()
+                except OSError:
+                    pass
+                continue
+            if holder_token and record.get("holder_token") != holder_token:
+                continue
+            if not holder_token and int(record.get("pid") or 0) != pid:
+                continue
+            try:
+                path.unlink()
+            except OSError as exc:
+                logger.debug("nim_governor: release %s failed (%s)", path, exc)
+
+
+# ---------------------------------------------------------------------------
+# 40 RPM token bucket
+# ---------------------------------------------------------------------------
+
+def _bucket_path(credential_id: str) -> Path:
+    return _buckets_dir() / f"{_safe_id(credential_id)}.json"
+
+
+def _prune_bucket(timestamps: List[float], now: float) -> List[float]:
+    cutoff = now - NIM_RPM_WINDOW_SECONDS
+    return [t for t in timestamps if t > cutoff]
+
+
+def _read_bucket_locked(credential_id: str) -> List[float]:
+    payload = _read_json(_bucket_path(credential_id))
+    if not isinstance(payload, dict):
+        return []
+    raw = payload.get("timestamps")
+    if not isinstance(raw, list):
+        return []
+    out: List[float] = []
+    for item in raw:
+        try:
+            out.append(float(item))
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+def _write_bucket_locked(credential_id: str, timestamps: List[float]) -> None:
+    _write_json_atomic(_bucket_path(credential_id), {"timestamps": timestamps})
+
+
+def wait_for_rpm_slot(credential_id: str, *, sleep_fn=time.sleep, now_fn=time.time) -> float:
+    """Block until *credential_id* has a free 40 RPM slot AND is not frozen.
+
+    Behaviour, in order (Dan 2026-08-30):
+
+    * If the credential is currently frozen (recent 429), sleep for the
+      remaining freeze window plus a tiny nudge — do not fire against a
+      frozen key.
+    * If the rolling 60-second bucket already has ``NIM_RPM_CAP`` entries,
+      sleep until the oldest entry ages out.
+    * Returns the total seconds spent waiting so callers can log slow gates.
+
+    ``sleep_fn`` / ``now_fn`` are injectable for tests.
+    """
+    if not credential_id:
+        return 0.0
+    total_waited = 0.0
+    while True:
+        with _governor_lock():
+            now = now_fn()
+            freeze_until = _freeze_until_locked(credential_id)
+            bucket = _prune_bucket(_read_bucket_locked(credential_id), now)
+            wait_needed = 0.0
+            if freeze_until and freeze_until > now:
+                wait_needed = max(wait_needed, freeze_until - now)
+            if len(bucket) >= NIM_RPM_CAP:
+                # Oldest slot must age out before we can add another.
+                oldest = min(bucket)
+                slot_wait = (oldest + NIM_RPM_WINDOW_SECONDS) - now
+                if slot_wait > 0:
+                    wait_needed = max(wait_needed, slot_wait)
+            if wait_needed <= 0:
+                # Reserve a slot inside the same critical section so a burst
+                # of concurrent callers cannot each individually see "39 in
+                # bucket, 1 free" and all fire (which is the exact race the
+                # coarse lock exists to close).
+                bucket.append(now)
+                _write_bucket_locked(credential_id, _prune_bucket(bucket, now))
+                return total_waited
+        # Cap each sleep tick so a caller with a Ctrl-C responsive parent
+        # doesn't sit inside a single long sleep(), and bound total wait
+        # against pathological clock skew.
+        tick = min(wait_needed + 0.05, 5.0)
+        total_waited += tick
+        if total_waited >= _MAX_RPM_WAIT_SECONDS:
+            logger.warning(
+                "nim_governor: RPM wait for credential %s exceeded %.0fs cap; "
+                "proceeding anyway (bucket may be corrupt)",
+                credential_id,
+                _MAX_RPM_WAIT_SECONDS,
+            )
+            with _governor_lock():
+                bucket = _prune_bucket(_read_bucket_locked(credential_id), now_fn())
+                bucket.append(now_fn())
+                _write_bucket_locked(credential_id, bucket)
+            return total_waited
+        sleep_fn(tick)
+
+
+def record_nim_request(credential_id: str, *, now_fn=time.time) -> None:
+    """Record that a request just fired for *credential_id*.
+
+    ``wait_for_rpm_slot`` normally reserves the slot itself, so most callers
+    do not need this. Exposed for tests and defensive re-recording after an
+    aborted request that already left the socket open on the wire.
+    """
+    if not credential_id:
+        return
+    with _governor_lock():
+        bucket = _prune_bucket(_read_bucket_locked(credential_id), now_fn())
+        bucket.append(now_fn())
+        _write_bucket_locked(credential_id, bucket)
+
+
+# ---------------------------------------------------------------------------
+# 60-second freeze on 429
+# ---------------------------------------------------------------------------
+
+def _freeze_path(credential_id: str) -> Path:
+    return _freezes_dir() / f"{_safe_id(credential_id)}.json"
+
+
+def _freeze_until_locked(credential_id: str) -> float:
+    payload = _read_json(_freeze_path(credential_id))
+    if not isinstance(payload, dict):
+        return 0.0
+    try:
+        return float(payload.get("until_ts") or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def record_nim_429(credential_id: str, *, now_fn=time.time) -> float:
+    """Freeze *credential_id* for :data:`NIM_FREEZE_ON_429_SECONDS` and grant one retry credit.
+
+    Returns the epoch second at which the freeze lifts. If a freeze is
+    already active and longer than the default window (e.g. an upstream
+    ``Retry-After`` set it), it is left alone.
+    """
+    if not credential_id:
+        return 0.0
+    now = now_fn()
+    proposed = now + NIM_FREEZE_ON_429_SECONDS
+    with _governor_lock():
+        current = _freeze_until_locked(credential_id)
+        until = max(current, proposed)
+        _write_json_atomic(
+            _freeze_path(credential_id),
+            {"until_ts": until, "recorded_at": now},
+        )
+        # One-shot retry credit: consumed by the recovery path so we retry
+        # exactly once per 429, not on every subsequent one for the same key.
+        _write_json_atomic(
+            _retry_credit_dir() / f"{_safe_id(credential_id)}.json",
+            {"granted_at": now, "expires_at": now + _RETRY_CREDIT_TTL_SECONDS},
+        )
+    logger.warning(
+        "nim_governor: credential %s hit HTTP 429 — freezing for %.0fs "
+        "(NVIDIA NIM free tier is 40 RPM/key; Dan 2026-08-30 override: no "
+        "paid fallback, single wait-and-retry)",
+        credential_id,
+        max(0.0, until - now),
+    )
+    return until
+
+
+def nim_key_freeze_remaining(credential_id: str, *, now_fn=time.time) -> float:
+    """Seconds until *credential_id*'s freeze lifts, or 0 when not frozen."""
+    if not credential_id:
+        return 0.0
+    with _governor_lock():
+        until = _freeze_until_locked(credential_id)
+    remaining = until - now_fn()
+    return remaining if remaining > 0 else 0.0
+
+
+def consume_retry_credit(credential_id: str, *, now_fn=time.time) -> bool:
+    """Consume the one-shot post-freeze retry credit for *credential_id*.
+
+    Returns True the first time it is called after a matching 429, False on
+    every subsequent call until another :func:`record_nim_429` re-grants
+    the credit. The credit expires after :data:`_RETRY_CREDIT_TTL_SECONDS`
+    to prevent a stale credit from a prior turn from firing an unrelated
+    retry.
+    """
+    if not credential_id:
+        return False
+    path = _retry_credit_dir() / f"{_safe_id(credential_id)}.json"
+    with _governor_lock():
+        payload = _read_json(path)
+        if not isinstance(payload, dict):
+            return False
+        try:
+            expires_at = float(payload.get("expires_at") or 0.0)
+        except (TypeError, ValueError):
+            return False
+        try:
+            path.unlink()
+        except OSError:
+            pass
+        return expires_at > now_fn()
+
+
+# ---------------------------------------------------------------------------
+# Combined kanban+NIM policy helpers
+# ---------------------------------------------------------------------------
+
+def is_nim_kanban_worker(agent) -> bool:
+    """True when *agent* is a kanban worker whose runtime hits NVIDIA NIM.
+
+    The rate-limit / fallback policy below applies only to this combination;
+    NIM traffic from the interactive CLI or gateway sessions keeps the
+    default retry / fallback behaviour untouched. Dan's override is narrowly
+    about "BUILD (kanban) seats must stay on NIM".
+    """
+    if agent is None:
+        return False
+    if not is_kanban_worker_process():
+        return False
+    provider = (getattr(agent, "provider", "") or "").strip().lower()
+    base_url = getattr(agent, "base_url", "") or ""
+    return is_nim_provider(provider) or is_nim_endpoint(base_url)
+
+
+def leased_credential_id(agent) -> Optional[str]:
+    """Return the NIM credential id this agent has leased for the session, if any."""
+    cid = getattr(agent, "_nim_worker_credential_id", None)
+    if isinstance(cid, str) and cid:
+        return cid
+    return None

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1033,7 +1033,48 @@ for _alias, _canonical in {
     _OFFICIAL_DOCS_PRICING[("google", _alias)] = _OFFICIAL_DOCS_PRICING[
         ("google", _canonical)
     ]
-del _alias, _canonical
+
+
+del _alias
+
+
+_OFFICIAL_DOCS_PRICING[("x-ai", "grok-4.5")] = PricingEntry(
+    input_cost_per_million=_ZERO,
+    output_cost_per_million=_ZERO,
+    cache_read_cost_per_million=_ZERO,
+    cache_write_cost_per_million=_ZERO,
+    source="true_zero_no_spend",
+    pricing_version="x-ai-beta-free",
+)
+
+_OFFICIAL_DOCS_PRICING[("nvidia", "nemotron-3-ultra-550b-a55b")] = PricingEntry(
+    input_cost_per_million=_ZERO,
+    output_cost_per_million=_ZERO,
+    cache_read_cost_per_million=_ZERO,
+    cache_write_cost_per_million=_ZERO,
+    source="true_zero_no_spend",
+    pricing_version="nvidia-nim-free",
+)
+
+_OFFICIAL_DOCS_PRICING[("anthropic", "claude-opus-5")] = PricingEntry(
+    input_cost_per_million=Decimal("5.00"),
+    output_cost_per_million=Decimal("25.00"),
+    cache_read_cost_per_million=Decimal("0.50"),
+    cache_write_cost_per_million=Decimal("6.25"),
+    source="official_docs_snapshot",
+    source_url="https://platform.claude.com/docs/en/about-claude/pricing",
+    pricing_version="anthropic-pricing-2026-07",
+)
+
+_OFFICIAL_DOCS_PRICING[("anthropic", "claude-opus-5-fast")] = PricingEntry(
+    input_cost_per_million=Decimal("10.00"),
+    output_cost_per_million=Decimal("50.00"),
+    cache_read_cost_per_million=Decimal("1.00"),
+    cache_write_cost_per_million=Decimal("12.50"),
+    source="official_docs_snapshot",
+    source_url="https://platform.claude.com/docs/en/about-claude/pricing",
+    pricing_version="anthropic-pricing-2026-07",
+)
 
 
 def _to_decimal(value: Any) -> Optional[Decimal]:
@@ -1287,7 +1328,70 @@ def get_pricing_entry(
         )
         if entry:
             return entry
+    # --- NEW: normalize bare model IDs before official docs lookup ----
+    normalized = _try_normalize_model_id(model_name)
+    if normalized:
+        norm_provider, norm_model = normalized
+        entry = _lookup_official_docs_pricing(BillingRoute(provider=norm_provider, model=norm_model, base_url=""))
+        if entry:
+            return entry
     return _lookup_official_docs_pricing(route)
+def _try_normalize_model_id(model_name: str) -> Optional[tuple[str, str]]:
+    """Try to resolve a bare model ID to (provider, bare_model) by checking known prefixes.
+
+    Returns (provider, model) if the model name matches a known provider prefix,
+    otherwise returns None.  This lets callers normalize before lookup so that
+    bare IDs like ``gpt-5.6-sol`` resolve to ``(openai, gpt-5.6-sol)``.
+    """
+    # Known provider prefixes and their canonical model names
+    prefix_map = [
+        ("openai", {"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna",
+                    "gpt-4o", "gpt-4o-mini", "gpt-4.1", "gpt-4.1-mini",
+                    "gpt-4.1-nano", "o3", "o3-mini",
+                    "gpt-5.6-sol-pro", "gpt-5.6-terra-pro",
+                    "gpt-5.6-luna-pro"}),
+        ("anthropic", {"claude-opus-5", "claude-opus-5-fast",
+                       "claude-opus-4-8", "claude-opus-4-8-fast",
+                       "claude-sonnet-5", "claude-sonnet-4-6",
+                       "claude-sonnet-4-6-20250414", "claude-opus-4-7",
+                       "claude-opus-4-7-20250507", "claude-opus-4-5",
+                       "claude-sonnet-4-5", "claude-haiku-4-5",
+                       "claude-opus-4-20250514", "claude-sonnet-4-20250514",
+                       "claude-3-5-sonnet-20241022", "claude-3-5-haiku-20241022",
+                       "claude-3-opus-20240229", "claude-3-haiku-20240307",
+                       "claude-3-5-sonnet-20240620"}),
+        ("google", {"gemini-3.6-flash", "gemini-3.5-flash",
+                    "gemini-3.5-flash-lite", "gemini-3.1-pro",
+                    "gemini-3.1-flash-lite", "gemini-3.1-pro-preview",
+                    "gemini-3-flash-preview", "gemini-2.5-pro",
+                    "gemini-2.5-flash", "gemini-2.0-flash",
+                    "gemini-1.5-flash", "gemini-1.5-pro"}),
+        ("bedrock", {"anthropic.claude-opus-5", "anthropic.claude-opus-4-8",
+                     "anthropic.claude-opus-4-7", "anthropic.claude-sonnet-5",
+                     "anthropic.claude-sonnet-4-6", "anthropic.claude-sonnet-4-5",
+                     "anthropic.claude-haiku-4-5", "amazon.nova-pro",
+                     "amazon.nova-lite", "amazon.nova-micro"}),
+        ("fireworks", {"kimi-k2p6", "kimi-k2p7-code", "glm-5p2", "glm-5p1",
+                       "kimi-k2p6-fast", "kimi-k2p6-turbo", "kimi-k2p7-code-fast",
+                       "glm-5p2-fast", "glm-5p1-fast", "minimax-m3",
+                       "minimax-m2p7", "gpt-oss-120b", "gpt-oss-20b",
+                       }),
+        ("nvidia", {"nemotron-3-ultra-550b-a55b", "nemotron-3-ultra-550b",
+                    "nemotron", "neva-3-ultra-550b-a55b"}),
+        ("x-ai", {"grok-4.5"}),
+    ]
+    model_lower = model_name.lower().strip()
+    for provider, known_models in prefix_map:
+        if model_lower in known_models:
+            return (provider, model_lower)
+    # Also try rsplit for fireworks-style "accounts/fireworks/models/<name>"
+    if model_lower.startswith("accounts/fireworks/models/"):
+        bare = model_lower[len("accounts/fireworks/models/"):]
+        return ("fireworks", bare)
+    return None
+
+
+
 
 
 def normalize_usage(

--- a/tests/agent/test_nim_governor.py
+++ b/tests/agent/test_nim_governor.py
@@ -1,0 +1,381 @@
+"""NVIDIA NIM cross-process governor: lease + 40 RPM + 60s 429 freeze.
+
+Covers Dan's 2026-08-30 override for HEL-6108 / HEL-6226:
+
+* Two NVIDIA kanban-style worker inits with two pool entries take TWO
+  DIFFERENT keys (exclusive lease across processes; matches the delegate-
+  subagent path already using ``acquire_lease()`` in-process).
+* A simulated 429 freezes the key for ~60s and grants a single retry credit
+  the recovery path can consume — never falls back to a paid provider.
+* The RPM bucket refuses a 41st call inside the same 60-second window.
+
+All tests use temp ``HERMES_HOME`` (the autouse ``_isolate_hermes_home``
+fixture in ``tests/conftest.py`` handles that already) and inject fake
+``sleep_fn`` / ``now_fn`` so wall-clock waits do not appear in the suite.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import List, Optional
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Minimal in-memory pool fake — matches the tiny surface nim_governor uses.
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _Entry:
+    id: str
+    runtime_api_key: Optional[str] = None
+
+
+class _FakePool:
+    def __init__(self, ids: List[str]):
+        self._entries = [_Entry(id=i, runtime_api_key=f"key-{i}") for i in ids]
+
+    def entries(self):
+        return list(self._entries)
+
+
+def _reset_gov_state(tmp_path, monkeypatch):
+    """Point HERMES_HOME at a fresh temp dir and clear any leases."""
+    home = tmp_path / ".hermes"
+    home.mkdir(exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+
+# ---------------------------------------------------------------------------
+# 1. Exclusive lease across two worker-init calls
+# ---------------------------------------------------------------------------
+
+def test_two_kanban_worker_inits_pick_distinct_keys_when_two_keys_exist(
+    tmp_path, monkeypatch,
+):
+    _reset_gov_state(tmp_path, monkeypatch)
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_a")
+    from agent import nim_governor
+
+    pool = _FakePool(["cred-a", "cred-b"])
+    first = nim_governor.acquire_kanban_worker_lease(
+        pool, holder_token="worker-1",
+    )
+    second = nim_governor.acquire_kanban_worker_lease(
+        pool, holder_token="worker-2",
+    )
+    assert first is not None
+    assert second is not None
+    assert first != second, (
+        "Two kanban workers must lease DIFFERENT NIM keys when two exist "
+        "(HEL-6226 exclusive claim)."
+    )
+
+    # Third worker layers onto the least-leased (both have 1 now, ties
+    # broken by input order → cred-a).
+    third = nim_governor.acquire_kanban_worker_lease(
+        pool, holder_token="worker-3",
+    )
+    assert third == "cred-a"
+
+    # Releasing worker-1 must free cred-a so the next lease picks it first.
+    nim_governor.release_kanban_worker_lease("cred-a", "worker-1")
+    fourth = nim_governor.acquire_kanban_worker_lease(
+        pool, holder_token="worker-4",
+    )
+    assert fourth == "cred-a"
+
+
+def test_lease_reclaims_dead_holder_pid(tmp_path, monkeypatch):
+    """A lease held by a dead PID must be reclaimed on the next acquire."""
+    _reset_gov_state(tmp_path, monkeypatch)
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_a")
+    from agent import nim_governor
+
+    # Manually plant a lease record for a PID that will never exist.
+    nim_governor._ensure_dirs()
+    dead_pid = 2  # PID 2 is reserved by the kernel; user-space cannot signal it.
+    import json
+    import time as _t
+
+    path = nim_governor._lease_path("cred-a", "ghost")
+    path.write_text(json.dumps({
+        "credential_id": "cred-a",
+        "holder_token": "ghost",
+        "pid": dead_pid,
+        "kanban_task": "t_dead",
+        "acquired_at": _t.time() - 3600,
+        "heartbeat_at": _t.time() - 3600,
+    }))
+
+    pool = _FakePool(["cred-a", "cred-b"])
+    chosen = nim_governor.acquire_kanban_worker_lease(
+        pool, holder_token="worker-alive",
+    )
+    # The dead lease must have been reclaimed, so the fresh worker still
+    # gets cred-a (no other worker holds it).
+    assert chosen == "cred-a"
+
+
+# ---------------------------------------------------------------------------
+# 2. 429 freeze + one-shot retry credit
+# ---------------------------------------------------------------------------
+
+def test_first_429_freezes_key_for_60s_then_grants_single_retry(tmp_path, monkeypatch):
+    _reset_gov_state(tmp_path, monkeypatch)
+    from agent import nim_governor
+
+    t = [1_000_000.0]
+
+    def _now():
+        return t[0]
+
+    until = nim_governor.record_nim_429("cred-a", now_fn=_now)
+    assert until - t[0] == pytest.approx(nim_governor.NIM_FREEZE_ON_429_SECONDS)
+
+    # Freeze window is active — remaining is > 0 and close to 60s.
+    remaining = nim_governor.nim_key_freeze_remaining("cred-a", now_fn=_now)
+    assert 55.0 <= remaining <= 60.0, remaining
+
+    # The one-shot retry credit exists exactly once — the recovery path
+    # consumes it on the SECOND 429 to enforce "bounded at ONE wait-and-retry".
+    assert nim_governor.consume_retry_credit("cred-a", now_fn=_now) is True
+    assert nim_governor.consume_retry_credit("cred-a", now_fn=_now) is False
+
+
+def test_freeze_lifts_after_60s(tmp_path, monkeypatch):
+    _reset_gov_state(tmp_path, monkeypatch)
+    from agent import nim_governor
+
+    t = [1_000_000.0]
+
+    def _now():
+        return t[0]
+
+    nim_governor.record_nim_429("cred-a", now_fn=_now)
+    t[0] += nim_governor.NIM_FREEZE_ON_429_SECONDS + 1
+    assert nim_governor.nim_key_freeze_remaining("cred-a", now_fn=_now) == 0.0
+
+
+def test_rpm_gate_waits_on_frozen_key(tmp_path, monkeypatch):
+    """A frozen key must make ``wait_for_rpm_slot`` sleep until it lifts."""
+    _reset_gov_state(tmp_path, monkeypatch)
+    from agent import nim_governor
+
+    t = [1_000_000.0]
+    slept: List[float] = []
+
+    def _now():
+        return t[0]
+
+    def _sleep(sec: float):
+        slept.append(sec)
+        t[0] += sec
+
+    nim_governor.record_nim_429("cred-a", now_fn=_now)
+    waited = nim_governor.wait_for_rpm_slot(
+        "cred-a", sleep_fn=_sleep, now_fn=_now,
+    )
+    assert waited >= nim_governor.NIM_FREEZE_ON_429_SECONDS - 1
+    # After the wait, the bucket must have recorded exactly one entry for
+    # the request we reserved a slot for.
+    with nim_governor._governor_lock():
+        bucket = nim_governor._read_bucket_locked("cred-a")
+    assert len(bucket) == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. 40 RPM bucket
+# ---------------------------------------------------------------------------
+
+def test_bucket_refuses_41st_call_inside_same_minute(tmp_path, monkeypatch):
+    _reset_gov_state(tmp_path, monkeypatch)
+    from agent import nim_governor
+
+    t = [1_000_000.0]
+
+    def _now():
+        return t[0]
+
+    # Instant zero-cost sleeps: the gate should never actually block on the
+    # first 40 calls in a row (bucket is empty each time we advance below
+    # the cap), and on the 41st call it must sleep enough to age out the
+    # oldest slot.
+    slept: List[float] = []
+
+    def _sleep(sec: float):
+        slept.append(sec)
+        t[0] += sec
+
+    for i in range(nim_governor.NIM_RPM_CAP):
+        waited = nim_governor.wait_for_rpm_slot(
+            "cred-a", sleep_fn=_sleep, now_fn=_now,
+        )
+        assert waited == 0.0
+        # Space calls 0.1s apart so the bucket is genuinely full at t=~4s,
+        # not all sharing the same timestamp.
+        t[0] += 0.1
+
+    with nim_governor._governor_lock():
+        bucket = nim_governor._read_bucket_locked("cred-a")
+    assert len(bucket) == nim_governor.NIM_RPM_CAP
+
+    # 41st call inside the 60s window must WAIT — never fire and 429.
+    waited = nim_governor.wait_for_rpm_slot(
+        "cred-a", sleep_fn=_sleep, now_fn=_now,
+    )
+    assert waited > 0.0, "41st call inside the same minute must be gated"
+    assert slept, "gate must have slept at least once for the 41st call"
+
+
+def test_bucket_prunes_old_timestamps(tmp_path, monkeypatch):
+    _reset_gov_state(tmp_path, monkeypatch)
+    from agent import nim_governor
+
+    t = [1_000_000.0]
+
+    def _now():
+        return t[0]
+
+    def _sleep(sec):
+        t[0] += sec
+
+    # Fill the bucket, then advance beyond the 60s window and confirm the
+    # next call sees an empty bucket and fires without waiting.
+    for _ in range(nim_governor.NIM_RPM_CAP):
+        nim_governor.wait_for_rpm_slot(
+            "cred-a", sleep_fn=_sleep, now_fn=_now,
+        )
+    t[0] += nim_governor.NIM_RPM_WINDOW_SECONDS + 1.0
+    waited = nim_governor.wait_for_rpm_slot(
+        "cred-a", sleep_fn=_sleep, now_fn=_now,
+    )
+    assert waited == 0.0
+
+
+# ---------------------------------------------------------------------------
+# 4. Provider / endpoint detection
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("url,expected", [
+    ("https://integrate.api.nvidia.com/v1", True),
+    ("https://INTEGRATE.api.nvidia.com/v1", True),
+    ("https://api.openai.com/v1", False),
+    ("", False),
+    (None, False),
+])
+def test_is_nim_endpoint(url, expected):
+    from agent.nim_governor import is_nim_endpoint
+    assert is_nim_endpoint(url) is expected
+
+
+@pytest.mark.parametrize("provider,expected", [
+    ("nvidia", True),
+    ("NVIDIA-NIM", True),
+    ("openai", False),
+    ("", False),
+    (None, False),
+])
+def test_is_nim_provider(provider, expected):
+    from agent.nim_governor import is_nim_provider
+    assert is_nim_provider(provider) is expected
+
+
+def test_is_nim_kanban_worker_requires_both_env_and_provider(tmp_path, monkeypatch):
+    from agent.nim_governor import is_nim_kanban_worker
+
+    class _Agent:
+        provider = "nvidia"
+        base_url = "https://integrate.api.nvidia.com/v1"
+
+    # Not a kanban worker (no env var) → False even for a NIM agent.
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    assert is_nim_kanban_worker(_Agent()) is False
+
+    # kanban worker + NIM → True
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_a")
+    assert is_nim_kanban_worker(_Agent()) is True
+
+    # kanban worker but different provider → False (policy is NIM-only).
+    class _OtherAgent:
+        provider = "anthropic"
+        base_url = "https://api.anthropic.com"
+
+    assert is_nim_kanban_worker(_OtherAgent()) is False
+
+
+# ---------------------------------------------------------------------------
+# 5. 429 recovery path in agent_runtime_helpers wires into nim_governor and
+#    does NOT engage the fallback chain.
+# ---------------------------------------------------------------------------
+
+def test_recover_with_credential_pool_nim_kanban_freeze_then_retry(tmp_path, monkeypatch):
+    """First 429 → freeze + wait + retry True. Second 429 → give up, no fallback."""
+    _reset_gov_state(tmp_path, monkeypatch)
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_a")
+
+    from agent import nim_governor
+    from agent.agent_runtime_helpers import recover_with_credential_pool
+    from agent.error_classifier import FailoverReason
+
+    # Collapse the freeze window so the recovery-path wall-clock sleep loop
+    # returns in a couple hundred milliseconds instead of the production 60s
+    # (the loop uses real time.time() against _deadline; monkey-patching only
+    # time.sleep would deadlock).
+    monkeypatch.setattr(nim_governor, "NIM_FREEZE_ON_429_SECONDS", 0.2)
+
+    # Fake pool: single leased key, so no rotation is possible.
+    class _PoolWithLease:
+        provider = "nvidia"
+
+        def entries(self):
+            return [_Entry(id="cred-a", runtime_api_key="key-a")]
+
+        def current(self):
+            return _Entry(id="cred-a", runtime_api_key="key-a")
+
+    class _Agent:
+        provider = "nvidia"
+        base_url = "https://integrate.api.nvidia.com/v1"
+        api_key = "key-a"
+        _credential_pool = _PoolWithLease()
+        _credential_pool_entry_id = "cred-a"
+        _nim_worker_credential_id = "cred-a"
+        _interrupt_requested = False
+
+        def _swap_credential(self, entry):
+            pass
+
+    agent = _Agent()
+
+    # First 429: recovery must return recovered=True with the freeze applied.
+    recovered, has_retried = recover_with_credential_pool(
+        agent,
+        status_code=429,
+        has_retried_429=False,
+        classified_reason=FailoverReason.rate_limit,
+    )
+    assert recovered is True, "First NIM 429 must recover-and-retry"
+    assert has_retried is True
+    # Freeze must have been recorded on the credential.
+    assert nim_governor.nim_key_freeze_remaining("cred-a") >= 0.0
+
+    # Retry credit has been granted by record_nim_429 in the first call.
+    # A SECOND consecutive 429 for the same key must give up (recovered=False)
+    # rather than retry-storm or fall through to a paid provider.
+    recovered2, has_retried2 = recover_with_credential_pool(
+        agent,
+        status_code=429,
+        has_retried_429=True,
+        classified_reason=FailoverReason.rate_limit,
+    )
+    assert recovered2 is False, (
+        "Second consecutive NIM 429 must NOT recover — Dan 2026-08-30: "
+        "bounded at ONE wait-and-retry."
+    )
+    assert getattr(agent, "_nim_no_more_retries", False) is True, (
+        "Second NIM 429 must set _nim_no_more_retries so the conversation "
+        "loop surfaces the error instead of drifting into jittered backoff."
+    )


### PR DESCRIPTION
## Defect

HAL cannot close rows honestly for most fleet models because the rate-card lookup only matches **provider-prefixed** model ids, while HAL stamps the **bare** session model string.

Reproduce:
```python
from agent.usage_pricing import get_pricing_entry, has_known_pricing
has_known_pricing("gpt-5.6-sol")
has_known_pricing("openai/gpt-5.6-sol")
has_known_pricing("claude-opus-5")
has_known_pricing("anthropic/claude-opus-5")
```

## Fix

1. `_try_normalize_model_id` checks known prefixes and normalizes bare model IDs before the `_OFFICIAL_DOCS_PRICING` lookup.
2. Added missing `x-ai/grok-4.5` and `nvidia/nemotron-3-ultra-550b-a55b` entries with `true_zero_no_spend` pricing version.
3. Added missing `claude-opus-5-fast` pricing.
