### PR TITLE
fix(providers): keep Token Plan Team editions in the Qwen picker group

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1400,7 +1400,7 @@ PROVIDER_GROUPS: dict[str, tuple[str, str, list[str]]] = {
     "xai":      ("xAI Grok",        "Direct API or SuperGrok / Premium+ OAuth",        ["xai", "xai-oauth"]),
     "google":   ("Google Gemini",   "Google AI Studio (API key)",                     ["gemini"]),
     "openai":   ("OpenAI",          "ChatGPT/Codex subscription or direct OpenAI API", ["openai-codex", "openai-api"]),
-    "qwen":     ("Qwen",            "Qwen Cloud / DashScope, Coding Plan, Token Plan & Qwen CLI OAuth", ["alibaba", "alibaba-cn", "alibaba-coding-plan", "alibaba-coding-plan-cn", "alibaba-token-plan", "alibaba-token-plan-cn", "qwen-oauth"]),
+    "qwen":     ("Qwen",            "Qwen Cloud / DashScope, Coding Plan, Token Plan & Qwen CLI OAuth", ["alibaba", "alibaba-cn", "alibaba-coding-plan", "alibaba-coding-plan-cn", "alibaba-token-plan", "alibaba-token-plan-team", "alibaba-token-plan-cn", "alibaba-token-plan-cn-team", "qwen-oauth"]),
     "opencode": ("OpenCode",        "Zen pay-as-you-go, Go subscription, or free tier", ["opencode-zen", "opencode-go", "opencode-free"]),
     "copilot":  ("GitHub Copilot",  "GitHub token API or copilot --acp process",       ["copilot", "copilot-acp"]),
     "tencent":  ("Tencent Hy",      "Hy4 / Hy3 via TokenHub & TokenPlan", ["tencent-tokenhub", "tencent-tokenplan"]),

--- a/tests/hermes_cli/test_provider_groups.py
+++ b/tests/hermes_cli/test_provider_groups.py
@@ -37,6 +37,38 @@ def test_reverse_index_matches_groups():
 
 
 
+def test_token_plan_tiers_fold_into_qwen_members():
+    # Token Plan ships Personal and Team editions per region. The Team slugs
+    # are registered by a user plugin rather than in-tree, so listing them as
+    # Qwen group members is what keeps them folded into the Qwen row instead
+    # of leaking out as top-level singles when the plugin is installed.
+    team_slugs = ("alibaba-token-plan-team", "alibaba-token-plan-cn-team")
+    personal_slugs = ("alibaba-token-plan", "alibaba-token-plan-cn")
+    members = PROVIDER_GROUPS["qwen"][2]
+    for slug in personal_slugs + team_slugs:
+        assert slug in members, f"{slug} must be a declared Qwen member"
+
+    # Feed an explicit input (not the group list) so a fold that wrongly
+    # emitted a Team slug as a top-level single, or dropped it, is caught:
+    # every Token Plan slug must land in the Qwen row's members, and none may
+    # also appear as a standalone single row.
+    rows = group_providers(list(personal_slugs) + list(team_slugs) + ["openrouter"])
+    assert len(rows) == 2  # one Qwen group + the ungrouped openrouter single
+    qwen = next(r for r in rows if r["kind"] == "group")
+    singles = {r["slug"] for r in rows if r["kind"] == "single"}
+    assert qwen["group_id"] == "qwen"
+    for slug in personal_slugs + team_slugs:
+        assert slug in qwen["members"], f"{slug} folded out of the Qwen row"
+        assert slug not in singles, f"{slug} leaked as a top-level single"
+
+    # Absent members are inert: with only the plugin uninstalled (no Team
+    # slugs in the picker input), the Personal pair still folds and the Team
+    # names add nothing.
+    rows = group_providers([*personal_slugs, "openrouter"])
+    qwen = next(r for r in rows if r["kind"] == "group")
+    assert qwen["members"] == [*personal_slugs]
+
+
 def test_multi_member_group_folds_to_one_row():
     rows = group_providers(["minimax", "minimax-oauth", "minimax-cn"])
     assert len(rows) == 1


### PR DESCRIPTION
## What does this PR do?

The Qwen picker group lists the two Personal Alibaba Token Plan slugs, so those fold into the `Qwen ▸` row. The Team editions (`alibaba-token-plan-team`, `alibaba-token-plan-cn-team`) are registered by the standalone Token Plan provider plugin and were never added to the group, so with the plugin installed the picker splits one product family: Personal under `Qwen ▸`, the two Team editions as ungrouped top-level rows.

This adds the two Team slugs to the `qwen` member list so all four editions fold into the same row.

It costs nothing when the plugin is not installed: `group_providers()` restricts a group's members to the slugs actually present in the picker input, so the extra names are inert until a registration exists. One edge to name honestly: the reverse index `_SLUG_TO_GROUP` maps the Team slugs unconditionally, so a leftover `model.provider: alibaba-token-plan-team` on a box where the plugin has since been uninstalled now highlights the Qwen row as "currently active" with no Team option present, instead of showing nothing. That is the pre-existing behaviour of every grouped slug, flagged here only because these slugs come and go with a plugin. Grouping is display-only; `--provider` and `/model <provider>:<model>` addressing are untouched, and no model catalogue, credential, or base URL changes.

## Related Issue

Fixes #101218

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/models.py`: add `alibaba-token-plan-team` and `alibaba-token-plan-cn-team` to the `qwen` entry of `PROVIDER_GROUPS`.
- `tests/hermes_cli/test_provider_groups.py`: add `test_token_plan_tiers_fold_into_qwen_members`, which pins all four Token Plan editions as Qwen members, folds an explicit slug input through `group_providers()` and asserts the Team slugs land in the group row rather than leaking out as top-level singles, and asserts the no-plugin case (Personal input only) still folds just the Personal pair.

## How to Test

1. `pytest tests/hermes_cli/test_provider_groups.py -q` (project venv, per CONTRIBUTING.md) → 3 passed.
2. Negative control: check out the parent commit's `models.py` and re-run → the new test fails on the missing Team members, proving it guards the change.
3. A wider slice (`pytest tests/hermes_cli/ -q -k "group or provider or model"`) surfaces a moving set of pre-existing failures (48 one run, 55 the next; env-dependent web-server/profile tests that fail identically on a clean `main` worktree in this checkout, unrelated to grouping). Full-suite CI on this PR is the authoritative run.
4. The fold is validated through synthetic slug inputs in the unit test, not through real plugin registration: end-to-end discovery with the external Token Plan plugin installed is out of scope here, so the "inert when absent" claim rests on the membership filter in `group_providers()` plus the no-plugin case asserted in the test.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs`, docstrings) - N/A: a picker member list change, no docs describe the group contents
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) - N/A: data change in one Python list, display-only

On the pytest checkbox: I ran the targeted grouping tests (green) and a provider/model slice of the suite, but not the full suite end to end; the failures that slice surfaced reproduce identically on clean `main` in this checkout, and I'd rather let CI run the whole thing than tick it honestly.

Related but distinct: PR #86138 proposes a generic `ProviderProfile.group` so plugins can declare their own grouping. This PR deliberately avoids new core surface and just extends the existing in-tree group, which also keeps it consistent with where upstream put the Personal Token Plan slugs. Worth stating plainly since the collision is concrete rather than hypothetical: the shipped Token Plan plugin already passes `group=` conditionally (it activates as soon as core grows the field), so if #86138 merges, installed copies of that plugin immediately pull `alibaba-token-plan` and `alibaba-token-plan-cn` out of the Qwen row into their own parent (`_SLUG_TO_GROUP` is last-write-wins). The reconciliation then lives plugin-side: the plugin should stop claiming the Personal slugs, or claim only the Team pair. If only this PR merges, nothing conflicts.

---

🤖 Generated with Hermes Agent (Qwen qwen3.8-flash via Alibaba Token Plan)
🧑‍💻 Ideated, directed and reviewed by a human, @oliver-mee
