### PR TITLE
fix(desktop): leftover 4001 resume must not revive a deleted chat

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
@@ -101,6 +101,60 @@ describe('useRouteResume', () => {
     expect(resumeSession).not.toHaveBeenCalled()
   })
 
+  it('does not honor a leftover 4001 rebind during a /:sid -> /new delete transition', () => {
+    const resumeSession = vi.fn(async () => undefined)
+    const startFreshSessionDraft = vi.fn()
+    const activeSessionIdRef: MutableRefObject<null | string> = { current: 'runtime-1' }
+    const creatingSessionRef = { current: false }
+    const runtimeIdByStoredSessionIdRef = { current: new Map([['session-1', 'runtime-1']]) }
+    const selectedStoredSessionIdRef: MutableRefObject<null | string> = { current: 'session-1' }
+
+    const { rerender } = render(
+      <RouteResumeHarness
+        activeSessionId="runtime-1"
+        activeSessionIdRef={activeSessionIdRef}
+        creatingSessionRef={creatingSessionRef}
+        currentView="chat"
+        freshDraftReady={false}
+        gatewayState="open"
+        locationPathname="/session-1"
+        resumeSession={resumeSession}
+        routedSessionId="session-1"
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        selectedStoredSessionId="session-1"
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        startFreshSessionDraft={startFreshSessionDraft}
+      />
+    )
+
+    expect(resumeSession).not.toHaveBeenCalled()
+
+    // Idle reap queued requestSessionResume, then the user deleted the chat.
+    // Draft state lands before React Router flips /:sid -> /new.
+    activeSessionIdRef.current = null
+    selectedStoredSessionIdRef.current = null
+    rerender(
+      <RouteResumeHarness
+        activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
+        creatingSessionRef={creatingSessionRef}
+        currentView="chat"
+        freshDraftReady
+        gatewayState="open"
+        locationPathname="/session-1"
+        resumeSession={resumeSession}
+        routedSessionId="session-1"
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        selectedStoredSessionId={null}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        sessionResumeRequest={{ sequence: 1, sessionId: 'session-1' }}
+        startFreshSessionDraft={startFreshSessionDraft}
+      />
+    )
+
+    expect(resumeSession).not.toHaveBeenCalled()
+  })
+
   it('self-heals a stranded routed session (null selected/active, same pathname, not a fresh draft)', () => {
     const resumeSession = vi.fn(async () => undefined)
     const startFreshSessionDraft = vi.fn()

--- a/apps/desktop/src/app/session/hooks/use-route-resume.ts
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.ts
@@ -132,7 +132,13 @@ export function useRouteResume({
         Boolean(cachedRuntime) &&
         cachedRuntime === activeSessionIdRef.current
 
+      // A leftover 4001 recovery (`requestSessionResume`) must not rebind a
+      // chat the user just deleted: startFreshSessionDraft nulls selection one
+      // render before the pathname flips /:sid -> /new. Honoring that queued
+      // resume re-selects the doomed id, the RPC 404s, and Desktop toasts
+      // "Resume failed / Session not found".
       const explicitlyRequested =
+        !freshDraftReady &&
         sessionResumeRequest?.sessionId === routedSessionId &&
         sessionResumeRequest.sequence > handledResumeRequestRef.current
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -1077,6 +1077,8 @@ describe('resumeSession failure recovery', () => {
     setResumeFailedSessionId(null)
     setMessages([])
     setSessions([])
+    $removedSessionIds.set(new Set())
+    $sessionMutationsInFlight.set(new Set())
     clearClarifyRequest()
     vi.restoreAllMocks()
   })
@@ -1093,6 +1095,20 @@ describe('resumeSession failure recovery', () => {
     await waitFor(() => expect(resume).not.toBeNull())
     await resume!('stored-1', true)
   }
+
+  it('does not resume a tombstoned session after delete', async () => {
+    $removedSessionIds.set(new Set(['stored-1']))
+
+    const requestGateway = vi.fn(async () => {
+      throw new Error('404: Session not found')
+    })
+
+    await runResume(requestGateway)
+
+    expect(requestGateway).not.toHaveBeenCalled()
+    expect($resumeFailedSessionId.get()).toBeNull()
+    expect($selectedStoredSessionId.get()).toBeNull()
+  })
 
   it.each([
     ['Codex tool-only', ''],

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -51,6 +51,8 @@ import {
 } from '@/store/profile'
 import {
   $projectScope,
+  $removedSessionIds,
+  $sessionMutationsInFlight,
   beginSessionMutation,
   endSessionMutation,
   resolveNewSessionCwd,
@@ -858,6 +860,13 @@ export function useSessionActions({
 
   const resumeSession = useCallback(
     async (storedSessionId: string, replaceRoute = false, capturedOwner?: SessionProfileRoute) => {
+      // Delete/archive tombstones the durable id before the route flips.
+      // A leftover 4001 rebind must not re-select that id and toast
+      // "Resume failed / Session not found".
+      if ($removedSessionIds.get().has(storedSessionId) || $sessionMutationsInFlight.get().has(storedSessionId)) {
+        return
+      }
+
       const requestId = resumeRequestRef.current + 1
       resumeRequestRef.current = requestId
       const resumedSameSelectedSession = selectedStoredSessionIdRef.current === storedSessionId


### PR DESCRIPTION
## Summary
- Deleting a Desktop chat still toasted **Resume failed / Session not found** when an idle-reap `4001` had already queued `requestSessionResume`.
- `#100102` stopped *new* rebinds after tombstone, but a leftover resume still fired on the one render where the route was `/<deleted-id>` and the draft had already cleared selection.
- Ignore that queued resume while `freshDraftReady`, and no-op `resumeSession` for tombstoned / in-flight-delete ids so the doomed chat cannot be re-selected.

## Test plan
- [x] `npx vitest run --project ui src/app/session/hooks/use-route-resume.test.tsx src/app/session/hooks/use-session-actions.test.tsx` (114 passed)
- [ ] Desktop: new chat → send a message → wait a few seconds → delete that chat. No **Resume failed / Session not found** toast.
- [ ] Existing `#100102` path still holds: delete the selected chat while activity is settling, land on a fresh chat, no reopen.