### PR TITLE
fix(state): flock non-contention errors fail fast; gateway retries deferred FTS rebuild in-process (salvage #100130)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -32621,6 +32621,7 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
     AUTO_ARCHIVE_EVERY = 60  # ticks — poll hourly (state_meta gate owns the real cadence)
     MEMORY_TRIM_EVERY = 1    # shared helper cooldown bounds actual allocator work
     MISFIRE_SWEEP_EVERY = 5  # ticks — every 5 minutes (grace window gates real work)
+    FTS_STALE_RETRY_EVERY = 1  # SessionDB rate-limits the real work (_FTS_STALE_RETRY_SECONDS)
 
     # Every platform media cache prunes on the same hourly cadence — one loop
     # over (name, cleanup_fn), not a copy-pasted try/except per cache.
@@ -32754,6 +32755,29 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
                         release_or_close(_adb)
             except Exception as e:
                 logger.debug("Auto-archive tick error: %s", e)
+
+        # Deferred stale-FTS rebuild retry (#100108). A SessionDB that opened
+        # while another process held state.db / the rebuild lock fails closed
+        # and leaves search on the LIKE fallback; a short-lived CLI clears
+        # that on its next open, but the gateway opens once and stays up for
+        # days. Retry here, on the existing tick, against the shared
+        # instances this process already holds: non-blocking admission, no
+        # new thread, rate-limited inside SessionDB. No-op when nothing is
+        # stale (one attribute read per instance).
+        if tick_count % FTS_STALE_RETRY_EVERY == 0:
+            try:
+                from hermes_state_registry import live_shared_session_dbs
+
+                for _sdb in live_shared_session_dbs():
+                    _retry = getattr(_sdb, "retry_deferred_fts_recovery", None)
+                    if callable(_retry) and _retry():
+                        logger.info(
+                            "Deferred state.db FTS rebuild completed in-process "
+                            "for %s; full-text search restored.",
+                            getattr(_sdb, "db_path", "state.db"),
+                        )
+            except Exception as exc:
+                logger.debug("Deferred FTS retry tick error: %s", exc)
 
         # This is the long-lived messaging-gateway counterpart to the TUI idle
         # reaper. The helper is config-gated and rate-limited, so calling it on

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -100,6 +100,7 @@ from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     _clear_lock_holder_record,
     _describe_lock_holder,
     _read_lock_holder_record,
+    is_advisory_lock_contention,
 )
 from hermes_state_portability import SessionPortabilityMixin
 from hermes_state_schema import SessionSchemaMixin
@@ -1776,13 +1777,14 @@ def _log_wal_reset_bug_once(
     # for git/pip/system Python installs (#75153).
     repair_hint = _wal_reset_repair_hint()
     logger.warning(
-        "%s: linked SQLite %s is vulnerable to the WAL-reset corruption "
-        "bug (https://sqlite.org/wal.html#walresetbug) — %s. "
+        "%s: linked SQLite %s (interpreter %s) is vulnerable to the WAL-reset "
+        "corruption bug (https://sqlite.org/wal.html#walresetbug) — %s. "
         "Upgrade to SQLite 3.51.3+ (or backports 3.50.7 / 3.44.6); "
         "%s. See `hermes doctor`. This warning fires once per "
         "process per database.",
         db_label,
         sqlite3.sqlite_version,
+        sys.executable,
         action,
         repair_hint,
     )
@@ -2388,7 +2390,15 @@ def _cross_process_repair_lock(db_path: Path):
                     msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
                     acquired = True
                     break
-                except (BlockingIOError, OSError):
+                except (BlockingIOError, OSError) as exc:
+                    if not is_advisory_lock_contention(exc):
+                        logger.warning(
+                            "Could not acquire state.db repair lock %s (%s) — "
+                            "skipping schema surgery on a non-contention error.",
+                            lock_path, exc,
+                        )
+                        acquired = None
+                        break
                     if time.monotonic() >= deadline:
                         break
                     time.sleep(_REPAIR_LOCK_POLL_SECONDS)
@@ -2400,7 +2410,10 @@ def _cross_process_repair_lock(db_path: Path):
                 _REPAIR_LOCK_POLL_SECONDS,
                 "state.db repair lock",
             )
-        if not acquired:
+        if acquired is None:
+            # Non-contention failure already logged with its errno.
+            acquired = False
+        elif not acquired:
             record = None if _IS_WINDOWS else _read_lock_holder_record(handle)
             logger.warning(
                 "state.db repair lock %s held by another process for more "

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -7,6 +7,7 @@ hermes_state re-imports every name here for backward compatibility.
 """
 
 import contextlib
+import errno
 import json
 import logging
 import os
@@ -924,6 +925,32 @@ _IS_WINDOWS = sys.platform == "win32"
 # short bounded wait suffices — never re-enter the full timeout.
 _LOCK_BREAK_REACQUIRE_SECONDS = 5.0
 
+# errno set for "another process holds this advisory lock". flock() reports
+# contention as EWOULDBLOCK/EAGAIN; msvcrt.locking() as EACCES (and EDEADLK
+# when its internal retry gives up). Anything else — ESTALE on a dropped NFS
+# handle, ENOTSUP/ENOLCK on a filesystem without advisory locks, EIO — is a
+# persistent environment failure that no amount of polling turns into an
+# acquire. Treating every OSError as contention made such a failure look
+# like a live holder and burned the full 120s admission timeout on every
+# attempt (#100108, PR #100130).
+_LOCK_CONTENTION_ERRNOS = {errno.EAGAIN, errno.EACCES, errno.EWOULDBLOCK}
+if hasattr(errno, "EDEADLK"):
+    _LOCK_CONTENTION_ERRNOS.add(errno.EDEADLK)
+
+
+def is_advisory_lock_contention(exc: BaseException) -> bool:
+    """True when *exc* means another process holds the advisory lock.
+
+    False for every other ``OSError`` (ESTALE, ENOTSUP, ENOLCK, EIO, ...):
+    callers must fail closed IMMEDIATELY rather than poll to the deadline,
+    because retrying cannot succeed and the wait only stalls the caller.
+    """
+    if isinstance(exc, BlockingIOError):
+        return True
+    if not isinstance(exc, OSError):
+        return False
+    return exc.errno in _LOCK_CONTENTION_ERRNOS
+
 
 def _proc_start_ticks(pid: int):
     """Kernel start time of *pid* in clock ticks, or None when unknowable.
@@ -1032,7 +1059,11 @@ def _acquire_db_flock(lock_path, handle, timeout_seconds, poll_seconds, descript
     """Bounded POSIX flock acquire with orphaned-holder staleness break.
 
     Returns ``(acquired, handle)``; *handle* may have been re-opened (the
-    caller owns closing whichever handle comes back).
+    caller owns closing whichever handle comes back). *acquired* is True on
+    success, False when a holder kept the lock past the deadline, and None
+    when a non-contention ``OSError`` (ESTALE/ENOTSUP/EIO) made acquisition
+    impossible — already logged here; callers treat None as "not acquired"
+    without emitting the held-by-another-process warning.
 
     Why breaking exists at all (issue #100108): ``flock`` belongs to the open
     file DESCRIPTION, which ``fork()`` duplicates into every child. A holder
@@ -1055,7 +1086,21 @@ def _acquire_db_flock(lock_path, handle, timeout_seconds, poll_seconds, descript
     while True:
         try:
             fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except (BlockingIOError, OSError):
+        except (BlockingIOError, OSError) as exc:
+            if not is_advisory_lock_contention(exc):
+                # ESTALE / ENOTSUP / EIO: not a holder, and polling cannot
+                # fix it. Defer NOW instead of pretending a live process
+                # held the lock for the whole timeout (#100108).
+                logger.warning(
+                    "Could not acquire %s %s (%s) — deferring rather than "
+                    "waiting out the %.0fs holder timeout on a "
+                    "non-contention error.",
+                    description,
+                    lock_path,
+                    exc,
+                    timeout_seconds,
+                )
+                return None, handle
             if time.monotonic() < deadline:
                 time.sleep(poll_seconds)
                 continue
@@ -1128,7 +1173,7 @@ def _describe_lock_holder(record) -> str:
 
 
 @contextlib.contextmanager
-def fts_rebuild_admission(db_path):
+def fts_rebuild_admission(db_path, *, timeout_seconds=None):
     """Serialize full structural FTS rebuilds on *db_path* across processes.
 
     Yields True when this process holds the rebuild authority, False when the
@@ -1141,10 +1186,20 @@ def fts_rebuild_admission(db_path):
     ``db_path`` may be a str or Path; None (in-memory DB / tests without a
     file path) yields True — a private in-memory DB has no cross-process
     surface.
+
+    *timeout_seconds* defaults to ``_FTS_REBUILD_LOCK_TIMEOUT_SECONDS``.
+    Opportunistic in-process retries (``retry_deferred_fts_recovery``) pass
+    ``0`` so a live holder never stalls a long-lived writer for two minutes;
+    the orphaned-holder break still applies on the single attempt.
     """
     if db_path is None:
         yield True
         return
+    timeout = (
+        _FTS_REBUILD_LOCK_TIMEOUT_SECONDS
+        if timeout_seconds is None
+        else max(float(timeout_seconds), 0.0)
+    )
     lock_path = f"{db_path}.fts_rebuild.lock"
     try:
         handle = open(lock_path, "a+b")
@@ -1170,7 +1225,7 @@ def fts_rebuild_admission(db_path):
     acquired = False
     try:
         if _IS_WINDOWS:
-            deadline = time.monotonic() + _FTS_REBUILD_LOCK_TIMEOUT_SECONDS
+            deadline = time.monotonic() + timeout
             while True:
                 try:
                     import msvcrt
@@ -1179,7 +1234,15 @@ def fts_rebuild_admission(db_path):
                     msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
                     acquired = True
                     break
-                except (BlockingIOError, OSError):
+                except (BlockingIOError, OSError) as exc:
+                    if not is_advisory_lock_contention(exc):
+                        logger.warning(
+                            "Could not acquire FTS rebuild lock %s (%s) — "
+                            "deferring on a non-contention error.",
+                            lock_path, exc,
+                        )
+                        acquired = None
+                        break
                     if time.monotonic() >= deadline:
                         break
                     time.sleep(_FTS_REBUILD_LOCK_POLL_SECONDS)
@@ -1187,20 +1250,35 @@ def fts_rebuild_admission(db_path):
             acquired, handle = _acquire_db_flock(
                 lock_path,
                 handle,
-                _FTS_REBUILD_LOCK_TIMEOUT_SECONDS,
+                timeout,
                 _FTS_REBUILD_LOCK_POLL_SECONDS,
                 "FTS rebuild lock",
             )
-        if not acquired:
+        if acquired is None:
+            # Non-contention failure: already logged with the real errno;
+            # a "held by another process" line here would be a lie.
+            acquired = False
+        elif not acquired:
             record = None if _IS_WINDOWS else _read_lock_holder_record(handle)
-            logger.warning(
-                "FTS rebuild lock %s held by another process for more than "
-                "%.0fs — deferring this rebuild to avoid racing the holder "
-                "(the stale-FTS breadcrumb keeps it retryable). "
-                "Recorded holder: %s.",
-                lock_path, _FTS_REBUILD_LOCK_TIMEOUT_SECONDS,
-                _describe_lock_holder(record),
-            )
+            if timeout <= 0:
+                # Non-blocking probe from an in-process retry: a busy lock
+                # is expected and will be tried again, so keep it quiet.
+                logger.info(
+                    "FTS rebuild lock %s is busy — deferring this retry "
+                    "(the stale-FTS breadcrumb keeps it retryable). "
+                    "Recorded holder: %s.",
+                    lock_path,
+                    _describe_lock_holder(record),
+                )
+            else:
+                logger.warning(
+                    "FTS rebuild lock %s held by another process for more than "
+                    "%.0fs — deferring this rebuild to avoid racing the holder "
+                    "(the stale-FTS breadcrumb keeps it retryable). "
+                    "Recorded holder: %s.",
+                    lock_path, timeout,
+                    _describe_lock_holder(record),
+                )
         yield acquired
     finally:
         try:

--- a/hermes_state_registry.py
+++ b/hermes_state_registry.py
@@ -42,7 +42,7 @@ from __future__ import annotations
 import logging
 import threading
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 if TYPE_CHECKING:  # pragma: no cover - import cycle guard, typed only
     from hermes_state import SessionDB
@@ -257,6 +257,18 @@ def close_all() -> int:
         _teardown(generation.db)
         closed += 1
     return closed
+
+
+def live_shared_session_dbs() -> List["SessionDB"]:
+    """Snapshot of every live (non-retired) shared SessionDB in this process.
+
+    For periodic in-process maintenance (the gateway housekeeping tick's
+    deferred-FTS retry). Refcounts are NOT touched: the caller only invokes
+    a method on an instance that some holder already keeps alive; a
+    concurrent final release closes it and the callee sees ``_conn is None``.
+    """
+    with _lock:
+        return [g.db for g in _generations.values() if not g.retired]
 
 
 def stats() -> Dict[str, int]:

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -43,6 +43,15 @@ logger = logging.getLogger("hermes_state")
 
 _FTS_HOLDER_ESCALATE_ATTEMPTS = 3
 _FTS_HOLDER_ESCALATE_SECONDS = 60.0
+# Minimum spacing between in-process retries of a deferred stale-FTS rebuild
+# (``retry_deferred_fts_recovery``). The startup open already paid the full
+# admission wait once; later retries are non-blocking probes on this cadence
+# so a live holder never stalls a long-lived writer.
+_FTS_STALE_RETRY_SECONDS = 60.0
+# Each failed retry doubles the spacing up to this cap, so a holder that never
+# goes away (a second long-lived writer) costs one deferral warning per hour,
+# not one per minute. A successful rebuild clears the stale state entirely.
+_FTS_STALE_RETRY_MAX_SECONDS = 3600.0
 
 # Cache for schema_read_probe_statements() — parsing SCHEMA_SQL spins up an
 # in-memory SQLite database, so derive the statements once per process.
@@ -422,8 +431,14 @@ class SessionSchemaMixin:
             )
             return None
 
-    def _recover_stale_fts(self, cursor: sqlite3.Cursor, *, legacy: bool) -> bool:
-        """Atomically rebuild stale base/trigram indexes and resume syncing."""
+    def _recover_stale_fts(
+        self, cursor: sqlite3.Cursor, *, legacy: bool, timeout_seconds=None
+    ) -> bool:
+        """Atomically rebuild stale base/trigram indexes and resume syncing.
+
+        *timeout_seconds* bounds the cross-process admission wait; None uses
+        the full startup budget, ``0`` is the non-blocking in-process retry.
+        """
         foreign_holders = self._foreign_state_db_holders()
         if foreign_holders:
             now = time.time()
@@ -502,7 +517,9 @@ class SessionSchemaMixin:
         # authority (fail closed). Losing the race means another process is
         # already performing this exact recovery; the stale breadcrumb stays
         # set, so this process simply keeps FTS detached and retries later.
-        with fts_rebuild_admission(getattr(self, "db_path", None)) as admitted:
+        with fts_rebuild_admission(
+            getattr(self, "db_path", None), timeout_seconds=timeout_seconds
+        ) as admitted:
             if not admitted:
                 logger.warning(
                     "Deferred stale state.db FTS rebuild: another process "
@@ -511,6 +528,65 @@ class SessionSchemaMixin:
                 )
                 return False
             return self._recover_stale_fts_locked(cursor, legacy=legacy)
+
+    def retry_deferred_fts_recovery(self) -> bool:
+        """Retry a deferred stale-FTS rebuild on this open SessionDB.
+
+        ``_recover_stale_fts`` runs at open and fails closed when foreign
+        holders or the rebuild lock are busy, leaving ``_fts_stale`` set and
+        search on the LIKE fallback. Live write/search paths must never start
+        a full rebuild (#97940), so on a short-lived CLI that deferral is
+        cleared by the next process open — but a gateway opens state.db
+        once and stays up for days, so "next open" never came (#100108).
+        This is the in-process retry: bounded backoff from
+        ``_FTS_STALE_RETRY_SECONDS`` doubling to ``_FTS_STALE_RETRY_MAX_SECONDS``,
+        non-blocking admission (``timeout=0``) so a live holder is skipped and
+        tried again later, no new thread — the caller is an existing periodic
+        tick (gateway housekeeping).
+
+        Returns True only when the index was rebuilt and sync triggers
+        restored. Never raises.
+        """
+        if not getattr(self, "_fts_stale", False):
+            return False
+        if getattr(self, "read_only", False) or getattr(self, "_conn", None) is None:
+            return False
+        now = time.monotonic()
+        if now < getattr(self, "_fts_stale_retry_after", 0.0):
+            return False
+        interval = float(
+            getattr(self, "_fts_stale_retry_interval", 0.0)
+        ) or _FTS_STALE_RETRY_SECONDS
+        self._fts_stale_retry_after = now + interval
+        self._fts_stale_retry_interval = min(
+            interval * 2.0, _FTS_STALE_RETRY_MAX_SECONDS
+        )
+        try:
+            with self._lock:
+                if self._conn is None or not self._fts_stale:
+                    return False
+                cursor = self._conn.cursor()
+                legacy = self._db_has_legacy_inline_fts(cursor)
+                recovered = self._recover_stale_fts(
+                    cursor, legacy=legacy, timeout_seconds=0.0
+                )
+                if recovered:
+                    # CJK was detached alongside the base indexes; its own
+                    # ensure path decides when it comes back online.
+                    self._ensure_fts_cjk_schema(cursor)
+                    self._fts_stale_retry_interval = 0.0
+                try:
+                    self._conn.commit()
+                except sqlite3.Error:
+                    pass
+                return recovered
+        except Exception:  # noqa: BLE001 - background retry must never raise
+            logger.warning(
+                "In-process retry of the deferred stale state.db FTS rebuild "
+                "failed; will retry later.",
+                exc_info=True,
+            )
+            return False
 
     def _recover_stale_fts_locked(
         self, cursor: sqlite3.Cursor, *, legacy: bool
@@ -1510,7 +1586,8 @@ class SessionSchemaMixin:
         breadcrumb is persisted, mirroring ``_enter_fts_fail_open``'s
         ordering contract: triggers must never be live over an index with an
         unrebuilt gap. FTS stays detached for this instance; the winner's
-        rebuild — or ``_recover_stale_fts`` at the next startup — restores
+        rebuild — or ``retry_deferred_fts_recovery`` from the gateway
+        housekeeping tick, or ``_recover_stale_fts`` at the next startup — restores
         the index and triggers atomically.
         """
         with fts_rebuild_admission(getattr(self, "db_path", None)) as admitted:

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -554,12 +554,13 @@ class SessionSchemaMixin:
         now = time.monotonic()
         if now < getattr(self, "_fts_stale_retry_after", 0.0):
             return False
-        interval = float(
-            getattr(self, "_fts_stale_retry_interval", 0.0)
-        ) or _FTS_STALE_RETRY_SECONDS
+        interval = float(getattr(self, "_fts_stale_retry_interval", 0.0))
+        if interval <= 0.0:
+            interval = _FTS_STALE_RETRY_SECONDS
         self._fts_stale_retry_after = now + interval
         self._fts_stale_retry_interval = min(
-            interval * 2.0, _FTS_STALE_RETRY_MAX_SECONDS
+            max(interval, _FTS_STALE_RETRY_SECONDS, 1.0) * 2.0,
+            _FTS_STALE_RETRY_MAX_SECONDS,
         )
         try:
             with self._lock:

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -2382,7 +2382,9 @@ class SessionSearchMixin:
         FAILS CLOSED: if another process holds the rebuild lock beyond the
         bounded wait, this call defers (returns 0) rather than racing it.
         Callers already treat 0 as "rebuild made no progress" and fall back
-        to the stale-FTS breadcrumb path, which retries at next startup.
+        to the stale-FTS breadcrumb path, which retries in-process from the
+        gateway housekeeping tick (``retry_deferred_fts_recovery``) and at
+        next startup.
 
         Safe to call when FTS tables don't exist (skips them).
         Returns the number of FTS indexes that were rebuilt.

--- a/tests/state/test_fts_rebuild_admission.py
+++ b/tests/state/test_fts_rebuild_admission.py
@@ -17,9 +17,11 @@ prove nothing.
 """
 
 import contextlib
+import errno
 import subprocess
 import sqlite3
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -363,3 +365,68 @@ os._exit(1)
         finally:
             with contextlib.suppress(OSError):
                 os.kill(grandchild, signal.SIGKILL)
+
+
+class TestNonContentionErrnoFailsFast:
+    def test_non_contention_oserror_does_not_wait_out_timeout(
+        self, tmp_path, monkeypatch
+    ):
+        import fcntl
+
+        monkeypatch.setattr(
+            hermes_state_common, "_FTS_REBUILD_LOCK_TIMEOUT_SECONDS", 30.0
+        )
+
+        def _flock(*_args, **_kwargs):
+            raise OSError(getattr(errno, "ESTALE", errno.EIO), "stale handle")
+
+        monkeypatch.setattr(fcntl, "flock", _flock)
+        db_path = tmp_path / "state.db"
+        t0 = time.monotonic()
+        with hermes_state_common.fts_rebuild_admission(db_path) as admitted:
+            assert admitted is False
+        assert time.monotonic() - t0 < 2.0
+
+    def test_retry_deferred_fts_recovery_rebuilds_same_instance(
+        self, tmp_path, monkeypatch
+    ):
+        """Gateway-shaped: same SessionDB stays open and retries after deferral."""
+        import hermes_state_schema
+
+        monkeypatch.setattr(hermes_state_schema, "_FTS_STALE_RETRY_SECONDS", 0.0)
+        db_path = tmp_path / "state.db"
+        d = SessionDB(db_path=db_path)
+        if not d._fts_enabled:
+            d.close()
+            pytest.skip("FTS5 unavailable in this build")
+        d.create_session("s1", source="test")
+        d.append_message("s1", "user", "hello recovery path")
+        d.close()
+
+        raw = sqlite3.connect(str(db_path))
+        raw.execute(
+            "INSERT OR REPLACE INTO state_meta(key, value) VALUES (?, '1')",
+            (FTS_STALE_KEY,),
+        )
+        for trig in _FTS_TRIGGERS:
+            raw.execute(f"DROP TRIGGER IF EXISTS {trig}")
+        raw.commit()
+        raw.close()
+
+        holders = [(4242, str(db_path))]
+        monkeypatch.setattr(
+            SessionDB, "_foreign_state_db_holders", lambda self: list(holders)
+        )
+        d2 = SessionDB(db_path=db_path)
+        try:
+            assert d2._fts_stale is True
+            d2._fts_stale_retry_after = 0.0
+            assert d2.retry_deferred_fts_recovery() is False
+            holders.clear()
+            d2._fts_stale_retry_after = 0.0
+            assert d2.retry_deferred_fts_recovery() is True
+            assert d2._fts_stale is False
+        finally:
+            d2.close()
+        assert _meta_value(db_path, FTS_STALE_KEY) is None
+        assert _base_fts_triggers(db_path) == set(_FTS_TRIGGERS)

--- a/tests/state/test_fts_rebuild_admission.py
+++ b/tests/state/test_fts_rebuild_admission.py
@@ -430,3 +430,195 @@ class TestNonContentionErrnoFailsFast:
             d2.close()
         assert _meta_value(db_path, FTS_STALE_KEY) is None
         assert _base_fts_triggers(db_path) == set(_FTS_TRIGGERS)
+
+    def test_non_contention_errno_skips_holder_warning(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """The fast-fail must not ALSO log the misleading 'held by another
+        process for more than Ns' line — there is no holder."""
+        import fcntl
+        import logging
+
+        monkeypatch.setattr(
+            hermes_state_common, "_FTS_REBUILD_LOCK_TIMEOUT_SECONDS", 30.0
+        )
+
+        def _flock(*_args, **_kwargs):
+            raise OSError(errno.ENOTSUP, "no locks on this fs")
+
+        monkeypatch.setattr(fcntl, "flock", _flock)
+        with caplog.at_level(logging.INFO, logger="hermes_state"):
+            with hermes_state_common.fts_rebuild_admission(
+                tmp_path / "state.db"
+            ) as admitted:
+                assert admitted is False
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("non-contention error" in m for m in messages)
+        assert not any("held by another process" in m for m in messages)
+
+    def test_repair_lock_non_contention_errno_fails_fast(
+        self, tmp_path, monkeypatch
+    ):
+        """Sibling site: the state.db repair lock shares the errno filter."""
+        import fcntl
+
+        import hermes_state
+
+        monkeypatch.setattr(hermes_state, "_REPAIR_LOCK_TIMEOUT_SECONDS", 30.0)
+
+        def _flock(*_args, **_kwargs):
+            raise OSError(errno.EIO, "i/o error")
+
+        monkeypatch.setattr(fcntl, "flock", _flock)
+        t0 = time.monotonic()
+        with hermes_state._cross_process_repair_lock(tmp_path / "state.db") as ok:
+            assert ok is False
+        assert time.monotonic() - t0 < 2.0
+
+    @pytest.mark.parametrize(
+        "exc, expected",
+        [
+            (BlockingIOError(errno.EAGAIN, "x"), True),
+            (OSError(errno.EWOULDBLOCK, "x"), True),
+            (OSError(errno.EACCES, "x"), True),
+            (OSError(errno.ESTALE, "x"), False),
+            (OSError(errno.ENOTSUP, "x"), False),
+            (OSError(errno.ENOLCK, "x"), False),
+            (OSError(errno.EIO, "x"), False),
+            (ValueError("not an oserror"), False),
+        ],
+    )
+    def test_is_advisory_lock_contention_table(self, exc, expected):
+        assert hermes_state_common.is_advisory_lock_contention(exc) is expected
+
+
+class TestDeferredFtsRetryInProcess:
+    """Gateway shape (#100108): one SessionDB stays open for days. A deferral
+    at open must be recoverable from an in-process periodic tick, with the
+    REAL rebuild lock held by a REAL child process at open time."""
+
+    @staticmethod
+    def _mark_stale(db_path: Path) -> None:
+        raw = sqlite3.connect(str(db_path))
+        raw.execute(
+            "INSERT OR REPLACE INTO state_meta(key, value) VALUES (?, '1')",
+            (FTS_STALE_KEY,),
+        )
+        for trig in _FTS_TRIGGERS:
+            raw.execute(f"DROP TRIGGER IF EXISTS {trig}")
+        raw.commit()
+        raw.close()
+
+    def test_retry_is_non_blocking_while_live_holder_and_backs_off(
+        self, tmp_path, fast_timeout, monkeypatch
+    ):
+        import hermes_state_schema
+
+        db_path = tmp_path / "state.db"
+        d = SessionDB(db_path=db_path)
+        if not d._fts_enabled:
+            d.close()
+            pytest.skip("FTS5 unavailable in this build")
+        d.create_session("s1", source="test")
+        d.append_message("s1", "user", "hello gateway retry")
+        d.close()
+        self._mark_stale(db_path)
+
+        with _rebuild_lock_held_by_other_process(db_path):
+            gw = SessionDB(db_path=db_path)  # long-lived "gateway" open
+            try:
+                assert gw._fts_stale is True
+                # Live holder: the retry must return quickly (timeout=0),
+                # not wait out any admission budget.
+                monkeypatch.setattr(
+                    hermes_state_common, "_FTS_REBUILD_LOCK_TIMEOUT_SECONDS", 30.0
+                )
+                t0 = time.monotonic()
+                assert gw.retry_deferred_fts_recovery() is False
+                assert time.monotonic() - t0 < 2.0
+                assert gw._fts_stale is True
+                # Rate limit engaged: an immediate second call is a no-op.
+                assert gw.retry_deferred_fts_recovery() is False
+                # Backoff doubled (60s -> 120s) but capped at the max.
+                assert gw._fts_stale_retry_interval == min(
+                    2 * hermes_state_schema._FTS_STALE_RETRY_SECONDS,
+                    hermes_state_schema._FTS_STALE_RETRY_MAX_SECONDS,
+                )
+                assert gw._fts_stale_retry_after > time.monotonic()
+            except BaseException:
+                gw.close()
+                raise
+        # Holder gone. Same instance recovers on the next eligible tick.
+        try:
+            gw._fts_stale_retry_after = 0.0
+            assert gw.retry_deferred_fts_recovery() is True
+            assert gw._fts_stale is False
+            assert gw._fts_enabled is True
+            # Search actually works again on this very instance.
+            gw.append_message("s1", "user", "needle-after-holder-gone")
+            assert gw.retry_deferred_fts_recovery() is False  # nothing stale
+        finally:
+            gw.close()
+        assert _meta_value(db_path, FTS_STALE_KEY) is None
+        assert _base_fts_triggers(db_path) == set(_FTS_TRIGGERS)
+
+    def test_gateway_housekeeping_tick_drives_the_retry(
+        self, tmp_path, fast_timeout, monkeypatch
+    ):
+        """The retry hangs off the EXISTING housekeeping loop (no new thread)
+        and reaches shared-registry instances."""
+        import threading
+
+        import hermes_state_registry
+        import hermes_state_schema
+        import gateway.run as grun
+
+        monkeypatch.setattr(hermes_state_schema, "_FTS_STALE_RETRY_SECONDS", 0.0)
+        db_path = tmp_path / "state.db"
+        d = SessionDB(db_path=db_path)
+        if not d._fts_enabled:
+            d.close()
+            pytest.skip("FTS5 unavailable in this build")
+        d.create_session("s1", source="test")
+        d.append_message("s1", "user", "hello housekeeping")
+        d.close()
+        self._mark_stale(db_path)
+
+        with _rebuild_lock_held_by_other_process(db_path):
+            gw = hermes_state_registry.acquire(db_path)
+        try:
+            assert gw._fts_stale is True
+            assert gw in hermes_state_registry.live_shared_session_dbs()
+            stop = threading.Event()
+            th = threading.Thread(
+                target=grun._start_gateway_housekeeping,
+                args=(stop,),
+                kwargs={"interval": 0.05},
+                daemon=True,
+            )
+            th.start()
+            deadline = time.monotonic() + 10.0
+            while gw._fts_stale and time.monotonic() < deadline:
+                time.sleep(0.05)
+            stop.set()
+            th.join(timeout=5)
+            assert gw._fts_stale is False
+            assert gw._fts_enabled is True
+        finally:
+            hermes_state_registry.release_or_close(gw)
+        assert _meta_value(db_path, FTS_STALE_KEY) is None
+
+    def test_retry_noop_when_not_stale_or_read_only(self, tmp_path):
+        db_path = tmp_path / "state.db"
+        d = SessionDB(db_path=db_path)
+        try:
+            assert d._fts_stale is False
+            assert d.retry_deferred_fts_recovery() is False
+        finally:
+            d.close()
+        ro = SessionDB(db_path=db_path, read_only=True)
+        try:
+            ro._fts_stale = True
+            assert ro.retry_deferred_fts_recovery() is False
+        finally:
+            ro.close()

--- a/tests/test_sqlite_wal_reset_gate.py
+++ b/tests/test_sqlite_wal_reset_gate.py
@@ -69,6 +69,7 @@ class TestApplyWalWalResetGate:
         assert mode == "delete"
         assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "delete"
         assert any("instead of enabling WAL" in r.getMessage() for r in caplog.records)
+        assert any(sys.executable in r.getMessage() for r in caplog.records)
         conn.close()
 
     def test_existing_wal_left_alone_when_vulnerable(


### PR DESCRIPTION
## Summary
Salvage of the two valid pieces of #100130 (@HexLab98): flock acquisition now fails fast on non-contention errnos instead of burning the full 120s admission timeout, and a gateway whose startup FTS rebuild was deferred now recovers it in-process from the existing housekeeping tick instead of staying on LIKE-only search until restart.

## Changes
- **`is_advisory_lock_contention` (hermes_state_common)** — only `EAGAIN`/`EWOULDBLOCK`/`EACCES`/`EDEADLK` mean "another process holds the lock". `ESTALE`/`ENOTSUP`/`ENOLCK`/`EIO` are environment failures polling cannot fix: `_acquire_db_flock` (shared by FTS admission + repair lock) and both Windows `msvcrt` loops now defer immediately with the real errno, and the misleading "held by another process for more than 120s" line is suppressed on that path (returns `None` from `_acquire_db_flock` → callers treat as not-acquired without the holder warning).
- **`SessionDB.retry_deferred_fts_recovery()` (hermes_state_schema)** — in-process retry of a deferred `_recover_stale_fts`: non-blocking admission (`fts_rebuild_admission(timeout_seconds=0)`, new kwarg), bounded backoff 60s→1h, still fails closed on live foreign holders / busy lock, never raises, no-op when not stale or read-only.
- **Gateway housekeeping tick (`gateway/run.py::_start_gateway_housekeeping`)** — calls the retry on every live shared-registry `SessionDB` (`hermes_state_registry.live_shared_session_dbs()`, new). No new thread; the tick already exists (60s). Logs once at INFO when the rebuild lands.
- **WAL-reset warning** names `sys.executable` so a "linked SQLite 3.45.1" line can be matched to the interpreter that linked it (#100108 point 3).
- **Not carried from #100130:** the "leftover 0-byte lock file = holder" premise (a lock file never blocked `flock`; the real cause was the fork-inherited fd, fixed in 894fc35337 / #100525) and the `_rebuild_fts_once` one-shot rework / dedicated retry thread.

## Validation
| Check | Result |
|---|---|
| `tests/state/test_fts_rebuild_admission.py` + `tests/test_sqlite_wal_reset_gate.py` | 51 passed |
| Sabotage (source at `origin/main`, new tests) | 16 failed / 35 passed — fast-fail tests stall to their 30s budget, retry method missing |
| `tests/state/` + `tests/gateway/test_session.py` + `tests/test_state_db_malformed_repair.py` | 251 passed |
| `tests/hermes_state/` + conn-lock audit + repair-live-writer guard + journal-mode + WAL fallback + housekeeping memory-trim + doctor journal modes | 324 passed, 1 skipped |
| `ruff check` on all touched files | clean |
| `scripts/audit_pr_attribution.py --fix` | all emails mapped |

**Live repro:** real-import harness (`SessionDB` from the worktree, isolated `HERMES_HOME`, real child process holding the `.fts_rebuild.lock` flock, real `_start_gateway_housekeeping` loop driven at 50 ms) —
before (origin/main): (a) `flock` raising `ESTALE` → `admitted=False elapsed=4.00s` against a 4.0 s budget (full timeout burned, then a bogus "held by another process for more than 4s" warning); (b) `SessionDB` opened under a live holder → `_fts_stale=True`; holder killed; same instance after housekeeping ticks: `_fts_stale=True _fts_enabled=False breadcrumb=('1',) triggers=0/6` — stays stale until restart.
after: (a) `admitted=False elapsed=0.00s`, single warning `Could not acquire FTS rebuild lock … ([Errno 116] Stale file handle) — deferring rather than waiting out the 4s holder timeout on a non-contention error.`; (b) same instance after ticks: `_fts_stale=False _fts_enabled=True breadcrumb=None triggers=6/6`, log `Rebuilt stale state.db FTS indexes from canonical messages and restored sync triggers.`

Salvages #100130 — thanks @HexLab98 (test commit cherry-picked with authorship; fix re-applied with `Co-authored-by`).
Related: #100108 (closed by #100525 for the orphaned-flock half; this covers the remaining errno / long-lived-process pieces).

## Infographic
![statedb-fts-retry](https://v3b.fal.media/files/b/0aa8cd24/ByUkeZVZIQwWegs8ofu17_gLN8nCLG.png)
