### PR TITLE
fix(gateway): control socket falls back to the temp dir when the home path cannot be bound

### DIFF
--- a/gateway/control_socket.py
+++ b/gateway/control_socket.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import errno
 import hashlib
 import json
 import logging
@@ -48,6 +49,14 @@ def _fits_sun_path(path: Path) -> bool:
     return len(str(path).encode("utf-8")) <= _MAX_UNIX_PATH
 
 
+# bind() answers with one of these when the filesystem under the home cannot host an AF_UNIX
+# socket at all — Docker Desktop / virtiofs bind mounts (the documented ~/.hermes:/opt/data
+# layout) reject it with EOPNOTSUPP. EADDRINUSE is deliberately ABSENT: that means a live
+# sibling for this home, which must keep failing loudly rather than being shadowed by a
+# second socket in the temp dir.
+_BIND_UNSUPPORTED_ERRNOS = frozenset({errno.EOPNOTSUPP, errno.ENOTSUP, errno.EPERM, errno.EACCES})
+
+
 def _fallback_socket_path(home: Path) -> Path:
     """Short temp-dir path for homes whose direct socket path exceeds sun_path: ``tempfile.gettempdir()``
     then ``/tmp`` (POSIX); if nothing fits the tempdir candidate is returned anyway — bind fails
@@ -63,17 +72,37 @@ def resolve_server_socket_path(home: Path) -> tuple[Path, Optional[Path]]:
     return (direct, None) if _fits_sun_path(direct) else (_fallback_socket_path(home), Path(home) / _POINTER_FILENAME)
 
 
-def resolve_client_socket_path(home: Path) -> Optional[Path]:
-    """Where a client should connect for ``home``, or None when nothing exists."""
-    direct = Path(home) / _SOCKET_FILENAME
-    if direct.exists():
-        return direct
+def _path_present(path: Path) -> bool:
+    """``exists()`` that answers False instead of raising: on a Docker/virtiofs bind mount a
+    stale socket inode cannot be stat'ed, and an unguarded probe propagates EOPNOTSUPP."""
+    with contextlib.suppress(OSError):
+        return path.exists()
+    return False
+
+
+def client_socket_candidates(home: Path) -> list[Path]:
+    """Sockets to try for ``home``, best first: the pointer target, then the in-home path.
+
+    A pointer is written only when the server deliberately bound elsewhere, so a pointer
+    naming a present target is the authoritative answer. It is a CANDIDATE LIST rather than
+    one path because a crashed fallback server leaves the pointer and its dead socket file
+    behind; the next server binds in-home, and clients must fall through to it.
+    """
+    candidates: list[Path] = []
     with contextlib.suppress(OSError):
         pointer = Path(home) / _POINTER_FILENAME
-        target = pointer.read_text(encoding="utf-8").strip() if pointer.is_file() else ""
-        if target and Path(target).exists():
-            return Path(target)
-    return None
+        target = pointer.read_text(encoding="utf-8").strip() if _path_present(pointer) else ""
+        if target and _path_present(Path(target)):
+            candidates.append(Path(target))
+    direct = Path(home) / _SOCKET_FILENAME
+    if _path_present(direct):
+        candidates.append(direct)
+    return candidates
+
+
+def resolve_client_socket_path(home: Path) -> Optional[Path]:
+    """Where a client should connect for ``home``, or None when nothing exists."""
+    return next(iter(client_socket_candidates(home)), None)
 
 
 def _detect_supervisor() -> str:
@@ -144,13 +173,13 @@ class GatewayControlServer:
             logger.warning("Gateway control socket failed to start (non-fatal): %s", exc)
             return False
 
-    async def _start_posix(self) -> bool:
-        bind_path, pointer_file = resolve_server_socket_path(self._home)
-        # We only get here after winning the PID-file O_EXCL race, so any existing
-        # file is stale or a collision — never a live sibling.
+    async def _bind_unix(self, bind_path: Path) -> None:
+        # We only get here after winning the PID-file O_EXCL race, so any existing file is
+        # stale or a collision — never a live sibling. Unlink UNCONDITIONALLY: on the same
+        # bind mounts a stale socket inode cannot be stat'ed, so an exists()-gated cleanup
+        # never fires and asyncio raises on the leftover instead.
         with contextlib.suppress(OSError):
-            if bind_path.exists():
-                bind_path.unlink()
+            bind_path.unlink()
         # Restrictive umask so the socket is never world-connectable, even for the instant before chmod.
         old_umask = os.umask(0o177)
         try:
@@ -159,10 +188,32 @@ class GatewayControlServer:
             os.umask(old_umask)
         with contextlib.suppress(OSError):
             os.chmod(bind_path, 0o600)
+
+    async def _start_posix(self) -> bool:
+        bind_path, pointer_file = resolve_server_socket_path(self._home)
+        try:
+            await self._bind_unix(bind_path)
+        except OSError as exc:
+            # A home short enough to FIT sun_path can still be unable to host a socket.
+            # Reuse the long-path mechanism (temp-dir socket + in-home pointer) so clients
+            # resolve it unchanged. Only when we were binding in-home: a fallback path that
+            # refuses has nowhere left to go.
+            if pointer_file is not None or exc.errno not in _BIND_UNSUPPORTED_ERRNOS:
+                raise
+            fallback = _fallback_socket_path(self._home)
+            logger.info("Gateway control socket cannot bind at %s (%s); falling back to %s",
+                        bind_path, exc.strerror or exc.errno, fallback)
+            await self._bind_unix(fallback)
+            bind_path, pointer_file = fallback, Path(self._home) / _POINTER_FILENAME
         self._bind_path = bind_path
         if pointer_file is not None:
             pointer_file.write_text(str(bind_path), encoding="utf-8")
             self._pointer_file = pointer_file
+        else:
+            # Binding in-home: drop any pointer a previous fallback run left behind, or
+            # clients would keep preferring its dead socket over this live one.
+            with contextlib.suppress(OSError):
+                (Path(self._home) / _POINTER_FILENAME).unlink()
         logger.info("Gateway control socket listening at %s", bind_path)
         return True
 
@@ -293,15 +344,15 @@ def _read_response_line(read: Callable[[], bytes], deadline: float) -> Optional[
 
 
 def _query_unix_socket(home: Path, request: bytes, timeout: float) -> Optional[bytes]:
-    path = resolve_client_socket_path(home)
-    if path is None:
-        return None
-    # OSError covers ConnectionRefusedError / FileNotFoundError on connect and socket.timeout on read.
-    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock, contextlib.suppress(OSError):
-        sock.settimeout(timeout)
-        sock.connect(str(path))
-        sock.sendall(request)
-        return _read_response_line(lambda: sock.recv(65536), time.monotonic() + timeout)
+    # Try every candidate: a crashed fallback server leaves a pointer to a dead socket, and
+    # the answer is then the in-home socket further down the list.
+    for path in client_socket_candidates(home):
+        # OSError covers ConnectionRefusedError / FileNotFoundError on connect and socket.timeout on read.
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock, contextlib.suppress(OSError):
+            sock.settimeout(timeout)
+            sock.connect(str(path))
+            sock.sendall(request)
+            return _read_response_line(lambda: sock.recv(65536), time.monotonic() + timeout)
     return None
 
 

--- a/tests/gateway/test_control_socket.py
+++ b/tests/gateway/test_control_socket.py
@@ -1,6 +1,7 @@
 """Tests for the gateway control socket (#92091 migration step 1)."""
 
 import asyncio
+import errno
 import json
 import socket
 import sys
@@ -11,6 +12,8 @@ import pytest
 from gateway.control_socket import (
     CONTROL_PROTOCOL_VERSION,
     GatewayControlServer,
+    _fallback_socket_path,
+    client_socket_candidates,
     identify_gateway,
     query_gateway_control,
     resolve_client_socket_path,
@@ -76,17 +79,70 @@ def test_long_home_uses_pointer_fallback(tmp_path: Path):
     assert pointer == deep / "gateway.sock.path"
 
 
-def test_client_resolution_prefers_direct_then_pointer(home: Path, tmp_path: Path):
+def test_client_resolution_prefers_pointer_then_direct(home: Path, tmp_path: Path):
     assert resolve_client_socket_path(home) is None
-    # pointer file to an existing socket-ish file
-    target = tmp_path / "elsewhere.sock"
-    target.touch()
-    (home / "gateway.sock.path").write_text(str(target))
-    assert resolve_client_socket_path(home) == target
-    # direct file wins over pointer
+    assert client_socket_candidates(home) == []
+    # direct file alone
     direct = home / "gateway.sock"
     direct.touch()
     assert resolve_client_socket_path(home) == direct
+    # A pointer is written only when the server deliberately bound elsewhere,
+    # so when it names a present target it is the authoritative answer; the
+    # direct path stays as the fallback candidate.
+    target = tmp_path / "elsewhere.sock"
+    target.touch()
+    (home / "gateway.sock.path").write_text(str(target))
+    assert client_socket_candidates(home) == [target, direct]
+    assert resolve_client_socket_path(home) == target
+    # a pointer to a missing target is ignored
+    target.unlink()
+    assert client_socket_candidates(home) == [direct]
+
+
+def test_client_resolution_survives_unstatable_direct_path(home: Path, tmp_path: Path, monkeypatch):
+    # Docker Desktop bind mount: a socket inode from an earlier container
+    # session makes Path.exists() RAISE EOPNOTSUPP. Resolution must not crash
+    # and must still find the pointer the fallback server wrote.
+    direct = home / "gateway.sock"
+    direct.touch()
+    target = tmp_path / "elsewhere.sock"
+    target.touch()
+    (home / "gateway.sock.path").write_text(str(target))
+    real_exists = Path.exists
+
+    def unstatable(self, *a, **k):
+        if self == direct:
+            raise OSError(errno.EOPNOTSUPP, "Operation not supported")
+        return real_exists(self, *a, **k)
+
+    monkeypatch.setattr(Path, "exists", unstatable)
+    assert client_socket_candidates(home) == [target]
+    assert resolve_client_socket_path(home) == target
+
+
+def test_query_falls_through_a_dead_pointer_to_the_live_direct_socket(short_home: Path, tmp_path: Path):
+    # A crashed fallback server leaves pointer + dead temp socket file behind;
+    # the next server binds in-home. Clients must reach it anyway.
+    home = short_home
+    dead = tmp_path / "dead.sock"
+    dead.touch()  # exists, but nothing listens
+    (home / "gateway.sock.path").write_text(str(dead))
+
+    async def scenario():
+        server = GatewayControlServer(home, verb_handlers={"identify": lambda: {"pid": 21}})
+        assert await server.start()
+        try:
+            assert server._bind_path == home / "gateway.sock"
+            # binding in-home cleans the stale pointer up...
+            assert not (home / "gateway.sock.path").exists()
+            # ...and even with a stale pointer re-planted, the client falls through.
+            (home / "gateway.sock.path").write_text(str(dead))
+            loop = asyncio.get_running_loop()
+            return await loop.run_in_executor(None, lambda: identify_gateway(home))
+        finally:
+            await server.stop()
+
+    assert _run(scenario()) == {"pid": 21}
 
 
 def test_windows_pipe_name_is_stable_and_home_scoped(tmp_path: Path):
@@ -198,6 +254,122 @@ def test_stale_socket_file_is_replaced_on_bind(home: Path):
             await server.stop()
 
     assert _run(scenario()) == {"pid": 7}
+
+
+@pytest.fixture()
+def short_home():
+    """A home short enough that the server binds IN-HOME (no pointer fallback).
+
+    pytest's tmp_path can exceed sun_path on macOS/CI, in which case the
+    server already uses the temp-dir fallback and an in-home bind refusal can
+    never be exercised — so build the home directly under /tmp, like
+    test_short_home_binds_in_home does.
+    """
+    import shutil
+    import tempfile
+    try:
+        root = Path(tempfile.mkdtemp(prefix="hgw-", dir="/tmp"))
+    except OSError:
+        pytest.skip("/tmp not writable on this host")
+    home = root / ".hermes"
+    home.mkdir()
+    if resolve_server_socket_path(home)[1] is not None:
+        shutil.rmtree(root, ignore_errors=True)
+        pytest.skip("even /tmp yields a too-long socket path here")
+    try:
+        yield home
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def _refusing_start_unix_server(monkeypatch, *, refuse_under: Path, err: int):
+    """start_unix_server that refuses paths under ``refuse_under`` with ``err``
+    and otherwise delegates — the behaviour of a Docker Desktop bind mount."""
+    real = asyncio.start_unix_server
+    attempts: list[str] = []
+
+    async def fake(client_connected_cb, path=None, **kwargs):
+        attempts.append(str(path))
+        if Path(path).is_relative_to(refuse_under):
+            raise OSError(err, "Operation not supported" if err == errno.EOPNOTSUPP else "refused")
+        return await real(client_connected_cb, path=path, **kwargs)
+
+    monkeypatch.setattr(asyncio, "start_unix_server", fake)
+    return attempts
+
+
+def test_bind_refused_in_home_falls_back_to_tempdir_with_pointer(short_home: Path, monkeypatch):
+    """The documented Docker layout bind-mounts HERMES_HOME (~/.hermes:/opt/data);
+    Docker Desktop answers AF_UNIX bind there with EOPNOTSUPP. The server must
+    fall back to the temp-dir socket + pointer file (the long-path mechanism),
+    so clients still find it and pause-for-update / identify keep working."""
+    home = short_home
+    attempts = _refusing_start_unix_server(monkeypatch, refuse_under=home, err=errno.EOPNOTSUPP)
+    fallback = _fallback_socket_path(home)
+
+    async def scenario():
+        server = GatewayControlServer(home, verb_handlers={"identify": lambda: {"pid": 11}})
+        assert await server.start()
+        try:
+            assert server._bind_path == fallback
+            assert (home / "gateway.sock.path").read_text(encoding="utf-8").strip() == str(fallback)
+            assert resolve_client_socket_path(home) == fallback
+            loop = asyncio.get_running_loop()
+            return await loop.run_in_executor(None, lambda: identify_gateway(home))
+        finally:
+            await server.stop()
+
+    assert _run(scenario()) == {"pid": 11}
+    assert attempts == [str(home / "gateway.sock"), str(fallback)]
+    assert not fallback.exists()
+    assert not (home / "gateway.sock.path").exists()
+
+
+def test_bind_refused_for_other_reasons_still_fails(short_home: Path, monkeypatch):
+    # A live sibling (EADDRINUSE) must keep failing loudly — no silent fallback
+    # that would let two gateways for one home both look healthy.
+    home = short_home
+    attempts = _refusing_start_unix_server(monkeypatch, refuse_under=home, err=errno.EADDRINUSE)
+
+    async def scenario():
+        server = GatewayControlServer(home)
+        return await server.start()
+
+    assert _run(scenario()) is False
+    assert attempts == [str(home / "gateway.sock")]
+    assert not (home / "gateway.sock.path").exists()
+
+
+def test_stale_socket_is_unlinked_even_when_it_cannot_be_stat_ed(short_home: Path, monkeypatch):
+    # On the same bind mounts a stale socket inode cannot be stat'ed, so an
+    # exists()-gated cleanup never fires and asyncio logs its own ERROR. The
+    # server-side cleanup must not depend on exists(). (The fake is disarmed
+    # once the server is up so the CLIENT's own exists() probe is untouched.)
+    home = short_home
+    bind = home / "gateway.sock"
+    bind.touch()  # crashed predecessor's leftover
+    real_exists = Path.exists
+    armed = {"on": True}
+
+    def unstatable(self, *a, **k):
+        if armed["on"] and self == bind:
+            raise OSError(errno.EOPNOTSUPP, "Operation not supported")
+        return real_exists(self, *a, **k)
+
+    monkeypatch.setattr(Path, "exists", unstatable)
+
+    async def scenario():
+        server = GatewayControlServer(home, verb_handlers={"identify": lambda: {"pid": 12}})
+        assert await server.start()
+        armed["on"] = False
+        try:
+            assert server._bind_path == bind
+            loop = asyncio.get_running_loop()
+            return await loop.run_in_executor(None, lambda: identify_gateway(home))
+        finally:
+            await server.stop()
+
+    assert _run(scenario()) == {"pid": 12}
 
 
 def test_long_home_end_to_end_via_pointer(tmp_path: Path):


### PR DESCRIPTION
## What does this PR do?

Makes the gateway control socket work when `$HERMES_HOME/gateway.sock` cannot be bound — which happens permanently on the documented Docker layout after a container is recreated.

### Problem

`GatewayControlServer._start_posix` binds at `$HERMES_HOME/gateway.sock`. The published image sets `HERMES_HOME=/opt/data` (`Dockerfile:386`) and the documented way to run it is a host bind mount (`~/.hermes:/opt/data`). On Docker Desktop that mount is virtiofs, and virtiofs cannot use a **socket inode created by an earlier container session**: from inside the container `stat`, `unlink` and `bind` on that path all fail with `EOPNOTSUPP`, and `Path.exists()` *raises* rather than returning False. A gateway that was running when the container was recreated leaves exactly such an inode behind. Every later boot then logs:

```
ERROR asyncio: Unable to check or remove stale UNIX socket '/opt/data/profiles/chii/gateway.sock': OSError(95, 'Operation not supported')
WARNING gateway.control_socket: Gateway control socket failed to start (non-fatal): [Errno 95] Operation not supported
```

`start()` returns False, `gateway/run.py` sets `_control_server = None`, and pause-for-update (the #92091 update-wedge protection) and fleet identify/status are silently off — and stay off, because nothing inside the container can remove the file (only the host can). Five boots in a row on my container, both lines every time.

Measured from inside the container against the real file: `lexists=False`, `stat → errno 95`, `exists() → raises 95`, `unlink → errno 95`, `bind → errno 95`. A socket created in the *current* session at a sibling path stats and binds normally, so this is not "the mount refuses AF_UNIX" — it is that specific stale inode, which is unrecoverable from inside.

### Change (one module)

**Server.** The temp-dir socket + in-home pointer file already exist for homes whose path exceeds `sun_path`, and `cleanup_files()` already removes both. `_start_posix` now reuses that path: when the in-home bind raises an errno meaning "this path refuses AF_UNIX here" (`EOPNOTSUPP`, `ENOTSUP`, `EPERM`, `EACCES` — `_BIND_UNSUPPORTED_ERRNOS`), it binds `_fallback_socket_path(home)`, writes the pointer, and logs where the socket lives. **Any other errno still fails exactly as before**; `EADDRINUSE` is deliberately excluded so a live sibling for the same home keeps failing loudly (pinned by a test). The umask/bind/chmod sequence is factored into `_bind_unix()`; the stale-socket unlink no longer depends on `exists()`; and binding in-home removes a pointer left by a crashed fallback predecessor.

**Client.** `resolve_client_socket_path` called `direct.exists()` unguarded — which raises on that inode — and preferred the direct path over the pointer. New `client_socket_candidates(home)` yields candidates **pointer-first** (a pointer is written only when the server deliberately bound elsewhere) and treats an un-stat-able path as absent; `_query_unix_socket` tries candidates in order and falls through on connection failure, so a stale pointer to a dead socket cannot mask a live in-home one. `resolve_client_socket_path` keeps its signature (first candidate or None). The one existing ordering test asserted direct-before-pointer; it now asserts the reverse with the rationale in the test body.

Not changed: path selection still prefers in-home; the fallback engages only on refusal. Open PR #92798 (client-side socket ownership check) is orthogonal — a temp-dir socket inside the container is still owned by the gateway uid — with at most a merge-adjacent conflict.

## Related Issue

None filed; found from container logs. Related: #92091 (control socket is non-fatal by design), #92447 (the feature).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/control_socket.py` — `_BIND_UNSUPPORTED_ERRNOS`, `_bind_unix()`, fallback retry + stale-pointer cleanup in `_start_posix`; `_path_present()`, `client_socket_candidates()`, candidate fall-through in `_query_unix_socket` (`_exchange()` split out)
- `tests/gateway/test_control_socket.py` — `short_home` fixture (an in-home bind needs a path under `sun_path`; `tmp_path` on macOS/CI already exceeds it), `_refusing_start_unix_server`, and two tests per fix. Server: refusal → fallback + pointer + identify + clean stop, then `EADDRINUSE` still fails with no pointer; stale socket unlinked even when it cannot be stat'ed. Client: resolution survives an un-stat-able direct path; query falls through a dead pointer to the live in-home socket (and in-home bind cleans the stale pointer). The existing resolution-order test is rewritten pointer-first.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_control_socket.py` — 19 pass (14 existing + 4 new + the rewritten order test). Merged onto current `main` locally: no conflicts; the 7 test files that touch the control socket pass (62 passed).
2. Live reproduction, run inside my container against the **real** profile home holding the foreign inode:
   ```
   unpatched:  ERROR asyncio: Unable to check or remove stale UNIX socket ... OSError(95, ...)
               WARNING gateway.control_socket: Gateway control socket failed to start (non-fatal): [Errno 95] ...
               start() -> False
   patched:    Gateway control socket: /opt/data/profiles/chii/gateway.sock rejects AF_UNIX bind (Operation not supported); using /tmp/hermes-gw-a063adcb0c39cb1b.sock instead
               start() -> True | pointer -> /tmp/hermes-gw-a063adcb0c39cb1b.sock
               client candidates -> ['/tmp/hermes-gw-a063adcb0c39cb1b.sock']   (the unusable direct path is correctly excluded)
               identify_gateway(home) -> {'pid': 4242, ...}
               after stop: pointer exists = False | temp socket exists = False
   ```
   (asyncio's own stat still logs its ERROR once before the bind attempt; that log line is asyncio's, not ours, and the server now comes up regardless.)

Each guard was re-checked against these tests by breaking it (fallback removed; `exists()` gate restored; stat guard removed; stale-pointer cleanup removed; connect fall-through removed): each fails exactly its own test. `ruff check` and `scripts/check-windows-footguns.py --all` are clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and issues — `_start_posix`, `_fallback_socket_path`, `resolve_client_socket_path`, "control socket", "gateway.sock", "Operation not supported", "stale UNIX socket"; only #92447 (the feature) and #92798 (client ownership) touch this module
- [x] My PR contains **only** changes related to this fix
- [x] Ran the module's test suite, `ruff check`, and the Windows footgun linter; relying on CI for the full matrix
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS host + the Linux/aarch64 container (Python 3.13)

### Documentation & Housekeeping

- [x] Documentation — N/A (behavioural fix; logged at info when the fallback engages)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform — POSIX code path only; the Windows named pipe is untouched; footgun linter clean
- [x] Tool descriptions/schemas — N/A

