### PR TITLE
feat(azure-foundry): discover resource deployments and route Claude/GPT per model

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -4288,6 +4288,15 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
                     return live
         except Exception:
             pass
+    if normalized == "azure-foundry":
+        # Azure has no useful /models: the OpenAI route lists Microsoft's
+        # whole catalog and the Anthropic route has none. List the resource's
+        # own deployments instead so the picker mirrors the Azure portal.
+        try:
+            return _azure_foundry_provider_model_ids()
+        except Exception as exc:
+            logger.debug("Azure Foundry deployment discovery failed: %s", exc)
+            return []
     if normalized == "anthropic":
         model_cfg = _get_model_config_dict()
         cfg_provider = normalize_provider(str(model_cfg.get("provider", "") or ""))
@@ -4645,6 +4654,14 @@ def _credential_fingerprint(provider: str) -> str:
             parts.append(f"effective_base={_openai_discovery_base_url(provider)}")
         except Exception:
             pass
+    if provider == "azure-foundry":
+        # Deployment discovery is scoped to the configured resource; switching
+        # resources in config.yaml must not serve the previous one's list.
+        model_cfg = _get_model_config_dict()
+        parts.append(
+            "model.provider="
+            f"{model_cfg.get('provider', '')}|model.base_url={model_cfg.get('base_url', '')}"
+        )
 
     if provider == "ollama":
         parts.append(f"OLLAMA_HOST={_os.environ.get('OLLAMA_HOST', '')}")
@@ -5689,14 +5706,18 @@ def azure_foundry_model_api_mode(model_name: Optional[str]) -> Optional[str]:
 
     Returns ``"codex_responses"`` when the model name matches a family that
     only accepts the Responses API on Azure Foundry (GPT-5.x, codex, o1/o3/o4
-    reasoning models).  Returns ``None`` otherwise — the caller should fall
-    back to the configured/default api_mode (typically ``chat_completions``)
-    so GPT-4o, GPT-4 Turbo, Llama, Mistral, etc. keep working.
+    reasoning models).  Returns ``"anthropic_messages"`` for Claude
+    deployments: Azure serves Claude only through the native Anthropic
+    Messages route (``/anthropic/v1/messages``) and rejects
+    ``/openai/v1/chat/completions`` for them with ``api_not_supported``.
+    Returns ``None`` otherwise — the caller should fall back to the
+    configured/default api_mode (typically ``chat_completions``) so GPT-4o,
+    GPT-4 Turbo, Llama, Mistral, etc. keep working.
 
-    Intentionally does NOT return ``anthropic_messages``; Anthropic-style
-    Azure endpoints are disambiguated by URL (``/anthropic`` suffix) in
-    ``runtime_provider._detect_api_mode_for_url`` and by the user setting
-    ``model.api_mode: anthropic_messages`` explicitly.
+    A single Azure Foundry resource can host Claude and GPT deployments side
+    by side; :func:`azure_foundry_base_url_for_mode` rewrites the configured
+    base URL onto the matching route so one ``azure-foundry`` provider entry
+    can serve every deployment the discovery probe returns.
     """
     raw = str(model_name or "").strip().lower()
     if not raw:
@@ -5704,6 +5725,8 @@ def azure_foundry_model_api_mode(model_name: Optional[str]) -> Optional[str]:
     # Strip any vendor/ prefix a user may have copied from OpenRouter / Copilot.
     if "/" in raw:
         raw = raw.rsplit("/", 1)[-1]
+    if raw.startswith("claude"):
+        return "anthropic_messages"
     # gpt-5-mini speaks chat completions on Copilot but Azure Foundry deploys
     # the full gpt-5 family uniformly on Responses API — don't carve an
     # exception here.
@@ -5711,6 +5734,137 @@ def azure_foundry_model_api_mode(model_name: Optional[str]) -> Optional[str]:
         if raw.startswith(prefix):
             return "codex_responses"
     return None
+
+
+# Azure Foundry exposes several API surfaces under one resource host:
+#   <host>/openai/v1      OpenAI-compatible (chat/completions, responses, models)
+#   <host>/anthropic      Anthropic Messages (Claude deployments only)
+#   <host>/openai/deployments?api-version=...   the resource's own deployments
+# Both ``<resource>.openai.azure.com`` and ``<resource>.services.ai.azure.com``
+# serve all three routes. The regex strips whichever route suffix the user
+# configured so we can re-attach the right one for the selected model.
+_AZURE_FOUNDRY_ROUTE_SUFFIX_RE = re.compile(
+    r"/(?:openai(?:/v1)?|anthropic(?:/v1)?|models(?:/v1)?|v1)/?$",
+    re.IGNORECASE,
+)
+_AZURE_FOUNDRY_DEPLOYMENTS_API_VERSION = "2023-03-15-preview"
+
+
+def azure_foundry_resource_root(base_url: Optional[str]) -> str:
+    """Return the Azure Foundry resource host root for a configured base URL.
+
+    ``https://r.services.ai.azure.com/anthropic`` and
+    ``https://r.openai.azure.com/openai/v1`` both collapse to
+    ``https://<host>``. Unknown paths are left untouched (minus the trailing
+    slash) so private gateways that mount Azure under a prefix still work.
+    """
+    url = str(base_url or "").strip().rstrip("/")
+    if not url:
+        return ""
+    return _AZURE_FOUNDRY_ROUTE_SUFFIX_RE.sub("", url).rstrip("/")
+
+
+def azure_foundry_base_url_for_mode(base_url: Optional[str], api_mode: Optional[str]) -> str:
+    """Rewrite an Azure Foundry base URL onto the route matching *api_mode*.
+
+    The user configures ONE endpoint for the ``azure-foundry`` provider, but
+    Claude deployments only answer on ``/anthropic`` while GPT deployments
+    only answer on ``/openai/v1``. Picking a Claude model while the config
+    points at ``/openai/v1`` (or vice-versa) must not 404 — swap the route.
+    """
+    url = str(base_url or "").strip().rstrip("/")
+    if not url:
+        return ""
+    if not _is_azure_foundry_host(url):
+        # Custom gateways: trust the configured path as-is.
+        return url
+    root = azure_foundry_resource_root(url)
+    if api_mode == "anthropic_messages":
+        return root + "/anthropic"
+    return root + "/openai/v1"
+
+
+def _is_azure_foundry_host(url: str) -> bool:
+    host = (urllib.parse.urlparse(url).hostname or "").lower()
+    return host.endswith(".openai.azure.com") or host.endswith(".services.ai.azure.com")
+
+
+def fetch_azure_foundry_deployments(
+    api_key: Optional[str],
+    base_url: Optional[str],
+    timeout: float = 5.0,
+) -> Optional[list[str]]:
+    """List the deployments of the Azure Foundry resource behind *base_url*.
+
+    Azure's OpenAI-compatible ``/openai/v1/models`` returns Microsoft's whole
+    catalog (hundreds of embeddings / TTS / image models the user never
+    deployed), and the Anthropic route has no ``/v1/models`` at all. The
+    resource-scoped ``/openai/deployments`` endpoint is the only listing that
+    reflects what the user actually deployed — and it updates the moment a
+    deployment is created or deleted in the Azure portal.
+
+    Returns deployment names in Azure's order (succeeded first, then any
+    still-provisioning entries), or ``None`` when the probe fails so callers
+    fall back to the configured default model.
+    """
+    key = str(api_key or "").strip()
+    root = azure_foundry_resource_root(base_url)
+    if not key or not root:
+        return None
+    url = (
+        f"{root}/openai/deployments?api-version="
+        f"{_AZURE_FOUNDRY_DEPLOYMENTS_API_VERSION}"
+    )
+    req = urllib.request.Request(
+        url,
+        headers={"api-key": key, "User-Agent": _HERMES_USER_AGENT},
+    )
+    try:
+        with _urlopen_model_catalog_request(req, timeout=timeout) as resp:
+            data = json.loads(resp.read().decode())
+    except Exception as exc:
+        logger.debug("Azure Foundry deployments probe failed (%s): %s", url, exc)
+        return None
+    rows = data.get("data") if isinstance(data, dict) else None
+    if not isinstance(rows, list):
+        return None
+    ready: list[str] = []
+    pending: list[str] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        name = str(row.get("id") or "").strip()
+        if not name:
+            continue
+        status = str(row.get("status") or "").strip().lower()
+        (ready if status in {"", "succeeded"} else pending).append(name)
+    return list(dict.fromkeys([*ready, *pending]))
+
+
+def _azure_foundry_provider_model_ids() -> list[str]:
+    """Live picker catalog for the built-in ``azure-foundry`` provider.
+
+    Reads the endpoint from ``model.base_url`` (when the main model is Azure)
+    or ``AZURE_FOUNDRY_BASE_URL``, the key from ``AZURE_FOUNDRY_API_KEY``, and
+    lists the resource's deployments. Always includes the configured default
+    model so the current selection never disappears from the picker.
+    """
+    from hermes_cli.config import get_env_value
+
+    model_cfg = _get_model_config_dict()
+    cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
+    base_url = ""
+    default_model = ""
+    if cfg_provider == "azure-foundry":
+        base_url = str(model_cfg.get("base_url") or "").strip()
+        default_model = str(model_cfg.get("default") or "").strip()
+    if not base_url:
+        base_url = str(get_env_value("AZURE_FOUNDRY_BASE_URL") or "").strip()
+    api_key = str(get_env_value("AZURE_FOUNDRY_API_KEY") or "").strip()
+    live = fetch_azure_foundry_deployments(api_key, base_url) or []
+    if default_model and default_model not in live:
+        live = [default_model, *live]
+    return live
 
 
 def opencode_provider_family(provider_id: Optional[str]) -> Optional[str]:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -567,11 +567,11 @@ def _resolve_runtime_from_pool_entry(
             configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
             if configured_mode:
                 api_mode = configured_mode
-        # Model-family inference for GPT-5.x / codex / o1-o4: Azure rejects
-        # /chat/completions on these with 400 "operation unsupported" — see
-        # azure_foundry_model_api_mode() for rationale.  Skip when the user
-        # explicitly picked anthropic_messages (Anthropic-style endpoint).
-        if effective_model and api_mode != "anthropic_messages":
+        # Model-family inference for GPT-5.x / codex / o1-o4 (Responses-only)
+        # and Claude (Anthropic-Messages-only) — see
+        # azure_foundry_model_api_mode() for rationale.  Then move the base
+        # URL onto the route the inferred mode needs.
+        if effective_model:
             try:
                 from hermes_cli.models import azure_foundry_model_api_mode
 
@@ -580,6 +580,12 @@ def _resolve_runtime_from_pool_entry(
                 inferred = None
             if inferred:
                 api_mode = inferred
+        try:
+            from hermes_cli.models import azure_foundry_base_url_for_mode
+
+            base_url = azure_foundry_base_url_for_mode(base_url, api_mode) or base_url
+        except Exception:
+            pass
         # For Anthropic-style endpoints, strip /v1 suffix
         if api_mode == "anthropic_messages":
             base_url = re.sub(r"/v1/?$", "", base_url)
@@ -1653,12 +1659,13 @@ def _resolve_azure_foundry_runtime(
             cfg_entra = _entra
 
     # Model-family inference: Azure Foundry deploys GPT-5.x / codex / o1-o4
-    # reasoning models as Responses-API-only.  Calling /chat/completions
-    # against them returns 400 "The requested operation is unsupported."
-    # Upgrade api_mode when the model name matches, unless the user has
-    # explicitly chosen anthropic_messages (Anthropic-style endpoint).
+    # reasoning models as Responses-API-only (calling /chat/completions
+    # returns 400 "The requested operation is unsupported") and Claude
+    # deployments as Anthropic-Messages-only.  Infer api_mode from the model
+    # name and move the base URL onto the matching route so one configured
+    # endpoint serves every deployment of the resource.
     effective_model = str(target_model or model_cfg.get("default") or "").strip()
-    if effective_model and cfg_api_mode != "anthropic_messages":
+    if effective_model:
         try:
             from hermes_cli.models import azure_foundry_model_api_mode
 
@@ -1675,6 +1682,13 @@ def _resolve_azure_foundry_runtime(
             "Azure Foundry requires a base URL. Set it via 'hermes model' or "
             "the AZURE_FOUNDRY_BASE_URL environment variable."
         )
+    if not explicit_base_url_clean:
+        try:
+            from hermes_cli.models import azure_foundry_base_url_for_mode
+
+            base_url = azure_foundry_base_url_for_mode(base_url, cfg_api_mode) or base_url
+        except Exception:
+            pass
 
     # Anthropic SDK appends /v1/messages itself, so strip any trailing /v1
     # we inherited from the configured base_url to avoid double-/v1 paths.

--- a/tests/hermes_cli/test_azure_foundry_discovery.py
+++ b/tests/hermes_cli/test_azure_foundry_discovery.py
@@ -1,0 +1,188 @@
+"""Azure Foundry deployment discovery + per-model route selection.
+
+One Azure Foundry resource hosts Claude (Anthropic Messages route) and GPT
+(OpenAI Responses / chat route) deployments side by side. The picker must list
+the resource's *deployments* (not Microsoft's whole catalog, not nothing), and
+the runtime must move the configured base URL onto the route each model needs.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+
+import pytest
+
+from hermes_cli import models as models_mod
+from hermes_cli.models import (
+    azure_foundry_base_url_for_mode,
+    azure_foundry_model_api_mode,
+    azure_foundry_resource_root,
+    fetch_azure_foundry_deployments,
+)
+
+SERVICES = "https://res.services.ai.azure.com"
+OPENAI_HOST = "https://res.openai.azure.com"
+
+
+@pytest.mark.parametrize(
+    "model, expected",
+    [
+        ("claude-sonnet-4-6", "anthropic_messages"),
+        ("claude-opus-4-8-anthropic", "anthropic_messages"),
+        ("anthropic/claude-haiku-4-5", "anthropic_messages"),
+        ("gpt-5.3-codex", "codex_responses"),
+        ("o3-mini", "codex_responses"),
+        ("gpt-4o", None),
+        ("Llama-3.3-70B-Instruct", None),
+        ("", None),
+    ],
+)
+def test_api_mode_inferred_from_deployment_name(model, expected):
+    assert azure_foundry_model_api_mode(model) == expected
+
+
+@pytest.mark.parametrize(
+    "url, root",
+    [
+        (f"{SERVICES}/anthropic", SERVICES),
+        (f"{SERVICES}/anthropic/v1/", SERVICES),
+        (f"{OPENAI_HOST}/openai/v1", OPENAI_HOST),
+        (f"{OPENAI_HOST}/openai", OPENAI_HOST),
+        (f"{SERVICES}/models", SERVICES),
+        ("https://gw.example.com/azure/openai/v1", "https://gw.example.com/azure"),
+        ("", ""),
+    ],
+)
+def test_resource_root_strips_route_suffix(url, root):
+    assert azure_foundry_resource_root(url) == root
+
+
+def test_base_url_rewritten_per_mode_on_azure_hosts():
+    anth = f"{SERVICES}/anthropic"
+    assert azure_foundry_base_url_for_mode(anth, "codex_responses") == f"{SERVICES}/openai/v1"
+    assert azure_foundry_base_url_for_mode(anth, "chat_completions") == f"{SERVICES}/openai/v1"
+    assert azure_foundry_base_url_for_mode(anth, "anthropic_messages") == anth
+    oai = f"{OPENAI_HOST}/openai/v1"
+    assert azure_foundry_base_url_for_mode(oai, "anthropic_messages") == f"{OPENAI_HOST}/anthropic"
+    assert azure_foundry_base_url_for_mode(oai, "codex_responses") == oai
+
+
+def test_base_url_untouched_for_non_azure_gateways():
+    for url in ("http://localhost:4001/v1", "https://litellm.corp/anthropic"):
+        for mode in ("anthropic_messages", "codex_responses", "chat_completions"):
+            assert azure_foundry_base_url_for_mode(url, mode) == url
+
+
+class _Resp(io.BytesIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def test_fetch_deployments_lists_resource_scoped_endpoint(monkeypatch):
+    seen = {}
+
+    def fake_open(req, *, timeout, ssl_context=None):
+        seen["url"] = req.full_url
+        seen["headers"] = {k.lower(): v for k, v in req.header_items()}
+        body = {
+            "data": [
+                {"id": "claude-sonnet-4-6", "status": "succeeded"},
+                {"id": "gpt-5.3-codex", "status": "succeeded"},
+                {"id": "claude-opus-5", "status": "creating"},
+                {"id": "", "status": "succeeded"},
+                "garbage",
+            ]
+        }
+        return _Resp(json.dumps(body).encode())
+
+    monkeypatch.setattr(models_mod, "_urlopen_model_catalog_request", fake_open)
+    out = fetch_azure_foundry_deployments("k3y", f"{SERVICES}/anthropic")
+
+    assert out == ["claude-sonnet-4-6", "gpt-5.3-codex", "claude-opus-5"]
+    assert seen["url"].startswith(f"{SERVICES}/openai/deployments?api-version=")
+    assert seen["headers"]["api-key"] == "k3y"
+
+
+def test_fetch_deployments_returns_none_on_failure_or_missing_inputs(monkeypatch):
+    def boom(req, *, timeout, ssl_context=None):
+        raise OSError("down")
+
+    monkeypatch.setattr(models_mod, "_urlopen_model_catalog_request", boom)
+    assert fetch_azure_foundry_deployments("k", f"{SERVICES}/anthropic") is None
+    assert fetch_azure_foundry_deployments("", f"{SERVICES}/anthropic") is None
+    assert fetch_azure_foundry_deployments("k", "") is None
+
+
+def test_provider_model_ids_uses_deployments_and_keeps_default(monkeypatch):
+    monkeypatch.setattr(
+        models_mod,
+        "_get_model_config_dict",
+        lambda: {"provider": "azure-foundry", "base_url": f"{SERVICES}/anthropic", "default": "claude-custom"},
+    )
+    monkeypatch.setattr(
+        models_mod,
+        "fetch_azure_foundry_deployments",
+        lambda key, url, timeout=5.0: ["claude-sonnet-4-6", "gpt-5.3-codex"],
+    )
+    import hermes_cli.config as cfg_mod
+
+    monkeypatch.setattr(cfg_mod, "get_env_value", lambda k: "secret" if k == "AZURE_FOUNDRY_API_KEY" else "")
+    assert models_mod.provider_model_ids("azure-foundry") == [
+        "claude-custom",
+        "claude-sonnet-4-6",
+        "gpt-5.3-codex",
+    ]
+
+
+def test_provider_model_ids_empty_when_probe_fails(monkeypatch):
+    monkeypatch.setattr(models_mod, "_get_model_config_dict", lambda: {"provider": "anthropic"})
+    monkeypatch.setattr(models_mod, "fetch_azure_foundry_deployments", lambda *a, **k: None)
+    import hermes_cli.config as cfg_mod
+
+    monkeypatch.setattr(cfg_mod, "get_env_value", lambda k: "x")
+    assert models_mod.provider_model_ids("azure-foundry") == []
+
+
+def test_runtime_routes_each_model_to_its_azure_route(monkeypatch):
+    from hermes_cli import runtime_provider as rp
+
+    monkeypatch.setattr(rp, "_getenv", lambda name, default="": "k3y" if name == "AZURE_FOUNDRY_API_KEY" else default)
+    model_cfg = {
+        "provider": "azure-foundry",
+        "default": "claude-sonnet-4-6",
+        "base_url": f"{SERVICES}/anthropic",
+        "auth_mode": "api_key",
+    }
+
+    claude = rp._resolve_azure_foundry_runtime(
+        requested_provider="azure-foundry", model_cfg=model_cfg, target_model="claude-opus-5"
+    )
+    assert claude["api_mode"] == "anthropic_messages"
+    assert claude["base_url"] == f"{SERVICES}/anthropic"
+
+    codex = rp._resolve_azure_foundry_runtime(
+        requested_provider="azure-foundry", model_cfg=model_cfg, target_model="gpt-5.3-codex"
+    )
+    assert codex["api_mode"] == "codex_responses"
+    assert codex["base_url"] == f"{SERVICES}/openai/v1"
+
+    # Config pointing at the OpenAI route still serves Claude on /anthropic.
+    model_cfg["base_url"] = f"{OPENAI_HOST}/openai/v1"
+    claude2 = rp._resolve_azure_foundry_runtime(
+        requested_provider="azure-foundry", model_cfg=model_cfg, target_model="claude-haiku-4-5"
+    )
+    assert claude2["base_url"] == f"{OPENAI_HOST}/anthropic"
+
+    # Explicit --base-url overrides are honoured verbatim (no route rewrite;
+    # only the pre-existing trailing-/v1 strip for the Anthropic SDK applies).
+    forced = rp._resolve_azure_foundry_runtime(
+        requested_provider="azure-foundry",
+        model_cfg=model_cfg,
+        explicit_base_url="https://gw.corp/azure/openai/v1",
+        target_model="claude-haiku-4-5",
+    )
+    assert forced["base_url"] == "https://gw.corp/azure/openai"


### PR DESCRIPTION
## What does this PR do?

Makes the built-in `azure-foundry` provider list **the resource's actual deployments** in the model picker, and lets **one** provider entry serve both Claude and GPT deployments of the same resource.

Related: #27989 (picker shows 0 models for azure-foundry). Complements #28006 — see "Relationship to #28006" below.

### Problem

1. `provider_model_ids("azure-foundry")` falls through to the static `[]`, so the picker shows only the configured default.
2. Probing `<base>/models` does not fix it on current Azure hosts: on both `<res>.openai.azure.com/openai/v1` and `<res>.services.ai.azure.com/openai/v1` that endpoint returns **Microsoft's whole catalog** (400+ ids: dall-e, whisper, tts, embeddings, Llama, Phi, …), not what the user deployed. The Anthropic route (`/anthropic/v1/models`) answers `api_not_supported`.
3. A single Foundry resource commonly hosts Claude (served **only** on `/anthropic`, Messages API) and GPT-5.x/codex (served **only** on `/openai/v1`, Responses API). With one `model.base_url`, picking a model from the other family fails with `api_not_supported` / 404.

### Fix

- **Discovery** (`hermes_cli/models.py`): new `fetch_azure_foundry_deployments()` calls the resource-scoped `GET <host>/openai/deployments?api-version=2023-03-15-preview` (works on both host families with the same `api-key`). Succeeded deployments first, then provisioning ones. `provider_model_ids("azure-foundry")` uses it and always keeps the configured default. Falls back to `[]` on probe failure (unchanged behaviour).
- **Per-model routing** (`hermes_cli/models.py`, `hermes_cli/runtime_provider.py`): `azure_foundry_model_api_mode()` now also returns `anthropic_messages` for `claude*` deployments. New `azure_foundry_base_url_for_mode()` rewrites the configured Azure base URL onto `/anthropic` or `/openai/v1` to match the inferred mode. Applied in both Azure resolution paths (`_resolve_azure_foundry_runtime` and the pool-entry path). Only touches `*.openai.azure.com` / `*.services.ai.azure.com` hosts; custom gateways and explicit `--base-url` overrides are left verbatim.
- **Cache**: `_credential_fingerprint("azure-foundry")` folds in `model.provider` + `model.base_url`, so switching resources doesn't serve the previous resource's deployment list.

### Relationship to #28006

#28006 wires the wizard's `_probe_openai_models` (`GET <base>/models`) into `provider_model_ids`. On the hosts above that returns the catalog, not deployments (also reported in that thread by @realchrisolin on 2026-08-07); @poumpouy independently found the deployments endpoint in #27989. This PR uses that endpoint and additionally handles mixed Claude/GPT resources. Happy to rebase onto #28006 or have this folded into it — opened as draft to avoid a competing PR.

## Test plan

- [x] E2E against a real Foundry resource (Sweden Central) with 8 deployments (6× Claude incl. `claude-opus-5`, `claude-fable-5-1`; `gpt-5.3-codex`): picker lists exactly the 8 deployments; runtime routes each model to its working route and requests succeed (`/anthropic/v1/messages` for Claude, `/openai/v1/responses` for codex), with config pointing at either `/anthropic` or `/openai/v1`.
- [x] New `tests/hermes_cli/test_azure_foundry_discovery.py` (8 tests: mode inference, root/route rewrite, non-Azure passthrough, deployments parsing + failure, picker ids, runtime routing).
- [x] Existing Azure/runtime/picker suites pass: `test_azure_foundry_entra`, `test_azure_detect`, `test_runtime_provider_resolution`, `test_custom_provider_model_switch`, `test_auxiliary_client_azure_foundry`, `test_detect_provider_entra`, `test_model_validation`, `test_callable_api_key`, `test_models*` (280 passed).
- [x] `ruff check` clean.
