### PR TITLE
feat(auth): track Codex token usage per account

### DIFF
--- a/agent/account_token_usage.py
+++ b/agent/account_token_usage.py
@@ -1,0 +1,212 @@
+"""Secret-safe provider-account identity for local token accounting.
+
+Only stable, one-way account keys are persisted. OAuth access tokens, raw
+provider account IDs, and email addresses never enter the usage database.
+"""
+
+from __future__ import annotations
+
+import base64
+import datetime as dt
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Iterable, Optional
+
+from agent.codex_headers import extract_chatgpt_account_id
+
+
+@dataclass(frozen=True)
+class AccountIdentity:
+    """A stable persisted key plus an ephemeral display label."""
+
+    account_key: str
+    email: Optional[str] = None
+
+
+def _jwt_claims(access_token: Any) -> dict[str, Any]:
+    token = str(access_token or "").strip()
+    try:
+        parts = token.split(".")
+        if len(parts) < 2:
+            return {}
+        encoded = parts[1] + "=" * (-len(parts[1]) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(encoded))
+        return claims if isinstance(claims, dict) else {}
+    except Exception:
+        return {}
+
+
+def codex_account_identity(access_token: Any) -> Optional[AccountIdentity]:
+    """Return a stable, non-secret identity for a ChatGPT Codex OAuth token."""
+
+    claims = _jwt_claims(access_token)
+    account_id = extract_chatgpt_account_id(access_token)
+    if account_id is None:
+        return None
+
+    digest = hashlib.sha256(
+        f"openai-codex\0{account_id.strip()}".encode("utf-8")
+    ).hexdigest()
+    profile = claims.get("https://api.openai.com/profile") or {}
+    email = profile.get("email") if isinstance(profile, dict) else None
+    if not isinstance(email, str) or not email.strip():
+        email = claims.get("email")
+    normalized_email = email.strip() if isinstance(email, str) and email.strip() else None
+    return AccountIdentity(
+        account_key=f"openai-codex:{digest}",
+        email=normalized_email,
+    )
+
+
+def account_key_for_agent(
+    agent: object,
+    *,
+    request_client: object | None = None,
+) -> Optional[str]:
+    """Return the stable account key for the credential serving this request.
+
+    Attribution is intentionally fail-closed. Unknown providers, malformed
+    tokens, and tokens without a stable provider account id return ``None`` so
+    Hermes never files usage against a guessed or misleading identity.
+    """
+    if getattr(request_client, "is_moa_client", False) is True:
+        return None
+    provider = str(getattr(agent, "provider", "") or "").strip().lower()
+    if provider != "openai-codex":
+        return None
+    identity = codex_account_identity(str(getattr(agent, "api_key", "") or ""))
+    return identity.account_key if identity is not None else None
+
+
+def _empty_local_usage(account_key: str) -> dict[str, Any]:
+    return {
+        "account_key": account_key,
+        "billing_provider": "openai-codex",
+        "api_call_count": 0,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "reasoning_tokens": 0,
+        "total_tokens": 0,
+        "first_seen": None,
+        "last_seen": None,
+    }
+
+
+def build_codex_account_usage_report(
+    *,
+    entries: Iterable[object],
+    local_rows: Iterable[dict[str, Any]],
+) -> dict[str, Any]:
+    """Merge current pool identities with forward-only local token totals.
+
+    Pool entries are deduplicated by the stable account key, not by editable
+    labels or rotating OAuth token values. The returned object contains no
+    credentials or raw provider account ids.
+    """
+    groups: dict[str, dict[str, Any]] = {}
+    for entry in entries:
+        identity = codex_account_identity(getattr(entry, "access_token", ""))
+        if identity is None:
+            continue
+        group = groups.setdefault(
+            identity.account_key,
+            {
+                "account_key": identity.account_key,
+                "email": identity.email,
+                "pool_labels": [],
+            },
+        )
+        if group["email"] is None and identity.email:
+            group["email"] = identity.email
+        label = str(getattr(entry, "label", "") or "").strip()
+        if label and label not in group["pool_labels"]:
+            group["pool_labels"].append(label)
+
+    local_by_key = {
+        str(row.get("account_key") or ""): dict(row)
+        for row in local_rows
+        if row.get("account_key")
+    }
+    for account_key in local_by_key:
+        groups.setdefault(
+            account_key,
+            {"account_key": account_key, "email": None, "pool_labels": []},
+        )
+
+    accounts: list[dict[str, Any]] = []
+    for account_key, group in groups.items():
+        accounts.append(
+            {
+                **group,
+                "local_usage": local_by_key.get(
+                    account_key, _empty_local_usage(account_key)
+                ),
+            }
+        )
+
+    accounts.sort(
+        key=lambda item: (
+            item["local_usage"].get("last_seen") or 0,
+            item.get("email") or item["account_key"],
+        ),
+        reverse=True,
+    )
+    tracked: list[float] = [
+        float(value)
+        for row in local_by_key.values()
+        if isinstance((value := row.get("first_seen")), (int, float))
+    ]
+    return {
+        "provider": "openai-codex",
+        "tracking_mode": "forward_only",
+        "attribution_scope": {
+            "supported": ["codex_responses", "codex_auxiliary_authoritative"],
+            "omitted": [
+                "codex_app_server",
+                "moa",
+                "background_review",
+            ],
+        },
+        "tracking_started_at": min(tracked) if tracked else None,
+        "accounts": accounts,
+    }
+
+
+def format_codex_account_usage_report(report: dict[str, Any]) -> str:
+    """Render a compact terminal report for ``hermes auth token-usage``."""
+    lines = [
+        "OpenAI Codex account usage (forward-only local accounting)",
+        "Coverage: standard Codex Responses and account-aware auxiliary calls; "
+        "app-server, MoA, and background-review calls are omitted.",
+    ]
+    started = report.get("tracking_started_at")
+    if isinstance(started, (int, float)):
+        started_text = dt.datetime.fromtimestamp(started).astimezone().isoformat(
+            timespec="seconds"
+        )
+        lines.append(f"Tracking since: {started_text}")
+    else:
+        lines.append(
+            "Tracking since: not started (restart any long-running Hermes process after upgrading)"
+        )
+    for account in report.get("accounts") or []:
+        local = account.get("local_usage") or {}
+        label = account.get("email") or account.get("account_key") or "unknown"
+        lines.extend(
+            [
+                "",
+                str(label),
+                f"  Local API calls: {int(local.get('api_call_count') or 0):,}",
+                f"  Local total tokens: {int(local.get('total_tokens') or 0):,}",
+                "  Token detail: "
+                f"input {int(local.get('input_tokens') or 0):,}, "
+                f"cache-read {int(local.get('cache_read_tokens') or 0):,}, "
+                f"cache-write {int(local.get('cache_write_tokens') or 0):,}, "
+                f"output {int(local.get('output_tokens') or 0):,}, "
+                f"reasoning {int(local.get('reasoning_tokens') or 0):,}",
+            ]
+        )
+    return "\n".join(lines)

--- a/agent/aux_accounting.py
+++ b/agent/aux_accounting.py
@@ -37,6 +37,13 @@ _accounting: ContextVar[Optional[tuple]] = ContextVar(
     "aux_accounting_context", default=None
 )
 
+# Background-review workers inherit the foreground session context so their
+# model usage remains visible, but their aggregate/forked requests do not have
+# authoritative per-request account provenance.
+_account_attribution_suppressed: ContextVar[bool] = ContextVar(
+    "aux_account_attribution_suppressed", default=False
+)
+
 # Aux tasks whose usage is already accounted by the main loop — recording
 # them here would double-count. MoA advisor/aggregator usage is folded into
 # conversation_loop's update_token_counts delta (tokens AND cost).
@@ -68,6 +75,19 @@ def get_accounting_context() -> Optional[tuple]:
     return _accounting.get()
 
 
+def set_account_attribution_suppressed():
+    """Suppress only account attribution while retaining model accounting."""
+    return _account_attribution_suppressed.set(True)
+
+
+def reset_account_attribution_suppressed(token) -> None:
+    """Restore the previous account-attribution suppression state."""
+    try:
+        _account_attribution_suppressed.reset(token)
+    except Exception:
+        _account_attribution_suppressed.set(False)
+
+
 def record_aux_usage(
     response: Any,
     task: Optional[str],
@@ -86,8 +106,9 @@ def record_aux_usage(
     * the response carries no usage object.
 
     The model is read from ``response.model`` (accurate even after the aux
-    client's provider-fallback chains); *provider*/*base_url* reflect the
-    originally-resolved route and are best-effort.
+    client's provider-fallback chains). *provider*/*base_url* are best-effort
+    caller hints unless a response carries authoritative account-route
+    metadata for the credential that actually served it.
     """
     try:
         if not task or task in _EXCLUDED_TASKS:
@@ -99,6 +120,28 @@ def record_aux_usage(
         raw_usage = getattr(response, "usage", None)
         if raw_usage is None:
             return
+
+        # A successful adapter response is authoritative about the credential
+        # and route that actually served it. Caller hints can describe the
+        # pre-fallback route, so prefer the response metadata whenever an
+        # account key is present.
+        response_account_key = getattr(response, "_hermes_account_key", None)
+        if response_account_key:
+            response_provider = str(
+                getattr(response, "_hermes_billing_provider", "") or ""
+            ).strip()
+            response_base_url = str(
+                getattr(response, "_hermes_billing_base_url", "") or ""
+            ).strip()
+            if response_provider:
+                provider = response_provider
+            if response_base_url:
+                base_url = response_base_url
+        account_key = (
+            None
+            if _account_attribution_suppressed.get()
+            else response_account_key
+        )
 
         from agent.usage_pricing import estimate_usage_cost, normalize_usage
 
@@ -127,6 +170,7 @@ def record_aux_usage(
             model=model,
             billing_provider=provider,
             billing_base_url=base_url,
+            account_key=account_key,
             input_tokens=usage.input_tokens,
             output_tokens=usage.output_tokens,
             cache_read_tokens=usage.cache_read_tokens,

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1712,9 +1712,16 @@ class _CodexCompletionsAdapter:
     """Drop-in shim that accepts chat.completions.create() kwargs and
     routes them through the Codex Responses streaming API."""
 
-    def __init__(self, real_client: OpenAI, model: str):
+    def __init__(
+        self,
+        real_client: OpenAI,
+        model: str,
+        *,
+        account_provider: Optional[str] = None,
+    ):
         self._client = real_client
         self._model = model
+        self._account_provider = account_provider
 
     def create(self, **kwargs) -> Any:
         messages = kwargs.get("messages", [])
@@ -2291,13 +2298,24 @@ class _CodexCompletionsAdapter:
 
             resp_usage = getattr(final, "usage", None)
             if resp_usage:
+                input_details = _item_get(resp_usage, "input_tokens_details", None)
+                output_details = _item_get(resp_usage, "output_tokens_details", None)
+                cache_write_tokens = _item_get(
+                    input_details, "cache_write_tokens", 0
+                ) or _item_get(input_details, "cache_creation_tokens", 0)
                 usage = SimpleNamespace(
-                    prompt_tokens=getattr(resp_usage, "input_tokens", 0)
-                        or (resp_usage.get("input_tokens", 0) if isinstance(resp_usage, dict) else 0),
-                    completion_tokens=getattr(resp_usage, "output_tokens", 0)
-                        or (resp_usage.get("output_tokens", 0) if isinstance(resp_usage, dict) else 0),
-                    total_tokens=getattr(resp_usage, "total_tokens", 0)
-                        or (resp_usage.get("total_tokens", 0) if isinstance(resp_usage, dict) else 0),
+                    prompt_tokens=_item_get(resp_usage, "input_tokens", 0),
+                    completion_tokens=_item_get(resp_usage, "output_tokens", 0),
+                    total_tokens=_item_get(resp_usage, "total_tokens", 0),
+                    prompt_tokens_details=SimpleNamespace(
+                        cached_tokens=_item_get(input_details, "cached_tokens", 0),
+                        cache_write_tokens=cache_write_tokens,
+                    ),
+                    completion_tokens_details=SimpleNamespace(
+                        reasoning_tokens=_item_get(
+                            output_details, "reasoning_tokens", 0
+                        ),
+                    ),
                 )
         except Exception as exc:
             if timed_out.is_set():
@@ -2339,10 +2357,28 @@ class _CodexCompletionsAdapter:
             message=message,
             finish_reason="stop" if not tool_calls_raw else "tool_calls",
         )
+        from agent.account_token_usage import codex_account_identity
+
+        account_identity = None
+        if self._account_provider == "openai-codex":
+            account_identity = codex_account_identity(
+                getattr(self._client, "api_key", "")
+            )
         return SimpleNamespace(
             choices=[choice],
             model=model,
             usage=usage,
+            _hermes_account_key=(
+                account_identity.account_key if account_identity is not None else None
+            ),
+            _hermes_billing_provider=(
+                self._account_provider if account_identity is not None else None
+            ),
+            _hermes_billing_base_url=(
+                str(getattr(self._client, "base_url", "") or "")
+                if account_identity is not None
+                else None
+            ),
         )
 
 
@@ -2360,9 +2396,19 @@ class CodexAuxiliaryClient:
     Also exposes .api_key and .base_url for introspection by async wrappers.
     """
 
-    def __init__(self, real_client: OpenAI, model: str):
+    def __init__(
+        self,
+        real_client: OpenAI,
+        model: str,
+        *,
+        account_provider: Optional[str] = None,
+    ):
         self._real_client = real_client
-        adapter = _CodexCompletionsAdapter(real_client, model)
+        adapter = _CodexCompletionsAdapter(
+            real_client,
+            model,
+            account_provider=account_provider,
+        )
         self.chat = _CodexChatShim(adapter)
         self.api_key = real_client.api_key
         self.base_url = real_client.base_url
@@ -4228,7 +4274,11 @@ def _build_codex_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
         base_url=base_url,
         default_headers=_codex_cloudflare_headers(codex_token, base_url=base_url),
     )
-    return CodexAuxiliaryClient(real_client, model), model
+    return CodexAuxiliaryClient(
+        real_client,
+        model,
+        account_provider="openai-codex",
+    ), model
 
 
 def _try_azure_foundry(

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -1799,13 +1799,22 @@ def spawn_background_review_thread(
         )
 
     def _target() -> None:
-        _run_review_in_thread(
-            agent,
-            messages_snapshot,
-            prompt,
-            task_cfg=task_cfg,
-            review_run=review_run,
+        from agent.aux_accounting import (
+            reset_account_attribution_suppressed,
+            set_account_attribution_suppressed,
         )
+
+        suppression_token = set_account_attribution_suppressed()
+        try:
+            _run_review_in_thread(
+                agent,
+                messages_snapshot,
+                prompt,
+                task_cfg=task_cfg,
+                review_run=review_run,
+            )
+        finally:
+            reset_account_attribution_suppressed(suppression_token)
 
     return _target, prompt
 

--- a/agent/codex_headers.py
+++ b/agent/codex_headers.py
@@ -9,11 +9,31 @@ from __future__ import annotations
 
 import base64
 import json
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 from urllib.parse import urlparse
 
 
 CODEX_AUX_BASE_URL = "https://chatgpt.com/backend-api/codex"
+
+
+def extract_chatgpt_account_id(access_token: Any) -> Optional[str]:
+    """Best-effort stable account ID extraction from a Codex OAuth JWT."""
+    if not isinstance(access_token, str) or not access_token.strip():
+        return None
+    try:
+        parts = access_token.split(".")
+        if len(parts) < 2:
+            return None
+        payload_b64 = parts[1] + "=" * (-len(parts[1]) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(payload_b64))
+        auth_claims = claims.get("https://api.openai.com/auth", {})
+        account_id = auth_claims.get("chatgpt_account_id")
+        if not isinstance(account_id, str):
+            return None
+        normalized = account_id.strip()
+        return normalized or None
+    except Exception:
+        return None
 
 
 def is_official_codex_base_url(base_url: str) -> bool:
@@ -57,19 +77,9 @@ def codex_cloudflare_headers(
             "User-Agent": f"HermesAgent/{__version__}",
             "originator": "hermes-agent",
         })
-    if not isinstance(access_token, str) or not access_token.strip():
-        return headers
-    try:
-        parts = access_token.split(".")
-        if len(parts) < 2:
-            return headers
-        payload_b64 = parts[1] + "=" * (-len(parts[1]) % 4)
-        claims = json.loads(base64.urlsafe_b64decode(payload_b64))
-        acct_id = claims.get("https://api.openai.com/auth", {}).get("chatgpt_account_id")
-        if isinstance(acct_id, str) and acct_id:
-            headers["ChatGPT-Account-ID"] = acct_id
-    except Exception:
-        pass
+    account_id = extract_chatgpt_account_id(access_token)
+    if account_id:
+        headers["ChatGPT-Account-ID"] = account_id
     return headers
 
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -26,6 +26,7 @@ import sys
 import time
 from typing import Any, Dict, List, Optional
 
+from agent.account_token_usage import account_key_for_agent as _account_key_for_usage
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.conversation_compression import (
     COMPRESSION_RETRY_CONTEXT_REDUCED_STATUS_TEMPLATE,
@@ -4838,6 +4839,10 @@ def run_conversation(
                                 billing_base_url=agent.base_url,
                                 billing_mode="subscription_included"
                                 if cost_result.status == "included" else None,
+                                account_key=_account_key_for_usage(
+                                    agent,
+                                    request_client=_moa_client,
+                                ),
                                 model=agent.model,
                                 api_call_count=1,
                             )

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -2317,6 +2317,8 @@ class MoAChatCompletions:
 
 
 class MoAClient:
+    is_moa_client = True
+
     def __init__(self, preset_name: str, reference_callback: Any = None, agent: Any = None):
         self.chat = type("_MoAChat", (), {})()
         self.chat.completions = MoAChatCompletions(

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 from hermes_cli.cli_output import line_input
 
+import json
 import math
 import sys
 import time
@@ -886,6 +887,37 @@ def _interactive_strategy() -> None:
     print(f"Set {provider} strategy to: {strategy}")
 
 
+def auth_token_usage_command(args) -> None:
+    """Show forward-only local token totals for supported account-aware paths."""
+    provider = str(getattr(args, "provider", "openai-codex") or "").strip().lower()
+    if provider != "openai-codex":
+        raise SystemExit(
+            "Per-account token usage currently supports only openai-codex."
+        )
+
+    from agent.account_token_usage import (
+        build_codex_account_usage_report,
+        format_codex_account_usage_report,
+    )
+    from hermes_state import SessionDB
+
+    db = SessionDB()
+    try:
+        local_rows = db.account_usage_totals(provider=provider)
+        entries = load_pool(provider).entries()
+        report = build_codex_account_usage_report(
+            entries=entries,
+            local_rows=local_rows,
+        )
+    finally:
+        db.close()
+
+    if bool(getattr(args, "json", False)):
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+    else:
+        print(format_codex_account_usage_report(report))
+
+
 def auth_command(args) -> None:
     action = getattr(args, "auth_action", "")
     if action == "add":
@@ -893,6 +925,9 @@ def auth_command(args) -> None:
         return
     if action == "list":
         auth_list_command(args)
+        return
+    if action == "token-usage":
+        auth_token_usage_command(args)
         return
     if action == "remove":
         auth_remove_command(args)

--- a/hermes_cli/subcommands/auth.py
+++ b/hermes_cli/subcommands/auth.py
@@ -51,6 +51,15 @@ def build_auth_parser(subparsers, *, cmd_auth: Callable) -> None:
     auth_add.add_argument("--ca-bundle", help="Custom CA bundle for OAuth login")
     auth_list = auth_subparsers.add_parser("list", help="List pooled credentials")
     auth_list.add_argument("provider", nargs="?", help="Optional provider filter")
+    auth_usage = auth_subparsers.add_parser(
+        "token-usage", help="Show supported forward-only per-account token usage"
+    )
+    auth_usage.add_argument(
+        "provider", nargs="?", default="openai-codex", help="Provider id"
+    )
+    auth_usage.add_argument(
+        "--json", action="store_true", help="Emit machine-readable JSON"
+    )
     auth_remove = auth_subparsers.add_parser(
         "remove", help="Remove a pooled credential by index, id, or label"
     )

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -10060,7 +10060,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     _TOKEN_DELTA_COST_FIELDS = ("estimated_cost_usd", "actual_cost_usd")
     _TOKEN_DELTA_ROUTE_FIELDS = (
         "model", "cost_status", "cost_source", "pricing_version",
-        "billing_provider", "billing_base_url", "billing_mode",
+        "billing_provider", "billing_base_url", "billing_mode", "account_key",
     )
 
     def queue_token_counts(self, session_id: str, **kwargs) -> None:
@@ -10328,6 +10328,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         billing_provider: Optional[str] = None,
         billing_base_url: Optional[str] = None,
         billing_mode: Optional[str] = None,
+        account_key: Optional[str] = None,
         api_call_count: int = 0,
         absolute: bool = False,
     ) -> None:
@@ -10478,7 +10479,125 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     cost_source=cost_source,
                     api_call_count=api_call_count,
                 )
+            if record_model_usage and account_key:
+                self._record_account_usage(
+                    conn,
+                    session_id,
+                    account_key=account_key,
+                    model=model,
+                    billing_provider=billing_provider,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    cache_read_tokens=cache_read_tokens,
+                    cache_write_tokens=cache_write_tokens,
+                    reasoning_tokens=reasoning_tokens,
+                    api_call_count=api_call_count,
+                )
         self._execute_write(_do)
+
+    def _record_account_usage(
+        self,
+        conn,
+        session_id: str,
+        *,
+        account_key: str,
+        model: Optional[str],
+        billing_provider: Optional[str],
+        input_tokens: int,
+        output_tokens: int,
+        cache_read_tokens: int,
+        cache_write_tokens: int,
+        reasoning_tokens: int,
+        api_call_count: int,
+    ) -> None:
+        """Accumulate a forward-only, secret-safe provider-account delta."""
+        row = conn.execute(
+            "SELECT model, billing_provider FROM sessions WHERE id = ?",
+            (session_id,),
+        ).fetchone()
+        eff_model = model or (row["model"] if row is not None else None) or "unknown"
+        eff_provider = (
+            billing_provider
+            or (row["billing_provider"] if row is not None else None)
+            or ""
+        )
+        now = time.time()
+        conn.execute(
+            """INSERT INTO session_account_usage (
+                   session_id, account_key, billing_provider, model,
+                   api_call_count, input_tokens, output_tokens,
+                   cache_read_tokens, cache_write_tokens, reasoning_tokens,
+                   first_seen, last_seen
+               ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(session_id, account_key, billing_provider, model)
+               DO UPDATE SET
+                   api_call_count = api_call_count + excluded.api_call_count,
+                   input_tokens = input_tokens + excluded.input_tokens,
+                   output_tokens = output_tokens + excluded.output_tokens,
+                   cache_read_tokens = cache_read_tokens + excluded.cache_read_tokens,
+                   cache_write_tokens = cache_write_tokens + excluded.cache_write_tokens,
+                   reasoning_tokens = reasoning_tokens + excluded.reasoning_tokens,
+                   last_seen = excluded.last_seen""",
+            (
+                session_id,
+                account_key,
+                eff_provider,
+                eff_model,
+                api_call_count or 0,
+                input_tokens or 0,
+                output_tokens or 0,
+                cache_read_tokens or 0,
+                cache_write_tokens or 0,
+                reasoning_tokens or 0,
+                now,
+                now,
+            ),
+        )
+
+    def account_usage_totals(
+        self,
+        *,
+        provider: Optional[str] = None,
+        account_key: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """Return forward-only token totals grouped by stable provider account."""
+        self.flush_token_counts()
+        clauses: List[str] = []
+        params: List[Any] = []
+        if provider:
+            clauses.append("billing_provider = ?")
+            params.append(provider)
+        if account_key:
+            clauses.append("account_key = ?")
+            params.append(account_key)
+        where = " WHERE " + " AND ".join(clauses) if clauses else ""
+        with self._read_ctx() as conn:
+            rows = conn.execute(
+                """SELECT account_key, billing_provider,
+                          SUM(api_call_count) AS api_call_count,
+                          SUM(input_tokens) AS input_tokens,
+                          SUM(output_tokens) AS output_tokens,
+                          SUM(cache_read_tokens) AS cache_read_tokens,
+                          SUM(cache_write_tokens) AS cache_write_tokens,
+                          SUM(reasoning_tokens) AS reasoning_tokens,
+                          MIN(first_seen) AS first_seen,
+                          MAX(last_seen) AS last_seen
+                     FROM session_account_usage"""
+                + where
+                + " GROUP BY account_key, billing_provider ORDER BY last_seen DESC",
+                tuple(params),
+            ).fetchall()
+        result: List[Dict[str, Any]] = []
+        for row in rows:
+            item = dict(row)
+            item["total_tokens"] = (
+                int(item.get("input_tokens") or 0)
+                + int(item.get("cache_read_tokens") or 0)
+                + int(item.get("cache_write_tokens") or 0)
+                + int(item.get("output_tokens") or 0)
+            )
+            result.append(item)
+        return result
 
     def _record_model_usage(
         self,
@@ -10601,6 +10720,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         model: Optional[str] = None,
         billing_provider: Optional[str] = None,
         billing_base_url: Optional[str] = None,
+        account_key: Optional[str] = None,
         input_tokens: int = 0,
         output_tokens: int = 0,
         cache_read_tokens: int = 0,
@@ -10614,9 +10734,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         Auxiliary calls (vision, compression, title_generation, web_extract,
         session_search, ...) historically discarded their usage, leaving the
         dashboard's per-model analytics blind to aux model spend. This writes
-        a per-(model, provider, task) delta into ``session_model_usage`` —
-        the same table the main loop's ``update_token_counts`` feeds — WITHOUT
-        touching the ``sessions`` summary row. That separation is deliberate:
+        a per-(model, provider, task) delta into ``session_model_usage`` and,
+        when ``account_key`` is available, the same non-overlapping token delta
+        into ``session_account_usage`` in one transaction. It does not touch the
+        ``sessions`` summary row. That separation is deliberate:
         the gateway overwrites session counters with absolute main-loop totals,
         so folding aux tokens into the summary row would either be clobbered
         or double-counted. Insights/analytics read the union of both.
@@ -10635,6 +10756,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # initial create_session() can fail under concurrent SQLite locking).
         self._insert_session_row(session_id, "unknown")
 
+        effective_api_calls = 1 if api_call_count is None else int(api_call_count)
+
         def _do(conn):
             self._record_model_usage(
                 conn,
@@ -10652,11 +10775,23 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 actual_cost_usd=None,
                 cost_status=None,
                 cost_source=None,
-                api_call_count=(
-                    1 if api_call_count is None else int(api_call_count)
-                ),
+                api_call_count=effective_api_calls,
                 task=task,
             )
+            if account_key:
+                self._record_account_usage(
+                    conn,
+                    session_id,
+                    account_key=account_key,
+                    model=model,
+                    billing_provider=billing_provider,
+                    input_tokens=input_tokens or 0,
+                    output_tokens=output_tokens or 0,
+                    cache_read_tokens=cache_read_tokens or 0,
+                    cache_write_tokens=cache_write_tokens or 0,
+                    reasoning_tokens=reasoning_tokens or 0,
+                    api_call_count=effective_api_calls,
+                )
         self._execute_write(_do)
 
     def prune_empty_ghost_sessions(self, sessions_dir: "Optional[Path]" = None) -> int:

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -354,7 +354,7 @@ def _sql_session_last_active_by_id(session_id_expr: str) -> str:
     )
 
 
-SCHEMA_VERSION = 27
+SCHEMA_VERSION = 28
 
 
 # FTS storage-layout version, tracked INDEPENDENTLY of SCHEMA_VERSION in the
@@ -505,6 +505,25 @@ CREATE TABLE IF NOT EXISTS session_model_usage (
     PRIMARY KEY (session_id, model, billing_provider, billing_base_url, billing_mode, task)
 );
 
+-- Forward-only, secret-safe provider-account token attribution. account_key is
+-- a one-way hash derived from the provider's stable account id; raw account
+-- ids, email addresses, OAuth tokens, and API keys are never stored here.
+CREATE TABLE IF NOT EXISTS session_account_usage (
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    account_key TEXT NOT NULL,
+    billing_provider TEXT NOT NULL DEFAULT '',
+    model TEXT NOT NULL DEFAULT 'unknown',
+    api_call_count INTEGER NOT NULL DEFAULT 0,
+    input_tokens INTEGER NOT NULL DEFAULT 0,
+    output_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_write_tokens INTEGER NOT NULL DEFAULT 0,
+    reasoning_tokens INTEGER NOT NULL DEFAULT 0,
+    first_seen REAL NOT NULL,
+    last_seen REAL NOT NULL,
+    PRIMARY KEY (session_id, account_key, billing_provider, model)
+);
+
 CREATE TABLE IF NOT EXISTS state_meta (
     key TEXT PRIMARY KEY,
     value TEXT
@@ -622,6 +641,10 @@ CREATE INDEX IF NOT EXISTS idx_compression_locks_expires ON compression_locks(ex
 CREATE INDEX IF NOT EXISTS idx_session_turn_leases_expires ON session_turn_leases(expires_at);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_session ON session_model_usage(session_id);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_model ON session_model_usage(model);
+CREATE INDEX IF NOT EXISTS idx_session_account_usage_account
+    ON session_account_usage(account_key, last_seen DESC);
+CREATE INDEX IF NOT EXISTS idx_session_account_usage_session
+    ON session_account_usage(session_id);
 CREATE INDEX IF NOT EXISTS idx_async_delegations_delivery
     ON async_delegations(delivery_state, completed_at);
 """

--- a/tests/agent/test_account_token_usage.py
+++ b/tests/agent/test_account_token_usage.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import base64
+import json
+from types import SimpleNamespace
+
+from agent.account_token_usage import (
+    account_key_for_agent,
+    build_codex_account_usage_report,
+    codex_account_identity,
+    format_codex_account_usage_report,
+)
+
+
+def _jwt(*, account_id: str | None = None, email: str | None = None, nonce: str = "a") -> str:
+    claims: dict = {"nonce": nonce}
+    if account_id is not None:
+        claims["https://api.openai.com/auth"] = {
+            "chatgpt_account_id": account_id,
+        }
+    if email is not None:
+        claims["https://api.openai.com/profile"] = {"email": email}
+    payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).rstrip(b"=").decode()
+    return f"e30.{payload}.signature"
+
+
+def test_codex_account_identity_groups_rotated_tokens_without_storing_pii():
+    first = codex_account_identity(
+        _jwt(account_id="acct-123", email="one@example.com", nonce="first")
+    )
+    rotated = codex_account_identity(
+        _jwt(account_id="acct-123", email="one@example.com", nonce="rotated")
+    )
+
+    assert first is not None
+    assert rotated is not None
+    assert first.account_key == rotated.account_key
+    assert first.email == "one@example.com"
+    assert first.account_key.startswith("openai-codex:")
+    assert "acct-123" not in first.account_key
+    assert "one@example.com" not in first.account_key
+
+
+def test_codex_account_identity_distinguishes_accounts_and_rejects_malformed_tokens():
+    first = codex_account_identity(_jwt(account_id="acct-123"))
+    second = codex_account_identity(_jwt(account_id="acct-456"))
+
+    assert first is not None
+    assert second is not None
+    assert first.account_key != second.account_key
+    assert codex_account_identity("not-a-jwt") is None
+    assert codex_account_identity(_jwt(email="missing-account@example.com")) is None
+    assert codex_account_identity(_jwt(account_id="   ")) is None
+
+
+def test_account_key_for_agent_only_attributes_codex_oauth_accounts():
+    token = _jwt(account_id="acct-stable", email="person@example.com")
+    expected = codex_account_identity(token)
+
+    assert account_key_for_agent(
+        SimpleNamespace(provider="openai-codex", api_key=token)
+    ) == expected.account_key
+    assert account_key_for_agent(
+        SimpleNamespace(provider="openrouter", api_key=token)
+    ) is None
+    assert account_key_for_agent(
+        SimpleNamespace(provider="openai-codex", api_key=token),
+        request_client=SimpleNamespace(is_moa_client=True),
+    ) is None
+
+
+def test_account_usage_report_deduplicates_pool_slots_and_never_leaks_tokens():
+    first_token = _jwt(
+        account_id="acct-123", email="one@example.com", nonce="first"
+    )
+    rotated_token = _jwt(
+        account_id="acct-123", email="one@example.com", nonce="rotated"
+    )
+    identity = codex_account_identity(first_token)
+    assert identity is not None
+    entries = [
+        SimpleNamespace(
+            label="wrong-label@example.com",
+            access_token=first_token,
+            runtime_api_key=first_token,
+            runtime_base_url="https://chatgpt.com/backend-api/codex",
+        ),
+        SimpleNamespace(
+            label="openai-codex-oauth-2",
+            access_token=rotated_token,
+            runtime_api_key=rotated_token,
+            runtime_base_url="https://chatgpt.com/backend-api/codex",
+        ),
+    ]
+    local_rows = [{
+        "account_key": identity.account_key,
+        "billing_provider": "openai-codex",
+        "api_call_count": 2,
+        "input_tokens": 10,
+        "output_tokens": 5,
+        "cache_read_tokens": 20,
+        "cache_write_tokens": 0,
+        "reasoning_tokens": 2,
+        "total_tokens": 35,
+        "first_seen": 1.0,
+        "last_seen": 2.0,
+    }]
+    report = build_codex_account_usage_report(
+        entries=entries,
+        local_rows=local_rows,
+    )
+
+    assert len(report["accounts"]) == 1
+    account = report["accounts"][0]
+    assert account["email"] == "one@example.com"
+    assert account["pool_labels"] == [
+        "wrong-label@example.com",
+        "openai-codex-oauth-2",
+    ]
+    assert account["local_usage"]["total_tokens"] == 35
+    assert report["attribution_scope"]["supported"] == [
+        "codex_responses",
+        "codex_auxiliary_authoritative",
+    ]
+    assert "codex_app_server" in report["attribution_scope"]["omitted"]
+    output = format_codex_account_usage_report(report)
+    assert "app-server, MoA, and background-review calls are omitted" in output
+    assert "Local total tokens: 35" in output
+    rendered = repr(report)
+    assert first_token not in rendered
+    assert rotated_token not in rendered
+    assert "acct-123" not in rendered
+
+
+def test_codex_auxiliary_response_carries_anonymous_account_key(monkeypatch):
+    from agent.auxiliary_client import _CodexCompletionsAdapter
+
+    token = _jwt(account_id="acct-aux", email="aux@example.com")
+    expected = codex_account_identity(token)
+    assert expected is not None
+    real_client = SimpleNamespace(
+        api_key=token,
+        base_url="https://chatgpt.com/backend-api/codex",
+        responses=SimpleNamespace(create=lambda **_kwargs: iter(())),
+    )
+
+    monkeypatch.setattr(
+        "agent.codex_runtime._consume_codex_event_stream",
+        lambda _stream, *, model, on_event: SimpleNamespace(
+            output=[],
+            usage=SimpleNamespace(
+                input_tokens=30,
+                input_tokens_details=SimpleNamespace(cached_tokens=20),
+                output_tokens=5,
+                output_tokens_details=SimpleNamespace(reasoning_tokens=2),
+                total_tokens=35,
+            ),
+        ),
+    )
+
+    response = _CodexCompletionsAdapter(
+        real_client,
+        "gpt-5.6-sol",
+        account_provider="openai-codex",
+    ).create(
+        messages=[{"role": "user", "content": "summarize"}],
+    )
+
+    assert response._hermes_account_key == expected.account_key
+    assert response._hermes_billing_provider == "openai-codex"
+    assert response._hermes_billing_base_url == (
+        "https://chatgpt.com/backend-api/codex"
+    )
+    from agent.usage_pricing import normalize_usage
+
+    usage = normalize_usage(response.usage, provider="openai-codex")
+    assert usage.input_tokens == 10
+    assert usage.cache_read_tokens == 20
+    assert usage.output_tokens == 5
+    assert usage.reasoning_tokens == 2
+    assert usage.total_tokens == 35
+    assert token not in repr(response)
+
+
+def test_generic_codex_adapter_does_not_guess_account_provider(monkeypatch):
+    from agent.auxiliary_client import _CodexCompletionsAdapter
+
+    token = _jwt(account_id="acct-custom", email="custom@example.com")
+    real_client = SimpleNamespace(
+        api_key=token,
+        base_url="https://custom.example/v1",
+        responses=SimpleNamespace(create=lambda **_kwargs: iter(())),
+    )
+    monkeypatch.setattr(
+        "agent.codex_runtime._consume_codex_event_stream",
+        lambda _stream, *, model, on_event: SimpleNamespace(
+            output=[],
+            usage=SimpleNamespace(input_tokens=4, output_tokens=1, total_tokens=5),
+        ),
+    )
+
+    response = _CodexCompletionsAdapter(real_client, "custom-model").create(
+        messages=[{"role": "user", "content": "summarize"}],
+    )
+
+    assert response._hermes_account_key is None
+    assert response._hermes_billing_provider is None

--- a/tests/agent/test_background_review_usage.py
+++ b/tests/agent/test_background_review_usage.py
@@ -184,6 +184,30 @@ def test_spawn_reuses_provided_task_cfg_without_rereading():
         assert prompt  # built-in skill-review prompt selected
         assert callable(_target)
 
+
+def test_background_review_target_suppresses_account_attribution():
+    agent = type("A", (), {})()
+    observed = []
+
+    def fake_run(*_args, **_kwargs):
+        from agent.aux_accounting import _account_attribution_suppressed
+
+        observed.append(_account_attribution_suppressed.get())
+
+    with patch.object(background_review, "_run_review_in_thread", side_effect=fake_run):
+        target, _prompt = background_review.spawn_background_review_thread(
+            agent,
+            messages_snapshot=[{"role": "user", "content": "hi"}],
+            review_skills=True,
+            task_cfg={"enabled": True},
+        )
+        target()
+
+    from agent.aux_accounting import _account_attribution_suppressed
+
+    assert observed == [True]
+    assert _account_attribution_suppressed.get() is False
+
 def test_log_review_completion_emits_thread_tag(caplog):
     with caplog.at_level(logging.INFO, logger="agent.background_review"):
         background_review._log_review_completion(

--- a/tests/agent/test_codex_account_token_recording.py
+++ b/tests/agent/test_codex_account_token_recording.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import base64
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from agent.codex_runtime import _record_codex_app_server_usage
+from hermes_state import SessionDB
+
+
+def _jwt(account_id: str) -> str:
+    payload = json.dumps(
+        {"https://api.openai.com/auth": {"chatgpt_account_id": account_id}}
+    ).encode()
+    encoded = base64.urlsafe_b64encode(payload).decode().rstrip("=")
+    return f"header.{encoded}.signature"
+
+
+def test_codex_app_server_usage_does_not_infer_account_from_agent_token():
+    token = _jwt("acct-real")
+    db = MagicMock()
+    agent = SimpleNamespace(
+        api_key=token,
+        provider="openai-codex",
+        model="gpt-test",
+        base_url="https://chatgpt.com/backend-api/codex",
+        session_id="session-1",
+        _session_db=db,
+        _session_db_created=True,
+        context_compressor=None,
+        session_api_calls=0,
+        session_prompt_tokens=0,
+        session_completion_tokens=0,
+        session_total_tokens=0,
+        session_input_tokens=0,
+        session_output_tokens=0,
+        session_cache_read_tokens=0,
+        session_cache_write_tokens=0,
+        session_reasoning_tokens=0,
+        session_estimated_cost_usd=0.0,
+        session_cost_status=None,
+        session_cost_source=None,
+    )
+    turn = SimpleNamespace(
+        token_usage_last={
+            "inputTokens": 30,
+            "cachedInputTokens": 20,
+            "outputTokens": 5,
+            "reasoningOutputTokens": 2,
+            "totalTokens": 35,
+        },
+        model_context_window=200_000,
+    )
+    cost = SimpleNamespace(amount_usd=None, status="included", source="subscription")
+
+    with patch("agent.usage_pricing.estimate_usage_cost", return_value=cost):
+        _record_codex_app_server_usage(agent, turn)
+
+    kwargs = db.queue_token_counts.call_args.kwargs
+    assert "account_key" not in kwargs
+    assert token not in repr(kwargs)
+    assert "acct-real" not in repr(kwargs)
+
+
+def test_codex_app_server_usage_remains_unattributed_without_authoritative_identity(
+    tmp_path,
+):
+    token = _jwt("acct-real")
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("session-1", "feishu", model="gpt-test")
+        agent = SimpleNamespace(
+            api_key=token,
+            provider="openai-codex",
+            model="gpt-test",
+            base_url="https://chatgpt.com/backend-api/codex",
+            session_id="session-1",
+            _session_db=db,
+            _session_db_created=True,
+            context_compressor=None,
+            session_api_calls=0,
+            session_prompt_tokens=0,
+            session_completion_tokens=0,
+            session_total_tokens=0,
+            session_input_tokens=0,
+            session_output_tokens=0,
+            session_cache_read_tokens=0,
+            session_cache_write_tokens=0,
+            session_reasoning_tokens=0,
+            session_estimated_cost_usd=0.0,
+            session_cost_status=None,
+            session_cost_source=None,
+        )
+        turn = SimpleNamespace(
+            token_usage_last={
+                "inputTokens": 30,
+                "cachedInputTokens": 20,
+                "outputTokens": 5,
+                "reasoningOutputTokens": 2,
+                "totalTokens": 35,
+            },
+            model_context_window=200_000,
+        )
+        cost = SimpleNamespace(
+            amount_usd=None, status="included", source="subscription"
+        )
+
+        with patch("agent.usage_pricing.estimate_usage_cost", return_value=cost):
+            _record_codex_app_server_usage(agent, turn)
+
+        assert db.account_usage_totals(provider="openai-codex") == []
+    finally:
+        db.close()

--- a/tests/agent/test_codex_cloudflare_headers.py
+++ b/tests/agent/test_codex_cloudflare_headers.py
@@ -57,6 +57,13 @@ def _make_codex_jwt(account_id: str = "acct-test-123") -> str:
 
 class TestCodexCloudflareHeaders:
 
+    def test_public_account_id_extractor_matches_required_header(self):
+        from agent.codex_headers import extract_chatgpt_account_id
+
+        token = _make_codex_jwt("acct-shared-helper")
+        assert extract_chatgpt_account_id(token) == "acct-shared-helper"
+        assert extract_chatgpt_account_id("not-a-jwt") is None
+
     def test_user_agent_advertises_hermes_version(self):
         from agent.auxiliary_client import _codex_cloudflare_headers
         headers = _codex_cloudflare_headers(_make_codex_jwt())

--- a/tests/hermes_cli/test_auth_account_usage_command.py
+++ b/tests/hermes_cli/test_auth_account_usage_command.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import argparse
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_cli.auth_commands import auth_command
+from hermes_cli.subcommands.auth import build_auth_parser
+
+
+def test_auth_token_usage_parser_exposes_provider_and_json_flag():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    handler = MagicMock()
+    build_auth_parser(subparsers, cmd_auth=handler)
+
+    args = parser.parse_args(["auth", "token-usage", "openai-codex", "--json"])
+
+    assert args.auth_action == "token-usage"
+    assert args.provider == "openai-codex"
+    assert args.json is True
+    assert args.func is handler
+
+
+def test_auth_token_usage_command_routes_to_read_only_usage_handler():
+    args = argparse.Namespace(
+        auth_action="token-usage", provider="openai-codex", json=False
+    )
+    with patch("hermes_cli.auth_commands.auth_token_usage_command") as handler:
+        auth_command(args)
+    handler.assert_called_once_with(args)
+
+
+def test_auth_token_usage_rejects_unsupported_provider():
+    from hermes_cli.auth_commands import auth_token_usage_command
+
+    args = argparse.Namespace(provider="anthropic", json=False)
+    with pytest.raises(SystemExit, match="supports only openai-codex"):
+        auth_token_usage_command(args)

--- a/tests/hermes_state/test_aux_usage_accounting.py
+++ b/tests/hermes_state/test_aux_usage_accounting.py
@@ -96,6 +96,32 @@ class TestRecordAuxiliaryUsage:
         tasks = sorted(r["task"] for r in rows)
         assert tasks == ["", "title_generation"]
 
+    def test_records_auxiliary_usage_against_provider_account(self, db):
+        db.create_session("s1", source="cli")
+        db.record_auxiliary_usage(
+            "s1",
+            "compression",
+            model="gpt-5.6-sol",
+            billing_provider="openai-codex",
+            account_key="openai-codex:test-account",
+            input_tokens=80,
+            output_tokens=20,
+            cache_read_tokens=300,
+            reasoning_tokens=5,
+            api_call_count=2,
+        )
+
+        totals = db.account_usage_totals(
+            provider="openai-codex",
+            account_key="openai-codex:test-account",
+        )
+        assert len(totals) == 1
+        assert totals[0]["api_call_count"] == 2
+        assert totals[0]["input_tokens"] == 80
+        assert totals[0]["cache_read_tokens"] == 300
+        assert totals[0]["output_tokens"] == 20
+        assert totals[0]["total_tokens"] == 400
+
 
 
 
@@ -188,6 +214,80 @@ class TestAmbientAccountingContext:
         assert rows[0]["model"] == "aux-m"
         assert rows[0]["input_tokens"] == 100
         assert rows[0]["output_tokens"] == 20
+
+    def test_record_aux_usage_prefers_authoritative_response_account_route(self, db):
+        from agent.aux_accounting import (
+            record_aux_usage,
+            reset_accounting_context,
+            set_accounting_context,
+        )
+
+        db.create_session("s1", source="cli")
+        response = _mk_response(model="gpt-5.6-sol", prompt=100, completion=20)
+        response.usage.prompt_tokens_details = SimpleNamespace(cached_tokens=80)
+        response.usage.completion_tokens_details = SimpleNamespace(
+            reasoning_tokens=5
+        )
+        response._hermes_account_key = "openai-codex:test-account"
+        response._hermes_billing_provider = "openai-codex"
+        response._hermes_billing_base_url = "https://chatgpt.com/backend-api/codex"
+        token = set_accounting_context(db, "s1")
+        try:
+            record_aux_usage(
+                response,
+                "compression",
+                # Simulate a fallback whose caller still has the original route.
+                provider="gemini",
+                base_url="https://generativelanguage.googleapis.com/v1beta",
+            )
+        finally:
+            reset_accounting_context(token)
+
+        totals = db.account_usage_totals(
+            provider="openai-codex",
+            account_key="openai-codex:test-account",
+        )
+        assert len(totals) == 1
+        assert totals[0]["total_tokens"] == 120
+        assert totals[0]["input_tokens"] == 20
+        assert totals[0]["cache_read_tokens"] == 80
+        assert totals[0]["output_tokens"] == 20
+        assert totals[0]["reasoning_tokens"] == 5
+        assert db.account_usage_totals(provider="gemini") == []
+
+    def test_account_attribution_suppression_keeps_model_usage(self, db):
+        from agent.aux_accounting import (
+            record_aux_usage,
+            reset_account_attribution_suppressed,
+            reset_accounting_context,
+            set_account_attribution_suppressed,
+            set_accounting_context,
+        )
+
+        db.create_session("s1", source="cli")
+        response = _mk_response(model="gpt-5.6-sol", prompt=100, completion=20)
+        response.usage.prompt_tokens_details = SimpleNamespace(cached_tokens=80)
+        response.usage.completion_tokens_details = SimpleNamespace(
+            reasoning_tokens=5
+        )
+        response._hermes_account_key = "openai-codex:test-account"
+        response._hermes_billing_provider = "openai-codex"
+        response._hermes_billing_base_url = "https://chatgpt.com/backend-api/codex"
+        accounting_token = set_accounting_context(db, "s1")
+        suppression_token = set_account_attribution_suppressed()
+        try:
+            record_aux_usage(response, "compression", provider="openai-codex")
+        finally:
+            reset_account_attribution_suppressed(suppression_token)
+            reset_accounting_context(accounting_token)
+
+        rows = _usage_rows(db, "s1")
+        assert len(rows) == 1
+        assert rows[0]["input_tokens"] == 20
+        assert rows[0]["cache_read_tokens"] == 80
+        assert rows[0]["output_tokens"] == 20
+        assert rows[0]["reasoning_tokens"] == 5
+        assert db.account_usage_totals(provider="openai-codex") == []
 
 
     def test_moa_tasks_excluded(self, db):

--- a/tests/run_agent/test_token_persistence_non_cli.py
+++ b/tests/run_agent/test_token_persistence_non_cli.py
@@ -1,5 +1,6 @@
 from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, patch
+import base64
 import json
 import sys
 
@@ -54,6 +55,28 @@ def test_run_conversation_persists_tokens_for_telegram_sessions():
     # (queue_token_counts) rather than written inline on the turn thread.
     session_db.queue_token_counts.assert_called_once()
     assert session_db.queue_token_counts.call_args.args[0] == "telegram-session"
+
+
+def test_run_conversation_attributes_codex_tokens_to_account():
+    payload = base64.urlsafe_b64encode(json.dumps({
+        "https://api.openai.com/auth": {"chatgpt_account_id": "acct-real"}
+    }).encode()).decode().rstrip("=")
+    token = f"header.{payload}.signature"
+    session_db = MagicMock()
+    agent = _make_agent(session_db, platform="telegram")
+    agent.provider = "openai-codex"
+    agent.api_key = token
+
+    result = agent.run_conversation("hello")
+
+    assert result["final_response"] == "done"
+    kwargs = session_db.queue_token_counts.call_args.kwargs
+    from agent.account_token_usage import codex_account_identity
+    identity = codex_account_identity(token)
+    assert identity is not None
+    assert kwargs["account_key"] == identity.account_key
+    assert token not in repr(kwargs)
+
 
 
 

--- a/tests/state/test_session_account_usage.py
+++ b/tests/state/test_session_account_usage.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import sqlite3
+
+from hermes_state import SessionDB
+from hermes_state_common import SCHEMA_VERSION
+
+
+def test_existing_v27_store_adds_account_usage_table_without_touching_sessions(tmp_path):
+    path = tmp_path / "state.db"
+    db = SessionDB(db_path=path)
+    db.create_session("existing", "feishu", model="gpt-old")
+    db.close()
+
+    conn = sqlite3.connect(path)
+    conn.execute("DROP TABLE session_account_usage")
+    conn.execute("UPDATE schema_version SET version = 27")
+    conn.commit()
+    conn.close()
+
+    reopened = SessionDB(db_path=path)
+    try:
+        assert reopened._conn.execute(
+            "SELECT version FROM schema_version"
+        ).fetchone()[0] == SCHEMA_VERSION == 28
+        assert reopened._conn.execute(
+            "SELECT COUNT(*) FROM sqlite_master "
+            "WHERE type='table' AND name='session_account_usage'"
+        ).fetchone()[0] == 1
+        assert reopened.get_session("existing")["model"] == "gpt-old"
+    finally:
+        reopened.close()
+
+    # Declarative table creation and the version bump must be idempotent.
+    reopened_again = SessionDB(db_path=path)
+    try:
+        conn_again = reopened_again._conn
+        assert conn_again is not None
+        assert conn_again.execute(
+            "SELECT version FROM schema_version"
+        ).fetchone()[0] == SCHEMA_VERSION == 28
+        assert conn_again.execute(
+            "SELECT COUNT(*) FROM sqlite_master "
+            "WHERE type='table' AND name='session_account_usage'"
+        ).fetchone()[0] == 1
+        existing = reopened_again.get_session("existing")
+        assert existing is not None
+        assert existing["model"] == "gpt-old"
+    finally:
+        reopened_again.close()
+
+
+def test_account_usage_totals_group_duplicate_credentials_by_stable_account_key(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("s1", "feishu", model="gpt-test")
+        db.update_token_counts(
+            "s1",
+            model="gpt-test",
+            billing_provider="openai-codex",
+            account_key="openai-codex:acct-a",
+            input_tokens=10,
+            cache_read_tokens=20,
+            output_tokens=5,
+            reasoning_tokens=2,
+            api_call_count=1,
+        )
+        db.update_token_counts(
+            "s1",
+            model="gpt-test-2",
+            billing_provider="openai-codex",
+            account_key="openai-codex:acct-a",
+            input_tokens=7,
+            cache_write_tokens=3,
+            output_tokens=4,
+            reasoning_tokens=1,
+            api_call_count=1,
+        )
+
+        rows = db.account_usage_totals(provider="openai-codex")
+
+        assert len(rows) == 1
+        assert rows[0]["account_key"] == "openai-codex:acct-a"
+        assert rows[0]["api_call_count"] == 2
+        assert rows[0]["input_tokens"] == 17
+        assert rows[0]["cache_read_tokens"] == 20
+        assert rows[0]["cache_write_tokens"] == 3
+        assert rows[0]["output_tokens"] == 9
+        assert rows[0]["reasoning_tokens"] == 3
+        assert rows[0]["total_tokens"] == 49
+    finally:
+        db.close()
+
+
+def test_account_usage_is_forward_only_when_no_account_key_is_supplied(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("s1", "feishu", model="gpt-test")
+        db.update_token_counts(
+            "s1",
+            model="gpt-test",
+            billing_provider="openai-codex",
+            input_tokens=10,
+            output_tokens=5,
+            api_call_count=1,
+        )
+
+        assert db.account_usage_totals(provider="openai-codex") == []
+    finally:
+        db.close()
+
+
+def test_deleting_session_removes_its_account_usage(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("s1", "feishu", model="gpt-test")
+        db.update_token_counts(
+            "s1",
+            model="gpt-test",
+            billing_provider="openai-codex",
+            account_key="openai-codex:acct-a",
+            input_tokens=10,
+            output_tokens=5,
+            api_call_count=1,
+        )
+        assert db.account_usage_totals(provider="openai-codex")
+
+        assert db.delete_session("s1")
+
+        assert db.account_usage_totals(provider="openai-codex") == []
+    finally:
+        db.close()
+
+
+def test_async_account_usage_queue_never_coalesces_different_accounts(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("s1", "feishu", model="gpt-test")
+        common = {
+            "model": "gpt-test",
+            "billing_provider": "openai-codex",
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "api_call_count": 1,
+        }
+        db.queue_token_counts(
+            "s1", account_key="openai-codex:acct-a", **common
+        )
+        db.queue_token_counts(
+            "s1", account_key="openai-codex:acct-b", **common
+        )
+        assert db.flush_token_counts(timeout=5.0)
+
+        rows = db.account_usage_totals(provider="openai-codex")
+
+        assert {row["account_key"] for row in rows} == {
+            "openai-codex:acct-a",
+            "openai-codex:acct-b",
+        }
+        assert sum(row["api_call_count"] for row in rows) == 2
+    finally:
+        db.close()

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -91,6 +91,17 @@ Don't have a subscription yet? Get one at [portal.nousresearch.com/manage-subscr
 The OpenAI Codex provider authenticates via device code (open a URL, enter a code). Hermes stores the resulting credentials in its own auth store under `~/.hermes/auth.json` and can import existing Codex CLI credentials from `~/.codex/auth.json` when present. No Codex CLI installation is required.
 
 If a token refresh fails with a terminal error (HTTP 4xx, `invalid_grant`, revoked grant, etc.), Hermes marks the refresh token as dead and stops replaying it so you don't see a flood of identical auth failures. The next request surfaces a typed re-auth message instead. Run `hermes auth add openai-codex` (or `hermes model` → **ChatGPT or Codex Subscription**) to start a fresh device-code login; the quarantine clears on the next successful exchange.
+
+To inspect forward-only Hermes token usage attributed to each signed-in Codex account, run:
+
+```bash
+hermes auth token-usage openai-codex
+hermes auth token-usage openai-codex --json
+```
+
+Accounting starts when this feature is installed; it cannot reconstruct earlier usage, and pruning a session also removes that session's account-usage rows. Duplicate credential slots for the same ChatGPT account are grouped by the account ID in the OAuth token. The account-usage table persists only a one-way hash of that ID; email is decoded transiently from current pool credentials for display, while OAuth credentials remain stored separately in `~/.hermes/auth.json`. Provider quota remains separate because ChatGPT subscription limits are not a token-to-percentage conversion.
+
+Account attribution is deliberately fail-closed. Hermes currently attributes the standard Codex Responses path and Codex auxiliary-adapter responses whose serving credential is known. Codex app-server turns, MoA usage, and background-review calls remain in session/model totals but are omitted from per-account totals until those paths expose an authoritative per-request account identity.
 :::
 
 :::warning


### PR DESCRIPTION
## What does this PR do?

Adds forward-only, per-account token accounting for pooled OpenAI Codex credentials.

Hermes already records session/model usage and can inspect provider rate-limit windows, but it cannot answer which real Codex account served a request after credential rotation. This PR attributes supported successful Codex calls to a stable anonymous account key and exposes the retained local totals through:

```bash
hermes auth token-usage openai-codex
hermes auth token-usage openai-codex --json
```

The command is deliberately named `token-usage` rather than `usage`: #81819 already proposes `hermes auth usage` for live provider quota. This PR records local Hermes token consumption; it does not estimate or duplicate provider quota.

### Supported attribution scope

Account attribution is deliberately fail-closed.

Attributed today:

- the standard Codex Responses main-conversation path;
- Codex auxiliary-adapter responses when the adapter exposes the credential and route that actually served the request, including fallback from another initially selected provider.

Still included in existing session/model totals but omitted from per-account totals:

- Codex app-server turns, because the subprocess credential may differ from the parent agent token;
- MoA legs, because aggregate usage does not carry authoritative identity per leg;
- background-review calls, because a review can rotate credentials across calls and inherited auxiliary contexts must not guess.

This avoids silently filing tokens against the wrong account. Those paths can be added later once they expose authoritative per-request identity.

### Privacy and accounting contract

- The account-usage table persists `sha256("openai-codex\0" + chatgpt_account_id)`, never the OAuth token, raw account ID, or email; OAuth credentials remain in Hermes' existing auth store.
- Resolves display labels from the current credential pool only when the report is queried.
- Groups rotated/duplicate credential slots only by the stable `chatgpt_account_id` claim, not by editable labels or token hashes.
- Malformed tokens and credentials without a stable account ID remain unattributed instead of being guessed.
- Starts forward-only. Historical calls cannot be reconstructed.
- Account rows follow session retention and are deleted when their session is pruned.
- Uses disjoint input/cache/output buckets. `reasoning_tokens` remains informational because it is a subset of output and is not added twice.

## Related work

Complementary to #81819 (live CLI quota), #83014 (desktop quota and provider/model analytics), #70466 (gateway exposure of a live quota snapshot), #85378 (correct account headers for quota fetches), and #55805 (per-message accounting). None of those persist forward-only local token totals by the actual Codex account serving each supported request.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/account_token_usage.py`: secret-safe Codex identity, duplicate-slot grouping, and report formatting.
- `agent/codex_headers.py`: shared public `chatgpt_account_id` extractor used by request headers and accounting.
- `agent/conversation_loop.py`: attributes supported main Codex Responses calls to the credential active for that successful response.
- `agent/auxiliary_client.py` / `agent/aux_accounting.py`: propagate authoritative account and route metadata for supported Codex auxiliary responses, including provider fallback.
- `hermes_state_common.py` / `hermes_state.py`: schema v28 `session_account_usage`, updated transactionally beside existing usage rows; async queue routing includes `account_key` so rotated accounts never coalesce.
- `hermes auth token-usage openai-codex [--json]`: read-only local report.
- Provider documentation plus focused migration, identity, cache-semantics, queue, CLI, auxiliary, and fail-closed exclusion tests.

## How to Test

1. Install the locked dev/test environment:
   ```bash
   uv sync --locked --extra all --extra dev --extra anthropic --extra mistral --extra fal --extra modal --extra daytona --extra hindsight --extra parallel-web
   ```
2. Run the repository's canonical isolated test runner:
   ```bash
   scripts/run_tests.sh -j 8
   ```
3. Run focused accounting regressions if iterating on this feature:
   ```bash
   pytest -q tests/agent/test_account_token_usage.py tests/agent/test_codex_account_token_recording.py tests/hermes_state/test_aux_usage_accounting.py tests/state/test_session_account_usage.py tests/hermes_cli/test_auth_account_usage_command.py
   ```
4. With two pooled Codex credentials, run a supported request on each account and verify `hermes auth token-usage openai-codex` increments only the account that served the request.
5. Rotate a token for the same ChatGPT account and verify the totals remain grouped.

## Verification

- Focused and adjacent regression suites: **370 passed**.
- Fresh temporary `HERMES_HOME` CLI JSON E2E: passed.
- Ruff, compileall, targeted type checks, `git diff --check`, and private-path/credential scan: passed.
- Canonical full-suite runner reached **10,926 passed / 0 failed** before it was stopped to rebase onto an advancing `main`; GitHub CI is authoritative for the rebased commit.


## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched open and closed PRs/issues and documented related non-duplicate work above
- [x] My PR contains only changes related to this feature
- [ ] The canonical full-suite runner passes
- [x] I've added tests for my changes
- [x] I've tested on Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation and docstrings
- [x] `cli-config.yaml.example` is N/A: no config key was added
- [x] `CONTRIBUTING.md` / `AGENTS.md` is N/A: no project workflow changed
- [x] I've considered cross-platform impact: stdlib JWT parsing and SQLite schema paths are platform-neutral; platform-specific CI remains authoritative
- [x] Tool descriptions/schemas are N/A: no model tool changed

## Example output

```text
OpenAI Codex account usage (forward-only local accounting)
Tracking since: 2026-09-02T10:00:00+00:00

user@example.com
  Local API calls: 3
  Local total tokens: 12,345
  Token detail: input 1,000, cache-read 10,000, cache-write 0, output 1,345, reasoning 400
```
