### PR TITLE
fix(teams): drop inbound with unknown conversation type

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -1026,6 +1026,24 @@ class TeamsAdapter(BasePlatformAdapter):
         if msg_id and self._dedup.is_duplicate(msg_id):
             return
 
+        # Determine chat type from conversation. Unknown/missing
+        # conversationType must not be labelled dm: that would run pairing
+        # and post operator text into the chat. Fail closed — log only.
+        conv = activity.conversation
+        conv_type = getattr(conv, "conversation_type", None) or ""
+        if conv_type == "personal":
+            chat_type = "dm"
+        elif conv_type == "groupChat":
+            chat_type = "group"
+        elif conv_type == "channel":
+            chat_type = "channel"
+        else:
+            logger.info(
+                "[teams] dropping inbound with unknown conversation type %r",
+                conv_type or "missing",
+            )
+            return
+
         # Cache the conversation reference for proactive sends (approval cards, etc.)
         conv_id = getattr(activity.conversation, "id", None)
         if conv_id:
@@ -1039,18 +1057,6 @@ class TeamsAdapter(BasePlatformAdapter):
         if "<at>" in text:
             import re
             text = re.sub(r"<at>[^<]*</at>\s*", "", text).strip()
-
-        # Determine chat type from conversation
-        conv = activity.conversation
-        conv_type = getattr(conv, "conversation_type", None) or ""
-        if conv_type == "personal":
-            chat_type = "dm"
-        elif conv_type == "groupChat":
-            chat_type = "group"
-        elif conv_type == "channel":
-            chat_type = "channel"
-        else:
-            chat_type = "dm"
 
         # Build source
         from_account = activity.from_

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -528,6 +528,43 @@ class TestTeamsMessageHandling:
         event = adapter.handle_message.call_args[0][0]
         assert event.source.chat_type == "group"
 
+    @pytest.mark.anyio
+    async def test_missing_conversation_type_does_not_dispatch(self, caplog):
+        """Unknown/missing Teams conversationType must not be labelled dm.
+
+        Labelling it dm would run pairing and post operator text into the
+        chat. Fail closed: log only, no handle_message, no send, no conv ref.
+        """
+        import logging
+
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id", client_secret="secret", tenant_id="tenant",
+        ))
+        adapter._app = MagicMock()
+        adapter._app.id = "bot-id"
+        adapter.handle_message = AsyncMock()
+        adapter.send = AsyncMock()
+
+        activity = self._make_activity(activity_id="activity-missing-type")
+        activity.conversation = SimpleNamespace(
+            id="19:abc@thread.v2",
+            name="Test Chat",
+            tenant_id="tenant-789",
+        )
+        ctx = self._make_ctx(activity)
+        ctx.conversation_ref = object()
+
+        with caplog.at_level(logging.INFO):
+            await adapter._on_message(ctx)
+
+        adapter.handle_message.assert_not_awaited()
+        adapter.send.assert_not_awaited()
+        assert "19:abc@thread.v2" not in adapter._conv_refs
+        joined = " ".join(r.getMessage() for r in caplog.records)
+        assert "unknown conversation type" in joined.lower()
+        assert "pair" not in joined.lower()
+        assert "unauthorized" not in joined.lower()
+
 
 class TestTeamsAttachmentClassification:
     """Document attachments must set MessageType.DOCUMENT so run.py's


### PR DESCRIPTION
## Summary
Teams inbound without a known `conversationType` was labelled `dm`, which would run pairing and post operator text into that chat.

Fail closed: unknown/missing type is logged and dropped. No `handle_message`, no send, no cached conversation ref.

House context: runi-services/governance#1224 (residual, independent of #821). Separate from PR 101148.

## Test plan
- [x] `scripts/run_tests.sh tests/gateway/test_teams.py -k TestTeamsMessageHandling` → 3 passed (includes missing-type case)
- [ ] Hermes review