### PR TITLE
fix(desktop): group chat picker rows truncate long bot names instead of scrolling the list sideways

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/create-dialog.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/create-dialog.tsx
@@ -1271,7 +1271,7 @@ export function CreateGroupChatDialog({ open, roster, onClose, onCreated }: Crea
                 return (
                   <label
                     className={cn(
-                      'flex cursor-pointer items-center gap-2 rounded-md px-1.5 py-1 transition-colors hover:bg-(--chrome-action-hover)',
+                      'flex min-w-0 cursor-pointer items-center gap-2 rounded-md px-1.5 py-1 transition-colors hover:bg-(--chrome-action-hover)',
                       disabled && 'cursor-not-allowed opacity-50'
                     )}
                     key={botRosterKey(bot)}

--- a/apps/desktop/src/plugins/hermes-bots/create-group-chat-dialog.picker-row-truncate.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/create-group-chat-dialog.picker-row-truncate.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * The New Group Chat picker rows are `label` flex containers wrapping a
+ * `min-w-0 flex-1` text column whose lines are `truncate`. A flex/grid item
+ * defaults to `min-width: auto`, so without `min-w-0` on the label itself the
+ * row can never shrink below its longest line (`@handle · in "A", "B", …`),
+ * `truncate` never engages, and the list widens past the viewport. The first
+ * click then focuses a checkbox that sits off-screen and scrolls every name
+ * out of view (PR #90624: wrapper 593px in a 414px viewport, scrollLeft 0 →
+ * 178.38 on click; 414px / 0 → 0 with the class).
+ *
+ * jsdom does no layout, so this asserts the contract the layout engine needs:
+ * the row label must opt out of the auto minimum width.
+ */
+
+import type * as HermesSdk from '@hermes/plugin-sdk'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { translateBots } from './i18n-test-helper'
+import type { RosterRow } from './types'
+
+vi.mock('@hermes/plugin-sdk', async importOriginal => {
+  const original = await importOriginal<typeof HermesSdk>()
+
+  return {
+    ...original,
+    host: {
+      ...original.host,
+      connections: vi.fn(async () => []),
+      notify: vi.fn(),
+      notifyError: vi.fn(),
+      request: vi.fn(async () => ({})),
+      requestProfile: vi.fn(async () => ({}))
+    },
+    // The plugin bundle normally lands via `ctx.i18n.register` at load.
+    usePluginI18n: () => translateBots
+  }
+})
+
+vi.setConfig({ testTimeout: 30_000 })
+
+const LONG_NAME = 'An Extraordinarily Long Bot Name That Would Widen The Picker Row Past The Dialog Edge'
+
+const roster: RosterRow[] = [
+  { connectionId: 'local', display_name: LONG_NAME, name: 'long-bot' },
+  { connectionId: 'local', name: 'short' }
+]
+
+beforeAll(async () => {
+  // Radix Dialog reaches for APIs jsdom does not implement.
+  Element.prototype.scrollIntoView = () => undefined
+  Element.prototype.hasPointerCapture = () => false
+  Element.prototype.releasePointerCapture = () => undefined
+  Element.prototype.setPointerCapture = () => undefined
+  await import('./create-dialog')
+}, 120_000)
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('CreateGroupChatDialog picker rows', () => {
+  it('lets the row label shrink so long bot names truncate instead of widening the list', async () => {
+    const { CreateGroupChatDialog } = await import('./create-dialog')
+
+    render(<CreateGroupChatDialog onClose={() => undefined} onCreated={() => undefined} open roster={roster} />)
+
+    const nameCell = screen.getByText(LONG_NAME)
+    const label = nameCell.closest('label')
+
+    expect(label).not.toBeNull()
+    // The row is a flex container AND a grid item; both default to
+    // `min-width: auto`, which is what defeats the inner `truncate`.
+    expect(label!.className.split(/\s+/)).toContain('min-w-0')
+    expect(label!.className.split(/\s+/)).toContain('flex')
+    // The text column it wraps is the one that actually ellipsizes.
+    expect(nameCell.className.split(/\s+/)).toContain('truncate')
+    expect(nameCell.parentElement!.className.split(/\s+/)).toEqual(expect.arrayContaining(['min-w-0', 'flex-1']))
+
+    // Every row gets the same treatment, not just the long one.
+    const labels = screen.getAllByRole('checkbox').map(box => box.closest('label'))
+
+    expect(labels).toHaveLength(roster.length)
+
+    for (const row of labels) {
+      expect(row!.className.split(/\s+/)).toContain('min-w-0')
+    }
+  })
+})


### PR DESCRIPTION
Supersedes #90624 — cherry-picked from @johnsonAyo (Jay) with authorship preserved, plus a regression test on top. All credit for the diagnosis and the fix to the original author; the PR thread names no issue number ("No existing issue — I couldn't find one").

## Summary

The New Group Chat bot picker scrolled bot names out of view the moment you clicked a row. Each picker row is a `<label>` flex container wrapping a `min-w-0 flex-1` text column whose two lines are `truncate`. The label itself had no `min-w-0`, so as a flex/grid item it kept its `min-width: auto` and could never shrink below its content — `truncate` never engaged, and the row grew to fit its longest secondary line (`@handle · in "Group A", "Group B", …`). The list widened past the dialog; the checkbox ended up off-screen; the first click focused it and the browser scrolled the whole list sideways, clipping every name. The offset persisted until the dialog was remounted.

## Changes

- `apps/desktop/src/plugins/hermes-bots/create-dialog.tsx` (+1/−1, @johnsonAyo's commit) — add `min-w-0` to the picker-row `<label>` in `CreateGroupChatDialog` so it can shrink and the inner `truncate` engages as the markup already intended. The ScrollArea wrapper's `display: table` is left alone.
- `apps/desktop/src/plugins/hermes-bots/create-group-chat-dialog.picker-row-truncate.test.tsx` (new, ours) — renders the real `CreateGroupChatDialog` with a long-named bot and asserts the row `<label>` className contains `min-w-0` (and that the inner text column keeps `min-w-0 flex-1` + `truncate`), across every row.

## Validation

- `npx vitest run --project ui src/plugins/hermes-bots/create-group-chat-dialog.picker-row-truncate.test.tsx` → 1 passed.
- Sabotage run: with `create-dialog.tsx` reverted to `origin/main`, the same test fails with `expected [ 'flex', 'cursor-pointer', …(7) ] to include 'min-w-0'` — the test bites on the pre-fix markup.
- `npx tsc -p tsconfig.json --noEmit` → clean. `npx eslint` on both touched files → clean.
- `python3 scripts/audit_pr_attribution.py --fix` → all contributor emails mapped (author email normalized to the existing `contributors/emails/johnsonafuye@gmail.com` mapping).

**Live repro:** packaged Electron build over CDP (author's measurements from #90624, same roster, 414 px viewport) — before: ScrollArea wrapper 593 px, widest row 585 px, viewport overflows, `scrollLeft` jumps 0 → 178.38 (= 593 − 414) on the first row click and names are clipped from the left; after: wrapper 414 px, widest row 406 px, no overflow, `scrollLeft` stays 0 → 0 on click, long rows ellipsize. jsdom does no layout, so the added unit test asserts the class contract the layout engine needs rather than re-measuring; the before/after screenshots are on #90624.

## Infographic

![salv-picker](https://v3b.fal.media/files/b/0aa8cd39/qC_cXc0uTVrNWz6P0sDW6_wBj5XtdI.png)
