### PR TITLE
fix(desktop): show one minute-precision clock on chat bubbles

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/agent-delivery.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/agent-delivery.tsx
@@ -1,6 +1,7 @@
 import { type ToolCallMessagePartProps } from '@assistant-ui/react'
 import { type FC, useEffect, useState } from 'react'
 
+import { TimelineTimestamp } from '@/components/assistant-ui/thread/timeline-timestamp'
 import { AGENT_MESSAGE_RE, agentAvatarCache, resolveAgentAvatar } from '@/components/assistant-ui/thread/user-message'
 
 // Sender-side inter-agent delivery: `hermes -p <agent> chat … -q "Message
@@ -87,7 +88,9 @@ const AgentGlyph: FC<{ handle: string }> = ({ handle }) => {
 /** "Messaged X" (+ "Message from X" once the reply lands) for a delivery
  *  command run via the terminal tool. Returns null when the command is not
  *  a delivery — caller falls through to the normal terminal row. */
-export const AgentDeliveryNotice: FC<ToolCallMessagePartProps> = props => {
+type TimelineToolCallMessagePartProps = ToolCallMessagePartProps & { completedAt?: number; timestamp?: number }
+
+export const AgentDeliveryNotice: FC<TimelineToolCallMessagePartProps> = props => {
   const command = typeof props.args?.command === 'string' ? props.args.command : ''
   const target = deliveryTargetFromCommand(command)
 
@@ -103,6 +106,7 @@ export const AgentDeliveryNotice: FC<ToolCallMessagePartProps> = props => {
   return (
     <div className="flex w-full min-w-0 flex-col items-stretch gap-0.5">
       <div className={NOTICE_CLASS} data-slot="aui_agent-delivery-notice">
+        <TimelineTimestamp className="self-center" precision="clock" timestamp={props.timestamp} />
         <span className="flex items-center justify-center gap-1.5">
           <AgentGlyph handle={target} />
           <span className="wrap-anywhere">
@@ -113,6 +117,11 @@ export const AgentDeliveryNotice: FC<ToolCallMessagePartProps> = props => {
       </div>
       {!pending && replyBody && (
         <div className={NOTICE_CLASS} data-slot="aui_agent-reply-notice">
+          <TimelineTimestamp
+            className="self-center"
+            precision="clock"
+            timestamp={props.completedAt ?? props.timestamp}
+          />
           <span className="flex items-center justify-center gap-1.5">
             <AgentGlyph handle={target} />
             <span className="wrap-anywhere">Message from {target}</span>

--- a/apps/desktop/src/components/assistant-ui/thread/agent-message-timestamp.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/agent-message-timestamp.test.tsx
@@ -1,0 +1,46 @@
+import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, expect, it } from 'vitest'
+
+import { $displayTimestamps } from '@/store/display-timestamps'
+
+import { stubThreadEnvironment } from '../test-utils'
+
+import { Thread } from '.'
+
+$displayTimestamps.set(true)
+stubThreadEnvironment()
+
+const createdAt = new Date('2026-05-01T00:00:00.000Z')
+
+function Harness() {
+  const message = {
+    id: 'agent-delivery-1',
+    role: 'user',
+    content: [{ type: 'text', text: 'Message from 🤖 Badr (@badr): review complete' }],
+    attachments: [],
+    createdAt,
+    metadata: { custom: { timelineTimestamp: createdAt.getTime() / 1000 } }
+  } as unknown as ThreadMessage
+
+  const runtime = useExternalStoreRuntime<ThreadMessage>({
+    messages: [message],
+    isRunning: false,
+    onNew: async () => {}
+  })
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread />
+    </AssistantRuntimeProvider>
+  )
+}
+
+afterEach(cleanup)
+
+it('shows a send clock on an agent delivery notice', () => {
+  const { container } = render(<Harness />)
+  const row = container.querySelector('[data-slot="aui_user-message-root"]')
+
+  expect(row?.querySelector('[data-slot="timeline-timestamp"]')).toBeTruthy()
+})

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.test.tsx
@@ -156,15 +156,15 @@ describe('message timeline timestamps', () => {
     expect(stamps).toContain(formatClockTimestamp(landedAt))
   })
 
-  it('suppresses an aggregate assistant stamp that exactly duplicates its sole part', async () => {
+  it('shows one assistant clock when its prose part starts after the message', async () => {
     const startedAt = createdAt.getTime() / 1000
-    // Cross a minute boundary so the assistant's landing clock is textually
-    // distinct from the user bubble's send clock and the two can be counted.
+    // Live prose starts on the first text delta, after the message lifecycle.
+    const partStartedAt = startedAt + 0.125
     const landedAt = startedAt + 130
 
     const assistant = {
       ...assistantMessage(),
-      content: [{ completedAt: landedAt, text: 'done', timestamp: startedAt, type: 'text' }],
+      content: [{ completedAt: landedAt, text: 'done', timestamp: partStartedAt, type: 'text' }],
       metadata: {
         ...assistantMessage().metadata,
         custom: { timelineCompletedAt: landedAt, timelineTimestamp: startedAt }
@@ -179,11 +179,36 @@ describe('message timeline timestamps', () => {
       node.textContent?.trim()
     )
 
-    // Aggregate and sole part now render identically, so exactly one survives
-    // on the assistant bubble — plus the user bubble's own send clock.
     expect(formatClockTimestamp(landedAt)).not.toBe(formatClockTimestamp(startedAt))
     expect(stamps.filter(stamp => stamp === formatClockTimestamp(landedAt))).toHaveLength(1)
     expect(stamps.filter(stamp => stamp === formatClockTimestamp(startedAt))).toHaveLength(1)
     expect(stamps).not.toContain(formatTimelineRange(startedAt, landedAt))
+  })
+
+  it('shows one assistant clock when reasoning precedes prose', async () => {
+    const startedAt = createdAt.getTime() / 1000
+    const landedAt = startedAt + 130
+
+    const assistant = {
+      ...assistantMessage(),
+      content: [
+        { completedAt: startedAt + 0.1, text: 'thinking', timestamp: startedAt + 0.05, type: 'reasoning' },
+        { completedAt: landedAt, text: 'done', timestamp: startedAt + 0.125, type: 'text' }
+      ],
+      metadata: {
+        ...assistantMessage().metadata,
+        custom: { timelineCompletedAt: landedAt, timelineTimestamp: startedAt }
+      }
+    } as unknown as ThreadMessage
+
+    const { container } = render(<Harness assistant={assistant} />)
+    await screen.findByText('done')
+
+    const stamps = Array.from(container.querySelectorAll('[data-slot="timeline-timestamp"]')).map(node =>
+      node.textContent?.trim()
+    )
+
+    expect(stamps.filter(stamp => stamp === formatClockTimestamp(landedAt))).toHaveLength(1)
+    expect(stamps).toContain(formatTimelineRange(startedAt + 0.05, startedAt + 0.1))
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.test.tsx
@@ -70,13 +70,15 @@ function assistantMessage(): ThreadMessage {
 
 function Harness({
   assistant = assistantMessage(),
-  onBranchInNewChat
+  onBranchInNewChat,
+  user = userMessage()
 }: {
   assistant?: ThreadMessage
   onBranchInNewChat?: (messageId: string) => void
+  user?: ThreadMessage
 }) {
   const runtime = useExternalStoreRuntime<ThreadMessage>({
-    messages: [userMessage(), assistant],
+    messages: [user, assistant],
     isRunning: false,
     onNew: async () => {}
   })
@@ -210,5 +212,95 @@ describe('message timeline timestamps', () => {
 
     expect(stamps.filter(stamp => stamp === formatClockTimestamp(landedAt))).toHaveLength(1)
     expect(stamps).toContain(formatTimelineRange(startedAt + 0.05, startedAt + 0.1))
+  })
+
+  it('shows one assistant clock across multiple prose parts', async () => {
+    const startedAt = createdAt.getTime() / 1000
+    const landedAt = startedAt + 130
+
+    const assistant = {
+      ...assistantMessage(),
+      content: [
+        { completedAt: startedAt + 0.2, text: 'first', timestamp: startedAt + 0.1, type: 'text' },
+        { completedAt: landedAt, text: 'second', timestamp: startedAt + 1, type: 'text' }
+      ],
+      metadata: {
+        ...assistantMessage().metadata,
+        custom: { timelineCompletedAt: landedAt, timelineTimestamp: startedAt }
+      }
+    } as unknown as ThreadMessage
+
+    const { container } = render(<Harness assistant={assistant} />)
+    await screen.findByText('second')
+
+    const stamps = Array.from(container.querySelectorAll('[data-slot="timeline-timestamp"]')).map(node =>
+      node.textContent?.trim()
+    )
+
+    expect(stamps.filter(stamp => stamp === formatClockTimestamp(landedAt))).toHaveLength(1)
+  })
+
+  it('shows one clock on an outbound agent delivery notice', async () => {
+    const startedAt = createdAt.getTime() / 1000
+    const landedAt = startedAt + 130
+
+    const assistant = {
+      ...assistantMessage(),
+      content: [
+        {
+          args: {
+            command: 'hermes -p badr chat --in ~ -c "Bot Chat" -Q -q "Message from 🤖 Abu Saud: review"'
+          },
+          argsText: '{}',
+          completedAt: landedAt,
+          result: { exit_code: 0, output: 'done' },
+          timestamp: startedAt,
+          toolCallId: 'delivery-1',
+          toolName: 'terminal',
+          type: 'tool-call'
+        }
+      ],
+      metadata: {
+        ...assistantMessage().metadata,
+        custom: { timelineCompletedAt: landedAt, timelineTimestamp: startedAt }
+      }
+    } as unknown as ThreadMessage
+
+    const { container } = render(<Harness assistant={assistant} />)
+    await screen.findByText('Messaged badr')
+
+    const assistantRow = container.querySelector('[data-slot="aui_assistant-message-root"]')
+    const stamps = Array.from(assistantRow?.querySelectorAll('[data-slot="timeline-timestamp"]') ?? [])
+
+    expect(stamps).toHaveLength(1)
+    expect(stamps[0]?.textContent?.trim()).toBe(formatClockTimestamp(landedAt))
+  })
+
+  it('shows one clock on a settled inter-agent reply notice', async () => {
+    const startedAt = createdAt.getTime() / 1000
+    const landedAt = startedAt + 130
+
+    const user = {
+      ...userMessage(),
+      content: [{ type: 'text', text: 'Message from 🤖 Badr (@badr): review this' }]
+    } as unknown as ThreadMessage
+
+    const assistant = {
+      ...assistantMessage(),
+      content: [{ completedAt: landedAt, text: 'reviewed', timestamp: startedAt, type: 'text' }],
+      metadata: {
+        ...assistantMessage().metadata,
+        custom: { timelineCompletedAt: landedAt, timelineTimestamp: startedAt }
+      }
+    } as unknown as ThreadMessage
+
+    const { container } = render(<Harness assistant={assistant} user={user} />)
+    await screen.findByText('Replied to Badr')
+
+    const assistantRow = container.querySelector('[data-slot="aui_assistant-message-root"]')
+    const stamps = Array.from(assistantRow?.querySelectorAll('[data-slot="timeline-timestamp"]') ?? [])
+
+    expect(stamps).toHaveLength(1)
+    expect(stamps[0]?.textContent?.trim()).toBe(formatClockTimestamp(landedAt))
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.test.tsx
@@ -123,10 +123,12 @@ describe('message timeline timestamps', () => {
     expect(stamps).toContain(formatClockTimestamp(startedAt))
     expect(stamps).toContain(formatClockTimestamp(completedAt))
     expect(stamps).not.toContain(formatTimelineRange(startedAt, completedAt))
+    // The text part carries the prose, so it is a bubble row too — this is
+    // the exact row that used to print `5:06:59.615 AM → 5:08:37.037 AM`.
+    expect(stamps).not.toContain(formatTimelineRange(startedAt + 0.125, startedAt + 0.5))
 
-    // Activity parts keep full precision — they measure duration.
+    // Reasoning stays an activity boundary and keeps full precision.
     expect(stamps).toContain(formatTimelineRange(startedAt + 0.05, startedAt + 0.1))
-    expect(stamps).toContain(formatTimelineRange(startedAt + 0.125, startedAt + 0.5))
   })
 
   it('renders the assistant landing clock from the completion time, not the send time', async () => {
@@ -156,10 +158,17 @@ describe('message timeline timestamps', () => {
 
   it('suppresses an aggregate assistant stamp that exactly duplicates its sole part', async () => {
     const startedAt = createdAt.getTime() / 1000
+    // Cross a minute boundary so the assistant's landing clock is textually
+    // distinct from the user bubble's send clock and the two can be counted.
+    const landedAt = startedAt + 130
 
     const assistant = {
       ...assistantMessage(),
-      content: [{ completedAt, text: 'done', timestamp: startedAt, type: 'text' }]
+      content: [{ completedAt: landedAt, text: 'done', timestamp: startedAt, type: 'text' }],
+      metadata: {
+        ...assistantMessage().metadata,
+        custom: { timelineCompletedAt: landedAt, timelineTimestamp: startedAt }
+      }
     } as unknown as ThreadMessage
 
     const { container } = render(<Harness assistant={assistant} />)
@@ -170,9 +179,11 @@ describe('message timeline timestamps', () => {
       node.textContent?.trim()
     )
 
-    expect(stamps.filter(stamp => stamp === formatTimelineRange(startedAt, completedAt))).toHaveLength(1)
-    // Only the user bubble keeps a clock row; the suppressed assistant
-    // aggregate must not reappear as a second one.
+    // Aggregate and sole part now render identically, so exactly one survives
+    // on the assistant bubble — plus the user bubble's own send clock.
+    expect(formatClockTimestamp(landedAt)).not.toBe(formatClockTimestamp(startedAt))
+    expect(stamps.filter(stamp => stamp === formatClockTimestamp(landedAt))).toHaveLength(1)
     expect(stamps.filter(stamp => stamp === formatClockTimestamp(startedAt))).toHaveLength(1)
+    expect(stamps).not.toContain(formatTimelineRange(startedAt, landedAt))
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.test.tsx
@@ -240,7 +240,7 @@ describe('message timeline timestamps', () => {
     expect(stamps.filter(stamp => stamp === formatClockTimestamp(landedAt))).toHaveLength(1)
   })
 
-  it('shows one clock on an outbound agent delivery notice', async () => {
+  it('shows one clock on each outbound agent delivery notice', async () => {
     const startedAt = createdAt.getTime() / 1000
     const landedAt = startedAt + 130
 
@@ -272,8 +272,120 @@ describe('message timeline timestamps', () => {
     const assistantRow = container.querySelector('[data-slot="aui_assistant-message-root"]')
     const stamps = Array.from(assistantRow?.querySelectorAll('[data-slot="timeline-timestamp"]') ?? [])
 
+    expect(stamps).toHaveLength(2)
+    expect(stamps.map(stamp => stamp.textContent?.trim())).toEqual([
+      formatClockTimestamp(startedAt),
+      formatClockTimestamp(landedAt)
+    ])
+  })
+
+  it('shows one clock while an outbound agent delivery is pending', async () => {
+    const startedAt = createdAt.getTime() / 1000
+
+    const assistant = {
+      ...assistantMessage(),
+      content: [
+        {
+          args: {
+            command: 'hermes -p badr chat --in ~ -c "Bot Chat" -Q -q "Message from 🤖 Abu Saud: review"'
+          },
+          argsText: '{}',
+          timestamp: startedAt,
+          toolCallId: 'delivery-pending',
+          toolName: 'terminal',
+          type: 'tool-call'
+        }
+      ],
+      status: { type: 'running' },
+      metadata: {
+        ...assistantMessage().metadata,
+        custom: { timelineTimestamp: startedAt }
+      }
+    } as unknown as ThreadMessage
+
+    const { container } = render(<Harness assistant={assistant} />)
+    await screen.findByText(/Messaging badr/)
+
+    const assistantRow = container.querySelector('[data-slot="aui_assistant-message-root"]')
+    const stamps = Array.from(assistantRow?.querySelectorAll('[data-slot="timeline-timestamp"]') ?? [])
+
     expect(stamps).toHaveLength(1)
-    expect(stamps[0]?.textContent?.trim()).toBe(formatClockTimestamp(landedAt))
+    expect(stamps[0]?.textContent?.trim()).toBe(formatClockTimestamp(startedAt))
+  })
+
+  it('keeps the aggregate prose clock beside delivery notice clocks', async () => {
+    const startedAt = createdAt.getTime() / 1000
+    const landedAt = startedAt + 130
+
+    const assistant = {
+      ...assistantMessage(),
+      content: [
+        { completedAt: startedAt + 1, text: 'I sent this for review.', timestamp: startedAt + 0.5, type: 'text' },
+        {
+          args: {
+            command: 'hermes -p badr chat --in ~ -c "Bot Chat" -Q -q "Message from 🤖 Abu Saud: review"'
+          },
+          argsText: '{}',
+          completedAt: landedAt,
+          result: { exit_code: 0, output: 'reviewed' },
+          timestamp: startedAt + 1,
+          toolCallId: 'delivery-with-prose',
+          toolName: 'terminal',
+          type: 'tool-call'
+        }
+      ],
+      metadata: {
+        ...assistantMessage().metadata,
+        custom: { timelineCompletedAt: landedAt, timelineTimestamp: startedAt }
+      }
+    } as unknown as ThreadMessage
+
+    const { container } = render(<Harness assistant={assistant} />)
+    await screen.findByText('I sent this for review.')
+    await screen.findByText('Messaged badr')
+
+    const assistantRow = container.querySelector('[data-slot="aui_assistant-message-root"]')
+    const stamps = Array.from(assistantRow?.querySelectorAll('[data-slot="timeline-timestamp"]') ?? [])
+
+    expect(stamps).toHaveLength(3)
+    expect(stamps.filter(stamp => stamp.textContent?.trim() === formatClockTimestamp(landedAt))).toHaveLength(2)
+  })
+
+  it('keeps the aggregate clock when an agent delivery tool fails', async () => {
+    const startedAt = createdAt.getTime() / 1000
+    const landedAt = startedAt + 130
+
+    const assistant = {
+      ...assistantMessage(),
+      content: [
+        {
+          args: {
+            command: 'hermes -p badr chat --in ~ -c "Bot Chat" -Q -q "Message from 🤖 Abu Saud: review"'
+          },
+          argsText: '{}',
+          completedAt: landedAt,
+          isError: true,
+          result: { error: 'delivery failed' },
+          timestamp: startedAt,
+          toolCallId: 'delivery-failed',
+          toolName: 'terminal',
+          type: 'tool-call'
+        }
+      ],
+      metadata: {
+        ...assistantMessage().metadata,
+        custom: { timelineCompletedAt: landedAt, timelineTimestamp: startedAt }
+      }
+    } as unknown as ThreadMessage
+
+    const { container } = render(<Harness assistant={assistant} />)
+    await screen.findByText(/Ran hermes -p badr/)
+
+    const assistantRow = container.querySelector('[data-slot="aui_assistant-message-root"]')
+    const stamps = Array.from(assistantRow?.querySelectorAll('[data-slot="timeline-timestamp"]') ?? [])
+
+    expect(stamps.filter(stamp => stamp.textContent?.trim() === formatClockTimestamp(landedAt))).toHaveLength(1)
+    expect(stamps.map(stamp => stamp.textContent?.trim())).toContain(formatTimelineRange(startedAt, landedAt))
   })
 
   it('shows one clock on a settled inter-agent reply notice', async () => {

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.test.tsx
@@ -12,7 +12,7 @@ import { $displayTimestamps } from '@/store/display-timestamps'
 
 import { stubThreadEnvironment } from '../test-utils'
 
-import { formatTimelineRange, formatTimelineTimestamp } from './timestamp'
+import { formatClockTimestamp, formatTimelineRange } from './timestamp'
 
 import { Thread } from '.'
 
@@ -108,7 +108,7 @@ describe('AssistantMessage branch button visibility (bug #2 fix)', () => {
 })
 
 describe('message timeline timestamps', () => {
-  it('always renders precise user and assistant lifecycle times', async () => {
+  it('shows chat bubbles as a minute-precision clock and activity parts as precise ranges', async () => {
     const { container } = render(<Harness />)
 
     await screen.findByText('done')
@@ -119,10 +119,39 @@ describe('message timeline timestamps', () => {
 
     const startedAt = createdAt.getTime() / 1000
 
-    expect(stamps).toContain(formatTimelineTimestamp(startedAt))
-    expect(stamps).toContain(formatTimelineRange(startedAt, completedAt))
+    // Bubble rows: "when was it sent" / "when did it land", no seconds.
+    expect(stamps).toContain(formatClockTimestamp(startedAt))
+    expect(stamps).toContain(formatClockTimestamp(completedAt))
+    expect(stamps).not.toContain(formatTimelineRange(startedAt, completedAt))
+
+    // Activity parts keep full precision — they measure duration.
     expect(stamps).toContain(formatTimelineRange(startedAt + 0.05, startedAt + 0.1))
     expect(stamps).toContain(formatTimelineRange(startedAt + 0.125, startedAt + 0.5))
+  })
+
+  it('renders the assistant landing clock from the completion time, not the send time', async () => {
+    const startedAt = createdAt.getTime() / 1000
+    // Deliberately crosses a minute boundary so "sent" and "landed" differ.
+    const landedAt = startedAt + 130
+
+    const assistant = {
+      ...assistantMessage(),
+      metadata: {
+        ...assistantMessage().metadata,
+        custom: { timelineCompletedAt: landedAt, timelineTimestamp: startedAt }
+      }
+    } as unknown as ThreadMessage
+
+    const { container } = render(<Harness assistant={assistant} />)
+
+    await screen.findByText('done')
+
+    const stamps = Array.from(container.querySelectorAll('[data-slot="timeline-timestamp"]')).map(node =>
+      node.textContent?.trim()
+    )
+
+    expect(formatClockTimestamp(landedAt)).not.toBe(formatClockTimestamp(startedAt))
+    expect(stamps).toContain(formatClockTimestamp(landedAt))
   })
 
   it('suppresses an aggregate assistant stamp that exactly duplicates its sole part', async () => {
@@ -142,5 +171,8 @@ describe('message timeline timestamps', () => {
     )
 
     expect(stamps.filter(stamp => stamp === formatTimelineRange(startedAt, completedAt))).toHaveLength(1)
+    // Only the user bubble keeps a clock row; the suppressed assistant
+    // aggregate must not reappear as a second one.
+    expect(stamps.filter(stamp => stamp === formatClockTimestamp(startedAt))).toHaveLength(1)
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -261,7 +261,7 @@ const AssistantMessageBody: FC<AssistantMessageProps & { collapsedNotice?: null 
               </ErrorPrimitive.Root>
             </MessagePrimitive.Error>
           </div>
-          <MessageTimelineTimestamp className="px-(--message-text-indent) pt-0.5" suppressIfDuplicatePart />
+          <MessageTimelineTimestamp className="px-(--message-text-indent) pt-0.5" suppressIfPartClock />
           {hasVisibleText && !isInterim && (
             <AssistantFooter
               durationS={turnDurationS}

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -133,6 +133,7 @@ const InterAgentCollapsedNotice: FC<{ sender: string }> = ({ sender }) => (
       <Codicon className="shrink-0 text-muted-foreground/55" name="arrow-small-right" size="0.8125rem" />
       <span className="wrap-anywhere">Replied to {sender}</span>
     </span>
+    <MessageTimelineTimestamp className="self-center" />
     <details className="self-center">
       <summary className="cursor-pointer select-none text-center text-muted-foreground/45 hover:text-muted-foreground/70">
         show reply
@@ -261,7 +262,7 @@ const AssistantMessageBody: FC<AssistantMessageProps & { collapsedNotice?: null 
               </ErrorPrimitive.Root>
             </MessagePrimitive.Error>
           </div>
-          <MessageTimelineTimestamp className="px-(--message-text-indent) pt-0.5" suppressIfPartClock />
+          <MessageTimelineTimestamp className="px-(--message-text-indent) pt-0.5" />
           {hasVisibleText && !isInterim && (
             <AssistantFooter
               durationS={turnDurationS}

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -12,6 +12,7 @@ import { useInRouterContext, useNavigate } from 'react-router'
 
 import { useSessionView } from '@/app/chat/session-view'
 import { SETTINGS_ROUTE } from '@/app/routes'
+import { deliveryTargetFromCommand } from '@/components/assistant-ui/thread/agent-delivery'
 import { ChangedFilesCard } from '@/components/assistant-ui/thread/changed-files-card'
 import {
   contentHasVisibleText,
@@ -187,6 +188,22 @@ const AssistantMessageBody: FC<AssistantMessageProps & { collapsedNotice?: null 
   // the markdown part and the tiny status leaves — not the footer, the
   // preview block, or this root.
   const hasVisibleText = useAuiState(s => contentHasVisibleText(s.message.content))
+
+  const hasAgentDeliveryNotice = useAuiState(s =>
+    s.message.parts.some(part => {
+      const candidate = part as { args?: { command?: unknown }; isError?: unknown; toolName?: unknown; type?: unknown }
+      const command = candidate.args?.command
+
+      return (
+        candidate.type === 'tool-call' &&
+        candidate.toolName === 'terminal' &&
+        candidate.isError !== true &&
+        typeof command === 'string' &&
+        Boolean(deliveryTargetFromCommand(command))
+      )
+    })
+  )
+
   // Sealed mid-turn commentary keeps its text but not the footer, so a
   // tool-heavy turn doesn't grow a copy/refresh bar per paragraph (see
   // ChatMessage.interim).
@@ -262,7 +279,11 @@ const AssistantMessageBody: FC<AssistantMessageProps & { collapsedNotice?: null 
               </ErrorPrimitive.Root>
             </MessagePrimitive.Error>
           </div>
-          <MessageTimelineTimestamp className="px-(--message-text-indent) pt-0.5" />
+          {/* Delivery-only rows contain distinct outbound/reply notices, each
+          with its own clock. Do not add a third aggregate stamp beneath them. */}
+          {(!hasAgentDeliveryNotice || hasVisibleText) && (
+            <MessageTimelineTimestamp className="px-(--message-text-indent) pt-0.5" />
+          )}
           {hasVisibleText && !isInterim && (
             <AssistantFooter
               durationS={turnDurationS}

--- a/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
@@ -12,10 +12,7 @@ import { ClarifyTool } from '@/components/assistant-ui/clarify-tool'
 import { MarkdownText, MarkdownTextContent } from '@/components/assistant-ui/markdown-text'
 import { McpSetupTool } from '@/components/assistant-ui/mcp-setup-tool'
 import { AgentDeliveryNotice, deliveryTargetFromCommand } from '@/components/assistant-ui/thread/agent-delivery'
-import {
-  MessageTimelineTimestamp,
-  TimelineTimestamp
-} from '@/components/assistant-ui/thread/timeline-timestamp'
+import { TimelineTimestamp } from '@/components/assistant-ui/thread/timeline-timestamp'
 import { DelegateTool } from '@/components/assistant-ui/tool/delegate'
 import { ToolFallback, ToolGroupSlot } from '@/components/assistant-ui/tool/fallback'
 import { formatElapsed, useElapsedSeconds, useMeasuredDuration } from '@/components/chat/activity-timer'
@@ -114,20 +111,7 @@ const ChainToolFallback: FC<TimelineToolCallProps> = props => {
   return <ToolFallback {...props} />
 }
 
-type TimelineTextPartProps = TextMessagePartProps & { completedAt?: number; timestamp?: number }
-
-const TimelineMarkdownText: FC<TimelineTextPartProps> = () => (
-  <>
-    {/*
-      Prose is the bubble, not an activity boundary: it answers "when did this
-      land", so it uses the assistant message's completion clock. Reasoning and
-      tool rows below keep `exact` — they measure duration, where seconds and
-      milliseconds are the point.
-    */}
-    <MessageTimelineTimestamp className="mb-0.5 block" />
-    <MarkdownText />
-  </>
-)
+const TimelineMarkdownText: FC<TextMessagePartProps> = () => <MarkdownText />
 
 const ThinkingDisclosure: FC<{
   children: ReactNode

--- a/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
@@ -115,7 +115,13 @@ type TimelineTextPartProps = TextMessagePartProps & { completedAt?: number; time
 
 const TimelineMarkdownText: FC<TimelineTextPartProps> = ({ completedAt, timestamp }) => (
   <>
-    <TimelineTimestamp className="mb-0.5 block" completedAt={completedAt} timestamp={timestamp} />
+    {/*
+      Prose is the bubble, not an activity boundary: it answers "when did this
+      land", so it takes the same minute-precision clock as the aggregate
+      message stamp. Reasoning and tool rows below keep `exact` — they measure
+      duration, where seconds and milliseconds are the point.
+    */}
+    <TimelineTimestamp className="mb-0.5 block" completedAt={completedAt} precision="clock" timestamp={timestamp} />
     <MarkdownText />
   </>
 )

--- a/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
@@ -12,7 +12,10 @@ import { ClarifyTool } from '@/components/assistant-ui/clarify-tool'
 import { MarkdownText, MarkdownTextContent } from '@/components/assistant-ui/markdown-text'
 import { McpSetupTool } from '@/components/assistant-ui/mcp-setup-tool'
 import { AgentDeliveryNotice, deliveryTargetFromCommand } from '@/components/assistant-ui/thread/agent-delivery'
-import { TimelineTimestamp } from '@/components/assistant-ui/thread/timeline-timestamp'
+import {
+  MessageTimelineTimestamp,
+  TimelineTimestamp
+} from '@/components/assistant-ui/thread/timeline-timestamp'
 import { DelegateTool } from '@/components/assistant-ui/tool/delegate'
 import { ToolFallback, ToolGroupSlot } from '@/components/assistant-ui/tool/fallback'
 import { formatElapsed, useElapsedSeconds, useMeasuredDuration } from '@/components/chat/activity-timer'
@@ -113,15 +116,15 @@ const ChainToolFallback: FC<TimelineToolCallProps> = props => {
 
 type TimelineTextPartProps = TextMessagePartProps & { completedAt?: number; timestamp?: number }
 
-const TimelineMarkdownText: FC<TimelineTextPartProps> = ({ completedAt, timestamp }) => (
+const TimelineMarkdownText: FC<TimelineTextPartProps> = () => (
   <>
     {/*
       Prose is the bubble, not an activity boundary: it answers "when did this
-      land", so it takes the same minute-precision clock as the aggregate
-      message stamp. Reasoning and tool rows below keep `exact` — they measure
-      duration, where seconds and milliseconds are the point.
+      land", so it uses the assistant message's completion clock. Reasoning and
+      tool rows below keep `exact` — they measure duration, where seconds and
+      milliseconds are the point.
     */}
-    <TimelineTimestamp className="mb-0.5 block" completedAt={completedAt} precision="clock" timestamp={timestamp} />
+    <MessageTimelineTimestamp className="mb-0.5 block" />
     <MarkdownText />
   </>
 )

--- a/apps/desktop/src/components/assistant-ui/thread/system-message.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/system-message.test.tsx
@@ -64,4 +64,10 @@ describe('system message timestamp text separation', () => {
 
     expectTimestampSeparated(container, 'rerun tests')
   })
+
+  it('shows a timestamp on review rows', () => {
+    const { container } = render(<Harness text="review:Saved: memory updated" />)
+
+    expectTimestampSeparated(container, 'memory updated')
+  })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/system-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/system-message.tsx
@@ -43,7 +43,8 @@ export const SystemMessage: FC = () => {
         </span>
         {detail && (
           <span className={cn(SCAFFOLD_LABEL_CLASS, 'tool-memory-legendary-meta min-w-0 wrap-anywhere')}>{detail}</span>
-        )}
+        )}{' '}
+        <MessageTimelineTimestamp className="self-center" />
       </MessagePrimitive.Root>
     )
   }

--- a/apps/desktop/src/components/assistant-ui/thread/timeline-timestamp.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline-timestamp.test.tsx
@@ -50,6 +50,19 @@ describe('TimelineTimestamp precision', () => {
   const started = new Date(2026, 4, 1, 16, 30, 3, 456).getTime() / 1000
   const finished = new Date(2026, 4, 1, 16, 32, 9, 789).getTime() / 1000
 
+  // Mirrors the component's own hover formatter, so the assertion survives a
+  // locale that renders digits differently (e.g. ar-SA).
+  const preciseFormat = (d: Date) =>
+    new Intl.DateTimeFormat(undefined, {
+      day: 'numeric',
+      fractionalSecondDigits: 3,
+      hour: 'numeric',
+      minute: '2-digit',
+      month: 'short',
+      second: '2-digit',
+      year: 'numeric'
+    }).format(d)
+
   beforeEach(() => {
     $displayTimestamps.set(true)
   })
@@ -59,8 +72,10 @@ describe('TimelineTimestamp precision', () => {
     const text = container.querySelector('[data-slot="timeline-timestamp"]')?.textContent ?? ''
 
     expect(text).toContain('→')
-    expect(text).toContain('456')
-    expect(text).toContain('789')
+    // Sub-minute detail is exactly what an activity row must keep: two
+    // instants in the same minute stay distinguishable here.
+    expect(text).not.toBe(formatClockTimestamp(started))
+    expect(text.split('→')[0]?.trim()).not.toBe(formatClockTimestamp(started))
   })
 
   it('collapses to a single landing clock with no seconds when precision is clock', () => {
@@ -69,11 +84,11 @@ describe('TimelineTimestamp precision', () => {
     const text = node?.textContent ?? ''
 
     expect(text).not.toContain('→')
-    expect(text).not.toContain('456')
-    expect(text).not.toContain('789')
     expect(text).toBe(formatClockTimestamp(finished))
     // Full precision is still reachable on hover.
-    expect(node?.getAttribute('title') ?? '').toContain('456')
+    expect(node?.getAttribute('title') ?? '').toBe(
+      `${preciseFormat(new Date(started * 1000))} → ${preciseFormat(new Date(finished * 1000))}`
+    )
   })
 
   it('falls back to the send time in clock mode when the turn never completed', () => {

--- a/apps/desktop/src/components/assistant-ui/thread/timeline-timestamp.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline-timestamp.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { $displayTimestamps, setDisplayTimestampsFromConfig } from '@/store/display-timestamps'
 
 import { TimelineTimestamp } from './timeline-timestamp'
+import { formatClockTimestamp } from './timestamp'
 
 afterEach(cleanup)
 
@@ -42,5 +43,42 @@ describe('TimelineTimestamp display.timestamps gate', () => {
     const { container } = render(<TimelineTimestamp timestamp={timestamp} />)
 
     expect(container.querySelector('[data-slot="timeline-timestamp"]')).toBeTruthy()
+  })
+})
+
+describe('TimelineTimestamp precision', () => {
+  const started = new Date(2026, 4, 1, 16, 30, 3, 456).getTime() / 1000
+  const finished = new Date(2026, 4, 1, 16, 32, 9, 789).getTime() / 1000
+
+  beforeEach(() => {
+    $displayTimestamps.set(true)
+  })
+
+  it('defaults to the precise range for activity boundaries', () => {
+    const { container } = render(<TimelineTimestamp completedAt={finished} timestamp={started} />)
+    const text = container.querySelector('[data-slot="timeline-timestamp"]')?.textContent ?? ''
+
+    expect(text).toContain('→')
+    expect(text).toContain('456')
+    expect(text).toContain('789')
+  })
+
+  it('collapses to a single landing clock with no seconds when precision is clock', () => {
+    const { container } = render(<TimelineTimestamp completedAt={finished} precision="clock" timestamp={started} />)
+    const node = container.querySelector('[data-slot="timeline-timestamp"]')
+    const text = node?.textContent ?? ''
+
+    expect(text).not.toContain('→')
+    expect(text).not.toContain('456')
+    expect(text).not.toContain('789')
+    expect(text).toBe(formatClockTimestamp(finished))
+    // Full precision is still reachable on hover.
+    expect(node?.getAttribute('title') ?? '').toContain('456')
+  })
+
+  it('falls back to the send time in clock mode when the turn never completed', () => {
+    const { container } = render(<TimelineTimestamp precision="clock" timestamp={started} />)
+
+    expect(container.querySelector('[data-slot="timeline-timestamp"]')?.textContent).toBe(formatClockTimestamp(started))
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/timeline-timestamp.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline-timestamp.tsx
@@ -105,8 +105,7 @@ export const TimelineTimestamp: FC<{
 /** Timestamp for the current assistant-ui message lifecycle. */
 export const MessageTimelineTimestamp: FC<{
   className?: string
-  suppressIfPartClock?: boolean
-}> = ({ className, suppressIfPartClock = false }) => {
+}> = ({ className }) => {
   const timestamp = useAuiState(s => {
     const value = (s.message.metadata?.custom as { timelineTimestamp?: unknown } | undefined)?.timelineTimestamp
 
@@ -118,15 +117,6 @@ export const MessageTimelineTimestamp: FC<{
 
     return validUnixSeconds(value) ? value : undefined
   })
-
-  // Every prose part renders the assistant's landing clock itself. Suppress the
-  // aggregate clock by rendered role rather than raw timestamps: live prose
-  // starts on the first text delta, which is normally later than the message.
-  const hasPartClock = useAuiState(s => s.message.parts.some(part => part.type === 'text'))
-
-  if (suppressIfPartClock && hasPartClock) {
-    return null
-  }
 
   return <TimelineTimestamp className={className} completedAt={completedAt} precision="clock" timestamp={timestamp} />
 }

--- a/apps/desktop/src/components/assistant-ui/thread/timeline-timestamp.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline-timestamp.tsx
@@ -105,8 +105,8 @@ export const TimelineTimestamp: FC<{
 /** Timestamp for the current assistant-ui message lifecycle. */
 export const MessageTimelineTimestamp: FC<{
   className?: string
-  suppressIfDuplicatePart?: boolean
-}> = ({ className, suppressIfDuplicatePart = false }) => {
+  suppressIfPartClock?: boolean
+}> = ({ className, suppressIfPartClock = false }) => {
   const timestamp = useAuiState(s => {
     const value = (s.message.metadata?.custom as { timelineTimestamp?: unknown } | undefined)?.timelineTimestamp
 
@@ -119,24 +119,12 @@ export const MessageTimelineTimestamp: FC<{
     return validUnixSeconds(value) ? value : undefined
   })
 
-  const duplicatePart = useAuiState(s => {
-    const custom = (s.message.metadata?.custom ?? {}) as {
-      timelineCompletedAt?: unknown
-      timelineTimestamp?: unknown
-    }
+  // Every prose part renders the assistant's landing clock itself. Suppress the
+  // aggregate clock by rendered role rather than raw timestamps: live prose
+  // starts on the first text delta, which is normally later than the message.
+  const hasPartClock = useAuiState(s => s.message.parts.some(part => part.type === 'text'))
 
-    const solePart =
-      s.message.parts.length === 1 ? (s.message.parts[0] as { completedAt?: unknown; timestamp?: unknown }) : null
-
-    return (
-      Boolean(solePart) &&
-      solePart?.timestamp === custom.timelineTimestamp &&
-      (solePart?.completedAt === custom.timelineCompletedAt ||
-        (!validUnixSeconds(solePart?.completedAt) && !validUnixSeconds(custom.timelineCompletedAt)))
-    )
-  })
-
-  if (suppressIfDuplicatePart && duplicatePart) {
+  if (suppressIfPartClock && hasPartClock) {
     return null
   }
 

--- a/apps/desktop/src/components/assistant-ui/thread/timeline-timestamp.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline-timestamp.tsx
@@ -61,9 +61,14 @@ export const TimelineTimestamp: FC<{
 
   if (precision === 'clock') {
     // A chat bubble answers "when did this arrive", so it shows the settled
-    // moment (completion when the turn produced one, otherwise the send time)
-    // as a single `4:30 PM`. Full precision stays on hover.
-    const landed = completed ?? started
+    // moment as a single `4:30 PM`. Full precision stays on hover.
+    //
+    // Two deliberate fallbacks to the start time: a turn that never completed
+    // (still streaming, errored, or cancelled) has no completion to show, and
+    // an instant turn whose completion equals its start has nothing to add.
+    // While streaming, the row therefore shows the send minute and settles to
+    // the landing minute — invisible for sub-minute turns, a single quiet
+    // change for long ones.
     const landedSeconds = validCompletedAt ?? timestamp
 
     return (
@@ -72,7 +77,7 @@ export const TimelineTimestamp: FC<{
         data-slot="timeline-timestamp"
         title={title}
       >
-        <time dateTime={landed.toISOString()}>{formatClockTimestamp(landedSeconds)}</time>
+        <time dateTime={(completed ?? started).toISOString()}>{formatClockTimestamp(landedSeconds)}</time>
       </span>
     )
   }
@@ -100,9 +105,8 @@ export const TimelineTimestamp: FC<{
 /** Timestamp for the current assistant-ui message lifecycle. */
 export const MessageTimelineTimestamp: FC<{
   className?: string
-  precision?: 'clock' | 'exact'
   suppressIfDuplicatePart?: boolean
-}> = ({ className, precision = 'clock', suppressIfDuplicatePart = false }) => {
+}> = ({ className, suppressIfDuplicatePart = false }) => {
   const timestamp = useAuiState(s => {
     const value = (s.message.metadata?.custom as { timelineTimestamp?: unknown } | undefined)?.timelineTimestamp
 
@@ -136,5 +140,5 @@ export const MessageTimelineTimestamp: FC<{
     return null
   }
 
-  return <TimelineTimestamp className={className} completedAt={completedAt} precision={precision} timestamp={timestamp} />
+  return <TimelineTimestamp className={className} completedAt={completedAt} precision="clock" timestamp={timestamp} />
 }

--- a/apps/desktop/src/components/assistant-ui/thread/timeline-timestamp.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline-timestamp.tsx
@@ -5,7 +5,7 @@ import type { FC } from 'react'
 import { cn } from '@/lib/utils'
 import { $displayTimestamps } from '@/store/display-timestamps'
 
-import { formatTimelineRange } from './timestamp'
+import { formatClockTimestamp, formatTimelineRange } from './timestamp'
 
 const preciseDateTime = new Intl.DateTimeFormat(undefined, {
   day: 'numeric',
@@ -33,8 +33,14 @@ const unixDate = (value: unknown): Date | null => {
 export const TimelineTimestamp: FC<{
   className?: string
   completedAt?: number
+  /**
+   * `exact` keeps the millisecond range used by tool/activity boundaries.
+   * `clock` collapses the row to a single minute-precision wall clock — the
+   * moment a chat bubble was sent or landed (#41531 follow-up).
+   */
+  precision?: 'clock' | 'exact'
   timestamp?: number
-}> = ({ className, completedAt, timestamp }) => {
+}> = ({ className, completedAt, precision = 'exact', timestamp }) => {
   // One config key everywhere (#41531): `display.timestamps` in config.yaml
   // gates transcript timestamps here exactly as it gates the classic CLI's
   // [HH:MM] labels. Display-only, so toggling never touches model context.
@@ -48,12 +54,31 @@ export const TimelineTimestamp: FC<{
   const completed = validUnixSeconds(completedAt) && completedAt > timestamp ? unixDate(completedAt) : null
 
   const validCompletedAt = completed && validUnixSeconds(completedAt) ? completedAt : undefined
-  const startLabel = formatTimelineRange(timestamp, undefined)
-  const completedLabel = validCompletedAt === undefined ? '' : formatTimelineRange(validCompletedAt, undefined)
 
   const title = completed
     ? `${preciseDateTime.format(started)} → ${preciseDateTime.format(completed)}`
     : preciseDateTime.format(started)
+
+  if (precision === 'clock') {
+    // A chat bubble answers "when did this arrive", so it shows the settled
+    // moment (completion when the turn produced one, otherwise the send time)
+    // as a single `4:30 PM`. Full precision stays on hover.
+    const landed = completed ?? started
+    const landedSeconds = validCompletedAt ?? timestamp
+
+    return (
+      <span
+        className={cn('text-[0.625rem] leading-4 tabular-nums text-muted-foreground/55', className)}
+        data-slot="timeline-timestamp"
+        title={title}
+      >
+        <time dateTime={landed.toISOString()}>{formatClockTimestamp(landedSeconds)}</time>
+      </span>
+    )
+  }
+
+  const startLabel = formatTimelineRange(timestamp, undefined)
+  const completedLabel = validCompletedAt === undefined ? '' : formatTimelineRange(validCompletedAt, undefined)
 
   return (
     <span
@@ -75,8 +100,9 @@ export const TimelineTimestamp: FC<{
 /** Timestamp for the current assistant-ui message lifecycle. */
 export const MessageTimelineTimestamp: FC<{
   className?: string
+  precision?: 'clock' | 'exact'
   suppressIfDuplicatePart?: boolean
-}> = ({ className, suppressIfDuplicatePart = false }) => {
+}> = ({ className, precision = 'clock', suppressIfDuplicatePart = false }) => {
   const timestamp = useAuiState(s => {
     const value = (s.message.metadata?.custom as { timelineTimestamp?: unknown } | undefined)?.timelineTimestamp
 
@@ -110,5 +136,5 @@ export const MessageTimelineTimestamp: FC<{
     return null
   }
 
-  return <TimelineTimestamp className={className} completedAt={completedAt} timestamp={timestamp} />
+  return <TimelineTimestamp className={className} completedAt={completedAt} precision={precision} timestamp={timestamp} />
 }

--- a/apps/desktop/src/components/assistant-ui/thread/timestamp.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/timestamp.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { formatMessageTimestamp, formatTimelineRange, formatTimelineTimestamp } from './timestamp'
+import { formatClockTimestamp, formatMessageTimestamp, formatTimelineRange, formatTimelineTimestamp } from './timestamp'
 
 const labels = {
   today: (time: string) => `Today at ${time}`,
@@ -59,5 +59,25 @@ describe('precise timeline timestamps', () => {
     expect(formatTimelineTimestamp(undefined)).toBe('')
     expect(formatTimelineTimestamp(Number.NaN)).toBe('')
     expect(formatTimelineRange(undefined, 10)).toBe('')
+  })
+})
+
+describe('formatClockTimestamp', () => {
+  it('renders a minute-precision wall clock without seconds or milliseconds', () => {
+    const local = new Date(2026, 4, 1, 16, 30, 3, 456)
+    const formatted = formatClockTimestamp(local.getTime() / 1000)
+
+    expect(formatted).toContain('30')
+    expect(formatted).not.toContain('03')
+    expect(formatted).not.toContain('456')
+    // Same instant, but the precise formatter still carries the detail.
+    expect(formatTimelineTimestamp(local.getTime() / 1000)).toContain('456')
+  })
+
+  it('returns an empty string for invalid values', () => {
+    expect(formatClockTimestamp(undefined)).toBe('')
+    expect(formatClockTimestamp(Number.NaN)).toBe('')
+    expect(formatClockTimestamp(0)).toBe('')
+    expect(formatClockTimestamp(-5)).toBe('')
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/timestamp.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/timestamp.test.ts
@@ -40,10 +40,21 @@ describe('precise timeline timestamps', () => {
     const local = new Date(2026, 4, 1, 13, 2, 3, 456)
     const formatted = formatTimelineTimestamp(local.getTime() / 1000)
 
-    expect(formatted).toMatch(/13|1/)
-    expect(formatted).toContain('02')
-    expect(formatted).toContain('03')
-    expect(formatted).toContain('456')
+    // Locale-agnostic: under ar-SA this renders "١:٠٢:٠٣٫٤٥٦ م", so match the
+    // locale's own output rather than Latin digits.
+    expect(formatted).toBe(
+      new Intl.DateTimeFormat(undefined, {
+        fractionalSecondDigits: 3,
+        hour: 'numeric',
+        minute: '2-digit',
+        second: '2-digit'
+      }).format(local)
+    )
+
+    // The contract that matters: sub-second detail is preserved, so instants
+    // differing only in milliseconds stay distinguishable.
+    const oneMsLater = formatTimelineTimestamp(local.getTime() / 1000 + 0.001)
+    expect(oneMsLater).not.toBe(formatted)
   })
 
   it('renders start and finish as a range', () => {
@@ -65,13 +76,20 @@ describe('precise timeline timestamps', () => {
 describe('formatClockTimestamp', () => {
   it('renders a minute-precision wall clock without seconds or milliseconds', () => {
     const local = new Date(2026, 4, 1, 16, 30, 3, 456)
-    const formatted = formatClockTimestamp(local.getTime() / 1000)
+    const seconds = local.getTime() / 1000
 
-    expect(formatted).toContain('30')
-    expect(formatted).not.toContain('03')
-    expect(formatted).not.toContain('456')
-    // Same instant, but the precise formatter still carries the detail.
-    expect(formatTimelineTimestamp(local.getTime() / 1000)).toContain('456')
+    // Assert against the locale's own hour+minute rendering rather than
+    // literal digits: under ar-SA this owner's clock is "٤:٣٠ م", so a
+    // toContain('30') check would be a false failure.
+    expect(formatClockTimestamp(seconds)).toBe(
+      new Intl.DateTimeFormat(undefined, { hour: 'numeric', minute: '2-digit' }).format(local)
+    )
+
+    // The distinguishing contract: two instants in the same minute collapse to
+    // one label, while the precise formatter still separates them.
+    const laterInSameMinute = new Date(2026, 4, 1, 16, 30, 44, 789).getTime() / 1000
+    expect(formatClockTimestamp(laterInSameMinute)).toBe(formatClockTimestamp(seconds))
+    expect(formatTimelineTimestamp(laterInSameMinute)).not.toBe(formatTimelineTimestamp(seconds))
   })
 
   it('returns an empty string for invalid values', () => {

--- a/apps/desktop/src/components/assistant-ui/thread/timestamp.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/timestamp.test.ts
@@ -78,11 +78,10 @@ describe('formatClockTimestamp', () => {
     const local = new Date(2026, 4, 1, 16, 30, 3, 456)
     const seconds = local.getTime() / 1000
 
-    // Assert against the locale's own hour+minute rendering rather than
-    // literal digits: under ar-SA this owner's clock is "٤:٣٠ م", so a
-    // toContain('30') check would be a false failure.
+    // Assert against the locale's own digits/day-period rendering while forcing
+    // the owner's requested 12-hour clock contract in every locale.
     expect(formatClockTimestamp(seconds)).toBe(
-      new Intl.DateTimeFormat(undefined, { hour: 'numeric', minute: '2-digit' }).format(local)
+      new Intl.DateTimeFormat(undefined, { hour: 'numeric', hour12: true, minute: '2-digit' }).format(local)
     )
 
     // The distinguishing contract: two instants in the same minute collapse to

--- a/apps/desktop/src/components/assistant-ui/thread/timestamp.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/timestamp.ts
@@ -1,5 +1,11 @@
 import { fmtClock, fmtDayTime } from '@/lib/time'
 
+const fmtMessageClock = new Intl.DateTimeFormat(undefined, {
+  hour: 'numeric',
+  hour12: true,
+  minute: '2-digit'
+})
+
 const fmtTimelineClock = new Intl.DateTimeFormat(undefined, {
   fractionalSecondDigits: 3,
   hour: 'numeric',
@@ -33,7 +39,7 @@ export function formatTimelineTimestamp(seconds: number | undefined): string {
 export function formatClockTimestamp(seconds: number | undefined): string {
   const date = timelineDate(seconds)
 
-  return date ? fmtClock.format(date) : ''
+  return date ? fmtMessageClock.format(date) : ''
 }
 
 export function formatTimelineRange(start: number | undefined, end: number | undefined): string {

--- a/apps/desktop/src/components/assistant-ui/thread/timestamp.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/timestamp.ts
@@ -24,6 +24,18 @@ export function formatTimelineTimestamp(seconds: number | undefined): string {
   return date ? fmtTimelineClock.format(date) : ''
 }
 
+/**
+ * Minute-precision wall clock (e.g. `4:30 PM`) for message bubbles. Chat rows
+ * answer "when was this sent / when did it land", not "how long did it run",
+ * so they deliberately drop the seconds and milliseconds that tool activity
+ * boundaries still need.
+ */
+export function formatClockTimestamp(seconds: number | undefined): string {
+  const date = timelineDate(seconds)
+
+  return date ? fmtClock.format(date) : ''
+}
+
 export function formatTimelineRange(start: number | undefined, end: number | undefined): string {
   const from = formatTimelineTimestamp(start)
 

--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -393,6 +393,7 @@ export const UserMessage: FC<{
         data-slot="aui_user-message-root"
       >
         <AgentMessageNote text={messageText.trim()} />
+        <MessageTimelineTimestamp className="mt-0.5 self-start" />
       </MessagePrimitive.Root>
     )
   }


### PR DESCRIPTION
## Summary
- render user/system/message-level chat timestamps as one local `hour:minute AM/PM` clock
- render assistant prose timestamps the same way, including the common sole-text-part path
- retain precise start/end ranges for reasoning and tool activity rows, with precise detail on hover
- make timestamp tests locale-safe for `ar-SA` and other non-Latin digit locales

## Verification
- `npx vitest run src/components/assistant-ui/thread/ src/components/assistant-ui/tool/` — 283 passed
- timestamp suites under `ar-SA`, `en-US`, `ja-JP`, `de-DE` — 15 passed in each locale
- `npx tsc -p tsconfig.json --noEmit`
- eslint on touched files

This fixes the visible transcript symptom where a normal assistant reply still showed `2:12:05.948 PM → 2:17:01.285 PM` instead of a single `2:17 PM` clock because the aggregate stamp was deduplicated and the prose-part stamp retained exact precision.