### PR TITLE
fix(tui_gateway): session.resume reuses live sessions only within the requesting profile

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5534,7 +5534,7 @@ def test_superseded_runtime_finalized_without_reclaimed_broadcast(monkeypatch):
         # mark it finalized-for-lookup via a different stored key is wrong —
         # instead simulate the mint race by removing it from lookup).
         old["_finalized"] = False
-        monkeypatch.setattr(server, "_find_live_session_by_key", lambda _k: None)
+        monkeypatch.setattr(server, "_find_live_session_by_key", lambda _k, *_a: None)
 
         result = server._claim_or_reuse_live("new-sid", "stored-super", fresh, None)
 

--- a/tests/tui_gateway/test_resume_live_profile_scope.py
+++ b/tests/tui_gateway/test_resume_live_profile_scope.py
@@ -1,0 +1,108 @@
+"""``session.resume`` reuses a live session only within the requested profile.
+
+The live registry is keyed by bare stored session id, and stored ids are
+timestamp-based, so the same id can legitimately be live under profile A while
+profile B's store also holds it. The resume fast path (and the post-build
+re-check / ``_claim_or_reuse_live``) used to hand profile B's resume profile
+A's runtime — the turn then ran with A's persona and wrote A's memory
+(#100029). Pinned here:
+
+* resume with profile B never reuses profile A's live session of the same id;
+* the launch profile (no ``profile``) still matches live records that carry
+  no ``profile_home`` — the pre-existing single-profile contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tui_gateway import server
+
+
+class _DB:
+    """Minimal ``SessionDB`` stand-in: every profile store knows ``s1``."""
+
+    def __init__(self, db_path=None, **_kwargs):
+        self.db_path = db_path
+
+    def close(self):
+        pass
+
+    def get_session(self, target):
+        return {"id": "s1", "cwd": ""} if target == "s1" else None
+
+    def get_session_by_title(self, _target):
+        return None
+
+    def resolve_resume_session_id(self, target):
+        return target
+
+    def reopen_session(self, _target):
+        pass
+
+    def get_resume_conversations(self, _target):
+        return ([], [])
+
+    def get_ancestor_display_prefix(self, _target):
+        return []
+
+    def get_messages_as_conversation(self, _target, **_kwargs):
+        return []
+
+
+@pytest.fixture()
+def homes(monkeypatch, tmp_path):
+    homes = {name: tmp_path / name for name in ("a", "b")}
+    for home in homes.values():
+        home.mkdir()
+    monkeypatch.setattr("hermes_state.get_shared_session_db", _DB)
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    monkeypatch.setattr(server, "_profile_home", lambda p: homes.get(p) if p else None)
+    monkeypatch.setattr(server, "_profile_configured_cwd", lambda _home: str(tmp_path))
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_maybe_schedule_auto_continue", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_default_session_cwd", lambda *a, **k: str(tmp_path))
+    monkeypatch.setattr(server, "_child_run_active", lambda _key: False)
+    monkeypatch.setattr(
+        server, "_live_session_payload", lambda sid, session, **_k: {"session_id": sid}
+    )
+    known = set(server._sessions)
+    yield homes
+    with server._sessions_lock:
+        for sid in [s for s in server._sessions if s not in known]:
+            server._sessions.pop(sid, None)
+
+
+def _resume(**params):
+    return server.handle_request({"id": "1", "method": "session.resume", "params": params})
+
+
+def _register_live(sid: str, profile_home) -> dict:
+    record = {"session_key": "s1", "history": [], "last_active": 0.0}
+    if profile_home is not None:
+        record["profile_home"] = str(profile_home)
+    with server._sessions_lock:
+        server._sessions[sid] = record
+    return record
+
+
+def test_resume_with_other_profile_never_reuses_live_session(homes):
+    _register_live("live-a", homes["a"])
+
+    same = _resume(session_id="s1", profile="a", source="desktop")
+    assert same["result"]["session_id"] == "live-a"
+
+    other = _resume(session_id="s1", profile="b", source="desktop")
+    new_sid = other["result"]["session_id"]
+    assert new_sid != "live-a"
+    assert server._sessions[new_sid]["profile_home"] == str(homes["b"])
+
+
+def test_launch_profile_still_matches_records_without_profile_home(homes):
+    _register_live("live-launch", None)
+    _register_live("live-a", homes["a"])
+
+    assert _resume(session_id="s1", source="desktop")["result"]["session_id"] == "live-launch"
+    assert _resume(session_id="s1", profile="a", source="desktop")["result"]["session_id"] == "live-a"

--- a/tests/tui_gateway/test_session_resume_db_ownership.py
+++ b/tests/tui_gateway/test_session_resume_db_ownership.py
@@ -98,7 +98,7 @@ def profile_dbs(monkeypatch, tmp_path):
     # The handler builds nothing on the paths under test; keep it hermetic and
     # off the real agent/secret/HERMES_HOME machinery.
     monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
-    monkeypatch.setattr(server, "_find_live_session_by_key", lambda _key: None)
+    monkeypatch.setattr(server, "_find_live_session_by_key", lambda _key, *_a: None)
     monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
     monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda *a, **k: None)
     monkeypatch.setattr(server, "_maybe_schedule_auto_continue", lambda *a, **k: None)
@@ -196,7 +196,7 @@ def test_resume_closes_profile_db_on_live_session_fast_path(profile_dbs, monkeyp
     monkeypatch.setattr(
         server,
         "_find_live_session_by_key",
-        lambda _key: ("live-sid", live_session),
+        lambda _key, *_a: ("live-sid", live_session),
     )
     monkeypatch.setattr(
         server,

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -752,9 +752,11 @@ def _(rid, params: dict) -> dict:
                 _cancel_ws_orphan_reap(sid)
                 return _ok(rid, _reuse_live_payload(sid, session))
 
-        # Fast path: if the session is already live, reuse it under the lock.
+        # Fast path: if the session is already live IN THIS PROFILE, reuse it
+        # under the lock. Never another profile's runtime of the same stored id
+        # — that ran profile B's turn on profile A's agent/memory (#100029).
         with _session_resume_lock:
-            live = _find_live_session_by_key(target)
+            live = _find_live_session_by_key(target, profile_home)
         if live is not None:
             return _reuse_live_response(*live)
 
@@ -1077,7 +1079,7 @@ def _(rid, params: dict) -> dict:
         # live session while we were building. Re-check under the lock; if it won,
         # discard our just-built agent and reuse theirs (no worker/poller wired yet).
         with _session_resume_lock:
-            live = _find_live_session_by_key(target)
+            live = _find_live_session_by_key(target, profile_home)
             if live is not None:
                 try:
                     if hasattr(agent, "close"):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10929,14 +10929,33 @@ def _deferred_session_record(
     }
 
 
+_ANY_PROFILE = object()  # default: match a live session regardless of profile
+
+
+def _live_profile_matches(session: dict, profile_home) -> bool:
+    """True when ``session`` belongs to ``profile_home`` (None = launch profile).
+
+    Same string compare as session.resume's ``_find_live_unpersisted``: a
+    record with no ``profile_home`` is the launch profile's. ``_ANY_PROFILE``
+    disables the check for callers that have no profile to scope by.
+    """
+    if profile_home is _ANY_PROFILE:
+        return True
+    want = str(profile_home) if profile_home else None
+    return (session.get("profile_home") or None) == want
+
+
 def _claim_or_reuse_live(
     sid: str, session_key: str, record: dict, lease
 ) -> tuple[str, dict] | None:
     """Register ``record`` as the live session for ``session_key`` under the
     resume lock, or — if a concurrent resume already won — release ``lease`` and
     return the winner for the caller to reuse."""
+    # The record carries the home this resume resolved; a live runtime of the
+    # same stored id under ANOTHER profile is not a winner to reuse (#100029).
+    profile_home = record.get("profile_home")
     with _session_resume_lock:
-        live = _find_live_session_by_key(session_key)
+        live = _find_live_session_by_key(session_key, profile_home)
         if live is not None:
             if lease is not None:
                 lease.release()
@@ -10954,7 +10973,7 @@ def _claim_or_reuse_live(
         # those quietly so the reap doesn't later broadcast session.reclaimed
         # for a session the client just re-resumed (auto-re-resume storm).
         _cancel_ws_orphan_reap(sid)
-        stale = _claim_parked_runtimes(session_key, keep_sid=sid)
+        stale = _claim_parked_runtimes(session_key, keep_sid=sid, profile_home=profile_home)
     # Slow finalization work stays OUTSIDE _session_resume_lock (see
     # _pop_session_by_id) — the stale records are already claimed above.
     _finalize_superseded_runtimes(stale)
@@ -10962,7 +10981,7 @@ def _claim_or_reuse_live(
 
 
 def _claim_parked_runtimes(
-    session_key: str, *, keep_sid: str
+    session_key: str, *, keep_sid: str, profile_home=_ANY_PROFILE
 ) -> list[tuple[str, dict]]:
     """Claim sentinel-parked stale runtimes of ``session_key`` for supersession.
 
@@ -10981,6 +11000,7 @@ def _claim_parked_runtimes(
             if old_sid != keep_sid
             and not old.get("_finalized")
             and _session_lookup_key(old, fallback=old_sid) == session_key
+            and _live_profile_matches(old, profile_home)
             and old.get("transport") is _detached_ws_transport
         ]
     for old_sid, _old in candidates:
@@ -11209,11 +11229,19 @@ def _session_lookup_key(session: dict, *, fallback: str = "") -> str:
     )
 
 
-def _find_live_session_by_key(session_key: str) -> tuple[str, dict] | None:
+def _find_live_session_by_key(
+    session_key: str, profile_home=_ANY_PROFILE
+) -> tuple[str, dict] | None:
+    # Stored session ids are timestamp-based and can legitimately exist in more
+    # than one profile's store, so a bare-id match can hand profile B's resume
+    # profile A's live runtime (#100029). Profile-aware callers pass the home
+    # they resolved; the match must then be on (profile_home, session_key).
     for sid, session in list(_sessions.items()):
         if session.get("_finalized"):
             continue
-        if _session_lookup_key(session, fallback=sid) == session_key:
+        if _session_lookup_key(session, fallback=sid) == session_key and _live_profile_matches(
+            session, profile_home
+        ):
             return sid, session
     return None
 


### PR DESCRIPTION
## Summary

`session.resume` could hand profile B a live runtime belonging to profile A. The TUI-gateway live registry is matched by bare stored session id (`_find_live_session_by_key`), and stored ids are timestamp-based, so the same id can be live under A while B's store also holds it. The resume fast path, the post-build re-check, and `_claim_or_reuse_live` all reused *any* live match regardless of `params['profile']` — the turn then ran with A's persona/tools and A's memory tools wrote B's content into A's store (#100029, reported by @Ayoola).

Main already had the correct scoped pattern for the unpersisted case (`_find_live_unpersisted` compares `record['profile_home']` to the requested home); this PR gives the persisted path the same scope, at the source.

Closes #100029
Supersedes #100213 (profile-scope half) — reimplemented from @Finn763's diagnosis with a `Co-authored-by:` trailer; thank you.

## Changes

`tui_gateway/server.py`
- `_live_profile_matches(session, profile_home)` — single owner of "does this live record belong to this profile home", same string compare `_find_live_unpersisted` already uses (no `Path.resolve`; `None`/missing `profile_home` = launch profile). `_ANY_PROFILE` sentinel disables the check.
- `_find_live_session_by_key(session_key, profile_home=_ANY_PROFILE)` — optional scope; unchanged for callers that pass nothing.
- `_claim_or_reuse_live` passes `record.get("profile_home")` for both the winner lookup and `_claim_parked_runtimes` (so a resume under B never finalizes A's parked runtime of the same id).

`tui_gateway/methods_session.py`
- `session.resume` fast path and post-build double-check pass the resolved `profile_home`.

`tests/tui_gateway/test_resume_live_profile_scope.py` (new, 2 tests) — "resume with profile B never reuses profile A's live session of the same id" and "launch profile still matches records with no profile_home". Both fail on main, pass here. `test_session_resume_db_ownership.py` / `tests/test_tui_gateway_server.py`: three monkeypatch lambdas widened to accept the new optional arg.

### Caller audit of `_find_live_session_by_key`

| Site | Scoped? | Why |
|---|---|---|
| `methods_session.py` resume fast path | yes | the bug site; requester's profile is known |
| `methods_session.py` post-build re-check | yes | same race, same profile |
| `server.py::_claim_or_reuse_live` (3 resume branches route here) | yes | record carries the home the resume resolved |
| `server.py::_claim_parked_runtimes` (sibling predicate) | yes | superseding A's parked runtime from B's resume would be the same leak |
| `server.py::_mirror_subagent_to_child` | no | keyed by child session id minted per run; no profile in the event payload; watch windows are per-child |
| `methods_prompt.py::_approval_respond_session_fallback` | no | resolves a stale live sid for an approval already on screen; `request_id` is the primary key and the profile isn't on the approval RPC |
| `tests/tui_gateway/test_session_hidden_rpc.py` | n/a | asserts `None` after finalize; sentinel default keeps it valid |

### Deliberately not carried from #100213
- The `_sync_bot_capabilities` extension to `Group:` titles (#100026 half) — Bot Mode group-room plumbing already follows the profile's current model/provider on main; that change is a separate concern and is left out.
- The fail-closed "unknown profile → 4007" guards in `session.create`/`session.resume`/`_db_for_profile` — with the registry scoped, a non-resolving profile can no longer *reuse* another profile's runtime, which is the reported leak. The fail-closed guard is a behaviour change for the launch-profile-name-passed-explicitly case and is out of scope for this minimal fix.

## Validation

- `tests/tui_gateway/test_resume_live_profile_scope.py test_session_resume_db_ownership.py test_resume_live_lazy_session.py test_session_hidden_rpc.py test_session_profile_db.py` → 27 passed. Sabotage: new tests against main's `tui_gateway/` → 2 failed (`assert 'live-a' != 'live-a'`, `assert 'live-launch' == 'live-a'`).
- `ruff check` clean on touched files.

**Live repro:** real `hermes_cli.web_server` + uvicorn, `/api/ws` WebSocket, isolated `HERMES_HOME` with two profiles `alpha`/`beta` whose `state.db`s both hold session `20260901_120000_dupe` — before (origin/main): `session.resume{profile:alpha}` → live sid `91c46018` (profile_home=…/alpha); `session.resume{profile:beta}` → **same sid `91c46018`, profile_home=…/alpha** (FIRES); after (this branch): alpha → `38406f39` (…/alpha), beta → `35a37d3e` (profile_home=…/beta), CLEAN.

## Infographic

![Live sessions are scoped by profile](https://v3b.fal.media/files/b/0aa8cd59/_OZywzYnWDcuk28WoLtkO_0Z9ncw65.png)
