### PR TITLE
fix(azure-foundry): suppress reasoning replay after completed tool history

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -322,11 +322,19 @@ def _is_azure_foundry_responses(params: dict[str, Any]) -> bool:
 
 
 def _is_post_tool_replay(messages: Optional[list[dict[str, Any]]]) -> bool:
-    """True when ``messages`` end on a tool-result run issued by the preceding assistant turn.
+    """True when ``messages`` replay a completed tool-call history.
 
-    Azure Foundry rejects only this post-tool shape when encrypted reasoning is
-    replayed, so only the *trailing* messages are checked (a whole-history scan
-    would make suppression sticky). Call ids resolve like ``_chat_messages_to_responses_input``.
+    Azure Foundry rejects the payload shape where a prior assistant
+    ``function_call`` and its ``function_call_output`` are replayed alongside
+    an encrypted ``reasoning`` item (HTTP 400 ``invalid_payload``). This
+    includes ordinary later user follow-ups after the assistant has already
+    answered the tool result: the old tool history is still present on the
+    wire. Suppression is therefore scoped to Azure conversations with a
+    completed, paired tool exchange, not to all Responses requests.
+
+    Tool-call identity is resolved the same way
+    ``_chat_messages_to_responses_input`` resolves it, because the pairing
+    that matters is the one that reaches the wire.
     """
     from agent.codex_responses_adapter import _canonical_call_id_from_fc, _split_responses_tool_id
 
@@ -342,26 +350,27 @@ def _is_post_tool_replay(messages: Optional[list[dict[str, Any]]]) -> bool:
             ids.add(canonical)
         return ids
 
-    trailing = set()
-    for msg in reversed(messages or ()):
-        role = msg.get("role") if isinstance(msg, dict) else None
+    saw_tool_result = False
+    issued_tool_ids = set()
+    result_tool_ids = set()
+    for msg in messages or ():
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role")
         if role == "system":
             continue
         if role == "tool":
             ids = _pair_ids(msg.get("tool_call_id"))
-            if not ids:
-                return False
-            trailing |= ids
+            if ids:
+                saw_tool_result = True
+                result_tool_ids |= ids
             continue
-        # First non-tool message must be the assistant turn that issued the run.
-        if role != "assistant":
-            return False
-        return any(
-            trailing & _pair_ids(call.get("id"), call.get("call_id"))
-            for call in msg.get("tool_calls") or []
-            if isinstance(call, dict)
-        )
-    return False
+        if role == "assistant":
+            for call in msg.get("tool_calls") or []:
+                if isinstance(call, dict):
+                    issued_tool_ids |= _pair_ids(call.get("id"), call.get("call_id"))
+
+    return saw_tool_result and bool(issued_tool_ids & result_tool_ids)
 
 
 def _native_compaction_active(context_management: Any) -> bool:

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -406,17 +406,16 @@ class TestCodexBuildKwargs:
         assert "function_call_output" not in item_types
         assert kw.get("include") == ["reasoning.encrypted_content"]
 
-    def test_azure_foundry_user_turn_after_completed_tool_call_keeps_reasoning(
+    def test_azure_foundry_user_turn_after_completed_tool_call_suppresses_reasoning(
         self, transport
     ):
-        """Suppression must not stick for the rest of the conversation.
+        """A later follow-up still replays the earlier tool-heavy history.
 
-        The tool call completed and the assistant already answered; this turn
-        is a plain user follow-up whose payload ends on a user message, which
-        Foundry accepts. A predicate that scanned the whole history for any
-        tool call plus any tool result would suppress reasoning here — and on
-        every later turn — which is the all-turns behavior this scoping
-        exists to avoid.
+        Azure Foundry rejects encrypted reasoning when it is replayed alongside
+        any persisted function-call history, even after the assistant has
+        already answered the tool result and the current turn ends on a user
+        message. Suppress reasoning for the affected Azure conversation while
+        preserving function-call continuity.
         """
         messages = self._post_tool_messages() + [
             {
@@ -435,10 +434,10 @@ class TestCodexBuildKwargs:
             replay_encrypted_reasoning=True,
         )
         item_types = [item.get("type") for item in kw["input"] if isinstance(item, dict)]
-        assert "reasoning" in item_types
+        assert "reasoning" not in item_types
         assert "function_call" in item_types
         assert "function_call_output" in item_types
-        assert kw.get("include") == ["reasoning.encrypted_content"]
+        assert kw.get("include") == []
 
     def test_azure_foundry_parallel_tool_results_suppress_reasoning(self, transport):
         """A trailing run of parallel tool results is still the rejected shape."""

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -424,16 +424,10 @@ def test_build_api_kwargs_azure_foundry_non_tool_preserves_reasoning(monkeypatch
     assert kwargs.get("include") == ["reasoning.encrypted_content"]
 
 
-def test_build_api_kwargs_azure_foundry_user_turn_after_tool_call_keeps_reasoning(
+def test_build_api_kwargs_azure_foundry_user_turn_after_tool_call_suppresses_reasoning(
     monkeypatch,
 ):
-    """Suppression does not stick once the tool call is answered.
-
-    Regression guard for the sticky-history shape: after the assistant has
-    replied to the tool result, a plain user follow-up is a payload Foundry
-    accepts, so reasoning replay must come back on rather than stay off for
-    the remainder of the conversation.
-    """
+    """A later follow-up suppresses replay for persisted tool history."""
     agent = _build_azure_foundry_agent(monkeypatch)
 
     messages = _azure_post_tool_messages() + [
@@ -448,10 +442,10 @@ def test_build_api_kwargs_azure_foundry_user_turn_after_tool_call_keeps_reasonin
     kwargs = agent._build_api_kwargs(messages)
 
     item_types = [item.get("type") for item in kwargs["input"] if isinstance(item, dict)]
-    assert "reasoning" in item_types
+    assert "reasoning" not in item_types
     assert "function_call" in item_types
     assert "function_call_output" in item_types
-    assert kwargs.get("include") == ["reasoning.encrypted_content"]
+    assert kwargs.get("include") == []
 
 
 


### PR DESCRIPTION
## Summary

Broadens the existing Azure Foundry Responses workaround to cover resumed or later follow-ups whose replayed history contains a completed, paired tool exchange. The previous condition only matched a request ending directly on a tool result; the reported Desktop follow-up ended on a normal user message and therefore still replayed encrypted reasoning, causing Azure HTTP 400 `invalid_payload`.

The patch preserves `function_call` / `function_call_output` continuity and suppresses only encrypted reasoning replay for Azure Foundry histories with a matched tool result. Non-Azure endpoints and Azure conversations without tool history retain reasoning replay.

## Validation

- `scripts/run_tests.sh tests/agent/transports/test_codex_transport.py tests/run_agent/test_run_agent_codex_responses.py`
  - 171 passed, 0 failed
- Exact stored-session payload reconstruction from session `20260902_085435_1007b6`
  - Before patch: 58 reasoning items, `include: ["reasoning.encrypted_content"]`
  - After patch: 0 reasoning items, `include: []`, 40 function calls and 40 outputs retained
- Live Azure Foundry request with the patched payload: succeeded, `status: completed`
- Live control request with the original payload: failed with HTTP 400 `invalid_payload`
- `git diff --check`: clean

## Related issue

Follow-up to #63257. This addresses the adjacent case where the history contains completed tool calls but the current request ends on a later user message.

## Scope

This PR is intentionally limited to the predicate, regression tests, and the affected Responses request path.
