### PR TITLE
fix(gateway): per-profile hooks, MCP discovery, webhook skills, and scoped browser/Hindsight threads under multiplex (#92672 #95518 #86402 #92608 #67277, salvage #92682 #95542 #86472)

### DIFF
--- a/agent/outbound_webhooks.py
+++ b/agent/outbound_webhooks.py
@@ -98,8 +98,12 @@ _TOOL_SCOPED_EVENTS = {"pre_tool_call", "post_tool_call"}
 # kwargs promoted to top-level payload keys (mirrors shell hooks wire).
 _TOP_LEVEL_PAYLOAD_KEYS = {"tool_name", "args", "session_id", "parent_session_id"}
 
-# (event, url) pairs already wired to the plugin manager in this process.
-_registered: Set[Tuple[str, str]] = set()
+# (home, event, url) triples already wired to the plugin manager in this
+# process. Home is part of the key so a multiplexed gateway's secondary
+# profiles — each with their own plugin manager (see
+# hermes_cli.plugins.get_plugin_manager) — can register identical webhook
+# targets without the first profile's registration shadowing the rest.
+_registered: Set[Tuple[str, str, str]] = set()
 _registered_lock = threading.Lock()
 
 _delivery_queue: "queue.Queue[Optional[Dict[str, Any]]]" = queue.Queue(
@@ -180,15 +184,17 @@ def register_from_config(cfg: Optional[Dict[str, Any]]) -> List[WebhookTarget]:
         return []
 
     from hermes_cli.plugins import get_plugin_manager
+    from hermes_constants import get_hermes_home
 
     manager = get_plugin_manager()
+    home_key = str(get_hermes_home().expanduser().resolve())
 
     registered: List[WebhookTarget] = []
     with _registered_lock:
         for target in targets:
             wired_any = False
             for event in target.events:
-                key = (event, target.url)
+                key = (home_key, event, target.url)
                 if key in _registered:
                     continue
                 manager._hooks.setdefault(event, []).append(

--- a/agent/outbound_webhooks.py
+++ b/agent/outbound_webhooks.py
@@ -445,8 +445,13 @@ def _serialize_payload(
         cwd = str(Path.cwd())
     except OSError:
         cwd = ""
+    # Resolved at fire time from the bound home so a multiplexed gateway's
+    # receivers can tell which profile emitted the event (#92674).
+    from hermes_cli.profiles import get_active_profile_name
+
     payload = {
         "hook_event_name": event,
+        "profile": get_active_profile_name(),
         "tool_name": kwargs.get("tool_name"),
         "tool_input": kwargs.get("args") if isinstance(kwargs.get("args"), dict) else None,
         "session_id": kwargs.get("session_id") or kwargs.get("parent_session_id") or "",

--- a/agent/outbound_webhooks.py
+++ b/agent/outbound_webhooks.py
@@ -237,6 +237,29 @@ def flush(timeout: float = 5.0) -> bool:
         return _delivery_queue.unfinished_tasks == 0
 
 
+def re_register_config_hooks() -> None:
+    """Re-register outbound webhooks from config after a plugin force-reload.
+
+    Mirrors ``agent.shell_hooks.re_register_config_hooks``: config-owned
+    outbound-webhook callbacks live in the same ``_hooks`` dict that
+    ``PluginManager.discover_and_load(force=True)`` clears via ``unload()``,
+    so without this the force-reloaded profile's outbound webhooks go
+    silently inert (#92682 review). Only the current home's idempotence
+    keys are cleared so a force-reload in one profile cannot invalidate
+    another profile's still-live registration.
+    """
+    from hermes_cli.config import load_config
+    from hermes_constants import get_hermes_home
+
+    home_key = str(get_hermes_home().expanduser().resolve())
+    with _registered_lock:
+        _registered.difference_update(
+            {key for key in _registered if key[0] == home_key}
+        )
+
+    register_from_config(load_config())
+
+
 def reset_for_tests() -> None:
     """Clear the idempotence set and drain the queue.  Test-only helper."""
     with _registered_lock:

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -182,13 +182,17 @@ _BLOCKING_EVENTS = frozenset({"pre_tool_call"})
 _STDERR_MESSAGE_LIMIT = 400
 
 
-# (event, matcher, command) triples that have been wired to the plugin
+# (home, event, matcher, command) tuples that have been wired to the plugin
 # manager in the current process.  Matcher is part of the key because
 # the same script can legitimately register for different matchers under
-# the same event (e.g. one entry per tool the user wants to gate).
-# Second registration attempts for the exact same triple become no-ops
+# the same event (e.g. one entry per tool the user wants to gate). Home is
+# part of the key so a multiplexed gateway's secondary profiles — each with
+# their own plugin manager (see hermes_cli.plugins.get_plugin_manager) — can
+# register identical hook triples without the first profile's registration
+# silently shadowing the rest.
+# Second registration attempts for the exact same tuple become no-ops
 # so the CLI and gateway can both call register_from_config() safely.
-_registered: Set[Tuple[str, Optional[str], str]] = set()
+_registered: Set[Tuple[str, str, Optional[str], str]] = set()
 _registered_lock = threading.Lock()
 
 # Intra-process lock for allowlist read-modify-write on platforms that
@@ -289,13 +293,14 @@ def register_from_config(
     from hermes_cli.plugins import get_plugin_manager
 
     manager = get_plugin_manager()
+    home_key = str(get_hermes_home().expanduser().resolve())
 
     # Idempotence + allowlist read happen under the lock; the TTY
     # prompt runs outside so other threads aren't parked on a blocking
     # input().  Mutation re-takes the lock with a defensive idempotence
     # re-check in case two callers ever race through the prompt.
     for spec in specs:
-        key = (spec.event, spec.matcher, spec.command)
+        key = (home_key, spec.event, spec.matcher, spec.command)
         with _registered_lock:
             if key in _registered:
                 continue

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -354,11 +354,20 @@ def re_register_config_hooks() -> None:
     are wired again (#60036 / PR #60267; tracking #64178 — salvaged from
     PR #64188).
 
+    Only the idempotence keys for the *current* Hermes home are cleared —
+    ``discover_and_load(force=True)`` only unloads the manager scoped to
+    that one home, so clearing every home's keys would make a force-reload
+    in profile A drop profile B's still-live registration from the ledger
+    and duplicate it on B's next registration call (#92682 review).
+
     Commands already allowlisted stay allowlisted, so this never re-prompts
     at a TTY for hooks the user previously approved.
     """
+    home_key = str(get_hermes_home().expanduser().resolve())
     with _registered_lock:
-        _registered.clear()
+        _registered.difference_update(
+            {key for key in _registered if key[0] == home_key}
+        )
     from hermes_cli.config import load_config
 
     register_from_config(load_config())

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -236,7 +236,7 @@ def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tu
         return None
 
     try:
-        from tools.skills_tool import SKILLS_DIR, skill_view
+        from tools.skills_tool import _skills_dir, skill_view
         from agent.skill_utils import normalize_skill_lookup_name
 
         normalized = normalize_skill_lookup_name(raw_identifier)
@@ -262,7 +262,7 @@ def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tu
         skill_dir = Path(abs_skill_dir)
     elif skill_path:
         try:
-            skill_dir = SKILLS_DIR / Path(skill_path).parent
+            skill_dir = _skills_dir() / Path(skill_path).parent
         except Exception:
             skill_dir = None
 
@@ -317,7 +317,7 @@ def _build_skill_message(
     session_id: str | None = None,
 ) -> str:
     """Format a loaded skill into a user/system message payload."""
-    from tools.skills_tool import SKILLS_DIR
+    from tools.skills_tool import _skills_dir
 
     content = str(loaded_skill.get("content") or "")
 
@@ -386,7 +386,7 @@ def _build_skill_message(
 
     if supporting and skill_dir:
         try:
-            skill_view_target = str(skill_dir.relative_to(SKILLS_DIR))
+            skill_view_target = str(skill_dir.relative_to(_skills_dir()))
         except ValueError:
             # Skill is from an external dir — use the skill name instead
             skill_view_target = skill_dir.name
@@ -441,7 +441,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     # each naming the same skill as its own incumbent (#74574).
     commands: Dict[str, Dict[str, Any]] = {}
     try:
-        from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
+        from tools.skills_tool import _skills_dir, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
         from agent.skill_utils import (
             get_external_skills_dirs,
             get_project_skills_dirs,
@@ -456,8 +456,12 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
         # Project dirs iterate through the quarantine chokepoint.
         project_dirs = list(get_project_skills_dirs())
         dirs_to_scan = list(project_dirs)
-        if SKILLS_DIR.exists():
-            dirs_to_scan.append(SKILLS_DIR)
+        # Resolve at call time: the import-time SKILLS_DIR is frozen to the
+        # launch home, so a multiplexed profile scope (set_hermes_home_override)
+        # would still scan the default profile's skills (#67277).
+        skills_dir = _skills_dir()
+        if skills_dir.exists():
+            dirs_to_scan.append(skills_dir)
         dirs_to_scan.extend(get_external_skills_dirs())
 
         for scan_dir in dirs_to_scan:

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -996,12 +996,15 @@ def normalize_skill_lookup_name(identifier: str) -> str:
     # Look the primary skills root up on tools.skills_tool at CALL time
     # (not via get_skills_dir()): callers and tests patch
     # ``tools.skills_tool.SKILLS_DIR`` and skill_view() itself resolves
-    # against that module attribute, so normalization must agree with the
-    # exact root skill_view() will enforce.  Import deferred to avoid a
-    # module cycle (tools.skills_tool imports agent.skill_utils).
+    # against ``_skills_dir()`` — which honors that patch and otherwise
+    # follows the live profile-scoped HERMES_HOME (the import-time
+    # SKILLS_DIR is frozen to the launch home, #67277) — so normalization
+    # must agree with the exact root skill_view() will enforce.  Import
+    # deferred to avoid a module cycle (tools.skills_tool imports
+    # agent.skill_utils).
     try:
         from tools import skills_tool as _skills_tool
-        primary_root = Path(_skills_tool.SKILLS_DIR)
+        primary_root = _skills_tool._skills_dir()
     except Exception:
         primary_root = get_skills_dir()
 

--- a/contributors/emails/tky.juani@gmail.com
+++ b/contributors/emails/tky.juani@gmail.com
@@ -1,0 +1,1 @@
+JuaniLezcano

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -42,6 +42,7 @@ import subprocess
 import sys
 import time
 from collections import deque
+from contextlib import nullcontext
 from typing import Any, Deque, Dict, List, Optional
 
 try:
@@ -633,6 +634,21 @@ class WebhookAdapter(BasePlatformAdapter):
         effective_profile = request_profile or "default"
         return configured_profile == effective_profile
 
+    @staticmethod
+    def _profile_scope(profile: Optional[str]):
+        """Enter the URL-resolved profile's runtime scope, or a no-op.
+
+        Only a resolved ``/p/<profile>/`` prefix enters a scope (same helper
+        the runner wraps ``handle_message`` in); bare routes keep serving the
+        launch profile exactly as before.
+        """
+        if not profile or not isinstance(profile, str):
+            return nullcontext()
+        from gateway.run import _profile_runtime_scope
+        from hermes_cli.profiles import get_profile_dir
+
+        return _profile_runtime_scope(get_profile_dir(profile))
+
     async def _handle_webhook(self, request: "web.Request") -> "web.Response":
         """POST /webhooks/{route_name} — receive and process a webhook event."""
         # Hot-reload dynamic subscriptions on each request (mtime-gated, cheap)
@@ -784,63 +800,71 @@ class WebhookAdapter(BasePlatformAdapter):
                 }
             )
 
-        if route_config.get("script"):
-            # run_route_script shells out (subprocess.run, up to its timeout);
-            # run it in a worker thread so it can't block the gateway event loop.
-            keep, transformed_payload = await asyncio.to_thread(
-                self._route_processor.run_route_script,
-                route_config.get("script"),
-                payload,
+        # The route script, prompt render and skill lookup below read the
+        # profile's home (skills/, config). The runner only enters the routed
+        # profile's scope later, around handle_message, so without this they
+        # ran against the launch (default) profile (#67277). Only a resolved
+        # /p/<profile>/ enters a scope; bare routes are unchanged.
+        with self._profile_scope(profile):
+            if route_config.get("script"):
+                # run_route_script shells out (subprocess.run, up to its
+                # timeout); run it in a worker thread so it can't block the
+                # gateway event loop. to_thread copies the contextvars, so
+                # the profile scope follows it.
+                keep, transformed_payload = await asyncio.to_thread(
+                    self._route_processor.run_route_script,
+                    route_config.get("script"),
+                    payload,
+                )
+                if not keep:
+                    logger.info(
+                        "[webhook] script ignored event=%s route=%s",
+                        event_type,
+                        route_name,
+                    )
+                    return web.json_response(
+                        {
+                            "status": "ignored",
+                            "reason": "script",
+                            "route": route_name,
+                        }
+                    )
+                payload = transformed_payload or payload
+
+            # Format prompt from template
+            prompt_template = route_config.get("prompt", "")
+            prompt = self._render_prompt(
+                prompt_template, payload, event_type, route_name
             )
-            if not keep:
-                logger.info(
-                    "[webhook] script ignored event=%s route=%s",
-                    event_type,
-                    route_name,
-                )
-                return web.json_response(
-                    {
-                        "status": "ignored",
-                        "reason": "script",
-                        "route": route_name,
-                    }
-                )
-            payload = transformed_payload or payload
 
-        # Format prompt from template
-        prompt_template = route_config.get("prompt", "")
-        prompt = self._render_prompt(
-            prompt_template, payload, event_type, route_name
-        )
+            # Inject skill content if configured.
+            # We call build_skill_invocation_message() directly rather than
+            # using /skill-name slash commands — the gateway's command parser
+            # would intercept those and break the flow.
+            skills = route_config.get("skills", [])
+            if skills:
+                try:
+                    from agent.skill_commands import (
+                        build_skill_invocation_message,
+                        get_skill_commands,
+                    )
 
-        # Inject skill content if configured.
-        # We call build_skill_invocation_message() directly rather than
-        # using /skill-name slash commands — the gateway's command parser
-        # would intercept those and break the flow.
-        skills = route_config.get("skills", [])
-        if skills:
-            try:
-                from agent.skill_commands import (
-                    build_skill_invocation_message,
-                    get_skill_commands,
-                )
-
-                skill_cmds = get_skill_commands()
-                for skill_name in skills:
-                    cmd_key = f"/{skill_name}"
-                    if cmd_key in skill_cmds:
-                        skill_content = build_skill_invocation_message(
-                            cmd_key, user_instruction=prompt
-                        )
-                        if skill_content:
-                            prompt = skill_content
-                            break  # Load the first matching skill
-                    else:
-                        logger.warning(
-                            "[webhook] Skill '%s' not found", skill_name
-                        )
-            except Exception as e:
-                logger.warning("[webhook] Skill loading failed: %s", e)
+                    skill_cmds = get_skill_commands()
+                    for skill_name in skills:
+                        cmd_key = f"/{skill_name}"
+                        if cmd_key in skill_cmds:
+                            skill_content = build_skill_invocation_message(
+                                cmd_key, user_instruction=prompt
+                            )
+                            if skill_content:
+                                prompt = skill_content
+                                break  # Load the first matching skill
+                        else:
+                            logger.warning(
+                                "[webhook] Skill '%s' not found", skill_name
+                            )
+                except Exception as e:
+                    logger.warning("[webhook] Skill loading failed: %s", e)
 
         # Build a unique delivery ID
         delivery_id = request.headers.get(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16991,6 +16991,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             from hermes_cli.plugins import discover_plugins
 
             discover_plugins()
+
+            # Register this profile's own declarative shell hooks and
+            # outbound webhooks. The startup-time registration in
+            # start() only ever sees the root/default profile's config
+            # (it runs before any profile scope exists), so without this
+            # a secondary profile's `hooks:` block is silently inert —
+            # its turns run under this profile's own plugin manager
+            # (hermes_cli.plugins.get_plugin_manager keys by resolved
+            # home), which never received the callbacks.
+            try:
+                from hermes_cli.config import load_config as _load_profile_config
+                from agent.shell_hooks import (
+                    register_from_config as _register_shell_hooks,
+                )
+                from agent.outbound_webhooks import (
+                    register_from_config as _register_outbound_webhooks,
+                )
+
+                _profile_hooks_cfg = _load_profile_config()
+                _register_shell_hooks(_profile_hooks_cfg, accept_hooks=False)
+                _register_outbound_webhooks(_profile_hooks_cfg)
+            except Exception:
+                logger.warning(
+                    "shell-hook/webhook registration failed for profile '%s'",
+                    profile_name,
+                    exc_info=True,
+                )
+
             profile_cfg = load_gateway_config()
             violation = _own_policy_open_startup_violation(profile_cfg)
         self._snapshot_profile_busy_modes(profile_name, profile_runtime_cfg)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2692,6 +2692,33 @@ def load_gateway_config_for_runner() -> "GatewayConfig":
         return cfg
 
 
+async def _discover_gateway_mcp_tools(config: object) -> None:
+    """Run startup MCP discovery for every profile this gateway serves.
+
+    ``discover_mcp_tools`` reads ``mcp_servers`` from ``get_hermes_home()``'s
+    config, so an unscoped call only ever connects the launch profile's
+    servers (#95518). Under multiplex, run it once per served profile inside
+    that profile's ``_profile_runtime_scope`` and carry the scope into the
+    executor thread with ``copy_context()`` (the same shape as
+    ``_run_in_executor_with_context``). Single-profile gateways keep the one
+    unscoped call.
+    """
+    from tools.mcp_tool import discover_mcp_tools
+
+    loop = asyncio.get_running_loop()
+    if not getattr(config, "multiplex_profiles", False):
+        await loop.run_in_executor(None, discover_mcp_tools)
+        return
+    for profile_name, profile_home in _multiplex_profile_homes(config):
+        try:
+            with _profile_runtime_scope(Path(profile_home)):
+                await loop.run_in_executor(None, copy_context().run, discover_mcp_tools)
+        except Exception:
+            logger.warning(
+                "MCP tool discovery failed for profile '%s'", profile_name, exc_info=True,
+            )
+
+
 def _platform_has_bot_credential(platform: "Platform", platform_config: "PlatformConfig") -> bool:
     """Return True when a token-authenticated platform has a usable bot credential.
 
@@ -3081,6 +3108,7 @@ from gateway.session import (
     SessionSource,
     SessionContext,
     TranscriptReadError,
+    _session_key_namespace,
     build_session_context,
     build_session_context_prompt,
     build_channel_continuity_note,
@@ -26112,25 +26140,53 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         Split out from ``_handle_reload_mcp_command`` so the confirmation
         wrapper can invoke the same path whether the user confirmed via
         button, text reply, or has the confirm gate disabled.
+
+        Under multiplex the reload runs inside the requesting profile's
+        runtime scope (entered here when the caller — e.g. a button-confirm
+        callback — did not), and only that profile's servers are torn down
+        and rediscovered (#95518).
         """
-        loop = asyncio.get_running_loop()
+        multiplex = bool(getattr(self.config, "multiplex_profiles", False))
+        if multiplex and not get_hermes_home_override():
+            profile_home = self._resolve_profile_home_for_source(event.source)
+            with _profile_runtime_scope(Path(profile_home)):
+                return await self._execute_mcp_reload(event)
         try:
             from tools.mcp_tool import shutdown_mcp_servers, discover_mcp_tools, _servers, _lock
+            from tools.mcp_tool import _server_scope_keys
+            from tools.registry import registry
+
+            reload_scope = registry.current_scope_key() if multiplex else None
+
+            def _scoped_server_names() -> set:
+                with _lock:
+                    return {
+                        name for name in _servers
+                        if reload_scope is None or _server_scope_keys.get(name) == reload_scope
+                    }
 
             # Capture old server names before shutdown
-            with _lock:
-                old_servers = set(_servers.keys())
+            old_servers = _scoped_server_names()
 
             # Read new config before shutting down, so we know what will be added/removed
             # Shutdown existing connections
-            await loop.run_in_executor(None, shutdown_mcp_servers)
+            await self._run_in_executor_with_context(
+                lambda: shutdown_mcp_servers(scope=reload_scope)
+            )
 
             # Reconnect by discovering tools (reads config.yaml fresh)
-            new_tools = await loop.run_in_executor(None, discover_mcp_tools)
+            new_tools = await self._run_in_executor_with_context(discover_mcp_tools)
 
             # Compute what changed
-            with _lock:
-                connected_servers = set(_servers.keys())
+            connected_servers = _scoped_server_names()
+            if reload_scope is not None:
+                from tools.mcp_tool import _mcp_tool_server_names
+
+                with _lock:
+                    new_tools = [
+                        n for n in new_tools
+                        if _mcp_tool_server_names.get(n) in connected_servers
+                    ]
 
             added = connected_servers - old_servers
             removed = old_servers - connected_servers
@@ -26159,8 +26215,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _cache = getattr(self, "_agent_cache", None)
                 _cache_lock = getattr(self, "_agent_cache_lock", None)
                 if _cache_lock is not None and _cache:
+                    # Multiplex: only this profile's sessions. Rebuilding
+                    # another profile's agent inside this scope would hand it
+                    # this profile's tool registry.
+                    _ns_prefix = (
+                        _session_key_namespace(event.source.profile) + ":"
+                        if multiplex else None
+                    )
                     with _cache_lock:
                         for _sess_key, _entry in list(_cache.items()):
+                            if _ns_prefix and not str(_sess_key).startswith(_ns_prefix):
+                                continue
                             try:
                                 _agent = _entry[0] if isinstance(_entry, tuple) else _entry
                             except Exception:
@@ -33962,9 +34027,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # heartbeats (Discord shard, Telegram polling) until it returned.
     # See #16856.
     try:
-        from tools.mcp_tool import discover_mcp_tools
-        _loop = asyncio.get_running_loop()
-        await _loop.run_in_executor(None, discover_mcp_tools)
+        await _discover_gateway_mcp_tools(runner.config)
     except Exception as e:
         logger.debug("MCP tool discovery failed: %s", e)
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -4262,18 +4262,21 @@ class PluginManager:
                 # first process sees plugin backends (tracking #64177).
                 self._refresh_secret_sources_after_discovery()
                 if force:
-                    # config.yaml shell hooks live in ``_hooks`` but are
-                    # config-owned, not plugin-owned — the ledger-driven
-                    # unload() above wiped them and cannot restore them.
-                    # Re-register so force-reload is symmetric (#60036;
-                    # tracking #64178 — salvaged from PR #64188).
-                    self._re_register_shell_hooks_after_force()
+                    # config.yaml shell hooks and outbound webhooks live in
+                    # ``_hooks`` but are config-owned, not plugin-owned —
+                    # the ledger-driven unload() above wiped them and
+                    # cannot restore them. Re-register so force-reload is
+                    # symmetric (#60036; tracking #64178 — salvaged from
+                    # PR #64188; outbound webhooks added per #92682 review).
+                    self._re_register_config_hooks_after_force()
             except BaseException:
                 self._discovered = False
                 raise
 
-    def _re_register_shell_hooks_after_force(self) -> None:
-        """Restore config.yaml shell hooks wiped by force-clear of ``_hooks``."""
+    def _re_register_config_hooks_after_force(self) -> None:
+        """Restore config.yaml shell hooks/outbound webhooks wiped by
+        force-clear of ``_hooks``. Each re-register call is independently
+        guarded so one failing does not skip the other."""
         try:
             from agent.shell_hooks import re_register_config_hooks
 
@@ -4281,6 +4284,14 @@ class PluginManager:
         except Exception as exc:
             # Import cycle / missing module must not abort force reload.
             logger.debug("force-reload shell-hook re-register skipped: %s", exc)
+        try:
+            from agent.outbound_webhooks import (
+                re_register_config_hooks as re_register_outbound_webhooks,
+            )
+
+            re_register_outbound_webhooks()
+        except Exception as exc:
+            logger.debug("force-reload outbound-webhook re-register skipped: %s", exc)
 
     def _refresh_secret_sources_after_discovery(self) -> None:
         """If any plugin secret source is enabled, reset cache and re-apply.

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import asyncio
 import atexit
+import contextvars
 import importlib
 import json
 import logging
@@ -1314,8 +1315,17 @@ class HindsightMemoryProvider(MemoryProvider):
         # If the previous writer exited (e.g. after a prior shutdown), reset
         # the flag so this fresh writer is allowed to drain new jobs.
         self._shutting_down.clear()
+        # Per-provider background threads start with an EMPTY contextvars
+        # Context. Under multiplex_profiles the spawning thread carries the
+        # profile's secret scope + HERMES_HOME override (gateway/run.py wraps
+        # the agent turn in copy_context().run), and get_secret fails closed
+        # without it (#92608). Snapshot the spawner's context into the thread.
+        # (The shared ``hindsight-loop`` thread needs no wrap: coroutines
+        # scheduled via run_coroutine_threadsafe inherit the submitter's
+        # context per call, so one loop can serve every profile.)
         thread = threading.Thread(
-            target=self._writer_loop,
+            target=contextvars.copy_context().run,
+            args=(self._writer_loop,),
             daemon=True,
             name="hindsight-writer",
         )
@@ -1835,7 +1845,12 @@ class HindsightMemoryProvider(MemoryProvider):
                         f.write(f"\n=== Daemon startup failed: {e} ===\n")
                         traceback.print_exc(file=f)
 
-            t = threading.Thread(target=_start_daemon, daemon=True, name="hindsight-daemon-start")
+            t = threading.Thread(
+                target=contextvars.copy_context().run,
+                args=(_start_daemon,),
+                daemon=True,
+                name="hindsight-daemon-start",
+            )
             t.start()
 
     def system_prompt_block(self) -> str:
@@ -1992,7 +2007,12 @@ class HindsightMemoryProvider(MemoryProvider):
                     self._prefetch_result = recalled.text
                     self._prefetch_count = recalled.count
 
-        self._prefetch_thread = threading.Thread(target=_run, daemon=True, name="hindsight-prefetch")
+        self._prefetch_thread = threading.Thread(
+            target=contextvars.copy_context().run,
+            args=(_run,),
+            daemon=True,
+            name="hindsight-prefetch",
+        )
         self._prefetch_thread.start()
 
     def _build_turn_messages(self, user_content: str, assistant_content: str) -> List[Dict[str, str]]:

--- a/tests/agent/test_outbound_webhooks.py
+++ b/tests/agent/test_outbound_webhooks.py
@@ -345,6 +345,46 @@ class TestRegistration:
         assert len(http_server.captured) == 1
 
 
+class TestForceReloadHomeScoping:
+    """Force-reloading one profile's plugin manager must restore that
+    profile's own outbound webhook and leave it firing exactly once —
+    the mirror of the shell-hook force-reload symmetry fix (#92682
+    review: outbound webhooks were the "same symptom class... after a
+    supported lifecycle transition instead of initial startup").
+    """
+
+    def test_force_reload_restores_webhook_and_fires_once(
+        self, monkeypatch, http_server,
+    ):
+        from hermes_cli import plugins
+
+        cfg = _cfg({"url": _url(http_server), "events": ["on_session_end"]})
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+
+        monkeypatch.setenv("HERMES_HOME", "/tmp/profile-b-webhook")
+        mgr_b = plugins.PluginManager()
+        plugins._plugin_manager = mgr_b
+        outbound_webhooks.register_from_config(cfg)
+        assert len(mgr_b._hooks.get("on_session_end", [])) == 1
+
+        # Force-reload: unload() wipes _hooks (config-owned webhook
+        # callbacks included, same as the ledger-driven plugin sweep), so
+        # without the fix the idempotence key alone would survive and a
+        # later register_from_config() call would see it and skip
+        # re-wiring — leaving the webhook silently inert.
+        mgr_b.unload()
+        assert mgr_b._hooks.get("on_session_end", []) == []
+
+        outbound_webhooks.re_register_config_hooks()
+        assert len(mgr_b._hooks.get("on_session_end", [])) == 1
+
+        plugins.get_plugin_manager().invoke_hook(
+            "on_session_end", session_id="s1",
+        )
+        assert outbound_webhooks.flush()
+        assert len(http_server.captured) == 1
+
+
 # ── E2E delivery against a real HTTP server ──────────────────────────────
 
 

--- a/tests/agent/test_outbound_webhooks.py
+++ b/tests/agent/test_outbound_webhooks.py
@@ -301,6 +301,23 @@ class TestPayload:
         assert payload["delivery_id"] == "did_1234"
         assert payload["timestamp"].endswith("Z")
 
+    def test_profile_field_reflects_bound_profile_home(self, tmp_path, monkeypatch):
+        """Receivers behind a multiplexed gateway need to know which profile
+        fired (#92674): ``profile`` follows the bound home at fire time."""
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        profile_home = tmp_path / "profiles" / "b"
+        profile_home.mkdir(parents=True)
+        token = set_hermes_home_override(profile_home)
+        try:
+            body = outbound_webhooks._serialize_payload("on_session_end", {}, "did_1")
+        finally:
+            reset_hermes_home_override(token)
+        assert json.loads(body)["profile"] == "b"
+        body = outbound_webhooks._serialize_payload("on_session_end", {}, "did_2")
+        assert json.loads(body)["profile"] == "default"
+
     def test_unserialisable_values_stringified(self):
         body = outbound_webhooks._serialize_payload(
             "on_session_end", {"weird": object()}, "did_1"

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -255,6 +255,41 @@ class TestScanSkillCommands:
             assert "/b-only" in profile_b_commands
             assert "/a-only" not in profile_b_commands
 
+    def test_get_skill_commands_scans_profile_skills_dir_not_frozen_import_dir(self, tmp_path):
+        """Under a profile home override the scan must read <profile>/skills/,
+        not the launch home's import-time ``SKILLS_DIR`` (#67277): a
+        multiplexed webhook routed to profile B otherwise sees default's skills.
+        Deliberately does NOT patch ``tools.skills_tool.SKILLS_DIR``.
+        """
+        import agent.skill_commands as sc_mod
+        from agent.skill_commands import build_skill_invocation_message, get_skill_commands
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+        profile_b = tmp_path / "profiles" / "b"
+        _make_skill(profile_b / "skills", "b-only", body="Body of b-only.")
+        (profile_b / "config.yaml").write_text("{}\n")
+
+        with (
+            patch.object(sc_mod, "_skill_commands", {}),
+            patch.object(sc_mod, "_skill_commands_platform", None),
+            patch.object(sc_mod, "_skill_commands_home", None),
+        ):
+            token = set_hermes_home_override(profile_b)
+            try:
+                commands = dict(get_skill_commands())
+                assert "/b-only" in commands
+                # Frozen SKILLS_DIR (the launch home) must not leak in.
+                launch_dir = str(skills_tool_module._SKILLS_DIR_AT_IMPORT)
+                assert not any(
+                    info["skill_dir"].startswith(launch_dir) for info in commands.values()
+                )
+                # And the absolute skill_dir round-trips through skill_view
+                # (normalize_skill_lookup_name must use the same live root).
+                msg = build_skill_invocation_message("/b-only", user_instruction="go")
+            finally:
+                reset_hermes_home_override(token)
+        assert msg is not None and "Body of b-only." in msg
+
     def test_get_skill_commands_rescans_when_leaving_platform_scope(self, tmp_path, monkeypatch):
         """Returning to no-platform-scope (CLI / cron / RL) after a gateway
         session must rescan so the unfiltered view is repopulated (#14536).

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -915,6 +915,53 @@ class TestSecondaryProfileConfigHandling:
         assert runner._profile_adapters["later"][photon] is later
 
 
+class TestSecondaryProfileHookRegistration:
+    """A secondary profile's own `hooks:` block must register on ITS
+    plugin manager, not just the root/default profile's (#92672).
+
+    Startup only calls agent.shell_hooks/outbound_webhooks
+    register_from_config() once, against the root config, before any
+    profile scope exists. Without a matching call inside
+    _start_one_profile_adapters, a secondary profile's config.yaml
+    `hooks:` block (shell hooks and outbound webhooks) never registers.
+    """
+
+    @pytest.mark.asyncio
+    async def test_registers_shell_hooks_and_webhooks_for_secondary_profile(
+        self, monkeypatch
+    ):
+        runner = _secondary_recovery_runner()
+        config = GatewayConfig(multiplex_profiles=True, platforms={})
+        monkeypatch.setattr("gateway.config.load_gateway_config", lambda: config)
+
+        profile_cfg = {
+            "hooks": {
+                "pre_tool_call": [
+                    {"matcher": "write_file", "command": "~/.hermes/deny.sh"}
+                ],
+                "outbound": [
+                    {"url": "http://127.0.0.1:9000/hook", "events": ["on_session_end"]}
+                ],
+            }
+        }
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: profile_cfg)
+
+        seen = []
+        monkeypatch.setattr(
+            "agent.shell_hooks.register_from_config",
+            lambda cfg, **kwargs: seen.append(("shell", cfg)) or [],
+        )
+        monkeypatch.setattr(
+            "agent.outbound_webhooks.register_from_config",
+            lambda cfg: seen.append(("webhook", cfg)) or [],
+        )
+
+        await runner._start_one_profile_adapters("second", "/tmp/second", {})
+
+        assert ("shell", profile_cfg) in seen
+        assert ("webhook", profile_cfg) in seen
+
+
 class TestFeishuPortBindingConditional:
     """Feishu websocket mode does NOT bind a port; only webhook mode does (#52563)."""
 

--- a/tests/gateway/test_multiplex_mcp_discovery.py
+++ b/tests/gateway/test_multiplex_mcp_discovery.py
@@ -1,0 +1,121 @@
+"""Multiplexed gateways discover and reload MCP servers per profile (#95518)."""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+from hermes_constants import get_hermes_home, hermes_home_key
+
+
+@pytest.mark.asyncio
+async def test_gateway_boot_discovers_mcp_under_every_profile_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import gateway.run as gateway_run
+    from tools import mcp_tool
+
+    homes = [("default", tmp_path / "default"), ("worker", tmp_path / "worker")]
+    for _name, home in homes:
+        home.mkdir()
+    seen: list[tuple[Path, str]] = []
+
+    def fake_discover() -> list[str]:
+        seen.append((get_hermes_home(), threading.current_thread().name))
+        return []
+
+    monkeypatch.setattr(
+        "hermes_cli.profiles.profiles_to_serve",
+        lambda multiplex, profile_allowlist=None: homes,
+    )
+    monkeypatch.setattr(mcp_tool, "discover_mcp_tools", fake_discover)
+
+    await gateway_run._discover_gateway_mcp_tools(GatewayConfig(multiplex_profiles=True))
+
+    # Ran once per profile, under that profile's home, off the loop thread.
+    assert [home for home, _ in seen] == [home for _, home in homes]
+    assert all(thread != threading.current_thread().name for _, thread in seen)
+
+
+@pytest.mark.asyncio
+async def test_reload_mcp_only_touches_requesting_profile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from gateway.run import GatewayRunner
+    from tools import mcp_tool
+
+    worker_home = tmp_path / "profiles" / "worker"
+    worker_home.mkdir(parents=True)
+    worker_scope = hermes_home_key(worker_home)
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner._resolve_profile_home_for_source = MagicMock(return_value=worker_home)
+    runner._agent_cache = {}
+    runner._agent_cache_lock = None
+    runner._async_session_store = SimpleNamespace(
+        get_or_create_session=MagicMock(side_effect=RuntimeError("skip transcript")),
+    )
+
+    monkeypatch.setattr(mcp_tool, "_servers", {"default-srv": object(), "worker-srv": object()})
+    monkeypatch.setattr(
+        mcp_tool, "_server_scope_keys",
+        {"default-srv": hermes_home_key(tmp_path), "worker-srv": worker_scope},
+    )
+    seen: list[tuple] = []
+
+    def fake_shutdown(*, scope=None) -> None:
+        seen.append(("shutdown", scope, get_hermes_home()))
+
+    def fake_discover() -> list[str]:
+        seen.append(("discover", get_hermes_home()))
+        return []
+
+    monkeypatch.setattr(mcp_tool, "shutdown_mcp_servers", fake_shutdown)
+    monkeypatch.setattr(mcp_tool, "discover_mcp_tools", fake_discover)
+
+    event = MessageEvent(
+        text="/reload-mcp", message_id="m1",
+        source=SessionSource(
+            platform=Platform.TELEGRAM, user_id="u1", chat_id="c1",
+            chat_type="dm", profile="worker",
+        ),
+    )
+    result = await runner._execute_mcp_reload(event)
+
+    # Entered worker's scope itself, shut down only worker's servers, and
+    # reported only worker's servers (default's untouched connection is not
+    # "removed").
+    assert seen == [
+        ("shutdown", worker_scope, worker_home),
+        ("discover", worker_home),
+    ]
+    assert "default-srv" not in result
+
+
+def test_deregister_scope_kwarg_targets_overlay_and_keeps_plugin_confinement() -> None:
+    from tools.registry import ToolRegistry
+
+    reg = ToolRegistry()
+    reg.register("mcp__s__t", "mcp-s", {"name": "mcp__s__t", "description": "d"},
+                 lambda **kw: None, scope="/home/p1")
+    assert reg.snapshot_registration("mcp__s__t", scope="/home/p1") is not None
+
+    reg.deregister("mcp__s__t")  # unscoped: global slot only, overlay untouched
+    assert reg.snapshot_registration("mcp__s__t", scope="/home/p1") is not None
+
+    reg.deregister("mcp__s__t", scope="/home/p1")
+    assert reg.snapshot_registration("mcp__s__t", scope="/home/p1") is None
+
+    # A plugin module may not name another profile's overlay.
+    reg._plugin_module_scopes["hermes_plugins.p"] = {"/home/p1"}
+    reg._caller_module = staticmethod(lambda: "hermes_plugins.p")
+    with pytest.raises(PermissionError):
+        reg.deregister("anything", scope="/home/p2")

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -1011,6 +1011,63 @@ class TestMultiplexProfileWebhookAuthentication:
             )
             assert default_profile.status == 404
 
+    @pytest.mark.asyncio
+    async def test_routed_profile_skills_resolve_under_that_profile(
+        self, tmp_path, monkeypatch
+    ):
+        """A /p/<profile>/ route's ``skills:`` must load from that profile's
+        skills/ dir (#67277). Before the fix the lookup ran with no profile
+        scope, so it scanned the launch profile and logged "Skill not found".
+        """
+        import agent.skill_commands as sc_mod
+
+        worker = tmp_path / "profiles" / "worker"
+        skill_dir = worker / "skills" / "worker-only"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: worker-only\ndescription: w\n---\n\nBody of worker-only.\n"
+        )
+        (worker / "config.yaml").write_text("{}\n")
+        (worker / ".env").write_text("")
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_profile_dir", lambda name: tmp_path / "profiles" / name
+        )
+        route_secret = "worker-route-secret-abc123"
+        adapter = _make_adapter(
+            routes={
+                "gh": {
+                    "profile": "worker",
+                    "secret": route_secret,
+                    "prompt": "PR: {action}",
+                    "skills": ["worker-only"],
+                }
+            },
+            host="127.0.0.1",
+        )
+        self._configure_profiles(adapter, tmp_path, monkeypatch)
+        seen = []
+
+        async def _capture(event):
+            seen.append(event)
+
+        adapter.handle_message = _capture
+        body = b'{"action":"opened"}'
+        headers = {
+            "Content-Type": "application/json",
+            "X-Hub-Signature-256": _github_signature(body, route_secret),
+        }
+        with (
+            patch.object(sc_mod, "_skill_commands", {}),
+            patch.object(sc_mod, "_skill_commands_home", None),
+        ):
+            async with TestClient(TestServer(self._app(adapter))) as cli:
+                resp = await cli.post("/p/worker/webhooks/gh", data=body, headers=headers)
+                assert resp.status == 202
+                await asyncio.sleep(0.05)
+        assert len(seen) == 1
+        assert seen[0].source.profile == "worker"
+        assert "Body of worker-only." in seen[0].text
+
 
 def test_route_profile_validation_fails_closed():
     assert WebhookAdapter._route_allows_profile({}, None) is True

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -933,6 +933,13 @@ class TestDeliveryParity:
 class TestForceReloadSymmetry:
     """Force rediscovery restores non-plugin state it wiped (#64178)."""
 
+    @pytest.fixture(autouse=True)
+    def _cleanup_shell_hook_registry(self):
+        yield
+        import agent.shell_hooks as shell_hooks_mod
+
+        shell_hooks_mod.reset_for_tests()
+
     def test_force_reload_re_registers_shell_hooks(self, monkeypatch):
         """config.yaml shell hooks are re-wired after force=True (#60036)."""
         calls = []
@@ -992,6 +999,7 @@ class TestForceReloadSymmetry:
 
     def test_re_register_config_hooks_clears_idempotence_set(self, monkeypatch):
         import agent.shell_hooks as shell_hooks_mod
+        from hermes_constants import get_hermes_home
 
         recorded = {}
         monkeypatch.setattr(
@@ -1002,8 +1010,9 @@ class TestForceReloadSymmetry:
         monkeypatch.setattr(
             "hermes_cli.config.load_config", lambda: {"hooks": {}}
         )
+        home_key = str(get_hermes_home().expanduser().resolve())
         with shell_hooks_mod._registered_lock:
-            shell_hooks_mod._registered.add(("post_llm_call", None, "echo hi"))
+            shell_hooks_mod._registered.add((home_key, "post_llm_call", None, "echo hi"))
 
         shell_hooks_mod.re_register_config_hooks()
 
@@ -1218,6 +1227,50 @@ class TestForceReloadSymmetry:
         assert dispatch_calls == []
         assert _PRE_TOOL_CALL_TIMEOUT_BLOCK_MESSAGE in result
         hold.set()
+
+    def test_force_reload_of_one_profile_does_not_orphan_another(self, monkeypatch):
+        """Real two-manager regression: force-reloading profile A's plugin
+        manager must leave profile B's shell hook registered exactly once —
+        not duplicated, not dropped (#92682 review).
+        """
+        import hermes_cli.plugins as plugins_mod
+        import agent.shell_hooks as shell_hooks_mod
+
+        cfg = {"hooks": {"on_session_start": [{"command": "/bin/true"}]}}
+        monkeypatch.setenv("HERMES_ACCEPT_HOOKS", "1")
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+        monkeypatch.setattr(
+            PluginManager, "_discover_and_load_inner", lambda self_inner: None,
+        )
+
+        monkeypatch.setenv("HERMES_HOME", "/tmp/profile-a")
+        mgr_a = PluginManager()
+        plugins_mod._plugin_manager = mgr_a
+        shell_hooks_mod.register_from_config(cfg, accept_hooks=True)
+
+        monkeypatch.setenv("HERMES_HOME", "/tmp/profile-b")
+        mgr_b = PluginManager()
+        plugins_mod._plugin_manager = mgr_b
+        shell_hooks_mod.register_from_config(cfg, accept_hooks=True)
+
+        assert len(mgr_a._hooks.get("on_session_start", [])) == 1
+        assert len(mgr_b._hooks.get("on_session_start", [])) == 1
+
+        # Force-reload A. Its own manager's hook is wiped and restored;
+        # B's manager (and idempotence key) must be untouched.
+        mgr_a.discover_and_load(force=True)
+
+        assert len(mgr_a._hooks.get("on_session_start", [])) == 1
+        assert len(mgr_b._hooks.get("on_session_start", [])) == 1
+
+        # B's later adapter reconnect re-runs register_from_config(); its
+        # idempotence key must still be intact, so this must be a no-op
+        # rather than appending a second callback to B's live manager.
+        monkeypatch.setenv("HERMES_HOME", "/tmp/profile-b")
+        second = shell_hooks_mod.register_from_config(cfg, accept_hooks=True)
+
+        assert second == []
+        assert len(mgr_b._hooks.get("on_session_start", [])) == 1
 
 
 class TestPreToolCallBlocking:

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -10,6 +10,7 @@ import os
 import re
 import stat
 import sys
+import threading
 import time
 from datetime import datetime
 from pathlib import Path
@@ -32,6 +33,7 @@ from plugins.memory.hindsight import (
     _normalize_retain_tags,
     _resolve_bank_id_template,
     _sanitize_bank_segment,
+    _WRITER_SENTINEL,
 )
 
 
@@ -1643,3 +1645,68 @@ class TestClientAutoUpgradeRoutesThroughLazyDeps:
         assert len(calls) == 1  # attempted exactly once, init still completed
         assert any("runtime installs are disabled" in r.getMessage()
                    for r in caplog.records)
+
+
+
+class TestMultiplexBackgroundScope:
+    """Under multiplex_profiles get_secret fails closed on an unscoped thread;
+    the writer / daemon-start threads are spawned from a scoped context and
+    must carry it along (#92608, #94933)."""
+
+    @pytest.fixture()
+    def scoped_embedded(self, tmp_path, monkeypatch):
+        from agent.secret_scope import (
+            build_profile_secret_scope, reset_secret_scope, set_multiplex_active, set_secret_scope,
+        )
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+        created = []
+
+        class FakeHindsightEmbedded:
+            def __init__(self, **kwargs):
+                created.append(kwargs["llm_api_key"])
+                self._manager = SimpleNamespace(is_running=lambda profile: False, stop=lambda profile: None)
+                self._ensure_started = lambda: None
+
+        dem = SimpleNamespace(console=None)
+        monkeypatch.setitem(sys.modules, "hindsight", SimpleNamespace(HindsightEmbedded=FakeHindsightEmbedded))
+        monkeypatch.setitem(sys.modules, "hindsight_embed", SimpleNamespace(daemon_embed_manager=dem))
+        monkeypatch.setitem(sys.modules, "hindsight_embed.daemon_embed_manager", dem)
+        monkeypatch.setattr("plugins.memory.hindsight._check_local_runtime", lambda: (True, ""))
+
+        home = tmp_path / "profiles" / "p1"
+        (home / "hindsight").mkdir(parents=True)
+        (home / ".env").write_text("HINDSIGHT_LLM_API_KEY=p1-secret\n")
+        (home / "hindsight" / "config.json").write_text(json.dumps(
+            {"mode": "local_embedded", "llm_provider": "openai", "llm_model": "m", "memory_mode": "hybrid"}
+        ))
+        # Enter the profile scope the way gateway _profile_runtime_scope does.
+        set_multiplex_active(True)
+        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: home)
+        home_tok = set_hermes_home_override(str(home))
+        scope_tok = set_secret_scope(build_profile_secret_scope(home))
+        yield created, home
+        set_multiplex_active(False)
+        reset_secret_scope(scope_tok)
+        reset_hermes_home_override(home_tok)
+
+    def test_writer_thread_resolves_profile_secret(self, scoped_embedded):
+        created, home = scoped_embedded
+        p = HindsightMemoryProvider()
+        p._mode = "local_embedded"
+        p._config = {"profile": "hermes", "llm_provider": "openai", "llm_model": "m"}
+        p._ensure_writer()
+        p._retain_queue.put(p._get_client)   # real body: get_secret(HINDSIGHT_LLM_API_KEY)
+        p._retain_queue.put(_WRITER_SENTINEL)
+        p._writer_thread.join(timeout=5)
+        assert created == ["p1-secret"]
+
+    def test_daemon_start_thread_resolves_profile_secret(self, scoped_embedded):
+        created, home = scoped_embedded
+        p = HindsightMemoryProvider()
+        p.initialize(session_id="s1", hermes_home=str(home), platform="cli")
+        for t in threading.enumerate():
+            if t.name == "hindsight-daemon-start":
+                t.join(timeout=5)
+        assert created == ["p1-secret"]
+        assert "Daemon started successfully" in (home / "logs" / "hindsight-embed.log").read_text()

--- a/tests/tools/test_browser_cleanup.py
+++ b/tests/tools/test_browser_cleanup.py
@@ -83,3 +83,106 @@ class TestBrowserCleanup:
         assert browser_tool._session_last_activity == {}
         assert browser_tool._recording_sessions == set()
         assert browser_tool._cleanup_done is True
+
+
+class TestInactivityJanitorMultiplex:
+    """#86402 / #100738: the process-global janitor thread has no profile scope."""
+
+    def setup_method(self):
+        from agent import secret_scope
+        from tools import browser_tool
+
+        self.bt = browser_tool
+        self.saved = {
+            name: getattr(browser_tool, name).copy()
+            for name in (
+                "_active_sessions", "_session_last_activity",
+                "_session_owner_homes", "_cleanup_failures", "_recording_sessions",
+            )
+        }
+        self.orig_timeout = browser_tool.BROWSER_SESSION_INACTIVITY_TIMEOUT
+        browser_tool.BROWSER_SESSION_INACTIVITY_TIMEOUT = 0
+        for name in self.saved:
+            getattr(browser_tool, name).clear()
+        secret_scope.set_multiplex_active(True)
+
+    def teardown_method(self):
+        from agent import secret_scope
+
+        secret_scope.set_multiplex_active(False)
+        self.bt.BROWSER_SESSION_INACTIVITY_TIMEOUT = self.orig_timeout
+        for name, saved in self.saved.items():
+            live = getattr(self.bt, name)
+            live.clear()
+            live.update(saved)
+
+    def test_janitor_tears_down_under_owner_profile_scope(self, tmp_path, monkeypatch):
+        from agent import secret_scope
+        from hermes_constants import (
+            get_hermes_home, reset_hermes_home_override, set_hermes_home_override,
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("CAMOFOX_URL", raising=False)
+        monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+        p1 = tmp_path / "profiles" / "p1"
+        p1.mkdir(parents=True)
+        (p1 / ".env").write_text("CAMOFOX_URL=http://127.0.0.1:1\n")
+
+        # Profile p1's turn opens the session; the janitor later runs unscoped.
+        home_tok = set_hermes_home_override(str(p1))
+        scope_tok = secret_scope.set_secret_scope(secret_scope.build_profile_secret_scope(p1))
+        try:
+            self.bt._update_session_activity("t1")
+            self.bt._active_sessions["t1"] = {"session_name": "s1", "bb_session_id": None}
+        finally:
+            secret_scope.reset_secret_scope(scope_tok)
+            reset_hermes_home_override(home_tok)
+        self.bt._session_last_activity["t1"] -= 10
+
+        seen = {}
+
+        def fake_close(task_id, cmd, args, timeout=None):
+            seen["home"] = str(get_hermes_home())
+            seen["url"] = secret_scope.get_secret("CAMOFOX_URL")
+            return {"success": True}
+
+        with (
+            patch("tools.browser_tool._run_browser_command", side_effect=fake_close),
+            patch("tools.browser_camofox._delete", return_value={}),
+            patch("tools.browser_tool.os.path.exists", return_value=False),
+        ):
+            self.bt._cleanup_inactive_browser_sessions()
+
+        assert seen == {"home": str(p1), "url": "http://127.0.0.1:1"}
+        assert "t1" not in self.bt._session_last_activity
+        assert "t1" not in self.bt._active_sessions
+        assert "t1" not in self.bt._session_owner_homes
+
+    def test_repeated_failures_force_reap_and_close_cloud_session(self):
+        from unittest.mock import MagicMock
+
+        self.bt._active_sessions["t1"] = {"session_name": "s1", "bb_session_id": "bb-1"}
+        self.bt._session_last_activity["t1"] = 1.0
+        provider = MagicMock()
+
+        with (
+            patch("tools.browser_tool.cleanup_browser", side_effect=RuntimeError("boom")),
+            patch("tools.browser_tool._get_cloud_provider", return_value=provider),
+            patch("tools.browser_tool.os.path.exists", return_value=False),
+        ):
+            for _ in range(self.bt.MAX_INACTIVITY_CLEANUP_FAILURES - 1):
+                self.bt._cleanup_inactive_browser_sessions()
+            # An activity touch must NOT reset the failure budget.
+            self.bt._update_session_activity("t1")
+            self.bt._session_last_activity["t1"] = 1.0
+            assert self.bt._cleanup_failures["t1"] == self.bt.MAX_INACTIVITY_CLEANUP_FAILURES - 1
+            assert "t1" in self.bt._active_sessions
+            provider.close_session.assert_not_called()
+
+            self.bt._cleanup_inactive_browser_sessions()
+
+        provider.close_session.assert_called_once_with("bb-1")
+        assert "t1" not in self.bt._active_sessions
+        assert "t1" not in self.bt._session_last_activity
+        assert "t1" not in self.bt._cleanup_failures

--- a/tests/tools/test_mcp_lazy_start.py
+++ b/tests/tools/test_mcp_lazy_start.py
@@ -285,7 +285,7 @@ class TestLazyFirstUseConnect:
              patch.object(registry, "deregister") as mock_dereg:
             assert mcp._ensure_lazy_server_connected("playwright") is True
 
-        mock_dereg.assert_called_once_with("mcp_playwright_tool_x")
+        mock_dereg.assert_called_once_with("mcp_playwright_tool_x", scope=None)
 
     def test_lazy_connect_failure_records_cooldown(self):
         mcp._lazy_server_configs["playwright"] = {"command": "npx", "lazy": True}

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -50,6 +50,7 @@ Usage:
 """
 
 import atexit
+import contextlib
 import functools
 import json
 import logging
@@ -72,6 +73,8 @@ from hermes_constants import (
     get_hermes_home_override,
     hermes_home_key,
     node_tool_runnable,
+    reset_hermes_home_override,
+    set_hermes_home_override,
 )
 from utils import env_int, is_truthy_value
 from hermes_cli.config import DEFAULT_CONFIG, cfg_get
@@ -2195,6 +2198,16 @@ BROWSER_ORPHAN_GRACE_SECONDS = max(3600, BROWSER_SESSION_INACTIVITY_TIMEOUT * 20
 
 # Track last activity time per session
 _session_last_activity: Dict[str, float] = {}
+# Owner Hermes home per session (#86402).  The inactivity janitor is one
+# process-global thread started by whichever profile first opens a browser,
+# so it has no profile scope of its own; under multiplexing every cleanup
+# must re-enter the *owning* profile's scope (copy_context at spawn would pin
+# the first profile's secrets onto every other profile's teardown).
+_session_owner_homes: Dict[str, str] = {}
+# Consecutive janitor cleanup failures per session; after
+# MAX_INACTIVITY_CLEANUP_FAILURES the session is force-reaped (#100738).
+_cleanup_failures: Dict[str, int] = {}
+MAX_INACTIVITY_CLEANUP_FAILURES = 3
 
 # Session keys flagged suspect after a command timeout (#72205 / #85125 3b).
 # Written by _BrowserSessionBackend.mark_suspect (cheap, lock-free — a single
@@ -2338,6 +2351,8 @@ def _emergency_cleanup_all_sessions():
             with _cleanup_lock:
                 _active_sessions.clear()
                 _session_last_activity.clear()
+                _session_owner_homes.clear()
+                _cleanup_failures.clear()
                 _recording_sessions.clear()
 
     # Lightpanda servers (Browser Use mode) are processes we spawned; the
@@ -2372,6 +2387,41 @@ atexit.register(_emergency_cleanup_all_sessions)
 # Inactivity Cleanup Functions
 # =============================================================================
 
+@contextlib.contextmanager
+def _session_owner_scope(task_id: str):
+    """Run under the Hermes home + secret scope that owns ``task_id``'s
+    browser session (recorded by ``_update_session_activity``).
+
+    No-op when no owner was recorded.  Mirrors
+    ``gateway.run._profile_runtime_scope`` — the janitor thread is
+    process-global, so each session's teardown must re-enter its OWN
+    profile's scope rather than inherit whichever profile spawned the
+    thread; never falls through to ``os.environ``.
+    """
+    owner_home = _session_owner_homes.get(task_id)
+    if owner_home is None:
+        yield
+        return
+
+    from agent.secret_scope import (
+        build_profile_secret_scope,
+        reset_secret_scope,
+        set_secret_scope,
+    )
+    from hermes_cli.env_loader import hydrate_profile_secret_sources
+
+    home_token = set_hermes_home_override(owner_home)
+    try:
+        hydrate_profile_secret_sources(Path(owner_home))
+        secret_token = set_secret_scope(build_profile_secret_scope(Path(owner_home)))
+        try:
+            yield
+        finally:
+            reset_secret_scope(secret_token)
+    finally:
+        reset_hermes_home_override(home_token)
+
+
 def _cleanup_inactive_browser_sessions():
     """
     Clean up browser sessions that have been inactive for longer than the timeout.
@@ -2379,6 +2429,11 @@ def _cleanup_inactive_browser_sessions():
     This function is called periodically by the background cleanup thread to
     automatically close sessions that haven't been used recently, preventing
     orphaned sessions (local or Browserbase) from accumulating.
+
+    Each session is torn down under its owner profile's scope (#86402).  A
+    session whose cleanup keeps failing is force-reaped after
+    ``MAX_INACTIVITY_CLEANUP_FAILURES`` attempts instead of retrying forever
+    (#100738); only a successful cleanup clears its failure count.
     """
     current_time = time.time()
     sessions_to_cleanup = []
@@ -2389,15 +2444,33 @@ def _cleanup_inactive_browser_sessions():
                 sessions_to_cleanup.append(task_id)
 
     for task_id in sessions_to_cleanup:
+        elapsed = int(current_time - _session_last_activity.get(task_id, current_time))
+        logger.info("Cleaning up inactive session for task: %s (inactive for %ss)", task_id, elapsed)
         try:
-            elapsed = int(current_time - _session_last_activity.get(task_id, current_time))
-            logger.info("Cleaning up inactive session for task: %s (inactive for %ss)", task_id, elapsed)
-            cleanup_browser(task_id)
+            with _session_owner_scope(task_id):
+                cleanup_browser(task_id)
             with _cleanup_lock:
-                if task_id in _session_last_activity:
-                    del _session_last_activity[task_id]
+                _session_last_activity.pop(task_id, None)
+                _session_owner_homes.pop(task_id, None)
+                _cleanup_failures.pop(task_id, None)
         except Exception as e:
-            logger.warning("Error cleaning up inactive session %s: %s", task_id, e)
+            with _cleanup_lock:
+                failures = _cleanup_failures[task_id] = _cleanup_failures.get(task_id, 0) + 1
+            if failures < MAX_INACTIVITY_CLEANUP_FAILURES:
+                logger.warning("Error cleaning up inactive session %s (attempt %d/%d): %s",
+                               task_id, failures, MAX_INACTIVITY_CLEANUP_FAILURES, e)
+                continue
+            logger.error("Browser cleanup failed %d times for inactive session %s; "
+                         "force-reaping: %s", failures, task_id, e)
+            try:
+                with _session_owner_scope(task_id):
+                    _force_reap_browser_session(task_id)
+            except Exception as reap_exc:
+                logger.error("Force-reap of browser session %s failed: %s", task_id, reap_exc)
+            finally:
+                with _cleanup_lock:
+                    _session_owner_homes.pop(task_id, None)
+                    _cleanup_failures.pop(task_id, None)
 
 
 def _write_owner_pid(socket_dir: str, session_name: str) -> None:
@@ -2778,9 +2851,16 @@ def _stop_browser_cleanup_thread():
 
 
 def _update_session_activity(task_id: str):
-    """Update the last activity timestamp for a session."""
+    """Update the last activity timestamp for a session.
+
+    Also records the owning Hermes home on first sight so the process-global
+    janitor can tear the session down under its owner's scope (#86402).  An
+    activity touch deliberately does NOT reset ``_cleanup_failures`` — only a
+    successful cleanup does.
+    """
     with _cleanup_lock:
         _session_last_activity[task_id] = time.time()
+        _session_owner_homes.setdefault(task_id, str(get_hermes_home()))
 
 
 # Register cleanup thread stop on exit
@@ -5848,6 +5928,91 @@ def cleanup_browser(task_id: Optional[str] = None) -> None:
         _last_active_session_key.pop(bare_task_id, None)
 
 
+def _release_session_resources(task_id: str, session_info: Dict[str, Any]) -> None:
+    """Untrack ``task_id``, close its cloud provider session, kill its daemon.
+
+    The unconditional tail of ``_cleanup_single_browser_session``; also the
+    whole of the janitor's force-reap path (#100738), which skips the polite
+    agent-browser/Camofox ``close`` that kept failing but must still release
+    the cloud session and the local Chromium.
+    """
+    bb_session_id = session_info.get("bb_session_id", "unknown")
+    # Now remove from tracking under lock
+    with _cleanup_lock:
+        _active_sessions.pop(task_id, None)
+        _session_last_activity.pop(task_id, None)
+        _session_owner_homes.pop(task_id, None)
+        _cleanup_failures.pop(task_id, None)
+
+    # Cloud mode: close the cloud browser session via provider API.
+    # Local sidecars have bb_session_id=None so this no-ops for them.
+    if bb_session_id:
+        provider = _get_cloud_provider()
+        if provider is not None:
+            try:
+                provider.close_session(bb_session_id)
+            except Exception as e:
+                logger.warning("Could not close cloud browser session: %s", e)
+
+    # Kill the daemon process and clean up socket directory
+    session_name = session_info.get("session_name", "")
+    if session_name:
+        socket_dir = os.path.join(_socket_safe_tmpdir(), f"agent-browser-{session_name}")
+        if os.path.exists(socket_dir):
+            # agent-browser writes {session}.pid in the socket dir
+            pid_file = os.path.join(socket_dir, f"{session_name}.pid")
+            if os.path.isfile(pid_file):
+                try:
+                    from tools.process_registry import ProcessRegistry
+                    daemon_pid = int(Path(pid_file).read_text(encoding="utf-8").strip())
+                    # The .pid file lives in a world-writable temp dir and
+                    # PIDs recycle: verify this really is our daemon for
+                    # this session before tree-killing, and pin the
+                    # identity with a start-time fingerprint so the kill
+                    # refuses if the PID is swapped between check and kill.
+                    if _verify_reapable_browser_daemon(
+                            daemon_pid, socket_dir, session_name):
+                        from gateway.status import get_process_start_time
+                        daemon_start = get_process_start_time(daemon_pid)
+                        if daemon_start is not None:
+                            ProcessRegistry._terminate_host_pid(
+                                daemon_pid, daemon_start)
+                            logger.debug("Killed daemon pid %s for %s", daemon_pid, session_name)
+                        else:
+                            logger.debug(
+                                "Skipped daemon kill for %s: no start-time "
+                                "fingerprint for pid %s", session_name, daemon_pid)
+                    else:
+                        logger.debug(
+                            "Skipped daemon kill for %s: pid %s failed identity "
+                            "verification", session_name, daemon_pid)
+                except (ProcessLookupError, ValueError, PermissionError, OSError):
+                    logger.debug("Could not kill daemon pid for %s (already dead or inaccessible)", session_name)
+            shutil.rmtree(socket_dir, ignore_errors=True)
+
+
+def _force_reap_browser_session(task_id: str) -> None:
+    """Janitor last resort after repeated cleanup failures (#100738).
+
+    Skips the ``close`` round-trips that keep failing and goes straight to
+    ``_release_session_resources`` (cloud close + daemon kill + untrack).
+    """
+    _stop_cdp_supervisor(task_id)
+    with _cleanup_lock:
+        session_info = _active_sessions.get(task_id)
+        _session_last_activity.pop(task_id, None)
+        _recording_sessions.discard(task_id)
+    if session_info:
+        _release_session_resources(task_id, session_info)
+    # Same ownership-binding drop as cleanup_browser().
+    if _is_local_sidecar_key(task_id):
+        bare_task_id = task_id[: -len(_LOCAL_SUFFIX)]
+        if _last_active_session_key.get(bare_task_id) == task_id:
+            _last_active_session_key.pop(bare_task_id, None)
+    else:
+        _last_active_session_key.pop(task_id, None)
+
+
 def _cleanup_single_browser_session(task_id: str) -> None:
     """Internal: reap a single browser session by its exact session key."""
     # Stop the CDP supervisor for this task FIRST so we close our WebSocket
@@ -5908,56 +6073,7 @@ def _cleanup_single_browser_session(task_id: str) -> None:
             except Exception as e:
                 logger.warning("agent-browser close failed for task %s: %s", task_id, e)
 
-        # Now remove from tracking under lock
-        with _cleanup_lock:
-            _active_sessions.pop(task_id, None)
-            _session_last_activity.pop(task_id, None)
-
-        # Cloud mode: close the cloud browser session via provider API.
-        # Local sidecars have bb_session_id=None so this no-ops for them.
-        if bb_session_id:
-            provider = _get_cloud_provider()
-            if provider is not None:
-                try:
-                    provider.close_session(bb_session_id)
-                except Exception as e:
-                    logger.warning("Could not close cloud browser session: %s", e)
-
-        # Kill the daemon process and clean up socket directory
-        session_name = session_info.get("session_name", "")
-        if session_name:
-            socket_dir = os.path.join(_socket_safe_tmpdir(), f"agent-browser-{session_name}")
-            if os.path.exists(socket_dir):
-                # agent-browser writes {session}.pid in the socket dir
-                pid_file = os.path.join(socket_dir, f"{session_name}.pid")
-                if os.path.isfile(pid_file):
-                    try:
-                        from tools.process_registry import ProcessRegistry
-                        daemon_pid = int(Path(pid_file).read_text(encoding="utf-8").strip())
-                        # The .pid file lives in a world-writable temp dir and
-                        # PIDs recycle: verify this really is our daemon for
-                        # this session before tree-killing, and pin the
-                        # identity with a start-time fingerprint so the kill
-                        # refuses if the PID is swapped between check and kill.
-                        if _verify_reapable_browser_daemon(
-                                daemon_pid, socket_dir, session_name):
-                            from gateway.status import get_process_start_time
-                            daemon_start = get_process_start_time(daemon_pid)
-                            if daemon_start is not None:
-                                ProcessRegistry._terminate_host_pid(
-                                    daemon_pid, daemon_start)
-                                logger.debug("Killed daemon pid %s for %s", daemon_pid, session_name)
-                            else:
-                                logger.debug(
-                                    "Skipped daemon kill for %s: no start-time "
-                                    "fingerprint for pid %s", session_name, daemon_pid)
-                        else:
-                            logger.debug(
-                                "Skipped daemon kill for %s: pid %s failed identity "
-                                "verification", session_name, daemon_pid)
-                    except (ProcessLookupError, ValueError, PermissionError, OSError):
-                        logger.debug("Could not kill daemon pid for %s (already dead or inaccessible)", session_name)
-                shutil.rmtree(socket_dir, ignore_errors=True)
+        _release_session_resources(task_id, session_info)
 
         logger.debug("Removed task %s from active sessions", task_id)
     else:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2807,7 +2807,7 @@ class MCPServerTask:
                 # is currently owned by another server.
                 if registry.get_toolset_for_tool(tool_name) != toolset_name:
                     continue
-                registry.deregister(tool_name)
+                registry.deregister(tool_name, scope=_server_registry_scope(self.name))
                 _forget_mcp_tool_server(tool_name)
 
             # 3. Re-register with the fresh list. The helper may skip names that
@@ -2825,7 +2825,7 @@ class MCPServerTask:
             for tool_name in old_tool_names - registered_name_set:
                 if registry.get_toolset_for_tool(tool_name) != toolset_name:
                     continue
-                registry.deregister(tool_name)
+                registry.deregister(tool_name, scope=_server_registry_scope(self.name))
                 _forget_mcp_tool_server(tool_name)
             self._registered_tool_names = registered_names
 
@@ -4481,7 +4481,7 @@ class MCPServerTask:
         from tools.registry import registry
 
         for tool_name in list(getattr(self, "_registered_tool_names", [])):
-            registry.deregister(tool_name)
+            registry.deregister(tool_name, scope=_server_registry_scope(self.name))
             _forget_mcp_tool_server(tool_name)
         self._registered_tool_names = []
 
@@ -4509,6 +4509,10 @@ class MCPServerTask:
 # ---------------------------------------------------------------------------
 
 _servers: Dict[str, MCPServerTask] = {}
+# Profile registry scope that owns each live connection (None outside
+# multiplex). A multiplexed /reload-mcp tears down only its own profile's
+# servers; process shutdown still takes everything.
+_server_scope_keys: Dict[str, Optional[str]] = {}
 _server_connecting: set[str] = set()
 _server_connect_errors: Dict[str, str] = {}
 # Lazy MCP startup (#56832): servers whose tools were registered from the
@@ -5400,6 +5404,36 @@ _mcp_thread: Optional[threading.Thread] = None
 # _parallel_safe_servers, _mcp_tool_server_names, and _stdio_pids.
 _lock = threading.Lock()
 
+
+def _mcp_registry_scope() -> Optional[str]:
+    """Registry scope owning MCP registrations made from the current context.
+
+    Under a profile multiplexer each profile's MCP tools live in that
+    profile's registry overlay (the same overlay its plugins use) so two
+    profiles' servers never share one process-global slot. Single-profile
+    processes keep MCP tools process-global (``None``).
+    """
+    from agent.secret_scope import is_multiplex_active
+
+    if not is_multiplex_active():
+        return None
+    from tools.registry import registry
+
+    return registry.current_scope_key()
+
+
+def _server_registry_scope(name: str) -> Optional[str]:
+    """Scope owning server *name*'s tools: recorded at connect, else current.
+
+    Teardown paths run on the MCP loop (process exit, reconnect exhaustion),
+    which does not carry the discovering profile's context, so the scope
+    captured when the server was adopted into ``_servers`` is authoritative.
+    """
+    if name in _server_scope_keys:
+        return _server_scope_keys[name]
+    return _mcp_registry_scope()
+
+
 # ---------------------------------------------------------------------------
 # Cross-process MCP discovery guard
 # ---------------------------------------------------------------------------
@@ -6131,7 +6165,7 @@ def _ensure_lazy_server_connected(server_name: str) -> bool:
         from tools.registry import registry
 
         for tool_name in phantom_names:
-            registry.deregister(tool_name)
+            registry.deregister(tool_name, scope=_server_registry_scope(server_name))
             _forget_mcp_tool_server(tool_name)
         logger.info(
             "MCP server '%s': deregistered %d phantom cached tool(s) not "
@@ -7523,6 +7557,7 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
             check_fn=candidate["check_fn"],
             is_async=False,
             description=candidate["schema"]["description"],
+            scope=_server_registry_scope(name),
         )
 
         # The pre-check above is advisory only. Multiple servers connect in
@@ -7680,6 +7715,7 @@ def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]
             check_fn=check_fn,
             is_async=False,
             description=schema["description"],
+            scope=_mcp_registry_scope(),
         )
         if registry.get_toolset_for_tool(registry_name) != toolset_name:
             continue
@@ -7713,6 +7749,7 @@ def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]
             check_fn=check_fn,
             is_async=False,
             description=schema.get("description") or "",
+            scope=_mcp_registry_scope(),
         )
         if registry.get_toolset_for_tool(util_name) != toolset_name:
             continue
@@ -7770,6 +7807,7 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
             # self-probe, so adopt it into the registry for shutdown/revival.
             with _lock:
                 _servers[name] = server
+                _server_scope_keys[name] = _mcp_registry_scope()
         elif server is not None:
             await server.shutdown()
         raise
@@ -7780,6 +7818,7 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
         _server_connecting.discard(name)
         _server_connect_errors.pop(name, None)
         _servers[name] = server
+        _server_scope_keys[name] = _mcp_registry_scope()
 
     registered_names = _register_server_tools(name, server, config)
     server._registered_tool_names = list(registered_names)
@@ -8511,15 +8550,24 @@ def _reinject_post_build_tools(agent, tools_list: list, name_set: set) -> set:
     return staged_engine_names
 
 
-def shutdown_mcp_servers():
-    """Close all MCP server connections and stop the background loop.
+def shutdown_mcp_servers(*, scope: Optional[str] = None):
+    """Close MCP server connections and stop the background loop.
 
     Each server Task is signalled to exit its ``async with`` block so that
     the anyio cancel-scope cleanup happens in the same Task that opened it.
     All servers are shut down in parallel via ``asyncio.gather``.
+
+    ``scope`` (a registry scope key) restricts teardown to the servers one
+    multiplexed profile owns — its ``/reload-mcp`` must not kill the other
+    profiles' connections — and leaves the shared loop running when anything
+    else is still connected. Without it every server goes, as before.
     """
     with _lock:
-        servers_snapshot = list(_servers.values())
+        selected = [
+            name for name in _servers
+            if scope is None or _server_scope_keys.get(name) == scope
+        ]
+        servers_snapshot = [_servers[name] for name in selected]
 
     # Fast path: nothing to shut down. The connect-cooldown maps can still
     # be populated here — a server that failed to connect is never recorded
@@ -8531,7 +8579,7 @@ def shutdown_mcp_servers():
         with _lock:
             _server_connect_retry_after.clear()
             _server_connect_failures.clear()
-        _stop_mcp_loop()
+        _stop_mcp_loop(only_if_idle=scope is not None)
         return
 
     async def _shutdown():
@@ -8545,7 +8593,9 @@ def shutdown_mcp_servers():
                     "Error closing MCP server '%s': %s", server.name, result,
                 )
         with _lock:
-            _servers.clear()
+            for name in selected:
+                _servers.pop(name, None)
+                _server_scope_keys.pop(name, None)
             # Drop connect-retry cooldowns too: a full shutdown/restart
             # should re-attempt every server immediately, not honour a
             # stale per-server backoff from before the restart (#50394).
@@ -8575,7 +8625,7 @@ def shutdown_mcp_servers():
         _server_connect_retry_after.clear()
         _server_connect_failures.clear()
 
-    _stop_mcp_loop()
+    _stop_mcp_loop(only_if_idle=scope is not None)
 
 
 def _kill_orphaned_mcp_children(

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -906,12 +906,17 @@ class ToolRegistry:
                 self._toolset_checks[toolset] = check_fn
             self._generation += 1
 
-    def deregister(self, name: str) -> None:
+    def deregister(self, name: str, *, scope: Optional[str] = None) -> None:
         """Remove a tool from the registry.
 
         Also cleans up the toolset check if no other tools remain in the
         same toolset.  Used by MCP dynamic tool discovery to nuke-and-repave
         when a server sends ``notifications/tools/list_changed``.
+
+        ``scope`` selects a profile overlay explicitly (multiplexed MCP tools
+        live in the owning profile's overlay). Plugin callers keep their own
+        scope and may not name another one; non-plugin callers without
+        ``scope`` keep the historical process-global target.
 
         Gated by the same operator opt-in policy ``register(override=True)``
         enforces. Without this, a plugin could bypass that gate entirely by
@@ -930,14 +935,21 @@ class ToolRegistry:
                 if caller_owner is not None
                 else None
             )
+            if caller_owner is not None and scope is not None and scope != caller_scope:
+                raise PermissionError(
+                    f"Plugin module {caller_mod!r} cannot deregister tools "
+                    "outside its own profile scope."
+                )
+            if scope is None:
+                scope = caller_scope
             target = (
-                self._scoped_tools.get(caller_scope, {})
-                if caller_scope is not None
+                self._scoped_tools.get(scope, {})
+                if scope is not None
                 else self._tools
             )
             entry = target.get(name)
-            if entry is None and caller_scope is not None:
-                if name in self._tools:
+            if entry is None and scope is not None:
+                if caller_owner is not None and name in self._tools:
                     raise PermissionError(
                         f"Scoped plugin module {caller_mod!r} cannot deregister "
                         f"process-global tool {name!r}; register a scoped "
@@ -977,13 +989,13 @@ class ToolRegistry:
                         f"opt-in (allow_tool_override)."
                     )
             del target[name]
-            if caller_scope is not None and not target:
-                self._scoped_tools.pop(caller_scope, None)
+            if scope is not None and not target:
+                self._scoped_tools.pop(scope, None)
             # Drop the toolset check and aliases if this was the last tool in
             # that toolset.
             toolset_still_exists = any(
                 e.toolset == entry.toolset
-                for e in self._merged_tools(caller_scope).values()
+                for e in self._merged_tools(scope).values()
             )
             if not toolset_still_exists:
                 self._toolset_checks.pop(entry.toolset, None)

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -1876,11 +1876,12 @@ Secrets: prefer `secret_env` (the name of an environment variable, typically set
 
 ### Wire format
 
-Each firing POSTs a JSON body with the same top-level shape as shell hooks' stdin, plus delivery metadata:
+Each firing POSTs a JSON body with the same top-level shape as shell hooks' stdin, plus delivery metadata. `profile` names the Hermes profile that emitted the event (`"default"` outside profiles), so receivers behind a multiplexed gateway can tell profiles apart:
 
 ```json
 {
   "hook_event_name": "on_session_end",
+  "profile": "default",
   "tool_name": null,
   "tool_input": null,
   "session_id": "sess_abc123",


### PR DESCRIPTION
## Summary
Under `multiplex_profiles`, several process-global startup/background paths still ran under the launch home only: hooks.* and mcp_servers registered once from the root config, the webhook route rendered skills before entering the routed profile's scope (and skill_commands scanned an import-time-frozen SKILLS_DIR), and the browser janitor / Hindsight background threads were bare threads that hit fail-closed `get_secret` with no scope. This PR routes each through the profile's own scope — contextvars propagation where the spawner is scoped, per-session owner scope for the process-global janitor — with no os.environ fallthrough anywhere.
## Changes
- Gateway registers each served profile's shell hooks + outbound webhooks inside `_start_one_profile_adapters`; idempotence keys are home-scoped; force-reload re-registers per home; webhook payloads carry `profile`.
- Boot MCP discovery runs once per served profile via `copy_context()`; `/reload-mcp` runs under the requesting profile and only tears down/rediscovers that profile's servers (`shutdown_mcp_servers(scope=)`, `registry.deregister(scope=)`).
- Browser inactivity janitor records each session's owner home, restores that scope around teardown, force-reaps (incl. cloud-provider close) after 3 failures; activity touch never resets the counter.
- Hindsight writer/daemon-start/prefetch threads inherit the spawner's context.
- Webhook adapter wraps route script/prompt/skill resolution in the routed profile's `_profile_runtime_scope`; `skill_commands`/`skill_utils` resolve the skills root at call time.
## Validation
| Item | Before (origin/main) | After |
|---|---|---|
| hooks | profile b callbacks `[]`, payload.profile None | shell + outbound registered for b, payload.profile `b` |
| MCP | boot/reload connect `['srv-default']` only | `['srv-beta','srv-default']`, beta overlay has only srv-beta tools |
| browser | 4× UnscopedSecretError, session still tracked | session reaped under owner scope |
| hindsight | UnscopedSecretError in writer/daemon threads, log in launch home | secrets resolve, log under profiles/p1 |
| webhook skills | `['/skill-a']`, skill-b not injected | `['/skill-b']`, skill-b prompt injected |
442 targeted tests pass; each fix sabotage-verified; ruff clean.
## Credits
@chelsealong (#92682, commits preserved); @fangliquanflq (#95542, #86472); @vKongv (#85204 first submitter); @roraag (#88525); @KIAgent01 (#81816 first submitter); @Parker-Fawcett (#93028); @JuaniLezcano (#67280 / issue #67277); @webtecnica (#67293). Reporters: @vszgdcn8cj-ctrl, @asw-86-svg, @nniejadlik, @zbabiarz, @jirathip-k, @nino339.

Fixes #92672
Fixes #92674
Fixes #95518
Fixes #86402
Fixes #100738
Fixes #92608
Fixes #94933
Fixes #67277

## Infographic

![mux-tools-scope-b](https://v3b.fal.media/files/b/0aa8cdc5/I-wkelcUI_0Vq9m3iqCEP_LYRerjU2.png)
