### PR TITLE
fix(gateway): suppress plain 'Still working...' spam on chat platforms (#101209)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -145,6 +145,8 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"|session\s+compressed\s+\d+\s+times"
     r"|rate\s+limited\.\s+waiting\s+\d"
     r"|retrying\s+in\s+\d"
+    r"|still\s+working\.{2,}\s*$"
+    r"|still\s+working…\s*$"
     r"|max\s+retries\s+\(\d+\).*(?:trying\s+fallback|exhausted|invalid\s+responses)"
     r"|stream\s+(?:drop|drop\s+mid\s+tool-call).+retry\s+\d"
     r"|stale\s+connections\s+from\s+a\s+previous\s+provider\s+issue"


### PR DESCRIPTION
Fixes #101209

Chat platforms filter transient retry/compression chatter via
`_TELEGRAM_NOISY_STATUS_RE` but the plain `Still working...` /`still
working…` bubble (reported with slow Ollama local qwen) slipped through,
flooding Telegram with uninformative status alongside `Retrying in`.

Extend the noisy-status regex to drop trailing-ellipsis `still working`
variants (`still working...\s*$` / `still working…\s*$`) while keeping
legitimate heartbeats such as `still working through it` and `still
working… (2m03s)` visible. Existing `retrying in` / `rate limited`
patterns already cover retry spam; this closes the remaining gap.

Users who prefer only the typing indicator can already set
`display.long_running_notifications: off` or
`agent.gateway_notify_interval: 0` to disable periodic heartbeats
entirely.

Tests: `test_telegram_noise_filter` (136 passed), `test_compression_progress_notices` (38 passed); verified new patterns match spam and preserve legitimate phrases.