### PR TITLE
fix(auxiliary): a configured fallback_chain opens the explicit-provider gate

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6036,6 +6036,22 @@ def _candidate_context_window(
     return None
 
 
+def _task_has_configured_fallback_chain(task: Optional[str]) -> bool:
+    """True when the user wrote a non-empty ``auxiliary.<task>.fallback_chain``.
+
+    Used by the explicit-provider gate. That gate exists to respect a user who
+    pinned ``auxiliary.<task>.provider`` — but writing a ``fallback_chain``
+    under the same task is itself explicit intent to fail over, so honouring
+    the pin by ignoring the chain inverts what the config asks for.
+
+    Cheap: ``_get_auxiliary_task_config`` reads the process-cached config.
+    """
+    if not task:
+        return False
+    chain = _get_auxiliary_task_config(task).get("fallback_chain")
+    return bool(chain) and isinstance(chain, list)
+
+
 def _try_configured_fallback_chain(
     task: str,
     failed_provider: str,
@@ -10864,7 +10880,18 @@ def _call_llm_impl(
             or _is_model_incompatible_error(first_err)
             or _is_invalid_aux_response_error(first_err)
         )
-        if should_fallback and (is_auto or is_capacity_error):
+        # A configured fallback_chain is itself explicit failover intent, so it
+        # also bypasses the pin. Without this an auth/validation failure on a
+        # pinned aux provider aborts the task with a fully-populated chain of
+        # healthy candidates sitting unused — for compression that means the
+        # transcript stays over threshold and the session keeps growing
+        # (aggregator relaying an upstream 401 as
+        # ``{'error': 'Invalid API key: HTTP 401'}``, telemetry
+        # ``fallback_used: false``).
+        honours_configured_chain = _task_has_configured_fallback_chain(task)
+        if should_fallback and (
+            is_auto or is_capacity_error or honours_configured_chain
+        ):
             if _is_auth_error(first_err):
                 reason = "auth error"
             elif _is_payment_error(first_err):
@@ -11617,7 +11644,18 @@ async def _async_call_llm_impl(
             or _is_model_incompatible_error(first_err)
             or _is_invalid_aux_response_error(first_err)
         )
-        if should_fallback and (is_auto or is_capacity_error):
+        # A configured fallback_chain is itself explicit failover intent, so it
+        # also bypasses the pin. Without this an auth/validation failure on a
+        # pinned aux provider aborts the task with a fully-populated chain of
+        # healthy candidates sitting unused — for compression that means the
+        # transcript stays over threshold and the session keeps growing
+        # (aggregator relaying an upstream 401 as
+        # ``{'error': 'Invalid API key: HTTP 401'}``, telemetry
+        # ``fallback_used: false``).
+        honours_configured_chain = _task_has_configured_fallback_chain(task)
+        if should_fallback and (
+            is_auto or is_capacity_error or honours_configured_chain
+        ):
             if _is_auth_error(first_err):
                 reason = "auth error"
             elif _is_payment_error(first_err):

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1833,6 +1833,91 @@ class TestAuxiliaryFallbackLayering:
 
 
 
+    def test_explicit_provider_auth_error_uses_configured_chain(self, monkeypatch):
+        """401 on a pinned aux provider must still consult fallback_chain.
+
+        Auth is deliberately absent from ``is_capacity_error`` (a 401 says
+        nothing about capacity), so before this fix an explicit-provider route
+        re-raised and the task aborted with a fully-populated chain of healthy
+        candidates unused. For compression that is the worst place to stop: the
+        transcript stays over threshold and the session keeps growing.
+
+        Writing ``auxiliary.<task>.fallback_chain`` IS explicit failover intent,
+        so it opens the gate the provider pin closes. The chain is declared
+        through the real config seam, not by stubbing the predicate, so this
+        exercises the gate itself.
+        """
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+
+        primary_client = MagicMock()
+        auth_err = Exception(
+            "Error code: 401 - {'error': 'Invalid API key: HTTP 401'}")
+        auth_err.status_code = 401
+        primary_client.chat.completions.create.side_effect = auth_err
+
+        fallback_client = MagicMock()
+        fallback_client.chat.completions.create.return_value = MagicMock(
+            choices=[MagicMock(message=MagicMock(content="from fallback chain"))])
+
+        task_config = {
+            "provider": "pinned-provider",
+            "model": "primary-model",
+            "fallback_chain": [
+                {"provider": "chain-provider", "model": "chain-model"},
+            ],
+        }
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(primary_client, "primary-model")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("pinned-provider", "primary-model",
+                                 None, None, None)), \
+             patch("agent.auxiliary_client._get_auxiliary_task_config",
+                   return_value=task_config), \
+             patch("agent.auxiliary_client._try_configured_fallback_chain",
+                   return_value=(fallback_client, "chain-model",
+                                 "fallback_chain[0](chain-provider)")) as mock_chain:
+            result = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "compress this"}],
+            )
+
+        mock_chain.assert_called()
+        assert result.choices[0].message.content == "from fallback chain"
+
+    def test_explicit_provider_auth_error_without_chain_still_raises(self, monkeypatch):
+        """Without a configured chain, the provider pin still holds on 401.
+
+        The gate must open for a declared chain and stay shut otherwise —
+        an unconfigured task has expressed no failover intent, so a 401 has
+        to surface instead of silently rerouting to another provider.
+        """
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+
+        primary_client = MagicMock()
+        auth_err = Exception(
+            "Error code: 401 - {'error': 'Invalid API key: HTTP 401'}")
+        auth_err.status_code = 401
+        primary_client.chat.completions.create.side_effect = auth_err
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(primary_client, "primary-model")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("pinned-provider", "primary-model",
+                                 None, None, None)), \
+             patch("agent.auxiliary_client._get_auxiliary_task_config",
+                   return_value={"provider": "pinned-provider",
+                                 "model": "primary-model"}), \
+             patch("agent.auxiliary_client._try_configured_fallback_chain",
+                   return_value=(None, None, "")), \
+             patch("agent.auxiliary_client._try_main_agent_model_fallback",
+                   return_value=(None, None, "")):
+            with pytest.raises(Exception, match="401"):
+                call_llm(
+                    task="compression",
+                    messages=[{"role": "user", "content": "compress this"}],
+                )
+
     def test_explicit_provider_rate_limit_triggers_fallback(self, monkeypatch):
         """429 rate-limit on an explicit provider must trigger fallback (not be ignored).
 


### PR DESCRIPTION
## What

An auth failure on a **pinned** auxiliary provider aborted the task even when
the user had written a full `fallback_chain` of healthy candidates.

`_call_llm_impl` classifies the error correctly — `should_fallback` is `True`
for 401 — but the gate immediately after is:

```python
is_capacity_error = (
    _is_payment_error(first_err)
    or _is_connection_error(first_err)
    or _is_rate_limit_error(first_err)
    or _is_model_incompatible_error(first_err)
    or _is_invalid_aux_response_error(first_err)
)
if should_fallback and (is_auto or is_capacity_error):
```

Auth is deliberately absent from `is_capacity_error` (a 401 says nothing about
capacity), and a pinned provider is not `"auto"`, so the gate closes and the
exception is re-raised with the chain never consulted.

The pin exists to respect the user. But writing `auxiliary.<task>.fallback_chain`
under that same task is *itself* explicit failover intent — honouring the pin by
ignoring the chain inverts what the config asks for.

## Why it matters

For compression this is the worst possible place to stop: the task aborts, a
cooldown starts, the transcript stays over threshold, and the session keeps
growing. Observed with an aggregator relaying an upstream 401 as
`{'error': 'Invalid API key: HTTP 401'}` while three healthy chain entries sat
unused, telemetry `fallback_used: false`:

```
⚠ Compression aborted: Error code: 401 - {'error': 'Invalid API key: HTTP 401'}.
⚠ Context is over the compression threshold (~211,347 tokens >= 204,800) but
  compression is currently blocked (cooldown:60).
```

The credential was fine — a direct call with the same key returned HTTP 200 for
the same model, and the error shape differs from this aggregator's own
client-key rejection (`{"error":{"message":"Invalid or expired shared API
key","type":"auth_error"}}`), i.e. it was an upstream 401 relayed verbatim. Any
relayed-401 provider reaches the same dead end.

## Change

Adds `_task_has_configured_fallback_chain()` as a third way to open the gate, at
both call sites (sync `_call_llm_impl` and async `_async_call_llm_impl`). With
no chain configured the pin still holds and the error surfaces unchanged.

## Testing

- 2 new tests in `TestAuxiliaryFallbackLayering`: a pinned provider + declared
  chain fails over on 401; a pinned provider *without* a chain still raises.
  Both declare the chain through the real config seam
  (`_get_auxiliary_task_config`), so they exercise the gate rather than stubbing
  the new predicate. Verified they fail on the parent commit.
- `tests/agent/test_auxiliary_client.py` — 190 passed
- fallback/compression neighbours (`test_compression_stall_fallback_78981`,
  `test_compression_fallback_budget`,
  `test_auxiliary_anthropic_pool_fallback_regression`,
  `test_compression_rotation_state`,
  `test_compression_split_failure_cooldown`) — 62 passed
- Live-endpoint check, not only mocks: pinned primary returning a real 401 plus
  one healthy chain entry → before, `AuthenticationError`; after, rescued by
  `chain[0]`. Same harness with no chain configured → still raises.

## Related

Same class of bug as #101018 (`503 model_not_found` was absent from both
predicate lists). That one added a missing *error class*; this one fixes the
*gate* that discards a user-declared chain. They are independent — either can
land alone.
