### PR TITLE
fix(mcp): degrade outputSchema validation failures instead of dropping results

### DIFF
--- a/tests/tools/test_mcp_structured_content.py
+++ b/tests/tools/test_mcp_structured_content.py
@@ -204,6 +204,106 @@ class TestMetaPassthrough:
         assert data == {"result": "done"}
 
 
+class _ValidatingFakeSession:
+    """Mimics ``mcp.ClientSession``: ``call_tool`` revalidates the result
+    against the tool's advertised outputSchema and raises RuntimeError on a
+    violation — discarding a result whose ``content`` blocks are usable
+    (#101330)."""
+
+    def __init__(self, result, invalid=True):
+        self._result = result
+        self._invalid = invalid
+        self.call_count = 0
+
+        async def _strict_validate(name, res):
+            if self._invalid:
+                raise RuntimeError(
+                    f"Invalid structured content returned by tool {name}: "
+                    "'locale' is a required property"
+                )
+
+        self.validate_tool_result = _strict_validate
+
+    def call_tool(self, name, arguments=None, **kwargs):
+        async def _coro():
+            self.call_count += 1
+            await self.validate_tool_result(name, self._result)
+            return self._result
+
+        return _coro()
+
+
+@pytest.fixture
+def _patch_validating_server():
+    """Register a schema-validating fake session under the real handler path."""
+    session = _ValidatingFakeSession(
+        _FakeCallToolResult(
+            content=[_FakeContentBlock("usable payload")],
+            structuredContent={"ok": False},
+        )
+    )
+    fake_server = SimpleNamespace(session=session, _rpc_lock=None)
+    with (
+        patch.dict(mcp_tool._servers, {"test-server": fake_server}),
+        patch(
+            "tools.mcp_tool._run_on_mcp_loop",
+            side_effect=_fake_run_on_mcp_loop,
+        ),
+        patch.dict(mcp_tool._server_error_counts, {}, clear=True),
+    ):
+        yield session
+
+
+class TestOutputSchemaTolerance:
+    """A schema-invalid structuredContent must degrade, not fail the call
+    or trip the per-server circuit breaker (#101330)."""
+
+    def test_schema_violation_serves_content(self, _patch_validating_server):
+        """content blocks survive an outputSchema validation failure."""
+        handler = mcp_tool._make_tool_handler("test-server", "my-tool", 30.0)
+        data = json.loads(handler({}))
+        assert data["result"] == "usable payload"
+
+    def test_schema_violation_does_not_trip_breaker(self, _patch_validating_server):
+        """Past the threshold (3), calls still reach the server — the RPC
+        completed, so the server is not 'unreachable'."""
+        handler = mcp_tool._make_tool_handler("test-server", "my-tool", 30.0)
+        for _ in range(4):
+            data = json.loads(handler({}))
+            assert data["result"] == "usable payload"
+        assert _patch_validating_server.call_count == 4
+        assert mcp_tool._server_error_counts.get("test-server", 0) == 0
+
+    def test_validation_failure_warns_once_per_tool(
+        self, _patch_validating_server, caplog
+    ):
+        handler = mcp_tool._make_tool_handler("test-server", "my-tool", 30.0)
+        with caplog.at_level("WARNING", logger="tools.mcp_tool"):
+            handler({})
+            handler({})
+        warnings = [
+            r
+            for r in caplog.records
+            if "violates its own outputSchema" in r.getMessage()
+        ]
+        assert len(warnings) == 1
+
+    def test_valid_structured_content_unaffected(self, _patch_validating_server):
+        """When validation passes, the tolerant wrapper is a no-op."""
+        _patch_validating_server._invalid = False
+        handler = mcp_tool._make_tool_handler("test-server", "my-tool", 30.0)
+        data = json.loads(handler({}))
+        assert data["result"] == "usable payload"
+        assert data["structuredContent"] == {"ok": False}
+
+    def test_install_is_idempotent(self):
+        session = _ValidatingFakeSession(_FakeCallToolResult(content=[]))
+        mcp_tool._install_schema_tolerant_validation(session, "srv")
+        wrapped = session.validate_tool_result
+        mcp_tool._install_schema_tolerant_validation(session, "srv")
+        assert session.validate_tool_result is wrapped
+
+
 class TestReservedMetaKeyPredicate:
     def test_reserved_prefixes(self):
         assert mcp_tool._is_reserved_mcp_meta_key("modelcontextprotocol.io/x")

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6229,6 +6229,50 @@ def _ensure_healthy_or_recycle(server: Any, server_name: str) -> None:
         _signal_reconnect(server)
 
 
+def _install_schema_tolerant_validation(session: Any, server_name: str) -> None:
+    """Degrade MCP outputSchema validation failures instead of failing the call.
+
+    ``ClientSession.call_tool`` revalidates ``structuredContent`` against the
+    tool's advertised ``outputSchema`` *after* the RPC round-trip completed,
+    and on a mismatch raises ``RuntimeError`` — discarding the usable
+    ``content`` blocks and striking the per-server circuit breaker as if the
+    server were down (#101330). A schema violation is the opposite of an
+    outage: the server is reachable and answering, and the failure is
+    deterministic per call, so "stop retrying this call" is right while "the
+    server is unreachable" is false. Wrap the SDK's public
+    ``validate_tool_result`` so a violation warns once per (server, tool)
+    and ``call_tool`` returns the result intact — Hermes' normal content
+    pipeline serves ``result.content``, and the success path resets the
+    breaker instead of advancing it.
+    """
+    if session is None:
+        return
+    if getattr(session, "_hermes_tolerant_output_schema", False):
+        return  # already wrapped — idempotent across calls and reconnects
+    original = getattr(session, "validate_tool_result", None)
+    if original is None:
+        return  # SDK variant without the validator — nothing to soften
+    session._hermes_tolerant_output_schema = True
+    warned: Set[str] = set()
+
+    async def _tolerant_validate(name: str, result: Any) -> None:
+        try:
+            await original(name, result)
+        except RuntimeError as exc:
+            if name not in warned:
+                warned.add(name)
+                logger.warning(
+                    "MCP %s: tool '%s' returned structuredContent that "
+                    "violates its own outputSchema (%s); serving "
+                    "result.content instead",
+                    server_name,
+                    name,
+                    exc,
+                )
+
+    session.validate_tool_result = _tolerant_validate
+
+
 def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
     """Return a sync handler that calls an MCP tool via the background loop.
 
@@ -6336,6 +6380,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                             f"MCP stdio subprocess for '{server_name}' had "
                             f"already exited when the call was dispatched"
                         )
+                    _install_schema_tolerant_validation(server.session, server_name)
                     _call_coro = server.session.call_tool(tool_name, arguments=args)
                     _watch_children = getattr(server, "_watch_stdio_children", None)
                     _watch_ok = (


### PR DESCRIPTION
## What does this PR do?

When an MCP server returns `structuredContent` that violates its own advertised `outputSchema`, the SDK's `ClientSession.call_tool` raises `RuntimeError` *after* the RPC round-trip already completed. Hermes' generic exception path then (1) discarded the whole result — including the usable `result.content` text blocks — and (2) struck the per-server circuit breaker, so after 3 such calls every *healthy* tool on that connector reported "server unreachable" for the cooldown (#101330).

A schema violation is the opposite of an outage: the server is reachable, authenticated, and answering correctly at the transport layer, and the failure is deterministic per call. So this PR wraps the SDK's public `validate_tool_result` (idempotently, per session): a violation logs a warning **once per (server, tool)** and `call_tool` returns the result intact. Hermes' normal content pipeline then serves `result.content`, and the success path *resets* the breaker instead of advancing it. Connect/transport/auth failures keep striking the breaker unchanged.

## Related Issue

Fixes #101330

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py`: new `_install_schema_tolerant_validation()` — wraps a session's `validate_tool_result` so an outputSchema violation warns once per (server, tool) instead of raising; skips sessions without the validator (older SDKs) and MagicMock test doubles (truthy-attribute guard).
- `tools/mcp_tool.py`: install the wrapper right before `server.session.call_tool(...)` in `_make_tool_handler`'s RPC path, so every transport (stdio/http/sse, incl. reconnected sessions) is covered through the single dispatch funnel.
- `tests/tools/test_mcp_structured_content.py`: `TestOutputSchemaTolerance` — schema violation serves `result.content`; 4 consecutive violations do not trip the breaker (all 4 RPCs still reach the server); warning fires once per tool; valid results unaffected; install is idempotent.

## How to Test

1. `python -m pytest tests/tools/test_mcp_structured_content.py -q` — 16 passed (11 pre-existing + 5 new).
2. `python -m pytest tests/tools/test_mcp_structured_content.py tests/tools/test_mcp_trust_gating.py tests/tools/test_mcp_resource_content.py tests/tools/test_mcp_lazy_start.py tests/tools/test_mcp_stdio_fastfail_reconnect.py tests/tools/test_mcp_elicitation.py tests/tools/test_mcp_initial_connect_shutdown.py -q` — 80 passed, no regressions.
3. Red/green check: removing the single install line before `call_tool` makes the three new behavior tests fail (result discarded / breaker tripped after threshold), confirming they lock the fix.

Observed result: with the fix, a server whose tool declares a `required` field but returns it as `null` (the Bonusly case in the issue) serves its text `content` to the agent; before the fix the same call returned `MCP call failed: RuntimeError: Invalid structured content returned by tool ...` and the 4th call short-circuited with "server unreachable".

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.11, mcp 2.0.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (behavior documented in the helper docstring)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure-Python session wrapper, no platform surface)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
