### PR TITLE
fix(providers): one Alibaba key no longer lights both intl and CN picker rows (#101122, salvage #101163)

### DIFF
--- a/contributors/emails/umit.ediz@hotmail.com
+++ b/contributors/emails/umit.ediz@hotmail.com
@@ -1,0 +1,1 @@
+Edizzier

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -3528,7 +3528,20 @@ def list_authenticated_providers(
         _cp_config = _auth_registry.get(_cp.slug)
         _cp_has_creds = False
         if _cp_config and _cp_config.api_key_env_vars:
-            _cp_has_creds = any(os.environ.get(ev) for ev in _cp_config.api_key_env_vars)
+            _cp_lit = {ev for ev in _cp_config.api_key_env_vars if os.environ.get(ev)}
+            _cp_has_creds = bool(_cp_lit)
+            # A regional "-cn" twin lit only by key vars it shares with its
+            # non-CN sibling (e.g. alibaba-coding-plan-cn off the intl
+            # ALIBABA_CODING_PLAN_API_KEY) is a phantom picker row (#101122).
+            # Hide it unless the user configured that CN provider -- and only
+            # when it has a dedicated var of its own the user could set instead.
+            _sib = _auth_registry.get(_cp.slug[:-3]) if _cp.slug.endswith("-cn") else None
+            _sib_vars = set(_sib.api_key_env_vars) if _sib else set()
+            if (
+                _cp_lit and _cp_lit <= _sib_vars < set(_cp_config.api_key_env_vars)
+                and _cp.slug != current_provider
+            ):
+                continue
         # Also check auth store and credential pool
         if not _cp_has_creds:
             try:

--- a/plugins/model-providers/alibaba-coding-plan/__init__.py
+++ b/plugins/model-providers/alibaba-coding-plan/__init__.py
@@ -9,6 +9,10 @@ Region split, mirroring the base DashScope pair (#73265):
 
 Profile names match the models.dev catalog keys exactly so model metadata
 lines up and ``model.provider: alibaba-coding-plan-cn`` resolves at runtime.
+
+The CN profile checks its own ``ALIBABA_CODING_PLAN_CN_API_KEY`` first (#101122,
+mirroring kimi-coding-cn) and keeps the shared vars as ordered fallbacks so
+existing CN users configured with the shared key keep working.
 """
 
 from providers import register_provider
@@ -31,7 +35,7 @@ alibaba_coding_plan_cn = ProviderProfile(
     display_name="Alibaba Cloud (Coding Plan, China)",
     description="Alibaba Cloud Coding Plan, mainland-China endpoint",
     signup_url="https://help.aliyun.com/zh/model-studio/",
-    env_vars=("ALIBABA_CODING_PLAN_API_KEY", "DASHSCOPE_API_KEY", "ALIBABA_CODING_PLAN_CN_BASE_URL"),
+    env_vars=("ALIBABA_CODING_PLAN_CN_API_KEY", "ALIBABA_CODING_PLAN_API_KEY", "DASHSCOPE_API_KEY", "ALIBABA_CODING_PLAN_CN_BASE_URL"),
     base_url="https://coding.dashscope.aliyuncs.com/v1",
     auth_type="api_key",
 )

--- a/plugins/model-providers/alibaba/__init__.py
+++ b/plugins/model-providers/alibaba/__init__.py
@@ -55,7 +55,7 @@ alibaba_token_plan_cn = ProviderProfile(
     display_name="Alibaba Cloud (Token Plan, China)",
     description="Alibaba Cloud Model Studio Token Plan, mainland-China endpoint",
     signup_url="https://help.aliyun.com/zh/model-studio/",
-    env_vars=("ALIBABA_TOKEN_PLAN_API_KEY", "ALIBABA_TOKEN_PLAN_CN_BASE_URL"),
+    env_vars=("ALIBABA_TOKEN_PLAN_CN_API_KEY", "ALIBABA_TOKEN_PLAN_API_KEY", "ALIBABA_TOKEN_PLAN_CN_BASE_URL"),
     base_url="https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
     auth_type="api_key",
 )

--- a/tests/hermes_cli/test_alibaba_coding_plan_cn_provider_listing.py
+++ b/tests/hermes_cli/test_alibaba_coding_plan_cn_provider_listing.py
@@ -1,0 +1,30 @@
+"""alibaba-coding-plan and alibaba-coding-plan-cn must not both appear in the
+/model picker off a single shared key (#101122).
+
+The CN profile now has its own ALIBABA_CODING_PLAN_CN_API_KEY (checked first),
+keeping the shared ALIBABA_CODING_PLAN_API_KEY / DASHSCOPE_API_KEY as ordered
+fallbacks so existing CN users are not broken.  The picker hides a ``-cn`` row
+whose only lit vars are shared with a lit non-CN sibling row.
+"""
+
+import os
+from unittest.mock import patch
+
+from hermes_cli.model_switch import list_authenticated_providers
+
+_CLEAR = {k: "" for k in ("ALIBABA_CODING_PLAN_API_KEY", "ALIBABA_CODING_PLAN_CN_API_KEY", "DASHSCOPE_API_KEY")}
+
+
+def _alibaba_slugs(current_provider=""):
+    return [p["slug"] for p in list_authenticated_providers(current_provider=current_provider) if "coding-plan" in p["slug"]]
+
+
+@patch.dict(os.environ, {**_CLEAR, "ALIBABA_CODING_PLAN_CN_API_KEY": "sk-cn-fake"}, clear=False)
+def test_alibaba_cn_appears_when_only_cn_key_set():
+    assert _alibaba_slugs() == ["alibaba-coding-plan-cn"]
+
+
+@patch.dict(os.environ, {**_CLEAR, "ALIBABA_CODING_PLAN_API_KEY": "sk-intl-fake"}, clear=False)
+def test_alibaba_cn_does_not_appear_when_only_intl_key_set():
+    """#101122: the shared intl key alone must light only the intl row."""
+    assert _alibaba_slugs() == ["alibaba-coding-plan"]

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -36,8 +36,8 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **xAI (Grok) — Responses API** | `XAI_API_KEY` in `~/.hermes/.env` (provider: `xai`) |
 | **xAI Grok OAuth (SuperGrok)** | `hermes model` → "xAI Grok OAuth (SuperGrok / Premium+)" — browser login, no API key. See [guide](../guides/xai-grok-oauth.md) |
 | **Qwen Cloud (Alibaba DashScope)** | `DASHSCOPE_API_KEY` in `~/.hermes/.env` (provider: `alibaba`; mainland-China endpoint: `alibaba-cn`) |
-| **Alibaba Cloud (Coding Plan)** | `ALIBABA_CODING_PLAN_API_KEY` (falls back to `DASHSCOPE_API_KEY`) (provider: `alibaba-coding-plan`, alias: `alibaba_coding`; mainland-China endpoint: `alibaba-coding-plan-cn`) — separate billing SKU, different endpoint |
-| **Alibaba Cloud (Token Plan)** | `ALIBABA_TOKEN_PLAN_API_KEY` in `~/.hermes/.env` (provider: `alibaba-token-plan`; mainland-China endpoint: `alibaba-token-plan-cn`) — Model Studio flat-token tier |
+| **Alibaba Cloud (Coding Plan)** | `ALIBABA_CODING_PLAN_API_KEY` (falls back to `DASHSCOPE_API_KEY`) (provider: `alibaba-coding-plan`, alias: `alibaba_coding`; mainland-China endpoint: `alibaba-coding-plan-cn` with `ALIBABA_CODING_PLAN_CN_API_KEY`, falling back to the shared keys) — separate billing SKU, different endpoint |
+| **Alibaba Cloud (Token Plan)** | `ALIBABA_TOKEN_PLAN_API_KEY` in `~/.hermes/.env` (provider: `alibaba-token-plan`; mainland-China endpoint: `alibaba-token-plan-cn` with `ALIBABA_TOKEN_PLAN_CN_API_KEY`, falling back to the shared key) — Model Studio flat-token tier |
 | **Kilo Code** | `KILOCODE_API_KEY` in `~/.hermes/.env` (provider: `kilocode`) |
 | **Xiaomi MiMo** | `XIAOMI_API_KEY` in `~/.hermes/.env` (provider: `xiaomi`, aliases: `mimo`, `xiaomi-mimo`) |
 | **Tencent TokenHub** | `TOKENHUB_API_KEY` in `~/.hermes/.env` (provider: `tencent-tokenhub`, aliases: `tencent`, `tokenhub`, `tencentmaas`) |
@@ -502,6 +502,8 @@ hermes chat --provider alibaba_coding --model qwen3-coder-plus
 ```
 
 `alibaba_coding` uses the same `DASHSCOPE_API_KEY` your `alibaba` entry already uses — no separate key needed, just a different routing target. Before this provider was registered, users who set `provider: alibaba_coding` in `config.yaml` silently fell through to OpenRouter routing.
+
+For the mainland-China endpoint (`alibaba-coding-plan-cn`, `https://coding.dashscope.aliyuncs.com/v1`) set `ALIBABA_CODING_PLAN_CN_API_KEY`. The CN provider still falls back to `ALIBABA_CODING_PLAN_API_KEY` / `DASHSCOPE_API_KEY`, but with only the shared key set the `/model` picker lists just the international row — set the CN key (or `provider: alibaba-coding-plan-cn` in `config.yaml`) to surface the CN one. The same applies to `alibaba-token-plan-cn` with `ALIBABA_TOKEN_PLAN_CN_API_KEY`.
 
 ### MiniMax (OAuth)
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -83,10 +83,12 @@ Hermes reads environment variables from the process environment and, for user-ma
 | `DASHSCOPE_API_KEY` | Qwen Cloud (Alibaba DashScope) API key for Qwen models ([modelstudio.console.alibabacloud.com](https://modelstudio.console.alibabacloud.com/)) |
 | `DASHSCOPE_BASE_URL` | Custom DashScope base URL (default: `https://dashscope-intl.aliyuncs.com/compatible-mode/v1`; use `https://dashscope.aliyuncs.com/compatible-mode/v1` for mainland-China region) |
 | `DASHSCOPE_CN_BASE_URL` | Override the `alibaba-cn` mainland-China DashScope base URL |
-| `ALIBABA_CODING_PLAN_API_KEY` | Qwen Coding Plan API key (`alibaba-coding-plan` / `alibaba-coding-plan-cn` providers) |
+| `ALIBABA_CODING_PLAN_API_KEY` | Qwen Coding Plan API key (`alibaba-coding-plan`; also a fallback for `alibaba-coding-plan-cn`) |
+| `ALIBABA_CODING_PLAN_CN_API_KEY` | Qwen Coding Plan API key for the mainland-China `alibaba-coding-plan-cn` provider (checked before the shared key, so only the CN row lights up) |
 | `ALIBABA_CODING_PLAN_BASE_URL` | Override the Qwen Coding Plan base URL (international) |
 | `ALIBABA_CODING_PLAN_CN_BASE_URL` | Override the Qwen Coding Plan base URL (mainland China) |
-| `ALIBABA_TOKEN_PLAN_API_KEY` | Alibaba Model Studio Token Plan API key (`alibaba-token-plan` / `alibaba-token-plan-cn` providers) |
+| `ALIBABA_TOKEN_PLAN_API_KEY` | Alibaba Model Studio Token Plan API key (`alibaba-token-plan`; also a fallback for `alibaba-token-plan-cn`) |
+| `ALIBABA_TOKEN_PLAN_CN_API_KEY` | Token Plan API key for the mainland-China `alibaba-token-plan-cn` provider (checked before the shared key) |
 | `ALIBABA_TOKEN_PLAN_BASE_URL` | Override the Token Plan base URL (international) |
 | `ALIBABA_TOKEN_PLAN_CN_BASE_URL` | Override the Token Plan base URL (mainland China) |
 | `DEEPSEEK_API_KEY` | DeepSeek API key for direct DeepSeek access ([platform.deepseek.com](https://platform.deepseek.com/api_keys)) |


### PR DESCRIPTION
## Summary
Setting only `ALIBABA_CODING_PLAN_API_KEY` no longer shows both `alibaba-coding-plan` and `alibaba-coding-plan-cn` in `/model`; `DASHSCOPE_API_KEY` alone shows 3 alibaba rows, not 4. Same fix for the `alibaba-token-plan` / `-cn` pair. Existing CN users keep working.

## Changes
- `plugins/model-providers/alibaba-coding-plan/__init__.py`, `plugins/model-providers/alibaba/__init__.py`: CN profiles get a dedicated key var first (`ALIBABA_CODING_PLAN_CN_API_KEY`, `ALIBABA_TOKEN_PLAN_CN_API_KEY`, kimi-coding-cn precedent) with the shared vars kept as ordered fallbacks — unlike #101163 as filed, nothing breaks for users who configured the CN endpoint with the shared key
- `hermes_cli/model_switch.py` (+14): picker hides a `-cn` row whose only lit vars are shared with its lit intl sibling, unless that CN provider is the configured `model.provider`
- Docs: providers.md, environment-variables.md; 2 tests (fail on main)

## Validation (live, temp HERMES_HOME)
| env | Before | After |
|---|---|---|
| CN key only | [] | [coding-plan-cn] |
| intl key only | [coding-plan, coding-plan-cn] | [coding-plan] |
| DASHSCOPE only | 4 rows | 3 rows |
| configured cn + shared key | both | both (CN user keeps row) |

Credit: @Edizzier (#101163, authorship preserved). #70361 (@ccctakexx, drop DASHSCOPE fallback) intentionally not folded — it conflicts with keeping fallbacks for existing users. Closes #101122.

## Infographic

![alibaba cn picker](https://v3b.fal.media/files/b/0aa8ce87/F01EXxyRV54yB0w-wE4MM_Uj626VY7.png)
