### PR TITLE
fix(agent): ignore Ollama num_ctx override on remote endpoints

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -3078,11 +3078,28 @@ def init_agent(
     _ollama_num_ctx_override = None
     if isinstance(_model_cfg, dict):
         _ollama_num_ctx_override = _model_cfg.get("ollama_num_ctx")
+    _provider_name = str(getattr(agent, "provider", "") or "").strip().lower().replace("_", "-")
+    # An explicit endpoint is authoritative: an Ollama-named provider can
+    # still be pointed at a remote-compatible service. Only fall back to the
+    # provider name when no endpoint was resolved (the local provider defaults
+    # supply their own local route later).
+    _is_local_ollama_route = (
+        bool(agent.base_url) and is_local_endpoint(agent.base_url)
+    ) or (
+        not agent.base_url and _provider_name in {"ollama", "lmstudio", "lm-studio"}
+    )
     if _ollama_num_ctx_override is not None:
-        try:
-            agent._ollama_num_ctx = int(_ollama_num_ctx_override)
-        except (TypeError, ValueError):
-            _ra().logger.debug("Invalid ollama_num_ctx config value: %r", _ollama_num_ctx_override)
+        if _is_local_ollama_route:
+            try:
+                agent._ollama_num_ctx = int(_ollama_num_ctx_override)
+            except (TypeError, ValueError):
+                _ra().logger.debug("Invalid ollama_num_ctx config value: %r", _ollama_num_ctx_override)
+        else:
+            _ra().logger.info(
+                "Ignoring model.ollama_num_ctx=%r for non-local endpoint %s",
+                _ollama_num_ctx_override,
+                agent.base_url or f"provider={getattr(agent, 'provider', '')}",
+            )
     if agent._ollama_num_ctx is None and agent.base_url and is_local_endpoint(agent.base_url):
         try:
             # ``agent.api_key`` may be a callable (Entra token provider).
@@ -3128,7 +3145,8 @@ def init_agent(
     # init-order half.)
     _cc_window = getattr(agent.context_compressor, "context_length", 0) or 0
     if (
-        agent._ollama_num_ctx
+        _is_local_ollama_route
+        and agent._ollama_num_ctx
         and agent._ollama_num_ctx > 0
         and _cc_window
         and agent._ollama_num_ctx < _cc_window

--- a/tests/test_ollama_num_ctx.py
+++ b/tests/test_ollama_num_ctx.py
@@ -143,7 +143,7 @@ class TestCompressorClampsToNumCtx:
     must not leave the compressor targeting the probed model window while
     requests run at the smaller served num_ctx."""
 
-    def _build_agent(self, cfg, probed_ctx):
+    def _build_agent(self, cfg, probed_ctx, *, base_url="http://localhost:11434/v1", provider=None):
         import agent.context_compressor as cc_mod
         with (
             patch("run_agent.get_tool_definitions", return_value=[]),
@@ -160,14 +160,17 @@ class TestCompressorClampsToNumCtx:
             ),
         ):
             from run_agent import AIAgent
-            return AIAgent(
-                model="gemma3:27b",
-                api_key="ollama",
-                base_url="http://localhost:11434/v1",
-                quiet_mode=True,
-                skip_context_files=True,
-                skip_memory=True,
-            )
+            kwargs = {
+                "model": "gemma3:27b",
+                "api_key": "ollama",
+                "base_url": base_url,
+                "quiet_mode": True,
+                "skip_context_files": True,
+                "skip_memory": True,
+            }
+            if provider is not None:
+                kwargs["provider"] = provider
+            return AIAgent(**kwargs)
 
     def test_num_ctx_only_config_clamps_compressor_window(self):
         agent = self._build_agent(
@@ -179,6 +182,33 @@ class TestCompressorClampsToNumCtx:
         # compaction never fires (#57275 claim 3).
         assert agent.context_compressor.context_length == 65536
         assert agent.context_compressor.threshold_tokens < 65536
+
+    def test_num_ctx_only_config_is_ignored_for_remote_endpoint(self):
+        with patch("run_agent.logger") as mock_logger:
+            agent = self._build_agent(
+                {"agent": {}, "model": {"ollama_num_ctx": 65536}},
+                probed_ctx=1_000_000,
+                base_url="https://api.anthropic.com/v1",
+                provider="anthropic",
+            )
+
+        # Ollama's num_ctx is not meaningful for remote providers. In
+        # particular, it must not shrink the compressor's remote context.
+        assert agent._ollama_num_ctx is None
+        assert agent.context_compressor.context_length == 1_000_000
+        ignored_calls = [
+            call
+            for call in mock_logger.info.call_args_list
+            if call.args
+            and call.args[0]
+            == "Ignoring model.ollama_num_ctx=%r for non-local endpoint %s"
+        ]
+        assert len(ignored_calls) == 1
+        mock_logger.info.assert_any_call(
+            "Ignoring model.ollama_num_ctx=%r for non-local endpoint %s",
+            65536,
+            "https://api.anthropic.com/v1",
+        )
 
     def test_larger_num_ctx_does_not_inflate_compressor_window(self):
         agent = self._build_agent(


### PR DESCRIPTION
## Summary

`model.ollama_num_ctx` is an Ollama-only setting, but the init-order compressor recalibration applied it to every endpoint. A remote profile such as `claude-fable-5-1` configured with `https://api.anthropic.com` could therefore shrink a 1,000,000-token compressor to 65,536 tokens.

This change:

- accepts the override only for a local endpoint (or an Ollama/LM Studio provider when no endpoint is resolved);
- logs once at INFO when the override is ignored for a non-local endpoint; and
- keeps the compressor clamp itself explicitly local-route-gated.

Observed affected log line:

```text
Compressor window clamped to Ollama num_ctx: 1000000 -> 65536
```

The affected profile also repeatedly reported `context=65,536` while other remote profiles retained their larger windows.

## Test plan

- `python -m pytest tests/test_ollama_num_ctx.py tests/run_agent/test_plugin_context_engine_init.py -q -o addopts=` — 15 passed.
- `python -m py_compile agent/agent_init.py tests/test_ollama_num_ctx.py` — passed.
- `git diff --check` and Ruff — passed.
- Mutation proof: temporarily removing the local-route gates caused the new remote regression test to fail (`agent._ollama_num_ctx` became `65536` instead of `None`).

No live-install, profile config, gateway, credential, deploy, or merge changes were made.