### PR TITLE
fix(context-engine): pass hermes_home on session transitions too

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -813,6 +813,15 @@ class AIAgent:
                 "model": getattr(self, "model", ""),
                 "context_length": getattr(engine, "context_length", None),
                 "conversation_id": getattr(self, "_gateway_session_key", None),
+                # Same key agent/agent_init.py passes when it opens the very
+                # first session on this engine.  Without it here, an engine
+                # that keys per-profile storage off ``hermes_home`` is told
+                # once at init and never again, so every later transition
+                # leaves it bound to whatever home the engine happened to see
+                # first.  Placed in the defaults so an explicit
+                # ``extra_context["hermes_home"]`` from a profile-aware caller
+                # still wins via the ``update`` below.
+                "hermes_home": str(get_hermes_home()),
             }
             start_context.update(extra_context)
             start_context = {k: v for k, v in start_context.items() if v not in (None, "")}

--- a/tests/agent/test_context_engine.py
+++ b/tests/agent/test_context_engine.py
@@ -345,3 +345,66 @@ class TestInitAgentDoesNotMutatePluginSingleton:
         assert not re.search(
             r"_selected_engine\s*=\s*_candidate\b", src
         ), "found the #42449 bug-shape alias `_selected_engine = _candidate`"
+
+
+class TestSessionTransitionPassesHermesHome:
+    """`hermes_home` must reach on_session_start on BOTH lifecycle paths.
+
+    agent/agent_init.py passes it when it opens the first session on an
+    engine. run_agent.py::_transition_context_engine_session did not, so an
+    engine that resolves per-profile storage from `hermes_home` was told once
+    at init and never again — every later transition left it bound to whatever
+    home it happened to see first.
+    """
+
+    class _Recorder:
+        name = "recorder"
+        context_length = 128000
+
+        def __init__(self):
+            self.starts = []
+
+        def on_session_start(self, session_id, **kwargs):
+            self.starts.append(kwargs)
+
+        def on_session_reset(self):
+            pass
+
+    class _StubAgent:
+        def __init__(self, engine):
+            from run_agent import AIAgent
+            self.context_compressor = engine
+            self.session_id = "S2"
+            self.platform = None
+            self.model = "m"
+            self._gateway_session_key = "C1"
+            self._transition = AIAgent._transition_context_engine_session
+
+    def test_transition_passes_hermes_home(self):
+        engine = self._Recorder()
+        agent = self._StubAgent(engine)
+        agent._transition(
+            agent,
+            old_session_id="S1",
+            new_session_id="S2",
+            previous_messages=[],
+        )
+        assert engine.starts, "on_session_start was not called"
+        assert "hermes_home" in engine.starts[-1], (
+            "the session-transition path must pass hermes_home, the same key "
+            "agent_init passes on first session start"
+        )
+        assert engine.starts[-1]["hermes_home"]
+
+    def test_caller_supplied_hermes_home_wins(self):
+        """A profile-aware caller must be able to override the default."""
+        engine = self._Recorder()
+        agent = self._StubAgent(engine)
+        agent._transition(
+            agent,
+            old_session_id="S1",
+            new_session_id="S2",
+            previous_messages=[],
+            hermes_home="/tmp/explicit-profile-home",
+        )
+        assert engine.starts[-1]["hermes_home"] == "/tmp/explicit-profile-home"


### PR DESCRIPTION
## Problem

`on_session_start` has two call sites and they disagree about `hermes_home`.

`agent/agent_init.py:3025` passes it when it opens the first session on an engine:

```python
agent.context_compressor.on_session_start(
    agent.session_id,
    hermes_home=str(get_hermes_home()),
    platform=agent.platform or "cli",
    ...
)
```

`run_agent.py::_transition_context_engine_session` — the path taken by `/new`,
a gateway session rollover, and a carried-over context — builds `start_context`
without it. So a kwarg that engines are told to rely on is delivered exactly
once per engine, at init, and never again.

This is invisible to the built-in `ContextCompressor`, which keeps no per-home
state. It is not invisible to a plugin context engine that resolves per-profile
storage from `hermes_home`. `hermes-lcm`, for instance, implements
`_rebind_storage_for_home()` precisely so a reused engine object can follow a
changing home — and its docstring names the case it is defending against:

> Older Hermes versions may still reuse the same plugin/context-engine object
> after `HERMES_HOME` changes, so the plugin must not assume the store captured
> during `register()` is still correct.

On the transition path that guard can never fire, because the argument it keys
on is not passed. The engine silently keeps whatever binding it had.

## Repro

Stub engine, stub agent, drive only the transition helper:

```python
from run_agent import AIAgent

class Recorder:
    name = "recorder"; context_length = 128000
    def __init__(self): self.starts = []
    def on_session_start(self, session_id, **kw): self.starts.append(kw)
    def on_session_reset(self): pass

class StubAgent:
    def __init__(self, engine):
        self.context_compressor = engine
        self.session_id = "S2"; self.platform = None; self.model = "m"
        self._gateway_session_key = "C1"
    _transition = AIAgent._transition_context_engine_session

e = Recorder(); a = StubAgent(e)
a._transition(a, old_session_id="S1", new_session_id="S2", previous_messages=[])
print(sorted(e.starts[-1]))
```

Before:

```
['carry_over_context', 'context_length', 'conversation_id', 'model',
 'old_session_id', 'platform']
```

`hermes_home` is absent, while `agent_init` supplies it on the other path.

## What this is *not*

To be precise about scope, since it would be easy to over-read the above: I did
**not** observe cross-profile misbinding on a multiplexed gateway. That path
looks correct today — `gateway/run.py::_profile_runtime_scope` installs
`set_hermes_home_override()` for the routed profile (a ContextVar, so it
propagates into the agent worker thread), and `agent_init` reads
`get_hermes_home()` inside that scope, so a per-profile engine is bound
correctly when it is created. I checked that directly before filing.

This PR is therefore a consistency fix, not an incident report: the same hook
should carry the same contract on both paths, so an engine that legitimately
rebinds on `hermes_home` is not quietly dependent on being constructed fresh
for every home.

## Fix

One key, added to the defaults dict rather than after
`start_context.update(extra_context)`, so an explicit
`extra_context["hermes_home"]` from a caller that already knows the target
profile still wins.

## Tests

Two added in `tests/agent/test_context_engine.py`:

- `test_transition_passes_hermes_home` — red before this change, green after.
- `test_caller_supplied_hermes_home_wins` — pins the override ordering.

Verified against the project's own suites for the surrounding lifecycle:

```
tests/agent/test_context_engine.py
tests/test_cli_manual_compress.py
tests/hermes_cli/test_lifecycle.py
tests/hermes_cli/test_plugin_api_compat.py
tests/run_agent/test_switch_model_context.py
tests/run_agent/test_compression_boundary_hook.py
→ 39 passed
```
