### PR TITLE
feat(teams): send RTL content as Adaptive Card with rtl=True

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -100,6 +100,44 @@ AdaptiveCard = None  # type: ignore[assignment,misc]
 ExecuteAction = None  # type: ignore[assignment,misc]
 TextBlock = None  # type: ignore[assignment,misc]
 
+def _is_rtl(text: str) -> bool:
+    """True when the text is predominantly Hebrew/Arabic.
+
+    Used to decide whether to send a plain markdown message (LTR) or an
+    Adaptive Card with ``rtl=True`` so Teams renders the content
+    right-to-left.
+    """
+    rtl = sum(1 for c in text if "\u0590" <= c <= "\u05ff" or "\u0600" <= c <= "\u06ff")
+    letters = sum(1 for c in text if c.isalpha())
+    return letters > 0 and rtl / letters > 0.3
+
+
+def _rtl_lists(text: str) -> str:
+    """Rewrite markdown list markers as plain leading characters.
+
+    Teams renders markdown lists (``- ``, ``1. ``) as LTR HTML lists whose
+    markers ignore the card's RTL, so in a Hebrew answer the bullets/numbers
+    end up on the left.  As plain text they flow with the RTL paragraph
+    (marker on the right).  A non-breaking space after a number stops Teams
+    re-detecting it as an ordered list.
+    """
+    out: list[str] = []
+    for line in text.split("\n"):
+        stripped = line.lstrip()
+        indent = line[: len(line) - len(stripped)]
+        if stripped[:2] in ("- ", "* "):
+            out.append(f"{indent}\u2022 {stripped[2:]}  ")
+        else:
+            n = 0
+            while n < len(stripped) and stripped[n].isdigit():
+                n += 1
+            if n and stripped[n : n + 2] == ". ":
+                out.append(f"{indent}{stripped[:n]}.\u00a0{stripped[n + 2:]}  ")
+            else:
+                out.append(line)
+    return "\n".join(out)
+
+
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.helpers import MessageDeduplicator
 from gateway.platforms.base import (
@@ -1361,6 +1399,27 @@ class TeamsAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Teams app not initialized")
 
         formatted = self.format_message(content)
+
+        # RTL content (Hebrew/Arabic) must be sent as an Adaptive Card with
+        # rtl=True — plain markdown messages always render LTR in Teams.
+        if _is_rtl(formatted) and AdaptiveCard is not None and TextBlock is not None:
+            rtl_text = _rtl_lists(formatted)
+            chunks = self.truncate_message(rtl_text)
+            last_message_id = None
+            for chunk in chunks:
+                card = (
+                    AdaptiveCard()
+                    .with_version("1.5")
+                    .with_rtl(True)
+                    .with_body([TextBlock(text=chunk, wrap=True)])
+                )
+                try:
+                    result = await self._send_card(chat_id, card)
+                    last_message_id = getattr(result, "id", None)
+                except Exception as e:
+                    return SendResult(success=False, error=str(e), retryable=True)
+            return SendResult(success=True, message_id=last_message_id)
+
         chunks = self.truncate_message(formatted)
         last_message_id = None
 


### PR DESCRIPTION
## What does this PR do?

Teams renders plain markdown messages as LTR regardless of content language. Hebrew and Arabic answers appear misaligned — bullets on the wrong side, text flowing left-to-right.

When the message is predominantly Hebrew/Arabic (>30% RTL characters), this PR sends it as an Adaptive Card with `rtl=True` instead of plain text. This mirrors the approach used by Copilot Studio bots. Gracefully falls back to the existing plain-text path when the SDK card classes are unavailable.

## Related Issue

Fixes #101236

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/teams/adapter.py`: Added `_is_rtl(text)` — detects predominantly Hebrew/Arabic content (>30% RTL character threshold)
- `plugins/platforms/teams/adapter.py`: Added `_rtl_lists(text)` — rewrites markdown list markers (`- `, `* `, `1. `) to plain Unicode bullets/numbers so they flow correctly in RTL
- `plugins/platforms/teams/adapter.py`: Modified `send()` — when RTL detected, sends an Adaptive Card with `rtl=True` via the existing `_send_card()` infrastructure instead of plain markdown

## How to Test

1. Connect Hermes to a Teams bot
2. Send a message that triggers a Hebrew/Arabic response (e.g. ask a question in Hebrew)
3. Verify the response renders right-to-left with bullets/numbers on the correct side
4. Send a message that triggers an English response — verify it still renders as plain markdown (no card)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10 (TOPAZ-AI server)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before: Hebrew content rendered LTR with bullets on the left side.
After: Hebrew content rendered RTL via Adaptive Card with correct bullet/number alignment.
