### PR TITLE
fix(config): validate the timezone key so a bad IANA name is reported, not silently ignored

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1146,6 +1146,39 @@ def _validate_voice(config: Dict[str, Any], issues: List[ConfigIssue]) -> None:
                "Set voice.submit_mode to direct (submit immediately) or draft (edit before sending)")
 
 
+def _validate_timezone(config: Dict[str, Any], issues: List[ConfigIssue]) -> None:
+    """``timezone`` must be an IANA name the runtime can load.
+
+    ``hermes_time._get_zoneinfo()`` swallows an invalid name behind a single WARNING in the
+    gateway log, then runs the agent clock AND every cron schedule on server-local time.
+    Surface it here, where doctor and the startup check both look. Silent when the
+    interpreter has no tz database at all (bare Windows without ``tzdata``) — nothing can be
+    judged there.
+    """
+    if "timezone" not in config:
+        return
+    tz = config.get("timezone")
+    hint = ("Use an IANA zone name such as America/New_York or Asia/Tokyo (see "
+            "`timedatectl list-timezones`). With an invalid value the agent clock and cron "
+            "schedules silently fall back to server-local time. HERMES_TIMEZONE overrides "
+            "this key when set.")
+    if tz is not None and not isinstance(tz, str):
+        _issue(issues, "error", f"timezone must be an IANA zone name string, got {tz!r}", hint)
+        return
+    if not (isinstance(tz, str) and tz.strip()):
+        return
+    name = tz.strip()
+    try:
+        import zoneinfo
+        zoneinfo.ZoneInfo("UTC")  # is a tz database available at all?
+    except Exception:
+        return
+    try:
+        zoneinfo.ZoneInfo(name)
+    except Exception:
+        _issue(issues, "error", f"timezone {name!r} is not a valid IANA zone name", hint)
+
+
 def _validate_entry_list(
     entries: list, label: str, issues: List[ConfigIssue], fields, *, non_dict: Tuple[str, str, str],
 ) -> None:
@@ -1227,6 +1260,7 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
 
     issues: List[ConfigIssue] = []
     _validate_voice(config, issues)
+    _validate_timezone(config, issues)
     cp = config.get("custom_providers")
     fb = config.get("fallback_model")
     for value, validator in ((cp, _validate_custom_providers), (fb, _validate_fallback_model)):

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -1,6 +1,8 @@
 """Tests for config.yaml structure validation (validate_config_structure)."""
 
 
+import pytest
+
 from hermes_cli.config import (
     DEFAULT_CONFIG,
     _EXTRA_KNOWN_ROOT_KEYS,
@@ -109,6 +111,59 @@ class TestVoiceSubmitModeValidation:
             and "draft" in issue.hint
             for issue in issues
         )
+
+
+def _tz_issues(config):
+    return [i for i in validate_config_structure(config) if "timezone" in i.message]
+
+
+def _has_tz_database() -> bool:
+    try:
+        import zoneinfo
+        zoneinfo.ZoneInfo("UTC")
+        return True
+    except Exception:
+        return False
+
+
+class TestTimezoneValidation:
+    """An invalid ``timezone`` silently puts the agent clock and every cron
+    schedule on server-local time (hermes_time._get_zoneinfo falls back with
+    one log warning). validate_config_structure must report it."""
+
+    def test_valid_zone_passes(self):
+        assert _tz_issues({"timezone": "Asia/Tokyo", "model": {"provider": "nous"}}) == []
+
+    def test_missing_or_blank_is_not_reported(self):
+        assert _tz_issues({"model": {"provider": "nous"}}) == []
+        assert _tz_issues({"timezone": "", "model": {"provider": "nous"}}) == []
+        assert _tz_issues({"timezone": "   ", "model": {"provider": "nous"}}) == []
+        assert _tz_issues({"timezone": None, "model": {"provider": "nous"}}) == []
+
+    @pytest.mark.skipif(not _has_tz_database(), reason="no tz database in this interpreter")
+    def test_invalid_zone_is_reported(self):
+        [issue] = _tz_issues({"timezone": "Asia/Tokio", "model": {"provider": "nous"}})
+        assert issue.severity == "error"
+        assert "Asia/Tokio" in issue.message
+        assert "IANA" in issue.hint
+        assert "HERMES_TIMEZONE" in issue.hint
+
+    def test_non_string_is_reported(self):
+        [issue] = _tz_issues({"timezone": 9, "model": {"provider": "nous"}})
+        assert issue.severity == "error"
+        assert "string" in issue.message
+
+    def test_silent_without_a_tz_database(self, monkeypatch):
+        # Bare Windows without tzdata: ZoneInfo cannot load anything, including
+        # UTC. A valid name must not be flagged just because it cannot be checked.
+        import zoneinfo
+
+        def no_db(_key):
+            raise zoneinfo.ZoneInfoNotFoundError("no tz database")
+
+        monkeypatch.setattr(zoneinfo, "ZoneInfo", no_db)
+        assert _tz_issues({"timezone": "Asia/Tokyo", "model": {"provider": "nous"}}) == []
+        assert _tz_issues({"timezone": "Asia/Tokio", "model": {"provider": "nous"}}) == []
 
 
 class TestUnknownTopLevelKeys:


### PR DESCRIPTION
## What does this PR do?

Reports an invalid `timezone` in `config.yaml` instead of silently running everything on server-local time.

### Problem

`hermes_time._resolve_timezone_name()` reads `HERMES_TIMEZONE`, then `config.yaml`'s `timezone`; `_get_zoneinfo()` (`hermes_time.py:99-110`) catches the `ZoneInfo` failure, logs one WARNING and returns None — server-local time. Nothing else validates the value: `hermes_cli/doctor.py` never reads it and `validate_config_structure` had no check. `gateway/run.py:2887-2889` even exports the unvalidated value as `HERMES_TIMEZONE` to children.

So a typo (`Asia/Tokio`, `Tokyo`, `EST5`) or a non-string value puts the agent's clock **and every cron schedule** on the server's zone, and the only evidence is a single line in the gateway log. Cron jobs fire at the wrong wall-clock hour with a green `hermes doctor`.

### Change

`validate_config_structure` (`hermes_cli/config.py`) gains a `timezone` block next to the existing `voice.submit_mode` enum check:

- non-string → `error` ("must be an IANA zone name string");
- non-empty string that `zoneinfo.ZoneInfo` cannot load → `error` naming the value;
- missing / `None` / blank → silent (server-local is the documented default);
- **no tz database in the interpreter** (bare Windows without `tzdata`) → silent: `ZoneInfo("UTC")` is probed first, and when even that fails nothing can be judged — flagging every valid name there would be worse than the bug. `web_server.py:1301` already treats an empty `available_timezones()` the same way.

The hint gives the IANA form, points at `timedatectl list-timezones`, and notes that `HERMES_TIMEZONE` overrides the key. Doctor renders the issue in its Config Structure section with `check_fail`, exactly as it does the other `error`-severity structure problems; the startup check surfaces it the same way. Runtime behaviour is unchanged — `hermes_time` still falls back safely (its existing test asserts that and still passes).

## Related Issue

Fixes #111725

None filed; found by comparing the config keys the runtime reads against what doctor validates.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py` — `timezone` block in `validate_config_structure`
- `tests/hermes_cli/test_config_validation.py` — `TestTimezoneValidation`: valid passes; missing/None/blank silent; invalid reported (skipped where no tz database exists); non-string reported; silent when `ZoneInfo` can load nothing at all

## How to Test

1. `pytest tests/hermes_cli/test_config_validation.py tests/test_timezone.py -q`
2. `hermes config set timezone Asia/Tokio && hermes doctor` → Config Structure: `✗ timezone 'Asia/Tokio' is not a valid IANA zone name` with the hint; `hermes config set timezone Asia/Tokyo` → clean.

Each assertion was checked by breaking the implementation (block removed → invalid/non-string tests fail; tz-database guard removed → the no-database test fails). `ruff check` and the Windows footgun linter are clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and issues — `_get_zoneinfo`, `_resolve_timezone_name`, "timezone validate", "invalid timezone doctor"; open PRs #83162/#97755/#43580 touch `_get_zoneinfo`'s runtime fallback, none validate config
- [x] My PR contains **only** changes related to this fix
- [x] Ran the config-validation and timezone suites, `ruff check`, and the footgun linter; relying on CI for the full matrix
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] Documentation — N/A (the hint is the documentation at the point of failure)
- [x] `cli-config.yaml.example` — N/A (no key added)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform — explicit no-tz-database guard for Windows; footgun linter clean
- [x] Tool descriptions/schemas — N/A