### PR TITLE
Desktop: restored background tabs show their session title without a click (#94167, salvage #94212)

### DIFF
--- a/apps/desktop/src/app/chat/session-tile.test.ts
+++ b/apps/desktop/src/app/chat/session-tile.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { sessionTileResumeFailure } from './session-tile'
+import { $gatewayState, $sessions, setSessions } from '@/store/session'
+import { $sessionTiles } from '@/store/session-states'
+
+import { sessionTileResumeFailure, startUnrestoredTileTitleBackfill } from './session-tile'
 
 describe('sessionTileResumeFailure', () => {
   it('keeps a confirmed durable session retryable instead of repeating a stale 404', () => {
@@ -15,5 +18,45 @@ describe('sessionTileResumeFailure', () => {
 
   it('does not overwrite a tile that rebound while the lookup was pending', () => {
     expect(sessionTileResumeFailure('session not found', true, false)).toBeUndefined()
+  })
+})
+
+describe('startUnrestoredTileTitleBackfill (#94167)', () => {
+  afterEach(() => {
+    $gatewayState.set('idle')
+    $sessionTiles.set([])
+    setSessions([])
+  })
+
+  it('backfills unlisted unrestored tiles by id via their ownerRoute once the gateway opens', async () => {
+    const ownerRoute = { connectionId: 'conn-a', profile: 'writer' }
+    setSessions([{ id: 'listed', title: 'Already listed' } as never])
+    $sessionTiles.set([
+      { ownerRoute, storedSessionId: 'old-chat' },
+      { storedSessionId: 'listed' },
+      { runtimeId: 'rt-live', storedSessionId: 'live' },
+      { storedSessionId: 'bot', workspaceTabTitle: 'Bot Chat' }
+    ])
+
+    const lookup = vi.fn(async (id: string) => {
+      const row = { id, title: 'Quarterly review' } as never
+      setSessions(prev => [row, ...prev])
+
+      return row
+    })
+
+    const stop = startUnrestoredTileTitleBackfill(lookup as never)
+    expect(lookup).not.toHaveBeenCalled()
+
+    $gatewayState.set('open')
+    await vi.waitFor(() => expect(lookup).toHaveBeenCalledTimes(1))
+    expect(lookup).toHaveBeenCalledWith('old-chat', ownerRoute)
+    expect($sessions.get().find(row => row.id === 'old-chat')?.title).toBe('Quarterly review')
+
+    // One-shot: a later reconnect does not re-probe.
+    $gatewayState.set('idle')
+    $gatewayState.set('open')
+    expect(lookup).toHaveBeenCalledTimes(1)
+    stop()
   })
 })

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -477,6 +477,33 @@ export function tileStoredRow(storedSessionId: string): SessionInfo | undefined 
   )
 }
 
+/** One-shot by-id title fill for restored tiles that never mount (#94167).
+ *  A restored background tab has no runtimeId and does not mount its pane, so
+ *  the resolution effect above never runs; when its row is outside the recents
+ *  page and project tree, `tileTitle()` reads "New session" until first click.
+ *  `resolveStoredSession` upserts the row into `$sessions`, which the tab strip
+ *  already watches — nothing is persisted. Runs once the gateway can answer. */
+export function startUnrestoredTileTitleBackfill(lookup = resolveStoredSession): () => void {
+  const run = () => {
+    if ($gatewayState.get() !== 'open') {
+      return
+    }
+
+    off()
+
+    for (const tile of $sessionTiles.get()) {
+      if (!tile.runtimeId && !tile.workspaceTabTitle && !tileStoredRow(tile.storedSessionId)) {
+        void lookup(tile.storedSessionId, tile.ownerRoute).catch(() => undefined)
+      }
+    }
+  }
+
+  const off = $gatewayState.listen(run)
+  run()
+
+  return off
+}
+
 /** The tab's REGISTERED name. Deliberately the bare placeholder for a draft
  *  rather than its live composer title (`tabTitle` renders that): re-registering
  *  per keystroke would re-render the strip, and holding the draft's text here

--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -82,6 +82,7 @@ import { startSessionDrag } from '../chat/session-drag'
 import {
   SessionTileCloseConfirm,
   stackSessionTilesIntoMain,
+  startUnrestoredTileTitleBackfill,
   watchSessionTiles,
   WorkspaceTabMenu
 } from '../chat/session-tile'
@@ -457,6 +458,7 @@ watchContributedPanes()
 // into the transparent overlay).
 if (!isBrowserWindow() && !isHudWindow()) {
   watchSessionTiles()
+  startUnrestoredTileTitleBackfill()
   watchRouteTiles()
   watchPreviewTiles()
 }


### PR DESCRIPTION
## Summary
Restored background session tabs now show their real title after launch instead of reading "New session" until they are clicked.

Root cause: a restored tile has no `runtimeId` and its pane does not mount until first activation, so the by-id resolution effect inside `SessionTilePane` never runs. When the session row is also outside the recents page and project tree, `tileTitle()` has nothing to resolve from and falls back to the placeholder.

Closes #94167. Supersedes #94212 — salvaged only the one-shot by-id backfill from @686f6c61's PR (co-authored on the commit). The title-persistence half (`knownSessionTabTitle`, `$sessions.listen` writer, `setSessionTileWorkspaceScope` change) was dropped: `workspaceTabTitle` stays the canonical Bot Chat marker and no new state is written to disk.

## Changes
- `session-tile.tsx`: `startUnrestoredTileTitleBackfill()` — once the gateway is open, look each tile with no `runtimeId`, no `workspaceTabTitle`, and no `tileStoredRow()` up via `resolveStoredSession(id, tile.ownerRoute)`. That call already upserts the row into `$sessions`, which the tab strip mirror watches (`also: [$sessions, …]`), so the tab re-labels itself. One shot per launch; owner route preferred so cross-profile tiles never probe the ambient gateway.
- `controller.tsx`: wire it next to `watchSessionTiles()` (same non-browser / non-HUD gate).
- `session-tile.test.ts`: one test — unlisted unrestored tiles are looked up by id with their `ownerRoute` once the gateway opens; listed, live, and explicitly titled tiles are skipped; a later reconnect does not re-probe.

## Validation
| | Before (main) | After |
|---|---|---|
| Electron e2e: target pushed off the 50-row recents page by 60 newer sessions, restored as a stacked background tab, no click | tab strip `["*sessions","Bots","*New session","New session","New session","terminal"]` — target reads "New session", pane unmounted | `[…,"E2E tile title target",…]` — real title, pane still unmounted; the nonexistent second tile correctly stays "New session" |
| New unit test | fails (`startUnrestoredTileTitleBackfill is not a function`) | passes (4/4 in file) |
| `tsc --noEmit`, `eslint` on touched files | — | clean |

**Live repro:** Electron e2e (built `dist/`, real backend, `RealSessionBuilder` seeded target + 60 filler rows via `SessionDB`, tiles restored from `hermes.desktop.sessionTiles.v2`, reload) — before: target tab labeled "New session" after boot with the transcript unmounted; after: labeled with its stored title, still unmounted. Repro spec was temporary and is not committed.

## Infographic

![Restored tabs keep their names](https://v3b.fal.media/files/b/0aa8ce0c/lzVirtzYsJ3FD2fRmVnP2_hO91YZS4.png)
