### PR TITLE
fix(gateway): per-profile /voice state, off-loop startup hydration, session-recovery owner fence, int route ids (#84872 #74285 #88381 #86470, salvage #99519 #70815 #85245)

### DIFF
--- a/contributors/emails/gobeumsu@gmail.com
+++ b/contributors/emails/gobeumsu@gmail.com
@@ -1,0 +1,1 @@
+GoBeromsu

--- a/gateway/profile_routing.py
+++ b/gateway/profile_routing.py
@@ -163,9 +163,22 @@ def _coerce_route_id(value: Any) -> Optional[str]:
     PyYAML loads unquoted numeric IDs (Discord snowflakes, Telegram negative
     chat ids) as ``int``. Inbound ``SessionSource`` fields are always ``str``
     via ``build_source``, so leaving ints here makes ``matches()`` fail silently.
+
+    Only ``int`` is coerced (the legitimate YAML-numeric case). ``bool`` is an
+    ``int`` subclass but never a valid id; floats and other types stringify to
+    something (``"123.0"``) that can never equal an inbound id — recreating the
+    silent no-match this exists to fix — so they are passed through with a
+    load-time warning instead of being silently "fixed" (#86470).
     """
-    if value is None:
-        return None
+    if value is None or isinstance(value, str):
+        return value
+    if isinstance(value, int) and not isinstance(value, bool):
+        return str(value)
+    logger.warning(
+        "Profile route discriminator %r (type %s) can never match an inbound "
+        "id — quote it in config.yaml (e.g. chat_id: \"%s\").",
+        value, type(value).__name__, value,
+    )
     return str(value)
 
 

--- a/gateway/profile_routing.py
+++ b/gateway/profile_routing.py
@@ -157,6 +157,18 @@ class ProfileRoute:
         return True
 
 
+def _coerce_route_id(value: Any) -> Optional[str]:
+    """Normalize a route discriminator to str for strict equality matching.
+
+    PyYAML loads unquoted numeric IDs (Discord snowflakes, Telegram negative
+    chat ids) as ``int``. Inbound ``SessionSource`` fields are always ``str``
+    via ``build_source``, so leaving ints here makes ``matches()`` fail silently.
+    """
+    if value is None:
+        return None
+    return str(value)
+
+
 def parse_profile_routes(raw: Optional[List[Dict[str, Any]]]) -> List[ProfileRoute]:
     """Parse profile_routes from config.yaml into ProfileRoute objects.
 
@@ -194,9 +206,9 @@ def parse_profile_routes(raw: Optional[List[Dict[str, Any]]]) -> List[ProfileRou
                 name=name,
                 platform=platform,
                 profile=profile,
-                guild_id=entry.get("guild_id"),
-                chat_id=entry.get("chat_id"),
-                thread_id=entry.get("thread_id"),
+                guild_id=_coerce_route_id(entry.get("guild_id")),
+                chat_id=_coerce_route_id(entry.get("chat_id")),
+                thread_id=_coerce_route_id(entry.get("thread_id")),
                 enabled=entry.get("enabled", True),
             )
         )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -28,6 +28,7 @@ import asyncio
 import concurrent.futures
 import dataclasses
 import faulthandler
+import functools
 import inspect
 import json
 import logging
@@ -8168,9 +8169,43 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     _VOICE_MODE_PATH = _hermes_home / "gateway_voice_mode.json"
 
-    def _voice_key(self, platform: Platform, chat_id: str) -> str:
-        """Return a platform-namespaced key for voice mode state."""
-        return f"{platform.value}:{chat_id}"
+    def _voice_key(
+        self, platform: Platform, chat_id: str, profile: Optional[str] = None
+    ) -> str:
+        """Return a platform-namespaced key for voice mode state.
+
+        Under multiplexing the key is additionally namespaced by the profile
+        whose bot speaks in the chat (``<profile>:<platform>:<chat_id>``); the
+        default profile keeps the historical ``<platform>:<chat_id>`` shape so
+        persisted state stays valid. Two bots in one Discord channel otherwise
+        share a key and one profile's ``/voice`` flips the other's (#75198).
+        """
+        base = f"{platform.value}:{chat_id}"
+        profile = profile.strip() if isinstance(profile, str) else ""
+        if not profile or profile == "default":
+            return base
+        return f"{profile}:{base}"
+
+    def _voice_key_for_source(self, source: SessionSource) -> str:
+        """Voice-state key for an inbound source, namespaced by its transport owner.
+
+        Voice mode belongs to the (bot, chat) pair, so the namespace is the
+        profile that OWNS the receiving adapter (``_adapter_profile_for_source``)
+        — the same profile ``_sync_voice_mode_state_to_adapter`` uses on
+        reconnect — not the routed runtime profile.
+        """
+        return self._voice_key(
+            source.platform,
+            source.chat_id,
+            profile=self._adapter_profile_for_source(source),
+        )
+
+    def _bind_voice_input_callback(self, adapter) -> None:
+        """Route voice transcripts back through the adapter that captured them."""
+        if hasattr(adapter, "_voice_input_callback"):
+            adapter._voice_input_callback = functools.partial(
+                self._handle_voice_channel_input, adapter=adapter
+            )
 
     def _load_voice_modes(self) -> Dict[str, str]:
         try:
@@ -8269,7 +8304,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if hasattr(adapter, "_auto_tts_default"):
             adapter._auto_tts_default = _auto_tts_default
 
-        prefix = f"{platform.value}:"
+        prefix = self._voice_key(platform, "", profile=getattr(adapter, "_owner_profile", None))
         if isinstance(disabled_chats, set):
             disabled_chats.clear()
             disabled_chats.update(
@@ -14276,8 +14311,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._sync_voice_mode_state_to_adapter(adapter)
                 # Wire voice input callback at connect time so voice
                 # transcription is forwarded without requiring /voice join.
-                if hasattr(adapter, "_voice_input_callback"):
-                    adapter._voice_input_callback = self._handle_voice_channel_input
+                self._bind_voice_input_callback(adapter)
                 connected_count += 1
                 self._update_platform_runtime_status(
                     platform.value, platform_state="connected", error_code=None, error_message=None,
@@ -16040,8 +16074,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         self.adapters[platform] = adapter
                         self._sync_voice_mode_state_to_adapter(adapter)
                         # Wire voice input callback on reconnect as well (#60623).
-                        if hasattr(adapter, "_voice_input_callback"):
-                            adapter._voice_input_callback = self._handle_voice_channel_input
+                        self._bind_voice_input_callback(adapter)
                         self.delivery_router.adapters = self.adapters
                         del self._failed_platforms[platform]
                         self._update_platform_runtime_status(
@@ -17156,6 +17189,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
                 if success:
                     profile_map[platform] = adapter
+                    # Restore persisted /voice state for this bot (#84872) —
+                    # primary startup and every reconnect path already do.
+                    self._sync_voice_mode_state_to_adapter(adapter)
                     if credential_claim is not None:
                         claimed[credential_claim] = profile_name
                     if listener_claim is not None:
@@ -17214,6 +17250,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         adapter.set_platform_event_handler(
             self._make_profile_platform_event_handler(profile_name)
         )
+        # Voice transcripts from this bot's channels dispatch through THIS
+        # adapter (primary wiring lives at connect time; see #75198).
+        self._bind_voice_input_callback(adapter)
         text_modes = getattr(self, "_busy_text_modes_by_profile", None)
         adapter._busy_text_mode = (
             text_modes.get(profile_name, self._busy_text_mode)
@@ -24549,15 +24588,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Wire callbacks BEFORE join so voice input arriving immediately
         # after connection is not lost.
-        if hasattr(adapter, "_voice_input_callback"):
-            adapter._voice_input_callback = self._handle_voice_channel_input
+        self._bind_voice_input_callback(adapter)
+        voice_profile = self._adapter_profile_for_source(event.source)
         if hasattr(adapter, "_on_voice_disconnect"):
-            adapter._on_voice_disconnect = self._handle_voice_timeout_cleanup
+            adapter._on_voice_disconnect = functools.partial(
+                self._handle_voice_timeout_cleanup, adapter=adapter
+            )
         # Let the adapter's inactivity timer see the live voice-reply mode so it
         # doesn't disconnect a deliberately text-only (/voice off) session.
         if hasattr(adapter, "_voice_mode_getter"):
             adapter._voice_mode_getter = lambda chat_id: self._voice_mode.get(
-                self._voice_key(Platform.DISCORD, str(chat_id)), "off"
+                self._voice_key(Platform.DISCORD, str(chat_id), profile=voice_profile),
+                "off",
             )
 
         try:
@@ -24577,7 +24619,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             adapter._voice_text_channels[guild_id] = int(event.source.chat_id)
             if hasattr(adapter, "_voice_sources"):
                 adapter._voice_sources[guild_id] = event.source.to_dict()
-            self._voice_mode[self._voice_key(event.source.platform, event.source.chat_id)] = "all"
+            self._voice_mode[self._voice_key_for_source(event.source)] = "all"
             self._save_voice_modes()
             self._set_adapter_auto_tts_enabled(adapter, event.source.chat_id, enabled=True)
             return (
@@ -24604,21 +24646,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception as e:
             logger.warning("Error leaving voice channel: %s", e)
         # Always clean up state even if leave raised an exception
-        self._voice_mode[self._voice_key(event.source.platform, event.source.chat_id)] = "off"
+        self._voice_mode[self._voice_key_for_source(event.source)] = "off"
         self._save_voice_modes()
         self._set_adapter_auto_tts_disabled(adapter, event.source.chat_id, disabled=True)
         if hasattr(adapter, "_voice_input_callback"):
             adapter._voice_input_callback = None
         return "Left voice channel."
 
-    def _handle_voice_timeout_cleanup(self, chat_id: str) -> None:
+    def _handle_voice_timeout_cleanup(self, chat_id: str, *, adapter=None) -> None:
         """Called by the adapter when a voice channel times out.
 
         Cleans up runner-side voice_mode state that the adapter cannot reach.
+        ``adapter`` is the Discord adapter that timed out (bound at join time);
+        under multiplexing that is a specific profile's bot, not necessarily
+        ``self.adapters[DISCORD]``.
         """
-        self._voice_mode[self._voice_key(Platform.DISCORD, chat_id)] = "off"
+        if adapter is None:
+            adapter = self.adapters.get(Platform.DISCORD)
+        profile = getattr(adapter, "_owner_profile", None)
+        self._voice_mode[self._voice_key(Platform.DISCORD, chat_id, profile=profile)] = "off"
         self._save_voice_modes()
-        adapter = self.adapters.get(Platform.DISCORD)
         self._set_adapter_auto_tts_disabled(adapter, chat_id, disabled=True)
 
     def _is_duplicate_voice_transcript(self, guild_id: int, user_id: int, transcript: str) -> bool:
@@ -24663,14 +24710,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return False
 
     async def _handle_voice_channel_input(
-        self, guild_id: int, user_id: int, transcript: str
+        self, guild_id: int, user_id: int, transcript: str, *, adapter=None
     ):
         """Handle transcribed voice from a user in a voice channel.
 
         Creates a synthetic MessageEvent and processes it through the
         adapter's full message pipeline (session, typing, agent, TTS reply).
+        ``adapter`` is the Discord adapter that captured the audio (bound via
+        ``_bind_voice_input_callback``); under multiplexing each profile's bot
+        must dispatch through its own adapter, never the default profile's.
         """
-        adapter = self.adapters.get(Platform.DISCORD)
+        if adapter is None:
+            adapter = self.adapters.get(Platform.DISCORD)
         if not adapter:
             return
 
@@ -24692,6 +24743,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 user_id=str(user_id),
                 user_name=str(user_id),
                 chat_type="channel",
+                profile=getattr(adapter, "_owner_profile", None),
             )
 
         # Check authorization before processing voice input
@@ -24763,11 +24815,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return False
 
         chat_id = event.source.chat_id
-        voice_key = self._voice_key(event.source.platform, chat_id)
+        voice_key = self._voice_key_for_source(event.source)
         voice_mode = self._voice_mode.get(voice_key)
         is_voice_input = (event.message_type == MessageType.VOICE)
 
-        adapter = self.adapters.get(event.source.platform)
+        adapter = self._adapter_for_source(event.source)
         adapter_auto_tts = False
         if adapter and hasattr(adapter, "_should_auto_tts_for_chat"):
             try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16992,8 +16992,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     ) -> int:
         """Create+connect one profile's adapters under its runtime scope."""
         from gateway.config import load_gateway_config
+        from hermes_cli.env_loader import hydrate_profile_secret_sources
 
-        with _profile_runtime_scope(profile_home):
+        # Hydrate external secret sources (1Password/vault/...) off-loop ONCE,
+        # then enter the scope without re-hydrating: the sync hydration is
+        # network-bound and would otherwise stall every other profile's
+        # heartbeat while this one boots (same class as the reconnect path).
+        await asyncio.to_thread(hydrate_profile_secret_sources, profile_home)
+
+        with _profile_runtime_scope(profile_home, hydrate_secrets=False):
             profile_runtime_cfg = _load_gateway_runtime_config()
             from hermes_cli.plugins import discover_plugins
 
@@ -17059,7 +17066,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             ):
                 continue
             try:
-                with _profile_runtime_scope(profile_home):
+                with _profile_runtime_scope(profile_home, hydrate_secrets=False):
                     adapter = self._create_adapter(platform, platform_config)
             except Exception as e:
                 logger.error(
@@ -17143,7 +17150,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._configure_profile_adapter(adapter, profile_name, platform)
 
             try:
-                with _profile_runtime_scope(profile_home):
+                with _profile_runtime_scope(profile_home, hydrate_secrets=False):
                     success = await self._connect_initial_adapter_with_timeout(
                         adapter, platform
                     )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2602,7 +2602,10 @@ def _load_profile_secret_scope(profile_home: "Path") -> dict:
 
 @_contextmanager
 def _profile_runtime_scope(
-    profile_home: "Path", prepared_secret_scope: Optional[dict] = None,
+    profile_home: "Path",
+    prepared_secret_scope: Optional[dict] = None,
+    *,
+    hydrate_secrets: bool = True,
 ):
     """Scope config/skills/memory AND credentials to a profile for one turn.
 
@@ -2628,11 +2631,15 @@ def _profile_runtime_scope(
     )
 
     home_token = set_hermes_home_override(str(profile_home))
-    secrets = (
-        prepared_secret_scope
-        if prepared_secret_scope is not None
-        else _load_profile_secret_scope(Path(profile_home))
-    )
+    if prepared_secret_scope is not None:
+        secrets = prepared_secret_scope
+    elif hydrate_secrets:
+        secrets = _load_profile_secret_scope(Path(profile_home))
+    else:
+        # Caller already hydrated external sources off-loop (#99519).
+        from agent.secret_scope import build_profile_secret_scope
+
+        secrets = build_profile_secret_scope(Path(profile_home))
     secret_token = set_secret_scope(secrets)
     # Per-turn terminal scope (third seam of the profile boundary): installs
     # the routed profile's COMPLETE terminal policy — never ambient env — via
@@ -17221,10 +17228,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 adapter = None
                 try:
                     from hermes_cli.profiles import get_profile_dir
+                    from hermes_cli.env_loader import hydrate_profile_secret_sources
                     from gateway.config import load_gateway_config
 
                     profile_home = get_profile_dir(profile_name)
-                    with _profile_runtime_scope(profile_home):
+                    # Like the #16856 MCP discovery path, hydrate external secret
+                    # sources off-loop so they cannot starve platform heartbeats.
+                    await asyncio.to_thread(
+                        hydrate_profile_secret_sources, profile_home
+                    )
+                    with _profile_runtime_scope(profile_home, hydrate_secrets=False):
                         profile_config = load_gateway_config().platforms.get(platform)
                         if profile_config is None or not profile_config.enabled:
                             return

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -2209,10 +2209,15 @@ class SessionStore:
         requested_session_key: str,
         recovered: Dict[str, Any],
     ) -> bool:
-        """Prevent non-multiplexed gateways from reviving another profile's row."""
-        if getattr(self.config, "multiplex_profiles", False):
-            return True
+        """Prevent a gateway from reviving another profile's row.
 
+        Single-profile: the recovered row's namespace must match the ACTIVE
+        profile. Multiplexed: several profiles serve traffic at once, so the
+        active profile is meaningless — the requested key carries the profile
+        the turn was routed to, and the recovered row must sit in the same
+        ``agent:<ns>:`` namespace (#74285). Rows with no key namespace stay
+        adoptable in both modes (legacy/keyless data owned by this store).
+        """
         recovered_key = str(recovered.get("session_key") or "")
         if not recovered_key or recovered_key == requested_session_key:
             return True
@@ -2220,6 +2225,10 @@ class SessionStore:
         recovered_profile = self._profile_from_session_key(recovered_key)
         if recovered_profile is None:
             return True
+
+        if getattr(self.config, "multiplex_profiles", False):
+            requested_profile = self._profile_from_session_key(requested_session_key)
+            return requested_profile is None or recovered_profile == requested_profile
 
         return recovered_profile == self._active_profile_name()
 
@@ -2427,8 +2436,7 @@ class SessionStore:
         ):
             logger.warning(
                 "Gateway session DB recovery ignored %s for %s because "
-                "multiplex_profiles is disabled and the row belongs to a "
-                "different profile",
+                "the row belongs to a different profile",
                 recovered.get("session_key"),
                 session_key,
             )
@@ -2504,8 +2512,7 @@ class SessionStore:
         ):
             logger.warning(
                 "Gateway session DB recovery ignored %s for %s because "
-                "multiplex_profiles is disabled and the row belongs to a "
-                "different profile",
+                "the row belongs to a different profile",
                 recovered.get("session_key"),
                 session_key,
             )

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3347,10 +3347,12 @@ class GatewaySlashCommandsMixin:
         """Handle /voice [on|off|tts|channel|leave|status] command."""
         args = event.get_command_args().strip().lower()
         chat_id = event.source.chat_id
-        platform = event.source.platform
-        voice_key = self._voice_key(platform, chat_id)
+        # Voice state belongs to the (bot, chat) pair: resolve the adapter that
+        # received the command and key the mode by its owning profile so two
+        # multiplexed bots in one chat keep independent /voice state (#75198).
+        voice_key = self._voice_key_for_source(event.source)
 
-        adapter = self.adapters.get(platform)
+        adapter = self._adapter_for_source(event.source)
 
         if args in {"on", "enable"}:
             self._voice_mode[voice_key] = "voice_only"
@@ -3382,7 +3384,6 @@ class GatewaySlashCommandsMixin:
                 "all": t("gateway.voice.label_all"),
             }
             # Append voice channel info if connected
-            adapter = self.adapters.get(event.source.platform)
             guild_id = self._get_guild_id(event)
             if guild_id and hasattr(adapter, "get_voice_channel_info"):
                 info = adapter.get_voice_channel_info(guild_id)

--- a/hermes_cli/platform_actions.py
+++ b/hermes_cli/platform_actions.py
@@ -99,7 +99,25 @@ class PlatformActions:
             platform_enum = Platform(str(platform).strip().lower())
         except Exception:
             return None, _err("unknown_platform", f"unknown platform {platform!r}")
-        adapter = getattr(runner, "adapters", {}).get(platform_enum)
+        # Multiplex/Team-Gateway: a secondary profile's adapters live in
+        # runner._profile_adapters[profile], not runner.adapters (the default
+        # profile's registry) — every other adapter-resolution path in this
+        # codebase (_authorization_adapter, plugin message-injection) goes
+        # through this same profile-aware, fail-closed lookup so a plugin
+        # scoped to one profile can never act through another profile's bot
+        # identity. Falls back to the bare default-profile lookup only when
+        # the gateway runner predates this method (defensive, not expected).
+        resolve_fn = getattr(runner, "_authorization_adapter", None)
+        if callable(resolve_fn):
+            try:
+                from hermes_cli.profiles import get_active_profile_name
+
+                profile_name = get_active_profile_name()
+            except Exception:
+                profile_name = None
+            adapter = resolve_fn(platform_enum, profile_name)
+        else:
+            adapter = getattr(runner, "adapters", {}).get(platform_enum)
         if adapter is None:
             return None, _err(
                 "adapter_not_registered",

--- a/hermes_cli/platform_actions.py
+++ b/hermes_cli/platform_actions.py
@@ -114,7 +114,18 @@ class PlatformActions:
 
                 profile_name = get_active_profile_name()
             except Exception:
-                profile_name = None
+                # Fail closed: an unresolvable profile must not degrade to the
+                # default profile's bot (the same rule _authorization_adapter
+                # applies to a stamped profile with no registry entry).
+                logger.debug(
+                    "platform_actions: profile resolution failed for %s",
+                    self._plugin_id, exc_info=True,
+                )
+                return None, _err(
+                    "adapter_not_registered",
+                    f"no {platform_enum.value} adapter is registered "
+                    "(active profile could not be resolved)",
+                )
             adapter = resolve_fn(platform_enum, profile_name)
         else:
             adapter = getattr(runner, "adapters", {}).get(platform_enum)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5180,6 +5180,18 @@ def classify_session_status(
     return SESSION_STATUS_COMPLETE
 
 
+# Parent→child ``profile_name`` inheritance fence (#88381). ``agent:<ns>:...``
+# gateway keys encode the profile namespace; a keyless row (CLI / subagent
+# lineage) carries none and inherits freely. Two keyed rows must agree on
+# ``agent:<ns>:`` — a default child (``agent:main:``) forked from a sibling
+# profile's row must not be durably mislabelled as that profile's.
+_SAME_KEY_NAMESPACE_SQL = (
+    "p.session_key IS NULL OR sessions.session_key IS NULL"
+    " OR substr(p.session_key, 1, instr(substr(p.session_key, 7), ':') + 6)"
+    "  = substr(sessions.session_key, 1, instr(substr(sessions.session_key, 7), ':') + 6)"
+)
+
+
 class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin):
     """
     SQLite-backed session storage with FTS5 search.
@@ -7338,7 +7350,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 self._delete_unreferenced_system_prompts(conn)
             if parent_session_id:
                 conn.execute(
-                    """UPDATE sessions
+                    f"""UPDATE sessions
                        SET cwd = COALESCE(sessions.cwd,
                                  (SELECT p.cwd FROM sessions p
                                    WHERE p.id = sessions.parent_session_id)),
@@ -7350,7 +7362,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                                           WHERE p.id = sessions.parent_session_id)),
                            profile_name = COALESCE(sessions.profile_name,
                                           (SELECT p.profile_name FROM sessions p
-                                            WHERE p.id = sessions.parent_session_id))
+                                            WHERE p.id = sessions.parent_session_id
+                                              AND ({_SAME_KEY_NAMESPACE_SQL})))
                      WHERE id = ? AND parent_session_id IS NOT NULL""",
                     (session_id,),
                 )
@@ -7922,6 +7935,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # tuple so we never cross chats/threads/users.
             if chat_id is None or chat_type is None:
                 return None
+            # Profile fence (#74285): a Telegram DM's peer tuple is identical
+            # for every bot (chat_id == user_id, no thread), so a sibling
+            # profile's row written into this store before the per-profile
+            # partition (legacy data) would otherwise be adopted here. Every
+            # profile-tree store has one owner; a row is ours when its
+            # profile_name is the owner or NULL (legacy rows this store
+            # minted). Stores outside the tree derive no owner and keep the
+            # historical unfenced behavior.
+            owner = self._own_profile_name()
             row = conn.execute(
                 f"""
                 SELECT s.*,
@@ -7937,6 +7959,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                   AND COALESCE(s.chat_id, '') = COALESCE(?, '')
                   AND COALESCE(s.chat_type, '') = COALESCE(?, '')
                   AND COALESCE(s.thread_id, '') = COALESCE(?, '')
+                  AND (? IS NULL OR COALESCE(s.profile_name, ?) = ?)
                   AND (s.ended_at IS NULL OR s.end_reason IN ({_RECOVERABLE_END_REASONS_SQL}))
                   AND (COALESCE(s.message_count, 0) > 0 OR EXISTS (
                       SELECT 1 FROM messages WHERE messages.session_id = s.id LIMIT 1
@@ -7956,7 +7979,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 ORDER BY COALESCE(s.last_activity_at, s.started_at) DESC
                 LIMIT 1
                 """,
-                (source, user_id, chat_id, chat_type, thread_id),
+                (source, user_id, chat_id, chat_type, thread_id, owner, owner, owner),
             ).fetchone()
         return self._session_row_dict(row) if row else None
 

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -1,6 +1,8 @@
 """Phase 3: secondary-profile adapter registry + same-token conflict detection."""
 import logging
 import asyncio
+import threading
+import time
 import types
 from contextlib import contextmanager
 from pathlib import Path
@@ -227,11 +229,15 @@ def _secondary_recovery_runner(*, running=True):
     return runner
 
 
-def _install_secondary_reconnect_context(monkeypatch, runner, adapter, scoped_homes=None):
+def _install_secondary_reconnect_context(
+    monkeypatch, runner, adapter, scoped_homes=None, hydration_flags=None
+):
     @contextmanager
-    def fake_scope(profile_home):
+    def fake_scope(profile_home, *, hydrate_secrets=True):
         if scoped_homes is not None:
             scoped_homes.append(Path(profile_home))
+        if hydration_flags is not None:
+            hydration_flags.append(hydrate_secrets)
         yield
 
     monkeypatch.setattr(gateway_run, "_profile_runtime_scope", fake_scope)
@@ -253,6 +259,61 @@ def _install_secondary_reconnect_context(monkeypatch, runner, adapter, scoped_ho
 
 
 class TestSecondaryProfileFatalRecovery:
+    @pytest.mark.asyncio
+    async def test_reconnect_hydrates_secrets_off_the_event_loop(self, monkeypatch):
+        runner = _secondary_recovery_runner()
+        replacement = _SecondaryRecoveryAdapter()
+        hydration_flags = []
+        _install_secondary_reconnect_context(
+            monkeypatch, runner, replacement, hydration_flags=hydration_flags
+        )
+        loop_thread_id = threading.get_ident()
+        hydration_started = threading.Event()
+        hydration_finished = threading.Event()
+        hydration_thread_ids = []
+        stop_ticker = asyncio.Event()
+        ticks_during_hydration = 0
+
+        def slow_hydrate(profile_home):
+            hydration_thread_ids.append(threading.get_ident())
+            hydration_started.set()
+            time.sleep(0.05)
+            hydration_finished.set()
+
+        async def ticker():
+            nonlocal ticks_during_hydration
+            while not stop_ticker.is_set():
+                if hydration_started.is_set() and not hydration_finished.is_set():
+                    ticks_during_hydration += 1
+                await asyncio.sleep(0)
+
+        async def connect(adapter, platform, *, is_reconnect=False):
+            assert adapter is replacement
+            assert platform is Platform.DISCORD
+            assert is_reconnect is True
+            return True
+
+        monkeypatch.setattr(
+            "hermes_cli.env_loader.hydrate_profile_secret_sources", slow_hydrate
+        )
+        monkeypatch.setattr(runner, "_connect_adapter_with_timeout", connect)
+        ticker_task = asyncio.create_task(ticker())
+        reconnect_task = asyncio.create_task(
+            runner._run_secondary_profile_reconnect("reviewer", Platform.DISCORD)
+        )
+        try:
+            assert await asyncio.to_thread(hydration_started.wait, 1.0)
+            await reconnect_task
+        finally:
+            stop_ticker.set()
+            await ticker_task
+
+        assert len(hydration_thread_ids) == 1
+        assert hydration_thread_ids[0] != loop_thread_id
+        assert ticks_during_hydration > 0
+        assert hydration_flags == [False]
+        assert runner._profile_adapters["reviewer"][Platform.DISCORD] is replacement
+
     @pytest.mark.asyncio
     async def test_retryable_secondary_fatal_reconnects_with_its_profile_scope(
         self, monkeypatch

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -326,6 +326,27 @@ class TestSecondaryProfileFatalRecovery:
         assert runner._profile_adapters["reviewer"][Platform.DISCORD] is replacement
 
     @pytest.mark.asyncio
+    async def test_secondary_initial_connect_syncs_voice_mode_state(self, monkeypatch):
+        """#84872: a secondary bot gets its persisted /voice state at INITIAL
+        connect, not only on reconnect."""
+        runner = _secondary_recovery_runner()
+        adapter = _SecondaryRecoveryAdapter()
+        _install_secondary_reconnect_context(monkeypatch, runner, adapter)
+        synced = []
+        runner._sync_voice_mode_state_to_adapter = synced.append
+        monkeypatch.setattr("hermes_cli.env_loader.hydrate_profile_secret_sources", lambda h: {})
+        monkeypatch.setattr(gateway_run, "_load_gateway_runtime_config", lambda: {})
+        monkeypatch.setattr(runner, "_snapshot_profile_busy_modes", lambda *a, **k: None)
+        monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda: None)
+
+        async def connect(a, platform):
+            return True
+
+        monkeypatch.setattr(runner, "_connect_initial_adapter_with_timeout", connect)
+        assert await runner._start_one_profile_adapters("reviewer", Path("/profiles/reviewer"), {}) == 1
+        assert synced == [adapter]
+
+    @pytest.mark.asyncio
     async def test_retryable_secondary_fatal_reconnects_with_its_profile_scope(
         self, monkeypatch
     ):

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -260,7 +260,11 @@ def _install_secondary_reconnect_context(
 
 class TestSecondaryProfileFatalRecovery:
     @pytest.mark.asyncio
-    async def test_reconnect_hydrates_secrets_off_the_event_loop(self, monkeypatch):
+    @pytest.mark.parametrize("entry", ["startup", "reconnect"])
+    async def test_secondary_hydrates_secrets_off_the_event_loop(self, monkeypatch, entry):
+        """#99519 class: both secondary entry points (initial start + reconnect)
+        hydrate external secret sources in a worker thread, exactly once, and
+        enter the runtime scope with hydration disabled."""
         runner = _secondary_recovery_runner()
         replacement = _SecondaryRecoveryAdapter()
         hydration_flags = []
@@ -287,23 +291,30 @@ class TestSecondaryProfileFatalRecovery:
                     ticks_during_hydration += 1
                 await asyncio.sleep(0)
 
-        async def connect(adapter, platform, *, is_reconnect=False):
+        async def connect(adapter, platform, **_kwargs):
             assert adapter is replacement
             assert platform is Platform.DISCORD
-            assert is_reconnect is True
             return True
 
         monkeypatch.setattr(
             "hermes_cli.env_loader.hydrate_profile_secret_sources", slow_hydrate
         )
         monkeypatch.setattr(runner, "_connect_adapter_with_timeout", connect)
+        monkeypatch.setattr(runner, "_connect_initial_adapter_with_timeout", connect)
+        monkeypatch.setattr(gateway_run, "_load_gateway_runtime_config", lambda: {})
+        monkeypatch.setattr(runner, "_snapshot_profile_busy_modes", lambda *a, **k: None)
+        monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda: None)
+        if entry == "startup":
+            coro = runner._start_one_profile_adapters(
+                "reviewer", Path("/profiles/reviewer"), {}
+            )
+        else:
+            coro = runner._run_secondary_profile_reconnect("reviewer", Platform.DISCORD)
         ticker_task = asyncio.create_task(ticker())
-        reconnect_task = asyncio.create_task(
-            runner._run_secondary_profile_reconnect("reviewer", Platform.DISCORD)
-        )
+        work = asyncio.create_task(coro)
         try:
             assert await asyncio.to_thread(hydration_started.wait, 1.0)
-            await reconnect_task
+            await work
         finally:
             stop_ticker.set()
             await ticker_task
@@ -311,7 +322,7 @@ class TestSecondaryProfileFatalRecovery:
         assert len(hydration_thread_ids) == 1
         assert hydration_thread_ids[0] != loop_thread_id
         assert ticks_during_hydration > 0
-        assert hydration_flags == [False]
+        assert hydration_flags and set(hydration_flags) == {False}
         assert runner._profile_adapters["reviewer"][Platform.DISCORD] is replacement
 
     @pytest.mark.asyncio
@@ -447,13 +458,15 @@ class TestSecondaryStartupFailureRecovery:
         # gateway is already running) to the regular reconnect task, which
         # publishes the replacement and clears its own slot.
         await asyncio.wait_for(bridge[0], timeout=0.5)
-        for _ in range(20):
-            if (
-                runner._profile_adapters.get("reviewer", {}).get(Platform.DISCORD)
-                is replacement
-            ):
-                break
-            await asyncio.sleep(0)
+        # The reconnect runner hops to a worker thread for secret hydration,
+        # so wait on a deadline rather than a fixed number of loop turns.
+        deadline = time.monotonic() + 1.0
+        while (
+            runner._profile_adapters.get("reviewer", {}).get(Platform.DISCORD)
+            is not replacement
+            and time.monotonic() < deadline
+        ):
+            await asyncio.sleep(0.005)
         assert (
             runner._profile_adapters["reviewer"][Platform.DISCORD] is replacement
         )
@@ -500,13 +513,15 @@ class TestSecondaryStartupFailureRecovery:
         bridge = list(runner._background_tasks)
         assert len(bridge) == 1
         await asyncio.wait_for(bridge[0], timeout=0.5)
-        for _ in range(20):
-            if (
-                runner._profile_adapters.get("reviewer", {}).get(Platform.DISCORD)
-                is replacement
-            ):
-                break
-            await asyncio.sleep(0)
+        # The reconnect runner hops to a worker thread for secret hydration,
+        # so wait on a deadline rather than a fixed number of loop turns.
+        deadline = time.monotonic() + 1.0
+        while (
+            runner._profile_adapters.get("reviewer", {}).get(Platform.DISCORD)
+            is not replacement
+            and time.monotonic() < deadline
+        ):
+            await asyncio.sleep(0.005)
         assert (
             runner._profile_adapters["reviewer"][Platform.DISCORD] is replacement
         )

--- a/tests/gateway/test_multiplex_phase0.py
+++ b/tests/gateway/test_multiplex_phase0.py
@@ -172,3 +172,27 @@ class TestSessionStoreUnmultiplexedRecovery:
         assert recovered.session_id == "sess-coder"
         assert recovered.session_key == "agent:main:telegram:dm:99"
         assert store._db.reopened == ["sess-coder"]
+
+    @pytest.mark.parametrize(
+        ("recovered_key", "adopted"),
+        [
+            ("agent:coder:telegram:dm:99", False),  # sibling namespace → fail closed
+            ("agent:main:telegram:dm:99:v1", True),  # same namespace → adoptable
+        ],
+        ids=["sibling-profile", "same-profile"],
+    )
+    def test_flag_on_fences_recovery_by_requested_namespace(
+        self, tmp_path, recovered_key, adopted
+    ):
+        """#74285: under multiplexing the guard compares the recovered row's
+        ``agent:<ns>:`` against the REQUESTED key, never the active profile."""
+        row = {"id": "sess", "started_at": 1700000000, "session_key": recovered_key}
+        store = self._store_with_row(tmp_path, row, multiplex_profiles=True)
+        store._db_pinned = store._db
+        with patch("hermes_cli.profiles.get_active_profile_name", return_value="coder"):
+            recovered = store._recover_session_from_db(
+                session_key="agent:main:telegram:dm:99",
+                source=_src(chat_id="99", chat_type="dm"),
+                now=datetime.fromtimestamp(1700000001),
+            )
+        assert (recovered is not None) is adopted

--- a/tests/gateway/test_profile_routing.py
+++ b/tests/gateway/test_profile_routing.py
@@ -52,6 +52,54 @@ class TestParseProfileRoutes:
         assert parse_profile_routes(None) == []
         assert parse_profile_routes([]) == []
 
+    def test_coerces_yaml_native_int_ids_to_str(self):
+        # PyYAML loads unquoted snowflakes as int; inbound SessionSource IDs are str.
+        raw = [
+            {
+                "name": "server",
+                "platform": "discord",
+                "profile": "p",
+                "guild_id": 111,
+                "chat_id": 222,
+                "thread_id": 333,
+            },
+        ]
+        routes = parse_profile_routes(raw)
+        assert routes[0].guild_id == "111"
+        assert routes[0].chat_id == "222"
+        assert routes[0].thread_id == "333"
+        assert all(isinstance(v, str) for v in (
+            routes[0].guild_id, routes[0].chat_id, routes[0].thread_id,
+        ))
+        matched = match_profile_route(
+            routes, "discord", guild_id="111", chat_id="222", thread_id="333",
+        )
+        assert matched is not None
+        assert matched.name == "server"
+
+    def test_coerces_negative_telegram_chat_id(self):
+        raw = [
+            {
+                "name": "tg",
+                "platform": "telegram",
+                "profile": "p",
+                "chat_id": -1001234567890,
+            },
+        ]
+        routes = parse_profile_routes(raw)
+        assert routes[0].chat_id == "-1001234567890"
+        matched = match_profile_route(routes, "telegram", chat_id="-1001234567890")
+        assert matched is not None
+        assert matched.name == "tg"
+
+    def test_omitted_ids_remain_none(self):
+        routes = parse_profile_routes([
+            {"name": "platform-only", "platform": "discord", "profile": "p"},
+        ])
+        assert routes[0].guild_id is None
+        assert routes[0].chat_id is None
+        assert routes[0].thread_id is None
+
 
 class TestMatchProfileRoute:
 

--- a/tests/gateway/test_profile_routing.py
+++ b/tests/gateway/test_profile_routing.py
@@ -53,52 +53,38 @@ class TestParseProfileRoutes:
         assert parse_profile_routes([]) == []
 
     def test_coerces_yaml_native_int_ids_to_str(self):
-        # PyYAML loads unquoted snowflakes as int; inbound SessionSource IDs are str.
-        raw = [
-            {
-                "name": "server",
-                "platform": "discord",
-                "profile": "p",
-                "guild_id": 111,
-                "chat_id": 222,
-                "thread_id": 333,
-            },
-        ]
-        routes = parse_profile_routes(raw)
-        assert routes[0].guild_id == "111"
-        assert routes[0].chat_id == "222"
-        assert routes[0].thread_id == "333"
-        assert all(isinstance(v, str) for v in (
-            routes[0].guild_id, routes[0].chat_id, routes[0].thread_id,
-        ))
-        matched = match_profile_route(
-            routes, "discord", guild_id="111", chat_id="222", thread_id="333",
-        )
-        assert matched is not None
-        assert matched.name == "server"
-
-    def test_coerces_negative_telegram_chat_id(self):
-        raw = [
-            {
-                "name": "tg",
-                "platform": "telegram",
-                "profile": "p",
-                "chat_id": -1001234567890,
-            },
-        ]
-        routes = parse_profile_routes(raw)
-        assert routes[0].chat_id == "-1001234567890"
-        matched = match_profile_route(routes, "telegram", chat_id="-1001234567890")
-        assert matched is not None
-        assert matched.name == "tg"
-
-    def test_omitted_ids_remain_none(self):
+        # PyYAML loads unquoted snowflakes / negative Telegram ids as int;
+        # inbound SessionSource ids are str, so un-coerced routes never match.
         routes = parse_profile_routes([
+            {"name": "server", "platform": "discord", "profile": "p",
+             "guild_id": 111, "chat_id": 222, "thread_id": 333},
+            {"name": "tg", "platform": "telegram", "profile": "p",
+             "chat_id": -1001234567890},
             {"name": "platform-only", "platform": "discord", "profile": "p"},
         ])
-        assert routes[0].guild_id is None
-        assert routes[0].chat_id is None
-        assert routes[0].thread_id is None
+        by_name = {r.name: r for r in routes}
+        assert (by_name["server"].guild_id, by_name["server"].chat_id,
+                by_name["server"].thread_id) == ("111", "222", "333")
+        assert match_profile_route(
+            routes, "discord", guild_id="111", chat_id="222", thread_id="333",
+        ).name == "server"
+        assert match_profile_route(
+            routes, "telegram", chat_id="-1001234567890",
+        ).name == "tg"
+        assert (by_name["platform-only"].guild_id, by_name["platform-only"].chat_id,
+                by_name["platform-only"].thread_id) == (None, None, None)
+
+    def test_non_int_numeric_ids_warn_instead_of_silently_coercing(self, caplog):
+        # #86470 nuance: float/bool stringify to values that can never match
+        # an inbound id, so surface the misconfiguration at load time.
+        with caplog.at_level("WARNING", logger="gateway.profile_routing"):
+            routes = parse_profile_routes([
+                {"name": "f", "platform": "discord", "profile": "p", "chat_id": 123.0},
+                {"name": "b", "platform": "discord", "profile": "p", "guild_id": True},
+            ])
+        assert {r.name for r in routes} == {"f", "b"}
+        assert match_profile_route(routes, "discord", chat_id="123") is None
+        assert sum("can never match" in rec.message for rec in caplog.records) == 2
 
 
 class TestMatchProfileRoute:

--- a/tests/gateway/test_voice_mode_platform_isolation.py
+++ b/tests/gateway/test_voice_mode_platform_isolation.py
@@ -9,7 +9,9 @@ same key. The fix prefixes keys with platform value: 'telegram:123' vs
 import json
 import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 
 from gateway.config import Platform
@@ -113,6 +115,88 @@ class TestSyncVoiceModeStateToAdapter:
 
         # Only telegram:123 should be in disabled_chats (mode="off" for telegram)
         assert mock_adapter._auto_tts_disabled_chats == {"123"}
+
+
+class TestVoiceModeProfileIsolation:
+    """Two multiplexed bots in one Discord channel keep independent /voice
+    state and voice transcripts dispatch through the bot that heard them
+    (#75198 voice half)."""
+
+    @staticmethod
+    def _discord_adapter(owner=None):
+        from unittest.mock import AsyncMock
+
+        a = MagicMock()
+        a.platform = Platform.DISCORD
+        a._owner_profile = owner
+        a._voice_text_channels = {111: 123}
+        a._voice_sources = {}
+        a._voice_input_callback = None
+        a._on_voice_disconnect = None
+        a._voice_mode_getter = None
+        a._auto_tts_enabled_chats = set()
+        a._auto_tts_disabled_chats = set()
+        a._client = MagicMock()
+        a._client.get_channel = MagicMock(return_value=None)
+        a.handle_message = AsyncMock()
+        return a
+
+    @pytest.mark.asyncio
+    async def test_voice_state_and_transcripts_stay_with_the_owning_bot(self, tmp_path):
+        from types import SimpleNamespace
+
+        from gateway.platforms.base import MessageEvent, MessageType, SessionSource
+
+        runner = _make_runner()
+        runner._VOICE_MODE_PATH = tmp_path / "voice.json"
+        runner._is_user_authorized = lambda source: True
+        default_ad = self._discord_adapter()
+        bot2_ad = self._discord_adapter(owner="bot2")
+        runner.adapters = {Platform.DISCORD: default_ad}
+        runner._profile_adapters = {"bot2": {Platform.DISCORD: bot2_ad}}
+        # Inbound event from bot2's transport in channel 123 (same id the
+        # default bot also sees).
+        src = SessionSource(platform=Platform.DISCORD, chat_id="123", user_id="u1",
+                            chat_type="channel", profile="bot2")
+        src._transport_adapter_ref = lambda: bot2_ad
+
+        await runner._handle_voice_command(
+            MessageEvent(text="/voice tts", message_type=MessageType.TEXT, source=src)
+        )
+        assert runner._voice_mode == {"bot2:discord:123": "all"}
+        assert "123" in bot2_ad._auto_tts_enabled_chats
+        assert "123" not in default_ad._auto_tts_enabled_chats
+
+        # A transcript captured by bot2's adapter runs through bot2, not default.
+        runner._bind_voice_input_callback(bot2_ad)
+        await bot2_ad._voice_input_callback(guild_id=111, user_id=42, transcript="hi")
+        bot2_ad.handle_message.assert_awaited_once()
+        default_ad.handle_message.assert_not_awaited()
+        assert bot2_ad.handle_message.call_args[0][0].source.profile == "bot2"
+
+        # Timeout cleanup from bot2's channel disables bot2's auto-TTS only.
+        join = MessageEvent(text="/voice channel", message_type=MessageType.TEXT, source=src)
+        join.raw_message = SimpleNamespace(guild_id=111, guild=None)
+        bot2_ad.join_voice_channel = AsyncMock(return_value=True)
+        ch = MagicMock(); ch.name = "General"
+        bot2_ad.get_user_voice_channel = AsyncMock(return_value=ch)
+        await runner._handle_voice_channel_join(join)
+        bot2_ad._on_voice_disconnect("123")
+        assert runner._voice_mode["bot2:discord:123"] == "off"
+        assert "123" in bot2_ad._auto_tts_disabled_chats
+        assert "123" not in default_ad._auto_tts_disabled_chats
+
+    def test_sync_restores_only_the_owning_profiles_chats(self):
+        runner = _make_runner()
+        runner._voice_mode = {"discord:1": "all", "bot2:discord:2": "all"}
+        default_ad = MagicMock(); default_ad.platform = Platform.DISCORD
+        default_ad._owner_profile = None; default_ad._auto_tts_enabled_chats = set()
+        bot2_ad = MagicMock(); bot2_ad.platform = Platform.DISCORD
+        bot2_ad._owner_profile = "bot2"; bot2_ad._auto_tts_enabled_chats = set()
+        runner._sync_voice_mode_state_to_adapter(default_ad)
+        runner._sync_voice_mode_state_to_adapter(bot2_ad)
+        assert default_ad._auto_tts_enabled_chats == {"1"}
+        assert bot2_ad._auto_tts_enabled_chats == {"2"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_platform_actions.py
+++ b/tests/hermes_cli/test_platform_actions.py
@@ -39,6 +39,37 @@ def _runner_with(adapters: dict):
     return patch("gateway.run._gateway_runner_ref", lambda: runner)
 
 
+class _MultiplexRunner:
+    """Minimal stand-in for GatewayRunner's real multiplex adapter split —
+    mirrors GatewayAuthorizationMixin._authorization_adapter's fail-closed
+    contract (default profile -> self.adapters; secondary profile -> its own
+    entry in self._profile_adapters, never falling back to another
+    profile's adapter of the same platform)."""
+
+    def __init__(self, adapters: dict, profile_adapters: dict, active_profile: str = "default"):
+        self.adapters = adapters
+        self._profile_adapters = profile_adapters
+        self._active_profile = active_profile
+
+    def _active_profile_name(self):
+        return self._active_profile
+
+    def _authorization_adapter(self, platform, profile=None):
+        profile_name = (profile or "").strip() or None
+        if profile_name and profile_name != "default":
+            if profile_name == self._active_profile:
+                return self.adapters.get(platform)
+            if profile_name in self._profile_adapters:
+                return self._profile_adapters[profile_name].get(platform)
+            return None
+        return self.adapters.get(platform)
+
+
+def _multiplex_runner_with(*, default: dict, profiles: dict, active_profile: str = "default"):
+    runner = _MultiplexRunner(default, profiles, active_profile)
+    return patch("gateway.run._gateway_runner_ref", lambda: runner)
+
+
 def _telegram_adapter(connected=True):
     a = MagicMock()
     a.platform = Platform.TELEGRAM
@@ -262,6 +293,106 @@ class TestVerbRouting:
                 actions.add_reaction("discord", "not-a-number", "456", "x")
             )
         assert result["error"] == "invalid_argument"
+
+
+class TestMultiplexProfileRouting:
+    """A plugin scoped to a secondary profile must act through THAT
+    profile's adapter, never the default profile's — the same invariant
+    gateway/authz_mixin.py's _authorization_adapter enforces for every
+    other adapter-resolution path in this codebase."""
+
+    def test_secondary_profile_routes_to_its_own_adapter_not_default(self):
+        actions = PlatformActions("p")
+        default_adapter = _telegram_adapter()
+        team_b_adapter = _telegram_adapter()
+        with (
+            _grant(True),
+            _multiplex_runner_with(
+                default={Platform.TELEGRAM: default_adapter},
+                profiles={"team-b": {Platform.TELEGRAM: team_b_adapter}},
+                active_profile="default",
+            ),
+            patch(
+                "hermes_cli.profiles.get_active_profile_name",
+                return_value="team-b",
+            ),
+        ):
+            result = asyncio.run(
+                actions.add_reaction("telegram", "1", "2", "x")
+            )
+        assert result["ok"] is True
+        team_b_adapter._set_reaction.assert_awaited_once()
+        default_adapter._set_reaction.assert_not_awaited()
+
+    def test_secondary_profile_with_no_registry_entry_fails_closed(self):
+        """A stamped secondary profile whose adapter isn't registered must
+        refuse — never silently fall back to the default profile's bot."""
+        actions = PlatformActions("p")
+        default_adapter = _telegram_adapter()
+        with (
+            _grant(True),
+            _multiplex_runner_with(
+                default={Platform.TELEGRAM: default_adapter},
+                profiles={},
+                active_profile="default",
+            ),
+            patch(
+                "hermes_cli.profiles.get_active_profile_name",
+                return_value="team-b",
+            ),
+        ):
+            result = asyncio.run(
+                actions.add_reaction("telegram", "1", "2", "x")
+            )
+        assert result["error"] == "adapter_not_registered"
+        default_adapter._set_reaction.assert_not_awaited()
+
+    def test_default_profile_still_routes_to_default_adapter(self):
+        """Healthy path unchanged: the default profile keeps using
+        runner.adapters via the same _authorization_adapter call."""
+        actions = PlatformActions("p")
+        default_adapter = _telegram_adapter()
+        with (
+            _grant(True),
+            _multiplex_runner_with(
+                default={Platform.TELEGRAM: default_adapter},
+                profiles={},
+                active_profile="default",
+            ),
+            patch(
+                "hermes_cli.profiles.get_active_profile_name",
+                return_value="default",
+            ),
+        ):
+            result = asyncio.run(
+                actions.add_reaction("telegram", "1", "2", "x")
+            )
+        assert result["ok"] is True
+        default_adapter._set_reaction.assert_awaited_once()
+
+    def test_active_profile_matching_secondary_name_uses_default_adapters(self):
+        """A profile that IS the process's own active profile resolves via
+        runner.adapters (not _profile_adapters), mirroring
+        _authorization_adapter's active-profile shortcut."""
+        actions = PlatformActions("p")
+        default_adapter = _telegram_adapter()
+        with (
+            _grant(True),
+            _multiplex_runner_with(
+                default={Platform.TELEGRAM: default_adapter},
+                profiles={},
+                active_profile="team-b",
+            ),
+            patch(
+                "hermes_cli.profiles.get_active_profile_name",
+                return_value="team-b",
+            ),
+        ):
+            result = asyncio.run(
+                actions.add_reaction("telegram", "1", "2", "x")
+            )
+        assert result["ok"] is True
+        default_adapter._set_reaction.assert_awaited_once()
 
 
 class TestPluginContextWiring:

--- a/tests/hermes_cli/test_platform_actions.py
+++ b/tests/hermes_cli/test_platform_actions.py
@@ -39,34 +39,14 @@ def _runner_with(adapters: dict):
     return patch("gateway.run._gateway_runner_ref", lambda: runner)
 
 
-class _MultiplexRunner:
-    """Minimal stand-in for GatewayRunner's real multiplex adapter split —
-    mirrors GatewayAuthorizationMixin._authorization_adapter's fail-closed
-    contract (default profile -> self.adapters; secondary profile -> its own
-    entry in self._profile_adapters, never falling back to another
-    profile's adapter of the same platform)."""
-
-    def __init__(self, adapters: dict, profile_adapters: dict, active_profile: str = "default"):
-        self.adapters = adapters
-        self._profile_adapters = profile_adapters
-        self._active_profile = active_profile
-
-    def _active_profile_name(self):
-        return self._active_profile
-
-    def _authorization_adapter(self, platform, profile=None):
-        profile_name = (profile or "").strip() or None
-        if profile_name and profile_name != "default":
-            if profile_name == self._active_profile:
-                return self.adapters.get(platform)
-            if profile_name in self._profile_adapters:
-                return self._profile_adapters[profile_name].get(platform)
-            return None
-        return self.adapters.get(platform)
-
-
 def _multiplex_runner_with(*, default: dict, profiles: dict, active_profile: str = "default"):
-    runner = _MultiplexRunner(default, profiles, active_profile)
+    """A runner using the REAL GatewayAuthorizationMixin resolution ladder."""
+    from gateway.authz_mixin import GatewayAuthorizationMixin
+
+    runner = GatewayAuthorizationMixin.__new__(GatewayAuthorizationMixin)
+    runner.adapters = default
+    runner._profile_adapters = profiles
+    runner._active_profile_name = lambda: active_profile
     return patch("gateway.run._gateway_runner_ref", lambda: runner)
 
 
@@ -296,10 +276,9 @@ class TestVerbRouting:
 
 
 class TestMultiplexProfileRouting:
-    """A plugin scoped to a secondary profile must act through THAT
-    profile's adapter, never the default profile's — the same invariant
-    gateway/authz_mixin.py's _authorization_adapter enforces for every
-    other adapter-resolution path in this codebase."""
+    """A plugin acting during a secondary profile's turn must act through THAT
+    profile's adapter, never the default profile's — the fail-closed contract
+    of GatewayAuthorizationMixin._authorization_adapter (#85245)."""
 
     def test_secondary_profile_routes_to_its_own_adapter_not_default(self):
         actions = PlatformActions("p")
@@ -310,89 +289,33 @@ class TestMultiplexProfileRouting:
             _multiplex_runner_with(
                 default={Platform.TELEGRAM: default_adapter},
                 profiles={"team-b": {Platform.TELEGRAM: team_b_adapter}},
-                active_profile="default",
             ),
-            patch(
-                "hermes_cli.profiles.get_active_profile_name",
-                return_value="team-b",
-            ),
+            patch("hermes_cli.profiles.get_active_profile_name", return_value="team-b"),
         ):
-            result = asyncio.run(
-                actions.add_reaction("telegram", "1", "2", "x")
-            )
+            result = asyncio.run(actions.add_reaction("telegram", "1", "2", "x"))
         assert result["ok"] is True
         team_b_adapter._set_reaction.assert_awaited_once()
         default_adapter._set_reaction.assert_not_awaited()
 
-    def test_secondary_profile_with_no_registry_entry_fails_closed(self):
-        """A stamped secondary profile whose adapter isn't registered must
-        refuse — never silently fall back to the default profile's bot."""
+    @pytest.mark.parametrize(
+        "resolver",
+        [
+            {"return_value": "team-b"},              # stamped profile, no registry entry
+            {"side_effect": RuntimeError("boom")},  # profile resolution itself fails
+        ],
+        ids=["no-registry-entry", "resolution-error"],
+    )
+    def test_unresolvable_profile_fails_closed_never_default_bot(self, resolver):
         actions = PlatformActions("p")
         default_adapter = _telegram_adapter()
         with (
             _grant(True),
-            _multiplex_runner_with(
-                default={Platform.TELEGRAM: default_adapter},
-                profiles={},
-                active_profile="default",
-            ),
-            patch(
-                "hermes_cli.profiles.get_active_profile_name",
-                return_value="team-b",
-            ),
+            _multiplex_runner_with(default={Platform.TELEGRAM: default_adapter}, profiles={}),
+            patch("hermes_cli.profiles.get_active_profile_name", **resolver),
         ):
-            result = asyncio.run(
-                actions.add_reaction("telegram", "1", "2", "x")
-            )
+            result = asyncio.run(actions.add_reaction("telegram", "1", "2", "x"))
         assert result["error"] == "adapter_not_registered"
         default_adapter._set_reaction.assert_not_awaited()
-
-    def test_default_profile_still_routes_to_default_adapter(self):
-        """Healthy path unchanged: the default profile keeps using
-        runner.adapters via the same _authorization_adapter call."""
-        actions = PlatformActions("p")
-        default_adapter = _telegram_adapter()
-        with (
-            _grant(True),
-            _multiplex_runner_with(
-                default={Platform.TELEGRAM: default_adapter},
-                profiles={},
-                active_profile="default",
-            ),
-            patch(
-                "hermes_cli.profiles.get_active_profile_name",
-                return_value="default",
-            ),
-        ):
-            result = asyncio.run(
-                actions.add_reaction("telegram", "1", "2", "x")
-            )
-        assert result["ok"] is True
-        default_adapter._set_reaction.assert_awaited_once()
-
-    def test_active_profile_matching_secondary_name_uses_default_adapters(self):
-        """A profile that IS the process's own active profile resolves via
-        runner.adapters (not _profile_adapters), mirroring
-        _authorization_adapter's active-profile shortcut."""
-        actions = PlatformActions("p")
-        default_adapter = _telegram_adapter()
-        with (
-            _grant(True),
-            _multiplex_runner_with(
-                default={Platform.TELEGRAM: default_adapter},
-                profiles={},
-                active_profile="team-b",
-            ),
-            patch(
-                "hermes_cli.profiles.get_active_profile_name",
-                return_value="team-b",
-            ),
-        ):
-            result = asyncio.run(
-                actions.add_reaction("telegram", "1", "2", "x")
-            )
-        assert result["ok"] is True
-        default_adapter._set_reaction.assert_awaited_once()
 
 
 class TestPluginContextWiring:

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -4355,6 +4355,63 @@ def test_gateway_session_recovery_does_not_cross_newer_reset_boundary(
     ) is None
 
 
+def test_peer_fallback_never_adopts_a_sibling_profiles_row(tmp_path, monkeypatch):
+    """#74285: the peer-tuple fallback is fenced by the store's own profile.
+
+    A Telegram DM peer tuple (chat_id == user_id, no thread) is identical for
+    every bot, so a legacy sibling-profile row sitting in this store — written
+    before the per-profile partition — must lose to the older own row, and
+    with no own row recovery must return nothing rather than the sibling's.
+    """
+    import hermes_state
+
+    root = tmp_path / "hermes"
+    root.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", hermes_state._IMPORT_DEFAULT_DB_PATH)
+    store = SessionDB(db_path=root / "state.db")  # owner: default
+    try:
+        peer = {"user_id": "42", "chat_id": "42", "chat_type": "dm"}
+        store.create_session("sibling", "telegram", session_key="agent:bot2:telegram:dm:42",
+                             profile_name="bot2", **peer)
+        store.append_message("sibling", "user", "bot2's conversation")
+
+        def recover():
+            return store.find_latest_gateway_session_for_peer(
+                source="telegram", session_key="agent:main:telegram:dm:42", **peer
+            )
+
+        assert recover() is None  # only the sibling exists: fail closed
+
+        store.create_session("own", "telegram", session_key="agent:main:telegram:dm:42:old", **peer)
+        store.append_message("own", "user", "default's conversation")
+        store._execute_write(
+            lambda c: c.execute("UPDATE sessions SET last_activity_at = 1 WHERE id = 'own'")
+        )
+        assert recover()["id"] == "own"  # older own row beats newer sibling row
+    finally:
+        store.close()
+
+
+def test_child_inherits_parent_profile_only_within_its_key_namespace(db):
+    """#88381: parent→child ``profile_name`` COALESCE is fenced by ``agent:<ns>:``.
+
+    A default child (``agent:main:``) forked from a sibling profile's row must
+    not be durably mislabelled as that profile's; same-namespace and keyless
+    (CLI/subagent) children keep inheriting.
+    """
+    db.create_session("parent", "telegram", session_key="agent:bot2:telegram:dm:42",
+                      profile_name="bot2")
+    db.create_session("cross", "telegram", parent_session_id="parent",
+                      session_key="agent:main:telegram:dm:42")
+    db.create_session("same", "telegram", parent_session_id="parent",
+                      session_key="agent:bot2:telegram:dm:42:r2")
+    db.create_session("keyless", "cli", parent_session_id="parent")
+    assert db.get_session("cross")["profile_name"] is None
+    assert db.get_session("same")["profile_name"] == "bot2"
+    assert db.get_session("keyless")["profile_name"] == "bot2"
+
+
 
 
 


### PR DESCRIPTION
## Summary
Six small multiplex bugs in gateway/run.py, gateway/session.py, hermes_state.py, profile_routing.py and platform_actions.py — all the same root cause: code that
still assumes one profile per process (self.adapters[DISCORD], unprefixed voice keys, on-loop secret hydration, peer-tuple recovery with no owner predicate,
default-adapter fallthrough, int route ids never equal str source ids).
## Changes
- Voice: profile-namespaced `_voice_key`, transcript/timeout callbacks bound to the capturing adapter, /voice + join/leave + auto-TTS decisions resolve the adapter fail-closed via `_adapter_for_source`; secondary initial connect restores persisted /voice state (#84872).
- Startup: `_start_one_profile_adapters` hydrates external secret sources once via `asyncio.to_thread`, enters every scope with `hydrate_secrets=False` (extends #99519 to the startup class).
- Recovery fence: peer-tuple fallback requires `COALESCE(profile_name, <store owner>) = <store owner>`; multiplex guard compares recovered vs requested `agent:<ns>:` (fail closed); parent→child `profile_name` inherits only within the same key namespace (#88381).
- Routing: YAML int ids coerced to str; bool/float warn as never-matching (#86470).
- platform_actions: profile-aware adapter lookup; profile-resolution failure → `adapter_not_registered`, never the default bot.
## Validation
| Probe (real functions, temp HERMES_HOME, multiplex on) | origin/main | branch |
|---|---|---|
| bot2 "/voice tts" in chan 123 | key discord:123, default adapter flipped | key bot2:discord:123, bot2 adapter only |
| bot2 voice transcript dispatch | via default adapter | via bot2 adapter, profile=bot2 |
| secondary initial connect voice sync | not synced | synced (#84872) |
| startup secret hydration | 3× on-loop, loop starved (0 ticks) | 1× off-loop, loop live |
| default peer fallback w/ legacy bot2 DM row in store | adopts bot2 row | own row / None |
| multiplex guard, sibling namespace | allowed | rejected |
| main-ns child of bot2 parent | profile_name=bot2 | None |
| unquoted guild_id route | int, no match | str, matched |
| plugin action during teamb turn / resolution error | default bot / default bot | teamb bot / adapter_not_registered |
Targeted pytest: 254 passed (13 files) + test_hermes_state 250 passed; sabotage-verified both new test groups; ruff clean.
## Credits
@GoBeromsu (#99519), @fangliquanflq (#70815), @pierrenode (#85245) — commits cherry-picked with authorship. Co-authored: @davidxyuan (#75198 voice), @pittosporum-seu (#86815), @pcaruba (#74153), @jiangtaoliu-source (#74593), @69k4xmdfm2-blip (#88387). Guard shape also reported by @vKongv (#85205).
```

Notes for the parent: worktree /tmp/salv-session-voice-startup left in place (plus a detached origin/main baseline at /tmp/salv-svs-main and probe scripts in /tmp/salv-svs-probes/). No PR opened, nothing posted to GitHub.

Fixes #84872
Fixes #74285
Fixes #88381
Fixes #86470

## Infographic

![mux-session-voice-startup](https://v3b.fal.media/files/b/0aa8cdb7/MUJg_fNKVP84ZvyY9CvVr_Q8I9sJWG.png)
