### PR TITLE
fix(telegram): multiplexed profiles keep separate DM topic lanes in the shared state.db (#76423 #87239, salvage #76487)

### DIFF
--- a/contributors/emails/crdesign8@hotmail.com
+++ b/contributors/emails/crdesign8@hotmail.com
@@ -1,0 +1,1 @@
+crdesign8

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -161,6 +161,12 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) 
         anchor = reply_to_message_id or getattr(source, "message_id", None)
         if anchor is not None:
             metadata["telegram_reply_to_message_id"] = str(anchor)
+    # Routed Hermes profile for shared state.db namespaces (topic bindings
+    # under multiplex / profile_routes). Outbound prune paths must not
+    # assume the transport adapter's static profile stamp.
+    profile = str(getattr(source, "profile", None) or "").strip()
+    if profile:
+        metadata["hermes_profile"] = profile
     return metadata
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8480,6 +8480,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             profile=_profile,
         )
 
+    @staticmethod
+    def _telegram_topic_profile_name(source: SessionSource) -> str:
+        """Profile namespace for Telegram topic-mode rows (issue #76423).
+
+        Prefer the profile already stamped on the routed event
+        (``source.profile``). Do **not** fall back to the process-global
+        active profile here — under multiplex that can mis-attribute
+        topic state across bots sharing one ``state.db``.
+        """
+        name = str(getattr(source, "profile", None) or "").strip()
+        return name if name else "default"
+
     def _telegram_topic_mode_enabled(self, source: SessionSource) -> bool:
         """Return whether Telegram DM topic mode is active for this chat."""
         if source.platform != Platform.TELEGRAM or source.chat_type != "dm":
@@ -8493,6 +8505,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             raw = session_db.is_telegram_topic_mode_enabled(
                 chat_id=str(source.chat_id),
                 user_id=str(source.user_id),
+                profile_name=self._telegram_topic_profile_name(source),
             )
         except Exception:
             logger.debug("Failed to read Telegram topic mode state", exc_info=True)
@@ -8594,6 +8607,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             user_id=str(source.user_id or ""),
             session_key=session_entry.session_key,
             session_id=session_entry.session_id,
+            profile_name=self._telegram_topic_profile_name(source),
         )
 
     def _sync_telegram_topic_binding(
@@ -8661,6 +8675,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         try:
             bindings = session_db.list_telegram_topic_bindings_for_chat(
                 chat_id=str(source.chat_id),
+                profile_name=self._telegram_topic_profile_name(source),
             )
         except Exception:
             logger.debug("topic-recover: read failed", exc_info=True)
@@ -17058,6 +17073,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if isinstance(text_modes, dict)
             else self._busy_text_mode
         )
+        # Secondary adapters always carry the profile they serve so prune
+        # paths namespace topic bindings correctly under multiplex (#76423).
+        adapter._hermes_profile_name = profile_name
 
     async def _run_secondary_profile_reconnect(
         self, profile_name: str, platform: Platform
@@ -20780,6 +20798,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 binding = (await self._session_db.get_telegram_topic_binding(
                     chat_id=str(source.chat_id),
                     thread_id=str(source.thread_id),
+                    profile_name=self._telegram_topic_profile_name(source),
                 )) if self._session_db else None
             except Exception:
                 logger.debug("Failed to read Telegram topic binding", exc_info=True)
@@ -25554,6 +25573,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 binding = await session_db.get_telegram_topic_binding(
                     chat_id=str(source.chat_id),
                     thread_id=str(source.thread_id),
+                    profile_name=self._telegram_topic_profile_name(source),
                 )
                 if binding and str(binding.get("session_id") or "") != str(session_id):
                     return
@@ -25711,13 +25731,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             currently_enabled = await self._session_db.is_telegram_topic_mode_enabled(
                 chat_id=chat_id,
                 user_id=str(source.user_id or ""),
+                profile_name=self._telegram_topic_profile_name(source),
             )
         except Exception:
             currently_enabled = False
         if not currently_enabled:
             return "Multi-session topic mode is not currently enabled for this chat."
         try:
-            await self._session_db.disable_telegram_topic_mode(chat_id=chat_id)
+            await self._session_db.disable_telegram_topic_mode(
+                chat_id=chat_id,
+                profile_name=self._telegram_topic_profile_name(source),
+            )
         except Exception as exc:
             logger.exception("Failed to disable Telegram topic mode")
             return f"Failed to disable topic mode: {exc}"
@@ -25748,6 +25772,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             sessions = await self._session_db.list_unlinked_telegram_sessions_for_user(
                 chat_id=str(source.chat_id),
                 user_id=str(source.user_id),
+                profile_name=self._telegram_topic_profile_name(source),
                 limit=10,
             )
         except Exception:
@@ -25797,9 +25822,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return "That session does not belong to this Telegram user."
 
         linked = await self._session_db.is_telegram_session_linked_to_topic(session_id=session_id)
+        topic_profile = self._telegram_topic_profile_name(source)
         current_binding = await self._session_db.get_telegram_topic_binding(
             chat_id=str(source.chat_id),
             thread_id=str(source.thread_id),
+            profile_name=topic_profile,
         )
         if linked:
             if not current_binding or current_binding.get("session_id") != session_id:
@@ -25814,6 +25841,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 session_key=session_key,
                 session_id=session_id,
                 managed_mode="restored",
+                profile_name=topic_profile,
             )
         except ValueError as exc:
             if "already linked" in str(exc):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8542,6 +8542,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     _TELEGRAM_LOBBY_REMINDER_COOLDOWN_S = 30.0
 
+    def _telegram_topic_cooldown_key(self, source: SessionSource) -> Optional[str]:
+        """Cooldown key for topic-mode cooldowns: (profile, chat_id).
+
+        Profiles sharing a Telegram private chat_id under multiplex must not
+        suppress each other's lobby reminders / capability hints (#76423).
+        """
+        chat_id = str(source.chat_id or "")
+        if not chat_id:
+            return None
+        return f"{self._telegram_topic_profile_name(source)}:{chat_id}"
+
     def _should_send_telegram_lobby_reminder(self, source: SessionSource) -> bool:
         """Rate-limit root-DM lobby reminders to one message per cooldown window.
 
@@ -8551,15 +8562,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         if not hasattr(self, "_telegram_lobby_reminder_ts"):
             self._telegram_lobby_reminder_ts = {}
-        chat_id = str(source.chat_id or "")
-        if not chat_id:
+        key = self._telegram_topic_cooldown_key(source)
+        if not key:
             return True
         import time as _time
         now = _time.monotonic()
-        last = self._telegram_lobby_reminder_ts.get(chat_id, 0.0)
+        last = self._telegram_lobby_reminder_ts.get(key, 0.0)
         if now - last < self._TELEGRAM_LOBBY_REMINDER_COOLDOWN_S:
             return False
-        self._telegram_lobby_reminder_ts[chat_id] = now
+        self._telegram_lobby_reminder_ts[key] = now
         return True
 
     def _telegram_topic_root_lobby_message(self) -> str:
@@ -25685,15 +25696,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         if not hasattr(self, "_telegram_capability_hint_ts"):
             self._telegram_capability_hint_ts = {}
-        chat_id = str(source.chat_id or "")
-        if not chat_id:
+        key = self._telegram_topic_cooldown_key(source)
+        if not key:
             return True
         import time as _time
         now = _time.monotonic()
-        last = self._telegram_capability_hint_ts.get(chat_id, 0.0)
+        last = self._telegram_capability_hint_ts.get(key, 0.0)
         if now - last < self._TELEGRAM_CAPABILITY_HINT_COOLDOWN_S:
             return False
-        self._telegram_capability_hint_ts[chat_id] = now
+        self._telegram_capability_hint_ts[key] = now
         return True
 
     def _telegram_topic_help_text(self) -> str:
@@ -25745,12 +25756,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception as exc:
             logger.exception("Failed to disable Telegram topic mode")
             return f"Failed to disable topic mode: {exc}"
-        # Reset per-chat debounce state so the user doesn't see a stale
-        # cooldown on the next activation.
-        for attr in ("_telegram_lobby_reminder_ts", "_telegram_capability_hint_ts"):
-            store = getattr(self, attr, None)
-            if isinstance(store, dict):
-                store.pop(chat_id, None)
+        # Reset per-profile+chat debounce state so the user doesn't see a
+        # stale cooldown on the next activation (issue #76423).
+        cooldown_key = self._telegram_topic_cooldown_key(source)
+        if cooldown_key:
+            for attr in ("_telegram_lobby_reminder_ts", "_telegram_capability_hint_ts"):
+                store = getattr(self, attr, None)
+                if isinstance(store, dict):
+                    store.pop(cooldown_key, None)
         return (
             "Multi-session topic mode is now OFF for this chat.\n\n"
             "Existing topics in Telegram aren't removed — they'll just stop "
@@ -26225,6 +26238,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     metadata.setdefault("scope_id", str(team_id))
                 if user_id:
                     metadata.setdefault("user_id", str(user_id))
+        # Routed profile for shared state.db namespaces (#76423): the Telegram
+        # prune path needs it because under profile_routes the transport
+        # adapter's stamp is not the profile that wrote the binding.
+        profile = str(getattr(source, "profile", None) or "").strip()
+        if profile and metadata is not None:
+            metadata = dict(metadata)
+            metadata["hermes_profile"] = profile
         return metadata
 
     def _thread_metadata_for_target(

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4977,6 +4977,7 @@ class GatewaySlashCommandsMixin:
             await self._session_db.enable_telegram_topic_mode(
                 chat_id=str(source.chat_id),
                 user_id=str(source.user_id),
+                profile_name=self._telegram_topic_profile_name(source),
                 has_topics_enabled=capabilities.get("has_topics_enabled"),
                 allows_users_to_create_topics=capabilities.get("allows_users_to_create_topics"),
             )
@@ -4992,6 +4993,7 @@ class GatewaySlashCommandsMixin:
                 binding = await self._session_db.get_telegram_topic_binding(
                     chat_id=str(source.chat_id),
                     thread_id=str(source.thread_id),
+                    profile_name=self._telegram_topic_profile_name(source),
                 )
             except Exception:
                 logger.debug("Failed to read Telegram topic binding", exc_info=True)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -15930,20 +15930,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                gateways (shared ``state.db``) isolate topic mode/bindings
                per Hermes profile (issue #76423).
         """
-        def _table_columns(conn, table: str) -> set:
-            try:
-                return {
-                    row[1]
-                    for row in conn.execute(f"PRAGMA table_info('{table}')").fetchall()
-                }
-            except sqlite3.OperationalError:
-                return set()
-
-        def _do(conn):
-            # Fresh installs get the v3 shape immediately.
-            conn.executescript(
+        # (table, column list, DDL body). ``profile_name`` leads the primary
+        # key so multiplexed profiles sharing one state.db never collide on a
+        # private chat_id (which is the user id, identical across bots).
+        tables = (
+            (
+                "telegram_dm_topic_mode",
+                "profile_name, chat_id, user_id, enabled, activated_at, updated_at, "
+                "has_topics_enabled, allows_users_to_create_topics, "
+                "capability_checked_at, intro_message_id, pinned_message_id",
                 """
-                CREATE TABLE IF NOT EXISTS telegram_dm_topic_mode (
                     profile_name TEXT NOT NULL DEFAULT 'default',
                     chat_id TEXT NOT NULL,
                     user_id TEXT NOT NULL,
@@ -15956,9 +15952,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     intro_message_id TEXT,
                     pinned_message_id TEXT,
                     PRIMARY KEY (profile_name, chat_id)
-                );
-
-                CREATE TABLE IF NOT EXISTS telegram_dm_topic_bindings (
+                """,
+            ),
+            (
+                "telegram_dm_topic_bindings",
+                "profile_name, chat_id, thread_id, user_id, session_key, "
+                "session_id, managed_mode, linked_at, updated_at",
+                """
                     profile_name TEXT NOT NULL DEFAULT 'default',
                     chat_id TEXT NOT NULL,
                     thread_id TEXT NOT NULL,
@@ -15969,93 +15969,43 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     linked_at REAL NOT NULL,
                     updated_at REAL NOT NULL,
                     PRIMARY KEY (profile_name, chat_id, thread_id)
-                );
+                """,
+            ),
+        )
+
+        def _do(conn):
+            for table, columns, ddl in tables:
+                # Fresh installs get the v3 shape immediately.
+                conn.execute(f"CREATE TABLE IF NOT EXISTS {table} ({ddl})")
+                have = {row[1] for row in conn.execute(f"PRAGMA table_info('{table}')")}
+                if "profile_name" in have:
+                    continue
+                # Pre-profile shape (v1 or v2) → v3. SQLite can't ALTER a
+                # primary key (or a foreign key), so rebuild; this also
+                # supplies the v2 ON DELETE CASCADE for v1 bindings tables.
+                # Legacy rows land in the "default" namespace only — never
+                # replicated across profiles.
+                legacy_columns = columns.replace("profile_name, ", "", 1)
+                conn.executescript(
+                    f"""
+                    CREATE TABLE {table}_new ({ddl});
+                    INSERT INTO {table}_new ({columns})
+                        SELECT 'default', {legacy_columns} FROM {table};
+                    DROP TABLE {table};
+                    ALTER TABLE {table}_new RENAME TO {table};
+                    """
+                )
+
+            # Indexes after any rebuild so they always target the v3 shape
+            # (a legacy table lacking profile_name can't take the user index).
+            conn.executescript(
                 """
-            )
-            # Indexes are created after any rebuild: a legacy table still
-            # lacking profile_name cannot accept the v3 user index.
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_telegram_dm_topic_bindings_session
+                ON telegram_dm_topic_bindings(session_id);
 
-            mode_cols = _table_columns(conn, "telegram_dm_topic_mode")
-            bind_cols = _table_columns(conn, "telegram_dm_topic_bindings")
-
-            # Any pre-profile shape (v1 or v2) → v3: rebuild both tables with
-            # profile_name in the primary key. SQLite can't ALTER a primary key
-            # (or a foreign key), so we rebuild; the bindings rebuild also
-            # supplies the v2 ON DELETE CASCADE for v1 tables. Legacy rows
-            # migrate into the "default" namespace only — never replicated
-            # across profiles (collision-contaminated data would multiply).
-            if "profile_name" not in mode_cols:
-                conn.executescript(
-                    """
-                    CREATE TABLE telegram_dm_topic_mode_new (
-                        profile_name TEXT NOT NULL DEFAULT 'default',
-                        chat_id TEXT NOT NULL,
-                        user_id TEXT NOT NULL,
-                        enabled INTEGER NOT NULL DEFAULT 1,
-                        activated_at REAL NOT NULL,
-                        updated_at REAL NOT NULL,
-                        has_topics_enabled INTEGER,
-                        allows_users_to_create_topics INTEGER,
-                        capability_checked_at REAL,
-                        intro_message_id TEXT,
-                        pinned_message_id TEXT,
-                        PRIMARY KEY (profile_name, chat_id)
-                    );
-                    INSERT INTO telegram_dm_topic_mode_new (
-                        profile_name, chat_id, user_id, enabled, activated_at,
-                        updated_at, has_topics_enabled, allows_users_to_create_topics,
-                        capability_checked_at, intro_message_id, pinned_message_id
-                    )
-                    SELECT
-                        'default', chat_id, user_id, enabled, activated_at,
-                        updated_at, has_topics_enabled, allows_users_to_create_topics,
-                        capability_checked_at, intro_message_id, pinned_message_id
-                    FROM telegram_dm_topic_mode;
-                    DROP TABLE telegram_dm_topic_mode;
-                    ALTER TABLE telegram_dm_topic_mode_new
-                        RENAME TO telegram_dm_topic_mode;
-                    """
-                )
-
-            if "profile_name" not in bind_cols:
-                conn.executescript(
-                    """
-                    CREATE TABLE telegram_dm_topic_bindings_new (
-                        profile_name TEXT NOT NULL DEFAULT 'default',
-                        chat_id TEXT NOT NULL,
-                        thread_id TEXT NOT NULL,
-                        user_id TEXT NOT NULL,
-                        session_key TEXT NOT NULL,
-                        session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
-                        managed_mode TEXT NOT NULL DEFAULT 'auto',
-                        linked_at REAL NOT NULL,
-                        updated_at REAL NOT NULL,
-                        PRIMARY KEY (profile_name, chat_id, thread_id)
-                    );
-                    INSERT INTO telegram_dm_topic_bindings_new (
-                        profile_name, chat_id, thread_id, user_id, session_key,
-                        session_id, managed_mode, linked_at, updated_at
-                    )
-                    SELECT
-                        'default', chat_id, thread_id, user_id, session_key,
-                        session_id, managed_mode, linked_at, updated_at
-                    FROM telegram_dm_topic_bindings;
-                    DROP TABLE telegram_dm_topic_bindings;
-                    ALTER TABLE telegram_dm_topic_bindings_new
-                        RENAME TO telegram_dm_topic_bindings;
-                    """
-                )
-
-            # Indexes after any rebuild so they always target the v3 shape.
-            conn.execute(
-                "CREATE UNIQUE INDEX IF NOT EXISTS "
-                "idx_telegram_dm_topic_bindings_session "
-                "ON telegram_dm_topic_bindings(session_id)"
-            )
-            conn.execute(
-                "CREATE INDEX IF NOT EXISTS "
-                "idx_telegram_dm_topic_bindings_user "
-                "ON telegram_dm_topic_bindings(profile_name, user_id, chat_id)"
+                CREATE INDEX IF NOT EXISTS idx_telegram_dm_topic_bindings_user
+                ON telegram_dm_topic_bindings(profile_name, user_id, chat_id);
+                """
             )
 
             conn.execute(

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1134,6 +1134,17 @@ def _strip_stale_tool_call_markers(
     return messages
 
 
+def _normalize_telegram_topic_profile_name(profile_name: Optional[str] = None) -> str:
+    """Normalize profile namespace for Telegram topic-mode tables.
+
+    Empty / missing values map to ``\"default\"`` so non-multiplexed gateways
+    keep a single namespace. Multiplexed callers must pass the *routed*
+    profile (``source.profile``), never the process-global active profile.
+    """
+    name = str(profile_name or "").strip()
+    return name if name else "default"
+
+
 def format_session_db_unavailable(prefix: str = "Session database not available") -> str:
     """Format a user-facing 'session DB unavailable' message with cause.
 
@@ -15915,12 +15926,26 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
           v1 — initial shape (no ON DELETE CASCADE on session_id FK)
           v2 — session_id FK gets ON DELETE CASCADE so session pruning
                automatically clears bindings.
+          v3 — ``profile_name`` dimension on both tables so multiplexed
+               gateways (shared ``state.db``) isolate topic mode/bindings
+               per Hermes profile (issue #76423).
         """
+        def _table_columns(conn, table: str) -> set:
+            try:
+                return {
+                    row[1]
+                    for row in conn.execute(f"PRAGMA table_info('{table}')").fetchall()
+                }
+            except sqlite3.OperationalError:
+                return set()
+
         def _do(conn):
+            # Fresh installs get the v3 shape immediately.
             conn.executescript(
                 """
                 CREATE TABLE IF NOT EXISTS telegram_dm_topic_mode (
-                    chat_id TEXT PRIMARY KEY,
+                    profile_name TEXT NOT NULL DEFAULT 'default',
+                    chat_id TEXT NOT NULL,
                     user_id TEXT NOT NULL,
                     enabled INTEGER NOT NULL DEFAULT 1,
                     activated_at REAL NOT NULL,
@@ -15929,10 +15954,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     allows_users_to_create_topics INTEGER,
                     capability_checked_at REAL,
                     intro_message_id TEXT,
-                    pinned_message_id TEXT
+                    pinned_message_id TEXT,
+                    PRIMARY KEY (profile_name, chat_id)
                 );
 
                 CREATE TABLE IF NOT EXISTS telegram_dm_topic_bindings (
+                    profile_name TEXT NOT NULL DEFAULT 'default',
                     chat_id TEXT NOT NULL,
                     thread_id TEXT NOT NULL,
                     user_id TEXT NOT NULL,
@@ -15941,65 +15968,100 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     managed_mode TEXT NOT NULL DEFAULT 'auto',
                     linked_at REAL NOT NULL,
                     updated_at REAL NOT NULL,
-                    PRIMARY KEY (chat_id, thread_id)
+                    PRIMARY KEY (profile_name, chat_id, thread_id)
                 );
-
-                CREATE UNIQUE INDEX IF NOT EXISTS idx_telegram_dm_topic_bindings_session
-                ON telegram_dm_topic_bindings(session_id);
-
-                CREATE INDEX IF NOT EXISTS idx_telegram_dm_topic_bindings_user
-                ON telegram_dm_topic_bindings(user_id, chat_id);
                 """
             )
+            # Indexes are created after any rebuild: a legacy table still
+            # lacking profile_name cannot accept the v3 user index.
 
-            # v1 → v2: rebuild telegram_dm_topic_bindings if its session_id FK
-            # lacks ON DELETE CASCADE. SQLite can't ALTER a foreign key, so we
-            # rebuild the table. Only runs once per DB (version gate).
-            current = conn.execute(
-                "SELECT value FROM state_meta WHERE key = ?",
-                ("telegram_dm_topic_schema_version",),
-            ).fetchone()
-            current_version = int(current[0]) if current and str(current[0]).isdigit() else 0
-            if current_version < 2:
-                fk_rows = conn.execute(
-                    "PRAGMA foreign_key_list('telegram_dm_topic_bindings')"
-                ).fetchall()
-                needs_rebuild = any(
-                    row[2] == "sessions" and (row[6] or "") != "CASCADE"
-                    for row in fk_rows
-                )
-                if needs_rebuild:
-                    conn.executescript(
-                        """
-                        CREATE TABLE telegram_dm_topic_bindings_new (
-                            chat_id TEXT NOT NULL,
-                            thread_id TEXT NOT NULL,
-                            user_id TEXT NOT NULL,
-                            session_key TEXT NOT NULL,
-                            session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
-                            managed_mode TEXT NOT NULL DEFAULT 'auto',
-                            linked_at REAL NOT NULL,
-                            updated_at REAL NOT NULL,
-                            PRIMARY KEY (chat_id, thread_id)
-                        );
-                        INSERT INTO telegram_dm_topic_bindings_new
-                            SELECT chat_id, thread_id, user_id, session_key,
-                                   session_id, managed_mode, linked_at, updated_at
-                            FROM telegram_dm_topic_bindings;
-                        DROP TABLE telegram_dm_topic_bindings;
-                        ALTER TABLE telegram_dm_topic_bindings_new
-                            RENAME TO telegram_dm_topic_bindings;
-                        CREATE UNIQUE INDEX idx_telegram_dm_topic_bindings_session
-                            ON telegram_dm_topic_bindings(session_id);
-                        CREATE INDEX idx_telegram_dm_topic_bindings_user
-                            ON telegram_dm_topic_bindings(user_id, chat_id);
-                        """
+            mode_cols = _table_columns(conn, "telegram_dm_topic_mode")
+            bind_cols = _table_columns(conn, "telegram_dm_topic_bindings")
+
+            # Any pre-profile shape (v1 or v2) → v3: rebuild both tables with
+            # profile_name in the primary key. SQLite can't ALTER a primary key
+            # (or a foreign key), so we rebuild; the bindings rebuild also
+            # supplies the v2 ON DELETE CASCADE for v1 tables. Legacy rows
+            # migrate into the "default" namespace only — never replicated
+            # across profiles (collision-contaminated data would multiply).
+            if "profile_name" not in mode_cols:
+                conn.executescript(
+                    """
+                    CREATE TABLE telegram_dm_topic_mode_new (
+                        profile_name TEXT NOT NULL DEFAULT 'default',
+                        chat_id TEXT NOT NULL,
+                        user_id TEXT NOT NULL,
+                        enabled INTEGER NOT NULL DEFAULT 1,
+                        activated_at REAL NOT NULL,
+                        updated_at REAL NOT NULL,
+                        has_topics_enabled INTEGER,
+                        allows_users_to_create_topics INTEGER,
+                        capability_checked_at REAL,
+                        intro_message_id TEXT,
+                        pinned_message_id TEXT,
+                        PRIMARY KEY (profile_name, chat_id)
+                    );
+                    INSERT INTO telegram_dm_topic_mode_new (
+                        profile_name, chat_id, user_id, enabled, activated_at,
+                        updated_at, has_topics_enabled, allows_users_to_create_topics,
+                        capability_checked_at, intro_message_id, pinned_message_id
                     )
+                    SELECT
+                        'default', chat_id, user_id, enabled, activated_at,
+                        updated_at, has_topics_enabled, allows_users_to_create_topics,
+                        capability_checked_at, intro_message_id, pinned_message_id
+                    FROM telegram_dm_topic_mode;
+                    DROP TABLE telegram_dm_topic_mode;
+                    ALTER TABLE telegram_dm_topic_mode_new
+                        RENAME TO telegram_dm_topic_mode;
+                    """
+                )
+
+            if "profile_name" not in bind_cols:
+                conn.executescript(
+                    """
+                    CREATE TABLE telegram_dm_topic_bindings_new (
+                        profile_name TEXT NOT NULL DEFAULT 'default',
+                        chat_id TEXT NOT NULL,
+                        thread_id TEXT NOT NULL,
+                        user_id TEXT NOT NULL,
+                        session_key TEXT NOT NULL,
+                        session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+                        managed_mode TEXT NOT NULL DEFAULT 'auto',
+                        linked_at REAL NOT NULL,
+                        updated_at REAL NOT NULL,
+                        PRIMARY KEY (profile_name, chat_id, thread_id)
+                    );
+                    INSERT INTO telegram_dm_topic_bindings_new (
+                        profile_name, chat_id, thread_id, user_id, session_key,
+                        session_id, managed_mode, linked_at, updated_at
+                    )
+                    SELECT
+                        'default', chat_id, thread_id, user_id, session_key,
+                        session_id, managed_mode, linked_at, updated_at
+                    FROM telegram_dm_topic_bindings;
+                    DROP TABLE telegram_dm_topic_bindings;
+                    ALTER TABLE telegram_dm_topic_bindings_new
+                        RENAME TO telegram_dm_topic_bindings;
+                    """
+                )
+
+            # Indexes after any rebuild so they always target the v3 shape.
+            conn.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS "
+                "idx_telegram_dm_topic_bindings_session "
+                "ON telegram_dm_topic_bindings(session_id)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS "
+                "idx_telegram_dm_topic_bindings_user "
+                "ON telegram_dm_topic_bindings(profile_name, user_id, chat_id)"
+            )
 
             conn.execute(
                 "INSERT INTO state_meta (key, value) VALUES (?, ?) "
                 "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-                ("telegram_dm_topic_schema_version", "2"),
+                ("telegram_dm_topic_schema_version", "3"),
             )
         self._execute_write(_do)
 
@@ -16008,6 +16070,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         *,
         chat_id: str,
         user_id: str,
+        profile_name: str = "default",
         has_topics_enabled: Optional[bool] = None,
         allows_users_to_create_topics: Optional[bool] = None,
     ) -> None:
@@ -16015,9 +16078,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         This method intentionally owns the explicit topic migration. Ordinary
         SessionDB startup must not create these side tables.
+
+        ``profile_name`` namespaces rows under a shared multiplex ``state.db``
+        (issue #76423). Callers handling a multiplexed event must pass the
+        routed profile from ``source.profile``, not the process-global active
+        profile.
         """
         self.apply_telegram_topic_migration()
         now = time.time()
+        profile_name = _normalize_telegram_topic_profile_name(profile_name)
 
         def _to_int(value: Optional[bool]) -> Optional[int]:
             if value is None:
@@ -16028,11 +16097,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             conn.execute(
                 """
                 INSERT INTO telegram_dm_topic_mode (
-                    chat_id, user_id, enabled, activated_at, updated_at,
+                    profile_name, chat_id, user_id, enabled, activated_at, updated_at,
                     has_topics_enabled, allows_users_to_create_topics,
                     capability_checked_at
-                ) VALUES (?, ?, 1, ?, ?, ?, ?, ?)
-                ON CONFLICT(chat_id) DO UPDATE SET
+                ) VALUES (?, ?, ?, 1, ?, ?, ?, ?, ?)
+                ON CONFLICT(profile_name, chat_id) DO UPDATE SET
                     user_id = excluded.user_id,
                     enabled = 1,
                     updated_at = excluded.updated_at,
@@ -16041,6 +16110,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     capability_checked_at = excluded.capability_checked_at
                 """,
                 (
+                    profile_name,
                     str(chat_id),
                     str(user_id),
                     now,
@@ -16056,6 +16126,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         self,
         *,
         chat_id: str,
+        profile_name: str = "default",
         clear_bindings: bool = True,
     ) -> None:
         """Disable Telegram DM topic mode for one private chat.
@@ -16068,33 +16139,43 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         Never creates the topic-mode tables from scratch; if they don't
         exist there is nothing to disable and the call is a no-op.
         """
+        profile_name = _normalize_telegram_topic_profile_name(profile_name)
+
         def _do(conn):
             try:
                 conn.execute(
                     "UPDATE telegram_dm_topic_mode SET enabled = 0, updated_at = ? "
-                    "WHERE chat_id = ?",
-                    (time.time(), str(chat_id)),
+                    "WHERE profile_name = ? AND chat_id = ?",
+                    (time.time(), profile_name, str(chat_id)),
                 )
                 if clear_bindings:
                     conn.execute(
-                        "DELETE FROM telegram_dm_topic_bindings WHERE chat_id = ?",
-                        (str(chat_id),),
+                        "DELETE FROM telegram_dm_topic_bindings "
+                        "WHERE profile_name = ? AND chat_id = ?",
+                        (profile_name, str(chat_id)),
                     )
             except sqlite3.OperationalError:
                 # Tables don't exist yet — nothing to disable.
                 return
         self._execute_write(_do)
 
-    def is_telegram_topic_mode_enabled(self, *, chat_id: str, user_id: str) -> bool:
+    def is_telegram_topic_mode_enabled(
+        self,
+        *,
+        chat_id: str,
+        user_id: str,
+        profile_name: str = "default",
+    ) -> bool:
         """Return whether Telegram DM topic mode is enabled for this chat/user."""
+        profile_name = _normalize_telegram_topic_profile_name(profile_name)
         with self._read_ctx() as conn:
             try:
                 row = conn.execute(
                     """
                     SELECT enabled FROM telegram_dm_topic_mode
-                    WHERE chat_id = ? AND user_id = ?
+                    WHERE profile_name = ? AND chat_id = ? AND user_id = ?
                     """,
-                    (str(chat_id), str(user_id)),
+                    (profile_name, str(chat_id), str(user_id)),
                 ).fetchone()
             except sqlite3.OperationalError:
                 return False
@@ -16108,16 +16189,18 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         *,
         chat_id: str,
         thread_id: str,
+        profile_name: str = "default",
     ) -> Optional[Dict[str, Any]]:
         """Return the session binding for a Telegram DM topic, if present."""
+        profile_name = _normalize_telegram_topic_profile_name(profile_name)
         with self._read_ctx() as conn:
             try:
                 row = conn.execute(
                     """
                     SELECT * FROM telegram_dm_topic_bindings
-                    WHERE chat_id = ? AND thread_id = ?
+                    WHERE profile_name = ? AND chat_id = ? AND thread_id = ?
                     """,
-                    (str(chat_id), str(thread_id)),
+                    (profile_name, str(chat_id), str(thread_id)),
                 ).fetchone()
             except sqlite3.OperationalError:
                 return None
@@ -16127,18 +16210,21 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         self,
         *,
         chat_id: str,
+        profile_name: str = "default",
     ) -> List[Dict[str, Any]]:
         """All Telegram DM topic bindings for one chat, newest first.
 
         Read-only; returns [] if the bindings table doesn't exist yet
         (does not trigger the topic-mode migration).
         """
+        profile_name = _normalize_telegram_topic_profile_name(profile_name)
         with self._read_ctx() as conn:
             try:
                 rows = conn.execute(
                     "SELECT * FROM telegram_dm_topic_bindings "
-                    "WHERE chat_id = ? ORDER BY updated_at DESC",
-                    (str(chat_id),),
+                    "WHERE profile_name = ? AND chat_id = ? "
+                    "ORDER BY updated_at DESC",
+                    (profile_name, str(chat_id)),
                 ).fetchall()
             except sqlite3.OperationalError:
                 return []
@@ -16173,6 +16259,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         *,
         chat_id: str,
         thread_id: str,
+        profile_name: str = "default",
     ) -> int:
         """Remove the binding row for a single (chat, thread) pair.
 
@@ -16203,6 +16290,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """
         chat_id = str(chat_id)
         thread_id = str(thread_id)
+        profile_name = _normalize_telegram_topic_profile_name(profile_name)
         deleted = {"count": 0}
 
         def _do(conn):
@@ -16210,9 +16298,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 cursor = conn.execute(
                     """
                     DELETE FROM telegram_dm_topic_bindings
-                    WHERE chat_id = ? AND thread_id = ?
+                    WHERE profile_name = ? AND chat_id = ? AND thread_id = ?
                     """,
-                    (chat_id, thread_id),
+                    (profile_name, chat_id, thread_id),
                 )
                 deleted["count"] = cursor.rowcount or 0
             except sqlite3.OperationalError:
@@ -16228,15 +16316,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 remaining = conn.execute(
                     """
                     SELECT 1 FROM telegram_dm_topic_bindings
-                    WHERE chat_id = ? LIMIT 1
+                    WHERE profile_name = ? AND chat_id = ? LIMIT 1
                     """,
-                    (chat_id,),
+                    (profile_name, chat_id),
                 ).fetchone()
                 if remaining is None:
                     conn.execute(
                         "UPDATE telegram_dm_topic_mode "
-                        "SET enabled = 0, updated_at = ? WHERE chat_id = ?",
-                        (time.time(), chat_id),
+                        "SET enabled = 0, updated_at = ? "
+                        "WHERE profile_name = ? AND chat_id = ?",
+                        (time.time(), profile_name, chat_id),
                     )
             except sqlite3.OperationalError:
                 # telegram_dm_topic_mode absent — binding prune still stands.
@@ -16254,6 +16343,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         session_key: str,
         session_id: str,
         managed_mode: str = "auto",
+        profile_name: str = "default",
     ) -> None:
         """Bind one Telegram DM topic thread to one Hermes session.
 
@@ -16268,28 +16358,38 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         user_id = str(user_id)
         session_key = str(session_key)
         session_id = str(session_id)
+        profile_name = _normalize_telegram_topic_profile_name(profile_name)
 
         def _do(conn):
             existing_session = conn.execute(
                 """
-                SELECT chat_id, thread_id FROM telegram_dm_topic_bindings
+                SELECT profile_name, chat_id, thread_id
+                FROM telegram_dm_topic_bindings
                 WHERE session_id = ?
                 """,
                 (session_id,),
             ).fetchone()
             if existing_session is not None:
-                linked_chat = existing_session["chat_id"] if isinstance(existing_session, sqlite3.Row) else existing_session[0]
-                linked_thread = existing_session["thread_id"] if isinstance(existing_session, sqlite3.Row) else existing_session[1]
-                if str(linked_chat) != chat_id or str(linked_thread) != thread_id:
+                if isinstance(existing_session, sqlite3.Row):
+                    linked_profile = existing_session["profile_name"]
+                    linked_chat = existing_session["chat_id"]
+                    linked_thread = existing_session["thread_id"]
+                else:
+                    linked_profile, linked_chat, linked_thread = existing_session
+                if (
+                    str(linked_profile) != profile_name
+                    or str(linked_chat) != chat_id
+                    or str(linked_thread) != thread_id
+                ):
                     raise ValueError("session is already linked to another Telegram topic")
 
             conn.execute(
                 """
                 INSERT INTO telegram_dm_topic_bindings (
-                    chat_id, thread_id, user_id, session_key, session_id,
+                    profile_name, chat_id, thread_id, user_id, session_key, session_id,
                     managed_mode, linked_at, updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(chat_id, thread_id) DO UPDATE SET
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(profile_name, chat_id, thread_id) DO UPDATE SET
                     user_id = excluded.user_id,
                     session_key = excluded.session_key,
                     session_id = excluded.session_id,
@@ -16297,6 +16397,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     updated_at = excluded.updated_at
                 """,
                 (
+                    profile_name,
                     chat_id,
                     thread_id,
                     user_id,
@@ -16336,6 +16437,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         *,
         chat_id: str,
         user_id: str,
+        profile_name: str = "default",
         limit: int = 10,
     ) -> List[Dict[str, Any]]:
         """List previous Telegram sessions for this user that are not bound to a topic.
@@ -16344,7 +16446,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         topic-mode tables are absent, fall back to a simpler query that
         just returns this user's Telegram sessions — there can't be any
         bindings yet.
+
+        Scoped by ``profile_name`` so multiplexed profiles do not surface
+        each other's unlinked sessions (issue #76423).
         """
+        profile_name = _normalize_telegram_topic_profile_name(profile_name)
+        # sessions.profile_name is NULL/empty for legacy rows → treat as default.
+        profile_clause = "AND COALESCE(NULLIF(TRIM(s.profile_name), ''), 'default') = ?"
         with self._read_ctx() as conn:
             try:
                 rows = conn.execute(
@@ -16366,6 +16474,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                       ON sp.hash = s.system_prompt_hash
                     WHERE s.source = 'telegram'
                       AND s.user_id = ?
+                      {profile_clause}
                       AND NOT EXISTS (
                           SELECT 1 FROM telegram_dm_topic_bindings b
                           WHERE b.session_id = s.id
@@ -16373,7 +16482,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     ORDER BY last_active DESC, s.started_at DESC
                     LIMIT ?
                     """,
-                    (str(user_id), int(limit)),
+                    (str(user_id), profile_name, int(limit)),
                 ).fetchall()
             except sqlite3.OperationalError:
                 # telegram_dm_topic_bindings doesn't exist yet — no bindings

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1709,8 +1709,13 @@ class TelegramAdapter(BasePlatformAdapter):
         if db is None or not hasattr(db, "delete_telegram_topic_binding"):
             return
         try:
+            # Prefer the profile stamped on this adapter under multiplex
+            # (issue #76423). Fall back to "default" for single-profile bots.
+            profile_name = getattr(self, "_hermes_profile_name", None) or "default"
             removed = db.delete_telegram_topic_binding(
-                chat_id=str(chat_id), thread_id=str(thread_id),
+                chat_id=str(chat_id),
+                thread_id=str(thread_id),
+                profile_name=profile_name,
             )
         except Exception:
             logger.debug(

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1686,7 +1686,11 @@ class TelegramAdapter(BasePlatformAdapter):
         return "thread not found" in str(error).lower()
 
     def _prune_stale_dm_topic_binding(
-        self, chat_id: Any, thread_id: Any,
+        self,
+        chat_id: Any,
+        thread_id: Any,
+        *,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Drop the stale ``telegram_dm_topic_bindings`` row for a
         topic Telegram has confirmed deleted.
@@ -1699,6 +1703,12 @@ class TelegramAdapter(BasePlatformAdapter):
         on to a fresh topic).  Best-effort: we never raise from a
         send-fallback path — a failed cleanup must not turn into a
         failed user-facing send.
+
+        Rows are namespaced by profile (#76423). Under
+        ``gateway.profile_routes`` the transport adapter may not be the
+        profile that wrote the binding, so the send's ``hermes_profile``
+        metadata wins over the adapter's own profile stamp; single-profile
+        bots fall back to ``"default"``.
         """
         if chat_id is None or thread_id is None:
             return
@@ -1709,9 +1719,11 @@ class TelegramAdapter(BasePlatformAdapter):
         if db is None or not hasattr(db, "delete_telegram_topic_binding"):
             return
         try:
-            # Prefer the profile stamped on this adapter under multiplex
-            # (issue #76423). Fall back to "default" for single-profile bots.
-            profile_name = getattr(self, "_hermes_profile_name", None) or "default"
+            profile_name = (
+                (metadata or {}).get("hermes_profile")
+                or getattr(self, "_hermes_profile_name", None)
+                or "default"
+            )
             removed = db.delete_telegram_topic_binding(
                 chat_id=str(chat_id),
                 thread_id=str(thread_id),
@@ -5595,7 +5607,9 @@ class TelegramAdapter(BasePlatformAdapter):
                                     self.name, effective_thread_id,
                                 )
                                 self._prune_stale_dm_topic_binding(
-                                    chat_id, effective_thread_id,
+                                    chat_id,
+                                    effective_thread_id,
+                                    metadata=metadata,
                                 )
                                 used_thread_fallback = True
                                 effective_thread_id = None
@@ -6385,7 +6399,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 # Same prune as the streaming send path — the
                 # control-message retry tells us the topic is gone,
                 # so the binding row in state.db must go too
-                # (#31501).
+                # (#31501). Control sends carry no gateway metadata, so
+                # the prune namespaces by this adapter's profile stamp.
                 self._prune_stale_dm_topic_binding(
                     kwargs.get("chat_id"), message_thread_id,
                 )

--- a/tests/gateway/test_telegram_topic_profile_isolation_76423.py
+++ b/tests/gateway/test_telegram_topic_profile_isolation_76423.py
@@ -1,0 +1,113 @@
+"""Issue #76423 — SessionDB: telegram topic tables namespace by profile."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from hermes_state import SessionDB
+
+
+CHAT = "208214988"
+
+
+def _session(db, sid, profile_name=None):
+    db.create_session(session_id=sid, source="telegram", user_id=CHAT, profile_name=profile_name)
+
+
+def test_legacy_v2_rows_migrate_only_to_default(tmp_path: Path):
+    db_path = tmp_path / "legacy.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(
+        f"""
+        CREATE TABLE state_meta (key TEXT PRIMARY KEY, value TEXT);
+        INSERT INTO state_meta(key, value) VALUES ('telegram_dm_topic_schema_version', '2');
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY, source TEXT, user_id TEXT, model TEXT,
+            model_config TEXT, system_prompt TEXT, parent_session_id TEXT,
+            started_at REAL, ended_at REAL, end_reason TEXT,
+            message_count INTEGER DEFAULT 0, tool_call_count INTEGER DEFAULT 0,
+            input_tokens INTEGER DEFAULT 0, output_tokens INTEGER DEFAULT 0
+        );
+        INSERT INTO sessions(id, source, user_id, started_at)
+            VALUES ('legacy-sess', 'telegram', '{CHAT}', 1.0);
+        CREATE TABLE telegram_dm_topic_mode (
+            chat_id TEXT PRIMARY KEY, user_id TEXT NOT NULL,
+            enabled INTEGER NOT NULL DEFAULT 1,
+            activated_at REAL NOT NULL, updated_at REAL NOT NULL,
+            has_topics_enabled INTEGER, allows_users_to_create_topics INTEGER,
+            capability_checked_at REAL, intro_message_id TEXT, pinned_message_id TEXT
+        );
+        INSERT INTO telegram_dm_topic_mode(chat_id, user_id, enabled, activated_at, updated_at)
+            VALUES ('{CHAT}', '{CHAT}', 1, 1.0, 1.0);
+        CREATE TABLE telegram_dm_topic_bindings (
+            chat_id TEXT NOT NULL, thread_id TEXT NOT NULL, user_id TEXT NOT NULL,
+            session_key TEXT NOT NULL,
+            session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+            managed_mode TEXT NOT NULL DEFAULT 'auto',
+            linked_at REAL NOT NULL, updated_at REAL NOT NULL,
+            PRIMARY KEY (chat_id, thread_id)
+        );
+        INSERT INTO telegram_dm_topic_bindings
+            VALUES ('{CHAT}', '99', '{CHAT}', 'k', 'legacy-sess', 'auto', 1.0, 1.0);
+        """
+    )
+    conn.close()
+
+    db = SessionDB(db_path=db_path)
+    db.apply_telegram_topic_migration()
+    assert db.get_meta("telegram_dm_topic_schema_version") == "3"
+    assert db.is_telegram_topic_mode_enabled(
+        chat_id=CHAT, user_id=CHAT, profile_name="default",
+    )
+    assert not db.is_telegram_topic_mode_enabled(
+        chat_id=CHAT, user_id=CHAT, profile_name="coder",
+    )
+    assert db.get_telegram_topic_binding(
+        chat_id=CHAT, thread_id="99", profile_name="default",
+    )["session_id"] == "legacy-sess"
+    assert db.get_telegram_topic_binding(
+        chat_id=CHAT, thread_id="99", profile_name="coder",
+    ) is None
+    db.close()
+
+
+def test_mode_and_bindings_isolated_across_profiles(tmp_path: Path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    _session(db, "sess-a", "alpha")
+    _session(db, "sess-b", "beta")
+
+    db.enable_telegram_topic_mode(chat_id=CHAT, user_id=CHAT, profile_name="alpha")
+    db.enable_telegram_topic_mode(chat_id=CHAT, user_id=CHAT, profile_name="beta")
+    db.disable_telegram_topic_mode(chat_id=CHAT, profile_name="alpha")
+    assert not db.is_telegram_topic_mode_enabled(chat_id=CHAT, user_id=CHAT, profile_name="alpha")
+    assert db.is_telegram_topic_mode_enabled(chat_id=CHAT, user_id=CHAT, profile_name="beta")
+
+    db.bind_telegram_topic(
+        chat_id=CHAT, thread_id="77", user_id=CHAT,
+        session_key="ka", session_id="sess-a", profile_name="alpha",
+    )
+    db.bind_telegram_topic(
+        chat_id=CHAT, thread_id="77", user_id=CHAT,
+        session_key="kb", session_id="sess-b", profile_name="beta",
+    )
+    assert db.get_telegram_topic_binding(
+        chat_id=CHAT, thread_id="77", profile_name="alpha",
+    )["session_id"] == "sess-a"
+    assert db.get_telegram_topic_binding(
+        chat_id=CHAT, thread_id="77", profile_name="beta",
+    )["session_id"] == "sess-b"
+
+    assert db.delete_telegram_topic_binding(
+        chat_id=CHAT, thread_id="77", profile_name="alpha",
+    ) == 1
+    assert db.get_telegram_topic_binding(
+        chat_id=CHAT, thread_id="77", profile_name="alpha",
+    ) is None
+    assert db.get_telegram_topic_binding(
+        chat_id=CHAT, thread_id="77", profile_name="beta",
+    ) is not None
+    # Omitted kwarg == the single-profile "default" namespace, not a wildcard.
+    assert not db.is_telegram_topic_mode_enabled(chat_id=CHAT, user_id=CHAT)
+    assert db.get_telegram_topic_binding(chat_id=CHAT, thread_id="77") is None
+    db.close()

--- a/tests/gateway/test_telegram_topic_profile_isolation_76423.py
+++ b/tests/gateway/test_telegram_topic_profile_isolation_76423.py
@@ -15,13 +15,14 @@ def _session(db, sid, profile_name=None):
     db.create_session(session_id=sid, source="telegram", user_id=CHAT, profile_name=profile_name)
 
 
-def test_legacy_v2_rows_migrate_only_to_default(tmp_path: Path):
+def test_legacy_rows_migrate_only_to_default(tmp_path: Path):
+    """v1 shape (no CASCADE, old user index) → v3: rows land in 'default' only."""
     db_path = tmp_path / "legacy.db"
     conn = sqlite3.connect(str(db_path))
     conn.executescript(
         f"""
         CREATE TABLE state_meta (key TEXT PRIMARY KEY, value TEXT);
-        INSERT INTO state_meta(key, value) VALUES ('telegram_dm_topic_schema_version', '2');
+        INSERT INTO state_meta(key, value) VALUES ('telegram_dm_topic_schema_version', '1');
         CREATE TABLE sessions (
             id TEXT PRIMARY KEY, source TEXT, user_id TEXT, model TEXT,
             model_config TEXT, system_prompt TEXT, parent_session_id TEXT,
@@ -43,11 +44,13 @@ def test_legacy_v2_rows_migrate_only_to_default(tmp_path: Path):
         CREATE TABLE telegram_dm_topic_bindings (
             chat_id TEXT NOT NULL, thread_id TEXT NOT NULL, user_id TEXT NOT NULL,
             session_key TEXT NOT NULL,
-            session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+            session_id TEXT NOT NULL REFERENCES sessions(id),
             managed_mode TEXT NOT NULL DEFAULT 'auto',
             linked_at REAL NOT NULL, updated_at REAL NOT NULL,
             PRIMARY KEY (chat_id, thread_id)
         );
+        CREATE INDEX idx_telegram_dm_topic_bindings_user
+            ON telegram_dm_topic_bindings(user_id, chat_id);
         INSERT INTO telegram_dm_topic_bindings
             VALUES ('{CHAT}', '99', '{CHAT}', 'k', 'legacy-sess', 'auto', 1.0, 1.0);
         """
@@ -69,6 +72,8 @@ def test_legacy_v2_rows_migrate_only_to_default(tmp_path: Path):
     assert db.get_telegram_topic_binding(
         chat_id=CHAT, thread_id="99", profile_name="coder",
     ) is None
+    fk = db._conn.execute("PRAGMA foreign_key_list('telegram_dm_topic_bindings')").fetchall()
+    assert any(row[2] == "sessions" and row[6] == "CASCADE" for row in fk)
     db.close()
 
 

--- a/tests/gateway/test_telegram_topic_profile_routing_76423.py
+++ b/tests/gateway/test_telegram_topic_profile_routing_76423.py
@@ -52,3 +52,42 @@ def test_gateway_uses_source_profile_not_global(tmp_path: Path):
         chat_id=CHAT, thread_id="42", profile_name="default",
     ) is None
     db.close()
+
+
+def test_routed_profile_flows_into_prune_via_send_metadata(tmp_path: Path):
+    """profile_routes: the transport adapter may be the primary (default) bot
+    while the turn is routed to another profile — the outbound metadata built
+    by the gateway carries the routed profile, and prune uses it over the
+    adapter's own stamp (#76423)."""
+    from gateway.run import GatewayRunner
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    runner = object.__new__(GatewayRunner)
+    runner._thread_metadata_for_target = lambda *a, **k: {"thread_id": "99"}
+    meta = runner._thread_metadata_for_source(_source("coder", "99"))
+    assert meta["hermes_profile"] == "coder"
+    assert "hermes_profile" not in runner._thread_metadata_for_source(_source(None, "99"))
+
+    # Cooldowns are keyed (profile, chat): alpha's reminder must not gag beta.
+    assert runner._should_send_telegram_lobby_reminder(_source("alpha")) is True
+    assert runner._should_send_telegram_lobby_reminder(_source("beta")) is True
+    assert runner._should_send_telegram_lobby_reminder(_source("alpha")) is False
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(session_id="sess-default", source="telegram", user_id=CHAT)
+    db.create_session(session_id="sess-coder", source="telegram", user_id=CHAT, profile_name="coder")
+    for prof, sid in (("default", "sess-default"), ("coder", "sess-coder")):
+        db.bind_telegram_topic(
+            chat_id=CHAT, thread_id="99", user_id=CHAT,
+            session_key=f"k-{prof}", session_id=sid, profile_name=prof,
+        )
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter.platform = Platform.TELEGRAM
+    adapter._session_store = SimpleNamespace(_db=db)
+    adapter._hermes_profile_name = "default"  # transport = primary bot
+    adapter._prune_stale_dm_topic_binding(CHAT, "99", metadata=meta)
+
+    assert db.get_telegram_topic_binding(chat_id=CHAT, thread_id="99", profile_name="coder") is None
+    assert db.get_telegram_topic_binding(chat_id=CHAT, thread_id="99", profile_name="default") is not None
+    db.close()

--- a/tests/gateway/test_telegram_topic_profile_routing_76423.py
+++ b/tests/gateway/test_telegram_topic_profile_routing_76423.py
@@ -1,0 +1,54 @@
+"""Issue #76423 — Gateway routes source.profile into telegram topic state."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from hermes_state import SessionDB
+from gateway.config import Platform
+from gateway.session import SessionSource
+
+
+CHAT = "208214988"
+
+
+def _source(profile=None, thread_id="42"):
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id=CHAT,
+        chat_id=CHAT,
+        user_name="tester",
+        chat_type="dm",
+        thread_id=thread_id,
+        profile=profile,
+    )
+
+
+def test_gateway_uses_source_profile_not_global(tmp_path: Path):
+    from gateway.run import GatewayRunner
+
+    assert GatewayRunner._telegram_topic_profile_name(_source("coder")) == "coder"
+    assert GatewayRunner._telegram_topic_profile_name(_source(None)) == "default"
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(session_id="sess-coder", source="telegram", user_id=CHAT, profile_name="coder")
+    db.enable_telegram_topic_mode(chat_id=CHAT, user_id=CHAT, profile_name="coder")
+
+    runner = object.__new__(GatewayRunner)
+    runner._session_db = db
+    assert runner._telegram_topic_mode_enabled(_source("coder")) is True
+    assert runner._telegram_topic_mode_enabled(_source("other")) is False
+    assert runner._telegram_topic_mode_enabled(_source(None)) is False
+
+    runner._record_telegram_topic_binding(
+        _source("coder", "42"),
+        SimpleNamespace(session_key="k", session_id="sess-coder"),
+    )
+    assert db.get_telegram_topic_binding(
+        chat_id=CHAT, thread_id="42", profile_name="coder",
+    ) is not None
+    assert db.get_telegram_topic_binding(
+        chat_id=CHAT, thread_id="42", profile_name="default",
+    ) is None
+    db.close()

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1775,7 +1775,7 @@ class TestSchemaInit:
         assert binding["user_id"] == "208214988"
         assert binding["session_key"] == "telegram:dm:208214988:thread:17585"
         assert binding["session_id"] == "topic-session"
-        assert db.get_meta("telegram_dm_topic_schema_version") == "2"
+        assert db.get_meta("telegram_dm_topic_schema_version") == "3"
         db.close()
 
 

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -848,29 +848,31 @@ Shows the current topic's binding: session title, session ID, and hints for `/ne
 
 ### Under the hood
 
-- Activation persists to `telegram_dm_topic_mode(chat_id, user_id, enabled, ...)` in `state.db`
-- Each topic binding persists to `telegram_dm_topic_bindings(chat_id, thread_id, session_id, ...)` with `ON DELETE CASCADE` on `session_id` — pruning a session automatically clears its topic binding
-- The topic-mode SQLite migration is **opt-in**: it runs on the first `/topic` call, never on gateway startup. Until a user runs `/topic` in this profile, `state.db` is unchanged
-- Each inbound DM message looks up its `(chat_id, thread_id)` binding. If present, the lookup routes the message to the bound session via `SessionStore.switch_session()` so the session-key-to-session-id mapping stays consistent on disk
+- Activation persists to `telegram_dm_topic_mode(profile_name, chat_id, user_id, enabled, ...)` in `state.db`. Primary key is `(profile_name, chat_id)` so multiplexed / profile-routed bots sharing one `state.db` do not clobber each other when the same Telegram user DMs multiple bots (private `chat_id` is the user id and is identical across bots).
+- Each topic binding persists to `telegram_dm_topic_bindings(profile_name, chat_id, thread_id, session_id, ...)` with PK `(profile_name, chat_id, thread_id)` and `ON DELETE CASCADE` on `session_id` — pruning a session automatically clears its topic binding
+- The topic-mode SQLite migration is **opt-in**: it runs on the first `/topic` call, never on gateway startup. Until a user runs `/topic` in this profile, `state.db` is unchanged. Schema v3 adds `profile_name`; legacy rows migrate into the `default` namespace only
+- Each inbound DM message looks up its `(profile_name, chat_id, thread_id)` binding using the **routed** profile (`source.profile`, not the process-global active profile). If present, the lookup routes the message to the bound session via `SessionStore.switch_session()` so the session-key-to-session-id mapping stays consistent on disk
 - `/new` inside a topic rewrites the binding row to point at the new session ID, so the next message stays on the fresh session
 - Topics declared in `extra.dm_topics` are **never auto-renamed** — the operator-chosen name is preserved even when multi-session mode is enabled
 - Set `extra.disable_topic_auto_rename: true` to turn off auto-rename for **all** topics in the chat (ad-hoc topics created via Threaded Mode included)
 - The General (pinned top) topic in a forum-enabled DM is treated as the root lobby, regardless of whether Telegram delivers its messages with `message_thread_id=1` or with no thread_id
-- Root-lobby reminders are rate-limited to one message per 30 seconds per chat — a user who forgets topic mode is on and types ten prompts in the root won't get ten replies
-- BotFather setup screenshots are rate-limited to one send per 5 minutes per chat — repeated `/topic` attempts while Threads Settings are still disabled won't re-upload the same image
+- Root-lobby reminders are rate-limited to one message per 30 seconds per **(profile, chat)** — a user who forgets topic mode is on and types ten prompts in the root won't get ten replies, and two multiplexed profiles sharing a chat id do not suppress each other's reminders
+- BotFather setup screenshots are rate-limited to one send per 5 minutes per **(profile, chat)** — repeated `/topic` attempts while Threads Settings are still disabled won't re-upload the same image
 - `/bg <prompt>` started inside a topic delivers its result back to the same topic; background sessions don't trigger auto-rename of the owning topic
 - `/topic` itself is gated by the bot's user authorization check — unauthorized DMs get a refusal instead of activation
 
 ### Disabling multi-session mode
 
-Send `/topic off` in the root DM. Hermes flips the row off, clears the chat's `(thread_id → session_id)` bindings, and the root DM reverts to a normal Hermes chat. Existing topics in Telegram aren't deleted — they just stop being gated as independent sessions. Re-run `/topic` later to turn it back on.
+Send `/topic off` in the root DM. Hermes flips the row off for **this profile's** namespace, clears that profile's `(thread_id → session_id)` bindings for the chat, and the root DM reverts to a normal Hermes chat. Existing topics in Telegram aren't deleted — they just stop being gated as independent sessions. Re-run `/topic` later to turn it back on.
 
-If you need to clean up by hand (e.g. a bulk reset across many chats), remove the rows directly:
+If you need to clean up by hand (e.g. a bulk reset across many chats), scope rows by `profile_name` (use `default` for single-profile installs):
 
 ```bash
 sqlite3 ~/.hermes/state.db \
-  "UPDATE telegram_dm_topic_mode SET enabled = 0 WHERE chat_id = '<your_chat_id>'; \
-   DELETE FROM telegram_dm_topic_bindings WHERE chat_id = '<your_chat_id>';"
+  "UPDATE telegram_dm_topic_mode SET enabled = 0
+     WHERE profile_name = 'default' AND chat_id = '<your_chat_id>';
+   DELETE FROM telegram_dm_topic_bindings
+     WHERE profile_name = 'default' AND chat_id = '<your_chat_id>';"
 ```
 
 ### Downgrading Hermes


### PR DESCRIPTION
## Summary
Two bots served by one multiplexed gateway share `state.db`, and a private Telegram chat_id is the user's id —
identical across bots — so `telegram_dm_topic_mode`/`telegram_dm_topic_bindings` keyed by `(chat_id)` /
`(chat_id, thread_id)` made `/topic` on one bot enable topic recovery for every bot, let bindings clobber each
other, and had prune/cooldowns act on the wrong profile. Both tables now carry `profile_name` (leading the PK),
every gateway read/write passes the routed `source.profile` (never the process-global active profile), and
stale-topic prune resolves the namespace from send metadata.
## Changes
- schema v3: `profile_name` on both topic tables; one table-driven rebuild for v1/v2 → v3, legacy rows → `default`
- `GatewayRunner._telegram_topic_profile_name(source)` threaded through all 10 topic call sites + `/topic` slash paths
- lobby-reminder / capability-hint cooldowns keyed `(profile, chat)`; `/topic off` resets the same key
- outbound `_thread_metadata_for_source` stamps `hermes_profile`; Telegram prune uses it over the adapter stamp;
  secondary adapters stamped with their profile
- docs: telegram.md under-the-hood + manual cleanup snippet
## Validation
| Probe (real SessionDB/GatewayRunner/TelegramAdapter, 2 profiles, 1 chat_id) | main | branch |
|---|---|---|
| `/topic` on alpha → beta topic mode | ON (leak) | OFF |
| alpha & beta bind thread 77 | beta clobbers alpha | both kept |
| beta root DM recovery | steered to '77' | None |
| prune stale 77 for routed alpha via primary bot | beta row deleted | beta row survives |
| alpha lobby reminder → beta reminder | suppressed | sent |
Tests: 4 new (2 state, 2 gateway) + existing topic/prune/resume suites green; sabotage of the profile predicate fails both gateway tests.
## Credits
@crdesign8 — #76487, commits cherry-picked with authorship (first submitter, 2026-08-02; sorry the conflicts sat
unanswered). @mjshorty — #76423 first report. @cherryb16 — #87239 / #87240 fuller diagnosis. @sadgen — #93491.

Fixes #76423
Fixes #87239

## Infographic

![mux-telegram-topics](https://v3b.fal.media/files/b/0aa8cdb7/SRIGNp_OamuhJUDSsIrcI_UDx49lQO.png)
