### PR TITLE
fix(desktop): persist clarify choices across interrupt and reconnect

### DIFF
--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -623,15 +623,22 @@ describe('ClarifyTool batch card', () => {
 
     expect((confirm as HTMLButtonElement).disabled).toBe(true)
 
-    // Staging a pick sends NOTHING to the server.
+    // Choice clicks flush a defer_complete lock; drafts stay local until Confirm.
     fireEvent.click(screen.getByRole('button', { name: /red/ }))
     expect(screen.getByText('1 of 2 answered')).toBeTruthy()
-    expect(request).not.toHaveBeenCalled()
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith('clarify.respond', {
+        answer: 'red',
+        defer_complete: true,
+        question_id: 'q0',
+        request_id: 'request-batch'
+      })
+    })
     expect((confirm as HTMLButtonElement).disabled).toBe(true)
 
     fireEvent.change(screen.getByPlaceholderText('Type your answer…'), { target: { value: 'packet' } })
     expect(screen.getByText('2 of 2 answered')).toBeTruthy()
-    expect(request).not.toHaveBeenCalled()
+    expect(request).toHaveBeenCalledTimes(1)
     expect((confirm as HTMLButtonElement).disabled).toBe(false)
   })
 
@@ -643,14 +650,20 @@ describe('ClarifyTool batch card', () => {
     fireEvent.submit(document.querySelector('form') as HTMLFormElement)
 
     await waitFor(() => {
-      expect(request).toHaveBeenCalledTimes(2)
+      expect(request).toHaveBeenCalledTimes(3)
     })
     expect(request).toHaveBeenNthCalledWith(1, 'clarify.respond', {
       answer: 'red',
+      defer_complete: true,
       question_id: 'q0',
       request_id: 'request-batch'
     })
     expect(request).toHaveBeenNthCalledWith(2, 'clarify.respond', {
+      answer: 'red',
+      question_id: 'q0',
+      request_id: 'request-batch'
+    })
+    expect(request).toHaveBeenNthCalledWith(3, 'clarify.respond', {
       answer: 'packet',
       question_id: 'q1',
       request_id: 'request-batch'
@@ -666,11 +679,17 @@ describe('ClarifyTool batch card', () => {
     fireEvent.submit(document.querySelector('form') as HTMLFormElement)
 
     await waitFor(() => {
-      expect(request).toHaveBeenCalledTimes(2)
+      expect(request).toHaveBeenCalledWith('clarify.respond', {
+        answer: 'blue',
+        question_id: 'q0',
+        request_id: 'request-batch'
+      })
     })
-    // The re-pick won: blue, not red.
-    expect(request).toHaveBeenNthCalledWith(1, 'clarify.respond', {
-      answer: 'blue',
+    // The re-pick won on Confirm (no defer flag). Incremental red/blue
+    // locks may also have flushed with defer_complete.
+    expect(request).toHaveBeenCalledWith('clarify.respond', {
+      answer: 'red',
+      defer_complete: true,
       question_id: 'q0',
       request_id: 'request-batch'
     })
@@ -813,11 +832,18 @@ describe('ClarifyTool owner routing', () => {
     fireEvent.click(screen.getByRole('button', { name: /Confirm and continue/ }))
 
     await waitFor(() => {
-      expect(gatewayMocks.requestGatewayForAgent).toHaveBeenCalledTimes(2)
+      expect(gatewayMocks.requestGatewayForAgent).toHaveBeenCalledTimes(3)
     })
-    // The LAST lock resolves the blocked tool, so order is load-bearing.
-    expectOwnerCall(1, { answer: 'red', question_id: 'q0', request_id: 'request-batch' })
-    expectOwnerCall(2, { answer: 'packet', question_id: 'q1', request_id: 'request-batch' })
+    // Incremental lock first; Confirm re-sends without defer so the waiter
+    // releases. The LAST non-defer lock still resolves the blocked tool.
+    expectOwnerCall(1, {
+      answer: 'red',
+      defer_complete: true,
+      question_id: 'q0',
+      request_id: 'request-batch'
+    })
+    expectOwnerCall(2, { answer: 'red', question_id: 'q0', request_id: 'request-batch' })
+    expectOwnerCall(3, { answer: 'packet', question_id: 'q1', request_id: 'request-batch' })
     expect(ambient).not.toHaveBeenCalled()
   })
 

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -943,12 +943,10 @@ function BatchQuestionBlock({
 const emptyStage = { choices: [] as string[], draft: '' }
 
 /** Live batch card: all questions at once, staged locally, ONE confirm.
- * Picks and drafts stay in component state — nothing reaches the server
- * until every question has a staged answer and the user presses the single
- * "Confirm and continue" button, which sends the per-question locks
- * back-to-back and completes the batch. Staged answers stay editable up to
- * that moment. The per-question wire protocol is unchanged (the TUI/CLI
- * still lock incrementally); this card just batches its locks at the end. */
+ * Choice clicks flush a defer_complete lock so the server holds the answer
+ * across reconnect / interrupt. Confirm sends the same locks without the
+ * defer flag and releases the waiter. Drafts still wait for Confirm.
+ * Staged answers stay editable up to Confirm (update-in-place). */
 function ClarifyToolBatchPending({ onAnswered, request }: { onAnswered: () => void; request: ClarifyRequest | null }) {
   const { t } = useI18n()
   const copy = t.assistant.clarify
@@ -1027,6 +1025,27 @@ function ClarifyToolBatchPending({ onAnswered, request }: { onAnswered: () => vo
   const answeredCount = questions.filter(q => stagedAnswer(q) !== null).length
   const allStaged = answeredCount === questions.length
 
+  const lockQuestion = useCallback(
+    async (question: ClarifyQuestion, answer: string, deferComplete: boolean) => {
+      if (!request || !gateway) {
+        return
+      }
+
+      await requestForOwnedSession<{ ok?: boolean }>(
+        request.sessionId,
+        gateway.request.bind(gateway) as typeof gateway.request,
+        'clarify.respond',
+        {
+          answer,
+          ...(deferComplete ? { defer_complete: true } : {}),
+          question_id: question.qid,
+          request_id: request.requestId
+        }
+      )
+    },
+    [gateway, request]
+  )
+
   const confirmAll = useCallback(async () => {
     if (!request || !gateway) {
       notifyError(new Error(request ? copy.gatewayDisconnected : copy.notReady), copy.sendFailed)
@@ -1048,16 +1067,7 @@ function ClarifyToolBatchPending({ onAnswered, request }: { onAnswered: () => vo
       for (const question of questions) {
         const answer = stagedAnswer(question)
 
-        await requestForOwnedSession<{ ok?: boolean }>(
-          request.sessionId,
-          gateway.request.bind(gateway) as typeof gateway.request,
-          'clarify.respond',
-          {
-            answer: answer ?? '',
-            question_id: question.qid,
-            request_id: request.requestId
-          }
-        )
+        await lockQuestion(question, answer ?? '', false)
       }
 
       triggerHaptic('submit')
@@ -1068,21 +1078,40 @@ function ClarifyToolBatchPending({ onAnswered, request }: { onAnswered: () => vo
       notifyError(error, copy.sendFailed)
       setSubmitting(false)
     }
-  }, [copy, gateway, onAnswered, questions, request, stagedAnswer])
+  }, [copy, gateway, lockQuestion, onAnswered, questions, request, stagedAnswer])
 
-  const toggleChoice = useCallback((question: ClarifyQuestion, choice: string) => {
-    setStaged(current => {
-      const stage = current[question.qid] ?? emptyStage
+  const toggleChoice = useCallback(
+    (question: ClarifyQuestion, choice: string) => {
+      let lockedAnswer: string | null = null
 
-      const next = question.multiSelect
-        ? stage.choices.includes(choice)
-          ? stage.choices.filter(value => value !== choice)
-          : [...stage.choices, choice]
-        : [choice]
+      setStaged(current => {
+        const stage = current[question.qid] ?? emptyStage
 
-      return { ...current, [question.qid]: { choices: next, draft: '' } }
-    })
-  }, [])
+        const next = question.multiSelect
+          ? stage.choices.includes(choice)
+            ? stage.choices.filter(value => value !== choice)
+            : [...stage.choices, choice]
+          : [choice]
+
+        lockedAnswer = question.multiSelect
+          ? next.length > 0
+            ? JSON.stringify(next.map(bareChoice))
+            : null
+          : next[0]
+            ? bareChoice(next[0])
+            : null
+
+        return { ...current, [question.qid]: { choices: next, draft: '' } }
+      })
+
+      if (lockedAnswer) {
+        void lockQuestion(question, lockedAnswer, true).catch(() => {
+          // Confirm retries; a missed incremental lock must not block the card.
+        })
+      }
+    },
+    [lockQuestion]
+  )
 
   const draftFor = useCallback((question: ClarifyQuestion, value: string) => {
     setStaged(current => ({ ...current, [question.qid]: { choices: [], draft: value } }))

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -496,6 +496,51 @@ def test_clarify_batch_cancel_all_returns_empty(server):
     assert box["answer"] == ""
 
 
+def test_clarify_batch_defer_complete_keeps_waiter_open(server):
+    """Desktop incremental locks must not release the tool until Confirm."""
+    thread, box, rid = _drain_batch_block(server, ["q0"])
+
+    first = server.handle_request({
+        "id": "a1", "method": "clarify.respond",
+        "params": {
+            "request_id": rid,
+            "question_id": "q0",
+            "answer": "Tea",
+            "defer_complete": True,
+        },
+    })
+    assert first["result"]["status"] == "ok"
+    assert first["result"]["remaining"] == []
+    assert thread.is_alive()
+
+    server.handle_request({
+        "id": "a2", "method": "clarify.respond",
+        "params": {"request_id": rid, "question_id": "q0", "answer": "Tea"},
+    })
+    thread.join(timeout=5)
+    assert not thread.is_alive()
+    assert json.loads(box["answer"]) == {"answers": {"q0": "Tea"}}
+
+
+def test_clarify_batch_interrupt_keeps_locked_answers(server):
+    """session.interrupt / WS reap must not cancel-all a batch with locks."""
+    thread, box, rid = _drain_batch_block(server, ["q0", "q1"], timeout=5)
+
+    server.handle_request({
+        "id": "a1", "method": "clarify.respond",
+        "params": {
+            "request_id": rid,
+            "question_id": "q0",
+            "answer": "Tea",
+            "defer_complete": True,
+        },
+    })
+    server._clear_pending("s1")
+    thread.join(timeout=5)
+    assert not thread.is_alive()
+    assert json.loads(box["answer"]) == {"answers": {"q0": "Tea"}}
+
+
 def test_clarify_batch_late_question_respond_is_idempotent(server):
     response = server.handle_request({
         "id": "late", "method": "clarify.respond",

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5042,7 +5042,12 @@ def _clear_pending(sid: str | None = None) -> None:
     with _prompt_lock:
         for rid, (owner_sid, ev) in list(_pending.items()):
             if sid is None or owner_sid == sid:
-                _answers[rid] = ""
+                # Writing "" into _answers is the Skip/cancel-all signal.
+                # Interrupt and WS-orphan reaps must not use that path for
+                # batch clarify — it discards per-qid locks and the tool
+                # returns empty user_response with interrupted_by_user.
+                if rid not in _batch_clarify:
+                    _answers[rid] = ""
                 ev.set()
 
 
@@ -14453,7 +14458,11 @@ def _respond(rid, params, key, *, allow_expired=False):
             remaining = [
                 qid for qid in batch["qids"] if qid not in batch["answers"]
             ]
-            if not remaining:
+            # Desktop stages locks incrementally (defer_complete) so a WS drop
+            # / interrupt can still return the clicked answers. Confirm omits
+            # the flag and releases the waiter when every qid is locked.
+            defer_complete = bool(params.get("defer_complete"))
+            if not remaining and not defer_complete:
                 ev.set()
             return _ok(rid, {"status": "ok", "remaining": remaining})
         _answers[r] = params.get(key, "")


### PR DESCRIPTION
## What does this PR do?

Desktop batch clarify cards kept picks in React state until Confirm. A click therefore never reached the gateway. WebSocket reconnect / `session.interrupt` then treated the wait as Skip (`_answers[rid]=""`), so the tool returned `user_response: ""` and the turn ended `interrupted_by_user`.

Choice clicks now flush a `defer_complete` lock (Confirm still releases the waiter). Interrupt no longer cancel-alls a batch that already has locks.

## Related Issue

Fixes #101203

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/components/assistant-ui/clarify-tool.tsx` — batch option clicks send `clarify.respond` with `defer_complete: true`
- `tui_gateway/server.py` — `_respond` honors `defer_complete`; `_clear_pending` does not write empty `_answers` for batch clarify
- `apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx` — incremental lock + Confirm still completes
- `tests/tui_gateway/test_protocol.py` — defer_complete keeps the waiter; interrupt keeps locked answers

## How to Test

1. Desktop app, new chat. Prompt: `Call the clarify tool now with one question: Prefer tea or coffee? choices Tea, Coffee. Do not answer in prose — you must call clarify.`
2. When the card appears, click Tea (do not Confirm). Restart the backend or interrupt the turn.
3. Tool result should include `user_response` for Tea (not `""`). Confirm still finishes a live wait.
4. `scripts/run_tests.sh tests/tui_gateway/test_protocol.py -q`
5. From `apps/desktop`: `npx vitest run src/components/assistant-ui/clarify-tool.test.tsx`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Hermes desktop v0.21.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Desktop session showed a live `Prefer tea or coffee?` card. Clicking Tea staged `1 of 1 answered` with no `clarify.respond` on the wire until this change.