### PR TITLE
fix(state): stop the housekeeping FTS retry from touching a quarantined SessionDB

### DIFF
--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -549,6 +549,28 @@ class SessionSchemaMixin:
         """
         if not getattr(self, "_fts_stale", False):
             return False
+        if getattr(self, "_db_corrupt", False):
+            # Quarantined: structural corruption was already observed on
+            # this handle, so the only safe policy is to stop touching the
+            # file (mirrors hermes_state.py's _try_wal_checkpoint). A full
+            # FTS rebuild is real DDL/DML against the same damaged image —
+            # exactly what quarantine exists to prevent — and this method
+            # is called unconditionally every housekeeping tick for the
+            # life of a long-running gateway process, so a stale-FTS flag
+            # left set on a now-corrupt handle would otherwise retry the
+            # rebuild forever.
+            #
+            # Reset the backoff bookkeeping too (mirrors the success path's
+            # own reset a few lines down): no code path today clears
+            # _db_corrupt on a live handle, so this is inert in practice,
+            # but leaving a doubled _fts_stale_retry_interval sitting behind
+            # a flag nothing currently clears is a footgun for whoever adds
+            # an un-quarantine/recovery path later — the next real retry
+            # should start from the default backoff, not wherever this
+            # handle's interval happened to be when it was quarantined.
+            self._fts_stale_retry_after = 0.0
+            self._fts_stale_retry_interval = 0.0
+            return False
         if getattr(self, "read_only", False) or getattr(self, "_conn", None) is None:
             return False
         now = time.monotonic()

--- a/tests/state/test_fts_rebuild_admission.py
+++ b/tests/state/test_fts_rebuild_admission.py
@@ -622,3 +622,48 @@ class TestDeferredFtsRetryInProcess:
             assert ro.retry_deferred_fts_recovery() is False
         finally:
             ro.close()
+
+    def test_retry_skips_quarantined_handle(self, tmp_path, fast_timeout):
+        """A structurally corrupt handle must never run a full FTS rebuild —
+        the housekeeping tick calls this unconditionally for the life of a
+        long-running gateway process, so a stale-FTS flag left set on a
+        now-corrupt handle must not retry the rebuild forever against the
+        damaged image (real DDL/DML the quarantine exists to prevent)."""
+        db_path = tmp_path / "state.db"
+        d = SessionDB(db_path=db_path)
+        if not d._fts_enabled:
+            d.close()
+            pytest.skip("FTS5 unavailable in this build")
+        d.create_session("s1", source="test")
+        d.append_message("s1", "user", "hello quarantine")
+        d.close()
+        self._mark_stale(db_path)
+
+        # Force the open-time recovery to defer (foreign rebuild-lock
+        # holder) so _fts_stale is still True once the handle is open —
+        # mirrors test_retry_is_non_blocking_while_live_holder_and_backs_off.
+        with _rebuild_lock_held_by_other_process(db_path):
+            gw = SessionDB(db_path=db_path)
+        try:
+            assert gw._fts_stale is True
+            gw._db_corrupt = True
+            gw._db_corrupt_reason = "database disk image is malformed"
+            # Simulate a handle that had already been backing off for a
+            # while before it tripped quarantine.
+            gw._fts_stale_retry_after = time.monotonic() + 900.0
+            gw._fts_stale_retry_interval = 900.0
+            assert gw.retry_deferred_fts_recovery() is False
+            # Untouched: still marked stale, triggers still absent — no
+            # rebuild ran against the "damaged" handle.
+            assert gw._fts_stale is True
+            # The backoff bookkeeping is reset too, mirroring the success
+            # path's own reset — a doubled interval left behind a flag
+            # nothing currently clears would otherwise make the next real
+            # retry (if this handle is ever un-quarantined) start from a
+            # stale multi-minute backoff instead of the default.
+            assert gw._fts_stale_retry_after == 0.0
+            assert gw._fts_stale_retry_interval == 0.0
+        finally:
+            gw.close()
+        assert _meta_value(db_path, FTS_STALE_KEY) == "1"
+        assert _base_fts_triggers(db_path) == set()


### PR DESCRIPTION
## Summary

`retry_deferred_fts_recovery()` (`hermes_state_schema.py`) is called unconditionally on every housekeeping tick for the entire life of a long-running gateway process (#100108's own rationale: "a gateway opens state.db once and stays up for days"). It checks `_fts_stale`, `read_only`, and `_conn is None`, but never `_db_corrupt` — the quarantine flag `bcc2e65818` (landed via #101095/#101224, just before this branch was cut) introduced to mean "structural corruption was observed on this handle; the only safe policy is to stop touching the file."

Every other corruption-aware call site in this class already respects that policy: `_try_wal_checkpoint()` has `if self._db_corrupt: return  # quarantined: never checkpoint over a damaged image`, and `close()` explicitly skips its checkpoint with a nearly identical comment. `retry_deferred_fts_recovery()` has neither.

**Concrete failure scenario:** a handle can plausibly have both a deferred stale-FTS breadcrumb (from an earlier open where a foreign holder blocked the rebuild) *and* later trip quarantine — the field incidents motivating the quarantine feature describe corruption touching FTS shadow tables and canonical B-trees on the same file. Once that happens, every subsequent housekeeping tick runs a real FTS rebuild — `DROP TABLE` / `CREATE VIRTUAL TABLE` / bulk `INSERT INTO messages_fts` — directly against the file the code has explicitly decided to stop touching. This is exactly the class of schema surgery quarantine exists to prevent, now reachable through a path the quarantine work didn't wire up.

## Fix

Added an early `return False` when `self._db_corrupt` is set, mirroring `_try_wal_checkpoint`'s guard and comment style. The method's own documented contract ("Never raises") is preserved — this is a quiet skip, not a raised `StateDbCorruptError`, consistent with the other corrupt-aware call sites in the same file.

## Tests

Added `test_retry_skips_quarantined_handle` to `tests/state/test_fts_rebuild_admission.py::TestDeferredFtsRetryInProcess`: marks a real handle's FTS stale, forces the open-time recovery to defer via a real held rebuild lock (mirroring the existing `test_retry_is_non_blocking_while_live_holder_and_backs_off`, using the `fast_timeout` fixture so the deferral resolves quickly) so `_fts_stale` survives construction, sets `_db_corrupt = True`, and asserts the retry is a no-op — the stale breadcrumb and dropped FTS triggers are left exactly as they were.

**Mutation-verified**: reverting `hermes_state_schema.py` makes the retry actually run the rebuild (`retry_deferred_fts_recovery()` returns `True`, log line "Rebuilt stale state.db FTS indexes from canonical messages and restored sync triggers" fires) against the "quarantined" handle — the exact bug this fixes.

Ran the full `tests/state/` + `tests/hermes_state/` suites (397 passed, 3 skipped — FTS5-unavailable skips, pre-existing) — no regressions.

## Competitor check

Searched `gh pr list --state all` across several keyword combinations ("retry_deferred_fts_recovery quarantine", "FTS rebuild corrupt", "housekeeping quarantine SessionDB", "_db_corrupt fts", "deferred FTS quarantined"). Confirmed `#101224`/`#101095` (merged, the quarantine mechanism this PR builds on) is already in this branch's base and doesn't touch `retry_deferred_fts_recovery`. Checked the other FTS-recovery-area PRs that turned up (`#99682` merged — different function, no `_db_corrupt`/`retry_deferred_fts_recovery` overlap via diff; `#100244`, `#92419`, `#94565` open — zero references to either symbol via `gh pr diff`). No open or closed PR covers this gap.

## Update: addressed review feedback (backoff bookkeeping reset)

[@Baophan00](https://github.com/Baophan00) pointed out that the quarantine early-return leaves `_fts_stale_retry_after`/`_fts_stale_retry_interval` at whatever value they had before quarantine, unlike the success path a few lines down which resets `_fts_stale_retry_interval` to `0.0`.

Verified before changing anything: `_db_corrupt` is set to `False` nowhere in the codebase outside `SessionDB.__init__` (repo-wide grep, production code only), and `hermes_state_registry.py`'s file-replace path always constructs a genuinely new `SessionDB` instance (fresh `__init__`) rather than clearing the flag on a live one — so no code path today revives a quarantined handle in place, and the stale backoff fields are currently inert (the only reader of them is this same method, which will always take the quarantine branch from now on for that instance).

Still made the change: it's a two-line, zero-risk reset that mirrors the success path's own pattern, and it closes a real footgun for whoever adds an un-quarantine/recovery path later — without it, a handle quarantined mid-backoff would carry a stale multi-minute interval into any future retry instead of starting from the default.

Extended `test_retry_skips_quarantined_handle` to seed a pre-existing multi-minute backoff before quarantining and assert both fields reset to `0.0`. Mutation-verified (reverting the addition makes the new assertions fail with the stale pre-quarantine values still in place). Amended into the same commit per request — no second commit.
