### PR TITLE
fix(desktop): preserve login PATH for SSH backends

### DIFF
--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -32,6 +32,7 @@ import {
   READY_RE,
   remotePidAlive,
   remoteSupportsSshOwnership,
+  resolveRemoteLoginPath,
   scrapeReadyPort,
   spawnLogPath,
   spawnRemoteDashboard,
@@ -372,6 +373,41 @@ test('locateHermes uses a login shell for the command -v probe', async () => {
     ssh.calls.some(c => /bash -lc/.test(c)),
     'must probe in a login shell (PATH pitfall)'
   )
+})
+
+test.skipIf(process.platform === 'win32')(
+  'resolveRemoteLoginPath executes the configured login shell and extracts its PATH',
+  async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), 'hermes-login-path-'))
+    const loginShell = path.join(directory, 'login-shell')
+
+    try {
+      await writeFile(
+        loginShell,
+        '#!/bin/sh\nprintf "profile banner\\n"\n[ "$1" = "-lc" ] || exit 64\nPATH=/custom/bin:/usr/bin\nexport PATH\nexec /bin/sh -c "$2"\n',
+        { mode: 0o700 }
+      )
+
+      const ssh = {
+        async exec(command) {
+          const { stdout } = await exec(command, {
+            env: { HOME: directory, PATH: '/usr/bin:/bin', SHELL: loginShell },
+            shell: '/bin/sh'
+          })
+
+          return stdout
+        }
+      }
+
+      assert.equal(await resolveRemoteLoginPath(ssh), '/custom/bin:/usr/bin')
+    } finally {
+      await rm(directory, { force: true, recursive: true })
+    }
+  }
+)
+
+test('resolveRemoteLoginPath preserves compatibility when no usable marked PATH is returned', async () => {
+  assert.equal(await resolveRemoteLoginPath(fakeSsh([[/HERMES_DESKTOP_LOGIN_PATH/, 'profile banner only\n']])), '')
 })
 
 test('probeRemotePlatform accepts Linux and macOS', async () => {
@@ -989,6 +1025,7 @@ test('connect() spawns fresh when there is no lockfile, adopts the served token'
     [/uname/, 'Linux\nx86_64'],
     [/\[ -x/, 'OK'],
     [/cat .*lock\.json/, ''], // no lockfile
+    [/HERMES_DESKTOP_LOGIN_PATH/, '__HERMES_DESKTOP_LOGIN_PATH__:/home/alice/.local/bin:/usr/local/bin:/usr/bin\n'],
     [/grep -q ssh-session-token-file/, 'YES\n'],
     [/python3 -c/, ''], // token file write
     [/printf '%s\\n'/, ''],
@@ -1005,6 +1042,12 @@ test('connect() spawns fresh when there is no lockfile, adopts the served token'
   assert.equal(result.token, 'the-served-token')
   assert.equal(result.baseUrl, 'http://127.0.0.1:50001')
   assert.equal(result.tokenFingerprint, fingerprintToken('the-served-token'))
+  const spawnCommand = ssh.calls.find(command => /setsid|nohup/.test(command)) || ''
+  const loginPath = '/home/alice/.local/bin:/usr/local/bin:/usr/bin'
+
+  assert.match(spawnCommand, /exec env HERMES_DESKTOP=1 PATH=/)
+  assert.ok(spawnCommand.includes(loginPath))
+  assert.ok(spawnCommand.indexOf(loginPath) < spawnCommand.indexOf('serve --isolated'))
 })
 
 test('managed SSH maps a local scope to a different non-default remote profile', async () => {
@@ -1465,6 +1508,17 @@ test('buildSpawnCommand raises the SSH child file limit before execing Hermes', 
   const cmd = buildSpawnCommand('/x/hermes', '', { logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE) })
   assert.match(cmd, /ulimit -n 65536 2>\/dev\/null \|\| true; exec env HERMES_DESKTOP=1/)
   assert.ok(cmd.indexOf('ulimit -n 65536') < cmd.indexOf('serve --isolated'))
+})
+
+test('buildSpawnCommand rejects control characters in the resolved remote login PATH', () => {
+  assert.throws(
+    () =>
+      buildSpawnCommand('/x/hermes', '', {
+        logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE),
+        remoteLoginPath: '/usr/bin\nmalicious=value'
+      }),
+    /Unsafe remote login PATH/
+  )
 })
 
 test('buildSpawnCommand payload variables keep $HOME expandable (no double quoting)', () => {

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -40,6 +40,7 @@ const REMOTE_LOCK_DIR = '~/.hermes/desktop-ssh'
 const SUPPORTED_REMOTE_OS = new Set(['Linux', 'Darwin'])
 const DEFAULT_READY_TIMEOUT_MS = 45_000
 const READY_POLL_INTERVAL_MS = 750
+const REMOTE_LOGIN_PATH_MARKER = '__HERMES_DESKTOP_LOGIN_PATH__:'
 // macOS sshd starts non-interactive shells with a 256-FD soft limit even when
 // the hard limit is unlimited. A Desktop backend can legitimately exceed that
 // while serving several profiles/tools, so raise only the child process limit.
@@ -161,6 +162,49 @@ function expandRemotePath(p) {
   }
 
   return shq(p)
+}
+
+// A command executed directly over SSH inherits sshd's minimal, non-login
+// PATH. Resolve the user's configured login-shell PATH before detaching the
+// backend so tools installed by nvm, pyenv, asdf, Cargo, Homebrew, or the
+// per-user Hermes/Codex installers remain discoverable by child processes.
+//
+// Startup files may print banners, so frame the value with a private marker
+// and take the final marked line. If the configured shell is unavailable or
+// exits unsuccessfully, preserve the non-login PATH as the compatibility rung.
+async function resolveRemoteLoginPath(ssh) {
+  const emitPath = `printf '\\n${REMOTE_LOGIN_PATH_MARKER}%s\\n' "$PATH"`
+
+  const command =
+    `remote_shell=\${SHELL:-/bin/sh}; ` +
+    `if test -x "$remote_shell" && "$remote_shell" -lc ${shq(emitPath)}; then exit 0; fi; ` +
+    emitPath
+
+  let output
+
+  try {
+    output = String(await ssh.exec(command))
+  } catch (cause) {
+    const error: any = new Error('Could not resolve the remote login-shell PATH.')
+
+    error.kind = 'transient-transport-error'
+    error.cause = cause
+    throw error
+  }
+
+  const markedLine = output
+    .split(/\r?\n/)
+    .filter(line => line.startsWith(REMOTE_LOGIN_PATH_MARKER))
+    .at(-1)
+
+  const remoteLoginPath = markedLine?.slice(REMOTE_LOGIN_PATH_MARKER.length) || ''
+
+  // eslint-disable-next-line no-control-regex -- reject unsafe PATH data before shell interpolation
+  if (!remoteLoginPath || /[\x00\n\r]/.test(remoteLoginPath)) {
+    return ''
+  }
+
+  return remoteLoginPath
 }
 
 // Resolve the remote hermes executable. An EXPLICIT path is honored strictly
@@ -1044,6 +1088,14 @@ function buildSpawnCommand(hermesPath, profile, opts: any = {}) {
   const ownerArg = opts.spawnNonce ? ` --ssh-owner-nonce ${validateSpawnNonce(opts.spawnNonce)}` : ''
   const subCmd = `serve --isolated --host 127.0.0.1 --port 0${tokenArg}${ownerArg}`
   const marker = expandRemotePath(`${remoteInstallRoot(opts.hermesHome || '~/.hermes')}/.hermes-update-in-progress`)
+  const remoteLoginPath = String(opts.remoteLoginPath || '')
+
+  // eslint-disable-next-line no-control-regex -- reject unsafe PATH data before shell interpolation
+  if (/[\x00\n\r]/.test(remoteLoginPath)) {
+    throw new Error('Unsafe remote login PATH: contains NUL or newline.')
+  }
+
+  const pathEnv = remoteLoginPath ? ` PATH=${shq(remoteLoginPath)}` : ''
 
   const updateMutex = expandRemotePath(
     `${remoteInstallRoot(opts.hermesHome || '~/.hermes')}/.hermes-update-in-progress.mutex`
@@ -1062,7 +1114,7 @@ function buildSpawnCommand(hermesPath, profile, opts: any = {}) {
 
   const dashCmd =
     `ulimit -n ${REMOTE_NOFILE_SOFT_LIMIT} 2>/dev/null || true; ` +
-    `exec env HERMES_DESKTOP=1 ${hermes} ${profileArgs}${subCmd}`
+    `exec env HERMES_DESKTOP=1${pathEnv} ${hermes} ${profileArgs}${subCmd}`
 
   const detachedShell = `eval "exec $1>&-"; ${dashCmd} </dev/null >> ${logPath} 2>&1 & echo $!`
   const detachedSpawn = `child=$("$(command -v setsid || echo nohup)" sh -c ${shq(detachedShell)} hermes-update-child "$1" & echo $!)`
@@ -1168,7 +1220,15 @@ async function scrapeReadyPort(ssh, logPath, { timeoutMs = DEFAULT_READY_TIMEOUT
 
 async function spawnRemoteDashboard(
   ssh,
-  { hermesPath, profile, token, ownershipId, hermesHome = '~/.hermes', assertInstallClear = async () => {} }
+  {
+    hermesPath,
+    profile,
+    token,
+    ownershipId,
+    hermesHome = '~/.hermes',
+    remoteLoginPath = '',
+    assertInstallClear = async () => {}
+  }
 ) {
   if (!(await remoteSupportsSshOwnership(ssh, hermesPath))) {
     const err: any = new Error(
@@ -1238,6 +1298,7 @@ async function spawnRemoteDashboard(
         tokenFilePath,
         logPath,
         hermesHome,
+        remoteLoginPath,
         ownershipId,
         reservationNonce: spawnNonce,
         lockMetadata: {
@@ -1533,6 +1594,7 @@ async function connect(deps) {
   assertBootstrapNotSuperseded(signal)
   await assertRemoteInstallUpdateClear(ssh, hermesHome)
   const spawnToken = mintToken()
+  const remoteLoginPath = await resolveRemoteLoginPath(ssh)
 
   const spawned = await spawnRemoteDashboard(ssh, {
     hermesPath,
@@ -1540,6 +1602,7 @@ async function connect(deps) {
     token: spawnToken,
     ownershipId,
     hermesHome,
+    remoteLoginPath,
     assertInstallClear: () => assertRemoteInstallUpdateClear(ssh, hermesHome)
   })
 
@@ -1679,6 +1742,7 @@ export {
   remoteProcessCreationTime,
   remoteSupportsSshOwnership,
   removeLockfile,
+  resolveRemoteLoginPath,
   scrapeReadyPort,
   shq,
   spawnLogPath,


### PR DESCRIPTION
## Summary

Fresh SSH-isolated Desktop backends now inherit the remote user's login-shell `PATH` before Hermes is detached. Lazy child processes can therefore resolve user-installed executables such as Codex, nvm, pyenv, asdf, Cargo, and Homebrew tools.

- Resolve `PATH` through the configured remote login shell while tolerating profile banner output.
- Fall back to the original SSH environment when a usable marked value is unavailable.
- Validate and shell-quote the resolved value before adding it to the detached backend environment.
- Cover real login-shell execution and the complete `connect()` to detached-spawn propagation path.

## Verification

- `vitest run apps/desktop/electron/remote-lifecycle.test.ts` — 94 passed.
- `tsc -p apps/desktop/tsconfig.electron.json --noEmit` — passed.
- `eslint apps/desktop/electron/` — passed.
- `vitest run --project electron` — 2,006 passed, 6 skipped, and 1 pre-existing macOS failure in `managed-ssh-update.test.ts` (`127 !== 0`), reproduced unchanged on the clean installed upstream checkout.

## Review

Please focus on login-shell fallback behavior and quoting through the nested `sh`/`setsid`/`nohup` spawn command.
