### PR TITLE
fix(bot-mode): DMs to a Desktop-owned Bot Chat land in the live session instead of being dropped (#100523)

### DIFF
--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -422,6 +422,29 @@ def test_delivery_runner_preserves_child_failure_and_unlinks(tmp_path):
     assert not dm_file.exists()
 
 
+def test_delivery_runner_surfaces_live_owner_refusal(tmp_path, capsys):
+    """#100523: the CLI's single-owner lease refusal is a delivery FAILURE the
+    sender can read, not a raw exit-1 with the payload silently gone."""
+    dm_file = tmp_path / "message.txt"
+    dm_file.write_text("hi", encoding="utf-8")
+    child = tmp_path / "owned.py"
+    child.write_text(
+        "import sys\n"
+        "print('Session abc already has a live owner (desktop, pid 1).', file=sys.stderr)\n"
+        "raise SystemExit(1)\n",
+        encoding="utf-8",
+    )
+
+    returncode = bot_mode_dm._run_delivery(
+        [sys.executable, str(child), "-p", "ops"], str(dm_file), stdin_file=False
+    )
+
+    assert returncode == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["reason"] == "target_busy"
+    assert "NOT delivered" in payload["error"]
+
+
 def test_query_file_delivery_closes_stdin_for_initial_attempt_and_retry(
     tmp_path, monkeypatch
 ):

--- a/tests/tui_gateway/test_bot_relay_methods.py
+++ b/tests/tui_gateway/test_bot_relay_methods.py
@@ -127,7 +127,8 @@ def test_deliver_lands_in_live_bot_chat_instead_of_subprocess(home, monkeypatch)
         {"profile_home": str(home / "profiles" / "ops"), "pending_title": "Bot Chat", "history": []},
     )
     out = _result(srv._methods["bot_relay.deliver"](1, {"profile": "ops", "message": "ping"}))
-    assert submitted == [{"session_id": "live-ops", "text": "ping"}]
+    # queued=True is the invariant: a DM never interrupts a turn in flight.
+    assert submitted == [{"session_id": "live-ops", "text": "ping", "queued": True}]
     assert not spawned
     assert "reply" in out
 

--- a/tests/tui_gateway/test_bot_relay_methods.py
+++ b/tests/tui_gateway/test_bot_relay_methods.py
@@ -106,6 +106,44 @@ def test_deliver_requires_params(home):
     assert "error" in err
 
 
+def test_deliver_lands_in_live_bot_chat_instead_of_subprocess(home, monkeypatch):
+    """#100523: a Desktop-owned Bot Chat receives the DM as a normal user turn.
+
+    With the target's Bot Chat live in this gateway, the subprocess transport
+    would be fenced out by the single-owner lease and drop the payload. The
+    handler must route through prompt.submit (the composer's choke point) and
+    never spawn the CLI.
+    """
+    spawned = []
+    submitted = []
+    monkeypatch.setattr("subprocess.run", lambda *a, **k: spawned.append(a) or None)
+    monkeypatch.setitem(
+        srv._methods, "prompt.submit", lambda rid, p: submitted.append(p) or srv._ok(rid, {"status": "streaming"})
+    )
+    monkeypatch.setattr(srv, "_profile_home", lambda name: home / "profiles" / name)
+    monkeypatch.setitem(
+        srv._sessions,
+        "live-ops",
+        {"profile_home": str(home / "profiles" / "ops"), "pending_title": "Bot Chat", "history": []},
+    )
+    out = _result(srv._methods["bot_relay.deliver"](1, {"profile": "ops", "message": "ping"}))
+    assert submitted == [{"session_id": "live-ops", "text": "ping"}]
+    assert not spawned
+    assert "reply" in out
+
+    # A live session titled anything else for the same profile does not qualify:
+    # the subprocess path runs exactly as before.
+    srv._sessions["live-ops"]["pending_title"] = "Scratch"
+    submitted.clear()
+
+    class _Proc:
+        returncode, stdout, stderr = 0, "pong", ""
+
+    monkeypatch.setattr("subprocess.run", lambda *a, **k: spawned.append(a) or _Proc())
+    out = _result(srv._methods["bot_relay.deliver"](2, {"profile": "ops", "message": "ping"}))
+    assert out["reply"] == "pong" and spawned and not submitted
+
+
 def test_reply_roundtrip_and_id_validation(home):
     envelope_id = "c" * 32
     _result(srv._methods["bot_relay.reply"](1, {"id": envelope_id, "reply": "hi"}))

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -609,6 +609,17 @@ def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool) -> int:
                     )
             # Re-emit the transport's streams: stdout is the reply text the
             # completion notification carries back to the sending agent.
+            if proc.returncode != 0 and "already has a live owner" in (proc.stderr or ""):
+                # #100523: the target's Bot Chat is held live by another
+                # surface (Desktop). The turn never ran, so tell the sender
+                # plainly instead of leaking a raw lease error + exit code.
+                who = argv[argv.index("-p") + 1] if "-p" in argv[:-1] else "the teammate"
+                print(json.dumps({
+                    "error": f"Delivery failed: @{who}'s Bot Chat is open on another "
+                             "surface right now, so your message was NOT delivered. Try again later.",
+                    "reason": "target_busy",
+                }))
+                return 1
             if proc.stdout:
                 sys.stdout.write(proc.stdout)
                 sys.stdout.flush()

--- a/tui_gateway/methods_bot_relay.py
+++ b/tui_gateway/methods_bot_relay.py
@@ -109,6 +109,38 @@ def _(rid, params: dict) -> dict:
         if resolved not in known:
             return _err(rid, 4092, f"no profile '{profile}' on this gateway")
 
+        # #100523: when THIS gateway already hosts the target's Bot Chat live
+        # (the Desktop has it open), the subprocess transport is fenced out by
+        # the single-owner lease ("already has a live owner") and the payload
+        # is dropped. Land the DM in the live session as a normal user turn
+        # via prompt.submit instead — same choke point the composer uses, so
+        # role alternation, persistence and streaming all behave as a typed
+        # message would. (Nested per method_ctx rebinding.)
+        def _live_bot_chat_sid(profile_name: str) -> str:
+            from tools.bot_mode_probe import BOT_CHAT_TITLE
+
+            live_home = _profile_home(profile_name)
+            want_home = str(live_home) if live_home is not None else None
+            for live_sid, record in list(_sessions.items()):
+                if not isinstance(record, dict):
+                    continue
+                if (record.get("profile_home") or None) != want_home:
+                    continue
+                key = _session_lookup_key(record, fallback=live_sid)
+                if _session_live_title(record, key) == BOT_CHAT_TITLE:
+                    return live_sid
+            return ""
+
+        live_sid = _live_bot_chat_sid(resolved)
+        if live_sid:
+            submitted = _methods["prompt.submit"](rid, {"session_id": live_sid, "text": message})
+            if "error" in submitted:
+                return submitted
+            return _ok(
+                rid,
+                {"reply": f"Delivered into @{resolved}'s open Bot Chat; the reply will appear there."},
+            )
+
         fd, tmp = tempfile.mkstemp(prefix="hermes-relay-dm-", suffix=".txt", text=True)
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as f:

--- a/tui_gateway/methods_bot_relay.py
+++ b/tui_gateway/methods_bot_relay.py
@@ -133,7 +133,10 @@ def _(rid, params: dict) -> dict:
 
         live_sid = _live_bot_chat_sid(resolved)
         if live_sid:
-            submitted = _methods["prompt.submit"](rid, {"session_id": live_sid, "text": message})
+            # queued=True: a teammate's DM runs as the NEXT turn. It must never
+            # interrupt or steer a turn already in flight (the default busy
+            # mode does); hundreds of arrivals simply queue in arrival order.
+            submitted = _methods["prompt.submit"](rid, {"session_id": live_sid, "text": message, "queued": True})
             if "error" in submitted:
                 return submitted
             return _ok(


### PR DESCRIPTION
## Summary

Fixes #100523: a Bot Mode DM sent to a teammate whose canonical **"Bot Chat" is open on the Desktop** was silently dropped. The Desktop-hosted session holds the single-owner lease, so the one-turn `hermes -p <bot> chat -c "Bot Chat"` subprocess that `bot_relay.deliver` spawns refused with `already has a live owner`, exited 1, and the payload was gone — while the sender had already been acked "sent".

Reworks #100544 (@fangliquanflq — routing-into-the-live-session insight) and #100542 (@686f6c61 — first claimant) down to the minimal in-process fix. Both authors carry `Co-authored-by:` trailers on the commit.

## Changes

- `tui_gateway/methods_bot_relay.py` — `bot_relay.deliver`: before spawning the subprocess, look up a live in-process session for the target profile whose title resolves to `Bot Chat` (same `profile_home` string compare as `session.resume`'s `_find_live_unpersisted`; `pending_title` for lazy sessions, db title otherwise via `_session_live_title`). If found, submit the message through the **existing `prompt.submit` handler** — the composer's choke point — so it lands as a normal user turn (role alternation preserved, no synthetic injection, streams to the open window) and return ok. No live owner → the subprocess path runs exactly as before. Helper is nested in the handler per the method_ctx rebinding rule. (+32)
- `tools/bot_mode_dm.py` — local `message_agent` subprocess path: when the CLI's stderr carries the lease refusal, emit a structured `{"error": "... NOT delivered ...", "reason": "target_busy"}` payload so the sender learns the message did not land, instead of a raw exit-1 with the text buried in stderr. (+11)
- 2 tests (+61): `test_deliver_lands_in_live_bot_chat_instead_of_subprocess` (live Bot Chat → prompt.submit used, subprocess never spawned; a live session with another title → subprocess as before) and `test_delivery_runner_surfaces_live_owner_refusal`.

## Validation

- `pytest tests/tui_gateway/test_bot_relay_methods.py tests/tools/test_bot_mode_dm.py` → 49 passed, 1 skipped. Sabotage run (fix stashed, tests kept): exactly the two new tests fail.
- `ruff check` clean on all four files.
- **Live repro:** real dashboard WebSocket harness (`uvicorn` + `/api/ws`, isolated `HERMES_HOME`, real provider creds, profile `beta`). A WS client did `session.create {profile: beta, title: "Bot Chat"}` + one real turn (holding the session live), then `bot_relay.deliver {profile: beta, message: "[relay from @alpha] ping-100523: reply with the word PONG only."}` was called over the same socket. — before (origin/main): `{"code": 5092, "message": "delivery turn failed: Session 20260902_051449_f1607d already has a live owner (tui, pid 3424374, running 2m)..."}` and beta's transcript stayed at `user: Reply with exactly the word OK / assistant: OK` — payload dropped; after (this branch): `{"reply": "Delivered into @beta's open Bot Chat; the reply will appear there."}` and beta's `state.db` transcript gained `user: [relay from @alpha] ping-100523 ... / assistant: PONG` — the DM landed as a normal user turn and the agent answered in the live session.

Closes #100523
Supersedes #100544, #100542

## Infographic

![Bot Chat DMs land in the live session](https://v3b.fal.media/files/b/0aa8cf01/3q_FGIeSLzVZjmSaru6vg_7L48mj7O.png)
