### PR TITLE
fix(gateway): slash config writes, executor hops, personality and status follow the routed profile (#87939 #75684 #89161, salvage #87976 #78440 #69118)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7523,7 +7523,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Load ephemeral config from config.yaml / env vars.
         # Both are injected at API-call time only and never persisted.
         self._prefill_messages = self._load_prefill_messages()
-        self._ephemeral_system_prompt = self._load_ephemeral_system_prompt()
         self._reasoning_config = self._load_reasoning_config()
         self._service_tier = self._load_service_tier()
         self._show_reasoning = self._load_show_reasoning()
@@ -10283,7 +10282,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     ) -> str:
         """Ephemeral system prompt for this channel/thread.
 
-        Uses ``channel_overrides`` when set, else the global gateway prompt.
+        Uses ``channel_overrides`` when set, else the gateway prompt resolved
+        from the CURRENT profile's config on every call. Callers run inside
+        ``_profile_runtime_scope`` (``run_sync`` under ``_run_agent``), so a
+        routed multiplex profile gets its own ``display.personality`` /
+        ``agent.system_prompt`` instead of a boot-time snapshot of the launch
+        profile's (#89161); ``/personality`` edits take effect on the next
+        turn for the same reason.
         Legacy ``channel_prompts`` are applied separately via ``event.channel_prompt``
         in ``run_sync`` (adapter ``resolve_channel_prompt``), so they are not
         duplicated here.
@@ -10299,7 +10304,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             if override and override.system_prompt:
                 return (override.system_prompt or "").strip()
-        return getattr(self, "_ephemeral_system_prompt", None) or ""
+        return self._load_ephemeral_system_prompt()
 
     @staticmethod
     def _load_reasoning_config(model: str = "") -> dict | None:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3079,8 +3079,6 @@ class GatewaySlashCommandsMixin:
             set_current_session_key,
         )
 
-        loop = asyncio.get_running_loop()
-
         def _dispatch():
             token = set_current_session_key(quick_key)
             try:
@@ -3091,7 +3089,10 @@ class GatewaySlashCommandsMixin:
                 reset_current_session_key(token)
 
         try:
-            result = await loop.run_in_executor(None, _dispatch)
+            # _run_in_executor_with_context, not a bare hop: the reviewer
+            # subagent is spawned from the worker and inherits its context,
+            # so a bare hop would run it under the launch home / no secret scope.
+            result = await self._run_in_executor_with_context(_dispatch)
         except ValueError as exc:
             return str(exc)
         except Exception as exc:
@@ -6016,11 +6017,12 @@ class GatewaySlashCommandsMixin:
         is written to the session transcript out-of-band, so message
         alternation is preserved.
         """
-        loop = asyncio.get_running_loop()
         try:
             from agent.skill_commands import reload_skills
 
-            result = await loop.run_in_executor(None, reload_skills)
+            # _run_in_executor_with_context, not a bare hop: the rescan walks
+            # get_hermes_home()/skills, a contextvar override under multiplex.
+            result = await self._run_in_executor_with_context(reload_skills)
             added = result.get("added", [])      # [{"name", "description"}, ...]
             removed = result.get("removed", [])  # [{"name", "description"}, ...]
             total = result.get("total", 0)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2874,8 +2874,12 @@ class GatewaySlashCommandsMixin:
                 import asyncio
                 from hermes_cli.goals import draft_contract
 
-                draft_contract_obj = await asyncio.get_running_loop().run_in_executor(
-                    None, draft_contract, objective
+                # _run_in_executor_with_context, not a bare hop: drafting a
+                # contract calls the auxiliary LLM, whose provider/credential
+                # resolution reads the profile secret scope — a contextvar that
+                # a default-executor hop drops, leaving it unscoped.
+                draft_contract_obj = await self._run_in_executor_with_context(
+                    draft_contract, objective
                 )
             except Exception as exc:
                 logger.debug("goal draft failed: %s", exc)
@@ -5912,8 +5916,6 @@ class GatewaySlashCommandsMixin:
             from hermes_state import get_shared_session_db, release_shared_session_db
             from agent.insights import InsightsEngine
 
-            loop = asyncio.get_running_loop()
-
             def _run_insights():
                 db = get_shared_session_db()
                 try:
@@ -5925,7 +5927,13 @@ class GatewaySlashCommandsMixin:
                     from hermes_state import release_or_close
                     release_or_close(db)
 
-            return await loop.run_in_executor(None, _run_insights)
+            # _run_in_executor_with_context, not a bare hop: ``SessionDB()``
+            # with no explicit path resolves ``get_hermes_home()`` at call
+            # time, and that override is a contextvar installed by
+            # ``_profile_runtime_scope``. A default-executor hop starts the
+            # worker with an EMPTY context, so /insights read the DEFAULT
+            # profile's state.db and reported another profile's conversations.
+            return await self._run_in_executor_with_context(_run_insights)
         except Exception as e:
             logger.error("Insights command error: %s", e, exc_info=True)
             return t("gateway.insights.error", error=e)
@@ -6320,8 +6328,6 @@ class GatewaySlashCommandsMixin:
             _GATEWAY_PRIVACY_NOTICE, _best_effort_sweep_expired_pastes,
         )
 
-        loop = asyncio.get_running_loop()
-
         # Run blocking I/O (dump capture, log reads, uploads) in a thread.
         def _collect_and_upload():
             _best_effort_sweep_expired_pastes()
@@ -6348,7 +6354,11 @@ class GatewaySlashCommandsMixin:
             lines.append(t("gateway.debug.share_hint"))
             return "\n".join(lines)
 
-        return await loop.run_in_executor(None, _collect_and_upload)
+        # _run_in_executor_with_context, not a bare hop: this collects the
+        # profile's logs/config off ``get_hermes_home()`` and uploads them to a
+        # public paste. Losing the contextvar override would publish the DEFAULT
+        # profile's diagnostics from another profile's chat.
+        return await self._run_in_executor_with_context(_collect_and_upload)
 
     async def _handle_update_command(self, event: MessageEvent) -> str:
         """Handle /update command — update Hermes Agent to the latest version.

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3760,9 +3760,9 @@ class GatewaySlashCommandsMixin:
     def _save_gateway_config_key(self, key_path: str, value) -> bool:
         """Save a dot-separated key to config.yaml (shared by /reasoning, /fast
         and their interactive pickers)."""
-        from gateway.run import _hermes_home
+        from gateway.run import _gateway_config_home
         from hermes_cli.config import read_user_config_raw
-        config_path = _hermes_home / "config.yaml"
+        config_path = _gateway_config_home() / "config.yaml"
         try:
             # Write-back round-trip: raw read is correct (merged defaults must
             # not be persisted back to the user's file).
@@ -4004,7 +4004,7 @@ class GatewaySlashCommandsMixin:
         Gate changes persist to config.yaml and evict the cached agent so the
         new setting takes effect on the next message.
         """
-        from gateway.run import _hermes_home
+        from gateway.run import _gateway_config_home
         from hermes_cli.write_approval_commands import handle_pending_subcommand
         from tools import write_approval as wa
         from tools.memory_tool import load_on_disk_store
@@ -4012,7 +4012,7 @@ class GatewaySlashCommandsMixin:
         raw_args = event.get_command_args().strip()
         args = raw_args.split() if raw_args else []
         session_key = self._session_key_for_source(event.source)
-        config_path = _hermes_home / "config.yaml"
+        config_path = _gateway_config_home() / "config.yaml"
 
         def _set_approval(enabled: bool):
             # Write-back round-trip: raw read is correct (merged defaults must
@@ -4053,14 +4053,14 @@ class GatewaySlashCommandsMixin:
         the write-approval ``diff <id>``; the CLI also has an unrelated
         ``hermes skills diff <name>`` that diffs a bundled skill vs stock.)
         """
-        from gateway.run import _hermes_home
+        from gateway.run import _gateway_config_home
         from hermes_cli.write_approval_commands import handle_pending_subcommand
         from tools import write_approval as wa
 
         raw_args = event.get_command_args().strip()
         args = raw_args.split() if raw_args else []
         session_key = self._session_key_for_source(event.source)
-        config_path = _hermes_home / "config.yaml"
+        config_path = _gateway_config_home() / "config.yaml"
 
         gate_on = wa.write_approval_enabled(wa.SKILLS)
         wants_toggle = bool(args) and args[0].lower() in {"approval", "mode"}
@@ -4240,9 +4240,9 @@ class GatewaySlashCommandsMixin:
         ``display.platforms.<platform>.tool_progress`` so each channel can
         have its own verbosity level independently.
         """
-        from gateway.run import _hermes_home, _load_gateway_config, _platform_config_key
+        from gateway.run import _gateway_config_home, _load_gateway_config, _platform_config_key
 
-        config_path = _hermes_home / "config.yaml"
+        config_path = _gateway_config_home() / "config.yaml"
         platform_key = _platform_config_key(event.source.platform)
 
         # --- check config gate ------------------------------------------------
@@ -4378,10 +4378,10 @@ class GatewaySlashCommandsMixin:
         are respected but not modified here — edit config.yaml directly for
         per-platform control.
         """
-        from gateway.run import _hermes_home, _load_gateway_config, _platform_config_key, _resolve_gateway_model
+        from gateway.run import _gateway_config_home, _load_gateway_config, _platform_config_key, _resolve_gateway_model
         from gateway.runtime_footer import resolve_footer_config
 
-        config_path = _hermes_home / "config.yaml"
+        config_path = _gateway_config_home() / "config.yaml"
         platform_key = _platform_config_key(event.source.platform)
 
         # --- parse argument -------------------------------------------------

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2592,7 +2592,6 @@ class GatewaySlashCommandsMixin:
             available_personalities,
             describe_personality,
             persist_personality,
-            prompt_text,
             resolve_personality,
         )
 
@@ -2621,24 +2620,21 @@ class GatewaySlashCommandsMixin:
             return "\n".join(lines)
 
         try:
-            name, new_prompt = resolve_personality(args, config)
+            name, _new_prompt = resolve_personality(args, config)
         except ValueError:
             available = "`none`, " + ", ".join(f"`{n}`" for n in personalities)
             return t("gateway.personality.unknown", name=args.lower(), available=available)
 
         # Persist the selection only — hermes_cli.personality never writes
-        # agent.system_prompt (user-owned manual overlay).
+        # agent.system_prompt (user-owned manual overlay). persist_personality
+        # writes get_hermes_home()/config.yaml, i.e. the routed profile under
+        # multiplex; the next turn re-resolves the prompt from that file
+        # (_get_system_prompt_for_channel), so no process-global state to update.
         if not persist_personality(name):
             return t("gateway.personality.save_failed", error="config write failed")
 
         if not name:
-            self._ephemeral_system_prompt = prompt_text(
-                cfg_get(config, "agent", "system_prompt", default="")
-            )
             return t("gateway.personality.cleared")
-
-        # Update in-memory so it takes effect on the very next message.
-        self._ephemeral_system_prompt = new_prompt
         return t("gateway.personality.set_to", name=name)
 
     async def _handle_retry_command(self, event: MessageEvent) -> str:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2219,14 +2219,17 @@ def _gateway_list() -> None:
             label += " (current)"
         parts = [f"  {marker} {label:<24s}"]
         if prof.gateway_running:
+            pid = None
             try:
                 from gateway.status import get_running_pid
 
                 pid = get_running_pid(prof.path / "gateway.pid", cleanup_stale=False)
-                if pid:
-                    parts.append(f"PID {pid}")
             except Exception:
                 pass
+            if pid:
+                parts.append(f"PID {pid}")
+            elif named_profile_served_by_running_multiplexer(prof.name):
+                parts.append("served by the default multiplexer")
         else:
             parts.append("not running")
         print(" — ".join(parts))
@@ -6276,18 +6279,20 @@ def _running_under_gateway_supervisor() -> bool:
     return is_gateway_supervisor_process()
 
 
-def named_profile_served_by_running_multiplexer() -> bool:
+def named_profile_served_by_running_multiplexer(profile_name: str | None = None) -> bool:
     """True when a live default multiplexer already ticks this named profile.
 
-    Shared by the named-profile start guard and cron liveness: a satellite
-    profile has no gateway.pid of its own, but the default multiplexer's
-    ticker still fires its jobs (#97120).
+    Shared by the named-profile start guard, cron liveness, and the
+    ``gateway status`` / ``gateway list`` / ``profile list`` reports: a
+    satellite profile has no gateway.pid of its own, but the default
+    multiplexer's ticker still fires its jobs (#97120) and serves its
+    platforms. ``profile_name`` defaults to the current HERMES_HOME profile.
     """
     try:
-        suffix = _profile_suffix()
+        suffix = profile_name if profile_name is not None else _profile_suffix()
     except Exception:
         return False
-    if not suffix:
+    if not suffix or suffix == "default":
         return False
 
     try:
@@ -9071,7 +9076,12 @@ def _gateway_command_inner(args):
             from hermes_cli import gateway_windows
 
             _windows_service_installed = gateway_windows.is_installed()
-        if supports_systemd_services() and (
+        if not snapshot.running and named_profile_served_by_running_multiplexer():
+            # Satellite profile: no gateway.pid / service of its own, but the
+            # default multiplexer is the live inbound process for it.
+            print("✓ Gateway is running via the default-profile multiplexer")
+            print("  Manage it from the default profile: hermes gateway status")
+        elif supports_systemd_services() and (
             get_systemd_unit_path(system=False).exists()
             or get_systemd_unit_path(system=True).exists()
         ):

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11462,6 +11462,7 @@ def cmd_profile(args):
             profile_exists,
             _read_config_model,
             _check_gateway_running,
+            _served_by_running_multiplexer,
             _count_skills,
             _read_distribution_meta,
             _get_wrapper_dir,
@@ -11475,7 +11476,7 @@ def cmd_profile(args):
             sys.exit(1)
         profile_dir = get_profile_dir(name)
         model, provider = _read_config_model(profile_dir)
-        gw = _check_gateway_running(profile_dir)
+        gw = _check_gateway_running(profile_dir) or _served_by_running_multiplexer(name)
         skills = _count_skills(profile_dir)
         dist_name, dist_version, dist_source = _read_distribution_meta(profile_dir)
         alias_name = find_alias_for_profile(name)

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -838,6 +838,22 @@ def _check_gateway_running(profile_dir: Path) -> bool:
         return False
 
 
+def _served_by_running_multiplexer(profile_name: str) -> bool:
+    """True when the live default gateway multiplexes ``profile_name``.
+
+    A served named profile has no gateway.pid of its own, so
+    ``_check_gateway_running`` alone reports it stopped while the default
+    multiplexer is actually its inbound process. Single shared lookup with the
+    named-profile start guard and cron liveness (#97120).
+    """
+    try:
+        from hermes_cli.gateway import named_profile_served_by_running_multiplexer
+
+        return named_profile_served_by_running_multiplexer(profile_name)
+    except Exception:
+        return False
+
+
 # In-process cache for skill counts. Walking ``skills_dir.rglob("SKILL.md")``
 # recurses the entire skill tree (each skill carries references/scripts/assets
 # sub-trees); the default profile alone has ~270 skills, and ``list_profiles``
@@ -1084,7 +1100,10 @@ def list_profiles() -> List[ProfileInfo]:
                 name=name,
                 path=entry,
                 is_default=False,
-                gateway_running=_check_gateway_running(entry),
+                gateway_running=(
+                    _check_gateway_running(entry)
+                    or _served_by_running_multiplexer(name)
+                ),
                 model=model,
                 provider=provider,
                 has_env=(entry / ".env").exists(),

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15116,7 +15116,13 @@ def _fallback_profile_dicts(profiles_mod) -> List[Dict[str, Any]]:
                 "provider": provider,
                 "has_env": _safe(lambda entry=entry_path: (entry / ".env").exists(), False),
                 "skill_count": _safe(lambda entry=entry_path: profiles_mod._count_skills(entry), 0),
-                "gateway_running": _safe(lambda entry=entry_path: profiles_mod._check_gateway_running(entry), False),
+                "gateway_running": _safe(
+                    lambda entry=entry_path, name=entry.name: (
+                        profiles_mod._check_gateway_running(entry)
+                        or profiles_mod._served_by_running_multiplexer(name)
+                    ),
+                    False,
+                ),
                 "description": _safe(lambda entry=entry_path: profiles_mod.read_profile_meta(entry).get("description", ""), ""),
                 "description_auto": _safe(lambda entry=entry_path: profiles_mod.read_profile_meta(entry).get("description_auto", False), False),
                 "distribution_name": None,

--- a/tests/cli/test_personality_none.py
+++ b/tests/cli/test_personality_none.py
@@ -87,7 +87,6 @@ class TestGatewayPersonalityNone:
     def _make_runner(self, personalities=None):
         from gateway.run import GatewayRunner
         runner = GatewayRunner.__new__(GatewayRunner)
-        runner._ephemeral_system_prompt = "You are kawaii~"
         runner.config = {
             "agent": {
                 "personalities": personalities or {"helpful": "You are helpful."}
@@ -125,7 +124,9 @@ class TestGatewayPersonalityNone:
         saved = yaml.safe_load(config_file.read_text())
         assert saved["agent"]["system_prompt"] == "manual forever"
         assert saved.get("display", {}).get("personality", None) == ""
-        assert runner._ephemeral_system_prompt == "manual forever"
+        # The next turn re-resolves from config (no in-memory snapshot).
+        with p1, p2:
+            assert runner._get_system_prompt_for_channel(None, "c") == "manual forever"
 
     @pytest.mark.asyncio
     async def test_set_persists_display_personality_not_system_prompt(self, tmp_path):
@@ -147,7 +148,8 @@ class TestGatewayPersonalityNone:
         saved = yaml.safe_load(config_file.read_text())
         assert saved["agent"]["system_prompt"] == "manual forever"
         assert saved["display"]["personality"] == "helpful"
-        assert runner._ephemeral_system_prompt == "You are helpful."
+        with p1, p2:
+            assert runner._get_system_prompt_for_channel(None, "c") == "You are helpful."
         assert "helpful" in result.lower()
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_personality_routed_profile.py
+++ b/tests/gateway/test_personality_routed_profile.py
@@ -1,0 +1,45 @@
+"""#89161: a routed multiplex profile's personality must reach its turns.
+
+``GatewayRunner`` used to snapshot ``_ephemeral_system_prompt`` once at boot
+from the launch profile's config and hand that string to every routed turn,
+so a secondary profile's ``display.personality`` / ``agent.system_prompt`` never
+injected. ``_get_system_prompt_for_channel`` now resolves from the config of
+the profile currently in scope (``run_sync`` runs inside
+``_profile_runtime_scope``).
+"""
+
+from __future__ import annotations
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.run import GatewayRunner, _profile_runtime_scope
+
+
+def test_routed_profile_prompt_resolves_from_its_own_config(tmp_path, monkeypatch):
+    default_home = tmp_path / "default"
+    routed_home = tmp_path / "profiles" / "beta"
+    default_home.mkdir()
+    routed_home.mkdir(parents=True)
+    (default_home / "config.yaml").write_text("agent:\n  system_prompt: DEFAULT-PERSONA\n")
+    (routed_home / "config.yaml").write_text(
+        "agent:\n  system_prompt: BETA-PERSONA\n  personalities:\n    pirate: ARR\n"
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", default_home)
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    monkeypatch.delenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", raising=False)
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = None
+
+    with _profile_runtime_scope(routed_home):
+        assert runner._get_system_prompt_for_channel(Platform.TELEGRAM, "c") == "BETA-PERSONA"
+    assert runner._get_system_prompt_for_channel(Platform.TELEGRAM, "c") == "DEFAULT-PERSONA"
+
+    # /personality from the routed chat writes the routed profile and only it.
+    from hermes_cli.personality import persist_personality
+
+    with _profile_runtime_scope(routed_home):
+        assert persist_personality("pirate")
+        assert runner._get_system_prompt_for_channel(Platform.TELEGRAM, "c") == "ARR"
+    assert "pirate" not in (default_home / "config.yaml").read_text()
+    assert runner._get_system_prompt_for_channel(Platform.TELEGRAM, "c") == "DEFAULT-PERSONA"

--- a/tests/gateway/test_slash_command_profile_scope.py
+++ b/tests/gateway/test_slash_command_profile_scope.py
@@ -1,0 +1,94 @@
+"""Gateway slash commands must do their blocking work inside the routed profile.
+
+The multiplexed inbound handler wraps the whole message in
+``_profile_runtime_scope``, which installs the routed profile's ``HERMES_HOME``
+override and its secret scope as **contextvars**. A bare
+``loop.run_in_executor(None, ...)`` starts the worker with an EMPTY context, so
+``SessionDB()`` / ``get_hermes_home()`` inside the worker resolve the LAUNCH
+home — /insights reported the default profile's conversations from another
+profile's chat. ``/compress`` already routes through
+``_run_in_executor_with_context``; every other hop in the mixin must too.
+
+Drives the real mixin methods and the real ``_profile_runtime_scope``: the
+contextvar loss is a property of the hop, so mocking the hop away would test
+nothing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def profile_home(tmp_path, monkeypatch):
+    root = tmp_path / ".hermes"
+    home = root / "profiles" / "coder"
+    home.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    return home
+
+
+@pytest.fixture
+def runner():
+    """Minimal host exposing the mixin plus the runner's executor helpers."""
+    from gateway.run import GatewayRunner
+    from gateway.slash_commands import GatewaySlashCommandsMixin
+
+    class _Runner(GatewaySlashCommandsMixin):
+        _run_in_executor_with_context = GatewayRunner._run_in_executor_with_context
+        _get_executor = GatewayRunner._get_executor
+
+    r = _Runner()
+    r.adapters = {}
+    r._pending_skills_reload_notes = {}
+    return r
+
+
+class _Event:
+    def __init__(self, args: str = ""):
+        self._args = args
+        self.source = None
+
+    def get_command_args(self) -> str:
+        return self._args
+
+
+@pytest.mark.asyncio
+async def test_insights_opens_session_db_under_the_routed_home(
+    runner, profile_home, monkeypatch
+):
+    import agent.insights as insights_mod
+    import hermes_state
+    from gateway.run import _profile_runtime_scope
+    from hermes_constants import get_hermes_home
+
+    seen: dict = {}
+
+    class _RecordingDB:
+        def __init__(self, *a, **kw):
+            seen["home"] = str(get_hermes_home())
+
+        def close(self):
+            pass
+
+    class _Engine:
+        def __init__(self, db):
+            pass
+
+        def generate(self, **kw):
+            return {}
+
+        def format_gateway(self, report):
+            return "ok"
+
+    monkeypatch.setattr(hermes_state, "SessionDB", _RecordingDB)
+    monkeypatch.setattr(insights_mod, "InsightsEngine", _Engine)
+
+    with _profile_runtime_scope(profile_home):
+        result = await runner._handle_insights_command(_Event(""))
+
+    assert result == "ok"
+    assert seen["home"] == str(profile_home)

--- a/tests/gateway/test_slash_config_writes_routed_profile.py
+++ b/tests/gateway/test_slash_config_writes_routed_profile.py
@@ -1,0 +1,70 @@
+"""Slash-command config writes must land in the routed profile's config.yaml.
+
+Regression for #87939 / #75684: the multiplexed inbound handler already runs
+every slash handler inside ``_profile_runtime_scope`` (routed HERMES_HOME
+override), but several handlers built their write path from the module
+constant ``gateway.run._hermes_home`` — the LAUNCH home — so ``/reasoning
+--global``, ``/fast``, ``/memory approval``, ``/skills approval``, ``/verbose``
+and ``/footer`` persisted into the default profile's config.yaml. They now go
+through ``_gateway_config_home()`` like the reads do.
+"""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+import gateway.run as gateway_run
+from gateway.run import GatewayRunner, _profile_runtime_scope
+from gateway.slash_commands import GatewaySlashCommandsMixin
+
+
+class _Runner(GatewaySlashCommandsMixin):
+    _run_in_executor_with_context = GatewayRunner._run_in_executor_with_context
+    _get_executor = GatewayRunner._get_executor
+
+    def _session_key_for_source(self, _source):
+        return "k"
+
+    def _evict_cached_agent(self, _session_key):
+        pass
+
+
+class _Event:
+    def __init__(self, args: str = ""):
+        self._args = args
+        self.source = None
+
+    def get_command_args(self) -> str:
+        return self._args
+
+
+@pytest.fixture
+def homes(tmp_path, monkeypatch):
+    default_home = tmp_path / "default"
+    routed_home = tmp_path / "profiles" / "beta"
+    default_home.mkdir()
+    routed_home.mkdir(parents=True)
+    (default_home / "config.yaml").write_text("agent:\n  reasoning_effort: medium\n")
+    (routed_home / "config.yaml").write_text("agent:\n  reasoning_effort: none\n")
+    monkeypatch.setattr(gateway_run, "_hermes_home", default_home)
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    return default_home, routed_home
+
+
+@pytest.mark.asyncio
+async def test_slash_config_writes_hit_routed_profile_and_leave_default_untouched(homes):
+    default_home, routed_home = homes
+    default_before = (default_home / "config.yaml").read_bytes()
+    runner = _Runner()
+
+    with _profile_runtime_scope(routed_home):
+        assert runner._save_gateway_config_key("agent.reasoning_effort", "high")
+        await runner._handle_memory_command(_Event("approval on"))
+        await runner._handle_skills_command(_Event("approval on"))
+
+    routed = yaml.safe_load((routed_home / "config.yaml").read_text())
+    assert routed["agent"]["reasoning_effort"] == "high"
+    assert routed["memory"]["write_approval"] is True
+    assert routed["skills"]["write_approval"] is True
+    assert (default_home / "config.yaml").read_bytes() == default_before

--- a/tests/hermes_cli/test_gateway_multiplex_status.py
+++ b/tests/hermes_cli/test_gateway_multiplex_status.py
@@ -1,0 +1,61 @@
+"""PR #69118: a named profile served by the default multiplexer reports as running.
+
+``hermes gateway status`` / ``gateway list`` / ``profile list`` keyed liveness
+off the profile's own gateway.pid, so a satellite profile served by the default
+multiplexer showed "not running" even though the multiplexer was its live
+inbound process. All three now consult the same
+``named_profile_served_by_running_multiplexer()`` lookup the start guard and
+cron liveness use.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+from contextlib import redirect_stdout
+from types import SimpleNamespace
+
+
+def _fake_multiplexer(monkeypatch, tmp_path, *, multiplex: bool):
+    import hermes_constants
+    import gateway.status as status
+
+    (tmp_path / "profiles" / "beta").mkdir(parents=True)
+    (tmp_path / "config.yaml").write_text(
+        f"gateway:\n  multiplex_profiles: {'true' if multiplex else 'false'}\n"
+    )
+    (tmp_path / "gateway.pid").write_text(str(os.getpid()))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profiles" / "beta"))
+    monkeypatch.setattr(hermes_constants, "_default_hermes_root_memo", None)
+    monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+
+
+def _run_status():
+    from hermes_cli import gateway as gw
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        gw._gateway_command_inner(
+            SimpleNamespace(gateway_command="status", deep=False, full=False, system=False)
+        )
+    return buf.getvalue().splitlines()[0]
+
+
+def test_served_named_profile_reports_running(monkeypatch, tmp_path):
+    from hermes_cli.profiles import list_profiles
+
+    _fake_multiplexer(monkeypatch, tmp_path, multiplex=True)
+
+    beta = next(p for p in list_profiles() if p.name == "beta")
+    assert beta.gateway_running is True
+    assert _run_status().startswith("✓ Gateway is running via the default-profile multiplexer")
+
+
+def test_unserved_named_profile_still_reports_stopped(monkeypatch, tmp_path):
+    from hermes_cli.profiles import list_profiles
+
+    _fake_multiplexer(monkeypatch, tmp_path, multiplex=False)
+
+    beta = next(p for p in list_profiles() if p.name == "beta")
+    assert beta.gateway_running is False
+    assert _run_status().startswith("✗ Gateway is not running")


### PR DESCRIPTION
## Summary
Under `gateway.multiplex_profiles`, slash dispatch already runs inside `_profile_runtime_scope` (9ab748abb99), but four residual paths still resolved the launch profile: handlers building write paths from the module constant `_hermes_home`, bare `loop.run_in_executor(None, …)` hops that drop the contextvar, a boot-time `_ephemeral_system_prompt` snapshot handed to every routed turn, and PID-only liveness that reported served named profiles as stopped.
## Changes
- `_save_gateway_config_key` (/reasoning, /fast, show/hide), /memory, /skills, /verbose, /footer write via `_gateway_config_home()` (reads already did).
- /insights, /debug, /goal draft (#78440) + siblings /review, /reload-skills use `_run_in_executor_with_context`.
- `_get_system_prompt_for_channel` resolves `display.personality`/`agent.system_prompt` per turn from the scoped profile's config; `/personality` only persists (routed profile), no process-global state.
- `named_profile_served_by_running_multiplexer(profile_name=None)` reused by `gateway status/list`, `profile list/show`, dashboard profiles payload.
## Validation
| Surface | Before (origin/main) | After |
|---|---|---|
| `_save_gateway_config_key` / `/memory approval on` in routed scope | wrote default config.yaml; routed untouched | routed updated; default byte-identical |
| `/insights`, `/reload-skills` worker `get_hermes_home()` | launch home | routed profile home |
| routed turn prompt | `DEFAULT-PERSONA`; `/personality` from routed chat changed default's turn too | `BETA-PERSONA`; after `/personality pirate`: routed `ARR`, default `DEFAULT-PERSONA` |
| `gateway list` / `gateway status` / `list_profiles` for served profile | ✗ not running / False | ✓ served by the default multiplexer / True |
Sabotage-verified: each new test fails with its fix reverted. Targeted suites: 500+ tests green.
## Credits
@StanleyStetson (#87976, commit author) · @kingrubic (#75729) · @Drexuxux (#78440, cherry-picked) · @worlldz (#89177) · @Mushisushi28 (#69118) · reporters @kh-mitya #87939, @jimzord12 #75684, @pipidaxian #89161

Fixes #87939
Fixes #75684
Fixes #89161

## Infographic

![mux-slash-scope](https://v3b.fal.media/files/b/0aa8cdae/4N3feA-TRqJXJPG6an8HS_RpF7DWQX.png)
