### PR TITLE
fix(codex): reap app-server process trees

### DIFF
--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 import os
 import queue
+import signal
 import subprocess
 import threading
 import time
@@ -131,6 +132,15 @@ class CodexAppServerClient:
         # (#56747). Hide-only — stdio pipes stay intact for the app-server wire.
         from hermes_cli._subprocess_compat import windows_hide_flags
 
+        popen_kwargs: dict[str, Any] = {}
+        if os.name == "posix":
+            # Codex starts MCP/tool helpers of its own. Put the complete tree
+            # in a dedicated process group so close() can reap descendants as
+            # well as the direct app-server child. Killing only _proc leaked
+            # python MCP workers and codex-code-mode helpers across completed
+            # gateway sessions until the host reached global OOM.
+            popen_kwargs["start_new_session"] = True
+
         self._proc = subprocess.Popen(
             cmd,
             stdin=subprocess.PIPE,
@@ -139,7 +149,9 @@ class CodexAppServerClient:
             bufsize=0,
             env=spawn_env,
             creationflags=windows_hide_flags(),
+            **popen_kwargs,
         )
+        self._process_group_id = self._proc.pid if os.name == "posix" else None
         self._next_id = 1
         self._pending: dict[int, _Pending] = {}
         self._pending_lock = threading.Lock()
@@ -183,7 +195,7 @@ class CodexAppServerClient:
         return result
 
     def close(self, timeout: float = 3.0) -> None:
-        """Close stdin and wait for the subprocess to exit, escalating to kill."""
+        """Close stdin and reap the complete Codex subprocess tree."""
         if self._closed:
             return
         self._closed = True
@@ -192,15 +204,36 @@ class CodexAppServerClient:
                 self._proc.stdin.close()
         except Exception:
             pass
+
+        process_group_id = self._process_group_id
+        kill_process_group = getattr(os, "killpg", None)
+        hard_kill_signal = getattr(signal, "SIGKILL", signal.SIGTERM)
+
+        def _signal_process_tree(sig: int) -> bool:
+            if process_group_id is None or kill_process_group is None:
+                return False
+            try:
+                kill_process_group(process_group_id, sig)
+                return True
+            except OSError:
+                return False
+
         try:
-            self._proc.terminate()
+            if not _signal_process_tree(signal.SIGTERM):
+                self._proc.terminate()
             self._proc.wait(timeout=timeout)
         except subprocess.TimeoutExpired:
             try:
-                self._proc.kill()
+                if not _signal_process_tree(hard_kill_signal):
+                    self._proc.kill()
                 self._proc.wait(timeout=1.0)
             except Exception:
                 pass
+        finally:
+            # The direct app-server can exit before an MCP/tool grandchild.
+            # A final group-wide kill guarantees no descendant survives after
+            # the owning Hermes session has been retired or evicted.
+            _signal_process_tree(hard_kill_signal)
 
     def __enter__(self) -> "CodexAppServerClient":
         return self

--- a/tests/agent/transports/test_codex_app_server_runtime.py
+++ b/tests/agent/transports/test_codex_app_server_runtime.py
@@ -111,6 +111,86 @@ class TestCodexAppServerModule:
         assert "-32600" in str(err)
 
 
+class TestProcessTreeCleanup:
+    """Codex-owned MCP/tool descendants must not outlive their session."""
+
+    def test_posix_spawn_uses_dedicated_process_group(self, monkeypatch):
+        import os
+        import subprocess
+        from agent.transports import codex_app_server as cas
+
+        captured = {}
+
+        class FakePopen:
+            def __init__(self, cmd, *args, **kwargs):
+                captured.update(kwargs)
+                self.stdin = None
+                self.stdout = None
+                self.stderr = None
+                self.pid = 4321
+
+            def poll(self):
+                return None
+
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+        client = cas.CodexAppServerClient(codex_bin="codex")
+        client._closed = True
+
+        if os.name == "posix":
+            assert captured["start_new_session"] is True
+            assert client._process_group_id == 4321
+        else:
+            assert "start_new_session" not in captured
+            assert client._process_group_id is None
+
+    def test_close_signals_complete_posix_process_group(self, monkeypatch):
+        import io
+        import signal
+        import subprocess
+        from agent.transports import codex_app_server as cas
+
+        if cas.os.name != "posix":
+            pytest.skip("POSIX process groups are not available")
+
+        signals = []
+
+        class FakePopen:
+            def __init__(self, cmd, *args, **kwargs):
+                self.stdin = io.BytesIO()
+                self.stdout = None
+                self.stderr = None
+                self.pid = 4321
+
+            def poll(self):
+                return None
+
+            def wait(self, timeout=None):
+                return 0
+
+            def terminate(self):
+                raise AssertionError(
+                    "direct child termination bypassed process group"
+                )
+
+            def kill(self):
+                raise AssertionError("direct child kill bypassed process group")
+
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+        monkeypatch.setattr(
+            cas.os,
+            "killpg",
+            lambda pgid, sig: signals.append((pgid, sig)),
+        )
+
+        client = cas.CodexAppServerClient(codex_bin="codex")
+        client.close()
+
+        assert signals == [
+            (4321, signal.SIGTERM),
+            (4321, signal.SIGKILL),
+        ]
+
+
 class TestSpawnEnvIsolation:
     """The codex spawn must NOT rewrite HOME — codex's shell tool spawns
     subprocesses (gh, git, npm, aws, gcloud, ...) that need to find their


### PR DESCRIPTION
## Summary
- start Codex app-server in a dedicated POSIX process group
- terminate and finally kill the whole group during client close
- cover spawn isolation and descendant cleanup with regression tests

## Incident
A 1.8 GiB gateway host accumulated retired Codex MCP/tool descendants across sessions. Five worker trees plus the gateway consumed about 1.15 GiB and triggered 28 global OOM kills. Killing only the direct app-server process left grandchildren alive.

## Validation
CI only; no project build was run on the server. Local validation was limited to AST parsing and `git diff --check`.