### PR TITLE
fix(cron): release background-review captures and trim heap after each review

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -1086,6 +1086,24 @@ def _classify_review_result(actions: List[str]) -> str:
     return "none"
 
 
+def clear_memory() -> None:
+    """Run garbage collection and trim malloc memory arena on Linux."""
+    try:
+        import gc
+        gc.collect()
+    except Exception:
+        pass
+    try:
+        import sys
+        if sys.platform == "linux":
+            import ctypes
+            libc = ctypes.CDLL(None)
+            if hasattr(libc, "malloc_trim"):
+                libc.malloc_trim(0)
+    except Exception:
+        pass
+
+
 def _log_review_completion(usage: Dict[str, Any], result: str) -> None:
     """Emit a per-fork completion line so cost is visible where it is incurred."""
     logger.info(
@@ -1702,6 +1720,14 @@ def _run_review_in_thread(
             )
             actions = []
 
+        # Explicitly release large captured objects (conversation snapshot, prompt,
+        # review history, and review messages) once summarization is complete,
+        # ensuring they are freed before constructing/pushing the final review summary.
+        messages_snapshot = None  # type: ignore
+        prompt = None  # type: ignore
+        _review_history = None  # type: ignore
+        review_messages = None  # type: ignore
+
         _log_review_completion(
             review_usage, _classify_review_result(actions)
         )
@@ -1749,6 +1775,8 @@ def _run_review_in_thread(
             _set_approval_callback(None)
         except Exception:
             pass
+        # Clear garbage collection and trim memory arena on Linux
+        clear_memory()
 
 
 def spawn_background_review_thread(


### PR DESCRIPTION
## Problem

The upstream agent-cache fixes (#25315, #25332, #25377) evict cached agents, but the background-review worker thread still pins full conversation snapshots (`messages_snapshot`, `prompt`, `_review_history`, `review_messages`) until the thread exits, and freed memory is never returned to glibc. Measured on our live gateway: ~3 GB/day RSS growth persists post-update; this path was the top suspect in our thread-dump investigation.

It is also the credential-persistence surface reported in #101351: those verbatim captures (tool output included) outlive their usefulness in the review thread.

## Fix

- Null out the large captured locals in `_run_review_in_thread` immediately after `summarize_background_review_actions()` consumes them.
- Add `clear_memory()` (`gc.collect` + guarded glibc `malloc_trim(0)`) and call it in the `finally` block of every review thread.

Single-file change: `agent/background_review.py` (+28).

Related: #101351