### PR TITLE
fix(desktop): a split-dragged Bot tab keeps its Bot workspace scope

### DIFF
--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -382,6 +382,45 @@ describe('SessionTile workspace scope', () => {
     })
   })
 
+  it('preserves an existing Bot tile scope when moving it without an explicit scope', () => {
+    const scope = {
+      ownerRoute: {
+        connectionId: 'connection-a',
+        mode: 'remote' as const,
+        profile: 'default',
+        targetProfile: 'default'
+      },
+      workspaceMode: 'bots' as const,
+      workspaceOwnerKey: 'bot:connection-a::default',
+      workspaceTabTitle: 'Bot chat'
+    }
+
+    openSessionTile('bot-chat', 'right', undefined, undefined, scope)
+    $layoutTree.set(group(['workspace', 'session-tile:bot-chat'], { id: 'workspace-group' }))
+    // A split drag re-docks the tab with no scope (session-drag onCommit).
+    openSessionTile('bot-chat', 'left', 'workspace')
+
+    expect($sessionTiles.get()).toEqual([
+      expect.objectContaining({
+        anchor: 'workspace',
+        dir: 'left',
+        ownerRoute: scope.ownerRoute,
+        storedSessionId: 'bot-chat',
+        workspaceMode: 'bots',
+        workspaceOwnerKey: scope.workspaceOwnerKey,
+        workspaceTabTitle: 'Bot chat'
+      })
+    ])
+
+    // An explicit scope from the caller still wins over the tile's current one.
+    openSessionTile('bot-chat', 'right', 'workspace', undefined, { workspaceMode: 'sessions' })
+
+    expect($sessionTiles.get()).toEqual([
+      expect.objectContaining({ dir: 'right', storedSessionId: 'bot-chat', workspaceMode: 'sessions' })
+    ])
+    expect($sessionTiles.get()[0]).not.toHaveProperty('workspaceOwnerKey', scope.workspaceOwnerKey)
+  })
+
   it('preserves workspace scope while dropping a stale runtime binding', () => {
     $sessionTiles.set([
       {

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -1409,9 +1409,17 @@ export function openSessionTile(
   dir: TileDock = 'right',
   anchor?: string,
   before?: null | string,
-  workspaceScope: SessionTileWorkspaceScope = { workspaceMode: 'sessions' }
+  explicitScope?: SessionTileWorkspaceScope
 ) {
   const tiles = $sessionTiles.get()
+  const existing = tiles.find(t => t.storedSessionId === storedSessionId)
+
+  // No scope on an already-open tile is a MOVE (a split drag re-docking a tab),
+  // not a re-scope: keep the workspace it lives in instead of re-bucketing it
+  // into Sessions — a Bot tab used to vanish from the Bot workspace on drop.
+  const workspaceScope: SessionTileWorkspaceScope = explicitScope ?? {
+    workspaceMode: existing?.workspaceMode ?? 'sessions'
+  }
 
   // Opening a session in a tab/tile is "reading" it — clear its unread dot
   // exactly like main-thread resume does. Previously only
@@ -1459,7 +1467,9 @@ export function openSessionTile(
     return
   }
 
-  setSessionTileWorkspaceScope(storedSessionId, workspaceScope)
+  if (explicitScope) {
+    setSessionTileWorkspaceScope(storedSessionId, explicitScope)
+  }
 
   // Already open: relocate the existing pane to the drop target (pane-mirror
   // only docks on first adoption, so a re-drag must move the tree pane itself).


### PR DESCRIPTION
## Summary

In the Bot workspace, dragging a session tab onto the edge band to create a split made the tab vanish: the drop committed through `openSessionTile(id, pos, anchor, before)` with no scope, and the function's default `{ workspaceMode: 'sessions' }` was written onto the already-open tile (`setSessionTileWorkspaceScope`) before the pane move. The tile re-bucketed into the Sessions workspace, so the Bot strip no longer rendered it.

Salvages #96998 by @lgy1027 (cherry-pick, trimmed to the minimal shape; contributor authorship preserved on the commit).

Closes #96865
Supersedes #96998

## Changes

`apps/desktop/src/store/session-states.ts` — `openSessionTile`:
- The scope parameter is now optional (`explicitScope`). When absent and the tile is already open, the effective scope defaults to the tile's **current** `workspaceMode` instead of `'sessions'` — a scope-less open of an open tile is a move, not a re-scope.
- The move branch only calls `setSessionTileWorkspaceScope` when the caller passed a scope explicitly, so sidebar/bot openers that name a scope still win.
- Brand-new tiles keep the `'sessions'` default; every existing caller that passes a scope is unchanged.

`apps/desktop/src/store/session-states.test.ts` — one regression test: a `'bots'` tile re-docked with no scope keeps `workspaceMode: 'bots'`, `workspaceOwnerKey`, `ownerRoute` and `workspaceTabTitle`; a follow-up explicit `{ workspaceMode: 'sessions' }` still re-scopes it.

Diff vs #96998: same intent, without re-deriving the full scope object from the tile (the `'sessions'` branch of `setSessionTileWorkspaceScope` already keeps an existing `ownerRoute`, and skipping the call entirely on a scope-less move keeps the bot fields intact by construction). +16/−3 in the store vs +21/−8.

## Validation

**Live repro:** unit surface — the contributor's regression test on `origin/main` fails with `workspaceMode: "sessions"` where `"bots"` was expected (the exact re-bucketing the issue describes); after the fix the same test passes and the added explicit-scope assertion confirms callers can still re-scope.

- `npx vitest run --project ui src/store/session-states.test.ts` → 77 passed (test fails on main / passes on branch; sabotage run with the fix stashed re-fails it).
- `npx tsc -p tsconfig.json --noEmit` → clean.
- `npx eslint src/store/session-states.ts src/store/session-states.test.ts` → clean.
- Callers audited: `session-drag.ts` (drag → no scope → now preserved), `open-session.ts` / `use-session-actions` / `reuseBlankDraftTile` / bot-tab openers (explicit scope → unchanged), `openNewSessionTile` (fresh tile → `'sessions'` default unchanged).

Not extended: the existing Playwright drag e2e (`tile-unread-bug.spec.ts`) drives the Sessions workspace and needs a full desktop build + display seat; the store-level test pins the contract at the exact line the drop path hits.

## Infographic

![salv-tilescope](https://v3b.fal.media/files/b/0aa8cd45/ewJ8iYnzoY15HIDtYEnf5_yoZGgHe3.png)
