### PR TITLE
fix: honor ESTOP in CLI kanban dispatch

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -789,7 +789,14 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     # --- dispatch ---
     p_disp = sub.add_parser(
         "dispatch",
-        help="One dispatcher pass: reclaim stale, promote ready, spawn workers",
+        help=(
+            "One dispatcher pass: reclaim stale, promote ready, spawn workers "
+            "(honors the global ESTOP pause and spawns nothing while paused)"
+        ),
+        description=(
+            "Run one dispatcher pass. When the global Hermes emergency stop "
+            "(ESTOP) is engaged, no workers are spawned."
+        ),
     )
     p_disp.add_argument("--dry-run", action="store_true",
                         help="Don't actually spawn processes; just print what would happen")
@@ -2740,6 +2747,25 @@ def _cmd_tail(args: argparse.Namespace) -> int:
 
 
 def _cmd_dispatch(args: argparse.Namespace) -> int:
+    # Check the shared emergency stop before loading config or entering the
+    # dispatcher.  The gateway and cron paths already honor this sentinel;
+    # the CLI must not provide a way around it.
+    from agent import estop
+
+    if estop.is_engaged():
+        state = estop.get_state() or {}
+        payload = {
+            "paused": True,
+            "reason": state.get("reason"),
+            "spawned": [],
+        }
+        if getattr(args, "json", False):
+            print(json.dumps(payload, indent=2))
+        else:
+            reason = f" ({payload['reason']})" if payload["reason"] else ""
+            print(f"Dispatch paused by global emergency stop{reason}; no workers spawned.")
+        return 0
+
     # Honour kanban.default_assignee as the fallback for unassigned ready
     # tasks (#27145), kanban.max_in_progress as the global concurrency cap
     # (#33488), kanban.max_in_progress_per_profile as the per-profile
@@ -2793,6 +2819,8 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         )
     if getattr(args, "json", False):
         print(json.dumps({
+            "paused": False,
+            "reason": None,
             "reclaimed": res.reclaimed,
             "crashed": res.crashed,
             "timed_out": res.timed_out,

--- a/tests/hermes_cli/test_kanban_cli_estop.py
+++ b/tests/hermes_cli/test_kanban_cli_estop.py
@@ -1,0 +1,106 @@
+"""CLI dispatch must honor the global emergency stop."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from agent import estop
+from hermes_cli import kanban as kb_cli
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def dispatch_environment(tmp_path, monkeypatch):
+    """Use a profile home and its canonical fleet root under one temp tree."""
+    root = tmp_path / ".hermes"
+    profile_home = root / "profiles" / "fixture"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    estop._reset_log_state_for_tests()
+    return root, profile_home
+
+
+def _dispatch_args() -> argparse.Namespace:
+    return argparse.Namespace(
+        kanban_action="dispatch",
+        board=None,
+        dry_run=False,
+        max=None,
+        failure_limit=2,
+        json=True,
+    )
+
+
+@pytest.mark.parametrize(
+    ("sentinel", "reason"),
+    (("profile", "profile pause"), ("canonical", "canonical pause")),
+)
+def test_cli_dispatch_blocks_estop(
+    dispatch_environment, monkeypatch, capsys, sentinel, reason
+):
+    """Either supported sentinel location stops dispatch before dispatch_once."""
+    root, profile_home = dispatch_environment
+    target = profile_home / "ESTOP" if sentinel == "profile" else root / "ESTOP"
+    target.write_text(json.dumps({"reason": reason}), encoding="utf-8")
+    dispatch_calls = []
+    monkeypatch.setattr(
+        kb,
+        "dispatch_once",
+        lambda *args, **kwargs: dispatch_calls.append((args, kwargs)),
+    )
+
+    rc = kb_cli.kanban_command(_dispatch_args())
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["paused"] is True
+    assert payload["reason"] == reason
+    assert payload["spawned"] == []
+    assert dispatch_calls == []
+
+
+def test_cli_dispatch_runs_when_estop_is_not_engaged(
+    dispatch_environment, monkeypatch, capsys
+):
+    """Without either sentinel, the normal dispatch result is returned."""
+    expected = [("fixture-task", "fixture", "/tmp/fixture-workspace")]
+    monkeypatch.setattr(
+        kb,
+        "dispatch_once",
+        lambda *args, **kwargs: kb.DispatchResult(spawned=expected),
+    )
+
+    rc = kb_cli.kanban_command(_dispatch_args())
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["paused"] is False
+    assert payload["spawned"] == [
+        {
+            "task_id": "fixture-task",
+            "assignee": "fixture",
+            "workspace": "/tmp/fixture-workspace",
+        }
+    ]
+
+
+def test_dispatch_help_documents_estop_behavior(capsys):
+    """The subcommand help must expose the pause safety contract."""
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    kb_cli.build_parser(subparsers)
+
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["kanban", "dispatch", "--help"])
+
+    assert exc_info.value.code == 0
+    help_text = capsys.readouterr().out.lower()
+    assert "estop" in help_text
+    assert "no workers are spawned" in help_text


### PR DESCRIPTION
## Summary

The standalone `hermes kanban dispatch` path now consults the shared `agent.estop` sentinel before loading configuration or entering the dispatcher. When engaged, it exits successfully without spawning workers and reports paused state in JSON; normal JSON output reports paused=false. The dispatch help text documents the safety behavior.

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_kanban_cli_estop.py tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py tests/test_estop.py -q`
- 3 files, 31 tests passed, 0 failed
- `git diff --check origin/main...HEAD`
- Regression covers both profile-local and canonical ESTOP sentinel locations, no-spawn-before-dispatch, normal dispatch, and help text.

This is a small generic upstream fix. No live install, cron store, gateway, or runtime configuration was changed.