### PR TITLE
fix(platforms): IRC/ntfy/Photon/WeCom/Mattermost/SimpleX/Matrix/Teams settings resolve per multiplexed profile (#89168, salvage nftpoetrist series #89169 #80825 #69042)

### DIFF
--- a/contributors/emails/joel.taylor@ccmschools.edu.au
+++ b/contributors/emails/joel.taylor@ccmschools.edu.au
@@ -1,0 +1,1 @@
+JoelMTaylor

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -444,6 +444,7 @@ PORT_BINDING_PLATFORM_VALUES = frozenset({
     "sms",
     "whatsapp_cloud",
     "line",
+    "teams",
 })
 
 # Platforms whose port-binding status depends on connection mode. Feishu in

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17043,12 +17043,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     platform.value,
                 )
                 continue
-            # Relay is shared process-level ingress in multiplex mode. The
-            # active profile owns the one connection; connector-stamped
-            # source.profile routes inbound turns to secondary profiles.
+            # Relay and WhatsApp are shared process-level ingress in multiplex
+            # mode: one connection owned by the active profile, with
+            # route-stamped source.profile fanning inbound turns out to
+            # secondary profiles. The WhatsApp bridge is a single authenticated
+            # session tied to one phone number -- a secondary profile has no
+            # credential of its own to bring, so constructing an adapter for it
+            # only yields a connect/retry loop that stalls startup for every
+            # profile queued behind it.
             if (
                 getattr(self.config, "multiplex_profiles", False)
-                and platform is Platform.RELAY
+                and platform in (Platform.RELAY, Platform.WHATSAPP)
             ):
                 continue
             try:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3414,6 +3414,7 @@ _PORT_BINDING_PLATFORM_PORTS: Dict[str, Tuple[str, int]] = {
     "sms": ("webhook_port", 8080),
     "whatsapp_cloud": ("webhook_port", 8090),
     "line": ("port", 8646),
+    "teams": ("port", 3978),
 }
 
 # Platform states that mean the adapter is NOT serving its port right now.

--- a/plugins/platforms/irc/adapter.py
+++ b/plugins/platforms/irc/adapter.py
@@ -130,16 +130,17 @@ class IRCAdapter(BasePlatformAdapter):
         extra = getattr(config, "extra", {}) or {}
 
         # Connection settings (env vars override config.yaml)
-        self.server = os.getenv("IRC_SERVER") or extra.get("server", "")
+        self.server = _get_scoped_secret("IRC_SERVER") or extra.get("server", "")
         try:
-            self.port = int(os.getenv("IRC_PORT") or extra.get("port", 6697))
+            self.port = int(_get_scoped_secret("IRC_PORT") or extra.get("port", 6697))
         except (ValueError, TypeError):
             self.port = 6697
-        self.nickname = os.getenv("IRC_NICKNAME") or extra.get("nickname", "hermes-bot")
-        self.channel = os.getenv("IRC_CHANNEL") or extra.get("channel", "")
+        self.nickname = _get_scoped_secret("IRC_NICKNAME") or extra.get("nickname", "hermes-bot")
+        self.channel = _get_scoped_secret("IRC_CHANNEL") or extra.get("channel", "")
+        _use_tls_raw = _get_scoped_secret("IRC_USE_TLS")
         self.use_tls = (
-            os.getenv("IRC_USE_TLS", "").lower() in {"1", "true", "yes"}
-            if os.getenv("IRC_USE_TLS")
+            _use_tls_raw.lower() in {"1", "true", "yes"}
+            if _use_tls_raw
             else extra.get("use_tls", True)
         )
         self.server_password = _get_scoped_secret("IRC_SERVER_PASSWORD") or extra.get("server_password", "")
@@ -545,8 +546,8 @@ def check_requirements() -> bool:
 
     Only requires the server and channel — no external pip packages needed.
     """
-    server = os.getenv("IRC_SERVER", "")
-    channel = os.getenv("IRC_CHANNEL", "")
+    server = _get_scoped_secret("IRC_SERVER", "")
+    channel = _get_scoped_secret("IRC_CHANNEL", "")
     # Also accept config.yaml-only configuration (no env vars).
     # The gateway passes PlatformConfig; we just check env for the
     # hermes setup / requirements check path.
@@ -556,8 +557,8 @@ def check_requirements() -> bool:
 def validate_config(config) -> bool:
     """Validate that the platform config has enough info to connect."""
     extra = getattr(config, "extra", {}) or {}
-    server = os.getenv("IRC_SERVER") or extra.get("server", "")
-    channel = os.getenv("IRC_CHANNEL") or extra.get("channel", "")
+    server = _get_scoped_secret("IRC_SERVER") or extra.get("server", "")
+    channel = _get_scoped_secret("IRC_CHANNEL") or extra.get("channel", "")
     return bool(server and channel)
 
 
@@ -671,8 +672,8 @@ def interactive_setup() -> None:
 def is_connected(config) -> bool:
     """Check whether IRC is configured (env or config.yaml)."""
     extra = getattr(config, "extra", {}) or {}
-    server = os.getenv("IRC_SERVER") or extra.get("server", "")
-    channel = os.getenv("IRC_CHANNEL") or extra.get("channel", "")
+    server = _get_scoped_secret("IRC_SERVER") or extra.get("server", "")
+    channel = _get_scoped_secret("IRC_CHANNEL") or extra.get("channel", "")
     return bool(server and channel)
 
 
@@ -689,24 +690,24 @@ def _env_enablement() -> dict | None:
     the core hook — it becomes a proper ``HomeChannel`` dataclass on the
     ``PlatformConfig`` rather than being merged into ``extra``.
     """
-    server = os.getenv("IRC_SERVER", "").strip()
-    channel = os.getenv("IRC_CHANNEL", "").strip()
+    server = _get_scoped_secret("IRC_SERVER", "").strip()
+    channel = _get_scoped_secret("IRC_CHANNEL", "").strip()
     if not (server and channel):
         return None
     seed: dict = {
         "server": server,
         "channel": channel,
     }
-    port = os.getenv("IRC_PORT", "").strip()
+    port = _get_scoped_secret("IRC_PORT", "").strip()
     if port:
         try:
             seed["port"] = int(port)
         except ValueError:
             pass
-    nickname = os.getenv("IRC_NICKNAME", "").strip()
+    nickname = _get_scoped_secret("IRC_NICKNAME", "").strip()
     if nickname:
         seed["nickname"] = nickname
-    use_tls = os.getenv("IRC_USE_TLS", "").strip().lower()
+    use_tls = _get_scoped_secret("IRC_USE_TLS", "").strip().lower()
     if use_tls:
         seed["use_tls"] = use_tls in {"1", "true", "yes"}
     # Passwords live in PlatformConfig.extra as well for back-compat with
@@ -718,11 +719,11 @@ def _env_enablement() -> dict | None:
     # Optional home-channel (usually the same as IRC_CHANNEL, but can be a
     # dedicated reports channel).  Defaults to IRC_CHANNEL so cron jobs
     # with ``deliver=irc`` have a sensible target without extra config.
-    home = os.getenv("IRC_HOME_CHANNEL") or channel
+    home = _get_scoped_secret("IRC_HOME_CHANNEL") or channel
     if home:
         seed["home_channel"] = {
             "chat_id": home,
-            "name": os.getenv("IRC_HOME_CHANNEL_NAME", home),
+            "name": _get_scoped_secret("IRC_HOME_CHANNEL_NAME", home),
         }
     return seed
 
@@ -770,19 +771,19 @@ async def _standalone_send(
     primitive.
     """
     extra = getattr(pconfig, "extra", {}) or {}
-    server = os.getenv("IRC_SERVER") or extra.get("server", "")
-    channel = os.getenv("IRC_CHANNEL") or extra.get("channel", "")
+    server = _get_scoped_secret("IRC_SERVER") or extra.get("server", "")
+    channel = _get_scoped_secret("IRC_CHANNEL") or extra.get("channel", "")
     if not server or not channel:
         return {"error": "IRC standalone send: IRC_SERVER and IRC_CHANNEL must be configured"}
 
-    port_value = os.getenv("IRC_PORT") or extra.get("port", 6697)
+    port_value = _get_scoped_secret("IRC_PORT") or extra.get("port", 6697)
     try:
         port = int(port_value)
     except (TypeError, ValueError):
         return {"error": f"IRC standalone send: invalid port {port_value!r}"}
 
-    nickname = os.getenv("IRC_NICKNAME") or extra.get("nickname", "hermes-bot")
-    use_tls_env = os.getenv("IRC_USE_TLS")
+    nickname = _get_scoped_secret("IRC_NICKNAME") or extra.get("nickname", "hermes-bot")
+    use_tls_env = _get_scoped_secret("IRC_USE_TLS")
     if use_tls_env is not None:
         use_tls = use_tls_env.lower() in {"1", "true", "yes"}
     else:

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -594,12 +594,13 @@ def _resolve_max_message_length(config) -> int:
 # Back-compat alias for callers/tests that import the module constant.
 MAX_MESSAGE_LENGTH = DEFAULT_MAX_MESSAGE_LENGTH
 
-# Store directory for E2EE keys and sync state.
-# Uses get_hermes_home() so each profile gets its own Matrix store.
+# Store directory for E2EE keys and sync state. Resolved per adapter in
+# ``connect()`` (see ``_resolve_store_dir``), NOT at module scope: the
+# multiplex gateway imports this module once, so a module-level constant
+# would pin the root HERMES_HOME for every profile and all bots' Olm
+# identities would collide in one crypto.db (#89168). Mirrors the
+# pairing-store fix (a6397c379).
 from hermes_constants import get_hermes_dir as _get_hermes_dir
-
-_STORE_DIR = _get_hermes_dir("platforms/matrix/store", "matrix/store")
-_CRYPTO_DB_PATH = _STORE_DIR / "crypto.db"
 
 # Grace period: ignore messages older than this many seconds before startup.
 _STARTUP_GRACE_SECONDS = 5
@@ -1019,7 +1020,7 @@ def check_matrix_requirements() -> bool:
     """
     token = _startup_env_secret("MATRIX_ACCESS_TOKEN")
     password = _startup_env_secret("MATRIX_PASSWORD")
-    homeserver = os.getenv("MATRIX_HOMESERVER", "")
+    homeserver = _startup_env_secret("MATRIX_HOMESERVER")
 
     if not token and not password:
         logger.debug("Matrix: neither MATRIX_ACCESS_TOKEN nor MATRIX_PASSWORD set")
@@ -1188,6 +1189,23 @@ class MatrixAdapter(BasePlatformAdapter):
     max_message_length = DEFAULT_MAX_MESSAGE_LENGTH
     _split_threshold = DEFAULT_MAX_MESSAGE_LENGTH - 100
 
+    def _resolve_store_dir(self) -> Path:
+        """Pin this adapter's crypto-store directory to the active profile.
+
+        Called from ``connect()``, which the multiplex gateway runs inside
+        ``_profile_runtime_scope`` -- ``get_hermes_dir`` honors that
+        context-local HERMES_HOME, so each profile's adapter gets its own
+        store. Cached on the instance so later reads (diagnostics, error
+        logs) outside the scope still report the store actually in use.
+        """
+        self._store_dir = _get_hermes_dir("platforms/matrix/store", "matrix/store")
+        return self._store_dir
+
+    @property
+    def _crypto_db_path(self) -> Path:
+        store_dir = self._store_dir or _get_hermes_dir("platforms/matrix/store", "matrix/store")
+        return store_dir / "crypto.db"
+
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.MATRIX)
 
@@ -1218,6 +1236,7 @@ class MatrixAdapter(BasePlatformAdapter):
 
         self._client: Any = None  # mautrix.client.Client
         self._crypto_db: Any = None  # mautrix.util.async_db.Database
+        self._store_dir: Optional[Path] = None  # pinned per profile in connect()
         self._sync_task: Optional[asyncio.Task] = None
         self._invite_join_tasks: Dict[str, asyncio.Task] = {}
         self._closing = False
@@ -1673,7 +1692,7 @@ class MatrixAdapter(BasePlatformAdapter):
                     "Matrix: server has different identity keys for device %s — "
                     "local crypto state is stale. Delete %s and restart.",
                     client.device_id,
-                    _CRYPTO_DB_PATH,
+                    str(self._crypto_db_path),
                 )
                 return False
 
@@ -1729,8 +1748,9 @@ class MatrixAdapter(BasePlatformAdapter):
             logger.error("Matrix: homeserver URL not configured")
             return False
 
-        # Ensure store dir exists for E2EE key persistence.
-        _STORE_DIR.mkdir(parents=True, exist_ok=True)
+        # Ensure store dir exists for E2EE key persistence (resolved here,
+        # inside the profile scope, so multiplexed profiles never share it).
+        self._resolve_store_dir().mkdir(parents=True, exist_ok=True)
 
         # Create the HTTP API layer.
         client_session = _create_matrix_session(self._proxy_url)
@@ -1887,7 +1907,7 @@ class MatrixAdapter(BasePlatformAdapter):
                     from mautrix.crypto.store.asyncpg import PgCryptoStore
                     from mautrix.util.async_db import Database
 
-                    _STORE_DIR.mkdir(parents=True, exist_ok=True)
+                    self._store_dir.mkdir(parents=True, exist_ok=True)
                 except Exception as exc:
                     if self._e2ee_mode == "optional":
                         logger.warning(
@@ -1908,7 +1928,7 @@ class MatrixAdapter(BasePlatformAdapter):
             if self._encryption:
                 try:
                     # Remove legacy pickle file from pre-SQLite era.
-                    legacy_pickle = _STORE_DIR / "crypto_store.pickle"
+                    legacy_pickle = self._store_dir / "crypto_store.pickle"
                     if legacy_pickle.exists():
                         logger.info(
                             "Matrix: removing legacy crypto_store.pickle (migrated to SQLite)"
@@ -1916,7 +1936,7 @@ class MatrixAdapter(BasePlatformAdapter):
                         legacy_pickle.unlink()
 
                     crypto_db = Database.create(
-                        f"sqlite:///{_CRYPTO_DB_PATH}",
+                        f"sqlite:///{self._crypto_db_path}",
                         upgrade_table=PgCryptoStore.upgrade_table,
                     )
                     await crypto_db.start()
@@ -2044,7 +2064,7 @@ class MatrixAdapter(BasePlatformAdapter):
                     client.crypto = olm
                     logger.info(
                         "Matrix: E2EE enabled (store: %s%s)",
-                        str(_CRYPTO_DB_PATH),
+                        str(self._crypto_db_path),
                         f", device_id={client.device_id}" if client.device_id else "",
                     )
                 except Exception as exc:
@@ -2288,7 +2308,7 @@ class MatrixAdapter(BasePlatformAdapter):
                 "mode": self._e2ee_mode,
                 "enabled": bool(self._encryption),
                 "deps_available": _check_e2ee_deps(),
-                "crypto_store_path": str(_CRYPTO_DB_PATH),
+                "crypto_store_path": str(self._crypto_db_path),
                 "recovery_key_configured": bool(
                     _scoped_recovery_key().strip()
                 ),

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -101,7 +101,7 @@ def validate_mattermost_config(config: PlatformConfig) -> bool:
     """Return True when Mattermost has enough config to connect."""
     extra = getattr(config, "extra", {}) or {}
     token = (getattr(config, "token", None) or _get_scoped_secret("MATTERMOST_TOKEN", "")).strip()
-    url = (extra.get("url", "") or os.getenv("MATTERMOST_URL", "")).strip()
+    url = (extra.get("url", "") or _get_scoped_secret("MATTERMOST_URL", "")).strip()
     if not token:
         logger.debug("Mattermost: MATTERMOST_TOKEN not set")
         return False
@@ -121,7 +121,7 @@ class MattermostAdapter(BasePlatformAdapter):
 
         self._base_url: str = (
             config.extra.get("url", "")
-            or os.getenv("MATTERMOST_URL", "")
+            or _get_scoped_secret("MATTERMOST_URL", "")
         ).rstrip("/")
         self._token: str = config.token or _get_scoped_secret("MATTERMOST_TOKEN", "")
 
@@ -138,7 +138,7 @@ class MattermostAdapter(BasePlatformAdapter):
         # Reply mode: "thread" to nest replies, "off" for flat messages.
         self._reply_mode: str = (
             config.extra.get("reply_mode", "")
-            or os.getenv("MATTERMOST_REPLY_MODE", "off")
+            or _get_scoped_secret("MATTERMOST_REPLY_MODE", "off")
         ).lower()
 
         self._last_post_status: Optional[int] = None
@@ -872,7 +872,7 @@ class MattermostAdapter(BasePlatformAdapter):
             # ignored, even if @mentioned.  DMs are already excluded above.
             allowed_raw = self.config.extra.get("allowed_channels") if self.config.extra else None
             if allowed_raw is None:
-                allowed_raw = os.getenv("MATTERMOST_ALLOWED_CHANNELS", "")
+                allowed_raw = _get_scoped_secret("MATTERMOST_ALLOWED_CHANNELS", "")
             if isinstance(allowed_raw, list):
                 allowed_channels = {str(c).strip() for c in allowed_raw if str(c).strip()}
             else:
@@ -886,12 +886,18 @@ class MattermostAdapter(BasePlatformAdapter):
                 )
                 return
 
-            require_mention = os.getenv(
-                "MATTERMOST_REQUIRE_MENTION", "true"
-            ).lower() not in {"false", "0", "no"}
+            require_mention_raw = self.config.extra.get("require_mention") if self.config.extra else None
+            if require_mention_raw is None:
+                require_mention_raw = _get_scoped_secret("MATTERMOST_REQUIRE_MENTION", "true")
+            require_mention = str(require_mention_raw).lower() not in {"false", "0", "no"}
 
-            free_channels_raw = os.getenv("MATTERMOST_FREE_RESPONSE_CHANNELS", "")
-            free_channels = {ch.strip() for ch in free_channels_raw.split(",") if ch.strip()}
+            free_channels_raw = self.config.extra.get("free_response_channels") if self.config.extra else None
+            if free_channels_raw is None:
+                free_channels_raw = _get_scoped_secret("MATTERMOST_FREE_RESPONSE_CHANNELS", "")
+            if isinstance(free_channels_raw, list):
+                free_channels = {str(ch).strip() for ch in free_channels_raw if str(ch).strip()}
+            else:
+                free_channels = {ch.strip() for ch in str(free_channels_raw).split(",") if ch.strip()}
             is_free_channel = channel_id in free_channels
 
             mention_patterns = [
@@ -1059,7 +1065,7 @@ async def _standalone_send(
 
     base_url = (
         (getattr(pconfig, "extra", {}) or {}).get("url")
-        or os.getenv("MATTERMOST_URL", "")
+        or _get_scoped_secret("MATTERMOST_URL", "")
     ).rstrip("/")
     token = (getattr(pconfig, "token", None) or _get_scoped_secret("MATTERMOST_TOKEN", "")).strip()
     if not base_url or not token:
@@ -1234,40 +1240,62 @@ def interactive_setup() -> None:
 # ---------------------------------------------------------------------------
 
 
+def _profile_scoped_config_load() -> bool:
+    """True when running inside a multiplexed secondary profile's scope.
+
+    Secondary-profile adapters are constructed and connected inside
+    ``_profile_runtime_scope`` (secret scope installed + multiplex active) --
+    the same discriminator the Buzz/Discord/Telegram/WhatsApp/LINE/DingTalk
+    adapters use for this bug class (#98738 / #72348 / #80099). The DEFAULT
+    profile under multiplexing runs unscoped: ``os.environ`` holds its own
+    bridge output there and keeps its legacy precedence.
+    """
+    try:
+        from agent.secret_scope import current_secret_scope, is_multiplex_active
+
+        return bool(is_multiplex_active() and current_secret_scope() is not None)
+    except Exception:
+        return False
+
+
 def _apply_yaml_config(yaml_cfg: dict, mattermost_cfg: dict) -> dict | None:
-    """Translate ``config.yaml`` ``mattermost:`` keys into env vars.
+    """Translate ``config.yaml`` ``mattermost:`` keys into env vars and
+    ``PlatformConfig.extra`` entries.
 
     Implements the ``apply_yaml_config_fn`` contract (#24836 / #25443).
     Mirrors the legacy ``mattermost_cfg`` block that used to live in
     ``gateway/config.py::load_gateway_config()`` before this migration.
 
-    The MattermostAdapter reads its runtime configuration via
-    ``os.getenv()`` for ``MATTERMOST_REQUIRE_MENTION``,
-    ``MATTERMOST_FREE_RESPONSE_CHANNELS``, and
-    ``MATTERMOST_ALLOWED_CHANNELS``.  Rather than rewrite those call sites
-    to read from ``PlatformConfig.extra``, this hook keeps the env-driven
-    model and merely owns the YAML→env translation here, next to the
-    adapter that consumes it.
-
-    Env vars take precedence over YAML — every assignment is guarded
-    by ``not os.getenv(...)`` so an explicit env var survives a config.yaml
-    update.  Returns ``None`` because no extras are seeded into
-    ``PlatformConfig.extra`` directly (everything flows through env).
+    Env vars take precedence over YAML for single-profile deployments --
+    each env write is guarded by ``not os.getenv(...)`` so an explicit env
+    var survives a config.yaml update. Under a multiplexed secondary
+    profile's scope, the env write is skipped entirely (it would otherwise
+    leak into the process-global ``os.environ`` and be inherited by every
+    other profile); instead the values are returned so the caller merges
+    them into this profile's own ``PlatformConfig.extra``, which the
+    require_mention/free_response_channels/allowed_channels read sites now
+    check first.
     """
-    if "require_mention" in mattermost_cfg and not os.getenv("MATTERMOST_REQUIRE_MENTION"):
-        os.environ["MATTERMOST_REQUIRE_MENTION"] = str(mattermost_cfg["require_mention"]).lower()
+    _skip_env_bridge = _profile_scoped_config_load()
+    seeded: dict = {}
+    if "require_mention" in mattermost_cfg:
+        seeded["require_mention"] = mattermost_cfg["require_mention"]
+        if not _skip_env_bridge and not os.getenv("MATTERMOST_REQUIRE_MENTION"):
+            os.environ["MATTERMOST_REQUIRE_MENTION"] = str(mattermost_cfg["require_mention"]).lower()
     frc = mattermost_cfg.get("free_response_channels")
-    if frc is not None and not os.getenv("MATTERMOST_FREE_RESPONSE_CHANNELS"):
-        if isinstance(frc, list):
-            frc = ",".join(str(v) for v in frc)
-        os.environ["MATTERMOST_FREE_RESPONSE_CHANNELS"] = str(frc)
+    if frc is not None:
+        seeded["free_response_channels"] = frc
+        if not _skip_env_bridge and not os.getenv("MATTERMOST_FREE_RESPONSE_CHANNELS"):
+            _frc = ",".join(str(v) for v in frc) if isinstance(frc, list) else str(frc)
+            os.environ["MATTERMOST_FREE_RESPONSE_CHANNELS"] = _frc
     # allowed_channels: if set, bot ONLY responds in these channels (whitelist)
     ac = mattermost_cfg.get("allowed_channels")
-    if ac is not None and not os.getenv("MATTERMOST_ALLOWED_CHANNELS"):
-        if isinstance(ac, list):
-            ac = ",".join(str(v) for v in ac)
-        os.environ["MATTERMOST_ALLOWED_CHANNELS"] = str(ac)
-    return None  # all settings flow through env; nothing to merge into extras
+    if ac is not None:
+        seeded["allowed_channels"] = ac
+        if not _skip_env_bridge and not os.getenv("MATTERMOST_ALLOWED_CHANNELS"):
+            _ac = ",".join(str(v) for v in ac) if isinstance(ac, list) else str(ac)
+            os.environ["MATTERMOST_ALLOWED_CHANNELS"] = _ac
+    return seeded or None
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/platforms/ntfy/adapter.py
+++ b/plugins/platforms/ntfy/adapter.py
@@ -155,21 +155,21 @@ def check_requirements() -> bool:
     """
     if not HTTPX_AVAILABLE:
         return False
-    topic = os.getenv("NTFY_TOPIC", "").strip()
+    topic = _get_scoped_secret("NTFY_TOPIC", "").strip()
     return bool(topic)
 
 
 def validate_config(config) -> bool:
     """Validate that the configured ntfy platform has a topic set."""
     extra = getattr(config, "extra", {}) or {}
-    topic = extra.get("topic") or os.getenv("NTFY_TOPIC", "")
+    topic = extra.get("topic") or _get_scoped_secret("NTFY_TOPIC", "")
     return bool(topic)
 
 
 def is_connected(config) -> bool:
     """Check whether ntfy is configured (env or config.yaml)."""
     extra = getattr(config, "extra", {}) or {}
-    topic = os.getenv("NTFY_TOPIC") or extra.get("topic", "")
+    topic = _get_scoped_secret("NTFY_TOPIC") or extra.get("topic", "")
     return bool(topic)
 
 
@@ -189,12 +189,12 @@ class NtfyAdapter(BasePlatformAdapter):
         extra = config.extra or {}
         self._server: str = (
             extra.get("server")
-            or os.getenv("NTFY_SERVER_URL", DEFAULT_SERVER)
+            or _get_scoped_secret("NTFY_SERVER_URL", DEFAULT_SERVER)
         ).rstrip("/")
-        self._topic: str = extra.get("topic") or os.getenv("NTFY_TOPIC", "")
+        self._topic: str = extra.get("topic") or _get_scoped_secret("NTFY_TOPIC", "")
         self._publish_topic: str = (
             extra.get("publish_topic")
-            or os.getenv("NTFY_PUBLISH_TOPIC", "")
+            or _get_scoped_secret("NTFY_PUBLISH_TOPIC", "")
             or self._topic
         )
         self._token: str = extra.get("token") or _get_scoped_secret("NTFY_TOKEN", "")
@@ -488,27 +488,27 @@ def _env_enablement() -> dict | None:
     core hook — it becomes a proper ``HomeChannel`` dataclass on the
     ``PlatformConfig`` rather than being merged into ``extra``.
     """
-    topic = os.getenv("NTFY_TOPIC", "").strip()
+    topic = _get_scoped_secret("NTFY_TOPIC", "").strip()
     if not topic:
         return None
     seed: dict = {
         "topic": topic,
-        "server": os.getenv("NTFY_SERVER_URL", DEFAULT_SERVER).rstrip("/"),
+        "server": _get_scoped_secret("NTFY_SERVER_URL", DEFAULT_SERVER).rstrip("/"),
     }
-    publish_topic = os.getenv("NTFY_PUBLISH_TOPIC", "").strip()
+    publish_topic = _get_scoped_secret("NTFY_PUBLISH_TOPIC", "").strip()
     if publish_topic:
         seed["publish_topic"] = publish_topic
     token = _get_scoped_secret("NTFY_TOKEN", "").strip()
     if token:
         seed["token"] = token
-    markdown = os.getenv("NTFY_MARKDOWN", "").strip().lower()
+    markdown = _get_scoped_secret("NTFY_MARKDOWN", "").strip().lower()
     if markdown:
         seed["markdown"] = markdown in ("1", "true", "yes")
-    home = os.getenv("NTFY_HOME_CHANNEL", "").strip() or topic
+    home = _get_scoped_secret("NTFY_HOME_CHANNEL", "").strip() or topic
     if home:
         seed["home_channel"] = {
             "chat_id": home,
-            "name": os.getenv("NTFY_HOME_CHANNEL_NAME", home),
+            "name": _get_scoped_secret("NTFY_HOME_CHANNEL_NAME", home),
         }
     return seed
 
@@ -540,20 +540,20 @@ async def _standalone_send(
     extra = getattr(pconfig, "extra", {}) or {}
     server = (
         extra.get("server")
-        or os.getenv("NTFY_SERVER_URL", DEFAULT_SERVER)
+        or _get_scoped_secret("NTFY_SERVER_URL", DEFAULT_SERVER)
     ).rstrip("/")
     publish_topic = (
         chat_id
         or extra.get("publish_topic")
-        or os.getenv("NTFY_PUBLISH_TOPIC", "").strip()
+        or _get_scoped_secret("NTFY_PUBLISH_TOPIC", "").strip()
         or extra.get("topic")
-        or os.getenv("NTFY_TOPIC", "").strip()
+        or _get_scoped_secret("NTFY_TOPIC", "").strip()
     )
     if not publish_topic:
         return {"error": "ntfy standalone send: NTFY_TOPIC not configured"}
 
     token = extra.get("token") or _get_scoped_secret("NTFY_TOKEN", "")
-    markdown_env = os.getenv("NTFY_MARKDOWN", "").strip().lower()
+    markdown_env = _get_scoped_secret("NTFY_MARKDOWN", "").strip().lower()
     markdown_enabled = bool(extra.get("markdown")) or markdown_env in ("1", "true", "yes")
 
     headers = {"Content-Type": "text/plain; charset=utf-8", "X-Tags": _ECHO_TAG, **_build_auth_header(token)}

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -423,10 +423,10 @@ def check_requirements() -> bool:
     if not HTTPX_AVAILABLE:
         logger.warning("photon: httpx not installed — pip install httpx")
         return False
-    if not shutil.which(os.getenv("PHOTON_NODE_BIN") or "node"):
+    if not shutil.which(_get_scoped_secret("PHOTON_NODE_BIN") or "node"):
         logger.warning(
             "photon: node binary '%s' not found on PATH",
-            os.getenv("PHOTON_NODE_BIN") or "node",
+            _get_scoped_secret("PHOTON_NODE_BIN") or "node",
         )
         return False
     if not sidecar_deps_installed():
@@ -551,7 +551,7 @@ def _reinstall_sidecar_deps() -> None:
 
 def validate_config(cfg: PlatformConfig) -> bool:
     extra = cfg.extra or {}
-    project_id = extra.get("project_id") or os.getenv("PHOTON_PROJECT_ID")
+    project_id = extra.get("project_id") or _get_scoped_secret("PHOTON_PROJECT_ID")
     project_secret = extra.get("project_secret") or _get_scoped_secret("PHOTON_PROJECT_SECRET")
     if not project_id or not project_secret:
         # Fall back to auth.json
@@ -574,11 +574,11 @@ def _env_enablement() -> Optional[dict]:
     if not (project_id and project_secret):
         return None
     seed: dict = {"project_id": project_id, "project_secret": project_secret}
-    home = os.getenv("PHOTON_HOME_CHANNEL", "").strip()
+    home = _get_scoped_secret("PHOTON_HOME_CHANNEL", "").strip()
     if home:
         seed["home_channel"] = {
             "chat_id": home,
-            "name": os.getenv("PHOTON_HOME_CHANNEL_NAME", "Home"),
+            "name": _get_scoped_secret("PHOTON_HOME_CHANNEL_NAME", "Home"),
         }
     return seed
 
@@ -591,7 +591,7 @@ def _markdown_enabled() -> bool:
     ``PHOTON_MARKDOWN=false`` is the kill-switch back to stripped plain
     text without a release.
     """
-    return os.getenv("PHOTON_MARKDOWN", "true").strip().lower() not in {
+    return _get_scoped_secret("PHOTON_MARKDOWN", "true").strip().lower() not in {
         "false", "0", "no",
     }
 
@@ -729,7 +729,7 @@ class PhotonAdapter(BasePlatformAdapter):
         # the spectrum-ts SDK authenticates with.
         stored_id, stored_sec = load_project_credentials()
         self._project_id: str = (
-            os.getenv("PHOTON_PROJECT_ID")
+            _get_scoped_secret("PHOTON_PROJECT_ID")
             or extra.get("project_id")
             or stored_id
             or ""
@@ -743,7 +743,7 @@ class PhotonAdapter(BasePlatformAdapter):
 
         # Sidecar
         self._sidecar_port = _coerce_port(
-            extra.get("sidecar_port") or os.getenv("PHOTON_SIDECAR_PORT"),
+            extra.get("sidecar_port") or _get_scoped_secret("PHOTON_SIDECAR_PORT"),
             _DEFAULT_SIDECAR_PORT,
         )
         self._sidecar_bind = _DEFAULT_SIDECAR_BIND
@@ -751,9 +751,9 @@ class PhotonAdapter(BasePlatformAdapter):
             _get_scoped_secret("PHOTON_SIDECAR_TOKEN") or secrets.token_hex(16)
         )
         self._autostart_sidecar = str(
-            os.getenv("PHOTON_SIDECAR_AUTOSTART", "true")
+            _get_scoped_secret("PHOTON_SIDECAR_AUTOSTART", "true")
         ).lower() not in ("0", "false", "no")
-        self._node_bin = os.getenv("PHOTON_NODE_BIN") or shutil.which("node") or "node"
+        self._node_bin = _get_scoped_secret("PHOTON_NODE_BIN") or shutil.which("node") or "node"
 
         # Presence watchdog. spectrum-ts only reconnects when its inbound
         # iterator throws or ends; a half-open ("zombie") gRPC socket makes the
@@ -776,21 +776,21 @@ class PhotonAdapter(BasePlatformAdapter):
         self._probe_interval = _coerce_float(
             _first_set(
                 extra.get("probe_interval_seconds"),
-                os.getenv("PHOTON_PROBE_INTERVAL_SECONDS"),
+                _get_scoped_secret("PHOTON_PROBE_INTERVAL_SECONDS"),
             ),
             600.0,
         )
         self._probe_timeout = _coerce_float(
             _first_set(
                 extra.get("probe_timeout_seconds"),
-                os.getenv("PHOTON_PROBE_TIMEOUT_SECONDS"),
+                _get_scoped_secret("PHOTON_PROBE_TIMEOUT_SECONDS"),
             ),
             10.0,
         )
         self._probe_max_failures = _coerce_int(
             _first_set(
                 extra.get("probe_max_failures"),
-                os.getenv("PHOTON_PROBE_MAX_FAILURES"),
+                _get_scoped_secret("PHOTON_PROBE_MAX_FAILURES"),
             ),
             3,
         )
@@ -843,14 +843,14 @@ class PhotonAdapter(BasePlatformAdapter):
         # always processed. Config key wins, then env var.
         _require_mention = extra.get("require_mention")
         if _require_mention is None:
-            _require_mention = os.getenv("PHOTON_REQUIRE_MENTION")
+            _require_mention = _get_scoped_secret("PHOTON_REQUIRE_MENTION")
         self.require_mention = str(_require_mention).strip().lower() in {
             "true", "1", "yes", "on",
         }
         self._mention_patterns = self._compile_mention_patterns(
             extra["mention_patterns"]
             if "mention_patterns" in extra
-            else os.getenv("PHOTON_MENTION_PATTERNS")
+            else _get_scoped_secret("PHOTON_MENTION_PATTERNS")
         )
 
     # -- Group-mention gating (parity with BlueBubbles) -------------------
@@ -2274,7 +2274,7 @@ class PhotonAdapter(BasePlatformAdapter):
         return True
 
     def _reactions_enabled(self) -> bool:
-        return os.getenv("PHOTON_REACTIONS", "false").strip().lower() in {
+        return _get_scoped_secret("PHOTON_REACTIONS", "false").strip().lower() in {
             "true", "1", "yes", "on",
         }
 
@@ -2805,7 +2805,7 @@ async def _standalone_send(
     if not HTTPX_AVAILABLE:
         return {"error": "httpx not installed"}
     port = _coerce_port(
-        (pconfig.extra or {}).get("sidecar_port") or os.getenv("PHOTON_SIDECAR_PORT"),
+        (pconfig.extra or {}).get("sidecar_port") or _get_scoped_secret("PHOTON_SIDECAR_PORT"),
         _DEFAULT_SIDECAR_PORT,
     )
     token = _get_scoped_secret("PHOTON_SIDECAR_TOKEN")

--- a/plugins/platforms/photon/auth.py
+++ b/plugins/platforms/photon/auth.py
@@ -254,7 +254,7 @@ def load_project_credentials() -> Tuple[Optional[str], Optional[str]]:
     use.  This is the pair the Node sidecar feeds to ``spectrum-ts``; the id
     is the unified project id (dashboard id == spectrumProjectId).
     """
-    env_id = os.getenv("PHOTON_PROJECT_ID")
+    env_id = _get_scoped_secret("PHOTON_PROJECT_ID")
     env_sec = _get_scoped_secret("PHOTON_PROJECT_SECRET")
     if env_id and env_sec:
         return env_id, env_sec
@@ -277,7 +277,7 @@ def load_dashboard_project_id() -> Optional[str]:
     rewrote (it now 404s), while the Spectrum id always matches the live row.
     Falls back to the legacy keys for older records.
     """
-    env_id = os.getenv("PHOTON_DASHBOARD_PROJECT_ID")
+    env_id = _get_scoped_secret("PHOTON_DASHBOARD_PROJECT_ID")
     if env_id:
         return env_id
     auth = _load_auth()

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -56,6 +56,28 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
+from agent.secret_scope import get_secret as _scoped_get_secret
+
+
+def _get_scoped_secret(name, default=None):
+    """Scope-aware env read with the default-profile startup fallback.
+
+    Secondary profiles construct their adapters under a profile secret
+    scope -- the scope is authoritative and a scoped miss returns ``default``
+    (no cross-profile borrow from ``os.environ``, which holds the DEFAULT
+    profile's YAML-to-env bridge output under multiplexing). The default
+    profile's adapter constructs *unscoped*, where a bare ``get_secret``
+    would raise ``UnscopedSecretError``; there ``os.environ`` is that
+    profile's own value, so fall back to it. Same helper as the IRC/ntfy/
+    Mattermost plugins.
+    """
+    try:
+        val = _scoped_get_secret(name, default)
+    except _UnscopedSecretError:
+        val = os.getenv(name)
+    return val if val is not None else default
+
 # Lazy import: BasePlatformAdapter and friends live in the main repo.
 # Imported at module top because they're stdlib-only inside Hermes — no
 # external dependency that would block the plugin from loading.
@@ -153,7 +175,7 @@ class SimplexAdapter(BasePlatformAdapter):
         # Contact-request auto-accept (on by default — matches the way most
         # bot deployments expect to behave). Read from env first, then fall
         # back to the value seeded by ``_env_enablement``.
-        env_auto = os.getenv("SIMPLEX_AUTO_ACCEPT")
+        env_auto = _get_scoped_secret("SIMPLEX_AUTO_ACCEPT")
         if env_auto is not None:
             self.auto_accept = env_auto.strip().lower() not in {"0", "false", "no", ""}
         else:
@@ -162,7 +184,7 @@ class SimplexAdapter(BasePlatformAdapter):
         # Group allowlist. Without ``SIMPLEX_GROUP_ALLOWED``, group messages
         # are ignored entirely (safer default — a bot in a group otherwise
         # processes every member's traffic). Use ``*`` to accept any group.
-        group_allowed_str = os.getenv("SIMPLEX_GROUP_ALLOWED", "") or extra.get(
+        group_allowed_str = _get_scoped_secret("SIMPLEX_GROUP_ALLOWED", "") or extra.get(
             "group_allowed", ""
         )
         self.group_allow_from = set(_parse_comma_list(group_allowed_str))
@@ -1172,7 +1194,7 @@ def check_requirements() -> bool:
     so the gateway never instantiates the adapter when the dependency is
     missing or no daemon URL is configured.
     """
-    if not os.getenv("SIMPLEX_WS_URL"):
+    if not _get_scoped_secret("SIMPLEX_WS_URL"):
         return False
     try:
         import websockets  # noqa: F401
@@ -1184,14 +1206,14 @@ def check_requirements() -> bool:
 def validate_config(config) -> bool:
     """Validate that the platform config has enough info to connect."""
     extra = getattr(config, "extra", {}) or {}
-    ws_url = os.getenv("SIMPLEX_WS_URL") or extra.get("ws_url", "")
+    ws_url = _get_scoped_secret("SIMPLEX_WS_URL") or extra.get("ws_url", "")
     return bool(ws_url)
 
 
 def is_connected(config) -> bool:
     """Check whether SimpleX is configured (env or config.yaml)."""
     extra = getattr(config, "extra", {}) or {}
-    ws_url = os.getenv("SIMPLEX_WS_URL") or extra.get("ws_url", "")
+    ws_url = _get_scoped_secret("SIMPLEX_WS_URL") or extra.get("ws_url", "")
     return bool(ws_url)
 
 
@@ -1207,24 +1229,24 @@ def _env_enablement() -> Optional[dict]:
     becomes a proper ``HomeChannel`` dataclass on the ``PlatformConfig``
     rather than being merged into ``extra``.
     """
-    ws_url = os.getenv("SIMPLEX_WS_URL", "").strip()
+    ws_url = _get_scoped_secret("SIMPLEX_WS_URL", "").strip()
     if not ws_url:
         return None
     seed: dict = {"ws_url": ws_url}
 
-    auto_accept = os.getenv("SIMPLEX_AUTO_ACCEPT", "").strip().lower()
+    auto_accept = _get_scoped_secret("SIMPLEX_AUTO_ACCEPT", "").strip().lower()
     if auto_accept:
         seed["auto_accept"] = auto_accept not in {"0", "false", "no"}
 
-    group_allowed = os.getenv("SIMPLEX_GROUP_ALLOWED", "").strip()
+    group_allowed = _get_scoped_secret("SIMPLEX_GROUP_ALLOWED", "").strip()
     if group_allowed:
         seed["group_allowed"] = group_allowed
 
-    home = os.getenv("SIMPLEX_HOME_CHANNEL", "").strip()
+    home = _get_scoped_secret("SIMPLEX_HOME_CHANNEL", "").strip()
     if home:
         seed["home_channel"] = {
             "chat_id": home,
-            "name": os.getenv("SIMPLEX_HOME_CHANNEL_NAME", "").strip() or home,
+            "name": _get_scoped_secret("SIMPLEX_HOME_CHANNEL_NAME", "").strip() or home,
         }
     return seed
 
@@ -1257,7 +1279,7 @@ async def _standalone_send(
         return {"error": "websockets not installed. Run: pip install websockets"}
 
     extra = getattr(pconfig, "extra", {}) or {}
-    ws_url = os.getenv("SIMPLEX_WS_URL") or extra.get(
+    ws_url = _get_scoped_secret("SIMPLEX_WS_URL") or extra.get(
         "ws_url", "ws://127.0.0.1:5225"
     )
     if not ws_url:

--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -323,7 +323,7 @@ class WeComAdapter(BasePlatformAdapter):
         self._ws_url = str(
             extra.get("websocket_url")
             or extra.get("websocketUrl")
-            or os.getenv("WECOM_WEBSOCKET_URL", DEFAULT_WS_URL)
+            or _get_scoped_secret("WECOM_WEBSOCKET_URL", DEFAULT_WS_URL)
         ).strip() or DEFAULT_WS_URL
 
         self._dm_policy = str(extra.get("dm_policy") or _get_scoped_secret("WECOM_DM_POLICY", "pairing")).strip().lower()

--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -318,7 +318,7 @@ class WeComAdapter(BasePlatformAdapter):
         super().__init__(config, Platform.WECOM)
 
         extra = config.extra or {}
-        self._bot_id = str(extra.get("bot_id") or os.getenv("WECOM_BOT_ID", "")).strip()
+        self._bot_id = str(extra.get("bot_id") or _get_scoped_secret("WECOM_BOT_ID", "")).strip()
         self._secret = str(extra.get("secret") or _get_scoped_secret("WECOM_SECRET", "")).strip()
         self._ws_url = str(
             extra.get("websocket_url")

--- a/tests/gateway/test_irc_adapter.py
+++ b/tests/gateway/test_irc_adapter.py
@@ -18,6 +18,8 @@ check_requirements = _irc_mod.check_requirements
 validate_config = _irc_mod.validate_config
 register = _irc_mod.register
 _standalone_send = _irc_mod._standalone_send
+is_connected = _irc_mod.is_connected
+_env_enablement = _irc_mod._env_enablement
 
 
 class TestIRCProtocolHelpers:
@@ -405,4 +407,97 @@ class TestIRCStandaloneSend:
         assert "error" in result
         assert "registration" in result["error"].lower() or "timeout" in result["error"].lower()
 
+
+# ---------------------------------------------------------------------------
+# Multiplex secondary-profile scope
+# ---------------------------------------------------------------------------
+#
+# __init__'s server/port/nickname/channel/use_tls, check_requirements/
+# validate_config/is_connected's server/channel, and _env_enablement's
+# server/channel/port/nickname/use_tls/home_channel, all previously read raw
+# os.getenv unconditionally (only IRC_SERVER_PASSWORD/IRC_NICKSERV_PASSWORD
+# were already scoped). Under multiplex, os.environ holds the DEFAULT
+# profile's YAML-to-env bridge output -- a secondary profile with its own
+# (different or absent) IRC config would silently connect to the default
+# profile's server/channel, or (for _env_enablement) get auto-enabled using
+# the default's channel as its cron home_channel -- a real message-
+# misdelivery risk, not just cosmetic. Mirrors the LINE/Buzz/SimpleX fix for
+# #98738.
+
+@pytest.fixture
+def multiplex_scope():
+    """Install multiplex + a secondary-profile secret scope; restore after."""
+    tokens = []
+
+    def install(scope=None):
+        from agent.secret_scope import set_multiplex_active, set_secret_scope
+
+        set_multiplex_active(True)
+        tokens.append(set_secret_scope(scope or {}))
+        return tokens[-1]
+
+    yield install
+
+    from agent.secret_scope import reset_secret_scope, set_multiplex_active
+
+    for token in reversed(tokens):
+        reset_secret_scope(token)
+    set_multiplex_active(False)
+
+
+@pytest.fixture
+def default_profile_env(monkeypatch):
+    """The default profile's YAML-to-env bridge output in os.environ."""
+    monkeypatch.setenv("IRC_SERVER", "default.example.net")
+    monkeypatch.setenv("IRC_CHANNEL", "#default")
+    monkeypatch.setenv("IRC_PORT", "6667")
+    monkeypatch.setenv("IRC_NICKNAME", "default-bot")
+    monkeypatch.setenv("IRC_USE_TLS", "false")
+
+
+class TestMultiplexProfileScope:
+
+    def test_secondary_extra_wins_over_default_profile_env(
+        self, multiplex_scope, default_profile_env
+    ):
+        """The secondary profile's own config.yaml extra is authoritative,
+        not the default profile's bridged server/channel/port/nick/tls."""
+        from gateway.config import PlatformConfig
+
+        multiplex_scope()
+        cfg = PlatformConfig(
+            enabled=True,
+            extra={
+                "server": "profile.example.net",
+                "channel": "#profile",
+                "port": 6697,
+                "nickname": "profile-bot",
+                "use_tls": True,
+            },
+        )
+        adapter = IRCAdapter(cfg)
+        assert adapter.server == "profile.example.net"
+        assert adapter.channel == "#profile"
+        assert adapter.port == 6697
+        assert adapter.nickname == "profile-bot"
+        assert adapter.use_tls is True
+
+    def test_secondary_missing_keys_fail_closed(
+        self, multiplex_scope, default_profile_env
+    ):
+        """Keys absent from the profile's own scope must NOT borrow the
+        default profile's bridged env values -- that would silently connect
+        the secondary profile's bot to the wrong IRC server/channel."""
+        from gateway.config import PlatformConfig
+
+        multiplex_scope()
+        adapter = IRCAdapter(PlatformConfig(enabled=True, extra={}))
+        assert adapter.server == ""
+        assert adapter.channel == ""
+        assert adapter.port == 6697  # falls through to the hardcoded default
+        assert adapter.nickname == "hermes-bot"
+        assert adapter.use_tls is True  # extra.get("use_tls", True) default
+        # Nor may the registry auto-enable IRC for this profile off the default's channel.
+        assert _env_enablement() is None
+        assert is_connected(PlatformConfig(enabled=True, extra={})) is False
 

--- a/tests/gateway/test_matrix_crypto_store_per_profile.py
+++ b/tests/gateway/test_matrix_crypto_store_per_profile.py
@@ -1,0 +1,47 @@
+"""Matrix crypto store must be pinned per profile at connect(), not at import.
+
+Under ``gateway.multiplex_profiles`` one process imports
+``plugins.platforms.matrix.adapter`` once; the old module-level
+``_STORE_DIR``/``_CRYPTO_DB_PATH`` resolved against the root HERMES_HOME at
+import time, so every profile's adapter opened the SAME crypto.db and inbound
+E2EE failed with "no session found" (#89168). ``connect()`` calls
+``_resolve_store_dir()`` inside ``_profile_runtime_scope`` (context-local
+HERMES_HOME), so resolving there -- and caching on the instance -- gives each
+profile its own store. Exercised via ``_resolve_store_dir`` directly so the
+test needs no mautrix install.
+"""
+from gateway.config import PlatformConfig
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from plugins.platforms.matrix import adapter as matrix_adapter
+
+
+def _make_adapter() -> matrix_adapter.MatrixAdapter:
+    return matrix_adapter.MatrixAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="syt_test_token",
+            extra={"homeserver": "https://matrix.example.org", "user_id": "@bot:example.org"},
+        )
+    )
+
+
+def test_store_dir_pinned_to_each_profile_home(tmp_path):
+    """Two profiles resolving in one process get two stores, and each
+    adapter keeps reporting its own store after the scope is gone."""
+    stores = {}
+    for profile in ("accountant", "engineering-lead"):
+        home = tmp_path / "profiles" / profile
+        home.mkdir(parents=True)
+        adapter = _make_adapter()
+        token = set_hermes_home_override(str(home))
+        try:
+            adapter._resolve_store_dir().mkdir(parents=True, exist_ok=True)
+        finally:
+            reset_hermes_home_override(token)
+        # Cached on the instance: correct even when read outside the scope.
+        path = adapter.get_diagnostics()["e2ee"]["crypto_store_path"]
+        assert path.startswith(str(home)), f"store not profile-scoped: {path}"
+        assert adapter._store_dir.is_dir()
+        stores[profile] = path
+
+    assert stores["accountant"] != stores["engineering-lead"]

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -594,3 +594,118 @@ async def test_mattermost_top_level_channel_post_is_thread_root():
     assert msg_event.message_id == "top_post_123"
 
 
+# ---------------------------------------------------------------------------
+# Multiplex secondary-profile scope
+# ---------------------------------------------------------------------------
+#
+# __init__'s url/reply_mode, validate_mattermost_config's url,
+# _standalone_send's url, and _handle_ws_event's require_mention/
+# free_response_channels/allowed_channels, all previously read raw
+# os.getenv unconditionally (only MATTERMOST_TOKEN was already scoped).
+# _apply_yaml_config also wrote MATTERMOST_REQUIRE_MENTION/
+# MATTERMOST_FREE_RESPONSE_CHANNELS/MATTERMOST_ALLOWED_CHANNELS into the
+# process-global os.environ unconditionally. Under multiplex, os.environ
+# holds the DEFAULT profile's YAML-to-env bridge output -- a secondary
+# profile with its own (different or absent) Mattermost config would
+# silently connect to the default profile's server, or have its
+# mention-gating/channel-allowlist decisions driven by the default
+# profile's settings. Mirrors the LINE/DingTalk/IRC fix for #98738.
+
+@pytest.fixture
+def multiplex_scope():
+    """Install multiplex + a secondary-profile secret scope; restore after."""
+    tokens = []
+
+    def install(scope=None):
+        from agent.secret_scope import set_multiplex_active, set_secret_scope
+
+        set_multiplex_active(True)
+        tokens.append(set_secret_scope(scope or {}))
+        return tokens[-1]
+
+    yield install
+
+    from agent.secret_scope import reset_secret_scope, set_multiplex_active
+
+    for token in reversed(tokens):
+        reset_secret_scope(token)
+    set_multiplex_active(False)
+
+
+@pytest.fixture
+def default_profile_env(monkeypatch):
+    """The default profile's YAML-to-env bridge output in os.environ."""
+    monkeypatch.setenv("MATTERMOST_URL", "https://default.example.com")
+    monkeypatch.setenv("MATTERMOST_REPLY_MODE", "thread")
+    monkeypatch.setenv("MATTERMOST_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("MATTERMOST_FREE_RESPONSE_CHANNELS", "chan_default")
+    monkeypatch.setenv("MATTERMOST_ALLOWED_CHANNELS", "chan_default")
+
+
+class TestMultiplexProfileScope:
+
+    @pytest.mark.asyncio
+    async def test_ws_event_gating_uses_scoped_settings_not_default(
+        self, monkeypatch
+    ):
+        """A secondary profile's own require_mention/free_response_channels/
+        allowed_channels (installed via the scope) must gate its messages --
+        not the default profile's bridged settings."""
+        from agent.secret_scope import (
+            reset_secret_scope,
+            set_multiplex_active,
+            set_secret_scope,
+        )
+        from plugins.platforms.mattermost.adapter import MattermostAdapter
+
+        monkeypatch.setenv("MATTERMOST_REQUIRE_MENTION", "true")
+        monkeypatch.delenv("MATTERMOST_FREE_RESPONSE_CHANNELS", raising=False)
+
+        adapter = _make_adapter()
+        adapter._bot_user_id = "bot_user_id"
+        adapter._bot_username = "hermes-bot"
+        adapter.handle_message = AsyncMock()
+
+        post_data = {
+            "id": "post_scoped",
+            "user_id": "user_123",
+            "channel_id": "chan_456",
+            "message": "hello with no mention",
+        }
+        event = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(post_data),
+                "channel_type": "O",
+                "sender_name": "@alice",
+            },
+        }
+
+        set_multiplex_active(True)
+        token = set_secret_scope({"MATTERMOST_REQUIRE_MENTION": "false"})
+        try:
+            await adapter._handle_ws_event(event)
+        finally:
+            reset_secret_scope(token)
+            set_multiplex_active(False)
+
+        # The profile's own scope disables require_mention -- the message
+        # must be dispatched even without an @mention, despite the default
+        # profile's env bridge saying require_mention=true.
+        assert adapter.handle_message.called
+
+    def test_apply_yaml_config_scoped_skips_env_write_and_seeds_extra(
+        self, multiplex_scope
+    ):
+        from plugins.platforms.mattermost.adapter import _apply_yaml_config
+
+        multiplex_scope()
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MATTERMOST_REQUIRE_MENTION", None)
+            seeded = _apply_yaml_config({}, {"require_mention": False, "allowed_channels": ["c1"]})
+            assert seeded == {"require_mention": False, "allowed_channels": ["c1"]}
+            # Under a secondary profile's scope the env bridge must be
+            # skipped -- writing here would leak into every other profile's
+            # os.environ.
+            assert "MATTERMOST_REQUIRE_MENTION" not in os.environ
+

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -937,6 +937,43 @@ class TestSecondaryProfileConfigHandling:
         assert "reviewer" in str(exc_info.value)
         assert "reviewer" not in runner._profile_adapters
 
+    @pytest.mark.asyncio
+    async def test_secondary_profile_adapter_start_skips_whatsapp(self, monkeypatch):
+        """WhatsApp is shared process-level ingress like Relay: the bridge is
+        one authenticated session tied to a single phone number, so a
+        credential-less secondary profile must be skipped (not stall startup
+        in a connect/retry loop) while its other platforms start normally."""
+        runner = _secondary_recovery_runner()
+        direct = _SecondaryRecoveryAdapter()
+        _install_secondary_reconnect_context(monkeypatch, runner, direct)
+        monkeypatch.setattr(
+            "gateway.config.load_gateway_config",
+            lambda: GatewayConfig(
+                multiplex_profiles=True,
+                platforms={
+                    Platform.WHATSAPP: PlatformConfig(enabled=True),
+                    Platform.DISCORD: PlatformConfig(enabled=True, token="profile-token"),
+                },
+            ),
+        )
+        factory_calls = []
+
+        def _create_adapter(platform, config):
+            factory_calls.append(platform)
+            return direct
+
+        async def _connect(adapter, platform):
+            return True
+
+        monkeypatch.setattr(runner, "_create_adapter", _create_adapter)
+        monkeypatch.setattr(runner, "_connect_initial_adapter_with_timeout", _connect)
+
+        connected = await runner._start_one_profile_adapters("clientbot", "/tmp/x", {})
+
+        assert connected == 1
+        assert factory_calls == [Platform.DISCORD]
+        assert runner._profile_adapters["clientbot"] == {Platform.DISCORD: direct}
+
 
 class TestFeishuPortBindingConditional:
     """Feishu websocket mode does NOT bind a port; only webhook mode does (#52563)."""

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -914,6 +914,29 @@ class TestSecondaryProfileConfigHandling:
         assert second == 1
         assert runner._profile_adapters["later"][photon] is later
 
+    @pytest.mark.asyncio
+    async def test_secondary_teams_uses_degradable_error(self, monkeypatch):
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+        from gateway.run import SecondaryPortBindingConfigError
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._profile_adapters = {}
+
+        reviewer_cfg = GatewayConfig(multiplex_profiles=True)
+        reviewer_cfg.platforms = {
+            Platform("teams"): PlatformConfig(enabled=True, extra={"port": 3978}),
+        }
+        monkeypatch.setattr(
+            "gateway.config.load_gateway_config", lambda: reviewer_cfg
+        )
+
+        with pytest.raises(SecondaryPortBindingConfigError) as exc_info:
+            await runner._start_one_profile_adapters("reviewer", "/tmp/x", {})
+        assert "teams" in str(exc_info.value)
+        assert "reviewer" in str(exc_info.value)
+        assert "reviewer" not in runner._profile_adapters
+
 
 class TestFeishuPortBindingConditional:
     """Feishu websocket mode does NOT bind a port; only webhook mode does (#52563)."""

--- a/tests/gateway/test_ntfy_plugin.py
+++ b/tests/gateway/test_ntfy_plugin.py
@@ -491,3 +491,82 @@ class TestTruncateHelper:
         assert _ntfy._truncate_body("hi", context="test") == b"hi"
 
 
+# ---------------------------------------------------------------------------
+# 13. Multiplex secondary-profile scope
+# ---------------------------------------------------------------------------
+#
+# __init__'s server/topic/publish_topic, _env_enablement's topic/server/
+# publish_topic/markdown/home_channel, and check_requirements/validate_config/
+# is_connected's topic reads, all previously read raw os.getenv
+# unconditionally (only NTFY_TOKEN was already scoped). Under multiplex,
+# os.environ holds the DEFAULT profile's YAML-to-env bridge output -- a
+# secondary profile with its own (different or absent) ntfy config would
+# silently subscribe to / publish on the default profile's topic, or get
+# auto-enabled using the default profile's topic entirely. Mirrors the
+# LINE/Buzz/SimpleX fix for #98738.
+
+@pytest.fixture
+def multiplex_scope():
+    """Install multiplex + a secondary-profile secret scope; restore after."""
+    tokens = []
+
+    def install(scope=None):
+        from agent.secret_scope import set_multiplex_active, set_secret_scope
+
+        set_multiplex_active(True)
+        tokens.append(set_secret_scope(scope or {}))
+        return tokens[-1]
+
+    yield install
+
+    from agent.secret_scope import reset_secret_scope, set_multiplex_active
+
+    for token in reversed(tokens):
+        reset_secret_scope(token)
+    set_multiplex_active(False)
+
+
+@pytest.fixture
+def default_profile_env(monkeypatch):
+    """The default profile's YAML-to-env bridge output in os.environ."""
+    monkeypatch.setenv("NTFY_TOPIC", "default-topic")
+    monkeypatch.setenv("NTFY_SERVER_URL", "https://default.example.com")
+    monkeypatch.setenv("NTFY_PUBLISH_TOPIC", "default-out")
+
+
+class TestMultiplexProfileScope:
+
+    def test_secondary_extra_wins_over_default_profile_env(
+        self, multiplex_scope, default_profile_env
+    ):
+        """The secondary profile's own config.yaml extra is authoritative,
+        not the default profile's bridged topic/server/publish_topic."""
+        multiplex_scope()
+        cfg = PlatformConfig(
+            enabled=True,
+            extra={
+                "topic": "profile-topic",
+                "server": "https://profile.example.com",
+                "publish_topic": "profile-out",
+            },
+        )
+        adapter = NtfyAdapter(cfg)
+        assert adapter._topic == "profile-topic"
+        assert adapter._server == "https://profile.example.com"
+        assert adapter._publish_topic == "profile-out"
+
+    def test_secondary_missing_keys_fail_closed(
+        self, multiplex_scope, default_profile_env
+    ):
+        """Keys absent from the profile's own scope must NOT borrow the
+        default profile's bridged env values -- that would silently
+        subscribe/publish on the wrong topic."""
+        multiplex_scope()
+        adapter = NtfyAdapter(PlatformConfig(enabled=True, extra={}))
+        assert adapter._topic == ""
+        assert adapter._server == DEFAULT_SERVER
+        assert adapter._publish_topic == ""
+        # Nor may the registry auto-enable ntfy for this profile off the default's topic.
+        assert _env_enablement() is None
+        assert is_connected(PlatformConfig(enabled=True, extra={})) is False
+

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -388,3 +388,73 @@ def _make_file_chat_item(file_path: str, file_name: str) -> dict:
     }
 
 
+
+
+# ---------------------------------------------------------------------------
+# Multiplex secondary-profile scope
+# ---------------------------------------------------------------------------
+#
+# Every SIMPLEX_* read (auto_accept / group_allowed in __init__, ws_url in the
+# registry gates, everything in _env_enablement) went through raw os.getenv,
+# which under multiplexing holds the DEFAULT profile's YAML-to-env bridge
+# output -- a secondary profile silently borrowed the default's daemon URL,
+# group allowlist and auto-accept setting. Reads now go through the module's
+# ``_get_scoped_secret`` (profile .env AND extra both honored; scoped miss
+# fails closed; unscoped default profile keeps env precedence).
+
+
+@pytest.fixture
+def multiplex_scope():
+    """Install multiplex + a secondary-profile secret scope; restore after."""
+    from agent.secret_scope import (
+        reset_secret_scope,
+        set_multiplex_active,
+        set_secret_scope,
+    )
+
+    tokens = []
+
+    def install(scope=None):
+        set_multiplex_active(True)
+        tokens.append(set_secret_scope(scope or {}))
+
+    yield install
+    for token in reversed(tokens):
+        reset_secret_scope(token)
+    set_multiplex_active(False)
+
+
+@pytest.fixture
+def default_profile_env(monkeypatch):
+    """The default profile's YAML-to-env bridge output in os.environ."""
+    monkeypatch.setenv("SIMPLEX_WS_URL", "ws://default:5225")
+    monkeypatch.setenv("SIMPLEX_GROUP_ALLOWED", "*")
+    monkeypatch.setenv("SIMPLEX_AUTO_ACCEPT", "true")
+
+
+def test_multiplex_scoped_miss_does_not_borrow_default_profile_env(
+    multiplex_scope, default_profile_env
+):
+    """A secondary profile with no SimpleX config of its own must not be
+    auto-enabled off the default's daemon URL, nor inherit its wide-open
+    group allowlist."""
+    from gateway.config import PlatformConfig
+
+    multiplex_scope({"SOMETHING_ELSE": "x"})
+    assert _env_enablement() is None
+    assert check_requirements() is False
+    assert is_connected(PlatformConfig(enabled=True, extra={})) is False
+    adapter = SimplexAdapter(PlatformConfig(enabled=True, extra={"auto_accept": False}))
+    assert adapter.group_allow_from == set()
+    assert adapter.auto_accept is False
+
+
+def test_multiplex_scope_reads_profile_own_env_not_default(
+    multiplex_scope, default_profile_env
+):
+    """A secondary profile's own .env (installed as the scope) is honored --
+    the extra-only shape would have ignored it."""
+    multiplex_scope({"SIMPLEX_WS_URL": "ws://profile:5225", "SIMPLEX_GROUP_ALLOWED": "g1"})
+    seeded = _env_enablement()
+    assert seeded == {"ws_url": "ws://profile:5225", "group_allowed": "g1"}
+    assert check_requirements() is True

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -76,6 +76,38 @@ class TestWeComAdapterAuthzScope:
         assert adapter._dm_policy == "pairing"
         assert adapter._allow_from == []
 
+    def test_scoped_construction_reads_bot_id_from_scope_not_environ(self, multiplex_on, monkeypatch):
+        """bot_id must honor the same scope as its neighboring _secret read
+        (both are read on adjacent lines in __init__) -- a secondary profile's
+        own bot_id must never fall back to the default profile's os.environ
+        value."""
+        from agent import secret_scope
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        monkeypatch.setenv("WECOM_BOT_ID", "default-profile-bot-id")
+        monkeypatch.setenv("WECOM_SECRET", "default-profile-secret")
+        token = secret_scope.set_secret_scope(
+            {"WECOM_BOT_ID": "scoped-bot-id", "WECOM_SECRET": "scoped-secret"}
+        )
+        try:
+            adapter = WeComAdapter(PlatformConfig(enabled=True))
+        finally:
+            secret_scope.reset_secret_scope(token)
+        assert adapter._bot_id == "scoped-bot-id"
+        assert adapter._secret == "scoped-secret"
+
+    def test_scoped_miss_does_not_leak_default_profiles_bot_id(self, multiplex_on, monkeypatch):
+        from agent import secret_scope
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        monkeypatch.setenv("WECOM_BOT_ID", "default-profile-bot-id")
+        token = secret_scope.set_secret_scope({"SOMETHING_ELSE": "x"})
+        try:
+            adapter = WeComAdapter(PlatformConfig(enabled=True))
+        finally:
+            secret_scope.reset_secret_scope(token)
+        assert adapter._bot_id == ""
+
 
 class TestWeComConnect:
 

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -98,15 +98,17 @@ class TestWeComAdapterAuthzScope:
 
     def test_scoped_miss_does_not_leak_default_profiles_bot_id(self, multiplex_on, monkeypatch):
         from agent import secret_scope
-        from plugins.platforms.wecom.adapter import WeComAdapter
+        from plugins.platforms.wecom.adapter import DEFAULT_WS_URL, WeComAdapter
 
         monkeypatch.setenv("WECOM_BOT_ID", "default-profile-bot-id")
+        monkeypatch.setenv("WECOM_WEBSOCKET_URL", "wss://default-profile.example/ws")
         token = secret_scope.set_secret_scope({"SOMETHING_ELSE": "x"})
         try:
             adapter = WeComAdapter(PlatformConfig(enabled=True))
         finally:
             secret_scope.reset_secret_scope(token)
         assert adapter._bot_id == ""
+        assert adapter._ws_url == DEFAULT_WS_URL
 
 
 class TestWeComConnect:

--- a/tests/plugins/platforms/photon/test_multiplex_profile_scope.py
+++ b/tests/plugins/platforms/photon/test_multiplex_profile_scope.py
@@ -1,0 +1,122 @@
+"""Multiplex secondary-profile scope tests for the Photon adapter + auth module.
+
+__init__'s project_id, check_requirements'/validate_config's node_bin/
+project_id, _env_enablement's home_channel, _reactions_enabled's
+PHOTON_REACTIONS, __init__'s require_mention, and _standalone_send's
+sidecar_port, plus auth.py's load_project_credentials/
+load_dashboard_project_id, all previously read raw os.getenv
+unconditionally (only PHOTON_PROJECT_SECRET/PHOTON_SIDECAR_TOKEN were
+already scoped via _get_scoped_secret). Under gateway.multiplex_profiles,
+os.environ holds the DEFAULT profile's YAML-to-env bridge output -- a
+secondary profile with its own (different or absent) Photon config could
+silently authenticate against the default profile's Spectrum project, or
+have its mention-gating/reaction behavior driven by the default profile's
+settings.
+
+Notably project_id was a stronger variant of the bug (like the IRC fix in
+this series): __init__'s original
+`os.getenv("PHOTON_PROJECT_ID") or extra.get("project_id") or stored_id`
+ordering let a raw env read override even an explicitly configured
+config.yaml extra.
+
+Mirrors the LINE/DingTalk/IRC/Mattermost fix for #98738.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.photon import auth as photon_auth
+from plugins.platforms.photon.adapter import PhotonAdapter
+
+_PHOTON_ENV = (
+    "PHOTON_PROJECT_ID",
+    "PHOTON_PROJECT_SECRET",
+    "PHOTON_DASHBOARD_PROJECT_ID",
+    "PHOTON_REQUIRE_MENTION",
+    "PHOTON_REACTIONS",
+    "PHOTON_HOME_CHANNEL",
+    "PHOTON_HOME_CHANNEL_NAME",
+    "PHOTON_SIDECAR_PORT",
+)
+
+
+@pytest.fixture
+def tmp_hermes_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Isolate from the real ~/.hermes/auth.json fallback in load_project_credentials()."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    for key in _PHOTON_ENV:
+        monkeypatch.delenv(key, raising=False)
+    yield home
+    for key in _PHOTON_ENV:
+        os.environ.pop(key, None)
+
+
+@pytest.fixture
+def multiplex_scope():
+    """Install multiplex + a secondary-profile secret scope; restore after."""
+    tokens = []
+
+    def install(scope=None):
+        from agent.secret_scope import set_multiplex_active, set_secret_scope
+
+        set_multiplex_active(True)
+        tokens.append(set_secret_scope(scope or {}))
+        return tokens[-1]
+
+    yield install
+
+    from agent.secret_scope import reset_secret_scope, set_multiplex_active
+
+    for token in reversed(tokens):
+        reset_secret_scope(token)
+    set_multiplex_active(False)
+
+
+@pytest.fixture
+def default_profile_env(monkeypatch):
+    """The default profile's YAML-to-env bridge output in os.environ."""
+    monkeypatch.setenv("PHOTON_PROJECT_ID", "default-project-id")
+    monkeypatch.setenv("PHOTON_PROJECT_SECRET", "default-project-secret")
+    monkeypatch.setenv("PHOTON_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("PHOTON_REACTIONS", "true")
+
+
+class TestAuthMultiplexProfileScope:
+    """load_project_credentials / load_dashboard_project_id (auth.py)."""
+
+    def test_scoped_miss_does_not_leak_default_project_id(
+        self, tmp_hermes_home, multiplex_scope, default_profile_env
+    ):
+        multiplex_scope({"SOMETHING_ELSE": "x"})
+        sid, secret = photon_auth.load_project_credentials()
+        assert sid is None
+        assert secret is None
+        adapter = PhotonAdapter(PlatformConfig(enabled=True, extra={}))
+        assert adapter._project_id == ""
+        assert adapter.require_mention is False
+        assert adapter._reactions_enabled() is False
+
+class TestAdapterMultiplexProfileScope:
+    """PhotonAdapter.__init__ / _env_enablement / _reactions_enabled (adapter.py)."""
+
+    def test_secondary_extra_wins_over_default_profile_env(
+        self, tmp_hermes_home, multiplex_scope, default_profile_env
+    ):
+        """A secondary profile's own config.yaml extra project_id must be
+        authoritative -- not the default profile's bridged env value. The
+        pre-fix ordering (raw os.getenv checked BEFORE extra) meant even an
+        explicit extra config was silently overridden."""
+        multiplex_scope({"PHOTON_PROJECT_SECRET": "profile-secret"})
+        cfg = PlatformConfig(
+            enabled=True,
+            extra={"project_id": "profile-project-id"},
+        )
+        adapter = PhotonAdapter(cfg)
+        assert adapter._project_id == "profile-project-id"
+

--- a/website/docs/user-guide/multi-profile-gateways.md
+++ b/website/docs/user-guide/multi-profile-gateways.md
@@ -157,7 +157,7 @@ configure them only on the default profile.
 
 Port-binding platforms covered by this rule: `webhook`, `api_server`,
 `msgraph_webhook`, `feishu`, `wecom_callback`, `bluebubbles`, `sms`,
-`whatsapp_cloud`, `line`. Configure any of these **only on the default profile**;
+`whatsapp_cloud`, `line`, `teams`. Configure any of these **only on the default profile**;
 every profile is reachable through its `/p/<profile>/` prefix.
 
 Authentication follows the profile named in the URL. Unprefixed endpoints keep


### PR DESCRIPTION
## Summary
Under `gateway.multiplex_profiles`, secondary profiles were silently reusing the default profile's settings: plugin adapters (IRC, ntfy, Photon, WeCom, Mattermost, SimpleX) read non-secret config via raw `os.getenv` — which holds the default's YAML→env bridge output — so secondaries connected to the wrong server/topic/project or got auto-enabled off the default's channel; the Matrix E2EE store path was resolved at import so every profile shared one crypto.db; Teams wasn't in the port-binding guard so a secondary tried to bind :3978 twice; and a credential-less WhatsApp secondary spun in a connect/retry loop stalling startup.
## Changes
- irc/ntfy/photon(+auth)/wecom/mattermost/simplex: every `*_`-setting read goes through the module-local `_get_scoped_secret` (scope authoritative; env fallback only for the unscoped default profile). Mattermost `_apply_yaml_config` skips os.environ writes under a profile scope and always seeds extra. SimpleX rewritten from #100241's extra-only shape so the secondary's own `.env` is honored. Widened to `WECOM_WEBSOCKET_URL` and Matrix `check_matrix_requirements` homeserver.
- matrix: store dir resolved in `connect()` (inside `_profile_runtime_scope`) and cached on the instance; module constants and dead None alias removed.
- gateway/config.py + web_server.py: `teams` added to port-binding platform sets; docs list updated.
- gateway/run.py: `_start_one_profile_adapters` skips WhatsApp on secondaries like Relay.
- Single-profile note: Mattermost YAML `require_mention/free_response_channels/allowed_channels` now take precedence over an explicit env var (Discord precedent, #72348).
## Validation
| Probe (multiplex on, secondary scope) | before (main) | after |
|---|---|---|
| irc/ntfy/photon/mattermost validate/is_connected/_env_enablement with no own config | True / default's server+topic seeded | False / None |
| wecom bot_id / ws_url | 'default-bot' / 'wss://default.wecom' | '' / DEFAULT_WS_URL |
| simplex `_env_enablement` (own .env ws://bob) | default's ws://default:5225, '*' | ws://bob:5225, 'g-bob' |
| Matrix crypto_store_path for profiles alice/bob | both `$HOME/platforms/matrix/store/crypto.db` | `$HOME/profiles/<p>/platforms/matrix/store/crypto.db` each |
| Teams on secondary | adapter constructed → EADDRINUSE | SecondaryPortBindingConfigError, profile skipped |
| WhatsApp+Discord secondary | 2 adapters constructed | only Discord (1) |
Tests: 372 passed across the touched files; each fix sabotage-verified (revert → test fails). ruff clean.
## Credits
@nftpoetrist (#100640, #100634, #100654, #100627, #100647 cherry-picked with authorship; #100241 rewritten, co-authored), @mjshorty (#89169 / #89168), @JoelMTaylor (#80825, cherry-picked), @lsshawn (#69042, co-authored).

Fixes #89168

## Infographic

![mux-adapter-scoping-a](https://v3b.fal.media/files/b/0aa8cdd4/1XsdmLuSVOL0Ahie5IVe6_7zUg1jgJ.png)
