### PR TITLE
feat(email): Proton Mail Bridge and local relays work — configurable IMAP/SMTP TLS mode (salvage #99641)

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -92,7 +92,40 @@ def _esecret_int(name: str, default: int) -> int:
 
 def _esecret_bool(name: str, default: bool = False) -> bool:
     """Scope-aware boolean read (``env_bool`` variant of ``_get_esecret``)."""
-    return is_truthy_value(_get_esecret(name, ""), default=default)
+    raw = str(_get_esecret(name, "")).strip()
+    return is_truthy_value(raw, default=default) if raw else default
+
+
+_SECURITY_ALIASES = {
+    "tls": "tls", "ssl": "tls", "implicit": "tls",
+    "starttls": "starttls",
+    "plain": "plain", "none": "plain",
+}
+
+
+def _normalize_security(value: Any, default: str = "tls") -> str:
+    """Map an IMAP/SMTP security setting to ``tls`` | ``starttls`` | ``plain``.
+
+    Unknown values log a warning and fall back to *default* rather than
+    failing the connection, so a typo never silently downgrades to plaintext.
+    """
+    raw = str(value or "").strip().lower().replace("-", "").replace("_", "")
+    if not raw:
+        return default
+    mode = _SECURITY_ALIASES.get(raw)
+    if mode is None:
+        logger.warning("Unknown email security mode %r; using %r", value, default)
+        return default
+    return mode
+
+
+def _tls_context(verify: bool, host: str) -> ssl.SSLContext:
+    """Verified context by default; unverified only when explicitly opted out."""
+    if verify:
+        return ssl.create_default_context()
+    if host not in ("127.0.0.1", "::1", "localhost"):
+        logger.warning("TLS verification disabled for non-loopback host %s", host)
+    return ssl._create_unverified_context()
 
 
 # Automated sender patterns — emails from these are silently ignored
@@ -558,22 +591,19 @@ class EmailAdapter(BasePlatformAdapter):
         self._password = _get_secret("EMAIL_PASSWORD", "")
         self._imap_host = (_get_secret("EMAIL_IMAP_HOST", "") or extra.get("imap_host", "")).strip()
         self._imap_port = _esecret_int("EMAIL_IMAP_PORT", 993)
-        self._imap_security = (
-            _get_secret("EMAIL_IMAP_SECURITY", "")
-            or extra.get("imap_security", "")
-            or "tls"
-        ).strip().lower()
+        self._imap_security = _normalize_security(
+            _get_secret("EMAIL_IMAP_SECURITY", "") or extra.get("imap_security", "")
+        )
         self._imap_tls_verify = _esecret_bool(
             "EMAIL_IMAP_TLS_VERIFY",
             is_truthy_value(extra.get("imap_tls_verify"), default=True),
         )
         self._smtp_host = (_get_secret("EMAIL_SMTP_HOST", "") or extra.get("smtp_host", "")).strip()
         self._smtp_port = _esecret_int("EMAIL_SMTP_PORT", 587)
-        self._smtp_security = (
-            _get_secret("EMAIL_SMTP_SECURITY", "")
-            or extra.get("smtp_security", "")
-            or ("tls" if self._smtp_port == 465 else "starttls")
-        ).strip().lower()
+        self._smtp_security = _normalize_security(
+            _get_secret("EMAIL_SMTP_SECURITY", "") or extra.get("smtp_security", ""),
+            default="tls" if self._smtp_port == 465 else "starttls",
+        )
         self._smtp_tls_verify = _esecret_bool(
             "EMAIL_SMTP_TLS_VERIFY",
             is_truthy_value(extra.get("smtp_tls_verify"), default=True),
@@ -649,35 +679,20 @@ class EmailAdapter(BasePlatformAdapter):
             # Fallback: just clear old entries if sort fails
             self._seen_uids = set(list(self._seen_uids)[-self._seen_uids_max // 2:])
 
-    @staticmethod
-    def _tls_context(verify: bool) -> ssl.SSLContext:
-        """Return a verified context unless loopback/custom TLS opts out."""
-        return ssl.create_default_context() if verify else ssl._create_unverified_context()
-
     def _connect_imap(self) -> imaplib.IMAP4:
         """Create an IMAP connection using implicit TLS, STARTTLS, or plaintext."""
-        security = self._imap_security.replace("_", "-")
-        valid_modes = {
-            "tls", "ssl", "implicit", "implicit-tls",
-            "starttls", "start-tls",
-            "none", "plain", "plaintext",
-        }
-        if security not in valid_modes:
-            raise ValueError(
-                "Unsupported EMAIL_IMAP_SECURITY value: " + self._imap_security
-            )
-        if security in {"tls", "ssl", "implicit", "implicit-tls"}:
+        if self._imap_security == "tls":
             return imaplib.IMAP4_SSL(
                 self._imap_host,
                 self._imap_port,
                 timeout=30,
-                ssl_context=self._tls_context(self._imap_tls_verify),
+                ssl_context=_tls_context(self._imap_tls_verify, self._imap_host),
             )
 
         imap = imaplib.IMAP4(self._imap_host, self._imap_port, timeout=30)
-        if security in {"starttls", "start-tls"}:
+        if self._imap_security == "starttls":
             try:
-                imap.starttls(ssl_context=self._tls_context(self._imap_tls_verify))
+                imap.starttls(ssl_context=_tls_context(self._imap_tls_verify, self._imap_host))
             except Exception:
                 _close_imap(imap)
                 raise
@@ -698,28 +713,19 @@ class EmailAdapter(BasePlatformAdapter):
         Returns a connected SMTP object with TLS established — callers
         can proceed directly to ``login()``.
         """
-        ctx = self._tls_context(self._smtp_tls_verify)
         host = self._smtp_host
         port = self._smtp_port
-        security = self._smtp_security.replace("_", "-")
-        valid_modes = {
-            "tls", "ssl", "implicit", "implicit-tls",
-            "starttls", "start-tls",
-            "none", "plain", "plaintext",
-        }
-        if security not in valid_modes:
-            raise ValueError(
-                "Unsupported EMAIL_SMTP_SECURITY value: " + self._smtp_security
-            )
+        security = self._smtp_security
+        ctx = _tls_context(self._smtp_tls_verify, host)
 
         def _connect(*, ipv4_only: bool = False) -> smtplib.SMTP:
             """Attempt one SMTP connection."""
             smtp_cls = _IPv4SMTP if ipv4_only else smtplib.SMTP
             smtp_ssl_cls = _IPv4SMTP_SSL if ipv4_only else smtplib.SMTP_SSL
-            if security in {"tls", "ssl", "implicit", "implicit-tls"}:
+            if security == "tls":
                 return smtp_ssl_cls(host, port, timeout=SMTP_CONNECT_TIMEOUT, context=ctx)
             smtp = smtp_cls(host, port, timeout=SMTP_CONNECT_TIMEOUT)
-            if security in {"starttls", "start-tls"}:
+            if security == "starttls":
                 try:
                     smtp.starttls(context=ctx)
                 except Exception:
@@ -1505,7 +1511,6 @@ async def _standalone_send(
     """Out-of-process Email delivery via SMTP (one-shot). Implements the
     standalone_sender_fn contract; replaces the legacy _send_email helper."""
     import smtplib
-    import ssl as _ssl
     from email.mime.text import MIMEText
     from email.utils import formatdate
 
@@ -1517,25 +1522,17 @@ async def _standalone_send(
         smtp_port = int(_get_secret("EMAIL_SMTP_PORT", "587") or "587")
     except (ValueError, TypeError):
         smtp_port = 587
-    smtp_security = (
-        _get_secret("EMAIL_SMTP_SECURITY", "")
-        or str(extra.get("smtp_security") or "")
-        or ("tls" if smtp_port == 465 else "starttls")
-    ).strip().lower().replace("_", "-")
+    smtp_security = _normalize_security(
+        _get_secret("EMAIL_SMTP_SECURITY", "") or extra.get("smtp_security"),
+        default="tls" if smtp_port == 465 else "starttls",
+    )
     smtp_tls_verify = _esecret_bool(
         "EMAIL_SMTP_TLS_VERIFY",
         is_truthy_value(extra.get("smtp_tls_verify"), default=True),
     )
-    valid_modes = {
-        "tls", "ssl", "implicit", "implicit-tls",
-        "starttls", "start-tls",
-        "none", "plain", "plaintext",
-    }
 
     if not all([address, password, smtp_host]):
         return {"error": "Email not configured (EMAIL_ADDRESS, EMAIL_PASSWORD, EMAIL_SMTP_HOST required)"}
-    if smtp_security not in valid_modes:
-        return {"error": "Unsupported EMAIL_SMTP_SECURITY value: " + smtp_security}
 
     try:
         msg = MIMEText(message, "plain", "utf-8")
@@ -1544,16 +1541,12 @@ async def _standalone_send(
         msg["Subject"] = "Hermes Agent"
         msg["Date"] = formatdate(localtime=True)
 
-        ctx = (
-            _ssl.create_default_context()
-            if smtp_tls_verify
-            else _ssl._create_unverified_context()
-        )
-        if smtp_security in {"tls", "ssl", "implicit", "implicit-tls"}:
+        ctx = _tls_context(smtp_tls_verify, smtp_host)
+        if smtp_security == "tls":
             server = smtplib.SMTP_SSL(smtp_host, smtp_port, context=ctx)
         else:
             server = smtplib.SMTP(smtp_host, smtp_port)
-            if smtp_security in {"starttls", "start-tls"}:
+            if smtp_security == "starttls":
                 try:
                     server.starttls(context=ctx)
                 except Exception:

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -7,8 +7,12 @@ Uses IMAP to receive and SMTP to send messages.
 Environment variables:
     EMAIL_IMAP_HOST     — IMAP server host (e.g., imap.gmail.com)
     EMAIL_IMAP_PORT     — IMAP server port (default: 993)
+    EMAIL_IMAP_SECURITY — IMAP transport: tls, starttls, or plain (default: tls)
+    EMAIL_IMAP_TLS_VERIFY — Verify the IMAP TLS certificate (default: true)
     EMAIL_SMTP_HOST     — SMTP server host (e.g., smtp.gmail.com)
     EMAIL_SMTP_PORT     — SMTP server port (default: 587)
+    EMAIL_SMTP_SECURITY — SMTP transport: tls, starttls, or plain (port-based default)
+    EMAIL_SMTP_TLS_VERIFY — Verify the SMTP TLS certificate (default: true)
     EMAIL_ADDRESS       — Email address for the agent
     EMAIL_PASSWORD      — Email password or app-specific password
     EMAIL_POLL_INTERVAL — Seconds between mailbox checks (default: 15)
@@ -554,8 +558,26 @@ class EmailAdapter(BasePlatformAdapter):
         self._password = _get_secret("EMAIL_PASSWORD", "")
         self._imap_host = (_get_secret("EMAIL_IMAP_HOST", "") or extra.get("imap_host", "")).strip()
         self._imap_port = _esecret_int("EMAIL_IMAP_PORT", 993)
+        self._imap_security = (
+            _get_secret("EMAIL_IMAP_SECURITY", "")
+            or extra.get("imap_security", "")
+            or "tls"
+        ).strip().lower()
+        self._imap_tls_verify = _esecret_bool(
+            "EMAIL_IMAP_TLS_VERIFY",
+            is_truthy_value(extra.get("imap_tls_verify"), default=True),
+        )
         self._smtp_host = (_get_secret("EMAIL_SMTP_HOST", "") or extra.get("smtp_host", "")).strip()
         self._smtp_port = _esecret_int("EMAIL_SMTP_PORT", 587)
+        self._smtp_security = (
+            _get_secret("EMAIL_SMTP_SECURITY", "")
+            or extra.get("smtp_security", "")
+            or ("tls" if self._smtp_port == 465 else "starttls")
+        ).strip().lower()
+        self._smtp_tls_verify = _esecret_bool(
+            "EMAIL_SMTP_TLS_VERIFY",
+            is_truthy_value(extra.get("smtp_tls_verify"), default=True),
+        )
         self._poll_interval = _esecret_int("EMAIL_POLL_INTERVAL", 15)
 
         # Skip attachments — configured via config.yaml:
@@ -627,6 +649,40 @@ class EmailAdapter(BasePlatformAdapter):
             # Fallback: just clear old entries if sort fails
             self._seen_uids = set(list(self._seen_uids)[-self._seen_uids_max // 2:])
 
+    @staticmethod
+    def _tls_context(verify: bool) -> ssl.SSLContext:
+        """Return a verified context unless loopback/custom TLS opts out."""
+        return ssl.create_default_context() if verify else ssl._create_unverified_context()
+
+    def _connect_imap(self) -> imaplib.IMAP4:
+        """Create an IMAP connection using implicit TLS, STARTTLS, or plaintext."""
+        security = self._imap_security.replace("_", "-")
+        valid_modes = {
+            "tls", "ssl", "implicit", "implicit-tls",
+            "starttls", "start-tls",
+            "none", "plain", "plaintext",
+        }
+        if security not in valid_modes:
+            raise ValueError(
+                "Unsupported EMAIL_IMAP_SECURITY value: " + self._imap_security
+            )
+        if security in {"tls", "ssl", "implicit", "implicit-tls"}:
+            return imaplib.IMAP4_SSL(
+                self._imap_host,
+                self._imap_port,
+                timeout=30,
+                ssl_context=self._tls_context(self._imap_tls_verify),
+            )
+
+        imap = imaplib.IMAP4(self._imap_host, self._imap_port, timeout=30)
+        if security in {"starttls", "start-tls"}:
+            try:
+                imap.starttls(ssl_context=self._tls_context(self._imap_tls_verify))
+            except Exception:
+                _close_imap(imap)
+                raise
+        return imap
+
     def _connect_smtp(self) -> smtplib.SMTP:
         """Create an SMTP connection, selecting the correct protocol for the port.
 
@@ -642,22 +698,33 @@ class EmailAdapter(BasePlatformAdapter):
         Returns a connected SMTP object with TLS established — callers
         can proceed directly to ``login()``.
         """
-        ctx = ssl.create_default_context()
+        ctx = self._tls_context(self._smtp_tls_verify)
         host = self._smtp_host
         port = self._smtp_port
+        security = self._smtp_security.replace("_", "-")
+        valid_modes = {
+            "tls", "ssl", "implicit", "implicit-tls",
+            "starttls", "start-tls",
+            "none", "plain", "plaintext",
+        }
+        if security not in valid_modes:
+            raise ValueError(
+                "Unsupported EMAIL_SMTP_SECURITY value: " + self._smtp_security
+            )
 
         def _connect(*, ipv4_only: bool = False) -> smtplib.SMTP:
             """Attempt one SMTP connection."""
             smtp_cls = _IPv4SMTP if ipv4_only else smtplib.SMTP
             smtp_ssl_cls = _IPv4SMTP_SSL if ipv4_only else smtplib.SMTP_SSL
-            if port == 465:
+            if security in {"tls", "ssl", "implicit", "implicit-tls"}:
                 return smtp_ssl_cls(host, port, timeout=SMTP_CONNECT_TIMEOUT, context=ctx)
             smtp = smtp_cls(host, port, timeout=SMTP_CONNECT_TIMEOUT)
-            try:
-                smtp.starttls(context=ctx)
-            except Exception:
-                smtp.close()
-                raise
+            if security in {"starttls", "start-tls"}:
+                try:
+                    smtp.starttls(context=ctx)
+                except Exception:
+                    smtp.close()
+                    raise
             return smtp
 
         try:
@@ -711,7 +778,7 @@ class EmailAdapter(BasePlatformAdapter):
             # (#79889).
             imap = None
             try:
-                imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
+                imap = self._connect_imap()
                 imap.login(self._address, self._password)
                 _send_imap_id(imap)
                 imap.select("INBOX")
@@ -855,7 +922,7 @@ class EmailAdapter(BasePlatformAdapter):
         results = []
         imap: Optional[imaplib.IMAP4] = None
         try:
-            imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
+            imap = self._connect_imap()
             try:
                 imap.login(self._address, self._password)
                 _send_imap_id(imap)
@@ -1450,9 +1517,25 @@ async def _standalone_send(
         smtp_port = int(_get_secret("EMAIL_SMTP_PORT", "587") or "587")
     except (ValueError, TypeError):
         smtp_port = 587
+    smtp_security = (
+        _get_secret("EMAIL_SMTP_SECURITY", "")
+        or str(extra.get("smtp_security") or "")
+        or ("tls" if smtp_port == 465 else "starttls")
+    ).strip().lower().replace("_", "-")
+    smtp_tls_verify = _esecret_bool(
+        "EMAIL_SMTP_TLS_VERIFY",
+        is_truthy_value(extra.get("smtp_tls_verify"), default=True),
+    )
+    valid_modes = {
+        "tls", "ssl", "implicit", "implicit-tls",
+        "starttls", "start-tls",
+        "none", "plain", "plaintext",
+    }
 
     if not all([address, password, smtp_host]):
         return {"error": "Email not configured (EMAIL_ADDRESS, EMAIL_PASSWORD, EMAIL_SMTP_HOST required)"}
+    if smtp_security not in valid_modes:
+        return {"error": "Unsupported EMAIL_SMTP_SECURITY value: " + smtp_security}
 
     try:
         msg = MIMEText(message, "plain", "utf-8")
@@ -1461,8 +1544,21 @@ async def _standalone_send(
         msg["Subject"] = "Hermes Agent"
         msg["Date"] = formatdate(localtime=True)
 
-        server = smtplib.SMTP(smtp_host, smtp_port)
-        server.starttls(context=_ssl.create_default_context())
+        ctx = (
+            _ssl.create_default_context()
+            if smtp_tls_verify
+            else _ssl._create_unverified_context()
+        )
+        if smtp_security in {"tls", "ssl", "implicit", "implicit-tls"}:
+            server = smtplib.SMTP_SSL(smtp_host, smtp_port, context=ctx)
+        else:
+            server = smtplib.SMTP(smtp_host, smtp_port)
+            if smtp_security in {"starttls", "start-tls"}:
+                try:
+                    server.starttls(context=ctx)
+                except Exception:
+                    server.close()
+                    raise
         server.login(address, password)
         server.send_message(msg)
         server.quit()

--- a/tests/gateway/test_email_robustness.py
+++ b/tests/gateway/test_email_robustness.py
@@ -77,5 +77,39 @@ class TestMessageIdDomain(unittest.TestCase):
         self.assertEqual(adapter._message_id_domain(), "localhost")
 
 
+class TestTransportSecurity(unittest.TestCase):
+    """platforms.email.extra.imap_security / smtp_security select the transport (#99641)."""
+
+    def _adapter(self, **extra):
+        from gateway.config import PlatformConfig
+
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com", "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "127.0.0.1", "EMAIL_IMAP_PORT": "1143",
+            "EMAIL_SMTP_HOST": "127.0.0.1", "EMAIL_SMTP_PORT": "1025",
+        }, clear=True):
+            from plugins.platforms.email.adapter import EmailAdapter
+
+            return EmailAdapter(PlatformConfig(enabled=True, extra=extra))
+
+    def test_starttls_builds_plain_imap_then_upgrades(self):
+        adapter = self._adapter(imap_security="starttls", imap_tls_verify=False)
+        imap = MagicMock()
+        with patch("imaplib.IMAP4", return_value=imap) as imap_cls, \
+             patch("imaplib.IMAP4_SSL") as imap_ssl_cls:
+            self.assertIs(adapter._connect_imap(), imap)
+        imap_cls.assert_called_once_with("127.0.0.1", 1143, timeout=30)
+        imap_ssl_cls.assert_not_called()
+        imap.starttls.assert_called_once()
+
+    def test_unknown_mode_falls_back_to_secure_default(self):
+        adapter = self._adapter(imap_security="bogus", smtp_security="bogus")
+        self.assertEqual(adapter._imap_security, "tls")
+        self.assertEqual(adapter._smtp_security, "starttls")  # port 1025 != 465
+        # verification stays ON unless explicitly opted out
+        self.assertTrue(adapter._imap_tls_verify)
+        self.assertTrue(adapter._smtp_tls_verify)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/website/docs/user-guide/messaging/email.md
+++ b/website/docs/user-guide/messaging/email.md
@@ -48,6 +48,31 @@ Most email providers support IMAP/SMTP. Check your provider's documentation for:
 - SMTP host and port (usually port 587 with STARTTLS)
 - Whether app passwords are required
 
+### Proton Mail Bridge / local relays
+
+Proton Mail Bridge (and similar local relays such as a self-hosted MTA) listen on
+loopback with **STARTTLS** and a self-signed certificate, so the defaults
+(implicit TLS on IMAP 993, verified certificates) won't connect. Override the
+transport in `~/.hermes/config.yaml`:
+
+```yaml
+platforms:
+  email:
+    enabled: true
+    extra:
+      imap_host: 127.0.0.1
+      imap_security: starttls     # tls (default) | starttls | plain
+      imap_tls_verify: false      # Bridge uses a self-signed cert
+      smtp_host: 127.0.0.1
+      smtp_security: starttls     # default: tls on port 465, starttls otherwise
+      smtp_tls_verify: false
+```
+
+and set `EMAIL_IMAP_PORT=1143` / `EMAIL_SMTP_PORT=1025` alongside your Bridge
+credentials in `~/.hermes/.env`. Unknown `*_security` values log a warning and
+fall back to the secure default. Only disable `*_tls_verify` for loopback hosts —
+Hermes logs a warning when verification is off for any other host.
+
 ---
 
 ## Step 1: Configure Hermes


### PR DESCRIPTION
## Summary
The email adapter can now talk to Proton Mail Bridge and other local relays: IMAP/SMTP transport security is configurable (`tls` / `starttls` / `plain`) with an opt-in TLS-verify toggle, instead of hardwired `IMAP4_SSL` + STARTTLS with a strict default context.

## Changes
- `plugins/platforms/email/adapter.py`: `platforms.email.extra.imap_security / smtp_security / imap_tls_verify / smtp_tls_verify` (env `EMAIL_*` bridge kept); cherry-pick of #99641's feature commit (@alessandrolamberti)
- Follow-up: one module-level `_normalize_security()` replaces 3 copies of alias handling; `_tls_context()` warns once when verification is disabled for a non-loopback host; `_esecret_bool` helper; no new `hermes setup` prompts
- Docs: email.md "Proton Mail Bridge / local relays" recipe; 2 tests

## Validation
| | Before | After |
|---|---|---|
| IMAP 127.0.0.1:1143 starttls | `IMAP4_SSL` handshake fails | `IMAP4` + `.starttls()` |
| unknown mode | — | warns, defaults to tls |
| default config | tls / starttls-by-port | unchanged |

Credit: @alessandrolamberti (#99641, authorship preserved). Same bug reported/fixed independently in #88226 (@DOSNostalgia, earliest), #51275 (@liuhao1024, #51263), #42907 (@sayurinana) — thanks all.

## Infographic

![email tls modes](https://v3b.fal.media/files/b/0aa8ce87/Z7vUIkjMA28wa1ZAw38Ki_XoaqWy1D.png)
