### PR TITLE
fix(cli): non-interactive `chat -q` reports failures in its exit code

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5700,6 +5700,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # don't auto-queue another continuation on top of a user-cancelled
         # turn (which would make Ctrl+C feel like it did nothing).
         self._last_turn_interrupted = False
+        # The raw ``run_conversation()`` result of the turn that just
+        # finished. ``chat()`` returns only the response text, so the
+        # non-interactive single-query path in ``main()`` reads the
+        # outcome (failed / failure_reason) from here to pick its exit
+        # code — see hermes_cli/single_query_exit.py. ``None`` means no
+        # agent turn happened at all (credentials / agent init failed).
+        self._last_turn_result = None
         # When stdout/PTY raises EIO (broken pipe after a stream-stall
         # interrupt), freeze further UI paints so we don't spin the main
         # thread at hundreds of escape-sequence writes/sec (#81521).
@@ -16919,6 +16926,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # this to True. Early returns (credential refresh failure, etc.)
         # leave it False, which is correct — those aren't user interrupts.
         self._last_turn_interrupted = False
+        # Clear the previous turn's outcome so an early return below cannot
+        # let a stale success mask this turn's failure (the single-query
+        # exit-code path reads it).
+        self._last_turn_result = None
 
         # Refresh provider credentials if needed (handles key rotation transparently)
         if not self._ensure_runtime_credentials():
@@ -17476,6 +17487,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
             # Get the final response
             response = result.get("final_response", "") if result else ""
+
+            # Publish the turn's raw outcome for callers that need more than
+            # the response text — notably the non-interactive single-query
+            # path in main(), which must translate a failed turn into a
+            # non-zero exit code for automation wrappers and the kanban
+            # dispatcher (see hermes_cli/single_query_exit.py).
+            self._last_turn_result = result
 
             # Session titling now runs at TURN START (agent/turn_context.py)
             # from the user's message alone, so it is already done — or in
@@ -22302,31 +22320,13 @@ def main(
                         print(f"\nsession_id: {cli.session_id}", file=sys.stderr)
 
                         # Ensure proper exit code for automation wrappers.
-                        #
-                        # Kanban workers get a special case: when the run failed
-                        # purely because the provider rate-limited / exhausted
-                        # quota (not because the task itself is broken), exit with
-                        # the EX_TEMPFAIL sentinel instead of the generic 1. The
-                        # dispatcher's reap classifier maps that code to a
-                        # ``rate_limited`` exit and releases the task back to
-                        # ``ready`` WITHOUT incrementing the failure counter, so a
-                        # 5-hour quota window can't trip the circuit breaker and
-                        # permanently block the card. Non-kanban runs keep the
-                        # plain 0/1 contract automation wrappers expect.
-                        _exit_code = 0
-                        if isinstance(result, dict) and result.get("failed"):
-                            _exit_code = 1
-                            if os.environ.get("HERMES_KANBAN_TASK") and result.get(
-                                "failure_reason"
-                            ) in ("rate_limit", "billing"):
-                                try:
-                                    from hermes_cli.kanban_db import (
-                                        KANBAN_RATE_LIMIT_EXIT_CODE as _RL_CODE,
-                                    )
-                                    _exit_code = _RL_CODE
-                                except Exception:
-                                    _exit_code = 1
-                        sys.exit(_exit_code)
+                        # Shared with the human-facing single-query path below
+                        # so the two cannot drift; contract documented in
+                        # hermes_cli/single_query_exit.py.
+                        from hermes_cli.single_query_exit import (
+                            single_query_exit_code,
+                        )
+                        sys.exit(single_query_exit_code(result))
 
                 # Exit with error code if credentials or agent init fails
                 sys.exit(1)
@@ -22352,6 +22352,26 @@ def main(
                 cli._show_security_advisories()
                 cli.chat(query, images=single_query_images or None)
                 cli._print_exit_summary(clear_screen=False)
+                # Same exit-code contract as the fully-quiet path above.
+                # This branch is what the kanban dispatcher spawns (`chat
+                # -q` with no `-Q`, see `_default_spawn`), and it used to
+                # return 0 no matter what: a provider quota wall reached
+                # the dispatcher as a clean exit, which its reap
+                # classifier can only read as "worker finished without
+                # calling kanban_complete" — a protocol violation blamed
+                # on the agent, one failure-counter life burned per
+                # attempt (incident 2026-09-02, card t_d16778b1: eight
+                # such runs during one Copilot session-limit window).
+                # Only a non-zero code is raised here so a successful run
+                # keeps falling through to the normal return below.
+                from hermes_cli.single_query_exit import (
+                    single_query_exit_code,
+                )
+                _exit_code = single_query_exit_code(
+                    getattr(cli, "_last_turn_result", None)
+                )
+                if _exit_code:
+                    sys.exit(_exit_code)
         finally:
             _finalize_single_query(cli)
         return

--- a/hermes_cli/single_query_exit.py
+++ b/hermes_cli/single_query_exit.py
@@ -1,0 +1,82 @@
+"""Exit-code contract for non-interactive single-query runs.
+
+Both non-interactive entry points — the fully-quiet machine path
+(``hermes chat -q … -Q``) and the human-facing single-query path
+(``hermes chat -q …``) — must report the turn's outcome through the
+process exit code, because their only consumers are automation wrappers:
+shell scripts, cron jobs, and the kanban dispatcher.
+
+The logic lives here rather than inline in ``cli.py`` so the two call
+sites cannot drift apart again. They did drift: the quiet path grew the
+0/1/75 contract while the human-facing path never inspected the turn
+result at all and returned 0 unconditionally. Kanban workers are spawned
+with ``-q`` and no ``-Q`` (see ``_default_spawn`` in
+``hermes_cli/kanban_db.py``), so every provider-side failure reached the
+dispatcher as a clean exit — which its reap classifier can only read as
+"the worker finished without calling ``kanban_complete``", i.e. a
+protocol violation by the agent. Incident 2026-09-02: a Copilot session
+limit produced eight consecutive ``crashed`` runs on card ``t_d16778b1``,
+each labelled a protocol violation, each burning one of the card's
+failure-counter lives, none of them the agent's doing.
+
+The contract:
+
+* success / interrupted → ``0``
+* failed turn → ``1``
+* failed turn **inside a kanban worker** because the provider walled the
+  quota (``failure_reason`` of ``rate_limit`` or ``billing``) →
+  ``KANBAN_RATE_LIMIT_EXIT_CODE`` (75, ``EX_TEMPFAIL``). The dispatcher's
+  reap classifier maps that code to a ``rate_limited`` exit and releases
+  the card back to ``ready`` WITHOUT incrementing the failure counter, so
+  a multi-hour quota window cannot trip the circuit breaker and block the
+  card permanently.
+
+Non-kanban runs keep the plain 0/1 contract automation wrappers expect.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Mapping, Optional
+
+# ``failure_reason`` values that mean "quota wall, not a task error".
+QUOTA_FAILURE_REASONS = ("rate_limit", "billing")
+
+
+def single_query_exit_code(
+    result: Optional[Any],
+    *,
+    env: Optional[Mapping[str, str]] = None,
+) -> int:
+    """Return the process exit code for a finished single-query turn.
+
+    ``result`` is the dict ``Agent.run_conversation()`` returns (or
+    ``None`` when the turn never got that far, e.g. a credential refresh
+    failure — treated as a failure, since no answer was produced).
+    ``env`` defaults to ``os.environ`` and is injectable for tests.
+    """
+    _env = os.environ if env is None else env
+
+    if result is None:
+        # The turn never reached the agent (credentials, agent init) — no
+        # answer was produced, so this is a failure. Matches the quiet
+        # path's ``sys.exit(1)`` for a failed init.
+        return 1
+    if not isinstance(result, dict):
+        # The quiet path already tolerates a non-dict result by printing
+        # ``str(result)``; something was produced, so don't call it a
+        # failure.
+        return 0
+    if not result.get("failed"):
+        return 0
+
+    if _env.get("HERMES_KANBAN_TASK") and result.get(
+        "failure_reason"
+    ) in QUOTA_FAILURE_REASONS:
+        try:
+            from hermes_cli.kanban_db import KANBAN_RATE_LIMIT_EXIT_CODE
+        except Exception:
+            return 1
+        return int(KANBAN_RATE_LIMIT_EXIT_CODE)
+
+    return 1

--- a/tests/cli/test_chat_q_exit_clear.py
+++ b/tests/cli/test_chat_q_exit_clear.py
@@ -86,6 +86,13 @@ def test_single_query_main_skips_clear_on_exit_summary(monkeypatch):
 
         def chat(self, query, images=None):
             calls.append(("chat", query, images))
+            # Mirrors the real chat(): publish the turn's raw result so
+            # main()'s single-query exit-code path sees a successful turn
+            # instead of "no turn happened" (which exits 1).
+            self._last_turn_result = {
+                "final_response": "done",
+                "completed": True,
+            }
             return "done"
 
         def _print_exit_summary(self, clear_screen=True):

--- a/tests/cli/test_single_query_session_finalize.py
+++ b/tests/cli/test_single_query_session_finalize.py
@@ -108,6 +108,12 @@ def test_human_single_query_main_finalizes_after_query(monkeypatch):
 
         def chat(self, query, images=None):
             calls.append(("chat", query, images))
+            # Mirrors the real chat(): the turn's raw result is published
+            # for the single-query exit-code path.
+            self._last_turn_result = {
+                "final_response": "done",
+                "completed": True,
+            }
             return "done"
 
         def _print_exit_summary(self, clear_screen=True):
@@ -201,3 +207,117 @@ def test_quiet_single_query_main_finalizes_while_preserving_exit_code(monkeypatc
     assert ("claim", "cli", True) in calls
     assert ("run", "hello", []) in calls
     assert calls[-1] == ("finalize", "quiet-session")
+
+
+def _run_human_single_query(monkeypatch, calls, turn_result):
+    """Drive main()'s human-facing ``chat -q`` branch with a stub CLI.
+
+    Returns the ``SystemExit`` code, or ``None`` when main() returned
+    normally (the success path falls through instead of exiting).
+    """
+    import cli as cli_mod
+
+    class _Console:
+        def print(self, *_args, **_kwargs):
+            pass
+
+    class FakeCLI:
+        def __init__(self, **_kwargs):
+            self.console = _Console()
+            self.session_id = "human-session"
+            self.agent = SimpleNamespace(
+                session_id="human-session",
+                platform="cli",
+            )
+
+        def _claim_active_session(self, surface, *, stderr=False):
+            return True
+
+        def _show_security_advisories(self):
+            pass
+
+        def chat(self, query, images=None):
+            calls.append(("chat", query))
+            self._last_turn_result = turn_result
+            return (turn_result or {}).get("final_response", "")
+
+        def _print_exit_summary(self, clear_screen=True):
+            calls.append("summary")
+
+    monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
+    monkeypatch.setattr(cli_mod.atexit, "register", lambda *_a, **_kw: None)
+    monkeypatch.setattr(
+        cli_mod,
+        "_finalize_single_query",
+        lambda fake_cli: calls.append(("finalize", fake_cli.session_id)),
+    )
+
+    try:
+        cli_mod.main(query="hello", quiet=False, toolsets="terminal")
+    except SystemExit as exc:
+        return exc.code
+    return None
+
+
+def test_human_single_query_failed_turn_exits_nonzero(monkeypatch):
+    """A failed turn on the ``-q`` path must not look like success.
+
+    This branch is what the kanban dispatcher spawns; before the fix it
+    returned 0 for every provider failure, so the dispatcher recorded a
+    protocol violation ("worker exited cleanly without kanban_complete")
+    and burned one of the card's failure-counter lives per attempt.
+    """
+    calls = []
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+
+    code = _run_human_single_query(
+        monkeypatch,
+        calls,
+        {
+            "final_response": "",
+            "failed": True,
+            "error": "provider failed",
+            "failure_reason": "api_error",
+        },
+    )
+
+    assert code == 1
+    # The exit code must not cost us session finalization.
+    assert calls[-1] == ("finalize", "human-session")
+
+
+def test_human_single_query_quota_wall_exits_tempfail_for_kanban(monkeypatch):
+    """A quota wall in a kanban worker exits 75, not 0 and not 1."""
+    from hermes_cli.kanban_db import KANBAN_RATE_LIMIT_EXIT_CODE
+
+    calls = []
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_d16778b1")
+
+    code = _run_human_single_query(
+        monkeypatch,
+        calls,
+        {
+            "final_response": "",
+            "failed": True,
+            "error": "You've hit your session limit",
+            "failure_reason": "rate_limit",
+        },
+    )
+
+    assert code == KANBAN_RATE_LIMIT_EXIT_CODE
+    assert calls[-1] == ("finalize", "human-session")
+
+
+def test_human_single_query_successful_turn_does_not_exit(monkeypatch):
+    """Success still falls through to a normal return (no SystemExit)."""
+    calls = []
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+
+    code = _run_human_single_query(
+        monkeypatch,
+        calls,
+        {"final_response": "done", "completed": True},
+    )
+
+    assert code is None
+    assert calls[-1] == ("finalize", "human-session")

--- a/tests/hermes_cli/test_single_query_exit.py
+++ b/tests/hermes_cli/test_single_query_exit.py
@@ -1,0 +1,84 @@
+"""Exit-code contract for non-interactive single-query runs.
+
+Regression cover for the drift that made a Copilot session limit look
+like an agent protocol violation on the kanban board (2026-09-02, card
+``t_d16778b1``): the quiet path owned the 0/1/75 contract while the
+human-facing ``chat -q`` path — the one the dispatcher actually spawns —
+never inspected the turn result and always exited 0.
+"""
+
+import pytest
+
+from hermes_cli.kanban_db import KANBAN_RATE_LIMIT_EXIT_CODE
+from hermes_cli.single_query_exit import single_query_exit_code
+
+
+def test_successful_turn_exits_zero():
+    result = {"final_response": "hi", "completed": True}
+    assert single_query_exit_code(result, env={}) == 0
+
+
+def test_successful_turn_in_kanban_worker_exits_zero():
+    result = {"final_response": "hi", "completed": True}
+    assert (
+        single_query_exit_code(result, env={"HERMES_KANBAN_TASK": "t_1"}) == 0
+    )
+
+
+def test_failed_turn_exits_one():
+    result = {"failed": True, "error": "boom", "failure_reason": "api_error"}
+    assert single_query_exit_code(result, env={}) == 1
+
+
+def test_interrupted_but_not_failed_turn_exits_zero():
+    result = {"final_response": "", "interrupted": True}
+    assert single_query_exit_code(result, env={}) == 0
+
+
+@pytest.mark.parametrize("reason", ["rate_limit", "billing"])
+def test_quota_wall_in_kanban_worker_exits_tempfail(reason):
+    """The dispatcher must see EX_TEMPFAIL, not a task failure.
+
+    Its reap classifier maps 75 to ``rate_limited`` and releases the card
+    back to ``ready`` without counting a failure, so a multi-hour quota
+    window cannot trip the circuit breaker.
+    """
+    result = {"failed": True, "error": "quota", "failure_reason": reason}
+    code = single_query_exit_code(result, env={"HERMES_KANBAN_TASK": "t_1"})
+    assert code == KANBAN_RATE_LIMIT_EXIT_CODE
+    assert code == 75
+
+
+@pytest.mark.parametrize("reason", ["rate_limit", "billing"])
+def test_quota_wall_outside_kanban_exits_one(reason):
+    """Plain automation wrappers keep the 0/1 contract they expect."""
+    result = {"failed": True, "error": "quota", "failure_reason": reason}
+    assert single_query_exit_code(result, env={}) == 1
+
+
+def test_kanban_worker_task_failure_still_exits_one():
+    """A genuine task error must count against the card, not bounce it."""
+    result = {"failed": True, "error": "boom", "failure_reason": "api_error"}
+    assert (
+        single_query_exit_code(result, env={"HERMES_KANBAN_TASK": "t_1"}) == 1
+    )
+
+
+def test_no_turn_result_exits_one():
+    """``None`` means the turn never reached the agent — credentials or
+    agent init failed, so no answer was produced."""
+    assert single_query_exit_code(None, env={}) == 1
+
+
+def test_non_dict_result_exits_zero():
+    """The quiet path prints ``str(result)`` for an odd shape; something
+    was produced, so it is not reported as a failure."""
+    assert single_query_exit_code("plain text answer", env={}) == 0
+
+
+def test_env_defaults_to_os_environ(monkeypatch):
+    result = {"failed": True, "error": "quota", "failure_reason": "rate_limit"}
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_env")
+    assert single_query_exit_code(result) == KANBAN_RATE_LIMIT_EXIT_CODE
+    monkeypatch.delenv("HERMES_KANBAN_TASK")
+    assert single_query_exit_code(result) == 1


### PR DESCRIPTION
## Problem

The kanban dispatcher spawns workers as `hermes -p <profile> --cli chat -q "work kanban task <id>"` — **without `-Q`**. That lands in `main()`'s human-facing single-query branch, which calls `cli.chat()` and returns without ever inspecting the turn result. Every failure — provider wall, auth failure, agent init error — exits `0`.

The dispatcher's reap classifier reads a clean exit of a still-`running` task as "the worker finished without calling `kanban_complete`/`kanban_block`", i.e. a protocol violation by the agent. So a provider-side outage is reported as agent misbehaviour, and each attempt costs the card a life from its failure counter until it is given up on.

Observed 2026-09-02 on card `t_d16778b1`: a Copilot `You've hit your session limit · resets 12pm` produced eight consecutive `crashed` runs, each labelled a protocol violation, each with `Messages: 1 (1 user, 0 tool calls)` — the worker never got a single token out of the provider. The card was abandoned with a diagnosis that blamed the agent for a wall it never got past.

The quiet path (`-Q`) already had the right contract: `0` on success, `1` on failure, `75` (`EX_TEMPFAIL`) for a kanban worker walled by quota, which requeues the card *without* counting a failure. Since only goal mode passes `-Q`, that rate-limit requeue path was dead code for every other worker.

## Fix

- The contract moves into `hermes_cli/single_query_exit.py` and is used from **both** branches, so they cannot drift apart again.
- `chat()` publishes the raw turn result as `_last_turn_result` (it returns only the response text). `None` there means no turn happened at all — credentials or agent init failed — and exits `1`, matching the quiet path.
- The human path raises only a non-zero code, so a successful run still falls through to the normal `return` and keeps its existing exit summary.

## Verification

End-to-end against a local stub provider, patched tree vs `main`:

| scenario | main | patched |
| --- | --- | --- |
| successful turn (kanban) | 0 | 0 |
| HTTP 429, `HERMES_KANBAN_TASK` set | 0 | **75** |
| HTTP 429, no kanban env | 0 | **1** |
| agent init failure | 0 | **1** |

## Tests

- `tests/hermes_cli/test_single_query_exit.py` — 12 tests on the contract itself: success, rate limit with and without a kanban task, other failures, missing turn result.
- `tests/cli/test_single_query_session_finalize.py` — 3 tests on the human-facing `main()` branch: a walled kanban worker exits 75, a walled plain run exits 1, a successful run does not raise.

`tests/cli` runs 1403 passed / 1 failed; that one (`test_resume_quiet_stderr`) fails identically on unpatched `main` under the same ordering and is unrelated to this change.
