### PR TITLE
fix(banner): don't let a hung git kill the update-check thread

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -295,11 +295,12 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
         # Local-ahead: the remote tip is an ancestor of HEAD. Checked against
         # the FRESH upstream SHA (not the possibly stale origin/main tracking
         # ref) so a stale ref can't fake an up-to-date report.
-        ancestor = subprocess.run(
-            ["git", "merge-base", "--is-ancestor", upstream_rev, "HEAD"],
-            capture_output=True, timeout=5, cwd=str(repo_dir),
-        )
-        if ancestor.returncode == 0:
+        # Routed through _git_stdout so a slow or hung git can't raise
+        # TimeoutExpired out of the background update thread and kill it.
+        # Returns "" when HEAD is a descendant, None on non-zero exit,
+        # timeout, or any other subprocess failure.
+        if _git_stdout(["merge-base", "--is-ancestor", upstream_rev, "HEAD"],
+                       cwd=repo_dir) is not None:
             return 0
         # Genuinely behind (or diverged). Recover the exact count via the
         # GitHub compare API; a local-only HEAD 404s there, which safely
@@ -677,8 +678,12 @@ def prefetch_update_check():
     """Kick off update check in a background daemon thread."""
     def _run():
         global _update_result
-        _update_result = check_for_updates()
-        _update_check_done.set()
+        try:
+            _update_result = check_for_updates()
+        except Exception:
+            _update_result = None  # inconclusive; never crash the daemon thread
+        finally:
+            _update_check_done.set()
     t = threading.Thread(target=_run, daemon=True)
     t.start()
 

--- a/tests/hermes_cli/test_banner_git_state.py
+++ b/tests/hermes_cli/test_banner_git_state.py
@@ -48,8 +48,6 @@ def test_check_via_local_git_ssh_fastpath_ahead_not_behind(tmp_path):
     is an ancestor of HEAD — that is "ahead", and reporting it as behind
     nudges the user into `hermes update`, which can wipe the carried work.
     """
-    from unittest.mock import MagicMock
-
     from hermes_cli import banner
 
     repo_dir = tmp_path / "repo"
@@ -60,13 +58,13 @@ def test_check_via_local_git_ssh_fastpath_ahead_not_behind(tmp_path):
             return "git@github.com:NousResearch/hermes-agent.git"
         if args == ["rev-parse", "HEAD"]:
             return "b" * 40  # carried commit, differs from upstream tip
+        if args[:2] == ["merge-base", "--is-ancestor"]:
+            return ""  # exit 0: upstream tip IS an ancestor of HEAD
         raise AssertionError(f"unexpected git call: {args}")
 
     with (
         patch.object(banner, "_git_stdout", side_effect=fake_git_stdout),
         patch.object(banner, "_upstream_main_sha", return_value="a" * 40),
-        # merge-base --is-ancestor exits 0: upstream tip IS an ancestor of HEAD
-        patch.object(banner.subprocess, "run", return_value=MagicMock(returncode=0)),
     ):
         behind = banner._check_via_local_git(repo_dir)
 
@@ -75,8 +73,6 @@ def test_check_via_local_git_ssh_fastpath_ahead_not_behind(tmp_path):
 
 def test_check_via_local_git_ssh_fastpath_genuinely_behind(tmp_path):
     """SSH fast path reports the exact count (compare API) when behind."""
-    from unittest.mock import MagicMock
-
     from hermes_cli import banner
 
     repo_dir = tmp_path / "repo"
@@ -87,13 +83,13 @@ def test_check_via_local_git_ssh_fastpath_genuinely_behind(tmp_path):
             return "git@github.com:NousResearch/hermes-agent.git"
         if args == ["rev-parse", "HEAD"]:
             return "b" * 40
+        if args[:2] == ["merge-base", "--is-ancestor"]:
+            return None  # exit 1: not an ancestor -> genuinely behind
         raise AssertionError(f"unexpected git call: {args}")
 
     with (
         patch.object(banner, "_git_stdout", side_effect=fake_git_stdout),
         patch.object(banner, "_upstream_main_sha", return_value="a" * 40),
-        # merge-base --is-ancestor exits 1: not an ancestor -> genuinely behind
-        patch.object(banner.subprocess, "run", return_value=MagicMock(returncode=1)),
         patch.object(banner, "_github_compare_behind", return_value=3),
     ):
         behind = banner._check_via_local_git(repo_dir)
@@ -103,8 +99,6 @@ def test_check_via_local_git_ssh_fastpath_genuinely_behind(tmp_path):
 
 def test_check_via_local_git_ssh_fastpath_offline_keeps_sentinel(tmp_path):
     """Behind + compare API unreachable = honest no-count sentinel, never 1."""
-    from unittest.mock import MagicMock
-
     from hermes_cli import banner
 
     repo_dir = tmp_path / "repo"
@@ -115,14 +109,32 @@ def test_check_via_local_git_ssh_fastpath_offline_keeps_sentinel(tmp_path):
             return "git@github.com:NousResearch/hermes-agent.git"
         if args == ["rev-parse", "HEAD"]:
             return "b" * 40
+        if args[:2] == ["merge-base", "--is-ancestor"]:
+            return None  # exit 1: not an ancestor -> genuinely behind
         raise AssertionError(f"unexpected git call: {args}")
 
     with (
         patch.object(banner, "_git_stdout", side_effect=fake_git_stdout),
         patch.object(banner, "_upstream_main_sha", return_value="a" * 40),
-        patch.object(banner.subprocess, "run", return_value=MagicMock(returncode=1)),
         patch.object(banner, "_github_compare_behind", return_value=None),
     ):
         behind = banner._check_via_local_git(repo_dir)
 
     assert behind == banner.UPDATE_AVAILABLE_NO_COUNT
+
+
+def test_prefetch_update_check_survives_exception():
+    """A raising check must not kill the daemon thread or leave waiters hanging.
+
+    ``check_for_updates`` shells out to git; a hung git raises TimeoutExpired.
+    Uncaught, that killed the thread before it set the done event, so every
+    waiter burned its full timeout.
+    """
+    from hermes_cli import banner
+
+    with patch.object(banner, "check_for_updates", side_effect=RuntimeError("boom")):
+        banner._update_check_done.clear()
+        banner.prefetch_update_check()
+        assert banner._update_check_done.wait(timeout=5)
+
+    assert banner._update_result is None


### PR DESCRIPTION
## Problem

The banner's background update check crashed its own daemon thread:

```
File "hermes_cli/banner.py", line 298, in _check_via_local_git
    ancestor = subprocess.run(
subprocess.TimeoutExpired: Command '['git', 'merge-base', '--is-ancestor', <sha>, 'HEAD']' timed out after 5 seconds
```

`_check_via_local_git` was the only place in `banner.py` calling `subprocess.run` without an exception guard — every other call site either uses `_git_stdout` or sits inside a `try/except`. A slow or hung git (network FS, contended index lock) raises `TimeoutExpired`, which propagates out of `prefetch_update_check._run` and kills the thread **before** it sets `_update_check_done`. Waiters at lines 724 and 763 then burn their full timeout every startup.

## Fix

1. Route the `merge-base --is-ancestor` probe through the existing `_git_stdout` helper, which already handles timeouts, non-zero exits and utf-8 decoding. `""` means ancestor, `None` means not-an-ancestor-or-failed — the same two-way answer the return code gave.
2. Guard the thread body with `try/except/finally` so no future exception can kill the thread or strand the event. An unexpected failure now yields `None` (inconclusive), which `check_for_updates` already refuses to cache.

## Test plan

- [x] New `test_prefetch_update_check_survives_exception` — verified it fails on the pre-fix code and passes after.
- [x] Updated the three `_check_via_local_git` SSH fast-path tests, which stubbed `subprocess.run` for the merge-base call, to stub `_git_stdout` instead.
- [x] `pytest tests/hermes_cli/test_banner_git_state.py test_update_check.py test_update_behind_count_recovery.py test_banner.py` — 31 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ADzbRwD5M5k5bgEykZfNmz