### PR TITLE
fix(feishu): multiplexed profiles keep their own WS loop and admission gates; cloned app credentials refused (#73779 #76793 #86905, salvage #76800 #86908 #84165)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17680,6 +17680,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # of a bot token. Including its secret keeps multiplexed profiles
             # from spawning competing sidecars for the same account and port.
             "_project_secret",
+            # Feishu/Lark authenticates with an app_id/app_secret pair rather
+            # than a single token (one active WebSocket connection per app).
+            # app_id is stable, log-safe, and already used as the adapter's
+            # _app_lock_identity, so including it lets the multiplex guard
+            # refuse cloned profiles competing for the same Feishu app.
+            "_app_id",
         ):
             val = getattr(adapter, attr, None)
             if isinstance(val, str) and val.strip():

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17686,6 +17686,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # _app_lock_identity, so including it lets the multiplex guard
             # refuse cloned profiles competing for the same Feishu app.
             "_app_id",
+            # Same class: Teams (client_id/client_secret) and WeCom
+            # (bot_id/secret) authenticate with an app-style id pair too.
+            "_client_id",
+            "_bot_id",
         ):
             val = getattr(adapter, attr, None)
             if isinstance(val, str) and val.strip():

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1325,16 +1325,96 @@ def _strip_edge_self_mentions(
             return remaining
 
 
+# ---------------------------------------------------------------------------
+# Multiplex isolation for the lark_oapi WebSocket client (#73779)
+# ---------------------------------------------------------------------------
+#
+# ``lark_oapi.ws.client`` keeps the asyncio loop used by ``Client.start()``
+# and every coroutine it spawns in a *module-level global* (``loop``), and
+# Hermes also monkey-patches ``websockets.connect`` on the shared
+# ``websockets`` module to inject per-adapter ping settings. In multiplex
+# mode every profile runs its own WS client on a dedicated thread, so the N
+# threads overwrite each other's module globals (last-write-wins): a client
+# ends up scheduling tasks on a sibling profile's loop ("Future attached to
+# a different loop" crashes) or binds to the wrong loop at construction time
+# and goes deaf from the start.
+#
+# The fix installs process-wide, thread-dispatching shims exactly once:
+#
+#   * ``ws_client_module.loop`` becomes a proxy that forwards every attribute
+#     access to the loop registered by the *current thread*. All SDK reads of
+#     the global happen on the thread that owns the loop (``start()`` blocks
+#     in ``run_until_complete`` and every ``create_task`` callback runs on
+#     the loop's own thread), so each profile transparently sees its own
+#     loop. Threads that never registered one (single-profile installs, CLI)
+#     fall back to the SDK's original module loop.
+#   * ``websockets.connect`` becomes a single dispatcher that merges the
+#     per-thread ping overrides registered by the calling profile, so
+#     profiles no longer race over the global patch or restore each other's
+#     hooks while a sibling is still connected.
+
+_WS_ISOLATION_LOCK = threading.Lock()
+_WS_ISOLATION_INSTALLED = False
+# Per-WS-thread registration: ``.loop`` (the thread's asyncio loop) and
+# ``.connect_kwargs`` (websockets.connect overrides, e.g. ping settings).
+_ws_isolation_state = threading.local()
+
+
+class _ThreadLocalLoopProxy:
+    """Forwards attribute access to the current thread's registered loop."""
+
+    def __init__(self, fallback: Any) -> None:
+        self._fallback = fallback
+
+    def _target(self) -> Any:
+        return getattr(_ws_isolation_state, "loop", None) or self._fallback
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._target(), name)
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"<ThreadLocalLoopProxy target={self._target()!r}>"
+
+
+def _install_lark_ws_isolation(ws_client_module: Any) -> None:
+    """Install the thread-dispatching shims once per process (idempotent)."""
+    global _WS_ISOLATION_INSTALLED
+    with _WS_ISOLATION_LOCK:
+        if _WS_ISOLATION_INSTALLED:
+            return
+
+        ws_client_module.loop = _ThreadLocalLoopProxy(ws_client_module.loop)
+
+        real_connect = ws_client_module.websockets.connect
+
+        def _dispatch_connect(*args: Any, **kwargs: Any) -> Any:
+            overrides = getattr(_ws_isolation_state, "connect_kwargs", None) or {}
+            for key, value in overrides.items():
+                kwargs.setdefault(key, value)
+            return real_connect(*args, **kwargs)
+
+        # Keep ``inspect.signature(websockets.connect)`` honest: the SDK's
+        # ``_ws_connect_kwargs()`` probes the real signature to decide whether
+        # the installed websockets generation supports the ``proxy`` kwarg.
+        _dispatch_connect.__wrapped__ = real_connect
+        _dispatch_connect.__name__ = getattr(real_connect, "__name__", "connect")
+        ws_client_module.websockets.connect = _dispatch_connect
+        _WS_ISOLATION_INSTALLED = True
+
+
 def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
-    """Run the official Lark WS client in its own thread-local event loop."""
+    """Run the official Lark WS client in its own thread-local event loop.
+
+    In multiplex mode several profiles run this concurrently; the shims
+    installed by ``_install_lark_ws_isolation`` make each thread see its own
+    loop and connect overrides (see the isolation comment block above).
+    """
     import lark_oapi.ws.client as ws_client_module
 
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
-    ws_client_module.loop = loop
     adapter._ws_thread_loop = loop
 
-    original_connect = ws_client_module.websockets.connect
     original_configure = getattr(ws_client, "_configure", None)
 
     def _apply_runtime_ws_overrides() -> None:
@@ -1346,12 +1426,15 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
         except Exception:
             logger.debug("[Feishu] Failed to apply websocket runtime overrides", exc_info=True)
 
-    def _connect_with_overrides(*args: Any, **kwargs: Any) -> Any:
-        if adapter._ws_ping_interval is not None and "ping_interval" not in kwargs:
-            kwargs["ping_interval"] = adapter._ws_ping_interval
-        if adapter._ws_ping_timeout is not None and "ping_timeout" not in kwargs:
-            kwargs["ping_timeout"] = adapter._ws_ping_timeout
-        return original_connect(*args, **kwargs)
+    connect_overrides: Dict[str, Any] = {}
+    if adapter._ws_ping_interval is not None:
+        connect_overrides["ping_interval"] = adapter._ws_ping_interval
+    if adapter._ws_ping_timeout is not None:
+        connect_overrides["ping_timeout"] = adapter._ws_ping_timeout
+
+    _install_lark_ws_isolation(ws_client_module)
+    _ws_isolation_state.loop = loop
+    _ws_isolation_state.connect_kwargs = connect_overrides
 
     def _configure_with_overrides(conf: Any) -> Any:
         if original_configure is None:
@@ -1360,7 +1443,6 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
         _apply_runtime_ws_overrides()
         return result
 
-    ws_client_module.websockets.connect = _connect_with_overrides
     if original_configure is not None:
         setattr(ws_client, "_configure", _configure_with_overrides)
     _apply_runtime_ws_overrides()
@@ -1369,7 +1451,8 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     except Exception:
         pass
     finally:
-        ws_client_module.websockets.connect = original_connect
+        _ws_isolation_state.loop = None
+        _ws_isolation_state.connect_kwargs = None
         if original_configure is not None:
             setattr(ws_client, "_configure", original_configure)
         pending = [t for t in asyncio.all_tasks(loop) if not t.done()]
@@ -1520,6 +1603,8 @@ class FeishuAdapter(BasePlatformAdapter):
         self._sdk_executor_closing = False
         self._ws_client: Optional[Any] = None
         self._ws_future: Optional[asyncio.Future] = None
+        self._ws_supervisor: Optional[asyncio.Task] = None
+        self._ws_restart_backoff = 5.0
         self._ws_thread_loop: Optional[asyncio.AbstractEventLoop] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._webhook_runner: Optional[Any] = None
@@ -1826,6 +1911,13 @@ class FeishuAdapter(BasePlatformAdapter):
 
             self._loop = asyncio.get_running_loop()
             await self._connect_with_retry()
+            if self._connection_mode == "websocket":
+                # Supervised reconnect (#73779): the WS thread can die without
+                # any external signal; keep a watcher alive for as long as this
+                # adapter is supposed to be connected.
+                self._ws_supervisor = asyncio.ensure_future(
+                    self._supervise_websocket_thread()
+                )
             self._mark_connected()
             logger.info("[Feishu] Connected in %s mode (%s)", self._connection_mode, self._domain_name)
             # Plugin-registered native handlers (lark_oapi client).
@@ -1841,6 +1933,9 @@ class FeishuAdapter(BasePlatformAdapter):
     async def disconnect(self) -> None:
         """Disconnect from Feishu/Lark."""
         self._running = False
+        if self._ws_supervisor is not None:
+            self._ws_supervisor.cancel()
+            self._ws_supervisor = None
         await self._cancel_pending_tasks(self._pending_text_batch_tasks)
         await self._cancel_pending_tasks(self._pending_media_batch_tasks)
         self._reset_batch_buffers()
@@ -4958,6 +5053,52 @@ class FeishuAdapter(BasePlatformAdapter):
                     exc,
                 )
                 await asyncio.sleep(wait_seconds)
+
+    async def _supervise_websocket_thread(self) -> None:
+        """Restart the WS client thread if it dies while the adapter is up.
+
+        ``lark_oapi``'s ``start()`` blocks forever on a healthy connection
+        and only returns on fatal errors. Before this watcher existed the
+        executor future was awaited solely by ``disconnect()``, so a dead
+        thread left the profile silently deaf until a gateway restart
+        (#73779). Watch the future and, on unexpected exit, rebuild the
+        client with capped exponential backoff.
+        """
+        backoff = initial_backoff = float(self._ws_restart_backoff)
+        last_dead: Optional[asyncio.Future] = None
+        while self._running:
+            ws_future = self._ws_future
+            if ws_future is None:
+                return
+            try:
+                await asyncio.shield(ws_future)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                pass
+            # Deliberate disconnect paths nil ``_ws_client`` / ``_running``
+            # before the thread exits; only restart when the link is still
+            # expected to be up.
+            if not self._running or self._ws_client is None:
+                return
+            if ws_future is not last_dead:
+                logger.error(
+                    "[Feishu] WebSocket client thread exited unexpectedly; "
+                    "restarting in %.0fs",
+                    backoff,
+                )
+                last_dead = ws_future
+            await asyncio.sleep(backoff)
+            if not self._running:
+                return
+            try:
+                await self._connect_websocket()
+                backoff = initial_backoff
+            except Exception as exc:
+                logger.warning(
+                    "[Feishu] WebSocket restart failed (retrying): %s", exc
+                )
+                backoff = min(backoff * 2, 60.0)
 
     async def _connect_websocket(self) -> None:
         if not FEISHU_WEBSOCKET_AVAILABLE:

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -436,6 +436,9 @@ class FeishuAdapterSettings:
     group_rules: Dict[str, FeishuGroupRule] = field(default_factory=dict)
     allow_bots: str = "none"  # "none" | "mentions" | "all"
     require_mention: bool = True
+    # DM allow-all (FEISHU_ALLOW_ALL_USERS / GATEWAY_ALLOW_ALL_USERS), resolved
+    # per-profile so multiplexed secondary adapters honor their own .env.
+    allow_all_dm: bool = False
 
 
 @dataclass
@@ -1591,7 +1594,9 @@ class FeishuAdapter(BasePlatformAdapter):
 
         # Env-only so adapter and gateway auth bypass share one source; yaml
         # feishu.allow_bots is bridged to this env var at config load.
-        allow_bots = os.getenv("FEISHU_ALLOW_BOTS", "none").strip().lower()
+        # Scope-aware read: under multiplex a secondary profile's .env must
+        # govern its own adapter (same pattern as app_secret below) — #86905.
+        allow_bots = _get_scoped_secret("FEISHU_ALLOW_BOTS", "none").strip().lower()
         if allow_bots not in {"none", "mentions", "all"}:
             logger.warning(
                 "[Feishu] Unknown allow_bots=%r, falling back to 'none'. Valid: none, mentions, all.",
@@ -1599,8 +1604,13 @@ class FeishuAdapter(BasePlatformAdapter):
             )
             allow_bots = "none"
 
+        allow_all_dm = any(
+            _get_scoped_secret(var, "").strip().lower() in {"true", "1", "yes"}
+            for var in ("FEISHU_ALLOW_ALL_USERS", "GATEWAY_ALLOW_ALL_USERS")
+        )
+
         return FeishuAdapterSettings(
-            app_id=str(extra.get("app_id") or os.getenv("FEISHU_APP_ID", "")).strip(),
+            app_id=str(extra.get("app_id") or _get_scoped_secret("FEISHU_APP_ID", "")).strip(),
             app_secret=str(extra.get("app_secret") or _get_scoped_secret("FEISHU_APP_SECRET", "")).strip(),
             domain_name=str(extra.get("domain") or os.getenv("FEISHU_DOMAIN", "feishu")).strip().lower(),
             connection_mode=str(
@@ -1610,15 +1620,15 @@ class FeishuAdapter(BasePlatformAdapter):
             verification_token=str(
                 extra.get("verification_token") or _get_scoped_secret("FEISHU_VERIFICATION_TOKEN", "")
             ).strip(),
-            group_policy=os.getenv("FEISHU_GROUP_POLICY", "allowlist").strip().lower(),
+            group_policy=_get_scoped_secret("FEISHU_GROUP_POLICY", "allowlist").strip().lower(),
             allowed_group_users=frozenset(
                 item.strip()
-                for item in os.getenv("FEISHU_ALLOWED_USERS", "").split(",")
+                for item in _get_scoped_secret("FEISHU_ALLOWED_USERS", "").split(",")
                 if item.strip()
             ),
-            bot_open_id=os.getenv("FEISHU_BOT_OPEN_ID", "").strip(),
-            bot_user_id=os.getenv("FEISHU_BOT_USER_ID", "").strip(),
-            bot_name=os.getenv("FEISHU_BOT_NAME", "").strip(),
+            bot_open_id=_get_scoped_secret("FEISHU_BOT_OPEN_ID", "").strip(),
+            bot_user_id=_get_scoped_secret("FEISHU_BOT_USER_ID", "").strip(),
+            bot_name=_get_scoped_secret("FEISHU_BOT_NAME", "").strip(),
             dedup_cache_size=max(
                 32,
                 env_int("HERMES_FEISHU_DEDUP_CACHE_SIZE", _DEFAULT_DEDUP_CACHE_SIZE),
@@ -1658,8 +1668,9 @@ class FeishuAdapter(BasePlatformAdapter):
             default_group_policy=default_group_policy,
             group_rules=group_rules,
             allow_bots=allow_bots,
+            allow_all_dm=allow_all_dm,
             require_mention=_to_boolean(
-                extra.get("require_mention", os.getenv("FEISHU_REQUIRE_MENTION", "true"))
+                extra.get("require_mention", _get_scoped_secret("FEISHU_REQUIRE_MENTION", "true"))
             ),
         )
 
@@ -1692,6 +1703,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._ws_ping_interval = settings.ws_ping_interval
         self._ws_ping_timeout = settings.ws_ping_timeout
         self._allow_bots = settings.allow_bots
+        self._allow_all_dm = settings.allow_all_dm
         self._require_mention = settings.require_mention
 
     def _build_event_handler(self) -> Any:
@@ -4390,9 +4402,10 @@ class FeishuAdapter(BasePlatformAdapter):
                 return "bot_not_mentioned"
 
         if not is_group:
-            if os.getenv("FEISHU_ALLOW_ALL_USERS", "").strip().lower() in {"true", "1", "yes"}:
-                return None
-            if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").strip().lower() in {"true", "1", "yes"}:
+            # Snapshotted per-profile in _load_settings: _admit runs on the
+            # lark_oapi WS thread with no secret scope, and a bare os.getenv
+            # here would read the default profile's value (#86905).
+            if self._allow_all_dm:
                 return None
             # Empty FEISHU_ALLOWED_USERS is the pairing-mode default from setup:
             # forward DMs to gateway intake so the pairing handshake can run.

--- a/tests/gateway/feishu_helpers.py
+++ b/tests/gateway/feishu_helpers.py
@@ -34,6 +34,7 @@ def make_adapter_skeleton(
     allow_bots: str = "none",
     require_mention: bool = True,
     group_policy: str = "allowlist",
+    allow_all_dm: bool = False,
 ) -> Any:
     from plugins.platforms.feishu.adapter import FeishuAdapter
 
@@ -48,6 +49,7 @@ def make_adapter_skeleton(
     adapter._default_group_policy = group_policy
     adapter._allowed_group_users = frozenset()
     adapter._allow_bots = allow_bots
+    adapter._allow_all_dm = allow_all_dm
     adapter._require_mention = require_mention
     return adapter
 

--- a/tests/gateway/test_feishu_bot_admission.py
+++ b/tests/gateway/test_feishu_bot_admission.py
@@ -566,3 +566,77 @@ def test_handle_message_event_data_forwards_sender_when_admitted():
     assert captured.get("sender_id") is sender.sender_id
     assert captured.get("is_bot") is True
     assert captured.get("message_id") == "om_bot_ok"
+
+
+# --- Profile-scoped admission config (#86905) -------------------------------
+
+
+def test_dm_admission_config_resolves_from_profile_scope_under_multiplex(tmp_path, monkeypatch):
+    """os.environ holds the DEFAULT profile's admission view; a secondary
+    profile's .env must govern its own adapter — Feishu open_ids are
+    app-scoped, so the default allow-list can never match the role app's
+    senders, and the role profile's allow-all flag must be honored."""
+    import agent.secret_scope as ss
+    from plugins.platforms.feishu.adapter import FeishuAdapter
+
+    monkeypatch.setenv("FEISHU_APP_ID", "cli_default")
+    monkeypatch.setenv("FEISHU_APP_SECRET", "secret_default")
+    monkeypatch.setenv("FEISHU_ALLOWED_USERS", "ou_default_view")
+    monkeypatch.setenv("FEISHU_ALLOW_BOTS", "all")
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("FEISHU_ALLOW_ALL_USERS", raising=False)
+    (tmp_path / ".env").write_text(
+        "FEISHU_APP_ID=cli_role\nFEISHU_APP_SECRET=secret_role\n"
+        "FEISHU_ALLOWED_USERS=ou_role_view\n",
+        encoding="utf-8",
+    )
+
+    ss.set_multiplex_active(True)
+    tok = ss.set_secret_scope(ss.build_profile_secret_scope(tmp_path))
+    try:
+        settings = FeishuAdapter._load_settings(extra={})
+    finally:
+        ss.reset_secret_scope(tok)
+    (tmp_path / ".env").write_text(
+        "FEISHU_APP_ID=cli_role\nFEISHU_APP_SECRET=secret_role\nGATEWAY_ALLOW_ALL_USERS=true\n",
+        encoding="utf-8",
+    )
+    tok = ss.set_secret_scope(ss.build_profile_secret_scope(tmp_path))
+    try:
+        allow_all = FeishuAdapter._load_settings(extra={})
+    finally:
+        ss.reset_secret_scope(tok)
+        ss.set_multiplex_active(False)
+
+    assert settings.app_id == "cli_role"
+    assert settings.allowed_group_users == frozenset({"ou_role_view"})
+    assert settings.allow_bots == "none"  # default's "all" must not leak in
+    assert settings.allow_all_dm is False
+
+    # _admit runs on the WS thread with no scope: the snapshot must carry.
+    adapter = object.__new__(FeishuAdapter)
+    adapter._apply_settings(settings)
+    assert adapter._admit(make_sender(open_id="ou_role_view"), make_message(chat_type="p2p")) is None
+    assert adapter._admit(make_sender(open_id="ou_default_view"), make_message(chat_type="p2p")) == "dm_policy_rejected"
+
+    assert allow_all.allow_all_dm is True
+    adapter = object.__new__(FeishuAdapter)
+    adapter._apply_settings(allow_all)
+    assert adapter._admit(make_sender(open_id="ou_anyone"), make_message(chat_type="p2p")) is None
+
+
+def test_dm_admission_config_falls_back_to_os_environ_when_unscoped(monkeypatch):
+    """Single-profile behavior unchanged: process env still configures DMs."""
+    from plugins.platforms.feishu.adapter import FeishuAdapter
+
+    monkeypatch.setenv("FEISHU_APP_ID", "cli_test")
+    monkeypatch.setenv("FEISHU_APP_SECRET", "secret_test")
+    monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+    monkeypatch.setenv("FEISHU_ALLOWED_USERS", "ou_a,ou_b")
+
+    settings = FeishuAdapter._load_settings(extra={})
+    assert settings.allow_all_dm is True
+    assert settings.allowed_group_users == frozenset({"ou_a", "ou_b"})
+    adapter = object.__new__(FeishuAdapter)
+    adapter._apply_settings(settings)
+    assert adapter._admit(make_sender(open_id="ou_anyone"), make_message(chat_type="p2p")) is None

--- a/tests/gateway/test_feishu_ws_multiplex_isolation.py
+++ b/tests/gateway/test_feishu_ws_multiplex_isolation.py
@@ -1,0 +1,167 @@
+"""Multiplex isolation for the lark_oapi WS client (issue #73779).
+
+``lark_oapi.ws.client`` keeps the loop used by ``Client.start()`` in a
+module-level global and Hermes monkey-patches ``websockets.connect`` on the
+shared module. With N profile WS threads the globals were last-write-wins:
+"Future attached to a different loop" crashes or a client bound to a
+sibling's loop that never hears anything again.
+"""
+
+import asyncio
+import sys
+import threading
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from plugins.platforms.feishu import adapter as feishu_adapter
+
+
+def _inject_fake_lark_module(monkeypatch, connect=None):
+    """Make ``import lark_oapi.ws.client`` resolve to a module with the SDK's
+    global layout (``loop`` + ``websockets.connect``)."""
+    if connect is None:
+        connect = MagicMock(name="real-connect")
+    lark = types.ModuleType("lark_oapi")
+    lark_ws = types.ModuleType("lark_oapi.ws")
+    client_mod = types.ModuleType("lark_oapi.ws.client")
+    client_mod.loop = SimpleNamespace(name="sdk-default-loop")
+    client_mod.websockets = SimpleNamespace(connect=connect)
+    lark.ws = lark_ws
+    lark_ws.client = client_mod
+    monkeypatch.setitem(sys.modules, "lark_oapi", lark)
+    monkeypatch.setitem(sys.modules, "lark_oapi.ws", lark_ws)
+    monkeypatch.setitem(sys.modules, "lark_oapi.ws.client", client_mod)
+    monkeypatch.setattr(feishu_adapter, "_WS_ISOLATION_INSTALLED", False)
+    return client_mod
+
+
+def _adapter_stub(**overrides):
+    stub = SimpleNamespace(
+        _ws_thread_loop=None,
+        _ws_reconnect_nonce=None,
+        _ws_reconnect_interval=None,
+        _ws_ping_interval=None,
+        _ws_ping_timeout=None,
+    )
+    for key, value in overrides.items():
+        setattr(stub, key, value)
+    return stub
+
+
+def test_two_concurrent_clients_each_use_their_own_loop_and_overrides(monkeypatch):
+    """Two profiles start() concurrently through the module global: each must
+    run on its own loop, and websockets.connect must receive only the
+    calling profile's ping overrides. On main both are last-write-wins."""
+    real_connect = MagicMock(name="real-connect")
+    client_mod = _inject_fake_lark_module(monkeypatch, connect=real_connect)
+
+    results = {}
+    barrier = threading.Barrier(2)
+
+    class FakeClient:
+        def __init__(self, name):
+            self._name = name
+
+        def start(self):
+            barrier.wait(timeout=10)  # both threads past the global "assign"
+
+            async def probe():
+                await asyncio.sleep(0.02)
+                return id(asyncio.get_running_loop())
+
+            results[self._name] = client_mod.loop.run_until_complete(probe())
+            client_mod.websockets.connect(f"wss://{self._name}")
+
+    pings = {"p0": 10, "p1": 20}
+
+    def run(name):
+        feishu_adapter._run_official_feishu_ws_client(
+            FakeClient(name), _adapter_stub(_ws_ping_interval=pings[name])
+        )
+
+    threads = [threading.Thread(target=run, args=(f"p{i}",)) for i in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=15)
+        assert not t.is_alive()
+
+    assert results["p0"] != results["p1"]
+    calls = {c.args[0]: c.kwargs for c in real_connect.call_args_list}
+    assert calls == {"wss://p0": {"ping_interval": 10}, "wss://p1": {"ping_interval": 20}}
+    # Thread-local registrations are cleared for the pooled executor thread.
+    assert getattr(feishu_adapter._ws_isolation_state, "loop", None) is None
+    assert getattr(feishu_adapter._ws_isolation_state, "connect_kwargs", None) is None
+
+
+def _supervisor_stub():
+    stub = SimpleNamespace(
+        _running=True,
+        _ws_future=None,
+        _ws_client=object(),
+        _ws_restart_backoff=0.01,
+        connect_calls=0,
+        connect_should_fail=0,
+    )
+
+    async def _connect_websocket():
+        stub.connect_calls += 1
+        if stub.connect_should_fail > 0:
+            stub.connect_should_fail -= 1
+            raise RuntimeError("simulated restart failure")
+        fut = asyncio.get_running_loop().create_future()
+        fut.set_result(None)  # new thread dies immediately too
+        stub._ws_future = fut
+
+    stub._connect_websocket = _connect_websocket
+    return stub
+
+
+def test_supervisor_restarts_a_dead_ws_thread_with_backoff():
+    """A dead WS thread used to leave the profile silently deaf (the future
+    was awaited only by disconnect()). The supervisor must rebuild the client
+    and survive a failed restart without hot-looping."""
+
+    async def scenario():
+        stub = _supervisor_stub()
+        stub.connect_should_fail = 1
+        fut = asyncio.get_running_loop().create_future()
+        fut.set_result(None)  # the WS "thread" is already dead
+        stub._ws_future = fut
+
+        task = asyncio.ensure_future(
+            feishu_adapter.FeishuAdapter._supervise_websocket_thread(stub)
+        )
+        for _ in range(300):
+            await asyncio.sleep(0.01)
+            if stub.connect_calls >= 2:
+                break
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        return stub.connect_calls
+
+    assert asyncio.run(scenario()) == 2  # failed restart, then a successful one
+
+
+def test_supervisor_stops_when_disconnect_nils_the_client():
+    async def scenario():
+        stub = _supervisor_stub()
+        fut = asyncio.get_running_loop().create_future()  # thread "alive"
+        stub._ws_future = fut
+
+        task = asyncio.ensure_future(
+            feishu_adapter.FeishuAdapter._supervise_websocket_thread(stub)
+        )
+        await asyncio.sleep(0.01)
+        stub._ws_client = None  # deliberate disconnect ...
+        fut.set_result(None)  # ... then the thread exits
+        await asyncio.wait_for(asyncio.shield(task), timeout=2.0)
+        return stub, task
+
+    stub, task = asyncio.run(scenario())
+    assert task.done()
+    assert stub.connect_calls == 0

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -39,6 +39,38 @@ class TestCredentialFingerprint:
         assert fp1 is not None
         assert "shared-project-secret" not in fp1
 
+    def test_reads_feishu_app_id(self):
+        """Feishu/Lark authenticates via app_id/app_secret, not a token.
+
+        Without _app_id in the fingerprint attribute list, every Feishu
+        adapter in a multiplexed gateway returns None here and the
+        same-credential conflict check is silently skipped — N profiles
+        spawn WebSocket clients against the same app, which evict each
+        other in a 1000 bye loop until all go offline.
+        """
+        class _FeishuAdapter:
+            def __init__(self):
+                self._app_id = "cli_a1b2c3"
+                self._app_secret = "top-secret"
+
+        fp1 = GatewayRunner._adapter_credential_fingerprint(_FeishuAdapter())
+        fp2 = GatewayRunner._adapter_credential_fingerprint(_FeishuAdapter())
+
+        assert fp1 is not None
+        assert fp1 == fp2  # same app -> same fingerprint -> conflict detected
+        assert "cli_a1b2c3" not in fp1  # log-safe, never the raw credential
+
+    def test_distinct_feishu_app_ids_distinct_fp(self):
+        class _FeishuAdapter:
+            def __init__(self, app_id):
+                self._app_id = app_id
+                self._app_secret = "s"
+
+        fp_a = GatewayRunner._adapter_credential_fingerprint(_FeishuAdapter("app-A"))
+        fp_b = GatewayRunner._adapter_credential_fingerprint(_FeishuAdapter("app-B"))
+
+        assert fp_a is not None and fp_b is not None
+        assert fp_a != fp_b
 
     def test_reads_config_token(self):
         """Adapters like Discord store token on `config`, not on self.

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -1,6 +1,7 @@
 """Phase 3: secondary-profile adapter registry + same-token conflict detection."""
 import logging
 import asyncio
+import types
 from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
@@ -71,6 +72,18 @@ class TestCredentialFingerprint:
 
         assert fp_a is not None and fp_b is not None
         assert fp_a != fp_b
+
+    @pytest.mark.parametrize("attr", ["_client_id", "_bot_id"])
+    def test_reads_app_style_ids_teams_wecom(self, attr):
+        """Teams (_client_id) and WeCom (_bot_id) are the same class as Feishu:
+        id/secret pairs, no token — cloned profiles must collide."""
+        a = types.SimpleNamespace(**{attr: "app-1"})
+        b = types.SimpleNamespace(**{attr: "app-1"})
+        c = types.SimpleNamespace(**{attr: "app-2"})
+        fp = GatewayRunner._adapter_credential_fingerprint
+        assert fp(a) is not None and fp(a) == fp(b)
+        assert fp(a) != fp(c)
+        assert "app-1" not in fp(a)
 
     def test_reads_config_token(self):
         """Adapters like Discord store token on `config`, not on self.


### PR DESCRIPTION
## Summary
Under `multiplex_profiles`, Feishu bots went deaf or rejected every DM: lark_oapi's module-global event loop was last-writer-wins across profile WS threads, the adapter's admission gates read the default profile's `os.environ`, and the credential guard could not fingerprint app_id-style credentials so cloned profiles started competing clients against one app (Teams/WeCom shared the same gap).
## Changes
- `gateway/run.py`: fingerprint `_app_id`, `_client_id`, `_bot_id` in `_adapter_credential_fingerprint` (Feishu/qqbot, Teams, WeCom).
- `plugins/platforms/feishu/adapter.py`: admission/identity reads via `_get_scoped_secret`; `allow_all_dm` snapshot consumed by `_admit`; thread-local loop proxy + connect dispatcher for lark_oapi globals; per-adapter WS thread supervisor with capped backoff.
- Tests: 3 fingerprint, 2 admission, 3 WS isolation/supervision.
## Validation
| Probe (real adapters, real `_profile_runtime_scope`, real lark_oapi 1.7.3) | main | branch |
|---|---|---|
| Two cloned profiles, same app creds (feishu/teams/wecom) | claim=None, not refused | same fingerprint, refused |
| Secondary profile DM admission (own ALLOWED_USERS / allow-all) | `dm_policy_rejected`, default's allowlist leaked | admitted per own .env |
| Two concurrent WS threads via module-global loop | one profile deaf (start() raised) | both on own loop |
Targeted pytest: 104 passed; sabotage-verified all three regression tests; ruff clean.
## Credits
@webtecnica (#76800, cherry-picked), @JonthanaHanh (#76803, same fix), @pittosporum-seu (#86908, #84165, authored commits), @zmlgit (first loop-isolation proposal #64247/#69904, co-author), @bchsjdss (#76793 diagnosis), @thelonewander3r (#78889/#78514 analysis), @zhe97396-tech (#78514, #91310 reports).

Fixes #76793
Fixes #78514
Fixes #86905
Fixes #73779
Fixes #91310

## Infographic

![mux-feishu](https://v3b.fal.media/files/b/0aa8cdb7/Ch1TnZOUWpbpGaYzjOZz5_EZnnDRya.png)
