### PR TITLE
fix(desktop): sessions, windows, transcripts and new chats follow their owning profile under multiplex (#79005 #82768 #61286, salvage #97042 #99333 #99387 #89100)

### DIFF
--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -707,13 +707,13 @@ test('registry local route: a per-profile remote override delegates to the overr
   assert.deepEqual(route, { delegate: true, poolKey: 'research' })
 })
 
-test('registry local route: global remote keeps forced-local even when a profile override is absent', () => {
-  // Witness for the other half of the split: app-global remote mode still
-  // forces "This device" to spawn genuinely-local children (migration
-  // scenario above) — only the per-profile override delegates.
-  const route = resolveRegistryLocalRoute('research', { globalRemote: true })
+test('registry local route: per-profile override wins when global remote is also active', () => {
+  const route = resolveRegistryLocalRoute('research', {
+    globalRemote: true,
+    profileRemoteOverride: true
+  })
 
-  assert.deepEqual(route, { delegate: false, poolKey: 'conn:local::research' })
+  assert.deepEqual(route, { delegate: true, poolKey: 'research' })
 })
 
 // --- shouldDeferLocalEnumeration (roster's connect-on-demand for 'local') ---

--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -697,8 +697,21 @@ test('registry local route: v1 REMOTE global mode forces a genuinely-local backe
   assert.notEqual(route.poolKey, backendScopeKey(LOCAL_CONNECTION_ID, 'default'))
 })
 
-test('registry local route: a per-profile remote override also forces local', () => {
+test('registry local route: a per-profile remote override delegates to the override (#90477)', () => {
+  // The per-profile SSH/remote override is the authoritative route for that
+  // profile. Forcing local here made the roster list the profile via its
+  // override but open the thread in a local child — which fails when the
+  // profile exists only on the remote. The override must win.
   const route = resolveRegistryLocalRoute('research', { profileRemoteOverride: true })
+
+  assert.deepEqual(route, { delegate: true, poolKey: 'research' })
+})
+
+test('registry local route: global remote keeps forced-local even when a profile override is absent', () => {
+  // Witness for the other half of the split: app-global remote mode still
+  // forces "This device" to spawn genuinely-local children (migration
+  // scenario above) — only the per-profile override delegates.
+  const route = resolveRegistryLocalRoute('research', { globalRemote: true })
 
   assert.deepEqual(route, { delegate: false, poolKey: 'conn:local::research' })
 })

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -493,7 +493,17 @@ export function resolveRegistryLocalRoute(
 ): RegistryLocalRoute {
   const profileKey = String(profile ?? '').trim() || 'default'
 
-  if (opts.globalRemote || opts.profileRemoteOverride) {
+  // A per-profile SSH/remote override is an explicit per-profile routing
+  // decision: the override owns this profile's backend, so the 'local' entry
+  // must delegate to the legacy profile route (which resolves the override),
+  // not spawn a forced-local child. Forcing local here is the #90477 split:
+  // the roster lists the profile via its override, but opening the thread
+  // spawned a local backend that fails when the profile doesn't exist locally.
+  if (opts.profileRemoteOverride) {
+    return { delegate: true, poolKey: profileKey }
+  }
+
+  if (opts.globalRemote) {
     return { delegate: false, poolKey: `${backendScopePrefix(LOCAL_CONNECTION_ID)}${profileKey}` }
   }
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -13053,7 +13053,11 @@ function focusWindow(win) {
   win.focus()
 }
 
-function spawnSecondaryWindow({ sessionId, watch }: { sessionId?: string; watch?: boolean } = {}) {
+function spawnSecondaryWindow({
+  sessionId,
+  profile,
+  watch
+}: { sessionId?: string; profile?: null | string; watch?: boolean } = {}) {
   const icon = getAppIconPath()
 
   const win = new BrowserWindow({
@@ -13115,6 +13119,7 @@ function spawnSecondaryWindow({ sessionId, watch }: { sessionId?: string; watch?
     win,
     buildSessionWindowUrl(sessionId, {
       devServer: DEV_SERVER,
+      profile,
       rendererIndexPath: DEV_SERVER ? undefined : resolveRendererIndex(),
       watch
     }),
@@ -13125,8 +13130,8 @@ function spawnSecondaryWindow({ sessionId, watch }: { sessionId?: string; watch?
 }
 
 // Open (or focus) a standalone window for a single chat session.
-function createSessionWindow(sessionId, { watch = false } = {}) {
-  return sessionWindows.openOrFocus(sessionId, () => spawnSecondaryWindow({ sessionId, watch }))
+function createSessionWindow(sessionId, { profile = null, watch = false } = {}) {
+  return sessionWindows.openOrFocus(sessionId, () => spawnSecondaryWindow({ sessionId, profile, watch }))
 }
 
 // Popped-out in-app Browser: same webview + address bar as a docked Browser
@@ -14613,7 +14618,10 @@ ipcMain.handle('hermes:window:openSession', async (_event, sessionId, opts) => {
     return { ok: false, error: 'invalid-session-id' }
   }
 
-  createSessionWindow(sessionId.trim(), { watch: opts?.watch === true })
+  createSessionWindow(sessionId.trim(), {
+    profile: typeof opts?.profile === 'string' ? opts.profile : null,
+    watch: opts?.watch === true
+  })
 
   return { ok: true }
 })

--- a/apps/desktop/electron/session-windows.test.ts
+++ b/apps/desktop/electron/session-windows.test.ts
@@ -68,6 +68,12 @@ test('buildSessionWindowUrl avoids a double slash when the dev server has a trai
   assert.equal(url, 'http://localhost:5173/?win=secondary#/abc123')
 })
 
+test('buildSessionWindowUrl carries the owning profile in the query before the hash (#82768)', () => {
+  const url = buildSessionWindowUrl('abc123', { devServer: 'http://localhost:5173', profile: 'work', watch: true })
+
+  assert.equal(url, 'http://localhost:5173/?win=secondary&watch=1&profile=work#/abc123')
+})
+
 test('buildSessionWindowUrl encodes the session id in the hash route', () => {
   const url = buildSessionWindowUrl('a b/c', { devServer: 'http://localhost:5173' })
 

--- a/apps/desktop/electron/session-windows.ts
+++ b/apps/desktop/electron/session-windows.ts
@@ -64,8 +64,13 @@ function chatWindowWebPreferences(preloadPath: string) {
 // onboarding overlays and the global session sidebar. `watch=1` marks a
 // spectator window (e.g. a running subagent's session): the renderer resumes it
 // lazily so the gateway never builds an agent just to stream into it.
-function buildSessionWindowUrl(sessionId: string, { devServer, rendererIndexPath, watch }: any = {}) {
-  const query = `?win=secondary${watch ? '&watch=1' : ''}`
+// `profile` names the backend the window must boot against (same carry as the
+// HUD's buildHudWindowUrl): without it a pop-out/watch window adopts the
+// PRIMARY profile and resolves the session id against the wrong backend
+// (#82768, #61286). Absent → unchanged primary adoption.
+function buildSessionWindowUrl(sessionId: string, { devServer, profile, rendererIndexPath, watch }: any = {}) {
+  const profileKey = typeof profile === 'string' ? profile.trim() : ''
+  const query = `?win=secondary${watch ? '&watch=1' : ''}${profileKey ? `&profile=${encodeURIComponent(profileKey)}` : ''}`
   const route = `#/${encodeURIComponent(sessionId)}`
 
   if (devServer) {

--- a/apps/desktop/src/app/session/workspace-session-target.test.ts
+++ b/apps/desktop/src/app/session/workspace-session-target.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { $activeGatewayProfile, $newChatProfile } from '@/store/profile'
 import { $projectScope, $projectTree, ALL_PROJECTS } from '@/store/projects'
 import {
   $currentBranch,
@@ -22,6 +23,8 @@ describe('startWorkspaceSession', () => {
     setNewChatWorkspaceTarget(undefined)
     $projectScope.set(ALL_PROJECTS)
     $projectTree.set([])
+    $activeGatewayProfile.set('default')
+    $newChatProfile.set(null)
     vi.restoreAllMocks()
   })
 
@@ -106,5 +109,23 @@ describe('startWorkspaceSession', () => {
     expect(requestGateway).not.toHaveBeenCalled()
     expect($newChatWorkspaceTarget.get()).toBeNull()
     expect($currentCwd.get()).toBe('')
+  })
+
+  // #79005 flaw 3: the project "+" must pin the profile the tree is shown
+  // under; otherwise session.create reads $activeGatewayProfile after a swap.
+  it('pins the new chat to the profile the project tree is displayed under', () => {
+    $activeGatewayProfile.set('work')
+    $newChatProfile.set(null)
+
+    startWorkspaceSession({
+      activeSessionIdRef: { current: null },
+      path: '/workspace-work',
+      requestGateway: vi.fn(() => new Promise<never>(() => {})),
+      startFreshSessionDraft: vi.fn()
+    })
+
+    $activeGatewayProfile.set('personal')
+
+    expect($newChatProfile.get()).toBe('work')
   })
 })

--- a/apps/desktop/src/app/session/workspace-session-target.ts
+++ b/apps/desktop/src/app/session/workspace-session-target.ts
@@ -1,6 +1,7 @@
 import type { MutableRefObject } from 'react'
 
-import { followActiveSessionCwd, resolveNewSessionCwd } from '@/store/projects'
+import { pinNewChatProfile } from '@/store/profile'
+import { followActiveSessionCwd, projectProfile, resolveNewSessionCwd } from '@/store/projects'
 import {
   $newChatWorkspaceTargetGeneration,
   type NewChatWorkspaceTarget,
@@ -26,6 +27,16 @@ export function startWorkspaceSession({
   requestGateway,
   startFreshSessionDraft
 }: WorkspaceSessionOptions): void {
+  // The project tree is rendered under one profile; the "+" belongs to it.
+  // Pin that intent now — otherwise desktopSessionCreateParams falls back to
+  // $activeGatewayProfile, which a still-settling profile swap can move
+  // between this click and Send (#79005). All-profiles view has no owner.
+  const profile = projectProfile()
+
+  if (profile) {
+    pinNewChatProfile(profile)
+  }
+
   // Home's "+" passes path=null on purpose ("no folder"). That must stay
   // detached — do NOT fall through to resolveNewSessionCwd(), which can still
   // return a default/remembered project folder and re-attach the last repo

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -52,7 +52,10 @@ declare global {
       // with an error code when the sessionId is empty/invalid. `watch` opens
       // a spectator window (lazy resume — no agent build) for live-streaming
       // a running subagent's session.
-      openSessionWindow: (sessionId: string, opts?: { watch?: boolean }) => Promise<{ ok: boolean; error?: string }>
+      openSessionWindow: (
+        sessionId: string,
+        opts?: { profile?: null | string; watch?: boolean }
+      ) => Promise<{ ok: boolean; error?: string }>
       // Resume this session in the user's own terminal emulator (`hermes --tui
       // --resume <id>`) — the external terminal, not the in-app pane.
       openSessionInTerminal: (

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -9,7 +9,7 @@ import type { ProfileInfo } from '@/types/hermes'
 const ensureGatewayForProfile = vi.fn(async () => undefined)
 const ensureGatewayForAgent = vi.fn(async () => undefined)
 const openGatewayForProfile = vi.fn(async (_profile: string) => undefined)
-const $gateway = atom<unknown>({ id: 'live-socket' })
+const $gateway = atom<unknown>({ id: 'live-socket', connectionState: 'open' })
 const resetStarmapGraph = vi.fn()
 
 vi.mock('@/store/gateway', () => ({ $gateway, ensureGatewayForAgent, ensureGatewayForProfile, openGatewayForProfile }))
@@ -55,7 +55,7 @@ beforeEach(() => {
   getConnection.mockReset()
   ensureGatewayForProfile.mockClear()
   openGatewayForProfile.mockClear()
-  $gateway.set({ id: 'live-socket' })
+  $gateway.set({ id: 'live-socket', connectionState: 'open' })
   $activeGatewayProfile.set('default')
   $connection.set(localConn())
   $profiles.set([])
@@ -114,6 +114,17 @@ describe('ensureGatewayProfile → $connection sync (#46651)', () => {
     expect(getConnection).not.toHaveBeenCalled()
     expect(ensureGatewayForProfile).not.toHaveBeenCalled()
     expect($connection.get()?.mode).toBe('remote')
+  })
+
+  it('reconnects when the target profile is active but its gateway socket is closed', async () => {
+    $activeGatewayProfile.set('vps-remote')
+    $connection.set(remoteConn())
+    $gateway.set({ connectionState: 'closed' })
+    getConnection.mockResolvedValue(remoteConn())
+
+    await ensureGatewayProfile('vps-remote')
+
+    expect(ensureGatewayForProfile).toHaveBeenCalledWith('vps-remote')
   })
 })
 

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -491,7 +491,7 @@ export async function ensureGatewayProfile(profile: string | null | undefined): 
 
   const target = normalizeProfileKey(profile)
 
-  if (normalizeProfileKey($activeGatewayProfile.get()) === target && $gateway.get()) {
+  if (normalizeProfileKey($activeGatewayProfile.get()) === target && $gateway.get()?.connectionState === 'open') {
     return
   }
 
@@ -503,7 +503,7 @@ export async function ensureGatewayProfile(profile: string | null | undefined): 
     await gatewaySwitch.catch(() => undefined)
   }
 
-  if (normalizeProfileKey($activeGatewayProfile.get()) === target && $gateway.get()) {
+  if (normalizeProfileKey($activeGatewayProfile.get()) === target && $gateway.get()?.connectionState === 'open') {
     return
   }
 

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -857,6 +857,18 @@ function activateOnCurrentSource(target: string): Promise<void> {
   return connectionId ? ensureGatewayAgent(connectionId, target) : ensureGatewayProfile(target)
 }
 
+// Pin the next new chat to `name` (legacy profile-only door) so session.create
+// reads the profile the user clicked "+" under, not whatever
+// $activeGatewayProfile holds once an in-flight profile swap settles (#79005).
+export function pinNewChatProfile(name: string): string {
+  const target = normalizeProfileKey(name)
+  $newChatProfile.set(target)
+  $newChatRoute.set(null)
+  captureNewChatSource(profilePickConnectionId(target))
+
+  return target
+}
+
 // Start a fresh session in `name` WITHOUT collapsing the "All profiles" browse
 // view. Unlike selectProfile, it leaves $showAllProfiles untouched, so the
 // unified sidebar stays put — used by the per-profile "+" in the all-profiles
@@ -864,10 +876,7 @@ function activateOnCurrentSource(target: string): Promise<void> {
 // is in. Points new chats at the profile and opens its backend so the next
 // message lands in the right place.
 export function newSessionInProfile(name: string): void {
-  const target = normalizeProfileKey(name)
-  $newChatProfile.set(target)
-  $newChatRoute.set(null)
-  captureNewChatSource(profilePickConnectionId(target))
+  const target = pinNewChatProfile(name)
   requestFreshSession()
   // #81094: surface the failed dial instead of failing silently.
   void activateOnCurrentSource(target).catch((error: unknown) => {

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -349,7 +349,7 @@ async function gatewayRequest<T>(method: string, params: Record<string, unknown>
   return gateway.request<T>(method, params)
 }
 
-function projectProfile(): null | string {
+export function projectProfile(): null | string {
   const profile = normalizeProfileKey($activeGatewayProfile.get())
 
   return $profileScope.get() === ALL_PROFILES || profile === ALL_PROFILES ? null : profile

--- a/apps/desktop/src/store/windows.test.ts
+++ b/apps/desktop/src/store/windows.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { $activeGatewayProfile } from './profile'
+import { $sessions } from './session'
 import {
   canOpenBrowserWindow,
   canOpenNewWindow,
@@ -88,23 +90,17 @@ describe('openSessionInNewWindow', () => {
     expect(notifyError).not.toHaveBeenCalled()
   })
 
-  it('invokes the bridge with the session id', async () => {
+  it('carries the owning profile: stamped row wins, an unstamped child inherits the viewed profile (#82768)', async () => {
     const open = vi.fn().mockResolvedValue({ ok: true })
     installBridge(open)
+    $activeGatewayProfile.set('work')
+    $sessions.set([{ id: 's1', profile: 'research' } as never])
 
     await openSessionInNewWindow('s1')
+    await openSessionInNewWindow('child-not-listed-yet', { watch: true })
 
-    expect(open).toHaveBeenCalledWith('s1', undefined)
-    expect(notifyError).not.toHaveBeenCalled()
-  })
-
-  it('forwards the watch flag for spectator (subagent) windows', async () => {
-    const open = vi.fn().mockResolvedValue({ ok: true })
-    installBridge(open)
-
-    await openSessionInNewWindow('s1', { watch: true })
-
-    expect(open).toHaveBeenCalledWith('s1', { watch: true })
+    expect(open).toHaveBeenCalledWith('s1', { profile: 'research' })
+    expect(open).toHaveBeenCalledWith('child-not-listed-yet', { profile: 'work', watch: true })
     expect(notifyError).not.toHaveBeenCalled()
   })
 

--- a/apps/desktop/src/store/windows.ts
+++ b/apps/desktop/src/store/windows.ts
@@ -189,13 +189,26 @@ async function runWindowOpen(call: () => Promise<WindowOpenResult>, failMessage:
 // Open (or focus) a standalone OS window for a single chat session. No-ops
 // gracefully outside Electron so callers can wire it unconditionally.
 // `watch: true` opens a spectator window (lazy resume, live-mirror stream).
+// The window is a full renderer that adopts the PRIMARY profile unless told
+// otherwise, so the owning profile rides along (same ladder as openHud,
+// #82285): the session's stamped owner wins, and an unstamped/uncached id —
+// a brand-new subagent child — inherits the profile the user is looking at
+// (#82768, #61286).
 export async function openSessionInNewWindow(sessionId: string, opts?: { watch?: boolean }): Promise<void> {
   if (!sessionId || !canOpenSessionWindow()) {
     return
   }
 
+  // Lazy imports: `./profile` subscribes to the API client on load, so a
+  // static import here would drag it into every page that opens windows.
+  const [{ $activeGatewayProfile, normalizeProfileKey }, { $sessions, rememberedSessionProfile }] = await Promise.all([
+    import('./profile'),
+    import('./session')
+  ])
+  const profile = normalizeProfileKey(rememberedSessionProfile($sessions.get(), sessionId, $activeGatewayProfile.get()))
+
   await runWindowOpen(
-    () => window.hermesDesktop.openSessionWindow(sessionId, opts),
+    () => window.hermesDesktop.openSessionWindow(sessionId, { ...opts, profile }),
     'Could not open chat in a new window'
   )
 }

--- a/tests/tui_gateway/test_change_watcher.py
+++ b/tests/tui_gateway/test_change_watcher.py
@@ -64,6 +64,23 @@ def test_state_db_move_broadcasts_sessions_changed(watcher_home):
     assert ("sessions.changed", {}) in events
 
 
+def test_served_profile_store_move_broadcasts_sessions_changed(watcher_home, monkeypatch):
+    """A backend serving a sibling profile must see that profile's state.db
+    move too — otherwise a routed profile's Bot Chat never refreshes (#99333)."""
+    home, events = watcher_home
+    bot_home = home / "profiles" / "bot"
+    bot_home.mkdir(parents=True)
+    monkeypatch.setattr(server, "_served_profile_homes", set())
+    monkeypatch.setattr("hermes_cli.profiles.get_profile_dir", lambda name: home / "profiles" / name)
+    assert server._profile_home("bot") == bot_home
+    server._broadcast_watched_changes(now=0.0)
+
+    (bot_home / "state.db").write_text("x")
+    server._broadcast_watched_changes(now=10.0)
+
+    assert ("sessions.changed", {}) in events
+
+
 def test_gateway_state_move_broadcasts_platforms_changed(watcher_home):
     home, events = watcher_home
     server._broadcast_watched_changes(now=0.0)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2457,7 +2457,18 @@ def _profile_home(profile: str | None) -> Path | None:
     # Already the launch profile? No override needed.
     if home.resolve() == Path(_hermes_home).resolve():
         return None
-    return home if (home / "state.db").exists() or home.exists() else None
+    if (home / "state.db").exists() or home.exists():
+        # Remember every sibling home this backend was asked to serve so the
+        # change watcher stats its store too (#99333 class).
+        _served_profile_homes.add(home)
+        return home
+    return None
+
+
+# Profile homes served by this process besides the launch home — the only
+# extra stores the sessions watcher must probe. Empty on single-profile
+# installs, so their watcher stays byte-identical (two stats per tick).
+_served_profile_homes: set[Path] = set()
 
 
 def _profile_scoped(handler):
@@ -5203,15 +5214,17 @@ def _sessions_sig():
     """Newest mtime across state.db and its WAL — the cross-process change
     signal. Messaging-gateway turns and cron runs are written by OTHER
     processes that never touch this gateway's transports; the shared SQLite
-    file is the one thing they all move (#58671)."""
-    home = _watcher_home()
+    file is the one thing they all move (#58671). A backend serving several
+    profiles owns one store per profile, so every served sibling home is
+    probed too — otherwise a routed profile's Bot Chat never refreshes."""
     sig = None
-    for name in ("state.db", "state.db-wal"):
-        try:
-            mtime = (home / name).stat().st_mtime_ns
-        except OSError:
-            continue
-        sig = mtime if sig is None else max(sig, mtime)
+    for root in (_watcher_home(), *_served_profile_homes):
+        for name in ("state.db", "state.db-wal"):
+            try:
+                mtime = (root / name).stat().st_mtime_ns
+            except OSError:
+                continue
+            sig = mtime if sig is None else max(sig, mtime)
     return sig
 
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1948,6 +1948,9 @@ export interface SessionInfo {
   output_tokens: number;
   preview: string | null;
   parent_session_id?: string | null;
+  /** Owning profile stamped by the list/detail endpoints (the store the row
+   * was read from). Absent on search-endpoint rows, which carry no stamp. */
+  profile?: string;
 }
 
 export interface SessionLatestDescendantResponse {

--- a/web/src/pages/SessionsPage.test.tsx
+++ b/web/src/pages/SessionsPage.test.tsx
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiMocks = vi.hoisted(() => ({
+  getSessions: vi.fn(),
+  getSessionMessages: vi.fn(),
+  getEmptySessionsCount: vi.fn(),
+  getStatus: vi.fn(),
+  searchSessions: vi.fn(),
+  importSessions: vi.fn(),
+  exportSessionUrl: vi.fn(),
+  renameSession: vi.fn(),
+  pruneSessions: vi.fn(),
+  deleteSession: vi.fn(),
+  deleteEmptySessions: vi.fn(),
+  bulkDeleteSessions: vi.fn(),
+  getProfiles: vi.fn(),
+  getActiveProfile: vi.fn(),
+  getSessionStats: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: apiMocks,
+  // ProfileProvider mirrors its selection into the api module.
+  setManagementProfile: vi.fn(),
+  getManagementProfile: vi.fn(() => ""),
+}));
+vi.mock("@/components/PlatformsCard", () => ({ PlatformsCard: () => null }));
+vi.mock("@/components/Markdown", () => ({ Markdown: () => null }));
+
+let container: HTMLDivElement;
+let root: Root;
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function waitFor(cond: () => boolean, timeoutMs = 5000) {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor: condition never became true");
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+  }
+}
+
+function click(el: Element | null) {
+  if (!el) throw new Error("element not rendered");
+  el.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+}
+
+const button = (label: string) => document.querySelector(`button[aria-label="${label}"]`);
+
+async function renderSessionsPage(rows: Record<string, unknown>[]) {
+  // Page list uses limit 20; the overview tab's recent-cards fetch uses 50 —
+  // keep the overview empty so the list view (with row actions) renders.
+  apiMocks.getSessions.mockImplementation(async (limit: number) => ({
+    sessions: limit >= 50 ? [] : rows,
+    total: limit >= 50 ? 0 : rows.length,
+    limit,
+    offset: 0,
+  }));
+  const [{ default: SessionsPage }, { I18nProvider }, { SystemActionsProvider }, { ProfileProvider }, { PageHeaderProvider }] =
+    await Promise.all([
+      import("./SessionsPage"),
+      import("@/i18n"),
+      import("@/contexts/SystemActions"),
+      import("@/contexts/ProfileProvider"),
+      import("@/contexts/PageHeaderProvider"),
+    ]);
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  await act(async () =>
+    root.render(
+      <I18nProvider>
+        <MemoryRouter>
+          <SystemActionsProvider>
+            <ProfileProvider>
+              <PageHeaderProvider pluginTabs={[]}>
+                <SessionsPage />
+              </PageHeaderProvider>
+            </ProfileProvider>
+          </SystemActionsProvider>
+        </MemoryRouter>
+      </I18nProvider>,
+    ),
+  );
+  await waitFor(() => Boolean(button("Delete session")));
+}
+
+beforeEach(() => {
+  for (const fn of Object.values(apiMocks)) fn.mockReset();
+  apiMocks.getStatus.mockResolvedValue({});
+  apiMocks.getEmptySessionsCount.mockResolvedValue({ count: 0 });
+  apiMocks.getProfiles.mockResolvedValue({ profiles: [] });
+  // active === current keeps the management profile "" — the precondition
+  // under which an unstamped request hits the process's own store.
+  apiMocks.getActiveProfile.mockResolvedValue({ current: "default", active: "default" });
+  apiMocks.getSessionStats.mockResolvedValue({ by_source: {} });
+  apiMocks.getSessionMessages.mockResolvedValue({ messages: [] });
+  apiMocks.deleteSession.mockResolvedValue({ ok: true });
+  apiMocks.renameSession.mockResolvedValue({ ok: true, title: "Renamed" });
+  apiMocks.exportSessionUrl.mockReturnValue("/api/sessions/x/export");
+  vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, status: 500 })));
+  vi.stubGlobal("ResizeObserver", class { disconnect() {} observe() {} unobserve() {} });
+  // gsap ticks through rAF; a synchronous callback recurses to death.
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => setTimeout(() => cb(0), 0) as unknown as number);
+  vi.stubGlobal("cancelAnimationFrame", (id: number) => clearTimeout(id));
+  vi.stubGlobal("matchMedia", () => ({ addEventListener() {}, matches: false, media: "", removeEventListener() {} }));
+  sessionStorage.clear();
+});
+
+afterEach(async () => {
+  await act(async () => root?.unmount());
+  container?.remove();
+  vi.unstubAllGlobals();
+});
+
+describe("SessionsPage per-row profile routing (#99387)", () => {
+  it("sends every per-row request to the row's owning profile, not the management default", async () => {
+    await renderSessionsPage([
+      { id: "sid-guanli", profile: "guanli", source: "cli", model: null, title: "Managed", started_at: 1, ended_at: null,
+        last_active: 1, is_active: false, message_count: 2, tool_call_count: 0, input_tokens: 1, output_tokens: 1, preview: "hi" },
+    ]);
+
+    // expand → transcript read
+    await act(async () => click(button("Delete session")!.closest("div.cursor-pointer")));
+    await waitFor(() => apiMocks.getSessionMessages.mock.calls.length > 0);
+    expect(apiMocks.getSessionMessages).toHaveBeenCalledWith("sid-guanli", "guanli");
+
+    await act(async () => click(button("Export session")));
+    expect(apiMocks.exportSessionUrl).toHaveBeenCalledWith("sid-guanli", "guanli");
+
+    await act(async () => click(button("Rename session")));
+    const input = document.querySelector<HTMLInputElement>('input[placeholder="Session title"]');
+    if (!input) throw new Error("rename input not rendered");
+    await act(async () => {
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!.call(input, "Renamed");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await act(async () => click(button("Save title")));
+    expect(apiMocks.renameSession).toHaveBeenCalledWith("sid-guanli", "Renamed", "guanli");
+
+    await act(async () => click(button("Delete session")));
+    await waitFor(() => Boolean(document.querySelector('[role="alertdialog"]')));
+    const confirm = Array.from(document.querySelectorAll('[role="alertdialog"] button')).find(
+      (b) => b.textContent?.trim() === "Delete",
+    );
+    await act(async () => click(confirm ?? null));
+    expect(apiMocks.deleteSession).toHaveBeenCalledWith("sid-guanli", "guanli");
+  });
+});

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -487,7 +487,7 @@ function SessionRow({
     if (!isExpanded || messages !== null) return;
     let cancelled = false;
     api
-      .getSessionMessages(session.id)
+      .getSessionMessages(session.id, session.profile)
       .then((resp) => {
         if (!cancelled) setMessages(resp.messages);
       })
@@ -497,7 +497,7 @@ function SessionRow({
     return () => {
       cancelled = true;
     };
-  }, [isExpanded, session.id, messages]);
+  }, [isExpanded, session.id, session.profile, messages]);
 
   const sourceKey = session.source?.split(":")[0];
   const sourceInfo = (session.source
@@ -1274,11 +1274,22 @@ export default function SessionsPage() {
     };
   }, [search, sessionQueryOptions]);
 
+  // The profile a listed row was read from — the store that owns it. Every
+  // per-row request (delete, rename, export, messages) must go there, not to
+  // the global management profile, which lags the row (it stays "" while the
+  // sticky active profile equals the dashboard process's own, so the request
+  // hits the process store — a delete then "succeeds" as already_absent).
+  // Search rows carry no stamp: undefined falls back to the management profile.
+  const rowProfile = useCallback(
+    (id: string) => sessions.find((s) => s.id === id)?.profile,
+    [sessions],
+  );
+
   const sessionDelete = useConfirmDelete({
     onDelete: useCallback(
       async (id: string) => {
         try {
-          await api.deleteSession(id);
+          await api.deleteSession(id, rowProfile(id));
           setSessions((prev) => prev.filter((s) => s.id !== id));
           setTotal((prev) => prev - 1);
           if (expandedId === id) setExpandedId(null);
@@ -1304,6 +1315,7 @@ export default function SessionsPage() {
       [
         expandedId,
         refreshEmptyCount,
+        rowProfile,
         showToast,
         loadStats,
         t.sessions.sessionDeleted,
@@ -1373,7 +1385,13 @@ export default function SessionsPage() {
     }
     setDeletingSelected(true);
     try {
-      const resp = await api.bulkDeleteSessions(ids);
+      // The selection comes from one listed page, so its rows share one
+      // owning profile; a mixed selection falls back to the management profile.
+      const owners = new Set(ids.map(rowProfile));
+      const resp = await api.bulkDeleteSessions(
+        ids,
+        owners.size === 1 ? [...owners][0] : undefined,
+      );
       showToast(
         t.sessions.selectedSessionsDeleted.replace(
           "{count}",
@@ -1404,6 +1422,7 @@ export default function SessionsPage() {
     loadSessions,
     page,
     refreshEmptyCount,
+    rowProfile,
     selectedIds,
     showToast,
     t.sessions.failedToDeleteSelected,
@@ -1449,7 +1468,7 @@ export default function SessionsPage() {
   const handleRename = useCallback(
     async (id: string, title: string) => {
       try {
-        await api.renameSession(id, title);
+        await api.renameSession(id, title, rowProfile(id));
         setSessions((prev) =>
           prev.map((s) => (s.id === id ? { ...s, title } : s)),
         );
@@ -1462,13 +1481,13 @@ export default function SessionsPage() {
         showToast("Failed to rename session", "error");
       }
     },
-    [showToast, loadStats],
+    [rowProfile, showToast, loadStats],
   );
 
   const handleExport = useCallback(
     async (id: string) => {
       try {
-        const res = await fetch(api.exportSessionUrl(id), {
+        const res = await fetch(api.exportSessionUrl(id, rowProfile(id)), {
           credentials: "include",
           headers: {
             "X-Hermes-Session-Token":
@@ -1488,7 +1507,7 @@ export default function SessionsPage() {
         showToast("Failed to export session", "error");
       }
     },
-    [showToast],
+    [rowProfile, showToast],
   );
 
   const handlePrune = useCallback(async () => {


### PR DESCRIPTION
## Summary
Under multiplexed profiles, several Desktop and dashboard paths dropped the session's owning
profile and routed at the primary/active backend instead: new chats from a project's "+",
session pop-out/watch windows, tile transcript refreshes, per-row dashboard delete/rename/export/
read, and the forced-local registry route overriding a per-profile remote. Each site now carries
the owner explicitly; a swap-in-flight reconnect (#89100) closes the last #79005 gap.

## Changes
- desktop: per-profile remote override wins over the forced-local registry route (#97042, @SZWzz)
- desktop + tui_gateway: routed-profile Bot Chat transcripts refresh; _sessions_sig watches every
  served profile home (#99333, @StodsEcho5)
- dashboard: rowProfile(id) feeds delete/bulk-delete + rename/exportUrl/getMessages siblings
  (#99387, @liuhao1024)
- desktop: session pop-out/watch windows carry `&profile=` like the HUD already does
  (#82768, #61286; diagnosis @DomGrieco #82794)
- desktop: reconnect an active profile whose gateway is closed (#89100, @ayushnangia)
- desktop: project "+" pins $newChatProfile to the profile the tree is displayed under
  (#79005 flaw 3, second path)

## Validation
| Path | Before | After |
|---|---|---|
| Project "+" → session.create | profile = $activeGatewayProfile (moves during swap); test: expected null to be 'work' | pinned to tree's profile; 3/3 pass |
| Pop-out / watch window | URL had no profile → primary backend, blank session | `&profile=` carried; session-windows tests pass |
| Dashboard row delete/rename/export/read | sent to management profile → false `already_absent` | rowProfile(id) → owning profile; SessionsPage test pass |
| Tile transcript refresh | unscoped read; sibling-profile state.db not watched | ownerRoute-scoped; 16 change_watcher tests pass |
| Profile w/ remote override | forced-local child → "Profile no longer exists" | override authoritative; connection-registry tests pass |
Desktop vitest 183/183, web 1/1, pytest 16/16, tsc + eslint + ruff clean.

## Credits
@SZWzz (#97042), @StodsEcho5 (#99333), @liuhao1024 (#99387), @DomGrieco (#82794),
@ayushnangia (#89100), reporter @binharry (#79005).
```

Files modified this pass: `apps/desktop/src/app/session/workspace-session-target.ts`, `…/workspace-session-target.test.ts`, `apps/desktop/src/store/profile.ts`, `apps/desktop/src/store/projects.ts`. Worktree `/tmp/salv-desktop-ts` left in place (has two untracked-but-ignored `node_modules` symlinks).

Fixes #79005
Fixes #82768
Fixes #61286

## Infographic

![mux-desktop-ts](https://v3b.fal.media/files/b/0aa8ce73/M5HCNVUWRS0Oj44XYaUou_PcvUIhmJ.png)
