### PR TITLE
fix(desktop): keep project chats from orphaning, double-listing, and blanking on remote lag

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -74,6 +74,7 @@ import {
 } from '@/store/layout'
 import { notifyError } from '@/store/notifications'
 import {
+  $activeGatewayProfile,
   $newChatProfile,
   $profileColors,
   $profiles,
@@ -92,6 +93,7 @@ import {
   $removedSessionIds,
   $reposScanning,
   ALL_PROJECTS,
+  cachedProjectSessions,
   enterProject,
   exitProjectScope,
   fetchProjectSessions,
@@ -154,6 +156,7 @@ import { ProjectDialog } from './project-dialog'
 import {
   excludeProjectSessions,
   liveSessionProjectId,
+  namedProjectSessionIds,
   orderProjectsByIds,
   overlayLiveLanes,
   overlayLivePreviews,
@@ -968,9 +971,16 @@ export function ChatSidebar({
     }
 
     let cancelled = false
+    const cached = cachedProjectSessions(enteredProjectId, $activeGatewayProfile.get())
+
+    if (cached?.id === enteredProjectId) {
+      setEnteredProjectTree(cached)
+    }
 
     void fetchProjectSessions(enteredProjectId).then(project => {
-      if (!cancelled) {
+      // A null result is a stale/failed RPC — keep the last good tree (cache or
+      // previous hydrate) so remote lag cannot blank the entered project.
+      if (!cancelled && project) {
         setEnteredProjectTree(project)
       }
     })
@@ -1019,10 +1029,17 @@ export function ChatSidebar({
   // different times, but a row visible in the overview must not disappear on
   // entry. The backend seeds each project folder as an (empty) repo, so the
   // overlay always has a lane to place a missing in-project session into.
+  const claimedNamedIds = useMemo(
+    () => namedProjectSessionIds(agentProjectTree ?? []),
+    [agentProjectTree]
+  )
+
   const enteredProjectContent = useMemo(
     () =>
-      enteredProject ? overlayLiveLanes(enteredProject, enteredProjectOverlaySessions, removedSessionIds) : undefined,
-    [enteredProject, enteredProjectOverlaySessions, removedSessionIds]
+      enteredProject
+        ? overlayLiveLanes(enteredProject, enteredProjectOverlaySessions, removedSessionIds, claimedNamedIds)
+        : undefined,
+    [enteredProject, enteredProjectOverlaySessions, removedSessionIds, claimedNamedIds]
   )
 
   const scopedRepoPaths = useMemo(

--- a/apps/desktop/src/app/chat/sidebar/projects/index.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/index.ts
@@ -13,6 +13,7 @@ export { SidebarWorkspaceGroup } from './workspace-group'
 export {
   excludeProjectSessions,
   liveSessionProjectId,
+  namedProjectSessionIds,
   overlayLiveLanes,
   overlayLivePreviews,
   reconcileEnteredProjectSessions,

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
@@ -11,6 +11,7 @@ import {
   liveSessionProjectId,
   mergeRepoWorktreeGroups,
   NO_PROJECT_ID,
+  namedProjectSessionIds,
   overlayLiveLanes,
   overlayLivePreviews,
   reconcileEnteredProjectSessions,
@@ -1044,6 +1045,59 @@ describe('overlayLiveLanes', () => {
     expect(overlayLiveLanes(home, [makeCwdSession('/www/app', { id: 'fresh' })])).toBe(home)
   })
 
+  it('collects session ids from named projects and skips Home', () => {
+    const bound = makeCwdSession('/www/app', { id: 'bound' })
+    const homeRow = makeCwdSession(null, { id: 'home-row' })
+    const ids = namedProjectSessionIds([
+      projectNode({ id: 'p_app', previewSessions: [bound] }),
+      homeNode([homeRow])
+    ])
+
+    expect([...ids]).toEqual(['bound'])
+  })
+
+  it('does not inject a named-project chat into Home when it is already claimed', () => {
+    const bound = makeCwdSession(null, { id: 'bound' })
+    const home = homeNode([])
+    const claimed = new Set(['bound'])
+
+    const overlaid = overlayLiveLanes(home, [bound], new Set(), claimed)
+
+    expect(overlaid.repos[0].groups[0].sessions.map(s => s.id)).not.toContain('bound')
+    expect(overlaid.sessionCount).toBe(0)
+  })
+
+  it('refreshes a snapshot row in place when live cwd is empty', () => {
+    const existing = makeCwdSession('/www/app', { id: 'keep', git_branch: 'main', title: 'old' })
+    const project = projectNode({
+      id: '/www/app',
+      repos: [
+        {
+          id: '/www/app',
+          label: 'app',
+          path: '/www/app',
+          sessionCount: 1,
+          groups: [
+            lane({
+              id: '/www/app::branch::main',
+              label: 'main',
+              isMain: true,
+              path: '/www/app',
+              sessions: [existing]
+            })
+          ]
+        }
+      ]
+    })
+    const live = [makeCwdSession(null, { id: 'keep', title: 'updated' })]
+
+    const overlaid = overlayLiveLanes(project, live)
+
+    expect(overlaid.repos[0].groups.flatMap(g => g.sessions.map(s => s.id))).toEqual(['keep'])
+    expect(overlaid.repos[0].groups[0].sessions[0].title).toBe('updated')
+    expect(overlaid.sessionCount).toBe(1)
+  })
+
   it('evicts a session from the main lane when the live overlay places it into a worktree lane', () => {
     // Session was in main when the backend tree was captured, but the live
     // $sessions cache now has it under a worktree cwd. The overlay must place
@@ -1130,6 +1184,56 @@ describe('overlayLivePreviews', () => {
     const previews = overlayLivePreviews([homeNode([])], [makeCwdSession(null, { id: 'fresh' })], [], 3)
 
     expect(previews[NO_PROJECT_ID].map(s => s.id)).toEqual(['fresh'])
+  })
+
+  it('keeps a bound snapshot row out of Home when live cwd is empty', () => {
+    const bound = makeCwdSession('/www/app', { id: 'bound', git_branch: 'main' })
+    const project = projectNode({
+      id: 'p_app',
+      previewSessions: [bound],
+      repos: [
+        {
+          id: '/www/app',
+          label: 'app',
+          path: '/www/app',
+          sessionCount: 1,
+          groups: [lane({ id: '/www/app::branch::main', label: 'main', isMain: true, path: '/www/app', sessions: [bound] })]
+        }
+      ]
+    })
+    const home = homeNode([])
+    const live = [makeCwdSession(null, { id: 'bound' })]
+
+    const previews = overlayLivePreviews([project, home], live, [makeProject('p_app', ['/www/app'])], 3)
+
+    expect(previews['p_app']?.map(s => s.id)).toEqual(['bound'])
+    expect(previews[NO_PROJECT_ID]).toBeUndefined()
+  })
+
+  it('does not list the same live session under two projects', () => {
+    const row = makeCwdSession('/www/app', { id: 'dup', git_branch: 'main' })
+    const projectA = projectNode({
+      id: 'p_a',
+      previewSessions: [row]
+    })
+    const projectB = projectNode({
+      id: 'p_b',
+      previewSessions: []
+    })
+    // Live cwd now sits under B, so overlay must move it — not clone it.
+    const live = [makeCwdSession('/www/other', { id: 'dup', git_repo_root: '/www/other' })]
+
+    const previews = overlayLivePreviews(
+      [projectA, projectB],
+      live,
+      [makeProject('p_a', ['/www/app']), makeProject('p_b', ['/www/other'])],
+      3
+    )
+
+    const inA = previews['p_a']?.map(s => s.id) ?? []
+    const inB = previews['p_b']?.map(s => s.id) ?? []
+    expect(inA).not.toContain('dup')
+    expect(inB).toEqual(['dup'])
   })
 })
 

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -531,7 +531,20 @@ export function overlayRepoLanes(
   for (const session of live) {
     const sessionPath = livePathForRepo(repo.path ?? '', session)
 
-    if (removed.has(session.id) || !sessionPath) {
+    if (removed.has(session.id)) {
+      continue
+    }
+
+    // Empty cwd+root cannot pick a lane, but a row already in this snapshot
+    // must stay put and still receive live title/activity — otherwise the
+    // entered project goes blank while Home picks the chat up (#75330/#77591).
+    if (!sessionPath) {
+      for (const g of lanes) {
+        if (g.sessions.some(s => s.id === session.id)) {
+          g.sessions = upsertSession(g.sessions, session)
+          changed = true
+        }
+      }
       continue
     }
 
@@ -635,11 +648,17 @@ export function overlayRepoLanes(
 function overlayHomeLane(
   project: SidebarProjectTree,
   live: SessionInfo[],
-  removed: ReadonlySet<string>
+  removed: ReadonlySet<string>,
+  claimedNamedIds: ReadonlySet<string> = NO_REMOVED
 ): SidebarProjectTree {
   const lane = project.repos[0]?.groups[0]
-  const detached = live.filter(session => isDetachedSession(session) && !removed.has(session.id))
-  const kept = (lane?.sessions ?? []).filter(session => !removed.has(session.id))
+  const isClaimed = (session: SessionInfo): boolean =>
+    claimedNamedIds.has(session.id) ||
+    Boolean(session._lineage_root_id && claimedNamedIds.has(session._lineage_root_id))
+  const detached = live.filter(
+    session => isDetachedSession(session) && !removed.has(session.id) && !isClaimed(session)
+  )
+  const kept = (lane?.sessions ?? []).filter(session => !removed.has(session.id) && !isClaimed(session))
 
   if (!detached.length && kept.length === (lane?.sessions.length ?? 0)) {
     return project
@@ -718,10 +737,11 @@ export function excludeProjectSessions(
 export function overlayLiveLanes(
   project: SidebarProjectTree,
   live: SessionInfo[],
-  removed: ReadonlySet<string> = NO_REMOVED
+  removed: ReadonlySet<string> = NO_REMOVED,
+  claimedNamedIds: ReadonlySet<string> = NO_REMOVED
 ): SidebarProjectTree {
   if (project.isNoProject) {
-    return overlayHomeLane(project, live, removed)
+    return overlayHomeLane(project, live, removed, claimedNamedIds)
   }
 
   let changed = false
@@ -767,6 +787,86 @@ interface PreviewOverlayOptions {
   rankIds?: string[]
 }
 
+/** Session ids already listed under named (non-Home) projects in a snapshot. */
+export function namedProjectSessionIds(projects: SidebarProjectTree[]): Set<string> {
+  const ids = new Set<string>()
+
+  const take = (session: SessionInfo) => {
+    ids.add(session.id)
+
+    if (session._lineage_root_id) {
+      ids.add(session._lineage_root_id)
+    }
+  }
+
+  for (const project of projects) {
+    if (project.isNoProject) {
+      continue
+    }
+
+    for (const session of project.previewSessions ?? []) {
+      take(session)
+    }
+
+    for (const repo of project.repos) {
+      for (const group of repo.groups) {
+        for (const session of group.sessions) {
+          take(session)
+        }
+      }
+    }
+  }
+
+  return ids
+}
+
+function snapshotProjectOwner(projects: SidebarProjectTree[]): Map<string, string> {
+  const owners = new Map<string, string>()
+
+  const take = (session: SessionInfo, projectId: string) => {
+    if (!owners.has(session.id)) {
+      owners.set(session.id, projectId)
+    }
+
+    if (session._lineage_root_id && !owners.has(session._lineage_root_id)) {
+      owners.set(session._lineage_root_id, projectId)
+    }
+  }
+
+  for (const project of projects) {
+    for (const session of project.previewSessions ?? []) {
+      take(session, project.id)
+    }
+
+    for (const repo of project.repos) {
+      for (const group of repo.groups) {
+        for (const session of group.sessions) {
+          take(session, project.id)
+        }
+      }
+    }
+  }
+
+  return owners
+}
+
+function overlayPreviewProjectId(
+  session: SessionInfo,
+  explicitProjects: ProjectInfo[],
+  snapshotOwner: string | undefined
+): null | string {
+  const computed = liveSessionProjectId(session, explicitProjects)
+  const detached = isDetachedSession(session)
+  const stickyNamed = snapshotOwner && snapshotOwner !== NO_PROJECT_ID ? snapshotOwner : undefined
+
+  // Bound membership wins over a transient empty cwd (Home demotion / orphan).
+  if (stickyNamed && (detached || !computed)) {
+    return stickyNamed
+  }
+
+  return computed ?? (detached ? NO_PROJECT_ID : null)
+}
+
 /** Merge live sessions into per-project overview previews, keyed by project id. */
 export function overlayLivePreviews(
   projects: SidebarProjectTree[],
@@ -775,20 +875,26 @@ export function overlayLivePreviews(
   limit: number,
   { removed = NO_REMOVED, rankIds }: PreviewOverlayOptions = {}
 ): Record<string, SessionInfo[]> {
+  const owners = snapshotProjectOwner(projects)
   const byProject = new Map<string, SessionInfo[]>()
+  const liveOwner = new Map<string, string>()
 
   for (const session of live) {
     if (removed.has(session.id)) {
       continue
     }
 
-    const projectId =
-      liveSessionProjectId(session, explicitProjects) ?? (isDetachedSession(session) ? NO_PROJECT_ID : null)
+    const projectId = overlayPreviewProjectId(
+      session,
+      explicitProjects,
+      owners.get(session.id) ?? (session._lineage_root_id ? owners.get(session._lineage_root_id) : undefined)
+    )
 
     if (!projectId) {
       continue
     }
 
+    liveOwner.set(session.id, projectId)
     const arr = byProject.get(projectId) ?? []
     arr.push(session)
     byProject.set(projectId, arr)
@@ -798,7 +904,17 @@ export function overlayLivePreviews(
 
   for (const node of projects) {
     const liveRows = byProject.get(node.id) ?? []
-    const base = (node.previewSessions ?? []).filter(session => !removed.has(session.id))
+    const base = (node.previewSessions ?? []).filter(session => {
+      if (removed.has(session.id)) {
+        return false
+      }
+
+      const assigned = liveOwner.get(session.id)
+
+      // A live row placed in another project must not also remain in this
+      // snapshot (double-list / ghost-dupe).
+      return !assigned || assigned === node.id
+    })
 
     if (!liveRows.length && !base.length) {
       continue

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -580,6 +580,16 @@ async function refreshProjectTreeAcrossProfiles(): Promise<void> {
 // when the user enters it. Same backend grouping as `projects.tree`, so ids and
 // membership match exactly.
 let projectSessionsRefreshGeneration = 0
+const projectSessionsCache = new Map<string, SidebarProjectTree>()
+
+function projectSessionsCacheKey(projectId: string, profile?: null | string): string {
+  return `${profile ?? ''}::${projectId}`
+}
+
+/** Last successful drill-in payload for this project+profile, if any. */
+export function cachedProjectSessions(projectId: string, profile?: null | string): SidebarProjectTree | null {
+  return projectSessionsCache.get(projectSessionsCacheKey(projectId, profile)) ?? null
+}
 
 export async function fetchProjectSessions(projectId: string): Promise<SidebarProjectTree | null> {
   const generation = ++projectSessionsRefreshGeneration
@@ -597,7 +607,12 @@ export async function fetchProjectSessions(projectId: string): Promise<SidebarPr
       return null
     }
 
-    return res.project ?? null
+    if (res.project) {
+      projectSessionsCache.set(projectSessionsCacheKey(projectId, context.profile), res.project)
+      return res.project
+    }
+
+    return cachedProjectSessions(projectId, context.profile)
   } catch {
     return null
   }

--- a/tests/tui_gateway/test_project_tree.py
+++ b/tests/tui_gateway/test_project_tree.py
@@ -657,3 +657,25 @@ def test_equivalent_windows_spellings_derive_one_lane_key():
     b = pt._place_by_heuristic("C:\\work\\notes\\")
     assert a is not None and b is not None
     assert pt._lane_key(a["lane_key"]) == pt._lane_key(b["lane_key"])
+
+
+def test_cwdless_session_with_repo_root_stays_in_explicit_project():
+    """A bound chat that lost cwd must not fall into Home when git_repo_root remains.
+
+    Remote/VPS session.info often arrives with an empty cwd while the persisted
+    repo root still identifies the project folder. Home is only for never-bound
+    detached rows.
+    """
+    project = _project("p_app", "App", ["/www/app"])
+    owned = _session(None, repo_root="/www/app", branch="main")
+    never_bound = _session(None)
+
+    tree = pt.build_tree([project], [owned, never_bound], [], resolve=lambda _cwd: None, hydrate=True)
+
+    explicit = next(p for p in tree["projects"] if p["id"] == "p_app")
+    assert owned["id"] in [s["id"] for repo in explicit["repos"] for g in repo["groups"] for s in g["sessions"]]
+    assert never_bound["id"] not in [
+        s["id"] for repo in explicit["repos"] for g in repo["groups"] for s in g["sessions"]
+    ]
+    assert _home_session_ids(tree) == [never_bound["id"]]
+    assert owned["id"] not in _home_session_ids(tree)

--- a/tui_gateway/project_tree.py
+++ b/tui_gateway/project_tree.py
@@ -355,14 +355,19 @@ def _build_repos(sessions: list[dict], resolve: Optional[Resolve], hydrate: bool
 
     for session in sessions:
         cwd = (session.get("cwd") or "").strip()
-        if not cwd:
+        persisted_root = (session.get("git_repo_root") or "").strip()
+        # Remote/imported rows may have lost cwd while still carrying a repo
+        # root. Place those on the persisted root (main lane) instead of
+        # dropping them out of an explicit project they already belong to.
+        anchor = cwd or persisted_root
+        if not anchor:
             continue
 
         placement = _place(
-            cwd,
+            anchor,
             (session.get("git_branch") or "").strip(),
             resolve,
-            (session.get("git_repo_root") or "").strip(),
+            persisted_root,
         )
         if not placement:
             continue
@@ -507,10 +512,17 @@ def _project_for_path(index: _FolderIndex, target: str) -> Optional[dict]:
 
 def _project_for_session(session: dict, index: _FolderIndex, resolve: Optional[Resolve]) -> Optional[dict]:
     cwd = (session.get("cwd") or "").strip()
-    if not cwd:
-        return None
     repo_root = _session_repo_root(session, resolve)
-    candidates = [cwd, repo_root] if repo_root and repo_root != cwd else [cwd]
+    # Empty cwd used to short-circuit to Home even when git_repo_root still
+    # identified an explicit project (remote/VPS rows, imported history). Match
+    # on whichever anchors exist so a bound chat cannot become homeless.
+    candidates: list[str] = []
+    if cwd:
+        candidates.append(cwd)
+    if repo_root and repo_root not in candidates:
+        candidates.append(repo_root)
+    if not candidates:
+        return None
 
     best: Optional[dict] = None
     best_len = -1


### PR DESCRIPTION
## Bug Description

Hermes Desktop Project chats (especially on a remote/VPS gateway) could:

- vanish from every named Project (orphan)
- appear under the wrong Project, or two Projects at once
- flash a duplicate row then drop it
- blank the entered-project list for many seconds
- silently move into **Home**

Fixes #77591
Fixes #75330

## Root Cause

Membership was recomputed from live `cwd` / treated empty cwd as detached:

1. Backend `_project_for_session` and `_build_repos` ignored `git_repo_root` when `cwd` was empty, so bound chats fell into Home.
2. Desktop `overlayLivePreviews` sent detached live rows to Home even when the snapshot still owned them, and did not strip a live-moved id from the old project's preview (double-list).
3. `overlayHomeLane` injected every detached live session into Home with no named-project claim check.
4. Entered-project hydrate treated a null `projects.project_sessions` result (stale generation, RPC failure, remote lag) as “wipe the tree.”

## Fix

- Place sessions by `git_repo_root` when cwd is missing (explicit project match + main-lane hydrate).
- Overlay: snapshot named-project owner wins over a detached live row; a live row belongs to exactly one overview preview.
- Home overlay skips session ids already claimed by named projects.
- Cache last successful drill-in payload; ignore null refetches so remote lag cannot blank the entered project.

## How to Verify

1. Create a named Desktop Project with a registered folder; start a chat in it.
2. Clear/omit cwd on that session row while leaving `git_repo_root` under the project folder (or simulate a slow VPS `session.info`).
3. Overview and entered-project lists still show the chat under that Project, not Home, and not under a second Project.
4. Re-enter the Project while `projects.project_sessions` is delayed: last-good lanes stay on screen (no empty shell).
5. A truly never-bound detached chat still lands in Home.

## Test Plan

- [x] Added regression tests (`workspace-groups.test.ts`, `test_project_tree.py`)
- [x] `pytest tests/tui_gateway/test_project_tree.py` — 34 passed
- [x] `vitest` `workspace-groups.test.ts` — 69 passed
- [ ] Manual: macOS Desktop × local + remote/VPS gateway

## Risk Assessment

Medium — overlay membership is the sidebar source of truth between snapshots. Changes are gated to empty-cwd / detached rows and to single-id preview ownership; true never-bound Home chats and cwd-based placement are preserved. Stale-generation `fetchProjectSessions` still returns null so a profile switch cannot paint the previous profile's tree.
