### PR TITLE
fix(kanban): route notifications by transport profile

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -211,6 +211,43 @@ def _wake_scope_id(adapter: Any, sub: dict) -> Optional[str]:
 class GatewayKanbanWatchersMixin:
     """Kanban watcher / notifier / dispatcher loops for GatewayRunner."""
 
+    def _kanban_delivery_adapter(self, platform: Any, sub: dict) -> Any:
+        """Resolve the credential-owning adapter for one subscription.
+
+        New subscriptions persist the transport profile. For older rows, allow
+        the primary adapter only when the destination explicitly matches a
+        profile route and that profile does not configure its own adapter for
+        this platform. A configured-but-disconnected adapter fails closed.
+        """
+        owner_profile = str(sub.get("notifier_profile") or "").strip() or None
+        resolve_owned = getattr(self, "_authorization_adapter", None)
+        adapter = resolve_owned(platform, owner_profile) if callable(resolve_owned) else None
+        if adapter is not None or not owner_profile:
+            return adapter
+
+        configured = getattr(self, "_profile_configured_platforms", {}) or {}
+        if platform in (configured.get(owner_profile) or set()):
+            return None
+
+        routes = getattr(getattr(self, "config", None), "profile_routes", None) or []
+        if not routes:
+            return None
+        metadata = sub.get("delivery_metadata")
+        metadata = metadata if isinstance(metadata, dict) else {}
+        from gateway.profile_routing import match_profile_route
+
+        matched = match_profile_route(
+            routes,
+            getattr(platform, "value", str(platform)).lower(),
+            guild_id=str(metadata.get("scope_id") or "") or None,
+            chat_id=str(sub.get("chat_id") or "") or None,
+            thread_id=str(sub.get("thread_id") or "") or None,
+            parent_chat_id=str(metadata.get("parent_chat_id") or "") or None,
+        )
+        if matched is None or matched.profile != owner_profile:
+            return None
+        return (getattr(self, "adapters", None) or {}).get(platform)
+
     def _owns_kanban_dispatcher_lock(self) -> bool:
         """Return whether this gateway currently owns the singleton lock."""
         return getattr(self, "_kanban_dispatcher_lock_handle", None) is not None
@@ -462,15 +499,6 @@ class GatewayKanbanWatchersMixin:
                                 logger.debug("kanban notifier: board %s has no subscriptions", slug)
                             for sub in subs:
                                 try:
-                                    owner_profile = sub.get("notifier_profile") or None
-                                    if owner_profile and owner_profile != notifier_profile:
-                                        _owner_adapters = getattr(self, "_profile_adapters", {}).get(owner_profile)
-                                        if not _owner_adapters:
-                                            logger.debug(
-                                                "kanban notifier: subscription for %s owned by profile %s; current profile %s has no adapter for it, skipping",
-                                                sub.get("task_id"), owner_profile, notifier_profile,
-                                            )
-                                            continue
                                     platform = (sub.get("platform") or "").lower()
                                     if platform not in active_platforms:
                                         logger.debug(
@@ -538,7 +566,7 @@ class GatewayKanbanWatchersMixin:
                     # wrong bot (the cross-profile mis-delivery this whole change
                     # exists to fix). The helper returns None only when the profile
                     # (or default) genuinely has no adapter for the platform.
-                    adapter = self._authorization_adapter(plat, sub_profile or None)
+                    adapter = self._kanban_delivery_adapter(plat, sub)
                     if adapter is None:
                         logger.debug(
                             "kanban notifier: adapter %s disconnected before delivery for %s; rewinding claim",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7517,6 +7517,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # sites are untouched when multiplexing is off (this dict is empty).
         # Populated by _start_secondary_profile_adapters().
         self._profile_adapters: Dict[str, Dict[Platform, BasePlatformAdapter]] = {}
+        # Enabled declarations are separate from connected adapters. An empty
+        # profile map can mean either "virtual route through the primary bot"
+        # or "own bot configured but failed"; notifier fallback must know which.
+        self._profile_configured_platforms: Dict[str, set[Platform]] = {}
         self._warn_if_docker_media_delivery_is_risky()
         _gateway_runner_ref = _weakref.ref(self)
 
@@ -16991,6 +16995,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
 
         profile_map = self._profile_adapters.setdefault(profile_name, {})
+        configured_platforms = getattr(self, "_profile_configured_platforms", None)
+        if not isinstance(configured_platforms, dict):
+            # Keep object.__new__ test/plugin runners compatible with the real
+            # constructor while still installing the ownership distinction.
+            configured_platforms = {}
+            self._profile_configured_platforms = configured_platforms
+        configured_platforms[profile_name] = {
+            platform
+            for platform, platform_config in profile_cfg.platforms.items()
+            if platform_config.enabled
+            and not (
+                getattr(self.config, "multiplex_profiles", False)
+                and platform is Platform.RELAY
+            )
+        }
         connected = 0
         for platform, platform_config in profile_cfg.platforms.items():
             if not platform_config.enabled:
@@ -27144,6 +27163,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _adapters = getattr(self, "adapters", None) or {}
         _adapter = _adapters.get(context.source.platform)
         _async_delivery = getattr(_adapter, "supports_async_delivery", True)
+        # Agent/runtime routing and transport ownership are distinct. The
+        # source's in-process adapter provenance is authoritative when a shared
+        # primary bot routes a chat into a secondary profile.
+        _registered_transport = self._registered_transport_adapter(context.source)
+        _transport_profile = self._adapter_profile_for_source(context.source)
+        if _registered_transport is not None and not _transport_profile:
+            _transport_profile = (
+                getattr(self, "_primary_profile_name", None)
+                or self._active_profile_name()
+                or "default"
+            )
+        elif not _transport_profile:
+            # Hand-built/restored sources have no live adapter provenance.
+            # Preserve the historical runtime stamp rather than guessing.
+            _transport_profile = getattr(context.source, "profile", "") or ""
         return set_session_vars(
             platform=context.source.platform.value,
             chat_id=context.source.chat_id,
@@ -27159,6 +27193,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             session_key=context.session_key,
             message_id=str(context.source.message_id) if context.source.message_id else "",
             profile=getattr(context.source, "profile", "") or "",
+            transport_profile=_transport_profile,
             async_delivery=_async_delivery,
             cron_session="",
         )

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -102,6 +102,12 @@ _SESSION_UI_SESSION_ID: ContextVar = ContextVar("HERMES_UI_SESSION_ID", default=
 _SESSION_MESSAGE_ID: ContextVar = ContextVar("HERMES_SESSION_MESSAGE_ID", default=_UNSET)
 
 _SESSION_PROFILE: ContextVar = ContextVar("HERMES_SESSION_PROFILE", default=_UNSET)
+# Profile that owns the live messaging adapter for this turn. This can differ
+# from _SESSION_PROFILE when a primary bot routes one chat into a secondary
+# agent/runtime profile via gateway.profile_routes.
+_SESSION_TRANSPORT_PROFILE: ContextVar = ContextVar(
+    "HERMES_SESSION_TRANSPORT_PROFILE", default=_UNSET
+)
 _BROWSER_CONTROL_PRINCIPAL: ContextVar = ContextVar(
     "HERMES_BROWSER_CONTROL_PRINCIPAL", default=_UNSET
 )
@@ -157,6 +163,7 @@ _VAR_MAP = {
     "HERMES_UI_SESSION_ID": _SESSION_UI_SESSION_ID,
     "HERMES_SESSION_MESSAGE_ID": _SESSION_MESSAGE_ID,
     "HERMES_SESSION_PROFILE": _SESSION_PROFILE,
+    "HERMES_SESSION_TRANSPORT_PROFILE": _SESSION_TRANSPORT_PROFILE,
     "HERMES_BROWSER_CONTROL_PRINCIPAL": _BROWSER_CONTROL_PRINCIPAL,
     "HERMES_BROWSER_CONTROL_TRANSPORT_FAMILY": _BROWSER_CONTROL_TRANSPORT_FAMILY,
     "HERMES_CRON_SESSION": _CRON_SESSION,
@@ -236,6 +243,7 @@ def set_session_vars(
     session_id: str = "",
     message_id: str = "",
     profile: str = "",
+    transport_profile: str = "",
     browser_control_principal: str = "",
     browser_control_transport_family: str = "",
     cwd: str = "",
@@ -283,6 +291,7 @@ def set_session_vars(
         _SESSION_UI_SESSION_ID.set(ui_session_id),
         _SESSION_MESSAGE_ID.set(message_id),
         _SESSION_PROFILE.set(profile),
+        _SESSION_TRANSPORT_PROFILE.set(transport_profile),
         _BROWSER_CONTROL_PRINCIPAL.set(browser_control_principal),
         _BROWSER_CONTROL_TRANSPORT_FAMILY.set(browser_control_transport_family),
         _CRON_SESSION.set(cron_session),
@@ -324,6 +333,7 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_UI_SESSION_ID,
         _SESSION_MESSAGE_ID,
         _SESSION_PROFILE,
+        _SESSION_TRANSPORT_PROFILE,
         _BROWSER_CONTROL_PRINCIPAL,
         _BROWSER_CONTROL_TRANSPORT_FAMILY,
         _CRON_SESSION,

--- a/tests/gateway/test_kanban_notifier_transport_profile.py
+++ b/tests/gateway/test_kanban_notifier_transport_profile.py
@@ -1,0 +1,193 @@
+"""Kanban notifier routing regressions for multiplexed profile routes."""
+
+from __future__ import annotations
+
+import asyncio
+import weakref
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from gateway.config import Platform
+from gateway.profile_routing import ProfileRoute
+from gateway.run import GatewayRunner
+from gateway.session import SessionContext, SessionSource
+from gateway.session_context import get_session_env
+from hermes_cli import kanban_db as kb
+from tools.kanban_tools import _maybe_auto_subscribe
+
+
+class RecordingAdapter:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, chat_id, text, metadata=None):
+        self.sent.append(
+            {"chat_id": chat_id, "text": text, "metadata": metadata or {}}
+        )
+
+
+async def _run_one_tick(monkeypatch, runner):
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(delay):
+        if delay == 5:
+            return None
+        runner._running = False
+        await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    await runner._kanban_notifier_watcher(interval=1)
+
+
+def _runner(primary, *, secondary=None, configured=None):
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = {Platform.TELEGRAM: primary}
+    runner._primary_profile_name = "default"
+    runner._kanban_notifier_profile = "default"
+    runner._kanban_dispatcher_lock_handle = object()
+    runner._kanban_sub_fail_counts = {}
+    runner._profile_adapters = {"daily": secondary or {}}
+    runner._profile_configured_platforms = {
+        "daily": set(configured or set()),
+    }
+    runner.config = SimpleNamespace(
+        profile_routes=[
+            ProfileRoute(
+                name="daily-topic",
+                platform="telegram",
+                chat_id="-1003858887056",
+                thread_id="2",
+                profile="daily",
+            )
+        ]
+    )
+    return runner
+
+
+def _completed_sub(*, notifier_profile="daily"):
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="canary", assignee="dev")
+        kb.add_notify_sub(
+            conn,
+            task_id=task_id,
+            platform="telegram",
+            chat_id="-1003858887056",
+            thread_id="2",
+            notifier_profile=notifier_profile,
+            delivery_mode="notify",
+        )
+        kb.complete_task(conn, task_id, summary="canary done")
+        return task_id
+    finally:
+        conn.close()
+
+
+def _subscription(task_id):
+    conn = kb.connect()
+    try:
+        return kb.list_notify_subs(conn, task_id)[0]
+    finally:
+        conn.close()
+
+
+def test_auto_subscribe_stamps_primary_transport_for_routed_secondary(
+    tmp_path, monkeypatch,
+):
+    """A routed runtime profile must persist the bot/transport owner profile."""
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "auto-sub.db"))
+    kb.init_db()
+
+    primary = RecordingAdapter()
+    runner = _runner(primary)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1003858887056",
+        chat_type="group",
+        thread_id="2",
+        profile="daily",
+    )
+    source._transport_adapter_ref = weakref.ref(primary)
+    context = SessionContext(
+        source=source,
+        connected_platforms=[Platform.TELEGRAM],
+        home_channels={},
+        session_key="agent:daily:telegram:group:-1003858887056:2",
+    )
+
+    tokens = runner._set_session_env(context)
+    try:
+        assert get_session_env("HERMES_SESSION_TRANSPORT_PROFILE") == "default"
+        conn = kb.connect()
+        try:
+            task_id = kb.create_task(conn, title="child", assignee="dev")
+            with patch("tools.kanban_tools.load_config", return_value={}):
+                assert _maybe_auto_subscribe(conn, task_id) is True
+        finally:
+            conn.close()
+    finally:
+        runner._clear_session_env(tokens)
+
+    assert _subscription(task_id)["notifier_profile"] == "default"
+
+
+def test_virtual_routed_profile_replays_existing_subscription_once(
+    tmp_path, monkeypatch,
+):
+    """Legacy runtime-stamped rows route through the matching primary bot."""
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "virtual.db"))
+    kb.init_db()
+    task_id = _completed_sub()
+    before = _subscription(task_id)["last_event_id"]
+
+    primary = RecordingAdapter()
+    runner = _runner(primary)
+    asyncio.run(_run_one_tick(monkeypatch, runner))
+
+    assert len(primary.sent) == 1
+    assert primary.sent[0]["chat_id"] == "-1003858887056"
+    assert primary.sent[0]["metadata"]["thread_id"] == "2"
+    after = _subscription(task_id)["last_event_id"]
+    assert after > before
+
+    runner._running = True
+    asyncio.run(_run_one_tick(monkeypatch, runner))
+    assert len(primary.sent) == 1
+    assert _subscription(task_id)["last_event_id"] == after
+
+
+def test_secondary_profile_with_distinct_bot_uses_its_own_adapter(
+    tmp_path, monkeypatch,
+):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "distinct.db"))
+    kb.init_db()
+    _completed_sub()
+
+    primary = RecordingAdapter()
+    secondary = RecordingAdapter()
+    runner = _runner(
+        primary,
+        secondary={Platform.TELEGRAM: secondary},
+        configured={Platform.TELEGRAM},
+    )
+    asyncio.run(_run_one_tick(monkeypatch, runner))
+
+    assert primary.sent == []
+    assert len(secondary.sent) == 1
+
+
+def test_secondary_profile_with_failed_adapter_never_falls_back_to_primary(
+    tmp_path, monkeypatch,
+):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "failed.db"))
+    kb.init_db()
+    task_id = _completed_sub()
+    before = _subscription(task_id)["last_event_id"]
+
+    primary = RecordingAdapter()
+    runner = _runner(primary, configured={Platform.TELEGRAM})
+    asyncio.run(_run_one_tick(monkeypatch, runner))
+
+    assert primary.sent == []
+    assert _subscription(task_id)["last_event_id"] == before

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1583,8 +1583,12 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
         user_id = get_session_env("HERMES_SESSION_USER_ID", "") or None
         user_id_alt = get_session_env("HERMES_SESSION_USER_ID_ALT", "") or None
         message_id = get_session_env("HERMES_SESSION_MESSAGE_ID", "") or ""
+        # Notification delivery belongs to the transport credential, not
+        # necessarily the routed agent runtime. A primary bot may route one
+        # chat into a secondary profile that has no adapter of its own.
         notifier_profile = (
-            get_session_env("HERMES_SESSION_PROFILE", "")
+            get_session_env("HERMES_SESSION_TRANSPORT_PROFILE", "")
+            or get_session_env("HERMES_SESSION_PROFILE", "")
             or os.environ.get("HERMES_PROFILE")
         )
         if not notifier_profile:


### PR DESCRIPTION
Summary
- persist the live transport-owning profile separately from the routed agent profile when auto-subscribing Kanban tasks
- replay legacy runtime-stamped subscriptions through the primary adapter only when their destination matches an explicit profile route
- fail closed when a secondary profile configures its own adapter but that adapter is disconnected

Tests
- scripts/run_tests.sh tests/gateway/test_kanban_notifier_transport_profile.py tests/gateway/test_multiplex_adapter_registry.py tests/gateway/test_multiplex_busy_input_mode.py tests/gateway/test_kanban_notifier.py tests/gateway/test_session_env.py tests/gateway/test_session_context_inheritance.py tests/tools/test_local_env_session_leak.py tests/tools/test_kanban_tools.py -q
- 109 passed

Broader gateway run
- 7,566 passed; 33 failed before the object.__new__ compatibility fix
- 28 task-related failures were fixed and re-run green; the remaining 5 are macOS host constraints in AF_UNIX/abstract-socket/long-path/diagnostic tests