### PR TITLE
fix(bot-mode): empty Bot Chat lookup fails closed instead of minting; group tab hands off to remote bots

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/canonical-chat-registry.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/canonical-chat-registry.test.ts
@@ -280,4 +280,29 @@ describe('a failed lookup fails CLOSED — never "no chat exists"', () => {
     await expect(createCanonicalChat('ops')).rejects.toThrow(/Bot Chat registry/)
     expect(calls.some(call => call.method === 'session.create')).toBe(false)
   })
+
+  // #98383: a profile backend mid-restart can answer `session.list`
+  // SUCCESSFULLY with an empty list instead of throwing. `rows.find(...) ||
+  // null` used to read that identically to "this bot never had a chat",
+  // which minted a replacement and re-fired the kickoff on every click.
+  it('refuses to mint on an empty lookup when the roster already confirmed a canonical chat', async () => {
+    const calls = respondWith(method => {
+      if (method === 'session.list') {
+        return { sessions: [] }
+      }
+
+      if (method === 'session.create') {
+        throw new Error('must not create: an empty result is not confirmed absence')
+      }
+
+      return {}
+    })
+
+    const bot = { canonical_session: { id: 'forever-chat' }, name: 'ops' } as RosterRow
+    const { openBotCanonicalChat } = await loadModule()
+
+    await expect(openBotCanonicalChat(bot)).rejects.toThrow(/Bot Chat registry/)
+    expect(calls.some(call => call.method === 'session.create')).toBe(false)
+    expect(hostMock.openSession).not.toHaveBeenCalled()
+  })
 })

--- a/apps/desktop/src/plugins/hermes-bots/canonical-chat.ts
+++ b/apps/desktop/src/plugins/hermes-bots/canonical-chat.ts
@@ -213,8 +213,25 @@ async function findExistingCanonicalChat(owner: RosterRow | string): Promise<Can
   }
 
   const rows = res?.sessions ?? []
+  const match = rows.find(row => isCanonicalBotChatHistory(row))
 
-  return rows.find(row => isCanonicalBotChatHistory(row)) || null
+  if (match) {
+    return match
+  }
+
+  // A zero-row result is NOT the same as a thrown error, but it is just as
+  // capable of forking the forever chat: a profile backend mid-restart can
+  // answer `session.list` successfully with an empty list rather than
+  // failing it, and `|| null` used to read that identically to "this bot
+  // never had a chat" (#98383). The roster's own `canonical_session` is the
+  // last positive confirmation this profile HAD one — when that exists,
+  // an empty lookup is unconfirmed absence, not confirmed absence, so fail
+  // closed the same way a thrown RPC error already does instead of minting.
+  if (bot?.canonical_session?.id) {
+    throw new Error(`Could not confirm ${name}'s Bot Chat registry — not starting a new chat`)
+  }
+
+  return null
 }
 
 interface CreateCanonicalChatOptions {

--- a/apps/desktop/src/plugins/hermes-bots/group-bot-handoff.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-bot-handoff.test.ts
@@ -76,6 +76,14 @@ async function loadRoom(): Promise<Room> {
 
 const BOT: RosterRow = { name: 'alpha', title: 'Alpha' }
 
+const REMOTE_BOT: RosterRow = {
+  connectionId: 'remote-1',
+  name: 'alpha',
+  remoteSource: true,
+  sourceScoped: true,
+  title: 'Alpha'
+}
+
 /** Seat a room and front it as a main-window tab, recording tab closes in
  *  the order they happen relative to the canonical open. */
 function registerGroup(room: Room, group: string, timeline: string[]) {
@@ -111,6 +119,22 @@ describe('opening a bot from a fronted room', () => {
     expect(room.panes.groupChatMainTabs.has('Core')).toBe(false)
   })
 
+  it('retires the group tab before opening a bot from another connection', async () => {
+    const timeline: string[] = []
+    const room = await loadRoom()
+    registerGroup(room, 'Core', timeline)
+    openBotCanonicalChat.mockImplementation(async () => {
+      timeline.push('canonicalOpen')
+
+      return { openedId: 'stored-chat', registryId: 'stored-chat' }
+    })
+
+    expect(await room.actions.openRosterBot(REMOTE_BOT)).toBe(true)
+    expect(timeline.filter(event => event.includes(':group:'))).toHaveLength(1)
+    expect(timeline.findIndex(event => event.includes(':group:'))).toBeLessThan(timeline.indexOf('canonicalOpen'))
+    expect(room.panes.groupChatMainTabs.has('Core')).toBe(false)
+  })
+
   it('is safe with no room fronted', async () => {
     const timeline: string[] = []
     const room = await loadRoom()
@@ -141,8 +165,9 @@ describe('a failed open must not steal the center', () => {
     registerGroup(room, 'Core', [])
     prepareBotSource.mockRejectedValue(new Error('source preparation failed'))
 
-    expect(await room.actions.openRosterBot({ ...BOT, connectionId: 'local', sourceScoped: true })).toBe(false)
+    expect(await room.actions.openRosterBot(REMOTE_BOT)).toBe(false)
     expect(room.chat.$groupChatWorkspace.get()).toBe('Core')
+    expect(room.panes.groupChatMainTabs.has('Core')).toBe(true)
   })
 
   it('restores the room by its immutable roomId, so a rename mid-open still finds it', async () => {

--- a/apps/desktop/src/plugins/hermes-bots/roster-actions.ts
+++ b/apps/desktop/src/plugins/hermes-bots/roster-actions.ts
@@ -201,7 +201,7 @@ export async function openRosterBot(bot: RosterRow): Promise<boolean> {
   haptic('tap')
   saveSelectedRosterBot(bot)
   setBotsWorkspaceOwner(botWorkspaceOwnerKey(bot), bot)
-  const dismissedGroup = bot.remoteSource ? null : dismissGroupChatForLocalBotOpen()
+  const dismissedGroup = dismissGroupChatForBotOpen()
 
   if (!dismissedGroup) {
     $groupChatWorkspace.set(null)
@@ -319,7 +319,7 @@ export async function openRosterBot(bot: RosterRow): Promise<boolean> {
 /** Bot-open handoff: capture the selected group and retire its registered
  * main tab (or clear the in-panel selection) before async source prep /
  * canonical open. */
-function dismissGroupChatForLocalBotOpen(): null | { group: string; roomId: string } {
+function dismissGroupChatForBotOpen(): null | { group: string; roomId: string } {
   const group = $groupChatWorkspace.get()
 
   if (!group) {


### PR DESCRIPTION
## Summary

Two small contributor fixes on the Bot Mode open path, salvaged together because they share the same surface (`apps/desktop/src/plugins/hermes-bots/`) and the same failure class: the click-a-bot path doing the wrong thing in a transient/edge state.

1. **Empty registry lookup no longer mints a duplicate Bot Chat** (@chelsealong, #98388). `session.list` can succeed with `sessions: []` while a profile backend is mid-restart, and `findExistingCanonicalChat`'s `rows.find(...) || null` read that exactly like "this bot never had a chat" — the click path then minted a replacement Bot Chat and re-fired the kickoff intro on an intact, hidden canonical row (#98383). When the roster's own `canonical_session` already confirms the profile HAS a Bot Chat, a zero-row lookup is now treated as unconfirmed absence and fails closed (same toast-and-retry outcome a thrown RPC error already produces) instead of calling `session.create`.
2. **Group tab hands off to remote bots too** (@helix4u, #101024). `openRosterBot` only retired the fronted group main tab for local bots (`bot.remoteSource ? null : dismissGroupChatForLocalBotOpen()`), so opening a bot from another connection left the group tab in place and the new Bot Chat landed behind it. The handoff now runs for every bot; the existing rollback on failed source preparation keeps restoring the group tab.

Closes #98383
Supersedes #98388, #101024

Both contributor commits are cherry-picked with authorship preserved (chelsealong, Gille/@helix4u).

## Changes

- `canonical-chat.ts` — after the `session.list` lookup, if no canonical row matched and `bot.canonical_session.id` is set, throw `Could not confirm <name>'s Bot Chat registry — not starting a new chat` instead of returning `null`.
- `roster-actions.ts` — `dismissGroupChatForLocalBotOpen` → `dismissGroupChatForBotOpen`, called unconditionally (drops the `remoteSource` guard).
- `canonical-chat-registry.test.ts` — one new case: `refuses to mint on an empty lookup when the roster already confirmed a canonical chat`.
- `group-bot-handoff.test.ts` — one new case: `retires the group tab before opening a bot from another connection`; the existing `restores the group when source preparation rejects` now uses a remote bot and also asserts the main tab is restored.

+71 / −4 across 4 files. No docs change: no user-facing config or UI surface changes, only wrong behavior removed.

## Validation

- **Before (origin/main `32fe1293244`):** the two new tests fail — `× refuses to mint on an empty lookup …` (`session.create` is called) and `× retires the group tab before opening a bot from another connection` (group tab still registered). 14/16 pass.
- **After (this branch):** whole `src/plugins/hermes-bots/` vitest dir: 59 files, 566/566 tests pass.
- `npx tsc -p tsconfig.json --noEmit` clean; `npx eslint` on the 4 touched files clean.
- **Live repro:** Playwright Electron e2e on the built desktop app (`npm run build`, DISPLAY=:99) — `e2e/group-to-local-bot-handoff.spec.ts` (local bot replaces an open group main workspace) and `e2e/bot-mode-row-click-mirrors-registry.spec.ts` (a bot row click lands on the Bot Chat the row previews, not a side thread) — before: the empty-lookup mint and remote-handoff gaps are unit-pinned above (no e2e harness yet exercises a mid-restart empty `session.list` or a second gateway connection); after: both existing live specs pass (2/2, 2.1m), proving the open path and local handoff still work end to end with the fail-closed branch in place.
- `scripts/audit_pr_attribution.py --fix`: all contributor emails mapped.

## Infographic

![Bot Chat open path: fail closed + remote handoff](https://v3b.fal.media/files/b/0aa8cd3a/n-tMczWAAqshRHO7Q9fpU_3Agx7JOt.png)
