### PR TITLE
fix(skills): surface atomic background-review updates

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -726,6 +726,57 @@ _COMBINED_REVIEW_PROMPT = (
 
 
 
+def _summarize_skill_batch_results(
+    results: Any,
+    operations: Any,
+    *,
+    verbose: bool,
+) -> List[str]:
+    """Project successful ``skill_manage operations[]`` results into notices."""
+    if not isinstance(results, list):
+        return []
+    ops = operations if isinstance(operations, list) else []
+    actions: List[str] = []
+    for index, raw_result in enumerate(results):
+        if not isinstance(raw_result, dict) or raw_result.get("success") is False:
+            continue
+        op = ops[index] if index < len(ops) and isinstance(ops[index], dict) else {}
+        name = str(raw_result.get("name") or op.get("name") or "").strip()
+        action = str(raw_result.get("action") or op.get("action") or "").strip()
+        if not name or not action:
+            continue
+        file_path = str(
+            raw_result.get("file_path") or op.get("file_path") or ""
+        ).strip()
+        target = file_path or "SKILL.md"
+
+        if action == "patch":
+            if verbose and (op.get("old_string") or op.get("new_string")):
+                old_text = str(op.get("old_string") or "")
+                new_text = str(op.get("new_string") or "")
+                old_preview = old_text[:80].replace("\n", " ") + (
+                    "…" if len(old_text) > 80 else ""
+                )
+                new_preview = new_text[:80].replace("\n", " ") + (
+                    "…" if len(new_text) > 80 else ""
+                )
+                actions.append(
+                    f'📝 Skill \'{name}\' patched: "{old_preview}" → "{new_preview}"'
+                )
+            else:
+                actions.append(f"Patched {target} in skill '{name}'.")
+        elif action == "write_file":
+            prefix = "📝 " if verbose else ""
+            actions.append(f"{prefix}Wrote {target} in skill '{name}'.")
+        elif action == "remove_file":
+            prefix = "📝 " if verbose else ""
+            actions.append(f"{prefix}Removed {target} from skill '{name}'.")
+        elif action == "create":
+            prefix = "📝 " if verbose else ""
+            actions.append(f"{prefix}Skill '{name}' created.")
+    return actions
+
+
 def summarize_background_review_actions(
     review_messages: List[Dict],
     prior_snapshot: List[Dict],
@@ -832,6 +883,14 @@ def summarize_background_review_actions(
             detail = {}
         target = data.get("target", "") or detail.get("target", "")
         is_skill = detail.get("tool") == "skill_manage"
+        operations = detail.get("operations")
+        if is_skill and isinstance(data.get("results"), list):
+            batch_actions = _summarize_skill_batch_results(
+                data["results"], operations, verbose=verbose
+            )
+            if batch_actions:
+                actions.extend(batch_actions)
+                continue
 
         message_lower = message.lower()
         if not verbose:

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -885,3 +885,76 @@ def test_skill_patch_off_silent_verbose_shows_diff():
     )
     assert len(verbose) == 1
     assert "demo" in verbose[0] and "→" in verbose[0]
+
+
+def _skill_batch_review():
+    operations = [
+        {
+            "name": "demo",
+            "action": "patch",
+            "old_string": "old",
+            "new_string": "new",
+        },
+        {
+            "name": "demo",
+            "action": "write_file",
+            "file_path": "references/batch.md",
+            "file_content": "details",
+        },
+    ]
+    return [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_skill_batch",
+                    "function": {
+                        "name": "skill_manage",
+                        "arguments": _json.dumps({"operations": operations}),
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_skill_batch",
+            "content": _json.dumps(
+                {
+                    "success": True,
+                    "operations_applied": 2,
+                    "results": [
+                        {"name": "demo", "action": "patch", "success": True},
+                        {
+                            "name": "demo",
+                            "action": "write_file",
+                            "file_path": "references/batch.md",
+                            "success": True,
+                        },
+                    ],
+                }
+            ),
+        },
+    ]
+
+
+def test_skill_batch_on_surfaces_each_successful_mutation():
+    actions = summarize_background_review_actions(
+        _skill_batch_review(), [], notification_mode="on"
+    )
+
+    assert actions == [
+        "Patched SKILL.md in skill 'demo'.",
+        "Wrote references/batch.md in skill 'demo'.",
+    ]
+
+
+def test_skill_batch_verbose_uses_operation_details_not_placeholder():
+    actions = summarize_background_review_actions(
+        _skill_batch_review(), [], notification_mode="verbose"
+    )
+
+    assert len(actions) == 2
+    assert "demo" in actions[0]
+    assert '"old" → "new"' in actions[0]
+    assert actions[1] == "📝 Wrote references/batch.md in skill 'demo'."
+    assert all("?" not in action for action in actions)


### PR DESCRIPTION
## Summary

Atomic `skill_manage operations[]` writes now produce the same post-turn self-improvement notifications as legacy flat skill calls.

**Root cause:** `skill_manage` changed its successful batch response to `{success, operations_applied, results}`, but `summarize_background_review_actions()` still depended on the legacy top-level `message`, `action`, and `name` fields. The writes landed and were ledgered, while `display.memory_notifications: on` emitted nothing and `verbose` emitted `Skill ?`.

## Changes

- **`agent/background_review.py`**: project every successful atomic skill result into an action-aware notification; pair result rows with their originating operation so verbose patch notices retain useful before/after previews.
- **`tests/run_agent/test_background_review.py`**: reproduce the real batch call/result shape and cover both normal and verbose notification modes.
- Preserve legacy flat-call summaries and ignore malformed or explicitly failed result rows.

## Validation

| Scenario | Before | After |
|---|---|---|
| `operations[]` patch + support-file write, notifications `on` | no actions | one notice per successful mutation |
| Same batch, notifications `verbose` | `Skill ?` | named skill, patch preview, and support-file path |
| Existing background-review suites | n/a | 37 passed |

Commands run:

- `python -m pytest tests/run_agent/test_background_review.py::test_skill_batch_on_surfaces_each_successful_mutation tests/run_agent/test_background_review.py::test_skill_batch_verbose_uses_operation_details_not_placeholder -q` — RED: 2 failed, then GREEN: 2 passed.
- `python -m pytest tests/run_agent/test_background_review.py tests/run_agent/test_background_review_summary.py tests/test_background_review_list_shapes.py tests/agent/test_background_review_usage.py -q` — 37 passed, one pre-existing collection warning.
- `uvx ruff check agent/background_review.py tests/run_agent/test_background_review.py` — passed.
- `python -m py_compile agent/background_review.py tests/run_agent/test_background_review.py` — passed.
- `git diff --check` — passed.
- Hosted GitHub CI on exact head `3bfcc8587adfd749db3953b91a2b802597367f92` — all required checks passed, including Python tests, Ruff/Ty, Windows-only tests, macOS-only tests, e2e, Nix, supply-chain scans, and both Docker architectures.

## Infographic

```mermaid
flowchart LR
    A[Background review] --> B[skill_manage operations array]
    B --> C[Atomic writes succeed]
    C --> D[Per-operation results]
    D --> E[Action-aware summary]
    E --> F[Telegram or CLI notification]
```

## Scope

This does not change skill ownership, write approval, curator eligibility, or bundled-skill protection. It repairs only the user-visible projection of already-successful atomic mutations.
