### PR TITLE
feat(telegram): add per-chat require_mention_chats opt-in

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1216,6 +1216,12 @@ platform_toolsets:
 #     # Default false; ordinary messages, replies, and regex wake words stay blocked.
 #     guest_mode: false
 #     # allowed_chats: ["-1001234567890"]
+#     # require_mention: false           # Global default: respond to every message (default: false)
+#     # free_response_chats: []          # Opt specific chats OUT of require_mention when it's true globally
+#     # require_mention_chats: []        # Opt specific chats INTO @mention-only gating when require_mention
+#     #                                   # is false globally — e.g. a multi-bot room where the bot should
+#     #                                   # stay quiet unless addressed. If a chat appears in both lists,
+#     #                                   # free_response_chats wins (fail open).
 #     extra:
 #       disable_link_previews: false  # Set true to suppress Telegram URL previews in bot messages
 #       rich_messages: false          # Bot API 10.1 rich messages (tables/task lists/details/math); default false for copyable legacy MarkdownV2, set true to opt in

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8790,8 +8790,17 @@ class TelegramAdapter(BasePlatformAdapter):
 
     # ── Group mention gating ──────────────────────────────────────────────
 
-    def _telegram_require_mention(self) -> bool:
-        """Return whether group chats should require an explicit bot trigger."""
+    def _telegram_require_mention(self, chat_id: Optional[str] = None) -> bool:
+        """Return whether group chats should require an explicit bot trigger.
+
+        When *chat_id* is supplied and appears in ``require_mention_chats``, the
+        mention requirement is forced on for that chat regardless of the global
+        setting — the per-chat opt-in counterpart to ``free_response_chats``.
+        Call sites check ``free_response_chats``/``free_response_topics`` first,
+        so a chat listed in both resolves to the chattier option.
+        """
+        if chat_id is not None and str(chat_id) in self._telegram_require_mention_chats():
+            return True
         configured = self.config.extra.get("require_mention")
         if configured is not None:
             if isinstance(configured, str):
@@ -8838,6 +8847,24 @@ class TelegramAdapter(BasePlatformAdapter):
         raw = self.config.extra.get("free_response_chats")
         if raw is None:
             raw = _scoped_gate_env("TELEGRAM_FREE_RESPONSE_CHATS")
+        if isinstance(raw, list):
+            return {str(part).strip() for part in raw if str(part).strip()}
+        return {part.strip() for part in str(raw).split(",") if part.strip()}
+
+    def _telegram_require_mention_chats(self) -> set[str]:
+        """Return group chat IDs that require an explicit bot trigger even when
+        ``require_mention`` is globally disabled.
+
+        This is the opt-in counterpart to ``free_response_chats``: it lets the
+        bot stay chatty everywhere by default while still requiring an @mention
+        in specific chats — e.g. a multi-bot room, or a group with outside
+        participants where the bot should observe silently and only speak when
+        addressed. DMs are never affected. Empty set means no per-chat override
+        (backward compatible).
+        """
+        raw = self.config.extra.get("require_mention_chats")
+        if raw is None:
+            raw = _scoped_gate_env("TELEGRAM_REQUIRE_MENTION_CHATS")
         if isinstance(raw, list):
             return {str(part).strip() for part in raw if str(part).strip()}
         return {part.strip() for part in str(raw).split(",") if part.strip()}
@@ -9383,7 +9410,7 @@ class TelegramAdapter(BasePlatformAdapter):
             return False
         if self._telegram_is_free_response_topic(message):
             return False
-        if not self._telegram_require_mention():
+        if not self._telegram_require_mention(chat_id_str):
             return False
         if self._is_reply_to_bot(message):
             return False
@@ -9767,7 +9794,7 @@ class TelegramAdapter(BasePlatformAdapter):
             return True
         if self._telegram_is_free_response_topic(message):
             return True
-        if not self._telegram_require_mention():
+        if not self._telegram_require_mention(chat_id_str):
             return True
         if self._is_reply_to_bot(message):
             return True
@@ -11098,6 +11125,13 @@ def _apply_yaml_config(yaml_cfg: dict, telegram_cfg: dict) -> dict | None:
             frc = ",".join(str(v) for v in frc)
         if not _skip_env_bridge and not os.getenv("TELEGRAM_FREE_RESPONSE_CHATS"):
             os.environ["TELEGRAM_FREE_RESPONSE_CHATS"] = str(frc)
+    rmc = telegram_cfg.get("require_mention_chats")
+    if rmc is not None:
+        extras.setdefault("require_mention_chats", rmc)
+        if isinstance(rmc, list):
+            rmc = ",".join(str(v) for v in rmc)
+        if not _skip_env_bridge and not os.getenv("TELEGRAM_REQUIRE_MENTION_CHATS"):
+            os.environ["TELEGRAM_REQUIRE_MENTION_CHATS"] = str(rmc)
     frt = telegram_cfg.get("free_response_topics")
     if frt is not None:
         if isinstance(frt, list):

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -11,6 +11,7 @@ from gateway.session import SessionSource
 def _make_adapter(
     require_mention=None,
     free_response_chats=None,
+    require_mention_chats=None,
     free_response_topics=None,
     mention_patterns=None,
     exclusive_bot_mentions=None,
@@ -31,6 +32,8 @@ def _make_adapter(
         extra["require_mention"] = require_mention
     if free_response_chats is not None:
         extra["free_response_chats"] = free_response_chats
+    if require_mention_chats is not None:
+        extra["require_mention_chats"] = require_mention_chats
     if free_response_topics is not None:
         extra["free_response_topics"] = free_response_topics
     if mention_patterns is not None:
@@ -334,6 +337,35 @@ def test_group_messages_can_require_direct_trigger_via_config():
     assert adapter_no_mention._should_process_message(_group_message("/status"), is_command=True) is True
 
 
+def test_require_mention_chats_opt_in_gates_specific_chat():
+    """require_mention_chats forces @mention gating in listed chats even when
+    require_mention is globally off — the opt-in counterpart to
+    free_response_chats (e.g. a multi-bot room where several agents share a
+    group and should not all answer every unaddressed message)."""
+    adapter = _make_adapter(require_mention=False, require_mention_chats=["-200"])
+
+    assert adapter._should_process_message(_group_message("hello everyone", chat_id=-200)) is False
+    mentioned = _group_message(
+        "hi @hermes_bot",
+        chat_id=-200,
+        entities=[_mention_entity("hi @hermes_bot")],
+    )
+    assert adapter._should_process_message(mentioned) is True
+    # Chats not listed keep the global chatty default.
+    assert adapter._should_process_message(_group_message("hello everyone", chat_id=-201)) is True
+
+
+def test_require_mention_chats_from_env(monkeypatch):
+    """TELEGRAM_REQUIRE_MENTION_CHATS feeds the per-chat opt-in when config is absent."""
+    monkeypatch.setenv("TELEGRAM_REQUIRE_MENTION_CHATS", "-200, -300")
+    adapter = _make_adapter(require_mention=False)
+
+    assert adapter._telegram_require_mention_chats() == {"-200", "-300"}
+    assert adapter._telegram_require_mention("-200") is True
+    assert adapter._telegram_require_mention("-999") is False
+    assert adapter._telegram_require_mention() is False
+
+
 def test_explicit_multi_bot_mentions_route_only_to_named_bots():
     text = "@research_bot @ops_bot hi"
     entities = _mention_entities(text, ["@research_bot", "@ops_bot"])
@@ -535,6 +567,8 @@ def test_config_bridges_telegram_group_settings(monkeypatch, tmp_path):
         "    - \"^\\\\s*chompy\\\\b\"\n"
         "  free_response_chats:\n"
         "    - \"-123\"\n"
+        "  require_mention_chats:\n"
+        "    - \"-456\"\n"
         "  allowed_chats:\n"
         "    - \"-100\"\n"
         "  group_allowed_chats:\n"
@@ -557,6 +591,7 @@ def test_config_bridges_telegram_group_settings(monkeypatch, tmp_path):
         "TELEGRAM_GUEST_MODE",
         "TELEGRAM_OBSERVE_UNMENTIONED_GROUP_MESSAGES",
         "TELEGRAM_FREE_RESPONSE_CHATS",
+        "TELEGRAM_REQUIRE_MENTION_CHATS",
         "TELEGRAM_ALLOWED_CHATS",
         "TELEGRAM_GROUP_ALLOWED_CHATS",
         "TELEGRAM_ALLOWED_TOPICS",
@@ -583,10 +618,13 @@ def test_config_bridges_telegram_group_settings(monkeypatch, tmp_path):
     assert tg_cfg.extra.get("allowed_chats") == ["-100"]
     assert tg_cfg.extra.get("group_allowed_chats") == ["-100"]
     assert tg_cfg.extra.get("allowed_topics") == [8]
-    # free_response_chats is bridged to the env var only (not PlatformConfig.extra).
-    # TELEGRAM_FREE_RESPONSE_CHATS is not a key that appears in developer .env
-    # files, so asserting it via os.environ stays deterministic.
+    assert tg_cfg.extra.get("require_mention_chats") == ["-456"]
+    # free_response_chats/require_mention_chats are also bridged to their env
+    # vars. Neither TELEGRAM_FREE_RESPONSE_CHATS nor TELEGRAM_REQUIRE_MENTION_CHATS
+    # is a key that appears in developer .env files, so asserting them via
+    # os.environ stays deterministic.
     assert __import__("os").environ["TELEGRAM_FREE_RESPONSE_CHATS"] == "-123"
+    assert __import__("os").environ["TELEGRAM_REQUIRE_MENTION_CHATS"] == "-456"
 
 
 def test_top_level_require_mention_bridges_to_telegram(monkeypatch, tmp_path):


### PR DESCRIPTION
## What

Adds `require_mention_chats`, the inverse counterpart to the existing
`free_response_chats`. Today, `require_mention` is a single global switch:
- `false` (default): the bot responds to every group message.
- `true`: the bot only responds when @mentioned, except in chats listed
  under `free_response_chats`/`free_response_topics`.

There was no way to keep the global default chatty while requiring an
explicit @mention in a *specific* chat — e.g. a multi-bot room where several
agents share a group and shouldn't all answer every unaddressed message, or
a group with outside participants where the bot should observe silently and
only speak when addressed.

`require_mention_chats` fills that gap:

```yaml
telegram:
  require_mention: false          # bot listens to everything by default
  require_mention_chats:
    - "-1001234567890"            # ...except this chat, which needs @mention
```

or via `TELEGRAM_REQUIRE_MENTION_CHATS` (comma-separated chat IDs).

## Why

Requested by a user running a personal Hermes deployment who wanted the bot
chatty in their main channels but mention-gated in a shared/multi-bot group.
This exact feature has prior history in the repo:

- Supersedes #58794 (same feature, implemented against the pre-move file
  path `gateway/platforms/telegram.py`; now unmergeable/stale after the
  Telegram adapter moved to `plugins/platforms/telegram/adapter.py`).
- Related to #78277 (closed as duplicate) and #13855 (closed, broader
  multi-platform version).

This PR reimplements the feature fresh against current `main`, keeping the
same conflict-precedence design that #58794/#13855 converged on: if a chat
is listed in both `free_response_chats` and `require_mention_chats`,
`free_response_chats` wins (fail open — the chattier option wins).

## How

- `_telegram_require_mention()` now accepts an optional `chat_id`. When
  supplied and present in the new `_telegram_require_mention_chats()` set,
  it returns `True` regardless of the global setting.
- Both call sites (`_should_process_message`,
  `_should_observe_unmentioned_group_message`) already check
  `free_response_chats`/`free_response_topics` before calling
  `_telegram_require_mention()`, so those exemptions still take precedence.
- `_apply_yaml_config` bridges `telegram.require_mention_chats` from
  `config.yaml` into `PlatformConfig.extra` and `TELEGRAM_REQUIRE_MENTION_CHATS`,
  mirroring the existing `free_response_chats` bridge.
- Documented in `cli-config.yaml.example` next to the related Telegram knobs.
- DMs are unaffected (this is a group-chat gate, like the settings it mirrors).

## Test plan

- Added `test_require_mention_chats_opt_in_gates_specific_chat` and
  `test_require_mention_chats_from_env` to
  `tests/gateway/test_telegram_group_gating.py`.
- Extended `test_config_bridges_telegram_group_settings` to cover the new
  YAML → `extra`/env bridging.
- `tests/gateway/test_telegram_group_gating.py`: 25 passed, 0 failed.

## Platforms tested

Telegram only (this feature is Telegram-specific; Discord already has an
equivalent `free_response_channels` mechanism).