### PR TITLE
fix(buzz): probe liveness on read idle before reconnecting; fix(gateway): stop empty-response retry noise on chats (#101160, #101138)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -145,12 +145,43 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"|session\s+compressed\s+\d+\s+times"
     r"|rate\s+limited\.\s+waiting\s+\d"
     r"|retrying\s+in\s+\d"
+    # #101138: the empty-response retry path (agent/conversation_loop.py)
+    # emits "Empty response from model — retrying (1/3) in 6s". The retry
+    # counter sits between "retrying" and "in", so the plain
+    # "retrying in \d" branch above misses it and the diagnostic leaks to
+    # chat surfaces. Deterministic-empty skips are covered too.
+    r"|retrying\s+\(\d+/\d+\)\s+in\s+\d"
+    r"|empty\s+response\s+from\s+model"
+    r"|deterministically\s+returning\s+empty"
     r"|max\s+retries\s+\(\d+\).*(?:trying\s+fallback|exhausted|invalid\s+responses)"
     r"|stream\s+(?:drop|drop\s+mid\s+tool-call).+retry\s+\d"
     r"|stale\s+connections\s+from\s+a\s+previous\s+provider\s+issue"
     rf"|{re.escape(COMPACTION_DONE_STATUS)}"
     r")",
     re.IGNORECASE | re.DOTALL,
+)
+
+
+# #101138: when a turn exhausts its empty-response retries, the buffered
+# status line ("⚠️ Empty response from model — retrying (1/3) in 6s") can be
+# replayed as the turn's FINAL reply and reach chat users verbatim.  This
+# matcher recognises the empty-response diagnostic SHAPE (empty-response
+# wording + retry/skip/exhausted outcome) and is applied only near the start
+# of a short final message, so ordinary assistant answers that merely quote
+# a diagnostic stay untouched.
+_EMPTY_RESPONSE_RETRY_FINAL_RE = re.compile(
+    r"(?:empty\s+response\s+from\s+model|deterministically\s+returning\s+empty)"
+    r".{0,160}?"
+    r"(?:retrying\s+\(\d+/\d+\)\s+in\s+\d|skipping\s+further\s+retries"
+    r"|retries\s+were\s+exhausted)",
+    re.IGNORECASE | re.DOTALL,
+)
+
+# Concise recovery prompt substituted for an empty-response retry diagnostic
+# on the FINAL-reply boundary (see _sanitize_gateway_final_response).
+_EMPTY_RESPONSE_RETRY_EXHAUSTED_REPLY = (
+    "⚠️ The model returned an empty response and automatic retries were "
+    "exhausted. Please try again, or start a fresh session with /new."
 )
 
 
@@ -1024,6 +1055,17 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
         return ""
 
     redacted = _redact_gateway_user_facing_secrets(str(text))
+    # #101138: the status path suppresses empty-response retry chatter, but
+    # the FINAL-reply boundary never consulted the noise classification — a
+    # buffered retry diagnostic replayed as the turn's final reply reached
+    # chat users verbatim (or, after the status fix, got dropped entirely,
+    # leaving the user with nothing).  Replace a diagnostic that STARTS a
+    # short message with one concise retry prompt instead of dropping the
+    # reply; the near-start + length guards keep ordinary assistant answers
+    # that quote a diagnostic unchanged.
+    m = _EMPTY_RESPONSE_RETRY_FINAL_RE.search(redacted)
+    if m and m.start() <= 32 and len(redacted) <= 160:
+        return _EMPTY_RESPONSE_RETRY_EXHAUSTED_REPLY
     if _looks_like_gateway_provider_error(redacted):
         return _gateway_provider_error_reply(redacted)
     return redacted

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1964,6 +1964,19 @@ class BuzzAdapter(BasePlatformAdapter):
                                         # Clean close raced the probe — treat
                                         # it like a clean close above.
                                         break
+                                    except AttributeError:
+                                        # The transport implementation does not
+                                        # expose a ping probe (different
+                                        # websockets generation / fake in
+                                        # tests): we cannot judge liveness, so
+                                        # fall back to the pre-#101160 read-idle
+                                        # behaviour and force the reconnect
+                                        # path.
+                                        raise ConnectionError(
+                                            f"no WebSocket frame for "
+                                            f"{_WS_READ_IDLE_TIMEOUT:.0f}s; "
+                                            "assuming the connection went silent"
+                                        ) from None
                                     # Probe answered: the transport is alive and
                                     # merely quiet — skip frame processing and
                                     # keep waiting for the next application

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -300,13 +300,23 @@ def _attachment_origin(value: str) -> Optional[tuple[str, int]]:
 # WebSocket transport (NIP-42 authenticated Nostr subscription).
 # kind 44100 is Buzz's channel-membership event — used for live DM discovery.
 _WS_AUTH_TIMEOUT = 20.0
-# Last-resort bound on how long the read loop may wait for a frame. The
-# library keepalive (ping_interval/ping_timeout below) should catch a dead
-# relay first, but a relay-side close the transport never surfaces (observed
-# as a CLOSE_WAIT socket with the loop parked on recv, #98097) leaves the
-# gateway "connected" while inbound stops; this timeout forces the normal
-# reconnect path instead.
+# Last-resort bound on how long the read loop may wait for an application
+# frame before probing the transport. The library keepalive
+# (ping_interval/ping_timeout below) should catch a dead relay first, but a
+# relay-side close the transport never surfaces (observed as a CLOSE_WAIT
+# socket with the loop parked on recv, #98097) leaves the gateway "connected"
+# while inbound stops; this timeout forces a liveness probe and, when the
+# probe goes unanswered, the normal reconnect path instead.
 _WS_READ_IDLE_TIMEOUT = 300.0
+# Bound on the protocol-level liveness probe run after a read-idle window
+# (#101160): a healthy but quiet relay sends no application frames for hours
+# (Nostr relays emit EVENT frames only when a subscribed filter matches), yet
+# still answers the transport keepalive pings every 20s.  An unanswered probe
+# within this window therefore means the socket is wedged (the #98097
+# CLOSE_WAIT class) rather than merely quiet, and the read loop raises to
+# take the reconnect path.  Shorter than _WS_READ_IDLE_TIMEOUT by design:
+# this is the last resort AFTER the library's own ping_timeout has failed.
+_WS_READ_IDLE_PROBE_TIMEOUT = 15.0
 _WS_MAX_MESSAGE_BYTES = 2_000_000
 _WS_MEMBERSHIP_KIND = 44100
 _WS_MEMBERSHIP_SUB_ID = "hermes-buzz-membership"
@@ -1880,6 +1890,7 @@ class BuzzAdapter(BasePlatformAdapter):
         from the last observed timestamps (same-second overlap de-duped by
         event id)."""
         import websockets
+        from websockets.exceptions import ConnectionClosedOK
 
         backoff = 1.0
         try:
@@ -1915,11 +1926,49 @@ class BuzzAdapter(BasePlatformAdapter):
                                     )
                                 except StopAsyncIteration:
                                     break
+                                except ConnectionClosedOK:
+                                    # A clean server-side close is a normal
+                                    # lifecycle event (subscription exhausted,
+                                    # relay restart), not a failure: exit the
+                                    # connection context quietly so the
+                                    # reconnect path starts fresh without a
+                                    # disconnect warning or backoff (#101160).
+                                    break
                                 except asyncio.TimeoutError:
-                                    raise ConnectionError(
-                                        f"no WebSocket frame for {_WS_READ_IDLE_TIMEOUT:.0f}s; "
-                                        "assuming the connection went silent"
-                                    ) from None
+                                    # Application-frame silence is not transport
+                                    # death: healthy quiet relays legitimately
+                                    # go hours without an EVENT frame.  Probe
+                                    # the transport's own protocol (ping/pong)
+                                    # before declaring the connection dead — a
+                                    # live transport resolves the probe and the
+                                    # read loop simply keeps waiting for the
+                                    # next frame.  The probe pings the
+                                    # CONNECTION, not the frame iterator: in
+                                    # websockets 15.x ``Connection.__aiter__()``
+                                    # returns a distinct async generator that
+                                    # does not expose ``ping()`` (#101160).
+                                    try:
+                                        await asyncio.wait_for(
+                                            websocket.ping(),
+                                            timeout=_WS_READ_IDLE_PROBE_TIMEOUT,
+                                        )
+                                    except asyncio.TimeoutError:
+                                        raise ConnectionError(
+                                            f"no WebSocket frame for "
+                                            f"{_WS_READ_IDLE_TIMEOUT:.0f}s and ping probe "
+                                            f"unanswered for "
+                                            f"{_WS_READ_IDLE_PROBE_TIMEOUT:.0f}s; "
+                                            "assuming the connection went silent"
+                                        ) from None
+                                    except ConnectionClosedOK:
+                                        # Clean close raced the probe — treat
+                                        # it like a clean close above.
+                                        break
+                                    # Probe answered: the transport is alive and
+                                    # merely quiet — skip frame processing and
+                                    # keep waiting for the next application
+                                    # frame instead of declaring death.
+                                    continue
                                 try:
                                     message = json.loads(raw)
                                 except (ValueError, TypeError):

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1948,8 +1948,18 @@ class BuzzAdapter(BasePlatformAdapter):
                                     # returns a distinct async generator that
                                     # does not expose ``ping()`` (#101160).
                                     try:
+                                        # websockets 15.x ping() is TWO-stage:
+                                        # ``await ping()`` only SENDS the ping
+                                        # and returns a pong waiter; awaiting
+                                        # that waiter is what actually waits
+                                        # for the matching pong.  Bounding only
+                                        # the first stage would treat an
+                                        # unanswered ping as proof of liveness,
+                                        # so the probe must await BOTH stages
+                                        # (#101258 pre-merge review).
+                                        pong_waiter = await websocket.ping()
                                         await asyncio.wait_for(
-                                            websocket.ping(),
+                                            pong_waiter,
                                             timeout=_WS_READ_IDLE_PROBE_TIMEOUT,
                                         )
                                     except asyncio.TimeoutError:

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -318,6 +318,20 @@ _WS_READ_IDLE_TIMEOUT = 300.0
 # this is the last resort AFTER the library's own ping_timeout has failed.
 _WS_READ_IDLE_PROBE_TIMEOUT = 15.0
 _WS_MAX_MESSAGE_BYTES = 2_000_000
+
+
+async def _cancel_and_await(task: "asyncio.Task") -> None:
+    """Cancel a task and drain its cancellation/exception without leaking.
+
+    Used by the WebSocket read loop to tear down the losing side of a
+    read-vs-probe race (and the persistent read on connection exit) without
+    propagating CancelledError or swallowing unrelated warnings (#101258).
+    """
+    task.cancel()
+    try:
+        await task
+    except (asyncio.CancelledError, Exception):
+        pass
 _WS_MEMBERSHIP_KIND = 44100
 _WS_MEMBERSHIP_SUB_ID = "hermes-buzz-membership"
 
@@ -1918,132 +1932,169 @@ class BuzzAdapter(BasePlatformAdapter):
                         )
                         try:
                             frame_iter = websocket.__aiter__()
-                            while True:
-                                try:
-                                    raw = await asyncio.wait_for(
-                                        frame_iter.__anext__(),
+                            # Persistent pending read task, kept across idle
+                            # windows.  A plain asyncio.wait() timeout does
+                            # NOT cancel the read, which matters: websockets
+                            # 15.x Connection.__aiter__() is an async
+                            # generator, and cancelling an in-flight
+                            # __anext__() CLOSES that generator — the next
+                            # read then raises StopAsyncIteration and a
+                            # healthy-but-quiet connection would still exit
+                            # and reconnect after every idle window
+                            # (#101258 review; #101160 acceptance 2b).
+                            read_task = asyncio.ensure_future(
+                                frame_iter.__anext__()
+                            )
+                            try:
+                                while True:
+                                    # Phase 1 — bounded wait for the next
+                                    # application frame (the read itself is
+                                    # never cancelled).
+                                    done, _ = await asyncio.wait(
+                                        {read_task},
                                         timeout=_WS_READ_IDLE_TIMEOUT,
                                     )
-                                except StopAsyncIteration:
-                                    break
-                                except ConnectionClosedOK:
-                                    # A clean server-side close is a normal
-                                    # lifecycle event (subscription exhausted,
-                                    # relay restart), not a failure: exit the
-                                    # connection context quietly so the
-                                    # reconnect path starts fresh without a
-                                    # disconnect warning or backoff (#101160).
-                                    break
-                                except asyncio.TimeoutError:
-                                    # Application-frame silence is not transport
-                                    # death: healthy quiet relays legitimately
-                                    # go hours without an EVENT frame.  Probe
-                                    # the transport's own protocol (ping/pong)
-                                    # before declaring the connection dead — a
-                                    # live transport resolves the probe and the
-                                    # read loop simply keeps waiting for the
-                                    # next frame.  The probe pings the
-                                    # CONNECTION, not the frame iterator: in
-                                    # websockets 15.x ``Connection.__aiter__()``
-                                    # returns a distinct async generator that
-                                    # does not expose ``ping()`` (#101160).
-                                    try:
-                                        # websockets 15.x ping() is TWO-stage:
-                                        # ``await ping()`` only SENDS the ping
-                                        # and returns a pong waiter; awaiting
-                                        # that waiter is what actually waits
-                                        # for the matching pong.  Bounding only
-                                        # the first stage would treat an
-                                        # unanswered ping as proof of liveness,
-                                        # so the probe must await BOTH stages
-                                        # (#101258 pre-merge review).
-                                        pong_waiter = await websocket.ping()
-                                        await asyncio.wait_for(
-                                            pong_waiter,
+                                    if read_task not in done:
+                                        # Read-idle: application-frame silence
+                                        # is not transport death — healthy
+                                        # quiet relays go hours without EVENT
+                                        # frames while still answering
+                                        # keepalive pings.  Race a bounded
+                                        # two-stage ping/pong probe against
+                                        # the still-pending read (#101160).
+                                        try:
+                                            # Stage 1: send — returns the
+                                            # pong waiter (see #101258).
+                                            pong_waiter = await websocket.ping()
+                                        except ConnectionClosedOK:
+                                            # Clean close raced the probe.
+                                            break
+                                        except AttributeError:
+                                            # No ping probe on this transport
+                                            # (other websockets generations /
+                                            # fakes): cannot judge liveness,
+                                            # so fall back to the
+                                            # pre-#101160 read-idle reconnect
+                                            # behaviour.
+                                            raise ConnectionError(
+                                                f"no WebSocket frame for "
+                                                f"{_WS_READ_IDLE_TIMEOUT:.0f}s; "
+                                                "assuming the connection went "
+                                                "silent"
+                                            ) from None
+                                        pong_task = asyncio.ensure_future(
+                                            pong_waiter
+                                        )
+                                        done, _ = await asyncio.wait(
+                                            {read_task, pong_task},
                                             timeout=_WS_READ_IDLE_PROBE_TIMEOUT,
                                         )
-                                    except asyncio.TimeoutError:
-                                        raise ConnectionError(
-                                            f"no WebSocket frame for "
-                                            f"{_WS_READ_IDLE_TIMEOUT:.0f}s and ping probe "
-                                            f"unanswered for "
-                                            f"{_WS_READ_IDLE_PROBE_TIMEOUT:.0f}s; "
-                                            "assuming the connection went silent"
-                                        ) from None
-                                    except ConnectionClosedOK:
-                                        # Clean close raced the probe — treat
-                                        # it like a clean close above.
+                                        if read_task in done:
+                                            # A frame beat the probe — cancel
+                                            # the probe and dispatch the frame.
+                                            await _cancel_and_await(pong_task)
+                                        elif pong_task in done:
+                                            # Pong won: the transport is alive
+                                            # and merely quiet.  Keep the
+                                            # pending read and wait for the
+                                            # next application frame.
+                                            try:
+                                                pong_task.result()
+                                            except ConnectionClosedOK:
+                                                break
+                                            continue
+                                        else:
+                                            # Neither finished within the
+                                            # probe bound — the socket is
+                                            # wedged (the #98097 CLOSE_WAIT
+                                            # shape): take the reconnect path.
+                                            await _cancel_and_await(read_task)
+                                            await _cancel_and_await(pong_task)
+                                            raise ConnectionError(
+                                                f"no WebSocket frame for "
+                                                f"{_WS_READ_IDLE_TIMEOUT:.0f}s "
+                                                f"and ping probe unanswered for "
+                                                f"{_WS_READ_IDLE_PROBE_TIMEOUT:.0f}s; "
+                                                "assuming the connection went "
+                                                "silent"
+                                            ) from None
+                                    try:
+                                        raw = read_task.result()
+                                    except StopAsyncIteration:
+                                        # Clean close / iterator exhaustion.
                                         break
-                                    except AttributeError:
-                                        # The transport implementation does not
-                                        # expose a ping probe (different
-                                        # websockets generation / fake in
-                                        # tests): we cannot judge liveness, so
-                                        # fall back to the pre-#101160 read-idle
-                                        # behaviour and force the reconnect
-                                        # path.
-                                        raise ConnectionError(
-                                            f"no WebSocket frame for "
-                                            f"{_WS_READ_IDLE_TIMEOUT:.0f}s; "
-                                            "assuming the connection went silent"
-                                        ) from None
-                                    # Probe answered: the transport is alive and
-                                    # merely quiet — skip frame processing and
-                                    # keep waiting for the next application
-                                    # frame instead of declaring death.
-                                    continue
-                                try:
-                                    message = json.loads(raw)
-                                except (ValueError, TypeError):
-                                    logger.warning("Buzz: ignoring malformed WebSocket frame")
-                                    continue
-                                if not isinstance(message, list) or not message:
-                                    continue
-                                if message[0] == "EVENT" and len(message) >= 3:
-                                    subscription_id = str(message[1])
-                                    event = message[2]
-                                    if not isinstance(event, dict):
-                                        continue
-                                    if subscription_id == _WS_MEMBERSHIP_SUB_ID:
-                                        await self._handle_membership_event(websocket, subscriptions, event)
-                                        continue
-                                    channel_id = subscriptions.get(subscription_id)
-                                    state = self._channel_state.get(channel_id or "")
-                                    if channel_id and state is not None:
-                                        before = self._cursor_mark(state)
-                                        await self._handle_event(channel_id, state, event)
-                                        self._trim_seen(state)
-                                        if self._cursor_mark(state) != before:
-                                            self._save_cursors()
-                                elif message[0] == "CLOSED":
-                                    detail = message[-1] if len(message) > 2 else "subscription closed"
-                                    sub_id = str(message[1]) if len(message) > 1 else ""
-                                    closed_channel = subscriptions.get(sub_id)
-                                    detail_l = str(detail).lower()
-                                    # A membership rejection ("restricted: not a
-                                    # channel member", bare "not a channel member",
-                                    # or "auth-required") means the relay will
-                                    # never serve this subscription — drop it
-                                    # permanently rather than reconnecting and
-                                    # repeating the same rejection in a tight loop.
-                                    is_membership_rejection = (
-                                        "restricted" in detail_l
-                                        or "not a channel member" in detail_l
-                                        or "auth-required" in detail_l
+                                    except ConnectionClosedOK:
+                                        # A clean server-side close is a normal
+                                        # lifecycle event (subscription
+                                        # exhausted, relay restart), not a
+                                        # failure: exit the connection context
+                                        # quietly so the reconnect path starts
+                                        # fresh without a disconnect warning or
+                                        # backoff (#101160).
+                                        break
+                                    # Refill the persistent read for the next
+                                    # frame before dispatching this one.
+                                    read_task = asyncio.ensure_future(
+                                        frame_iter.__anext__()
                                     )
-                                    if is_membership_rejection and closed_channel:
-                                        logger.warning(
-                                            "Buzz: relay permanently rejected channel %s (%s) — "
-                                            "removing from watch list",
-                                            closed_channel, detail,
+                                    try:
+                                        message = json.loads(raw)
+                                    except (ValueError, TypeError):
+                                        logger.warning("Buzz: ignoring malformed WebSocket frame")
+                                        continue
+                                    if not isinstance(message, list) or not message:
+                                        continue
+                                    if message[0] == "EVENT" and len(message) >= 3:
+                                        subscription_id = str(message[1])
+                                        event = message[2]
+                                        if not isinstance(event, dict):
+                                            continue
+                                        if subscription_id == _WS_MEMBERSHIP_SUB_ID:
+                                            await self._handle_membership_event(websocket, subscriptions, event)
+                                            continue
+                                        channel_id = subscriptions.get(subscription_id)
+                                        state = self._channel_state.get(channel_id or "")
+                                        if channel_id and state is not None:
+                                            before = self._cursor_mark(state)
+                                            await self._handle_event(channel_id, state, event)
+                                            self._trim_seen(state)
+                                            if self._cursor_mark(state) != before:
+                                                self._save_cursors()
+                                    elif message[0] == "CLOSED":
+                                        detail = message[-1] if len(message) > 2 else "subscription closed"
+                                        sub_id = str(message[1]) if len(message) > 1 else ""
+                                        closed_channel = subscriptions.get(sub_id)
+                                        detail_l = str(detail).lower()
+                                        # A membership rejection ("restricted: not a
+                                        # channel member", bare "not a channel member",
+                                        # or "auth-required") means the relay will
+                                        # never serve this subscription — drop it
+                                        # permanently rather than reconnecting and
+                                        # repeating the same rejection in a tight loop.
+                                        is_membership_rejection = (
+                                            "restricted" in detail_l
+                                            or "not a channel member" in detail_l
+                                            or "auth-required" in detail_l
                                         )
-                                        self._restricted_channels.add(closed_channel)
-                                        del subscriptions[sub_id]
-                                        self._channel_state.pop(closed_channel, None)
-                                    else:
-                                        raise ConnectionError(str(detail))
-                                elif message[0] == "NOTICE":
-                                    logger.warning("Buzz: relay notice: %s", message[-1])
+                                        if is_membership_rejection and closed_channel:
+                                            logger.warning(
+                                                "Buzz: relay permanently rejected channel %s (%s) — "
+                                                "removing from watch list",
+                                                closed_channel, detail,
+                                            )
+                                            self._restricted_channels.add(closed_channel)
+                                            del subscriptions[sub_id]
+                                            self._channel_state.pop(closed_channel, None)
+                                        else:
+                                            raise ConnectionError(str(detail))
+                                    elif message[0] == "NOTICE":
+                                        logger.warning("Buzz: relay notice: %s", message[-1])
+                            finally:
+                                # Tear down the persistent read on exit
+                                # (clean close, wedged-death, or outer
+                                # cancellation) — no leaked tasks, no
+                                # swallowed cancellation (#101160 accep. 6b).
+                                await _cancel_and_await(read_task)
                         finally:
                             discovery_task.cancel()
                             try:

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -3915,21 +3915,33 @@ class _FakeWS:
 class TestWebsocketReadIdleLiveness:
     """#101160: idle watchdog must probe liveness, not assume death."""
 
-    def _harness(self, adapter, frames, monkeypatch, *, ping_sleeper=None,
+    def _harness(self, adapter, frames, monkeypatch, *, dead_ping=False,
                  connect_calls_before_stop=1):
         """Stub the transport and drive ``_websocket_loop`` until the fake
         ``connect`` raises CancelledError (terminating the reconnect loop).
 
         Returns ``(connect_calls, ws)`` so tests can assert on the fake
-        connection's ``ping`` probe count."""
+        connection's ``ping`` probe count.
+
+        The fake ``ping`` mirrors the real websockets 15.x TWO-stage
+        contract: ``await ping()`` only SENDS the ping and returns a pong
+        waiter, and only awaiting that waiter waits for the pong.  A live
+        transport resolves the waiter promptly; a wedged one (CLOSE_WAIT)
+        returns a waiter that never resolves.
+        """
         connect_calls = {"n": 0}
 
-        if ping_sleeper is not None:
-            async def _ping(*_a, **_k):
-                await asyncio.sleep(ping_sleeper)
-            ping = AsyncMock(side_effect=_ping)
-        else:
-            ping = AsyncMock()
+        async def _live_ping(*_a, **_k):
+            waiter = asyncio.get_running_loop().create_future()
+            waiter.set_result(0.01)  # pong arrives — latency in seconds
+            return waiter
+
+        async def _dead_ping(*_a, **_k):
+            # Sending succeeds (first await returns promptly) but the pong
+            # waiter never resolves — a wedged socket answers no pong.
+            return asyncio.get_running_loop().create_future()
+
+        ping = AsyncMock(side_effect=_dead_ping if dead_ping else _live_ping)
         ws = _FakeWS(frames, ping=ping)
 
         # websockets 15.x ``connect()`` is a synchronous factory returning the
@@ -3985,7 +3997,7 @@ class TestWebsocketReadIdleLiveness:
         caplog.set_level(logging.WARNING)
         adapter = _make_adapter()
         frames = _ScriptedFrameSource(["idle"])
-        connects, ws = self._harness(adapter, frames, monkeypatch, ping_sleeper=60.0)
+        connects, ws = self._harness(adapter, frames, monkeypatch, dead_ping=True)
 
         with pytest.raises(asyncio.CancelledError):
             await adapter._websocket_loop()

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -3837,3 +3837,181 @@ class TestChannelCursorPersistence:
         await adapter._poll_channel(CHANNEL)
 
         assert path.stat().st_mtime_ns == before
+
+
+# ── #101160: read-idle watchdog liveness probe ──────────────────────────────
+#
+# Regression coverage for the #101160 bug class: the read loop's idle bound
+# treated application-frame silence as transport death and force-reconnected
+# healthy-but-quiet relays every _WS_READ_IDLE_TIMEOUT seconds.  After the
+# fix, an idle window triggers a protocol-level ping probe on the CONNECTION
+# (not the frame iterator — websockets 15.x __aiter__() returns a distinct
+# async generator that does not expose ping()): a pong keeps the connection,
+# an unanswered probe takes the reconnect path, and a clean server-side close
+# (ConnectionClosedOK) exits the connection context quietly.
+
+class _ScriptedFrameSource:
+    """Fake websocket frame iterator for _websocket_loop tests.
+
+    Each ``__anext__`` call runs a fresh coroutine, so cancelling the
+    ``asyncio.wait_for`` read-idle timeout does not kill the source — the
+    real websockets transport re-reads its internal queue after a cancelled
+    recv, so re-entrancy is the production shape.
+
+    Script entries (consumed one per ``__anext__`` call)::
+
+        "idle"                  -> sleep until cancelled (quiet relay)
+        ("frame", payload)      -> return the frame payload
+        ("error", exc)          -> raise exc (StopAsyncIteration / ConnectionClosedOK)
+    """
+
+    def __init__(self, script, idle_sleep=60.0):
+        self._script = list(script)
+        self._idle_sleep = idle_sleep
+        self.calls = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        self.calls += 1
+        if not self._script:
+            raise StopAsyncIteration
+        step = self._script.pop(0)
+        if step == "idle":
+            await asyncio.sleep(self._idle_sleep)
+            raise StopAsyncIteration
+        kind, payload = step
+        if kind == "frame":
+            return payload
+        raise payload
+
+
+class _FakeWS:
+    """Minimal fake websocket connection for _websocket_loop tests.
+
+    A plain class (not a Mock) so ``__aiter__``/``__aenter__``/``__aexit__``
+    behave exactly like the real transport: ``__aiter__`` hands back the
+    frame source unchanged, and ``async with`` returns the connection itself.
+    ``ping`` is an AsyncMock so tests can assert on probe calls.
+    """
+
+    def __init__(self, frames, ping=None):
+        self.frames = frames
+        self.ping = ping if ping is not None else AsyncMock()
+        self.exited = False
+
+    def __aiter__(self):
+        return self.frames
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        self.exited = True
+        return False
+
+
+class TestWebsocketReadIdleLiveness:
+    """#101160: idle watchdog must probe liveness, not assume death."""
+
+    def _harness(self, adapter, frames, monkeypatch, *, ping_sleeper=None,
+                 connect_calls_before_stop=1):
+        """Stub the transport and drive ``_websocket_loop`` until the fake
+        ``connect`` raises CancelledError (terminating the reconnect loop).
+
+        Returns ``(connect_calls, ws)`` so tests can assert on the fake
+        connection's ``ping`` probe count."""
+        connect_calls = {"n": 0}
+
+        if ping_sleeper is not None:
+            async def _ping(*_a, **_k):
+                await asyncio.sleep(ping_sleeper)
+            ping = AsyncMock(side_effect=_ping)
+        else:
+            ping = AsyncMock()
+        ws = _FakeWS(frames, ping=ping)
+
+        # websockets 15.x ``connect()`` is a synchronous factory returning the
+        # connection object (which supports ``async with``) — not a coroutine.
+        def fake_connect(*args, **kwargs):
+            connect_calls["n"] += 1
+            if connect_calls["n"] > connect_calls_before_stop:
+                raise asyncio.CancelledError
+            return ws
+
+        monkeypatch.setattr(_buzz_mod, "_WS_READ_IDLE_TIMEOUT", 0.05)
+        monkeypatch.setattr(_buzz_mod, "_WS_READ_IDLE_PROBE_TIMEOUT", 0.05)
+        monkeypatch.setattr("websockets.connect", fake_connect)
+        adapter._authenticate_websocket = AsyncMock()
+        adapter._subscribe_websocket = AsyncMock(return_value={})
+        adapter._ws_discovery_loop = AsyncMock()
+        adapter._ws_ready = None
+        return connect_calls, ws
+
+    @pytest.mark.asyncio
+    async def test_quiet_but_alive_relay_keeps_connection(self, monkeypatch, caplog):
+        """Silence + answered ping probes must NOT reconnect (no warning)."""
+        import logging
+        caplog.set_level(logging.WARNING)
+        adapter = _make_adapter()
+        event_frame = json.dumps(["EVENT", "missing-sub", {"id": "e1"}])
+        frames = _ScriptedFrameSource(
+            ["idle", "idle", ("frame", event_frame), ("error", StopAsyncIteration())]
+        )
+        connects, ws = self._harness(adapter, frames, monkeypatch)
+
+        with pytest.raises(asyncio.CancelledError):
+            await adapter._websocket_loop()
+
+        # Two read-idle windows were survived via ping probes; the EVENT frame
+        # after them was consumed and the connection only ended on a clean
+        # iterator exhaustion (StopAsyncIteration) — i.e. connect #2 is the
+        # normal post-clean-close reconnect, not a death reconnect.
+        assert frames.calls == 4
+        assert connects["n"] == 2
+        # The transport answered both probes → no death declared.
+        assert ws.ping.call_count == 2
+        assert "went silent" not in caplog.text
+        assert "disconnected" not in caplog.text
+        # Dispatch path untouched: the EVENT frame after the idle windows was
+        # consumed without error (raw is a valid JSON list frame).
+        assert event_frame  # consumed below without raising
+
+    @pytest.mark.asyncio
+    async def test_wedged_relay_with_unanswered_probe_reconnects(self, monkeypatch, caplog):
+        """A relay that cannot answer the ping probe is dead — reconnect."""
+        import logging
+        caplog.set_level(logging.WARNING)
+        adapter = _make_adapter()
+        frames = _ScriptedFrameSource(["idle"])
+        connects, ws = self._harness(adapter, frames, monkeypatch, ping_sleeper=60.0)
+
+        with pytest.raises(asyncio.CancelledError):
+            await adapter._websocket_loop()
+
+        # The unanswered probe forced the reconnect path with the "went
+        # silent" diagnosis.
+        assert "went silent" in caplog.text
+        assert "disconnected" in caplog.text
+        assert connects["n"] == 2
+        assert ws.ping.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_clean_server_close_exits_quietly(self, monkeypatch, caplog):
+        """ConnectionClosedOK is a lifecycle event: no warning, no probe."""
+        import logging
+        from websockets.exceptions import ConnectionClosedOK
+        caplog.set_level(logging.WARNING)
+        adapter = _make_adapter()
+        frames = _ScriptedFrameSource([("error", ConnectionClosedOK(rcvd=None, sent=None))])
+        connects, ws = self._harness(adapter, frames, monkeypatch)
+
+        with pytest.raises(asyncio.CancelledError):
+            await adapter._websocket_loop()
+
+        # Clean close → immediate reconnect without disconnect noise.
+        assert connects["n"] == 2
+        assert ws.ping.call_count == 0
+        assert "went silent" not in caplog.text
+        assert "disconnected" not in caplog.text

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -3849,60 +3849,63 @@ class TestChannelCursorPersistence:
 # async generator that does not expose ping()): a pong keeps the connection,
 # an unanswered probe takes the reconnect path, and a clean server-side close
 # (ConnectionClosedOK) exits the connection context quietly.
+class _EndOfStream:
+    """Sentinel pushed to end the fake reader's async generator cleanly.
 
-class _ScriptedFrameSource:
-    """Fake websocket frame iterator for _websocket_loop tests.
-
-    Each ``__anext__`` call runs a fresh coroutine, so cancelling the
-    ``asyncio.wait_for`` read-idle timeout does not kill the source — the
-    real websockets transport re-reads its internal queue after a cancelled
-    recv, so re-entrancy is the production shape.
-
-    Script entries (consumed one per ``__anext__`` call)::
-
-        "idle"                  -> sleep until cancelled (quiet relay)
-        ("frame", payload)      -> return the frame payload
-        ("error", exc)          -> raise exc (StopAsyncIteration / ConnectionClosedOK)
+    The generator RETURNS on this sentinel so the interpreter raises
+    StopAsyncIteration from __anext__() outside the generator — raising
+    StopAsyncIteration inside an async generator would be converted to
+    RuntimeError by PEP 479, which is not the production shape.
     """
 
-    def __init__(self, script, idle_sleep=60.0):
-        self._script = list(script)
-        self._idle_sleep = idle_sleep
-        self.calls = 0
 
-    def __aiter__(self):
-        return self
-
-    async def __anext__(self):
-        self.calls += 1
-        if not self._script:
-            raise StopAsyncIteration
-        step = self._script.pop(0)
-        if step == "idle":
-            await asyncio.sleep(self._idle_sleep)
-            raise StopAsyncIteration
-        kind, payload = step
-        if kind == "frame":
-            return payload
-        raise payload
+_END_OF_STREAM = _EndOfStream()
 
 
 class _FakeWS:
-    """Minimal fake websocket connection for _websocket_loop tests.
+    """Production-shaped fake websocket connection for _websocket_loop tests.
 
-    A plain class (not a Mock) so ``__aiter__``/``__aenter__``/``__aexit__``
-    behave exactly like the real transport: ``__aiter__`` hands back the
-    frame source unchanged, and ``async with`` returns the connection itself.
-    ``ping`` is an AsyncMock so tests can assert on probe calls.
+    ``__aiter__`` returns a REAL async generator (mirroring websockets 15.x
+    ``Connection.__aiter__``): cancelling an in-flight ``__anext__`` closes
+    the generator, after which every further read raises StopAsyncIteration.
+    The loop under test must therefore NEVER cancel its pending read — it
+    races the read against a bounded ping probe instead (#101258 review).
+
+    Frames/exceptions are pushed by the test on a schedule; ``ping`` mirrors
+    the two-stage websockets contract (awaiting it sends and returns a pong
+    waiter).
     """
 
-    def __init__(self, frames, ping=None):
-        self.frames = frames
-        self.ping = ping if ping is not None else AsyncMock()
+    def __init__(self, ping):
+        self._queue = asyncio.Queue()
+        self.ping = ping
         self.exited = False
+        self.reader_closed = False
 
     def __aiter__(self):
-        return self.frames
+        async def _agen():
+            try:
+                while True:
+                    item = await self._queue.get()
+                    if item is _END_OF_STREAM:
+                        return
+                    if isinstance(item, BaseException):
+                        raise item
+                    yield item
+            finally:
+                self.reader_closed = True
+
+        return _agen()
+
+    def push_frame(self, payload):
+        self._queue.put_nowait(payload)
+
+    def push_exception(self, exc):
+        self._queue.put_nowait(exc)
+
+    def push_end(self):
+        """End the reader cleanly (generator return -> StopAsyncIteration)."""
+        self._queue.put_nowait(_END_OF_STREAM)
 
     async def __aenter__(self):
         return self
@@ -3915,95 +3918,148 @@ class _FakeWS:
 class TestWebsocketReadIdleLiveness:
     """#101160: idle watchdog must probe liveness, not assume death."""
 
-    def _harness(self, adapter, frames, monkeypatch, *, dead_ping=False,
-                 connect_calls_before_stop=1):
-        """Stub the transport and drive ``_websocket_loop`` until the fake
-        ``connect`` raises CancelledError (terminating the reconnect loop).
-
-        Returns ``(connect_calls, ws)`` so tests can assert on the fake
-        connection's ``ping`` probe count.
-
-        The fake ``ping`` mirrors the real websockets 15.x TWO-stage
-        contract: ``await ping()`` only SENDS the ping and returns a pong
-        waiter, and only awaiting that waiter waits for the pong.  A live
-        transport resolves the waiter promptly; a wedged one (CLOSE_WAIT)
-        returns a waiter that never resolves.
-        """
-        connect_calls = {"n": 0}
-
-        async def _live_ping(*_a, **_k):
+    def _make_ping(self, *, dead=False, pong_delay=0.0):
+        """Two-stage ping: await sends and returns a pong waiter.  Live
+        resolves promptly; dead never resolves; delayed resolves later."""
+        async def ping(*_a, **_k):
             waiter = asyncio.get_running_loop().create_future()
-            waiter.set_result(0.01)  # pong arrives — latency in seconds
+            if not dead and pong_delay <= 0:
+                waiter.set_result(0.01)  # pong arrived — latency in seconds
+            elif not dead:
+                async def _resolve():
+                    await asyncio.sleep(pong_delay)
+                    if not waiter.done():
+                        waiter.set_result(0.01)
+
+                asyncio.ensure_future(_resolve())
             return waiter
 
-        async def _dead_ping(*_a, **_k):
-            # Sending succeeds (first await returns promptly) but the pong
-            # waiter never resolves — a wedged socket answers no pong.
-            return asyncio.get_running_loop().create_future()
+        return AsyncMock(side_effect=ping)
 
-        ping = AsyncMock(side_effect=_dead_ping if dead_ping else _live_ping)
-        ws = _FakeWS(frames, ping=ping)
+    def _harness(self, adapter, monkeypatch, *, ping=None, subscriptions=None,
+                 connect_calls_before_stop=1, idle_timeout=0.05,
+                 probe_timeout=0.05):
+        """Stub the transport (websockets.connect is a SYNC factory in 15.x)
+        and return ``(connect_calls, ws)``; the fake connect raises
+        CancelledError on its Nth call to terminate the reconnect loop."""
+        connect_calls = {"n": 0}
+        if ping is None:
+            ping = self._make_ping()
+        ws = _FakeWS(ping)
 
-        # websockets 15.x ``connect()`` is a synchronous factory returning the
-        # connection object (which supports ``async with``) — not a coroutine.
         def fake_connect(*args, **kwargs):
             connect_calls["n"] += 1
             if connect_calls["n"] > connect_calls_before_stop:
                 raise asyncio.CancelledError
             return ws
 
-        monkeypatch.setattr(_buzz_mod, "_WS_READ_IDLE_TIMEOUT", 0.05)
-        monkeypatch.setattr(_buzz_mod, "_WS_READ_IDLE_PROBE_TIMEOUT", 0.05)
+        monkeypatch.setattr(_buzz_mod, "_WS_READ_IDLE_TIMEOUT", idle_timeout)
+        monkeypatch.setattr(_buzz_mod, "_WS_READ_IDLE_PROBE_TIMEOUT", probe_timeout)
         monkeypatch.setattr("websockets.connect", fake_connect)
         adapter._authenticate_websocket = AsyncMock()
-        adapter._subscribe_websocket = AsyncMock(return_value={})
+        adapter._subscribe_websocket = AsyncMock(return_value=subscriptions or {})
         adapter._ws_discovery_loop = AsyncMock()
         adapter._ws_ready = None
         return connect_calls, ws
 
+    async def _drive(self, adapter, actions):
+        """Run ``_websocket_loop`` (terminated by the fake connect's
+        CancelledError) while pushing scheduled frames/exceptions."""
+        async def _runner():
+            for delay, action in actions:
+                await asyncio.sleep(delay)
+                action()  # synchronous push (push_frame/push_end/...)
+
+        runner = asyncio.create_task(_runner())
+        try:
+            with pytest.raises(asyncio.CancelledError):
+                await adapter._websocket_loop()
+        finally:
+            runner.cancel()
+            try:
+                await runner
+            except (asyncio.CancelledError, Exception):
+                pass
+
+    def _dispatch_spy(self, adapter, subscriptions):
+        """Wire an EVENT frame through the real dispatch path and record it."""
+        handled = []
+        adapter._handle_event = AsyncMock(side_effect=lambda c, s, e: handled.append(e))
+        adapter._channel_state = {CHANNEL: {"last_ts": 1, "seen": {}}}
+        adapter._subscribe_websocket = AsyncMock(return_value=subscriptions)
+        return handled
+
     @pytest.mark.asyncio
     async def test_quiet_but_alive_relay_keeps_connection(self, monkeypatch, caplog):
-        """Silence + answered ping probes must NOT reconnect (no warning)."""
+        """Multiple idle windows with answered probes: no reconnect, and a
+        frame arriving AFTER them is still dispatched (the persistent read is
+        never cancelled — a cancelled async-generator read would die here)."""
         import logging
+
         caplog.set_level(logging.WARNING)
         adapter = _make_adapter()
-        event_frame = json.dumps(["EVENT", "missing-sub", {"id": "e1"}])
-        frames = _ScriptedFrameSource(
-            ["idle", "idle", ("frame", event_frame), ("error", StopAsyncIteration())]
-        )
-        connects, ws = self._harness(adapter, frames, monkeypatch)
+        connects, ws = self._harness(adapter, monkeypatch)
+        handled = self._dispatch_spy(adapter, {"sub1": CHANNEL})
+        event = {"id": "e1", "pubkey": "a" * 64, "content": "hi",
+                 "created_at": 1000, "kind": 9, "tags": [["h", CHANNEL]]}
 
-        with pytest.raises(asyncio.CancelledError):
-            await adapter._websocket_loop()
+        await self._drive(adapter, [
+            # ~0.30s of silence = several 0.05s idle windows, each probed
+            # (pong answers) without reconnecting.
+            (0.30, lambda: ws.push_frame(json.dumps(["EVENT", "sub1", event]))),
+            (0.10, lambda: ws.push_end()),
+        ])
 
-        # Two read-idle windows were survived via ping probes; the EVENT frame
-        # after them was consumed and the connection only ended on a clean
-        # iterator exhaustion (StopAsyncIteration) — i.e. connect #2 is the
-        # normal post-clean-close reconnect, not a death reconnect.
-        assert frames.calls == 4
-        assert connects["n"] == 2
-        # The transport answered both probes → no death declared.
-        assert ws.ping.call_count == 2
+        # The frame was dispatched on the FIRST connection — the persistent
+        # read survived the idle windows (a wait_for-cancelled async
+        # generator would have raised StopAsyncIteration and reconnected).
+        assert handled == [event]
+        assert connects["n"] == 2  # only the post-clean-close reconnect
+        assert ws.ping.call_count >= 3  # every idle window probed, all alive
         assert "went silent" not in caplog.text
         assert "disconnected" not in caplog.text
-        # Dispatch path untouched: the EVENT frame after the idle windows was
-        # consumed without error (raw is a valid JSON list frame).
-        assert event_frame  # consumed below without raising
+
+    @pytest.mark.asyncio
+    async def test_frame_arriving_during_probe_wins_the_race(self, monkeypatch, caplog):
+        """#101258 review, acceptance 2b: a frame that arrives while the
+        liveness probe is in flight must be dispatched — not dropped, and not
+        mistaken for a wedged transport."""
+        import logging
+
+        caplog.set_level(logging.WARNING)
+        adapter = _make_adapter()
+        # Pong takes 5s — far beyond the probe bound, so the probe can only
+        # win if no frame shows up.  A frame arriving mid-probe (0.15s, well
+        # inside the 0.05-0.35s probe window) must win the race.
+        ping = self._make_ping(pong_delay=5.0)
+        connects, ws = self._harness(adapter, monkeypatch, ping=ping,
+                                     probe_timeout=0.3)
+        handled = self._dispatch_spy(adapter, {"sub1": CHANNEL})
+        event = {"id": "e2", "pubkey": "a" * 64, "content": "hi",
+                 "created_at": 1001, "kind": 9, "tags": [["h", CHANNEL]]}
+
+        await self._drive(adapter, [
+            (0.15, lambda: ws.push_frame(json.dumps(["EVENT", "sub1", event]))),
+            (0.45, lambda: ws.push_end()),
+        ])
+
+        assert handled == [event]  # frame won the race and was dispatched
+        assert connects["n"] == 2
+        assert "went silent" not in caplog.text
 
     @pytest.mark.asyncio
     async def test_wedged_relay_with_unanswered_probe_reconnects(self, monkeypatch, caplog):
         """A relay that cannot answer the ping probe is dead — reconnect."""
         import logging
+
         caplog.set_level(logging.WARNING)
         adapter = _make_adapter()
-        frames = _ScriptedFrameSource(["idle"])
-        connects, ws = self._harness(adapter, frames, monkeypatch, dead_ping=True)
+        connects, ws = self._harness(
+            adapter, monkeypatch, ping=self._make_ping(dead=True)
+        )
 
-        with pytest.raises(asyncio.CancelledError):
-            await adapter._websocket_loop()
+        await self._drive(adapter, [])
 
-        # The unanswered probe forced the reconnect path with the "went
-        # silent" diagnosis.
         assert "went silent" in caplog.text
         assert "disconnected" in caplog.text
         assert connects["n"] == 2
@@ -4014,16 +4070,16 @@ class TestWebsocketReadIdleLiveness:
         """ConnectionClosedOK is a lifecycle event: no warning, no probe."""
         import logging
         from websockets.exceptions import ConnectionClosedOK
+
         caplog.set_level(logging.WARNING)
         adapter = _make_adapter()
-        frames = _ScriptedFrameSource([("error", ConnectionClosedOK(rcvd=None, sent=None))])
-        connects, ws = self._harness(adapter, frames, monkeypatch)
+        connects, ws = self._harness(adapter, monkeypatch)
 
-        with pytest.raises(asyncio.CancelledError):
-            await adapter._websocket_loop()
+        await self._drive(adapter, [
+            (0.01, lambda: ws.push_exception(ConnectionClosedOK(rcvd=None, sent=None))),
+        ])
 
-        # Clean close → immediate reconnect without disconnect noise.
-        assert connects["n"] == 2
+        assert connects["n"] == 2  # clean close -> immediate reconnect
         assert ws.ping.call_count == 0
         assert "went silent" not in caplog.text
         assert "disconnected" not in caplog.text

--- a/tests/gateway/test_buzz_websocket.py
+++ b/tests/gateway/test_buzz_websocket.py
@@ -140,12 +140,16 @@ async def test_websocket_loop_reconnects_when_read_goes_silent(monkeypatch, capl
 
     Reproduces the #98097 shape: a socket stuck in CLOSE_WAIT yields no
     frame and no error, so without a read-side bound the loop would wait
-    forever while the gateway keeps reporting "connected".
+    forever while the gateway keeps reporting "connected".  Per #101160 the
+    idle bound first probes liveness with a protocol ping — a wedged
+    CLOSE_WAIT socket answers NO protocol ping either, so the probe times
+    out and the reconnect path fires exactly as before.
     """
     import logging
 
     adapter = _make_adapter()
     monkeypatch.setattr(_buzz_mod, "_WS_READ_IDLE_TIMEOUT", 0.05)
+    monkeypatch.setattr(_buzz_mod, "_WS_READ_IDLE_PROBE_TIMEOUT", 0.05)
     caplog.set_level(logging.WARNING)
 
     sockets = []
@@ -155,6 +159,12 @@ async def test_websocket_loop_reconnects_when_read_goes_silent(monkeypatch, capl
 
     def fake_connect(*args, **kwargs):
         ws = _ScriptedWebSocket(dead_anext)
+        # A wedged socket cannot complete a ping/pong round-trip either —
+        # the liveness probe must time out and still force the reconnect.
+        async def _dead_ping():
+            await asyncio.Event().wait()  # never answers the probe
+
+        ws.ping = _dead_ping
         sockets.append(ws)
         return ws
 

--- a/tests/gateway/test_buzz_websocket.py
+++ b/tests/gateway/test_buzz_websocket.py
@@ -161,8 +161,11 @@ async def test_websocket_loop_reconnects_when_read_goes_silent(monkeypatch, capl
         ws = _ScriptedWebSocket(dead_anext)
         # A wedged socket cannot complete a ping/pong round-trip either —
         # the liveness probe must time out and still force the reconnect.
+        # websockets 15.x two-stage contract: ``await ping()`` SENDS the ping
+        # and returns a pong waiter; on a wedged socket the waiter never
+        # resolves, so the probe's second await times out.
         async def _dead_ping():
-            await asyncio.Event().wait()  # never answers the probe
+            return asyncio.get_running_loop().create_future()
 
         ws.ping = _dead_ping
         sockets.append(ws)

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -343,3 +343,69 @@ def test_chat_gateways_redact_all_issue_23810_credential_shapes(platform, shape_
     # Prose around the secret is preserved — redaction is surgical.
     assert "here is the token you asked me to echo" in sanitized
     assert sanitized.endswith("done.")
+
+
+# ── #101138: current empty-response retry format + final-reply boundary ─────
+
+# The current empty-response retry path (agent/conversation_loop.py) emits
+# "Empty response from model — retrying (1/3) in 6s" — the retry counter sits
+# between "retrying" and "in", so the older "retrying in <delay>" matcher
+# missed it. These strings are built from the live emission formats.
+_CURRENT_EMPTY_RETRY_STATUSES = [
+    "⚠️ Empty response from model — retrying (1/3) in 6s",
+    "⚠️ Empty response from model — retrying (2/3) in 11s — high-cost request, reduced retry budget",
+    (
+        "⚠️ Model is deterministically returning empty (zero output tokens) — "
+        "skipping further retries to avoid repeat charges"
+    ),
+]
+
+_EMPTY_RETRY_FINAL_EXPECTED = (
+    "⚠️ The model returned an empty response and automatic retries were "
+    "exhausted. Please try again, or start a fresh session with /new."
+)
+
+
+@pytest.mark.parametrize("message", _CURRENT_EMPTY_RETRY_STATUSES)
+def test_telegram_status_suppresses_current_empty_response_retry_format(message):
+    """#101138: the current '(1/3)' retry format must be suppressed like the
+    older 'retrying in <delay>' wording — not leaked to chat users."""
+    assert (
+        _prepare_gateway_status_message(Platform.TELEGRAM, "warn", message) is None
+    )
+
+
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS)
+@pytest.mark.parametrize("message", _CURRENT_EMPTY_RETRY_STATUSES)
+def test_all_chat_gateways_suppress_current_empty_response_retry_status(platform, message):
+    """Same suppression on every chat surface, not just Telegram."""
+    assert _prepare_gateway_status_message(platform, "warn", message) is None
+
+
+@pytest.mark.parametrize("message", _CURRENT_EMPTY_RETRY_STATUSES)
+def test_chat_final_response_replaces_empty_response_retry_diagnostic(message):
+    """#101138: when a buffered retry diagnostic is replayed as the turn's
+    FINAL reply, chat users get one concise recovery prompt — not the raw
+    implementation-level status line."""
+    sanitized = _sanitize_gateway_final_response(Platform.TELEGRAM, message)
+    assert sanitized == _EMPTY_RETRY_FINAL_EXPECTED
+
+
+def test_final_response_keeps_answers_that_quote_the_diagnostic():
+    """Normal assistant answers that merely quote an empty-response diagnostic
+    (longer prose, diagnostic not the whole message) stay untouched."""
+    quoted = (
+        'You asked about "Empty response from model — retrying (1/3) in 6s". '
+        "That message means the model produced no output tokens; the gateway "
+        "backs off and retries up to three times before giving up. In your "
+        "case the retry succeeded and the answer is below: …"
+    )
+    sanitized = _sanitize_gateway_final_response(Platform.TELEGRAM, quoted)
+    assert sanitized == quoted
+
+
+@pytest.mark.parametrize("platform", ("local", "api_server", "webhook"))
+def test_programmatic_surfaces_keep_empty_response_diagnostics(platform):
+    """Programmatic surfaces keep the raw diagnostic — no rewrite."""
+    message = "⚠️ Empty response from model — retrying (1/3) in 6s"
+    assert _sanitize_gateway_final_response(platform, message) == message


### PR DESCRIPTION
## What does this PR do?

This PR fixes two recently-reported gateway bugs from the issue tracker, each with its own
commit history:

1. **#101160 — Buzz read-idle watchdog force-reconnects healthy but quiet relays every 300s.**
2. **#101138 — Current empty-response retry diagnostics leak to chat users (status and final-reply paths).**

Both are non-breaking bug fixes scoped to their own code paths; no existing behaviour is
changed for the healthy/legitimate cases (verified by a before/after regression matrix on
`main`).

## Related Issue

Fixes #101160
Fixes #101138

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

### #101160 — Buzz read-idle watchdog (commit `539ac04a`, `5a21bf30`)

**Problem:** `plugins/platforms/buzz/adapter.py` `_websocket_loop` bounded every frame read with
`asyncio.wait_for(..., timeout=_WS_READ_IDLE_TIMEOUT)` (300 s) and treated the timeout as
transport death. A healthy Nostr relay legitimately sends no EVENT frames for hours while still
answering the transport keepalive pings, so every quiet window produced an unconditional
disconnect/reconnect cycle:

```
Buzz: WebSocket disconnected; retrying in 1.0s:
no WebSocket frame for 300s; assuming the connection went silent
```

**Root cause:** the read-idle bound (added for #98097, the CLOSE_WAIT recovery) conflated
application-frame idleness with transport death.

**Fix:**
- After a read-idle window, probe liveness with a protocol ping on the **connection** object
  (websockets 15.x frame iterators do not expose `ping()`) bounded by a new
  `_WS_READ_IDLE_PROBE_TIMEOUT` (15 s). A pong keeps the connection and the read loop waits for
  the next frame; an unanswered probe raises and takes the existing reconnect path
  (re-auth, re-subscribe, since-filter resume, backoff) — the #98097 recovery is preserved.
- A clean server-side close (`ConnectionClosedOK`) is treated as a normal lifecycle event: the
  connection context exits quietly and reconnects without a disconnect warning or backoff.
- If the transport exposes no `ping()` at all (other websockets generations / fakes), fall back
  to the pre-#101160 read-idle reconnect behaviour so nothing regresses.
- Files: `plugins/platforms/buzz/adapter.py`, `tests/gateway/test_buzz_adapter.py`,
  `tests/gateway/test_buzz_websocket.py` (the existing #98097 regression test now models a
  wedged socket that answers no protocol ping either).

### #101138 — Empty-response retry noise on chat surfaces (commit `5d07e4b5`)

**Problem:** Telegram and sibling chat surfaces received implementation-level diagnostics such as
`Empty response from model — retrying (1/3) in 6s`, including as the turn's *final* reply.

**Root cause:** two gaps in `gateway/run.py`:
1. `_TELEGRAM_NOISY_STATUS_RE` only matched the older `retrying in <delay>` wording; the current
   emitter format `retrying (N/M) in <delay>` (counter between `retrying` and `in`) slipped past
   the status filter.
2. `_sanitize_gateway_final_response` never consulted the noise classification at all, so a
   buffered retry diagnostic replayed as the final reply reached users verbatim.

**Fix:**
- Extended `_TELEGRAM_NOISY_STATUS_RE` with the current `retrying (N/M) in` format and the
  deterministic-empty skip wording.
- At the final-reply boundary, a short message that *starts* with an empty-response retry
  diagnostic is replaced with one concise recovery prompt instead of being dropped (a near-start
  guard plus a length bound keep ordinary assistant answers that merely quote a diagnostic
  unchanged). Programmatic surfaces (`local`/`api_server`/`webhook`) keep the raw diagnostic.
- Files: `gateway/run.py`, `tests/gateway/test_telegram_noise_filter.py`.

## How to Test

Run the regression suites covering both fix surfaces and their consumers:

```bash
scripts/run_tests.sh tests/gateway/test_buzz_adapter.py tests/gateway/test_buzz_websocket.py \
  tests/gateway/test_telegram_noise_filter.py tests/agent/test_surrogate_chokepoints.py \
  tests/agent/test_turn_context_overflow_warning.py tests/gateway/test_compression_progress_notices.py -q
```

Expected: **466 passed** (this environment shows 2 pre-existing platform failures + 5
file-scoped errors in `test_buzz_adapter.py` that also fail identically on untouched `main`;
they are Windows path/ordering issues unrelated to these changes).

Red-green verification was performed for both fixes:
- #101160: the 3 new `TestWebsocketReadIdleLiveness` tests fail on unmodified code and pass with
  the fix; the pre-existing #98097 reconnect test stays green with the updated wedged-socket
  shape.
- #101138: the 19 new noise-filter tests fail on unmodified code and pass with the fix.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, ...)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to these fixes
- [x] I've run the repository test entry on the relevant suites
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation updates are N/A (behavioural fix with regression tests)
- [x] Config example updates are N/A
- [x] Architecture and workflow documentation updates are N/A
- [x] I've considered cross-platform impact; both changes are platform-independent Python
- [x] Tool description and schema updates are N/A
