### PR TITLE
fix(desktop): backend-pinned messaging and cron sessions can be unpinned — pin sync reconciles every sidebar slice

### DIFF
--- a/apps/desktop/src/store/session-pin-sync.test.ts
+++ b/apps/desktop/src/store/session-pin-sync.test.ts
@@ -133,6 +133,25 @@ describe('watchSessionPins remote pull', () => {
     expect(patch).toHaveBeenCalledWith('cron-pin', false, 'jobs')
   })
 
+  it('routes a cross-slice unpin to the active profile', async () => {
+    $activeGatewayProfile.set('work')
+
+    try {
+      $sessions.set([row('shared', { pinned: true, profile: 'default' })])
+      $messagingSessions.set([row('shared', { pinned: true, profile: 'work', source: 'photon' })])
+      await flush()
+      expect($pinnedSessionIds.get()).toEqual(['shared'])
+      patch.mockClear()
+
+      $pinnedSessionIds.set([])
+      await flush()
+
+      expect(patch).toHaveBeenCalledWith('shared', false, 'work')
+    } finally {
+      $activeGatewayProfile.set('default')
+    }
+  })
+
   it('adopts a pin another app made', async () => {
     $sessions.set([row('remote', { pinned: true })])
     await flush()

--- a/apps/desktop/src/store/session-pin-sync.test.ts
+++ b/apps/desktop/src/store/session-pin-sync.test.ts
@@ -15,7 +15,7 @@ vi.mock('@/hermes', () => ({
 
 import { $pinnedSessionIds } from '@/store/layout'
 import { $activeGatewayProfile } from '@/store/profile'
-import { $sessions } from '@/store/session'
+import { $cronSessions, $messagingSessions, $sessions } from '@/store/session'
 
 import { $unconfirmedPinWrites, resetSessionPinMirror, watchSessionPins } from './session-pin-sync'
 
@@ -33,6 +33,8 @@ beforeAll(() => {
 
 beforeEach(() => {
   $sessions.set([])
+  $cronSessions.set([])
+  $messagingSessions.set([])
   $pinnedSessionIds.set([])
   // The mirror/pending/unconfirmed maps are module-global, so one test's
   // bookkeeping would otherwise suppress the next test's PATCH (or fence out
@@ -43,6 +45,8 @@ beforeEach(() => {
 
 afterEach(() => {
   $sessions.set([])
+  $cronSessions.set([])
+  $messagingSessions.set([])
   $pinnedSessionIds.set([])
 })
 
@@ -103,6 +107,32 @@ describe('watchSessionPins', () => {
 })
 
 describe('watchSessionPins remote pull', () => {
+  it('adopts and durably unpins a backend-only messaging pin', async () => {
+    $messagingSessions.set([row('photon-pin', { pinned: true, profile: 'messages', source: 'photon' })])
+    await flush()
+
+    expect($pinnedSessionIds.get()).toEqual(['photon-pin'])
+    patch.mockClear()
+
+    $pinnedSessionIds.set([])
+    await flush()
+
+    expect(patch).toHaveBeenCalledWith('photon-pin', false, 'messages')
+  })
+
+  it('adopts and durably unpins a backend-only cron pin', async () => {
+    $cronSessions.set([row('cron-pin', { pinned: true, profile: 'jobs', source: 'cron' })])
+    await flush()
+
+    expect($pinnedSessionIds.get()).toEqual(['cron-pin'])
+    patch.mockClear()
+
+    $pinnedSessionIds.set([])
+    await flush()
+
+    expect(patch).toHaveBeenCalledWith('cron-pin', false, 'jobs')
+  })
+
   it('adopts a pin another app made', async () => {
     $sessions.set([row('remote', { pinned: true })])
     await flush()

--- a/apps/desktop/src/store/session-pin-sync.ts
+++ b/apps/desktop/src/store/session-pin-sync.ts
@@ -27,7 +27,13 @@ import { setSessionPinnedRemote } from '@/hermes'
 import { onConnectionScopeChange } from '@/lib/connection-scoped'
 import { $pinnedSessionIds, pinSession, unpinSession } from '@/store/layout'
 import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
-import { $sessions, sessionMatchesStoredId, sessionPinId } from '@/store/session'
+import {
+  $cronSessions,
+  $messagingSessions,
+  $sessions,
+  sessionMatchesStoredId,
+  sessionPinId
+} from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
 // pin ids we've successfully PATCHed pinned=true this session.
@@ -71,7 +77,11 @@ function publishUnconfirmed(): void {
 }
 
 function profileFor(pinId: string): null | string | undefined {
-  return $sessions.get().find(row => sessionMatchesStoredId(row, pinId))?.profile
+  return loadedSessionRows().find(row => sessionMatchesStoredId(row, pinId))?.profile
+}
+
+function loadedSessionRows(): SessionInfo[] {
+  return [...$sessions.get(), ...$cronSessions.get(), ...$messagingSessions.get()]
 }
 
 /**
@@ -140,7 +150,7 @@ function writePin(id: string, pinned: boolean, profile?: null | string): Promise
 function pullRemotePins(): void {
   const local = new Set($pinnedSessionIds.get())
 
-  for (const row of rowsByPinId($sessions.get()).values()) {
+  for (const row of rowsByPinId(loadedSessionRows()).values()) {
     // A backend without the flag has no opinion; never act on `undefined`.
     if (typeof row.pinned !== 'boolean') {
       continue
@@ -190,8 +200,8 @@ function pullRemotePins(): void {
   }
 }
 
-// Re-entrancy guard: reconcile() is subscribed to BOTH $sessions and
-// $pinnedSessionIds, and pullRemotePins() mutates $pinnedSessionIds (via
+// Re-entrancy guard: reconcile() is subscribed to every loaded-session slice
+// and $pinnedSessionIds, and pullRemotePins() mutates $pinnedSessionIds (via
 // pinSession/unpinSession), which fires reconcile() again synchronously.
 // Without this guard, a session whose pin state oscillates — two rows with the
 // same durable id but conflicting `pinned` flags, possible when profile
@@ -247,9 +257,9 @@ function reconcileInner(): void {
   }
 
   // Flush whatever we can resolve now; unresolved ids (row not loaded yet)
-  // retry on the next $sessions change.
+  // retry on the next loaded-session slice change.
   for (const id of [...pending]) {
-    const row = $sessions.get().find(entry => sessionMatchesStoredId(entry, id))
+    const row = loadedSessionRows().find(entry => sessionMatchesStoredId(entry, id))
 
     if (!row) {
       continue
@@ -276,6 +286,8 @@ export function watchSessionPins(): void {
   reconcile()
   $pinnedSessionIds.listen(reconcile)
   $sessions.listen(reconcile)
+  $cronSessions.listen(reconcile)
+  $messagingSessions.listen(reconcile)
 }
 
 /**

--- a/apps/desktop/src/store/session-pin-sync.ts
+++ b/apps/desktop/src/store/session-pin-sync.ts
@@ -77,11 +77,24 @@ function publishUnconfirmed(): void {
 }
 
 function profileFor(pinId: string): null | string | undefined {
-  return loadedSessionRows().find(row => sessionMatchesStoredId(row, pinId))?.profile
+  return loadedRowFor(pinId)?.profile
 }
 
 function loadedSessionRows(): SessionInfo[] {
   return [...$sessions.get(), ...$cronSessions.get(), ...$messagingSessions.get()]
+}
+
+/**
+ * The row a stored pin id resolves to, across every slice. Same tie-break as
+ * `rowsByPinId`: when two profiles share the id, the write must target the
+ * row the pull adopted — the active gateway's — or an unpin PATCHes the other
+ * profile and the next page re-adopts the pin.
+ */
+function loadedRowFor(pinId: string): SessionInfo | undefined {
+  const rows = loadedSessionRows().filter(row => sessionMatchesStoredId(row, pinId))
+  const gateway = normalizeProfileKey($activeGatewayProfile.get())
+
+  return rows.find(row => normalizeProfileKey(row.profile) === gateway) ?? rows[0]
 }
 
 /**
@@ -259,7 +272,7 @@ function reconcileInner(): void {
   // Flush whatever we can resolve now; unresolved ids (row not loaded yet)
   // retry on the next loaded-session slice change.
   for (const id of [...pending]) {
-    const row = loadedSessionRows().find(entry => sessionMatchesStoredId(entry, id))
+    const row = loadedRowFor(id)
 
     if (!row) {
       continue


### PR DESCRIPTION
## Summary

Desktop's pin sync (`session-pin-sync.ts`) read and subscribed to `$sessions` only, while the sidebar renders three slices — `$sessions`, `$cronSessions`, `$messagingSessions`. A Photon/iMessage or cron session pinned on the backend showed under Pinned, but its id was never adopted into `$pinnedSessionIds`, so Unpin filtered a missing id, emitted no change, and never PATCHed the backend: the row was stuck in Pinned forever.

Salvage of #92601 (@fangliquanflq, cherry-picked with authorship preserved) plus one minimal follow-up case from #92609 (@jakewvincent, `Co-authored-by`).

Closes #92593
Supersedes #74550 (@hashtag1974, earliest), #92601 (@fangliquanflq), #92609 (@jakewvincent) — all three reproduced the same slice-blind reconcile; #92601 is the smallest fix, so it's the base.

## Changes

- `apps/desktop/src/store/session-pin-sync.ts`
  - `loadedSessionRows()` concatenates all three sidebar slices; the pull pass, pending-pin flush, and `profileFor()` resolve rows from it (#92601).
  - `watchSessionPins()` also listens to `$cronSessions` and `$messagingSessions` (#92601).
  - `loadedRowFor()` — the push side resolves a stored id with the same active-gateway tie-break `rowsByPinId` already uses for the pull. With every slice in play, two profiles can share a session id; without this the unpin PATCHed the first-matched profile and the next page re-adopted the pin (case from #92609).
- `apps/desktop/src/store/session-pin-sync.test.ts` — three tests: backend-only messaging pin adopt + durable unpin, same for cron (#92601), cross-slice unpin routed to the active profile (#92609).

Not carried from #92609 / #74550: the conversation-grouping rewrite, conflicting-opinion deferral, and split-lineage tests — heavier machinery for cases the existing `rowsByPinId` tie-break already makes deterministic; not needed for the reported symptom.

## Validation

**Live repro:** `session-pin-sync.test.ts` against origin/main with the PR's tests — before: `adopts and durably unpins a backend-only messaging pin` and `... cron pin` FAIL (2 failed | 22 passed); after cherry-pick: 24/24. Follow-up test `routes a cross-slice unpin to the active profile` FAILS on the cherry-pick-only tree (`expected vi.fn() to be called with ['shared', false, 'work']`) and passes with `loadedRowFor()` — 25/25 on the branch.

- `npx vitest run --project ui src/store/session-pin-sync.test.ts` → 25 passed
- `npx tsc -p tsconfig.json --noEmit` → clean
- `npx eslint` on both files → clean
- `scripts/audit_pr_attribution.py` → all contributor emails mapped

## Infographic

![pin sync across all sidebar slices](https://v3b.fal.media/files/b/0aa8cd3a/AL4uzWgEiISK8ECNkTsy0_lyYj0kqe.png)
