### PR TITLE
fix(gateway): route bare Telegram delivery to active topic

### DIFF
--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -8,6 +8,7 @@ Routes messages to the appropriate destination based on:
 - Local (always saved to files)
 """
 
+import asyncio
 import logging
 import os
 import re
@@ -562,13 +563,42 @@ class DeliveryRouter:
                     send_metadata["user_id"] = home.user_id
                 if home.scope_id:
                     send_metadata["scope_id"] = home.scope_id
+
+        has_direct_topic = (
+            "direct_messages_topic_id" in send_metadata
+            or "telegram_direct_messages_topic_id" in send_metadata
+        )
+        if (
+            target.platform == Platform.TELEGRAM
+            and looks_like_telegram_private_chat_id(target.chat_id)
+            and not target.thread_id
+            and "thread_id" not in send_metadata
+            and "message_thread_id" not in send_metadata
+            and not has_direct_topic
+        ):
+            resolve_last_active = getattr(
+                adapter, "resolve_last_active_dm_topic", None
+            )
+            if callable(resolve_last_active):
+                try:
+                    last_active_thread_id = await asyncio.to_thread(
+                        resolve_last_active, target.chat_id
+                    )
+                except Exception:
+                    logger.debug(
+                        "Last-active Telegram topic resolution failed for chat=%s",
+                        target.chat_id,
+                        exc_info=True,
+                    )
+                    last_active_thread_id = None
+                if last_active_thread_id:
+                    send_metadata["thread_id"] = str(last_active_thread_id)
+                    send_metadata["telegram_last_active_topic_routing"] = True
+
         is_named_telegram_private_topic = False
         named_telegram_private_topic_name: Optional[str] = None
         if target.thread_id:
-            has_explicit_direct_topic = (
-                "direct_messages_topic_id" in send_metadata
-                or "telegram_direct_messages_topic_id" in send_metadata
-            )
+            has_explicit_direct_topic = has_direct_topic
             target_thread_id = target.thread_id
             is_named_telegram_private_topic = (
                 target.platform == Platform.TELEGRAM
@@ -650,8 +680,30 @@ class DeliveryRouter:
                 )
             if _send_result_failed(result):
                 raise RuntimeError(_send_result_error(result) or f"{target.platform.value} delivery failed")
+
+        if (
+            target.platform == Platform.TELEGRAM
+            and looks_like_telegram_private_chat_id(target.chat_id)
+            and not has_direct_topic
+            and not _send_result_failed(result)
+        ):
+            delivered_thread_id = (
+                send_metadata.get("thread_id")
+                or send_metadata.get("message_thread_id")
+            )
+            record_activity = getattr(adapter, "record_dm_topic_activity", None)
+            if delivered_thread_id and callable(record_activity):
+                try:
+                    await asyncio.to_thread(
+                        record_activity, target.chat_id, delivered_thread_id
+                    )
+                except Exception:
+                    logger.debug(
+                        "Telegram topic activity write failed for chat=%s thread=%s",
+                        target.chat_id,
+                        delivered_thread_id,
+                        exc_info=True,
+                    )
         return result
-
-
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8506,6 +8506,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return False
         return True
 
+    def _touch_telegram_topic_activity(self, source: SessionSource) -> None:
+        """Mark an authorized inbound DM topic as the user's active lane."""
+        if (
+            source.platform != Platform.TELEGRAM
+            or source.chat_type != "dm"
+            or not source.chat_id
+            or not source.user_id
+        ):
+            return
+        thread_id = str(source.thread_id or "")
+        if not thread_id or thread_id in self._TELEGRAM_GENERAL_TOPIC_IDS:
+            return
+        session_db = getattr(self, "_session_db", None)
+        session_db = getattr(session_db, "_db", session_db)
+        touch = getattr(session_db, "touch_telegram_topic_binding", None)
+        if not callable(touch):
+            return
+        try:
+            touch(
+                chat_id=str(source.chat_id),
+                thread_id=thread_id,
+                user_id=str(source.user_id),
+            )
+        except Exception:
+            logger.debug("Failed to record Telegram topic activity", exc_info=True)
+
     _TELEGRAM_LOBBY_REMINDER_COOLDOWN_S = 30.0
 
     def _should_send_telegram_lobby_reminder(self, source: SessionSource) -> bool:
@@ -18441,6 +18467,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # Record rate limit so subsequent messages are silently ignored
                     pairing_store._record_rate_limit(platform_name, source.user_id)
             return None
+
+        if not is_internal:
+            await asyncio.to_thread(self._touch_telegram_topic_activity, source)
 
         # Global emergency stop (`hermes pause`): give new turns a brief
         # paused notice instead of starting an agent run. Internal events

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -15958,6 +15958,72 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 return []
         return [dict(row) for row in rows]
 
+    def touch_telegram_topic_binding(
+        self,
+        *,
+        chat_id: str,
+        thread_id: str,
+        user_id: Optional[str] = None,
+    ) -> int:
+        """Mark an existing Telegram DM topic binding as recently active.
+
+        This never creates the opt-in topic tables or a new binding.  When a
+        ``user_id`` is supplied it must match the binding owner, preventing a
+        forged or cross-user event from changing the fallback route.
+        """
+        chat_id = str(chat_id)
+        thread_id = str(thread_id)
+        owner_id = str(user_id) if user_id is not None else None
+
+        def _do(conn):
+            try:
+                if owner_id is None:
+                    cursor = conn.execute(
+                        "UPDATE telegram_dm_topic_bindings SET updated_at = ? "
+                        "WHERE chat_id = ? AND thread_id = ?",
+                        (time.time(), chat_id, thread_id),
+                    )
+                else:
+                    cursor = conn.execute(
+                        "UPDATE telegram_dm_topic_bindings SET updated_at = ? "
+                        "WHERE chat_id = ? AND thread_id = ? AND user_id = ?",
+                        (time.time(), chat_id, thread_id, owner_id),
+                    )
+            except sqlite3.OperationalError:
+                return 0
+            return cursor.rowcount or 0
+
+        return int(self._execute_write(_do) or 0)
+
+    def get_last_active_telegram_topic_binding(
+        self,
+        *,
+        chat_id: str,
+    ) -> Optional[Dict[str, Any]]:
+        """Return the active topic-mode DM binding used for bare egress.
+
+        Disabled topic mode and pre-migration databases return ``None``.  The
+        join also requires the binding owner to match the opted-in owner for
+        the chat, so stale rows cannot route another user's delivery.
+        """
+        with self._read_ctx() as conn:
+            try:
+                row = conn.execute(
+                    """
+                    SELECT b.*
+                    FROM telegram_dm_topic_bindings AS b
+                    JOIN telegram_dm_topic_mode AS m
+                      ON m.chat_id = b.chat_id AND m.user_id = b.user_id
+                    WHERE b.chat_id = ? AND m.enabled = 1
+                    ORDER BY b.updated_at DESC, b.linked_at DESC, b.thread_id DESC
+                    LIMIT 1
+                    """,
+                    (str(chat_id),),
+                ).fetchone()
+            except sqlite3.OperationalError:
+                return None
+        return dict(row) if row else None
+
     def get_telegram_topic_binding_by_session(
         self,
         *,

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1726,6 +1726,78 @@ class TelegramAdapter(BasePlatformAdapter):
                 self.name, chat_id, thread_id,
             )
 
+    def _dm_topic_session_db(self, chat_id: Any):
+        """Resolve the SessionDB owned by this adapter's profile."""
+        if chat_id is None:
+            return None
+        store = getattr(self, "_session_store", None)
+        if store is None:
+            return None
+        try:
+            from gateway.session import SessionSource
+
+            source = SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id=str(chat_id),
+                chat_type="dm",
+                user_id=str(chat_id),
+                profile=self._session_key_profile(),
+            )
+            session_key = store._generate_session_key(source)
+            db_for_key = getattr(store, "_db_for_key", None)
+            if callable(db_for_key):
+                return db_for_key(session_key)
+        except Exception:
+            logger.debug(
+                "[%s] Failed to resolve profile-scoped Telegram topic DB",
+                self.name,
+                exc_info=True,
+            )
+            return None
+        return getattr(store, "_db", None)
+
+    def resolve_last_active_dm_topic(self, chat_id: Any) -> Optional[str]:
+        """Return the last active opted-in DM topic for a bare delivery."""
+        db = self._dm_topic_session_db(chat_id)
+        getter = getattr(db, "get_last_active_telegram_topic_binding", None)
+        if not callable(getter):
+            return None
+        try:
+            binding = getter(chat_id=str(chat_id))
+        except Exception:
+            logger.debug(
+                "[%s] Failed to read last-active Telegram topic for chat=%s",
+                self.name,
+                chat_id,
+                exc_info=True,
+            )
+            return None
+        thread_id = str((binding or {}).get("thread_id") or "")
+        return thread_id if thread_id and thread_id != "1" else None
+
+    def record_dm_topic_activity(self, chat_id: Any, thread_id: Any) -> None:
+        """Mark a successfully targeted DM topic as the next bare fallback."""
+        if chat_id is None or thread_id is None:
+            return
+        db = self._dm_topic_session_db(chat_id)
+        touch = getattr(db, "touch_telegram_topic_binding", None)
+        if not callable(touch):
+            return
+        try:
+            touch(
+                chat_id=str(chat_id),
+                thread_id=str(thread_id),
+                user_id=str(chat_id),
+            )
+        except Exception:
+            logger.debug(
+                "[%s] Failed to record Telegram topic activity for chat=%s thread=%s",
+                self.name,
+                chat_id,
+                thread_id,
+                exc_info=True,
+            )
+
     @staticmethod
     def _is_bad_request_error(error: Exception) -> bool:
         name = error.__class__.__name__.lower()

--- a/tests/gateway/test_delivery.py
+++ b/tests/gateway/test_delivery.py
@@ -1,16 +1,18 @@
 """Tests for the delivery routing module."""
 
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from typing import Any, cast
 
+import hermes_state
 from gateway.config import GatewayConfig, HomeChannel, Platform, PlatformConfig
 from gateway.delivery import DeliveryRouter, DeliveryTarget
 from gateway.platforms.base import SendResult
 from gateway.relay.adapter import RelayAdapter
 from gateway.relay.descriptor import CONTRACT_VERSION, CapabilityDescriptor
-from gateway.session import SessionSource
+from gateway.session import SessionSource, SessionStore
 
 
 class TestParseTargetPlatformChat:
@@ -275,6 +277,125 @@ async def test_explicit_telegram_private_thread_uses_reply_fallback_with_anchor(
                 "telegram_dm_topic_reply_fallback": True,
             },
         }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_bare_telegram_private_delivery_follows_last_active_topic(
+    tmp_path, monkeypatch
+):
+    """Bare egress follows activity; an explicit topic remains authoritative."""
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                enabled=True,
+                token="***",
+                typing_indicator=False,
+            )
+        }
+    )
+    store = SessionStore(sessions_dir=tmp_path / "sessions", config=config)
+    db = store._db
+    db.enable_telegram_topic_mode(chat_id="722341991", user_id="722341991")
+
+    clock = {"now": 100.0}
+    monkeypatch.setattr(hermes_state.time, "time", lambda: clock["now"])
+    first = store.get_or_create_session(
+        SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="722341991",
+            user_id="722341991",
+            thread_id="32344",
+        )
+    )
+    db.bind_telegram_topic(
+        chat_id="722341991",
+        thread_id="32344",
+        user_id="722341991",
+        session_key=first.session_key,
+        session_id=first.session_id,
+    )
+    clock["now"] = 200.0
+    second = store.get_or_create_session(
+        SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="722341991",
+            user_id="722341991",
+            thread_id="32345",
+        )
+    )
+    db.bind_telegram_topic(
+        chat_id="722341991",
+        thread_id="32345",
+        user_id="722341991",
+        session_key=second.session_key,
+        session_id=second.session_id,
+    )
+    clock["now"] = 300.0
+    assert db.touch_telegram_topic_binding(
+        chat_id="722341991",
+        thread_id="32344",
+        user_id="722341991",
+    ) == 1
+
+    adapter = TelegramAdapter(config.platforms[Platform.TELEGRAM])
+    adapter.set_session_store(store)
+    adapter.resolve_last_active_dm_topic = MagicMock(
+        wraps=adapter.resolve_last_active_dm_topic
+    )
+    adapter.send = AsyncMock(
+        return_value=SendResult(success=True, message_id="telegram-message")
+    )
+    router = DeliveryRouter(config, adapters={Platform.TELEGRAM: adapter})
+
+    bare = DeliveryTarget.parse("telegram:722341991")
+    await router._deliver_to_platform(bare, "bare one", metadata=None)
+
+    explicit = DeliveryTarget.parse("telegram:722341991:32345")
+    clock["now"] = 400.0
+    await router._deliver_to_platform(
+        explicit,
+        "explicit",
+        metadata={"thread_id": "32345"},
+    )
+
+    await router._deliver_to_platform(bare, "bare two", metadata=None)
+
+    assert adapter.resolve_last_active_dm_topic.call_count == 2
+    assert [call.kwargs["metadata"] for call in adapter.send.await_args_list] == [
+        {
+            "thread_id": "32344",
+            "telegram_last_active_topic_routing": True,
+        },
+        {"thread_id": "32345"},
+        {
+            "thread_id": "32345",
+            "telegram_last_active_topic_routing": True,
+        },
+    ]
+    db.close()
+
+
+@pytest.mark.asyncio
+async def test_bare_telegram_private_delivery_keeps_lobby_without_active_topic(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
+    adapter = RecordingAdapter()
+    adapter.resolve_last_active_dm_topic = MagicMock(return_value=None)
+    router = DeliveryRouter(GatewayConfig(), adapters={Platform.TELEGRAM: adapter})
+
+    await router._deliver_to_platform(
+        DeliveryTarget.parse("telegram:722341991"),
+        "hello",
+        metadata=None,
+    )
+
+    assert adapter.calls == [
+        {"chat_id": "722341991", "content": "hello", "metadata": None}
     ]
 
 

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -258,6 +258,28 @@ async def test_internal_root_telegram_dm_event_bypasses_topic_lobby(
 
 
 @pytest.mark.asyncio
+async def test_authorized_topic_command_marks_topic_active(monkeypatch):
+    """Commands count as user activity before their early-return handler."""
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._touch_telegram_topic_activity = MagicMock()
+    runner._handle_topic_command = AsyncMock(return_value="topic status")
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    source = _make_source(thread_id="17585")
+    result = await runner._handle_message(
+        MessageEvent(text="/topic", source=source, message_id="topic-command")
+    )
+
+    assert result == "topic status"
+    runner._touch_telegram_topic_activity.assert_called_once_with(source)
+
+
+@pytest.mark.asyncio
 async def test_root_telegram_dm_new_shows_create_topic_instruction(monkeypatch):
     import gateway.run as gateway_run
 
@@ -801,6 +823,34 @@ def test_list_telegram_topic_bindings_for_chat_no_table(tmp_path):
     assert tables == set()
 
 
+def test_last_active_telegram_topic_binding_requires_enabled_matching_owner(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    assert db.get_last_active_telegram_topic_binding(chat_id="208214988") is None
+
+    db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    db.create_session(session_id="sess-active", source="telegram", user_id="208214988")
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="17585",
+        user_id="208214988",
+        session_key="agent:main:telegram:dm:208214988:17585",
+        session_id="sess-active",
+    )
+
+    assert db.touch_telegram_topic_binding(
+        chat_id="208214988",
+        thread_id="17585",
+        user_id="someone-else",
+    ) == 0
+    assert db.get_last_active_telegram_topic_binding(
+        chat_id="208214988"
+    )["thread_id"] == "17585"
+
+    db.disable_telegram_topic_mode(chat_id="208214988", clear_bindings=False)
+    assert db.get_last_active_telegram_topic_binding(chat_id="208214988") is None
+    db.close()
+
+
 # ---------------------------------------------------------------------------
 # Tests for get_telegram_topic_binding_by_session (issue #27166)
 # ---------------------------------------------------------------------------
@@ -829,4 +879,3 @@ def test_get_telegram_topic_binding_by_session_returns_binding(tmp_path):
 # ---------------------------------------------------------------------------
 # Test for session-split thread_id recovery (issue #27166)
 # ---------------------------------------------------------------------------
-

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -805,6 +805,12 @@ After activation, the **root DM is a lobby**: normal prompts are rejected with g
 
 Every topic gets its own conversation history, model state, tool execution, and session ID. The isolation key is `agent:main:telegram:dm:{chat_id}:{thread_id}` — identical to the config-driven DM topics isolation.
 
+### Last-active delivery routing
+
+While `/topic` mode is enabled, Hermes remembers the most recently used DM topic. A bare Telegram delivery target such as `telegram:<chat_id>` — including a home-channel or cron delivery without a topic — is sent to that topic instead of disappearing into the root lobby.
+
+User messages and commands inside a topic make it active. A successful delivery to an explicitly selected topic also makes that topic active. Explicit targets such as `telegram:<chat_id>:<thread_id>` always win; Hermes only applies the fallback when no topic was supplied. If topic mode is off or no active binding exists, the existing root-chat behavior is unchanged.
+
 ### Auto-renamed topics
 
 When Hermes generates a session title for a topic (via the auto-title pipeline, after the first exchange), the Telegram topic itself is renamed to match — e.g. "New Topic" becomes "Database migration plan". The rename is best-effort: failures are logged but don't break the session.


### PR DESCRIPTION
## Summary

- remember the most recently active Telegram DM topic from authorized inbound activity
- route bare Telegram private-chat deliveries to that topic instead of the root lobby
- let an explicitly targeted successful topic delivery become the next fallback
- preserve explicit topic targets, Bot API direct-message topics, disabled topic mode, and chats without bindings

## Root cause

Telegram `/topic` mode turns the root DM into a system lobby, but `DeliveryRouter` sends a bare `telegram:<chat_id>` target without thread metadata. Cron and home-channel deliveries that omit a topic therefore land in a surface intended only for system commands.

The existing recovery path orders bindings by `updated_at`, but normal authorized activity in an already-bound topic did not refresh that field. "Newest binding" was therefore not the same as "last topic the user used."

## Implementation

- add fail-soft SessionDB helpers to touch an existing binding and read the last active binding only while topic mode is enabled
- touch the binding after authorization for user-originated topic messages and commands
- resolve the correct profile-scoped SessionDB through the live Telegram adapter
- add `thread_id` only for bare positive-ID Telegram DM targets; any explicit thread metadata or direct-message topic remains authoritative
- touch a successfully targeted topic so later bare deliveries follow that deliberate route

No new environment variable, config key, or schema column is introduced.

## Verification

- `HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/gateway/test_delivery.py tests/gateway/test_telegram_topic_mode.py tests/gateway/test_telegram_thread_fallback.py tests/gateway/test_telegram_prune_stale_topic_binding_31501.py -q` — 64 passed
- `HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/test_hermes_state.py -q` — 247 passed, 2 skipped
- `ruff check .` — passed (pre-existing invalid-noqa warnings only)
- `python scripts/check-windows-footguns.py --all` — passed
- `gitleaks git --no-banner --redact --log-opts='upstream/main..HEAD'` — no leaks found
- `git diff --check` — passed

## Relationship to #100941

This is independent of #100941. That PR keeps the explicit root-lobby `/new` change small; this PR addresses the separate last-active delivery-routing slice without coupling the two behaviors.

Addresses the last-active delivery portion of #88503.
