### PR TITLE
fix(gateway): rehydrate /model override with persisted model as target_model

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2269,11 +2269,11 @@ def _resolve_gateway_model_context(model: Optional[str] = None) -> _GatewayModel
         context_length=context_length, context_source=context_source)
 
 
-def _resolve_runtime_agent_kwargs_for_provider(provider: str) -> dict:
+def _resolve_runtime_agent_kwargs_for_provider(provider: str, target_model: Optional[str] = None) -> dict:
     """Resolve runtime credentials for a specific provider (e.g. from channel override)."""
     from hermes_cli.runtime_provider import resolve_runtime_provider, format_runtime_provider_error
     try:
-        runtime = resolve_runtime_provider(requested=provider)
+        runtime = resolve_runtime_provider(requested=provider, target_model=target_model)
     except Exception as exc:
         raise RuntimeError(format_runtime_provider_error(exc)) from exc
     return {

--- a/gateway/run_agent_cache.py
+++ b/gateway/run_agent_cache.py
@@ -166,12 +166,34 @@ class GatewayAgentCacheMixin:
             # Re-resolve credentials for the persisted provider. On failure (e.g. credentials removed
             # since the switch) keep the credential-less override — _resolve_session_agent_runtime
             # falls back to env resolution and layers model/provider.
+            #
+            # Crucially, pass the persisted model as target_model: OpenCode Zen/Go route different
+            # models through different API surfaces (anthropic_messages vs chat_completions), so
+            # re-resolving without the model derives api_mode from the stale config default and
+            # produces a mismatched combo (e.g. chat_completions api_mode with a /v1-stripped
+            # base_url) that 404s against opencode.ai. #100854.
             try:
-                runtime = _resolve_runtime_agent_kwargs_for_provider(provider)
+                runtime = _resolve_runtime_agent_kwargs_for_provider(
+                    provider, target_model=persisted.get("model") or None
+                )
                 for k in ("api_key", "api_mode", "credential_pool", "requested_provider", "max_tokens"):
                     override[k] = runtime.get(k)
                 override["request_overrides"] = dict(runtime.get("request_overrides") or {})
                 override["capabilities"] = dict(runtime.get("capabilities") or {})
+                # A persisted stripped /v1 URL (saved while an anthropic-routed model was active)
+                # must be re-normalized against the api_mode re-derived for the target model;
+                # otherwise a chat_completions model inherits the stripped URL and 404s. Refs #57585.
+                from hermes_cli.models import (
+                    normalize_opencode_base_url as _oc_norm,
+                    opencode_provider_family as _oc_fam,
+                )
+
+                if _oc_fam(provider) is not None and override.get("base_url"):
+                    override["base_url"] = _oc_norm(
+                        provider,
+                        override.get("api_mode"),
+                        override["base_url"],
+                    )
                 if not override.get("base_url"):
                     override["base_url"] = runtime.get("base_url")
             except Exception:

--- a/tests/gateway/test_session_model_override_persistence.py
+++ b/tests/gateway/test_session_model_override_persistence.py
@@ -150,3 +150,123 @@ def test_sanitize_model_override():
         "provider": "openai",
         "base_url": "https://api.openai.example/v1",
     }
+
+
+# ── OpenCode /v1 mismatch on rehydrate (#100854) ────────────────────────
+#
+# A session switched to an Anthropic-routed OpenCode model (e.g.
+# ``/model qwen3.8-flash`` on opencode-go) persists the /v1-stripped base_url
+# (https://opencode.ai/zen/go). After a gateway restart, rehydration re-resolved
+# credentials WITHOUT the persisted model, so api_mode was derived from the
+# stale config default (chat_completions) and the stripped URL was kept — the
+# OpenAI client then POSTed to /zen/go/chat/completions, a 404 on the opencode
+# marketing site. Refs #57585 (stripped/persisted /v1) + #100854 (rehydrate).
+
+_OPENCODE_QWEN_OVERRIDE = {
+    "model": "qwen3.8-flash",
+    "provider": "opencode-go",
+    "base_url": "https://opencode.ai/zen/go",  # anthropic-stripped form
+}
+
+
+def test_rehydrate_passes_persisted_model_as_target_model(store_factory):
+    """Rehydration must resolve with the persisted model so OpenCode api_mode
+    is re-derived from the model actually in use, not the config default."""
+    store = store_factory()
+    entry = store.get_or_create_session(_make_source())
+    session_key = entry.session_key
+    store.set_model_override(session_key, _OPENCODE_QWEN_OVERRIDE)
+
+    runner = _make_runner(store_factory())
+
+    calls = {}
+
+    def _fake_resolve(provider, target_model=None):
+        calls["target_model"] = target_model
+        return {
+            "api_key": "sk-fre...hain",
+            "api_mode": "chat_completions",
+            "base_url": "https://opencode.ai/zen/go/v1",
+            "provider": "opencode-go",
+            "requested_provider": "opencode-go",
+            "capabilities": {},
+            "max_tokens": 32_768,
+        }
+
+    with patch(
+        "gateway.run._resolve_runtime_agent_kwargs_for_provider",
+        side_effect=_fake_resolve,
+    ):
+        runner._rehydrate_session_model_override(session_key)
+
+    override = runner._session_model_overrides[session_key]
+    assert calls["target_model"] == "qwen3.8-flash", (
+        "rehydrate must pass the persisted model as target_model"
+    )
+    assert override["api_mode"] == "chat_completions"
+
+
+def test_rehydrate_heals_stripped_v1_for_chat_completions_model(store_factory):
+    """A persisted /v1-stripped URL rehydrated into a chat_completions api_mode
+    must be healed back to /zen/go/v1, or the first post-restart turn 404s."""
+    store = store_factory()
+    entry = store.get_or_create_session(_make_source())
+    session_key = entry.session_key
+    store.set_model_override(session_key, _OPENCODE_QWEN_OVERRIDE)
+
+    runner = _make_runner(store_factory())
+
+    def _fake_resolve(provider, target_model=None):
+        return {
+            "api_key": "sk-fre...hain",
+            "api_mode": "chat_completions",  # e.g. stale config default wins
+            "base_url": "https://opencode.ai/zen/go/v1",
+            "provider": "opencode-go",
+            "requested_provider": "opencode-go",
+            "capabilities": {},
+            "max_tokens": 32_768,
+        }
+
+    with patch(
+        "gateway.run._resolve_runtime_agent_kwargs_for_provider",
+        side_effect=_fake_resolve,
+    ):
+        runner._rehydrate_session_model_override(session_key)
+
+    override = runner._session_model_overrides[session_key]
+    assert override["base_url"] == "https://opencode.ai/zen/go/v1", (
+        "chat_completions api_mode must re-append /v1 to the persisted URL"
+    )
+
+
+def test_rehydrate_keeps_stripped_v1_for_anthropic_model(store_factory):
+    """The inverse: an anthropic_messages model must KEEP the stripped URL
+    (the Anthropic SDK prepends its own /v1/messages)."""
+    store = store_factory()
+    entry = store.get_or_create_session(_make_source())
+    session_key = entry.session_key
+    store.set_model_override(session_key, _OPENCODE_QWEN_OVERRIDE)
+
+    runner = _make_runner(store_factory())
+
+    def _fake_resolve(provider, target_model=None):
+        return {
+            "api_key": "sk-fre...hain",
+            "api_mode": "anthropic_messages",
+            "base_url": "https://opencode.ai/zen/go",  # resolver strips /v1
+            "provider": "opencode-go",
+            "requested_provider": "opencode-go",
+            "capabilities": {},
+            "max_tokens": 32_768,
+        }
+
+    with patch(
+        "gateway.run._resolve_runtime_agent_kwargs_for_provider",
+        side_effect=_fake_resolve,
+    ):
+        runner._rehydrate_session_model_override(session_key)
+
+    override = runner._session_model_overrides[session_key]
+    assert override["base_url"] == "https://opencode.ai/zen/go", (
+        "anthropic_messages api_mode must keep the /v1-stripped URL"
+    )


### PR DESCRIPTION
## What does this PR do?

A session that ran `/model` to an Anthropic-routed OpenCode model (e.g.
`qwen3.8-flash` on opencode-go) persisted the /v1-stripped base_url
(`https://opencode.ai/zen/go`). After a gateway restart,
`_rehydrate_session_model_override` re-resolved credentials **without the
persisted model**, so OpenCode's per-model api_mode routing derived
chat_completions (from the stale config default) and paired it with the
stripped URL → the OpenAI client POSTs `/zen/go/chat/completions` → HTTP 404
(`Not Found | opencode` SPA page), 3 retries, then fallback to
`fallback_providers`. The first turn after **every** gateway restart hit this.

Fix: pass the persisted model as `target_model` (so `opencode_model_api_mode`
re-derives api_mode from the model actually in use), and re-normalize the
persisted base_url against the resolved api_mode (same symmetric /v1
strip/heal logic already used by `/model` switch and `resolve_runtime_provider`).

## Related Issue

Fixes #100854 (same symptom class: qwen3.8-flash 404 on opencode-go after
gateway override of URL). Related earlier regressions: #57585 (stripped /v1
poisoning chat_completions models) and #16878 (/v1 strip on /model switch —
fixed only the switch path; rehydrate is this sibling).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`:
  - `_resolve_runtime_agent_kwargs_for_provider()` accepts `target_model` and
    forwards it to `resolve_runtime_provider()`
  - `_rehydrate_session_model_override()` passes `persisted.get("model")` as
    `target_model`, and re-normalizes the persisted base_url via
    `normalize_opencode_base_url()` against the resolved api_mode
- `tests/gateway/test_session_model_override_persistence.py`: 3 new
  regression tests (target_model propagation; /v1 heal for chat_completions;
  /v1 kept for anthropic_messages)

## How to Test

1. Reproduce: `/model qwen3.8-flash` in a gateway session (opencode-go) →
   restart gateway → send a message → first turn 404s
   (`base_url=https://opencode.ai/zen/go` + chat_completions client → 404 SPA).
2. Verify fix: restart gateway, send a message → agent.log shows
   `Rehydrated persisted /model override ... qwen3.8-flash` then first API
   call succeeds with `anthropic_messages` + `/zen/go` (Anthropic client).
3. Test evidence (real env, this machine): pre-fix
   `resolve_runtime_provider(requested="opencode-go")` →
   `chat_completions`; with `target_model="qwen3.8-flash"` →
   `anthropic_messages` + `/zen/go`. Post-restart turn logged:
   `API call #1: model=qwen3.8-flash provider=opencode-go ... finish_reason=stop`
   with zero 404/retries/fallback.

## Checklist

- [x] I've read the Contributing Guide
- [x] Conventional Commits (`fix(gateway):`)
- [x] Searched for existing PRs (no duplicate; #100854 open, no fix PR)
- [x] PR contains only this fix
- [x] Ran `pytest tests/gateway/ -q`: 7538 passed, 12 failed (all
  environment-only: SSRF URL blocking / test pollution — none touch this PR's
  code; targeted neighbor suites 83 passed)
- [x] Added tests for my changes
- [x] Tested on Linux (Fedora 44, real gateway restart + feishu message)
- [ ] Docs — N/A (internal fix, no README/config impact)
