### PR TITLE
fix(profiles): --clone-all skips the local-models runtime trees (models/, runtimes/, node/)

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -41,11 +41,16 @@ _CLONE_ALL_STRIP: list[str] = ["gateway.pid", "gateway_state.json", "processes.j
 
 # Infrastructure excluded from --clone-all ONLY when the source is the default profile
 # (``~/.hermes``): git checkout (+ ~3 GB venv), worktrees, sibling profiles, shared bins,
-# npm packages. Named profiles never hold these at root, so the gate avoids silently
-# dropping user data from a named-profile source. Export uses a root allow-list instead
-# (``_DEFAULT_EXPORT_INCLUDE_ROOT``): an archive is a portable snapshot, a clone must run.
+# npm packages, and the managed local-models trees — GGUF weights (tens of GB), the
+# llama.cpp runtime binaries and the managed Node install, all re-downloadable on demand
+# and resolved from the default root only. Named profiles never hold these at root, so the
+# gate avoids silently dropping user data from a named-profile source. Export uses a root
+# allow-list instead (``_DEFAULT_EXPORT_INCLUDE_ROOT``): an archive is a portable snapshot,
+# a clone must run. The last three mirror ``hermes_cli.backup._EXCLUDED_ROOT_DIRS`` — kept
+# as separate literals because importing it here would be circular; change both together.
 _CLONE_ALL_DEFAULT_EXCLUDE_ROOT: frozenset[str] = frozenset({
     "hermes-agent", ".worktrees", "profiles", "bin", "node_modules",
+    "models", "runtimes", "node",
 })
 
 # Per-profile history excluded from --clone-all for ANY source: SQLite session store

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -20,6 +20,7 @@ import yaml
 
 from hermes_cli import profiles
 from hermes_cli.profiles import (
+    _clone_all_copytree_ignore,
     normalize_profile_name,
     validate_profile_name,
     get_profile_dir,
@@ -1172,3 +1173,59 @@ class TestResolveProfileEnvSpelling:
         assert Path(resolve_profile_env("default")) == _get_default_hermes_home()
 
 
+# ===================================================================
+# TestCloneAllExcludesRuntimeTrees
+# ===================================================================
+
+class TestCloneAllExcludesRuntimeTrees:
+    """``--clone-all`` from the default profile must not copy the machine-scoped
+    runtime trees the local-models flow puts under ``~/.hermes``: ``models/``
+    (GGUF weights, tens of GB), ``runtimes/`` (llama.cpp binaries) and ``node/``
+    (managed Node). ``backup.py`` already excludes exactly these; the clone-all
+    ignore list had not followed.
+    """
+
+    RUNTIME_TREES = ("models", "runtimes", "node")
+
+    def _seed(self, home):
+        (home / "models").mkdir(); (home / "models" / "big.gguf").write_bytes(b"\0" * 64)
+        (home / "runtimes" / "llamacpp" / "bin").mkdir(parents=True)
+        (home / "runtimes" / "llamacpp" / "bin" / "llama-server").write_text("bin")
+        (home / "node" / "bin").mkdir(parents=True)
+        (home / "node" / "bin" / "node").write_text("bin")
+        (home / "skills" / "greet").mkdir(parents=True)
+        (home / "skills" / "greet" / "SKILL.md").write_text("# greet\n")
+        (home / "config.yaml").write_text("model: test\n")
+
+    def test_ignore_drops_runtime_trees_only_at_the_default_root(self, profile_env):
+        default_home = profile_env / ".hermes"
+        self._seed(default_home)
+        # a skill that happens to carry a nested models/ dir is user data
+        (default_home / "skills" / "greet" / "models").mkdir()
+        ignore = _clone_all_copytree_ignore(default_home)
+
+        at_root = ignore(str(default_home), ["models", "runtimes", "node", "skills", "config.yaml"])
+        nested = ignore(str(default_home / "skills" / "greet"), ["models", "SKILL.md"])
+
+        assert set(at_root) == set(self.RUNTIME_TREES)
+        assert nested == []
+
+    def test_named_profile_source_keeps_its_own_runtime_dirs(self, profile_env):
+        # The exclusion is gated on the default profile: a named profile that
+        # really has a models/ dir of its own must not have it dropped.
+        source = create_profile("source", no_alias=True)
+        (source / "models").mkdir()
+        ignore = _clone_all_copytree_ignore(source)
+
+        assert ignore(str(source), ["models", "runtimes", "node", "SOUL.md"]) == []
+
+    def test_clone_all_from_default_skips_runtime_trees_but_keeps_the_rest(self, profile_env):
+        default_home = profile_env / ".hermes"
+        self._seed(default_home)
+
+        clone = create_profile("clone", clone_all=True, no_alias=True)
+
+        for name in self.RUNTIME_TREES:
+            assert not (clone / name).exists(), name
+        assert (clone / "skills" / "greet" / "SKILL.md").is_file()
+        assert (clone / "config.yaml").is_file()


### PR DESCRIPTION
## What does this PR do?

`hermes profile create <name> --clone-all` from the default profile no longer copies the local-models runtime trees.

### Problem

43e67d872 (local models, 2026-09-01) put three machine-scoped trees under the default `HERMES_HOME`: `models/` (downloaded GGUF weights — tens of GB), `runtimes/` (managed llama.cpp binaries) and `node/` (the managed Node install). It taught `hermes_cli/backup.py` to exclude them (`_EXCLUDED_ROOT_DIRS`, `backup.py:119-123`), but the clone-all ignore list in `hermes_cli/profiles.py` (`_CLONE_ALL_DEFAULT_EXCLUDE_ROOT`, `:113-119`) was not updated. So a user who has downloaded a local model and then runs `--clone-all` copies all of it into a profile that never reads it — `models_dir()` (`hermes_cli/local_runtime/bootstrap.py:51`) is, in its own words, "Machine-scoped, deliberately NOT profile-scoped" and resolves from the default root — and cannot use the binaries either (they are re-downloaded on demand). A clone that should take seconds becomes a tens-of-GB copy.

### Change

Add `models`, `runtimes`, `node` to `_CLONE_ALL_DEFAULT_EXCLUDE_ROOT`, with rationale lines in the existing per-item comment and a note tying the set to `backup._EXCLUDED_ROOT_DIRS` (kept as separate literals on purpose: backup also matches `profiles/<name>/`, and importing it here would be a circular import).

The two existing safety properties of that set hold unchanged and are now pinned by tests:
- **default-source gate** — a *named* profile that genuinely carries a `models/` directory keeps it when used as a clone source;
- **root only** — a skill's nested `models/` directory is user data and is copied.

Open PRs #92755 / #91855 add `lost+found` / `portal-recovery` to the same set — different entries, at most a trivial merge conflict.

## Related Issue

Fixes #111718

None filed; found by comparing the exclusion lists added by 43e67d872.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/profiles.py` — three entries + comment in `_CLONE_ALL_DEFAULT_EXCLUDE_ROOT`
- `tests/hermes_cli/test_profiles.py` — `TestCloneAllExcludesRuntimeTrees`: ignore function drops the three names at the default root only (nested `models/` kept); named-profile source keeps its own `models/`; end-to-end `create_profile(..., clone_all=True)` leaves the three trees out while `skills/` and `config.yaml` arrive

## How to Test

1. `pytest tests/hermes_cli/test_profiles.py -q -k "CloneAll or clone"`.
2. Manually: download any local model (or `mkdir -p ~/.hermes/models && fallocate -l 1G ~/.hermes/models/x.gguf`), run `hermes profile create scratch --clone-all`, and check `du -sh ~/.hermes/profiles/scratch` — before this change it includes `models/`.

Each assertion was checked by removing the three entries again: the end-to-end test and the ignore-function test fail; the named-source test (unchanged behaviour) still passes. `ruff check` and the Windows footgun linter are clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and issues — `_CLONE_ALL_DEFAULT_EXCLUDE_ROOT`, `_clone_all_copytree_ignore`, "clone-all models"; only #92755/#91855 (different entries)
- [x] My PR contains **only** changes related to this fix
- [x] Ran the profile clone tests, `ruff check`, and the footgun linter; relying on CI for the full matrix
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] Documentation — the rationale lives in the code comment next to the set, like the existing entries
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform — pure path-name matching
- [x] Tool descriptions/schemas — N/A