### PR TITLE
fix(desktop): keep a finished transcript directive out of the remend pass

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -16,6 +16,7 @@ import { chunkByLines, SyntaxHighlighter } from '@/components/chat/shiki-highlig
 import { ZoomableImage } from '@/components/chat/zoomable-image'
 import { ErrorBoundary } from '@/components/error-boundary'
 import { detectArtifact } from '@/lib/artifact-detect'
+import { remendPreservingTrailingDirective } from '@/lib/directive-remend-guard'
 import { normalizeExternalUrl, openExternalLink, PrettyLink } from '@/lib/external-link'
 import { createMemoizedMathPlugin } from '@/lib/katex-memo'
 import { parseMarkdownIntoBlocksCached } from '@/lib/markdown-blocks'
@@ -99,9 +100,15 @@ function useCodePlugin(): CodePlugin | null {
 // Replaces Streamdown's `parseIncompleteMarkdown` (full-text remend per
 // flush) with a tail-bounded repair. Must stay module-scope so the prop
 // identity is stable across renders.
+//
+// A COMPLETE trailing transcript directive is held out of the repair: its
+// attribute values are natural language, so an unpaired `*` / `_` / backtick
+// inside a prompt made the repair append a closer after the directive's `}`
+// — which breaks the whole-paragraph match in parseTranscriptDirective and
+// degrades a claimed directive (the Follow-up panel) to raw text.
 function preprocessWithTailRepair(text: string): string {
   try {
-    return tailBoundedRemend(preprocessMarkdown(text))
+    return remendPreservingTrailingDirective(preprocessMarkdown(text), tailBoundedRemend)
   } catch {
     return text
   }

--- a/apps/desktop/src/lib/directive-remend-guard.test.ts
+++ b/apps/desktop/src/lib/directive-remend-guard.test.ts
@@ -1,0 +1,104 @@
+import { tailBoundedRemend } from '@assistant-ui/react-streamdown'
+import { describe, expect, it } from 'vitest'
+
+import { completeDirectiveTailStart, remendPreservingTrailingDirective } from '@/lib/directive-remend-guard'
+import { parseTranscriptDirective } from '@/lib/transcript-directives'
+
+/**
+ * The reported bug: a Follow-up panel rendered as raw
+ * `::followup{...}*` text. The prompt `Dọn các worktree wt-* đã merge`
+ * carries an unpaired `*`, so the incomplete-markdown repair appended a
+ * closing `*` after the directive's `}` — and core's parser, which requires
+ * the directive to be the whole paragraph, stopped matching.
+ *
+ * These tests pin the real repair function, not a stand-in.
+ */
+
+const REPORTED =
+  '::followup{p1="Bắn một đơn PRINTHUB canary mới lên Sheet và theo trọn vòng tới tracking" ' +
+  'p2="Đối chiếu chênh giá 23.89 và 11.89 của đơn 550728" ' +
+  'p3="Dọn các worktree wt-* đã merge để tránh lạc commit" ' +
+  'p4="Thêm log có ID job và đơn cho nhịp kéo Sheet để truy vết từng lượt"}'
+
+const guard = (text: string) => remendPreservingTrailingDirective(text, tailBoundedRemend)
+
+describe('remendPreservingTrailingDirective', () => {
+  it('reproduces the bug without the guard', () => {
+    // Guard rail on the guard: if upstream ever stops corrupting this, the
+    // test below stops proving anything and this failure says why.
+    expect(tailBoundedRemend(REPORTED)).not.toBe(REPORTED)
+    expect(parseTranscriptDirective(tailBoundedRemend(REPORTED))).toBeNull()
+  })
+
+  it('keeps the reported directive parseable', () => {
+    const out = guard(REPORTED)
+
+    expect(out).toBe(REPORTED)
+
+    const parsed = parseTranscriptDirective(out)
+
+    expect(parsed?.name).toBe('followup')
+    expect(parsed?.attrs.p3).toBe('Dọn các worktree wt-* đã merge để tránh lạc commit')
+  })
+
+  it.each([
+    ['asterisk', 'Dọn worktree wt-* đã merge'],
+    ['double asterisk', 'Chạy **npm test'],
+    ['underscore', 'Sửa file _config'],
+    ['backtick', 'Chạy `npm test'],
+    ['strikethrough', 'Bỏ ~~cũ'],
+    ['bracket', 'Mở issue [123']
+  ])('survives an unpaired %s inside a prompt', (_label, prompt) => {
+    const directive = `::followup{p1="${prompt}"}`
+
+    expect(guard(directive)).toBe(directive)
+    expect(parseTranscriptDirective(guard(directive))?.attrs.p1).toBe(prompt)
+  })
+
+  it('still repairs the prose above the directive', () => {
+    const text = `Đang chạy **dở dang\n\n${REPORTED}`
+    const out = guard(text)
+
+    expect(out.endsWith(REPORTED)).toBe(true)
+    // The paragraph above keeps its repair (the dangling ** is closed).
+    expect(out.slice(0, out.length - REPORTED.length)).toContain('**dở dang**')
+  })
+
+  it('tolerates trailing whitespace after the directive', () => {
+    const text = `Xong.\n\n${REPORTED}\n`
+
+    expect(guard(text).endsWith(`${REPORTED}\n`)).toBe(true)
+  })
+
+  it('leaves a still-streaming directive to the normal repair', () => {
+    const partial = '::followup{p1="Dọn worktree wt-* đã me'
+
+    expect(completeDirectiveTailStart(partial)).toBe(-1)
+    expect(guard(partial)).toBe(tailBoundedRemend(partial))
+  })
+
+  it('is a no-op for messages without a directive', () => {
+    const cases = [
+      'Đang chạy **dở dang',
+      'Không có directive nào ở đây.',
+      'Chỉ là prose có :: hai dấu hai chấm giữa câu.',
+      'echo "}" # a brace-terminated line that is not a directive'
+    ]
+
+    for (const text of cases) {
+      expect(guard(text)).toBe(tailBoundedRemend(text))
+    }
+  })
+
+  it('does not claim a directive that is not the whole last line', () => {
+    const text = 'Xem thêm ::followup{p1="x"}'
+
+    expect(completeDirectiveTailStart(text)).toBe(-1)
+  })
+
+  it('protects any directive name, not just followup', () => {
+    const directive = '::preview{file="wt-*/demo.html"}'
+
+    expect(guard(directive)).toBe(directive)
+  })
+})

--- a/apps/desktop/src/lib/directive-remend-guard.ts
+++ b/apps/desktop/src/lib/directive-remend-guard.ts
@@ -1,0 +1,83 @@
+/**
+ * DIRECTIVE REMEND GUARD — keeps a finished transcript directive out of the
+ * incomplete-markdown repair pass.
+ *
+ * `tailBoundedRemend` closes markdown constructs the model is still typing:
+ * a dangling `*`, `_`, `` ` ``, `~~` or `[` in the LAST block gets a synthetic
+ * closer appended so a half-streamed sentence doesn't flicker as raw syntax.
+ *
+ * A transcript directive is the pathological input for that repair. It is a
+ * whole paragraph of `::name{key="value"}` whose VALUES are natural language:
+ * a prompt like `Dọn các worktree wt-* đã merge` carries one unpaired `*`, so
+ * the repair appends `*` AFTER the closing brace:
+ *
+ *     ::followup{p1="Dọn các worktree wt-* đã merge"}*
+ *
+ * Core's parser (`parseTranscriptDirective`) requires the directive to be the
+ * ENTIRE paragraph — the trailing `*` breaks the match, the plugin never
+ * claims the paragraph, and the panel silently degrades to raw text. The same
+ * happens for a lone `_`, a single backtick, `~~` and `[`; each is ordinary
+ * prose inside a quoted prompt.
+ *
+ * The repair is only correct for text the model is mid-way through. A
+ * directive that already ends in `}` is COMPLETE, so this trims the window
+ * back to the text before it: everything above still gets repaired, the
+ * directive is passed through byte-for-byte, and a directive that is still
+ * streaming (no closing brace yet) is left to the normal repair path.
+ */
+
+/** A complete directive paragraph: `::name` or `::name{...}` and nothing else
+ *  on the line. Mirrors DIRECTIVE_RE in lib/transcript-directives.ts — kept
+ *  deliberately narrow so ordinary prose starting with `::` is untouched. */
+const COMPLETE_DIRECTIVE_LINE_RE = /^::[a-z][a-z0-9-]{0,63}(?:\{[^{}]{0,1024}\})?$/
+
+/** Split point: where the trailing complete-directive paragraph begins, or
+ *  -1 when the text does not end in one. Trailing whitespace is allowed (a
+ *  streamed message often ends with a newline). */
+export function completeDirectiveTailStart(text: string): number {
+  const trimmedEnd = text.replace(/\s+$/, '')
+
+  if (!trimmedEnd.endsWith('}') && !/::[a-z][a-z0-9-]*$/.test(trimmedEnd)) {
+    return -1
+  }
+
+  const lineStart = trimmedEnd.lastIndexOf('\n') + 1
+  const line = trimmedEnd.slice(lineStart)
+
+  if (!COMPLETE_DIRECTIVE_LINE_RE.test(line)) {
+    return -1
+  }
+
+  return lineStart
+}
+
+/**
+ * Run `repair` on everything EXCEPT a trailing complete directive paragraph.
+ * With no such paragraph the text is repaired exactly as before, so this is a
+ * no-op for every message that carries no directive.
+ */
+export function remendPreservingTrailingDirective(text: string, repair: (input: string) => string): string {
+  const start = completeDirectiveTailStart(text)
+
+  if (start < 0) {
+    return repair(text)
+  }
+
+  const head = text.slice(0, start)
+  const tail = text.slice(start)
+
+  // A directive alone in the message: nothing left to repair.
+  if (!head) {
+    return tail
+  }
+
+  // Repair the head WITHOUT the blank line that separates it from the
+  // directive, then put the separator back. Handing the separator to the
+  // repair would park the synthetic closer after it (`text\n\n**`), which
+  // renders as a stray literal on its own line instead of closing the span
+  // it belongs to.
+  const separator = /\s*$/.exec(head)?.[0] ?? ''
+  const body = head.slice(0, head.length - separator.length)
+
+  return repair(body) + separator + tail
+}


### PR DESCRIPTION
## Problem

A `::followup{...}` paragraph rendered as **raw text** in the transcript instead of the plugin's panel, whenever any prompt contained an unpaired inline-markdown character:

```
::followup{p1="Clean the wt-* worktrees"}*
```

`preprocessWithTailRepair` runs `tailBoundedRemend` over the last block to close constructs the model is still typing. A directive is the pathological input for that repair: it is one paragraph whose attribute values are natural language, so a lone `*`, `_`, `` ` ``, `~~` or `[` inside a prompt gets a synthetic closer appended **after** the directive's `}`.

`parseTranscriptDirective` requires the directive to be the entire paragraph, so the extra character stops the match — the claiming plugin never renders and the user sees the raw source. Verified against the real function:

| prompt fragment | after remend |
| --- | --- |
| `Clean the wt-* worktrees` | `...}*` |
| `Run **npm test` | `...}**` |
| `Edit _config` | `...}_` |
| `Drop ~~old` | `...}~~` |
| `Open issue [123` | rewritten as an incomplete link |

## Fix

`remendPreservingTrailingDirective` holds a **complete** trailing directive out of the repair and passes it through byte-for-byte:

- prose above the directive is still repaired -- minus the blank-line separator, so the synthetic closer lands on the span it belongs to instead of on its own line;
- a **streaming** directive has no closing brace yet, so it keeps the normal repair path and mid-stream behaviour is unchanged;
- a message with no trailing directive is untouched (`repair(text)`, identical to before);
- the guard is directive-agnostic -- `::preview{...}` and any future directive benefit too.

## Tests

`apps/desktop/src/lib/directive-remend-guard.test.ts` -- 14 cases against the **real** `tailBoundedRemend`, including a guard-rail test that fails loudly if upstream ever stops corrupting the input (so the fix cannot silently become a no-op), the exact reported directive, each unpaired-character class, streaming directives, and no-directive no-ops.

```
14 passed  src/lib/directive-remend-guard.test.ts
96 passed  7 related markdown/directive suites
tsc --noEmit and eslint clean
```
