### PR TITLE
fix(auth): never heal a profile store that symlinks to root auth.json

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1987,6 +1987,13 @@ def _heal_forked_single_use_oauth_grants(provider_id: str) -> Optional[Dict[str,
         if real_home_env and _same_path(root_path, Path(real_home_env) / ".hermes" / "auth.json"):
             return None
     profile_path = _auth_file_path()
+    if _same_path(profile_path, root_path):
+        # The profile's auth.json IS the root store — e.g. symlinked by
+        # dotfiles-managed deployments (#101356). ``_global_auth_file_path``
+        # only same-path-checks the directories, so a symlinked file slips
+        # through; reading one file as both stores would match every row
+        # against itself and strip the shared credential through the symlink.
+        return None
     profile_home = profile_path.parent
     root_home = root_path.parent
     profile_singleton = profile_home / ".anthropic_oauth.json" if provider_id == "anthropic" else None

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1993,6 +1993,10 @@ def _heal_forked_single_use_oauth_grants(provider_id: str) -> Optional[Dict[str,
         # only same-path-checks the directories, so a symlinked file slips
         # through; reading one file as both stores would match every row
         # against itself and strip the shared credential through the symlink.
+        # Best-effort guard: a TOCTOU window remains between this check and
+        # the later read/write — if the symlink is swapped in between, the
+        # open() follows the new target. Real protection against that
+        # window is filesystem permissions on the store and its parent.
         return None
     profile_home = profile_path.parent
     root_home = root_path.parent

--- a/tests/agent/test_credential_pool_profile_oauth_fork.py
+++ b/tests/agent/test_credential_pool_profile_oauth_fork.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import io
 import json
 import os
+import sys
 import time
 import urllib.error
 import urllib.request
@@ -450,3 +451,25 @@ def test_heal_is_a_noop_in_classic_mode(fleet):
     before = (fleet["root"] / "auth.json").read_text()
     assert heal_forked_single_use_oauth_grants("anthropic") is None
     assert (fleet["root"] / "auth.json").read_text() == before
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlink semantics")
+def test_heal_is_a_noop_when_profile_store_symlinks_to_root(fleet):
+    """A profile auth.json symlinked to the root file is ONE shared store, not
+    a fork — the heal must not read it as two stores and strip the shared
+    credential through the symlink (#101356)."""
+    from hermes_cli.auth import heal_forked_single_use_oauth_grants
+
+    kid = _profile(fleet, "kid")
+    kid.mkdir(parents=True, exist_ok=True)
+    kid_auth = kid / "auth.json"
+    if kid_auth.is_symlink() or kid_auth.exists():
+        kid_auth.unlink()
+    kid_auth.symlink_to(fleet["root"] / "auth.json")
+
+    fleet["use"](kid)
+    before = (fleet["root"] / "auth.json").read_text()
+    assert heal_forked_single_use_oauth_grants("anthropic") is None
+    assert (fleet["root"] / "auth.json").read_text() == before
+    assert fleet["rows"](fleet["root"]), "shared grant was stripped from the root store"
+    assert (kid / "auth.json").is_symlink()


### PR DESCRIPTION
## What does this PR do?

`heal_forked_single_use_oauth_grants` (from #100929) treats the profile `auth.json` and the root `auth.json` as two separate stores, consolidates forked single-use OAuth grants between them, and strips the profile copy. But it never checked whether the two **files** are the same file: `_global_auth_file_path()` only same-path-checks the parent **directories**, so a profile whose `auth.json` is a symlink to the root file (dotfiles-managed shared stores, #101356) slips through.

In that setup the heal reads the single shared file as both stores, matches every row against itself by lineage, and strips the "profile copy" — and because `_save_auth_store` writes through symlinks (`utils.atomic_replace` resolves them by design), the strip deletes the credential from the shared root store itself. The user's next `hermes auth` login gets removed again on the next pool load, which is exactly the "login reports success but Codex credentials are gone" loop in #101356.

The fix skips the heal when the two store paths resolve to the same file, using the existing `_same_path()` helper — the same guard pattern the function already applies for its pytest seat belt. A symlinked store is one store, not a fork: there is nothing to consolidate.

## Related Issue

Fixes #101356

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/auth.py` — `_heal_forked_single_use_oauth_grants()` returns early when `_same_path(profile_path, root_path)`, mirroring the existing classic-mode early return.
- `tests/agent/test_credential_pool_profile_oauth_fork.py` — regression test: profile `auth.json` symlinked to root keeps the shared `anthropic` pool row and leaves the root file byte-identical across a heal call.

## How to Test

1. `python -m pytest tests/agent/test_credential_pool_profile_oauth_fork.py -q` — all pass, including the new `test_heal_is_a_noop_when_profile_store_symlinks_to_root`.
2. Verified fail-closed: with the guard reverted, the new test fails exactly as the issue describes — `heal_forked_single_use_oauth_grants("anthropic")` returns `{'adopted': False, 'stripped_ids': ['abc123'], ...}` and the shared root store loses its grant; with the guard, it returns `None` and the root file is unchanged, symlink intact.
3. `python -m pytest tests/agent/test_credential_pool.py tests/agent/test_credential_pool_*.py tests/test_atomic_replace_symlinks.py -q` — 157 passed, 5 skipped.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — full credential-pool suite + symlink atomicity suite (157 passed, 5 skipped) on the affected area
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (guard comment documents the constraint)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `_same_path()` falls back to plain equality if `resolve()` fails; the regression test is skipped on win32 where unprivileged symlinks are unavailable
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Fail-closed verification (guard temporarily reverted):

```
>       assert heal_forked_single_use_oauth_grants("anthropic") is None
E       AssertionError: assert {'adopted': False, 'stripped_ids': ['abc123'], 'files': [], 'providers_block': False} is None
```

With the guard: `1 passed` — root store byte-identical, symlink survives.