### PR TITLE
fix(state): refuse a fresh read-pool open on a quarantined SessionDB handle

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5733,6 +5733,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """
         if not self._wal_active or self.read_only:
             return None
+        if self._db_corrupt:
+            # Quarantined: opening a fresh connection to this file is the
+            # same "reopen a damaged image" the write path already refuses
+            # in _reopen_after_close_locked. Fall back to the locked path
+            # instead, which reuses the already-open handle when there is
+            # one (no new open) or hits that same quarantine check when
+            # there isn't (self._conn is None) — never opens a new
+            # connection to a file already known to be structurally damaged.
+            return None
         with self._read_conns_lock:
             if self._read_conns_closed:
                 return None

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5742,6 +5742,24 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # there isn't (self._conn is None) — never opens a new
             # connection to a file already known to be structurally damaged.
             return None
+        if self._db_replaced or self._db_wal_generation_lost:
+            # Same reasoning as _db_corrupt above, for the other two halted
+            # states _reopen_after_close_locked already refuses to reopen
+            # for: the path has been resolved to a different file generation
+            # (_db_replaced, #89332) or this handle's WAL/SHM generation was
+            # deleted out from under it (_db_wal_generation_lost). Opening a
+            # fresh read-only connection here would hand out a connection to
+            # that new generation through stale WAL/shm assumptions — the
+            # same hazard a reopen would. Fall back to the locked path
+            # instead, which hits _reopen_after_close_locked's existing
+            # checks for both. Only the already-set flags are checked here
+            # (not the proactive _db_file_was_replaced()/
+            # _wal_generation_was_lost() stat probes _reopen_after_close_locked
+            # also runs) to keep this hot-path check as cheap as the
+            # _db_corrupt check above; an out-of-band replace/WAL-loss not yet
+            # observed by this handle is caught the next time a write or an
+            # explicit check touches it.
+            return None
         with self._read_conns_lock:
             if self._read_conns_closed:
                 return None

--- a/tests/hermes_state/test_state_db_corrupt_quarantine.py
+++ b/tests/hermes_state/test_state_db_corrupt_quarantine.py
@@ -141,6 +141,29 @@ class TestQuarantinedHandleStopsTouchingTheFile:
             db.get_session("s1")
         reopen.assert_not_called()
 
+    def test_get_read_conn_refuses_fresh_open_when_quarantined(self, tmp_path, monkeypatch):
+        """The WAL read-pool's miss path (_get_read_conn) opens a brand-new
+        sqlite3 connection to the same file — the same "reopen a damaged
+        image" _reopen_after_close_locked already refuses on the write
+        side. It must refuse too, even while the handle is still live (not
+        yet close()d), instead of happily opening a fresh connection to a
+        file already known to be structurally damaged."""
+        from unittest.mock import MagicMock
+
+        db, real_conn = _quarantined_db(tmp_path)
+        try:
+            # This sandbox's SQLite build falls back to journal_mode=DELETE,
+            # so _wal_active is never really True here — force it to
+            # exercise the WAL-only miss path directly, per this file's own
+            # established technique for testing quarantine interactions.
+            db._wal_active = True
+            reopen = MagicMock()
+            monkeypatch.setattr("hermes_state._connect_tracked_db", reopen)
+            assert db._get_read_conn() is None
+            reopen.assert_not_called()
+        finally:
+            db.close()
+
 
 class TestQuarantineScope:
     def test_fts_scoped_corruption_does_not_trip_flag(self, tmp_path):

--- a/tests/hermes_state/test_state_db_corrupt_quarantine.py
+++ b/tests/hermes_state/test_state_db_corrupt_quarantine.py
@@ -164,6 +164,51 @@ class TestQuarantinedHandleStopsTouchingTheFile:
         finally:
             db.close()
 
+    def test_get_read_conn_refuses_fresh_open_when_replaced(self, tmp_path, monkeypatch):
+        """Same guard as the _db_corrupt case above, for the other halted
+        state _reopen_after_close_locked already refuses to reopen for: the
+        path resolving to a different file generation (_db_replaced,
+        #89332). _get_read_conn() must not open a fresh connection to a
+        file already known to be a different generation than the one this
+        handle opened."""
+        from unittest.mock import MagicMock
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            db.create_session(session_id="s1", source="cli", model="test")
+            # This sandbox's SQLite build falls back to journal_mode=DELETE,
+            # so _wal_active is never really True here — force it to
+            # exercise the WAL-only miss path directly, per this file's own
+            # established technique for testing quarantine interactions.
+            db._wal_active = True
+            db._db_replaced = True
+            reopen = MagicMock()
+            monkeypatch.setattr("hermes_state._connect_tracked_db", reopen)
+            assert db._get_read_conn() is None
+            reopen.assert_not_called()
+        finally:
+            db.close()
+
+    def test_get_read_conn_refuses_fresh_open_when_wal_generation_lost(
+        self, tmp_path, monkeypatch
+    ):
+        """Same guard, for the third halted state _reopen_after_close_locked
+        already refuses to reopen for: this handle's WAL/SHM generation
+        deleted out from under it (_db_wal_generation_lost)."""
+        from unittest.mock import MagicMock
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            db.create_session(session_id="s1", source="cli", model="test")
+            db._wal_active = True
+            db._db_wal_generation_lost = True
+            reopen = MagicMock()
+            monkeypatch.setattr("hermes_state._connect_tracked_db", reopen)
+            assert db._get_read_conn() is None
+            reopen.assert_not_called()
+        finally:
+            db.close()
+
 
 class TestQuarantineScope:
     def test_fts_scoped_corruption_does_not_trip_flag(self, tmp_path):


### PR DESCRIPTION
## Summary

`_get_read_conn()` (the WAL read-pool's miss path, `hermes_state.py`) opens a brand-new `sqlite3` connection to `self.db_path` with no awareness of `self._db_corrupt` at all — it is a completely separate connection-opening path from `_reopen_after_close_locked()`, which already refuses exactly this class of operation on the write side:

> "reopening would hand a fresh connection... to a file we already know is structurally damaged"

Opening a fresh read-only connection to a file already known to be structurally corrupt is the same "reopen a damaged image" the write path refuses — `_get_read_conn()` just does it through a code path the quarantine work (`bcc2e65818`, #101095/#101224) never wired up.

**Empirically confirmed**: forced `_wal_active = True` on a quarantined handle (this sandbox's SQLite build falls back to `journal_mode=DELETE`, so WAL is never really active here — forcing it exercises the path directly) and called `_get_read_conn()` — it opened a new connection (the mocked `_connect_tracked_db` was called) with zero guard.

## Fix

Return `None` — the existing "read path unavailable, fall back to the locked path" contract `_get_read_conn()` already uses for every other unavailability reason (WAL inactive, read-only handle, pool closed, backoff window, permit exhausted) — when `self._db_corrupt` is set. The locked fallback in `_read_ctx()` then either reuses the already-open `self._conn` (no new open — a no-op change to the existing quarantine contract) or, if `self._conn` is already `None`, hits `_reopen_after_close_locked`'s existing quarantine check (already correctly raises `StateDbCorruptError`, proven by the existing `test_reopen_after_close_refused_when_quarantined`).

**Scope note** (deliberately narrow, matching the docstring's actual promise): the `StateDbCorruptError`/quarantine contract explicitly documents "no further writes, no automatic reopen, no explicit WAL checkpoint at close" — not "no read." I left two other "reuse an already-open connection" paths untouched:
- `_checkout_read_conn()`'s pool-hit branch (a connection opened *before* corruption was ever observed, sitting idle in the pool) — reuse, not reopen.
- `_read_ctx()`'s locked `self._conn` yield when `self._conn is not None` — same: reuse, not reopen.

Both are weaker cases (arguably already covered by "no read" not being part of the stated contract), and fixing only the unambiguous "fresh open == reopen" case keeps this PR narrowly scoped and easier to reason about than touching every reuse path at once.

## Tests

Added `test_get_read_conn_refuses_fresh_open_when_quarantined` to `tests/hermes_state/test_state_db_corrupt_quarantine.py`, reusing this file's own `_quarantined_db()` fixture and its established "force `_wal_active` to exercise the WAL-only path directly" technique. Mocks `hermes_state._connect_tracked_db` and asserts `_get_read_conn()` returns `None` without ever calling it.

**Mutation-verified**: reverting `hermes_state.py` makes the test fail — `_get_read_conn()` actually opens a connection (returns the mock) instead of refusing.

Ran `tests/state/` + `tests/hermes_state/` + the read-conn-pool/read-path-split/conn-lock-audit suites (653 passed, 29 skipped — pre-existing WAL/py3.12+-gated skips in this sandbox) — no regressions.

## Competitor check

Searched `gh pr list --state all` across several keyword combinations. Two open PRs touch nearby code but address different concerns, noted transparently:
- **`#100882`** ("keep WSL recovery alive through transient read IOERR") adds a `_RetryingReadConnection` wrapper at the very end of `_get_read_conn()`'s try block (after the CJK-extension load, right before return) — textually close but semantically distinct (retrying transient WSL I/O errors on an otherwise-healthy connection vs. refusing to open at all on a known-corrupt handle). My change is a small, isolated insertion near the top of the function; if `#100882` merges first, this PR should still apply cleanly since neither touches the other's lines.
- **`#85255`** ("evict a poisoned pooled read connection instead of requeuing it") touches `_read_ctx()` but its base predates the entire quarantine feature (confirmed via `git merge-base --is-ancestor` — its diff shows no `_db_corrupt`/reopen-refusal logic existing at all yet) and targets a different corruption class (`NOTADB`/replaced-file, evicting a connection that starts failing mid-use — not the "never open a fresh connection to an already-quarantined handle" gap this PR fixes).

No open or closed PR covers this specific gap.

---

**Update (second commit):** Since this PR's base commit, `hermes_state.py` gained two more halted states that `_reopen_after_close_locked()` already refuses to reopen for on the write side: `self._db_replaced` (the path now resolves to a different file generation, #89332) and `self._db_wal_generation_lost` (this handle's WAL/SHM generation was deleted out from under it, added by the merged salvage of #101081/#101221 — after this PR's original base). `_get_read_conn()`'s fresh-open guard only knew about `self._db_corrupt` and was unaware of both — same hazard, same fix shape: return `None` (fall back to the locked path) when either flag is set, checking only the already-set flags (not the proactive `_db_file_was_replaced()`/`_wal_generation_was_lost()` detection probes) to keep this hot-path check as cheap as the existing `_db_corrupt` check.

Added `test_get_read_conn_refuses_fresh_open_when_replaced` and `test_get_read_conn_refuses_fresh_open_when_wal_generation_lost`, mirroring the existing `test_get_read_conn_refuses_fresh_open_when_quarantined`. Mutation-verified (patch-based, not `git stash`, per this session's worktree-sharing caution): reverting the new `hermes_state.py` hunk alone makes both new tests fail (mock connection returned instead of `None`); restoring it makes them pass. Ran `tests/hermes_state/` (11 passed, 1 pre-existing skip) and `tests/state/` + `tests/hermes_state/` together (417 passed, 7 skipped, all pre-existing) — no regressions.

Fresh competitor check: no open or closed PR covers this specific gap. `#101042` ("set busy_timeout=5000 on writer and reader connections") also touches `_get_read_conn()`, but only inside the try block after the connection is already opened (adds a `busy_timeout` PRAGMA) — no line overlap with this commit's checks near the top of the function.
