### PR TITLE
fix(gateway): Google Chat scoped + ADC fail-closed, runner bound on all adapters, WhatsApp alias routes, relay profile carry (#73439, salvage #73445 #70831 #85081 #61012)

### DIFF
--- a/docs/relay-connector-contract.md
+++ b/docs/relay-connector-contract.md
@@ -119,8 +119,13 @@ Both absent ⇒ byte-identical to today. A connector that never sends them, or a
 
 `PassthroughForward` is the wire form of a forwarded passthrough-plane request
 (Class-2/3 webhooks — Discord interactions, Twilio): `{platform, botId, method,
-path, headers: [[k,v],…], bodyB64}`. The body is base64-encoded so arbitrary
-bytes survive the newline-delimited-JSON transport; the gateway base64-decodes
+path, headers: [[k,v],…], bodyB64, profile?}`. `profile` is optional — the
+connector stamps it when NAS resolves the target profile for a Team-Gateway
+interaction; omitting it (single-profile gateways) preserves legacy routing to
+the default `agent:main` session namespace, mirroring the `profile` field the
+`inbound` frame's `SessionSource` already carries (#60586). The body is
+base64-encoded so arbitrary bytes survive the newline-delimited-JSON transport;
+the gateway base64-decodes
 back to the exact bytes the connector forwarded (the connector already verified
 the provider signature and stripped any shared-identity credential at the edge —
 §6 — so the gateway re-processes a sanitized, token-free body and acts on it via

--- a/gateway/platform_registry.py
+++ b/gateway/platform_registry.py
@@ -4,10 +4,11 @@ Platform Adapter Registry
 Allows platform adapters (built-in and plugin) to self-register so the gateway
 can discover and instantiate them without hardcoded if/elif chains.
 
-Built-in adapters continue to use the existing if/elif in _create_adapter()
+Built-in adapters continue to use the existing if/elif in _instantiate_adapter()
 for now.  Plugin adapters register here via PluginContext.register_platform()
 and are looked up first -- if nothing is found the gateway falls through to
-the legacy code path.
+the legacy code path.  GatewayRunner._create_adapter() wraps both paths and
+binds every successful adapter to its runner.
 
 Usage (plugin side):
 

--- a/gateway/platforms/ADDING_A_PLATFORM.md
+++ b/gateway/platforms/ADDING_A_PLATFORM.md
@@ -174,7 +174,7 @@ Update `get_connected_platforms()` if your platform doesn't use token/api_key
 
 ## 3. Adapter Factory (`gateway/run.py`)
 
-Add to `_create_adapter()`:
+Add to `_instantiate_adapter()`:
 
 ```python
 elif platform == Platform.YOUR_PLATFORM:
@@ -184,6 +184,11 @@ elif platform == Platform.YOUR_PLATFORM:
         return None
     return YourAdapter(config)
 ```
+
+`_create_adapter()` wraps this factory and binds every successful adapter to
+its `GatewayRunner`. Do not construct platform adapters in lifecycle call sites;
+startup and reconnect must keep using the wrapper so profile routing is wired
+before `connect()`.
 
 ---
 

--- a/gateway/profile_routing.py
+++ b/gateway/profile_routing.py
@@ -35,6 +35,11 @@ Configuration (config.yaml):
           chat_id: "YOUR_CHANNEL_ID"
           thread_id: "YOUR_THREAD_ID"
           profile: thread-profile
+
+        - name: owner-whatsapp
+          platform: whatsapp
+          chat_id: "15551234567"   # phone, JID, or LID — all equivalent
+          profile: owner
 """
 
 from __future__ import annotations
@@ -45,6 +50,43 @@ from typing import Any, Dict, List, Optional
 import logging
 
 logger = logging.getLogger(__name__)
+
+# Baileys and Cloud share phone/JID/LID identity rules. Other platforms keep
+# exact string compare so Telegram numeric ids and Discord snowflakes stay
+# unchanged.
+_WHATSAPP_IDENTITY_PLATFORMS = {"whatsapp", "whatsapp_cloud"}
+_WHATSAPP_NON_USER_SUFFIXES = ("@g.us", "@broadcast", "@newsletter")
+
+
+def _is_whatsapp_non_user_chat(chat_id: Optional[str]) -> bool:
+    """True for group / broadcast / newsletter JIDs — not a sender identity."""
+    if not chat_id:
+        return False
+    cid = str(chat_id).strip().lower()
+    return any(cid.endswith(suffix) for suffix in _WHATSAPP_NON_USER_SUFFIXES)
+
+
+def _whatsapp_user_chat_ids_match(platform: str, left: Optional[str], right: Optional[str]) -> bool:
+    """True when two WhatsApp *user* chat_ids refer to the same person.
+
+    Reuses :func:`gateway.whatsapp_identity.expand_whatsapp_aliases` so a
+    bare phone number, a ``@s.whatsapp.net`` JID, and a ``@lid`` LID collapse
+    to one identity — the same helper session keys and adapter allowlists
+    already use. Group/broadcast JIDs are excluded: those are chats, not
+    senders. Returns False for non-WhatsApp platforms (exact match only).
+    """
+    if (platform or "").strip().lower() not in _WHATSAPP_IDENTITY_PLATFORMS:
+        return False
+    if not left or not right:
+        return False
+    if _is_whatsapp_non_user_chat(left) or _is_whatsapp_non_user_chat(right):
+        return False
+    from gateway.whatsapp_identity import expand_whatsapp_aliases
+
+    left_aliases = expand_whatsapp_aliases(str(left))
+    if not left_aliases:
+        return False
+    return bool(left_aliases & expand_whatsapp_aliases(str(right)))
 
 
 class ProfileRouteRejected(RuntimeError):
@@ -92,6 +134,11 @@ class ProfileRoute:
         - Thread in channel: parent_chat_id == route.chat_id
         A route declaring both ``guild_id`` and ``chat_id`` requires both to
         match (a chat match alone does not satisfy a guild constraint).
+
+        WhatsApp / WhatsApp Cloud ``chat_id`` also matches across user-identity
+        forms (bare number, JID, LID) after the exact-string check. Exact
+        matches always win first, so existing configs keep working. Groups
+        (``@g.us``) and broadcasts stay exact-only.
         """
         if not self.enabled:
             return False
@@ -100,7 +147,11 @@ class ProfileRoute:
         if self.thread_id and self.thread_id != thread_id:
             return False
         if self.chat_id and self.chat_id != chat_id and self.chat_id != parent_chat_id:
-            return False
+            if not (
+                _whatsapp_user_chat_ids_match(platform, self.chat_id, chat_id)
+                or _whatsapp_user_chat_ids_match(platform, self.chat_id, parent_chat_id)
+            ):
+                return False
         if self.guild_id and self.guild_id != guild_id:
             return False
         return True

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -1620,6 +1620,13 @@ class RelayAdapter(BasePlatformAdapter):
             # how platform=RELAY home channels slipped through in the first
             # place. Set locally, never read off the wire.
             delivered_via_upstream_relay=True,
+            # The HERMES profile this interaction is routed to (multiplex
+            # mode) — mirrors _event_from_wire's profile stamping for plain
+            # relayed messages (#60586). Without this, a Team-Gateway's
+            # Discord slash-command/button/modal always fell back to the
+            # legacy agent:main namespace even when the connector resolved
+            # a specific profile for it.
+            profile=getattr(forward, "profile", None),
         )
         event = MessageEvent(text=text, message_type=message_type, source=source)
         if itype == 3:

--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -402,6 +402,16 @@ class PassthroughForward:
     path: str
     headers: list[tuple[str, str]]
     body: bytes
+    # The HERMES profile this interaction is routed to (multiplex mode).
+    # Mirrors the ``profile`` field _event_from_wire already carries on the
+    # ``inbound`` frame's SessionSource (#60586) — the connector stamps it
+    # when NAS resolves the target profile for a Team-Gateway interaction;
+    # absent for a single-profile gateway, where it stays None and session
+    # keys keep the legacy ``agent:main`` namespace. Without this, a Discord
+    # slash-command/button/modal relayed through the passthrough plane always
+    # fell back to agent:main even when the equivalent plain message would
+    # have been routed to the correct profile.
+    profile: Optional[str] = None
 
 
 def _passthrough_from_wire(raw: Dict[str, Any]) -> PassthroughForward:
@@ -431,6 +441,7 @@ def _passthrough_from_wire(raw: Dict[str, Any]) -> PassthroughForward:
         path=str(raw.get("path", "")),
         headers=headers,
         body=body,
+        profile=raw.get("profile"),
     )
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17710,11 +17710,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return hashlib.sha256(("hermes-mux:" + token).encode("utf-8")).hexdigest()[:16]
 
     def _create_adapter(
-        self, 
-        platform: Platform, 
-        config: Any
+        self,
+        platform: Platform,
+        config: Any,
     ) -> Optional[BasePlatformAdapter]:
-        """Create the appropriate adapter for a platform.
+        """Create an adapter and bind it to this gateway runner.
+
+        Every lifecycle path — primary/secondary startup and reconnect — goes
+        through this method. Keep runner binding here so adapters can resolve
+        inbound profile routes before handlers or ``connect()`` run.
+        """
+        adapter = self._instantiate_adapter(platform, config)
+        if adapter is not None:
+            adapter.gateway_runner = self
+        return adapter
+
+    def _instantiate_adapter(
+        self,
+        platform: Platform,
+        config: Any,
+    ) -> Optional[BasePlatformAdapter]:
+        """Instantiate the appropriate adapter for a platform.
 
         Checks the platform_registry first (plugin adapters), then falls
         through to the built-in if/elif chain for core platforms.
@@ -17735,14 +17751,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if platform_registry.is_registered(platform.value):
                 adapter = platform_registry.create_adapter(platform.value, config)
                 if adapter is not None:
-                    # Inject a back-reference to the gateway runner so every
-                    # adapter can (a) deliver cross-platform admin alerts and
-                    # (b) resolve inbound profile routing through
-                    # ``runner._profile_name_for_source``. Unconditional:
-                    # ``BasePlatformAdapter`` declares ``gateway_runner``, so
-                    # this reaches ALL platforms (not just the ones that
-                    # pre-declared it), making profile routing platform-generic.
-                    adapter.gateway_runner = self
                     return adapter
                 # Registered but failed to instantiate — don't silently fall
                 # through to built-ins (there are none for plugin platforms).
@@ -17794,18 +17802,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if not check_api_server_requirements():
                 logger.warning("API Server: aiohttp not installed")
                 return None
-            adapter = APIServerAdapter(config)
-            adapter.gateway_runner = self
-            return adapter
+            return APIServerAdapter(config)
 
         elif platform == Platform.WEBHOOK:
             from gateway.platforms.webhook import WebhookAdapter, check_webhook_requirements
             if not check_webhook_requirements():
                 logger.warning("Webhook: aiohttp not installed")
                 return None
-            adapter = WebhookAdapter(config)
-            adapter.gateway_runner = self  # For cross-platform delivery
-            return adapter
+            return WebhookAdapter(config)
 
         elif platform == Platform.MSGRAPH_WEBHOOK:
             from gateway.platforms.msgraph_webhook import (

--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -48,6 +48,45 @@ import time
 from pathlib import Path as _Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
+from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
+from agent.secret_scope import get_secret as _scoped_get_secret
+from agent.secret_scope import is_multiplex_active
+
+
+def _get_scoped_secret(name: str, default: Optional[str] = None) -> Optional[str]:
+    """Scope-aware config/credential read with the default-profile fallback.
+
+    Secondary profiles construct their adapters under a profile secret
+    scope -- the scope is authoritative and a scoped miss returns ``default``
+    (no cross-profile borrow from ``os.environ``, which may hold another
+    profile's value). The DEFAULT profile's adapter constructs and connects
+    *unscoped* under multiplexing, where a bare ``get_secret`` would raise
+    ``UnscopedSecretError`` and crash startup/reconnect (#70652 class); there
+    ``os.environ`` is that profile's own value, so fall back to it. Same
+    pattern as ``whatsapp_common._get_wsecret`` and the WeCom/IRC/ntfy
+    plugin adapters.
+    """
+    try:
+        val = _scoped_get_secret(name, default)
+    except _UnscopedSecretError:
+        val = os.getenv(name)
+    return val if val is not None else default
+
+
+def _adc_would_borrow_foreign_credentials() -> bool:
+    """True when ADC would silently read another profile's SA from process env.
+
+    ``google.auth.default()`` consults ``os.environ`` directly. Under
+    multiplexing a scoped profile only reaches the ADC branch after its own
+    scope had no service-account setting -- if the process env still carries
+    one (the default profile's), ADC would authenticate this profile as that
+    other identity. Fail closed instead.
+    """
+    return is_multiplex_active() and bool(
+        os.environ.get("GOOGLE_CHAT_SERVICE_ACCOUNT_JSON")
+        or os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+    )
+
 # Heavy google-cloud + googleapiclient imports are deferred to first
 # adapter use. Importing them eagerly here added ~110ms wall and ~33MB
 # RSS to *every* CLI invocation (the plugin loader imports this module at
@@ -737,28 +776,48 @@ class GoogleChatAdapter(BasePlatformAdapter):
         # end-of-turn by on_processing_complete via patch-to-empty so
         # they don't sit in the chat forever as "Hermes is thinking…".
         self._orphan_typing_messages: Dict[str, List[str]] = {}
-        # FlowControl knobs (env-configurable).
+        # Snapshot profile-scoped settings while adapter construction still
+        # runs inside _profile_runtime_scope. Pub/Sub invokes callbacks from
+        # its own threads, where the ContextVar secret scope is intentionally
+        # unavailable; callbacks must use these instance values rather than
+        # consulting process-global environment state.
+        extra = self.config.extra
         try:
-            self._max_messages = int(os.getenv("GOOGLE_CHAT_MAX_MESSAGES", "1"))
+            self._max_messages = int(
+                extra.get("max_messages")
+                or _get_scoped_secret("GOOGLE_CHAT_MAX_MESSAGES", "1")
+            )
         except (ValueError, TypeError):
             self._max_messages = 1
         try:
-            self._max_bytes = int(os.getenv("GOOGLE_CHAT_MAX_BYTES", str(16 * 1024 * 1024)))
+            self._max_bytes = int(
+                extra.get("max_bytes")
+                or _get_scoped_secret("GOOGLE_CHAT_MAX_BYTES", str(16 * 1024 * 1024))
+            )
         except (ValueError, TypeError):
             self._max_bytes = 16 * 1024 * 1024
+        self._bootstrap_spaces = str(
+            extra.get("bootstrap_spaces")
+            or _get_scoped_secret("GOOGLE_CHAT_BOOTSTRAP_SPACES", "")
+            or ""
+        ).strip()
+        self._debug_raw = bool(
+            extra.get("debug_raw")
+            or _get_scoped_secret("GOOGLE_CHAT_DEBUG_RAW")
+        )
         self._http_events_url = (
-            self.config.extra.get("http_events_url")
-            or os.getenv("GOOGLE_CHAT_HTTP_EVENTS_URL", "")
+            extra.get("http_events_url")
+            or _get_scoped_secret("GOOGLE_CHAT_HTTP_EVENTS_URL", "")
             or ""
         ).strip()
         self._http_events_audience = (
-            self.config.extra.get("http_events_audience")
-            or os.getenv("GOOGLE_CHAT_HTTP_EVENTS_AUDIENCE", "")
+            extra.get("http_events_audience")
+            or _get_scoped_secret("GOOGLE_CHAT_HTTP_EVENTS_AUDIENCE", "")
             or self._http_events_url
         ).strip()
         self._http_events_service_account_email = (
-            self.config.extra.get("http_events_service_account_email")
-            or os.getenv("GOOGLE_CHAT_HTTP_EVENTS_SERVICE_ACCOUNT_EMAIL", "")
+            extra.get("http_events_service_account_email")
+            or _get_scoped_secret("GOOGLE_CHAT_HTTP_EVENTS_SERVICE_ACCOUNT_EMAIL", "")
             or ""
         ).strip().lower()
 
@@ -780,7 +839,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
         """
         sa_path = (
             self.config.extra.get("service_account_json")
-            or os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+            or _get_scoped_secret("GOOGLE_APPLICATION_CREDENTIALS")
         )
         if sa_path:
             # Inline JSON (rare, but supported).
@@ -812,6 +871,13 @@ class GoogleChatAdapter(BasePlatformAdapter):
 
         # No explicit SA configured — try ADC. This is the Cloud Run / GCE
         # path; google-auth picks up the workload identity automatically.
+        if _adc_would_borrow_foreign_credentials():
+            raise ValueError(
+                "Google Chat ADC skipped for this profile: service-account "
+                "credentials are set in the process environment but not in "
+                "this profile's secret scope. Set "
+                "GOOGLE_CHAT_SERVICE_ACCOUNT_JSON in this profile's .env."
+            )
         try:
             import google.auth as google_auth
         except ImportError:
@@ -917,8 +983,12 @@ class GoogleChatAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
     def _bot_id_cache_path(self) -> _Path:
         """Location where the resolved bot user_id is cached across restarts."""
-        base = os.getenv("HERMES_HOME", str(_Path.home() / ".hermes"))
-        return _Path(base) / "google_chat_bot_id.json"
+        # Resolve at call time (connect() runs inside the profile scope) so
+        # multiplexed profiles do not share one bot-identity cache file; the
+        # thread-count store above already resolves the same way.
+        from hermes_constants import get_hermes_home as _get_hermes_home
+
+        return _get_hermes_home() / "google_chat_bot_id.json"
 
     def _load_cached_bot_id(self) -> Optional[str]:
         path = self._bot_id_cache_path()
@@ -953,7 +1023,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
         if self.config.home_channel and self.config.home_channel.chat_id:
             candidate_spaces.append(self.config.home_channel.chat_id)
         # Env-configured allowed spaces (comma-separated). Optional.
-        extra_spaces = os.getenv("GOOGLE_CHAT_BOOTSTRAP_SPACES", "").strip()
+        extra_spaces = self._bootstrap_spaces
         if extra_spaces:
             candidate_spaces.extend(
                 s.strip() for s in extra_spaces.split(",") if s.strip()
@@ -1402,7 +1472,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
             list(envelope.keys()),
             ce_type,
         )
-        if os.getenv("GOOGLE_CHAT_DEBUG_RAW"):
+        if self._debug_raw:
             # Dangerous flag: contains message text and sender email. Route
             # through the global redaction filter and gate at DEBUG level so
             # default log configurations never surface it. Operators must
@@ -3363,14 +3433,14 @@ def _check_for_registry() -> bool:
     if not check_google_chat_requirements():
         return False
     project = (
-        os.getenv("GOOGLE_CHAT_PROJECT_ID")
-        or os.getenv("GOOGLE_CLOUD_PROJECT")
+        _get_scoped_secret("GOOGLE_CHAT_PROJECT_ID")
+        or _get_scoped_secret("GOOGLE_CLOUD_PROJECT")
     )
     subscription = (
-        os.getenv("GOOGLE_CHAT_SUBSCRIPTION_NAME")
-        or os.getenv("GOOGLE_CHAT_SUBSCRIPTION")
+        _get_scoped_secret("GOOGLE_CHAT_SUBSCRIPTION_NAME")
+        or _get_scoped_secret("GOOGLE_CHAT_SUBSCRIPTION")
     )
-    http_events_url = os.getenv("GOOGLE_CHAT_HTTP_EVENTS_URL")
+    http_events_url = _get_scoped_secret("GOOGLE_CHAT_HTTP_EVENTS_URL")
     return bool(http_events_url or (project and subscription))
 
 
@@ -3394,14 +3464,14 @@ def _env_enablement() -> Optional[Dict[str, Any]]:
     ``PlatformConfig`` rather than being merged into ``extra``.
     """
     project = (
-        os.getenv("GOOGLE_CHAT_PROJECT_ID")
-        or os.getenv("GOOGLE_CLOUD_PROJECT")
+        _get_scoped_secret("GOOGLE_CHAT_PROJECT_ID")
+        or _get_scoped_secret("GOOGLE_CLOUD_PROJECT")
     )
     subscription = (
-        os.getenv("GOOGLE_CHAT_SUBSCRIPTION_NAME")
-        or os.getenv("GOOGLE_CHAT_SUBSCRIPTION")
+        _get_scoped_secret("GOOGLE_CHAT_SUBSCRIPTION_NAME")
+        or _get_scoped_secret("GOOGLE_CHAT_SUBSCRIPTION")
     )
-    http_events_url = os.getenv("GOOGLE_CHAT_HTTP_EVENTS_URL")
+    http_events_url = _get_scoped_secret("GOOGLE_CHAT_HTTP_EVENTS_URL")
     if not (http_events_url or (project and subscription)):
         return None
     seed: Dict[str, Any] = {}
@@ -3411,23 +3481,32 @@ def _env_enablement() -> Optional[Dict[str, Any]]:
         seed["subscription_name"] = subscription
     if http_events_url:
         seed["http_events_url"] = http_events_url
-    http_events_audience = os.getenv("GOOGLE_CHAT_HTTP_EVENTS_AUDIENCE")
+    http_events_audience = _get_scoped_secret("GOOGLE_CHAT_HTTP_EVENTS_AUDIENCE")
     if http_events_audience:
         seed["http_events_audience"] = http_events_audience
-    http_events_sa_email = os.getenv("GOOGLE_CHAT_HTTP_EVENTS_SERVICE_ACCOUNT_EMAIL")
+    http_events_sa_email = _get_scoped_secret("GOOGLE_CHAT_HTTP_EVENTS_SERVICE_ACCOUNT_EMAIL")
     if http_events_sa_email:
         seed["http_events_service_account_email"] = http_events_sa_email
+    for env_name, extra_name in (
+        ("GOOGLE_CHAT_MAX_MESSAGES", "max_messages"),
+        ("GOOGLE_CHAT_MAX_BYTES", "max_bytes"),
+        ("GOOGLE_CHAT_BOOTSTRAP_SPACES", "bootstrap_spaces"),
+        ("GOOGLE_CHAT_DEBUG_RAW", "debug_raw"),
+    ):
+        value = _get_scoped_secret(env_name)
+        if value:
+            seed[extra_name] = value
     sa_json = (
-        os.getenv("GOOGLE_CHAT_SERVICE_ACCOUNT_JSON")
-        or os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+        _get_scoped_secret("GOOGLE_CHAT_SERVICE_ACCOUNT_JSON")
+        or _get_scoped_secret("GOOGLE_APPLICATION_CREDENTIALS")
     )
     if sa_json:
         seed["service_account_json"] = sa_json
-    home = os.getenv("GOOGLE_CHAT_HOME_CHANNEL")
+    home = _get_scoped_secret("GOOGLE_CHAT_HOME_CHANNEL")
     if home:
         seed["home_channel"] = {
             "chat_id": home,
-            "name": os.getenv("GOOGLE_CHAT_HOME_CHANNEL_NAME", "Home"),
+            "name": _get_scoped_secret("GOOGLE_CHAT_HOME_CHANNEL_NAME", "Home"),
         }
     return seed
 
@@ -3577,8 +3656,8 @@ async def _standalone_send(
     extra = getattr(pconfig, "extra", {}) or {}
     sa_value = (
         extra.get("service_account_json")
-        or os.getenv("GOOGLE_CHAT_SERVICE_ACCOUNT_JSON")
-        or os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+        or _get_scoped_secret("GOOGLE_CHAT_SERVICE_ACCOUNT_JSON")
+        or _get_scoped_secret("GOOGLE_APPLICATION_CREDENTIALS")
     )
 
     if service_account is None:
@@ -3608,6 +3687,12 @@ async def _standalone_send(
                     return {"error": f"Google Chat standalone send: SA JSON file is invalid: {exc}"}
                 creds = service_account.Credentials.from_service_account_info(info, scopes=_CHAT_SCOPES)
         else:
+            if _adc_would_borrow_foreign_credentials():
+                return {"error": (
+                    "Google Chat standalone send: ADC skipped for this profile: "
+                    "service-account credentials are set in the process environment "
+                    "but not in this profile's secret scope"
+                )}
             try:
                 import google.auth as _google_auth
             except ImportError:

--- a/tests/gateway/relay/test_relay_passthrough.py
+++ b/tests/gateway/relay/test_relay_passthrough.py
@@ -44,7 +44,7 @@ def adapter():
     return RelayAdapter(PlatformConfig(), _desc(), transport=StubConnector(_desc()))
 
 
-def _interaction_forward(payload: dict) -> PassthroughForward:
+def _interaction_forward(payload: dict, *, profile: str | None = None) -> PassthroughForward:
     body = json.dumps(payload).encode("utf-8")
     return PassthroughForward(
         platform="discord",
@@ -53,6 +53,7 @@ def _interaction_forward(payload: dict) -> PassthroughForward:
         path="/interactions/discord/appShared",
         headers=[("content-type", "application/json")],
         body=body,
+        profile=profile,
     )
 
 
@@ -73,6 +74,27 @@ def test_passthrough_from_wire_byte_preserves_body():
     assert fwd.bot_id == "appShared"
     assert fwd.body == original
     assert fwd.headers == [("content-type", "application/json")]
+
+
+def test_passthrough_from_wire_stamps_routed_profile():
+    """A connector-routed profile on the wire frame lands on PassthroughForward.
+
+    Mirrors _event_from_wire's profile stamping for the ``inbound`` frame
+    (#60586) — the passthrough plane needs the same carry-through so a
+    Team-Gateway's Discord interactions route to the same profile a plain
+    message would.
+    """
+    wire = {
+        "platform": "discord",
+        "botId": "appShared",
+        "method": "POST",
+        "path": "/interactions/discord/appShared",
+        "headers": [],
+        "bodyB64": "",
+        "profile": "reviewer",
+    }
+    fwd = _passthrough_from_wire(wire)
+    assert fwd.profile == "reviewer"
 
 
 @pytest.mark.asyncio
@@ -135,6 +157,40 @@ async def test_discord_interaction_routes_through_handle_message(adapter, monkey
     # The logical platform is now recorded for egress sender selection too
     # (_capture_scope skips only the generic "relay").
     assert adapter._platform_by_chat.get("chan-9") == "discord"
+
+
+@pytest.mark.asyncio
+async def test_discord_interaction_stamps_routed_profile(adapter, monkeypatch):
+    """A connector-routed profile on the passthrough forward lands on the
+    resulting event's SessionSource, the same way it does for a plain relayed
+    message (#60586) — so a Team-Gateway's Discord slash-command/button/modal
+    routes to the same profile a plain message would, instead of always
+    falling back to agent:main."""
+    await adapter.connect()
+    stub = adapter._transport
+
+    seen = []
+
+    async def fake_handle(event):
+        seen.append(event)
+
+    monkeypatch.setattr(adapter, "handle_message", fake_handle)
+
+    fwd = _interaction_forward(
+        {
+            "id": "interaction-2",
+            "type": 2,  # APPLICATION_COMMAND
+            "channel_id": "chan-9",
+            "guild_id": "guild-7",
+            "data": {"name": "summarize"},
+            "member": {"user": {"id": "user-3", "username": "ben"}},
+        },
+        profile="reviewer",
+    )
+    await stub.push_passthrough(fwd, buffer_id=None)
+
+    assert len(seen) == 1
+    assert seen[0].source.profile == "reviewer"
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -270,6 +270,61 @@ class TestEnvConfigLoading:
         cfg = load_gateway_config()
         assert _GC not in cfg.platforms
 
+    def test_multiplex_scoped_profile_never_borrows_process_env(
+        self, monkeypatch, tmp_path
+    ):
+        """Under multiplex a scoped profile sees ONLY its own Google Chat
+        settings, and the ADC branch fails closed instead of authenticating
+        as the default profile's service account (#73439)."""
+        from agent.secret_scope import (
+            build_profile_secret_scope,
+            set_multiplex_active,
+            set_secret_scope,
+        )
+
+        self._clean_env(monkeypatch)
+        monkeypatch.setenv("GOOGLE_CHAT_PROJECT_ID", "default-proj")
+        monkeypatch.setenv("GOOGLE_CHAT_SUBSCRIPTION_NAME", "default-sub")
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", "/secrets/default.json")
+        monkeypatch.setenv("GOOGLE_CHAT_BOOTSTRAP_SPACES", "spaces/DEFAULT")
+        profile_home = tmp_path / "beta"
+        profile_home.mkdir()
+        (profile_home / ".env").write_text(
+            "GOOGLE_CHAT_PROJECT_ID=beta-proj\nGOOGLE_CHAT_SUBSCRIPTION_NAME=beta-sub\n"
+        )
+        set_multiplex_active(True)
+        token = set_secret_scope(build_profile_secret_scope(profile_home))
+        try:
+            seed = _gc_mod._env_enablement() or {}
+            beta = GoogleChatAdapter(
+                PlatformConfig(enabled=True, extra={"project_id": "beta-proj", "subscription_name": "beta-sub"})
+            )
+            with pytest.raises(ValueError, match="ADC skipped"):
+                beta._load_sa_credentials()
+        finally:
+            from agent.secret_scope import reset_secret_scope
+
+            reset_secret_scope(token)
+            set_multiplex_active(False)
+        assert seed["project_id"] == "beta-proj"
+        assert "service_account_json" not in seed
+        assert beta._bootstrap_spaces == ""
+
+    def test_multiplex_default_profile_constructs_unscoped(self, monkeypatch):
+        """The default profile's adapter is built OUTSIDE any scope while
+        multiplex is active (gateway startup/reconnect); it must keep reading
+        its own process env instead of raising UnscopedSecretError."""
+        from agent.secret_scope import set_multiplex_active
+
+        self._clean_env(monkeypatch)
+        monkeypatch.setenv("GOOGLE_CHAT_BOOTSTRAP_SPACES", "spaces/DEFAULT")
+        set_multiplex_active(True)
+        try:
+            default = GoogleChatAdapter(_base_config())
+        finally:
+            set_multiplex_active(False)
+        assert default._bootstrap_spaces == "spaces/DEFAULT"
+
 
 # ===========================================================================
 # Pure helpers

--- a/tests/gateway/test_profile_resolution.py
+++ b/tests/gateway/test_profile_resolution.py
@@ -248,6 +248,69 @@ class TestGatewayRunnerInjection:
         assert hasattr(BasePlatformAdapter, "gateway_runner")
         assert BasePlatformAdapter.gateway_runner is None
 
+    def test_factory_binds_every_adapter_to_runner(self, monkeypatch):
+        """``_create_adapter`` binds the runner regardless of which branch
+        built the adapter (plugin registry OR built-in if/elif) — every
+        lifecycle path (startup, reconnect, secondary profiles) goes through
+        it, so this is the single seam that makes profile_routes reachable
+        for built-ins like Signal (#68332 / #70831)."""
+        from gateway.config import PlatformConfig
+
+        runner = object.__new__(GatewayRunner)
+        adapter = MagicMock(spec=BasePlatformAdapter)
+        monkeypatch.setattr(runner, "_instantiate_adapter", lambda platform, config: adapter)
+        assert runner._create_adapter(Platform.SIGNAL, PlatformConfig(enabled=True)) is adapter
+        assert adapter.gateway_runner is runner
+        monkeypatch.setattr(runner, "_instantiate_adapter", lambda platform, config: None)
+        assert runner._create_adapter(Platform.SIGNAL, PlatformConfig(enabled=True)) is None
+
+    @pytest.mark.asyncio
+    async def test_real_signal_factory_routes_inbound_group_event(self, monkeypatch):
+        """A factory-built (built-in) Signal adapter resolves profile_routes
+        for a real inbound envelope — fails on main where the Signal branch
+        returned a bare ``SignalAdapter(config)`` with no runner."""
+        from gateway.config import PlatformConfig
+
+        group_id = "test-signal-route"
+        monkeypatch.setenv("SIGNAL_GROUP_ALLOWED_USERS", group_id)
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(
+            multiplex_profiles=True,
+            profile_routes=[
+                ProfileRoute(name="signal", platform="signal", profile="ops", chat_id=f"group:{group_id}"),
+            ],
+        )
+        adapter = runner._create_adapter(
+            Platform.SIGNAL,
+            PlatformConfig(enabled=True, extra={"http_url": "http://127.0.0.1:18080", "account": "+15555550123"}),
+        )
+        assert adapter is not None and adapter.gateway_runner is runner
+
+        captured = {}
+
+        async def capture_event(event):
+            captured["event"] = event
+
+        adapter.handle_message = capture_event
+        with patch(
+            "hermes_cli.profiles.profiles_to_serve",
+            return_value=[("default", Path("/profiles/default")), ("ops", Path("/profiles/ops"))],
+        ):
+            await adapter._handle_envelope({
+                "envelope": {
+                    "sourceNumber": "+15555550124",
+                    "sourceName": "Test Operator",
+                    "timestamp": 1700000000000,
+                    "dataMessage": {
+                        "message": "diagnose the cluster",
+                        "groupInfo": {"groupId": group_id, "groupName": "US East 7"},
+                    },
+                },
+            })
+        source = captured["event"].source
+        assert source.profile == "ops"
+        assert build_session_key(source, profile=source.profile).startswith("agent:ops:")
+
 
 # A concrete adapter we can instantiate without the full platform stack.
 # ``build_source`` only reads ``self.platform`` and ``self.gateway_runner``, so a

--- a/tests/gateway/test_profile_routing.py
+++ b/tests/gateway/test_profile_routing.py
@@ -1,5 +1,7 @@
 """Tests for gateway/profile_routing.py — profile-based routing."""
 
+import json
+
 import pytest
 from gateway.profile_routing import (
     ProfileRoute,
@@ -106,3 +108,48 @@ class TestForumPostMatching:
                                  parent_chat_id="forum_channel_123")
         assert m is not None
         assert m.profile == "forum_profile"
+
+
+class TestWhatsAppChatIdIdentityMatching:
+    """WhatsApp ``chat_id`` routes match across number / JID / LID forms (the
+    same alias canonicalization allowlists and session keys already use);
+    every other platform, and WhatsApp groups, stay exact-compare."""
+
+    PHONE = "15551234567"
+    LID = "999999999999999"
+
+    def _write_lid_mapping(self, tmp_path, monkeypatch):
+        mapping_dir = tmp_path / "platforms" / "whatsapp" / "session"
+        mapping_dir.mkdir(parents=True)
+        (mapping_dir / f"lid-mapping-{self.PHONE}.json").write_text(json.dumps(f"{self.LID}@lid"))
+        (mapping_dir / f"lid-mapping-{self.LID}_reverse.json").write_text(
+            json.dumps(f"{self.PHONE}@s.whatsapp.net")
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    def test_number_route_matches_jid_and_mapped_lid_forms(self, tmp_path, monkeypatch):
+        self._write_lid_mapping(tmp_path, monkeypatch)
+        for platform in ("whatsapp", "whatsapp_cloud"):
+            r = ProfileRoute(name="owner", platform=platform, profile="owner", chat_id=self.PHONE)
+            assert r.matches(platform, chat_id=f"{self.PHONE}@s.whatsapp.net")
+            assert r.matches(platform, chat_id=f"{self.PHONE}:47@s.whatsapp.net")
+            assert r.matches(platform, chat_id=f"{self.LID}@lid")
+            # Alias fallback also applies to the thread-parent slot.
+            assert r.matches(platform, chat_id="thread-1", parent_chat_id=f"{self.LID}@lid")
+            assert not r.matches(platform, chat_id="15550001111@s.whatsapp.net")
+
+    def test_groups_and_other_platforms_stay_exact(self, tmp_path, monkeypatch):
+        self._write_lid_mapping(tmp_path, monkeypatch)
+        group = "120363012345678901@g.us"
+        owner = ProfileRoute(name="owner", platform="whatsapp", profile="owner", chat_id=self.PHONE)
+        assert not owner.matches("whatsapp", chat_id=group)
+        grp = ProfileRoute(name="grp", platform="whatsapp", profile="grp", chat_id=group)
+        assert grp.matches("whatsapp", chat_id=group)
+        assert not grp.matches("whatsapp", chat_id=f"{self.PHONE}@s.whatsapp.net")
+        # Stripping @g.us must never turn a group into a phone-identity match.
+        assert not ProfileRoute(
+            name="oops", platform="whatsapp", profile="owner", chat_id=group.split("@", 1)[0]
+        ).matches("whatsapp", chat_id=group)
+        tg = ProfileRoute(name="tg", platform="telegram", profile="owner", chat_id="640466638")
+        assert tg.matches("telegram", chat_id="640466638")
+        assert not tg.matches("telegram", chat_id="640466638@s.whatsapp.net")

--- a/website/docs/developer-guide/adding-platform-adapters.md
+++ b/website/docs/developer-guide/adding-platform-adapters.md
@@ -637,7 +637,7 @@ Three touchpoints:
 
 Six touchpoints:
 
-1. **`_create_adapter()`** — Add an `elif platform == Platform.NEWPLAT:` branch
+1. **`_instantiate_adapter()`** — Add an `elif platform == Platform.NEWPLAT:` branch. The `_create_adapter()` wrapper binds every successful adapter to its gateway runner.
 2. **`_is_user_authorized()` allowed_users map** — `Platform.NEWPLAT: "NEWPLAT_ALLOWED_USERS"`
 3. **`_is_user_authorized()` allow_all map** — `Platform.NEWPLAT: "NEWPLAT_ALLOW_ALL_USERS"`
 4. **Early env check `_any_allowlist` tuple** — Add `"NEWPLAT_ALLOWED_USERS"`

--- a/website/docs/user-guide/messaging/google_chat.md
+++ b/website/docs/user-guide/messaging/google_chat.md
@@ -166,6 +166,15 @@ GOOGLE_CHAT_MAX_BYTES=16777216                  # 16 MiB — cap on in-flight me
 The project ID also falls back to `GOOGLE_CLOUD_PROJECT`, and the SA path falls
 back to `GOOGLE_APPLICATION_CREDENTIALS` — use whichever convention you prefer.
 
+Under a [multi-profile gateway](../multi-profile-gateways.md), every
+`GOOGLE_CHAT_*` setting is read from the routed profile's own `.env`; a
+secondary profile never inherits the default profile's project, subscription,
+or service account. If a profile has no SA configured while the process
+environment carries one for another profile, the adapter refuses to fall back
+to Application Default Credentials (which would authenticate as that other
+profile) and logs an explicit error instead — put
+`GOOGLE_CHAT_SERVICE_ACCOUNT_JSON` in that profile's `.env`.
+
 Install the Google Chat adapter dependencies through its maintained installer.
 It applies the same pinned security floors used by the runtime checks:
 

--- a/website/docs/user-guide/multi-profile-gateways.md
+++ b/website/docs/user-guide/multi-profile-gateways.md
@@ -278,6 +278,12 @@ gateway:
       platform: telegram
       chat_id: "-1001234567890"
       profile: tg-profile
+
+    # A WhatsApp DM — write the phone number; JID and LID forms also match
+    - name: owner-whatsapp
+      platform: whatsapp
+      chat_id: "15551234567"
+      profile: owner
 ```
 
 Routes are matched most-specific-first (`thread_id` > `chat_id` > `guild_id`),
@@ -286,6 +292,18 @@ matches threads/forum posts whose parent is that channel. Messages that match
 no route stay on the default/active profile. The routed profile gets the full
 per-profile isolation described above (config, skills, memory, credentials,
 session namespace). Routing works on every platform adapter, not just Discord.
+
+On WhatsApp and WhatsApp Cloud, a `chat_id` route matches across user-identity
+forms: a bare phone number (`15551234567`), a JID
+(`15551234567@s.whatsapp.net`), and a LID (`…@lid`) all refer to the same
+person once the bridge has paired them (the same canonicalization session keys
+and adapter allowlists already use). You can put the phone number in
+`profile_routes` and inbound DMs still match whether WhatsApp delivers a JID or
+a LID. Without a LID mapping yet, the number form still matches a JID (the
+suffix is stripped) but cannot resolve an unknown LID — that inbound falls
+through to the default profile until the mapping appears. Group chats
+(`…@g.us`) are not sender identities and still match exactly. Telegram numeric
+ids are unchanged.
 
 `profile_routes` requires `gateway.multiplex_profiles: true`; with
 multiplexing off the routes are ignored. If an explicit route matches but its

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/developer-guide/adding-platform-adapters.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/developer-guide/adding-platform-adapters.md
@@ -537,9 +537,9 @@ await self.handle_message(event)
 
 ### 4. Gateway Runner（`gateway/run.py`）
 
-五个接触点：
+六个接触点：
 
-1. **`_create_adapter()`** — 添加 `elif platform == Platform.NEWPLAT:` 分支
+1. **`_instantiate_adapter()`** — 添加 `elif platform == Platform.NEWPLAT:` 分支。`_create_adapter()` 包装器会将每个成功创建的适配器绑定到其网关运行器。
 2. **`_is_user_authorized()` allowed_users 映射** — `Platform.NEWPLAT: "NEWPLAT_ALLOWED_USERS"`
 3. **`_is_user_authorized()` allow_all 映射** — `Platform.NEWPLAT: "NEWPLAT_ALLOW_ALL_USERS"`
 4. **早期环境检查 `_any_allowlist` 元组** — 添加 `"NEWPLAT_ALLOWED_USERS"`


### PR DESCRIPTION
## Summary
Under a multiplexed gateway, four adapter seams still resolved the wrong profile: Google Chat read all its config/credentials from process env (and fell through to ADC with another profile's SA), built-in adapters (Signal/WhatsApp Cloud/Weixin…) were never bound to the runner so `profile_routes` was unreachable, WhatsApp routes only matched exact strings (missing JID/LID forms), and relay passthrough interactions dropped the connector-routed profile. Root cause in each: per-site env/identity reads or per-branch wiring instead of one owner.
## Changes
- google_chat: `_get_scoped_secret` for all 27 reads; instance snapshot of Pub/Sub callback knobs; `_env_enablement` seeds them; ADC fail-closed guard (adapter + standalone send); bot-id cache path resolved via `get_hermes_home()`.
- gateway/run.py: `_create_adapter` = `_instantiate_adapter` + runner binding on every adapter (one seam covers startup/reconnect/secondary).
- profile_routing: WhatsApp/WhatsApp Cloud user chat_ids match across number/JID/LID (chat_id and parent_chat_id); groups and other platforms exact.
- relay: `PassthroughForward.profile` off the wire → interaction `SessionSource.profile`; contract doc updated.
- Docs: google_chat, multi-profile-gateways, adding-platform-adapters (en/zh), ADDING_A_PLATFORM.
## Validation
| Probe (temp HERMES_HOME, multiplex on) | main | branch |
|---|---|---|
| beta `_env_enablement` project / SA leak | default-proj / default SA path | beta-proj / none |
| beta `_load_sa_credentials` with default SA in env | returned default's Credentials | ValueError "ADC skipped" |
| default unscoped ctor | ok | ok |
| Signal/WA Cloud/Weixin `gateway_runner` bound; Signal inbound profile | False; None | True; ops |
| WA number route vs JID / LID / LID parent | None ×3 | owner ×3 |
| relay passthrough `SessionSource.profile` | None | reviewer |
224 targeted tests pass; 7 new regression tests, each sabotage-verified to fail on main.
## Credits
@rayjun (#57674, first Google Chat submitter — ADC guard, co-author), @zyz619963502zyz (#73445), @andyg5000-agent (#68332, first report), @heyhudson (#70831), @vKongv (#85081), @pierrenode (#61012).

Fixes #73439

## Infographic

![mux-adapter-scoping-b](https://v3b.fal.media/files/b/0aa8cddc/tttOzxJtQekbXD3ej6COT_k5eQoDuJ.png)
