### PR TITLE
feat(skills): index linked community skill repositories

### DIFF
--- a/contributors/emails/admin@foundationoperations.com
+++ b/contributors/emails/admin@foundationoperations.com
@@ -1,0 +1,1 @@
+FoundationOperations

--- a/scripts/build_skills_index.py
+++ b/scripts/build_skills_index.py
@@ -40,6 +40,7 @@ from tools.skills_hub import (
     ClawHubSource,
     LobeHubSource,
     BrowseShSource,
+    COMMUNITY_INDEX_TAPS,
     SkillMeta,
 )
 import httpx
@@ -253,7 +254,7 @@ def main():
     sources = {
         "official": OptionalSkillSource(),
         "well-known": WellKnownSkillSource(),
-        "github": GitHubSource(auth=auth),
+        "github": GitHubSource(auth=auth, extra_taps=COMMUNITY_INDEX_TAPS),
         "clawhub": ClawHubSource(),
         "lobehub": LobeHubSource(),
         "browse-sh": BrowseShSource(),

--- a/tests/scripts/test_build_skills_index_health.py
+++ b/tests/scripts/test_build_skills_index_health.py
@@ -51,7 +51,9 @@ def _install_fake_sources(monkeypatch, *, github_count,
     monkeypatch.setattr(build_mod, "WellKnownSkillSource", lambda: _FakeSource("well-known", well_known_count))
     monkeypatch.setattr(
         build_mod, "GitHubSource",
-        lambda auth: _FakeSource("github", github_count, rate_limited=github_rate_limited),
+        lambda auth, extra_taps=None: _FakeSource(
+            "github", github_count, rate_limited=github_rate_limited
+        ),
     )
     monkeypatch.setattr(build_mod, "ClawHubSource", lambda: _FakeSource("clawhub", 69000))
     monkeypatch.setattr(build_mod, "LobeHubSource", lambda: _FakeSource("lobehub", 500))

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -29,6 +29,7 @@ from tools.skills_hub import (
     append_audit_log,
     quarantine_bundle,
     _referenced_support_paths,
+    COMMUNITY_INDEX_TAPS,
 )
 
 
@@ -113,6 +114,85 @@ class TestSkillsShGroupings:
         assert len(skills) == 1
         assert skills[0].extra["category"] == "Decision Optimization"
 
+
+class TestGitHubRootSkills:
+    def test_list_treats_configured_path_with_skill_md_as_one_skill(self):
+        src = GitHubSource(auth=MagicMock(spec=GitHubAuth))
+        resp = MagicMock(status_code=200)
+        resp.json.return_value = [
+            {"type": "file", "name": "SKILL.md"},
+            {"type": "dir", "name": "references"},
+        ]
+        meta = SkillMeta(
+            name="detect-deepfake",
+            description="Detect synthetic media.",
+            source="github",
+            identifier="resemble-ai/detect-skill",
+            trust_level="community",
+        )
+
+        with patch.object(src, "_read_cache", return_value=None), \
+             patch.object(src, "_write_cache") as write_cache, \
+             patch.object(src, "_get_skillsh_groupings", return_value=None), \
+             patch.object(src, "_github_get", return_value=resp), \
+             patch.object(src, "inspect", return_value=meta) as inspect:
+            skills = src._list_skills_in_repo("resemble-ai/detect-skill", "")
+
+        assert skills == [meta]
+        inspect.assert_called_once_with("resemble-ai/detect-skill")
+        write_cache.assert_called_once()
+
+    def test_inspect_reads_repository_root_skill(self):
+        src = GitHubSource(auth=MagicMock(spec=GitHubAuth))
+        skill_md = "---\nname: root-skill\ndescription: Root skill.\n---\n"
+
+        with patch.object(src, "_fetch_file_content", return_value=skill_md) as fetch:
+            meta = src.inspect("owner/root-skill")
+
+        fetch.assert_called_once_with("owner/root-skill", "SKILL.md")
+        assert meta is not None
+        assert meta.name == "root-skill"
+        assert meta.path == ""
+        assert meta.trust_level == "community"
+
+    def test_fetch_root_skill_does_not_bundle_unrelated_repo_files(self):
+        src = GitHubSource(auth=MagicMock(spec=GitHubAuth))
+        skill_md = (
+            "---\nname: root-skill\ndescription: Root skill.\n---\n"
+            "Read [the guide](references/guide.md).\n"
+        )
+        tree = (
+            "main",
+            [
+                {"type": "blob", "mode": "100644", "path": "SKILL.md"},
+                {"type": "blob", "mode": "100644", "path": "references/guide.md"},
+                {"type": "blob", "mode": "100644", "path": "src/unrelated.py"},
+            ],
+        )
+        src._tree_revisions["owner/root-skill"] = "abc123"
+
+        def fetch_file(_repo, path, ref=None):
+            assert ref == "abc123"
+            return {
+                "SKILL.md": skill_md.encode(),
+                "references/guide.md": b"# Guide\n",
+            }.get(path)
+
+        with patch.object(src, "_get_repo_tree", return_value=tree), \
+             patch.object(src, "_fetch_file_bytes", side_effect=fetch_file):
+            bundle = src.fetch("owner/root-skill")
+
+        assert bundle is not None
+        assert bundle.name == "root-skill"
+        assert bundle.files == {
+            "SKILL.md": skill_md,
+            "references/guide.md": b"# Guide\n",
+        }
+        assert bundle.metadata["source_revision"] == "abc123"
+        assert bundle.metadata["source_url"] == (
+            "https://github.com/owner/root-skill/tree/abc123"
+        )
+
 # ---------------------------------------------------------------------------
 # GitHubSource.trust_level_for
 # ---------------------------------------------------------------------------
@@ -146,6 +226,27 @@ class TestTrustLevelFor:
                 "from GitHubSource.DEFAULT_TAPS — its skills will not be "
                 "browsable via `hermes skills browse`."
             )
+
+    def test_linked_community_repositories_are_browseable_but_not_trusted(self):
+        expected = {
+            "mattpocock/skills",
+            "ZeroPointRepo/youtube-skills",
+            "composio-community/skills",
+            "addyosmani/agent-skills",
+            "resemble-ai/detect-skill",
+            "calesthio/OpenMontage",
+            "mukul975/Anthropic-Cybersecurity-Skills",
+            "jakubkrehel/make-interfaces-feel-better",
+            "Panniantong/Agent-Reach",
+        }
+        tap_repos = {tap["repo"] for tap in COMMUNITY_INDEX_TAPS}
+
+        assert expected <= tap_repos
+        src = self._source()
+        assert all(
+            src.trust_level_for(f"{repo}/example") == "community"
+            for repo in expected
+        )
 
 
 class TestGitHubSourceFileFetch:
@@ -754,6 +855,34 @@ class TestHermesIndexSearch:
         ids = [h.identifier for h in hits]
         assert "NVIDIA/skills/skills/accelerated-computing-cudf" in ids
         assert "clawhub/unrelated" not in ids
+
+    def test_fetch_repository_root_skill(self):
+        src = _make_index_source([
+            {
+                "name": "resemble-detect",
+                "description": "Detect synthetic media.",
+                "source": "github",
+                "identifier": "resemble-ai/detect-skill",
+                "repo": "resemble-ai/detect-skill",
+                "path": "",
+                "tags": [],
+            },
+        ])
+        github = MagicMock()
+        github.fetch.return_value = SkillBundle(
+            name="resemble-detect",
+            files={"SKILL.md": "body"},
+            source="github",
+            identifier="resemble-ai/detect-skill",
+            trust_level="community",
+        )
+        src._github = github
+
+        bundle = src.fetch("resemble-ai/detect-skill")
+
+        github.fetch.assert_called_once_with("resemble-ai/detect-skill")
+        assert bundle is not None
+        assert bundle.name == "resemble-detect"
 
 class TestProviderFilter:
     def test_filter_results_by_provider_narrows_exactly(self):

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -43,6 +43,25 @@ from tools.website_policy import check_website_access
 logger = logging.getLogger(__name__)
 
 
+# Community repositories included in the centrally built skills index. They
+# are intentionally not live default taps: crawling the larger collections on
+# every interactive search would be slow and consume the user's GitHub quota.
+# Index results still install through GitHubSource and retain community trust.
+COMMUNITY_INDEX_TAPS = [
+    {"repo": "mattpocock/skills", "path": "skills/engineering/"},
+    {"repo": "mattpocock/skills", "path": "skills/misc/"},
+    {"repo": "mattpocock/skills", "path": "skills/productivity/"},
+    {"repo": "ZeroPointRepo/youtube-skills", "path": "skills/"},
+    {"repo": "composio-community/skills", "path": "skills/"},
+    {"repo": "addyosmani/agent-skills", "path": "skills/"},
+    {"repo": "resemble-ai/detect-skill", "path": ""},
+    {"repo": "calesthio/OpenMontage", "path": ".agents/skills/"},
+    {"repo": "mukul975/Anthropic-Cybersecurity-Skills", "path": "skills/"},
+    {"repo": "jakubkrehel/make-interfaces-feel-better", "path": "skills/"},
+    {"repo": "Panniantong/Agent-Reach", "path": "agent_reach/skill/"},
+]
+
+
 # ---------------------------------------------------------------------------
 # Paths
 # ---------------------------------------------------------------------------
@@ -754,14 +773,16 @@ class GitHubSource(SkillSource):
     def fetch(self, identifier: str) -> Optional[SkillBundle]:
         """
         Download a skill from GitHub.
-        identifier format: "owner/repo/path/to/skill-dir"
+        identifier format: "owner/repo/path/to/skill-dir". A repository-root
+        skill may use "owner/repo".
         """
-        parts = identifier.split("/", 2)
-        if len(parts) < 3:
+        parts = identifier.strip("/").split("/", 2)
+        if len(parts) < 2:
             return None
 
         repo = f"{parts[0]}/{parts[1]}"
-        skill_path = parts[2]
+        skill_path = parts[2].strip("/") if len(parts) == 3 else ""
+        skill_md_path = f"{skill_path}/SKILL.md" if skill_path else "SKILL.md"
 
         # Resolve the tree FIRST so every byte fetch in this install —
         # SKILL.md included — can be pinned to the same revision. Without the
@@ -774,7 +795,7 @@ class GitHubSource(SkillSource):
         tree = self._get_repo_tree(repo)
         pinned_ref = self._tree_revisions.get(repo)
         skill_md = self._fetch_file_content(
-            repo, f"{skill_path.rstrip('/')}/SKILL.md", ref=pinned_ref
+            repo, skill_md_path, ref=pinned_ref
         )
         if skill_md is None:
             return None
@@ -783,7 +804,7 @@ class GitHubSource(SkillSource):
             return None
 
         files: Dict[str, Union[str, bytes]] = {"SKILL.md": skill_md}
-        if tree is not None:
+        if tree is not None and skill_path:
             # Download the FULL skill directory, not just SKILL.md-linked
             # paths. Link-driven fetching silently dropped every support file
             # a skill keeps under a non-canonical dir name (`reference/`,
@@ -842,16 +863,32 @@ class GitHubSource(SkillSource):
                     )
             revision = self._tree_revisions.get(repo) or branch
         else:
+            root_entries = {
+                item.get("path", ""): item
+                for item in tree[1]
+            } if tree is not None and not skill_path else {}
             for rel_path in referenced:
-                content = self._fetch_file_bytes(repo, f"{skill_path.rstrip('/')}/{rel_path}")
+                item_path = f"{skill_path}/{rel_path}" if skill_path else rel_path
+                item = root_entries.get(item_path)
+                if item is not None and (
+                    item.get("type") != "blob" or item.get("mode") == "120000"
+                ):
+                    logger.warning(
+                        "Rejected non-regular referenced file in skill bundle: %s",
+                        item_path,
+                    )
+                    return None
+                content = self._fetch_file_bytes(repo, item_path, ref=pinned_ref)
                 if content is None:
                     logger.warning("Failed to fetch referenced skill support "
                                    "file; continuing without it: %s", rel_path)
                     continue
                 files[rel_path] = content
-            revision = ""
+            revision = pinned_ref or ""
 
-        skill_name = skill_path.rstrip("/").split("/")[-1]
+        frontmatter = self._parse_frontmatter_quick(skill_md)
+        fallback_name = skill_path.rsplit("/", 1)[-1] if skill_path else parts[1]
+        skill_name = str(frontmatter.get("name") or fallback_name)
         trust = self.trust_level_for(identifier)
 
         return SkillBundle(
@@ -862,8 +899,8 @@ class GitHubSource(SkillSource):
             trust_level=trust,
             metadata={
                 "source_url": (
-                    f"https://github.com/{repo}/tree/{revision}/{skill_path}"
-                    if revision else f"https://github.com/{repo}/{skill_path}"
+                    f"https://github.com/{repo}/tree/{revision}/{skill_path}".rstrip("/")
+                    if revision else f"https://github.com/{repo}/{skill_path}".rstrip("/")
                 ),
                 "source_revision": revision,
             },
@@ -871,20 +908,21 @@ class GitHubSource(SkillSource):
 
     def inspect(self, identifier: str) -> Optional[SkillMeta]:
         """Fetch just the SKILL.md metadata for preview."""
-        parts = identifier.split("/", 2)
-        if len(parts) < 3:
+        parts = identifier.strip("/").split("/", 2)
+        if len(parts) < 2:
             return None
 
         repo = f"{parts[0]}/{parts[1]}"
-        skill_path = parts[2].rstrip("/")
-        skill_md_path = f"{skill_path}/SKILL.md"
+        skill_path = parts[2].strip("/") if len(parts) == 3 else ""
+        skill_md_path = f"{skill_path}/SKILL.md" if skill_path else "SKILL.md"
 
         content = self._fetch_file_content(repo, skill_md_path)
         if not content:
             return None
 
         fm = self._parse_frontmatter_quick(content)
-        skill_name = fm.get("name", skill_path.split("/")[-1])
+        fallback_name = skill_path.rsplit("/", 1)[-1] if skill_path else parts[1]
+        skill_name = fm.get("name", fallback_name)
         description = fm.get("description", "")
 
         tags = []
@@ -934,6 +972,21 @@ class GitHubSource(SkillSource):
 
         skills: List[SkillMeta] = []
         groupings = self._get_skillsh_groupings(repo)
+        # Some repositories publish one skill at the configured path instead
+        # of a directory of skills. Treat that path as the skill root and do
+        # not probe its support directories as sibling skills.
+        if any(
+            entry.get("type") == "file" and entry.get("name") == "SKILL.md"
+            for entry in entries
+        ):
+            prefix = path.strip("/")
+            skill_identifier = f"{repo}/{prefix}" if prefix else repo
+            meta = self.inspect(skill_identifier)
+            if meta:
+                skills.append(meta)
+            self._write_cache(cache_key, [self._meta_to_dict(s) for s in skills])
+            return skills
+
         for entry in entries:
             if entry.get("type") != "dir":
                 continue
@@ -4723,8 +4776,8 @@ class HermesIndexSource(SkillSource):
         # Fall back to identifier-based fetch via repo/path
         repo = entry.get("repo", "")
         path = entry.get("path", "")
-        if repo and path:
-            github_id = f"{repo}/{path}"
+        if repo:
+            github_id = f"{repo}/{path}" if path else repo
             bundle = self._get_github().fetch(github_id)
             if bundle:
                 bundle.source = entry.get("source", "hermes-index")


### PR DESCRIPTION
## Summary

- add nine community Agent Skill repositories to the centrally generated Hermes Skills Index (977 currently published skills)
- support repositories and configured tap paths that publish `SKILL.md` at the path root
- keep large community collections out of live default taps so interactive search does not crawl GitHub or consume the user's API quota
- preserve community trust: every install still goes through quarantine and the existing skill scanner

## Repositories indexed

- `mattpocock/skills` (`engineering`, `misc`, and `productivity`; excludes deprecated and in-progress content)
- `ZeroPointRepo/youtube-skills`
- `composio-community/skills`
- `addyosmani/agent-skills`
- `resemble-ai/detect-skill`
- `calesthio/OpenMontage`
- `mukul975/Anthropic-Cybersecurity-Skills`
- `jakubkrehel/make-interfaces-feel-better`
- `Panniantong/Agent-Reach`

The remaining links from the supplied collection are deliberately not duplicated into the index:

- `blader/humanizer` is already bundled at `skills/creative/humanizer`.
- `witt3rd/oh-my-hermes` publishes plugin-scoped skills that depend on its plugin runtime and should be installed as that standalone plugin.
- `AMAP-ML/SkillClaw` and `agent37-platform/minions` are standalone Hermes integrations, not Agent Skill repositories.
- `kepano/defuddle` does not publish a `SKILL.md`; the dedicated Hermes adapter is already proposed in #71460.

## Safety and behavior

Repository-root bundles only fetch support files explicitly referenced by `SKILL.md`; they do not copy the entire repository. Referenced symlinks and other non-regular tree entries remain rejected. Root installs are pinned to the same source revision as tree inspection.

## Validation

- `uv run --extra dev pytest tests/tools/test_skills_hub.py tests/scripts/test_build_skills_index_health.py -q -o 'addopts='` (110 passed)
- `uv run --extra dev ruff check tools/skills_hub.py scripts/build_skills_index.py tests/tools/test_skills_hub.py tests/scripts/test_build_skills_index_health.py`
- `git diff --check`
- live discovery smoke test against `resemble-ai/detect-skill`, `Panniantong/Agent-Reach`, and `addyosmani/agent-skills`
- GitHub tree verification of all configured source paths (977 current `SKILL.md` entries)
