### PR TITLE
fix(agent): make Kanban worker guidance board-aware

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -286,10 +286,11 @@ SKILLS_GUIDANCE = (
 KANBAN_GUIDANCE = (
     "# Kanban task execution protocol\n"
     "You have been assigned ONE task from "
-    "the shared board at `~/.hermes/kanban.db`. Your task id is in "
+    "the active shared board resolved from `$HERMES_KANBAN_DB` / "
+    "`$HERMES_KANBAN_BOARD`. Your task id is in "
     "`$HERMES_KANBAN_TASK`; your workspace is `$HERMES_KANBAN_WORKSPACE`. "
     "The `kanban_*` tools in your schema are your primary coordination surface — "
-    "they write directly to the shared SQLite DB and work regardless of terminal "
+    "they write directly to that resolved SQLite board and work regardless of terminal "
     "backend (local/docker/modal/ssh).\n"
     "\n"
     "## Lifecycle\n"

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -568,6 +568,16 @@ def test_kanban_guidance_prompt_size_bounded():
     )
 
 
+def test_kanban_guidance_uses_runtime_board_selectors():
+    """Worker guidance must describe the resolved board, not claim that every
+    worker uses the default-profile database path."""
+    from agent.prompt_builder import KANBAN_GUIDANCE
+
+    assert "HERMES_KANBAN_DB" in KANBAN_GUIDANCE
+    assert "HERMES_KANBAN_BOARD" in KANBAN_GUIDANCE
+    assert "~/.hermes/kanban.db" not in KANBAN_GUIDANCE
+
+
 def test_kanban_guidance_orchestrator_decision_ownership():
     """The orchestrator section must carry the split-brain prevention
     contract: decisions are made by the orchestrator before fan-out and


### PR DESCRIPTION
## Problem

`KANBAN_GUIDANCE` tells every dispatched worker that its shared board is `~/.hermes/kanban.db`. That is stale for named/project boards: the dispatcher selects the active database/board through `HERMES_KANBAN_DB` and `HERMES_KANBAN_BOARD`, and the `kanban_*` tools resolve that selection internally. The prompt can therefore send a worker looking at the wrong profile/default database.

## Change

- describe the active board through the two runtime selectors without interpolating a host-specific path
- clarify that `kanban_*` tools operate on that resolved SQLite board
- add a narrow regression contract that rejects the obsolete universal path

All other worker lifecycle guidance is unchanged.

## Verification

- proof-of-bite: the new test on current `main` failed exactly because `HERMES_KANBAN_DB` was absent and the universal `~/.hermes/kanban.db` claim remained (1 failed, 32 passed)
- focused/related canonical gate: 65 passed, 0 failed, 1 skipped
- Ruff check: pass
- `git diff --check`: pass
- full canonical suite on the implementation base and untouched base: identical pre-existing 139 failures in the same 42 files
- independent fresh-context correctness/security review: PASS, no blockers

## Overlap check

Open PR #61222 edits the same introductory guidance for a distinct profile-tool-availability ambiguity, but retains the hardcoded database path. It is adjacent rather than a duplicate; if it lands first, the two wording changes should be composed rather than dropping either contract.

## Risk / rollback

Risk is limited to worker prompt wording and one prompt-contract test. Roll back by reverting this commit.