### PR TITLE
fix(mcp): extend stdio-dead-child fast-fail/respawn-retry to resources/prompts handlers

### DIFF
--- a/tests/tools/test_mcp_stdio_fastfail_reconnect_utility_handlers.py
+++ b/tests/tools/test_mcp_stdio_fastfail_reconnect_utility_handlers.py
@@ -1,0 +1,226 @@
+"""Regression tests: the #81995 stdio-dead-child fast-fail/respawn-retry
+protection (already covered for ``tools/call`` in
+tests/tools/test_mcp_stdio_fastfail_reconnect.py) never reached the four
+"generated utility" RPC handlers registered in the same MCP tool namespace:
+``resources/list``, ``resources/read``, ``prompts/list``, ``prompts/get``.
+
+A gateway restart kills every MCP stdio subprocess. Before this fix, a call
+to any of these four RPC types made right after such a restart rode out the
+full ``tool_timeout`` instead of failing fast and auto-recovering, exactly
+reproducing the pre-#81995 bug for these four RPC types while ``tools/call``
+had already been fixed.
+
+Mirrors the fixture shape of test_mcp_stdio_fastfail_reconnect.py (stub
+server + reconnect-event adapter), parameterized over the four handler
+factories and their session RPC method names.
+"""
+
+import asyncio
+import json
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from tools import mcp_tool  # noqa: E402
+
+
+def _install_stub_server(name: str, session_method_name: str, rpc_impl,
+                          *, children_dead, on_reconnect=None):
+    """Fake MCP server with real-bool stdio liveness and a countable
+    reconnect event (mirrors test_mcp_stdio_fastfail_reconnect.py)."""
+    server = MagicMock()
+    server.name = name
+    session = MagicMock()
+    setattr(session, session_method_name, rpc_impl)
+    server.session = session
+
+    ready_flag = threading.Event()
+    ready_flag.set()
+
+    class _ReconnectAdapter:
+        def __init__(self):
+            self.set_calls = 0
+
+        def set(self):
+            self.set_calls += 1
+            if on_reconnect is not None:
+                on_reconnect(server)
+
+    server._reconnect_event = _ReconnectAdapter()
+    server._ready = ready_flag
+    server._is_recycled_stdio.return_value = False
+    server._stdio_children_dead = children_dead
+
+    mcp_tool._servers[name] = server
+    mcp_tool._server_error_counts.pop(name, None)
+    return server
+
+
+def _cleanup(name: str) -> None:
+    mcp_tool._servers.pop(name, None)
+    mcp_tool._server_error_counts.pop(name, None)
+
+
+def _resources_page(items):
+    result = MagicMock()
+    result.resources = items
+    result.next_cursor = None
+    return result
+
+
+def _prompts_page(items):
+    result = MagicMock()
+    result.prompts = items
+    result.next_cursor = None
+    return result
+
+
+def _read_resource_result(text="ok"):
+    result = MagicMock()
+    block = MagicMock()
+    block.text = text
+    block.blob = None
+    result.contents = [block]
+    return result
+
+
+def _get_prompt_result(text="ok"):
+    result = MagicMock()
+    msg = MagicMock()
+    msg.role = "user"
+    msg.content = text
+    result.messages = [msg]
+    result.description = None
+    return result
+
+
+# Each case: (handler_factory_name, session_method_name, args, success_impl,
+#             hanging_impl, assert_success)
+_CASES = [
+    (
+        "_make_list_resources_handler",
+        "list_resources",
+        {},
+        lambda *a, **kw: _resources_page([]),
+        lambda parsed: parsed.get("resources") == [],
+    ),
+    (
+        "_make_read_resource_handler",
+        "read_resource",
+        {"uri": "file:///x"},
+        lambda *a, **kw: _read_resource_result("ok"),
+        lambda parsed: parsed.get("result") == "ok",
+    ),
+    (
+        "_make_list_prompts_handler",
+        "list_prompts",
+        {},
+        lambda *a, **kw: _prompts_page([]),
+        lambda parsed: parsed.get("prompts") == [],
+    ),
+    (
+        "_make_get_prompt_handler",
+        "get_prompt",
+        {"name": "p1"},
+        lambda *a, **kw: _get_prompt_result("ok"),
+        lambda parsed: parsed.get("messages") == [{"role": "user", "content": "ok"}],
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "factory_name,method_name,args,success_impl,assert_success", _CASES,
+)
+def test_precall_dead_children_respawn_and_retry(
+    monkeypatch, tmp_path, factory_name, method_name, args, success_impl,
+    assert_success,
+):
+    """Dead-at-call-time subprocess: respawn, retry once, clean result —
+    no error reaches the model, for every utility RPC type."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    handler_factory = getattr(mcp_tool, factory_name)
+
+    called = {"n": 0}
+    alive = {"v": False}
+
+    async def _rpc(*a, **kw):
+        called["n"] += 1
+        return success_impl(*a, **kw)
+
+    def _respawn(server):
+        alive["v"] = True
+        new_session = MagicMock()
+        setattr(new_session, method_name, _rpc)
+        server.session = new_session
+        server._ready.set()
+
+    name = f"srv-dead-{method_name}"
+    server = _install_stub_server(
+        name, method_name, _rpc,
+        children_dead=lambda: not alive["v"],
+        on_reconnect=_respawn,
+    )
+    mcp_tool._ensure_mcp_loop()
+    try:
+        handler = handler_factory(name, 10.0)
+        parsed = json.loads(handler(dict(args)))
+        assert "error" not in parsed, parsed
+        assert assert_success(parsed), parsed
+        assert server._reconnect_event.set_calls == 1
+        assert called["n"] == 1, "exactly one RPC — the retry after respawn"
+        assert mcp_tool._server_error_counts.get(name, 0) == 0
+    finally:
+        _cleanup(name)
+
+
+@pytest.mark.parametrize(
+    "factory_name,method_name,args,success_impl,assert_success", _CASES,
+)
+def test_midcall_child_exit_respawn_and_retry(
+    monkeypatch, tmp_path, factory_name, method_name, args, success_impl,
+    assert_success,
+):
+    """Subprocess dies while the RPC is in flight → respawn and retry once,
+    for every utility RPC type."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    handler_factory = getattr(mcp_tool, factory_name)
+
+    alive = {"v": True}
+
+    async def _hanging_rpc(*a, **kw):
+        await asyncio.sleep(30)
+
+    async def _good_rpc(*a, **kw):
+        return success_impl(*a, **kw)
+
+    async def _watch_children():
+        while alive["v"]:
+            await asyncio.sleep(0.05)
+
+    def _respawn(server):
+        alive["v"] = True
+        new_session = MagicMock()
+        setattr(new_session, method_name, _good_rpc)
+        server.session = new_session
+        server._ready.set()
+
+    name = f"srv-midcall-{method_name}"
+    server = _install_stub_server(
+        name, method_name, _hanging_rpc,
+        children_dead=lambda: not alive["v"],
+        on_reconnect=_respawn,
+    )
+    server._watch_stdio_children = _watch_children
+    mcp_tool._ensure_mcp_loop()
+    try:
+        handler = handler_factory(name, 10.0)
+        alive["v"] = False
+        parsed = json.loads(handler(dict(args)))
+        assert "error" not in parsed, parsed
+        assert assert_success(parsed), parsed
+        assert server._reconnect_event.set_calls == 1
+    finally:
+        _cleanup(name)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5381,6 +5381,73 @@ def _handle_stdio_child_exited_and_retry(
     )
 
 
+async def _run_mcp_rpc_with_stdio_watch(
+    server: Any, server_name: str, rpc_coro_factory, op_description: str,
+):
+    """Await an MCP RPC, guarded against a dead/dying stdio child (#81995).
+
+    Mirrors the fast-fail-before-call + watch-race-during-call protection
+    ``_make_tool_handler`` applies to ``tools/call``: a stdio subprocess
+    killed by a gateway restart must fail the call immediately (or as soon
+    as the death is observed mid-call) instead of riding out the full tool
+    timeout on a transport nobody will ever answer. Raises
+    ``_StdioChildExited`` on either detection path so the caller's
+    ``_handle_stdio_child_exited_and_retry`` can respawn and retry once.
+
+    ``rpc_coro_factory`` is called (not awaited) here so a fresh coroutine
+    is created only after the pre-call dead-child check passes.
+    """
+    _stdio_dead = getattr(server, "_stdio_children_dead", None)
+    # callable() + real-bool result: MagicMock attributes return truthy
+    # Mocks, which would spuriously trip the fast-fail.
+    if (
+        callable(_stdio_dead)
+        and isinstance(_stdio_dead_result := _stdio_dead(), bool)
+        and _stdio_dead_result
+    ):
+        raise _StdioChildExited(
+            f"MCP stdio subprocess for '{server_name}' had already exited "
+            f"when the {op_description} call was dispatched"
+        )
+
+    _call_coro = rpc_coro_factory()
+    _watch_children = getattr(server, "_watch_stdio_children", None)
+    _watch_ok = (
+        _watch_children is not None
+        and inspect.iscoroutinefunction(_watch_children)
+        and asyncio.iscoroutine(_call_coro)
+    )
+    if not _watch_ok:
+        # Stubbed sessions (MagicMock in tests) return a non-awaitable, or
+        # there is no child-watcher to race against: plain await is exactly
+        # the pre-#81995 semantics.
+        return await _call_coro if asyncio.iscoroutine(_call_coro) else _call_coro
+
+    rpc_task = asyncio.ensure_future(_call_coro)
+    watch_task = asyncio.ensure_future(_watch_children())
+    try:
+        done, _pending = await asyncio.wait(
+            {rpc_task, watch_task}, return_when=asyncio.FIRST_COMPLETED,
+        )
+        if watch_task in done and not rpc_task.done():
+            rpc_task.cancel()
+            # Same stale-session problem as the pre-call gate above: the
+            # subprocess died mid-call but nothing clears server.session, so
+            # without a reconnect the server would stay dead until the idle
+            # keepalive probe notices. The handler's respawn-and-retry path
+            # owns the reconnect signal.
+            raise _StdioChildExited(
+                f"MCP stdio subprocess for '{server_name}' exited "
+                f"mid-{op_description} call"
+            )
+        return await rpc_task
+    finally:
+        watch_task.cancel()
+        if not rpc_task.done():
+            rpc_task.cancel()
+        await asyncio.gather(rpc_task, watch_task, return_exceptions=True)
+
+
 # Exact raw server names whose ``supports_parallel_tool_calls`` config is True.
 # Raw identity matters: distinct names such as ``foo-bar`` and ``foo_bar`` both
 # sanitize to ``foo_bar`` but must not share policy.
@@ -6589,8 +6656,12 @@ def _make_list_resources_handler(server_name: str, tool_timeout: float):
         async def _call():
             _mark_server_call_started(server)
             async with server._rpc_lock:
-                all_resources = await _paginate_full_list(
-                    server.session.list_resources, "resources", server_name
+                all_resources = await _run_mcp_rpc_with_stdio_watch(
+                    server, server_name,
+                    lambda: _paginate_full_list(
+                        server.session.list_resources, "resources", server_name
+                    ),
+                    "resources/list",
                 )
             resources = []
             for r in all_resources:
@@ -6617,6 +6688,11 @@ def _make_list_resources_handler(server_name: str, tool_timeout: float):
         except InterruptedError:
             return _interrupted_call_result()
         except Exception as exc:
+            recovered = _handle_stdio_child_exited_and_retry(
+                server_name, exc, _call_once, "resources/list",
+            )
+            if recovered is not None:
+                return recovered
             recovered = _handle_auth_error_and_retry(
                 server_name, exc, _call_once, "resources/list",
             )
@@ -6652,7 +6728,11 @@ def _make_read_resource_handler(server_name: str, tool_timeout: float):
         async def _call():
             _mark_server_call_started(server)
             async with server._rpc_lock:
-                result = await server.session.read_resource(uri)
+                result = await _run_mcp_rpc_with_stdio_watch(
+                    server, server_name,
+                    lambda: server.session.read_resource(uri),
+                    "resources/read",
+                )
             # read_resource returns ReadResourceResult with .contents list
             parts: List[str] = []
             contents = result.contents if hasattr(result, "contents") else []
@@ -6678,6 +6758,11 @@ def _make_read_resource_handler(server_name: str, tool_timeout: float):
         except InterruptedError:
             return _interrupted_call_result()
         except Exception as exc:
+            recovered = _handle_stdio_child_exited_and_retry(
+                server_name, exc, _call_once, "resources/read",
+            )
+            if recovered is not None:
+                return recovered
             recovered = _handle_auth_error_and_retry(
                 server_name, exc, _call_once, "resources/read",
             )
@@ -6709,8 +6794,12 @@ def _make_list_prompts_handler(server_name: str, tool_timeout: float):
         async def _call():
             _mark_server_call_started(server)
             async with server._rpc_lock:
-                all_prompts = await _paginate_full_list(
-                    server.session.list_prompts, "prompts", server_name
+                all_prompts = await _run_mcp_rpc_with_stdio_watch(
+                    server, server_name,
+                    lambda: _paginate_full_list(
+                        server.session.list_prompts, "prompts", server_name
+                    ),
+                    "prompts/list",
                 )
             prompts = []
             for p in all_prompts:
@@ -6739,6 +6828,11 @@ def _make_list_prompts_handler(server_name: str, tool_timeout: float):
         except InterruptedError:
             return _interrupted_call_result()
         except Exception as exc:
+            recovered = _handle_stdio_child_exited_and_retry(
+                server_name, exc, _call_once, "prompts/list",
+            )
+            if recovered is not None:
+                return recovered
             recovered = _handle_auth_error_and_retry(
                 server_name, exc, _call_once, "prompts/list",
             )
@@ -6775,7 +6869,11 @@ def _make_get_prompt_handler(server_name: str, tool_timeout: float):
         async def _call():
             _mark_server_call_started(server)
             async with server._rpc_lock:
-                result = await server.session.get_prompt(name, arguments=arguments)
+                result = await _run_mcp_rpc_with_stdio_watch(
+                    server, server_name,
+                    lambda: server.session.get_prompt(name, arguments=arguments),
+                    "prompts/get",
+                )
             # GetPromptResult has .messages list
             messages = []
             for msg in (result.messages if hasattr(result, "messages") else []):
@@ -6804,6 +6902,11 @@ def _make_get_prompt_handler(server_name: str, tool_timeout: float):
         except InterruptedError:
             return _interrupted_call_result()
         except Exception as exc:
+            recovered = _handle_stdio_child_exited_and_retry(
+                server_name, exc, _call_once, "prompts/get",
+            )
+            if recovered is not None:
+                return recovered
             recovered = _handle_auth_error_and_retry(
                 server_name, exc, _call_once, "prompts/get",
             )


### PR DESCRIPTION
## Summary

#100987 (merged just before this branch was cut) added a fast-fail-before-call + watch-race-during-call guard to `tools/call` so a gateway restart — which kills every MCP stdio subprocess — fails a call immediately and transparently respawns + retries once, instead of riding out the full `tool_timeout` on a transport nobody will ever answer.

That guard only reached `_make_tool_handler` (`tools/call`). The four "generated utility" handlers registered in the same tool namespace — `resources/list`, `resources/read`, `prompts/list`, `prompts/get` — had none of it: no fast-fail gate before the call, no watch race during the call, and their `except` blocks never called `_handle_stdio_child_exited_and_retry`.

**Concrete failure scenario:** a gateway restart kills every MCP stdio subprocess (the exact scenario #100987's own description centers on — "Cron runs spanning a restart lose tool calls silently"). A cron job or live session that calls `read_resource`/`list_prompts`/`get_prompt`/`list_resources` right after such a restart hangs out the full `tool_timeout` instead of failing fast and auto-recovering, reproducing the pre-#100987 bug for these four RPC types while `tools/call` had already been fixed.

## Fix

Extracted the fast-fail-gate + watch-race logic that `_make_tool_handler` already has inline into a shared `_run_mcp_rpc_with_stdio_watch()` helper, and wired it — plus `_handle_stdio_child_exited_and_retry` — into all four utility handlers, mirroring `_make_tool_handler`'s exact ordering (stdio-exit recovery is checked before auth-error and session-expired recovery in the except chain).

`_make_tool_handler`'s own inline copy of this logic is left completely untouched — this only adds a shared helper used by the four siblings, with zero risk to the existing, tested `tools/call` path.

## Tests

Added `tests/tools/test_mcp_stdio_fastfail_reconnect_utility_handlers.py`: 8 regression tests (precall-dead-child + midcall-child-exit scenarios, parameterized over all 4 handlers), mirroring the fixture shape of the existing `test_mcp_stdio_fastfail_reconnect.py`.

**Mutation-verified**: reverting `tools/mcp_tool.py` makes all 8 new tests fail with the exact pre-fix symptom (`TimeoutError: MCP call timed out after 10.0s`, not a clean respawn+retry).

Ran the full MCP test cluster (`tests/tools/test_mcp_*.py` + `test_refresh_agent_mcp_tools.py` + `test_setup_mcp_tool.py`, 631 tests) — all pass, no regressions.

## Scope note

While reading `_make_tool_handler`, I noticed its RPC is also wrapped in `_track_inflight_rpc(server, server_name, op)` (a separate #48069 mechanism: converts a reconnect-teardown cancel into a clean retryable error). That context manager's own docstring says "every user-visible request family wraps its RPC in this context," but `tools/call` is in fact its only call site — the four utility handlers don't have it either. This is a different bug class (teardown-race handling, not stdio-dead-child fast-fail) from what this PR fixes, so it's intentionally left out of scope here; flagging it in case it's worth a separate, narrowly-scoped follow-up.

## Competitor check

Searched `gh pr list --state all` across several keyword combinations ("mcp stdio retry", "resources/list prompts/get stdio", "list_resources read_resource stdio", "_handle_stdio_child_exited_and_retry", "get_prompt list_prompts respawn"). The only hits are #100814/#100987 themselves (the already-merged PR this one extends, confirmed via `gh pr diff 100987` to touch only `tools/call`) and #94184 (merged, "recover poisoned connections + fail fast on dead stdio transports" — confirmed via diff to not touch any of the four utility handlers either). No open or closed PR covers this gap.