### PR TITLE
Desktop Projects sidebar no longer goes stale after external session create/delete/rename/cwd change (#100354)

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -38,7 +38,13 @@ vi.mock('@/hermes', async importOriginal => ({
   getLatestSessionMessages: vi.fn()
 }))
 
+vi.mock('@/store/projects', async importOriginal => ({
+  ...(await importOriginal()),
+  refreshProjectTree: vi.fn(async () => undefined)
+}))
+
 const { getLatestSessionMessages } = await import('@/hermes')
+const { refreshProjectTree } = await import('@/store/projects')
 
 const ACTIVE_RUNTIME_ID = 'runtime-active'
 const ACTIVE_STORED_ID = 'stored-active'
@@ -412,6 +418,16 @@ describe('active transcript refresh', () => {
     })
 
     expect(refresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('refreshes the project tree on a sessions.changed tick, alongside the sessions list (#100354)', async () => {
+    $changeEventsAvailable.set(true)
+
+    renderSync(vi.fn(async () => undefined))
+
+    act(() => notifySessionsChanged())
+
+    await waitFor(() => expect(refreshProjectTree).toHaveBeenCalledTimes(1))
   })
 })
 

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -9,6 +9,7 @@ import { sessionMessagesSignature } from '@/lib/session-signatures'
 import { $changeEventsAvailable, $cronChangeTick, $sessionsChangeTick } from '@/store/live-sync'
 import { $onBattery, batteryPollInterval } from '@/store/power'
 import { refreshActiveProfile } from '@/store/profile'
+import { refreshProjectTree } from '@/store/projects'
 import {
   $activeSessionId,
   $busy,
@@ -691,6 +692,11 @@ export function useBackgroundSync({
       lastRunAt = Date.now()
       void refreshSessions()
       void refreshMessagingSessions()
+      // The project tree is a grouping of the same stored rows, so a session
+      // created/deleted/renamed/re-homed outside this window goes stale in the
+      // Projects sidebar without this (#100354). refreshProjectTree() keeps the
+      // cached tree on failure, so a not-yet-ready backend costs nothing.
+      void refreshProjectTree()
       requestActiveTranscriptRefresh(true)
       // Bot canonical chats live in workspace tiles, never in the main-pane
       // selection — without this they never see background deliveries


### PR DESCRIPTION
## Summary
The Desktop Projects sidebar now updates when a session is created, deleted, renamed, or re-homed to another cwd from outside the window (CLI, TUI, cron, another Desktop window), instead of staying stale until the user switches views or refocuses the app.

Root cause: the gateway already broadcasts `sessions.changed` on every state.db write, and `use-background-sync.ts` already coalesces those ticks into a pass that refreshes the sessions list, messaging sessions, the active transcript, and tile transcripts — but that pass never touched the project tree, which is a grouping of the same rows.

Closes #100354

## Changes
- `apps/desktop/src/app/contrib/hooks/use-background-sync.ts`: call `refreshProjectTree()` inside the existing `sessions.changed` `run()` pass, so it rides the same `SESSIONS_LIST_TICK_GAP_MS` coalescing and typing-burst deferral as `refreshSessions()`. No new flags or timers; `refreshProjectTree()` already keeps the cached tree on failure.
- `apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts`: one test pinning that a `sessions.changed` tick invokes `refreshProjectTree` (fails on main, passes here).

The entered-project lane view (`sidebar/index.tsx`) re-runs its `fetchProjectSessions()` drill-in whenever `$projectTree` changes, so it follows this refresh with no extra wiring.

No "loaded once" flag exists on the tree store, and the sidebar already warms the tree shortly after boot in flat view, so no gate was added.

## Validation
| | Before | After |
|---|---|---|
| `use-background-sync.test.ts` "refreshes the project tree on a sessions.changed tick" | fails (`refreshProjectTree` called 0 times) | 27/27 pass |
| `npx tsc -p tsconfig.json --noEmit`, `eslint` on touched files | — | clean |
| Sibling suites using `useBackgroundSync` (profile, live-status-spinner, live-status-reap, use-background-sync.test.tsx) | — | 28/28 pass |

**Live repro:** vitest harness on the real `useBackgroundSync` hook with `notifySessionsChanged()` (the same store bump `live-sync.ts` performs on a gateway `sessions.changed` frame) — before: `refreshProjectTree` never invoked, tree stays stale; after: invoked once per coalesced pass alongside `refreshSessions`. No Desktop e2e spec covers the Projects sidebar, so none was adapted.

## Infographic

![salv-projtree](https://v3b.fal.media/files/b/0aa8cd35/RMQvxmE9eUQNxq5d5rHIR_bOiPlYQb.png)
