### PR TITLE
fix(kanban): notify subscriptions on stale blocked tasks are reaped (#100955, salvage #101103)

### DIFF
--- a/contributors/emails/itsflownium@users.noreply.github.com
+++ b/contributors/emails/itsflownium@users.noreply.github.com
@@ -1,0 +1,1 @@
+itsflownium

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -422,7 +422,7 @@ class GatewayKanbanWatchersMixin:
                             if _gc_due:
                                 # Hourly (plus once at startup) stale-sub GC:
                                 # drop subscriptions for tasks that have been
-                                # ``done`` untouched past the retention
+                                # ``done``/``blocked`` untouched past the retention
                                 # window. Best-effort — a failed sweep never
                                 # blocks delivery; the next hourly gate
                                 # retries it.
@@ -433,7 +433,7 @@ class GatewayKanbanWatchersMixin:
                                     )
                                     if _purged:
                                         logger.info(
-                                            "kanban notifier: purged %d stale done-task subscription(s) on board %s (retention %dd)",
+                                            "kanban notifier: purged %d stale done/blocked-task subscription(s) on board %s (retention %dd)",
                                             _purged, slug, _gc_retention_days,
                                         )
                                 except Exception as _gc_exc:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -11685,8 +11685,8 @@ def purge_stale_done_notify_subs(
     *,
     max_age_days: int = 30,
 ) -> int:
-    """Delete notify subscriptions whose task has sat in ``done`` untouched
-    for longer than ``max_age_days``.
+    """Delete notify subscriptions whose task has sat in ``done`` or
+    ``blocked`` untouched for longer than ``max_age_days``.
 
     The notifier keeps subscriptions alive through ``done`` because a
     completed task can be reopened (review corrections, continuation) and
@@ -11695,7 +11695,10 @@ def purge_stale_done_notify_subs(
     subscription rows forever — each one scanned every notifier tick.
     This GC bounds that: a task that has been ``done`` with no new events
     for the retention window is treated as settled and its subscriptions
-    are purged. Age is measured from the task's most recent event
+    are purged. ``blocked`` tasks (circuit-breaker trips, dead workers)
+    are reaped on the same clock — they are abandoned, not idle, unlike a
+    ``backlog``/``ready`` card that is merely waiting for pickup (#100955).
+    Age is measured from the task's most recent event
     (falling back to ``completed_at`` then ``created_at``), so ANY
     activity — including a reopen, which also moves the task off
     ``done`` — resets or exempts it.
@@ -11714,7 +11717,7 @@ def purge_stale_done_notify_subs(
         cur = conn.execute(
             "DELETE FROM kanban_notify_subs WHERE task_id IN ("
             " SELECT t.id FROM tasks t"
-            " WHERE t.status = 'done'"
+            " WHERE t.status IN ('done', 'blocked')"
             " AND COALESCE("
             "  (SELECT MAX(e.created_at) FROM task_events e"
             "   WHERE e.task_id = t.id),"

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -1113,6 +1113,34 @@ def test_gc_spares_reopened_task_even_when_old(kanban_home):
         conn.close()
 
 
+def _set_task_status(kb, conn, tid, status):
+    """Force a task into ``status`` with a matching status event."""
+    with kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET status = ? WHERE id = ?", (status, tid))
+        kb._append_event(conn, tid, "status", {"status": status})
+
+
+def test_gc_purges_blocked_task_that_never_done(kanban_home):
+    import hermes_cli.kanban_db as kb
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="stuck blocked", assignee="worker1")
+        kb.add_notify_sub(
+            conn, task_id=tid, platform="telegram", chat_id="c-blocked",
+            notifier_profile="default",
+        )
+        _set_task_status(kb, conn, tid, "blocked")
+        _backdate_task(kb, conn, tid, days=45)
+
+        purged = kb.purge_stale_done_notify_subs(conn, max_age_days=30)
+
+        assert purged == 1
+        assert kb.list_notify_subs(conn, tid) == []
+    finally:
+        conn.close()
+
+
 def test_gc_archived_rows_already_removed_by_unsub(kanban_home):
     import hermes_cli.kanban_db as kb
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -614,7 +614,7 @@ Config knobs (all under `kanban:` in `~/.hermes/config.yaml`):
 | `orchestrator_profile` | `""` | Profile assigned to the root/orchestration task after decomposition. Empty = fall back to active default profile. |
 | `default_assignee` | `""` | Where a child task lands when the LLM picks an unknown profile. Empty = fall back to active default. |
 | `auto_subscribe_on_create` | `true` | When `kanban_create` runs inside a persistent gateway/TUI session, terminal events resume that originating agent with a synthetic status turn. Set to `false` for passive completion or to require explicit `kanban_notify-subscribe` calls. Independent of `auto_decompose`. |
-| `done_sub_retention_days` | `30` | Notify subscriptions survive `done` (reopen-safe) and are removed on `archived`. The notifier GC purges subscriptions whose task has been `done` with no new events for this many days, bounding sub-table growth on boards that never archive. `0` disables the sweep. |
+| `done_sub_retention_days` | `30` | Notify subscriptions survive `done` (reopen-safe) and are removed on `archived`. The notifier GC purges subscriptions whose task has been `done` or `blocked` with no new events for this many days, bounding sub-table growth on boards that never archive. `0` disables the sweep. |
 
 And the two auxiliary LLM slots:
 
@@ -887,7 +887,7 @@ bot> ✓ t_9fc1a3 completed by transcriber
      transcribed 42 minutes, saved to podcast/2026-05-04.md
 ```
 
-Subscriptions survive a task reaching `done` — completion is reversible (a reviewer or controller can reopen a done task), so the origin session keeps getting notified through reopen cycles. They auto-remove on `archived` (the irreversible end state). On boards that never archive, a GC sweep purges subscriptions for tasks that have sat in `done` with no new activity for `kanban.done_sub_retention_days` days (default 30; set 0 to disable), so stale rows don't accumulate forever. If you script a create with `--json` (machine output) the auto-subscribe is skipped — the assumption is that scripted callers want to manage subscriptions explicitly via `/kanban notify-subscribe`.
+Subscriptions survive a task reaching `done` — completion is reversible (a reviewer or controller can reopen a done task), so the origin session keeps getting notified through reopen cycles. They auto-remove on `archived` (the irreversible end state). On boards that never archive, a GC sweep purges subscriptions for tasks that have sat in `done` or `blocked` with no new activity for `kanban.done_sub_retention_days` days (default 30; set 0 to disable), so stale rows don't accumulate forever. If you script a create with `--json` (machine output) the auto-subscribe is skipped — the assumption is that scripted callers want to manage subscriptions explicitly via `/kanban notify-subscribe`.
 
 A chat-originated auto-subscribe is created in `notify+wake` mode: on a terminal event the destination agent both receives the passive message **and** takes a real turn, so it can read the board context and reply in its own voice. See [Delivery modes](#delivery-modes) below.
 


### PR DESCRIPTION
## Summary
Notify-subscription rows on tasks that sit in `blocked` past the retention window are now purged by the hourly GC; before, only `done` tasks qualified, so blocked/dead-running tasks kept their subs forever.

Deliberately NOT status-agnostic (the shape #101103 proposed): a 30-day-old `ready`/`backlog` card is idle, not abandoned, and its origin chat must still be notified when a worker finally picks it up. Dead `running` tasks are already moved to `blocked` by `release_stale_claims`, so the blocked clause covers them.

## Changes
- `hermes_cli/kanban_db.py`: `t.status = 'done'` → `t.status IN ('done', 'blocked')` (1 SQL line) + docstring
- `gateway/kanban_watchers.py`: comment/log wording done/blocked
- Docs: kanban.md retention row; 1 test (blocked-old purged, from #101103 adapted) + existing spared-reopen test still pins the contract

## Validation
| | Before | After |
|---|---|---|
| blocked task, 31d silent | subs kept forever | subs purged |
| ready task, 31d old | subs kept | subs kept (unchanged) |
| reopened old task | spared | spared |

Credit: @itsflownium (#101103; test cherry-picked with authorship, fix co-authored). Closes #100955.

## Infographic

![kanban subs gc](https://v3b.fal.media/files/b/0aa8ce87/E5XphlSAyL0lq3LmtdEnx_iZen9ahz.png)
