### PR TITLE
fix: show rooted kanban sessions under projects

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -10717,6 +10717,27 @@ def _retag_legacy_worker_sessions(workspaces_root_path: str) -> None:
         _log.debug("kanban worker: legacy session retag skipped (%s)", exc)
 
 
+def _worker_session_title(
+    board: str, task_title: str, run_id: Optional[int]
+) -> str:
+    """Build a bounded, word-safe project-sidebar title for a worker run."""
+    import textwrap
+
+    run_suffix = f" · run {run_id}" if run_id is not None else ""
+    title_prefix = f"{board} · {task_title}"
+    # Keep this aligned with SessionDB.MAX_TITLE_LENGTH; the regression test
+    # binds the formatter to that public contract without creating a core-state
+    # import in the Kanban persistence module.
+    max_prefix = max(1, 100 - len(run_suffix))
+    if len(title_prefix) > max_prefix:
+        title_prefix = textwrap.shorten(
+            title_prefix,
+            width=max_prefix,
+            placeholder="…",
+        )
+    return title_prefix + run_suffix
+
+
 def _default_spawn(
     task: Task,
     workspace: str,
@@ -10774,13 +10795,9 @@ def _default_spawn(
         env["HERMES_TENANT"] = task.tenant
     env["HERMES_KANBAN_TASK"] = task.id
     env["HERMES_KANBAN_WORKSPACE"] = workspace
-    # Tag the worker's session so it lands in state.db as `kanban`, not as an
-    # untitled `cli` row. A worker is a dispatcher-owned run whose transcript is
-    # read on the board and in `hermes kanban log` — it is not a conversation
-    # the user started, so every session-browsing surface (desktop sidebar, TUI
-    # resume picker, session_search) filters it out by source. Without this the
-    # sidebar renders one row per attempt, labeled with the worker's own prompt
-    # ("work kanban task t_…").
+    # Keep dispatcher runs distinguishable from interactive sessions. Global
+    # Recents can still omit this source, while the project tree renders it from
+    # the persisted workspace metadata below.
     env["HERMES_SESSION_SOURCE"] = "kanban"
     # Pin TERMINAL_CWD to the task's workspace so the worker's file tools and
     # context-file loader anchor on the workspace, not whatever cwd the
@@ -10835,6 +10852,13 @@ def _default_spawn(
     # board slug still forces it to the right directory.
     resolved_board = _normalize_board_slug(board) or get_current_board()
     env["HERMES_KANBAN_BOARD"] = resolved_board
+    # The worker prompt is intentionally machine-shaped (the task id is the
+    # durable lookup key), so give its transcript a separate human-facing name.
+    # Keep the run suffix when truncating: it makes retries distinct without
+    # exposing the task's random id in the project sidebar.
+    env["HERMES_KANBAN_SESSION_TITLE"] = _worker_session_title(
+        resolved_board, task.title, task.current_run_id
+    )
     # HERMES_PROFILE is the author the kanban_comment tool defaults to.
     # `hermes -p <assignee>` activates the profile, but the env var is
     # what the tool reads — set it explicitly here so comments are

--- a/hermes_state_portability.py
+++ b/hermes_state_portability.py
@@ -43,7 +43,11 @@ class SessionPortabilityMixin:
             )
         return cls._session_compact_cols_sql
 
-    def distinct_session_cwds(self, include_archived: bool = False) -> List[Dict[str, Any]]:
+    def distinct_session_cwds(
+        self,
+        include_archived: bool = False,
+        exclude_sources: Optional[List[str]] = None,
+    ) -> List[Dict[str, Any]]:
         """Distinct non-empty session cwds with usage stats, for repo discovery.
 
         Aggregates across ALL session history (not a single page), so the desktop
@@ -52,13 +56,19 @@ class SessionPortabilityMixin:
         count: a worktree session is still a real workspace signal.
         """
         where = "cwd IS NOT NULL AND TRIM(cwd) != ''"
+        params: List[Any] = []
         if not include_archived:
             where += " AND archived = 0"
+        excluded = [str(source) for source in (exclude_sources or []) if str(source)]
+        if excluded:
+            where += f" AND source NOT IN ({','.join('?' for _ in excluded)})"
+            params.extend(excluded)
         with self._lock:
             rows = self._conn.execute(
                 "SELECT cwd AS cwd, COUNT(*) AS sessions, "
                 "MAX(COALESCE(ended_at, started_at, 0)) AS last_active "
-                f"FROM sessions WHERE {where} GROUP BY cwd"
+                f"FROM sessions WHERE {where} GROUP BY cwd",
+                params,
             ).fetchall()
         return [
             {

--- a/run_agent.py
+++ b/run_agent.py
@@ -69,16 +69,17 @@ from hermes_constants import get_hermes_home
 def _launch_cwd_for_session(source: str) -> Optional[str]:
     """Working directory to stamp on a new session row, or None.
 
-    Only local CLI sessions get a recorded cwd: the directory the process was
-    launched from is meaningful for ``hermes -c`` / ``--resume`` (relaunch
-    where you left off). Gateway/cron/remote-backend sessions have no stable
-    host cwd to restore, so they record nothing.
+    Local CLI and Kanban worker sessions get a recorded cwd. For the CLI this
+    restores where an interactive session left off; for Kanban it anchors the
+    worker transcript to the named project that owns its isolated worktree.
+    Gateway/cron/remote-backend sessions have no stable host cwd to restore, so
+    they record nothing.
 
     ``TERMINAL_ENV`` is set by the CLI's config bridge (``load_cli_config``);
     a non-"local" backend (docker/ssh/modal/...) means the host cwd is
     irrelevant to the agent's tools, so we skip it there too.
     """
-    if source != "cli":
+    if source not in ("cli", "kanban"):
         return None
     backend = (os.environ.get("TERMINAL_ENV") or "local").strip().lower()
     if backend and backend != "local":
@@ -755,6 +756,16 @@ class AIAgent:
                 cwd=_launch_cwd_for_session(source),
                 profile_name=_profile_for_session,
             )
+            if source == "kanban":
+                worker_title = str(
+                    os.environ.get("HERMES_KANBAN_SESSION_TITLE", "") or ""
+                ).strip()
+                if worker_title:
+                    self._session_db.set_auto_title(
+                        self.session_id,
+                        worker_title,
+                        source=self._session_db.TITLE_SOURCE_LLM,
+                    )
             self._session_db_created = True
         except Exception as e:
             # Transient failure (e.g. SQLite lock). Keep _session_db alive —

--- a/tests/hermes_cli/test_kanban_worker_session_source.py
+++ b/tests/hermes_cli/test_kanban_worker_session_source.py
@@ -1,8 +1,8 @@
-"""Kanban worker runs must not surface as user conversations.
+"""Kanban workers persist enough metadata for a readable project transcript.
 
-Workers spawn as `hermes chat -q "work kanban task <id>"`, which used to land in
-state.db as an untitled `cli` row — the desktop sidebar then rendered one entry
-per attempt, labeled with the worker's own prompt.
+Workers remain a distinct ``kanban`` source so global Recents can omit them,
+but their session rows carry the workspace and a deterministic title so the
+project tree can render every run alongside ordinary project conversations.
 """
 
 import os
@@ -53,6 +53,7 @@ def test_worker_spawn_tags_session_source_kanban(monkeypatch, tmp_path):
         claim_lock=None,
         claim_expires=None,
         tenant=None,
+        current_run_id=7,
     )
     workspace = str(tmp_path / "ws")
     os.makedirs(workspace, exist_ok=True)
@@ -60,6 +61,63 @@ def test_worker_spawn_tags_session_source_kanban(monkeypatch, tmp_path):
     kb._default_spawn(task, workspace)
 
     assert captured["env"]["HERMES_SESSION_SOURCE"] == "kanban"
+    assert captured["env"]["HERMES_KANBAN_SESSION_TITLE"] == (
+        "default · ship it · run 7"
+    )
+
+
+def test_worker_session_title_shortens_long_card_at_word_boundary():
+    """Long card names stay readable instead of being cut mid-word."""
+    from hermes_cli import kanban_db as kb
+
+    title = kb._worker_session_title(
+        "dunbar-dossier",
+        (
+            "DD-S2B Build Change Inbox candidate review with accept, "
+            "edit-and-accept, reject, and immutable evidence"
+        ),
+        13,
+    )
+
+    assert len(title) <= SessionDB.MAX_TITLE_LENGTH
+    assert title.endswith("… · run 13")
+    assert title.startswith("dunbar-dossier · DD-S2B Build Change Inbox")
+
+
+def test_worker_session_persists_workspace_and_readable_title(monkeypatch, tmp_path):
+    """The agent row keeps the worker's real cwd and dispatcher-provided title."""
+    from run_agent import AIAgent
+
+    workspace = tmp_path / "repo" / ".worktrees" / "slice-2a"
+    workspace.mkdir(parents=True)
+    monkeypatch.chdir(workspace)
+    monkeypatch.setenv("HERMES_SESSION_SOURCE", "kanban")
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(workspace))
+    monkeypatch.setenv(
+        "HERMES_KANBAN_SESSION_TITLE", "dunbar-dossier · DD-S2A foundation · run 11"
+    )
+
+    database = SessionDB(db_path=tmp_path / "worker-state.db")
+    try:
+        agent = AIAgent(
+            base_url="https://example.invalid/v1",
+            api_key="test",
+            model="test/model",
+            quiet_mode=True,
+            session_db=database,
+            session_id="worker-session",
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent._ensure_db_session()
+
+        row = database.get_session("worker-session")
+        assert row["source"] == "kanban"
+        assert row["cwd"] == str(workspace)
+        assert row["title"] == "dunbar-dossier · DD-S2A foundation · run 11"
+        assert row["title_source"] == SessionDB.TITLE_SOURCE_LLM
+    finally:
+        database.close()
 
 
 def test_kanban_rows_stay_out_of_the_session_list(db):

--- a/tests/tui_gateway/test_projects_rpc.py
+++ b/tests/tui_gateway/test_projects_rpc.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import json
 import os
 import subprocess
 import threading
@@ -686,13 +687,15 @@ def _create_project(home: Path, name: str, folder: Path, *, use: bool = False) -
         reset_hermes_home_override(token)
 
 
-def _create_session(home: Path, session_id: str, cwd: Path) -> None:
+def _create_session(
+    home: Path, session_id: str, cwd: Path, *, source: str = "cli"
+) -> None:
     """Seed one message-bearing session in ``home``'s state.db."""
     from hermes_state import SessionDB
 
     db = SessionDB(db_path=home / "state.db")
     try:
-        db.create_session(session_id, "cli", cwd=str(cwd))
+        db.create_session(session_id, source, cwd=str(cwd))
         db.append_message(session_id, "user", f"hello from {session_id}")
     finally:
         db.close()
@@ -770,6 +773,47 @@ def test_projects_reads_are_scoped_to_the_requested_profile(monkeypatch, tmp_pat
     lane = coder_sessions["project"]["repos"][0]["groups"][0]
     assert [s["id"] for s in lane["sessions"]] == ["coder-session"]
     assert [s["profile"] for s in lane["sessions"]] == ["coder"]
+
+
+def test_projects_tree_includes_kanban_worker_sessions(monkeypatch, tmp_path):
+    """A rooted Kanban run is visible inside its named project, not orphaned."""
+    home = _profile_dir(tmp_path, "launch")
+    repo = tmp_path / "repos" / "dunbar-dossier"
+    repo.mkdir(parents=True)
+    _bind_profiles(monkeypatch, tmp_path, {"default": home})
+    project = _create_project(home, "Dunbar Dossier", repo, use=True)
+    _create_session(home, "kanban-worker", repo, source="kanban")
+
+    with _serving_launch_profile(home):
+        tree = _call("projects.tree")
+        detail = _call(
+            "projects.project_sessions", {"project_id": project["id"]}
+        )
+
+    assert tree["scoped_session_ids"] == ["kanban-worker"]
+    lane = detail["project"]["repos"][0]["groups"][0]
+    assert [session["id"] for session in lane["sessions"]] == ["kanban-worker"]
+
+
+def test_projects_tree_excludes_kanban_sessions_outside_registered_projects(
+    monkeypatch, tmp_path
+):
+    """Scratch and legacy workers do not leak into Home or auto-projects."""
+    home = _profile_dir(tmp_path, "launch")
+    repo = tmp_path / "repos" / "dunbar-dossier"
+    scratch = tmp_path / "kanban" / "workspaces" / "t_legacy"
+    (repo / ".git").mkdir(parents=True)
+    (scratch / ".git").mkdir(parents=True)
+    _bind_profiles(monkeypatch, tmp_path, {"default": home})
+    _create_project(home, "Dunbar Dossier", repo, use=True)
+    _create_session(home, "ordinary-project-session", repo)
+    _create_session(home, "unbound-kanban-worker", scratch, source="kanban")
+
+    with _serving_launch_profile(home):
+        tree = _call("projects.tree", {"session_limit": 1})
+
+    assert "ordinary-project-session" in json.dumps(tree)
+    assert "unbound-kanban-worker" not in json.dumps(tree)
 
 
 def test_projects_tree_is_scoped_to_the_requested_profile(monkeypatch, tmp_path):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -15706,7 +15706,12 @@ def _scan_discovered_repos_remote(conn, policy: dict) -> bool:
 
 
 def _discover_repos_payload(
-    db, *, conn=None, backfill: bool = True, include_cached: bool = True
+    db,
+    *,
+    conn=None,
+    backfill: bool = True,
+    include_cached: bool = True,
+    exclude_sources: list[str] | None = None,
 ) -> list[dict]:
     """Merge filesystem-scanned repos (cached) with session-derived repo roots.
 
@@ -15728,7 +15733,7 @@ def _discover_repos_payload(
 
     # Session-derived roots (common repo root, folding worktrees; cached) +
     # backfill the column so persisted git_repo_root matches the tree grouping.
-    cwd_rows = list(db.distinct_session_cwds())
+    cwd_rows = list(db.distinct_session_cwds(exclude_sources=exclude_sources))
     # Warm the per-cwd git probes in parallel so a cold first paint doesn't
     # serialize one subprocess per distinct cwd before this loop reads the cache.
     git_probe.warm_roots(str(r.get("cwd") or "") for r in cwd_rows)
@@ -15795,11 +15800,11 @@ def _discover_repos_payload(
     return out
 
 
-# Sources excluded from the project tree: cron runs, and kanban dispatcher
-# workers, are not user conversations. Subagent/compression children are
-# already dropped by list_sessions_rich(include_children=False); cron has its
-# own section, and kanban runs are read on the board.
-_PROJECT_TREE_EXCLUDED_SOURCES = ["cron", "kanban"]
+# Cron has its own section. Kanban workers remain absent from global Recents,
+# but are first-class project transcripts when their persisted cwd resolves
+# under a named project. Subagent/compression children are already dropped by
+# list_sessions_rich(include_children=False).
+_PROJECT_TREE_EXCLUDED_SOURCES = ["cron"]
 
 
 def _project_tree_row(r: dict) -> dict:
@@ -15851,25 +15856,6 @@ def _project_tree_inputs(
     which already has sessions — avoiding the distinct-cwd scan + git probes on
     that per-turn path. One projects.db connection serves both reads.
     """
-    rows = db.list_sessions_rich(
-        limit=session_limit,
-        offset=0,
-        order_by_last_active=True,
-        min_message_count=1,
-        include_children=False,
-        exclude_sources=_PROJECT_TREE_EXCLUDED_SOURCES,
-        include_archived=False,
-        # `_project_tree_row` keeps ~18 fields and drops the rest, so selecting
-        # the system-prompt blob only to discard it costs tens of MB of B-tree
-        # reads per build on a long-lived database.
-        compact_rows=True,
-    )
-    sessions = [_project_tree_row(r) for r in rows]
-    # Parallel-warm the git cache so build_tree's resolver reads it instead of
-    # cold-probing each cwd in sequence (matters on the drill-in path, which
-    # skips the discovery warm-up below).
-    git_probe.warm_roots(s["cwd"] for s in sessions if s.get("cwd"))
-
     from hermes_cli import projects_db as pdb
 
     policy = _repo_discovery_policy()
@@ -15890,10 +15876,55 @@ def _project_tree_inputs(
                 conn=conn,
                 backfill=False,
                 include_cached=policy["enabled"],
+                exclude_sources=["kanban"],
             )
             if include_discovered
             else []
         )
+
+    project_folders = [
+        str(folder.get("path") or "")
+        for project in projects
+        for folder in (project.get("folders") or [])
+        if str(folder.get("path") or "").strip()
+    ]
+    common_query = {
+        "limit": session_limit,
+        "offset": 0,
+        "order_by_last_active": True,
+        "min_message_count": 1,
+        "include_children": False,
+        "include_archived": False,
+        # `_project_tree_row` keeps ~18 fields and drops the rest, so selecting
+        # the system-prompt blob only to discard it costs tens of MB of B-tree
+        # reads per build on a long-lived database.
+        "compact_rows": True,
+    }
+    # Query ordinary sessions separately so recent excluded scratch workers
+    # cannot consume the page limit before filtering. Kanban rows are fetched
+    # only below registered project folders, which keeps them out of Home and
+    # auto-project discovery while making project worktree transcripts visible.
+    rows = db.list_sessions_rich(
+        exclude_sources=[*_PROJECT_TREE_EXCLUDED_SOURCES, "kanban"],
+        **common_query,
+    )
+    by_id = {str(row.get("id")): row for row in rows}
+    for folder in project_folders:
+        for row in db.list_sessions_rich(
+            source="kanban",
+            cwd_prefix=folder,
+            **common_query,
+        ):
+            by_id[str(row.get("id"))] = row
+    rows = sorted(
+        by_id.values(),
+        key=lambda row: float(row.get("last_active") or row.get("started_at") or 0),
+        reverse=True,
+    )[:session_limit]
+    sessions = [_project_tree_row(row) for row in rows]
+    # Parallel-warm only the retained session roots so excluded scratch workers
+    # do not trigger pointless git probes.
+    git_probe.warm_roots(s["cwd"] for s in sessions if s.get("cwd"))
 
     return sessions, projects, discovered, active_id
 


### PR DESCRIPTION
## What does this PR do?

Shows Kanban worker sessions underneath their owning project in the Desktop and TUI session tree, instead of hiding them entirely.

Today `HERMES_SESSION_SOURCE=kanban` runs are excluded from the project tree as a blanket rule. They were originally dropped because they rendered as noisy, untitled `cli` rows labeled with the raw worker prompt (`work kanban task t_…`). That works for global Recents, but it also removes a project's own worker transcripts from that project's sidebar. You see the cards on the board, but you can't open the conversation underneath one from the project that owns it.

This change makes kanban runs visible, titled, and project-anchored:

1. **Titled** — the spawn path names the transcript from durable, human-readable context (`board · task title · run N`), truncated safely on a word boundary and kept within `SessionDB.MAX_TITLE_LENGTH`, instead of the machine-shaped prompt.
2. **Anchored** — worker sessions record the task's workspace as their `cwd`, so the persisted session row resolves to a named project.
3. **Scoped** — the project tree still keeps kanban runs out of Home/global Recents and out of automatic repo discovery, but now surfaces them under registered project folders where their `cwd` lives, via a dedicated per-folder query so a burst of scratch workers can't consume the visible row budget.

## Why this matters

The Kanban board is meant to be the autonomous execution layer. You hand your agent a goal (say "set up a board from `HANDOFF.md` or the build spec"), and it breaks that goal into tasks that then:

- **Run across profiles and worker pods.** Workers spawn with `hermes -p <profile>` and join a shared board. Per the board's own design docstring, the shared board is the cross-profile coordination primitive, and each worker stays isolated to its own workspace and worktree.
- **Queue by dependency.** A task with unmet dependencies stays gated and is promoted automatically (`recompute_ready`) once its parents finish, instead of all tasks piling into one undifferentiated list.
- **Surface approvals.** Tasks that genuinely need a human go to `blocked` with a reason (`needs_input`, `capability`), so you can see what is waiting on you, and then adjust the outcome by adding or editing tasks and prompts.

For that workflow to be usable, you need to look at a project and see its current execution state: which tasks are running, which are blocked waiting on you, and which worktree each session ran on. This PR closes the gap where you could see the board but not the sessions behind it, within the project's own tree.

This is a visibility fix. It does not change board behavior, task routing, or the dispatcher. It only changes where and how worker sessions show up in the session list.

## Related Issue

No issue yet. This is a fix for project-tree visibility observed on a running deployment (two real projects with active boards). Happy to file one if it helps triage.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`hermes_cli/kanban_db.py`**
  - New `_worker_session_title(board, task_title, run_id)`: bounded, word-safe title. Truncation keeps the ` · run N` suffix so retries stay distinct without exposing the raw task id.
  - `_default_spawn` now exports `HERMES_KANBAN_SESSION_TITLE` (with the resolved board slug), and the comment on `HERMES_SESSION_SOURCE` is corrected to reflect the new scoping. The source value stays `kanban` so Recents can still filter it out.
- **`run_agent.py`**
  - `_launch_cwd_for_session` now records a `cwd` for `kanban`-sourced sessions too (local backend only, same as `cli`), anchoring the transcript to the owning worktree or project.
  - On session creation, kanban runs apply the exported human title via `set_auto_title`.
- **`hermes_state_portability.py`**
  - `distinct_session_cwds()` gains `exclude_sources` (parametrized `NOT IN (...)`) so the repo-discovery scan can keep kanban scratch cwds out of auto-discovery while the project tree still reads them from session rows.
- **`tui_gateway/server.py`**
  - `_PROJECT_TREE_EXCLUDED_SOURCES` narrows to `["cron"]`; canonical comment updated.
  - `_discover_repos_payload()` threads `exclude_sources` through (kanban still excluded from discovery).
  - `_project_tree_inputs()`: regular sessions are fetched with kanban excluded so they can't eat the row budget, then per registered project folder we fetch `source=kanban` sessions under that folder's `cwd_prefix`, merge, re-sort by last activity, and apply the limit. Git probe warm-up now only warms retained rows' roots.
- **Tests**
  - `tests/hermes_cli/test_kanban_worker_session_source.py`: regression tests for title shortening at a word boundary with the run suffix preserved, plus the spawn env-var contract pinning `HERMES_SESSION_SOURCE=kanban` and the new title env var.
  - `tests/tui_gateway/test_projects_rpc.py`: tests that the projects tree includes kanban sessions rooted under a registered project folder, and still excludes kanban sessions whose cwd is not under any registered project (Home/scratch stays clean).

## How to Test

1. Start from a running deployment that has a Kanban board and at least one task whose workspace is a registered project folder (a project with a worktree).
2. Trigger or resume a task so a worker session launches.
3. In the Desktop/TUI project tree:
   - The worker transcript appears under that project, titled `<board> · <task title> · run <N>` (truncated cleanly if long), not labeled with the raw `work kanban task t_…` prompt.
4. Verify global Recents / Home still does not show the kanban runner row.
5. Verify a kanban run whose workspace is not under any registered project still does not appear in the tree (scratch runs stay hidden).
6. Run the regression tests: `pytest tests/hermes_cli/test_kanban_worker_session_source.py tests/tui_gateway/test_projects_rpc.py -q`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (full suite pending on CI; the two target test files are exercised locally)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (DGX Spark, Ubuntu-family), Desktop client on Windows via Tailscale

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A: docstring/comment updates included for the changed invariants
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys (N/A)
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows (N/A)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior (N/A)

## Screenshots / Logs

Verified live on two real projects with active boards. Three scenarios below.

**1. Project sidebar, kanban worker sessions now visible under the owning project (YouTube Learning Center).**

<img width="546" height="633" alt="Project sidebar with kanban worker sessions anchored under the YouTube Learning Center project, titled rather than raw prompt" src="https://github.com/user-attachments/assets/ae76a958-7900-4f50-aadb-07b65fd5a3cd" />

The rows under the `kanban` section of the sidebar (`youtube-learning-center · AL1 · Freeze active-learning…`) are the worker transcripts of tasks on that board. They are now titled and project-anchored instead of being dropped from the tree.

**2. The same project's Kanban board (17 tasks across triage/todo/ready/running/blocked/review/done).**

<img width="1439" height="990" alt="YouTube Learning Center Kanban board with 17 tasks across the full workflow, including DONE column" src="https://github.com/user-attachments/assets/1c7aea24-a747-4134-ae03-3112820a523d" />

The sidebar row opens the transcript of a card on this board. The two views now point at the same underlying work, which is what makes the session visible and auditable.

**3. A second project (Dunbar Dossier, 47 tasks) showing the same behavior, including blocked approval gates.**

<img width="1685" height="958" alt="Dunbar Dossier Kanban board with 47 tasks, blocked human-approval gates, and worker sessions anchored in the sidebar" src="https://github.com/user-attachments/assets/41e87e89-e232-4e95-9d16-1e527953baa2" />

The `blocked` cards (e.g. `DD-G3 human approval: authorize Slice 3`) are the tasks waiting on a human, and their worker sessions are now visible in the project tree on the left rather than being hidden.

Worker-side logs confirm the spawn env vars are exported: `HERMES_SESSION_SOURCE=kanban` and `HERMES_KANBAN_SESSION_TITLE=<board> · <task title> · run <N>`.