### PR TITLE
fix(gateway): Raft/A2A identity, A2A authz, webhook disable, TTS cache and log files scoped per multiplexed profile (#100697 #99634 #85637 #80884, salvage #100392 #100382 #100709 #98756 #85712 #80956)

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -204,11 +204,22 @@ class GatewayAuthorizationMixin:
         ``self.adapters``. ``SessionSource.profile`` selects which map to consult.
         When a stamped profile has its own adapter registry entry, the default
         profile's same-platform adapter must not be consulted as a fallback.
+
+        Consult ``_profile_adapters`` *before* comparing against
+        ``_active_profile_name()``. Multiplex turns wrap authz in
+        ``_profile_runtime_scope``, which overrides ``HERMES_HOME`` so
+        ``get_active_profile_name()`` returns the secondary profile for the
+        duration of the turn. Treating that scoped name as "primary" would
+        look up ``self.adapters`` (empty for secondary-only platforms like
+        A2A) and default-deny an already-authenticated peer.
         """
         if not platform:
             return None
         profile_name = (profile or "").strip() or None
         if profile_name and profile_name != "default":
+            profile_adapters = getattr(self, "_profile_adapters", None) or {}
+            if profile_name in profile_adapters:
+                return profile_adapters[profile_name].get(platform)
             # Adapter ownership is process-wide: only the profile the gateway
             # was LAUNCHED as owns ``self.adapters``. ``_active_profile_name()``
             # reads the per-turn HERMES_HOME override, so inside a secondary
@@ -226,9 +237,6 @@ class GatewayAuthorizationMixin:
             if profile_name == primary_profile:
                 adapters = getattr(self, "adapters", None) or {}
                 return adapters.get(platform)
-            profile_adapters = getattr(self, "_profile_adapters", None) or {}
-            if profile_name in profile_adapters:
-                return profile_adapters[profile_name].get(platform)
             # Fail closed: a stamped secondary profile with no registry entry
             # (e.g. its adapter failed to connect) must NOT fall back to the
             # default profile's adapter — that sends replies out the wrong bot.

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -2406,7 +2406,21 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     if webhook_enabled:
         if Platform.WEBHOOK not in config.platforms:
             config.platforms[Platform.WEBHOOK] = PlatformConfig()
-        config.platforms[Platform.WEBHOOK].enabled = True
+        # Honor an explicit ``enabled: false`` in config.yaml (flagged by
+        # ``_enabled_explicit``). In multiplex mode a secondary profile's
+        # config.yaml pins ``platforms.webhook.enabled: false`` so it shares
+        # the default profile's listener instead of binding its own port. That
+        # profile may still carry ``WEBHOOK_ENABLED`` in its own .env (or the
+        # process env, single-profile); without this guard the env var would
+        # force-enable the listener and trip the MultiplexConfigError check.
+        # Pop (don't read) the marker — the webhook branch is terminal (no
+        # later registry pass re-enables it), matching the api_server branch
+        # above.
+        webhook_explicit = config.platforms[Platform.WEBHOOK].extra.pop(
+            "_enabled_explicit", False
+        )
+        if not webhook_explicit or config.platforms[Platform.WEBHOOK].enabled:
+            config.platforms[Platform.WEBHOOK].enabled = True
         if webhook_port:
             try:
                 config.platforms[Platform.WEBHOOK].extra["port"] = int(webhook_port)

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -2448,7 +2448,13 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         if Platform.MSGRAPH_WEBHOOK not in config.platforms:
             config.platforms[Platform.MSGRAPH_WEBHOOK] = PlatformConfig()
         if msgraph_webhook_enabled:
-            config.platforms[Platform.MSGRAPH_WEBHOOK].enabled = True
+            # Same explicit-disable guard as the webhook branch above (#85637).
+            # READ (don't pop) the marker here: the relay-exclusive pass below
+            # still consults it, and the end-of-function scrub removes it for
+            # every platform.
+            msgraph_cfg = config.platforms[Platform.MSGRAPH_WEBHOOK]
+            if not msgraph_cfg.extra.get("_enabled_explicit", False) or msgraph_cfg.enabled:
+                msgraph_cfg.enabled = True
         if msgraph_webhook_port:
             try:
                 config.platforms[Platform.MSGRAPH_WEBHOOK].extra["port"] = int(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2479,6 +2479,30 @@ def _multiplex_profile_homes(config: object) -> list[tuple[str, "Path"]]:
     )
 
 
+def _enable_multiplex_log_routing(config: object) -> bool:
+    """Route agent.log/errors.log/gateway.log records to their owning profile.
+
+    ``setup_logging(mode="gateway")`` binds the queued file handlers to the
+    launch home, so under ``multiplex_profiles`` every secondary profile's
+    records (emitted inside ``_profile_runtime_scope``) land in the default
+    profile's log files (#82936). Swap the static handlers for the
+    profile routers from #99440 — the same primitive the Desktop cron ticker
+    uses — once the served-profile set is known. Inert for single-profile
+    gateways (``enable_profile_log_routing`` is a no-op below two homes).
+    """
+    if not getattr(config, "multiplex_profiles", False):
+        return False
+    try:
+        from hermes_logging import enable_profile_log_routing
+
+        return enable_profile_log_routing(
+            [home for _name, home in _multiplex_profile_homes(config)]
+        )
+    except Exception:
+        logger.debug("could not enable per-profile log routing", exc_info=True)
+        return False
+
+
 def _handoff_watch_scopes(runner: object) -> list:
     """``(profile_name, home)`` pairs whose ``state.db`` the watcher must poll.
 
@@ -33608,6 +33632,10 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             logging.getLogger().setLevel(_stderr_level)
 
     runner = GatewayRunner(config)
+    # Multiplex: swap the launch-home file handlers for per-profile routers so
+    # each profile's records land in its own logs/ (#82936). Must run after
+    # the runner resolved the (possibly None) config and after setup_logging.
+    _enable_multiplex_log_routing(runner.config)
     # ``--replace`` is explicit startup authority, not a durable reconnect
     # policy. GatewayRunner scopes this bit to cold adapter connects and clears
     # it before the background reconnect watcher starts.

--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -74,8 +74,30 @@ def _reply_timeout() -> float:
         return 300.0
 
 
+def _profile_scoped() -> bool:
+    """True when running inside a multiplexed secondary profile's scope.
+
+    Secondary-profile adapters are constructed inside ``_profile_runtime_scope``
+    (secret scope installed + multiplex active) — the same discriminator the
+    Buzz/SimpleX adapters use for this bug class (#98738). The DEFAULT profile
+    under multiplexing runs unscoped: ``os.environ`` holds its own bridge
+    output there and keeps its legacy precedence.
+    """
+    try:
+        from agent.secret_scope import current_secret_scope, is_multiplex_active
+
+        return bool(is_multiplex_active() and current_secret_scope() is not None)
+    except Exception:
+        return False
+
+
 def _default_agent_name() -> str:
-    name = os.getenv("A2A_AGENT_NAME", "").strip()
+    # Scope-aware: inside a secondary multiplex profile, os.environ holds the
+    # DEFAULT profile's bridged A2A_AGENT_NAME — borrowing it would brand a
+    # secondary profile's Agent Card with another profile's identity. There
+    # is no per-profile config.yaml equivalent yet, so a scoped profile just
+    # falls through to the hostname-based default below instead.
+    name = "" if _profile_scoped() else os.getenv("A2A_AGENT_NAME", "").strip()
     if name:
         return name
     try:
@@ -343,7 +365,15 @@ class A2AAdapter(BasePlatformAdapter):
         super().__init__(config=config, platform=platform)
 
         extra = getattr(config, "extra", {}) or {}
-        self.port = int(os.getenv("A2A_PORT") or extra.get("port", _DEFAULT_PORT))
+        # Scope-aware: a secondary multiplex profile must not borrow the
+        # default profile's bridged A2A_PORT (mirrors the Buzz/SimpleX fix
+        # for #98738) — an unconfigured profile falls closed to the module
+        # default port instead. (advertised_toolsets has the same env-leak
+        # shape but is left unscoped here — see the "Scope note" in this
+        # fix's PR description: open PR #98937 is actively rewriting this
+        # field's None-vs-empty-list semantics.)
+        _port_env = None if _profile_scoped() else os.getenv("A2A_PORT")
+        self.port = int(_port_env or extra.get("port", _DEFAULT_PORT))
         self.host = security.resolve_bind_host()
         self.agent_name = _default_agent_name()
         self._advertised_toolsets = [
@@ -502,9 +532,15 @@ class A2AAdapter(BasePlatformAdapter):
             raw = cfg.get("a2a_served_agents") or (cfg.get("a2a") or {}).get("served_agents")
 
         agents: dict[str, dict] = {}
-        default_desc = os.getenv(
-            "A2A_AGENT_DESCRIPTION",
-            "Hermes Agent — a general-purpose agent reachable over A2A.",
+        # Scope-aware for the same reason as port/toolsets above: a secondary
+        # profile must not inherit the default profile's A2A_AGENT_DESCRIPTION.
+        default_desc = (
+            "Hermes Agent — a general-purpose agent reachable over A2A."
+            if _profile_scoped()
+            else os.getenv(
+                "A2A_AGENT_DESCRIPTION",
+                "Hermes Agent — a general-purpose agent reachable over A2A.",
+            )
         )
         agents[""] = {
             "slug": "",

--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -249,7 +249,7 @@ class A2ARequestHandler(BaseHTTPRequestHandler):
             }
             # Do not leak profile/tenant topology on remote unauthenticated GETs.
             # Agent Cards are intentionally public; health topology is not.
-            if security.localhost_only() or security.authenticate(
+            if self.adapter._security_context.localhost_only() or self.adapter._security_context.authenticate(
                 self.headers.get("Authorization"),
                 self.client_address[0] if self.client_address else "",
             ) is not None:
@@ -268,7 +268,9 @@ class A2ARequestHandler(BaseHTTPRequestHandler):
 
         # Identity comes from the presented credential (or the socket in
         # localhost-only mode) — never from the request body.
-        identity = security.authenticate(self.headers.get("Authorization"), client_ip)
+        identity = adapter._security_context.authenticate(
+            self.headers.get("Authorization"), client_ip
+        )
         if identity is None:
             self._json(401, protocol.jsonrpc_error(None, protocol.ERR_UNAUTHORIZED, "unauthorized"))
             return
@@ -314,7 +316,7 @@ class A2ARequestHandler(BaseHTTPRequestHandler):
             self._json(429, protocol.jsonrpc_error(req_id, protocol.ERR_RATE_LIMITED, "rate limit exceeded"))
             return
 
-        if not security.is_trusted_peer(identity):
+        if not adapter._security_context.is_trusted_peer(identity):
             self._json(403, protocol.jsonrpc_error(
                 req_id, protocol.ERR_UNTRUSTED_PEER, f"peer '{identity}' not trusted"))
             return
@@ -372,9 +374,10 @@ class A2AAdapter(BasePlatformAdapter):
         # shape but is left unscoped here — see the "Scope note" in this
         # fix's PR description: open PR #98937 is actively rewriting this
         # field's None-vs-empty-list semantics.)
+        self._security_context = security.A2ASecurityContext.capture()
         _port_env = None if _profile_scoped() else os.getenv("A2A_PORT")
         self.port = int(_port_env or extra.get("port", _DEFAULT_PORT))
-        self.host = security.resolve_bind_host()
+        self.host = self._security_context.resolve_bind_host()
         self.agent_name = _default_agent_name()
         self._advertised_toolsets = [
             t.strip() for t in (
@@ -470,7 +473,11 @@ class A2AAdapter(BasePlatformAdapter):
 
         self._mark_connected()
 
-        exposure = "localhost-only" if security.localhost_only() else "REMOTE (bearer auth)"
+        exposure = (
+            "localhost-only"
+            if self._security_context.localhost_only()
+            else "REMOTE (bearer auth)"
+        )
         logger.info(
             "A2A: serving Agent Card + JSON-RPC on http://%s:%s (%s) as %r; %d routed agent(s)",
             self.host, self.port, exposure, self.agent_name, len(self._agents),
@@ -649,7 +656,7 @@ class A2AAdapter(BasePlatformAdapter):
             skills=self._advertised_skills(agent),
             streaming=bool(agent.get("local", True)),
             push_notifications=True,
-            auth_required=not security.localhost_only(),
+            auth_required=not self._security_context.localhost_only(),
             tenant=str(agent.get("tenant") or ""),
         )
 
@@ -1228,7 +1235,10 @@ class A2AAdapter(BasePlatformAdapter):
         if not callback_url:
             return
 
-        if not security.is_safe_callback_url(callback_url):
+        if not security.is_safe_callback_url(
+            callback_url,
+            localhost_mode=self._security_context.localhost_only(),
+        ):
             logger.warning("A2A: push notification for task %s blocked — unsafe callback URL: %s",
                            task_id, callback_url)
             protocol.metrics.push_failed += 1
@@ -1237,7 +1247,7 @@ class A2AAdapter(BasePlatformAdapter):
         # Push payload uses the StreamResponse format (same as streaming).
         payload = protocol.status_update(task_id, context_id, state, (reply or "")[:2000])
 
-        signature = security.sign_push_payload(payload)
+        signature = self._security_context.sign_push_payload(payload)
         headers = {"Content-Type": "application/json"}
         if signature:
             headers["X-A2A-Signature"] = signature

--- a/plugins/platforms/a2a/security.py
+++ b/plugins/platforms/a2a/security.py
@@ -31,29 +31,44 @@ import logging
 import os
 import re
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
 logger = logging.getLogger(__name__)
 
 
-# --------------------------------------------------------------------------
-# Bearer auth + peer identity
-# --------------------------------------------------------------------------
+def _profile_scoped() -> bool:
+    """True when running inside a multiplexed secondary profile's scope.
 
-def get_bearer_token() -> str:
-    """Return the configured shared inbound bearer token (empty if none)."""
-    return os.getenv("A2A_BEARER_TOKEN", "").strip()
-
-
-def get_peer_tokens() -> dict[str, str]:
-    """Parse A2A_PEER_TOKENS ("alice:tok1,bob:tok2") into {token: peer_name}.
-
-    Per-peer tokens give each remote agent its own credential, so the identity
-    used for rate limiting, trust, and audit is authenticated — not whatever
-    the request body claims.
+    Same discriminator as the Buzz/SimpleX/Raft adapters (#98738): secret
+    scope installed + multiplex active. The DEFAULT profile under
+    multiplexing (and every single-profile process) runs unscoped and keeps
+    its legacy ``os.environ`` precedence.
     """
-    raw = os.getenv("A2A_PEER_TOKENS", "").strip()
+    try:
+        from agent.secret_scope import current_secret_scope, is_multiplex_active
+
+        return bool(is_multiplex_active() and current_secret_scope() is not None)
+    except Exception:
+        return False
+
+
+def _startup_env(name: str) -> str:
+    """Read one A2A setting from the active profile's scope, else the env.
+
+    Inside a secondary profile's scope the scope is authoritative: a miss
+    yields "" and never falls through to ``os.environ`` (which holds the
+    default profile's tokens in a multiplexer).
+    """
+    if _profile_scoped():
+        from agent.secret_scope import get_secret
+
+        return (get_secret(name) or "").strip()
+    return os.getenv(name, "").strip()
+
+
+def _parse_peer_tokens(raw: str) -> dict[str, str]:
     out: dict[str, str] = {}
     for pair in raw.split(","):
         pair = pair.strip()
@@ -64,6 +79,115 @@ def get_peer_tokens() -> dict[str, str]:
         if name and token:
             out[token] = name
     return out
+
+
+def _configured_trusted_peers() -> frozenset[str]:
+    raw = _startup_env("A2A_TRUSTED_PEERS")
+    if raw:
+        return frozenset(p.strip() for p in raw.split(",") if p.strip())
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        peers = (cfg.get("a2a") or {}).get("trusted_peers", [])
+        if isinstance(peers, list):
+            return frozenset(str(peer).strip() for peer in peers if str(peer).strip())
+    except Exception:
+        pass
+    return frozenset()
+
+
+@dataclass(frozen=True)
+class A2ASecurityContext:
+    """Immutable, profile-scoped security settings captured at adapter startup.
+
+    ``ThreadingHTTPServer`` handles requests on fresh threads that do not inherit
+    the gateway's profile ContextVars. Keeping the resolved settings on the
+    adapter prevents those threads from falling back to another profile's
+    process-global environment.
+    """
+
+    bearer_token: str
+    peer_tokens: tuple[tuple[str, str], ...]
+    trusted_peers: frozenset[str]
+    allow_all_users: bool
+    requested_host: str
+    push_secret: str
+
+    @classmethod
+    def capture(cls) -> "A2ASecurityContext":
+        bearer_token = _startup_env("A2A_BEARER_TOKEN")
+        return cls(
+            bearer_token=bearer_token,
+            peer_tokens=tuple(_parse_peer_tokens(_startup_env("A2A_PEER_TOKENS")).items()),
+            trusted_peers=_configured_trusted_peers(),
+            allow_all_users=_startup_env("A2A_ALLOW_ALL_USERS").lower()
+            in {"1", "true", "yes"},
+            requested_host=_startup_env("A2A_HOST") or "127.0.0.1",
+            push_secret=_startup_env("A2A_PUSH_SECRET") or bearer_token,
+        )
+
+    def localhost_only(self) -> bool:
+        return not (self.bearer_token or self.peer_tokens)
+
+    def resolve_bind_host(self) -> str:
+        loopback = {"127.0.0.1", "localhost", "::1"}
+        if self.requested_host in loopback:
+            return self.requested_host
+        if self.localhost_only():
+            logger.warning(
+                "A2A: A2A_HOST=%s ignored — no A2A_BEARER_TOKEN or "
+                "A2A_PEER_TOKENS set; binding to 127.0.0.1. Configure a token "
+                "to expose A2A remotely.",
+                self.requested_host,
+            )
+            return "127.0.0.1"
+        return self.requested_host
+
+    def authenticate(self, auth_header: Optional[str], client_ip: str = "") -> Optional[str]:
+        if self.localhost_only():
+            return f"ip:{client_ip or 'local'}"
+        presented = _parse_bearer(auth_header)
+        if presented is None:
+            return None
+        for token, name in self.peer_tokens:
+            if hmac.compare_digest(presented, token):
+                return name
+        if self.bearer_token and hmac.compare_digest(presented, self.bearer_token):
+            return f"ip:{client_ip or 'unknown'}"
+        return None
+
+    def is_trusted_peer(self, identity: str) -> bool:
+        if self.allow_all_users or self.localhost_only() or not self.trusted_peers:
+            return True
+        return identity in self.trusted_peers
+
+    def sign_push_payload(self, payload: dict) -> str:
+        if not self.push_secret:
+            return ""
+        body = json.dumps(payload, sort_keys=True, ensure_ascii=False).encode("utf-8")
+        return hmac.new(
+            self.push_secret.encode("utf-8"), body, hashlib.sha256
+        ).hexdigest()
+
+
+# --------------------------------------------------------------------------
+# Bearer auth + peer identity
+# --------------------------------------------------------------------------
+
+def get_bearer_token() -> str:
+    """Return the configured shared inbound bearer token (empty if none)."""
+    return _startup_env("A2A_BEARER_TOKEN")
+
+
+def get_peer_tokens() -> dict[str, str]:
+    """Parse A2A_PEER_TOKENS ("alice:tok1,bob:tok2") into {token: peer_name}.
+
+    Per-peer tokens give each remote agent its own credential, so the identity
+    used for rate limiting, trust, and audit is authenticated — not whatever
+    the request body claims.
+    """
+    return _parse_peer_tokens(_startup_env("A2A_PEER_TOKENS"))
 
 
 def _parse_bearer(auth_header: Optional[str]) -> Optional[str]:
@@ -85,24 +209,12 @@ def authenticate(auth_header: Optional[str], client_ip: str = "") -> Optional[st
 
     Comparisons are constant-time (hmac.compare_digest).
     """
-    peer_tokens = get_peer_tokens()
-    shared = get_bearer_token()
-    if not peer_tokens and not shared:
-        return f"ip:{client_ip or 'local'}"
-    presented = _parse_bearer(auth_header)
-    if presented is None:
-        return None
-    for token, name in peer_tokens.items():
-        if hmac.compare_digest(presented, token):
-            return name
-    if shared and hmac.compare_digest(presented, shared):
-        return f"ip:{client_ip or 'unknown'}"
-    return None
+    return A2ASecurityContext.capture().authenticate(auth_header, client_ip)
 
 
 def localhost_only() -> bool:
     """True when we must refuse non-loopback binds (no token of any kind set)."""
-    return not (get_bearer_token() or get_peer_tokens())
+    return A2ASecurityContext.capture().localhost_only()
 
 
 def resolve_bind_host() -> str:
@@ -112,18 +224,7 @@ def resolve_bind_host() -> str:
     per-peer) AND explicitly asked for a wider host. A token alone does not
     widen the bind — opting into remote exposure must be deliberate.
     """
-    requested = os.getenv("A2A_HOST", "").strip() or "127.0.0.1"
-    loopback = {"127.0.0.1", "localhost", "::1"}
-    if requested in loopback:
-        return requested
-    if localhost_only():
-        logger.warning(
-            "A2A: A2A_HOST=%s ignored — no A2A_BEARER_TOKEN or A2A_PEER_TOKENS "
-            "set; binding to 127.0.0.1. Configure a token to expose A2A remotely.",
-            requested,
-        )
-        return "127.0.0.1"
-    return requested
+    return A2ASecurityContext.capture().resolve_bind_host()
 
 
 # --------------------------------------------------------------------------
@@ -138,18 +239,7 @@ def get_trusted_peers() -> set[str]:
     names from ``authenticate()`` — peer-token names, or ``ip:<addr>`` for
     shared-token callers.
     """
-    env_peers = os.getenv("A2A_TRUSTED_PEERS", "").strip()
-    if env_peers:
-        return {p.strip() for p in env_peers.split(",") if p.strip()}
-    try:
-        from hermes_cli.config import load_config
-        cfg = load_config() or {}
-        peers_list = (cfg.get("a2a") or {}).get("trusted_peers", [])
-        if isinstance(peers_list, list):
-            return {str(p).strip() for p in peers_list if p}
-    except Exception:
-        pass
-    return set()
+    return set(_configured_trusted_peers())
 
 
 def is_trusted_peer(identity: str) -> bool:
@@ -160,14 +250,7 @@ def is_trusted_peer(identity: str) -> bool:
     otherwise any *authenticated* identity is allowed (authentication is the
     primary gate — the allow-list is an optional restriction on top).
     """
-    if os.getenv("A2A_ALLOW_ALL_USERS", "").strip().lower() in ("1", "true", "yes"):
-        return True
-    if localhost_only():
-        return True
-    trusted = get_trusted_peers()
-    if not trusted:
-        return True
-    return identity in trusted
+    return A2ASecurityContext.capture().is_trusted_peer(identity)
 
 
 # --------------------------------------------------------------------------
@@ -259,10 +342,7 @@ def get_push_secret() -> str:
     Falls back to the bearer token if no dedicated push secret is set.
     If neither is configured, push notifications are unsigned (localhost-only mode).
     """
-    secret = os.getenv("A2A_PUSH_SECRET", "").strip()
-    if secret:
-        return secret
-    return get_bearer_token()
+    return A2ASecurityContext.capture().push_secret
 
 
 def sign_push_payload(payload: dict) -> str:
@@ -304,12 +384,14 @@ _BLOCKED_PREFIXES = (
 )
 
 
-def is_safe_callback_url(url: str) -> bool:
+def is_safe_callback_url(url: str, *, localhost_mode: Optional[bool] = None) -> bool:
     """Check if a push notification callback URL is safe from SSRF.
 
     Blocks internal/private/loopback/metadata addresses.
     Only allows http:// and https:// schemes.
     """
+    if localhost_mode is None:
+        localhost_mode = localhost_only()
     if not url or not isinstance(url, str):
         return False
     try:
@@ -324,16 +406,16 @@ def is_safe_callback_url(url: str) -> bool:
     hostname_lower = hostname.lower()
     if hostname_lower == "localhost":
         # Loopback callbacks only make sense for local testing.
-        return localhost_only()
+        return localhost_mode
     for prefix in _BLOCKED_PREFIXES:
         if hostname_lower.startswith(prefix.lower()):
-            if localhost_only() and prefix in ("127.", "::1"):
+            if localhost_mode and prefix in ("127.", "::1"):
                 return True
             return False
     try:
         ip = ipaddress.ip_address(hostname)
         if ip.is_loopback or ip.is_link_local or ip.is_private or ip.is_reserved:
-            if localhost_only() and ip.is_loopback:
+            if localhost_mode and ip.is_loopback:
                 return True
             return False
     except ValueError:

--- a/plugins/platforms/raft/adapter.py
+++ b/plugins/platforms/raft/adapter.py
@@ -97,6 +97,52 @@ _RAFT_TURN_IDS: set[str] = set()
 _RAFT_PROMPT_TURN_IDS: set[str] = set()
 
 
+def _profile_scoped() -> bool:
+    """True when running inside a multiplexed secondary profile's scope.
+
+    Secondary-profile adapters are constructed, connected, and reloaded
+    inside ``_profile_runtime_scope`` (secret scope installed + multiplex
+    active) — the same discriminator the Buzz/SimpleX adapters use for this
+    bug class (#98738). The DEFAULT profile under multiplexing runs
+    unscoped: ``os.environ`` holds its own bridge output there and keeps its
+    legacy precedence.
+    """
+    try:
+        from agent.secret_scope import current_secret_scope, is_multiplex_active
+
+        return bool(is_multiplex_active() and current_secret_scope() is not None)
+    except Exception:
+        return False
+
+
+def _resolve_raft_profile() -> str:
+    """Scope-aware resolution of the ``RAFT_PROFILE`` slug.
+
+    Raft has no ``config.yaml`` equivalent for this value (env-only), so a
+    secondary multiplex profile's only way to configure Raft is via its own
+    ``.env`` file — which the installed secret scope (built from that
+    profile's ``.env`` by ``_profile_runtime_scope``) already carries.
+    Reading raw ``os.environ.get("RAFT_PROFILE")`` here would instead return
+    the DEFAULT profile's bridged value, misdirecting the bridge subprocess
+    or CLI hint at another profile's external Raft workspace/agent identity.
+
+    ``get_secret()`` is only called when ``_profile_scoped()`` is True — the
+    callers of this helper (``connect()``/``register()``) run inside
+    ``_profile_runtime_scope`` for secondary profiles, but the DEFAULT
+    profile's own startup path never installs a scope, where ``get_secret()``
+    would raise ``UnscopedSecretError``; the guard keeps that path on the
+    unchanged ``os.environ`` read.
+    """
+    if _profile_scoped():
+        try:
+            from agent.secret_scope import get_secret
+
+            return (get_secret("RAFT_PROFILE") or "").strip()
+        except Exception:
+            return ""
+    return os.environ.get("RAFT_PROFILE", "").strip()
+
+
 def check_raft_requirements() -> bool:
     """Check if Raft channel dependencies are available.
 
@@ -533,7 +579,7 @@ class RaftAdapter(BasePlatformAdapter):
             logger.warning("[raft] raft CLI not found in PATH; bridge not spawned — wake-only polling mode")
             return
 
-        profile = os.environ.get("RAFT_PROFILE", "")
+        profile = _resolve_raft_profile()
         if not profile:
             logger.warning("[raft] RAFT_PROFILE not set; bridge not spawned")
             return
@@ -777,8 +823,12 @@ def _env_enablement() -> Optional[dict]:
     """Seed PlatformConfig.extra from env vars during gateway config load.
 
     Auto-enables when RAFT_PROFILE is set (the adapter needs it anyway).
+    Scope-aware: consults the active profile's own RAFT_PROFILE (env, or a
+    secondary profile's own .env via the secret scope) instead of the
+    default profile's bridged env value (mirrors the Buzz/SimpleX fix for
+    #98738) — see ``_resolve_raft_profile``.
     """
-    if not os.getenv("RAFT_PROFILE"):
+    if not _resolve_raft_profile():
         return None
 
     return {"enabled": True}
@@ -839,12 +889,18 @@ def register(ctx) -> None:
         setup_fn=interactive_setup,
         env_enablement_fn=_env_enablement,
         emoji="🔔",
+        # Scope-aware (mirrors _resolve_raft_profile's docstring): register()
+        # runs inside _profile_runtime_scope for a secondary multiplex
+        # profile (via discover_plugins() in
+        # gateway/run.py::_start_one_profile_adapters), so this resolves
+        # that profile's own RAFT_PROFILE instead of the default profile's
+        # bridged env value baked into a shared registry entry.
         platform_hint=(
             "You are connected to Raft via an external-agent channel. "
             "Run `raft --profile {profile} profile show` to confirm which agent profile is active. "
             "Run `raft --profile {profile} manual get raft-cli-overview` to learn available Raft commands. "
             "Always pass `--profile {profile}` to every raft CLI call."
-        ).format(profile=os.environ.get("RAFT_PROFILE", "your-agent-profile")),
+        ).format(profile=_resolve_raft_profile() or "your-agent-profile"),
     )
     ctx.register_hook("on_session_start", _on_session_start)
     ctx.register_hook("pre_llm_call", _on_pre_llm_call)

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -1426,10 +1426,15 @@ class TestWebhookEnvOverride:
 
         The fix honors the explicit disable, flagged by ``_enabled_explicit``
         in the platform's extra (set when the config.yaml pins enabled).
+        The MSGRAPH_WEBHOOK branch shares the shape and the fix.
         """
         config = GatewayConfig(
             platforms={
                 Platform.WEBHOOK: PlatformConfig(
+                    enabled=False,
+                    extra={"_enabled_explicit": True},
+                ),
+                Platform.MSGRAPH_WEBHOOK: PlatformConfig(
                     enabled=False,
                     extra={"_enabled_explicit": True},
                 ),
@@ -1442,6 +1447,8 @@ class TestWebhookEnvOverride:
                 "WEBHOOK_ENABLED": "true",
                 "WEBHOOK_PORT": "9999",
                 "WEBHOOK_SECRET": "shared-secret",
+                "MSGRAPH_WEBHOOK_ENABLED": "true",
+                "MSGRAPH_WEBHOOK_PORT": "9998",
             },
             clear=True,
         ):
@@ -1449,6 +1456,8 @@ class TestWebhookEnvOverride:
 
         # Explicit disable wins over the env-var presence.
         assert config.platforms[Platform.WEBHOOK].enabled is False
+        assert config.platforms[Platform.MSGRAPH_WEBHOOK].enabled is False
+        assert config.platforms[Platform.MSGRAPH_WEBHOOK].extra.get("port") == 9998
         # Port/secret are still wired through for the shared listener.
         assert config.platforms[Platform.WEBHOOK].extra.get("port") == 9999
         assert (

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -1409,3 +1409,49 @@ class TestApiServerEnvOverride:
         assert config.platforms[Platform.API_SERVER].enabled is False
         # The key is still wired through for the shared listener.
         assert config.platforms[Platform.API_SERVER].extra.get("key") == api_server_key
+
+
+class TestWebhookEnvOverride:
+    def test_env_key_does_not_reenable_explicitly_disabled_webhook(self):
+        """An explicit ``platforms.webhook.enabled: false`` must survive
+        _apply_env_overrides() even when WEBHOOK_ENABLED is truthy in the env.
+
+        Regression (#85637): _apply_env_overrides() force-set
+        webhook.enabled = True whenever WEBHOOK_ENABLED was truthy. In
+        multiplex mode a secondary profile pins ``webhook.enabled: false`` so
+        it shares the default profile's listener instead of binding its own
+        port, but it still inherits the process-level WEBHOOK_ENABLED
+        (or carries one in its own .env). The unconditional re-enable
+        flipped it back on and tripped the MultiplexConfigError check.
+
+        The fix honors the explicit disable, flagged by ``_enabled_explicit``
+        in the platform's extra (set when the config.yaml pins enabled).
+        """
+        config = GatewayConfig(
+            platforms={
+                Platform.WEBHOOK: PlatformConfig(
+                    enabled=False,
+                    extra={"_enabled_explicit": True},
+                ),
+            },
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                "WEBHOOK_ENABLED": "true",
+                "WEBHOOK_PORT": "9999",
+                "WEBHOOK_SECRET": "shared-secret",
+            },
+            clear=True,
+        ):
+            _apply_env_overrides(config)
+
+        # Explicit disable wins over the env-var presence.
+        assert config.platforms[Platform.WEBHOOK].enabled is False
+        # Port/secret are still wired through for the shared listener.
+        assert config.platforms[Platform.WEBHOOK].extra.get("port") == 9999
+        assert (
+            config.platforms[Platform.WEBHOOK].extra.get("secret")
+            == "shared-secret"
+        )

--- a/tests/gateway/test_multiplex_log_routing.py
+++ b/tests/gateway/test_multiplex_log_routing.py
@@ -1,0 +1,67 @@
+"""Multiplex gateway log routing (#82936, salvage of #84954).
+
+``setup_logging(mode="gateway")`` binds agent.log/errors.log/gateway.log to
+the launch home. Under ``multiplex_profiles`` every secondary profile's
+records — emitted inside ``_profile_runtime_scope`` — used to fan out into
+the DEFAULT profile's files. The gateway now enables the #99440 profile
+routers at startup so each record lands in its owner's ``logs/``.
+"""
+
+import logging
+import types
+from pathlib import Path
+
+import pytest
+
+import hermes_logging
+from gateway import run
+
+
+@pytest.fixture
+def clean_logging():
+    hermes_logging._reset_queued_handlers()
+    hermes_logging._logging_initialized = False
+    yield
+    hermes_logging._reset_queued_handlers()
+    hermes_logging._logging_initialized = False
+
+
+def _emit_under(home: Path, name: str, level: int, msg: str) -> None:
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    token = set_hermes_home_override(home)
+    try:
+        logging.getLogger(name).log(level, msg)
+    finally:
+        reset_hermes_home_override(token)
+
+
+def _contains(home: Path, filename: str, needle: str) -> bool:
+    path = home / "logs" / filename
+    return path.exists() and needle in path.read_text()
+
+
+def test_multiplex_gateway_routes_profile_records_to_their_own_logs(
+    tmp_path, monkeypatch, clean_logging
+):
+    default_home = tmp_path / "default"
+    beta_home = tmp_path / "default" / "profiles" / "beta"
+    beta_home.mkdir(parents=True)
+    homes = [("default", default_home), ("beta", beta_home)]
+    monkeypatch.setattr(run, "_multiplex_profile_homes", lambda _cfg: homes)
+
+    hermes_logging.setup_logging(hermes_home=default_home, mode="gateway")
+
+    # Single-profile gateway: wiring is inert and handlers stay static.
+    assert run._enable_multiplex_log_routing(types.SimpleNamespace(multiplex_profiles=False)) is False
+    assert run._enable_multiplex_log_routing(types.SimpleNamespace(multiplex_profiles=True)) is True
+
+    _emit_under(beta_home, "gateway.run", logging.WARNING, "BETA-GATEWAY-WARN")
+    _emit_under(default_home, "gateway.run", logging.INFO, "DEFAULT-GATEWAY-INFO")
+    hermes_logging.flush_log_queue()
+
+    for filename in ("agent.log", "errors.log", "gateway.log"):
+        assert _contains(beta_home, filename, "BETA-GATEWAY-WARN"), filename
+        assert not _contains(default_home, filename, "BETA-GATEWAY-WARN"), filename
+    assert _contains(default_home, "gateway.log", "DEFAULT-GATEWAY-INFO")
+    assert not _contains(beta_home, "gateway.log", "DEFAULT-GATEWAY-INFO")

--- a/tests/gateway/test_multiplex_profile_authz.py
+++ b/tests/gateway/test_multiplex_profile_authz.py
@@ -74,6 +74,52 @@ def test_active_profile_stamp_resolves_primary_adapter(monkeypatch):
     assert runner._authorization_adapter(Platform.WECOM, profile="dev") is default_adapter
 
 
+def test_scoped_secondary_profile_still_uses_profile_adapters(monkeypatch):
+    """Runtime scope must not redirect secondary authz to primary adapters.
+
+    ``_make_profile_message_handler`` wraps ``_handle_message`` in
+    ``_profile_runtime_scope``, which overrides HERMES_HOME so
+    ``get_active_profile_name()`` equals the secondary profile for that turn.
+    Authorization must still read ``_profile_adapters[profile]``, not the
+    empty primary ``self.adapters`` map — otherwise upstream-auth platforms
+    such as A2A default-deny an already-authenticated peer (#80884). A
+    secondary profile with NO registry entry still fails closed.
+    """
+    from gateway.run import GatewayRunner
+
+    _clear_auth_env(monkeypatch)
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner.adapters = {}
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = False
+
+    secondary = SimpleNamespace(
+        authorization_is_upstream=True,
+        enforces_own_access_policy=False,
+    )
+    runner._profile_adapters = {"beta": {Platform("a2a"): secondary}}
+    # Simulate the scoped turn: active profile name collapses to the secondary.
+    runner._active_profile_name = lambda: "beta"
+
+    assert runner._authorization_adapter(Platform("a2a"), profile="beta") is secondary
+
+    source = SessionSource(
+        platform=Platform("a2a"),
+        chat_id="a2a-context",
+        user_id="alpha",
+        user_name="alpha",
+        chat_type="dm",
+        profile="beta",
+    )
+    assert runner._is_user_authorized(source) is True
+
+    # Fail-closed guard is untouched: no registry entry -> no default fallback.
+    runner._profile_adapters = {"beta": {}}
+    assert runner._authorization_adapter(Platform("a2a"), profile="beta") is None
+
+
 def test_secondary_allowlist_dm_behavior_ignores_unauthorized(monkeypatch):
     """Unauthorized-DM behavior must read the secondary adapter's dm_policy."""
     runner, _default_adapter, secondary_adapter = _make_multiplex_runner(monkeypatch)

--- a/tests/gateway/test_raft_adapter.py
+++ b/tests/gateway/test_raft_adapter.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import os
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -218,3 +219,104 @@ class TestRaftConfig:
         assert os.environ["RAFT_PROFILE"] == "existing"
         assert "Keeping RAFT_PROFILE=existing" in capsys.readouterr().out
 
+
+# ---------------------------------------------------------------------------
+# Multiplex secondary-profile scope (RAFT_PROFILE resolution)
+# ---------------------------------------------------------------------------
+#
+# _spawn_bridge, _env_enablement, and register()'s platform_hint all
+# previously read RAFT_PROFILE via raw os.environ.get unconditionally. Under
+# a multiplexed secondary profile, os.environ holds the DEFAULT profile's
+# YAML-to-env bridge output — a secondary profile with its own RAFT_PROFILE
+# (set only in its own .env, resolved via the installed secret scope) would
+# silently connect the bridge subprocess / CLI hint to the default profile's
+# external Raft workspace/agent identity instead of its own. Mirrors the
+# Buzz/SimpleX fix for #98738.
+
+@pytest.fixture
+def multiplex_scope():
+    """Install multiplex + a secondary-profile secret scope; restore after."""
+    tokens = []
+
+    def install(scope=None):
+        from agent.secret_scope import set_multiplex_active, set_secret_scope
+
+        set_multiplex_active(True)
+        tokens.append(set_secret_scope(scope or {}))
+        return tokens[-1]
+
+    yield install
+
+    from agent.secret_scope import reset_secret_scope, set_multiplex_active
+
+    for token in reversed(tokens):
+        reset_secret_scope(token)
+    set_multiplex_active(False)
+
+
+@pytest.fixture
+def default_profile_env(monkeypatch):
+    """The default profile's YAML-to-env bridge output in os.environ."""
+    monkeypatch.setenv("RAFT_PROFILE", "default-profile-slug")
+
+
+class _FakeCtx:
+    """Minimal ``ctx`` capturing ``register_platform``'s kwargs."""
+
+    def __init__(self):
+        self.platform_kwargs = None
+
+    def register_platform(self, **kwargs):
+        self.platform_kwargs = kwargs
+
+    def register_hook(self, *args, **kwargs):
+        pass
+
+
+class TestMultiplexProfileScope:
+
+    def test_secondary_profile_uses_its_own_slug_and_never_borrows_default(
+        self, multiplex_scope, default_profile_env, monkeypatch
+    ):
+        """Bridge spawn, env-enablement and the register() hint all resolve
+        the secondary profile's own RAFT_PROFILE; with none of its own the
+        profile fails closed (bridge not spawned, not auto-enabled)."""
+        import plugins.platforms.raft.adapter as raft_mod
+
+        monkeypatch.setattr(raft_mod.shutil, "which", lambda name: "/usr/bin/raft")
+        spawned = []
+        monkeypatch.setattr(
+            raft_mod.subprocess, "Popen",
+            lambda cmd, **kwargs: spawned.append(cmd) or SimpleNamespace(pid=1),
+        )
+
+        multiplex_scope({"RAFT_PROFILE": "secondary-profile-slug"})
+        _make_adapter()._spawn_bridge(9999)
+        assert spawned[-1][:3] == ["/usr/bin/raft", "--profile", "secondary-profile-slug"]
+        assert _env_enablement() == {"enabled": True}
+        ctx = _FakeCtx()
+        register(ctx)
+        assert "--profile secondary-profile-slug" in ctx.platform_kwargs["platform_hint"]
+        assert "default-profile-slug" not in ctx.platform_kwargs["platform_hint"]
+
+        spawned.clear()
+        multiplex_scope({})
+        _make_adapter()._spawn_bridge(9999)
+        assert spawned == []
+        assert _env_enablement() is None
+
+    def test_default_profile_unscoped_keeps_env_precedence(
+        self, monkeypatch, default_profile_env
+    ):
+        """Multiplex ON but no scope (the DEFAULT profile constructs
+        unscoped): env is its own bridge output and still wins."""
+        from agent.secret_scope import set_multiplex_active
+
+        set_multiplex_active(True)
+        try:
+            assert _env_enablement() == {"enabled": True}
+            ctx = _FakeCtx()
+            register(ctx)
+            assert "--profile default-profile-slug" in ctx.platform_kwargs["platform_hint"]
+        finally:
+            set_multiplex_active(False)

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -1618,3 +1618,101 @@ print('fake reply')
         title = con.execute("SELECT title FROM sessions WHERE id='sess-1'").fetchone()[0]
         con.close()
         assert title == "a2a-dev-ctx-unsafe-value"
+
+
+# --------------------------------------------------------------------------
+# Multiplex secondary-profile scope (construction-time config leak)
+# --------------------------------------------------------------------------
+#
+# __init__'s port/advertised-toolsets reads and _load_served_agents's
+# description default all previously read raw A2A_* env vars unconditionally.
+# Under a multiplexed secondary profile, os.environ holds the DEFAULT
+# profile's YAML-to-env bridge output — a secondary profile with its own
+# (different, or absent) A2A config would silently borrow the default
+# profile's port, toolset advertisement, agent name, or Agent Card
+# description. Mirrors the Buzz/SimpleX fix for #98738.
+
+_A2A_ENV_VARS = (
+    "A2A_PORT",
+    "A2A_AGENT_NAME",
+    "A2A_ADVERTISED_TOOLSETS",
+    "A2A_AGENT_DESCRIPTION",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_a2a_construction_env(monkeypatch):
+    """Keep the new multiplex tests hermetic regardless of ambient env."""
+    for var in _A2A_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    yield
+
+
+@pytest.fixture
+def multiplex_scope():
+    """Install multiplex + a secondary-profile secret scope; restore after."""
+    tokens = []
+
+    def install(scope=None):
+        from agent.secret_scope import set_multiplex_active, set_secret_scope
+
+        set_multiplex_active(True)
+        tokens.append(set_secret_scope(scope or {}))
+        return tokens[-1]
+
+    yield install
+
+    from agent.secret_scope import reset_secret_scope, set_multiplex_active
+
+    for token in reversed(tokens):
+        reset_secret_scope(token)
+    set_multiplex_active(False)
+
+
+@pytest.fixture
+def default_profile_env(monkeypatch):
+    """The default profile's YAML-to-env bridge output in os.environ."""
+    monkeypatch.setenv("A2A_PORT", "9111")
+    monkeypatch.setenv("A2A_AGENT_NAME", "default-profile-agent")
+    monkeypatch.setenv("A2A_ADVERTISED_TOOLSETS", "default-only-toolset")
+    monkeypatch.setenv("A2A_AGENT_DESCRIPTION", "Default profile's own agent.")
+
+
+class TestMultiplexConstructionScope:
+
+    def test_secondary_profile_never_borrows_default_profile_env(
+        self, multiplex_scope, default_profile_env
+    ):
+        """The secondary profile's own config is authoritative; keys absent
+        from it fall to the module defaults, never to the default profile's
+        bridged A2A_* env values."""
+        from plugins.platforms.a2a.adapter import A2AAdapter, _DEFAULT_PORT
+        from gateway.config import PlatformConfig
+
+        multiplex_scope()
+        assert A2AAdapter(PlatformConfig(enabled=True, extra={"port": 9222})).port == 9222
+
+        adapter = A2AAdapter(PlatformConfig(enabled=True, extra={}))
+        assert adapter.port == _DEFAULT_PORT
+        assert adapter.agent_name != "default-profile-agent"
+        assert adapter._agents[""]["description"] == (
+            "Hermes Agent — a general-purpose agent reachable over A2A."
+        )
+
+    def test_default_profile_unscoped_keeps_env_precedence(
+        self, monkeypatch, default_profile_env
+    ):
+        """Multiplex ON but no scope (the DEFAULT profile constructs
+        unscoped): env is its own bridge output and still wins."""
+        from agent.secret_scope import set_multiplex_active
+        from plugins.platforms.a2a.adapter import A2AAdapter
+        from gateway.config import PlatformConfig
+
+        set_multiplex_active(True)
+        try:
+            adapter = A2AAdapter(PlatformConfig(enabled=True, extra={}))
+        finally:
+            set_multiplex_active(False)
+        assert adapter.port == 9111
+        assert adapter.agent_name == "default-profile-agent"
+        assert adapter._agents[""]["description"] == "Default profile's own agent."

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -910,7 +910,9 @@ def _make_live_adapter(monkeypatch, reply_fn=None):
     port = _free_port()
     monkeypatch.setenv("A2A_PORT", str(port))
 
-    adapter = A2AAdapter(PlatformConfig(enabled=True))
+    # A scoped secondary profile ignores the process env (#100382); pass the
+    # port through config.extra so both construction paths bind the same port.
+    adapter = A2AAdapter(PlatformConfig(enabled=True, extra={"port": port}))
 
     async def fake_handle_message(event):
         if reply_fn is None:
@@ -1222,6 +1224,54 @@ class TestInboundRoundTrip:
             await adapter.disconnect()
 
         asyncio.run(run())
+
+    def test_multiplex_adapter_keeps_profile_scoped_peer_tokens(self, monkeypatch):
+        """A secondary listener must not authenticate with the default profile's tokens."""
+        from agent.secret_scope import (
+            reset_secret_scope,
+            set_multiplex_active,
+            set_secret_scope,
+        )
+
+        monkeypatch.setenv("A2A_PEER_TOKENS", "default:default-token")
+        monkeypatch.delenv("A2A_BEARER_TOKEN", raising=False)
+        monkeypatch.setenv("A2A_HOST", "127.0.0.1")
+
+        set_multiplex_active(True)
+        scope_token = set_secret_scope(
+            {"A2A_PEER_TOKENS": "secondary:secondary-token"}
+        )
+        try:
+            adapter, base = _make_live_adapter(monkeypatch)
+        finally:
+            reset_secret_scope(scope_token)
+
+        async def run():
+            try:
+                assert await adapter.connect() is True
+                response = await asyncio.to_thread(
+                    _post_json,
+                    base + "/",
+                    _send_body("profile-scoped auth"),
+                    {"Authorization": "Bearer secondary-token"},
+                )
+                assert response["result"]["status"]["state"] == "TASK_STATE_COMPLETED"
+
+                with pytest.raises(urllib.error.HTTPError) as exc_info:
+                    await asyncio.to_thread(
+                        _post_json,
+                        base + "/",
+                        _send_body("wrong profile"),
+                        {"Authorization": "Bearer default-token"},
+                    )
+                assert exc_info.value.code == 401
+            finally:
+                await adapter.disconnect()
+
+        try:
+            asyncio.run(run())
+        finally:
+            set_multiplex_active(False)
 
 
 # --------------------------------------------------------------------------

--- a/tests/tools/test_terminal_tool_requirements.py
+++ b/tests/tools/test_terminal_tool_requirements.py
@@ -360,3 +360,34 @@ class TestCheckFnTransientFailureSuppression:
 
         assert "terminal" not in names
         assert "execute_code" not in names
+
+
+class TestUnscopedSecretReadLogging:
+    """#100697: with multiplexing on, boot-time check_fns run before any
+    profile secret scope exists, so get_secret fails closed with
+    UnscopedSecretError. That expected signal must not be logged like a
+    crashed check_fn (WARNING + traceback); an unscoped read reported while
+    the scope was *resolved* is a genuinely lost scope and stays loud."""
+
+    def test_expected_fail_closed_probe_is_quiet_but_lost_scope_stays_loud(self, caplog):
+        import logging
+
+        import tools.registry as reg
+        from agent.secret_scope import get_secret, set_multiplex_active
+
+        def probe():
+            return bool(get_secret("REGISTRY_LOG_PROBE_TOKEN", ""))
+
+        set_multiplex_active(True)
+        try:
+            with caplog.at_level(logging.DEBUG, logger="tools.registry"):
+                assert reg._run_check_fn_uncached(probe, unresolved_scope=True) is False
+                boot = [r for r in caplog.records if r.name == "tools.registry"]
+                caplog.clear()
+                assert reg._run_check_fn_uncached(probe, unresolved_scope=False) is False
+                lost = [r for r in caplog.records if r.name == "tools.registry"]
+        finally:
+            set_multiplex_active(False)
+
+        assert boot and all(r.levelno == logging.DEBUG and r.exc_info is None for r in boot)
+        assert any(r.levelno >= logging.WARNING and r.exc_info for r in lost)

--- a/tests/tools/test_tts_output_dir_profile_scope.py
+++ b/tests/tools/test_tts_output_dir_profile_scope.py
@@ -1,0 +1,60 @@
+"""Regression tests for profile-scoped TTS default output dir (#98749).
+
+``DEFAULT_OUTPUT_DIR`` was resolved once at import time, so long-lived
+multi-profile runtimes (dashboard console, TUI/Desktop backend, cron, kanban
+workers) kept writing synthesized audio into the launch profile's
+``cache/audio`` even while the request was scoped to a different profile via
+``HERMES_HOME`` or ``set_hermes_home_override()``. The call-time accessor
+``_default_output_dir()`` re-resolves from the live profile-scoped home;
+these pins keep the synthesis paths from re-freezing the launch profile.
+"""
+
+import importlib
+from pathlib import Path
+
+
+def _reload_tts_tool(import_home: Path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(import_home))
+    import tools.tts_tool as tts_tool
+
+    return importlib.reload(tts_tool)
+
+
+def test_default_output_dir_follows_contextvar_profile_override(tmp_path, monkeypatch):
+    """The web server scopes profiles via set_hermes_home_override() rather
+    than mutating the process env; the accessor must follow that override."""
+    default_home = tmp_path / "default-home"
+    profile_home = tmp_path / "profiles" / "ramona"
+    default_home.mkdir(parents=True)
+    profile_home.mkdir(parents=True)
+
+    tts_tool = _reload_tts_tool(default_home, monkeypatch)
+
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    token = set_hermes_home_override(str(profile_home))
+    try:
+        assert tts_tool._default_output_dir() == str(
+            profile_home / "cache" / "audio"
+        )
+    finally:
+        reset_hermes_home_override(token)
+
+    # Outside the override scope the launch home applies again.
+    assert tts_tool._default_output_dir() == str(default_home / "cache" / "audio")
+
+
+def test_explicit_default_output_dir_monkeypatch_still_wins(tmp_path, monkeypatch):
+    """Existing tests and external patchers can still override
+    tools.tts_tool.DEFAULT_OUTPUT_DIR directly."""
+    default_home = tmp_path / "default-home"
+    default_home.mkdir(parents=True)
+
+    tts_tool = _reload_tts_tool(default_home, monkeypatch)
+
+    monkeypatch.setattr(tts_tool, "DEFAULT_OUTPUT_DIR", "/custom/audio")
+
+    assert tts_tool._default_output_dir() == "/custom/audio"

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -348,8 +348,33 @@ def check_fn_cache_scope() -> Optional[str]:
 
 def _run_check_fn_uncached(fn: Callable, *, unresolved_scope: bool = False) -> bool:
     """Run an availability check without cache/grace handling."""
+    from agent.secret_scope import UnscopedSecretError
+
     try:
         return bool(fn())
+    except UnscopedSecretError:
+        if unresolved_scope:
+            # Expected fail-closed probe: with multiplexing on, boot-time
+            # check_fns run before any profile secret scope exists, so
+            # get_secret raises by design. The tool re-probes on the first
+            # scoped turn — log without a traceback so this cannot be
+            # mistaken for a crashed check_fn (#100697).
+            logger.debug(
+                "check_fn %s hit the multiplex fail-closed path with no "
+                "profile secret scope active; dependent tools re-probe on "
+                "the first scoped turn",
+                getattr(fn, "__qualname__", fn),
+            )
+            return False
+        # The scope resolved but the read still failed closed: a genuinely
+        # lost scope. Keep the loud crash-style report.
+        logger.warning(
+            "check_fn %s raised UnscopedSecretError while the profile cache "
+            "scope was resolved; dependent tools will be unavailable this turn",
+            getattr(fn, "__qualname__", fn),
+            exc_info=True,
+        )
+        return False
     except Exception:
         detail = " while profile cache scope was unresolved" if unresolved_scope else ""
         logger.warning(

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -266,6 +266,26 @@ def _get_default_output_dir() -> str:
     return str(get_hermes_dir("cache/audio", "audio_cache"))
 
 DEFAULT_OUTPUT_DIR = _get_default_output_dir()
+_DEFAULT_OUTPUT_DIR_AT_IMPORT = DEFAULT_OUTPUT_DIR
+
+def _default_output_dir() -> str:
+    """Return the active profile's audio output dir at call time.
+
+    Same bug class as skills_tool (f8723c478) and skills_sync (#65828):
+    long-lived multi-profile runtimes (dashboard console, TUI/Desktop backend,
+    cron, kanban workers) import this module once under the launch
+    HERMES_HOME and later scope requests to a different profile via
+    ``hermes_constants.set_hermes_home_override()`` — a frozen module
+    constant keeps writing synthesized audio into the launch profile's
+    cache instead of the active profile's (#98749). Keep the legacy
+    ``DEFAULT_OUTPUT_DIR`` module attribute for tests and external patchers;
+    when it has not been patched, re-resolve from the live profile-scoped
+    HERMES_HOME on every call.
+    """
+    configured = DEFAULT_OUTPUT_DIR
+    if configured != _DEFAULT_OUTPUT_DIR_AT_IMPORT:
+        return configured
+    return _get_default_output_dir()
 
 # ---------------------------------------------------------------------------
 # Per-provider input-character limits (from official provider docs).
@@ -3498,7 +3518,7 @@ def _text_to_speech_single(
             }, ensure_ascii=False)
     else:
         timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S_%f")
-        out_dir = Path(DEFAULT_OUTPUT_DIR)
+        out_dir = Path(_default_output_dir())
         out_dir.mkdir(parents=True, exist_ok=True)
         if command_provider_config is not None:
             fmt = _get_command_tts_output_format(command_provider_config)
@@ -3856,7 +3876,7 @@ def text_to_speech_tool(
             }, ensure_ascii=False)
     else:
         timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S_%f")
-        out_dir = Path(DEFAULT_OUTPUT_DIR)
+        out_dir = Path(_default_output_dir())
         out_dir.mkdir(parents=True, exist_ok=True)
         if command_provider_config is not None:
             fmt = _get_command_tts_output_format(command_provider_config)
@@ -4739,7 +4759,7 @@ if __name__ == "__main__":
     print(f"  MiniMax:    {minimax_status}")
     print(f"  Piper:      {'installed' if _check_piper_available() else 'not installed (pip install piper-tts)'}")
     print(f"  ffmpeg:     {'✅ found' if _has_ffmpeg() else '❌ not found (needed for Telegram Opus)'}")
-    print(f"\n  Output dir: {DEFAULT_OUTPUT_DIR}")
+    print(f"\n  Output dir: {_default_output_dir()}")
 
     provider = _get_provider(config)
     print(f"  Configured provider: {provider}")


### PR DESCRIPTION
## Summary
Seven small multiplex scope leaks in one branch: under `multiplex_profiles`, secondary profiles read identity/credential/config from process-global `os.environ` or import-time module constants instead of their own scope, so they inherited the default profile's Raft slug, A2A port/name/tokens, `WEBHOOK_ENABLED`, TTS cache dir and log files — and the gateway logged expected fail-closed probes as crashes. Root cause per site is either an unscoped `os.getenv` under `_profile_runtime_scope`, a frozen module-level `get_hermes_dir()` constant, or an env-override branch bypassing `_enabled_explicit`.

## Changes
- raft: `RAFT_PROFILE` via `get_secret` only inside a secondary scope (`_profile_scoped()`); default profile unchanged
- a2a: construction (`A2A_PORT`/`A2A_AGENT_NAME`/`A2A_AGENT_DESCRIPTION`) skips env under secondary scope; `A2ASecurityContext` captured at construction and used by request threads; `_startup_env` scope-gated, no environ fallthrough
- authz_mixin: `_profile_adapters` consulted before active-profile compare; fail-closed None preserved
- gateway/config: webhook AND msgraph_webhook env-override honor `enabled: false`; port/secret still wired
- tools/registry: `UnscopedSecretError` from boot check_fn → debug w/o traceback; resolved-scope case stays loud
- tools/tts_tool: `_default_output_dir()` call-time accessor; `DEFAULT_OUTPUT_DIR` patch compat kept
- gateway/run: `_enable_multiplex_log_routing()` wires #99440's `enable_profile_log_routing` at multiplex startup

## Validation
| Probe (isolated HERMES_HOME, multiplex on, beta scope) | origin/main | branch |
|---|---|---|
| raft slug w/ alpha .env=alpha-raft / beta none | default-raft / default-raft | alpha-raft / '' |
| a2a (port, name), extra.port=9001 | (7777, default-agent) | (9001, hostname) |
| registry boot probe log | WARNING+traceback | DEBUG, no traceback |
| tts dir under beta override | default/cache/audio | profiles/beta/cache/audio |
| yaml enabled:false + env *_ENABLED=true (webhook, msgraph) | (True, True) | (False, False) |
| `_authorization_adapter(A2A,'beta')` in scope | None | beta adapter |
| bare-thread auth: beta-token / default-token | reject / accept | accept / reject |
| beta record → (default agent.log, beta agent.log) | (True, False) | (False, True) |
Tests: 255 passed across 9 targeted files; 2 sabotage checks bite. One pre-existing order-dependent a2a failure reproduced on main.

## Credits
@nftpoetrist (#100392, #100382), @liuhao1024 (#100709, #98756), @jl97mcad (#100697 fix design), @webtecnica (#85712), @fangliquanflq (#80956), @michaldziwisz (#84954, Co-authored-by), reporters @FabIAne10 (#99634), @Jind0la (#85637), @BBOYYUE (#80884).

NOTES: During a stash mishap I dropped and then restored (via `git stash store`) a pre-existing shared-repo stash "WIP on fix/compression-rearm-preflight-block" (2b23667316e); `git stash list` shows it intact. `git cherry-pick -q` is not a valid flag and silently no-ops — don't use it.

Fixes #100697
Fixes #99634
Fixes #85637
Fixes #80884
Fixes #80874

## Infographic

![mux-tools-scope-a](https://v3b.fal.media/files/b/0aa8cde2/z_54rQ6GE_ZXsMsbrcH8F_436OnOqn.png)
