### PR TITLE
fix(sessions): the auto-titler can no longer rename a canonical Bot Chat whose title is derived-provenance

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -10760,13 +10760,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """Write a title, enforcing provenance precedence.
 
         ``source`` is one of ``TITLE_SOURCE_{DERIVED,LLM,USER}``. A ``user``
-        write is authoritative except for a canonical Bot Chat identity. An
-        automatic write (``derived``/``llm``) lands only when the row is
-        untitled or the stored title has strictly lower authority, so the
-        instant ``derived`` title upgrades to ``llm`` exactly once and neither
-        can ever overwrite a name the user typed. Re-running the titler on an
-        already-``llm`` row is a no-op, which is what stops a session renaming
-        itself.
+        write always lands — an explicit rename is authoritative. An automatic
+        write (``derived``/``llm``) lands only when the row is untitled or the
+        stored title has strictly lower authority, so the instant ``derived``
+        title upgrades to ``llm`` exactly once and neither can ever overwrite a
+        name the user typed. Re-running the titler on an already-``llm`` row is
+        a no-op, which is what stops a session renaming itself. The one thing
+        no writer may do is move a hidden canonical Bot Chat off its title.
 
         The read and the write are one compare-and-swap inside a single
         transaction, so a manual ``/title`` racing an in-flight generation
@@ -10791,7 +10791,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # surface funnels through (gateway session.title, /title, CLI
             # rename, REST). Hidden is the discriminator: canonical chats are
             # born hidden; an ordinary visible session a user happens to call
-            # "Bot Chat" stays freely renameable.
+            # "Bot Chat" stays freely renameable. Provenance-blind: an
+            # automatic llm write outranks a derived title, so the auto-titler
+            # would otherwise rename the row too (#99517) — it no-ops instead.
             if (
                 (current["title"] or "") == self.CANONICAL_BOT_CHAT_TITLE
                 and bool(current["hidden"])

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -10647,8 +10647,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     # Bot Mode's forever-chat registry: the session titled exactly this, on a
     # bot's profile, IS the bot's canonical chat — resolved by exact-title
     # lookup on every open (no session-id pointer exists). The title is the
-    # identity, which is why _set_session_title refuses user renames of a
-    # hidden row holding it (#92473).
+    # identity, which is why _set_session_title refuses renames of a hidden
+    # row holding it (#92473).
     CANONICAL_BOT_CHAT_TITLE = "Bot Chat"
 
     @classmethod
@@ -10760,12 +10760,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """Write a title, enforcing provenance precedence.
 
         ``source`` is one of ``TITLE_SOURCE_{DERIVED,LLM,USER}``. A ``user``
-        write always lands — an explicit rename is authoritative. An automatic
-        write (``derived``/``llm``) lands only when the row is untitled or the
-        stored title has strictly lower authority, so the instant ``derived``
-        title upgrades to ``llm`` exactly once and neither can ever overwrite a
-        name the user typed. Re-running the titler on an already-``llm`` row is
-        a no-op, which is what stops a session renaming itself.
+        write is authoritative except for a canonical Bot Chat identity. An
+        automatic write (``derived``/``llm``) lands only when the row is
+        untitled or the stored title has strictly lower authority, so the
+        instant ``derived`` title upgrades to ``llm`` exactly once and neither
+        can ever overwrite a name the user typed. Re-running the titler on an
+        already-``llm`` row is a no-op, which is what stops a session renaming
+        itself.
 
         The read and the write are one compare-and-swap inside a single
         transaction, so a manual ``/title`` racing an in-flight generation
@@ -10792,16 +10793,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # born hidden; an ordinary visible session a user happens to call
             # "Bot Chat" stays freely renameable.
             if (
-                is_user
-                and (current["title"] or "") == self.CANONICAL_BOT_CHAT_TITLE
+                (current["title"] or "") == self.CANONICAL_BOT_CHAT_TITLE
                 and bool(current["hidden"])
                 and title != self.CANONICAL_BOT_CHAT_TITLE
             ):
-                raise ValueError(
-                    "This is the bot's canonical Bot Chat — its name is its "
-                    "identity, and renaming it would orphan the conversation. "
-                    "To start fresh, create a new bot instead."
-                )
+                if is_user:
+                    raise ValueError(
+                        "This is the bot's canonical Bot Chat — its name is its "
+                        "identity, and renaming it would orphan the conversation. "
+                        "To start fresh, create a new bot instead."
+                    )
+                return 0
             if not is_user and current["title"] is not None:
                 if self._title_rank(current["title_source"]) >= new_rank:
                     return 0

--- a/tests/hermes_state/test_canonical_title_guard.py
+++ b/tests/hermes_state/test_canonical_title_guard.py
@@ -72,6 +72,9 @@ def test_auto_titler_still_cannot_touch_the_canonical_row(db):
 
 
 def test_auto_titler_cannot_rename_derived_canonical_bot_chat(db):
+    # #99517: the guard must be provenance-blind. A derived (rank 0) canonical
+    # title loses to an llm (rank 1) auto-title on precedence alone, so the
+    # identity check — not precedence — has to stop the write.
     db.create_session("derived", source="desktop")
     assert db._set_session_title(
         "derived",
@@ -91,6 +94,8 @@ def test_auto_titler_cannot_rename_derived_canonical_bot_chat(db):
 
 
 def test_auto_titler_can_rename_visible_derived_bot_chat(db):
+    # Control: hidden is still the discriminator — a visible session that
+    # merely carries the text "Bot Chat" upgrades derived -> llm as usual.
     db.create_session("visible", source="desktop")
     assert db._set_session_title(
         "visible",

--- a/tests/hermes_state/test_canonical_title_guard.py
+++ b/tests/hermes_state/test_canonical_title_guard.py
@@ -69,3 +69,38 @@ def test_auto_titler_still_cannot_touch_the_canonical_row(db):
     assert not db.set_auto_title(sid, "Chat about groceries", source=SessionDB.TITLE_SOURCE_LLM)
     row = db.get_session_by_title(SessionDB.CANONICAL_BOT_CHAT_TITLE)
     assert row and row["id"] == sid
+
+
+def test_auto_titler_cannot_rename_derived_canonical_bot_chat(db):
+    db.create_session("derived", source="desktop")
+    assert db._set_session_title(
+        "derived",
+        SessionDB.CANONICAL_BOT_CHAT_TITLE,
+        source=SessionDB.TITLE_SOURCE_DERIVED,
+    )
+    assert db.set_session_hidden("derived", True)
+
+    assert not db.set_auto_title(
+        "derived",
+        "Renamed by titler",
+        source=SessionDB.TITLE_SOURCE_LLM,
+    )
+    row = db.get_session("derived")
+    assert row["title"] == SessionDB.CANONICAL_BOT_CHAT_TITLE
+    assert row["title_source"] == SessionDB.TITLE_SOURCE_DERIVED
+
+
+def test_auto_titler_can_rename_visible_derived_bot_chat(db):
+    db.create_session("visible", source="desktop")
+    assert db._set_session_title(
+        "visible",
+        SessionDB.CANONICAL_BOT_CHAT_TITLE,
+        source=SessionDB.TITLE_SOURCE_DERIVED,
+    )
+
+    assert db.set_auto_title(
+        "visible",
+        "Renamed by titler",
+        source=SessionDB.TITLE_SOURCE_LLM,
+    )
+    assert db.get_session("visible")["title"] == "Renamed by titler"


### PR DESCRIPTION
## Summary

Salvage of #99560 by @fangliquanflq, fixing #99517 (@r5th): the canonical-Bot-Chat rename guard in `SessionDB._set_session_title` (#95397) was gated on `is_user`, so it only protected against explicit renames. The turn-start auto-titler bypassed it: a hidden `"Bot Chat"` row whose `title_source` is `derived` (rank 0) loses to an `llm` (rank 1) automatic title on provenance precedence alone, the row is renamed, and Bot Mode's exact-title registry lookup no longer finds the forever-chat — the same orphaning #95397 set out to close, via the one writer it didn't cover.

The guard is now **provenance-blind**: `hidden + "Bot Chat"` refuses any writer that would move the row off its title. A user rename still raises the explanatory `ValueError`; an automatic (`derived`/`llm`) write silently no-ops (`return 0` → `False`) so the every-turn titler never raises on the hot path. Rewriting the same canonical title remains a pass-through no-op (the plugin's eager `session.title` re-assert depends on it), and a *visible* session that merely carries the text "Bot Chat" is untouched — `hidden` stays the discriminator.

Closes #99517
Supersedes #99560 — @fangliquanflq's commit is cherry-picked with authorship preserved; my follow-up commit only restores/extends the docstring and comments the two new tests.

## Changes

- `hermes_state.py` — drop `is_user and` from the canonical guard predicate; branch on `is_user` inside it (`raise ValueError` for user writes, `return 0` for automatic). Comments/docstring name the llm-outranks-derived hole (#99517). Net code change ≈ 6 lines.
- `tests/hermes_state/test_canonical_title_guard.py` — two tests: the `derived`→`llm` regression (fails on main, passes here) and the visible-non-canonical control (a visible "Bot Chat" still upgrades `derived`→`llm`).

Sibling-path audit: every title write in the tree (`gateway session.title`, `/title`, CLI rename, REST `sessions.py`, cron scheduler, `title_generator.py` derived/llm, compression rotation) funnels through `_set_session_title`, so one predicate covers the class. The two raw `UPDATE sessions SET title` sites (`gateway/platforms/api_server.py` session-create and `plugins/platforms/a2a/adapter.py` forwarded-session titling) only write titles onto sessions they just created, never onto a pre-existing hidden canonical row.

## Validation

- `pytest tests/hermes_state/test_canonical_title_guard.py -q` → 7 passed.
- Sabotage: same test file against `origin/main`'s `hermes_state.py` → `test_auto_titler_cannot_rename_derived_canonical_bot_chat` FAILS, 6 pass — the regression test bites.
- `ruff check` clean on both files; `scripts/audit_pr_attribution.py --fix` → all contributor emails mapped (`contributors/emails/fangliquan@qq.com` already on main).

**Live repro:** real `SessionDB` on a temp `HERMES_HOME` state.db, worktree imports, no mocks — `create_session` → `_set_session_title("Bot Chat", source=derived)` → `set_session_hidden(True)` → `set_auto_title("Renamed by titler", source=llm)`.
- before (origin/main `32fe1293244`): `auto_title wrote=True title='Renamed by titler' source='llm' registry_hit=False` — canonical row orphaned; and `set_session_title(...)` user rename LANDED on the now-mistitled row.
- after: `auto_title wrote=False title='Bot Chat' source='derived' registry_hit=True`; user rename → `ValueError: This is the bot's canonical Bot Chat …`; control visible "Bot Chat" → `auto_title wrote=True title='Groceries'`.

## Infographic

![salv-titleguard](https://v3b.fal.media/files/b/0aa8cd37/qMR5wi_t8C5KFmnicCZS9_8ID5uPDZ.png)
