### PR TITLE
docs(skills): enforce minimal reproduction escalation

### DIFF
--- a/skills/software-development/systematic-debugging/SKILL.md
+++ b/skills/software-development/systematic-debugging/SKILL.md
@@ -97,6 +97,8 @@ You MUST complete each phase before proceeding to the next.
 9. **Differential loop** comparing old vs new version, two configs, two providers, or two datasets.
 10. **Human-in-the-loop script** only as a last resort: script the human steps and capture their result so the loop stays structured.
 
+**Escalation discipline:** Start at the cheapest layer capable of reproducing the exact symptom: unit/component, integration/E2E, API/protocol, or browser/UI. Escalate only when the lower layer cannot reproduce or exercise it, and stop at the first conclusive reproduction. Record the exact commands and outcomes. Treat the successful layer as localization evidence, not automatic ownership by that component.
+
 **Tighten the loop once it exists:**
 
 - Make it faster: cache setup, narrow scope, skip unrelated initialization.

--- a/tests/skills/test_systematic_debugging_skill.py
+++ b/tests/skills/test_systematic_debugging_skill.py
@@ -1,0 +1,34 @@
+"""Behavior contracts for the bundled systematic-debugging skill."""
+
+import json
+from pathlib import Path
+
+from tools import skills_tool
+
+
+SKILLS_ROOT = Path(__file__).resolve().parents[2] / "skills"
+
+
+def test_reproduction_guidance_escalates_from_the_cheapest_capable_layer(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", SKILLS_ROOT)
+
+    result = json.loads(
+        skills_tool.skill_view("systematic-debugging", preprocess=False)
+    )
+
+    assert result["success"] is True
+    content = result["content"]
+    guidance = content.split(
+        "**Ways to construct a loop — try in roughly this order:**", 1
+    )[1].split("**Tighten the loop once it exists:**", 1)[0]
+
+    for layer in ("unit/component", "integration/E2E", "API/protocol", "browser/UI"):
+        assert layer in guidance
+    assert "cheapest layer" in guidance
+    assert "only when" in guidance
+    assert "first conclusive reproduction" in guidance
+    assert "exact commands and outcomes" in guidance
+    assert "localization evidence" in guidance
+    assert "ownership" in guidance

--- a/website/docs/user-guide/skills/bundled/software-development/software-development-systematic-debugging.md
+++ b/website/docs/user-guide/skills/bundled/software-development/software-development-systematic-debugging.md
@@ -115,6 +115,8 @@ You MUST complete each phase before proceeding to the next.
 9. **Differential loop** comparing old vs new version, two configs, two providers, or two datasets.
 10. **Human-in-the-loop script** only as a last resort: script the human steps and capture their result so the loop stays structured.
 
+**Escalation discipline:** Start at the cheapest layer capable of reproducing the exact symptom: unit/component, integration/E2E, API/protocol, or browser/UI. Escalate only when the lower layer cannot reproduce or exercise it, and stop at the first conclusive reproduction. Record the exact commands and outcomes. Treat the successful layer as localization evidence, not automatic ownership by that component.
+
 **Tighten the loop once it exists:**
 
 - Make it faster: cache setup, narrow scope, skip unrelated initialization.


### PR DESCRIPTION
## Summary
- add smallest-credible-reproduction escalation discipline to systematic debugging
- preserve the rule in generated skill documentation
- add a focused skill-loading contract test

## Verification
- `scripts/run_tests.sh tests/skills/test_systematic_debugging_skill.py -q`
- `scripts/run_tests.sh tests/website/test_generate_skill_docs.py -q`
- `.venv/bin/python -m tools.skill_linter skills/software-development/systematic-debugging/SKILL.md`
- `.venv/bin/ruff check tests/skills/test_systematic_debugging_skill.py`
- `git diff --cached --check`