### PR TITLE
fix(custom): omit reasoning_effort on disable for non-Ollama endpoints

### DIFF
--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -92,11 +92,15 @@ class CustomProfile(ProviderProfile):
             if _effort == "none" or _enabled is False:
                 # Ollama's /v1/chat/completions silently ignores
                 # extra_body.think (only /api/chat honours it — ollama#14820)
-                # but respects the top-level reasoning_effort field (#25758).
-                # Always emit reasoning_effort="none"; only add think=False
-                # when the URL is actually Ollama.
-                top_level["reasoning_effort"] = "none"
+                # but respects the top-level reasoning_effort field (#25758),
+                # so Ollama URLs emit reasoning_effort="none" + think=False.
+                # Everything else OMITS the parameter entirely: litellm-based
+                # proxies (e.g. UnsupportedParamsError 400s) reject the field
+                # even at "none", and omitting lets the endpoint apply its
+                # server-side thinking default — same wire shape as the
+                # desktop's disable-reasoning toggle.
                 if _looks_like_ollama_endpoint(ctx.get("base_url")):
+                    top_level["reasoning_effort"] = "none"
                     extra_body["think"] = False
             elif _effort:
                 # Clamp the internal ladder onto the widest OpenAI-compatible

--- a/tests/plugins/model_providers/test_custom_profile.py
+++ b/tests/plugins/model_providers/test_custom_profile.py
@@ -83,7 +83,8 @@ class TestCustomReasoningWireShape:
             base_url="https://api.mistral.ai/v1",
         )
         assert "think" not in eb
-        assert tl == {"reasoning_effort": "none"}
+        # non-Ollama: omit reasoning_effort entirely (litellm proxies 400 even on "none")
+        assert tl == {}
 
     def test_disabled_omits_think_without_base_url(self, custom_profile):
         """Unknown custom endpoint — do not send the Ollama-only flag."""
@@ -91,7 +92,8 @@ class TestCustomReasoningWireShape:
             reasoning_config={"enabled": False}, model="glm-5.2"
         )
         assert "think" not in eb
-        assert tl == {"reasoning_effort": "none"}
+        # non-Ollama: omit entirely (litellm proxies 400 on the field, even "none")
+        assert tl == {}
 
     @pytest.mark.parametrize(
         "base_url",
@@ -108,7 +110,9 @@ class TestCustomReasoningWireShape:
             base_url=base_url,
         )
         assert "think" not in eb
-        assert tl == {"reasoning_effort": "none"}
+        # non-Ollama relays: omit reasoning_effort entirely rather than
+        # sending "none" — litellm-based proxies reject the field outright.
+        assert tl == {}
 
     def test_disabled_sends_think_false_on_ollama_cloud_host(self, custom_profile):
         eb, tl = custom_profile.build_api_kwargs_extras(
@@ -141,7 +145,7 @@ class TestCustomReasoningWireShape:
             base_url=base_url,
         )
         assert "think" not in eb
-        assert tl == {"reasoning_effort": "none"}
+        assert tl == {}  # non-Ollama: omit reasoning_effort entirely
 
     @pytest.mark.parametrize(
         "effort", ["minimal", "low", "medium", "high", "xhigh", "max"]


### PR DESCRIPTION
litellm-based proxies (e.g. freellm UnsupportedParamsError) reject the `reasoning_effort` field even at `"none"` — emitting it made the TUI's disable-reasoning path 400 while the desktop toggle (which omits the field) worked. Disable now omits the parameter entirely for non-Ollama endpoints so the server-side thinking default applies; Ollama keeps `reasoning_effort="none"` + `think=false`, which it requires (#25758).

## What does this PR do?

Fixes the disable-reasoning wire shape in the `custom` model-provider profile so it works against litellm-based OpenAI-compatible proxies.

**Problem:** The custom profile's `build_api_kwargs_extras()` unconditionally emitted a top-level `reasoning_effort: "none"` whenever reasoning was disabled. This is required for Ollama (`/v1/chat/completions` ignores `extra_body.think` and only honors the top-level field — ollama#14820, #25758), but litellm-based proxies reject the parameter outright with `litellm.UnsupportedParamsError: openai does not support parameters: ['reasoning_effort']` — **even at `"none"`**. A user pointing Hermes at such a proxy with `agent.reasoning_effort: medium` could not disable reasoning at all: the session-scoped/per-model override correctly resolved to "disabled", but the emitted `"none"` still 400'd. The desktop app's disable-reasoning toggle worked because its wire shape omits the field entirely, so CLI/TUI and desktop disagreed.

**Fix:** On disable (`effort == "none"` or `enabled is False`), emit `reasoning_effort="none"` + `extra_body.think=false` **only** for Ollama endpoints (unchanged behavior there — Ollama requires the field). For every other endpoint, omit the parameter completely so the endpoint applies its server-side thinking default — the same wire shape the desktop toggle already produces, and the same policy the profile already uses for "enabled + no effort".

Enabled paths (effort levels) are untouched.

## Related Issue

Fixes # — no upstream issue filed yet; the full reproduction is in "How to Test" below.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/model-providers/custom/__init__.py` — in `CustomProfile.build_api_kwargs_extras()`: the disabled branch now emits `top_level["reasoning_effort"] = "none"` + `extra_body["think"] = False` only when `_looks_like_ollama_endpoint(base_url)`; non-Ollama endpoints get the parameter omitted entirely (empty `top_level`). Updated the branch comment to document the litellm constraint and the desktop-toggle parity rationale.
- `tests/plugins/model_providers/test_custom_profile.py` — updated 8 disabled-shape expectations (`TestCustomReasoningWireShape`: no-base-url, Mistral, non-Ollama relays, malformed-port params) from `tl == {"reasoning_effort": "none"}` to `tl == {}`. Ollama-shape tests (localhost:11434, effort="none" alias, ollama.com cloud host) are unchanged and still assert the dual emission.

## How to Test

1. Configure a custom provider whose base_url is a litellm proxy that rejects `reasoning_effort` (any model group not in the proxy's allowed-params list), with `agent.reasoning_effort: medium` and `agent.reasoning_overrides.<model>: false` in config.yaml.
2. On `main`: send any chat message from the TUI → HTTP 400 `litellm.UnsupportedParamsError ... ['reasoning_effort']`, while the desktop's disable-reasoning toggle on the same config works.
3. On this branch: the same TUI message succeeds; a request dump shows no `reasoning_effort` key in the JSON body at all (verified: `disabled @ freellm → top_level = {}`).
4. Regression: point the same config at an Ollama URL (`http://localhost:11434/v1`) with reasoning disabled → body still contains `reasoning_effort: "none"` and `think: false`.
5. `uv run --python 3.11 --with pytest pytest tests/plugins/model_providers/ -q` → 244 passed.

Direct unit-level verification of the patched builder:

```
disabled @ freellm (https://freellm.partcorp.ir/v1): top_level = {} | extra_body = {}
disabled @ ollama  (http://localhost:11434/v1):      top_level = {'reasoning_effort': 'none'} | extra_body = {'think': False}
enabled high @ freellm:                              top_level = {'reasoning_effort': 'high'}   # unchanged
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(custom): omit reasoning_effort on disable for non-Ollama endpoints`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (`tests/plugins/model_providers/`: 244 passed; full suite not run — targeted suite for the touched module)
- [x] I've added tests for my changes (8 expectations updated to the new wire contract; existing Ollama tests pin the unchanged behavior)
- [x] I've tested on my platform: Linux 6.8.0 (Ubuntu-based), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstring/comment block in the patched branch documents the constraint) — otherwise N/A, no user-facing docs cover this wire detail
- [x] N/A — `cli-config.yaml.example` unchanged (no config keys added or changed)
- [x] N/A — no architecture or workflow changes
- [x] I've considered cross-platform impact — provider wire shape is platform-independent; `_looks_like_ollama_endpoint` logic untouched
- [x] N/A — no tool descriptions/schemas changed

## Screenshots / Logs

Error before the fix (request dump of the failing request — note the override resolved correctly and still 400'd):

```
model: minimax-m3-reasoning
request body: reasoning_effort: "none"
error: 400 - litellm.UnsupportedParamsError: openai does not support parameters:
['reasoning_effort'], for model=MiniMax-M3. To drop these, set `litellm.drop_params=True`
or for proxy: `litellm_settings: drop_params: true`. If you want to use these params
dynamically send allowed_openai_params=['reasoning_effort'] in your request.
```

After the fix: request body contains no `reasoning_effort` key; request succeeds against the same proxy.
