### PR TITLE
fix(skills): make synced bundled-skill copies owner-writable (#101226)

### DIFF
--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -522,6 +522,175 @@ class TestSyncSkills:
             assert (skills_dir / "category" / "new-skill" / "SKILL.md").exists()
 
 
+class TestSyncedCopyIsWritable:
+    """#101226: copies made from an immutable (Nix/Homebrew) bundled source
+    must land owner-writable so the user and the curator can edit them.
+
+    ``sync_skills()`` exists precisely so bundled skills live in a writable
+    location; ``list_user_modified_bundled_skills`` / ``diff_bundled_skill``
+    / ``reset_bundled_skill`` and origin-hash tracking all presuppose an
+    editable copy. ``shutil.copytree`` uses ``copy2``, preserving the source
+    tree's read-only modes verbatim — the same fingerprint as #34860 /
+    #34972, which fixed removal but never the copy that creates the
+    read-only tree in the first place.
+    """
+
+    RO_DIR = (
+        stat.S_IRUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP
+        | stat.S_IROTH | stat.S_IXOTH
+    )  # r-xr-xr-x — the Nix-store directory mode
+
+    def _make_readonly_source(self, bundled):
+        """Make the bundled source tree read-only like an immutable package."""
+        for p in sorted(bundled.rglob("*"), reverse=True):
+            if p.is_dir():
+                os.chmod(p, self.RO_DIR)
+            else:
+                os.chmod(p, stat.S_IREAD)  # r--r--r--
+
+    def _restore_writable(self, root):
+        """Best-effort perm restore so pytest tmp_path teardown succeeds.
+
+        Needed in the RED phase too: the bug being tested leaves the synced
+        copy itself read-only, which would break teardown of skills_dir.
+        """
+        if not root or not Path(root).exists():
+            return
+        for p in sorted(Path(root).rglob("*"), reverse=True):
+            try:
+                os.chmod(p, 0o700 if p.is_dir() else 0o600)
+            except OSError:
+                pass
+        try:
+            os.chmod(root, 0o700)
+        except OSError:
+            pass
+
+    def _setup_bundled(self, tmp_path):
+        """Create a fake bundled skills directory (as in TestSyncSkills)."""
+        bundled = tmp_path / "bundled_skills"
+        (bundled / "category" / "new-skill").mkdir(parents=True)
+        (bundled / "category" / "new-skill" / "SKILL.md").write_text("# New")
+        (bundled / "category" / "new-skill" / "main.py").write_text("print(1)")
+        (bundled / "category" / "DESCRIPTION.md").write_text("Category desc")
+        (bundled / "old-skill").mkdir()
+        (bundled / "old-skill" / "SKILL.md").write_text("# Old")
+        return bundled
+
+    def _patches(self, bundled, skills_dir, manifest_file):
+        """Return context manager stack for patching sync globals."""
+        from contextlib import ExitStack
+        stack = ExitStack()
+        stack.enter_context(patch("tools.skills_sync._get_bundled_dir", return_value=bundled))
+        stack.enter_context(patch("tools.skills_sync._get_optional_dir", return_value=bundled.parent / "optional-skills"))
+        stack.enter_context(patch("tools.skills_sync.SKILLS_DIR", skills_dir))
+        stack.enter_context(patch("tools.skills_sync.MANIFEST_FILE", manifest_file))
+        return stack
+
+    def test_new_skill_copy_is_writable_from_readonly_source(self, tmp_path):
+        """Layer 1: the first-seed copy (new-skill branch) must not inherit
+        the source's read-only modes."""
+        bundled = self._setup_bundled(tmp_path)
+        self._make_readonly_source(bundled)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            result = sync_skills(quiet=True)
+
+        assert "new-skill" in result["copied"]
+        dest = skills_dir / "category" / "new-skill"
+        assert (dest / "SKILL.md").exists()
+        # File owner-writable and dir owner-writable — editable copy.
+        assert os.stat(dest / "SKILL.md").st_mode & stat.S_IWUSR, (
+            "synced skill file is not owner-writable"
+        )
+        assert os.stat(dest).st_mode & stat.S_IWUSR, (
+            "synced skill dir is not owner-writable"
+        )
+        self._restore_writable(bundled)
+
+    def test_updated_skill_copy_is_writable_from_readonly_source(self, tmp_path):
+        """Layer 2: the update-path copy must not inherit read-only modes
+        either."""
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+
+        # Simulate an existing install of old-skill at v1.
+        user_skill = skills_dir / "old-skill"
+        user_skill.mkdir(parents=True)
+        (user_skill / "SKILL.md").write_text("# Old v1")
+        # Bundled ships a newer version; the whole bundled tree is read-only.
+        (bundled / "old-skill" / "SKILL.md").write_text("# Old v2")
+        # Manifest records the v1 (user copy) hash so the update branch runs.
+        manifest_file.write_text(
+            f"old-skill:{_dir_hash(user_skill)}\n"
+        )
+        self._make_readonly_source(bundled)
+
+        try:
+            with self._patches(bundled, skills_dir, manifest_file):
+                result = sync_skills(quiet=True)
+
+            assert "old-skill" in result["updated"]
+            assert (user_skill / "SKILL.md").read_text() == "# Old v2"
+            assert os.stat(user_skill / "SKILL.md").st_mode & stat.S_IWUSR, (
+                "updated skill file is not owner-writable"
+            )
+            assert os.stat(user_skill).st_mode & stat.S_IWUSR, (
+                "updated skill dir is not owner-writable"
+            )
+        finally:
+            self._restore_writable(bundled)
+            self._restore_writable(skills_dir)
+
+    def test_official_optional_restore_copy_is_writable(self, tmp_path):
+        """Layer 3: official-optional restore is a sibling call path with the
+        same immutable source; its copy must be owner-writable too."""
+        bundled = self._setup_bundled(tmp_path)
+        optional = tmp_path / "optional-skills"
+        (optional / "research" / "opt-skill").mkdir(parents=True)
+        (optional / "research" / "opt-skill" / "SKILL.md").write_text(
+            "---\nname: opt-skill\ndescription: test optional skill.\n---\n# Opt\n"
+        )
+        self._make_readonly_source(optional)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+
+        with patch("tools.skills_sync._get_optional_dir", return_value=optional), \
+                patch("tools.skills_sync.SKILLS_DIR", skills_dir), \
+                patch("tools.skills_sync.MANIFEST_FILE", manifest_file):
+            result = restore_official_optional_skill("opt-skill", restore=True)
+
+        assert result["ok"] is True
+        dest = skills_dir / "research" / "opt-skill"
+        assert (dest / "SKILL.md").exists()
+        assert os.stat(dest / "SKILL.md").st_mode & stat.S_IWUSR, (
+            "restored optional skill file is not owner-writable"
+        )
+        assert os.stat(dest).st_mode & stat.S_IWUSR, (
+            "restored optional skill dir is not owner-writable"
+        )
+        self._restore_writable(optional)
+
+    def test_chmod_failure_is_tolerated(self, tmp_path):
+        """Layer 5: a chmod failure on an exotic filesystem must not crash
+        sync — matching the OSError tolerance _rmtree_writable applies."""
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            with patch("tools.skills_sync._make_tree_owner_writable",
+                       side_effect=OSError("EPERM on exotic fs")):
+                result = sync_skills(quiet=True)
+
+        assert "new-skill" in result["copied"], (
+            "chmod failure aborted the copy — sync must stay resilient"
+        )
+
+
 class TestGetBundledDir:
     def test_env_var_override_with_default_fallback(self, tmp_path, monkeypatch):
         custom_dir = tmp_path / "custom_skills"

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -27,6 +27,7 @@ import json
 import logging
 import os
 import shutil
+import stat
 import sys
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
@@ -431,7 +432,7 @@ def restore_official_optional_skill(name: str, *, restore: bool = False) -> dict
                 backed_up.append(_move_to_restore_backup(dest, backup_root))
             if not dest.exists():
                 dest.parent.mkdir(parents=True, exist_ok=True)
-                shutil.copytree(src, dest)
+                _copy_skill_tree(src, dest)
                 restored.append(folder_name)
         elif not canonical_ok:
             continue
@@ -868,7 +869,7 @@ def sync_skills(quiet: bool = False) -> dict:
                         )
                 else:
                     dest.parent.mkdir(parents=True, exist_ok=True)
-                    shutil.copytree(skill_src, dest)
+                    _copy_skill_tree(skill_src, dest)
                     copied.append(skill_name)
                     manifest[skill_name] = bundled_hash
                     if not quiet:
@@ -924,7 +925,7 @@ def sync_skills(quiet: bool = False) -> dict:
                         _rmtree_writable(backup)
                     shutil.move(str(dest), str(backup))
                     try:
-                        shutil.copytree(skill_src, dest)
+                        _copy_skill_tree(skill_src, dest)
                         manifest[skill_name] = bundled_hash
                         updated.append(skill_name)
                         if not quiet:
@@ -1010,6 +1011,60 @@ def sync_skills(quiet: bool = False) -> dict:
     }
 
 
+def _make_tree_owner_writable(path: Path) -> None:
+    """Make ``path`` and everything under it owner-writable, in place.
+
+    Bundled-skill sources may be immutable package trees (Nix store,
+    Homebrew Cellar) where directories are ``r-xr-xr-x`` and files
+    ``r--r--r--``. ``shutil.copytree`` copies with ``copy2``, preserving
+    those modes verbatim, so a synced skill would land unwritable — the
+    exact fingerprint of #34860 / #34972, whose removal-side fixes this
+    prevents at the source (#101226): if no read-only tree is ever created
+    under ``~/.hermes/skills/``, nothing downstream has to tolerate one.
+    Editing is the point of the sync — ``diff_bundled_skill``,
+    ``reset_bundled_skill`` and curator patching all presuppose a copy the
+    user (and the agent) can write.
+
+    Additive-only: existing bits are kept, ``S_IWUSR`` is OR'd in for
+    files, plus ``S_IWUSR | S_IXUSR`` where missing for directories (a
+    writable file inside a non-writable dir still cannot be replaced).
+    Best-effort per entry (OSError swallowed) — a chmod failure on an
+    exotic filesystem must not abort a sync that otherwise succeeded.
+    """
+    try:
+        entries = [Path(path), *Path(path).rglob("*")]
+    except OSError:
+        return
+    for entry in entries:
+        try:
+            mode = entry.stat().st_mode
+            if entry.is_dir():
+                entry.chmod(mode | stat.S_IWUSR | stat.S_IXUSR)
+            else:
+                entry.chmod(mode | stat.S_IWUSR)
+        except OSError:
+            continue
+
+
+def _copy_skill_tree(src: Path, dest: Path) -> None:
+    """Copy a skill directory, dropping the source's read-only modes.
+
+    Bundled/optional sources may be immutable (Nix store, Homebrew) where
+    ``copytree``'s ``copy2`` preserves ``r-xr-xr-x`` dirs and ``r--r--r--``
+    files into ``~/.hermes/skills/`` — see ``_make_tree_owner_writable``,
+    #34860, #34972, #101226.
+
+    Mode normalisation is best-effort: if it fails wholesale (exotic
+    filesystem), the copy has still delivered the correct content, so the
+    failure is swallowed rather than reported as a failed copy.
+    """
+    shutil.copytree(src, dest)
+    try:
+        _make_tree_owner_writable(dest)
+    except OSError:
+        logger.debug("Could not normalise permissions on %s", dest, exc_info=True)
+
+
 def _rmtree_writable(path: Path) -> None:
     """Remove a directory tree, making read-only entries writable first.
 
@@ -1044,7 +1099,6 @@ def _rmtree_writable(path: Path) -> None:
             f"refusing to rmtree {target!r}: not strictly under {skills_root!r} "
             f"(scope guard — see #48200)"
         )
-    import stat
 
     def _on_error(func, fpath, exc_info):
         # Unlinking a child requires the parent dir to be writable, so chmod


### PR DESCRIPTION
## What

`sync_skills()` copies bundled skills into `~/.hermes/skills/` with plain `shutil.copytree()`, which preserves source mode bits. When the bundled tree is read-only — Nix store, Homebrew Cellar, any `HERMES_BUNDLED_SKILLS` pointing at an immutable package source — every synced copy lands as `r-xr-xr-x` dirs / `r--r--r--` files with epoch mtimes. Bundled skills then **cannot be edited** on those installs, defeating the purpose of the sync: `diff_bundled_skill`, `reset_bundled_skill`, origin-hash tracking, and curator patching all presuppose a writable copy.

This is the same root cause as #34860 and #34972, both fixed downstream on the *removal* side (`_rmtree_writable`) while the copy that creates the read-only tree was left alone. Fixing the copy prevents the whole class: if no read-only tree ever exists under `~/.hermes/skills/`, nothing downstream has to tolerate one.

## How

- `_make_tree_owner_writable(path)` — additive-only chmod walk (`S_IWUSR` for files, `S_IWUSR | S_IXUSR` for dirs), best-effort per entry (OSError swallowed), matching the tolerance `_rmtree_writable` already applies.
- `_copy_skill_tree(src, dest)` — `shutil.copytree` + normalise; a wholesale normalisation failure is logged at debug, not reported as a failed copy.
- All three copy sites converted: new-skill seed (~L872), bundled update (~L928), and the sibling `restore_official_optional_skill(restore=True)` path (~L435) — the one remaining producer of read-only skill trees had it not been included.
- Inline `import stat` inside `_rmtree_writable` hoisted to module level (now shared).

## Verification

- 4 new regression tests in `TestSyncedCopyIsWritable` (tests/tools/test_skills_sync.py) exercising real production paths — new-skill copy, update copy, optional-restore copy (each asserting file **and** dir owner-writable from a `r-xr-xr-x`/`r--r--r--` source), plus chmod-failure tolerance.
- RED phase confirmed on pristine main: 4/4 failed (`st_mode=33024, r--r--r--`).
- Post-fix, post-rebase onto current main: **38/38 passed** in the focused file; **133/133 passed** across the nearby skills suites (`test_skills_sync_client`, `test_skills_list_modified_diff`, `test_skill_manage_batch`, `test_skill_bundle_provenance`).
- `_dir_hash` (content-only) unaffected; the failing-copytree manifest contract test still passes (helper keeps calling `shutil.copytree`).

## Competing PRs

- #101274 (Edizzier) closed unmerged in favor of #34577.
- #34577 / #69473 fix the same root cause but as part of a broader change (+663/−13 across 6 files including `AGENTS.md` and profile clone/distribution code). This PR is the minimal, skills-sync-only fix; the profile-side handling can land separately.

Closes #101226.

Auto-published by Moonsong via Path B automated pipeline.
