### PR TITLE
fix(tts): scope the TTS engine lease/cache and dashboard route by profile

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -5688,10 +5688,10 @@ async def tts_lease(payload: TTSLeaseRequest, profile: Optional[str] = None):
     def _apply():
         from tools.tts_tool import acquire_tts_lease, release_tts_lease
 
-        if payload.active:
-            with _config_profile_scope(profile):
+        with _config_profile_scope(profile):
+            if payload.active:
                 return acquire_tts_lease(lease)
-        return release_tts_lease(lease)
+            return release_tts_lease(lease)
 
     try:
         result = await asyncio.get_running_loop().run_in_executor(None, _apply)

--- a/tests/hermes_cli/test_web_server_tts_lease.py
+++ b/tests/hermes_cli/test_web_server_tts_lease.py
@@ -152,6 +152,55 @@ def test_acquire_resolves_provider_inside_target_profile(client, isolated_profil
     assert seen["provider"] == "kittentts"
 
 
+def test_cross_profile_same_lease_name_does_not_collapse(client, isolated_profiles, monkeypatch):
+    """Two different profiles toggling speech output with the SAME bare
+    lease name (e.g. "tui:voice-tts") must be tracked as two distinct
+    holders under gateway.multiplex_profiles — releasing one profile's
+    lease must never unload the local TTS model another profile is still
+    speaking through mid-conversation."""
+    from tools import tts_tool
+
+    monkeypatch.setattr(
+        tts_tool, "warm_tts_provider",
+        lambda cfg=None, provider=None: {"action": "noop", "warmed": False, "provider": "piper"},
+    )
+    tts_tool._piper_voice_cache["voice"] = object()
+
+    default_acquire = client.post(
+        "/api/audio/tts-lease", json={"lease": "tui:voice-tts", "active": True},
+    ).json()
+    assert default_acquire["leases"] == 1
+
+    worker_acquire = client.post(
+        "/api/audio/tts-lease?profile=worker_beta",
+        json={"lease": "tui:voice-tts", "active": True},
+    ).json()
+    assert worker_acquire["leases"] == 2, (
+        "two distinct profiles holding the same bare lease name must count "
+        "as two holders, not collapse into one"
+    )
+
+    default_release = client.post(
+        "/api/audio/tts-lease", json={"lease": "tui:voice-tts", "active": False},
+    ).json()
+    assert default_release["leases"] == 1, (
+        "worker_beta still holds its own lease — must not look like the "
+        "last holder released"
+    )
+    assert default_release["released"] == 0
+    assert len(tts_tool._piper_voice_cache) == 1, (
+        "worker_beta's resident model must survive the default profile's release"
+    )
+
+    worker_release = client.post(
+        "/api/audio/tts-lease?profile=worker_beta",
+        json={"lease": "tui:voice-tts", "active": False},
+    ).json()
+    assert worker_release["leases"] == 0
+    assert worker_release["released"] == 1
+    assert tts_tool._piper_voice_cache == {}
+
+
 def test_unknown_profile_404(client):
     resp = client.post("/api/audio/tts-lease?profile=ghost", json={"lease": "desktop:read-aloud", "active": True})
     assert resp.status_code == 404

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -58,7 +58,7 @@ from typing import Callable, Dict, Any, Iterator, List, Optional, Tuple
 from urllib.parse import urljoin, urlparse
 
 from hermes_cli._subprocess_compat import windows_hide_flags
-from hermes_constants import display_hermes_home
+from hermes_constants import display_hermes_home, hermes_home_key
 
 logger = logging.getLogger(__name__)
 def get_env_value(name, default=None):
@@ -2941,7 +2941,17 @@ def _lazy_sdk_feature_for_provider(provider: str) -> Optional[str]:
 
 
 _tts_lease_lock = threading.Lock()
+# (profile home key, lease name) pairs — profile-scoped so two profiles
+# toggling speech output with the same lease name (e.g. "tui:voice-tts")
+# under gateway.multiplex_profiles don't collapse into one holder. Without
+# this, one profile releasing its lease would look like the last holder
+# released and unload the local TTS models another profile is still
+# speaking through mid-conversation, even though its own lease is still held.
 _tts_leases: set = set()
+
+
+def _scoped_lease(lease: str) -> Tuple[str, str]:
+    return (hermes_home_key(), lease)
 
 
 def warm_tts_provider(
@@ -3030,7 +3040,7 @@ def acquire_tts_lease(lease: str, tts_config: Optional[Dict[str, Any]] = None) -
     re-warms — cheap on a cache hit, and heals a cache cleared elsewhere).
     """
     with _tts_lease_lock:
-        _tts_leases.add(lease)
+        _tts_leases.add(_scoped_lease(lease))
         holders = len(_tts_leases)
     result = warm_tts_provider(tts_config)
     result["leases"] = holders
@@ -3042,10 +3052,13 @@ def release_tts_lease(lease: str) -> Dict[str, Any]:
 
     Releasing a lease that was never acquired is a no-op (still reports the
     live holder count) so surfaces can call it unconditionally on their
-    "off" path.
+    "off" path. Must be called under the SAME profile scope (contextvar
+    override) the matching ``acquire_tts_lease`` call used — otherwise the
+    scoped key resolves to the wrong profile and the real lease is never
+    found (never released, never counted).
     """
     with _tts_lease_lock:
-        _tts_leases.discard(lease)
+        _tts_leases.discard(_scoped_lease(lease))
         holders = len(_tts_leases)
         result: Dict[str, Any] = {"leases": holders, "released": 0}
         if holders == 0:
@@ -3054,9 +3067,9 @@ def release_tts_lease(lease: str) -> Dict[str, Any]:
 
 
 def tts_lease_holders() -> List[str]:
-    """Snapshot of live lease names (diagnostics / tests)."""
+    """Snapshot of live lease names across all profiles (diagnostics / tests)."""
     with _tts_lease_lock:
-        return sorted(_tts_leases)
+        return sorted({lease for _scope, lease in _tts_leases})
 
 
 def _reset_tts_leases_for_tests() -> None:


### PR DESCRIPTION
## Summary

`tools/tts_tool.py`'s speech-output lease mechanism (#100881/#100912) is process-global, not profile-scoped: `_tts_leases` is a bare `set` of lease name strings (`"desktop:read-aloud"`, `"tui:voice-tts"`, ...), never qualified by which profile acquired it.

**Concrete failure scenario:** under `gateway.multiplex_profiles`, two different profiles each toggling speech output with the SAME lease name (e.g. two desktop connections both using `"tui:voice-tts"`) collapse into ONE set entry. Turning voice off on one profile drops the shared entry to zero holders and calls `release_tts_provider()`, which unloads EVERY resident local TTS model process-wide — including the one another profile is actively speaking through mid-conversation, forcing a silent reload (dead air) or worse for that profile.

## Fix

Scoped each lease entry with the acquiring profile's home key (`hermes_home_key()`, the same contextvar-aware helper used throughout this codebase for this exact class of bug — module-level state not isolated per multiplex profile). `_tts_leases` now holds `(profile_key, lease_name)` pairs, so two profiles' identical lease names correctly track as two distinct holders. `tts_lease_holders()`'s external contract (a flat list of bare lease names, used by tests/diagnostics) is preserved by de-scoping on read — no observable behavior change for the common single-profile case.

**Found a second, independent bug while verifying reachability** (per "hiçbir şeyi varsaymadan" — didn't assume the scan finding was complete, traced the actual call sites): the dashboard's `/api/audio/tts-lease` route (`hermes_cli/web_server.py`) wraps the ACQUIRE call in `with _config_profile_scope(profile):` but **not** the RELEASE call:

```python
if payload.active:
    with _config_profile_scope(profile):
        return acquire_tts_lease(lease)
return release_tts_lease(lease)   # <- runs under the AMBIENT/default profile, ignores ?profile=
```

Fixing only `tools/tts_tool.py`'s lease-key scoping without also fixing this would have made things **worse**: a release request for a secondary profile (`?profile=worker_beta`) would resolve `hermes_home_key()` to the wrong (ambient/default) profile, never find the real scoped lease entry, and leak it forever — that profile's resident models would never unload. Wrapped both branches in the same scope, matching the acquire path.

Checked the other two call sites of these functions (`tui_gateway/server.py`'s `_tts_lease_async`, `cli.py`'s voice toggle) — both are per-process, single-profile-per-invocation surfaces (confirmed via `os.environ["HERMES_VOICE"]`/`HERMES_VOICE_TTS"` being read/written directly, process-global by the feature's own existing design, not per-session). `hermes_home_key()` resolves the same value for that process's whole lifetime there regardless of this fix, so no behavior change and no additional scoping needed at those call sites — the real, reachable multi-profile collision is specifically through the dashboard route, which the fix addresses.

## Tests

Added `test_cross_profile_same_lease_name_does_not_collapse` to `tests/hermes_cli/test_web_server_tts_lease.py`: two isolated profiles (`default`, `worker_beta`) acquire the same bare lease name via the dashboard route; releasing one must not drop the shared holder count to zero or unload the other profile's resident model, and releasing the second must correctly unload it.

**Mutation-verified in two independent steps**, confirming both halves of the fix are separately necessary:
1. Reverting `tools/tts_tool.py`'s scoping (keeping the route fix) makes the test fail at the "two distinct holders" assertion (`1 == 2`).
2. Reverting only the `web_server.py` route fix (keeping the `tools/tts_tool.py` scoping) makes the SECOND profile's release leak instead of clearing its lease (`worker_release["leases"] == 0` fails with `1`).

Ran the full `tests/tools/test_tts*.py` + `tests/hermes_cli/test_web_server*.py` suite (601 passed, 6 skipped, 9 errors). The 9 errors are in `test_web_server_approvals_broadcast.py` — confirmed via `git stash` to be pre-existing test-order pollution (a `conftest.py` fixture teardown issue) fully independent of this change: identical error count and messages with this PR's changes completely reverted, running the exact same combined test selection.

## Competitor check

Searched `gh pr list --state all` across several keyword combinations ("tts-lease profile", "TTS lease multiplex", "_tts_leases profile scope", "voice tts cross profile", "config_profile_scope tts-lease"). Checked the closest candidates by diff: `#75198` ("isolate multiplex profile sessions and voice state", open) touches `gateway/run.py`/`gateway/session.py`/`gateway/slash_commands.py`/`hermes_state.py` — a different mechanism (main-gateway voice-mode platform state), zero overlap confirmed via `gh pr diff`. `#98756` ("resolve default output dir from the active profile", open) does touch `tools/tts_tool.py` but at completely different line ranges (`_get_default_output_dir()`, `text_to_speech_tool()`) — a different concern (output file directory), no overlap with the lease/cache lines this PR touches. `#90506` (open) touches only desktop TypeScript config-write UI, zero overlap. No open or closed PR covers this gap.