### PR TITLE
fix: prevent delegated context leaking across terminal calls

### DIFF
--- a/tests/tools/test_delegate_kanban_isolation.py
+++ b/tests/tools/test_delegate_kanban_isolation.py
@@ -170,6 +170,33 @@ def test_delegate_child_execute_code_env_bridges_contextvar_and_scrubs_kanban(
     assert "HERMES_KANBAN_CLAIM_LOCK" not in env
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX bash snapshot path")
+def test_delegated_child_marker_does_not_persist_in_parent_terminal_snapshot(
+    monkeypatch,
+    tmp_path,
+):
+    """A child command must not poison later parent commands on the same backend."""
+    monkeypatch.delenv("HERMES_DELEGATED_CHILD_CONTEXT", raising=False)
+
+    from agent.delegation_context import delegated_child_context
+    from tools.environments.local import LocalEnvironment
+
+    command = 'printf "%s" "${HERMES_DELEGATED_CHILD_CONTEXT-unset}"'
+    env = LocalEnvironment(cwd=str(tmp_path), timeout=15)
+    try:
+        with delegated_child_context():
+            child = env.execute(command, timeout=15)
+        parent = env.execute(command, timeout=15)
+
+        assert child["output"] == "1"
+        assert parent["output"] == "unset"
+        assert "HERMES_DELEGATED_CHILD_CONTEXT" not in Path(
+            env._snapshot_path
+        ).read_text(encoding="utf-8")
+    finally:
+        env.cleanup()
+
+
 def test_delegate_child_kanban_cli_cannot_delete_parent_board(
     monkeypatch,
     tmp_path,

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -596,6 +596,10 @@ def _export_dump_excluding_session_vars(
         # harness value arriving via the process env, exactly like the
         # session-var leak this dump already guards against.
         "AI_AGENT HERMES_AGENT "
+        # Delegation lineage is derived afresh for every command by
+        # _make_run_env(). Persisting a child marker in the terminal snapshot
+        # would incorrectly fence later parent commands on the same backend.
+        "HERMES_DELEGATED_CHILD_CONTEXT "
         f"HERMES_UI_SESSION_ID{extra_unset} 2>/dev/null; "
         "export -p; "
         ") || true; } "


### PR DESCRIPTION
## Summary
- exclude `HERMES_DELEGATED_CHILD_CONTEXT` from persistent terminal snapshots
- keep child lineage derived per command so true delegated children remain fenced
- add an end-to-end regression covering child command -> later parent command on the same `LocalEnvironment`

## Root cause
A delegated child command received the marker correctly, but the terminal session snapshot persisted it. A later parent command sourced that snapshot, was misclassified as a delegated child, and had Kanban writes rejected.

## Verification
- regression test reproduced RED before the fix (`child=1`, later `parent=1`)
- regression test GREEN after the fix (`child=1`, later `parent=unset`)
- `39 passed` across delegation isolation and terminal snapshot suites
- `ruff check tools/environments/base.py tests/tools/test_delegate_kanban_isolation.py`
- live parent shell recovered; previously blocked MeetNote CN-16 Kanban task completed and read back as `done`
