### PR TITLE
fix(feishu): keep the websocket client off the default executor

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -218,6 +218,10 @@ _FEISHU_DOC_UPLOAD_TYPES = {
 
 _MAX_TEXT_INJECT_BYTES = 100 * 1024
 _FEISHU_CONNECT_ATTEMPTS = 3
+# Worker cap for the adapter-owned websocket pool.  Only one worker is ever
+# held by the long-lived WS client; the rest is headroom for a reconnect that
+# starts while the previous (wedged) client thread has not exited yet.
+_FEISHU_WS_POOL_SIZE = 4
 _FEISHU_SEND_ATTEMPTS = 3
 _FEISHU_APP_LOCK_SCOPE = "feishu-app-id"
 _DEFAULT_TEXT_BATCH_DELAY_SECONDS = 0.6
@@ -1517,6 +1521,11 @@ class FeishuAdapter(BasePlatformAdapter):
         self._sdk_executor_closing = False
         self._ws_client: Optional[Any] = None
         self._ws_future: Optional[asyncio.Future] = None
+        # Adapter-owned thread pool for the long-lived official Feishu WS
+        # client; never submit it to the loop default executor (see
+        # _get_ws_executor).  Recreated on demand after a teardown.
+        self._ws_executor_lock = threading.Lock()
+        self._ws_executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
         self._ws_thread_loop: Optional[asyncio.AbstractEventLoop] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._webhook_runner: Optional[Any] = None
@@ -1771,6 +1780,59 @@ class FeishuAdapter(BasePlatformAdapter):
         except TypeError:
             executor.shutdown(wait=False)
 
+    def _get_ws_executor(self) -> concurrent.futures.ThreadPoolExecutor:
+        """Return the adapter-owned executor that hosts the Feishu WS client.
+
+        ``_run_official_feishu_ws_client`` runs a private event loop for the
+        whole lifetime of the connection, so it pins one worker permanently.
+        Submitting it to the loop's *default* executor therefore burns
+        ``min(32, cpu + 4)`` shared threads one app at a time: on a 2-core
+        host, six multiplexed Feishu apps exhaust the pool and every other
+        default-executor task (``asyncio.to_thread``, reconnects, startup
+        restore, inbound dispatch) queues forever.  The gateway then reports
+        "connected" while inbound messages are never processed.  Hosting the
+        client on a per-adapter pool keeps the default executor free.
+
+        See https://github.com/NousResearch/hermes-agent/issues/78318
+
+        The pool is created lazily (threads spawn on demand) and rebuilt if a
+        previous teardown shut it down, so a reconnect cannot be wedged by a
+        dead pool.
+        """
+        lock = getattr(self, "_ws_executor_lock", None)
+        if lock is None:
+            lock = threading.Lock()
+            self._ws_executor_lock = lock
+        with lock:
+            executor = getattr(self, "_ws_executor", None)
+            if executor is None or getattr(executor, "_shutdown", False):
+                executor = concurrent.futures.ThreadPoolExecutor(
+                    max_workers=_FEISHU_WS_POOL_SIZE,
+                    thread_name_prefix="hermes-feishu-ws",
+                )
+                self._ws_executor = executor
+            return executor
+
+    def _shutdown_ws_executor(self) -> None:
+        """Release the adapter-owned WS pool without blocking on a wedged thread.
+
+        ``wait=False`` keeps disconnect() bounded — blocking the teardown on a
+        websocket thread that is already not responding is what trips the
+        shutdown watchdog.
+        """
+        lock = getattr(self, "_ws_executor_lock", None)
+        if lock is None:
+            return
+        with lock:
+            executor = getattr(self, "_ws_executor", None)
+            self._ws_executor = None
+        if executor is None:
+            return
+        try:
+            executor.shutdown(wait=False, cancel_futures=True)
+        except TypeError:
+            executor.shutdown(wait=False)
+
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Connect to Feishu/Lark."""
         # A fresh connect (or reconnect) re-arms the SDK executor after a prior
@@ -1905,6 +1967,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._loop = None
         self._event_handler = None
         self._shutdown_sdk_executor()
+        self._shutdown_ws_executor()
         self._persist_seen_message_ids()
         await self._release_app_lock()
 
@@ -4972,7 +5035,7 @@ class FeishuAdapter(BasePlatformAdapter):
             extra_ua_tags=["channel"],
         )
         self._ws_future = loop.run_in_executor(
-            None,
+            self._get_ws_executor(),
             _run_official_feishu_ws_client,
             self._ws_client,
             self,

--- a/tests/gateway/test_feishu_ws_executor.py
+++ b/tests/gateway/test_feishu_ws_executor.py
@@ -1,0 +1,187 @@
+"""Regression tests for the Feishu adapter's owned websocket executor.
+
+The official Feishu websocket client runs a private event loop for the whole
+lifetime of the connection, so it pins one worker permanently.  It used to be
+submitted to the loop's *default* executor, which is sized
+``min(32, cpu + 4)``: on a 2-core host six multiplexed Feishu apps exhausted
+that shared pool, and every other default-executor task (``asyncio.to_thread``,
+reconnects, startup restore, inbound dispatch) queued forever.  The gateway
+reported every platform as connected while inbound messages were never
+processed.  The client now runs on an adapter-owned pool that is recreated on
+demand after a teardown.
+
+Covers: #78318
+"""
+import asyncio
+import concurrent.futures
+import os
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.feishu.adapter import (
+    FeishuAdapter,
+    _FEISHU_WS_POOL_SIZE,
+    _run_official_feishu_ws_client,
+)
+from tests.gateway.test_feishu import _mock_event_dispatcher_builder
+
+
+def _bare_adapter() -> FeishuAdapter:
+    """A FeishuAdapter with only the websocket-executor fields wired (no __init__)."""
+    adapter = object.__new__(FeishuAdapter)
+    adapter._ws_executor_lock = threading.Lock()
+    adapter._ws_executor = None
+    return adapter
+
+
+def _completed_future():
+    future = asyncio.get_running_loop().create_future()
+    future.set_result(None)
+    return future
+
+
+def test_ws_executor_recreates_after_shutdown():
+    """A reconnect must never be wedged by a pool a prior teardown shut down."""
+    adapter = _bare_adapter()
+    first = adapter._get_ws_executor()
+    first.shutdown(wait=True)
+    assert getattr(first, "_shutdown", False) is True
+
+    second = adapter._get_ws_executor()
+    assert second is not first
+    assert getattr(second, "_shutdown", False) is False
+    adapter._shutdown_ws_executor()
+
+
+def test_ws_executor_is_bounded_and_reused():
+    """The pool is per-adapter, capped, and reused instead of leaking new ones."""
+    adapter = _bare_adapter()
+    executor = adapter._get_ws_executor()
+    try:
+        assert executor._max_workers == _FEISHU_WS_POOL_SIZE
+        assert executor._thread_name_prefix == "hermes-feishu-ws"
+        assert adapter._get_ws_executor() is executor
+    finally:
+        adapter._shutdown_ws_executor()
+
+
+def test_ws_client_work_runs_on_owned_pool_not_default():
+    """Actual work lands on a ``hermes-feishu-ws`` thread, not the default pool."""
+    adapter = _bare_adapter()
+    captured = {}
+
+    def _work():
+        captured["thread"] = threading.current_thread().name
+        return "ok"
+
+    pool = adapter._get_ws_executor()
+    assert pool.submit(_work).result(timeout=5) == "ok"
+    assert captured["thread"].startswith("hermes-feishu-ws")
+    adapter._shutdown_ws_executor()
+
+
+@pytest.mark.asyncio
+async def test_connect_websocket_submits_to_owned_executor():
+    """``_connect_websocket`` must never hand the WS client to the default pool."""
+    adapter = FeishuAdapter(PlatformConfig())
+    adapter._app_id = "cli_app"
+    adapter._app_secret = "secret_app"
+    adapter._connection_mode = "websocket"
+
+    submitted = []
+
+    class _Loop:
+        def is_closed(self):
+            return False
+
+        def run_in_executor(self, executor, func, *args):
+            submitted.append((executor, func, args))
+            return _completed_future()
+
+    with (
+        patch.dict(
+            os.environ,
+            {"FEISHU_APP_ID": "cli_app", "FEISHU_APP_SECRET": "secret_app"},
+            clear=True,
+        ),
+        patch("plugins.platforms.feishu.adapter.FEISHU_AVAILABLE", True),
+        patch("plugins.platforms.feishu.adapter.FEISHU_WEBSOCKET_AVAILABLE", True),
+        patch(
+            "plugins.platforms.feishu.adapter.lark",
+            SimpleNamespace(LogLevel=SimpleNamespace(INFO="INFO", WARNING="WARNING")),
+        ),
+        patch("plugins.platforms.feishu.adapter.EventDispatcherHandler") as mock_handler_class,
+        patch("plugins.platforms.feishu.adapter.FeishuWSClient", return_value=object()),
+        patch.object(adapter, "_hydrate_bot_identity", new=AsyncMock()),
+        patch.object(adapter, "_build_lark_client", return_value=object()),
+    ):
+        _mock_event_dispatcher_builder(mock_handler_class)
+        adapter._loop = _Loop()
+        await adapter._connect_websocket()
+
+    assert len(submitted) == 1, "expected exactly one websocket executor submission"
+    executor, func, _args = submitted[0]
+    assert func is _run_official_feishu_ws_client
+    # The regression itself: ``None`` here means "the loop's shared default pool".
+    assert executor is not None, "websocket client must not run on the default executor"
+    assert isinstance(executor, concurrent.futures.ThreadPoolExecutor)
+    assert executor._thread_name_prefix == "hermes-feishu-ws"
+    assert executor is adapter._ws_executor
+    adapter._shutdown_ws_executor()
+
+
+def test_disconnect_shuts_down_ws_executor():
+    """Teardown releases the pool so a later reconnect starts from a clean one."""
+    adapter = FeishuAdapter(PlatformConfig())
+    adapter._ws_future = None
+    adapter._ws_client = None
+    adapter._ws_thread_loop = None
+    pool = adapter._get_ws_executor()
+
+    asyncio.run(adapter.disconnect())
+
+    assert adapter._ws_executor is None
+    assert getattr(pool, "_shutdown", False) is True
+
+
+def test_disconnect_with_wedged_ws_thread_stays_bounded():
+    """Worst case for the added teardown: the websocket thread never returns.
+
+    This is the #99845 / #96801 shape — a wedged client thread plus a
+    disconnect.  Teardown must still complete within its documented 10s
+    websocket timeout (it must not block on the dead worker), must release
+    the pool, and a later reconnect must get a usable pool again.
+    """
+    adapter = FeishuAdapter(PlatformConfig())
+    release = threading.Event()
+
+    async def scenario():
+        pool = adapter._get_ws_executor()
+        # A ws client thread that will not exit until the test lets it go.
+        adapter._ws_future = asyncio.get_running_loop().run_in_executor(
+            pool, lambda: release.wait(30)
+        )
+        started = time.monotonic()
+        await adapter.disconnect()
+        return time.monotonic() - started, pool
+
+    try:
+        elapsed, old_pool = asyncio.run(scenario())
+    finally:
+        release.set()
+
+    # It spent the advertised websocket wait and nothing more — no hang.
+    assert 10.0 <= elapsed < 13.0, f"disconnect took {elapsed:.2f}s"
+    assert getattr(old_pool, "_shutdown", False) is True
+    assert adapter._ws_executor is None
+
+    # A reconnect after a wedged teardown must be able to run work again.
+    new_pool = adapter._get_ws_executor()
+    assert new_pool is not old_pool
+    assert new_pool.submit(lambda: "ok").result(timeout=5) == "ok"
+    adapter._shutdown_ws_executor()


### PR DESCRIPTION
The official Feishu WS client runs a private event loop for the whole lifetime of the connection, so it permanently pins one worker. It was submitted to the loop's default executor (min(32, cpu + 4) workers), so every connected app burned one of those shared threads. On a 2-core host six multiplexed Feishu apps exhausted the pool, and every remaining default-executor task (asyncio.to_thread, reconnects, startup restore, inbound dispatch) queued forever: the gateway reported all platforms as connected while inbound messages were never processed.

Host the client on an adapter-owned pool instead — created lazily and rebuilt after teardown so a reconnect can never be wedged by a dead pool — and release that pool on disconnect. Adds regression tests that fail against the previous submission path (#78318).

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

