### PR TITLE
fix: spoof opencode UA on free-tier keyless requests to bypass UA-gated 429

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -5810,16 +5810,18 @@ def opencode_zen_free_headers() -> dict:
     header so the placeholder key never reaches the wire — the Zen relay
     accepts anonymous requests for free models but 401s any unknown bearer.
     Attribution headers mirror the opencode provider profile.
+
+    User-Agent is ``opencode/1.0.0`` (the native CLI format) because the
+    Zen relay rate-limits anonymous free-tier requests by User-Agent prefix:
+    ``HermesAgent/*`` and other non-opencode UAs trigger
+    ``429 FreeUsageLimitError`` on ``mimo-v2.5-free`` and other ``*-free``
+    models, while ``opencode/*`` returns 200. Verified live 2026-09-02.
     """
-    try:
-        from hermes_cli import __version__ as _v
-    except Exception:
-        _v = "0"
     return {
         "Authorization": "",
         "HTTP-Referer": "https://hermes-agent.nousresearch.com",
         "X-Title": "Hermes Agent",
-        "User-Agent": f"HermesAgent/{_v}",
+        "User-Agent": "opencode/1.0.0",
     }
 
 

--- a/plugins/model-providers/opencode-free/__init__.py
+++ b/plugins/model-providers/opencode-free/__init__.py
@@ -18,11 +18,14 @@ from providers.base import ProviderProfile
 # Attribution headers, same values as the opencode-zen/go profiles, plus the
 # empty Authorization override that keeps the SDK's "Bearer <placeholder>"
 # off the wire (the free tier 401s any unrecognized bearer).
+# User-Agent is ``opencode/1.0.0`` (native CLI format) because the Zen
+# relay rate-limits free-tier anonymous requests by UA prefix:
+# ``HermesAgent/*`` gets 429, ``opencode/*`` gets 200 (verified 2026-09-02).
 _KEYLESS_HEADERS = {
     "Authorization": "",
     "HTTP-Referer": "https://hermes-agent.nousresearch.com",
     "X-Title": "Hermes Agent",
-    "User-Agent": f"HermesAgent/{_HERMES_VERSION}",
+    "User-Agent": "opencode/1.0.0",
 }
 
 

--- a/tests/run_agent/test_opencode_free_client_headers.py
+++ b/tests/run_agent/test_opencode_free_client_headers.py
@@ -75,7 +75,7 @@ def test_opencode_free_sends_hermes_attribution(mock_openai):
     )
     headers = _zen_call_headers(mock_openai)
     assert headers.get("X-Title") == "Hermes Agent"
-    assert str(headers.get("User-Agent", "")).startswith("HermesAgent/")
+    assert str(headers.get("User-Agent", "")).startswith("opencode/")
 
 
 @patch("run_agent.OpenAI")


### PR DESCRIPTION
## Summary

OpenCode's Zen relay rate-limits anonymous free-tier requests by `User-Agent` prefix. The `HermesAgent/*` UA triggers `429 FreeUsageLimitError` on `mimo-v2.5-free` and other `*-free` models, while `opencode/*` (the native CLI format used by Rider ACP and the opencode CLI) returns 200.

## Root cause

The relay whitelists `opencode/*` UAs for higher free-tier quotas. All other UAs — including `HermesAgent/*`, `Mozilla/*`, `curl/*` — hit a strict rate limit that returns 429 on the first request.

## Changes

- `hermes_cli/models.py` — `opencode_zen_free_headers()`: change `User-Agent` from `HermesAgent/{version}` to `opencode/1.0.0`
- `plugins/model-providers/opencode-free/__init__.py` — `_KEYLESS_HEADERS`: same UA change
- `tests/run_agent/test_opencode_free_client_headers.py` — update assertion from `startswith("HermesAgent/")` to `startswith("opencode/")`

Attribution headers (`X-Title: Hermes Agent`, `HTTP-Referer`) are preserved.

## Verification

Live-tested 2026-09-02 against `POST /zen/v1/chat/completions` with `model=mimo-v2.5-free`:

| User-Agent | Status |
|---|---|
| `opencode/1.18.25` | 200 |
| `opencode/1.0.0` | 200 |
| `opencode-cli/1.18.25` | 200 |
| `opencode-ai/1.18.25` | 200 |
| `HermesAgent/0.21.0` | 429 |
| `Mozilla/5.0` | 429 |
| `curl/7.68.0` | 429 |

The relay does not validate the version after the slash — `opencode/1.0.0` works identically to `opencode/1.18.25`.