### PR TITLE
fix(api_server): runs are owned by the requesting profile; handoff/readiness answer for the routed profile (#93689 #90415, salvage #93747 #100054 #94147)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4906,6 +4906,11 @@ class APIServerAdapter(BasePlatformAdapter):
         queue: "asyncio.Queue[Optional[tuple[str, Dict[str, Any]]]]" = asyncio.Queue()
         message_id = f"msg_{uuid.uuid4().hex}"
         run_id = f"run_{uuid.uuid4().hex}"
+        # Claim ownership while still inside the request's profile scope,
+        # before any run-keyed state exists — the same rule as /v1/runs, so
+        # /v1/runs/{id}* control of this turn is confined to the profile
+        # that started it (#93689).
+        self._run_owners[run_id] = self._run_idempotency_scope(request)
         self._set_run_status(
             run_id,
             "queued",
@@ -5041,6 +5046,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 await queue.put(_event_payload("error", {"message": _redact_api_error_text(exc)}))
             finally:
                 self._active_run_agents.pop(run_id, None)
+                self._release_run_owner_if_forgotten(run_id)
                 await queue.put(_event_payload("done", {}))
                 await queue.put(None)
 
@@ -7774,6 +7780,9 @@ class APIServerAdapter(BasePlatformAdapter):
 
     def _request_owns_run(self, request: "web.Request", run_id: str) -> bool:
         return _api_runs._request_owns_run(self, request, run_id)
+
+    def _release_run_owner_if_forgotten(self, run_id: str) -> None:
+        _api_runs._release_run_owner_if_forgotten(self, run_id)
 
     async def _handle_get_run(self, request: "web.Request") -> "web.Response":
         """GET /v1/runs/{run_id} — return pollable run status for external UIs."""

--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -1017,6 +1017,7 @@ async def _handle_runs(
             self._active_run_tasks.pop(run_id, None)
             self._run_approval_sessions.pop(run_id, None)
             self._stopping_run_ids.discard(run_id)
+            self._release_run_owner_if_forgotten(run_id)
 
     self._activate_admitted_request()
     task = asyncio.create_task(_run_and_close())
@@ -1038,25 +1039,36 @@ async def _handle_runs(
     )
 
 
-def _request_owns_run(self, request: "web.Request", run_id: str) -> bool:
-    scope = self._run_idempotency_scope(request)
-    owner = self._run_owners.get(run_id)
-    if self._room_grant_token(request):
-        return owner == scope or (
-            owner is None
-            and self._run_idempotency_store.owns_run(scope, run_id)
-        )
-    if owner is None and (
+def _release_run_owner_if_forgotten(self, run_id: str) -> None:
+    """Drop the owner stamp only once nothing keyed by *run_id* survives.
+
+    Ownership must outlive every surface it protects (statuses, live
+    agent/task refs, SSE transport, approval sessions), which are retired
+    on different clocks. Releasing earlier would leave a stateful run
+    without an owner, which ``_request_owns_run`` treats as fail-closed.
+    """
+    if (
         run_id in self._run_statuses
         or run_id in self._active_run_agents
         or run_id in self._active_run_tasks
+        or run_id in self._run_streams
+        or run_id in self._run_approval_sessions
     ):
-        # Backward compatibility for statuses created by older/in-process
-        # integrations before ownership tracking was introduced.
-        return True
-    return owner == scope or (
-        owner is None and self._run_idempotency_store.owns_run(scope, run_id)
-    )
+        return
+    self._run_owners.pop(run_id, None)
+
+
+def _request_owns_run(self, request: "web.Request", run_id: str) -> bool:
+    scope = self._run_idempotency_scope(request)
+    owner = self._run_owners.get(run_id)
+    if owner is not None:
+        return owner == scope
+    # No in-memory owner: only a durable record under the caller's own scope
+    # admits it. Run state that exists without an owner stamp is an
+    # unanswered authorization question, not a run anyone may control —
+    # under gateway.multiplex_profiles every served profile holds a valid
+    # key, so admitting it would make the boundary allow-all (#93689).
+    return self._run_idempotency_store.owns_run(scope, run_id)
 
 
 async def _handle_get_run(
@@ -1154,6 +1166,7 @@ async def _handle_run_events(
         self._run_stream_subscribers.discard(run_id)
         self._run_streams.pop(run_id, None)
         self._run_streams_created.pop(run_id, None)
+        self._release_run_owner_if_forgotten(run_id)
 
     return response
 
@@ -1485,6 +1498,7 @@ def _sweep_orphaned_runs_once(self, now: Optional[float] = None) -> None:
             self._active_run_tasks.pop(run_id, None)
             self._run_approval_sessions.pop(run_id, None)
             self._stopping_run_ids.discard(run_id)
+        self._release_run_owner_if_forgotten(run_id)
 
     stale_statuses = [
         run_id
@@ -1495,4 +1509,4 @@ def _sweep_orphaned_runs_once(self, now: Optional[float] = None) -> None:
     for run_id in stale_statuses:
         self._run_statuses.pop(run_id, None)
         self._run_idempotency_ids.discard(run_id)
-        self._run_owners.pop(run_id, None)
+        self._release_run_owner_if_forgotten(run_id)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1053,8 +1053,14 @@ def _relative_time(ts) -> str:
     return relative_time(ts)
 
 
-def _has_any_provider_configured() -> bool:
-    """Check if at least one inference provider is usable."""
+def _has_any_provider_configured(*, strict_profile_scope: bool = False) -> bool:
+    """Check if at least one inference provider is usable.
+
+    ``strict_profile_scope``: the caller has bound a NAMED profile's home and
+    secret scope and wants an answer for that profile only — launch-process
+    env and host-wide fallbacks (gh auth, Claude Code credentials) must not
+    make it appear ready. Unscoped callers keep the legacy behavior.
+    """
     from hermes_cli.config import get_env_path, get_hermes_home, load_config
     from hermes_cli.auth import get_auth_status
 
@@ -1097,7 +1103,13 @@ def _has_any_provider_configured() -> bool:
     for pconfig in PROVIDER_REGISTRY.values():
         if pconfig.auth_type == "api_key":
             provider_env_vars.update(pconfig.api_key_env_vars)
-    if any(os.getenv(v) for v in provider_env_vars):
+    if strict_profile_scope:
+        from agent.secret_scope import current_secret_scope
+
+        read_provider_env = (current_secret_scope() or {}).get
+    else:
+        read_provider_env = os.getenv
+    if any(read_provider_env(v) for v in provider_env_vars):
         return True
 
     # Check .env file for keys
@@ -1129,7 +1141,10 @@ def _has_any_provider_configured() -> bool:
 
             auth = json.loads(auth_file.read_text(encoding="utf-8-sig"))
             active = auth.get("active_provider")
-            if active:
+            active_config = PROVIDER_REGISTRY.get(str(active or "").strip().lower())
+            if active and not (
+                strict_profile_scope and active_config and active_config.auth_type == "api_key"
+            ):
                 status = get_auth_status(active)
                 if status.get("logged_in"):
                     return True
@@ -1148,20 +1163,21 @@ def _has_any_provider_configured() -> bool:
             return True
 
     # Check provider-specific auth fallbacks (for example, Copilot via gh auth).
-    try:
-        for provider_id, pconfig in PROVIDER_REGISTRY.items():
-            if pconfig.auth_type != "api_key":
-                continue
-            status = get_auth_status(provider_id)
-            if status.get("logged_in"):
-                return True
-    except Exception:
-        pass
+    if not strict_profile_scope:
+        try:
+            for provider_id, pconfig in PROVIDER_REGISTRY.items():
+                if pconfig.auth_type != "api_key":
+                    continue
+                status = get_auth_status(provider_id)
+                if status.get("logged_in"):
+                    return True
+        except Exception:
+            pass
 
     # Check for Claude Code OAuth credentials (~/.claude/.credentials.json)
     # Only count these if Hermes has been explicitly configured — Claude Code
     # being installed doesn't mean the user wants Hermes to use their tokens.
-    if _has_hermes_config:
+    if _has_hermes_config and not strict_profile_scope:
         try:
             from agent.anthropic_adapter import (
                 read_claude_code_credentials,

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -611,7 +611,9 @@ class TestDisconnectedAgentReap:
         adapter._active_run_agents["run_x"] = agent
 
         request = MagicMock()
+        request.headers = {}
         request.match_info = {"run_id": "run_x"}
+        adapter._run_owners["run_x"] = adapter._run_idempotency_scope(request)
         resp = await adapter._handle_stop_run(request)
         assert resp.status == 200
 

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -22,6 +22,7 @@ from aiohttp.test_utils import TestClient, TestServer
 from gateway.config import PlatformConfig
 from gateway.platforms.api_server import (
     APIServerAdapter,
+    _api_request_profile,
     _approval_event_choices,
     cors_middleware,
     security_headers_middleware,
@@ -66,6 +67,13 @@ def _make_adapter(api_key: str = "") -> APIServerAdapter:
     config = PlatformConfig(enabled=True, extra=extra)
     adapter = APIServerAdapter(config)
     return adapter
+
+
+def _claim_run(adapter: APIServerAdapter, run_id: str) -> None:
+    """Stamp *run_id* as owned by the unprefixed (default) request scope."""
+    request = MagicMock()
+    request.headers = {}
+    adapter._run_owners[run_id] = adapter._run_idempotency_scope(request)
 
 
 def _create_runs_app(adapter: APIServerAdapter) -> web.Application:
@@ -468,6 +476,7 @@ class TestSteerRun:
         adapter._active_run_agents["run_123"] = agent
         adapter._run_streams["run_123"] = queue
         adapter._set_run_status("run_123", "running")
+        _claim_run(adapter, "run_123")
 
         async with TestClient(TestServer(app)) as cli:
             resp = await cli.post("/v1/runs/run_123/steer", json={"input": "tighten the ending"})
@@ -500,6 +509,7 @@ class TestSteerRun:
     async def test_steer_inactive_run_returns_409(self, adapter):
         app = _create_runs_app(adapter)
         adapter._set_run_status("run_done", "completed")
+        _claim_run(adapter, "run_done")
 
         async with TestClient(TestServer(app)) as cli:
             resp = await cli.post("/v1/runs/run_done/steer", json={"input": "hello"})
@@ -515,6 +525,7 @@ class TestSteerRun:
         agent.steer.return_value = True
         adapter._active_run_agents["run_123"] = agent
         adapter._set_run_status("run_123", "running")
+        _claim_run(adapter, "run_123")
 
         async with TestClient(TestServer(app)) as cli:
             resp = await cli.post("/v1/runs/run_123/steer", json={"input": ""})
@@ -679,6 +690,92 @@ class TestRunLifecycleSweep:
                 stop_resp = await cli.post(f"/v1/runs/{run_id}/stop")
                 assert stop_resp.status == 200
                 mock_agent.interrupt.assert_called_once_with("Stop requested via API")
+
+
+# ---------------------------------------------------------------------------
+# Run ownership across served profiles (#93689 / #90415)
+# ---------------------------------------------------------------------------
+
+
+class TestRunOwnershipAcrossProfiles:
+    """Every served profile holds a valid key under multiplex; only the
+    creating profile may see or control a run."""
+
+    KEYS = {"victim": "sk-victim-profile-key-0001", "attacker": "sk-attacker-profile-key-01"}
+
+    @classmethod
+    def _profile_app(cls, adapter: APIServerAdapter) -> web.Application:
+        """Runs routes behind a stand-in for the /p/<profile>/ middleware:
+        the routed profile arrives in ``X-Test-Profile`` and each profile
+        authenticates with its own key, as under gateway.multiplex_profiles."""
+
+        @web.middleware
+        async def stamp_profile(request, handler):
+            token = _api_request_profile.set(request.headers.get("X-Test-Profile"))
+            try:
+                return await handler(request)
+            finally:
+                _api_request_profile.reset(token)
+
+        adapter._expected_api_key = lambda: cls.KEYS.get(_api_request_profile.get(), "")
+        app = _create_runs_app(adapter)
+        app.middlewares.append(stamp_profile)
+        app.router.add_post(
+            "/api/sessions/{session_id}/chat/stream", adapter._handle_session_chat_stream
+        )
+        return app
+
+    @pytest.mark.asyncio
+    async def test_unstamped_run_state_fails_closed(self, adapter):
+        """Run state with no owner stamp is nobody's — not everybody's."""
+        app = _create_runs_app(adapter)
+        adapter._active_run_agents["run_unstamped"] = MagicMock()
+        adapter._set_run_status("run_unstamped", "running")
+
+        async with TestClient(TestServer(app)) as cli:
+            get_resp = await cli.get("/v1/runs/run_unstamped")
+            stop_resp = await cli.post("/v1/runs/run_unstamped/stop")
+
+        assert (get_resp.status, stop_resp.status) == (404, 404)
+
+    @pytest.mark.asyncio
+    async def test_session_chat_stream_run_is_owned_by_creating_profile(self, adapter):
+        """The session-chat-stream run mint claims ownership like /v1/runs does."""
+        app = self._profile_app(adapter)
+        victim = {"X-Test-Profile": "victim", "Authorization": f"Bearer {self.KEYS['victim']}"}
+        attacker = {"X-Test-Profile": "attacker", "Authorization": f"Bearer {self.KEYS['attacker']}"}
+        gate = asyncio.Event()
+
+        async def slow_run_agent(**kwargs):
+            await gate.wait()
+            return {"final_response": "ok"}, {}
+
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(adapter, "_get_existing_session_or_404", new=AsyncMock(return_value=({"id": "s1"}, None))),
+                patch.object(adapter, "_conversation_history_for_session", new=AsyncMock(return_value=[])),
+                patch.object(adapter, "_run_agent", new=slow_run_agent),
+            ):
+                stream = await cli.post(
+                    "/api/sessions/s1/chat/stream", json={"message": "hi"}, headers=victim
+                )
+                await stream.content.readline()
+                (run_id,) = list(adapter._run_statuses)
+                assert run_id in adapter._run_owners
+
+                foreign_get = await cli.get(f"/v1/runs/{run_id}", headers=attacker)
+                foreign_stop = await cli.post(f"/v1/runs/{run_id}/stop", headers=attacker)
+                own_get = await cli.get(f"/v1/runs/{run_id}", headers=victim)
+                assert (foreign_get.status, foreign_stop.status, own_get.status) == (404, 404, 200)
+
+                gate.set()
+                await stream.text()
+
+        # The owner outlives the terminal status and goes with the last surface.
+        assert run_id in adapter._run_owners
+        adapter._run_statuses.pop(run_id)
+        adapter._release_run_owner_if_forgotten(run_id)
+        assert run_id not in adapter._run_owners
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -14989,6 +14989,73 @@ def test_session_most_recent_honors_params_profile(monkeypatch, tmp_path):
     assert resp["result"]["session_id"] == "ml-tip"
 
 
+def test_handoff_request_uses_session_profile_home(monkeypatch, tmp_path):
+    """Handoff validation must read the owning session's gateway config."""
+    import contextlib
+
+    from gateway.config import GatewayConfig, HomeChannel, Platform, PlatformConfig
+    from hermes_cli.config import get_hermes_home
+    from tui_gateway import methods_session
+
+    methods_session.register(server)
+    profile_home = tmp_path / "profiles" / "coder"
+    profile_home.mkdir(parents=True)
+    seen_homes = []
+
+    def load_config():
+        home = get_hermes_home()
+        seen_homes.append(home)
+        config = GatewayConfig()
+        if home == profile_home:
+            config.platforms[Platform.DISCORD] = PlatformConfig(
+                enabled=True,
+                home_channel=HomeChannel(
+                    platform=Platform.DISCORD,
+                    chat_id="discord-home",
+                    name="Hermes / #chat-coding",
+                ),
+            )
+        return config
+
+    class ProfileDB:
+        def get_session(self, _key):
+            return {"id": _key}
+
+        def request_handoff(self, _key, platform):
+            return platform == "discord"
+
+    @contextlib.contextmanager
+    def profile_db(_session):
+        yield ProfileDB()
+
+    monkeypatch.setattr("gateway.config.load_gateway_config", load_config)
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
+    monkeypatch.setattr(server, "_session_db", profile_db)
+    server._sessions["handoff-profile"] = {
+        "running": False,
+        "session_key": "desktop-coder-session",
+        "profile_home": str(profile_home),
+    }
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "handoff.request",
+                "params": {
+                    "session_id": "handoff-profile",
+                    "platform": "discord",
+                },
+            }
+        )
+    finally:
+        server._sessions.pop("handoff-profile", None)
+
+    assert "result" in resp, resp
+    assert resp["result"]["queued"] is True
+    assert seen_homes == [profile_home]
+    assert get_hermes_home() != profile_home
+
+
 def test_session_create_reports_requested_profile_name(monkeypatch, tmp_path):
     """Issue #62503: session.create info.profile_name must not always be launch."""
     profile_home = tmp_path / "profiles" / "mlperf"

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8903,7 +8903,7 @@ def test_enable_gateway_prompts_sets_gateway_env(monkeypatch):
 
 
 def test_setup_status_reports_provider_config(monkeypatch):
-    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda: False)
+    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda **_kw: False)
 
     resp = server.handle_request({"id": "1", "method": "setup.status", "params": {}})
 
@@ -8925,7 +8925,7 @@ def test_probe_credentials_allows_keyless_custom_runtime():
 
 
 def test_setup_runtime_check_rejects_empty_runtime_key(monkeypatch):
-    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda: True)
+    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda **_kw: True)
     monkeypatch.setattr(
         "hermes_cli.runtime_provider.resolve_runtime_provider",
         lambda requested=None: {
@@ -8947,7 +8947,7 @@ def test_setup_runtime_check_rejects_empty_runtime_key(monkeypatch):
 
 
 def test_setup_runtime_check_allows_no_key_custom_runtime(monkeypatch):
-    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda: True)
+    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda **_kw: True)
     monkeypatch.setattr(
         "hermes_cli.runtime_provider.resolve_runtime_provider",
         lambda requested=None: {
@@ -8964,7 +8964,7 @@ def test_setup_runtime_check_allows_no_key_custom_runtime(monkeypatch):
 
 
 def test_setup_runtime_check_rejects_implicit_bedrock_when_unconfigured(monkeypatch):
-    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda: False)
+    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda **_kw: False)
     monkeypatch.setattr(
         "hermes_cli.runtime_provider.resolve_runtime_provider",
         lambda requested=None: {
@@ -8982,7 +8982,7 @@ def test_setup_runtime_check_rejects_implicit_bedrock_when_unconfigured(monkeypa
 
 def test_setup_runtime_check_honors_requested_provider(monkeypatch):
     """Onboarding must be able to validate the provider the user just connected."""
-    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda: True)
+    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda **_kw: True)
 
     def fake_resolve(requested=None, **kwargs):
         if requested == "nous":
@@ -9011,6 +9011,67 @@ def test_setup_runtime_check_honors_requested_provider(monkeypatch):
     default = server.handle_request({"id": "1", "method": "setup.runtime_check", "params": {}})
     assert default["result"]["ok"] is False
     assert default["result"]["provider"] == "anthropic"
+
+
+def test_setup_readiness_scopes_to_requested_profile(monkeypatch, tmp_path):
+    """#94071: the Desktop preflights a freshly created bot on its target
+    backend. ``profile`` binds THAT profile's home + .env — launch-process
+    credentials must not make an unconfigured bot look ready, and the bot's
+    own .env must be what the strict check sees."""
+    from agent import secret_scope
+    from hermes_constants import get_hermes_home
+
+    bot_home = tmp_path / "profiles" / "bot"
+    bot_home.mkdir(parents=True)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-launch-profile-secret-0000")
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: name == "bot")
+    monkeypatch.setattr(server, "_profile_home", lambda profile: bot_home if profile == "bot" else None)
+    seen = {}
+
+    def fake_resolve(requested=None, **kwargs):
+        seen["home"] = Path(str(get_hermes_home())).resolve()
+        seen["secret"] = secret_scope.get_secret("OPENROUTER_API_KEY")
+        return {"provider": "openrouter", "api_key": seen["secret"] or "", "source": "env"}
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", fake_resolve)
+
+    secret_scope.set_multiplex_active(True)
+    try:
+        status = server.handle_request(
+            {"id": "1", "method": "setup.status", "params": {"profile": "bot"}}
+        )
+        assert status["result"] == {"provider_configured": False, "profile": "bot"}
+
+        (bot_home / ".env").write_text("OPENROUTER_API_KEY=sk-or-bot-profile-secret-00001\n")
+        status = server.handle_request(
+            {"id": "2", "method": "setup.status", "params": {"profile": "bot"}}
+        )
+        runtime = server.handle_request(
+            {"id": "3", "method": "setup.runtime_check", "params": {"profile": "bot"}}
+        )
+    finally:
+        secret_scope.set_multiplex_active(False)
+
+    assert status["result"] == {"provider_configured": True, "profile": "bot"}
+    assert runtime["result"]["ok"] is True
+    assert runtime["result"]["profile"] == "bot"
+    assert seen == {"home": bot_home.resolve(), "secret": "sk-or-bot-profile-secret-00001"}
+    assert Path(str(get_hermes_home())).resolve() != bot_home.resolve()
+
+
+def test_setup_readiness_unknown_profile_never_answers_for_launch_profile(monkeypatch):
+    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda **_kw: True)
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda requested=None, **kw: {"provider": "openrouter", "api_key": "sk-or-launch-0000000000", "source": "env"},
+    )
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: False)
+
+    for method in ("setup.status", "setup.runtime_check"):
+        resp = server.handle_request({"id": "1", "method": method, "params": {"profile": "ghost"}})
+        assert resp["result"]["ok"] is False
+        assert resp["result"]["profile"] == "ghost"
+        assert "does not exist" in resp["result"]["error"]
 
 
 def test_complete_slash_drops_removed_provider_alias():

--- a/tui_gateway/methods_config.py
+++ b/tui_gateway/methods_config.py
@@ -389,12 +389,49 @@ def _(rid, params: dict) -> dict:
     return _err(rid, 4002, f"unknown config key: {key}")
 
 
+def _readiness_profile_scope(params: dict):
+    """Resolve the optional ``profile`` param of the setup readiness RPCs.
+
+    Returns ``(profile, scope)`` where ``scope`` is a context manager binding
+    that profile's HERMES_HOME and ``.env`` secret scope (ContextVars, so
+    concurrent checks for different profiles stay isolated). The launch
+    profile / no param yields ``("", nullcontext())``. A profile unknown to
+    this host raises ``FileNotFoundError`` — a readiness check must never
+    quietly answer for the launch profile instead (#94071).
+    """
+    import contextlib
+
+    profile = str(params.get("profile") or "").strip() if isinstance(params, dict) else ""
+    if not profile:
+        return "", contextlib.nullcontext()
+    from hermes_cli import profiles as profiles_mod
+    from tui_gateway import server as _server
+
+    if not profiles_mod.profile_exists(profile):
+        raise FileNotFoundError(f"Profile '{profile}' does not exist on this backend.")
+    home = _server._profile_home(profile)
+    if home is None:
+        return profile, contextlib.nullcontext()
+    return profile, _server._session_profile_runtime_scope({"profile_home": str(home)})
+
+
 @method("setup.status")
 def _(rid, params: dict) -> dict:
+    """Loose provider check; ``profile`` (optional) scopes it to that profile's home."""
     try:
         from hermes_cli.main import _has_any_provider_configured
+        from tui_gateway.methods_config import _readiness_profile_scope
 
-        return _ok(rid, {"provider_configured": bool(_has_any_provider_configured())})
+        try:
+            profile, scope = _readiness_profile_scope(params)
+        except FileNotFoundError as e:
+            return _ok(rid, {"ok": False, "profile": params.get("profile"), "error": str(e)})
+        with scope:
+            configured = bool(_has_any_provider_configured(strict_profile_scope=bool(profile)))
+        payload = {"provider_configured": configured}
+        if profile:
+            payload["profile"] = profile
+        return _ok(rid, payload)
     except Exception as e:
         return _err(rid, 5016, str(e))
 
@@ -409,15 +446,27 @@ def _(rid, params: dict) -> dict:
     uses on session creation. It returns ok=False with the auth error message
     when the user's configured model cannot actually be served, so UIs can
     surface onboarding before the user submits a doomed prompt.
+
+    ``profile`` (optional): answer for THAT profile's home on this host — its
+    config.yaml model pin and its ``.env`` — instead of the launch profile's
+    (#94071). A profile unknown to this backend answers ``ok=False`` rather
+    than reporting the launch profile's readiness.
     """
     try:
         from hermes_cli.runtime_provider import resolve_runtime_provider
         from hermes_cli.auth import has_usable_secret
         from hermes_cli.main import _has_any_provider_configured
+        from tui_gateway.methods_config import _readiness_profile_scope
 
         requested = str(params.get("provider") or "").strip() or None
-        runtime = resolve_runtime_provider(requested=requested)
-        provider_configured = bool(_has_any_provider_configured())
+        try:
+            profile, scope = _readiness_profile_scope(params)
+        except FileNotFoundError as e:
+            return _ok(rid, {"ok": False, "profile": params.get("profile"), "error": str(e)})
+        with scope:
+            runtime = resolve_runtime_provider(requested=requested)
+            provider_configured = bool(_has_any_provider_configured(strict_profile_scope=bool(profile)))
+        scoped = {"profile": profile} if profile else {}
         provider = runtime.get("provider") or "provider"
         source = str(runtime.get("source") or "")
         if (
@@ -437,6 +486,7 @@ def _(rid, params: dict) -> dict:
                     "model": runtime.get("model"),
                     "source": source,
                     "error": "No Hermes provider is configured.",
+                    **scoped,
                 },
             )
 
@@ -458,6 +508,7 @@ def _(rid, params: dict) -> dict:
                     "model": runtime.get("model"),
                     "source": runtime.get("source"),
                     "error": f"No usable credentials found for {provider}.",
+                    **scoped,
                 },
             )
 
@@ -468,6 +519,7 @@ def _(rid, params: dict) -> dict:
                 "provider": runtime.get("provider"),
                 "model": runtime.get("model"),
                 "source": runtime.get("source"),
+                **scoped,
             },
         )
     except Exception as e:

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -1709,7 +1709,8 @@ def _(rid, params: dict) -> dict:
     except (ValueError, KeyError):
         return _err(rid, 4024, f"unknown platform '{platform_name}'")
     try:
-        gw_config = load_gateway_config()
+        with _session_profile_runtime_scope(session):
+            gw_config = load_gateway_config()
     except Exception as e:
         return _err(rid, 5021, f"could not load gateway config: {e}")
     pcfg = gw_config.platforms.get(platform)

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -629,6 +629,10 @@ to the routed profile**:
 - Unprefixed routes and `/p/default/...` keep using the default profile's key.
 - A named profile with no `API_SERVER_KEY` of its own fails closed — its
   prefix is unreachable until you set one.
+- Runs are per-profile scoped: `/v1/runs/{run_id}` and its `events`, `stop`,
+  `steer`, and `approval` routes only answer for the profile that created
+  the run (including runs started via `/api/sessions/{id}/chat/stream`);
+  another profile's run id returns `404`, never `403`.
 
 :::warning Breaking change (July 2026)
 Before this fix, a valid default-profile key was accepted on any


### PR DESCRIPTION
## Summary
Under `gateway.multiplex_profiles` three tui/api surfaces still answered for the wrong profile: run-scoped routes admitted any valid key for runs that had state but no owner stamp (and `/api/sessions/{id}/chat/stream` never stamped one), handoff preflight read the launch home's gateway config, and `setup.status`/`setup.runtime_check` reported the launch profile's readiness for any target. Root cause in every case: a request-scoped identity (profile) was dropped at a downstream site that reads ambient state.
## Changes
- `_request_owns_run` fails closed on unstamped run state; session-chat-stream claims `_run_owners` at mint; owner released only when the last run-keyed surface is gone (all 5 retirement sites).
- `handoff.request` loads gateway config under `_session_profile_runtime_scope(session)` (cherry-pick #100054, pyright suppression dropped).
- `setup.status` / `setup.runtime_check` accept `profile`, bind home + secret scope, unknown profile → `ok=False`; `_has_any_provider_configured(strict_profile_scope=True)` reads only the bound scope, no host fallbacks.
- Docs: runs are per-profile scoped.
## Validation
| Probe | main | branch |
|---|---|---|
| attacker owns stateful-unstamped run | True | False |
| attacker owns victim's chat-stream run | True | False |
| handoff.request, discord configured only in session profile | 4025 not configured | queued=True |
| setup.status profile=bot (no creds; launch env has key) | provider_configured=True | False |
| runtime_check profile=ghost (unknown) | ok=True (launch) | ok=False "does not exist" |
Tests: 4 new (2 runs ownership, 2 readiness) + 1 kept from #100054; sabotage-verified. 680 + 197 targeted tests green (7 TestHostedRoomRuns failures pre-exist on main in this env).
## Credits
@liuhao1024 (#93704, first PR), @RickyYii (#93747, invariants + review rounds), @Mehdi-Badawi (#90415, earliest report), @SourceChild (#93689, repro), @aeonsong (#100054), @Zeus-Deus (#94147), @245678000000 (#92822).

Fixes #93689
Fixes #90415

## Infographic

![mux-api-server-py](https://v3b.fal.media/files/b/0aa8cdc5/HH1ZkQSltMxKvzVN92zfZ_cRoSAsdp.png)
