### PR TITLE
fix(agent): use hostname-safe matching for the Ollama Cloud GLM exclusion

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1901,8 +1901,13 @@ class AIAgent:
             return False
         base = self._base_url_lower
         # Ollama Cloud (hosted service or :cloud proxy) forwards finish_reason
-        # faithfully — do not rewrite.
-        if "ollama.com" in base or ":cloud" in model_lower:
+        # faithfully — do not rewrite. Hostname-exact check (mirrors the
+        # sibling ollama.com check further down this file): a raw substring
+        # match would let a self-hosted base_url that merely contains
+        # "ollama.com" somewhere (an internal proxy hostname, a path
+        # segment) get misclassified as the cloud service, silently
+        # disabling this workaround for a real local Ollama GLM install.
+        if base_url_host_matches(base, "ollama.com") or ":cloud" in model_lower:
             return False
         if "ollama" in base or ":11434" in base:
             return True

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4397,6 +4397,19 @@ class TestRunConversation:
         unpunctuated = SimpleNamespace(content="Based on the results the best next step is to update the config", tool_calls=None)
         assert agent._should_treat_stop_as_truncated("stop", unpunctuated, [{"role": "tool", "content": "r"}]) is False
 
+    def test_ollama_com_path_decoy_is_not_treated_as_ollama_cloud(self, agent):
+        """A self-hosted base_url with "ollama.com" appearing in the PATH
+        (not the actual hostname) must not be misclassified as Ollama Cloud
+        — a raw substring match would wrongly disable the truncation
+        workaround for a real local/internal Ollama install whose URL
+        happens to contain that substring."""
+        self._setup_agent(agent)
+        agent.base_url = "https://internal-proxy.example.net/ollama.com/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "glm-4-9b"
+        unpunctuated = SimpleNamespace(content="Based on the results the best next step is to update the config", tool_calls=None)
+        assert agent._should_treat_stop_as_truncated("stop", unpunctuated, [{"role": "tool", "content": "r"}]) is True
+
     def test_length_thinking_exhausted_skips_continuation(self, agent):
         """When finish_reason='length' but content is only thinking, skip retries."""
         self._setup_agent(agent)


### PR DESCRIPTION
## Summary

`_is_ollama_glm_backend()`'s Ollama Cloud exclusion (added by merged `#100924`) uses a raw substring check:

```python
if "ollama.com" in base or ":cloud" in model_lower:
    return False
```

This file already has an established, hostname-safe helper for exactly this question — `base_url_host_matches()` — used a few hundred lines down in the same file (`run_agent.py:8193`) for the identical "is this really ollama.com" check. `base_url_host_matches()`'s own docstring documents precisely the substring false-positive class this raw check is vulnerable to:

```python
base_url_host_matches("https://evil.com/moonshot.ai/v1", "moonshot.ai") == False
base_url_host_matches("https://moonshot.ai.evil/v1", "moonshot.ai")     == False
```

**Concrete failure scenario:** a self-hosted/internal base_url that merely *contains* "ollama.com" as a substring — a path segment, an internal reverse-proxy hostname — gets misclassified as Ollama Cloud. The early `return False` short-circuits before the looser, intentionally-permissive `"ollama" in base` check further down in the same function ever runs, silently disabling the stop→length truncation workaround for what could be a real local/internal Ollama GLM install.

Not a credential/security issue here (no auth material involved in this particular check) — a correctness gap, consistent with `base_url_hostname()`'s own documented rationale for why this helper exists at all.

## Fix

One-line change: `"ollama.com" in base` → `base_url_host_matches(base, "ollama.com")`.

Left the other two checks in this function untouched, and said so in the commit — they're not the same kind of check:
- `"ollama" in base` / `":11434" in base` — deliberately loose substring matches; the function's own docstring explicitly documents `"ollama.local, /ollama/ path"` as meant to match, which `base_url_host_matches()` (exact hostname/subdomain only) would break.
- `":cloud" in model_lower` — inspects the model name, not the base_url, so it isn't a host-spoofing surface.

## Tests

Added `test_ollama_com_path_decoy_is_not_treated_as_ollama_cloud` to `tests/run_agent/test_run_agent.py`: a `base_url` with `"ollama.com"` appearing in the PATH (`https://internal-proxy.example.net/ollama.com/v1`, not the actual hostname) must still be treated as a local Ollama backend (`_should_treat_stop_as_truncated` returns `True`), not misclassified as the cloud service.

**Mutation-verified**: reverting `run_agent.py` makes the new test fail — `_should_treat_stop_as_truncated` returns `False` instead of `True` (the decoy wrongly short-circuits into the cloud-exclusion branch).

Ran the full `tests/run_agent/` suite (2059 passed, 4 skipped, 7 failed). The 7 failures are all Anthropic-provider tests failing on `"the 'anthropic' package is required"` — confirmed via `git stash` (this fix fully reverted) to fail identically, and via direct import that the `anthropic` package is simply not installed in this sandbox. Pre-existing environment gap, fully independent of this change.

## Competitor check

Searched `gh pr list --state all` across several keyword combinations ("_is_ollama_glm_backend", "ollama.com host spoof", "ollama cloud glm substring", "ollama_glm_backend base_url_host_matches"). `#100924` (merged) is the PR that introduced the exclusion this fix corrects — not a competitor, the root it builds on. `#22570` (open) touches `_is_ollama_glm_backend` but its base predates the ollama.com/`:cloud` exclusion logic entirely (confirmed stale via `git merge-base --is-ancestor`) and its actual change is unrelated (a `provider == "custom"` early-exit). No open or closed PR covers this specific gap.