### PR TITLE
fix(desktop): tile, cron and reconnected transcripts stay fresh (#94779; salvage #96386 #99333 #89728)

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -260,7 +260,7 @@ describe('active transcript refresh', () => {
 
     // Behavior assertions:
     expect(updaterCallCount).toBeGreaterThan(0)
-    expect(getLatestSessionMessages).toHaveBeenCalledWith(TILE_STORED_ID)
+    expect(getLatestSessionMessages).toHaveBeenCalledWith(TILE_STORED_ID, undefined)
   })
 
   it('reconciles an idle tile while the main pane is busy', async () => {
@@ -285,7 +285,7 @@ describe('active transcript refresh', () => {
       updateSessionState
     })
 
-    expect(getLatestSessionMessages).toHaveBeenCalledWith(storedId)
+    expect(getLatestSessionMessages).toHaveBeenCalledWith(storedId, undefined)
     expect(updateSessionState).toHaveBeenCalledTimes(1)
   })
 
@@ -345,6 +345,43 @@ describe('active transcript refresh', () => {
     await reconcile
 
     expect(updateSessionState).not.toHaveBeenCalled()
+  })
+
+  it('isolates tile transcript reads by connection and profile while preserving the legacy local path', async () => {
+    vi.mocked(getLatestSessionMessages).mockImplementation(async storedId => transcript(storedId, storedId) as never)
+
+    const updateSessionState: Parameters<typeof reconcileTileTranscriptsForTest>[0]['updateSessionState'] = vi.fn(
+      (_sessionId, updater) => updater({} as Parameters<typeof updater>[0])
+    )
+
+    await reconcileTileTranscriptsForTest({
+      tiles: [
+        {
+          ownerRoute: { connectionId: 'connection-a', mode: 'remote', profile: 'shared-profile', targetProfile: 'target-a' },
+          runtimeId: 'runtime-a',
+          storedSessionId: 'stored-a'
+        },
+        {
+          ownerRoute: { connectionId: 'connection-b', mode: 'remote', profile: 'shared-profile' },
+          runtimeId: 'runtime-b',
+          storedSessionId: 'stored-b'
+        },
+        { runtimeId: 'runtime-local', storedSessionId: 'stored-local' }
+      ],
+      requestSequenceRef: { current: 0 },
+      signatureRef: { current: new Map<string, string>() },
+      updateSessionState
+    })
+
+    expect(getLatestSessionMessages).toHaveBeenCalledWith('stored-a', { connectionId: 'connection-a', profile: 'target-a' })
+    expect(getLatestSessionMessages).toHaveBeenCalledWith('stored-b', {
+      connectionId: 'connection-b',
+      profile: 'shared-profile'
+    })
+    expect(getLatestSessionMessages).toHaveBeenCalledWith('stored-local', undefined)
+    expect(updateSessionState).toHaveBeenCalledWith('runtime-a', expect.any(Function), 'stored-a')
+    expect(updateSessionState).toHaveBeenCalledWith('runtime-b', expect.any(Function), 'stored-b')
+    expect(updateSessionState).toHaveBeenCalledWith('runtime-local', expect.any(Function), 'stored-local')
   })
 
   it('skips the tile fetch entirely when nothing changed (signature-gated)', async () => {

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -94,11 +94,13 @@ function useSyncHarness({
   activeIsMessaging = false,
   activeSessionId,
   activeStoredSessionId,
+  gatewayState = 'open',
   refreshActiveTranscript
 }: {
   activeIsMessaging?: boolean
   activeSessionId: string | null
   activeStoredSessionId: string | null
+  gatewayState?: string
   refreshActiveTranscript: () => Promise<void>
 }) {
   const updateSessionState: Parameters<typeof useBackgroundSync>[0]['updateSessionState'] = vi.fn(
@@ -116,7 +118,7 @@ function useSyncHarness({
     activeSessionId,
     activeStoredSessionId,
     freshDraftReady: false,
-    gatewayState: 'open',
+    gatewayState,
     refreshActiveTranscript,
     refreshCronJobs: vi.fn(),
     refreshCurrentModel: vi.fn(),
@@ -128,17 +130,23 @@ function useSyncHarness({
   })
 }
 
-function renderSync(
-  refreshActiveTranscript: () => Promise<void>,
-  options: { activeIsMessaging?: boolean; activeSessionId?: null | string; activeStoredSessionId?: null | string } = {}
-) {
-  return renderHook(() =>
-    useSyncHarness({
-      activeSessionId: ACTIVE_RUNTIME_ID,
-      activeStoredSessionId: ACTIVE_STORED_ID,
-      refreshActiveTranscript,
-      ...options
-    })
+type SyncOptions = {
+  activeIsMessaging?: boolean
+  activeSessionId?: null | string
+  activeStoredSessionId?: null | string
+  gatewayState?: string
+}
+
+function renderSync(refreshActiveTranscript: () => Promise<void>, options: SyncOptions = {}) {
+  return renderHook(
+    (props: SyncOptions) =>
+      useSyncHarness({
+        activeSessionId: ACTIVE_RUNTIME_ID,
+        activeStoredSessionId: ACTIVE_STORED_ID,
+        refreshActiveTranscript,
+        ...props
+      }),
+    { initialProps: options }
   )
 }
 
@@ -465,14 +473,15 @@ describe('active transcript refresh', () => {
     const refresh = vi.fn(async () => undefined)
 
     renderSync(refresh)
-    expect(refresh).not.toHaveBeenCalled()
+    // Exactly the one connect-time pull (#94779) — no timer after it.
+    expect(refresh).toHaveBeenCalledTimes(1)
 
     await act(async () => {
       vi.advanceTimersByTime(60_000)
       await Promise.resolve()
     })
 
-    expect(refresh).not.toHaveBeenCalled()
+    expect(refresh).toHaveBeenCalledTimes(1)
   })
 
   it('retains the existing periodic backstop for messaging sessions', async () => {
@@ -495,11 +504,12 @@ describe('active transcript refresh', () => {
 
   it('only defers an external tick while busy, then refreshes once after idle', async () => {
     $changeEventsAvailable.set(true)
-    setBusy(true)
     const refresh = vi.fn(async () => undefined)
 
     renderSync(refresh)
+    refresh.mockClear() // drop the connect-time pull; this test is about busy transitions
 
+    act(() => setBusy(true))
     act(() => setBusy(false))
     expect(refresh).not.toHaveBeenCalled()
     act(() => setBusy(true))
@@ -514,12 +524,31 @@ describe('active transcript refresh', () => {
     await waitFor(() => expect(refresh).toHaveBeenCalledTimes(1))
   })
 
+  it('pulls the open transcript once per (re)connect, not on session switches (#94779)', () => {
+    $changeEventsAvailable.set(true)
+    const refresh = vi.fn(async () => undefined)
+
+    const { rerender } = renderSync(refresh, { gatewayState: 'connecting' })
+    expect(refresh).not.toHaveBeenCalled()
+
+    rerender({ gatewayState: 'open' })
+    expect(refresh).toHaveBeenCalledTimes(1)
+
+    rerender({ activeSessionId: 'runtime-other', activeStoredSessionId: 'stored-other', gatewayState: 'open' })
+    expect(refresh).toHaveBeenCalledTimes(1)
+
+    rerender({ activeSessionId: 'runtime-other', activeStoredSessionId: 'stored-other', gatewayState: 'closed' })
+    rerender({ activeSessionId: 'runtime-other', activeStoredSessionId: 'stored-other', gatewayState: 'open' })
+    expect(refresh).toHaveBeenCalledTimes(2)
+  })
+
   it('coalesces a burst of global session-change ticks', async () => {
     vi.useFakeTimers()
     $changeEventsAvailable.set(true)
     const refresh = vi.fn(async () => undefined)
 
     renderSync(refresh)
+    refresh.mockClear() // drop the connect-time pull; this test is about tick coalescing
 
     act(() => {
       for (let index = 0; index < 20; index += 1) {

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -8,6 +8,7 @@ import {
   $activeSessionId,
   $selectedStoredSessionId,
   setBusy,
+  setCronSessions,
   setMessagingSessions,
   setSessionOwnerHint,
   setSessions
@@ -155,6 +156,7 @@ afterEach(() => {
   $activeSessionId.set(null)
   $selectedStoredSessionId.set(null)
   setSessions([])
+  setCronSessions([])
   setMessagingSessions([])
   setBusy(false)
   vi.clearAllMocks()
@@ -552,6 +554,19 @@ describe('reconcileActiveTranscript', () => {
     expect(getLatestSessionMessages).toHaveBeenCalledWith(ACTIVE_STORED_ID, 'messaging-profile')
     expect(fixture.states.get(ACTIVE_RUNTIME_ID)?.messages.at(-1)?.parts[0]).toMatchObject({
       text: 'telegram answer'
+    })
+  })
+
+  it('resolves and hydrates a cron session from the cron sessions store', async () => {
+    setCronSessions([{ id: ACTIVE_STORED_ID, profile: 'cron-profile', source: 'cron' } as never])
+    const fixture = makeRefresh(resolveActiveTranscriptSession)
+    vi.mocked(getLatestSessionMessages).mockResolvedValue(transcript('cron progress') as never)
+
+    await fixture.refresh()
+
+    expect(getLatestSessionMessages).toHaveBeenCalledWith(ACTIVE_STORED_ID, 'cron-profile')
+    expect(fixture.states.get(ACTIVE_RUNTIME_ID)?.messages.at(-1)?.parts[0]).toMatchObject({
+      text: 'cron progress'
     })
   })
 

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -14,9 +14,11 @@ import {
 } from '@/store/session'
 import {
   $attentionSessionIds,
+  $sessionTiles,
   $stalledSessionIds,
   $workingSessionIds,
   clearAllSessionStates,
+  publishSessionState,
   SESSION_WATCHDOG_TIMEOUT_MS
 } from '@/store/session-states'
 
@@ -158,6 +160,7 @@ afterEach(() => {
   vi.clearAllMocks()
   vi.restoreAllMocks()
   clearAllSessionStates()
+  $sessionTiles.set([])
   resetTypingActivityTracking()
 })
 
@@ -228,7 +231,6 @@ describe('active transcript refresh', () => {
 
     const signatureRef = { current: new Map<string, string>() }
     const requestSequenceRef = { current: 0 }
-    const busyRef = { current: false }
 
     vi.mocked(getLatestSessionMessages).mockImplementation(async (storedId: string) => {
       if (storedId === TILE_STORED_ID) {
@@ -250,7 +252,6 @@ describe('active transcript refresh', () => {
     await act(async () => {
       await reconcileTileTranscriptsForTest({
         tiles: [{ storedSessionId: TILE_STORED_ID, runtimeId: TILE_RUNTIME_ID }],
-        busyRef,
         requestSequenceRef,
         signatureRef,
         updateSessionState
@@ -260,6 +261,90 @@ describe('active transcript refresh', () => {
     // Behavior assertions:
     expect(updaterCallCount).toBeGreaterThan(0)
     expect(getLatestSessionMessages).toHaveBeenCalledWith(TILE_STORED_ID)
+  })
+
+  it('reconciles an idle tile while the main pane is busy', async () => {
+    const runtimeId = 'runtime-idle-tile'
+    const storedId = 'stored-idle-tile'
+    const idleState = createClientSessionState(storedId)
+
+    setBusy(true)
+    publishSessionState(runtimeId, idleState)
+    vi.mocked(getLatestSessionMessages).mockResolvedValue(transcript('idle tile update', storedId) as never)
+
+    const updateSessionState = vi.fn((sessionId: string, updater: (state: typeof idleState) => typeof idleState) => {
+      expect(sessionId).toBe(runtimeId)
+
+      return updater(idleState)
+    })
+
+    await reconcileTileTranscriptsForTest({
+      tiles: [{ runtimeId, storedSessionId: storedId }],
+      requestSequenceRef: { current: 0 },
+      signatureRef: { current: new Map() },
+      updateSessionState
+    })
+
+    expect(getLatestSessionMessages).toHaveBeenCalledWith(storedId)
+    expect(updateSessionState).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not reconcile a busy tile when the main pane is idle', async () => {
+    const runtimeId = 'runtime-busy-tile'
+    const storedId = 'stored-busy-tile'
+    const liveState = createClientSessionState(storedId)
+
+    liveState.busy = true
+    liveState.messages = [
+      {
+        id: 'live-assistant',
+        parts: [{ text: 'streaming answer', type: 'text' }],
+        pending: true,
+        role: 'assistant'
+      }
+    ]
+    publishSessionState(runtimeId, liveState)
+    vi.mocked(getLatestSessionMessages).mockResolvedValue({ messages: [], session_id: storedId } as never)
+
+    const updateSessionState = vi.fn()
+
+    await reconcileTileTranscriptsForTest({
+      tiles: [{ runtimeId, storedSessionId: storedId }],
+      requestSequenceRef: { current: 0 },
+      signatureRef: { current: new Map() },
+      updateSessionState
+    })
+
+    expect(getLatestSessionMessages).not.toHaveBeenCalled()
+    expect(updateSessionState).not.toHaveBeenCalled()
+  })
+
+  it('discards a tile snapshot when the tile closes during the read', async () => {
+    const runtimeId = 'runtime-closing-tile'
+    const storedId = 'stored-closing-tile'
+    let resolveRead: (value: unknown) => void = () => undefined
+
+    $sessionTiles.set([{ runtimeId, storedSessionId: storedId }])
+    publishSessionState(runtimeId, createClientSessionState(storedId))
+    vi.mocked(getLatestSessionMessages).mockReturnValueOnce(
+      new Promise(resolve => {
+        resolveRead = resolve
+      }) as never
+    )
+
+    const updateSessionState = vi.fn()
+
+    const reconcile = reconcileTileTranscriptsForTest({
+      requestSequenceRef: { current: 0 },
+      signatureRef: { current: new Map() },
+      updateSessionState
+    })
+
+    $sessionTiles.set([])
+    resolveRead(transcript('stale tile answer', storedId))
+    await reconcile
+
+    expect(updateSessionState).not.toHaveBeenCalled()
   })
 
   it('skips the tile fetch entirely when nothing changed (signature-gated)', async () => {
@@ -287,13 +372,11 @@ describe('active transcript refresh', () => {
     signatureRef.current.set(`tile:${TILE_STORED_ID}`, preSignature)
 
     const updateSessionState = vi.fn()
-    const busyRef = { current: false }
     const requestSequenceRef = { current: 0 }
 
     await act(async () => {
       await reconcileTileTranscriptsForTest({
         tiles: [{ storedSessionId: TILE_STORED_ID, runtimeId: TILE_RUNTIME_ID }],
-        busyRef,
         requestSequenceRef,
         signatureRef,
         updateSessionState

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -66,6 +66,12 @@ export interface ActiveTranscriptRefreshDeps {
   ) => ClientSessionState
 }
 
+function tileRuntimeOwnsLiveState(runtimeId: string): boolean {
+  const state = $sessionStates.get()[runtimeId]
+
+  return Boolean(state && (state.busy || state.awaitingResponse || state.needsInput || state.turnLive))
+}
+
 /**
  * Reconcile the persisted transcripts of every open WORKSPACE TILE (#93942
  * slice 1). Bot canonical chats live here — never in $sessions /
@@ -84,12 +90,10 @@ export interface ActiveTranscriptRefreshDeps {
  */
 export async function reconcileTileTranscripts({
   requestSequenceRef,
-  busyRef,
   signatureRef,
   updateSessionState,
   tiles: tilesOverride
 }: {
-  busyRef: MutableRefObject<boolean>
   requestSequenceRef: MutableRefObject<number>
   signatureRef: MutableRefObject<Map<string, string>>
   tiles?: Array<{ storedSessionId: string; runtimeId?: string }>
@@ -100,6 +104,13 @@ export async function reconcileTileTranscripts({
   ) => ClientSessionState
 }): Promise<void> {
   const tiles = tilesOverride ?? $sessionTiles.get()
+  const openSignatureKeys = new Set(tiles.map(tile => `tile:${tile.storedSessionId}`))
+
+  for (const signatureKey of signatureRef.current.keys()) {
+    if (!openSignatureKeys.has(signatureKey)) {
+      signatureRef.current.delete(signatureKey)
+    }
+  }
 
   for (const tile of tiles) {
     const storedSessionId = tile.storedSessionId
@@ -110,7 +121,7 @@ export async function reconcileTileTranscripts({
       continue
     }
 
-    if (!storedSessionId || !runtimeSessionId || busyRef.current) {
+    if (!storedSessionId || !runtimeSessionId || tileRuntimeOwnsLiveState(runtimeSessionId)) {
       continue
     }
 
@@ -123,14 +134,15 @@ export async function reconcileTileTranscripts({
 
     // With a tiles override (test path), the live $sessionTiles check can't
     // see the synthetic tile — treat override tiles as present.
-    const stillPresent = tilesOverride
-      ? tilesOverride.some(t => t.storedSessionId === storedSessionId && t.runtimeId === runtimeSessionId)
-      : $sessionTiles.get().some(t => t.storedSessionId === storedSessionId && t.runtimeId === runtimeSessionId)
+    const tileStillPresent = () =>
+      tilesOverride
+        ? tilesOverride.some(t => t.storedSessionId === storedSessionId && t.runtimeId === runtimeSessionId)
+        : $sessionTiles.get().some(t => t.storedSessionId === storedSessionId && t.runtimeId === runtimeSessionId)
 
     try {
       const latest = await getLatestSessionMessages(storedSessionId)
 
-      if (requestId !== requestSequenceRef.current || busyRef.current || !stillPresent) {
+      if (requestId !== requestSequenceRef.current || tileRuntimeOwnsLiveState(runtimeSessionId) || !tileStillPresent()) {
         // Tile closed or superseded mid-read — discard AND prune its
         // signature so the map doesn't grow one entry per ever-opened tile
         // for the app's lifetime (#94255 review point 3).
@@ -547,10 +559,8 @@ export function useBackgroundSync({
   // transcript signatures, so no-change ticks and closed tiles cost nothing.
   const tileRequestSequenceRef = useRef(0)
   const tileSignatureRef = useRef(new Map<string, string>())
-  // Read $busy.get() directly inside the reconcile loop instead of mirroring
-  // the atom into a ref (lint: no-restricted-syntax — refs synced from atoms
-  // lag one render). The reconcile runs on tick, not render, so .get() is
-  // always current.
+  // Tile reconciliation reads each runtime's live state directly from
+  // $sessionStates; the primary chat's $busy atom has no authority over tiles.
 
   const requestActiveTranscriptRefresh = useCallback(
     (preservePending: boolean) => {
@@ -697,11 +707,6 @@ export function useBackgroundSync({
       // (#93942 scenario A). Signature-gated per tile, so no-change ticks
       // cost nothing.
       void reconcileTileTranscripts({
-        busyRef: {
-          get current() {
-            return $busy.get()
-          }
-        },
         requestSequenceRef: tileRequestSequenceRef,
         signatureRef: tileSignatureRef,
         updateSessionState

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -72,6 +72,16 @@ function tileRuntimeOwnsLiveState(runtimeId: string): boolean {
   return Boolean(state && (state.busy || state.awaitingResponse || state.needsInput || state.turnLive))
 }
 
+type TileTranscriptTarget = { ownerRoute?: SessionProfileRoute; storedSessionId: string; runtimeId?: string }
+
+/** Signature key per tile — carries the owner route so two connections/profiles
+ *  sharing a stored id (or a tile re-homed to another owner) never alias. */
+function tileTranscriptSignatureKey(tile: TileTranscriptTarget): string {
+  const route = tile.ownerRoute
+
+  return `tile:${route ? `${route.connectionId}:${route.targetProfile ?? route.profile}:` : ''}${tile.storedSessionId}`
+}
+
 /**
  * Reconcile the persisted transcripts of every open WORKSPACE TILE (#93942
  * slice 1). Bot canonical chats live here — never in $sessions /
@@ -96,7 +106,7 @@ export async function reconcileTileTranscripts({
 }: {
   requestSequenceRef: MutableRefObject<number>
   signatureRef: MutableRefObject<Map<string, string>>
-  tiles?: Array<{ storedSessionId: string; runtimeId?: string }>
+  tiles?: TileTranscriptTarget[]
   updateSessionState: (
     sessionId: string,
     updater: (state: ClientSessionState) => ClientSessionState,
@@ -104,7 +114,7 @@ export async function reconcileTileTranscripts({
   ) => ClientSessionState
 }): Promise<void> {
   const tiles = tilesOverride ?? $sessionTiles.get()
-  const openSignatureKeys = new Set(tiles.map(tile => `tile:${tile.storedSessionId}`))
+  const openSignatureKeys = new Set(tiles.map(tileTranscriptSignatureKey))
 
   for (const signatureKey of signatureRef.current.keys()) {
     if (!openSignatureKeys.has(signatureKey)) {
@@ -139,19 +149,27 @@ export async function reconcileTileTranscripts({
         ? tilesOverride.some(t => t.storedSessionId === storedSessionId && t.runtimeId === runtimeSessionId)
         : $sessionTiles.get().some(t => t.storedSessionId === storedSessionId && t.runtimeId === runtimeSessionId)
 
+    // Bot tiles are pinned to an exact owner (connection + target profile);
+    // read from that backend, not whichever profile is foreground. Tiles
+    // without a route keep the legacy local read.
+    const profileScope: ProfileScope = tile.ownerRoute
+      ? { connectionId: tile.ownerRoute.connectionId, profile: tile.ownerRoute.targetProfile ?? tile.ownerRoute.profile }
+      : undefined
+
+    const signatureKey = tileTranscriptSignatureKey(tile)
+
     try {
-      const latest = await getLatestSessionMessages(storedSessionId)
+      const latest = await getLatestSessionMessages(storedSessionId, profileScope)
 
       if (requestId !== requestSequenceRef.current || tileRuntimeOwnsLiveState(runtimeSessionId) || !tileStillPresent()) {
         // Tile closed or superseded mid-read — discard AND prune its
         // signature so the map doesn't grow one entry per ever-opened tile
         // for the app's lifetime (#94255 review point 3).
-        signatureRef.current.delete(`tile:${storedSessionId}`)
+        signatureRef.current.delete(signatureKey)
 
         continue
       }
 
-      const signatureKey = `tile:${storedSessionId}`
       const signature = sessionMessagesSignature(latest.messages)
 
       if (signatureRef.current.get(signatureKey) === signature) {

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -13,10 +13,9 @@ import {
   $activeSessionId,
   $busy,
   $currentCwd,
-  $messagingSessions,
   $selectedStoredSessionId,
-  $sessions,
   getSessionOwnerHint,
+  ownerLookupSessionRows,
   sessionMatchesStoredId,
   setCurrentCwd
 } from '@/store/session'
@@ -39,9 +38,7 @@ interface ActiveTranscriptSession {
 
 /** Resolve an active transcript from visible rows or its unique hidden owner. */
 export function resolveActiveTranscriptSession(storedSessionId: string): ActiveTranscriptSession | undefined {
-  const visible =
-    $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId)) ??
-    $messagingSessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
+  const visible = ownerLookupSessionRows().find(session => sessionMatchesStoredId(session, storedSessionId))
 
   if (visible) {
     return { profile: visible.profile }

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -649,6 +649,19 @@ export function useBackgroundSync({
     }
   }, [activeConnectionId, activeGatewayProfile, gatewayState, refreshCurrentModel, refreshSessions, requestGateway])
 
+  // Reconnect backstop (#94779): turns that finished while the socket was
+  // down never replay their sessions.changed tick, so the open transcript
+  // stayed stale until the user reopened it. Pull one signature-gated tail on
+  // every (re)connect — a no-change read costs nothing. Keyed on the
+  // connection, not the session, so a plain session switch adds no read;
+  // messaging transcripts already refresh on open in their own effect below.
+  useEffect(() => {
+    if (gatewayState === 'open' && !activeIsMessaging && activeSessionId && activeStoredSessionId) {
+      requestActiveTranscriptRefresh(true)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- connect-scoped: session deps would fire on every switch
+  }, [activeConnectionId, activeGatewayProfile, gatewayState])
+
   // A reconnect loses renderer-only working/attention atoms while the backend
   // keeps the actual turns alive. Re-seed from the gateway's in-memory session
   // registry immediately, then re-pull on every sessions.changed broadcast; a


### PR DESCRIPTION
## Summary
Desktop transcripts in workspace tiles, cron-run panes and the main pane now stay fresh: a busy main pane no longer freezes idle tiles, bot tiles read from their own owner backend, open cron runs keep updating, and every (re)connect pulls one signature-gated tail so a turn that finished while the socket was down lands without reopening the session.

Closes #94779

Supersedes #96386 (@Dolverin — cherry-picked, authorship preserved), #99333 (client half only, @StodsEcho5 — co-authored), #89728 (@fangliquanflq — reimplemented on the ownerRoute rework, co-authored). Reported by @Kkkkkuro (#94779).

## Changes
All in `apps/desktop/src/app/contrib/hooks/use-background-sync.ts` (+ its `.test.ts`), one commit per fix:

- **Busy is per tile** (#96386, cherry-pick): `reconcileTileTranscripts` gates on the tile runtime's own `$sessionStates` entry (`busy`/`awaitingResponse`/`needsInput`/`turnLive`) instead of the main pane's `$busy`; signatures for closed tiles are pruned each pass. Tests trimmed from 6 to the 3 that pin distinct invariants.
- **Read from the owner** (#99333 client half): tiles carry `ownerRoute`; the read passes a `ProfileScope` (`connectionId` + `targetProfile ?? profile`) to `getLatestSessionMessages` and the signature key includes the route. Route-less tiles keep the legacy local read. The server-side `_sessions_sig` cross-profile scan from #99333 is **not** taken: the desktop runs one backend per profile, each with its own watcher, so scanning sibling profiles would misattribute ticks.
- **Cron runs included** (#89728, reimplemented, ~4 LOC): `resolveActiveTranscriptSession` resolves through `ownerLookupSessionRows()` (recents + cron + messaging) instead of `$sessions`/`$messagingSessions` only.
- **Reconnect backstop** (#94779): the gateway-open effect calls `requestActiveTranscriptRefresh(true)` when a non-messaging session is open — connection-scoped, so a plain session switch adds no read; messaging transcripts already refresh on open.

## Validation
| Test (`use-background-sync.test.ts`) | origin/main | branch |
|---|---|---|
| reconciles an idle tile while the main pane is busy | ✗ (fetch never issued) | ✓ |
| does not reconcile a busy tile when the main pane is idle | ✗ (busy tile overwritten) | ✓ |
| discards a tile snapshot when the tile closes during the read | ✗ (stale write) | ✓ |
| isolates tile transcript reads by connection and profile while preserving the legacy local path | ✗ (bare read, no scope) | ✓ |
| resolves and hydrates a cron session from the cron sessions store | ✗ (resolves to nothing) | ✓ |
| pulls the open transcript once per (re)connect, not on session switches (#94779) | ✗ (0 calls) | ✓ |

Full file: 32/32 pass; `tsc --noEmit` clean; `eslint` clean on both files. Neighbouring suites using the hook (`profile.test.ts`, `live-status-*.test.ts`, `use-background-sync.test.tsx`) pass.

**Live repro:** vitest against `origin/main`'s `use-background-sync.ts` — before: the six tests above fail with the behavioral assertions shown (each run against main's source before its commit); after: all pass on the branch. No existing Playwright e2e spec exercises a gateway socket drop or a tile transcript refresh (the mock server has no reconnect hook), so no e2e leg was run.

## Infographic
![Desktop tile transcripts stay fresh](https://v3b.fal.media/files/b/0aa8cd5b/B3psNYFbuOPLA-mdhKrAw_F7OqUruK.png)
