### PR TITLE
fix(cli): probe the real gateway control plane in status --deep

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -719,19 +719,45 @@ def show_status(args):
             except Exception as e:
                 print(f"  OpenRouter:   {check_mark(False)} error: {e}")
         
-        # Check gateway port
+        # Check the gateway control plane.
+        #
+        # The gateway's local coordination surface is a Unix domain socket
+        # ($HERMES_HOME/gateway.sock) on POSIX and a named pipe
+        # (\\.\pipe\hermes-gateway-<home-hash>) on Windows — never a TCP port
+        # (see gateway/control_socket.py). The probe this replaced dialled
+        # 127.0.0.1:18789, a port no Hermes process has ever bound, and read
+        # "in use" as "gateway likely running". So ANY unrelated listener on
+        # 18789 — OpenClaw's default, or this repo's own `hermes meet node run`
+        # — was reported as the gateway, and a perfectly healthy gateway on the
+        # pipe always read as "available" (#101195). Probe the real endpoint
+        # and print it: a connectable socket with a well-formed `identify`
+        # answer IS liveness, and naming the endpoint is what stops the next
+        # reader from inventing a transport Hermes does not use.
         try:
-            import socket
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            sock.settimeout(1)
-            result = sock.connect_ex(('127.0.0.1', 18789))
-            sock.close()
-            # Port in use = gateway likely running
-            port_in_use = result == 0
-            # This is informational, not necessarily bad
-            print(f"  Port 18789:   {'in use' if port_in_use else 'available'}")
-        except OSError:
-            pass
+            from gateway.control_socket import (
+                identify_gateway,
+                resolve_client_socket_path,
+                resolve_server_socket_path,
+                windows_pipe_name,
+            )
+
+            hermes_home = get_hermes_home()
+            if sys.platform == "win32":
+                endpoint = windows_pipe_name(hermes_home)
+            else:
+                # Prefer the live path; fall back to where a gateway WOULD bind
+                # so the endpoint is still nameable while nothing is running.
+                live_path = resolve_client_socket_path(hermes_home)
+                endpoint = str(live_path or resolve_server_socket_path(hermes_home)[0])
+
+            # identify_gateway never raises — None is "nobody answered".
+            answered = identify_gateway(hermes_home, timeout=1) is not None
+            print(f"  Control:      {check_mark(answered)} {'answering' if answered else 'no answer'}")
+            print(f"  Endpoint:     {endpoint}")
+        except Exception as e:
+            # A diagnostic that swallows its own failure is how #101195 got
+            # misdiagnosed in the first place. Say what broke.
+            print(f"  Control:      {check_mark(False)} probe failed: {e}")
 
     print()
     print(color("─" * 60, Colors.DIM))

--- a/tests/hermes_cli/test_status_gateway_control_plane.py
+++ b/tests/hermes_cli/test_status_gateway_control_plane.py
@@ -1,0 +1,143 @@
+"""`hermes status --deep` must probe the real gateway control plane (#101195).
+
+The deep check used to dial TCP 127.0.0.1:18789 and label the result a
+gateway-port check, but no Hermes process has ever bound that port — the
+gateway's control plane is a Unix domain socket / named pipe
+(``gateway/control_socket.py``). That made the line wrong in both directions:
+
+* false positive — any unrelated listener on 18789 (OpenClaw's default, or
+  this repo's own ``hermes meet node run --port 18789``) read as "gateway
+  likely running";
+* false negative — a healthy gateway on the pipe always read as "available".
+
+#101195 is the false positive reaching a user: they saw ``Port 18789: in
+use``, found OpenClaw bound there, and filed the desktop hang as "the client
+connects to the wrong endpoint (TCP 18789 vs named pipe)".
+"""
+
+import socket
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import gateway.control_socket as control_socket
+from hermes_cli.status import show_status
+
+
+@pytest.fixture()
+def deep_home(monkeypatch, tmp_path: Path) -> Path:
+    """An isolated HERMES_HOME with the network-touching deep checks disabled."""
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    # The OpenRouter deep check is a live HTTP call; keep it out of the test.
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    return home
+
+
+def _deep_output(capsys) -> str:
+    show_status(SimpleNamespace(all=False, deep=True))
+    return capsys.readouterr().out
+
+
+def test_deep_check_never_reports_the_phantom_18789_port(monkeypatch, capsys, deep_home):
+    """An unrelated listener on 18789 must not surface in the gateway status.
+
+    Binding the port is the exact #101195 environment. Skipped rather than
+    failed when the port is already taken on the host — the assertion below
+    is about what Hermes prints, not about who owns the port.
+    """
+    squatter = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    squatter.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        try:
+            squatter.bind(("127.0.0.1", 18789))
+            squatter.listen(1)
+        except OSError:
+            pytest.skip("127.0.0.1:18789 is unavailable on this host")
+
+        monkeypatch.setattr(control_socket, "identify_gateway", lambda home, **kw: None)
+        output = _deep_output(capsys)
+    finally:
+        squatter.close()
+
+    assert "18789" not in output
+
+
+def test_deep_check_names_the_real_control_endpoint(monkeypatch, capsys, deep_home):
+    """The endpoint is printed so nobody has to guess the transport."""
+    monkeypatch.setattr(control_socket, "identify_gateway", lambda home, **kw: None)
+
+    output = _deep_output(capsys)
+
+    endpoint_line = next(ln for ln in output.splitlines() if ln.strip().startswith("Endpoint:"))
+    if sys.platform == "win32":
+        assert r"\\.\pipe\hermes-gateway-" in endpoint_line
+    else:
+        assert endpoint_line.strip().endswith("gateway.sock")
+        assert str(deep_home) in endpoint_line
+
+
+def test_deep_check_reports_no_answer_when_nothing_serves(monkeypatch, capsys, deep_home):
+    monkeypatch.setattr(control_socket, "identify_gateway", lambda home, **kw: None)
+
+    output = _deep_output(capsys)
+
+    control_line = next(ln for ln in output.splitlines() if ln.strip().startswith("Control:"))
+    assert "no answer" in control_line
+
+
+def test_deep_check_reports_answering_when_the_control_plane_replies(monkeypatch, capsys, deep_home):
+    """A well-formed `identify` answer IS liveness, per control_socket.py."""
+    seen: list[Path] = []
+
+    def _identify(home, **kwargs):
+        seen.append(Path(home))
+        return {"pid": 4242, "profile": "default", "protocol": 1}
+
+    monkeypatch.setattr(control_socket, "identify_gateway", _identify)
+
+    output = _deep_output(capsys)
+
+    control_line = next(ln for ln in output.splitlines() if ln.strip().startswith("Control:"))
+    assert "answering" in control_line
+    # The probe must be scoped to the active HERMES_HOME, not a global default:
+    # the endpoint is derived from a hash of that path.
+    assert seen and seen[0].resolve() == deep_home.resolve()
+
+
+def test_deep_check_reports_a_failed_probe_instead_of_going_quiet(monkeypatch, capsys, deep_home):
+    """A broken probe must say so — a silent diagnostic is what caused #101195."""
+
+    def _boom(home, **kwargs):
+        raise RuntimeError("pipe handle exhausted")
+
+    monkeypatch.setattr(control_socket, "identify_gateway", _boom)
+
+    output = _deep_output(capsys)
+
+    control_line = next(ln for ln in output.splitlines() if ln.strip().startswith("Control:"))
+    assert "probe failed" in control_line
+    assert "pipe handle exhausted" in control_line
+
+
+def test_status_source_holds_no_hardcoded_gateway_port():
+    """Source guard: the phantom port must not creep back in as live code.
+
+    Token-scoped rather than a text search — the comment above the
+    replacement explains the old probe and legitimately names the port.
+    """
+    import ast
+
+    source = Path(__file__).resolve().parents[2] / "hermes_cli" / "status.py"
+    tree = ast.parse(source.read_text(encoding="utf-8"))
+
+    literals = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant) and node.value == 18789
+    ]
+
+    assert not literals


### PR DESCRIPTION
## What does this PR do?

`hermes status --deep` dialled TCP `127.0.0.1:18789` under the comment *"Check gateway port"* and read `in use` as *"gateway likely running"*. **No Hermes process has ever bound that port.** The literal was invented inside the deep check itself (`619c72e566`, Feb 2026) and never matched a listener; the gateway's control plane is a Unix domain socket (`$HERMES_HOME/gateway.sock`) on POSIX and a named pipe (`\.\pipe\hermes-gateway-<home-hash>`) on Windows. `gateway/control_socket.py` states it outright: *"Never a TCP port."*

This replaces the phantom probe with the real one and prints the endpoint.

## Related Issue

Fixes #101195

## Root cause

The check was wrong in **both** directions:

| | What the user sees | Reality |
|---|---|---|
| **False positive** | `Port 18789: in use` | An unrelated listener — OpenClaw's default, or this repo's own `hermes meet node run --port 18789` |
| **False negative** | `Port 18789: available` | A perfectly healthy gateway answering on the pipe |

#101195 is the false positive reaching a user. They saw `Port 18789: in use`, ran `netstat`, found OpenClaw bound there, and filed their desktop hang as *"the client connects to the wrong endpoint (TCP 18789 vs named pipe)"* — **a transport Hermes does not use, invented by Hermes' own diagnostic.**

`git grep 18789` over the whole tree returns exactly two kinds of hit: this deep check, and the unrelated `plugins/google_meet` node bridge. Desktop never dials it — it spawns its own backend with `serve --host 127.0.0.1 --port 0` and reads the announced ephemeral port.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    subgraph BEFORE["🩸 Before — Phantom Probe"]
        A["hermes status --deep"] -->|connect_ex| B["TCP 127.0.0.1:18789"]
        B --> C{"Bound?"}
        C -->|"Yes — by OpenClaw"| D["⚠️ Reports 'in use'<br/>= gateway likely running"]
        C -->|"No"| E["⚠️ Reports 'available'<br/>even with a live gateway"]
        D --> F["🔥 User invents a TCP transport<br/>Issue #101195 filed"]
    end

    subgraph AFTER["⚔️ After — Real Control Plane"]
        G["hermes status --deep"] -->|identify verb| H["UDS gateway.sock<br/>/ named pipe"]
        H --> I{"Well-formed answer?"}
        I -->|"Yes"| J["✅ Control: answering"]
        I -->|"No"| K["✅ Control: no answer"]
        J --> L["🛡️ Endpoint printed verbatim<br/>Transport is unguessable no more"]
        K --> L
    end
```

## Changes Made

- `hermes_cli/status.py` — the deep check now calls `gateway.control_socket.identify_gateway()` against the active `HERMES_HOME` and prints both the verdict and the resolved endpoint. A connectable socket with a well-formed `identify` answer **is** liveness (the module's own contract), so this is authoritative rather than heuristic. A failed probe reports itself instead of vanishing into `except OSError: pass` — a diagnostic that swallows its own failure is how #101195 got misdiagnosed in the first place.
- `tests/hermes_cli/test_status_gateway_control_plane.py` — new: an actual squatter bound on 18789 must not surface; the endpoint is named and transport-correct per platform; answering / no-answer / probe-failed verdicts; the probe is scoped to the active `HERMES_HOME` (the endpoint is a hash of that path); plus an AST source guard so the literal cannot creep back in as live code.

Output today:

```
◆ Deep Checks
  Control:      ✗ no answer
  Endpoint:     \.\pipe\hermes-gateway-a5d689933c0c4b4d
```

## Scope — what this deliberately does NOT touch

#101195 bundles a second defect, and it is **already owned**. Its `errors.log` excerpt (`ws send failed … 'utf-8' codec can't encode character '\ud83d' … reason=send_failed_after_heartbeat`) is the real desktop hang: `tui_gateway/ws.py::_safe_send_many` latches `_closed = True` when `send_text` cannot encode a lone surrogate. **#97622 owns that layer** and is open. This PR does not duplicate or supersede it — the two are complementary halves of the same report:

- **#97622** — why the desktop connection dies.
- **this PR** — why the reporter believed it died at TCP 18789.

Note also that the peer in that log line (`127.0.0.1:63869`) proves the desktop *did* establish a WebSocket to its own backend, which independently disconfirms the issue's stated "connects to 18789 and hangs" cause.

## How to Test

```bash
PYTHONPATH=. python -m pytest tests/hermes_cli/test_status_gateway_control_plane.py tests/hermes_cli/test_status.py -q
# 16 passed
```

Manual repro of the original false positive (any platform):

```bash
python -c "import socket,time; s=socket.socket(); s.bind(('127.0.0.1',18789)); s.listen(1); time.sleep(60)" &
hermes status --deep
# before: "Port 18789:   in use"
# after:  "Control:  ✗ no answer" + the real endpoint
```

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — no open PR touches the `status.py` port probe; the adjacent WebSocket-surrogate layer is #97622 and is intentionally left to it
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (native). Three failures in `tests/hermes_cli/test_subprocess_timeouts.py` are a pre-existing Windows-local baseline — `Path.read_text()` with no encoding hits cp1252 on `status.py`, `doctor.py` and `banner.py`; the same three fail on an unmodified checkout, including files this PR does not touch.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — the probe branches on `sys.platform` and mirrors `control_socket.py`'s own transport split; the pointer-file fallback for long POSIX homes is honored via `resolve_client_socket_path`
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A


