### PR TITLE
fix(gateway): handoffs fail closed and load secrets off-loop; Discord slash commands honor profile_routes (#97693 #100014 #69178 #91633, salvage #97694 #100049)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17377,7 +17377,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 pass
             if profile_home is not None:
-                with _profile_runtime_scope(profile_home):
+                async with _async_profile_runtime_scope(profile_home):
                     return await self._handle_message(event)
             return await self._handle_message(event)
 
@@ -17441,7 +17441,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if getattr(source, "profile", None)
                 else default_home
             )
-            with _profile_runtime_scope(profile_home):
+            async with _async_profile_runtime_scope(profile_home):
                 return await self._handle_message(event)
 
         return _handler
@@ -20435,7 +20435,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     ) -> Optional[str]:
         """Run inbound preprocessing under the routed profile when multiplexed."""
         if getattr(getattr(self, "config", None), "multiplex_profiles", False):
-            with _profile_runtime_scope(self._resolve_profile_home_for_source(source)):
+            async with _async_profile_runtime_scope(
+                self._resolve_profile_home_for_source(source)
+            ):
                 return await self._prepare_inbound_message_text(
                     event=event,
                     source=source,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2423,7 +2423,10 @@ def _current_max_iterations() -> int:
     return _resolve_turn_limit(os.getenv("HERMES_MAX_ITERATIONS"))
 
 
-from contextlib import contextmanager as _contextmanager
+from contextlib import (
+    asynccontextmanager as _asynccontextmanager,
+    contextmanager as _contextmanager,
+)
 
 
 # Platforms that bind a host TCP port (HTTP/webhook listeners). In a profile
@@ -2559,8 +2562,24 @@ def _terminal_scope_cwd(default: str = "") -> str:
     return _ts_env("TERMINAL_CWD", default)
 
 
+def _load_profile_secret_scope(profile_home: "Path") -> dict:
+    """Hydrate and load one profile's secrets under its home override."""
+    from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+    from agent.secret_scope import build_profile_secret_scope
+    from hermes_cli.env_loader import hydrate_profile_secret_sources
+
+    home_token = set_hermes_home_override(str(profile_home))
+    try:
+        hydrate_profile_secret_sources(Path(profile_home))
+        return build_profile_secret_scope(Path(profile_home))
+    finally:
+        reset_hermes_home_override(home_token)
+
+
 @_contextmanager
-def _profile_runtime_scope(profile_home: "Path"):
+def _profile_runtime_scope(
+    profile_home: "Path", prepared_secret_scope: Optional[dict] = None,
+):
     """Scope config/skills/memory AND credentials to a profile for one turn.
 
     Combines the two seams the multiplexer needs:
@@ -2580,15 +2599,17 @@ def _profile_runtime_scope(profile_home: "Path"):
     """
     from hermes_constants import set_hermes_home_override, reset_hermes_home_override
     from agent.secret_scope import (
-        build_profile_secret_scope,
         set_secret_scope,
         reset_secret_scope,
     )
-    from hermes_cli.env_loader import hydrate_profile_secret_sources
 
     home_token = set_hermes_home_override(str(profile_home))
-    hydrate_profile_secret_sources(Path(profile_home))
-    secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
+    secrets = (
+        prepared_secret_scope
+        if prepared_secret_scope is not None
+        else _load_profile_secret_scope(Path(profile_home))
+    )
+    secret_token = set_secret_scope(secrets)
     # Per-turn terminal scope (third seam of the profile boundary): installs
     # the routed profile's COMPLETE terminal policy — never ambient env — via
     # tools.terminal_scope. Without it terminal_tool reads the process-global
@@ -2602,6 +2623,14 @@ def _profile_runtime_scope(profile_home: "Path"):
         finally:
             reset_secret_scope(secret_token)
             reset_hermes_home_override(home_token)
+
+
+@_asynccontextmanager
+async def _async_profile_runtime_scope(profile_home: "Path"):
+    """Enter a profile scope without loading secret files on the event loop."""
+    secrets = await asyncio.to_thread(_load_profile_secret_scope, Path(profile_home))
+    with _profile_runtime_scope(Path(profile_home), secrets):
+        yield
 
 
 def load_gateway_config_for_runner() -> "GatewayConfig":
@@ -14874,7 +14903,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if _phome is None:
                     await _reclaim_stale(self)
                 else:
-                    with _profile_runtime_scope(_phome):
+                    async with _async_profile_runtime_scope(_phome):
                         await _reclaim_stale(self)
             except Exception:
                 logger.debug("Stale-handoff reclaim failed", exc_info=True)
@@ -14886,7 +14915,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         if profile_home is None:
                             await _tick(profile_name)
                         else:
-                            with _profile_runtime_scope(profile_home):
+                            async with _async_profile_runtime_scope(profile_home):
                                 await _tick(profile_name)
                 except asyncio.CancelledError:
                     raise

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14964,14 +14964,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # The watcher already entered _profile_runtime_scope for this
             # profile, so a fresh load resolves that profile's config.yaml
             # and .env (home channel, tokens) rather than the primary's.
+            # Fail closed on a load error: self.config is the primary's, so
+            # falling back would deliver through the right bot to the
+            # WRONG chat and report completed. A failed row the CLI can
+            # retry beats a wrong delivery.
             try:
                 handoff_config = load_gateway_config()
-            except Exception:
-                logger.warning(
+            except Exception as exc:
+                logger.error(
                     "Handoff: could not load config for profile %s; "
-                    "falling back to the primary's config",
+                    "failing the handoff instead of delivering via the "
+                    "primary's config",
                     profile_name, exc_info=True,
                 )
+                raise RuntimeError(
+                    f"could not load config for profile '{profile_name}': {exc}"
+                ) from exc
 
         # Adapter must be live. A relay-fronted gateway registers ONE adapter
         # under Platform.RELAY that fronts N logical platforms — so a literal

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -6456,6 +6456,14 @@ class DiscordAdapter(BasePlatformAdapter):
         )
         return (len(self._skill_entries), self._skill_group_hidden_count)
 
+    def _interaction_guild_id(self, interaction: discord.Interaction) -> Optional[str]:
+        """Resolve the guild id of a slash interaction (mirrors the message path)."""
+        guild_id = getattr(interaction, "guild_id", None)
+        if guild_id is None:
+            guild = getattr(getattr(interaction, "channel", None), "guild", None)
+            guild_id = getattr(guild, "id", None)
+        return str(guild_id) if guild_id else None
+
     def _build_slash_event(self, interaction: discord.Interaction, text: str) -> MessageEvent:
         """Build a MessageEvent from a Discord slash command interaction."""
         is_dm = isinstance(interaction.channel, discord.DMChannel)
@@ -6480,6 +6488,12 @@ class DiscordAdapter(BasePlatformAdapter):
         # For forum threads, inherit the parent forum's topic.
         chat_topic = self._get_effective_topic(interaction.channel, is_thread=is_thread)
 
+        # guild_id/parent_chat_id feed profile_routes matching in build_source,
+        # exactly as on_message passes them — without them a guild- or
+        # channel-routed profile never matches a native slash command (#69178).
+        parent_id = (
+            self._get_parent_channel_id(interaction.channel) if is_thread else None
+        ) or ""
         source = self.build_source(
             chat_id=str(interaction.channel_id),
             chat_name=chat_name,
@@ -6488,11 +6502,12 @@ class DiscordAdapter(BasePlatformAdapter):
             user_name=interaction.user.display_name,
             thread_id=thread_id,
             chat_topic=chat_topic,
+            guild_id=self._interaction_guild_id(interaction),
+            parent_chat_id=parent_id or None,
         )
 
         msg_type = MessageType.COMMAND if text.startswith("/") else MessageType.TEXT
         channel_id = str(interaction.channel_id)
-        parent_id = str(getattr(getattr(interaction, "channel", None), "parent_id", "") or "")
         return MessageEvent(
             text=text,
             message_type=msg_type,
@@ -6574,6 +6589,8 @@ class DiscordAdapter(BasePlatformAdapter):
         _chan = getattr(interaction, "channel", None)
         chat_topic = self._get_effective_topic(_chan, is_thread=True) if _chan else None
 
+        _parent_channel = self._thread_parent_channel(getattr(interaction, "channel", None))
+        _parent_id = str(getattr(_parent_channel, "id", "") or "")
         source = self.build_source(
             chat_id=thread_id,
             chat_name=chat_name,
@@ -6582,10 +6599,10 @@ class DiscordAdapter(BasePlatformAdapter):
             user_name=interaction.user.display_name,
             thread_id=thread_id,
             chat_topic=chat_topic,
+            guild_id=self._interaction_guild_id(interaction),
+            parent_chat_id=_parent_id or None,
         )
 
-        _parent_channel = self._thread_parent_channel(getattr(interaction, "channel", None))
-        _parent_id = str(getattr(_parent_channel, "id", "") or "")
         _skills = self._resolve_channel_skills(thread_id, _parent_id or None)
         _channel_prompt = self._resolve_channel_prompt(thread_id, _parent_id or None)
         event = MessageEvent(

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -602,3 +602,43 @@ def test_register_skill_command_payload_fits_discord_8kb_limit(adapter):
     )
 
 
+
+
+# ------------------------------------------------------------------
+# _build_slash_event — guild/parent ids reach profile_routes (#69178, #91633)
+# ------------------------------------------------------------------
+
+
+def test_build_slash_event_routes_guild_profile_like_messages(adapter, monkeypatch):
+    """A guild-keyed profile route must match a native slash command exactly
+    as it matches a regular message: build_source needs guild_id (and the
+    thread's parent_chat_id) or the route never fires and /new resets the
+    default profile's session instead of the routed one."""
+    from gateway import run as gateway_run
+    from gateway.config import GatewayConfig
+    from gateway.profile_routing import ProfileRoute
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.config = GatewayConfig(
+        multiplex_profiles=True,
+        profile_routes=[ProfileRoute(name="work", profile="work", platform="discord", guild_id="1")],
+    )
+    monkeypatch.setattr(gateway_run, "_multiplex_profile_homes", lambda _cfg: [("work", None)])
+    adapter.gateway_runner = runner
+    user = SimpleNamespace(display_name="Jezza", id=42)
+
+    channel_event = adapter._build_slash_event(
+        SimpleNamespace(channel=SimpleNamespace(id=200, name="general", guild=SimpleNamespace(id=1, name="G"), topic=None),
+                        channel_id=200, guild_id=1, user=user),
+        "/new",
+    )
+    thread_event = adapter._build_slash_event(
+        SimpleNamespace(channel=_FakeThreadChannel(channel_id=555), channel_id=555, guild_id=None, user=user),
+        "/status",
+    )
+
+    assert channel_event.source.guild_id == "1"
+    assert channel_event.source.profile == "work"
+    assert thread_event.source.guild_id == "1"
+    assert thread_event.source.parent_chat_id == "100"
+    assert thread_event.source.profile == "work"

--- a/tests/gateway/test_handoff_secondary_profile_adapter.py
+++ b/tests/gateway/test_handoff_secondary_profile_adapter.py
@@ -168,6 +168,34 @@ async def test_default_profile_handoff_keeps_primary_adapter(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_secondary_profile_config_load_failure_fails_closed(monkeypatch):
+    """A secondary profile whose config cannot load must fail the handoff.
+
+    Falling back to the primary's config delivers through the right bot to
+    the WRONG chat (the primary's home channel) and reports completed.
+    """
+    runner, _ = _make_multiplex_runner()
+    used = {}
+
+    def _boom():
+        raise RuntimeError("config.yaml exploded")
+
+    monkeypatch.setattr(
+        "gateway.run.resolve_delivery_transport", _spy_transport_factory(used),
+    )
+    monkeypatch.setattr("gateway.run.load_gateway_config", _boom)
+
+    with pytest.raises(RuntimeError, match="could not load config"):
+        await runner._process_handoff(
+            {"id": "cli-session", "title": "work", "handoff_platform": "telegram"},
+            profile_name="medicina",
+        )
+    assert used == {}, (
+        "nothing may be delivered when the profile config fails to load"
+    )
+
+
+@pytest.mark.asyncio
 async def test_secondary_profile_without_live_adapters_fails_loudly(monkeypatch):
     """Never silently fall back to the primary's bot — that ships to the wrong chat.
 

--- a/tests/gateway/test_handoff_watcher_multiprofile.py
+++ b/tests/gateway/test_handoff_watcher_multiprofile.py
@@ -15,6 +15,7 @@ These tests pin the two halves of the fix:
 """
 
 import asyncio
+import threading
 import types
 from pathlib import Path
 
@@ -111,14 +112,14 @@ async def test_watcher_enters_profile_scope_for_each_home(monkeypatch):
         def __init__(self, home):
             self.home = home
 
-        def __enter__(self):
+        async def __aenter__(self):
             entered.append(self.home)
             return self
 
-        def __exit__(self, *exc):
+        async def __aexit__(self, *exc):
             return False
 
-    monkeypatch.setattr(run, "_profile_runtime_scope", _SpyScope)
+    monkeypatch.setattr(run, "_async_profile_runtime_scope", _SpyScope)
 
     async def _no_sleep(_seconds):
         return None
@@ -160,6 +161,68 @@ async def test_watcher_enters_profile_scope_for_each_home(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_slow_profile_secret_load_does_not_block_event_loop(monkeypatch, tmp_path):
+    """A slow profile ``.env`` read must not stall unrelated loop work."""
+    profile_home = tmp_path / "profiles" / "slow"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setattr(
+        run,
+        "_handoff_watch_scopes",
+        lambda _runner: [(None, None), ("slow", profile_home)],
+    )
+
+    from agent import secret_scope
+
+    load_started = threading.Event()
+    ticker_progressed = threading.Event()
+    ticker_progressed_while_loading = []
+
+    def _slow_build(_home):
+        load_started.set()
+        ticker_progressed_while_loading.append(
+            ticker_progressed.wait(timeout=2)
+        )
+        return {}
+
+    monkeypatch.setattr(secret_scope, "build_profile_secret_scope", _slow_build)
+
+    class _DB:
+        async def list_pending_handoffs(self):
+            return []
+
+    fake = types.SimpleNamespace(
+        _session_db=_DB(),
+        _running=False,
+    )
+
+    async def _process_handoff(_row, _profile_name=None):
+        return None
+
+    fake._process_handoff = _process_handoff
+
+    real_sleep = asyncio.sleep
+
+    async def _skip_initial_delay(seconds):
+        await real_sleep(0 if seconds == 5 else seconds)
+
+    monkeypatch.setattr(run.asyncio, "sleep", _skip_initial_delay)
+    async def _ticker():
+        assert await asyncio.to_thread(load_started.wait, 5)
+        ticker_progressed.set()
+
+    watcher = asyncio.create_task(
+        run.GatewayRunner._handoff_watcher(fake, interval=0.0)
+    )
+    ticker = asyncio.create_task(_ticker())
+    await asyncio.wait_for(asyncio.gather(watcher, ticker), timeout=5)
+
+    assert ticker_progressed_while_loading == [True], (
+        "profile secret loading blocked the asyncio event loop until the "
+        "filesystem operation completed"
+    )
+
+
+@pytest.mark.asyncio
 async def test_each_scope_resolves_its_own_store_and_profile(monkeypatch):
     """The whole point: a DIFFERENT ``state.db`` per scope, and the profile
     name reaches ``_process_handoff`` so delivery uses that profile's adapter.
@@ -183,15 +246,15 @@ async def test_each_scope_resolves_its_own_store_and_profile(monkeypatch):
         def __init__(self, home):
             self.home = home
 
-        def __enter__(self):
+        async def __aenter__(self):
             active["home"] = self.home
             return self
 
-        def __exit__(self, *exc):
+        async def __aexit__(self, *exc):
             active["home"] = None
             return False
 
-    monkeypatch.setattr(run, "_profile_runtime_scope", _SpyScope)
+    monkeypatch.setattr(run, "_async_profile_runtime_scope", _SpyScope)
 
     async def _no_sleep(_seconds):
         return None

--- a/tests/gateway/test_handoff_watcher_resilience.py
+++ b/tests/gateway/test_handoff_watcher_resilience.py
@@ -219,13 +219,13 @@ async def test_reclaim_runs_per_profile_store(monkeypatch):
         def __init__(self, home):
             self.home = home
 
-        def __enter__(self):
+        async def __aenter__(self):
             return self
 
-        def __exit__(self, *exc):
+        async def __aexit__(self, *exc):
             return False
 
-    monkeypatch.setattr(run, "_profile_runtime_scope", _Scope)
+    monkeypatch.setattr(run, "_async_profile_runtime_scope", _Scope)
 
     async def _no_sleep(_seconds):
         return None


### PR DESCRIPTION
## Summary
Three multiplex-gateway bugs in one branch: a secondary-profile handoff whose config failed to load silently delivered through the primary's home channel; the handoff watcher (and per-message handlers) entered the profile secret scope synchronously on the event loop, stalling every adapter during slow secret reads; and native Discord slash commands built their SessionSource without guild_id/parent_chat_id, so guild/channel profile_routes never matched and /new, /reset, /model, /status ran against the default profile.
## Changes
- `_process_handoff`: config-load failure → error + raise (row marked failed) instead of falling back to `self.config` (#97694, @Adolanium, cherry-picked).
- `_load_profile_secret_scope` + `_async_profile_runtime_scope`: secret scope loaded via `asyncio.to_thread`, then the existing sync scope is entered with `prepared_secret_scope=`; watcher reclaim/tick use it (#100049, @fangliquanflq, cherry-picked).
- Class widening: the three async per-message scope entries (`_make_profile_message_handler`, `_make_default_profile_message_handler`, `_prepare_inbound_message_text_scoped`) now use the async scope too.
- Discord `_build_slash_event` / `_dispatch_thread_session` pass `guild_id` (new `_interaction_guild_id`, mirrors on_message) and `parent_chat_id` to `build_source`.
- Tests: 1 fail-closed handoff test, 1 loop-responsiveness test, 1 slash-routing parity test (+ existing watcher tests adapted to the async scope).
## Validation
| Scenario | origin/main | this branch |
|---|---|---|
| Secondary handoff, profile config unloadable | create_handoff_thread on PRIMARY home '111', row completed | RuntimeError, no adapter call, row failed |
| Watcher tick with 600ms secret hydration | loop stalled 601 ms | 21 ms |
| Discord /new in guild-routed channel | profile=None, reset key agent:main:… | profile='work', key agent:work:… (idle + busy) |
| /status in thread | guild_id/parent_chat_id None → no route | guild_id='1', parent_chat_id='100' → routed |
Sabotage: each regression test fails with its fix reverted. Targeted suites: 70 passed; 34-file seam sweep: 586 passed.
## Credits
@Adolanium (#97694 merged as-is), @fangliquanflq (#100049, first submitter), @Tranquil-Flow (#100076, same mechanism, co-author), @Sora-bluesky (#69242, first fix for #69178, co-author), @jondgilbert (#91634 / #91633, co-author), @tensorbit89-netizen (#31102, first report), @vKongv (#85355 diagnosis; its residual /new symptom is the guild_id gap fixed here).
```

Probes kept at /tmp/mux_sweep/hds/ (probe_failclosed.py, probe_watcher.py, probe_discord_slash.py, probe_reset_key.py, probe_85355.py). Baseline worktree /tmp/salv-hds-base (detached origin/main) also left in place.

Fixes #97693
Fixes #100014
Fixes #69178
Fixes #91633

## Infographic

![mux-handoff-discord-slash](https://v3b.fal.media/files/b/0aa8cde9/NJuZa3RsvwDHXZIDrBnou_BOEjghDB.png)
