### PR TITLE
fix(matrix): harden E2EE key delivery

### DIFF
--- a/gateway/control_socket.py
+++ b/gateway/control_socket.py
@@ -75,7 +75,7 @@ _MAX_UNIX_PATH = 100
 
 # Requests and responses are single JSON lines. Bound them so a misbehaving
 # peer can't balloon gateway memory.
-_MAX_REQUEST_BYTES = 64 * 1024
+_MAX_REQUEST_BYTES = 128 * 1024
 _MAX_RESPONSE_BYTES = 512 * 1024
 
 _DEFAULT_CLIENT_TIMEOUT = 2.0

--- a/gateway/control_socket.py
+++ b/gateway/control_socket.py
@@ -10,13 +10,16 @@ gateway process creates at startup and removes on clean shutdown, answering
 versioned JSON verbs. A connectable socket with a well-formed ``identify``
 answer IS liveness — no PID-reuse heuristics.
 
-v1 verbs (observation only — no behavior change for the gateway):
+v1 verbs:
 
 - ``identify`` → pid, profile label, hermes_home, code_sha/code_version
   (the #91283 stamps, now queryable live), supervisor kind, served profiles,
   start_time, protocol version.
 - ``status``   → the live runtime-status payload (what ``gateway_state.json``
   holds today, but answered by the process itself, race-free).
+- ``send-message`` (when registered by the gateway runner) → delivers through
+  the gateway-owned live adapter. This keeps stateful transports such as
+  Matrix E2EE on their single event loop and crypto-store owner.
 
 Transport:
 
@@ -224,7 +227,7 @@ def build_status_payload() -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 class GatewayControlServer:
-    """Gateway-owned control socket server (identify/status, v1).
+    """Gateway-owned control socket server (versioned local verbs, v1).
 
     Lifecycle is owned by the gateway process: ``start()`` after the PID-file
     claim (the point where this process becomes the authoritative gateway for
@@ -238,6 +241,9 @@ class GatewayControlServer:
         home: Optional[Path] = None,
         *,
         verb_handlers: Optional[dict[str, Callable[[], dict[str, Any]]]] = None,
+        request_handlers: Optional[
+            dict[str, Callable[[dict[str, Any]], dict[str, Any]]]
+        ] = None,
     ) -> None:
         if home is None:
             from gateway.status import _get_process_hermes_home
@@ -254,6 +260,7 @@ class GatewayControlServer:
         }
         if verb_handlers:
             self._handlers.update(verb_handlers)
+        self._request_handlers = dict(request_handlers or {})
 
     # -- lifecycle ---------------------------------------------------------
 
@@ -353,18 +360,29 @@ class GatewayControlServer:
             request_id = request.get("id")
             verb = request.get("verb")
             handler = self._handlers.get(verb) if isinstance(verb, str) else None
-            if handler is None:
+            request_handler = (
+                self._request_handlers.get(verb)
+                if isinstance(verb, str)
+                else None
+            )
+            if handler is None and request_handler is None:
                 response: dict[str, Any] = {
                     "ok": False,
                     "error": f"unknown verb: {verb!r}",
                     "protocol": CONTROL_PROTOCOL_VERSION,
-                    "supported_verbs": sorted(self._handlers),
+                    "supported_verbs": sorted(
+                        set(self._handlers) | set(self._request_handlers)
+                    ),
                 }
             else:
                 response = {
                     "ok": True,
                     "protocol": CONTROL_PROTOCOL_VERSION,
-                    "result": handler(),
+                    "result": (
+                        request_handler(request)
+                        if request_handler is not None
+                        else handler()
+                    ),
                 }
         except Exception as exc:
             response = {
@@ -416,6 +434,7 @@ class _PipeControlProtocol(asyncio.Protocol):
         self._server = server
         self._transport: Any = None
         self._buffer = bytearray()
+        self._handling = False
 
     def connection_made(self, transport) -> None:  # pragma: no cover - windows
         self._transport = transport
@@ -425,12 +444,25 @@ class _PipeControlProtocol(asyncio.Protocol):
         if len(self._buffer) > _MAX_REQUEST_BYTES:
             self._transport.close()
             return
-        if b"\n" in self._buffer:
+        if b"\n" in self._buffer and not self._handling:
+            self._handling = True
             line, _, _ = bytes(self._buffer).partition(b"\n")
-            try:
-                self._transport.write(self._server.handle_request_line(line))
-            finally:
-                self._transport.close()
+            loop = asyncio.get_running_loop()
+            future = loop.run_in_executor(
+                None, self._server.handle_request_line, line
+            )
+
+            def _finish(done) -> None:
+                try:
+                    self._transport.write(done.result())
+                except Exception:
+                    logger.debug(
+                        "Control pipe request handler error", exc_info=True
+                    )
+                finally:
+                    self._transport.close()
+
+            future.add_done_callback(_finish)
 
 
 # ---------------------------------------------------------------------------
@@ -441,20 +473,27 @@ def query_gateway_control(
     home: Path,
     verb: str,
     *,
+    payload: Optional[dict[str, Any]] = None,
     timeout: float = _DEFAULT_CLIENT_TIMEOUT,
 ) -> Optional[dict[str, Any]]:
     """Ask the gateway serving ``home`` a control verb; None when unanswered.
+
+    ``payload`` is included as an object for request-aware verbs. The socket's
+    owner-only filesystem permissions remain the authorization boundary.
 
     Returns the verb's ``result`` payload on success. Any failure — no
     socket, stale socket nobody accepts on, timeout, malformed answer,
     ``ok: false`` — returns None so callers fall back to the scan layer.
     Never raises.
     """
-    request = (
-        json.dumps({"verb": verb, "id": 1, "protocol": CONTROL_PROTOCOL_VERSION})
-        .encode("utf-8")
-        + b"\n"
-    )
+    request_data: dict[str, Any] = {
+        "verb": verb,
+        "id": 1,
+        "protocol": CONTROL_PROTOCOL_VERSION,
+    }
+    if payload is not None:
+        request_data["payload"] = payload
+    request = json.dumps(request_data).encode("utf-8") + b"\n"
     try:
         if _IS_WINDOWS:
             raw = _query_windows_pipe(Path(home), request, timeout)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -33593,8 +33593,60 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 "drain_timeout": _drain,
             }
 
+        def _send_message_handler(request: dict) -> dict:
+            """Send through this gateway's already-connected adapter.
+
+            The control server invokes request handlers on an executor thread.
+            ``send_message_tool`` detects this process's runner and marshals
+            the adapter coroutine back onto ``_main_loop``. This preserves a
+            single Olm/Megolm owner for encrypted Matrix delivery.
+            """
+            payload = request.get("payload")
+            if not isinstance(payload, dict):
+                return {"error": "send-message requires an object payload"}
+            target = payload.get("target")
+            message = payload.get("message")
+            if not isinstance(target, str) or not target.strip():
+                return {"error": "send-message requires a target"}
+            if not isinstance(message, str) or not message.strip():
+                return {"error": "send-message requires a message"}
+
+            # Never let the in-gateway dispatch fall back to a standalone
+            # sender during startup or teardown. That would defeat the reason
+            # this control verb exists for stateful encrypted platforms.
+            platform_name = target.split(":", 1)[0].strip().lower()
+            try:
+                from gateway.config import Platform
+
+                platform = Platform(platform_name)
+                adapter = runner.adapters.get(platform)
+            except Exception:
+                adapter = None
+            if adapter is None:
+                return {
+                    "error": (
+                        f"Gateway adapter for {platform_name or 'target'} "
+                        "is not connected"
+                    )
+                }
+
+            try:
+                from tools.send_message_tool import send_message_tool
+
+                result = send_message_tool(
+                    {"action": "send", "target": target, "message": message}
+                )
+                decoded = json.loads(result) if isinstance(result, str) else result
+                if isinstance(decoded, dict):
+                    return decoded
+                return {"error": "Gateway send returned an invalid result"}
+            except Exception as exc:
+                logger.exception("Gateway control send-message failed")
+                return {"error": f"Gateway send failed: {exc}"}
+
         _control_server = GatewayControlServer(
-            verb_handlers={"pause-for-update": _pause_for_update_handler}
+            verb_handlers={"pause-for-update": _pause_for_update_handler},
+            request_handlers={"send-message": _send_message_handler},
         )
         if not await _control_server.start():
             _control_server = None

--- a/hermes_cli/send_cmd.py
+++ b/hermes_cli/send_cmd.py
@@ -371,6 +371,29 @@ def cmd_send(args: argparse.Namespace) -> None:
     if subject:
         message = f"{subject}\n\n{message.lstrip()}"
 
+    # Prefer the running gateway's live adapter. Stateful platforms such as
+    # encrypted Matrix must never construct a second crypto machine in this
+    # CLI process, and a raw Client-Server API request would be plaintext.
+    try:
+        from gateway.control_socket import query_gateway_control
+        from hermes_constants import get_hermes_home
+
+        live_result = query_gateway_control(
+            get_hermes_home(),
+            "send-message",
+            payload={"target": target, "message": message},
+            timeout=40.0,
+        )
+    except Exception:
+        live_result = None
+    if live_result is not None:
+        exit_code = _emit_result(
+            json.dumps(live_result),
+            json_mode=getattr(args, "json", False),
+            quiet=getattr(args, "quiet", False),
+        )
+        sys.exit(exit_code)
+
     # Import lazily so `hermes send --help` stays fast and does not pull in
     # the full tool registry / gateway config stack.
     from tools.send_message_tool import send_message_tool

--- a/hermes_cli/send_cmd.py
+++ b/hermes_cli/send_cmd.py
@@ -375,15 +375,36 @@ def cmd_send(args: argparse.Namespace) -> None:
     # encrypted Matrix must never construct a second crypto machine in this
     # CLI process, and a raw Client-Server API request would be plaintext.
     try:
-        from gateway.control_socket import query_gateway_control
+        from gateway.control_socket import (
+            query_gateway_control,
+            resolve_client_socket_path,
+        )
         from hermes_constants import get_hermes_home
 
-        live_result = query_gateway_control(
-            get_hermes_home(),
-            "send-message",
-            payload={"target": target, "message": message},
-            timeout=40.0,
+        gateway_home = get_hermes_home()
+        is_matrix_target = target.split(":", 1)[0].strip().lower() == "matrix"
+        gateway_socket_present = (
+            is_matrix_target
+            and resolve_client_socket_path(gateway_home) is not None
         )
+        if gateway_socket_present:
+            live_result = query_gateway_control(
+                gateway_home,
+                "send-message",
+                payload={"target": target, "message": message},
+                timeout=40.0,
+            )
+            if live_result is None:
+                # The request may already have been accepted. Never retry an
+                # ambiguous Matrix send through a second transport/process.
+                live_result = {
+                    "error": (
+                        "Running gateway did not confirm the Matrix send; "
+                        "refusing an unsafe standalone retry"
+                    )
+                }
+        else:
+            live_result = None
     except Exception:
         live_result = None
     if live_result is not None:

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1707,6 +1707,144 @@ class MatrixAdapter(BasePlatformAdapter):
 
         return True
 
+    async def _allow_matrix_key_share(self, device: Any, request: Any) -> bool:
+        """Authorize recovery of a missed Megolm room key.
+
+        Mautrix only accepts room-key requests from another device of the
+        same Matrix account by default. Permit recovery for explicitly
+        allowed users, but only while the bot and requester are both joined
+        to the requested room and that room passes the configured policy.
+        """
+        client = self._client
+        olm = getattr(client, "crypto", None) if client else None
+        if olm is None:
+            return False
+
+        requester = str(getattr(device, "user_id", ""))
+        own_user_id = str(getattr(client, "mxid", "") or self._user_id)
+        if requester == own_user_id:
+            return await olm.default_allow_key_share(device, request)
+
+        # Cross-user recovery is deliberately narrower than normal message
+        # authorization: open/allow-all mode must never grant room history.
+        if not requester or requester not in self._allowed_user_ids:
+            return False
+        if bool(getattr(device, "deleted", False)):
+            return False
+
+        room_id = str(getattr(request, "room_id", ""))
+        if not room_id or room_id not in self._joined_rooms:
+            return False
+        if not await self._is_allowed_matrix_room_event(room_id):
+            return False
+
+        try:
+            joined_members = await client.get_joined_members(RoomID(room_id))
+        except Exception as exc:
+            logger.warning(
+                "Matrix: refusing room-key request from %s for %s: "
+                "could not verify current membership: %s",
+                requester,
+                room_id,
+                exc,
+            )
+            return False
+        if requester not in {str(user_id) for user_id in joined_members}:
+            return False
+
+        try:
+            trust = await olm.resolve_trust(device)
+        except Exception as exc:
+            logger.warning(
+                "Matrix: refusing room-key request from %s device %s: "
+                "could not resolve trust: %s",
+                requester,
+                getattr(device, "device_id", "?"),
+                exc,
+            )
+            return False
+        if trust < olm.share_keys_min_trust:
+            return False
+
+        logger.info(
+            "Matrix: accepting recovery key request from allowed member %s "
+            "device %s for room %s",
+            requester,
+            getattr(device, "device_id", "?"),
+            room_id,
+        )
+        return True
+
+    async def _share_matrix_keys_crash_safely(
+        self, olm: Any, current_otk_count: int | None
+    ) -> None:
+        """Upload Olm one-time keys without losing their private half."""
+        if current_otk_count is None or (
+            olm._last_key_share + 60 > time.monotonic()
+            and current_otk_count < 10
+        ):
+            olm.log.debug("Checking OTK count on server")
+            counts = await olm.client.upload_keys()
+            current_otk_count = next(
+                (
+                    int(count)
+                    for algorithm, count in counts.items()
+                    if str(algorithm) == "signed_curve25519"
+                ),
+                0,
+            )
+
+        current_otk_count = max(0, int(current_otk_count))
+        max_otk_count = int(olm.account.max_one_time_keys)
+        if current_otk_count > max_otk_count:
+            logger.error(
+                "Matrix: homeserver reports %d OTKs for this device, above "
+                "the local Olm maximum of %d; stale server keys must be reset",
+                current_otk_count,
+                max_otk_count,
+            )
+
+        device_keys = (
+            olm.account.get_device_keys(olm.client.mxid, olm.client.device_id)
+            if not olm.account.shared
+            else None
+        )
+        unpublished_count = sum(
+            len(keys) for keys in olm.account.one_time_keys.values()
+        )
+        generation_count = current_otk_count
+        if unpublished_count:
+            # These keys may be from a committed upload whose response was
+            # lost. Re-upload them verbatim instead of generating a new batch.
+            generation_count = max(generation_count, max_otk_count // 2)
+        one_time_keys = olm.account.get_one_time_keys(
+            olm.client.mxid, olm.client.device_id, generation_count
+        )
+        if not device_keys and not one_time_keys:
+            olm.log.warning(
+                "No one-time keys nor device keys got when trying to share keys"
+            )
+            return
+
+        if device_keys:
+            olm.log.debug("Going to upload initial account keys")
+        olm.log.debug("Uploading %d one-time keys", len(one_time_keys))
+
+        if one_time_keys:
+            # Once Synapse can see a public OTK, its private counterpart is
+            # already durable locally. This is the crash-safety boundary.
+            await olm.crypto_store.put_account(olm.account)
+
+        response = await olm.client.upload_keys(
+            one_time_keys=one_time_keys,
+            device_keys=device_keys,
+        )
+        olm.account.shared = True
+        olm.account.mark_keys_as_published()
+        olm._last_key_share = time.monotonic()
+        await olm.crypto_store.put_account(olm.account)
+        olm.log.debug("Shared keys and saved account, new keys: %s", response)
+
     # ------------------------------------------------------------------
     # Required overrides
     # ------------------------------------------------------------------
@@ -1914,6 +2052,20 @@ class MatrixAdapter(BasePlatformAdapter):
                         )
                         legacy_pickle.unlink()
 
+                    # Olm and Megolm ratchets have a single writer. In
+                    # particular, a standalone ``hermes send`` process must
+                    # not open the same SQLite crypto store while the gateway
+                    # is running: two in-memory OlmMachine instances can each
+                    # advance and then persist stale ratchet state, making
+                    # otherwise valid encrypted messages undecryptable.
+                    if not self._acquire_platform_lock(
+                        "matrix-crypto-store",
+                        str(_CRYPTO_DB_PATH.resolve()),
+                        "Matrix crypto store",
+                    ):
+                        await api.session.close()
+                        return False
+
                     crypto_db = Database.create(
                         f"sqlite:///{_CRYPTO_DB_PATH}",
                         upgrade_table=PgCryptoStore.upgrade_table,
@@ -1960,11 +2112,26 @@ class MatrixAdapter(BasePlatformAdapter):
                     olm.share_keys_min_trust = TrustState.UNVERIFIED
                     olm.send_keys_min_trust = TrustState.UNVERIFIED
 
+                    async def _share_keys_crash_safely(
+                        current_otk_count: int | None,
+                    ) -> None:
+                        await self._share_matrix_keys_crash_safely(
+                            olm, current_otk_count
+                        )
+
+                    # mautrix saves newly generated private OTKs only after
+                    # the HTTP upload. Persist before that network boundary so
+                    # a committed request with a lost response remains safe to
+                    # retry after a process restart.
+                    olm._share_keys = _share_keys_crash_safely
+                    olm.allow_key_share = self._allow_matrix_key_share
+
                     await olm.load()
 
                     if not await self._verify_device_keys_on_server(client, olm):
                         await crypto_db.stop()
                         await api.session.close()
+                        self._release_platform_lock()
                         return False
 
                     try:
@@ -1981,6 +2148,7 @@ class MatrixAdapter(BasePlatformAdapter):
                             )
                             await crypto_db.stop()
                             await api.session.close()
+                            self._release_platform_lock()
                             return False
                         logger.warning("Matrix: share_keys() warning during startup: %s", exc)
 
@@ -2048,6 +2216,7 @@ class MatrixAdapter(BasePlatformAdapter):
                     )
                 except Exception as exc:
                     if self._e2ee_mode == "optional":
+                        self._release_platform_lock()
                         logger.warning(
                             "Matrix: failed to create optional E2EE client; "
                             "continuing without encrypted-room support: %s. %s",
@@ -2056,6 +2225,7 @@ class MatrixAdapter(BasePlatformAdapter):
                         )
                         self._encryption = False
                     else:
+                        self._release_platform_lock()
                         logger.error(
                             "Matrix: failed to create E2EE client: %s. %s",
                             exc,
@@ -2179,6 +2349,8 @@ class MatrixAdapter(BasePlatformAdapter):
                 await self._crypto_db.stop()
             except Exception as exc:
                 logger.debug("Matrix: could not close crypto DB on disconnect: %s", exc)
+
+        self._release_platform_lock()
 
         if self._client:
             try:
@@ -5218,10 +5390,20 @@ async def _standalone_send(
     Implements the standalone_sender_fn contract so deliver=matrix cron jobs
     succeed when cron runs separately from the gateway. Converts markdown to
     HTML for rich rendering, falling back to plain text when the markdown
-    library is absent. Replaces the legacy _send_matrix helper.
+    library is absent. Replaces the legacy _send_matrix helper. Encrypted
+    configurations fail closed: a raw ``m.room.message`` request is not E2EE,
+    and creating another OlmMachine would race the running gateway's ratchets.
     """
     extra = getattr(pconfig, "extra", {}) or {}
     token = getattr(pconfig, "token", None)
+    if _resolve_e2ee_mode(extra) != "off":
+        return {
+            "error": (
+                "Encrypted Matrix delivery requires the live gateway adapter; "
+                "standalone sending is disabled to avoid plaintext delivery "
+                "and concurrent Olm/Megolm state corruption"
+            )
+        }
     try:
         import aiohttp
     except ImportError:

--- a/tests/gateway/test_control_socket.py
+++ b/tests/gateway/test_control_socket.py
@@ -128,6 +128,35 @@ def test_server_answers_identify_and_status(home: Path):
     assert status == {"gateway_state": "running"}
 
 
+def test_request_handler_receives_payload(home: Path):
+    async def scenario():
+        server = GatewayControlServer(
+            home,
+            request_handlers={
+                "echo": lambda request: {
+                    "received": request.get("payload"),
+                }
+            },
+        )
+        assert await server.start()
+        try:
+            loop = asyncio.get_running_loop()
+            return await loop.run_in_executor(
+                None,
+                lambda: query_gateway_control(
+                    home,
+                    "echo",
+                    payload={"target": "matrix:!room:test", "message": "hi"},
+                ),
+            )
+        finally:
+            await server.stop()
+
+    assert _run(scenario()) == {
+        "received": {"target": "matrix:!room:test", "message": "hi"}
+    }
+
+
 def test_unknown_verb_and_malformed_request(home: Path):
     async def scenario():
         server = GatewayControlServer(

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -12,6 +12,23 @@ from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import MessageType
 
 
+@pytest.fixture(autouse=True)
+def _isolate_matrix_platform_lock(monkeypatch):
+    """Unit tests must not create machine-global adapter lock files."""
+    from gateway.platforms.base import BasePlatformAdapter
+
+    monkeypatch.setattr(
+        BasePlatformAdapter,
+        "_acquire_platform_lock",
+        lambda self, scope, identity, resource_desc: True,
+    )
+    monkeypatch.setattr(
+        BasePlatformAdapter,
+        "_release_platform_lock",
+        lambda self: None,
+    )
+
+
 def _make_fake_mautrix():
     """Create a lightweight set of fake ``mautrix`` modules.
 
@@ -928,6 +945,8 @@ class TestMatrixAccessTokenAuth:
             },
         )
         adapter = MatrixAdapter(config)
+        adapter._acquire_platform_lock = MagicMock(return_value=True)
+        adapter._release_platform_lock = MagicMock()
 
         class FakeWhoamiResponse:
             def __init__(self, user_id, device_id):
@@ -979,8 +998,62 @@ class TestMatrixAccessTokenAuth:
 
         mock_client.whoami.assert_awaited_once()
         assert adapter._user_id == "@bot:example.org"
+        adapter._acquire_platform_lock.assert_called_once_with(
+            "matrix-crypto-store",
+            str(matrix_mod._CRYPTO_DB_PATH.resolve()),
+            "Matrix crypto store",
+        )
 
         await adapter.disconnect()
+        adapter._release_platform_lock.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_second_e2ee_process_stops_before_opening_crypto_store(self):
+        """A held store lock must reject a second OlmMachine owner."""
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        adapter = MatrixAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="syt_test_access_token",
+                extra={
+                    "homeserver": "https://matrix.example.org",
+                    "user_id": "@bot:example.org",
+                    "encryption": True,
+                },
+            )
+        )
+        adapter._acquire_platform_lock = MagicMock(return_value=False)
+
+        fake_mautrix_mods = _make_fake_mautrix()
+        mock_client = MagicMock()
+        mock_client.mxid = "@bot:example.org"
+        mock_client.device_id = None
+        mock_client.whoami = AsyncMock(
+            return_value=MagicMock(
+                user_id="@bot:example.org", device_id="DEV123"
+            )
+        )
+        fake_mautrix_mods["mautrix.client"].Client = MagicMock(
+            return_value=mock_client
+        )
+        database_cls = fake_mautrix_mods["mautrix.util.async_db"].Database
+        database_create = MagicMock(wraps=database_cls.create)
+        database_cls.create = database_create
+
+        import plugins.platforms.matrix.adapter as matrix_mod
+
+        with patch.object(
+            matrix_mod, "_check_e2ee_deps", return_value=True
+        ), patch.dict("sys.modules", fake_mautrix_mods):
+            assert await adapter.connect() is False
+
+        adapter._acquire_platform_lock.assert_called_once_with(
+            "matrix-crypto-store",
+            str(matrix_mod._CRYPTO_DB_PATH.resolve()),
+            "Matrix crypto store",
+        )
+        database_create.assert_not_called()
 
 
 class TestDeviceKeyReVerification:
@@ -1015,6 +1088,148 @@ class TestDeviceKeyReVerification:
 
         assert result is False
         mock_olm.share_keys.assert_awaited_once()
+
+
+class TestMatrixRoomKeyRecovery:
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.adapter._user_id = "@bot:example.org"
+        self.adapter._allowed_user_ids = {"@alice:example.org"}
+        self.adapter._allowed_room_ids = set()
+        self.adapter._joined_rooms = {"!room:example.org"}
+
+        self.olm = MagicMock()
+        self.olm.share_keys_min_trust = 0
+        self.olm.resolve_trust = AsyncMock(return_value=0)
+        self.olm.default_allow_key_share = AsyncMock(return_value=True)
+
+        self.client = MagicMock()
+        self.client.mxid = "@bot:example.org"
+        self.client.crypto = self.olm
+        self.client.get_joined_members = AsyncMock(
+            return_value={
+                "@bot:example.org": MagicMock(),
+                "@alice:example.org": MagicMock(),
+            }
+        )
+        self.adapter._client = self.client
+
+        self.device = MagicMock()
+        self.device.user_id = "@alice:example.org"
+        self.device.device_id = "ALICEPHONE"
+        self.device.deleted = False
+        self.request = MagicMock()
+        self.request.room_id = "!room:example.org"
+
+    @pytest.mark.asyncio
+    async def test_allows_explicitly_allowed_current_room_member(self):
+        assert await self.adapter._allow_matrix_key_share(self.device, self.request)
+        self.olm.resolve_trust.assert_awaited_once_with(self.device)
+
+    @pytest.mark.asyncio
+    async def test_rejects_user_not_in_explicit_allowlist(self):
+        self.device.user_id = "@mallory:example.org"
+
+        assert not await self.adapter._allow_matrix_key_share(self.device, self.request)
+        self.client.get_joined_members.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_rejects_user_who_is_no_longer_joined(self):
+        self.client.get_joined_members.return_value = {
+            "@bot:example.org": MagicMock()
+        }
+
+        assert not await self.adapter._allow_matrix_key_share(self.device, self.request)
+
+    @pytest.mark.asyncio
+    async def test_rejects_room_the_bot_has_not_joined(self):
+        self.request.room_id = "!other:example.org"
+
+        assert not await self.adapter._allow_matrix_key_share(self.device, self.request)
+        self.client.get_joined_members.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_rejects_when_membership_cannot_be_verified(self):
+        self.client.get_joined_members.side_effect = RuntimeError(
+            "homeserver unavailable"
+        )
+
+        assert not await self.adapter._allow_matrix_key_share(self.device, self.request)
+
+    @pytest.mark.asyncio
+    async def test_same_user_uses_mautrix_default_policy(self):
+        self.device.user_id = "@bot:example.org"
+
+        assert await self.adapter._allow_matrix_key_share(self.device, self.request)
+        self.olm.default_allow_key_share.assert_awaited_once_with(
+            self.device, self.request
+        )
+        self.client.get_joined_members.assert_not_awaited()
+
+
+class TestMatrixCrashSafeOtkUpload:
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.call_order = []
+
+        self.account = MagicMock()
+        self.account.shared = True
+        self.account.max_one_time_keys = 100
+        self.account.one_time_keys = {"curve25519": {}}
+        self.account.get_one_time_keys.return_value = {
+            "signed_curve25519:AAAA": {"key": "public"}
+        }
+        self.account.mark_keys_as_published.side_effect = (
+            lambda: self.call_order.append("mark")
+        )
+
+        self.store = MagicMock()
+        self.store.put_account = AsyncMock(
+            side_effect=lambda account: self.call_order.append("persist")
+        )
+        self.client = MagicMock()
+        self.client.mxid = "@bot:example.org"
+        self.client.device_id = "BOTDEVICE"
+        self.client.upload_keys = AsyncMock(
+            side_effect=lambda **kwargs: self.call_order.append("upload") or {}
+        )
+        self.olm = MagicMock()
+        self.olm.account = self.account
+        self.olm.client = self.client
+        self.olm.crypto_store = self.store
+        self.olm._last_key_share = 0.0
+
+    @pytest.mark.asyncio
+    async def test_persists_private_otks_before_network_upload(self):
+        await self.adapter._share_matrix_keys_crash_safely(self.olm, 0)
+
+        assert self.call_order == ["persist", "upload", "mark", "persist"]
+
+    @pytest.mark.asyncio
+    async def test_upload_failure_keeps_generated_private_otks_durable(self):
+        async def fail_upload(**kwargs):
+            self.call_order.append("upload")
+            raise RuntimeError("response lost")
+
+        self.client.upload_keys.side_effect = fail_upload
+
+        with pytest.raises(RuntimeError, match="response lost"):
+            await self.adapter._share_matrix_keys_crash_safely(self.olm, 0)
+
+        assert self.call_order == ["persist", "upload"]
+        self.account.mark_keys_as_published.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_retries_existing_unpublished_keys_without_new_generation(self):
+        self.account.one_time_keys = {
+            "curve25519": {"AAAA": "public", "AAAB": "public"}
+        }
+
+        await self.adapter._share_matrix_keys_crash_safely(self.olm, 0)
+
+        self.account.get_one_time_keys.assert_called_once_with(
+            "@bot:example.org", "BOTDEVICE", 50
+        )
 
 
 class TestMatrixE2EEHardFail:

--- a/tests/hermes_cli/test_send_cmd.py
+++ b/tests/hermes_cli/test_send_cmd.py
@@ -81,6 +81,10 @@ def test_send_prefers_running_gateway_control_socket(
         }
 
     monkeypatch.setattr("gateway.control_socket.query_gateway_control", _query)
+    monkeypatch.setattr(
+        "gateway.control_socket.resolve_client_socket_path",
+        lambda home: home / "gateway.sock",
+    )
 
     args = _parse(["--json", "--to", "matrix:!room:test", "hello"])
     with pytest.raises(SystemExit) as exc:
@@ -118,6 +122,31 @@ def test_send_falls_back_when_gateway_has_no_send_verb(
         {"action": "send", "target": "telegram:123", "message": "hello"}
     ]
     assert json.loads(capsys.readouterr().out)["message_id"] == "m123"
+
+
+def test_matrix_send_does_not_retry_after_ambiguous_gateway_result(
+    fake_tool, capsys, monkeypatch, tmp_path
+):
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "gateway.control_socket.resolve_client_socket_path",
+        lambda home: home / "gateway.sock",
+    )
+    monkeypatch.setattr(
+        "gateway.control_socket.query_gateway_control",
+        lambda *args, **kwargs: None,
+    )
+
+    args = _parse(["--json", "--to", "matrix:!room:test", "hello"])
+    with pytest.raises(SystemExit) as exc:
+        send_cmd.cmd_send(args)
+
+    assert exc.value.code == 1
+    assert fake_tool.calls == []
+    assert "refusing an unsafe standalone retry" in json.loads(
+        capsys.readouterr().out
+    )["error"]
 
 
 

--- a/tests/hermes_cli/test_send_cmd.py
+++ b/tests/hermes_cli/test_send_cmd.py
@@ -64,6 +64,61 @@ def fake_tool(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+def test_send_prefers_running_gateway_control_socket(
+    fake_tool, capsys, monkeypatch, tmp_path
+):
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    calls = []
+
+    def _query(home, verb, *, payload=None, timeout=None):
+        calls.append((home, verb, payload, timeout))
+        return {
+            "success": True,
+            "platform": "matrix",
+            "chat_id": "!room:test",
+            "message_id": "$encrypted",
+        }
+
+    monkeypatch.setattr("gateway.control_socket.query_gateway_control", _query)
+
+    args = _parse(["--json", "--to", "matrix:!room:test", "hello"])
+    with pytest.raises(SystemExit) as exc:
+        send_cmd.cmd_send(args)
+
+    assert exc.value.code == 0
+    assert fake_tool.calls == []
+    assert calls == [
+        (
+            tmp_path,
+            "send-message",
+            {"target": "matrix:!room:test", "message": "hello"},
+            40.0,
+        )
+    ]
+    assert json.loads(capsys.readouterr().out)["message_id"] == "$encrypted"
+
+
+def test_send_falls_back_when_gateway_has_no_send_verb(
+    fake_tool, capsys, monkeypatch, tmp_path
+):
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "gateway.control_socket.query_gateway_control",
+        lambda *args, **kwargs: None,
+    )
+
+    args = _parse(["--json", "--to", "telegram:123", "hello"])
+    with pytest.raises(SystemExit) as exc:
+        send_cmd.cmd_send(args)
+
+    assert exc.value.code == 0
+    assert fake_tool.calls == [
+        {"action": "send", "target": "telegram:123", "message": "hello"}
+    ]
+    assert json.loads(capsys.readouterr().out)["message_id"] == "m123"
+
 
 
 

--- a/tests/tools/test_send_message_missing_platforms.py
+++ b/tests/tools/test_send_message_missing_platforms.py
@@ -135,6 +135,22 @@ class TestSendMattermost:
 
 
 class TestSendMatrix:
+    def test_encrypted_standalone_send_fails_closed(self):
+        extra = {
+            "homeserver": "https://matrix.example.com",
+            "e2ee_mode": "required",
+        }
+
+        with patch("aiohttp.ClientSession") as client_session:
+            result = asyncio.run(
+                _send_matrix(
+                    "syt_tok", extra, "!room:example.com", "secret report"
+                )
+            )
+
+        assert "requires the live gateway adapter" in result["error"]
+        client_session.assert_not_called()
+
     def test_success(self):
         resp = _make_aiohttp_resp(200, json_data={"event_id": "$abc123"})
         session_ctx, session = _make_aiohttp_session(resp)

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -664,6 +664,58 @@ class TestMatrixMediaLiveAdapterReuse:
             ("send_image_file", "!room:example.com", str(img_path)),
         ]
 
+    def test_live_adapter_send_runs_on_gateway_owner_loop(self):
+        """Control-socket sends must not use the request thread's event loop."""
+        import threading
+
+        owner_loop = asyncio.new_event_loop()
+        owner_ready = threading.Event()
+
+        def _run_owner_loop():
+            asyncio.set_event_loop(owner_loop)
+            owner_ready.set()
+            owner_loop.run_forever()
+
+        owner_thread = threading.Thread(target=_run_owner_loop, daemon=True)
+        owner_thread.start()
+        assert owner_ready.wait(timeout=2.0)
+
+        observed_loops = []
+
+        class LiveAdapter:
+            async def send(self, chat_id, message, metadata=None):
+                observed_loops.append(asyncio.get_running_loop())
+                return SimpleNamespace(success=True, message_id="$encrypted")
+
+        fake_runner = SimpleNamespace(
+            adapters={Platform.MATRIX: LiveAdapter()},
+            _gateway_loop=owner_loop,
+        )
+
+        try:
+            with patch(
+                "gateway.run._gateway_runner_ref",
+                return_value=fake_runner,
+            ), patch.dict(
+                sys.modules,
+                {"plugins.platforms.matrix.adapter": SimpleNamespace()},
+            ):
+                result = asyncio.run(
+                    _send_matrix_via_adapter(
+                        SimpleNamespace(enabled=True, token="tok", extra={}),
+                        "!room:example.com",
+                        "hello",
+                    )
+                )
+        finally:
+            owner_loop.call_soon_threadsafe(owner_loop.stop)
+            owner_thread.join(timeout=2.0)
+            owner_loop.close()
+
+        assert result["success"] is True
+        assert result["message_id"] == "$encrypted"
+        assert observed_loops == [owner_loop]
+
     def test_live_adapter_not_available_falls_back_to_ephemeral(self, tmp_path):
         """When _gateway_runner_ref returns None, the ephemeral adapter
         path (connect + disconnect) is used as before."""

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -2224,6 +2224,25 @@ async def _send_matrix_via_adapter(pconfig, chat_id, message, media_files=None, 
         # disconnect it. Correctness here depends on this branch returning
         # before the ephemeral ``adapter`` is constructed below, so the
         # ephemeral ``finally`` disconnect never touches the live session.
+        gateway_loop = getattr(runner, "_gateway_loop", None)
+        try:
+            current_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            current_loop = None
+
+        # Control-socket request handlers run on an executor thread. Matrix's
+        # aiohttp client and crypto queues belong to the gateway loop, so the
+        # whole send coroutine must run there rather than on the temporary
+        # loop created by the synchronous send_message_tool wrapper.
+        if gateway_loop is not None and current_loop is not gateway_loop:
+            future = asyncio.run_coroutine_threadsafe(
+                _matrix_send_core(
+                    live_adapter, chat_id, message, media_files, metadata
+                ),
+                gateway_loop,
+            )
+            return await asyncio.wrap_future(future)
+
         return await _matrix_send_core(
             live_adapter, chat_id, message, media_files, metadata
         )


### PR DESCRIPTION
## Summary

- route Matrix sends through the running gateway control socket so the stateful adapter stays on its owning event loop
- persist newly generated Olm one-time keys before uploading them, allowing safe retries after uncertain HTTP results
- allow missed Megolm room keys to be re-shared only to trusted devices of explicit allowlisted users who remain joined to an allowed room
- enforce one process owner for the Matrix crypto store
- fail closed when an E2EE send cannot reach the live gateway instead of sending plaintext, opening a second OlmMachine, or retrying an ambiguous delivery

## Reproduction

Running two Matrix adapter instances against one crypto store lets independent in-memory OlmMachine instances advance and persist competing ratchet state. Recipients then receive a Megolm session key through an Olm state they cannot decrypt. An interrupted OTK upload can similarly leave a server-side public OTK without durable local private material. A raw standalone m.room.message request also bypasses E2EE entirely.

The CLI now submits its validated Matrix target and message over the existing owner-only local gateway socket. The gateway dispatches through its connected adapter and marshals the coroutine onto the adapter owner loop. When no gateway socket exists, the existing standalone behavior remains available; when a running gateway gives an ambiguous result, the CLI does not risk a duplicate fallback send.

## Security

The socket retains its owner-only filesystem or named-pipe authorization boundary. Cross-user key recovery requires an explicit user allowlist entry, current room membership, allowed-room policy, a non-deleted device, and the configured trust threshold. Wildcard allow-all mode does not grant history recovery.

## Validation

- Canonical test runner over control-socket, CLI-send, Matrix adapter, and standalone-send suites
- 162 passed, 1 skipped, 0 failed
- diff whitespace and Python bytecode checks passed
