### PR TITLE
fix(gateway): inline-button and early auth honor the routed profile, bot policy and per-profile Slack gates (#86296 #92840, salvage #65589 #86308 #72657)

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -209,14 +209,21 @@ class GatewayAuthorizationMixin:
             return None
         profile_name = (profile or "").strip() or None
         if profile_name and profile_name != "default":
-            active_profile = None
-            active_profile_fn = getattr(self, "_active_profile_name", None)
-            if callable(active_profile_fn):
-                try:
-                    active_profile = active_profile_fn()
-                except Exception:
-                    active_profile = None
-            if profile_name == active_profile:
+            # Adapter ownership is process-wide: only the profile the gateway
+            # was LAUNCHED as owns ``self.adapters``. ``_active_profile_name()``
+            # reads the per-turn HERMES_HOME override, so inside a secondary
+            # profile's ``_profile_runtime_scope`` it reports that secondary
+            # and would hand it the default bot. Compare against the identity
+            # captured at construction instead.
+            primary_profile = getattr(self, "_primary_profile_name", None)
+            if not primary_profile:
+                active_profile_fn = getattr(self, "_active_profile_name", None)
+                if callable(active_profile_fn):
+                    try:
+                        primary_profile = active_profile_fn()
+                    except Exception:
+                        primary_profile = None
+            if profile_name == primary_profile:
                 adapters = getattr(self, "adapters", None) or {}
                 return adapters.get(platform)
             profile_adapters = getattr(self, "_profile_adapters", None) or {}

--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -11,6 +11,7 @@ import json
 import logging
 import time
 from datetime import datetime
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from hermes_cli.config import get_hermes_home
@@ -18,7 +19,12 @@ from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
 
-DIRECTORY_PATH = get_hermes_home() / "channel_directory.json"
+# Resolved lazily (see ``_directory_path``): a multiplexed gateway serves
+# several profile homes from one process, so an import-time constant would pin
+# every profile's directory to whichever home imported this module first.
+# ``DIRECTORY_PATH`` / ``CHANNEL_ALIASES_PATH`` stay as explicit overrides
+# (tests patch them); ``None`` means "resolve from the current home".
+DIRECTORY_PATH: Optional[Path] = None
 # Throttle window for repeated Slack channel-directory refresh failures.
 # The directory rebuilds on a timer, so a persistent workspace error (e.g.
 # missing scope, revoked token) would otherwise re-log the same warning on
@@ -33,14 +39,23 @@ _slack_directory_warning_last: Dict[tuple[str, str], float] = {}
 # on every build AND every load, giving durable human-friendly names (and
 # letting you pre-name a chat before it has produced any traffic).
 # Format: {"<platform>": {"<chat_id>": "<friendly name>", ...}, ...}
-CHANNEL_ALIASES_PATH = get_hermes_home() / "channel_aliases.json"
+CHANNEL_ALIASES_PATH: Optional[Path] = None
+
+
+def _directory_path() -> Path:
+    return DIRECTORY_PATH or get_hermes_home() / "channel_directory.json"
+
+
+def _aliases_path() -> Path:
+    return CHANNEL_ALIASES_PATH or get_hermes_home() / "channel_aliases.json"
 
 
 def _load_channel_aliases() -> Dict[str, Dict[str, str]]:
-    if not CHANNEL_ALIASES_PATH.exists():
+    aliases_path = _aliases_path()
+    if not aliases_path.exists():
         return {}
     try:
-        with open(CHANNEL_ALIASES_PATH, encoding="utf-8") as f:
+        with open(aliases_path, encoding="utf-8") as f:
             data = json.load(f)
         return data if isinstance(data, dict) else {}
     except Exception:
@@ -143,7 +158,8 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
     """
     Build a channel directory from connected platform adapters and session data.
 
-    Returns the directory dict and writes it to DIRECTORY_PATH.
+    Returns the directory dict and writes it to the current home's
+    ``channel_directory.json``.
     """
     from gateway.config import Platform
 
@@ -206,7 +222,7 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
     }
 
     try:
-        await asyncio.to_thread(atomic_json_write, DIRECTORY_PATH, directory)
+        await asyncio.to_thread(atomic_json_write, _directory_path(), directory)
     except Exception as e:
         logger.warning("Channel directory: failed to write: %s", e)
 
@@ -525,12 +541,13 @@ def _build_from_sessions_json(platform_name: str) -> List[Dict[str, str]]:
 
 def load_directory() -> Dict[str, Any]:
     """Load the cached channel directory from disk."""
-    if not DIRECTORY_PATH.exists():
+    directory_path = _directory_path()
+    if not directory_path.exists():
         base = {"updated_at": None, "platforms": {}}
         _apply_channel_aliases(base["platforms"])
         return base
     try:
-        with open(DIRECTORY_PATH, encoding="utf-8") as f:
+        with open(directory_path, encoding="utf-8") as f:
             data = json.load(f)
         # Re-apply aliases on read so friendly names take effect immediately,
         # even between timed rebuilds and for brand-new alias entries.

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3968,6 +3968,9 @@ class BasePlatformAdapter(ABC):
         user_id: Optional[str],
         chat_type: Optional[str] = None,
         chat_id: Optional[str] = None,
+        *,
+        is_bot: bool = False,
+        thread_id: Optional[str] = None,
     ) -> Optional[bool]:
         """Return whether ``user_id`` is on the allowlist, if a check is configured.
 
@@ -3975,6 +3978,11 @@ class BasePlatformAdapter(ABC):
         registered via :meth:`set_authorization_check`. Returns ``None``
         when no check is registered (caller should treat as "trust unknown"
         and preserve legacy behaviour).
+
+        ``is_bot`` / ``thread_id`` are forwarded as keywords only when set, so
+        the gateway callback can apply its bot policy (``*_ALLOW_BOTS``) and
+        thread-level profile routes while legacy three-positional callbacks
+        keep working unchanged.
 
         Only the literal booleans are propagated. A callback that returns
         anything else is treated as "unknown" rather than coerced with
@@ -3984,8 +3992,13 @@ class BasePlatformAdapter(ABC):
         """
         if not user_id or self._authorization_check is None:
             return None
+        extra: Dict[str, Any] = {}
+        if is_bot:
+            extra["is_bot"] = True
+        if thread_id is not None:
+            extra["thread_id"] = thread_id
         try:
-            result = self._authorization_check(user_id, chat_type, chat_id)
+            result = self._authorization_check(user_id, chat_type, chat_id, **extra)
             if result is True:
                 return True
             if result is False:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7721,6 +7721,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # context pin; last-delivered voice-channel context) lives on
         # SessionState.conversation — see gateway/session_state.py.
         self._kanban_notifier_profile = self._active_profile_name()
+        # Launch-time identity of the profile that owns ``self.adapters``;
+        # ``_authorization_adapter`` compares against this rather than the
+        # per-turn ``_active_profile_name()`` (see gateway/authz_mixin.py).
+        self._primary_profile_name = self._kanban_notifier_profile
         # Teams meeting pipeline runtime (bound later when msgraph_webhook adapter exists).
         self._teams_pipeline_runtime = None
         self._teams_pipeline_runtime_error: Optional[str] = None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17793,11 +17793,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ``profile_name`` binds the callback to the secondary adapter's own
         multiplex profile, so its ``SessionSource`` resolves that profile's
         secret scope instead of falling back to the active profile.
+
+        For the shared primary adapter under ``multiplex_profiles``
+        (``profile_name`` is None) the callback mirrors the inbound message
+        path exactly: the chat's ``profile_routes`` match is stamped on the
+        source so the routed profile's pairing store is consulted, while the
+        allowlist/gate reads stay under the transport (launch) home via
+        ``_is_user_authorized_for_source`` — the same split
+        ``_make_default_profile_message_handler`` applies. Without this an
+        inline-button caller approved only in the routed profile's pairing
+        store was denied (#86296), because the adapter's callback source was
+        never route-stamped.
         """
+        multiplex = bool(getattr(self.config, "multiplex_profiles", False))
+        transport_home = (
+            Path(get_hermes_home()) if multiplex and profile_name is None else None
+        )
+
         def check(
             user_id: str,
             chat_type: Optional[str] = None,
             chat_id: Optional[str] = None,
+            *,
+            is_bot: bool = False,
+            thread_id: Optional[str] = None,
         ) -> bool:
             if not user_id:
                 return False
@@ -17806,9 +17825,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 chat_id=chat_id or "",
                 chat_type=chat_type or "group",
                 user_id=user_id,
+                thread_id=thread_id,
+                is_bot=bool(is_bot),
                 profile=profile_name,
             )
-            return self._is_user_authorized(source)
+            # Same in-process transport provenance ``build_source`` retains, so
+            # adapter-level policy reads (config.yaml group_allowed_chats,
+            # allow_from) resolve the receiving adapter even once the routed
+            # profile is stamped below.
+            registry = (
+                (getattr(self, "_profile_adapters", None) or {}).get(profile_name)
+                if profile_name
+                else getattr(self, "adapters", None)
+            ) or {}
+            adapter = registry.get(platform)
+            if adapter is not None:
+                source._transport_adapter_ref = _weakref.ref(adapter)
+            if transport_home is None:
+                return self._is_user_authorized(source)
+            source._authorization_profile_home = transport_home
+            from gateway.profile_routing import ProfileRouteRejected
+
+            try:
+                source.profile = self._profile_name_for_source(source)
+            except ProfileRouteRejected:
+                # Same fail-closed outcome as the ingress gate in
+                # ``_handle_message`` for a route to an unserved profile.
+                return False
+            return self._is_user_authorized_for_source(source)
         return check
 
 

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -6353,9 +6353,19 @@ class SlackAdapter(BasePlatformAdapter):
         # or file downloads.  The final gateway runner auth check happens
         # after MessageEvent construction, so adapter-side media fetches need
         # the same auth chain up front.
+        # Prefer the injected profile-bound check (survives the multiplex
+        # closure handler, which has no ``__self__``); fall back to runner
+        # introspection for adapters wired without one.
+        _early_decision = (
+            self._is_sender_authorized(
+                user_id, "dm" if is_dm else "group", channel_id
+            )
+            if user_id and getattr(self, "_authorization_check", None) is not None
+            else None
+        )
         _runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
         _auth_fn = getattr(_runner, "_is_user_authorized", None)
-        if user_id and callable(_auth_fn):
+        if _early_decision is None and user_id and callable(_auth_fn):
             _source = self.build_source(
                 chat_id=channel_id,
                 chat_name="",
@@ -6363,13 +6373,14 @@ class SlackAdapter(BasePlatformAdapter):
                 user_id=user_id,
                 user_name="",
             )
-            if not _auth_fn(_source):
-                logger.warning(
-                    "[Slack] Early reject of unauthorized user %s in channel %s",
-                    user_id,
-                    channel_id,
-                )
-                return
+            _early_decision = bool(_auth_fn(_source))
+        if _early_decision is False:
+            logger.warning(
+                "[Slack] Early reject of unauthorized user %s in channel %s",
+                user_id,
+                channel_id,
+            )
+            return
 
         # Build thread_ts for session keying.
         # In channels: fall back to ts so each top-level @mention starts a
@@ -7490,6 +7501,23 @@ class SlackAdapter(BasePlatformAdapter):
         if not normalized_user_id:
             return False
 
+        chat_type = "dm" if str(channel_id or "").startswith("D") else "group"
+
+        # Preferred path: the auth callback GatewayRunner injects at connect
+        # time (``set_authorization_check``) runs the full, profile-bound
+        # ``_is_user_authorized`` chain. Unlike the ``__self__`` introspection
+        # below it also resolves on a multiplexed adapter, whose message
+        # handler is a profile closure with no ``__self__`` (#72657, same
+        # class as Telegram's #86296).
+        # ``getattr``: adapters built via ``object.__new__`` never ran
+        # ``BasePlatformAdapter.__init__``.
+        if getattr(self, "_authorization_check", None) is not None:
+            injected = self._is_sender_authorized(
+                normalized_user_id, chat_type, str(channel_id or "")
+            )
+            if injected is not None:
+                return injected
+
         runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
         auth_fn = getattr(runner, "_is_user_authorized", None)
         if callable(auth_fn):
@@ -7499,7 +7527,7 @@ class SlackAdapter(BasePlatformAdapter):
                 source = SessionSource(
                     platform=Platform.SLACK,
                     chat_id=str(channel_id or normalized_user_id),
-                    chat_type="dm" if str(channel_id or "").startswith("D") else "group",
+                    chat_type=chat_type,
                     user_id=normalized_user_id,
                     user_name=str(user_name).strip() if user_name else None,
                     scope_id=str(team_id) if team_id else None,
@@ -7512,20 +7540,14 @@ class SlackAdapter(BasePlatformAdapter):
                     exc_info=True,
                 )
 
-        if os.getenv("SLACK_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
+        # Env-only fallback (no injected check, no bound runner). Gate reads go
+        # through the shared per-profile accessor: under multiplex a scoped
+        # miss returns "" instead of falling through to ``os.environ``, which
+        # holds the DEFAULT profile's allow-all flag / allowlist.
+        from gateway.authz_mixin import _platform_gate_env as _env
+
+        if _env("SLACK_ALLOW_ALL_USERS").lower() in {"true", "1", "yes"}:
             return True
-
-        def _env(name: str) -> str:
-            # Multiplex: profile .env is in secret_scope, not process environ.
-            try:
-                from agent.secret_scope import get_secret
-
-                val = get_secret(name)
-                if val is not None and str(val).strip():
-                    return str(val).strip()
-            except Exception:
-                pass
-            return (os.getenv(name) or "").strip()
 
         allowed_ids = set()
         platform_allowlist = _env("SLACK_ALLOWED_USERS")
@@ -7538,8 +7560,6 @@ class SlackAdapter(BasePlatformAdapter):
         if allowed_ids:
             return "*" in allowed_ids or normalized_user_id in allowed_ids
 
-        if _env("SLACK_ALLOW_ALL_USERS").lower() in {"true", "1", "yes"}:
-            return True
         return _env("GATEWAY_ALLOW_ALL_USERS").lower() in {"true", "1", "yes"}
 
     async def _handle_slash_confirm_action(self, ack, body, action) -> None:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1233,6 +1233,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 normalized_user_id,
                 chat_type=normalized_chat_type,
                 chat_id=str(chat_id or normalized_user_id),
+                thread_id=str(thread_id) if thread_id is not None else None,
             )
             if injected is not None:
                 return injected
@@ -1285,6 +1286,9 @@ class TelegramAdapter(BasePlatformAdapter):
         user = getattr(message, "from_user", None)
         chat = getattr(message, "chat", None)
         user_id = str(getattr(user, "id", "")).strip() or None
+        # Carry the bot flag so the runner's ``*_ALLOW_BOTS`` policy branch is
+        # reachable from this prefilter, exactly as it is for ``build_source``.
+        is_bot = bool(getattr(user, "is_bot", False)) if user is not None else False
         user_name = (
             str(getattr(user, "username", "") or getattr(user, "full_name", "") or "").strip()
             or None
@@ -1330,6 +1334,7 @@ class TelegramAdapter(BasePlatformAdapter):
             user_id=user_id,
             user_name=user_name,
             thread_id=thread_id,
+            is_bot=is_bot,
         )
 
     def _source_from_reaction_for_auth(self, update):
@@ -1411,14 +1416,20 @@ class TelegramAdapter(BasePlatformAdapter):
         if source.chat_type != "dm":
             return False
 
-        runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+        # The bound-handler ``__self__`` is None under multiplex (the handler is
+        # a profile closure); ``gateway_runner`` is injected on every adapter
+        # by ``GatewayRunner._create_adapter`` and survives that wrapping.
+        runner = getattr(
+            getattr(self, "_message_handler", None), "__self__", None
+        ) or getattr(self, "gateway_runner", None)
         behavior_fn = getattr(runner, "_get_unauthorized_dm_behavior", None)
         if callable(behavior_fn):
             try:
                 return (
                     behavior_fn(
                         Platform.TELEGRAM,
-                        profile=getattr(source, "profile", None),
+                        profile=getattr(source, "profile", None)
+                        or getattr(self, "_owner_profile", None),
                     )
                     == "pair"
                 )
@@ -1511,6 +1522,8 @@ class TelegramAdapter(BasePlatformAdapter):
                         user_id,
                         chat_type=source.chat_type,
                         chat_id=source.chat_id,
+                        is_bot=source.is_bot,
+                        thread_id=source.thread_id,
                     )
                     if has_callback
                     else None

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1213,17 +1213,38 @@ class TelegramAdapter(BasePlatformAdapter):
         if not normalized_user_id:
             return False
 
+        normalized_chat_type = str(chat_type or "dm").strip().lower() or "dm"
+        if normalized_chat_type == "private":
+            normalized_chat_type = "dm"
+        elif normalized_chat_type == "supergroup":
+            normalized_chat_type = "forum" if thread_id is not None else "group"
+
+        # Preferred path: the auth callback GatewayRunner injects at
+        # connection time (set_authorization_check), which delegates to the
+        # full _is_user_authorized chain -- env allowlists, group allowlists,
+        # pairing store, allow-all flags. Unlike the __self__ introspection
+        # below, this also works for a secondary multiplexed adapter, whose
+        # _message_handler is a profile closure with no __self__ (the same
+        # gap the admin-tier check had -- resolved the same way). The getattr
+        # tolerates partially-constructed adapters (object.__new__ in tests)
+        # that never ran BasePlatformAdapter.__init__.
+        if getattr(self, "_authorization_check", None) is not None:
+            injected = self._is_sender_authorized(
+                normalized_user_id,
+                chat_type=normalized_chat_type,
+                chat_id=str(chat_id or normalized_user_id),
+            )
+            if injected is not None:
+                return injected
+
+        # Legacy path: resolve the runner off the bound message handler.
+        # Still reachable for adapters wired without set_authorization_check
+        # (bare-adapter tests, direct embedding).
         runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
         auth_fn = getattr(runner, "_is_user_authorized", None)
         if callable(auth_fn):
             try:
                 from gateway.session import SessionSource
-
-                normalized_chat_type = str(chat_type or "dm").strip().lower() or "dm"
-                if normalized_chat_type == "private":
-                    normalized_chat_type = "dm"
-                elif normalized_chat_type == "supergroup":
-                    normalized_chat_type = "forum" if thread_id is not None else "group"
 
                 source = SessionSource(
                     platform=Platform.TELEGRAM,

--- a/tests/gateway/test_multiplex_interactive_auth.py
+++ b/tests/gateway/test_multiplex_interactive_auth.py
@@ -1,0 +1,110 @@
+"""Multiplex interactive-auth regressions (#86296, #92840, #72657, #87240 egress).
+
+Real ``GatewayRunner`` methods on an ``object.__new__`` runner, real
+``PairingStore`` files under a temp HERMES_HOME, multiplex active.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.pairing import PairingStore
+from gateway.profile_routing import ProfileRoute
+
+
+@pytest.fixture
+def mux_home(tmp_path, monkeypatch):
+    from agent import secret_scope
+
+    home = tmp_path / "hh"
+    (home / "profiles" / "secondary").mkdir(parents=True)
+    (home / ".env").write_text("")
+    (home / "profiles" / "secondary" / ".env").write_text("")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    for key in (
+        "TELEGRAM_ALLOWED_USERS",
+        "TELEGRAM_ALLOW_BOTS",
+        "GATEWAY_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOWED_USERS",
+        "SLACK_ALLOW_ALL_USERS",
+        "SLACK_ALLOWED_USERS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    prev = secret_scope.is_multiplex_active()
+    secret_scope.set_multiplex_active(True)
+    yield home
+    secret_scope.set_multiplex_active(prev)
+
+
+def _runner(home):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner.config.profile_routes = [
+        ProfileRoute(name="r", platform="telegram", chat_id="-100555", profile="secondary")
+    ]
+    runner.config.platforms = {Platform.TELEGRAM: PlatformConfig(enabled=True, extra={})}
+    runner.pairing_store = PairingStore(profile="default")
+    runner.pairing_stores = {
+        "default": runner.pairing_store,
+        "secondary": PairingStore(profile="secondary"),
+    }
+    runner._primary_profile_name = "default"
+    runner._profile_adapters = {"secondary": {}}
+    return runner
+
+
+def _telegram(runner):
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    tg = object.__new__(TelegramAdapter)
+    tg.config = PlatformConfig(enabled=True, extra={})
+    tg._authorization_check = None
+    tg._message_handler = runner._primary_message_handler()  # closure, no __self__
+    runner.adapters = {Platform.TELEGRAM: tg}
+    tg.set_authorization_check(runner._make_adapter_auth_check(Platform.TELEGRAM))
+    return tg
+
+
+def test_routed_primary_callback_uses_routed_pairing_store_and_transport_allowlist(mux_home):
+    """#86296: shared primary bot + profile_routes → the inline-button caller
+    is authorized by the ROUTED profile's pairing store, while env allowlists
+    resolve under the transport (launch) home, exactly like inbound messages."""
+    runner = _runner(mux_home)
+    store = runner.pairing_stores["secondary"]
+    store._save_json(store._approved_path("telegram"), {"777": {}})
+    (mux_home / ".env").write_text("TELEGRAM_ALLOWED_USERS=999\n")
+    tg = _telegram(runner)
+
+    # Paired only in the routed profile → allowed in the routed chat only.
+    assert tg._is_callback_user_authorized("777", chat_id="-100555", chat_type="supergroup") is True
+    assert tg._is_callback_user_authorized("777", chat_id="-100999", chat_type="supergroup") is False
+    # Transport-home allowlist honored in the routed chat (not the routed profile's empty scope).
+    assert tg._is_callback_user_authorized("999", chat_id="-100555", chat_type="supergroup") is True
+    assert tg._is_callback_user_authorized("888", chat_id="-100555", chat_type="supergroup") is False
+
+
+def test_bot_sender_reaches_allow_bots_policy_through_callback(mux_home):
+    """#92840: the early prefilter must carry ``is_bot`` so TELEGRAM_ALLOW_BOTS
+    admits bot-authored messages under the multiplex closure handler."""
+    from gateway.run import _profile_runtime_scope
+
+    runner = _runner(mux_home)
+    (mux_home / ".env").write_text("TELEGRAM_ALLOWED_USERS=999\nTELEGRAM_ALLOW_BOTS=all\n")
+    tg = _telegram(runner)
+
+    def msg(uid, is_bot):
+        return SimpleNamespace(
+            from_user=SimpleNamespace(id=uid, is_bot=is_bot, username="x", full_name="X"),
+            chat=SimpleNamespace(id=-100777, type="supergroup", is_forum=False),
+            sender_chat=None,
+            message_thread_id=None,
+            is_topic_message=False,
+        )
+
+    with _profile_runtime_scope(mux_home):
+        assert tg._is_user_authorized_from_message(msg(4242, True)) is True
+        assert tg._is_user_authorized_from_message(msg(4343, False)) is False

--- a/tests/gateway/test_multiplex_interactive_auth.py
+++ b/tests/gateway/test_multiplex_interactive_auth.py
@@ -108,3 +108,30 @@ def test_bot_sender_reaches_allow_bots_policy_through_callback(mux_home):
     with _profile_runtime_scope(mux_home):
         assert tg._is_user_authorized_from_message(msg(4242, True)) is True
         assert tg._is_user_authorized_from_message(msg(4343, False)) is False
+
+
+def test_authorization_adapter_ignores_per_turn_active_profile(mux_home):
+    """#87240 egress half: inside a secondary profile's runtime scope the
+    default bot must not be handed to that profile (fail-closed None); the
+    launch profile still resolves ``self.adapters``."""
+    from gateway.run import _profile_runtime_scope
+
+    runner = _runner(mux_home)
+    default_bot = object()
+    runner.adapters = {Platform.TELEGRAM: default_bot}
+
+    with _profile_runtime_scope(mux_home / "profiles" / "secondary"):
+        assert runner._authorization_adapter(Platform.TELEGRAM, profile="secondary") is None
+    assert runner._authorization_adapter(Platform.TELEGRAM, profile="default") is default_bot
+
+
+def test_channel_directory_path_follows_current_home(mux_home):
+    """#87240: the directory file resolves against the CURRENT profile home,
+    not the home that happened to import the module."""
+    import gateway.channel_directory as cd
+    from gateway.run import _profile_runtime_scope
+
+    assert cd.DIRECTORY_PATH is None
+    with _profile_runtime_scope(mux_home / "profiles" / "secondary"):
+        assert cd._directory_path() == Path(mux_home / "profiles" / "secondary" / "channel_directory.json")
+    assert cd._directory_path() == Path(mux_home / "channel_directory.json")

--- a/tests/gateway/test_multiplex_interactive_auth.py
+++ b/tests/gateway/test_multiplex_interactive_auth.py
@@ -110,6 +110,39 @@ def test_bot_sender_reaches_allow_bots_policy_through_callback(mux_home):
         assert tg._is_user_authorized_from_message(msg(4343, False)) is False
 
 
+def test_slack_interactive_auth_prefers_wired_profile_check(mux_home, monkeypatch):
+    """#72657: a multiplexed Slack adapter's button gate resolves through the
+    wired ``_make_adapter_auth_check`` for its own profile; the DEFAULT
+    profile's process-env allow-all never leaks in — not through the
+    injected path, and not through the env-only fallback either."""
+    from gateway.run import _profile_runtime_scope
+    from plugins.platforms.slack.adapter import SlackAdapter
+
+    runner = _runner(mux_home)
+    runner.adapters = {}
+    sec_home = mux_home / "profiles" / "secondary"
+    (sec_home / ".env").write_text("SLACK_ALLOWED_USERS=U_SEC\n")
+    monkeypatch.setenv("SLACK_ALLOW_ALL_USERS", "true")
+
+    def slack(with_check):
+        sl = object.__new__(SlackAdapter)
+        sl.config = PlatformConfig(enabled=True, extra={})
+        sl._authorization_check = None
+        sl._message_handler = runner._make_profile_message_handler("secondary")
+        if with_check:
+            runner._profile_adapters = {"secondary": {Platform.SLACK: sl}}
+            sl.set_authorization_check(
+                runner._make_adapter_auth_check(Platform.SLACK, profile_name="secondary")
+            )
+        return sl
+
+    with _profile_runtime_scope(sec_home):
+        wired = slack(True)
+        assert wired._is_interactive_user_authorized("U_SEC", channel_id="C1") is True
+        assert wired._is_interactive_user_authorized("U_X", channel_id="C1") is False
+        assert slack(False)._is_interactive_user_authorized("U_X", channel_id="C1") is False
+
+
 def test_authorization_adapter_ignores_per_turn_active_profile(mux_home):
     """#87240 egress half: inside a secondary profile's runtime scope the
     default bot must not be handed to that profile (fail-closed None); the

--- a/tests/gateway/test_telegram_callback_auth_fail_closed.py
+++ b/tests/gateway/test_telegram_callback_auth_fail_closed.py
@@ -87,3 +87,46 @@ class TestCallbackAuthFailClosed:
         assert adapter._is_callback_user_authorized("12345") is True
 
 
+class TestCallbackAuthPrefersInjectedCheck:
+    """_is_callback_user_authorized must use the auth callback GatewayRunner
+    injects via set_authorization_check before the _message_handler.__self__
+    introspection.
+
+    A secondary multiplexed adapter's _message_handler is a profile closure
+    (no __self__), so the introspection path resolves to nothing and the old
+    code fell through to the env-only fallback — which knows nothing about
+    profile config allowlists or the pairing store. The injected callback is
+    registered for every gateway-connected adapter, including multiplexed
+    secondaries, and delegates to the full _is_user_authorized chain.
+    """
+
+    def test_injected_check_used_when_handler_is_a_closure(self, monkeypatch):
+        """Multiplexed shape: closure handler (no __self__) + injected check
+        registered → the injected check decides, not the env fallback."""
+        monkeypatch.delenv("TELEGRAM_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        adapter = _make_adapter()
+        adapter._message_handler = lambda *a, **kw: None  # no __self__
+        seen = {}
+
+        def _check(user_id, chat_type=None, chat_id=None):
+            seen.update(user_id=user_id, chat_type=chat_type, chat_id=chat_id)
+            return user_id == "999"
+
+        adapter._authorization_check = _check
+
+        # Env fallback would deny (empty allowlist); the injected check allows.
+        assert adapter._is_callback_user_authorized(
+            "999", chat_id="777", chat_type="supergroup"
+        ) is True
+        assert seen == {"user_id": "999", "chat_type": "group", "chat_id": "777"}
+
+    def test_injected_check_deny_wins_over_env_allowlist(self, monkeypatch):
+        """The injected check is authoritative when registered — an env
+        allowlist entry must not override its deny."""
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "12345")
+        adapter = _make_adapter()
+        adapter._message_handler = lambda *a, **kw: None
+        adapter._authorization_check = lambda user_id, chat_type=None, chat_id=None: False
+
+        assert adapter._is_callback_user_authorized("12345") is False


### PR DESCRIPTION
## Summary
Under `gateway.multiplex_profiles` the primary adapter's handler is a closure, so Telegram/Slack interactive-button and early-intake gates couldn't reach the runner via `_message_handler.__self__` and fell to env-only auth; the injected `_authorization_check` callback existed but built a source that was never route-stamped and lacked `is_bot`. Callback callers paired only in the routed profile were denied (#86296), bot senders bypassed `TELEGRAM_ALLOW_BOTS` (#92840), and Slack's fallback read the default profile's `SLACK_ALLOW_ALL_USERS` from `os.environ`.
## Changes
- Telegram `_is_callback_user_authorized` prefers the injected check (#65589, cherry-pick).
- `_make_adapter_auth_check`: primary-under-multiplex stamps the profile route and authorizes under the transport home via `_is_user_authorized_for_source`; accepts `is_bot`/`thread_id`; `_is_sender_authorized` forwards them keyword-only.
- Telegram prefilter carries `from_user.is_bot`; `_should_pass_unauthorized_dm_for_pairing` falls back to `gateway_runner`.
- `_authorization_adapter` compares against launch-time `_primary_profile_name`; `channel_directory` paths resolve lazily.
- Slack interactive + pre-fetch gates prefer the injected check; env fallback via `_platform_gate_env`.
## Validation
| Probe | origin/main | branch |
|---|---|---|
| Routed-group callback, paired only in routed profile | denied | allowed |
| Transport-home allowlist in routed group | denied | allowed |
| Bot sender w/ TELEGRAM_ALLOW_BOTS=all at early gate | blocked | admitted |
| `_authorization_adapter` in secondary turn scope | default bot | None (fail-closed) |
| channel_directory path under secondary scope | root home | secondary home |
| Slack stranger vs default env SLACK_ALLOW_ALL_USERS | allowed | denied |
New regression tests: 5 (fail on main, pass here); 808 tests across 27 affected files green.
## Credits
@elphamale (#65589, first submitter), @PRATHAMESH75 (#86308), @Ahmett101 (#92844), @cherryb16 (#87240 egress/channel_directory), @MilaArtyNew (#72657); issue reporters @QuarkAssistant (#86296), @manuel-claw (#92840).

Fixes #86296
Fixes #92840

## Infographic

![mux-telegram-auth](https://v3b.fal.media/files/b/0aa8cdd9/5UvokIvskokmJw2g5Scuj_WZ7wqcqd.png)
