### PR TITLE
fix(gateway): keep the /loop --until judge inside the caller's profile scope

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -24122,8 +24122,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return
 
         # The --until judge is a sync aux-LLM call — keep it off the event loop.
-        decision = await asyncio.get_running_loop().run_in_executor(
-            None, mgr.complete_tick, final_response or ""
+        # _run_in_executor_with_context (not bare run_in_executor): the profile
+        # secret scope and auxiliary runtime context are contextvars, and a
+        # default-executor hop would drop them — aux-client provider
+        # resolution would then read credentials unscoped, which under
+        # multiplexing silently falls back to the default profile's raw
+        # process env instead of this session's own profile (same pattern as
+        # the /goal judge a few lines up, and compression in
+        # slash_commands.py).
+        decision = await self._run_in_executor_with_context(
+            mgr.complete_tick, final_response or "",
         )
         msg = decision.get("message") or ""
         if msg and source is not None:

--- a/tests/gateway/test_loop_command.py
+++ b/tests/gateway/test_loop_command.py
@@ -1,5 +1,6 @@
 """Gateway /loop command tests — dispatch, routing capture, mid-run guard."""
 
+import contextvars
 import logging
 import time
 from unittest.mock import AsyncMock, Mock
@@ -146,6 +147,61 @@ async def test_post_turn_loop_completion_noop_without_inflight_tick(loop_env):
     reloaded = loops.load_loop("sid-gateway-loop")
     assert reloaded.status == "active"
     assert reloaded.ticks_fired == 0
+
+
+_loop_ctx_probe: contextvars.ContextVar = contextvars.ContextVar(
+    "_loop_ctx_probe", default="unset"
+)
+
+
+@pytest.mark.asyncio
+async def test_post_turn_loop_completion_until_judge_preserves_caller_context(
+    loop_env, monkeypatch,
+):
+    """The --until judge (mgr.complete_tick -> judge_goal) must run inside the
+    caller's contextvars, not a fresh/empty executor Context.
+
+    Under gateway.multiplex_profiles the profile secret scope and HERMES_HOME
+    override are ContextVars installed per-turn by _profile_runtime_scope. A
+    bare run_in_executor hop starts with an empty Context, so get_secret()
+    inside the judge's aux-LLM call would read the wrong profile's (or the
+    default profile's raw process env) credentials instead of this session's
+    own — a cross-profile credential leak, not merely a failure.
+    """
+    from hermes_cli import goals as goals_module
+
+    seen = {}
+
+    def _fake_judge_goal(goal, last_response, **kwargs):
+        seen["value"] = _loop_ctx_probe.get()
+        return ("continue", "still working", False, None, False)
+
+    monkeypatch.setattr(goals_module, "judge_goal", _fake_judge_goal)
+
+    runner = _make_runner()
+    await GatewayRunner._handle_loop_command(
+        runner, _make_event("/loop 5m poll CI --until done"),
+    )
+
+    mgr = loops.LoopManager(session_id="sid-gateway-loop")
+    mgr.state.next_due_at = time.time() - 1
+    assert mgr.fire_tick() is not None
+
+    token = _loop_ctx_probe.set("caller-scoped-value")
+    try:
+        await GatewayRunner._post_turn_loop_completion(
+            runner,
+            session_entry=_FakeSessionEntry(),
+            source=None,
+            final_response="CI is still running, not done yet.",
+        )
+    finally:
+        _loop_ctx_probe.reset(token)
+
+    assert seen.get("value") == "caller-scoped-value", (
+        "the --until judge ran outside the caller's Context — a bare "
+        "run_in_executor hop drops profile-scoped contextvars"
+    )
 
 
 def test_streamed_already_sent_none_recovers_text_for_hooks():


### PR DESCRIPTION
## Summary

`_post_turn_loop_completion` offloads `mgr.complete_tick()` — the `/loop --until` judge, which reuses `judge_goal()`, the same sync aux-LLM call `evaluate_after_turn`'s `/goal` judge makes a few lines up in the same file — onto a bare `asyncio.get_running_loop().run_in_executor(None, ...)` worker:

```python
decision = await asyncio.get_running_loop().run_in_executor(
    None, mgr.complete_tick, final_response or ""
)
```

Under `gateway.multiplex_profiles` the profile secret scope and `HERMES_HOME` override are `ContextVars` installed per-turn by `_profile_runtime_scope`. A bare executor hop starts with an **empty Context**, so `get_secret(<PROVIDER>_API_KEY)` inside the judge's aux-LLM call raises `UnscopedSecretError`. `agent/auxiliary_client.py`'s `_scoped_key_env()` catches that and silently falls back to raw `os.getenv(name)` — for a secondary profile, that reads the **default profile's** provider API key out of the shared process environment.

Net effect: a secondary profile's `/loop --until` judge call is made with the wrong profile's credential instead of failing closed — a cross-profile credential leak, and actually worse than the sibling bug `c5c9aa8d44`/#100950 (merged just before this branch was cut) fixed for hygiene compaction, which only failed closed (`UnscopedSecretError` surfaced, no wrong-credential read).

## Fix

`evaluate_after_turn`'s own judge call, a few lines above this one in the same file, already goes through `self._run_in_executor_with_context()` — the established `copy_context().run` wrapper that keeps the caller's contextvars in the executor thread — for exactly this reason (its own comment spells it out: "the profile secret scope and auxiliary runtime context are contextvars, and a default-executor hop would drop them"). Applied the identical fix to `complete_tick`'s call site, one-line change:

```python
decision = await self._run_in_executor_with_context(
    mgr.complete_tick, final_response or "",
)
```

I checked whether `complete_tick` should instead follow the *other* pattern in this file — the hygiene-compaction sites (`c5c9aa8d44`) deliberately keep the **default** executor (`loop.run_in_executor(None, copy_context().run, ...)`) rather than the gateway's own thread pool, specifically so a fence-cancelled hung summary never occupies one of the gateway's limited agent-work slots. `complete_tick` has no such fencing/cancellation wrapper (no `asyncio.wait_for`/`CompressionCommitFence` around it, unlike hygiene compaction) and is structurally identical to `evaluate_after_turn`'s judge call — so mirroring `evaluate_after_turn` (the gateway's own executor via `_run_in_executor_with_context`) is the correct sibling here, not the hygiene-compaction pattern.

## Tests

Added `test_post_turn_loop_completion_until_judge_preserves_caller_context` to `tests/gateway/test_loop_command.py`: stubs `hermes_cli.goals.judge_goal` to record a probe `ContextVar`'s value as observed inside the executor, drives a real `/loop 5m poll CI --until done` tick through `fire_tick()` → `_post_turn_loop_completion()`, and asserts the judge saw the value set in the caller's context before the call.

**Mutation-verified**: reverting `gateway/run.py` makes the assertion fail with the probe read back as `"unset"` instead of `"caller-scoped-value"` — the exact symptom this fixes (empty Context in the executor).

Ran the full `test_loop_command.py` suite (11 tests) plus the broader gateway/goal/loop/hygiene-compaction regression cluster (141 tests total) — all pass, no regressions.

## Competitor check

Searched `gh pr list --state all` across several keyword combinations ("loop judge secret scope", "complete_tick contextvar", "until judge multiplex profile", "_post_turn_loop_completion", "loop run_in_executor context"). Found several PRs touching related-but-distinct concerns — `#94603` ("use asyncio.get_running_loop() in remaining async sites") touches `gateway/run.py` but only at `write_tool_log()` (line ~28901), confirmed via diff to have zero overlap with `_post_turn_loop_completion`; `#78400`/`#69847`/`#39390`/`#9391` all address contextvar propagation for *different* call sites (pre-turn hygiene compression, `_run_agent`, manual compression) and are all closed/superseded. `#100950` (merged) is the sibling fix this PR's commit message credits and builds on top of. No open or closed PR targets this specific site.