### PR TITLE
fix(desktop): one conversation never opens as two tabs after compaction

### DIFF
--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -331,6 +331,24 @@ describe('SessionTile workspace scope', () => {
     expect(focusOpenSession('bot-chat', scope)).toBe('tile')
   })
 
+  it('fronts the existing tab when compaction rotated the tip id — never a duplicate', () => {
+    // The tile was opened when seg-2 was the tip; the conversation has since
+    // rotated to seg-3 (projected row carries the full chain). Opening the
+    // new tip must front that tile, not open the same chat twice.
+    setSessions([
+      { _lineage_ids: ['seg-1', 'seg-2', 'seg-3'], _lineage_root_id: 'seg-1', id: 'seg-3' } as never
+    ])
+    openSessionTile('seg-2')
+
+    expect(focusOpenSession('seg-3')).toBe('tile')
+    expect($sessionTiles.get().map(t => t.storedSessionId)).toEqual(['seg-2'])
+
+    // The open path dedupes through the same lineage test.
+    openSessionTile('seg-3')
+    expect($sessionTiles.get().map(t => t.storedSessionId)).toEqual(['seg-2'])
+    setSessions([])
+  })
+
   it('keeps Bot tabs while a profile publication swaps the Sessions bucket', () => {
     const scope = { workspaceMode: 'bots' as const, workspaceOwnerKey: 'connection-a::writer' }
 

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -1406,7 +1406,9 @@ export function openSessionTile(
   markSessionRead(storedSessionId)
   ackStoredSessionId(storedSessionId)
 
-  if (workspaceScope.workspaceMode === 'sessions' && storedSessionId === $selectedStoredSessionId.get()) {
+  const aliases = lineageAliases(storedSessionId, $sessions.get())
+
+  if (workspaceScope.workspaceMode === 'sessions' && aliases.includes($selectedStoredSessionId.get() ?? '')) {
     return
   }
 
@@ -1414,7 +1416,7 @@ export function openSessionTile(
 
   const workspaceOwnerKey = workspaceScope.workspaceMode === 'bots' ? workspaceScope.workspaceOwnerKey : undefined
 
-  if (!tiles.some(t => t.storedSessionId === storedSessionId)) {
+  if (!tiles.some(t => aliases.includes(t.storedSessionId))) {
     saveTiles([
       ...tiles,
       {
@@ -1510,8 +1512,16 @@ export function focusOpenSession(
   storedSessionId: string,
   workspaceScope: SessionTileWorkspaceScope = { workspaceMode: 'sessions' }
 ): 'main' | 'tile' | null {
-  if ($sessionTiles.get().some(t => t.storedSessionId === storedSessionId)) {
-    const paneId = `${TILE_PANE_PREFIX}${storedSessionId}`
+  // Compression rotates a conversation's tip id while tiles stay keyed by
+  // whichever segment id they were opened with. An exact-id test right after
+  // a rotation said "not open" for a conversation that IS on screen, and
+  // callers opened the same chat in a second tab. Match any id of the
+  // lineage instead, and front the tile under ITS key.
+  const aliases = lineageAliases(storedSessionId, $sessions.get())
+  const tile = $sessionTiles.get().find(t => aliases.includes(t.storedSessionId))
+
+  if (tile) {
+    const paneId = `${TILE_PANE_PREFIX}${tile.storedSessionId}`
     revealTreePane(paneId) // un-dismiss + adopt + front in its group
     const tree = $layoutTree.get()
     const group = tree ? findGroupOfPane(tree, paneId) : null
@@ -1525,7 +1535,7 @@ export function focusOpenSession(
 
   // Already the main session: front the workspace tab and drop tile focus so
   // the readouts + sidebar highlight come home (a no-op when main is focused).
-  if (workspaceScope.workspaceMode === 'sessions' && storedSessionId === $selectedStoredSessionId.get()) {
+  if (workspaceScope.workspaceMode === 'sessions' && aliases.includes($selectedStoredSessionId.get() ?? '')) {
     revealTreePane('workspace')
     noteActiveTreeGroup(null)
 

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -380,13 +380,6 @@ describe('lineageAliases across a deep compression chain', () => {
     expect(lineageAliases('tip', rows).sort()).toEqual(['mid', 'root', 'tip'])
     expect(sessionMatchesStoredId(rows[0], 'mid')).toBe(true)
   })
-
-  it('keeps the root/tip pairing for gateways without the field', () => {
-    const rows = [session({ _lineage_root_id: 'root', id: 'tip' })]
-
-    expect(lineageAliases('tip', rows).sort()).toEqual(['root', 'tip'])
-    expect(lineageAliases('unknown', rows)).toEqual(['unknown'])
-  })
 })
 
 describe('resolveComposerSessionKey', () => {

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -45,10 +45,12 @@ import {
   keepFailedProfileMeta,
   knownSessionOwner,
   knownSessionProfile,
+  lineageAliases,
   mergeSessionPage,
   rememberedSessionProfile,
   resolveComposerSessionKey,
   sessionBelongsToProfile,
+  sessionMatchesStoredId,
   sessionOwnerRouteFromRow,
   sessionPinId,
   setComposerSelectionOwner,
@@ -363,6 +365,27 @@ describe('sessionPinId', () => {
     // After auto-compression the entry surfaces under a fresh tip id but keeps
     // the original root — pinning on the root keeps the pin stable.
     expect(sessionPinId(session({ id: 'tip', _lineage_root_id: 'root' }))).toBe('root')
+  })
+})
+
+describe('lineageAliases across a deep compression chain', () => {
+  it('aliases every segment, intermediates included', () => {
+    // The projected row carries the full chain: a tile or route can hold a
+    // MIDDLE segment's id from when IT was the tip.
+    const rows = [
+      session({ _lineage_ids: ['root', 'mid', 'tip'], _lineage_root_id: 'root', id: 'tip' })
+    ]
+
+    expect(lineageAliases('mid', rows).sort()).toEqual(['mid', 'root', 'tip'])
+    expect(lineageAliases('tip', rows).sort()).toEqual(['mid', 'root', 'tip'])
+    expect(sessionMatchesStoredId(rows[0], 'mid')).toBe(true)
+  })
+
+  it('keeps the root/tip pairing for gateways without the field', () => {
+    const rows = [session({ _lineage_root_id: 'root', id: 'tip' })]
+
+    expect(lineageAliases('tip', rows).sort()).toEqual(['root', 'tip'])
+    expect(lineageAliases('unknown', rows)).toEqual(['unknown'])
   })
 })
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -359,16 +359,19 @@ export const sessionPinId = (session: Pick<SessionInfo, '_lineage_root_id' | 'id
  *  the live id or the stable lineage root (see sessionPinId). The one place the
  *  "same conversation across compression" test lives. */
 export const sessionMatchesStoredId = (
-  session: Pick<SessionInfo, '_lineage_root_id' | 'id'>,
+  session: Pick<SessionInfo, '_lineage_ids' | '_lineage_root_id' | 'id'>,
   storedSessionId: string
-): boolean => session.id === storedSessionId || session._lineage_root_id === storedSessionId
+): boolean =>
+  session.id === storedSessionId ||
+  session._lineage_root_id === storedSessionId ||
+  Boolean(session._lineage_ids?.includes(storedSessionId))
 
 // Alias lookup, memoized per sessions-list reference. `lineageAliases` runs
 // per cached session state per status projection per message delta — an
 // O(sessions) scan there multiplies out to states × sessions × ~30Hz per busy
 // session, which is what made a populated recents list drag every stream. The
 // list is replaced wholesale (never mutated), so its reference is the cache key.
-type LineageRow = Pick<SessionInfo, '_lineage_root_id' | 'id'>
+type LineageRow = Pick<SessionInfo, '_lineage_ids' | '_lineage_root_id' | 'id'>
 const lineageIndexBySessions = new WeakMap<readonly LineageRow[], Map<string, string[]>>()
 
 function lineageIndex(sessions: readonly LineageRow[]): Map<string, string[]> {
@@ -397,6 +400,21 @@ function lineageIndex(sessions: readonly LineageRow[]): Map<string, string[]> {
       add(session.id, session._lineage_root_id)
       add(session._lineage_root_id, session.id)
       add(session._lineage_root_id, session._lineage_root_id)
+    }
+
+    // Chains three+ segments deep: the projected row carries every id the
+    // conversation has answered to, so a surface keyed to a MIDDLE segment
+    // (it was the tip when the surface opened) still aliases to the rest.
+    // Without this, only tip↔root connect and such a surface reads as a
+    // different conversation — one chat open twice after a compaction.
+    const ids = session._lineage_ids
+
+    if (ids && ids.length > 1) {
+      for (const a of ids) {
+        for (const b of ids) {
+          add(a, b)
+        }
+      }
     }
   }
 

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -508,6 +508,10 @@ export interface SessionInfo {
    *  continuation tip. Stable across compressions — used as the durable id for
    *  pins so a pinned conversation survives auto-compression. */
   _lineage_root_id?: null | string
+  /** Every id on the compression chain (root, intermediates, tip) when this
+   *  entry is a projected continuation tip. Intermediates matter: a persisted
+   *  tile or route can hold a middle segment's id from when IT was the tip. */
+  _lineage_ids?: null | string[]
   input_tokens: number
   /** Spend for the session, straight off the `sessions` row. `actual` is set
    *  when the provider reported a price; `estimated` is our own pricing-table

--- a/contributors/emails/praxis1244@gmail.com
+++ b/contributors/emails/praxis1244@gmail.com
@@ -1,0 +1,1 @@
+praxis1244-consulting

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -11398,8 +11398,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         return f"{base} #{max_num + 1}"
 
-    def get_compression_tip(self, session_id: str) -> Optional[str]:
-        """Walk the compression-continuation chain forward and return the tip.
+    def get_compression_chain(self, session_id: str) -> List[str]:
+        """Walk the compression-continuation chain forward and return every id.
+
+        Root-first order, ending at the tip; ``[session_id]`` when no
+        continuation exists. ``get_compression_tip`` is this walk's last
+        element — kept as the single implementation so the two can never
+        disagree about what the chain is.
 
         A compression continuation is a child of a session whose
         ``end_reason = 'compression'``.  Older builds tried to distinguish
@@ -11420,6 +11425,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         continuation exists.
         """
         current = session_id
+        chain = [current] if current else []
         seen = {current} if current else set()
         # Bound the walk defensively — compression chains this deep are
         # pathological and shouldn't happen in practice. 100 = plenty.
@@ -11450,13 +11456,21 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 )
                 row = cursor.fetchone()
             if row is None:
-                return current
+                return chain
             child_id = row["id"]
             if not child_id or child_id in seen:
-                return current
+                return chain
             seen.add(child_id)
             current = child_id
-        return current
+            chain.append(child_id)
+        return chain
+
+    def get_compression_tip(self, session_id: str) -> Optional[str]:
+        """The live tip of a compression-continuation chain (see
+        ``get_compression_chain`` for the walk's semantics). Returns the input
+        id when no continuation exists."""
+        chain = self.get_compression_chain(session_id)
+        return chain[-1] if chain else session_id
 
     # Columns excluded from compact_rows projections: only the payload-heavy
     # blob no list consumer renders. Everything else — including gateway
@@ -11834,12 +11848,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # call per compression root. Batch that half instead: resolve
             # every tip id first, then fetch all tip rows in a single query.
             tip_ids_by_root: Dict[str, str] = {}
+            chain_by_root: Dict[str, List[str]] = {}
             for s in sessions:
                 if s.get("end_reason") != "compression":
                     continue
-                tip_id = self.get_compression_tip(s["id"])
+                chain = self.get_compression_chain(s["id"])
+                tip_id = chain[-1] if chain else s["id"]
                 if tip_id != s["id"]:
                     tip_ids_by_root[s["id"]] = tip_id
+                    chain_by_root[s["id"]] = chain
 
             tip_rows = (
                 self._get_session_rich_rows_batch(
@@ -11867,6 +11884,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     if key in tip_row:
                         merged[key] = tip_row[key]
                 merged["_lineage_root_id"] = s["id"]
+                # Every id on the chain, intermediates included. Root and tip
+                # alone are not enough client-side: a persisted tile or route
+                # can hold a MIDDLE segment's id (it was the tip when opened,
+                # then rotated again), and with only the root/tip pair such a
+                # surface can no longer prove it names this conversation —
+                # which is how one chat ends up open twice after compaction.
+                merged["_lineage_ids"] = chain_by_root.get(s["id"]) or None
                 projected.append(merged)
             sessions = projected
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2752,6 +2752,36 @@ class TestCompressionChainProjection:
         assert db.get_compression_tip("mid1") == "tip1"
         assert db.get_compression_tip("tip1") == "tip1"
 
+    def test_get_compression_chain_lists_every_segment(self, db):
+        """Root-first order, intermediates included; a chainless id is its
+        own one-element chain."""
+        import time as _time
+        self._build_compression_chain(db, _time.time() - 3600)
+        assert db.get_compression_chain("root1") == ["root1", "mid1", "tip1"]
+        assert db.get_compression_chain("mid1") == ["mid1", "tip1"]
+        assert db.get_compression_chain("tip1") == ["tip1"]
+        db.create_session("solo_chain", "cli")
+        db._conn.commit()
+        assert db.get_compression_chain("solo_chain") == ["solo_chain"]
+
+    def test_list_serves_full_lineage_ids_for_projected_rows(self, db):
+        """The projected tip row must carry every chain id. Root and tip
+        alone are not enough client-side: a persisted tile or route can hold
+        a MIDDLE segment's id (it was the tip when opened), and without the
+        intermediates that surface cannot prove it names this conversation —
+        which is how one chat ends up open twice after a compaction."""
+        import time as _time
+        self._build_compression_chain(db, _time.time() - 3600)
+        db.create_session("solo", "cli")
+        db.append_message("solo", "user", "standalone")
+        db._conn.commit()
+
+        sessions = db.list_sessions_rich(source="cli", limit=20)
+        tip_row = next(s for s in sessions if s["id"] == "tip1")
+        assert tip_row["_lineage_ids"] == ["root1", "mid1", "tip1"]
+        solo_row = next(s for s in sessions if s["id"] == "solo")
+        assert solo_row.get("_lineage_ids") is None
+
 
 
     def test_list_surfaces_tip_for_compressed_root(self, db):

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2752,18 +2752,6 @@ class TestCompressionChainProjection:
         assert db.get_compression_tip("mid1") == "tip1"
         assert db.get_compression_tip("tip1") == "tip1"
 
-    def test_get_compression_chain_lists_every_segment(self, db):
-        """Root-first order, intermediates included; a chainless id is its
-        own one-element chain."""
-        import time as _time
-        self._build_compression_chain(db, _time.time() - 3600)
-        assert db.get_compression_chain("root1") == ["root1", "mid1", "tip1"]
-        assert db.get_compression_chain("mid1") == ["mid1", "tip1"]
-        assert db.get_compression_chain("tip1") == ["tip1"]
-        db.create_session("solo_chain", "cli")
-        db._conn.commit()
-        assert db.get_compression_chain("solo_chain") == ["solo_chain"]
-
     def test_list_serves_full_lineage_ids_for_projected_rows(self, db):
         """The projected tip row must carry every chain id. Root and tip
         alone are not enough client-side: a persisted tile or route can hold

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -15712,6 +15712,7 @@ def _project_tree_row(r: dict) -> dict:
     return {
         "id": r.get("id"),
         "_lineage_root_id": r.get("_lineage_root_id"),
+        "_lineage_ids": r.get("_lineage_ids"),
         # The sidebar nests branch/fork sessions under their parent
         # (flattenSessionsWithBranches keys on this); without it, lane rows can't
         # draw the └─ connector the flat Recents list shows.


### PR DESCRIPTION
## Summary

Supersedes #99763 by @praxis1244-consulting — cherry-picked with authorship preserved, trimmed to the invariant-pinning tests.

After context compaction rotates a conversation's tip id, the desktop could show the SAME conversation as two tabs ("duplicate Bot Chat tabs") or a tile keyed to a rotated-away middle segment rendered as an "Untitled" ghost. Tiles are keyed by whichever segment id they were opened with, and `openSessionTile` / `focusOpenSession` tested exact ids — so right after a rotation the open chat read as "not open" and opened again. The desktop already had lineage aliases; they only connected root↔tip, so a tile keyed to a MIDDLE segment of a 3+ segment chain could not prove it named the conversation at all.

## Changes

- `hermes_state.py`: `get_compression_chain()` (root-first walk, single implementation; `get_compression_tip()` is its last element). `list_sessions_rich` projected tip rows now carry `_lineage_ids` (every segment id). Non-projected rows get `None`.
- `tui_gateway/server.py`: `_project_tree_row` passes `_lineage_ids` through (1 line). `/api/sessions` (`hermes_cli/web_routers/sessions.py`) already forwards full `list_sessions_rich` rows, so the desktop list gets the field with no change there. `session.list` in `tui_gateway/methods_session.py` projects an explicit whitelist (`id/title/preview/started_at/message_count/source`) for the TUI resume picker and never carried `_lineage_root_id` either — unchanged, not a desktop tab consumer.
- `apps/desktop/src/store/session.ts`: `sessionMatchesStoredId` accepts chain membership; `lineageIndex` aliases every segment pairwise. Older gateways omit the field → today's root/tip pairing.
- `apps/desktop/src/store/session-states.ts`: `openSessionTile` / `focusOpenSession` dedupe through `lineageAliases` and front the existing tile under ITS key.
- `apps/desktop/src/types/hermes.ts`: `_lineage_ids?: null | string[]`.
- Tests: `aliases every segment, intermediates included` (session.test.ts), `fronts the existing tab when compaction rotated the tip id — never a duplicate` (session-states.test.ts), `test_list_serves_full_lineage_ids_for_projected_rows` (tests/test_hermes_state.py). Dropped the contributor's no-field fallback case and the separate `get_compression_chain` unit test (fallback is implied by the predicate; the walk is exercised through the real projection).

## Validation

- Both vitest cases fail on origin/main (`expected null to be 'tile'`; `expected ['mid'] to equal ['mid','root','tip']`) and pass on the branch; `session.test.ts` + `session-states.test.ts`: 181 passed. `tsc --noEmit` clean; eslint clean on touched files.
- `tests/test_hermes_state.py`: 249 passed; the 1 failure (`TestFTS5Search::test_search_projection_skips_context_enrichment_queries`) fails identically on origin/main and is unrelated.
- **Live repro:** real `SessionDB` in a temp `HERMES_HOME`, session compacted twice (`seg-1 → seg-2 → seg-3`, parents ended with `end_reason=compression`), `list_sessions_rich(compact_rows=True)` — before (origin/main `hermes_state.py`): projected tip row `_lineage_ids: null`, `seg-2` unreachable from any alias; after: `["seg-1","seg-2","seg-3"]`, standalone session `None`, intermediates not leaked as separate rows.

## Credit

Fix and tests by @praxis1244-consulting (#99763); commit cherry-picked with original authorship.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa8cd4e/0L1hqaHN0IdZO6fkRoQay_x0gOpJ9J.png)
