### PR TITLE
fix(desktop): surface unverified cron delivery in the Bot Mode routine inspector

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/cron-detail.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/cron-detail.test.tsx
@@ -121,6 +121,29 @@ describe('the facts the row never showed', () => {
       // The run that never happened outranks the delivery of a run that did.
     ).toBe('model timeout')
   })
+
+  it('surfaces an unverified delivery, ranked below an outright delivery failure', () => {
+    // The gateway sends this when a live adapter acked the send with no
+    // message_id/raw_response (Slack/Matrix/Mattermost shape) — accepted as
+    // delivered, but worth a heads-up, mirroring `hermes cron list`'s own
+    // "Delivery UNVERIFIED" line.
+    expect(
+      routineDetailIssue({ ...activeJob, last_delivery_unverified: ['telegram:12345'] })
+    ).toBe('Delivery unverified: adapter acked telegram:12345 without confirmation')
+
+    // An outright delivery failure still outranks a merely-unverified one.
+    expect(
+      routineDetailIssue({
+        ...activeJob,
+        last_delivery_error: 'telegram 401',
+        last_delivery_unverified: ['telegram:12345']
+      })
+    ).toBe('telegram 401')
+
+    // An empty/absent list is not an issue.
+    expect(routineDetailIssue({ ...activeJob, last_delivery_unverified: [] })).toBeNull()
+    expect(routineDetailIssue({ ...activeJob, last_delivery_unverified: null })).toBeNull()
+  })
 })
 
 describe('the row is reachable', () => {

--- a/apps/desktop/src/plugins/hermes-bots/cron.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/cron.tsx
@@ -400,7 +400,16 @@ export function routineDetailRows(job: RoutineJob | null | undefined): Array<{ l
  *  "paused"; the scheduler's own reason and the last fire/delivery failures
  *  had no surface in Bot Mode at all. */
 export function routineDetailIssue(job: RoutineJob | null | undefined): null | string {
-  const reasons = [job?.last_fire_error, job?.last_delivery_error, job?.paused_reason]
+  const unverified = job?.last_delivery_unverified
+  // A live adapter acked the last send but returned no message_id/
+  // raw_response (Slack/Matrix/Mattermost shape): accepted as delivered, but
+  // said here rather than only in a gateway WARNING log line, mirroring
+  // `hermes cron list`'s own "Delivery UNVERIFIED" line.
+  const unverifiedMessage = Array.isArray(unverified) && unverified.length > 0
+    ? `Delivery unverified: adapter acked ${unverified.join(', ')} without confirmation`
+    : null
+
+  const reasons = [job?.last_fire_error, job?.last_delivery_error, unverifiedMessage, job?.paused_reason]
   const first = reasons.find(value => typeof value === 'string' && value.trim())
 
   return first ? first.trim() : null

--- a/apps/desktop/src/plugins/hermes-bots/types.ts
+++ b/apps/desktop/src/plugins/hermes-bots/types.ts
@@ -244,6 +244,9 @@ export interface RoutineJob {
   enabled?: boolean
   job_id: string
   last_delivery_error?: string
+  /** `platform:chat_id` targets whose live adapter acked the send with no
+   *  message_id/raw_response — accepted as delivered, but unconfirmed. */
+  last_delivery_unverified?: Array<string> | null
   last_fire_error?: string
   last_run_at?: string
   last_status?: string


### PR DESCRIPTION
## Summary

`00a7115a02` (merged `#100908`) added `last_delivery_unverified` to cron jobs — a list of `platform:chat_id` targets whose live adapter acked the send with no `message_id`/`raw_response` (the Slack/Matrix/Mattermost bare `SendResult(success=True)` shape). It's persisted specifically "so `hermes cron list` shows the state instead of it living only in a WARNING log line" (per the field's own comment in `cron/scheduler.py`), and `hermes cron list`/`hermes cron doctor` already render it (`hermes_cli/cron.py`'s `⚠ Delivery UNVERIFIED:` line).

Desktop's Bot Mode routine inspector never got the same treatment: the `RoutineJob` TypeScript interface it reads `cron.manage`'s payload into never gained the field, and `routineDetailIssue()`/`routineDetailRows()` never reference it. **A job whose last run delivered but couldn't be confirmed shows as plain "Succeeded" in the desktop dashboard with zero indication**, while the CLI already warns about exactly the same job.

## Fix

- Added `last_delivery_unverified?: Array<string> | null` to `RoutineJob` (`types.ts`), matching the backend's actual shape (a list of targets, or `null`/absent).
- Extended `routineDetailIssue()` (`cron.tsx`) to surface it as a warning message mirroring the CLI's own wording (`Delivery unverified: adapter acked <targets> without confirmation`), inserted into the existing priority chain between `last_delivery_error` and `paused_reason` — an outright delivery failure still outranks a merely-unverified one, matching this function's own established "run that never happened outranks delivery of a run that did" ordering (per its existing doc comment and test).

## Tests

Extended the existing `'explains a failing or scheduler-paused job in failure order'` test in `cron-detail.test.tsx` with a new case: a bare `last_delivery_unverified` list produces the expected message; an outright `last_delivery_error` still wins when both are present; an empty array or `null` is correctly not treated as an issue.

**Mutation-verified**: reverting `cron.tsx` (keeping the type addition) makes the new test's first assertion fail — `routineDetailIssue()` returns `null` instead of the unverified-delivery message.

Ran the full `hermes-bots` plugin suite (`npx vitest run src/plugins/hermes-bots/` — 60 files, 568 tests, all pass) and `npx tsc --noEmit` (clean for every `hermes-bots` file) — no regressions.

## Competitor check

Searched `gh pr list --state all` across several keyword combinations ("last_delivery_unverified desktop", "routineDetailIssue", "RoutineJob desktop cron unverified", "Bot Mode delivery unverified"). The only relevant hit is `#100908` itself (merged, the backend PR that introduced this field) — confirmed via `gh pr view --json files` to touch only Python files (`cron/jobs.py`, `cron/scheduler.py`, `gateway/delivery.py`, `hermes_cli/cron.py`, `tools/cronjob_tools.py`, tests, docs) with zero desktop/TypeScript files. No open or closed PR covers this parity gap.