### PR TITLE
feat(tts): add configurable global reply scope

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3302,6 +3302,9 @@ class BasePlatformAdapter(ABC):
         #   fire if chat in _auto_tts_enabled_chats
         #     OR (_auto_tts_default and chat not in _auto_tts_disabled_chats)
         self._auto_tts_default: bool = False
+        # Global reply scope for ``voice.auto_tts``. ``all`` preserves the
+        # historical behavior; ``voice_only`` limits synthesis to voice input.
+        self._auto_tts_mode: str = "all"
         self._auto_tts_enabled_chats: set = set()
         self._auto_tts_disabled_chats: set = set()
         # Per-turn streaming-TTS completion flag (#60671).  When the gateway

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8211,8 +8211,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     def _sync_voice_mode_state_to_adapter(self, adapter) -> None:
         """Restore persisted /voice state into a live platform adapter.
 
-        Populates three fields from config + ``self._voice_mode``:
+        Populates four fields from config + ``self._voice_mode``:
           - ``_auto_tts_default``: global default from ``voice.auto_tts``
+          - ``_auto_tts_mode``: global scope from ``voice.auto_tts_mode``
           - ``_auto_tts_enabled_chats``: chats with mode ``voice_only``/``all``
           - ``_auto_tts_disabled_chats``: chats with mode ``off``
         """
@@ -8230,13 +8231,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         try:
             from hermes_cli.config import load_config as _load_full_config
             _full_cfg = _load_full_config()
-            _auto_tts_default = bool(
-                (_full_cfg.get("voice") or {}).get("auto_tts", False)
-            )
+            _voice_cfg = _full_cfg.get("voice") or {}
+            _auto_tts_default = bool(_voice_cfg.get("auto_tts", False))
+            _auto_tts_mode = str(
+                _voice_cfg.get("auto_tts_mode", "all")
+            ).strip().lower()
+            if _auto_tts_mode not in {"all", "voice_only"}:
+                logger.warning(
+                    "Invalid voice.auto_tts_mode=%r; falling back to 'all'",
+                    _auto_tts_mode,
+                )
+                _auto_tts_mode = "all"
         except Exception:
             _auto_tts_default = False
+            _auto_tts_mode = "all"
         if hasattr(adapter, "_auto_tts_default"):
             adapter._auto_tts_default = _auto_tts_default
+        if hasattr(adapter, "_auto_tts_mode"):
+            adapter._auto_tts_mode = _auto_tts_mode
 
         prefix = f"{platform.value}:"
         if isinstance(disabled_chats, set):
@@ -24711,9 +24723,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         adapter = self.adapters.get(event.source.platform)
         adapter_auto_tts = False
+        adapter_auto_tts_mode = "all"
         if adapter and hasattr(adapter, "_should_auto_tts_for_chat"):
             try:
                 adapter_auto_tts = bool(adapter._should_auto_tts_for_chat(chat_id))
+                adapter_auto_tts_mode = getattr(adapter, "_auto_tts_mode", "all")
             except Exception:
                 adapter_auto_tts = False
 
@@ -24723,7 +24737,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # ``voice.auto_tts`` is synced into the adapter on gateway startup.
             # It is the fallback only when the chat has no explicit mode;
             # otherwise the chat-level all/voice_only/off choice takes precedence.
-            or (voice_mode is None and adapter_auto_tts)
+            or (
+                voice_mode is None
+                and adapter_auto_tts
+                and (adapter_auto_tts_mode == "all" or is_voice_input)
+            )
         )
         if not should:
             logger.debug(

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2397,6 +2397,23 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
                 "Set voice.submit_mode to direct (submit immediately) or draft (edit before sending)",
             ))
 
+    # ── voice.auto_tts_mode: all | voice_only ────────────────────────────
+    if isinstance(voice_cfg, dict) and "auto_tts_mode" in voice_cfg:
+        auto_tts_mode = voice_cfg.get("auto_tts_mode")
+        normalized_auto_tts_mode = (
+            auto_tts_mode.strip().lower()
+            if isinstance(auto_tts_mode, str)
+            else None
+        )
+        if normalized_auto_tts_mode not in {"all", "voice_only"}:
+            issues.append(ConfigIssue(
+                "error",
+                "voice.auto_tts_mode must be 'all' or 'voice_only', "
+                f"got {auto_tts_mode!r}",
+                "Set voice.auto_tts_mode to all (audio with every reply) or "
+                "voice_only (audio only after voice input)",
+            ))
+
     # ── custom_providers must be a list, not a dict ──────────────────────
     cp = config.get("custom_providers")
     if cp is not None:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2017,6 +2017,7 @@ DEFAULT_CONFIG = {
         "submit_mode": "direct",       # TUI: direct submits immediately; draft leaves an editable transcript
         "max_recording_seconds": 120,
         "auto_tts": False,
+        "auto_tts_mode": "all",       # all (legacy) | voice_only (reply with audio only to voice input)
         # Desktop remote clients call the profile's STT/TTS providers
         # DIRECTLY (config + key fetched over the authenticated REST channel
         # at voice-session start) instead of relaying audio through the

--- a/tests/gateway/test_auto_voice_reply_format.py
+++ b/tests/gateway/test_auto_voice_reply_format.py
@@ -73,6 +73,43 @@ class TestAutoVoiceReplyFormat:
             voice_event, "hello", [], already_sent=True
         ) is True
 
+    def test_should_send_voice_reply_global_all_mode_preserves_text_input_tts(self):
+        """The default global mode keeps the existing text-reply behavior."""
+        runner = _make_runner()
+        adapter = _make_adapter(Platform.DISCORD)
+        adapter._should_auto_tts_for_chat = MagicMock(return_value=True)
+        adapter._auto_tts_mode = "all"
+        runner.adapters[Platform.DISCORD] = adapter
+        text_event = _make_event(
+            Platform.DISCORD, chat_id="123", message_type=MessageType.TEXT
+        )
+
+        assert runner._should_send_voice_reply(
+            text_event, "hello", [], already_sent=True
+        ) is True
+
+    def test_should_send_voice_reply_global_voice_only_mode_requires_voice_input(self):
+        """The opt-in global voice_only mode must not add audio to text input."""
+        runner = _make_runner()
+        adapter = _make_adapter(Platform.DISCORD)
+        adapter._should_auto_tts_for_chat = MagicMock(return_value=True)
+        adapter._auto_tts_mode = "voice_only"
+        runner.adapters[Platform.DISCORD] = adapter
+        text_event = _make_event(
+            Platform.DISCORD, chat_id="123", message_type=MessageType.TEXT
+        )
+
+        assert runner._should_send_voice_reply(
+            text_event, "hello", [], already_sent=True
+        ) is False
+
+        voice_event = _make_event(
+            Platform.DISCORD, chat_id="123", message_type=MessageType.VOICE
+        )
+        assert runner._should_send_voice_reply(
+            voice_event, "hello", [], already_sent=True
+        ) is True
+
     def test_should_send_voice_reply_voice_only_still_requires_voice_input(self):
         """Explicit voice_only must not widen to text input (#73508 regression).
 

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -169,6 +169,40 @@ class TestHandleVoiceCommand:
 
         assert adapter._auto_tts_default is True
 
+    def test_sync_pushes_configured_auto_tts_mode_onto_adapter(self, runner, monkeypatch):
+        """The global reply scope must be frozen onto the adapter at startup."""
+        from gateway.config import Platform
+
+        fake_cfg = {"voice": {"auto_tts": True, "auto_tts_mode": "voice_only"}}
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: fake_cfg,
+        )
+        adapter = SimpleNamespace(
+            _auto_tts_default=False,
+            _auto_tts_mode="all",
+            _auto_tts_disabled_chats=set(),
+            _auto_tts_enabled_chats=set(),
+            _should_auto_tts_for_chat=lambda _chat_id: True,
+            platform=Platform.TELEGRAM,
+        )
+
+        runner._sync_voice_mode_state_to_adapter(adapter)
+
+        assert adapter._auto_tts_mode == "voice_only"
+
+        runner.adapters[Platform.TELEGRAM] = adapter
+        text_event = _make_event("text", message_type=MessageType.TEXT)
+        voice_event = _make_event("voice", message_type=MessageType.VOICE)
+        text_event.source.platform = Platform.TELEGRAM
+        voice_event.source.platform = Platform.TELEGRAM
+        assert runner._should_send_voice_reply(
+            text_event, "reply", [], already_sent=True
+        ) is False
+        assert runner._should_send_voice_reply(
+            voice_event, "reply", [], already_sent=True
+        ) is True
+
 
     @pytest.mark.asyncio
     async def test_platform_isolation(self, runner):

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -111,6 +111,27 @@ class TestVoiceSubmitModeValidation:
         )
 
 
+class TestVoiceAutoTtsModeValidation:
+    def test_default_preserves_existing_all_replies_behavior(self):
+        assert DEFAULT_CONFIG["voice"]["auto_tts_mode"] == "all"
+
+    def test_all_and_voice_only_are_valid(self):
+        for mode in ("all", "voice_only"):
+            issues = validate_config_structure({"voice": {"auto_tts_mode": mode}})
+            assert not any("voice.auto_tts_mode" in issue.message for issue in issues)
+
+    def test_invalid_mode_is_reported(self):
+        issues = validate_config_structure({"voice": {"auto_tts_mode": "sometimes"}})
+
+        assert any(
+            issue.severity == "error"
+            and "voice.auto_tts_mode" in issue.message
+            and "all" in issue.hint
+            and "voice_only" in issue.hint
+            for issue in issues
+        )
+
+
 class TestUnknownTopLevelKeys:
     """Arbitrary top-level keys must NOT warn — they are bridged to os.environ.
 

--- a/website/docs/guides/use-voice-mode-with-hermes.md
+++ b/website/docs/guides/use-voice-mode-with-hermes.md
@@ -169,6 +169,7 @@ voice:
   submit_mode: "direct"  # TUI: direct | draft
   max_recording_seconds: 120
   auto_tts: false
+  auto_tts_mode: "all"  # all (legacy default) | voice_only
   beep_enabled: true
   silence_threshold: 200
   silence_duration: 3.0

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2230,7 +2230,8 @@ The final prompt is sent to the configured STT provider alongside the audio file
 voice:
   record_key: "ctrl+b"         # Push-to-talk key inside the CLI
   max_recording_seconds: 120    # Hard stop for long recordings
-  auto_tts: false               # Enable spoken replies automatically when /voice on
+  auto_tts: false               # Enable automatic spoken replies in gateway chats
+  auto_tts_mode: "all"          # "all" (legacy default) | "voice_only"
   beep_enabled: true            # Play record start/stop beeps in CLI voice mode
   beep_volume: 0.3              # Beep amplitude (0.0-1.0); raise it on quiet systems / headphones
   silence_threshold: 200        # RMS threshold for speech detection
@@ -2238,6 +2239,13 @@ voice:
 ```
 
 Use `/voice on` in the CLI to enable microphone mode, `record_key` to start/stop recording, and `/voice tts` to toggle spoken replies. See [Voice Mode](/user-guide/features/voice-mode) for end-to-end setup and platform-specific behavior.
+
+For gateway chats with no explicit per-chat `/voice` mode, `voice.auto_tts_mode`
+controls which replies receive audio when `voice.auto_tts` is enabled. The
+default, `all`, preserves the existing behavior: replies to both text and voice
+input include audio. Set it to `voice_only` to include audio only when the
+triggering message is voice input. Explicit `/voice off`, `/voice on`, and
+`/voice tts` choices still override the global default for that chat.
 
 ## Streaming
 

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -429,7 +429,8 @@ DISCORD_ALLOWED_USERS=284102345871466496
 voice:
   record_key: "ctrl+b"            # Key to start/stop recording
   max_recording_seconds: 120       # Maximum recording length
-  auto_tts: false                  # Auto-enable TTS when voice mode starts
+  auto_tts: false                  # Enable automatic spoken replies in gateway chats
+  auto_tts_mode: "all"             # "all" (legacy default) | "voice_only"
   beep_enabled: true               # Play record start/stop beeps
   silence_threshold: 200           # RMS level (0-32767) below which counts as silence
   silence_duration: 3.0            # Seconds of silence before auto-stop


### PR DESCRIPTION
## Summary

Add an explicit global auto-TTS reply scope without changing existing configurations:

```yaml
voice:
  auto_tts: true
  auto_tts_mode: voice_only  # all | voice_only
```

- `all` remains the default and preserves the current behavior: replies to both text and voice input include audio.
- `voice_only` adds audio only when the triggering message is voice input.
- Explicit per-chat `/voice off`, `/voice on`, and `/voice tts` modes remain authoritative.
- Invalid values are reported by `hermes config check`; runtime loading fails safe to the legacy `all` behavior.

This resolves the ambiguity between the global `voice.auto_tts` path and the existing per-chat `voice_only` contract without breaking users who rely on global auto-TTS for text replies.

## Validation

- `100 passed`:
  - `tests/gateway/test_auto_voice_reply_format.py`
  - `tests/gateway/test_voice_command.py`
  - `tests/hermes_cli/test_config_validation.py`
- Ruff clean on all touched Python files.
- `git diff --check` clean.

## Documentation

Updated the voice-mode guide, feature reference, and configuration reference with the new setting and precedence rules.
