### PR TITLE
fix(groups): recover room tasks across local state cleanup

### DIFF
--- a/gateway/hosted_room_policy_checkpoint.py
+++ b/gateway/hosted_room_policy_checkpoint.py
@@ -609,7 +609,10 @@ class HostedRoomPolicyCheckpoint:
         status: str,
         execution_generation: int,
     ) -> bool:
-        """Return whether one exact driver outcome is already in the room log."""
+        """Return whether one exact driver outcome is already in the room log.
+
+        Repair the bounded publication index when an older runtime skipped it.
+        """
 
         kind = f"turn.{status}"
         generation = execution_generation if status == "deferred" else 0
@@ -629,28 +632,43 @@ class HostedRoomPolicyCheckpoint:
                        )""",
                     (room_id, task_id),
                 ).fetchone()
-            if row is None:
-                if status == "deferred":
-                    row = conn.execute(
-                        """SELECT 1 FROM hosted_room_events
-                           WHERE room_id=? AND kind=?
-                             AND json_extract(payload_json, '$.task_id')=?
-                             AND COALESCE(CAST(json_extract(
-                                 payload_json, '$.execution_generation'
-                             ) AS INTEGER), 0)=?
-                           LIMIT 1""",
-                        (room_id, kind, task_id, generation),
-                    ).fetchone()
-                else:
-                    row = conn.execute(
-                        """SELECT 1 FROM hosted_room_events
-                           WHERE room_id=? AND kind IN (
-                               'turn.settled', 'turn.failed', 'turn.cancelled'
-                           ) AND json_extract(payload_json, '$.task_id')=?
-                           LIMIT 1""",
-                        (room_id, task_id),
-                    ).fetchone()
-        return row is not None
+            if row is not None:
+                return True
+            if status == "deferred":
+                publication = conn.execute(
+                    """SELECT kind, seq FROM hosted_room_events
+                       WHERE room_id=? AND kind=?
+                         AND json_extract(payload_json, '$.task_id')=?
+                         AND COALESCE(CAST(json_extract(
+                             payload_json, '$.execution_generation'
+                         ) AS INTEGER), 0)=?
+                       ORDER BY seq LIMIT 1""",
+                    (room_id, kind, task_id, generation),
+                ).fetchone()
+            else:
+                publication = conn.execute(
+                    """SELECT kind, seq FROM hosted_room_events
+                       WHERE room_id=? AND kind IN (
+                           'turn.settled', 'turn.failed', 'turn.cancelled'
+                       ) AND json_extract(payload_json, '$.task_id')=?
+                       ORDER BY seq LIMIT 1""",
+                    (room_id, task_id),
+                ).fetchone()
+            if publication is None:
+                return False
+            conn.execute(
+                """INSERT OR IGNORE INTO hosted_room_policy_publications (
+                       room_id, task_id, kind, execution_generation, seq
+                   ) VALUES (?, ?, ?, ?, ?)""",
+                (
+                    room_id,
+                    task_id,
+                    str(publication["kind"]),
+                    generation,
+                    int(publication["seq"]),
+                ),
+            )
+            return True
 
     def events_for_task(
         self,

--- a/gateway/hosted_room_policy_checkpoint.py
+++ b/gateway/hosted_room_policy_checkpoint.py
@@ -629,6 +629,27 @@ class HostedRoomPolicyCheckpoint:
                        )""",
                     (room_id, task_id),
                 ).fetchone()
+            if row is None:
+                if status == "deferred":
+                    row = conn.execute(
+                        """SELECT 1 FROM hosted_room_events
+                           WHERE room_id=? AND kind=?
+                             AND json_extract(payload_json, '$.task_id')=?
+                             AND COALESCE(CAST(json_extract(
+                                 payload_json, '$.execution_generation'
+                             ) AS INTEGER), 0)=?
+                           LIMIT 1""",
+                        (room_id, kind, task_id, generation),
+                    ).fetchone()
+                else:
+                    row = conn.execute(
+                        """SELECT 1 FROM hosted_room_events
+                           WHERE room_id=? AND kind IN (
+                               'turn.settled', 'turn.failed', 'turn.cancelled'
+                           ) AND json_extract(payload_json, '$.task_id')=?
+                           LIMIT 1""",
+                        (room_id, task_id),
+                    ).fetchone()
         return row is not None
 
     def events_for_task(

--- a/gateway/hosted_room_policy_checkpoint.py
+++ b/gateway/hosted_room_policy_checkpoint.py
@@ -340,14 +340,26 @@ class HostedRoomPolicyCheckpoint:
                    WHERE room_id=? AND discussion_event_id=? LIMIT 1""",
                 (room_id, discussion_event_id),
             ).fetchone()
+            source_compacted = source is None
             if source is None:
-                return
-            self._store_active_event(
-                conn,
-                event=event,
-                thread_id=thread_id,
-                discussion_event_id=discussion_event_id,
-            )
+                source = conn.execute(
+                    """SELECT payload_json FROM hosted_room_events
+                       WHERE room_id=? AND event_id=? AND kind='message.user'""",
+                    (room_id, discussion_event_id),
+                ).fetchone()
+                if source is None or str(
+                    json.loads(source["payload_json"]).get("thread_id") or ""
+                ) != thread_id:
+                    return
+                if kind not in _TERMINAL_KINDS:
+                    return
+            else:
+                self._store_active_event(
+                    conn,
+                    event=event,
+                    thread_id=thread_id,
+                    discussion_event_id=discussion_event_id,
+                )
             if kind in _TERMINAL_KINDS:
                 task_id = str(payload.get("task_id") or "")
                 execution_generation = (
@@ -368,6 +380,8 @@ class HostedRoomPolicyCheckpoint:
                             seq,
                         ),
                     )
+                if source_compacted:
+                    return
                 member_id = str(payload.get("member_id") or "")
                 seen_through_seq = int(payload.get("seen_through_seq") or 0)
                 if kind == "turn.settled" and payload.get("message_event_id"):

--- a/gateway/hosted_room_policy_checkpoint.py
+++ b/gateway/hosted_room_policy_checkpoint.py
@@ -632,22 +632,39 @@ class HostedRoomPolicyCheckpoint:
                    WHERE room_id=? AND seq=?""",
                 (room_id, source_event_seq),
             ).fetchone()
+            source_event = None
             if source is None:
-                return []
+                source_row = conn.execute(
+                    """SELECT room_id, seq, event_id, kind, actor_json,
+                              authority_epoch, payload_json, created_at
+                       FROM hosted_room_events
+                       WHERE room_id=? AND seq=? AND kind='message.user'""",
+                    (room_id, source_event_seq),
+                ).fetchone()
+                if source_row is None:
+                    return []
+                source_event = self._event_from_room_row(source_row)
+                discussion_event_id = str(source_event["event_id"])
+                thread_id = str(source_event["payload"].get("thread_id") or "")
+                if not thread_id:
+                    return []
+            else:
+                discussion_event_id = str(source["discussion_event_id"])
+                thread_id = str(source["thread_id"])
             active_rows = conn.execute(
                 """SELECT event_json FROM hosted_room_policy_events
                    WHERE room_id=? AND discussion_event_id=?
                    ORDER BY seq LIMIT ?""",
                 (
                     room_id,
-                    str(source["discussion_event_id"]),
+                    discussion_event_id,
                     MAX_ACTIVE_POLICY_EVENTS + 1,
                 ),
             ).fetchall()
             transcript_events = self._transcript_events(
                 conn,
                 room_id=room_id,
-                thread_id=str(source["thread_id"]),
+                thread_id=thread_id,
             )
         if len(active_rows) > MAX_ACTIVE_POLICY_EVENTS:
             raise RuntimeError("task policy projection exceeded its bound")
@@ -656,6 +673,7 @@ class HostedRoomPolicyCheckpoint:
             for event in (
                 *transcript_events,
                 *(json.loads(row["event_json"]) for row in active_rows),
+                *((source_event,) if source_event is not None else ()),
             )
         }
         return [events_by_seq[seq] for seq in sorted(events_by_seq)]

--- a/tests/tui_gateway/test_hosted_room_service.py
+++ b/tests/tui_gateway/test_hosted_room_service.py
@@ -587,6 +587,14 @@ def test_restart_indexes_terminal_task_after_policy_compaction(tmp_path: Path):
         status="settled",
         execution_generation=0,
     )
+    with sqlite3.connect(db) as conn:
+        conn.execute("DELETE FROM hosted_room_policy_publications")
+    assert service.policy_checkpoint.publication_exists(
+        room_id="room-1",
+        task_id=task["identity"].task_id,
+        status="settled",
+        execution_generation=0,
+    )
 
 
 def test_policy_checkpoint_bounds_replay_after_completed_room_history(

--- a/tests/tui_gateway/test_hosted_room_service.py
+++ b/tests/tui_gateway/test_hosted_room_service.py
@@ -513,6 +513,82 @@ def test_restart_republishes_terminal_task_before_admitting_more(tmp_path: Path)
     assert replayed == events
 
 
+def test_restart_indexes_terminal_task_after_policy_compaction(tmp_path: Path):
+    db = tmp_path / "state.db"
+    service = HostedRoomService(_server(), db_path=db)
+    service.local_profiles = lambda: ("default", "ops")
+    service.create_room(
+        room_id="room-1",
+        name="Release room",
+        members=[
+            {"member_id": "default", "profile": "default", "handle": "hermes"},
+            {"member_id": "ops", "profile": "ops", "handle": "ops"},
+        ],
+    )
+    source = _append_room_event(
+        db,
+        room_id="room-1",
+        event_id="user-1",
+        kind="message.user",
+        actor={"kind": "user", "id": "desktop"},
+        payload={"text": "@ops inspect", "thread_id": "thread-1"},
+    )
+    binding = service.bindings()[0]
+    service.prepare_room(binding)
+    task = driver.list_tasks(db, room_id="room-1", status="queued")[0]
+    lease = driver.acquire_lease(
+        db,
+        room_id="room-1",
+        gateway_id=binding.gateway_id,
+        authority_epoch=binding.authority_epoch,
+        process_generation="crashed",
+        ttl_seconds=30,
+        clock=time.time,
+    )
+    attempt = driver.start_task(
+        db,
+        task["identity"],
+        lease,
+        expected_cancel_generation=0,
+        clock=time.time,
+    )
+    driver.settle_task(
+        db,
+        attempt,
+        settlement_id="reply-1",
+        status="settled",
+        result={"text": "done"},
+        clock=time.time,
+    )
+    current = hosted_rooms.room_state(db, room_id="room-1")
+    _append_room_event(
+        db,
+        room_id="room-1",
+        event_id="activity-1",
+        kind="room.activity",
+        actor={"kind": "gateway", "id": current["authority_gateway_id"]},
+        payload={
+            "status": "settled",
+            "reason_code": "silent_round",
+            "thread_id": "thread-1",
+            "discussion_event_id": "user-1",
+        },
+        authority_gateway_id=current["authority_gateway_id"],
+        authority_epoch=current["authority_epoch"],
+    )
+    service._policy_snapshot(hosted_rooms.room_state(db, room_id="room-1"))
+
+    service.prepare_room(binding)
+    service._policy_snapshot(hosted_rooms.room_state(db, room_id="room-1"))
+
+    assert service.policy_checkpoint.publication_exists(
+        room_id="room-1",
+        task_id=task["identity"].task_id,
+        status="settled",
+        execution_generation=0,
+    )
+
+
 def test_policy_checkpoint_bounds_replay_after_completed_room_history(
     tmp_path: Path,
     monkeypatch,

--- a/tests/tui_gateway/test_hosted_room_service.py
+++ b/tests/tui_gateway/test_hosted_room_service.py
@@ -595,6 +595,12 @@ def test_restart_indexes_terminal_task_after_policy_compaction(tmp_path: Path):
         status="settled",
         execution_generation=0,
     )
+    assert driver.prune_published_terminal_tasks(
+        db,
+        room_id="room-1",
+        clock=time.time,
+        retain=0,
+    ) == 1
 
 
 def test_policy_checkpoint_bounds_replay_after_completed_room_history(

--- a/tests/tui_gateway/test_hosted_room_service.py
+++ b/tests/tui_gateway/test_hosted_room_service.py
@@ -407,6 +407,54 @@ def test_create_send_drive_publish_and_replay_without_client_transport(tmp_path:
     assert service.status("room-1")["working"] is False
 
 
+def test_task_projection_recovers_source_after_policy_compaction(tmp_path: Path):
+    db = tmp_path / "state.db"
+    service = HostedRoomService(_server(), db_path=db)
+    service.local_profiles = lambda: ("default", "ops")
+    service.create_room(
+        room_id="room-1",
+        name="Release room",
+        members=[
+            {"member_id": "default", "profile": "default", "handle": "hermes"},
+            {"member_id": "ops", "profile": "ops", "handle": "ops"},
+        ],
+    )
+    source = _append_room_event(
+        db,
+        room_id="room-1",
+        event_id="user-1",
+        kind="message.user",
+        actor={"kind": "user", "id": "desktop"},
+        payload={"text": "@ops inspect", "thread_id": "thread-1"},
+    )
+    service._policy_snapshot(hosted_rooms.room_state(db, room_id="room-1"))
+    current = hosted_rooms.room_state(db, room_id="room-1")
+    _append_room_event(
+        db,
+        room_id="room-1",
+        event_id="activity-1",
+        kind="room.activity",
+        actor={"kind": "gateway", "id": current["authority_gateway_id"]},
+        payload={
+            "status": "settled",
+            "reason_code": "silent_round",
+            "thread_id": "thread-1",
+            "discussion_event_id": "user-1",
+        },
+        authority_gateway_id=current["authority_gateway_id"],
+        authority_epoch=current["authority_epoch"],
+    )
+    service._policy_snapshot(hosted_rooms.room_state(db, room_id="room-1"))
+
+    events = service.policy_checkpoint.events_for_task(
+        room_id="room-1", source_event_seq=source["seq"]
+    )
+
+    assert [(event["seq"], event["kind"]) for event in events] == [
+        (source["seq"], "message.user")
+    ]
+
+
 def test_restart_republishes_terminal_task_before_admitting_more(tmp_path: Path):
     db = tmp_path / "state.db"
     service = HostedRoomService(_server(), db_path=db)

--- a/tests/tui_gateway/test_hosted_room_service.py
+++ b/tests/tui_gateway/test_hosted_room_service.py
@@ -306,6 +306,19 @@ def _server():
     return SimpleNamespace(_methods={}, _sessions={}, _sessions_lock=threading.Lock())
 
 
+def test_local_profiles_ignore_non_profile_directories(tmp_path: Path):
+    (tmp_path / "profiles" / "pm-chair").mkdir(parents=True)
+    (tmp_path / "profiles" / ".deleted").mkdir()
+    (tmp_path / "profiles" / "bad profile").mkdir()
+
+    service = HostedRoomService(
+        _server(),  # type: ignore[arg-type]
+        db_path=tmp_path / "state.db",
+    )
+
+    assert service.local_profiles() == ("default", "pm-chair")
+
+
 def _wait_for(predicate, timeout=2.0):
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:

--- a/tui_gateway/hosted_room_service.py
+++ b/tui_gateway/hosted_room_service.py
@@ -149,12 +149,19 @@ class HostedRoomService:
         return self.db_path.parent
 
     def local_profiles(self) -> tuple[str, ...]:
+        from hermes_cli.profiles import validate_profile_name
+
         profiles = {"default"}
         profiles_dir = self.root / "profiles"
         if profiles_dir.is_dir():
-            profiles.update(
-                path.name for path in profiles_dir.iterdir() if path.is_dir()
-            )
+            for path in profiles_dir.iterdir():
+                if not path.is_dir():
+                    continue
+                try:
+                    validate_profile_name(path.name)
+                except ValueError:
+                    continue
+                profiles.add(path.name)
         return tuple(sorted(profiles))
 
     def bindings(self) -> tuple[HostedRoomBinding, ...]:


### PR DESCRIPTION
## Summary
- ignore hidden/non-profile directories while discovering hosted-room members
- recover a terminal task source from the bounded room log after its active policy projection was compacted
- index recovered terminal publications without reviving completed projections
- fall back to the immutable room log when an older runtime already advanced the policy cursor without indexing a terminal publication
- restore the bounded publication index from the immutable fallback so terminal driver tasks remain prunable
- add focused regressions for all five failures

## Verification
- strict RED reproduced the missing-index defect (`prune_published_terminal_tasks` returned 0)
- 175 affected hosted-room service, driver, discussion, and persistence tests passed
- recovered-publication/pruning regression repeated 10 times
- independent exact-SHA review: PASS, P0 0, P1 0
- Ruff and `git diff --check` passed

Exact head: `488f35aef831ec8fd05a415c975523304dc04c1d`  
Tree: `d8d619c5ccef95f25610dccc23b5f04ce0695cc7`
