### PR TITLE
feat(agent): safe machine-global AFK operation

### DIFF
--- a/agent/afk.py
+++ b/agent/afk.py
@@ -463,10 +463,17 @@ def _read_state(root: _Root) -> dict | None:
 
 
 def get_state() -> dict | None:
+    with locked_state() as state:
+        return state
+
+
+@contextmanager
+def locked_state():
+    """Yield one validated AFK snapshot while holding the AFK file lock."""
     with _transaction() as root:
         state = _read_state(root)
         root.revalidate()
-        return state
+        yield state
 
 
 def is_afk() -> bool:
@@ -596,7 +603,14 @@ def engage(reason: str | None = None) -> dict:
             raise AfkStateChangedUnconfirmed(
                 "AFK state could not be verified", changed=True
             )
-        return result
+    # Wake approval waiters only after releasing the AFK file lock.  The
+    # approval queue takes its own lock and must never invert AFK->queue order.
+    try:
+        from tools.approval import cancel_gateway_approvals_for_afk
+        cancel_gateway_approvals_for_afk()
+    except Exception:
+        pass
+    return result
 
 
 def clear() -> bool:

--- a/agent/afk.py
+++ b/agent/afk.py
@@ -1,0 +1,668 @@
+"""Machine-global, durable away-from-keyboard state."""
+
+from __future__ import annotations
+
+import errno
+import json
+import os
+import secrets
+import stat
+import threading
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+STATE_NAME = "afk.json"
+LOCK_NAME = "afk.lock"
+STATE_MODE = 0o600
+MAX_REASON_CHARS = 200
+MAX_STATE_BYTES = 16 * 1024
+
+
+class AfkStateError(RuntimeError):
+    def __init__(self, message: str, *, changed: bool = False):
+        super().__init__(message)
+        self.changed = changed
+
+
+class AfkStateChangedUnconfirmed(AfkStateError):
+    """A mutation happened, but the validated root no longer matches its path."""
+
+
+def _root() -> Path:
+    try:
+        from hermes_constants import get_default_hermes_root
+
+        return Path(get_default_hermes_root())
+    except Exception as exc:
+        raise AfkStateError(
+            f"could not resolve the machine-global Hermes root: {exc}"
+        ) from exc
+
+
+def state_path() -> Path:
+    return _root() / STATE_NAME
+
+
+def _lock_path() -> Path:
+    return _root() / LOCK_NAME
+
+
+def _flags(*names: str) -> int:
+    return sum(getattr(os, name, 0) for name in names)
+
+
+def _allowed_owner(info: os.stat_result) -> bool:
+    return info.st_uid in (0, os.geteuid()) if hasattr(os, "geteuid") else True
+
+
+def _check_directory(fd: int, *, final: bool) -> None:
+    info = os.fstat(fd)
+    if not stat.S_ISDIR(info.st_mode):
+        raise AfkStateError("AFK root path component is not a directory")
+    if not _allowed_owner(info):
+        raise AfkStateError("AFK root path component has an unsafe owner")
+    mode = stat.S_IMODE(info.st_mode)
+    if mode & 0o022 and not (mode & stat.S_ISVTX and not final):
+        raise AfkStateError("AFK root path component is writable by group or other")
+
+
+class _Root:
+    def __init__(self, path: Path, fd: int | None):
+        self.path, self.fd = path, fd
+        self.mutated = False
+        self.identity = (
+            os.fstat(fd) if fd is not None else os.stat(path, follow_symlinks=False)
+        )
+
+    def close(self) -> None:
+        fd = self.fd
+        self.fd = None
+        if fd is not None:
+            os.close(fd)
+
+    def revalidate(self, *, changed: bool = False) -> None:
+        try:
+            current = os.stat(self.path, follow_symlinks=False)
+        except OSError as exc:
+            raise AfkStateChangedUnconfirmed(
+                f"AFK root identity changed: {exc}", changed=changed
+            ) from exc
+        if (current.st_dev, current.st_ino) != (
+            self.identity.st_dev,
+            self.identity.st_ino,
+        ):
+            raise AfkStateChangedUnconfirmed(
+                "AFK root identity changed; durability could not be confirmed",
+                changed=changed,
+            )
+
+
+def _path_value(root: _Root, name: str) -> str | Path:
+    return name if root.fd is not None else root.path / name
+
+
+def _path_open(root: _Root, name: str, flags: int, mode: int = 0) -> int:
+    kwargs = {"dir_fd": root.fd} if root.fd is not None else {}
+    args = (
+        (_path_value(root, name), flags)
+        if not mode
+        else (_path_value(root, name), flags, mode)
+    )
+    return os.open(*args, **kwargs)
+
+
+def _path_stat(root: _Root, name: str) -> os.stat_result:
+    kwargs = (
+        {"dir_fd": root.fd, "follow_symlinks": False}
+        if root.fd is not None
+        else {"follow_symlinks": False}
+    )
+    return os.stat(_path_value(root, name), **kwargs)
+
+
+def _path_replace(root: _Root, source: str, destination: str) -> None:
+    kwargs = (
+        {"src_dir_fd": root.fd, "dst_dir_fd": root.fd} if root.fd is not None else {}
+    )
+    os.replace(_path_value(root, source), _path_value(root, destination), **kwargs)
+
+
+def _path_unlink(root: _Root, name: str) -> None:
+    kwargs = {"dir_fd": root.fd} if root.fd is not None else {}
+    os.unlink(_path_value(root, name), **kwargs)
+
+
+def _open_root() -> _Root:
+    path = Path(os.path.abspath(os.fspath(_root().expanduser())))
+    if os.name == "nt":
+        try:
+            for component in (path, *path.parents):
+                try:
+                    if stat.S_ISLNK(component.lstat().st_mode):
+                        raise AfkStateError("refusing symlinked AFK root component")
+                except FileNotFoundError:
+                    pass
+            path.mkdir(parents=True, exist_ok=True)
+            return _Root(path, None)
+        except OSError as exc:
+            raise AfkStateError(f"could not set up AFK root: {exc}") from exc
+
+    parts = path.parts
+    try:
+        fd = os.open(parts[0], _flags("O_RDONLY", "O_DIRECTORY", "O_CLOEXEC"))
+    except OSError as exc:
+        raise AfkStateError(f"could not set up AFK root: {exc}") from exc
+    child = -1
+    primary_error = None
+    try:
+        for index, component in enumerate(parts[1:], 1):
+            child = -1
+            try:
+                if stat.S_ISLNK(
+                    os.stat(component, dir_fd=fd, follow_symlinks=False).st_mode
+                ):
+                    raise AfkStateError("refusing symlinked AFK root path component")
+            except FileNotFoundError:
+                pass
+            try:
+                child = os.open(
+                    component,
+                    _flags("O_RDONLY", "O_DIRECTORY", "O_CLOEXEC", "O_NOFOLLOW"),
+                    dir_fd=fd,
+                )
+            except FileNotFoundError:
+                _check_directory(fd, final=False)
+                os.mkdir(component, 0o700, dir_fd=fd)
+                child = os.open(
+                    component,
+                    _flags("O_RDONLY", "O_DIRECTORY", "O_CLOEXEC", "O_NOFOLLOW"),
+                    dir_fd=fd,
+                )
+            _check_directory(child, final=index == len(parts) - 1)
+            old_fd = fd
+            fd = child
+            child = -1
+            os.close(old_fd)
+        _check_directory(fd, final=True)
+        root = _Root(path, fd)
+        fd = -1
+        return root
+    except OSError as exc:
+        primary_error = exc
+        raise AfkStateError(f"could not set up AFK root: {exc}") from exc
+    except BaseException as exc:
+        primary_error = exc
+        raise
+    finally:
+        cleanup_error = None
+        for owned_fd in (child, fd):
+            if owned_fd >= 0:
+                if owned_fd == child:
+                    child = -1
+                else:
+                    fd = -1
+                try:
+                    os.close(owned_fd)
+                except OSError as exc:
+                    if cleanup_error is None:
+                        cleanup_error = exc
+        if primary_error is None and cleanup_error is not None:
+            raise AfkStateError(
+                f"could not close AFK root: {cleanup_error}"
+            ) from cleanup_error
+
+
+class _FileLock:
+    def __init__(self, root: _Root | Path):
+        self.root = root
+        self.file = None
+
+    def __enter__(self):
+        compat = isinstance(self.root, Path)
+        compat_root_fd = -1
+        self._compat = compat
+        fd = -1
+        try:
+            if compat:
+                compat_root_fd = os.open(self.root.parent, os.O_RDONLY)
+                self.root = _Root(self.root.parent, compat_root_fd)
+                compat_root_fd = -1
+            fd = _path_open(
+                self.root,
+                LOCK_NAME,
+                _flags("O_RDWR", "O_CREAT", "O_CLOEXEC", "O_NOFOLLOW"),
+                STATE_MODE,
+            )
+            info = os.fstat(fd)
+            if (
+                not stat.S_ISREG(info.st_mode)
+                or info.st_nlink != 1
+                or not _allowed_owner(info)
+            ):
+                raise AfkStateError("AFK lock is not a safe regular file")
+            self.file = os.fdopen(fd, "a+b")
+            fd = -1
+            if os.name == "nt":
+                import msvcrt
+
+                self.file.seek(0, os.SEEK_END)
+                if self.file.tell() == 0:
+                    self.file.write(b"\0")
+                    self.file.flush()
+                self.file.seek(0)
+                msvcrt.locking(self.file.fileno(), msvcrt.LK_LOCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(self.file.fileno(), fcntl.LOCK_EX)
+            return self
+        except BaseException as primary:
+            file = self.file
+            self.file = None
+            cleanup_error = None
+            if file is not None:
+                try:
+                    file.close()
+                except OSError as exc:
+                    cleanup_error = exc
+            if fd >= 0:
+                owned_fd = fd
+                fd = -1
+                try:
+                    os.close(owned_fd)
+                except OSError as exc:
+                    if cleanup_error is None:
+                        cleanup_error = exc
+            if compat_root_fd >= 0:
+                owned_fd = compat_root_fd
+                compat_root_fd = -1
+                try:
+                    os.close(owned_fd)
+                except OSError as exc:
+                    if cleanup_error is None:
+                        cleanup_error = exc
+            if compat and isinstance(self.root, _Root):
+                try:
+                    self.root.close()
+                except OSError as exc:
+                    if cleanup_error is None:
+                        cleanup_error = exc
+            if isinstance(primary, OSError):
+                raise AfkStateError(
+                    f"could not acquire AFK lock: {primary}"
+                ) from primary
+            raise
+
+    def __exit__(self, exc_type, exc, tb):
+        if self.file is None:
+            return False
+        cleanup_error = None
+        file = self.file
+        try:
+            try:
+                if os.name == "nt":
+                    import msvcrt
+
+                    file.seek(0)
+                    msvcrt.locking(file.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+
+                    fcntl.flock(file.fileno(), fcntl.LOCK_UN)
+            except OSError as error:
+                cleanup_error = error
+        finally:
+            self.file = None
+            try:
+                file.close()
+            except OSError as error:
+                if cleanup_error is None:
+                    cleanup_error = error
+            finally:
+                if getattr(self, "_compat", False):
+                    try:
+                        self.root.close()
+                    except OSError as error:
+                        if cleanup_error is None:
+                            cleanup_error = error
+        if exc_type is not None:
+            return False
+        if cleanup_error is not None:
+            raise AfkStateError(
+                f"could not release AFK lock: {cleanup_error}",
+                changed=self.root.mutated,
+            ) from cleanup_error
+        return False
+
+
+_mutex = threading.RLock()
+_local = threading.local()
+
+
+@contextmanager
+def _transaction():
+    with _mutex:
+        if getattr(_local, "depth", 0):
+            _local.depth += 1
+            try:
+                yield _local.root
+            finally:
+                _local.depth -= 1
+            return
+        root = _open_root()
+        primary_error = None
+        try:
+            try:
+                with _FileLock(root):
+                    _local.root, _local.depth = root, 1
+                    try:
+                        yield root
+                    finally:
+                        _local.root, _local.depth = None, 0
+            except BaseException as exc:
+                primary_error = exc
+                raise
+        finally:
+            try:
+                root.close()
+            except OSError as exc:
+                if primary_error is None:
+                    raise AfkStateError(
+                        f"could not close AFK root: {exc}",
+                        changed=root.mutated,
+                    ) from exc
+
+
+def _neutralize(value: Any, limit: int = MAX_REASON_CHARS) -> str | None:
+    if not isinstance(value, str):
+        return None
+    value = "".join(" " if ord(ch) < 32 or ord(ch) == 127 else ch for ch in value)
+    value = " ".join(value.replace("[", "(").replace("]", ")").split())
+    if not value:
+        return None
+    return value[: limit - 1].rstrip() + "…" if len(value) > limit else value
+
+
+def _unverifiable() -> dict:
+    return {"unverifiable": True}
+
+
+def _reject_state_symlink(root: _Root) -> None:
+    try:
+        info = _path_stat(root, STATE_NAME)
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        raise AfkStateError(f"could not inspect AFK state: {exc}") from exc
+    if stat.S_ISLNK(info.st_mode):
+        raise AfkStateError("refusing symlinked AFK state")
+
+
+def _read_state(root: _Root) -> dict | None:
+    _reject_state_symlink(root)
+    primary_error = None
+    try:
+        fd = _path_open(root, STATE_NAME, _flags("O_RDONLY", "O_CLOEXEC", "O_NOFOLLOW"))
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        if exc.errno in (errno.ELOOP, errno.ENOTDIR):
+            raise AfkStateError("refusing symlinked AFK state") from exc
+        return _unverifiable()
+    try:
+        info = os.fstat(fd)
+        if (
+            not stat.S_ISREG(info.st_mode)
+            or info.st_nlink != 1
+            or not _allowed_owner(info)
+            or info.st_size > MAX_STATE_BYTES
+            or (os.name != "nt" and stat.S_IMODE(info.st_mode) & 0o077)
+        ):
+            return _unverifiable()
+        raw = os.read(fd, MAX_STATE_BYTES + 1)
+        if len(raw) > MAX_STATE_BYTES:
+            return _unverifiable()
+        try:
+            data = json.loads(raw.decode("utf-8"))
+        except (UnicodeError, TypeError, ValueError):
+            return _unverifiable()
+    except OSError:
+        return _unverifiable()
+    except BaseException as exc:
+        primary_error = exc
+        raise
+    finally:
+        owned_fd = fd
+        fd = -1
+        try:
+            os.close(owned_fd)
+        except OSError as exc:
+            if primary_error is None:
+                raise AfkStateError(
+                    f"could not close AFK state: {exc}"
+                ) from exc
+    if not isinstance(data, dict) or not isinstance(data.get("engaged_at"), str):
+        return _unverifiable()
+    try:
+        timestamp = datetime.fromisoformat(data["engaged_at"])
+        if timestamp.tzinfo is None or timestamp.utcoffset() is None:
+            return _unverifiable()
+    except ValueError:
+        return _unverifiable()
+    reason = data.get("reason")
+    if reason is not None and (
+        not isinstance(reason, str) or len(reason) > MAX_REASON_CHARS * 4
+    ):
+        return _unverifiable()
+    return {
+        "engaged_at": _neutralize(data["engaged_at"], 64),
+        "reason": _neutralize(reason),
+    }
+
+
+def get_state() -> dict | None:
+    with _transaction() as root:
+        state = _read_state(root)
+        root.revalidate()
+        return state
+
+
+def is_afk() -> bool:
+    return get_state() is not None
+
+
+def _atomic_replace_json(root: _Root, payload: dict) -> None:
+    temporary, fd, primary_error = None, -1, None
+    try:
+        for _ in range(20):
+            temporary = f".afk.{secrets.token_hex(8)}"
+            try:
+                fd = _path_open(
+                    root,
+                    temporary,
+                    _flags("O_WRONLY", "O_CREAT", "O_EXCL", "O_CLOEXEC", "O_NOFOLLOW"),
+                    STATE_MODE,
+                )
+                break
+            except FileExistsError:
+                temporary = None
+        if fd < 0:
+            raise AfkStateError("could not create a unique AFK temporary file")
+        if os.name != "nt":
+            os.fchmod(fd, STATE_MODE)
+        raw = (json.dumps(payload, ensure_ascii=False) + "\n").encode("utf-8")
+        written = 0
+        while written < len(raw):
+            count = os.write(fd, raw[written:])
+            if count <= 0:
+                raise AfkStateError("AFK state write made no progress")
+            written += count
+        os.fsync(fd)
+        owned_fd = fd
+        fd = -1
+        os.close(owned_fd)
+        _path_replace(root, temporary, STATE_NAME)
+        root.mutated = True
+        temporary = None
+        _sync_parent(root)
+    except AfkStateError as exc:
+        primary_error = exc
+        raise
+    except (OSError, TypeError) as exc:
+        primary_error = exc
+        raise AfkStateError(
+            f"could not write AFK state: {exc}", changed=root.mutated
+        ) from exc
+    finally:
+        cleanup_error = None
+        if fd >= 0:
+            owned_fd = fd
+            fd = -1
+            try:
+                os.close(owned_fd)
+            except OSError as exc:
+                cleanup_error = exc
+        if temporary is not None:
+            try:
+                _path_unlink(root, temporary)
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                if cleanup_error is None:
+                    cleanup_error = exc
+        if primary_error is None and cleanup_error is not None:
+            raise AfkStateError(
+                f"could not clean up AFK temporary state: {cleanup_error}",
+                changed=root.mutated,
+            ) from cleanup_error
+
+
+def _sync_parent(root: _Root) -> None:
+    if os.name != "nt" and root.fd is not None:
+        os.fsync(root.fd)
+
+
+def _verify_owner_only(root: _Root) -> None:
+    fd = _path_open(root, STATE_NAME, _flags("O_RDONLY", "O_CLOEXEC", "O_NOFOLLOW"))
+    primary_error = None
+    try:
+        info = os.fstat(fd)
+        if (
+            not stat.S_ISREG(info.st_mode)
+            or info.st_nlink != 1
+            or not _allowed_owner(info)
+        ):
+            raise AfkStateError("AFK state is not a safe regular file")
+        if os.name != "nt":
+            os.fchmod(fd, STATE_MODE)
+            if stat.S_IMODE(info.st_mode) & 0o077:
+                raise AfkStateError("AFK state is not owner-only")
+    except BaseException as exc:
+        primary_error = exc
+        raise
+    finally:
+        owned_fd = fd
+        fd = -1
+        try:
+            os.close(owned_fd)
+        except OSError as exc:
+            if primary_error is None:
+                raise AfkStateError(
+                    f"could not close AFK state: {exc}"
+                ) from exc
+
+
+def engage(reason: str | None = None) -> dict:
+    payload = {
+        "engaged_at": datetime.now(timezone.utc).isoformat(),
+        "reason": _neutralize(reason),
+    }
+    with _transaction() as root:
+        _reject_state_symlink(root)
+        _atomic_replace_json(root, payload)
+        try:
+            _verify_owner_only(root)
+        except AfkStateError as exc:
+            raise AfkStateChangedUnconfirmed(str(exc), changed=True) from exc
+        except OSError as exc:
+            raise AfkStateChangedUnconfirmed(
+                f"could not verify AFK state: {exc}", changed=True
+            ) from exc
+        result = _read_state(root)
+        root.revalidate(changed=True)
+        if result is None or result.get("unverifiable"):
+            raise AfkStateChangedUnconfirmed(
+                "AFK state could not be verified", changed=True
+            )
+        return result
+
+
+def clear() -> bool:
+    with _transaction() as root:
+        try:
+            if stat.S_ISLNK(_path_stat(root, STATE_NAME).st_mode):
+                raise AfkStateError("refusing symlinked AFK state")
+            _path_unlink(root, STATE_NAME)
+            root.mutated = True
+        except FileNotFoundError:
+            root.revalidate()
+            return False
+        except OSError as exc:
+            raise AfkStateError(f"could not clear AFK state: {exc}") from exc
+        try:
+            _sync_parent(root)
+            root.revalidate(changed=True)
+        except AfkStateChangedUnconfirmed:
+            raise
+        except OSError as exc:
+            raise AfkStateChangedUnconfirmed(
+                f"could not sync cleared AFK state: {exc}", changed=True
+            ) from exc
+        return True
+
+
+def _reply(*lines: str) -> str:
+    return "\n".join((
+        *lines,
+        "AFK never widens approvals or authorizes consequential work.",
+    ))
+
+
+def handle_command(args: str = "") -> str:
+    parts = (args or "").strip().split(None, 1)
+    verb = parts[0].lower() if parts else ""
+    rest = parts[1].strip() if len(parts) > 1 else ""
+    try:
+        if not args.strip():
+            state = get_state()
+            if state and state.get("unverifiable"):
+                return _reply(
+                    "AFK state is present but unreadable/unverifiable; remaining fail-closed."
+                )
+            if state is not None:
+                return _reply("Already AFK. Use `/afk off` when you're back.")
+        if not args.strip() or verb == "on":
+            state = engage(rest or None)
+            suffix = f" ({state['reason']})" if state.get("reason") else ""
+            return _reply(f"AFK recorded since {state['engaged_at']}{suffix}.")
+        if verb == "off" and not rest:
+            return _reply("AFK cleared." if clear() else "You weren't marked AFK.")
+        if verb == "status" and not rest:
+            state = get_state()
+            if not state:
+                return _reply("Not AFK.")
+            if state.get("unverifiable"):
+                return _reply(
+                    "AFK state is present but unreadable/unverifiable; remaining fail-closed."
+                )
+            suffix = f" ({state['reason']})" if state.get("reason") else ""
+            return _reply(f"AFK since {state['engaged_at']}{suffix}.")
+    except AfkStateError as exc:
+        if exc.changed:
+            return _reply(
+                "AFK state changed, but durability could not be confirmed; check /afk status."
+            )
+        return _reply("Couldn't safely change the machine-global AFK state.")
+    return _reply("Usage: `/afk [on [reason] | off | status]`")

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3470,6 +3470,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
 
     # Check plugin hooks for a block or approval directive before executing.
     block_message: Optional[str] = None
+    approval_required = False
     if not pre_tool_block_checked:
         try:
             from hermes_cli.plugins import _dispatch_pre_tool_call_hooks
@@ -3483,8 +3484,16 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             )
             if modified_args is not None:
                 function_args = modified_args
+            from hermes_cli.plugins import current_pre_tool_approval_required
+            approval_required = current_pre_tool_approval_required()
+            from hermes_cli.plugins import clear_pre_tool_approval_required
+            clear_pre_tool_approval_required()
         except Exception:
             block_message = None
+    else:
+        from hermes_cli.plugins import current_pre_tool_approval_required, clear_pre_tool_approval_required
+        approval_required = current_pre_tool_approval_required()
+        clear_pre_tool_approval_required()
     if block_message is not None:
         result = json.dumps({"error": block_message}, ensure_ascii=False)
         try:
@@ -3506,6 +3515,13 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
         except Exception:
             pass
         return result
+
+    from hermes_cli.plugins import final_pre_tool_call_authorization
+    final_block = final_pre_tool_call_authorization(
+        function_name, approval_required=approval_required
+    )
+    if final_block:
+        return json.dumps({"error": final_block}, ensure_ascii=False)
 
     tool_start_time = time.monotonic()
 

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -606,6 +606,7 @@ def _run_agent_tool_execution_middleware(
         "middleware_trace": trace,
         "blocked": False,
         "dispatched": False,
+        "approval_required": False,
     }
     dispatch_lock = threading.Lock()
 
@@ -657,6 +658,10 @@ def _run_agent_tool_execution_middleware(
                         or "",
                         middleware_trace=list(state["middleware_trace"]),
                     )
+                    from hermes_cli.plugins import current_pre_tool_approval_required
+                    state["approval_required"] = current_pre_tool_approval_required()
+                    from hermes_cli.plugins import clear_pre_tool_approval_required
+                    clear_pre_tool_approval_required()
                     if modified_args is not None:
                         final_args = modified_args
                         state["args"] = modified_args
@@ -702,6 +707,29 @@ def _run_agent_tool_execution_middleware(
                 status="blocked",
                 error_type=error_type,
                 error_message=error_message,
+                middleware_trace=list(state["middleware_trace"]),
+            )
+            return result
+
+        if scope_block is not None:
+            from hermes_cli.plugins import current_pre_tool_approval_required, clear_pre_tool_approval_required
+            state["approval_required"] = current_pre_tool_approval_required()
+            clear_pre_tool_approval_required()
+
+        from hermes_cli.plugins import final_pre_tool_call_authorization
+        final_block = final_pre_tool_call_authorization(
+            function_name,
+            approval_required=state["approval_required"],
+        )
+        if final_block:
+            _advance_start_order()
+            result = json.dumps({"error": final_block}, ensure_ascii=False)
+            state["blocked"] = True
+            _emit_terminal_post_tool_call(
+                agent, function_name=function_name, function_args=final_args,
+                result=result, effective_task_id=effective_task_id,
+                tool_call_id=tool_call_id, status="blocked",
+                error_type="plugin_afk_block", error_message=final_block,
                 middleware_trace=list(state["middleware_trace"]),
             )
             return result

--- a/cli.py
+++ b/cli.py
@@ -13105,6 +13105,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             self._handle_wake_command(cmd_original)
         elif canonical == "busy":
             self._handle_busy_command(cmd_original)
+        elif canonical == "afk":
+            from agent.afk import handle_command
+            parts = cmd_original.split(None, 1)
+            self._console_print(handle_command(parts[1] if len(parts) > 1 else ""))
         elif canonical == "indicator":
             self._handle_indicator_command(cmd_original)
         else:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17962,6 +17962,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "approve": self._handle_approve_command,
             "deny": self._handle_deny_command,
             "pause": self._handle_pause_command,
+            "afk": self._handle_afk_command,
             "agents": self._handle_agents_command,
             "bg": self._handle_background_command,
             "btw": self._handle_btw_command,
@@ -18064,6 +18065,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             f"⏸️ Paused{suffix}. New cron/kanban/gateway work is on hold; "
             "in-flight work finishes normally. Use `/pause off` to resume."
         )
+
+    async def _handle_afk_command(self, event: MessageEvent):
+        from agent.afk import handle_command
+
+        return handle_command(event.get_command_args() or "")
 
     async def _busy_start_command(self, event: MessageEvent, quick_key: str, source):
         # Telegram sends /start for bot launches/deep-links. Treat it as a

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -191,6 +191,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("pause", "Pause new work globally (emergency stop); '/pause off' resumes", "Session",
                gateway_only=True, args_hint="[reason | off]",
                busy_policy="dispatch"),
+    CommandDef("afk", "Mark the operator away or available", "Session",
+               args_hint="[on [reason] | off | status]", busy_policy="dispatch"),
     CommandDef("approve", "Approve a pending dangerous command", "Session",
                gateway_only=True, args_hint="[session|always]", busy_policy="dispatch",
                desktop="messaging"),

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -81,6 +81,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "session_id": t.session_id,
         "workflow_template_id": t.workflow_template_id,
         "current_step_key": t.current_step_key,
+        "unattended_safe": t.unattended_safe,
     }
 
 
@@ -431,6 +432,10 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                           metavar="N", dest="goal_max_turns",
                           help="Turn budget for --goal workers (default 20). "
                                "Ignored without --goal.")
+    p_create.add_argument(
+        "--unattended-safe", action="store_true",
+        help="Explicitly allow this task to be newly dispatched while AFK is engaged.",
+    )
     p_create.add_argument("--initial-status",
                           choices=sorted(kb.VALID_INITIAL_STATUSES),
                           default="running",
@@ -1685,6 +1690,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             provider_override=getattr(args, "provider_override", None),
             goal_mode=bool(getattr(args, "goal_mode", False)),
             goal_max_turns=getattr(args, "goal_max_turns", None),
+            unattended_safe=bool(getattr(args, "unattended_safe", False)),
             initial_status=getattr(args, "initial_status", "running"),
         )
         task = kb.get_task(conn, task_id)
@@ -2781,6 +2787,7 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
                 for (tid, who, ws) in res.spawned
             ],
             "skipped_unassigned": res.skipped_unassigned,
+            "skipped_unattended": res.skipped_unattended,
             "skipped_nonspawnable": res.skipped_nonspawnable,
             "skipped_per_profile_capped": [
                 {"task_id": tid, "assignee": who, "current": current}
@@ -2814,6 +2821,8 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         )
     if res.skipped_unassigned:
         print(f"Skipped (unassigned): {', '.join(res.skipped_unassigned)}")
+    if res.skipped_unattended:
+        print(f"Deferred (AFK): {', '.join(res.skipped_unattended)}")
     if res.skipped_per_profile_capped:
         for tid, who, current in res.skipped_per_profile_capped:
             print(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -89,6 +89,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Optional
 
+from agent import afk
+
 from hermes_cli.sqlite_util import add_column_if_missing as _add_column_if_missing
 from toolsets import get_toolset_names
 
@@ -343,6 +345,7 @@ def _fire_dispatch_tick_hook(
             result.respawn_guarded,
             result.skipped_per_profile_capped,
             result.skipped_unassigned,
+            result.skipped_unattended,
             result.skipped_nonspawnable,
         )):
             outcome = "idle"
@@ -1141,6 +1144,8 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    # Explicit opt-in for dispatch while machine-global AFK is engaged.
+    unattended_safe: bool = False
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -1234,6 +1239,11 @@ class Task:
                 int(row["block_recurrences"])
                 if "block_recurrences" in keys and row["block_recurrences"] is not None
                 else 0
+            ),
+            unattended_safe=(
+                bool(row["unattended_safe"])
+                if "unattended_safe" in keys and row["unattended_safe"] is not None
+                else False
             ),
         )
 
@@ -1422,7 +1432,9 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    -- Explicit scheduling opt-in while machine-global AFK is engaged.
+    unattended_safe      INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -2690,6 +2702,14 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "block_recurrences INTEGER NOT NULL DEFAULT 0",
         )
 
+    if "unattended_safe" not in cols:
+        _add_column_if_missing(
+            conn,
+            "tasks",
+            "unattended_safe",
+            "unattended_safe INTEGER NOT NULL DEFAULT 0",
+        )
+
     # Indexes over additive ``tasks`` columns must be created after the
     # columns exist. Keeping them in SCHEMA_SQL breaks legacy boards: SQLite
     # parses each statement in ``executescript`` against the live schema, so a
@@ -3194,6 +3214,7 @@ def create_task(
     board: Optional[str] = None,
     project_id: Optional[str] = None,
     project_source_task_id: Optional[str] = None,
+    unattended_safe: bool = False,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -3508,8 +3529,8 @@ def create_task(
                         max_runtime_seconds,
                         skills, max_retries, model_override, provider_override,
                         reasoning_effort,
-                        goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        goal_mode, goal_max_turns, session_id, unattended_safe
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -3535,6 +3556,7 @@ def create_task(
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
+                        1 if unattended_safe else 0,
                     ),
                 )
                 for pid in parents:
@@ -4836,6 +4858,37 @@ def claim_review_task(
             run_id=run_id,
         )
         return get_task(conn, task_id)
+
+
+def _rollback_unspawned_claim(conn: sqlite3.Connection, task_id: str) -> bool:
+    """Return a just-claimed task to its source lane before any worker exists."""
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT current_run_id, status FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if not row or row["status"] != "running" or not row["current_run_id"]:
+            return False
+        run_id = int(row["current_run_id"])
+        source = _retry_status_for_run(conn, task_id, run_id)
+        cur = conn.execute(
+            "UPDATE tasks SET status = ?, claim_lock = NULL, claim_expires = NULL, "
+            "worker_pid = NULL, current_run_id = NULL WHERE id = ? AND status = 'running'",
+            (source, task_id),
+        )
+        if cur.rowcount != 1:
+            return False
+        conn.execute(
+            "UPDATE task_runs SET status = 'reclaimed', outcome = 'reclaimed', "
+            "ended_at = ?, claim_lock = NULL, claim_expires = NULL, worker_pid = NULL "
+            "WHERE id = ? AND ended_at IS NULL",
+            (int(time.time()), run_id),
+        )
+        _append_event(conn, task_id, "claim_rejected", {
+            "reason": "afk_engaged_before_spawn", "run_id": run_id,
+            "source_status": source,
+        }, run_id=run_id)
+        return True
 
 
 def _retry_status_for_run(
@@ -8039,6 +8092,8 @@ class DispatchResult:
     skipped_unassigned: list[str] = field(default_factory=list)
     """Ready task ids skipped because they have no assignee at all.
     Operator-actionable — usually a misfiled task waiting for routing."""
+    skipped_unattended: list[str] = field(default_factory=list)
+    """Task ids deferred because AFK is engaged or could not be verified."""
     auto_assigned_default: list[str] = field(default_factory=list)
     """Task ids that were unassigned in the DB and had
     ``kanban.default_assignee`` applied this tick before spawning (#27145).
@@ -9816,6 +9871,43 @@ def _memory_pressure_level(sample: Optional[Mapping[str, Any]] = None) -> str:
         return "unknown"
 
 
+def _afk_dispatch_state(state: Optional[dict]) -> str:
+    """Classify one validated AFK snapshot for dispatch policy."""
+    if state is None:
+        return "off"
+    if isinstance(state, dict) and not state.get("unverifiable"):
+        return "engaged"
+    return "unavailable"
+
+
+def _afk_allows_new_start(state: str, task_safe: bool) -> bool:
+    return state == "off" or (state == "engaged" and task_safe)
+
+
+def _claim_under_afk_lock(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    task_safe: bool,
+    review: bool = False,
+    ttl_seconds: Optional[int] = None,
+) -> tuple[Optional[Task], str]:
+    """Claim only while the AFK snapshot and durable claim share a boundary."""
+    claimed = None
+    try:
+        with afk.locked_state() as state:
+            afk_state = _afk_dispatch_state(state)
+            if not _afk_allows_new_start(afk_state, task_safe):
+                return None, afk_state
+            claim = claim_review_task if review else claim_task
+            claimed = claim(conn, task_id, ttl_seconds=ttl_seconds)
+    except afk.AfkStateError:
+        if claimed is not None:
+            _rollback_unspawned_claim(conn, claimed.id)
+        return None, "unavailable"
+    return claimed, "eligible"
+
+
 def dispatch_once(
     conn: sqlite3.Connection,
     *,
@@ -9953,6 +10045,11 @@ def _dispatch_once_locked(
     reap_worker_zombies()
 
     result = DispatchResult()
+    try:
+        with afk.locked_state() as state:
+            dispatch_afk_state = _afk_dispatch_state(state)
+    except afk.AfkStateError:
+        dispatch_afk_state = "unavailable"
     result.reclaimed = release_stale_claims(conn)
     if reconcile_orphans:
         # Orphaned-card reconciliation: requeue 'running' cards whose claim
@@ -10045,7 +10142,7 @@ def _dispatch_once_locked(
             spawn_budget = 1
 
     ready_rows = conn.execute(
-        "SELECT id, assignee FROM tasks "
+        "SELECT id, assignee, unattended_safe FROM tasks "
         "WHERE status = 'ready' AND claim_lock IS NULL "
         "ORDER BY priority DESC, created_at ASC"
     ).fetchall()
@@ -10054,7 +10151,7 @@ def _dispatch_once_locked(
     review_rows = []
     if review_dispatch_enabled():
         review_rows = conn.execute(
-            "SELECT id, assignee FROM tasks "
+            "SELECT id, assignee, unattended_safe FROM tasks "
             "WHERE status = 'review' AND claim_lock IS NULL "
             "ORDER BY priority DESC, created_at ASC"
         ).fetchall()
@@ -10072,20 +10169,34 @@ def _dispatch_once_locked(
     def _any_spawnable_review() -> bool:
         if not review_rows:
             return False
+        def _eligible(row: sqlite3.Row) -> bool:
+            if not row["assignee"]:
+                return False
+            if not _afk_allows_new_start(
+                dispatch_afk_state, bool(row["unattended_safe"])
+            ):
+                return False
+            return True
+
         try:
             from hermes_cli.profiles import profile_exists as _rpe
         except Exception:
             # Profiles module unavailable (test stubs, exotic envs) —
             # assume spawnable, matching the review loop's own fallback.
-            return any(row["assignee"] for row in review_rows)
+            return any(_eligible(row) for row in review_rows)
         return any(
-            row["assignee"] and _rpe(row["assignee"]) for row in review_rows
+            _eligible(row)
+            and _rpe(row["assignee"])
+            for row in review_rows
         )
 
     ready_budget = spawn_budget
     if spawn_budget is not None and spawn_budget > 0 and _any_spawnable_review():
         ready_budget = max(spawn_budget - 1, 0)
     spawned = 0
+    def _skip_unattended(task_id: str) -> None:
+        if task_id not in result.skipped_unattended:
+            result.skipped_unattended.append(task_id)
     # Per-profile concurrency cap (#21582): when set, track how many
     # workers each assignee already has in flight, and refuse to spawn
     # when this would push that assignee past the cap. Prevents
@@ -10125,6 +10236,9 @@ def _dispatch_once_locked(
     for row in ready_rows:
         if ready_budget is not None and spawned >= ready_budget:
             break
+        if dispatch_afk_state != "off" and not bool(row["unattended_safe"]):
+            _skip_unattended(row["id"])
+            continue
         row_assignee = row["assignee"]
         if not row_assignee:
             # Honour kanban.default_assignee: when the dispatcher hits an
@@ -10238,7 +10352,13 @@ def _dispatch_once_locked(
                     _per_profile_running.get(row_assignee, 0) + 1
                 )
             continue
-        claimed = claim_task(conn, row["id"], ttl_seconds=ttl_seconds)
+        claimed, claim_state = _claim_under_afk_lock(
+            conn, row["id"], task_safe=bool(row["unattended_safe"]),
+            ttl_seconds=ttl_seconds,
+        )
+        if claim_state != "eligible":
+            _skip_unattended(row["id"])
+            continue
         if claimed is None:
             continue
         try:
@@ -10330,6 +10450,9 @@ def _dispatch_once_locked(
     for row in review_rows:
         if spawn_budget is not None and spawned >= spawn_budget:
             break
+        if dispatch_afk_state != "off" and not bool(row["unattended_safe"]):
+            _skip_unattended(row["id"])
+            continue
         if not row["assignee"]:
             result.skipped_unassigned.append(row["id"])
             continue
@@ -10365,7 +10488,13 @@ def _dispatch_once_locked(
                     _per_profile_running.get(row["assignee"], 0) + 1
                 )
             continue
-        claimed = claim_review_task(conn, row["id"], ttl_seconds=ttl_seconds)
+        claimed, claim_state = _claim_under_afk_lock(
+            conn, row["id"], task_safe=bool(row["unattended_safe"]),
+            review=True, ttl_seconds=ttl_seconds,
+        )
+        if claim_state != "eligible":
+            _skip_unattended(row["id"])
+            continue
         if claimed is None:
             continue
         try:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -55,6 +55,10 @@ from functools import wraps
 from pathlib import Path
 from typing import (Any, Callable, Dict, Iterable, List, Mapping, Optional, Set, Tuple, Type, Union)
 
+_pre_tool_approval_required = contextvars.ContextVar(
+    "hermes_pre_tool_approval_required", default=False
+)
+
 from hermes_constants import (
     get_hermes_home,
     hermes_home_key,
@@ -349,7 +353,7 @@ VALID_HOOKS: Set[str] = {
     #     promoted, reconciled_orphans, crashed, stale, timed_out,
     #     auto_blocked, rate_limited, auto_assigned_default,
     #     respawn_guarded, skipped_per_profile_capped, skipped_unassigned,
-    #     skipped_nonspawnable, skipped_locked).
+    #     skipped_unattended, skipped_nonspawnable, skipped_locked).
     #   Privacy: result carries task ids, assignees, and workspace paths.
     "on_kanban_dispatch_tick",
     # Gateway platform-boundary observer hooks (#64176). Observer-only; each
@@ -6786,8 +6790,10 @@ def _resolve_block_from_details(
     proceeds.
     """
     if details.action == "block":
+        _pre_tool_approval_required.set(False)
         return details.message
     if details.action == "approve":
+        _pre_tool_approval_required.set(True)
         try:
             from tools.approval import (
                 request_tool_approval,
@@ -6819,13 +6825,54 @@ def _resolve_block_from_details(
         except Exception:
             # Fail-closed: if the gate itself errors, block rather than
             # silently execute an action a plugin flagged for approval.
+            _pre_tool_approval_required.set(False)
             return f"BLOCKED: plugin approval gate failed for {tool_name}"
         if not result.get("approved"):
+            _pre_tool_approval_required.set(False)
             return str(
                 result.get("message")
                 or f"BLOCKED: plugin approval required for {tool_name}"
             )
     return None
+
+
+def final_pre_tool_call_authorization(
+    tool_name: str, *, approval_required: Optional[bool] = None
+) -> Optional[str]:
+    """Perform the shared final AFK check immediately before tool execution.
+
+    The caller owns the immutable ``approval_required`` decision for this
+    invocation.  The ContextVar is only a hand-off for the current call; it
+    is never consumed by this final check, so middleware retries cannot turn a
+    previously approved operation into an unguarded retry.
+    """
+    required = (
+        _pre_tool_approval_required.get()
+        if approval_required is None
+        else bool(approval_required)
+    )
+    # Callers that may retry carry ``required`` in their invocation-local
+    # closure. Clear only the ambient hand-off so nested/future calls cannot
+    # inherit it; the explicit value is never consumed by a retry.
+    _pre_tool_approval_required.set(False)
+    if not required:
+        return None
+    try:
+        from tools.approval import afk_approval_blocked
+
+        return afk_approval_blocked()
+    except Exception:
+        return f"BLOCKED: AFK state could not be verified before {tool_name}"
+
+
+def current_pre_tool_approval_required() -> bool:
+    """Return the approval decision captured by the current hook invocation."""
+    return bool(_pre_tool_approval_required.get())
+
+
+def clear_pre_tool_approval_required() -> None:
+    """Clear the hand-off after the caller has captured its local decision."""
+    _pre_tool_approval_required.set(False)
 
 
 def _dispatch_pre_tool_call_hooks(
@@ -6856,6 +6903,7 @@ def _dispatch_pre_tool_call_hooks(
     Callers that also need input transformation should call this
     function and apply ``modified_args`` if not ``None``.
     """
+    _pre_tool_approval_required.set(False)
     details = _get_pre_tool_call_directive_details(
         tool_name, args, task_id=task_id, session_id=session_id,
         tool_call_id=tool_call_id, turn_id=turn_id,

--- a/model_tools.py
+++ b/model_tools.py
@@ -1447,6 +1447,7 @@ def handle_function_call(
         # (for `modify` directives). Observer plugins see
         # the hook on that same pass. When skip=True, the caller already
         # fired it — do nothing here.
+        approval_required = False
         if not skip_pre_tool_call_hook:
             block_message: Optional[str] = None
             try:
@@ -1463,6 +1464,10 @@ def handle_function_call(
                 )
                 if modified_args is not None:
                     function_args = modified_args
+                from hermes_cli.plugins import current_pre_tool_approval_required
+                approval_required = current_pre_tool_approval_required()
+                from hermes_cli.plugins import clear_pre_tool_approval_required
+                clear_pre_tool_approval_required()
             except Exception as _hook_err:
                 logger.debug("pre_tool_call hook error: %s", _hook_err)
 
@@ -1483,6 +1488,10 @@ def handle_function_call(
                     middleware_trace=list(_tool_middleware_trace),
                 )
                 return result
+        else:
+            from hermes_cli.plugins import current_pre_tool_approval_required, clear_pre_tool_approval_required
+            approval_required = current_pre_tool_approval_required()
+            clear_pre_tool_approval_required()
 
         # ACP/Zed edit approval runs before any file mutation.  The requester
         # is bound via ContextVar only for ACP sessions, so CLI/gateway paths
@@ -1561,6 +1570,12 @@ def handle_function_call(
                 # the parent's tool set via the process-global.
                 sandbox_enabled = enabled_tools if enabled_tools is not None else _last_resolved_tool_names
                 def _dispatch(next_args: Dict[str, Any]) -> Any:
+                    from hermes_cli.plugins import final_pre_tool_call_authorization
+                    final_block = final_pre_tool_call_authorization(
+                        function_name, approval_required=approval_required
+                    )
+                    if final_block:
+                        return tool_error(final_block)
                     return registry.dispatch(
                         function_name, next_args,
                         task_id=task_id,
@@ -1569,6 +1584,12 @@ def handle_function_call(
                     )
             else:
                 def _dispatch(next_args: Dict[str, Any]) -> Any:
+                    from hermes_cli.plugins import final_pre_tool_call_authorization
+                    final_block = final_pre_tool_call_authorization(
+                        function_name, approval_required=approval_required
+                    )
+                    if final_block:
+                        return tool_error(final_block)
                     return registry.dispatch(
                         function_name, next_args,
                         task_id=task_id,

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -611,6 +611,7 @@ class CreateTaskBody(BaseModel):
     skills: Optional[list[str]] = None
     goal_mode: bool = False
     goal_max_turns: Optional[int] = None
+    unattended_safe: bool = False
     model_override: Optional[str] = None
     provider_override: Optional[str] = None
     # Per-task thinking depth (none|minimal|…|ultra). None = inherit the
@@ -643,6 +644,7 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             skills=payload.skills,
             goal_mode=payload.goal_mode,
             goal_max_turns=payload.goal_max_turns,
+            unattended_safe=payload.unattended_safe,
             model_override=payload.model_override,
             provider_override=payload.provider_override,
             reasoning_effort=payload.reasoning_effort,

--- a/tests/agent/test_afk_state.py
+++ b/tests/agent/test_afk_state.py
@@ -14,7 +14,7 @@ from agent import afk
 
 
 def _hold_afk_transaction(ready, release):
-    with afk._transaction():
+    with afk.locked_state():
         ready.set()
         release.wait(5)
 
@@ -28,6 +28,29 @@ def _engage_afk_after_signal(attempted, completed, errors):
     else:
         errors.put("<no error>")
         completed.set()
+
+
+def test_locked_state_yields_valid_off_snapshot(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    with afk.locked_state() as state:
+        assert state is None
+
+
+def test_locked_state_yields_valid_engaged_snapshot(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    afk.engage("away")
+
+    with afk.locked_state() as state:
+        assert state["reason"] == "away"
+
+
+def test_locked_state_yields_unverifiable_snapshot_fail_closed(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    afk.state_path().write_text("not json", encoding="utf-8")
+
+    with afk.locked_state() as state:
+        assert state == {"unverifiable": True}
 
 
 def test_state_is_shared_by_profiles_under_one_default_root(monkeypatch, tmp_path):

--- a/tests/agent/test_afk_state.py
+++ b/tests/agent/test_afk_state.py
@@ -1,0 +1,833 @@
+"""Focused tests for machine-global AFK state."""
+
+from __future__ import annotations
+
+import json
+import multiprocessing
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from agent import afk
+
+
+def _hold_afk_transaction(ready, release):
+    with afk._transaction():
+        ready.set()
+        release.wait(5)
+
+
+def _engage_afk_after_signal(attempted, completed, errors):
+    attempted.set()
+    try:
+        afk.engage("from process B")
+    except BaseException as exc:
+        errors.put(repr(exc))
+    else:
+        errors.put("<no error>")
+        completed.set()
+
+
+def test_state_is_shared_by_profiles_under_one_default_root(monkeypatch, tmp_path):
+    root = tmp_path / "hermes"
+    profile = root / "profiles" / "coder"
+    profile.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile))
+
+    afk.engage("away for lunch")
+
+    assert afk.state_path() == root / "afk.json"
+    assert afk.get_state() == {
+        "engaged_at": afk.get_state()["engaged_at"],
+        "reason": "away for lunch",
+    }
+
+
+def test_path_operations_with_path_only_root_omit_dir_fd_keywords(
+    monkeypatch, tmp_path
+):
+    root = afk._Root(tmp_path, None)
+    calls = []
+
+    def record(name):
+        def operation(*args, **kwargs):
+            calls.append((name, args, kwargs))
+            if name == "open":
+                return 123
+            return None
+
+        return operation
+
+    monkeypatch.setattr(os, "open", record("open"))
+    monkeypatch.setattr(os, "stat", record("stat"))
+    monkeypatch.setattr(os, "replace", record("replace"))
+    monkeypatch.setattr(os, "unlink", record("unlink"))
+
+    afk._path_open(root, afk.STATE_NAME, os.O_RDONLY)
+    afk._path_stat(root, afk.STATE_NAME)
+    afk._path_replace(root, ".tmp", afk.STATE_NAME)
+    afk._path_unlink(root, ".tmp")
+
+    assert [name for name, _args, _kwargs in calls] == [
+        "open",
+        "stat",
+        "replace",
+        "unlink",
+    ]
+    assert all(
+        not {"dir_fd", "src_dir_fd", "dst_dir_fd"}.intersection(kwargs)
+        for _name, _args, kwargs in calls
+    )
+
+
+def test_root_close_transfers_ownership_before_close_failure(monkeypatch, tmp_path):
+    root = object.__new__(afk._Root)
+    root.path = tmp_path
+    root.fd = 41
+    close_calls = []
+
+    def fail_close(fd):
+        close_calls.append(fd)
+        raise OSError("close failed")
+
+    monkeypatch.setattr(os, "close", fail_close)
+
+    with pytest.raises(OSError, match="close failed"):
+        root.close()
+    root.close()
+
+    assert root.fd is None
+    assert close_calls == [41]
+
+
+def test_read_state_preserves_body_error_when_close_fails(monkeypatch, tmp_path):
+    root = afk._Root(tmp_path, None)
+    close_calls = []
+    monkeypatch.setattr(afk, "_path_open", lambda *_args, **_kwargs: 31)
+    monkeypatch.setattr(os, "fstat", lambda _fd: (_ for _ in ()).throw(ValueError("body failed")))
+
+    def fail_close(fd):
+        close_calls.append(fd)
+        raise OSError("close failed")
+
+    monkeypatch.setattr(os, "close", fail_close)
+
+    with pytest.raises(ValueError, match="body failed"):
+        afk._read_state(root)
+
+    assert close_calls == [31]
+
+
+def test_read_state_bounds_close_only_failure(monkeypatch, tmp_path):
+    root = afk._Root(tmp_path, None)
+    close_calls = []
+    path = tmp_path / afk.STATE_NAME
+    info = path.stat() if path.exists() else tmp_path.stat()
+    monkeypatch.setattr(afk, "_path_open", lambda *_args, **_kwargs: 32)
+    monkeypatch.setattr(os, "fstat", lambda _fd: os.stat_result((stat.S_IFREG | 0o600, 1, 1, 1, info.st_uid, info.st_gid, 2, 0, 0, 0)))
+    monkeypatch.setattr(os, "read", lambda _fd, _size: b"{}")
+
+    def fail_close(fd):
+        close_calls.append(fd)
+        raise OSError("close failed")
+
+    monkeypatch.setattr(os, "close", fail_close)
+
+    with pytest.raises(afk.AfkStateError, match="close failed") as exc_info:
+        afk._read_state(root)
+
+    assert exc_info.value.changed is False
+    assert close_calls == [32]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX descriptor ownership")
+def test_open_root_closes_child_and_parent_once_when_child_validation_fails(
+    monkeypatch,
+):
+    monkeypatch.setattr(afk, "_root", lambda: Path("/a/b"))
+    open_fds = iter((10, 11))
+    close_calls = []
+    monkeypatch.setattr(os, "open", lambda *_args, **_kwargs: next(open_fds))
+    monkeypatch.setattr(os, "stat", lambda *_args, **_kwargs: os.stat_result((stat.S_IFDIR | 0o700, 1, 1, 1, getattr(os, "geteuid", lambda: 0)(), 0, 0, 0, 0, 0)))
+    monkeypatch.setattr(os, "close", close_calls.append)
+
+    def fail_child_check(fd, *, final):
+        if fd == 11:
+            raise afk.AfkStateError("child validation failed")
+
+    monkeypatch.setattr(afk, "_check_directory", fail_child_check)
+
+    with pytest.raises(afk.AfkStateError, match="child validation failed"):
+        afk._open_root()
+
+    assert close_calls == [11, 10]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX descriptor ownership")
+def test_open_root_preserves_acquisition_error_when_parent_close_fails(monkeypatch):
+    monkeypatch.setattr(afk, "_root", lambda: Path("/a/b"))
+    close_calls = []
+
+    def fake_open(*_args, **kwargs):
+        if kwargs.get("dir_fd") is None:
+            return 10
+        raise OSError("child open failed")
+
+    def fail_close(fd):
+        close_calls.append(fd)
+        raise OSError("parent close failed")
+
+    monkeypatch.setattr(os, "open", fake_open)
+    monkeypatch.setattr(os, "stat", lambda *_args, **_kwargs: os.stat_result((stat.S_IFDIR | 0o700, 1, 1, 1, getattr(os, "geteuid", lambda: 0)(), 0, 0, 0, 0, 0)))
+    monkeypatch.setattr(afk, "_check_directory", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(os, "close", fail_close)
+
+    with pytest.raises(afk.AfkStateError, match="child open failed"):
+        afk._open_root()
+
+    assert close_calls == [10]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX advisory lock")
+def test_file_lock_enter_preserves_acquisition_error_when_cleanup_fails(
+    monkeypatch, tmp_path
+):
+    lock = afk._FileLock(tmp_path / "afk.lock")
+    current_uid = getattr(os, "geteuid", lambda: 0)()
+    regular = os.stat_result((stat.S_IFREG | 0o600, 1, 1, 1, current_uid, 0, 0, 0, 0, 0))
+    directory = os.stat_result((stat.S_IFDIR | 0o700, 1, 1, 1, current_uid, 0, 0, 0, 0, 0))
+    open_fds = iter((40, 41))
+    close_calls = []
+    file_close_calls = []
+
+    monkeypatch.setattr(os, "open", lambda *_args, **_kwargs: next(open_fds))
+    monkeypatch.setattr(os, "fstat", lambda fd: directory if fd == 40 else regular)
+
+    class FailingFile:
+        def fileno(self):
+            return 41
+
+        def close(self):
+            file_close_calls.append(41)
+            raise OSError("file close failed")
+
+    monkeypatch.setattr(os, "fdopen", lambda *_args, **_kwargs: FailingFile())
+    monkeypatch.setattr(os, "close", lambda fd: (close_calls.append(fd), (_ for _ in ()).throw(OSError("root close failed")))[1])
+    import fcntl
+
+    monkeypatch.setattr(fcntl, "flock", lambda *_args: (_ for _ in ()).throw(OSError("lock failed")))
+
+    with pytest.raises(afk.AfkStateError, match="lock failed"):
+        lock.__enter__()
+
+    assert lock.file is None
+    assert lock.root.fd is None
+    assert file_close_calls == [41]
+    assert close_calls == [40]
+
+
+def test_mutation_marker_only_tracks_canonical_state_changes(monkeypatch, tmp_path):
+    root = afk._Root(tmp_path, None)
+    temporary = ".afk.temporary"
+    (tmp_path / temporary).write_text("temporary", encoding="utf-8")
+
+    afk._path_unlink(root, temporary)
+
+    assert root.mutated is False
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    afk.engage("away")
+    original_unlink = afk._path_unlink
+    observed = []
+
+    def unlink_and_observe(canonical_root, name):
+        original_unlink(canonical_root, name)
+        observed.append((name, canonical_root))
+
+    monkeypatch.setattr(afk, "_path_unlink", unlink_and_observe)
+
+    assert afk.clear() is True
+    assert observed[0][0] == afk.STATE_NAME
+    assert observed[0][1].mutated is True
+
+
+def test_corrupt_or_unreadable_state_is_engaged(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = afk.state_path()
+    path.write_text("not json", encoding="utf-8")
+    assert afk.is_afk() is True
+    path.unlink()
+    path.mkdir()
+    assert afk.is_afk() is True
+
+
+def test_unverifiable_state_is_distinct_and_status_is_truthful(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = afk.state_path()
+    path.write_text("not json", encoding="utf-8")
+
+    state = afk.get_state()
+
+    assert state["unverifiable"] is True
+    assert "None" not in afk.handle_command("status")
+    assert "unreadable" in afk.handle_command("status").lower()
+    assert "None" not in afk.handle_command("")
+    assert "unverifiable" in afk.handle_command("").lower()
+
+
+def test_status_bounds_non_not_found_state_stat_error(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    def fail_state_stat(_root, _name):
+        raise OSError("state stat failed")
+
+    monkeypatch.setattr(afk, "_path_stat", fail_state_stat)
+
+    reply = afk.handle_command("status")
+
+    assert "Couldn't safely change" in reply
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission contract")
+def test_state_with_group_or_other_bits_is_unverifiable(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = afk.state_path()
+    path.write_text(
+        json.dumps({"engaged_at": "2026-01-01T00:00:00+00:00", "reason": "secret"}),
+        encoding="utf-8",
+    )
+    path.chmod(0o640)
+
+    assert afk.get_state() == {"unverifiable": True}
+
+
+def test_clear_refuses_symlinked_state_leaf(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    target = tmp_path / "elsewhere"
+    target.write_text("keep", encoding="utf-8")
+    path = afk.state_path()
+    path.symlink_to(target)
+
+    with pytest.raises(afk.AfkStateError, match="symlink"):
+        afk.clear()
+
+    assert path.is_symlink()
+    assert target.read_text(encoding="utf-8") == "keep"
+
+
+def test_zero_write_result_fails(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    calls = 0
+
+    def no_progress(*_args):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return 0
+        raise AssertionError("write loop did not make progress")
+
+    monkeypatch.setattr(os, "write", no_progress)
+    with pytest.raises(afk.AfkStateError, match="write"):
+        afk.engage("x")
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX descriptor-relative path safety")
+def test_ancestor_symlink_is_refused_without_writing_through_it(monkeypatch, tmp_path):
+    real_parent = tmp_path / "real-parent"
+    real_parent.mkdir()
+    alias = tmp_path / "alias"
+    alias.symlink_to(real_parent, target_is_directory=True)
+    monkeypatch.setenv("HERMES_HOME", str(alias / "hermes"))
+
+    with pytest.raises(afk.AfkStateError, match="symlink"):
+        afk.engage("blocked")
+
+    assert not (real_parent / "hermes" / afk.STATE_NAME).exists()
+
+
+@pytest.mark.skipif(
+    os.name == "nt", reason="POSIX descriptor-relative publication race"
+)
+def test_root_replacement_during_publication_never_reports_success(
+    monkeypatch, tmp_path
+):
+    root = tmp_path / "hermes"
+    root.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    real_replace = os.replace
+    moved = tmp_path / "moved-root"
+    swapped = False
+
+    def replace_with_root_swap(src, dst, **kwargs):
+        nonlocal swapped
+        if not swapped:
+            swapped = True
+            root.rename(moved)
+            root.mkdir(mode=0o700)
+        return real_replace(src, dst, **kwargs)
+
+    monkeypatch.setattr(os, "replace", replace_with_root_swap)
+
+    reply = afk.handle_command("on race")
+
+    assert "durability could not be confirmed" in reply
+    assert not (root / afk.STATE_NAME).exists()
+    assert (moved / afk.STATE_NAME).is_file()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX descriptor-relative read race")
+def test_get_state_rejects_root_replacement_after_read(monkeypatch, tmp_path):
+    root = tmp_path / "hermes"
+    root.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    afk.engage("old root")
+    moved = tmp_path / "moved-root"
+    real_read_state = afk._read_state
+
+    def read_then_swap(bound_root):
+        state = real_read_state(bound_root)
+        root.rename(moved)
+        root.mkdir(mode=0o700)
+        return state
+
+    monkeypatch.setattr(afk, "_read_state", read_then_swap)
+
+    with pytest.raises(afk.AfkStateError) as exc_info:
+        afk.get_state()
+
+    assert exc_info.value.changed is False
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX advisory lock test")
+def test_file_lock_serializes_across_processes(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    context = multiprocessing.get_context("spawn")
+    ready = context.Event()
+    release = context.Event()
+    attempted = context.Event()
+    completed = context.Event()
+    errors = context.SimpleQueue()
+    holder = context.Process(target=_hold_afk_transaction, args=(ready, release))
+    contender = context.Process(
+        target=_engage_afk_after_signal,
+        args=(attempted, completed, errors),
+    )
+    holder.start()
+    contender_started = False
+    try:
+        assert ready.wait(5), "process A did not acquire the AFK transaction"
+        contender.start()
+        contender_started = True
+        assert attempted.wait(5), "process B did not attempt engage"
+        assert not completed.wait(0.25), "process B bypassed the AFK lock"
+        release.set()
+        assert completed.wait(5), "process B did not complete after release"
+        holder.join(5)
+        contender.join(5)
+        assert not holder.is_alive()
+        assert not contender.is_alive()
+        assert not errors.empty(), "process B did not report its result"
+        assert errors.get() == "<no error>"
+    finally:
+        release.set()
+        holder.join(5)
+        if contender_started:
+            contender.join(5)
+        if holder.is_alive():
+            holder.terminate()
+            holder.join(5)
+        if contender_started and contender.is_alive():
+            contender.terminate()
+            contender.join(5)
+
+
+def test_reason_is_bounded_and_display_neutralized(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    reason = "  [31m" + ("x" * 10_000) + "\nprivate\tdata  "
+    afk.engage(reason)
+    state = afk.get_state()
+    assert afk.is_afk() is True
+    assert len(state["reason"] or "") <= afk.MAX_REASON_CHARS
+    assert "\x1b" not in (state["reason"] or "")
+    assert "[" not in (state["reason"] or "")
+    assert "]" not in (state["reason"] or "")
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX advisory lock test")
+def test_file_lock_closes_file_when_lock_acquisition_fails(monkeypatch, tmp_path):
+    lock = afk._FileLock(tmp_path / "afk.lock")
+
+    import fcntl
+
+    def fail_flock(*_args):
+        raise OSError("lock failed")
+
+    monkeypatch.setattr(fcntl, "flock", fail_flock)
+
+    with pytest.raises(afk.AfkStateError, match="lock failed"):
+        lock.__enter__()
+
+    assert lock.file is None
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX advisory lock test")
+def test_file_lock_release_closes_file_once(monkeypatch, tmp_path):
+    lock = afk._FileLock(tmp_path / "afk.lock")
+    real_fdopen = os.fdopen
+    close_calls = 0
+
+    class TrackingFile:
+        def __init__(self, file):
+            self._file = file
+
+        def close(self):
+            nonlocal close_calls
+            close_calls += 1
+            return self._file.close()
+
+        def __getattr__(self, name):
+            return getattr(self._file, name)
+
+    def tracked_fdopen(*args, **kwargs):
+        return TrackingFile(real_fdopen(*args, **kwargs))
+
+    monkeypatch.setattr(os, "fdopen", tracked_fdopen)
+    lock.__enter__()
+    lock.__exit__(None, None, None)
+    lock.__exit__(None, None, None)
+
+    assert close_calls == 1
+    assert lock.file is None
+
+
+def test_status_handles_symlinked_lock_leaf(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    target = tmp_path / "elsewhere"
+    target.write_text("keep", encoding="utf-8")
+    afk._lock_path().symlink_to(target)
+
+    assert "Couldn't safely change" in afk.handle_command("status")
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX advisory lock test")
+def test_status_bounds_lock_release_error_as_unchanged(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    import fcntl
+
+    real_flock = fcntl.flock
+
+    def fail_unlock(fd, operation):
+        if operation == fcntl.LOCK_UN:
+            raise OSError("unlock failed")
+        return real_flock(fd, operation)
+
+    monkeypatch.setattr(fcntl, "flock", fail_unlock)
+
+    reply = afk.handle_command("status")
+
+    assert "Couldn't safely change" in reply
+
+
+class _FakeTransactionRoot:
+    def __init__(self, *, mutated=False):
+        self.fd = None
+        self.mutated = mutated
+        self.close_calls = 0
+
+    def close(self):
+        self.close_calls += 1
+        raise OSError("root close failed")
+
+    def revalidate(self, **_kwargs):
+        return None
+
+
+class _FakeTransactionLock:
+    def __init__(self, root, error=None):
+        self.root = root
+        self.error = error
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        if self.error is not None:
+            raise self.error
+        return False
+
+
+def test_transaction_bounds_root_close_before_mutation(monkeypatch):
+    root = _FakeTransactionRoot()
+    monkeypatch.setattr(afk, "_open_root", lambda: root)
+    monkeypatch.setattr(afk, "_FileLock", _FakeTransactionLock)
+
+    with pytest.raises(afk.AfkStateError, match="root close failed") as exc_info:
+        with afk._transaction():
+            pass
+
+    assert exc_info.value.changed is False
+
+
+def test_handle_command_bounds_root_close_after_canonical_mutation(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    def fail_close(_root):
+        raise OSError("root close failed")
+
+    monkeypatch.setattr(afk._Root, "close", fail_close)
+
+    reply = afk.handle_command("on lunch")
+
+    assert "AFK state changed" in reply
+    assert afk.state_path().is_file()
+
+
+def test_transaction_preserves_body_error_when_root_close_fails(monkeypatch):
+    root = _FakeTransactionRoot()
+    monkeypatch.setattr(afk, "_open_root", lambda: root)
+    monkeypatch.setattr(afk, "_FileLock", _FakeTransactionLock)
+
+    with pytest.raises(ValueError, match="body failed"):
+        with afk._transaction():
+            raise ValueError("body failed")
+
+
+def test_transaction_preserves_lock_cleanup_error_when_root_close_fails(monkeypatch):
+    root = _FakeTransactionRoot()
+    monkeypatch.setattr(afk, "_open_root", lambda: root)
+    monkeypatch.setattr(
+        afk,
+        "_FileLock",
+        lambda lock_root: _FakeTransactionLock(lock_root, OSError("unlock failed")),
+    )
+
+    with pytest.raises(OSError, match="unlock failed"):
+        with afk._transaction():
+            pass
+
+
+def test_atomic_temp_fd_close_is_bounded_and_owned_once(monkeypatch, tmp_path):
+    root = afk._Root(tmp_path, None)
+    close_calls = []
+    monkeypatch.setattr(afk, "_path_open", lambda *_args, **_kwargs: 101)
+    monkeypatch.setattr(os, "fchmod", lambda *_args: None)
+    monkeypatch.setattr(os, "write", lambda _fd, data: len(data))
+    monkeypatch.setattr(os, "fsync", lambda _fd: None)
+    monkeypatch.setattr(
+        os, "close", lambda fd: (close_calls.append(fd), (_ for _ in ()).throw(OSError("temp close failed")))[1]
+    )
+    unlinked = []
+    monkeypatch.setattr(afk, "_path_unlink", lambda _root, name: unlinked.append(name))
+
+    with pytest.raises(afk.AfkStateError, match="temp close failed") as exc_info:
+        afk._atomic_replace_json(root, {"reason": "x"})
+
+    assert exc_info.value.changed is False
+    assert close_calls == [101]
+    assert len(unlinked) == 1
+    assert root.mutated is False
+
+
+def test_atomic_temp_unlink_cleanup_failure_is_bounded(monkeypatch, tmp_path):
+    root = afk._Root(tmp_path, None)
+    monkeypatch.setattr(afk, "_path_open", lambda *_args, **_kwargs: 101)
+    monkeypatch.setattr(os, "fchmod", lambda *_args: None)
+    monkeypatch.setattr(os, "write", lambda _fd, data: len(data))
+    monkeypatch.setattr(os, "fsync", lambda _fd: None)
+    monkeypatch.setattr(os, "close", lambda _fd: None)
+    monkeypatch.setattr(
+        afk, "_path_replace", lambda *_args: (_ for _ in ()).throw(OSError("replace failed"))
+    )
+    monkeypatch.setattr(
+        afk, "_path_unlink", lambda *_args: (_ for _ in ()).throw(OSError("unlink failed"))
+    )
+
+    with pytest.raises(afk.AfkStateError, match="replace failed") as exc_info:
+        afk._atomic_replace_json(root, {"reason": "x"})
+
+    assert exc_info.value.changed is False
+    assert root.mutated is False
+
+
+def test_atomic_cleanup_failures_preserve_primary_write_error(monkeypatch, tmp_path):
+    root = afk._Root(tmp_path, None)
+    close_calls = []
+    monkeypatch.setattr(afk, "_path_open", lambda *_args, **_kwargs: 101)
+    monkeypatch.setattr(os, "fchmod", lambda *_args: None)
+    monkeypatch.setattr(
+        os, "write", lambda *_args: (_ for _ in ()).throw(OSError("write failed"))
+    )
+    monkeypatch.setattr(os, "close", lambda fd: close_calls.append(fd))
+    monkeypatch.setattr(
+        afk, "_path_unlink", lambda *_args: (_ for _ in ()).throw(OSError("unlink failed"))
+    )
+
+    with pytest.raises(afk.AfkStateError, match="write failed") as exc_info:
+        afk._atomic_replace_json(root, {"reason": "x"})
+
+    assert exc_info.value.changed is False
+    assert close_calls == [101]
+    assert root.mutated is False
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX advisory lock test")
+def test_engage_reports_lock_release_error_after_state_change(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    import fcntl
+
+    real_flock = fcntl.flock
+
+    def fail_unlock(fd, operation):
+        if operation == fcntl.LOCK_UN:
+            raise OSError("unlock failed")
+        return real_flock(fd, operation)
+
+    monkeypatch.setattr(fcntl, "flock", fail_unlock)
+
+    reply = afk.handle_command("on lunch")
+
+    assert "AFK state changed" in reply
+    assert "durability could not be confirmed" in reply
+    assert afk.state_path().is_file()
+
+
+def test_status_handles_unusable_root(monkeypatch, tmp_path):
+    root = tmp_path / "not-a-directory"
+    root.write_text("keep", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    assert "Couldn't safely change" in afk.handle_command("status")
+
+
+def test_symlink_leaf_is_refused_for_read_and_write(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    target = tmp_path / "elsewhere"
+    target.write_text(json.dumps({"engaged": False}), encoding="utf-8")
+    path = afk.state_path()
+    path.symlink_to(target)
+
+    with pytest.raises(afk.AfkStateError):
+        afk.engage("no")
+    with pytest.raises(afk.AfkStateError):
+        afk.get_state()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX durability contract")
+def test_write_and_unlink_fsync_file_and_parent_in_order(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    calls = []
+    real_fsync = os.fsync
+
+    def record_fsync(fd):
+        calls.append((
+            "fsync",
+            "directory" if stat.S_ISDIR(os.fstat(fd).st_mode) else "file",
+        ))
+        return real_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", record_fsync)
+    afk.engage("temporary")
+    afk.clear()
+    assert calls[-1][0] == "fsync"
+    assert calls[-1][1] == "directory"
+
+
+def test_state_file_is_owner_only(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    afk.engage(None)
+    assert afk.state_path().stat().st_mode & 0o077 == 0
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX durability contract")
+def test_file_fsync_failure_is_propagated(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    def fail_fsync(fd):
+        if not stat.S_ISDIR(os.fstat(fd).st_mode):
+            raise OSError("file barrier failed")
+
+    monkeypatch.setattr(os, "fsync", fail_fsync)
+    with pytest.raises(afk.AfkStateError, match="file barrier") as exc_info:
+        afk.engage("x")
+    assert exc_info.value.changed is False
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX durability contract")
+def test_replace_failure_is_propagated(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        os,
+        "replace",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("replace failed")),
+    )
+    with pytest.raises(afk.AfkStateError, match="replace failed") as exc_info:
+        afk.engage("x")
+    assert exc_info.value.changed is False
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX durability contract")
+def test_command_reports_verification_failure_after_replace_as_changed(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        afk,
+        "_verify_owner_only",
+        lambda _path: (_ for _ in ()).throw(OSError("verification failed")),
+    )
+
+    reply = afk.handle_command("on lunch")
+
+    assert "AFK state changed" in reply
+    assert "durability could not be confirmed" in reply
+    assert afk.state_path().is_file()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX durability contract")
+def test_command_reports_replace_applied_when_parent_sync_fails(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        afk, "_sync_parent", lambda _path: (_ for _ in ()).throw(OSError("sync failed"))
+    )
+
+    reply = afk.handle_command("on lunch")
+
+    assert "AFK state changed" in reply
+    assert "durability could not be confirmed" in reply
+    assert afk.state_path().is_file()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX durability contract")
+def test_command_reports_clear_applied_when_parent_sync_fails(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    afk.engage("lunch")
+    monkeypatch.setattr(
+        afk, "_sync_parent", lambda _path: (_ for _ in ()).throw(OSError("sync failed"))
+    )
+
+    reply = afk.handle_command("off")
+
+    assert "AFK state changed" in reply
+    assert "durability could not be confirmed" in reply
+    assert not afk.state_path().exists()
+
+
+@pytest.mark.parametrize(
+    ("args", "expected"),
+    [
+        ("", "AFK recorded since"),
+        ("on lunch", "AFK recorded since"),
+        ("status", "Not AFK."),
+        ("off", "You weren't marked AFK."),
+        ("later", "Usage: `/afk [on [reason] | off | status]`"),
+    ],
+)
+def test_command_grammar(monkeypatch, tmp_path, args, expected):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    assert expected in afk.handle_command(args)

--- a/tests/gateway/test_afk_command.py
+++ b/tests/gateway/test_afk_command.py
@@ -1,0 +1,83 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agent import afk
+from hermes_cli.commands import COMMANDS, GATEWAY_KNOWN_COMMANDS, resolve_command
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.session import SessionSource
+
+
+def test_afk_is_shared_and_busy_dispatchable():
+    command = resolve_command("afk")
+    assert command is not None
+    assert command.busy_policy == "dispatch"
+    assert "/afk" in COMMANDS
+    assert "afk" in GATEWAY_KNOWN_COMMANDS
+    assert "on" in command.args_hint and "off" in command.args_hint
+
+
+def test_afk_command_renders_only_sanitized_reason(monkeypatch):
+    monkeypatch.setattr(
+        afk, "get_state", lambda: {"engaged_at": "now", "reason": "lunch (safe)"}
+    )
+    reply = afk.handle_command("status")
+    assert "lunch (safe)" in reply
+
+
+@pytest.mark.asyncio
+async def test_gateway_afk_handler_uses_durable_shared_command(monkeypatch):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    event = MagicMock()
+    event.get_command_args.return_value = "on picking up the kids"
+    monkeypatch.setattr(afk, "handle_command", lambda args: f"handled:{args}")
+    assert await runner._handle_afk_command(event) == "handled:on picking up the kids"
+
+
+def test_cli_afk_uses_shared_command(monkeypatch):
+    pytest.importorskip("prompt_toolkit")
+    from cli import HermesCLI
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = "test"
+    cli._pending_resume_sessions = None
+    cli._console_print = MagicMock()
+    monkeypatch.setattr(afk, "handle_command", lambda args: f"handled:{args}")
+    assert cli.process_command("/afk status") is True
+    assert cli._console_print.call_args.args[0] == "handled:status"
+
+
+@pytest.mark.asyncio
+async def test_afk_busy_dispatches_without_interrupting(monkeypatch):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._handle_afk_command = AsyncMock(return_value="afk while busy")
+    event = MagicMock()
+    command = resolve_command("afk")
+    assert (
+        await runner._dispatch_busy_slash_command(event, command, "session", object())
+        == "afk while busy"
+    )
+
+
+def test_afk_keeps_existing_gateway_admin_gate():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={
+            Platform.DISCORD: PlatformConfig(
+                enabled=True,
+                token="token",
+                extra={"allow_admin_from": ["admin"], "user_allowed_commands": []},
+            )
+        }
+    )
+    source = SessionSource(
+        platform=Platform.DISCORD, user_id="guest", chat_id="c", chat_type="dm"
+    )
+    denial = runner._check_slash_access(source, "afk")
+    assert denial is not None and "admin-only" in denial

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -57,6 +57,64 @@ def test_kanban_list_json_includes_session_id(kanban_home):
     )
 
 
+def test_kanban_create_unattended_safe_round_trips_in_json(kanban_home, capsys):
+    parser = argparse.ArgumentParser(prog="hermes", add_help=False)
+    sub = parser.add_subparsers(dest="command")
+    kc.build_parser(sub)
+    args = parser.parse_args([
+        "kanban", "create", "safe task", "--assignee", "alice",
+        "--unattended-safe", "--json",
+    ])
+
+    assert kc.kanban_command(args) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["unattended_safe"] is True
+
+
+def test_kanban_create_defaults_unattended_safe_false(kanban_home, capsys):
+    parser = argparse.ArgumentParser(prog="hermes", add_help=False)
+    sub = parser.add_subparsers(dest="command")
+    kc.build_parser(sub)
+    args = parser.parse_args(["kanban", "create", "ordinary", "--json"])
+
+    assert kc.kanban_command(args) == 0
+    assert json.loads(capsys.readouterr().out)["unattended_safe"] is False
+
+
+def test_kanban_dispatch_json_exposes_skipped_unattended(kanban_home, monkeypatch, capsys):
+    monkeypatch.setattr(
+        kb,
+        "dispatch_once",
+        lambda conn, **kwargs: kb.DispatchResult(
+            skipped_unattended=["t_afk"]
+        ),
+    )
+    parser = argparse.ArgumentParser(prog="hermes", add_help=False)
+    sub = parser.add_subparsers(dest="command")
+    kc.build_parser(sub)
+    args = parser.parse_args(["kanban", "dispatch", "--json"])
+
+    assert kc.kanban_command(args) == 0
+    assert json.loads(capsys.readouterr().out)["skipped_unattended"] == ["t_afk"]
+
+
+def test_kanban_dispatch_text_exposes_skipped_unattended(kanban_home, monkeypatch, capsys):
+    monkeypatch.setattr(
+        kb,
+        "dispatch_once",
+        lambda conn, **kwargs: kb.DispatchResult(
+            skipped_unattended=["t_afk"]
+        ),
+    )
+    parser = argparse.ArgumentParser(prog="hermes", add_help=False)
+    sub = parser.add_subparsers(dest="command")
+    kc.build_parser(sub)
+    args = parser.parse_args(["kanban", "dispatch"])
+
+    assert kc.kanban_command(args) == 0
+    assert "Deferred (AFK): t_afk" in capsys.readouterr().out
+
+
 def test_kanban_show_text_renders_graph_with_open_connection(kanban_home):
     with kb.connect_closing() as conn:
         parent_id = kb.create_task(conn, title="parent task")
@@ -177,5 +235,3 @@ def test_run_slash_reclaim_running_task(kanban_home):
 # ---------------------------------------------------------------------------
 # /kanban help / no-args / unknown-action UX (issue #21794)
 # ---------------------------------------------------------------------------
-
-

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -11,11 +11,21 @@ import time
 import types
 import unittest.mock
 from pathlib import Path
+from contextlib import contextmanager
 
 import pytest
 
 import hermes_state
+from agent import afk
 from hermes_cli import kanban_db as kb
+
+
+def _locked_afk_state(monkeypatch, state):
+    @contextmanager
+    def locked_state():
+        yield state
+
+    monkeypatch.setattr(afk, "locked_state", locked_state)
 
 
 @pytest.fixture
@@ -153,12 +163,16 @@ def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
                 "SELECT name FROM sqlite_master WHERE type = 'index'"
             )
         }
+        legacy_unattended_safe = migrated.execute(
+            "SELECT unattended_safe FROM tasks WHERE id = 'legacy'"
+        ).fetchone()[0]
 
     # Additive columns added by migration:
     assert "session_id" in task_columns
     assert "tenant" in task_columns
     assert "idempotency_key" in task_columns
     assert "run_id" in event_columns
+    assert legacy_unattended_safe == 0
     # And their indexes — the regression scope of this test:
     assert "idx_tasks_session_id" in indexes
     assert "idx_tasks_tenant" in indexes
@@ -169,6 +183,24 @@ def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
 # ---------------------------------------------------------------------------
 # Task creation + status inference
 # ---------------------------------------------------------------------------
+
+
+def test_task_unattended_safe_is_explicit_and_persisted(kanban_home):
+    with kb.connect_closing() as conn:
+        safe_id = kb.create_task(
+            conn,
+            title="safe",
+            assignee="worker",
+            unattended_safe=True,
+        )
+        default_id = kb.create_task(
+            conn,
+            title="default",
+            assignee="worker",
+        )
+
+        assert kb.get_task(conn, safe_id).unattended_safe is True
+        assert kb.get_task(conn, default_id).unattended_safe is False
 
 
 
@@ -1301,6 +1333,116 @@ def test_dispatch_max_in_progress_blocks_review_when_at_limit(
     assert not spawns
     assert review_task is not None
     assert review_task.status == "review"
+
+
+def test_dispatch_in_afk_only_claims_unattended_safe_tasks(
+    kanban_home, all_assignees_spawnable, monkeypatch,
+):
+    _locked_afk_state(monkeypatch, {"engaged_at": "now"})
+    spawns = []
+
+    def fake_spawn(task, workspace, board=None):
+        spawns.append(task.id)
+        return 42
+
+    with kb.connect() as conn:
+        unsafe = kb.create_task(conn, title="unsafe", assignee="alice")
+        safe = kb.create_task(
+            conn, title="safe", assignee="alice", unattended_safe=True
+        )
+        result = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+
+        assert unsafe in result.skipped_unattended
+        assert safe in spawns
+        assert kb.get_task(conn, unsafe).status == "ready"
+        assert kb.get_task(conn, unsafe).claim_lock is None
+
+
+def test_dispatch_afk_off_reserves_spawnable_review_against_ready_backlog(
+    kanban_home, all_assignees_spawnable, monkeypatch,
+):
+    _locked_afk_state(monkeypatch, None)
+    spawns = []
+
+    def fake_spawn(task, workspace, board=None):
+        spawns.append(task.id)
+        return 42
+
+    with kb.connect() as conn:
+        ready = kb.create_task(conn, title="ready", assignee="alice", unattended_safe=True)
+        review = kb.create_task(conn, title="review", assignee="alice")
+        _set_task_status(conn, review, "review")
+        result = kb.dispatch_once(conn, spawn_fn=fake_spawn, max_spawn=1)
+
+    assert result.spawned == [(review, "alice", result.spawned[0][2])]
+    assert spawns == [review]
+    assert ready not in spawns
+
+
+def test_dispatch_afk_review_reservation_requires_unattended_safe(
+    kanban_home, all_assignees_spawnable, monkeypatch,
+):
+    _locked_afk_state(monkeypatch, {"engaged_at": "now"})
+    spawns = []
+
+    def fake_spawn(task, workspace, board=None):
+        spawns.append(task.id)
+        return 42
+
+    with kb.connect() as conn:
+        ready = kb.create_task(conn, title="ready", assignee="alice", unattended_safe=True)
+        review = kb.create_task(conn, title="review", assignee="alice")
+        _set_task_status(conn, review, "review")
+        result = kb.dispatch_once(conn, spawn_fn=fake_spawn, max_spawn=1)
+
+    assert ready in spawns
+    assert review not in spawns
+    with kb.connect() as conn:
+        assert kb.get_task(conn, review).status == "review"
+
+
+def test_dispatch_unreadable_afk_state_fails_closed(kanban_home, all_assignees_spawnable, monkeypatch):
+    @contextmanager
+    def unreadable_state():
+        raise afk.AfkStateError("unreadable")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(afk, "locked_state", unreadable_state)
+    spawns = []
+
+    with kb.connect() as conn:
+        task = kb.create_task(conn, title="must wait", assignee="alice", unattended_safe=False)
+        result = kb.dispatch_once(conn, spawn_fn=lambda *args, **kwargs: spawns.append(task))
+        assert task in result.skipped_unattended
+        assert kb.get_task(conn, task).status == "ready"
+    assert spawns == []
+
+
+def test_dispatch_afk_transition_after_claim_rolls_back_without_spawn(
+    kanban_home, all_assignees_spawnable, monkeypatch,
+):
+    calls = 0
+
+    @contextmanager
+    def cleanup_fails_after_claim():
+        nonlocal calls
+        calls += 1
+        yield None
+        if calls == 2:
+            raise afk.AfkStateError("AFK lock cleanup failed")
+
+    monkeypatch.setattr(afk, "locked_state", cleanup_fails_after_claim)
+    spawns = []
+
+    with kb.connect() as conn:
+        task = kb.create_task(conn, title="race", assignee="alice")
+        result = kb.dispatch_once(conn, spawn_fn=lambda *args, **kwargs: spawns.append(task))
+        stored = kb.get_task(conn, task)
+
+    assert task in result.skipped_unattended
+    assert stored.status == "ready"
+    assert stored.claim_lock is None
+    assert spawns == []
 
 # Review column dispatch
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -18,6 +18,7 @@ from hermes_cli.plugins import (
     PluginManager,
     PluginManifest,
     _dispatch_pre_tool_call_hooks,
+    final_pre_tool_call_authorization,
     get_plugin_command_handler,
     get_plugin_commands,
     get_pre_tool_call_block_message,
@@ -33,6 +34,17 @@ from hermes_cli.middleware import (
     apply_tool_request_middleware,
     run_tool_execution_middleware,
 )
+
+
+class _locked_afk_state:
+    def __init__(self, value):
+        self.value = value
+
+    def __enter__(self):
+        return self.value
+
+    def __exit__(self, *_args):
+        return False
 
 
 # ── Helpers ────────────────────────────────────────────────────────────────
@@ -1484,6 +1496,16 @@ class TestPreToolCallModify:
             "write_file", {"path": "/original"}
         )
         assert modified == {"path": "/real"}
+
+
+def test_final_plugin_authorization_blocks_only_approved_directive(monkeypatch):
+    monkeypatch.setattr("agent.afk.locked_state", lambda: _locked_afk_state({"engaged_at": "now"}))
+    assert final_pre_tool_call_authorization("write_file", approval_required=True) is not None
+
+
+def test_final_plugin_authorization_leaves_safe_tool_alone(monkeypatch):
+    monkeypatch.setattr("agent.afk.locked_state", lambda: _locked_afk_state({"engaged_at": "now"}))
+    assert final_pre_tool_call_authorization("read_file", approval_required=False) is None
 
 
 class TestGetPreVerifyContinueMessage:

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -116,6 +116,15 @@ def test_create_task_appears_on_board(client):
     assert "researcher" in data["assignees"]
 
 
+def test_create_task_passes_unattended_safe_to_db(client):
+    response = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "safe dashboard task", "assignee": "researcher", "unattended_safe": True},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["task"]["unattended_safe"] is True
+
+
 def test_patch_board_sets_project_directory(client, tmp_path):
     """Board-level default_workdir must be editable after creation."""
     kb.create_board("late-config")
@@ -1228,5 +1237,4 @@ def test_specify_happy_path(client, monkeypatch):
 # ---------------------------------------------------------------------------
 # Final result visibility for Done cards
 # ---------------------------------------------------------------------------
-
 

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -10,6 +10,7 @@ from unittest.mock import patch as mock_patch
 import pytest
 
 import tools.approval as approval_module
+from agent import afk
 from hermes_constants import get_hermes_home
 from tools.approval import (
     _get_approval_mode,
@@ -35,10 +36,317 @@ class TestApprovalModeParsing:
         assert _normalize_approval_mode("") == "manual"
         assert _normalize_approval_mode("auto") == "manual"
 
-
     def test_config_bool_false_maps_to_off(self):
         with mock_patch("hermes_cli.config.load_config_readonly", return_value={"approvals": {"mode": False}}):
             assert _get_approval_mode() == "off"
+
+
+def test_afk_blocks_dangerous_command_even_when_yolo_is_enabled(monkeypatch):
+    monkeypatch.setattr(afk, "locked_state", lambda: _afk_snapshot({"engaged_at": "now"}))
+    monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", True)
+    result = approval_module.check_dangerous_command("rm -rf /tmp/stuff", "local")
+    assert result["approved"] is False
+    assert result["afk_blocked"] is True
+
+
+def test_afk_blocks_tirith_only_warning_even_when_yolo_is_enabled(monkeypatch):
+    monkeypatch.setattr(afk, "locked_state", lambda: _afk_snapshot({"engaged_at": "now"}))
+    monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", True)
+    monkeypatch.setattr(
+        "tools.tirith_security.check_command_security",
+        lambda _command: {
+            "action": "warn",
+            "findings": [{"rule_id": "homograph", "title": "lookalike URL"}],
+            "summary": "lookalike URL",
+        },
+    )
+    result = approval_module.check_all_command_guards("curl https://example.test", "local")
+    assert result["approved"] is False
+    assert result["afk_blocked"] is True
+
+
+def test_afk_off_preserves_yolo_for_combined_guard(monkeypatch):
+    monkeypatch.setattr(afk, "locked_state", lambda: _afk_snapshot(None))
+    monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", True)
+    monkeypatch.setattr(
+        "tools.tirith_security.check_command_security",
+        lambda _command: {"action": "allow", "findings": [], "summary": ""},
+    )
+
+    result = approval_module.check_all_command_guards("python -c 'print(1)'", "local")
+
+    assert result["approved"] is True
+
+
+def test_afk_approval_probe_reads_state_inside_locked_state(monkeypatch):
+    class LockedState:
+        def __enter__(self):
+            return {"engaged_at": "now"}
+
+        def __exit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(afk, "locked_state", lambda: LockedState())
+    monkeypatch.setattr(
+        afk,
+        "get_state",
+        lambda: pytest.fail("approval probe used an unlocked AFK snapshot"),
+    )
+
+    assert approval_module.afk_approval_blocked() is not None
+
+
+class _afk_snapshot:
+    def __init__(self, value):
+        self.value = value
+
+    def __enter__(self):
+        return self.value
+
+    def __exit__(self, *_args):
+        return False
+
+
+def test_final_terminal_guard_blocks_tirith_only_after_force_decision(monkeypatch):
+    monkeypatch.setattr(afk, "locked_state", lambda: _afk_snapshot({"engaged_at": "now"}))
+    monkeypatch.setattr(
+        "tools.tirith_security.check_command_security",
+        lambda _command: {"action": "warn", "findings": [], "summary": "warning"},
+    )
+    blocked = approval_module._afk_blocks_combined_command("curl https://example.test")
+    assert blocked is not None
+
+
+@pytest.mark.parametrize("value", [None, {"ok": True}])
+def test_run_with_afk_grant_preserves_successful_result_on_cleanup_failure(
+    monkeypatch, caplog, value
+):
+    calls = []
+
+    class CleanupFailure:
+        def __enter__(self):
+            return None
+
+        def __exit__(self, *_args):
+            raise RuntimeError("AFK cleanup failed")
+
+    monkeypatch.setattr(afk, "locked_state", lambda: CleanupFailure())
+
+    with caplog.at_level("WARNING"):
+        result = approval_module.run_with_afk_grant(
+            lambda: calls.append("invoked") or value,
+            command="printf safe",
+        )
+
+    assert result == (True, value)
+    assert calls == ["invoked"]
+    assert "AFK cleanup failed" in caplog.text
+
+
+def test_run_with_afk_grant_keeps_body_exception_authoritative(monkeypatch):
+    cleanup_args = []
+
+    class Context:
+        def __enter__(self):
+            return None
+
+        def __exit__(self, *args):
+            cleanup_args.append(args)
+            raise RuntimeError("cleanup failed")
+
+    monkeypatch.setattr(afk, "locked_state", lambda: Context())
+    with pytest.raises(ValueError, match="body failed"):
+        approval_module.run_with_afk_grant(
+            lambda: (_ for _ in ()).throw(ValueError("body failed")),
+            command="printf safe",
+        )
+
+    assert cleanup_args[0][0] is ValueError
+
+
+def test_run_with_afk_grant_blocks_before_invocation_when_afk_read_fails(monkeypatch):
+    calls = []
+
+    class ReadFailure:
+        def __enter__(self):
+            raise OSError("AFK read failed")
+
+    monkeypatch.setattr(afk, "locked_state", lambda: ReadFailure())
+
+    assert approval_module.run_with_afk_grant(
+        lambda: calls.append("invoked"), approval_required=True
+    ) == (
+        False,
+        "BLOCKED: AFK state could not be verified; approval is unavailable.",
+    )
+    assert calls == []
+
+
+def test_afk_approval_mutation_yields_once_and_preserves_body_exception(monkeypatch):
+    cleanup_args = []
+
+    class Context:
+        def __enter__(self):
+            return None
+
+        def __exit__(self, *args):
+            cleanup_args.append(args)
+            return False
+
+    monkeypatch.setattr(afk, "locked_state", lambda: Context())
+
+    with pytest.raises(ValueError, match="body failed"):
+        with approval_module.afk_approval_mutation() as allowed:
+            assert allowed is True
+            raise ValueError("body failed")
+
+    assert cleanup_args[0][0] is ValueError
+
+
+def test_commit_approval_choices_does_not_mutate_caches_when_persist_fails(monkeypatch):
+    session = "transactional-session"
+    approval_module._session_approved.clear()
+    approval_module._permanent_approved.clear()
+    approval_module._session_approved[session] = {"existing-session"}
+    approval_module._permanent_approved.add("existing-permanent")
+    before_session = {key: set(value) for key, value in approval_module._session_approved.items()}
+    before_permanent = set(approval_module._permanent_approved)
+
+    monkeypatch.setattr(
+        approval_module,
+        "save_permanent_allowlist",
+        lambda _snapshot: (_ for _ in ()).throw(OSError("disk full")),
+    )
+
+    with pytest.raises(OSError, match="disk full"):
+        approval_module.commit_approval_choices(
+            session, ["new-session"], ["new-permanent"]
+        )
+
+    assert approval_module._session_approved == before_session
+    assert approval_module._permanent_approved == before_permanent
+
+
+def test_commit_approval_choices_persists_before_cache_commit(monkeypatch):
+    session = "ordered-commit-session"
+    approval_module._session_approved.clear()
+    approval_module._permanent_approved.clear()
+    observed = []
+
+    def save(snapshot):
+        observed.append((set(snapshot), dict(approval_module._session_approved),
+                         set(approval_module._permanent_approved)))
+        return True
+
+    monkeypatch.setattr(approval_module, "save_permanent_allowlist", save)
+
+    assert approval_module.commit_approval_choices(
+        session, ["session-key"], ["permanent-key"]
+    ) is True
+    assert observed == [({"permanent-key"}, {}, set())]
+    assert approval_module._session_approved == {session: {"session-key"}}
+    assert approval_module._permanent_approved == {"permanent-key"}
+
+
+def test_cancel_gateway_approvals_denies_and_drops_entries_without_history():
+    session = "cancel-session"
+    approval_module._gateway_queues.clear()
+    entry = approval_module._ApprovalEntry({
+        "session_key": session,
+        "command": "sensitive payload",
+    })
+    approval_module._gateway_queues[session] = [entry]
+
+    assert approval_module.cancel_gateway_approvals_for_afk() == 1
+    assert approval_module._gateway_queues == {}
+    assert entry.result == "deny"
+    assert entry.event.is_set()
+    assert not hasattr(approval_module, "_gateway_history")
+
+
+def test_gateway_resolution_and_enqueue_are_afk_ordered_and_late_approval_denied(monkeypatch):
+    session = "lock-order-session"
+    approval_module._gateway_queues.clear()
+    approval_module._gateway_queues[session] = [
+        approval_module._ApprovalEntry({
+            "session_key": session,
+            "command": "rm -rf old",
+            "pattern_key": "dangerous",
+            "pattern_keys": ["dangerous"],
+        })
+    ]
+    afk_mutex = threading.Lock()
+    enqueue_entered = threading.Event()
+    release_enqueue = threading.Event()
+    resolver_called = threading.Event()
+    engaged = threading.Event()
+    calls = 0
+    calls_lock = threading.Lock()
+
+    class Context:
+        def __enter__(self):
+            nonlocal calls
+            afk_mutex.acquire()
+            with calls_lock:
+                calls += 1
+                first = calls == 1
+            if first:
+                enqueue_entered.set()
+                release_enqueue.wait(timeout=2)
+            else:
+                resolver_called.set()
+            return {"engaged_at": "now"} if engaged.is_set() else None
+
+        def __exit__(self, *_args):
+            afk_mutex.release()
+            return False
+
+    monkeypatch.setattr(afk, "locked_state", lambda: Context())
+    monkeypatch.setattr(
+        approval_module,
+        "afk_approval_blocked",
+        lambda: "BLOCKED: machine-global AFK is engaged; human approval is unavailable.",
+    )
+    enqueue_result = {}
+    enqueue_thread = threading.Thread(
+        target=lambda: enqueue_result.update(
+            approval_module._await_gateway_decision(
+                session,
+                lambda _data: None,
+                {
+                    "command": "rm -rf new",
+                    "description": "desc",
+                    "pattern_key": "dangerous",
+                    "pattern_keys": ["dangerous"],
+                },
+            )
+        ),
+        daemon=True,
+    )
+    enqueue_thread.start()
+    assert enqueue_entered.wait(timeout=2)
+
+    resolve_result = {}
+    resolver_thread = threading.Thread(
+        target=lambda: resolve_result.update(
+            count=approval_module.resolve_gateway_approval(session, "once")
+        ),
+        daemon=True,
+    )
+    resolver_thread.start()
+    # The resolver must be attempting the same AFK boundary while the
+    # enqueuer owns it; this is the deterministic inversion setup.
+    time.sleep(0.02)
+    engaged.set()
+    release_enqueue.set()
+    enqueue_thread.join(timeout=2)
+    resolver_thread.join(timeout=2)
+
+    assert not enqueue_thread.is_alive()
+    assert not resolver_thread.is_alive()
+    assert resolve_result == {"count": 1}
+    assert enqueue_result["choice"] == "deny"
+    assert approval_module.resolve_gateway_approval(session, "once") == 0
 
 
 class TestSmartApproval:

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -90,6 +90,20 @@ class TestRegistration:
 
 class TestDispatch:
 
+    def test_cua_rechecks_afk_before_backend_dispatch(self, monkeypatch, noop_backend):
+        from tools import computer_use as cu
+
+        monkeypatch.setattr(cu.tool, "_request_approval", lambda *a: None)
+        monkeypatch.setattr(
+            "tools.approval.run_with_afk_grant",
+            lambda *a, **k: (False, "blocked"),
+        )
+        called = []
+        monkeypatch.setattr(cu.tool, "_dispatch", lambda *a: called.append(a))
+        out = cu.tool.handle_computer_use({"action": "click", "element": 1})
+        assert json.loads(out)["code"] == "afk_approval_blocked"
+        assert called == []
+
     def test_unknown_action_returns_error(self):
         from tools.computer_use.tool import handle_computer_use
         out = handle_computer_use({"action": "nope"})

--- a/tests/tools/test_execute_code_approval_cluster.py
+++ b/tests/tools/test_execute_code_approval_cluster.py
@@ -419,6 +419,23 @@ def test_terminal_serializes_smart_deny_pending_capabilities(monkeypatch):
     assert payload["allow_permanent"] is False
 
 
+def test_terminal_public_safe_command_reaches_final_approval_note_path(monkeypatch):
+    """A successful public terminal call must not reference a missing detector result."""
+    from tools import terminal_tool as terminal_module
+
+    monkeypatch.setattr(
+        terminal_module,
+        "_check_all_guards",
+        lambda *_args, **_kwargs: {"approved": True},
+    )
+    monkeypatch.setattr(terminal_module, "_afk_blocks_combined_command", lambda *_: None)
+
+    payload = json.loads(terminal_module.terminal_tool(command="echo afk-regression"))
+
+    assert payload["exit_code"] == 0
+    assert "afk-regression" in payload["output"]
+
+
 def test_guard_session_yolo_bypasses(gw_session):
     A.enable_session_yolo(gw_session)
     try:

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -1255,6 +1255,20 @@ def test_command_dispatch_queue_sends_message(server):
     assert result["message"] == "tell me about quantum computing"
 
 
+def test_command_dispatch_afk_uses_shared_handler(server, monkeypatch):
+    from agent import afk
+
+    monkeypatch.setattr(afk, "handle_command", lambda arg: f"handled:{arg}")
+    resp = server.handle_request({
+        "id": "afk-1",
+        "method": "command.dispatch",
+        "params": {"name": "afk", "arg": "status", "session_id": ""},
+    })
+
+    assert "error" not in resp
+    assert resp["result"]["output"] == "handled:status"
+
+
 def test_skills_manage_search_uses_tools_hub_sources(server):
     result = type("Result", (), {
         "description": "Build better terminal demos",

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2576,6 +2576,7 @@ _pending: dict[str, dict] = {}
 _session_approved: dict[str, set] = {}
 _session_yolo: set[str] = set()
 _permanent_approved: set = set()
+_NOT_INVOKED = object()
 
 
 # =========================================================================
@@ -2837,6 +2838,150 @@ _gateway_queues: dict[str, list] = {}        # session_key → [_ApprovalEntry, 
 _gateway_notify_cbs: dict[str, object] = {}  # session_key → callable(approval_data)
 
 
+def cancel_gateway_approvals_for_afk() -> int:
+    """Terminally cancel pending human approvals when AFK engages."""
+    with _lock:
+        entries = [entry for queue in _gateway_queues.values() for entry in queue]
+        _gateway_queues.clear()
+        reason = (
+            "BLOCKED: machine-global AFK is engaged; human approval is unavailable."
+        )
+        for entry in entries:
+            entry.result = "deny"
+            entry.reason = reason
+    for entry in entries:
+        entry.event.set()
+    return len(entries)
+
+
+def afk_approval_blocked() -> str | None:
+    """Return a typed block reason when AFK forbids a human approval action."""
+    try:
+        from agent import afk
+        with afk.locked_state() as state:
+            if state is None:
+                return None
+            if isinstance(state, dict) and not state.get("unverifiable"):
+                return "BLOCKED: machine-global AFK is engaged; human approval is unavailable."
+            return "BLOCKED: AFK state could not be verified; approval is unavailable."
+    except Exception:
+        return "BLOCKED: AFK state could not be verified; approval is unavailable."
+
+
+def _afk_blocks_combined_command(command: str) -> str | None:
+    """Block only approval-dependent commands while AFK is engaged.
+
+    This probe deliberately runs before YOLO/off/cache shortcuts.  It does
+    not make safe commands depend on AFK, but it does include Tirith-only
+    findings in the same decision as dangerous-command detection.
+    """
+    try:
+        from agent import afk
+        with afk.locked_state() as state:
+            if state is None:
+                return None
+
+            dangerous, _pattern_key, _description = detect_dangerous_command(command)
+            tirith_warning = False
+            try:
+                from tools.tirith_security import check_command_security
+
+                tirith_warning = check_command_security(command).get("action") in {
+                    "block", "warn",
+                }
+            except ImportError:
+                # An explicitly fail-closed Tirith configuration is itself an
+                # approval-dependent warning. The normal combined flow owns the
+                # detailed message; this probe only decides whether AFK applies.
+                try:
+                    from hermes_cli.config import load_config_readonly
+
+                    security = (load_config_readonly() or {}).get("security") or {}
+                    tirith_warning = bool(
+                        security.get("tirith_enabled", True)
+                        and not security.get("tirith_fail_open", True)
+                    )
+                except Exception:
+                    tirith_warning = False
+            except Exception:
+                tirith_warning = True
+
+            if dangerous or tirith_warning:
+                if state.get("unverifiable"):
+                    return "BLOCKED: AFK state could not be verified; approval is unavailable."
+                return "BLOCKED: machine-global AFK is engaged; human approval is unavailable."
+            return None
+    except Exception:
+        return "BLOCKED: AFK state could not be verified; approval is unavailable."
+
+
+def run_with_afk_grant(invoke, *, command: str | None = None,
+                       approval_required: bool = False):
+    """Run one side-effect initiation under the AFK transaction lock.
+
+    The final approval grant is the start boundary: once granted while this
+    lock is held immediately before invocation, a later AFK transition sees
+    that invocation as existing work.  The lock covers only this initiation,
+    never the foreground command or network/tool wait that follows it.
+    """
+    blocked = "BLOCKED: AFK state could not be verified; approval is unavailable."
+    try:
+        from agent import afk
+        context = afk.locked_state()
+        state = context.__enter__()
+    except BaseException:
+        return False, blocked
+
+    result = _NOT_INVOKED
+    body_exc = None
+    try:
+        if state is not None and (
+            approval_required
+            or _command_has_approval_finding(command or "")
+        ):
+            blocked = (
+                "BLOCKED: AFK state could not be verified; approval is unavailable."
+                if state.get("unverifiable")
+                else "BLOCKED: machine-global AFK is engaged; human approval is unavailable."
+            )
+            return False, blocked
+        result = invoke()
+    except BaseException as exc:
+        body_exc = exc
+        raise
+    finally:
+        try:
+            context.__exit__(*sys.exc_info())
+        except BaseException as cleanup_exc:
+            if body_exc is not None:
+                logger.warning("AFK cleanup failed after invocation: %s", cleanup_exc)
+            elif result is not _NOT_INVOKED:
+                logger.warning("AFK cleanup failed after successful invocation: %s", cleanup_exc)
+            else:
+                logger.warning("AFK cleanup failed before invocation: %s", cleanup_exc)
+                # A return from the try block is already pending. Raising here
+                # would turn a fail-closed pre-invocation result into a caller
+                # error, so preserve the blocked outcome below.
+                result = _NOT_INVOKED
+
+    if result is _NOT_INVOKED:
+        return False, blocked
+    return True, result
+
+
+def _command_has_approval_finding(command: str) -> bool:
+    dangerous, _key, _description = detect_dangerous_command(command)
+    if dangerous:
+        return True
+    try:
+        from tools.tirith_security import check_command_security
+        return check_command_security(command).get("action") in {"block", "warn"}
+    except ImportError:
+        return False
+    except Exception:
+        return True
+
+
 def register_gateway_notify(session_key: str, cb) -> None:
     """Register a per-session callback for sending approval requests to the user.
 
@@ -2879,27 +3024,62 @@ def resolve_gateway_approval(session_key: str, choice: str,
 
     Returns the number of approvals resolved (0 means nothing was pending).
     """
-    with _lock:
-        queue = _gateway_queues.get(session_key)
-        if not queue:
-            return 0
-        if request_id:
-            targets = [entry for entry in queue if entry.data.get("request_id") == request_id]
-            if not targets:
-                return 0
-            queue[:] = [entry for entry in queue if entry not in targets]
-        elif resolve_all:
-            targets = list(queue)
-            queue.clear()
-        else:
-            targets = [queue.pop(0)]
-        if not queue:
-            _gateway_queues.pop(session_key, None)
+    targets = []
+    blocked = None
+
+    def _take_targets():
+        with _lock:
+            queue = _gateway_queues.get(session_key)
+            if not queue:
+                return []
+            if request_id:
+                selected = [
+                    entry for entry in queue
+                    if entry.data.get("request_id") == request_id
+                ]
+                if not selected:
+                    return []
+                queue[:] = [entry for entry in queue if entry not in selected]
+            elif resolve_all:
+                selected = list(queue)
+                queue.clear()
+            else:
+                selected = [queue.pop(0)]
+            if not queue:
+                _gateway_queues.pop(session_key, None)
+            return selected
+
+    def _finish_targets(selected, block_reason):
+        with _lock:
+            for entry in selected:
+                entry.result = "deny" if block_reason else choice
+                if block_reason:
+                    entry.reason = block_reason
+                elif reason:
+                    entry.reason = reason
+
+    try:
+        from agent import afk
+        # This is the linearization boundary for a gateway approval.  The
+        # AFK lock must be acquired before _lock, matching enqueue/waiters.
+        with afk.locked_state() as state:
+            if state is not None:
+                blocked = (
+                    "BLOCKED: AFK state could not be verified; approval is unavailable."
+                    if state.get("unverifiable")
+                    else "BLOCKED: machine-global AFK is engaged; human approval is unavailable."
+                )
+            targets = _take_targets()
+            _finish_targets(targets, blocked)
+    except BaseException:
+        # A failed AFK read/lock or final root validation is fail-closed.  The
+        # queue still has to be drained, but no AFK lock is held here.
+        blocked = "BLOCKED: AFK state could not be verified; approval is unavailable."
+        if not targets:
+            targets = _take_targets()
+        _finish_targets(targets, blocked)
 
     for entry in targets:
-        entry.result = choice
-        if reason:
-            entry.reason = reason
         entry.event.set()
     return len(targets)
 
@@ -2950,8 +3130,12 @@ def submit_pending(session_key: str, approval: dict):
 
 def approve_session(session_key: str, pattern_key: str):
     """Approve a pattern for this session only."""
-    with _lock:
-        _session_approved.setdefault(session_key, set()).add(pattern_key)
+    with afk_approval_mutation() as allowed:
+        if not allowed:
+            return False
+        with _lock:
+            _session_approved.setdefault(session_key, set()).add(pattern_key)
+    return True
 
 
 def _release_permission_mode_dependents(session_key: str) -> None:
@@ -3055,8 +3239,61 @@ def is_approved(session_key: str, pattern_key: str) -> bool:
 
 def approve_permanent(pattern_key: str):
     """Add a pattern to the permanent allowlist."""
-    with _lock:
-        _permanent_approved.add(pattern_key)
+    with afk_approval_mutation() as allowed:
+        if not allowed:
+            return False
+        with _lock:
+            _permanent_approved.add(pattern_key)
+    return True
+
+
+@contextlib.contextmanager
+def afk_approval_mutation():
+    """Guard a short-lived approval/cache mutation with the AFK lock."""
+    context = None
+    try:
+        from agent import afk
+        context = afk.locked_state()
+        state = context.__enter__()
+    except Exception:
+        yield False
+        return
+
+    body_info = None
+    try:
+        yield state is None
+    finally:
+        body_info = sys.exc_info()
+        try:
+            context.__exit__(*body_info)
+        except BaseException:
+            if body_info[0] is None:
+                raise
+            logger.warning(
+                "AFK approval mutation cleanup failed after body exception",
+                exc_info=True,
+            )
+
+
+def commit_approval_choices(session_key: str, pattern_keys: list[str],
+                            permanent_keys: list[str] | None = None) -> bool:
+    """Atomically commit short-lived approval/cache mutations while AFK-off."""
+    permanent_keys = permanent_keys or []
+    with afk_approval_mutation() as allowed:
+        if not allowed:
+            return False
+        with _lock:
+            snapshot = set(_permanent_approved)
+            snapshot.update(permanent_keys)
+        if permanent_keys:
+            if save_permanent_allowlist(snapshot) is False:
+                return False
+        with _lock:
+            if pattern_keys:
+                _session_approved.setdefault(session_key, set()).update(pattern_keys)
+            if permanent_keys:
+                _permanent_approved.update(permanent_keys)
+        return True
 
 
 def load_permanent(patterns: set):
@@ -3194,15 +3431,17 @@ def load_permanent_allowlist() -> set:
         return set()
 
 
-def save_permanent_allowlist(patterns: set):
+def save_permanent_allowlist(patterns: set) -> bool:
     """Save permanently allowed command patterns to config."""
     try:
         from hermes_cli.config import load_config, save_config
         config = load_config()
         config["command_allowlist"] = list(patterns)
         save_config(config)
+        return True
     except Exception as e:
         logger.warning("Could not save allowlist: %s", e)
+        return False
 
 
 # =========================================================================
@@ -3812,6 +4051,9 @@ def _run_approval_gate(
         ``{"approved": bool, "message": str|None, ...}`` — shape shared with
         ``check_dangerous_command`` so all callers handle it uniformly.
     """
+    blocked = afk_approval_blocked()
+    if blocked:
+        return {"approved": False, "message": blocked, "afk_blocked": True}
     # --yolo bypasses all approval prompts (session- or process-scoped).
     # Hardline blocks are handled by the caller BEFORE this gate, so yolo
     # here only skips the recoverable approval layer.
@@ -3977,11 +4219,11 @@ def _run_approval_gate(
                 }
 
             if choice == "session":
-                approve_session(session_key, pattern_key)
+                if not commit_approval_choices(session_key, [pattern_key]):
+                    return {"approved": False, "message": "BLOCKED: approval unavailable", "afk_blocked": True}
             elif choice == "always":
-                approve_session(session_key, pattern_key)
-                approve_permanent(pattern_key)
-                save_permanent_allowlist(_permanent_approved)
+                if not commit_approval_choices(session_key, [pattern_key], [pattern_key]):
+                    return {"approved": False, "message": "BLOCKED: approval unavailable", "afk_blocked": True}
             return {"approved": True, "message": None}
 
         # No notify callback: interactive CLI with a panel callback should
@@ -4063,11 +4305,11 @@ def _run_approval_gate(
         }
 
     if choice == "session":
-        approve_session(session_key, pattern_key)
+        if not commit_approval_choices(session_key, [pattern_key]):
+            return {"approved": False, "message": "BLOCKED: approval unavailable", "afk_blocked": True}
     elif choice == "always":
-        approve_session(session_key, pattern_key)
-        approve_permanent(pattern_key)
-        save_permanent_allowlist(_permanent_approved)
+        if not commit_approval_choices(session_key, [pattern_key], [pattern_key]):
+            return {"approved": False, "message": "BLOCKED: approval unavailable", "afk_blocked": True}
 
     return {"approved": True, "message": None}
 
@@ -4126,6 +4368,12 @@ def check_dangerous_command(command: str, env_type: str,
                        deny_pattern, command[:200])
         return _user_deny_block_result(deny_pattern)
 
+    is_dangerous, pattern_key, description = detect_dangerous_command(command)
+    if is_dangerous:
+        blocked = afk_approval_blocked()
+        if blocked:
+            return {"approved": False, "message": blocked, "afk_blocked": True}
+
     # --yolo: bypass all approval prompts. Gateway /yolo is session-scoped;
     # CLI --yolo remains process-scoped via the env var for local use.
     if _YOLO_MODE_FROZEN or is_current_session_yolo_enabled():
@@ -4134,7 +4382,6 @@ def check_dangerous_command(command: str, env_type: str,
     if _command_matches_permanent_allowlist(command):
         return {"approved": True, "message": None}
 
-    is_dangerous, pattern_key, description = detect_dangerous_command(command)
     if not is_dangerous:
         return {"approved": True, "message": None}
 
@@ -4497,6 +4744,10 @@ def _await_coalesced_leader(session_key: str, leader, approval_data: dict,
     resolved = False
     with human_wait_window(session_key):
         while True:
+            if afk_approval_blocked():
+                choice = "deny"
+                resolved = True
+                break
             if is_interrupted():
                 logger.info(
                     "Coalesced approval wait interrupted by user signal — "
@@ -4602,8 +4853,18 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
         # Leader resolved "once" — fall through to a fresh prompt below.
 
     entry = _ApprovalEntry(approval_data)
-    with _lock:
-        _gateway_queues.setdefault(session_key, []).append(entry)
+    entry.data["session_key"] = session_key
+    try:
+        from agent import afk
+        with afk.locked_state() as state:
+            if state is not None:
+                return {"resolved": True, "choice": "deny",
+                        "reason": afk_approval_blocked()}
+            with _lock:
+                _gateway_queues.setdefault(session_key, []).append(entry)
+    except Exception:
+        return {"resolved": True, "choice": "deny",
+                "reason": "BLOCKED: AFK state could not be verified; approval is unavailable."}
 
     def _drop_entry() -> None:
         with _lock:
@@ -4665,6 +4926,11 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     # excludes it (#79719).
     with human_wait_window(session_key):
         while True:
+            if afk_approval_blocked():
+                entry.result = "deny"
+                entry.reason = "BLOCKED: machine-global AFK is engaged; human approval is unavailable."
+                resolved = True
+                break
             # Respect interrupt signals (e.g. /stop, /new, or an inactivity
             # timeout from the gateway) so a pending approval doesn't keep the
             # session wedged on threading.Event.wait() until the 5-minute approval
@@ -4709,6 +4975,12 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
 
     _drop_entry()
 
+    # Final check for the waiter: AFK may have engaged after the gateway
+    # resolver committed a positive choice but before this thread resumes.
+    blocked = afk_approval_blocked()
+    if blocked:
+        entry.result = "deny"
+        entry.reason = blocked
     choice = entry.result
     # Normalize outcome for the post hook. Unresolved (timeout) and None both
     # mean the user never responded; report that explicitly so plugins can
@@ -4774,6 +5046,10 @@ def check_all_command_guards(command: str, env_type: str,
         logger.warning("User deny rule %r blocked command: %s",
                        deny_pattern, command[:200])
         return _user_deny_block_result(deny_pattern)
+
+    afk_block = _afk_blocks_combined_command(command)
+    if afk_block:
+        return {"approved": False, "message": afk_block, "afk_blocked": True}
 
     # --yolo or approvals.mode=off: bypass all approval prompts.
     # Gateway /yolo is session-scoped; CLI --yolo remains process-scoped.
@@ -5176,17 +5452,12 @@ def check_all_command_guards(command: str, env_type: str,
                     "description": combined_desc,
                     "outcome": "denied",
                     "user_consent": False,
-                }
+            }
             if not smart_denied_for_owner:
-                for key, _, is_tirith in warnings:
-                    if transport_choice == "session" or (
-                        transport_choice == "always" and is_tirith
-                    ):
-                        approve_session(session_key, key)
-                    elif transport_choice == "always":
-                        approve_session(session_key, key)
-                        approve_permanent(key)
-                        save_permanent_allowlist(_permanent_approved)
+                session_keys = [key for key, _, is_tirith in warnings if transport_choice == "session" or (transport_choice == "always" and is_tirith)]
+                permanent_keys = [key for key, _, is_tirith in warnings if transport_choice == "always" and not is_tirith]
+                if not commit_approval_choices(session_key, session_keys, permanent_keys):
+                    return {"approved": False, "message": "BLOCKED: approval unavailable", "afk_blocked": True}
             _reset_denials(session_key)
             return {
                 "approved": True,
@@ -5294,13 +5565,10 @@ def check_all_command_guards(command: str, env_type: str,
             # older client returns "session" or "always". Manual and ESCALATE
             # choices retain their existing persistence semantics.
             if not smart_denied_for_owner:
-                for key, _, is_tirith in warnings:
-                    if choice == "session" or (choice == "always" and is_tirith):
-                        approve_session(session_key, key)
-                    elif choice == "always":
-                        approve_session(session_key, key)
-                        approve_permanent(key)
-                        save_permanent_allowlist(_permanent_approved)
+                session_keys = [key for key, _, is_tirith in warnings if choice == "session" or (choice == "always" and is_tirith)]
+                permanent_keys = [key for key, _, is_tirith in warnings if choice == "always" and not is_tirith]
+                if not commit_approval_choices(session_key, session_keys, permanent_keys):
+                    return {"approved": False, "message": "BLOCKED: approval unavailable", "afk_blocked": True}
 
             # A human approval (including an ESCALATE-then-approve or a
             # smart-DENY owner override) resets the consecutive-denial tally.
@@ -5421,15 +5689,10 @@ def check_all_command_guards(command: str, env_type: str,
     # Smart-DENY owner overrides are one-operation scoped. Preserve existing
     # persistence for manual mode and smart ESCALATE.
     if not smart_denied_for_owner:
-        for key, _, is_tirith in warnings:
-            if choice == "session" or (choice == "always" and is_tirith):
-                # tirith: session only (no permanent broad allowlisting)
-                approve_session(session_key, key)
-            elif choice == "always":
-                # dangerous patterns: permanent allowed
-                approve_session(session_key, key)
-                approve_permanent(key)
-                save_permanent_allowlist(_permanent_approved)
+        session_keys = [key for key, _, is_tirith in warnings if choice == "session" or (choice == "always" and is_tirith)]
+        permanent_keys = [key for key, _, is_tirith in warnings if choice == "always" and not is_tirith]
+        if not commit_approval_choices(session_key, session_keys, permanent_keys):
+            return {"approved": False, "message": "BLOCKED: approval unavailable", "afk_blocked": True}
 
     # A human approval resets the consecutive-denial tally.
     _reset_denials(session_key)
@@ -5462,6 +5725,10 @@ def check_execute_code_guard(code: str, env_type: str,
         "mutate files without passing through terminal command approval; "
         "approval is one-shot for this run."
     )
+
+    blocked = afk_approval_blocked()
+    if blocked:
+        return {"approved": False, "message": blocked, "afk_blocked": True}
 
     # Isolated backends already sandbox the child — matches the container skip
     # in check_all_command_guards / check_dangerous_command. Docker stops
@@ -5669,11 +5936,11 @@ def check_execute_code_guard(code: str, env_type: str,
                 }
             if not smart_denied_for_owner:
                 if choice == "session":
-                    approve_session(session_key, pattern_key)
+                    if not commit_approval_choices(session_key, [pattern_key]):
+                        return {"approved": False, "message": "BLOCKED: approval unavailable", "afk_blocked": True}
                 elif choice == "always":
-                    approve_session(session_key, pattern_key)
-                    approve_permanent(pattern_key)
-                    save_permanent_allowlist(_permanent_approved)
+                    if not commit_approval_choices(session_key, [pattern_key], [pattern_key]):
+                        return {"approved": False, "message": "BLOCKED: approval unavailable", "afk_blocked": True}
             _reset_denials(session_key)
             return {
                 "approved": True,
@@ -5764,11 +6031,11 @@ def check_execute_code_guard(code: str, env_type: str,
                 }
             if not smart_denied_for_owner:
                 if choice == "session":
-                    approve_session(session_key, pattern_key)
+                    if not commit_approval_choices(session_key, [pattern_key]):
+                        return {"approved": False, "message": "BLOCKED: approval unavailable", "afk_blocked": True}
                 elif choice == "always":
-                    approve_session(session_key, pattern_key)
-                    approve_permanent(pattern_key)
-                    save_permanent_allowlist(_permanent_approved)
+                    if not commit_approval_choices(session_key, [pattern_key], [pattern_key]):
+                        return {"approved": False, "message": "BLOCKED: approval unavailable", "afk_blocked": True}
             _reset_denials(session_key)
             return {
                 "approved": True,
@@ -5863,11 +6130,11 @@ def check_execute_code_guard(code: str, env_type: str,
     # decisions preserve their existing session/permanent behavior.
     if not smart_denied_for_owner:
         if choice == "session":
-            approve_session(session_key, pattern_key)
+            if not commit_approval_choices(session_key, [pattern_key]):
+                return {"approved": False, "message": "BLOCKED: approval unavailable", "afk_blocked": True}
         elif choice == "always":
-            approve_session(session_key, pattern_key)
-            approve_permanent(pattern_key)
-            save_permanent_allowlist(_permanent_approved)
+            if not commit_approval_choices(session_key, [pattern_key], [pattern_key]):
+                return {"approved": False, "message": "BLOCKED: approval unavailable", "afk_blocked": True}
     # choice == "once": no persistence — approval lasts this single call only.
 
     # A human approval resets the consecutive-denial tally.

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1760,16 +1760,27 @@ def execute_code(
             child_python=_child_python,
         )
 
-        proc = subprocess.Popen(
-            [_child_python, _script_path],
-            cwd=_child_cwd,
-            env=child_env,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            stdin=subprocess.DEVNULL,
-            start_new_session=True,
-            creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
+        from tools.approval import run_with_afk_grant
+        granted, proc = run_with_afk_grant(
+            lambda: subprocess.Popen(
+                [_child_python, _script_path],
+                cwd=_child_cwd,
+                env=child_env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                stdin=subprocess.DEVNULL,
+                start_new_session=True,
+                creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
+            ),
+            approval_required=True,
         )
+        if not granted:
+            return json.dumps({
+                "status": "error",
+                "error": proc,
+                "tool_calls_made": 0,
+                "duration_seconds": 0,
+            }, ensure_ascii=False)
 
         # --- Poll loop: watch for exit, timeout, and interrupt ---
         deadline = time.monotonic() + timeout

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -582,7 +582,19 @@ def handle_computer_use(args: Dict[str, Any], **kwargs) -> Any:
         with _backend_lock:
             call_lock = _backend_call_locks.setdefault(session_id, threading.RLock())
         with call_lock:
-            return _dispatch(backend, action, args)
+            approval_dependent = action in _DESTRUCTIVE_ACTIONS or args.get("bring_to_front") or (
+                action == "focus_app" and args.get("raise_window")
+            )
+            from tools.approval import run_with_afk_grant
+            granted, result = run_with_afk_grant(
+                lambda: _dispatch(backend, action, args),
+                approval_required=approval_dependent,
+            )
+            if not granted:
+                return json.dumps({
+                    "error": result, "code": "afk_approval_blocked",
+                })
+            return result
     except Exception as e:
         logger.exception("computer_use %s failed", action)
         return json.dumps({"error": f"{action} failed: {e}"})
@@ -601,6 +613,10 @@ def _request_approval(action: str, args: Dict[str, Any],
     operation. State is keyed on session_id so concurrent runs don't leak
     unlocks into one another.
     """
+    from tools.approval import afk_approval_blocked
+    blocked = afk_approval_blocked()
+    if blocked:
+        return json.dumps({"error": blocked, "code": "afk_approval_blocked"})
     is_foreground = args.get("delivery_mode") == "foreground"
     scope_key = (action, "foreground" if is_foreground else "background")
     with _approval_lock:
@@ -620,12 +636,25 @@ def _request_approval(action: str, args: Dict[str, Any],
         logger.warning("approval callback failed: %s", e)
         verdict = "deny"
     if verdict == "approve_once":
+        blocked = afk_approval_blocked()
+        if blocked:
+            return json.dumps({"error": blocked, "code": "afk_approval_blocked"})
         return None
     if verdict == "approve_session" or verdict == "always_approve":
-        with _approval_lock:
-            _always_allow.setdefault(session_id, set()).add(scope_key)
-            if verdict == "always_approve":
-                _session_auto_approve[session_id] = True
+        blocked = afk_approval_blocked()
+        if blocked:
+            return json.dumps({"error": blocked, "code": "afk_approval_blocked"})
+        from tools.approval import afk_approval_mutation
+        with afk_approval_mutation() as allowed:
+            if not allowed:
+                return json.dumps({
+                    "error": "BLOCKED: machine-global AFK is engaged; human approval is unavailable.",
+                    "code": "afk_approval_blocked",
+                })
+            with _approval_lock:
+                _always_allow.setdefault(session_id, set()).add(scope_key)
+                if verdict == "always_approve":
+                    _session_auto_approve[session_id] = True
         return None
     if verdict == "timeout":
         return json.dumps({

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -1451,6 +1451,7 @@ class BaseEnvironment(ABC):
         stdin_data: str | None = None,
         rewrite_compound_background: bool = True,
         bounded_capture: bool = False,
+        spawn_guard=None,
     ) -> dict:
         """Execute a command, return {"output": str, "returncode": int}.
 
@@ -1508,9 +1509,16 @@ class BaseEnvironment(ABC):
         def _spawn_and_wait() -> dict:
             if parent_activity_cb is not None:
                 set_activity_callback(parent_activity_cb)
-            spawned = self._run_bash(
+            spawn = lambda: self._run_bash(
                 wrapped, login=login, timeout=effective_timeout, stdin_data=effective_stdin
             )
+            if spawn_guard is None:
+                spawned = spawn()
+            else:
+                granted, spawned = spawn_guard(spawn)
+                if not granted:
+                    return {"output": "", "returncode": -1,
+                            "error": spawned, "afk_blocked": True}
             proc_holder.append(spawned)
             return self._wait_for_process(
                 spawned,

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1408,6 +1408,11 @@ def _handle_create(args: dict, **kw) -> str:
     goal_mode, goal_bool_error = _parse_bool_arg(args, "goal_mode")
     if goal_bool_error:
         return tool_error(goal_bool_error)
+    unattended_safe, unattended_bool_error = _parse_bool_arg(
+        args, "unattended_safe"
+    )
+    if unattended_bool_error:
+        return tool_error(unattended_bool_error)
     goal_max_turns = args.get("goal_max_turns")
     model_override = args.get("model")
     provider_override = args.get("provider")
@@ -1458,6 +1463,7 @@ def _handle_create(args: dict, **kw) -> str:
                 goal_max_turns=(
                     int(goal_max_turns) if goal_max_turns is not None else None
                 ),
+                unattended_safe=unattended_safe,
                 initial_status=str(initial_status),
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
                 session_id=session_id,
@@ -2219,6 +2225,14 @@ KANBAN_CREATE_SCHEMA = {
                     "If true, task lands in 'triage' instead of 'todo' "
                     "— a specifier profile is expected to flesh out "
                     "the body before work starts."
+                ),
+            },
+            "unattended_safe": {
+                "type": "boolean",
+                "description": (
+                    "Explicitly permit new dispatch while machine-global AFK "
+                    "is engaged. This does not grant approval authority and "
+                    "is never inherited by child tasks. Defaults to false."
                 ),
             },
             "idempotency_key": {

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -357,6 +357,9 @@ def _reset_cached_sudo_passwords() -> None:
 # Dangerous command detection + approval now consolidated in tools/approval.py
 from tools.approval import (
     check_all_command_guards as _check_all_guards_impl,
+    afk_approval_blocked as _afk_approval_blocked,
+    _afk_blocks_combined_command as _afk_blocks_combined_command,
+    run_with_afk_grant as _run_with_afk_grant,
 )
 
 
@@ -3233,6 +3236,7 @@ def terminal_tool(
         # Pre-exec security checks (tirith + dangerous command detection)
         # Skip check if force=True (user has confirmed they want to run it)
         approval_note = None
+        approval = {}
         # True when the user explicitly approved this run (or pre-confirmed via
         # force).  Drives the clean-interrupt-slate clear before env.execute so
         # an approved command can't be SIGINT-killed by a bit that landed during
@@ -3270,14 +3274,20 @@ def terminal_tool(
                     "error": approval.get("message", fallback_msg),
                     "status": "blocked"
                 }, ensure_ascii=False)
+
+        # Final authorization boundary: AFK may engage after a prompt or
+        # force/yolo decision but before the shell side effect.
+        approval_dependent = bool(
+            approval.get("user_approved") or approval.get("smart_approved")
+        )
+        if not force and approval.get("user_approved"):
             # Track whether approval was explicitly granted by the user
-            if approval.get("user_approved"):
-                desc = approval.get("description", "flagged as dangerous")
-                approval_note = f"Command required approval ({desc}) and was approved by the user."
-                _approved_run = True
-            elif approval.get("smart_approved"):
-                desc = approval.get("description", "flagged as dangerous")
-                approval_note = f"Command was flagged ({desc}) and auto-approved by smart approval."
+            desc = approval.get("description", "flagged as dangerous")
+            approval_note = f"Command required approval ({desc}) and was approved by the user."
+            _approved_run = True
+        elif not force and approval.get("smart_approved"):
+            desc = approval.get("description", "flagged as dangerous")
+            approval_note = f"Command was flagged ({desc}) and auto-approved by smart approval."
 
         # Prepare command for execution
         pty_disabled_reason = None
@@ -3306,24 +3316,37 @@ def terminal_tool(
             )
             try:
                 if env_type == "local":
-                    proc_session = process_registry.spawn_local(
-                        command=command,
-                        cwd=effective_cwd,
-                        task_id=effective_task_id,
-                        owner_task_id=task_id or effective_task_id,
-                        session_key=session_key,
-                        env_vars=env.env if hasattr(env, 'env') else None,
-                        use_pty=effective_pty,
-                    )
+                    def _spawn():
+                        return process_registry.spawn_local(
+                            command=command,
+                            cwd=effective_cwd,
+                            task_id=effective_task_id,
+                            owner_task_id=task_id or effective_task_id,
+                            session_key=session_key,
+                            env_vars=env.env if hasattr(env, 'env') else None,
+                            use_pty=effective_pty,
+                        )
                 else:
-                    proc_session = process_registry.spawn_via_env(
-                        env=env,
-                        command=command,
-                        cwd=effective_cwd,
-                        task_id=effective_task_id,
-                        owner_task_id=task_id or effective_task_id,
-                        session_key=session_key,
-                    )
+                    def _spawn():
+                        return process_registry.spawn_via_env(
+                            env=env,
+                            command=command,
+                            cwd=effective_cwd,
+                            task_id=effective_task_id,
+                            owner_task_id=task_id or effective_task_id,
+                            session_key=session_key,
+                        )
+                granted, spawn_result = _run_with_afk_grant(
+                    _spawn,
+                    command=command,
+                    approval_required=approval_dependent,
+                )
+                if not granted:
+                    return json.dumps({
+                        "output": "", "exit_code": -1,
+                        "error": spawn_result, "status": "blocked",
+                    }, ensure_ascii=False)
+                proc_session = spawn_result
 
                 result_data = {
                     "output": "Background process started",
@@ -3589,6 +3612,14 @@ def terminal_tool(
                         # reads, RPC reads) intentionally stay unbounded.
                         "bounded_capture": True,
                     }
+                    if approval_dependent:
+                        # The environment owns the actual foreground spawn;
+                        # guard only that initiation, not its wait loop.
+                        execute_kwargs["spawn_guard"] = lambda spawn: _run_with_afk_grant(
+                            spawn,
+                            command=command,
+                            approval_required=True,
+                        )
                     result = env.execute(command, **execute_kwargs)
                 except Exception as e:
                     error_str = str(e).lower()

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -474,6 +474,10 @@ def _(rid, params: dict) -> dict:
         name = resolved
     session = _sessions.get(params.get("session_id", ""))
 
+    if name == "afk":
+        from agent.afk import handle_command
+        return _ok(rid, {"output": handle_command(arg)})
+
     qcmds = _load_cfg().get("quick_commands", {})
     if name in qcmds:
         qc = qcmds[name]

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -93,6 +93,7 @@ Type `/` in the CLI to open the autocomplete menu. Built-in commands are case-in
 | `/approvals [manual\|smart\|off]` | Show or set the persistent dangerous-command approval mode. |
 | `/footer [on\|off\|status]` | Toggle the gateway runtime-metadata footer on final replies (shows model, context %, and cwd). |
 | `/busy [queue\|steer\|interrupt\|status]` | Control what happens when you message while Hermes is working — queue the new message, steer mid-turn, or interrupt immediately. Works in the CLI and messaging gateway. |
+| `/afk [on [reason] \| off \| status]` | Record machine-global away/available state. The durable state is shared by profiles; an optional reason is display-only. |
 | `/indicator [kaomoji\|emoji\|unicode\|ascii]` | CLI-only: pick the TUI busy-indicator style. |
 | `/timestamps [on\|off\|status]` | CLI-only: toggle `[HH:MM]` timestamps on messages and in `/history`. |
 | `/wake [on\|off\|status]` | CLI-only: toggle the "Hey Hermes" wake word listener. |

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -59,7 +59,28 @@ They coexist: a kanban worker may call `delegate_task` internally during its run
   (e.g. one per project, repo, or domain); see [Boards (multi-project)](#boards-multi-project)
   below. Single-project users stay on the `default` board and never see the
   word "board" outside this docs section.
-- **Task** — a row with title, optional body, one assignee (a profile name), status (`triage | todo | ready | running | blocked | review | done | archived`), optional tenant namespace, optional idempotency key (dedup for retried automation).
+- **Task** — a row with title, optional body, one assignee (a profile name), status (`triage | todo | ready | running | blocked | review | done | archived`), optional tenant namespace, optional idempotency key (dedup for retried automation), and `unattended_safe` (default `false`).
+
+### AFK and unattended-safe tasks
+
+`unattended_safe` is an explicit scheduling opt-in. Create one with
+`hermes kanban create " nightly report " --assignee analyst --unattended-safe`,
+the `unattended_safe: true` field on `kanban_create`, or the same field in the
+dashboard Create Task request. It is never inferred from task prose and is not
+inherited by children or swarm tasks.
+
+When machine-global AFK is engaged, the dispatcher may newly claim only
+`unattended_safe` tasks in `ready` or `review`; other tasks remain queued.
+Unreadable AFK state fails closed for new starts. This flag is scheduling
+eligibility only: it does not change `approvals.mode`, YOLO, allowlists, or
+authority.
+
+AFK also blocks approval-requiring or human-judgment operations at their
+approval and execution boundaries, including mode-off, YOLO, cached/permanent
+approvals, stale queued replies, and approve-all. Safe operations and already
+running work continue; running work is stopped only when it reaches a new
+approval boundary. If AFK cannot be verified, approval is returned as an
+explicit `BLOCKED` result.
 - **Link** — `task_links` row recording a parent → child dependency. The dispatcher promotes `todo → ready` when all parents are `done`.
 - **Comment** — the inter-agent protocol. Agents and humans append comments; when a worker is (re-)spawned it reads the full comment thread as part of its context.
 - **Workspace** — the directory a worker operates in. Three kinds:


### PR DESCRIPTION
## Problem

Hermes can run through several profiles and interfaces, but it has no durable machine-global way to record that the operator is away. A profile-local flag would let one profile disagree with another. An informational flag alone also does not let unattended-safe work continue without risking approval-dependent work.

## This PR

- adds one machine-global AFK record under the default Hermes root
- adds `/afk [on [reason] | off | status]` to the shared command registry
- routes the command through CLI, gateway/messaging, and TUI dispatch
- adds an explicit persisted `unattended_safe` opt-in for Kanban tasks
- while AFK, dispatches only explicitly unattended-safe ready/review work; unclassified work remains queued
- keeps already-started work running
- stops approval-dependent shell, plugin, computer-use, and execute-code actions at a serialized final grant/launch boundary
- preserves the configured approval mode; AFK does not enable YOLO or widen authority

## Persistence and safety

- cross-process serialization around AFK reads and mutations
- atomic owner-only state replacement
- file fsync plus POSIX parent-directory fsync
- descriptor-relative POSIX operations bound to one validated Hermes root
- full ancestor, owner, permission, symlink, hard-link, size, and semantic checks
- fail-closed handling for corrupt or unreadable state
- bounded filesystem errors across acquisition, mutation, and cleanup paths
- exactly-once descriptor ownership and primary-error preservation
- truthful status when a mutation occurred but durability could not be confirmed
- bounded, display-neutralized optional reason
- durable task claim is the new-work linearization point and shares the AFK lock
- final approval grant/process spawn/tool dispatch shares the AFK lock
- YOLO, `approvals.mode: off`, cached approvals, smart approval, noninteractive defaults, and late gateway replies cannot bypass AFK
- approval persistence revalidates AFK under the same lock

## Policy

AFK is not another approval mode:

- AFK off: existing approval behavior is unchanged.
- AFK on: explicitly unattended-safe phases may start; other ready work remains queued.
- Approval-dependent or human-judgment actions stop at their approval boundary.
- A task/action durably claimed or launched before AFK engages counts as existing work and may continue.
- Missing, corrupt, or unreadable AFK state fails closed for new work and approval grants.

## Verification

- canonical affected suite: 659 passed, 0 failed, 1 Windows-only skip across 19 files
- Ruff: passed
- `py_compile`: passed
- `git diff --check`: passed
- immutable fail-closed review: passed on exact tree `870e91081a500d5bb050b57b62804bd6ad524a83`

One pre-existing macOS `/tmp` versus `/private/tmp` assertion fails identically on pristine HEAD and is excluded from the regression count. Hosted CI remains required.

Windows uses the path-only compatibility backend and one-byte `msvcrt` locking. This PR does not claim Windows ACL hardening.

Relates to #101104.

This focused PR supersedes #98162, which combined AFK state, approval policy, and model-context changes without a narrow trusted dispatch boundary.
