### PR TITLE
fix(cron): multiplex ticks isolate per profile, fire the bound port, deliver satellites fail-closed (#74878 #100489 #101113 #86519, salvage #70747 #84755 #96944)

### DIFF
--- a/cron/notepad.py
+++ b/cron/notepad.py
@@ -26,23 +26,34 @@ from __future__ import annotations
 import sqlite3
 import threading
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
 from hermes_constants import get_hermes_home
 from hermes_time import now as _hermes_now
 
-NOTEPAD_FILE = get_hermes_home().resolve() / "cron" / "notepad.db"
+# Optional test override. Production resolves the path at transaction time so
+# multiplexed profile ticks (set_hermes_home_override) cannot leak one
+# profile's notepad rows into the import-time home — and remove_job's
+# clear_notepad cannot wipe the wrong profile's DB (#86519). Same pattern as
+# cron/executions.py.
+NOTEPAD_FILE: Optional[Path] = None
 MAX_VALUE_BYTES = 16 * 1024
 MAX_KEY_CHARS = 128
 MAX_JOB_TOTAL_BYTES = 64 * 1024
 _lock = threading.RLock()
 
 
+def _current_notepad_file() -> Path:
+    return NOTEPAD_FILE or (get_hermes_home().resolve() / "cron" / "notepad.db")
+
+
 def _connect() -> sqlite3.Connection:
     from cron.jobs import _ensure_cron_dir
 
-    _ensure_cron_dir(NOTEPAD_FILE.parent)
-    return sqlite3.connect(NOTEPAD_FILE, timeout=5)
+    path = _current_notepad_file()
+    _ensure_cron_dir(path.parent)
+    return sqlite3.connect(path, timeout=5)
 
 
 def _initialize_schema(conn: sqlite3.Connection) -> None:
@@ -157,7 +168,7 @@ def clear_notepad(job_id: str) -> int:
     Called from ``cron.jobs.remove_job`` so deleted jobs don't orphan their
     rows. No-ops without creating the DB when no notepad file exists yet.
     """
-    if not NOTEPAD_FILE.exists():
+    if not _current_notepad_file().exists():
         return 0
     with _transaction() as conn:
         cur = conn.execute(

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3353,7 +3353,14 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
         from gateway.delivery import resolve_delivery_transport
 
-        transport = resolve_delivery_transport(platform, config, adapters)
+        target_adapters = adapters
+        if isinstance(adapters, SharedRouteAdapters):
+            # Credentialless satellite: the primary adapter is a valid
+            # transport for THIS target only when an exact primary route maps
+            # it to this profile (#101113). Miss → fail closed below.
+            shared = adapters.get(platform, target)
+            target_adapters = {platform: shared} if shared is not None else {}
+        transport = resolve_delivery_transport(platform, config, target_adapters)
         if transport is not None:
             pconfig = transport.config
             runtime_adapter = transport.adapter
@@ -3644,7 +3651,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 elif text_to_send:
                     from agent.async_utils import safe_schedule_threadsafe
 
-                    router = DeliveryRouter(config, adapters)
+                    router = DeliveryRouter(config, target_adapters)
                     route_target = DeliveryTarget(
                         platform=platform,
                         chat_id=str(chat_id),
@@ -5303,21 +5310,20 @@ def _preflight_check_provider_key(job: dict, cfg: dict) -> Optional[str]:
     return None
 
 
-def _delivery_platform_routed_from_primary_gateway(platform_name: str) -> bool:
-    """True when the primary gateway routes this platform to the profile the
-    scheduler is currently serving.
+def _primary_profile_routes_for_current_home() -> list:
+    """Primary gateway ``profile_routes`` that target the profile currently
+    being served, or ``[]`` (also when this IS the primary home).
 
     Under ``gateway.multiplex_profiles`` a satellite profile's cron jobs are
     ticked by the primary gateway's in-process ticker (#69377) and delivered
     through the primary gateway's live adapters — the satellite home never
     holds the platform credentials itself (giving it a token of its own is a
-    ``duplicate_credential`` fatal). ``_preflight_check_delivery`` loads the
-    gateway config of the job's OWN home, where such a platform correctly
-    reads as unconnected; consulting the primary home's ``profile_routes``
-    keeps routed satellite jobs from being permanently false-blocked (#97476).
-    Reads the primary config.yaml directly (both the top-level and nested
-    ``gateway.`` forms) instead of ``load_gateway_config()`` so no primary
-    platform config leaks into this process's environment.
+    ``duplicate_credential`` fatal). Reads the primary config.yaml directly
+    (both the top-level and nested ``gateway.`` forms) instead of
+    ``load_gateway_config()`` so no primary platform config leaks into this
+    process's environment. Shared by the preflight rescue (#97476) and the
+    delivery-time shared-transport resolver (#101113) so route semantics
+    cannot drift between the two halves.
     """
     try:
         from hermes_constants import get_default_hermes_root, get_hermes_home
@@ -5328,10 +5334,10 @@ def _delivery_platform_routed_from_primary_gateway(platform_name: str) -> bool:
             primary_home.expanduser().resolve(strict=False)
             == current_home.expanduser().resolve(strict=False)
         ):
-            return False  # this IS the primary home — nothing to consult
+            return []  # this IS the primary home — nothing to consult
         config_path = primary_home.expanduser() / "config.yaml"
         if not config_path.exists():
-            return False
+            return []
 
         import yaml
 
@@ -5341,25 +5347,75 @@ def _delivery_platform_routed_from_primary_gateway(platform_name: str) -> bool:
         if routes_raw is None and isinstance(raw.get("gateway"), dict):
             routes_raw = raw["gateway"].get("profile_routes")
         if not isinstance(routes_raw, list):
-            return False
+            return []
 
         from gateway.profile_routing import parse_profile_routes
         from hermes_cli.profiles import profile_matches_home
 
-        platform_key = platform_name.lower()
-        for route in parse_profile_routes(routes_raw):
-            if (
-                route.enabled
-                and str(route.platform).lower() == platform_key
-                and profile_matches_home(route.profile)
-            ):
-                return True
-        return False
+        return [
+            route
+            for route in parse_profile_routes(routes_raw)
+            if route.enabled and profile_matches_home(route.profile)
+        ]
     except Exception:
         logger.debug(
-            "preflight: primary-gateway profile-route lookup unavailable",
+            "primary-gateway profile-route lookup unavailable",
             exc_info=True,
         )
+        return []
+
+
+def _delivery_platform_routed_from_primary_gateway(platform_name: str) -> bool:
+    """True when the primary gateway routes this platform to the profile the
+    scheduler is currently serving (preflight rescue, #97476)."""
+    platform_key = platform_name.lower()
+    return any(
+        str(route.platform).lower() == platform_key
+        for route in _primary_profile_routes_for_current_home()
+    )
+
+
+class SharedRouteAdapters:
+    """Read-only adapter map for a credentialless satellite profile (#101113).
+
+    A satellite under ``gateway.profile_routes`` owns no bot credential and so
+    has no adapter map of its own; its inbound traffic arrives on the PRIMARY
+    adapter and is routed to it by an exact route. Its cron output must go
+    back out the same transport — but ONLY for targets an enabled primary
+    route maps to this profile. ``get(platform, target)`` resolves the primary
+    adapter iff the route matcher used by inbound routing
+    (``ProfileRoute.matches``) accepts the target's ``chat_id``/``thread_id``;
+    every other lookup is a miss, so an unmatched target, a disabled route, or
+    a route naming another profile still fails closed (never the default bot).
+    A plain ``get(platform)`` (no target) is always a miss: routing is
+    per-target, not per-platform.
+    """
+
+    def __init__(self, primary_adapters, routes) -> None:
+        self._primary = dict(primary_adapters or {})
+        self._routes = list(routes or [])
+
+    def __bool__(self) -> bool:
+        return bool(self._primary) and bool(self._routes)
+
+    def get(self, platform, target=None, default=None):
+        if not target:
+            return default
+        adapter = self._primary.get(platform)
+        if adapter is None:
+            return default
+        platform_key = str(getattr(platform, "value", platform)).lower()
+        chat_id = str(target.get("chat_id") or "") or None
+        thread_id = target.get("thread_id")
+        thread_id = str(thread_id) if thread_id else None
+        for route in self._routes:
+            if str(route.platform).lower() != platform_key:
+                continue
+            if not (route.chat_id or route.thread_id):
+                continue  # guild-only routes are not target-exact
+            if route.matches(str(route.platform), chat_id=chat_id, thread_id=thread_id):
+                return adapter
+        return default
         return False
 
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4005,7 +4005,19 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 try:
                     pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
                     try:
-                        future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files))
+                        # The fallback worker is a fresh thread: it does NOT
+                        # inherit the multiplexed profile ContextVars (home
+                        # override + secret scope). Run inside a copy of the
+                        # active context so the standalone sender reads THIS
+                        # profile's bot token, not the process default's
+                        # (#100489) — same pattern as the session-db and
+                        # heartbeat workers in this module.
+                        _fallback_context = contextvars.copy_context()
+                        future = pool.submit(
+                            _fallback_context.run,
+                            asyncio.run,
+                            _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files),
+                        )
                         result = future.result(timeout=30)
                     finally:
                         pool.shutdown(wait=False)

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -560,6 +560,7 @@ class InProcessCronScheduler(CronScheduler):
         profile_homes=None,
         profile_adapters=None,
         default_profile=None,
+        profile_gate=None,
     ):
         import logging
         from cron.scheduler import CronTickYielded
@@ -590,6 +591,7 @@ class InProcessCronScheduler(CronScheduler):
                 can_dispatch=can_dispatch,
                 profile_adapters=profile_adapters,
                 default_profile=default_profile,
+                profile_gate=profile_gate,
             )
             return
 
@@ -670,6 +672,7 @@ class InProcessCronScheduler(CronScheduler):
         can_dispatch=None,
         profile_adapters=None,
         default_profile=None,
+        profile_gate=None,
     ):
         """Tick every served profile's cron store when multiplex_profiles is on.
 
@@ -678,6 +681,11 @@ class InProcessCronScheduler(CronScheduler):
         agent execution to that profile's home — mirroring how
         ``_profile_runtime_scope`` scopes the multiplexed inbound path and
         ``web_server.py`` scopes per-profile cron API calls.
+
+        ``profile_gate(name, home) -> bool``, when given, is consulted every
+        cycle; a profile it rejects is neither ticked nor heartbeated that
+        cycle (the desktop ticker uses it to stand down for profiles whose
+        own gateway is running, #100489).
         """
         import logging
         from cron.scheduler import tick as cron_tick
@@ -734,11 +742,21 @@ class InProcessCronScheduler(CronScheduler):
             # Worst per-profile failure this cycle (fd exhaustion wins) so the
             # #87644 backoff/reclaim is applied once per cycle, not per profile.
             _cycle_exc: BaseException | None = None
+            cycle_homes = _existing_profile_homes(profile_homes)
+            if profile_gate is not None:
+                cycle_homes = [
+                    entry
+                    for entry in cycle_homes
+                    if profile_gate(
+                        entry[0] if isinstance(entry, tuple) else None,
+                        entry[1] if isinstance(entry, tuple) else entry,
+                    )
+                ]
             try:
                 if can_dispatch is not None and not can_dispatch():
                     logger.debug("Cron dispatch paused while gateway drains existing work")
                 else:
-                    for entry in _existing_profile_homes(profile_homes):
+                    for entry in cycle_homes:
                         _pname = entry[0] if isinstance(entry, tuple) else None
                         home = entry[1] if isinstance(entry, tuple) else entry
                         home_token = set_hermes_home_override(str(home))
@@ -803,7 +821,7 @@ class InProcessCronScheduler(CronScheduler):
             # beat reflects its own outcome, so a yielding profile does not
             # darken healthy siblings — from an aborted one (exception), where
             # no profile completed and all beats are unsuccessful (#32612).
-            for entry in _existing_profile_homes(profile_homes):
+            for entry in cycle_homes:
                 home = entry[1] if isinstance(entry, tuple) else entry
                 home_token = set_hermes_home_override(str(home))
                 try:

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -681,7 +681,7 @@ class InProcessCronScheduler(CronScheduler):
         """
         import logging
         from cron.scheduler import tick as cron_tick
-        from cron.scheduler import CronTickYielded
+        from cron.scheduler import CronTickYielded, _is_fd_exhaustion
         from cron.jobs import (
             clear_ticker_error,
             record_ticker_error,
@@ -701,6 +701,8 @@ class InProcessCronScheduler(CronScheduler):
         # A profile may have been deleted since this snapshot was taken;
         # never recreate a deleted home's cron workspace via the heartbeat
         # below (#47368).
+        # One profile's broken store (corrupt executions.db, unreadable
+        # cron dir) must not abort startup for every other profile (#74878).
         for entry in _existing_profile_homes(profile_homes):
             home = entry[1] if isinstance(entry, tuple) else entry
             home_token = set_hermes_home_override(str(home))
@@ -714,6 +716,13 @@ class InProcessCronScheduler(CronScheduler):
                             home,
                         )
                     record_ticker_heartbeat()
+            except BaseException as e:
+                logger.error(
+                    "Cron startup recovery error for profile at %s: %s",
+                    home,
+                    e,
+                    exc_info=True,
+                )
             finally:
                 reset_hermes_home_override(home_token)
 
@@ -722,6 +731,9 @@ class InProcessCronScheduler(CronScheduler):
             ok = False
             _tick_error = None
             _profile_errors: dict[str, str] = {}
+            # Worst per-profile failure this cycle (fd exhaustion wins) so the
+            # #87644 backoff/reclaim is applied once per cycle, not per profile.
+            _cycle_exc: BaseException | None = None
             try:
                 if can_dispatch is not None and not can_dispatch():
                     logger.debug("Cron dispatch paused while gateway drains existing work")
@@ -761,9 +773,26 @@ class InProcessCronScheduler(CronScheduler):
                             # only ticker in the same cycle.
                             logger.info("Cron tick yielded for profile at %s: %s", home, e)
                             _profile_errors[str(home)] = f"{type(e).__name__}: {e}"
+                        except BaseException as e:
+                            # Any other failure is THIS profile's failure
+                            # (#74878): record it against this profile's
+                            # status and keep ticking the remaining profiles.
+                            # BaseException for the same reason as the
+                            # single-profile loop (#32612).
+                            logger.error(
+                                "Cron tick error for profile at %s: %s",
+                                home,
+                                e,
+                                exc_info=True,
+                            )
+                            _profile_errors[str(home)] = f"{type(e).__name__}: {e}"
+                            if _cycle_exc is None or _is_fd_exhaustion(e):
+                                _cycle_exc = e
                         finally:
                             reset_hermes_home_override(home_token)
                     ok = not _profile_errors
+                    if _cycle_exc is not None:
+                        consecutive_failures = _note_tick_failure(_cycle_exc, consecutive_failures)
             except BaseException as e:
                 logger.error("Cron tick error: %s", e, exc_info=True)
                 _tick_error = f"{type(e).__name__}: {e}"

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -689,7 +689,12 @@ class InProcessCronScheduler(CronScheduler):
         """
         import logging
         from cron.scheduler import tick as cron_tick
-        from cron.scheduler import CronTickYielded, _is_fd_exhaustion
+        from cron.scheduler import (
+            CronTickYielded,
+            SharedRouteAdapters,
+            _is_fd_exhaustion,
+            _primary_profile_routes_for_current_home,
+        )
         from cron.jobs import (
             clear_ticker_error,
             record_ticker_error,
@@ -775,6 +780,20 @@ class InProcessCronScheduler(CronScheduler):
                                     _tick_adapters = adapters
                                 else:
                                     _tick_adapters = (profile_adapters or {}).get(_pname) or {}
+                                    if not _tick_adapters and adapters:
+                                        # Credentialless satellite under
+                                        # gateway.profile_routes: no bot of its
+                                        # own, so its output may ride the
+                                        # PRIMARY adapter — but only for
+                                        # targets an exact enabled primary
+                                        # route maps to this profile
+                                        # (#101113). Unmatched targets still
+                                        # fail closed; this is not a default
+                                        # fallback.
+                                        _tick_adapters = SharedRouteAdapters(
+                                            adapters,
+                                            _primary_profile_routes_for_current_home(),
+                                        )
                                 cron_tick(
                                     verbose=False,
                                     adapters=_tick_adapters,

--- a/cron/suggestions.py
+++ b/cron/suggestions.py
@@ -45,8 +45,17 @@ logger = logging.getLogger(__name__)
 # Per-profile by design (issue #4707): suggestions live alongside the active
 # profile's cron store. Anchor on get_hermes_home() (profile home), not the
 # shared default root. See cron/jobs.py for the full rationale.
-CRON_DIR = get_hermes_home().resolve() / "cron"
-SUGGESTIONS_FILE = CRON_DIR / "suggestions.json"
+#
+# Optional test overrides. Production resolves the path at call time so
+# multiplexed profile ticks (set_hermes_home_override) cannot leak one
+# profile's suggestions into the import-time home (#86519). Same pattern as
+# cron/executions.py.
+CRON_DIR: Optional[Path] = None
+SUGGESTIONS_FILE: Optional[Path] = None
+
+
+def _current_suggestions_file() -> Path:
+    return SUGGESTIONS_FILE or (get_hermes_home().resolve() / "cron" / "suggestions.json")
 
 # In-process lock protecting load->modify->save cycles (the background review
 # fork and the main agent can both write).
@@ -72,14 +81,15 @@ def _secure_file(path: Path) -> None:
 def _ensure_dir() -> None:
     from cron.jobs import _ensure_cron_dir
 
-    _ensure_cron_dir(CRON_DIR)
+    _ensure_cron_dir(_current_suggestions_file().parent)
 
 
 def _load_raw() -> Dict[str, Any]:
-    if not SUGGESTIONS_FILE.exists():
+    suggestions_file = _current_suggestions_file()
+    if not suggestions_file.exists():
         return {"suggestions": []}
     try:
-        with open(SUGGESTIONS_FILE, "r", encoding="utf-8") as f:
+        with open(suggestions_file, "r", encoding="utf-8") as f:
             data = json.load(f)
     except (json.JSONDecodeError, OSError) as e:
         logger.warning("suggestions.json unreadable (%s); starting empty", e)
@@ -94,7 +104,8 @@ def _load_raw() -> Dict[str, Any]:
 
 def _save_raw(suggestions: List[Dict[str, Any]]) -> None:
     _ensure_dir()
-    fd, tmp_path = tempfile.mkstemp(dir=str(SUGGESTIONS_FILE.parent), suffix=".tmp", prefix=".sugg_")
+    suggestions_file = _current_suggestions_file()
+    fd, tmp_path = tempfile.mkstemp(dir=str(suggestions_file.parent), suffix=".tmp", prefix=".sugg_")
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(
@@ -104,8 +115,8 @@ def _save_raw(suggestions: List[Dict[str, Any]]) -> None:
             )
             f.flush()
             os.fsync(f.fileno())
-        atomic_replace(tmp_path, SUGGESTIONS_FILE)
-        _secure_file(SUGGESTIONS_FILE)
+        atomic_replace(tmp_path, suggestions_file)
+        _secure_file(suggestions_file)
     except BaseException:
         try:
             os.unlink(tmp_path)

--- a/cron/suggestions.py
+++ b/cron/suggestions.py
@@ -46,11 +46,10 @@ logger = logging.getLogger(__name__)
 # profile's cron store. Anchor on get_hermes_home() (profile home), not the
 # shared default root. See cron/jobs.py for the full rationale.
 #
-# Optional test overrides. Production resolves the path at call time so
+# Optional test override. Production resolves the path at call time so
 # multiplexed profile ticks (set_hermes_home_override) cannot leak one
 # profile's suggestions into the import-time home (#86519). Same pattern as
 # cron/executions.py.
-CRON_DIR: Optional[Path] = None
 SUGGESTIONS_FILE: Optional[Path] = None
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -303,6 +303,17 @@ def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60
             profile_homes = list(profiles_to_serve(multiplex=True))
             if len(profile_homes) > 1:
                 start_kwargs["profile_homes"] = profile_homes
+                # Stand down, per tick, for any profile whose OWN gateway is
+                # running: that gateway ticks it with live adapters, and the
+                # tick-lock race otherwise lets this adapter-less ticker win
+                # and deliver the job through the standalone path (#100489).
+                # Evaluated every cycle so a gateway starting/stopping later
+                # is picked up without a dashboard restart.
+                from hermes_cli.profiles import _check_gateway_running
+
+                start_kwargs["profile_gate"] = (
+                    lambda _name, home: not _check_gateway_running(Path(home))
+                )
                 from hermes_logging import enable_profile_log_routing
 
                 enable_profile_log_routing(profile_homes)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -13514,20 +13514,47 @@ def _gateway_fire_endpoint(profile: str, home: Path) -> str:
     """Resolve the loopback URL of the gateway api_server's cron-fire route.
 
     Port resolution mirrors gateway/config.py's api_server load order for the
-    TARGET profile: ``platforms.api_server.extra.port`` in the profile's
-    config.yaml, then ``API_SERVER_PORT`` (process env for the active profile,
-    the profile's own .env otherwise), then the adapter default 8642. The bind
-    host is the adapter's loopback default — the dashboard and gateway share a
-    network namespace in every supported deployment (same host process tree,
-    or the same container under s6).
+    LISTENER-OWNER profile: ``platforms.api_server.extra.port`` in that
+    profile's config.yaml, then ``API_SERVER_PORT`` (process env for the
+    active profile, the profile's own .env otherwise), then the adapter
+    default 8642. The bind host is the adapter's loopback default — the
+    dashboard and gateway share a network namespace in every supported
+    deployment (same host process tree, or the same container under s6).
 
     Multiplex mode (one gateway serving several profiles) exposes per-profile
     mirrors under ``/p/<profile>/…``, so a non-default profile routes through
-    the default gateway's port with that prefix; per-profile-gateway mode
-    (each profile its own process/port) uses the bare path on the profile's
-    own port.
+    the default gateway's port with that prefix — only the DEFAULT profile's
+    api_server is bound in that mode, so the port must be read from the
+    default home, never the target profile's (a secondary's own
+    ``API_SERVER_PORT`` is a port nothing listens on). Per-profile-gateway
+    mode (each profile its own process/port) uses the bare path on the
+    profile's own port.
     """
     import os as _os
+
+    multiplex = False
+    try:
+        from gateway.config import _env_multiplex_profiles_override
+
+        cfg = load_config()
+        multiplex = bool(cfg_get(cfg, "gateway", "multiplex_profiles", default=False))
+        env_flag = _env_multiplex_profiles_override()
+        if env_flag is not None:
+            multiplex = env_flag
+    except Exception:
+        _log.debug("cron fire: multiplex detection failed; assuming single-profile", exc_info=True)
+
+    listener_profile, listener_home = profile, home
+    if multiplex and profile != "default":
+        from hermes_constants import get_default_hermes_root
+
+        listener_profile, listener_home = "default", get_default_hermes_root()
+        _log.info(
+            "cron fire: multiplex gateway — resolving api_server port for %s "
+            "from the default profile's listener (%s)",
+            profile,
+            listener_home,
+        )
 
     port = 0
     try:
@@ -13535,14 +13562,14 @@ def _gateway_fire_endpoint(profile: str, home: Path) -> str:
         # overlay, ${ENV_VAR} expansion, profile pathing) — never a raw
         # yaml.safe_load of config.yaml (tests/hermes_cli/
         # test_config_read_guard.py). The HERMES_HOME override scopes
-        # get_config_path() to the TARGET profile, same pattern the
+        # get_config_path() to the LISTENER-OWNER profile, same pattern the
         # deprecated _fire_cron_job_for_profile used for its store scope.
         from hermes_constants import (
             reset_hermes_home_override,
             set_hermes_home_override,
         )
 
-        token = set_hermes_home_override(str(home))
+        token = set_hermes_home_override(str(listener_home))
         try:
             profile_cfg = load_config()
         finally:
@@ -13557,8 +13584,8 @@ def _gateway_fire_endpoint(profile: str, home: Path) -> str:
     if not port:
         raw = (
             _os.getenv("API_SERVER_PORT", "")
-            if profile == _cron_default_profile()
-            else _profile_env_value(home, "API_SERVER_PORT")
+            if listener_profile == _cron_default_profile()
+            else _profile_env_value(listener_home, "API_SERVER_PORT")
         )
         try:
             port = int(raw) if raw else 0
@@ -13566,18 +13593,6 @@ def _gateway_fire_endpoint(profile: str, home: Path) -> str:
             port = 0
     if not port:
         port = 8642
-
-    multiplex = False
-    try:
-        cfg = load_config()
-        multiplex = bool(cfg_get(cfg, "gateway", "multiplex_profiles", default=False))
-        env_flag = _os.getenv("GATEWAY_MULTIPLEX_PROFILES", "").strip().lower()
-        if env_flag in {"1", "true", "yes", "on"}:
-            multiplex = True
-        elif env_flag in {"0", "false", "no", "off"}:
-            multiplex = False
-    except Exception:
-        pass
 
     if multiplex and profile != "default":
         return f"http://127.0.0.1:{port}/p/{profile}/api/cron/fire"

--- a/tests/cron/test_cron_multiplex_desktop_ticker_scope.py
+++ b/tests/cron/test_cron_multiplex_desktop_ticker_scope.py
@@ -1,0 +1,139 @@
+"""Regression tests for #100489 — desktop multiplex ticker must not deliver a
+secondary profile's cron output through the default profile's identity.
+
+Two halves:
+
+1. ``_deliver_result``'s standalone fallback pool (taken when the caller has a
+   RUNNING event loop — the desktop dashboard shape) spawns a fresh thread that
+   did not inherit the profile ContextVars; it must run inside a copy of the
+   active context so the sender reads THIS profile's home + secrets.
+2. The desktop ticker must stand down, per tick, for a profile whose OWN
+   gateway is running — that gateway ticks it with live adapters, and racing it
+   on the tick lock lets the adapter-less desktop ticker deliver standalone.
+"""
+import asyncio
+import threading
+from unittest.mock import patch
+
+
+
+def test_standalone_fallback_pool_keeps_profile_scope(tmp_path, monkeypatch):
+    from agent.secret_scope import (
+        get_secret,
+        set_multiplex_active,
+        set_secret_scope,
+    )
+    from hermes_constants import get_hermes_home, set_hermes_home_override
+    import cron.scheduler as sched
+    import tools.send_message_tool as smt
+
+    default_home = tmp_path / "default"
+    sec_home = tmp_path / "profiles" / "ops"
+    for home in (default_home, sec_home):
+        (home / "cron").mkdir(parents=True)
+        (home / "config.yaml").write_text("platforms:\n  telegram:\n    enabled: true\n")
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "DEFAULT-TOKEN")
+    set_multiplex_active(True)
+
+    seen = {}
+
+    async def fake_send(platform, pconfig, chat_id, message, **kwargs):
+        seen["home"] = str(get_hermes_home())
+        seen["token"] = get_secret("TELEGRAM_BOT_TOKEN", None)
+        return {"success": True, "message_id": "1"}
+
+    job = {"id": "j1", "name": "probe", "deliver": "telegram:12345", "schedule": {"kind": "cron"}}
+
+    async def _inside_running_loop():
+        # Emulate the multiplex ticker's per-profile scope on the caller.
+        set_hermes_home_override(str(sec_home))
+        set_secret_scope({"TELEGRAM_BOT_TOKEN": "OPS-TOKEN"})
+        return sched._deliver_result(job, "hello", adapters={}, loop=None)
+
+    try:
+        with patch.object(smt, "_send_to_platform", fake_send):
+            err = asyncio.run(_inside_running_loop())
+    finally:
+        set_multiplex_active(False)
+
+    assert err is None, err
+    assert seen["home"] == str(sec_home.resolve())
+    assert seen["token"] == "OPS-TOKEN"
+
+
+def test_multiplex_ticker_profile_gate_skips_rejected_profile(tmp_path):
+    from cron.scheduler_provider import InProcessCronScheduler
+    from hermes_constants import get_hermes_home
+
+    own_gateway = tmp_path / "own-gateway"
+    orphan = tmp_path / "orphan"
+    for home in (own_gateway, orphan):
+        (home / "cron").mkdir(parents=True)
+
+    stop = threading.Event()
+    ticked: list[str] = []
+
+    def _tick(*args, **kwargs):
+        ticked.append(str(get_hermes_home()))
+        if len(ticked) >= 3:
+            stop.set()
+        return 0
+
+    provider = InProcessCronScheduler()
+    with patch("cron.scheduler.tick", side_effect=_tick):
+        thread = threading.Thread(
+            target=provider.start,
+            args=(stop,),
+            kwargs={
+                "interval": 0,
+                "profile_homes": [("own-gateway", own_gateway), ("orphan", orphan)],
+                "profile_gate": lambda name, home: name != "own-gateway",
+            },
+            daemon=True,
+        )
+        thread.start()
+        thread.join(timeout=5)
+        stop.set()
+        thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert set(ticked) == {str(orphan)}
+    # The gated profile gets no tick-loop success marker either: its own
+    # gateway owns that status surface.
+    assert not (own_gateway / "cron" / "ticker_last_success").exists()
+    assert (orphan / "cron" / "ticker_last_success").exists()
+
+
+def test_desktop_ticker_gates_on_profile_gateway_running(tmp_path, monkeypatch):
+    """The desktop ticker wires the gate to ``_check_gateway_running``."""
+    from hermes_cli import web_server
+
+    homes = [("default", tmp_path / "default"), ("ops", tmp_path / "ops")]
+    monkeypatch.setattr(
+        "hermes_cli.profiles.profiles_to_serve", lambda multiplex=False: list(homes)
+    )
+    monkeypatch.setattr(
+        "hermes_cli.profiles._check_gateway_running", lambda home: home.name == "ops"
+    )
+    captured = {}
+
+    class _Provider:
+        name = "fake"
+
+        def start(self, stop_event, **kwargs):
+            captured.update(kwargs)
+
+    from cron import scheduler_provider as sp
+
+    monkeypatch.setattr(web_server, "resolve_cron_scheduler", lambda: _Provider(), raising=False)
+    monkeypatch.setattr(sp, "resolve_cron_scheduler", lambda: _Provider())
+    monkeypatch.setattr(sp, "InProcessCronScheduler", _Provider)
+    monkeypatch.setattr("hermes_logging.enable_profile_log_routing", lambda homes: None)
+
+    web_server._start_desktop_cron_ticker(threading.Event(), interval=0)
+
+    gate = captured.get("profile_gate")
+    assert gate is not None, "desktop ticker did not install a profile gate"
+    assert gate("default", tmp_path / "default") is True
+    assert gate("ops", tmp_path / "ops") is False

--- a/tests/cron/test_cron_multiplex_shared_route_delivery.py
+++ b/tests/cron/test_cron_multiplex_shared_route_delivery.py
@@ -1,0 +1,112 @@
+"""Regression tests for #101113 — a credentialless satellite profile under
+``gateway.profile_routes`` delivers cron output through the PRIMARY adapter
+for exactly the targets the primary routes to it, and fails closed otherwise.
+
+The multiplex ticker hands such a profile a ``SharedRouteAdapters`` view over
+the primary adapter map; ``_deliver_result`` resolves a transport from it per
+target using the same ``ProfileRoute.matches`` predicate as inbound routing.
+"""
+import asyncio
+from concurrent.futures import Future
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+from cron.scheduler import (
+    SharedRouteAdapters,
+    _deliver_result,
+    _primary_profile_routes_for_current_home,
+)
+from gateway.config import Platform, PlatformConfig
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+PRIMARY_YAML = {
+    "gateway": {
+        "multiplex_profiles": True,
+        "profile_routes": [
+            {"name": "fit", "platform": "discord", "chat_id": "1543065293755256852", "profile": "fitness"},
+            {"name": "off", "platform": "discord", "chat_id": "999", "profile": "fitness", "enabled": False},
+            {"name": "other", "platform": "discord", "chat_id": "777", "profile": "other"},
+        ],
+    }
+}
+
+
+def _job(chat_id: str) -> dict:
+    return {"id": "a7ae1520356c", "name": "brief", "deliver": f"discord:{chat_id}"}
+
+
+def _run(job, adapters):
+    """Drive ``_deliver_result`` with a live loop and a real DeliveryRouter."""
+    loop = MagicMock()
+    loop.is_running.return_value = True
+
+    def fake_run_coro(coro, _loop):
+        future = Future()
+        future.set_result(asyncio.run(coro))
+        return future
+
+    standalone = []
+
+    async def _fake_send_to_platform(platform, pconfig, chat_id, text, **kwargs):
+        standalone.append(chat_id)
+        return {"success": False, "error": "DISCORD_BOT_TOKEN is not set"}
+
+    config = MagicMock()
+    config.platforms = {Platform.DISCORD: PlatformConfig(enabled=True)}
+    config.get_home_channel = lambda p: None
+    with patch("gateway.config.load_gateway_config", return_value=config), \
+         patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+         patch("tools.send_message_tool._send_to_platform", _fake_send_to_platform), \
+         patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
+        error = _deliver_result(job, "hello", adapters=adapters, loop=loop)
+    return error, standalone
+
+
+def _primary_adapter():
+    adapter = MagicMock()
+    adapter.sent = []
+
+    async def send(chat_id, content, metadata=None):
+        adapter.sent.append(chat_id)
+        return {"success": True, "message_id": "m1"}
+
+    adapter.send = send
+    return adapter
+
+
+def test_satellite_routes_exact_target_through_primary_adapter(tmp_path, monkeypatch):
+    root = tmp_path / "root"
+    fitness_home = root / "profiles" / "fitness"
+    fitness_home.mkdir(parents=True)
+    (root / "config.yaml").write_text(yaml.safe_dump(PRIMARY_YAML), encoding="utf-8")
+    monkeypatch.setattr("hermes_constants.get_default_hermes_root", lambda: root)
+    primary = _primary_adapter()
+
+    token = set_hermes_home_override(str(fitness_home))
+    try:
+        shared = SharedRouteAdapters(
+            {Platform.DISCORD: primary}, _primary_profile_routes_for_current_home()
+        )
+        # exact enabled route → primary adapter sends, no standalone attempt
+        error, standalone = _run(_job("1543065293755256852"), shared)
+        assert error is None, error
+        assert primary.sent == ["1543065293755256852"]
+        assert standalone == []
+
+        # unmatched chat, disabled route, route for another profile → the
+        # primary bot is NEVER used; delivery stays on the satellite's own
+        # (credentialless) standalone path and reports its failure.
+        for chat in ("424242", "999", "777"):
+            primary.sent.clear()
+            error, standalone = _run(_job(chat), shared)
+            assert error is not None and "DISCORD_BOT_TOKEN" in error
+            assert primary.sent == []
+            assert standalone == [chat]
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_shared_view_is_falsy_without_routes_or_primary_adapters():
+    assert not SharedRouteAdapters({}, [])
+    assert SharedRouteAdapters({Platform.DISCORD: object()}, []).get(Platform.DISCORD) is None

--- a/tests/cron/test_notepad.py
+++ b/tests/cron/test_notepad.py
@@ -8,6 +8,7 @@ use the notepad, and the `hermes cron notepad` CLI handler.
 from __future__ import annotations
 
 import argparse
+import importlib
 import sys
 from pathlib import Path
 
@@ -101,6 +102,33 @@ class TestNotepadCrud:
         (remove_job calls clear_notepad unconditionally)."""
         assert notepad.clear_notepad("never-used") == 0
         assert not notepad.NOTEPAD_FILE.exists()
+
+
+class TestNotepadProfileIsolation:
+    def test_profile_override_routes_writes_to_current_home(self, tmp_path):
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+        import cron.notepad as notepad_mod
+
+        profile_a = tmp_path / "profile-a"
+        profile_b = tmp_path / "profile-b"
+
+        import_token = set_hermes_home_override(profile_a)
+        try:
+            importlib.reload(notepad_mod)
+        finally:
+            reset_hermes_home_override(import_token)
+
+        runtime_token = set_hermes_home_override(profile_b)
+        try:
+            notepad_mod.set_note("job-1", "cursor", "page=7")
+        finally:
+            reset_hermes_home_override(runtime_token)
+
+        assert (profile_b / "cron" / "notepad.db").exists()
+        assert not (profile_a / "cron" / "notepad.db").exists()
 
 
 class TestJobRemovalCleanup:

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -786,3 +786,109 @@ def test_multiplex_missing_secondary_does_not_fall_back_to_shared(tmp_path):
     assert default_ad is shared
     assert sec_ad is not shared
     assert not sec_ad
+
+
+def test_multiplex_ticker_isolates_profile_failures(tmp_path):
+    """A failing profile's tick must not skip healthy siblings in the same
+    cycle, nor darken their status (#74878)."""
+    from cron.jobs import get_ticker_last_error, record_ticker_error, use_cron_store
+    from cron.scheduler_provider import InProcessCronScheduler
+    from hermes_constants import get_hermes_home
+
+    failing_home = tmp_path / "failing"
+    healthy_home = tmp_path / "healthy"
+    for home in (failing_home, healthy_home):
+        (home / "cron").mkdir(parents=True)
+        with use_cron_store(home):
+            record_ticker_error("RuntimeError: stale failure")
+
+    stop = threading.Event()
+    tick_homes: list[str] = []
+
+    def _tick(*args, **kwargs):
+        home = str(get_hermes_home())
+        tick_homes.append(home)
+        if home == str(failing_home):
+            raise RuntimeError("profile-local failure")
+        stop.set()
+        return 0
+
+    provider = InProcessCronScheduler()
+    with patch("cron.scheduler.tick", side_effect=_tick):
+        thread = threading.Thread(
+            target=provider.start,
+            args=(stop,),
+            kwargs={
+                "interval": 0,
+                "profile_homes": [("failing", failing_home), ("healthy", healthy_home)],
+            },
+            daemon=True,
+        )
+        thread.start()
+        thread.join(timeout=5)
+        stop.set()
+        thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert str(healthy_home) in tick_homes, "healthy sibling was skipped"
+    assert not (failing_home / "cron" / "ticker_last_success").exists()
+    assert (healthy_home / "cron" / "ticker_last_success").exists()
+    with use_cron_store(failing_home):
+        assert get_ticker_last_error() == "RuntimeError: profile-local failure"
+    with use_cron_store(healthy_home):
+        assert get_ticker_last_error() is None
+
+
+def test_multiplex_recovery_isolates_profile_failures(tmp_path):
+    """A startup-recovery error in one profile's ledger must not kill the
+    ticker thread before it ever ticks (#74878)."""
+    import sqlite3
+
+    from cron.scheduler_provider import InProcessCronScheduler
+    from hermes_constants import get_hermes_home
+
+    failing_home = tmp_path / "failing"
+    healthy_home = tmp_path / "healthy"
+    for home in (failing_home, healthy_home):
+        (home / "cron").mkdir(parents=True)
+
+    stop = threading.Event()
+    recovery_homes: list[str] = []
+    tick_homes: list[str] = []
+
+    def _recover():
+        home = str(get_hermes_home())
+        recovery_homes.append(home)
+        if home == str(failing_home):
+            raise sqlite3.OperationalError("unable to open database file")
+        return 0
+
+    def _tick(*args, **kwargs):
+        tick_homes.append(str(get_hermes_home()))
+        if len(tick_homes) >= 2:
+            stop.set()
+        return 0
+
+    provider = InProcessCronScheduler()
+    with (
+        patch.object(provider, "recover_interrupted", side_effect=_recover),
+        patch("cron.scheduler.tick", side_effect=_tick),
+    ):
+        thread = threading.Thread(
+            target=provider.start,
+            args=(stop,),
+            kwargs={
+                "interval": 0,
+                "profile_homes": [("failing", failing_home), ("healthy", healthy_home)],
+            },
+            daemon=True,
+        )
+        thread.start()
+        thread.join(timeout=5)
+        stop.set()
+        thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert recovery_homes == [str(failing_home), str(healthy_home)]
+    # The failing profile stays in rotation: its ledger may still hold jobs.
+    assert set(tick_homes) == {str(failing_home), str(healthy_home)}

--- a/tests/cron/test_suggestions.py
+++ b/tests/cron/test_suggestions.py
@@ -19,7 +19,6 @@ def store(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
-    # Reload so module-level CRON_DIR/SUGGESTIONS_FILE pick up the temp home.
     import hermes_constants
     importlib.reload(hermes_constants)
     import cron.suggestions as s
@@ -38,6 +37,31 @@ def _add(store, key="k1", title="Test", source="catalog", schedule="0 9 * * *"):
 
 
 class TestStore:
+    def test_profile_override_routes_writes_to_current_home(self, tmp_path):
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+        import cron.suggestions as suggestions_mod
+
+        profile_a = tmp_path / "profile-a"
+        profile_b = tmp_path / "profile-b"
+
+        import_token = set_hermes_home_override(profile_a)
+        try:
+            importlib.reload(suggestions_mod)
+        finally:
+            reset_hermes_home_override(import_token)
+
+        runtime_token = set_hermes_home_override(profile_b)
+        try:
+            _add(suggestions_mod, key="profile-b")
+        finally:
+            reset_hermes_home_override(runtime_token)
+
+        assert (profile_b / "cron" / "suggestions.json").exists()
+        assert not (profile_a / "cron" / "suggestions.json").exists()
+
     def test_add_and_list_pending(self, store):
         rec = _add(store)
         assert rec is not None

--- a/tests/cron/test_suggestions.py
+++ b/tests/cron/test_suggestions.py
@@ -37,6 +37,26 @@ def _add(store, key="k1", title="Test", source="catalog", schedule="0 9 * * *"):
 
 
 class TestStore:
+    def test_explicit_file_override_wins_over_profile_home(self, tmp_path, monkeypatch):
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+        import cron.suggestions as suggestions_mod
+
+        explicit_file = tmp_path / "explicit" / "suggestions.json"
+        profile_home = tmp_path / "profile"
+        monkeypatch.setattr(suggestions_mod, "SUGGESTIONS_FILE", explicit_file)
+
+        token = set_hermes_home_override(profile_home)
+        try:
+            _add(suggestions_mod, key="explicit-file")
+        finally:
+            reset_hermes_home_override(token)
+
+        assert explicit_file.exists()
+        assert not (profile_home / "cron" / "suggestions.json").exists()
+
     def test_profile_override_routes_writes_to_current_home(self, tmp_path):
         from hermes_constants import (
             reset_hermes_home_override,

--- a/tests/hermes_cli/test_cron_fire_dashboard.py
+++ b/tests/hermes_cli/test_cron_fire_dashboard.py
@@ -250,6 +250,41 @@ def test_fire_endpoint_multiplex_profile_prefix(tmp_path, monkeypatch):
     assert url == "http://127.0.0.1:8642/p/worker_alpha/api/cron/fire"
 
 
+def test_fire_endpoint_multiplex_reads_port_from_default_listener(tmp_path, monkeypatch):
+    """Multiplex mode: only the DEFAULT profile's api_server is bound, so a
+    secondary's fire URL must use the default home's port — not the
+    secondary's own config.yaml/.env port, which nothing listens on
+    (PR #84755). Real config files, real load_config()."""
+    default_home = tmp_path / "root"
+    worker_home = default_home / "profiles" / "worker_alpha"
+    default_home.mkdir()
+    worker_home.mkdir(parents=True)
+    (default_home / "config.yaml").write_text(
+        "gateway:\n  multiplex_profiles: true\n"
+        "platforms:\n  api_server:\n    extra:\n      port: 8650\n",
+        encoding="utf-8",
+    )
+    (worker_home / "config.yaml").write_text(
+        "platforms:\n  api_server:\n    enabled: false\n    extra:\n      port: 8702\n",
+        encoding="utf-8",
+    )
+    (worker_home / ".env").write_text("API_SERVER_PORT=8701\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    monkeypatch.delenv("API_SERVER_PORT", raising=False)
+    monkeypatch.delenv("GATEWAY_MULTIPLEX_PROFILES", raising=False)
+    monkeypatch.setattr(web_server, "_cron_default_profile", lambda: "default")
+
+    url = web_server._gateway_fire_endpoint("worker_alpha", worker_home)
+
+    assert url == "http://127.0.0.1:8650/p/worker_alpha/api/cron/fire"
+    # The GATEWAY_MULTIPLEX_PROFILES env override is still honored (parity
+    # with gateway/config.py): forcing it off restores per-profile routing.
+    monkeypatch.setenv("GATEWAY_MULTIPLEX_PROFILES", "0")
+    assert web_server._gateway_fire_endpoint("worker_alpha", worker_home) == (
+        "http://127.0.0.1:8702/api/cron/fire"
+    )
+
+
 # ── OOF-266: intentional-stop drop + Retry-After on transient 503 ─────────
 
 

--- a/website/docs/user-guide/multi-profile-gateways.md
+++ b/website/docs/user-guide/multi-profile-gateways.md
@@ -294,6 +294,12 @@ the gateway rejects that ingress and logs the route and target. It does not run
 the default profile. Traffic that matches no route keeps the historical
 default-profile behavior.
 
+Cron jobs owned by a routed profile deliver through the shared bot too, but
+only to targets an enabled route with a `chat_id`/`thread_id` maps to that
+profile — a routed profile's job targeting an unrouted chat (or a chat routed
+to another profile) is never sent through the shared bot. Guild-only routes do
+not qualify a cron target; add a `chat_id` route for the delivery channel.
+
 ## Start, stop, or restart all gateways at once
 
 The CLI ships with single-profile lifecycle commands. To act across every


### PR DESCRIPTION
## Summary
Five multiplex cron bugs fixed in one branch: one profile's broken store killed every profile's ticker; dashboard fires targeted an unbound port; the desktop ticker delivered secondaries with the default identity; credentialless `profile_routes` satellites couldn't deliver at all; notepad/suggestions paths were frozen at import. Root causes: missing per-profile except in the ticker loops, target-profile port lookup under a shared listener, an unscoped `ThreadPoolExecutor` + unconditional desktop ticking, an empty adapter map with no route-exact transport resolver, and import-time `get_hermes_home()`.
## Changes
- cron/scheduler_provider.py: per-profile `except BaseException` in recovery + tick loops (CronTickYielded/_profile_errors + #87644 backoff preserved); optional `profile_gate`; `SharedRouteAdapters` view for map-less secondaries.
- cron/scheduler.py: `copy_context()` on the asyncio.run fallback pool; `_primary_profile_routes_for_current_home()` shared by preflight + delivery; `SharedRouteAdapters` (route-exact, fail-closed) used per target.
- hermes_cli/web_server.py: multiplex fire URL resolves port from the default listener (env override parity, logged fallback); desktop ticker stands down for profiles whose own gateway runs.
- cron/notepad.py, cron/suggestions.py: call-time path resolution (#96944).
- Tests: 9 new tests pinning each invariant; docs paragraph for routed-profile cron delivery.
## Validation
| Fix | Before (origin/main) | After |
|---|---|---|
| Ticker isolation | alpha's corrupt DB killed thread; no profile ticked | default+beta tick, alpha error recorded |
| Fire port | `:8701/p/worker_alpha/…` → connection refused | bound default port |
| Fallback pool scope | `UnscopedSecretError`, default home | ops home + OPS-TOKEN |
| Desktop gate | ticked ['default','ops'] beside ops' live gateway | ticked ['default'] |
| Satellite delivery | "DISCORD_BOT_TOKEN is not set" on routed chat | primary bot sends routed chat; unrouted never uses it |
| Store paths | notepad/suggestions written to default home | written to scoped profile |
## Credits
@Cyber-Yichen (#70747, authored), @OYLFLMH (#74888), @webtecnica (#74952), @bergusdz (#84755, authored), @wanliqin + @honor2030 (#96944, cherry-picked), @tachyon-r (#74017, first on suggestions half), @TheBlueHouse75 (#93043, independent identification), reporters @minkiboo (#101113), @herovivian-collab (#100489), @wanliqin (#86519).

Fixes #100489
Fixes #101113
Fixes #86519
Fixes #74878

## Infographic

![mux-cron](https://v3b.fal.media/files/b/0aa8cdae/uVfFGXaAoOTwVNfSAG2rr_zcfqjscF.png)
