### PR TITLE
fix: classify usage-limit 401/403 as rate-limit or billing, not auth

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1257,6 +1257,15 @@ def _classify_by_status(
     """Classify based on HTTP status code with message-aware refinement."""
 
     if status_code == 401:
+        # Some providers/proxies return usage-limit or billing errors as
+        # 401 (auth status) with the real cause in the body. Disambiguate
+        # before defaulting to auth so a transient quota is retried/rotated
+        # instead of being reported as an invalid/missing API key.
+        usage_limit_classified = _classify_usage_limit_4xx(
+            error_msg, error_code, body, response_headers, result_fn
+        )
+        if usage_limit_classified is not None:
+            return usage_limit_classified
         # Not retryable on its own — credential pool rotation and
         # provider-specific refresh (Codex, Anthropic, Nous) run before
         # the retryability check in run_agent.py.  If those succeed, the
@@ -1287,6 +1296,14 @@ def _classify_by_status(
                 should_rotate_credential=True,
                 should_fallback=True,
             )
+        # A 403 can also carry usage-limit/quota text without a billing
+        # phrase (some OpenAI-compatible gateways surface usage caps as
+        # 403 Forbidden). Disambiguate before defaulting to auth.
+        usage_limit_classified = _classify_usage_limit_4xx(
+            error_msg, error_code, body, response_headers, result_fn
+        )
+        if usage_limit_classified is not None:
+            return usage_limit_classified
         return result_fn(
             FailoverReason.auth,
             retryable=False,
@@ -1568,6 +1585,59 @@ def _has_usage_limit_transient_signal(
             if value is not None and value != "":
                 return True
     return False
+
+
+def _classify_usage_limit_4xx(
+    error_msg: str,
+    error_code: str,
+    body: dict,
+    response_headers,
+    result_fn,
+) -> Optional[ClassifiedError]:
+    """Disambiguate usage-limit/billing text in 401/403 responses.
+
+    401 and 403 are the auth status codes, but several providers and
+    OpenAI-compatible proxies return quota exhaustion or billing stops with
+    those codes while the real cause lives in the body. Without this check
+    Hermes reported "invalid/missing API key" for a transient usage limit,
+    marked the credential auth-failed (no reset timer), and triggered
+    re-auth flows — all wrong when the fix is to wait for the quota window.
+
+    Returns None when the body carries no usage-limit or billing signal, so
+    the caller falls through to its status-specific default (auth for
+    401/403). Mirrors the 429 disambiguation: usage-limit + explicit reset
+    signal → rate_limit; usage-limit without a reset window → billing; an
+    explicit rate-limit phrase always wins over the usage-limit wording.
+    """
+    has_billing = any(p in error_msg for p in _BILLING_PATTERNS)
+    has_usage_limit = (
+        str(error_code or "").lower() == "usage_limit_reached"
+        or "usage_limit_reached" in error_msg
+        or any(p in error_msg for p in _USAGE_LIMIT_PATTERNS)
+    )
+    if not (has_billing or has_usage_limit):
+        return None
+    has_explicit_rate_limit = any(p in error_msg for p in _RATE_LIMIT_PATTERNS)
+    has_transient_signal = _has_usage_limit_transient_signal(
+        error_msg, body, response_headers
+    )
+    if (
+        (has_billing or has_usage_limit)
+        and not has_explicit_rate_limit
+        and not has_transient_signal
+    ):
+        return result_fn(
+            FailoverReason.billing,
+            retryable=False,
+            should_rotate_credential=True,
+            should_fallback=True,
+        )
+    return result_fn(
+        FailoverReason.rate_limit,
+        retryable=True,
+        should_rotate_credential=True,
+        should_fallback=True,
+    )
 
 
 def _classify_402(error_msg: str, result_fn) -> ClassifiedError:

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -204,6 +204,122 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.auth
         assert result.should_fallback is True
 
+    # ── Usage-limit errors surfaced as 401/403 (not auth) ──
+
+    def test_401_usage_limit_with_reset_signal_is_rate_limit(self):
+        # OpenAI-compatible proxies can surface quota exhaustion as 401 with
+        # the real cause in the body. Without disambiguation this was
+        # reported as an invalid/missing API key instead of a transient cap.
+        e = MockAPIError(
+            "Your account has reached its usage limit. Please try again later.",
+            status_code=401,
+            body={
+                "error": {
+                    "code": "usage_limit_reached",
+                    "message": "Your account has reached its usage limit. "
+                    "Please try again later.",
+                }
+            },
+        )
+        result = classify_api_error(
+            e, provider="openai-codex", model="gpt-5.6-terra-900k"
+        )
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
+        assert result.should_rotate_credential is True
+        assert result.should_fallback is True
+
+    def test_401_usage_limit_without_reset_is_billing(self):
+        # Usage-limit text with no reset window is a quota wall — route to
+        # billing, not auth, so the surface offers credit/top-up guidance.
+        e = MockAPIError(
+            "As a safety precaution, access has been limited.",
+            status_code=401,
+            body={
+                "error": {
+                    "code": "usage_limit_reached",
+                    "message": "As a safety precaution, access has been limited.",
+                }
+            },
+        )
+        result = classify_api_error(e, provider="openai-codex")
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
+        assert result.should_rotate_credential is True
+        assert result.should_fallback is True
+
+    def test_401_plain_invalid_key_stays_auth(self):
+        # A genuinely invalid key must still be auth — the usage-limit
+        # disambiguation only fires on usage-limit/billing signals.
+        e = MockAPIError(
+            "Incorrect API key provided: sk-xxxx. You can find your API key at "
+            "https://platform.openai.com/account/api-keys.",
+            status_code=401,
+            body={"error": {"code": "invalid_api_key"}},
+        )
+        result = classify_api_error(e, provider="openai")
+        assert result.reason == FailoverReason.auth
+        assert result.retryable is False
+
+    def test_403_usage_limit_with_reset_is_rate_limit(self):
+        # Some OpenAI-compatible gateways surface usage caps as 403
+        # Forbidden without a billing phrase. With a reset signal it's a
+        # transient quota, not auth.
+        e = MockAPIError(
+            "Usage limit exceeded for this key. Resets in 1 hour.",
+            status_code=403,
+            body={
+                "error": {
+                    "message": "Usage limit exceeded for this key. Resets in 1 hour.",
+                }
+            },
+        )
+        result = classify_api_error(e, provider="openai-codex")
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
+        assert result.should_fallback is True
+
+    def test_403_usage_limit_without_reset_is_billing(self):
+        # Usage-limit text with no reset window is a quota wall — mirrors
+        # the 429 disambiguation (billing, not auth).
+        e = MockAPIError(
+            "Usage limit exceeded for this key",
+            status_code=403,
+            body={"error": {"message": "Usage limit exceeded for this key"}},
+        )
+        result = classify_api_error(e, provider="openai-codex")
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
+        assert result.should_rotate_credential is True
+        assert result.should_fallback is True
+
+    def test_403_plain_forbidden_stays_auth(self):
+        e = MockAPIError(
+            "Forbidden: token not authorized for this resource",
+            status_code=403,
+        )
+        result = classify_api_error(e, provider="openai-codex")
+        assert result.reason == FailoverReason.auth
+        assert result.retryable is False
+
+    def test_401_usage_limit_explicit_rate_limit_phrase_wins(self):
+        # "Rate limit exceeded" contains the "limit exceeded" usage-limit
+        # substring; an explicit rate-limit phrase must stay rate_limit.
+        e = MockAPIError(
+            "Rate limit exceeded: too many requests, please retry in 3 minutes",
+            status_code=401,
+            body={
+                "error": {
+                    "code": "rate_limit_exceeded",
+                    "message": "Rate limit exceeded: too many requests, "
+                    "please retry in 3 minutes",
+                }
+            },
+        )
+        result = classify_api_error(e, provider="openai-codex")
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
+
 
 
 


### PR DESCRIPTION
## Problem

Providers and OpenAI-compatible proxies sometimes return quota exhaustion or billing stops with HTTP 401/403 while the real cause lives in the error body. The 401/403 status paths in `_classify_by_status` defaulted to `FailoverReason.auth` without inspecting the body, so Hermes:

- reported an **invalid/missing API key** for a transient usage limit
- marked the credential **auth-failed without a reset timer**
- could trigger unnecessary re-auth flows

## Fix

Add `_classify_usage_limit_4xx()`, mirroring the existing 429 disambiguation in the same module:

| Body signal | Classification |
|---|---|
| usage-limit/billing text + explicit reset signal (`resets in/at`, `retry-after`, `resets_in_seconds`, ...) | `rate_limit` — retryable, rotate, fallback |
| usage-limit text without a reset window | `billing` — non-retryable, rotate, fallback |
| explicit rate-limit phrase ("rate limit exceeded") | always `rate_limit` (wins over ambiguous "limit exceeded") |
| no usage-limit/billing signal | `None` → falls through to `auth` as before |

Wired into the 401 and 403 branches.

## Tests

7 regression tests in `tests/agent/test_error_classifier.py`:
- 401 usage-limit with reset → rate_limit; without → billing
- 403 usage-limit with reset → rate_limit; without → billing
- plain 401 invalid-key and 403 forbidden still → auth
- explicit rate-limit phrase on 401 stays rate_limit

`129 passed` in the error classifier suite.