### PR TITLE
fix(skills): copy bundled/optional skills writable regardless of sour…

### DIFF
--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -15,6 +15,7 @@ from tools.skills_sync import (
     _write_manifest,
     _discover_bundled_skills,
     _compute_relative_dest,
+    _copy_skill_writable,
     _dir_hash,
     sync_skills,
     reset_bundled_skill,
@@ -520,6 +521,111 @@ class TestSyncSkills:
             result2 = sync_skills(quiet=True)
             assert "new-skill" in result2["copied"]
             assert (skills_dir / "category" / "new-skill" / "SKILL.md").exists()
+
+
+class TestCopySkillWritable:
+    """#101226: a bundled/optional skill copied from an immutable source (Nix
+    store, Homebrew Cellar -- dirs r-xr-xr-x, files r--r--r--) must land
+    owner-writable in ~/.hermes/skills/, not inherit the source's read-only
+    mode via shutil.copytree's default copy2 behavior."""
+
+    @staticmethod
+    def _make_readonly_source(root: Path) -> Path:
+        """Build a small skill tree and chmod it read-only, dirs and files
+        alike -- the same shape a Nix-store bundled source has."""
+        src = root / "ro-source" / "some-skill"
+        nested = src / "references"
+        nested.mkdir(parents=True)
+        (src / "SKILL.md").write_text("# read-only source\n")
+        (nested / "ref.md").write_text("# nested ref\n")
+
+        ro_dir = (
+            stat.S_IRUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP
+            | stat.S_IROTH | stat.S_IXOTH
+        )
+        os.chmod(nested / "ref.md", stat.S_IREAD)
+        os.chmod(src / "SKILL.md", stat.S_IREAD)
+        os.chmod(nested, ro_dir)
+        os.chmod(src, ro_dir)
+        return src
+
+    @staticmethod
+    def _assert_owner_writable(path: Path) -> None:
+        mode = stat.S_IMODE(path.stat().st_mode)
+        assert mode & stat.S_IWUSR, f"{path} is not owner-writable (mode {oct(mode)})"
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits are platform-specific")
+    def test_copy_from_readonly_source_is_owner_writable(self, tmp_path):
+        src = self._make_readonly_source(tmp_path)
+        dest = tmp_path / "dest" / "some-skill"
+
+        try:
+            _copy_skill_writable(src, dest)
+
+            # Content came across correctly.
+            assert (dest / "SKILL.md").read_text() == "# read-only source\n"
+            assert (dest / "references" / "ref.md").read_text() == "# nested ref\n"
+
+            # Every file and directory in the copy is owner-writable,
+            # regardless of the source's mode -- so it can be edited AND
+            # later removed with a plain shutil.rmtree, no special helper.
+            self._assert_owner_writable(dest)
+            self._assert_owner_writable(dest / "SKILL.md")
+            self._assert_owner_writable(dest / "references")
+            self._assert_owner_writable(dest / "references" / "ref.md")
+
+            # Prove it's not just chmod-in-place: a plain rmtree (no
+            # _rmtree_writable) must now succeed on the copy.
+            shutil.rmtree(dest)
+            assert not dest.exists()
+        finally:
+            for p in (src / "references", src):
+                if p.exists():
+                    os.chmod(p, stat.S_IRWXU)
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits are platform-specific")
+    def test_fresh_sync_from_readonly_bundled_source_is_editable(self, tmp_path):
+        """End-to-end: sync_skills() against a read-only-source bundled dir
+        (the Nix/Homebrew install shape) must not leave the user unable to
+        edit or reset the skill it just seeded."""
+        bundled = tmp_path / "bundled_skills"
+        skill = bundled / "some-skill"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text("# bundled\n")
+
+        ro_dir = (
+            stat.S_IRUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP
+            | stat.S_IROTH | stat.S_IXOTH
+        )
+        os.chmod(skill / "SKILL.md", stat.S_IREAD)
+        os.chmod(skill, ro_dir)
+
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+
+        try:
+            from contextlib import ExitStack
+            with ExitStack() as stack:
+                stack.enter_context(patch("tools.skills_sync._get_bundled_dir", return_value=bundled))
+                stack.enter_context(patch(
+                    "tools.skills_sync._get_optional_dir",
+                    return_value=bundled.parent / "optional-skills",
+                ))
+                stack.enter_context(patch("tools.skills_sync.SKILLS_DIR", skills_dir))
+                stack.enter_context(patch("tools.skills_sync.MANIFEST_FILE", manifest_file))
+                result = sync_skills(quiet=True)
+
+            assert "some-skill" in result["copied"]
+            dest = skills_dir / "some-skill"
+            self._assert_owner_writable(dest)
+            self._assert_owner_writable(dest / "SKILL.md")
+
+            # The curator/user can actually edit the synced copy now.
+            (dest / "SKILL.md").write_text("# edited\n")
+            assert (dest / "SKILL.md").read_text() == "# edited\n"
+        finally:
+            if skill.exists():
+                os.chmod(skill, stat.S_IRWXU)
 
 
 class TestGetBundledDir:

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -431,7 +431,7 @@ def restore_official_optional_skill(name: str, *, restore: bool = False) -> dict
                 backed_up.append(_move_to_restore_backup(dest, backup_root))
             if not dest.exists():
                 dest.parent.mkdir(parents=True, exist_ok=True)
-                shutil.copytree(src, dest)
+                _copy_skill_writable(src, dest)
                 restored.append(folder_name)
         elif not canonical_ok:
             continue
@@ -868,7 +868,7 @@ def sync_skills(quiet: bool = False) -> dict:
                         )
                 else:
                     dest.parent.mkdir(parents=True, exist_ok=True)
-                    shutil.copytree(skill_src, dest)
+                    _copy_skill_writable(skill_src, dest)
                     copied.append(skill_name)
                     manifest[skill_name] = bundled_hash
                     if not quiet:
@@ -924,7 +924,7 @@ def sync_skills(quiet: bool = False) -> dict:
                         _rmtree_writable(backup)
                     shutil.move(str(dest), str(backup))
                     try:
-                        shutil.copytree(skill_src, dest)
+                        _copy_skill_writable(skill_src, dest)
                         manifest[skill_name] = bundled_hash
                         updated.append(skill_name)
                         if not quiet:
@@ -1008,6 +1008,32 @@ def sync_skills(quiet: bool = False) -> dict:
         # callers report "opted out" rather than a normal full sync.
         "skipped_opt_out": essential_only,
     }
+
+
+def _copy_skill_writable(src: Path, dest: Path) -> None:
+    """Copy a skill directory, dropping the source's permissions.
+
+    Bundled/optional-skill sources may be immutable (Nix store, Homebrew
+    Cellar) where directories are ``r-xr-xr-x`` and files ``r--r--r--``.
+    ``shutil.copytree`` uses ``copy2`` by default, which preserves that mode
+    (and mtime) on the synced copy -- making it unwritable to the user and
+    the curator, and leaving ``diff_bundled_skill``/``reset_bundled_skill``
+    nothing to diff or reset. The unwritable tree also used to break cleanup
+    until ``_rmtree_writable`` was added for that side (#34860, #34972);
+    fixing permissions here, at the copy, means an unwritable tree is never
+    created in the first place. See #101226.
+    """
+    import stat
+
+    shutil.copytree(src, dest)
+    for p in [dest, *dest.rglob("*")]:
+        try:
+            mode = p.stat().st_mode | stat.S_IWUSR
+            if p.is_dir():
+                mode |= stat.S_IXUSR
+            p.chmod(mode)
+        except OSError:
+            pass
 
 
 def _rmtree_writable(path: Path) -> None:


### PR DESCRIPTION
…ce permissions

sync_skills() and restore_official_optional_skill() copy skills into ~/.hermes/skills/ with shutil.copytree(), which (via copy2) preserves the source's mode bits. On any install where HERMES_BUNDLED_SKILLS or HERMES_OPTIONAL_SKILLS points into an immutable package source -- Nix store, Homebrew Cellar -- the bundled tree is itself read-only (r-xr-xr-x dirs, r--r--r-- files), so every synced copy lands unwritable too. The curator and the user can never edit a bundled skill on those installs (list_user_modified_bundled_skills/diff_bundled_skill/ reset_bundled_skill have nothing to diff or reset), and an agent asked to fix a wrong instruction in a bundled skill gets EACCES.

This is the same root cause that already produced two closed bugs fixed downstream of it instead of at it: #34860 (stale .bak dirs because rmtree fails on read-only files) and #34972 (skills reset --restore corrupts the manifest on the same rmtree failure). Both were patched by making removal tolerate a read-only tree (_rmtree_writable); the copy that creates the read-only tree in the first place was never fixed, so the same class of bug could keep recurring at new call sites.

Add _copy_skill_writable(), a copytree wrapper that chmods every file and directory in the copy owner-writable afterward, and use it at all three sites that copy a skill from a possibly-immutable source: sync_skills()'s new-skill seed and existing-skill update paths, and restore_official_optional_skill()'s restore path (the issue named the first two; the third has the identical bundled/optional-source read-only exposure and was found while fixing the other two).

Added tests/tools/test_skills_sync.py::TestCopySkillWritable, covering both a direct unit test of the new helper against a read-only source tree and an end-to-end sync_skills() run against a read-only bundled directory, asserting the synced copy is owner-writable, editable, and removable with a plain shutil.rmtree (no special helper needed).

Fixes #101226

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

