### PR TITLE
feat(a2a): load bearer credentials from secure token files

### DIFF
--- a/plugins/platforms/a2a/README.md
+++ b/plugins/platforms/a2a/README.md
@@ -24,10 +24,13 @@ gateway:
 a2a_agents:
   researcher:
     url: "http://localhost:9999"
-    auth: { type: bearer, token: "sk-..." }
+    auth: { type: bearer, token_file: "~/.hermes/auth/researcher.token" }
     timeout: 120
     capabilities: [web_search, research]
 ```
+
+Bearer files must be regular files readable only by their owner (`0600`).
+Inline `token` remains supported, but it cannot be combined with `token_file`.
 
 ## Outbound — call other agents
 

--- a/plugins/platforms/a2a/tools.py
+++ b/plugins/platforms/a2a/tools.py
@@ -13,7 +13,7 @@ Peers are resolved from config.yaml under ``a2a_agents``::
     a2a_agents:
       researcher:
         url: "http://localhost:9999"
-        auth: { type: bearer, token: "sk-..." }
+        auth: { type: bearer, token_file: "~/.hermes/auth/researcher.token" }
         timeout: 120
         capabilities: [web_search, research]
 
@@ -25,9 +25,12 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import stat
 import urllib.error
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
 from typing import Any, Optional, TypedDict
 
 from . import protocol, security
@@ -69,8 +72,37 @@ def _resolve_peer(agent: str) -> Optional[dict]:
 
 
 def _auth_header(auth: dict) -> dict:
-    if auth and auth.get("type") == "bearer" and auth.get("token"):
-        return {"Authorization": f"Bearer {auth['token']}"}
+    if not auth or auth.get("type") != "bearer":
+        return {}
+    inline = str(auth.get("token") or "").strip()
+    token_file = str(auth.get("token_file") or "").strip()
+    if inline and token_file:
+        raise ValueError("bearer auth cannot combine token and token_file")
+    if token_file:
+        path = Path(token_file).expanduser()
+        descriptor: int | None = None
+        try:
+            flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+            descriptor = os.open(path, flags)
+            file_stat = os.fstat(descriptor)
+            if not stat.S_ISREG(file_stat.st_mode) or file_stat.st_mode & 0o077:
+                raise ValueError("bearer token_file must be a regular file with mode 0600")
+            with os.fdopen(descriptor, "r", encoding="utf-8") as handle:
+                descriptor = None
+                token = handle.read(4097).strip()
+        except ValueError:
+            raise
+        except (OSError, UnicodeError) as exc:
+            raise ValueError("bearer token_file is unreadable") from exc
+        finally:
+            if descriptor is not None:
+                os.close(descriptor)
+        token_bytes = token.encode("utf-8")
+        if len(token_bytes) < 32 or len(token_bytes) > 4096 or any(char.isspace() for char in token):
+            raise ValueError("bearer token_file must contain one bearer value of at least 32 bytes")
+        return {"Authorization": f"Bearer {token}"}
+    if inline:
+        return {"Authorization": f"Bearer {inline}"}
     return {}
 
 

--- a/plugins/platforms/a2a/tools.py
+++ b/plugins/platforms/a2a/tools.py
@@ -82,14 +82,19 @@ def _auth_header(auth: dict) -> dict:
         path = Path(token_file).expanduser()
         descriptor: int | None = None
         try:
-            flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+            no_follow = getattr(os, "O_NOFOLLOW", None)
+            if no_follow is None:
+                raise ValueError("bearer token_file secure no-follow open is unavailable")
+            flags = os.O_RDONLY | no_follow
             descriptor = os.open(path, flags)
             file_stat = os.fstat(descriptor)
             if not stat.S_ISREG(file_stat.st_mode) or file_stat.st_mode & 0o077:
                 raise ValueError("bearer token_file must be a regular file with mode 0600")
+            if file_stat.st_size > 4098:
+                raise ValueError("bearer token_file must contain at most 4096 bytes")
             with os.fdopen(descriptor, "r", encoding="utf-8") as handle:
                 descriptor = None
-                token = handle.read(4097).strip()
+                token = handle.read().strip()
         except ValueError:
             raise
         except (OSError, UnicodeError) as exc:
@@ -98,8 +103,12 @@ def _auth_header(auth: dict) -> dict:
             if descriptor is not None:
                 os.close(descriptor)
         token_bytes = token.encode("utf-8")
-        if len(token_bytes) < 32 or len(token_bytes) > 4096 or any(char.isspace() for char in token):
+        if len(token_bytes) < 32:
             raise ValueError("bearer token_file must contain one bearer value of at least 32 bytes")
+        if len(token_bytes) > 4096:
+            raise ValueError("bearer token_file must contain at most 4096 bytes")
+        if any(char.isspace() for char in token):
+            raise ValueError("bearer token_file must contain one bearer value")
         return {"Authorization": f"Bearer {token}"}
     if inline:
         return {"Authorization": f"Bearer {inline}"}

--- a/tests/plugins/test_a2a_token_file.py
+++ b/tests/plugins/test_a2a_token_file.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from pathlib import Path
+import os
+
+import pytest
+
+from plugins.platforms.a2a.tools import _auth_header
+
+
+def test_1221_bearer_token_file_is_loaded_without_putting_value_in_config(tmp_path: Path) -> None:
+    token_file = tmp_path / "arthur-to-abel.token"
+    token_file.write_text("peer-secret-value-0123456789abcdef\n", encoding="utf-8")
+    token_file.chmod(0o600)
+
+    assert _auth_header({"type": "bearer", "token_file": str(token_file)}) == {
+        "Authorization": "Bearer peer-secret-value-0123456789abcdef"
+    }
+
+
+def test_1221_bearer_token_file_fails_closed_on_missing_or_permissive_file(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.token"
+    with pytest.raises(ValueError, match="token_file"):
+        _auth_header({"type": "bearer", "token_file": str(missing)})
+
+    token_file = tmp_path / "permissive.token"
+    token_file.write_text("must-not-leak", encoding="utf-8")
+    token_file.chmod(0o644)
+    with pytest.raises(ValueError, match="mode 0600") as exc:
+        _auth_header({"type": "bearer", "token_file": str(token_file)})
+    assert "must-not-leak" not in str(exc.value)
+
+
+def test_1221_inline_and_file_bearers_cannot_be_combined(tmp_path: Path) -> None:
+    token_file = tmp_path / "peer.token"
+    token_file.write_text("file-value", encoding="utf-8")
+    token_file.chmod(0o600)
+    with pytest.raises(ValueError, match="cannot combine"):
+        _auth_header({"type": "bearer", "token": "inline-value", "token_file": str(token_file)})
+
+
+def test_1221_bearer_token_file_rejects_short_material(tmp_path: Path) -> None:
+    token_file = tmp_path / "short.token"
+    token_file.write_text("short", encoding="utf-8")
+    token_file.chmod(0o600)
+    with pytest.raises(ValueError, match="at least 32 bytes"):
+        _auth_header({"type": "bearer", "token_file": str(token_file)})
+
+
+@pytest.mark.skipif(not hasattr(os, "O_NOFOLLOW"), reason="O_NOFOLLOW unavailable")
+def test_1221_bearer_token_file_rejects_symlink(tmp_path: Path) -> None:
+    target = tmp_path / "target.token"
+    target.write_text("peer-secret-value-0123456789abcdef", encoding="utf-8")
+    target.chmod(0o600)
+    link = tmp_path / "linked.token"
+    link.symlink_to(target)
+    with pytest.raises(ValueError, match="unreadable"):
+        _auth_header({"type": "bearer", "token_file": str(link)})

--- a/tests/plugins/test_a2a_token_file.py
+++ b/tests/plugins/test_a2a_token_file.py
@@ -47,8 +47,9 @@ def test_1221_bearer_token_file_rejects_short_material(tmp_path: Path) -> None:
         _auth_header({"type": "bearer", "token_file": str(token_file)})
 
 
-@pytest.mark.skipif(not hasattr(os, "O_NOFOLLOW"), reason="O_NOFOLLOW unavailable")
 def test_1221_bearer_token_file_rejects_symlink(tmp_path: Path) -> None:
+    if not hasattr(os, "O_NOFOLLOW"):
+        pytest.skip("O_NOFOLLOW unavailable")
     target = tmp_path / "target.token"
     target.write_text("peer-secret-value-0123456789abcdef", encoding="utf-8")
     target.chmod(0o600)
@@ -56,3 +57,22 @@ def test_1221_bearer_token_file_rejects_symlink(tmp_path: Path) -> None:
     link.symlink_to(target)
     with pytest.raises(ValueError, match="unreadable"):
         _auth_header({"type": "bearer", "token_file": str(link)})
+
+
+def test_1221_bearer_token_file_fails_closed_without_no_follow(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    token_file = tmp_path / "peer.token"
+    token_file.write_text("peer-secret-value-0123456789abcdef", encoding="utf-8")
+    token_file.chmod(0o600)
+    monkeypatch.delattr(os, "O_NOFOLLOW", raising=False)
+    with pytest.raises(ValueError, match="secure no-follow"):
+        _auth_header({"type": "bearer", "token_file": str(token_file)})
+
+
+def test_1221_bearer_token_file_rejects_unread_trailing_content(tmp_path: Path) -> None:
+    token_file = tmp_path / "oversized.token"
+    token_file.write_text("x" * 4096 + "\nextra", encoding="utf-8")
+    token_file.chmod(0o600)
+    with pytest.raises(ValueError, match="at most 4096 bytes"):
+        _auth_header({"type": "bearer", "token_file": str(token_file)})

--- a/tests/plugins/test_a2a_token_file.py
+++ b/tests/plugins/test_a2a_token_file.py
@@ -9,7 +9,7 @@ from plugins.platforms.a2a.tools import _auth_header
 
 
 def test_1221_bearer_token_file_is_loaded_without_putting_value_in_config(tmp_path: Path) -> None:
-    token_file = tmp_path / "arthur-to-abel.token"
+    token_file = tmp_path / "sender-to-receiver.token"
     token_file.write_text("peer-secret-value-0123456789abcdef\n", encoding="utf-8")
     token_file.chmod(0o600)
 


### PR DESCRIPTION
## Summary
- add optional `token_file` support for outbound A2A bearer authentication
- require a regular mode-0600 file opened without following symlinks
- reject missing, permissive, short, oversized, whitespace-containing, or unreadable bearer material without exposing values

## Verification
- `scripts/run_tests.sh tests/plugins/test_a2a_token_file.py` — 7 passed
