### PR TITLE
ci: run all workflows on self-hosted runners

### DIFF
--- a/.github/workflows/case-collision-check.yml
+++ b/.github/workflows/case-collision-check.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   check-case-collisions:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci-review-comment.yml
+++ b/.github/workflows/ci-review-comment.yml
@@ -46,7 +46,7 @@ jobs:
     if: >-
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.head_repository.full_name == github.repository
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 60
     steps:
       - name: Checkout trusted default branch

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────
   detect:
     name: Detect affected areas
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 1
     outputs:
       python: ${{ steps.classify.outputs.python }}
@@ -256,7 +256,7 @@ jobs:
       # to block a merge. A separate run also stops it from holding this
       # run open. That is what blocked ``gh run rerun``.
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 10
     outputs:
       needs-json: ${{ steps.evaluate.outputs.needs-json }}
@@ -299,7 +299,7 @@ jobs:
     name: CI timing report
     needs: [all-checks-pass]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 10
     steps:
       - name: Checkout code

--- a/.github/workflows/contributor-check.yml
+++ b/.github/workflows/contributor-check.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   check-attribution:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 10
     outputs:
       review_status: ${{ steps.check-emails.outputs.review_status }}

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -40,7 +40,7 @@ jobs:
     # a skills-index PR that doesn't touch website/** paths and so
     # doesn't auto-deploy via the deploy-docs path.
     if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 30
     steps:
       - name: Trigger Vercel Deploy
@@ -48,7 +48,7 @@ jobs:
 
   deploy-docs:
     if: github.repository == 'NousResearch/hermes-agent'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 30
     environment:
       name: github-pages

--- a/.github/workflows/docker-lint.yml
+++ b/.github/workflows/docker-lint.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   hadolint:
     name: Lint Dockerfile (hadolint)
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 5
     steps:
       - name: Checkout code
@@ -38,7 +38,7 @@ jobs:
 
   shellcheck:
     name: Lint docker/ shell scripts (shellcheck)
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 5
     steps:
       - name: Checkout code

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,7 +36,7 @@ jobs:
   # open (every lane true), so post-merge validation is never weakened.
   detect:
     name: Detect affected areas
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 10
     outputs:
       build: ${{ steps.gate.outputs.build }}
@@ -76,14 +76,14 @@ jobs:
       matrix:
         include:
           - arch: amd64
-            runner: ubuntu-latest-32-core
+            runner: self-hosted
             platform: linux/amd64
             cache-from: type=gha,scope=docker-amd64
             cache-to: type=gha,mode=max,scope=docker-amd64
           # arm64 builds on the native arm64 larger runner. A build of
           # linux/arm64 on an x64 host uses emulation.
           - arch: arm64
-            runner: ubuntu-latest-32-arm-core
+            runner: self-hosted
             platform: linux/arm64
             cache-from: type=gha,scope=docker-arm64
             cache-to: type=gha,mode=max,scope=docker-arm64
@@ -193,13 +193,13 @@ jobs:
       matrix:
         include:
           - arch: amd64
-            runner: ubuntu-latest-32-core
+            runner: self-hosted
             platform: linux/amd64
             cache-from: type=gha,scope=docker-amd64
             cache-to: type=gha,mode=max,scope=docker-amd64
           # Native arm64 for the same reason as the build matrix above.
           - arch: arm64
-            runner: ubuntu-latest-32-arm-core
+            runner: self-hosted
             platform: linux/arm64
             cache-from: type=gha,scope=docker-arm64
             cache-to: type=gha,mode=max,scope=docker-arm64
@@ -270,7 +270,7 @@ jobs:
   # ---------------------------------------------------------------------------
   merge:
     if: github.repository == 'NousResearch/hermes-agent' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'release')
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: [publish]
     timeout-minutes: 10
     environment: container-publish

--- a/.github/workflows/docs-site-checks.yml
+++ b/.github/workflows/docs-site-checks.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   docs-site-checks:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/e2e-desktop.yml
+++ b/.github/workflows/e2e-desktop.yml
@@ -20,7 +20,7 @@ jobs:
     # This job builds the renderer and the electron bundle, then drives a real
     # Electron app under xvfb. vite, tsc and the Playwright workers all scale
     # with the core count.
-    runs-on: ubuntu-latest-32-core
+    runs-on: self-hosted
     timeout-minutes: 20
     outputs:
       review_status: ${{ steps.review-status.outputs.review_status }}

--- a/.github/workflows/history-check.yml
+++ b/.github/workflows/history-check.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   check-common-ancestor:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 10
     outputs:
       review_status: ${{ steps.merge-base-check.outputs.review_status }}

--- a/.github/workflows/infographic-check.yml
+++ b/.github/workflows/infographic-check.yml
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   check-no-committed-infographics:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 10
     outputs:
       review_status: ${{ steps.infographic-check.outputs.review_status }}

--- a/.github/workflows/install-e2e-run.yml
+++ b/.github/workflows/install-e2e-run.yml
@@ -33,7 +33,7 @@ on:
         description: 'Runner label.'
         required: false
         type: string
-        default: ubuntu-latest
+        default: self-hosted
       timeout-minutes:
         description: 'Job timeout. A cold run installs real toolchains twice.'
         required: false

--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -58,7 +58,7 @@ jobs:
   # by both route matrices, so the two routes cover the same set.
   pick-releases:
     name: Pick release tags
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 5
     outputs:
       tags: ${{ steps.pick.outputs.tags }}

--- a/.github/workflows/installer-tests.yml
+++ b/.github/workflows/installer-tests.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   powershell:
     name: PowerShell installer tests
-    runs-on: windows-latest
+    runs-on: self-hosted
     timeout-minutes: 15
     steps:
       - name: Checkout code

--- a/.github/workflows/js-autofix.yml
+++ b/.github/workflows/js-autofix.yml
@@ -57,7 +57,7 @@ concurrency:
 jobs:
   generate-patch:
     name: Generate eslint --fix patch
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 5
     outputs:
       has-fixes: ${{ steps.produce-patch.outputs.has-fixes }}
@@ -137,7 +137,7 @@ jobs:
     # Skip entirely when generate-patch found no fixes — saves a runner,
     # avoids a redundant checkout/download, and keeps the job graph honest.
     if: needs.generate-patch.outputs.has-fixes == 'true'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 15
     environment: trusted-automation
     permissions:

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -14,7 +14,7 @@ jobs:
     #
     # One larger runner installs one time. vitest, tsc and eslint each size
     # their own worker pool from the core count.
-    runs-on: ubuntu-latest-32-core
+    runs-on: self-hosted
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/label-rerun.yml
+++ b/.github/workflows/label-rerun.yml
@@ -29,7 +29,7 @@ jobs:
   rerun-review-labels:
     name: Rerun review-labels job
     if: github.event.label.name == 'ci-reviewed'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 40
     steps:
       - name: Wait for CI run to finish, then rerun failed jobs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
   lint-diff:
     name: ruff + ty diff
     if: inputs.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 10
     steps:
       - name: Checkout code
@@ -126,7 +126,7 @@ jobs:
     # ``lint-diff`` job above runs independently so reviewers still get
     # the diff comment even when enforcement fails.
     name: ruff enforcement (blocking)
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 5
     steps:
       - name: Checkout code
@@ -157,7 +157,7 @@ jobs:
     # shebang scripts via subprocess, bare open() without encoding=, etc.
     # See scripts/check-windows-footguns.py for the full rule list.
     name: Windows footguns (blocking)
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 5
     steps:
       - name: Checkout code

--- a/.github/workflows/lockfile-diff.yml
+++ b/.github/workflows/lockfile-diff.yml
@@ -34,7 +34,7 @@ concurrency:
 jobs:
   diff:
     name: package-lock.json semantic diff
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 5
     outputs:
       changed: ${{ steps.diff.outputs.changed }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -33,7 +33,7 @@ jobs:
   # flake inputs. On push the classifier fails open and every lane is true.
   detect:
     name: Detect affected areas
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 10
     outputs:
       nix: ${{ steps.classify.outputs.nix }}
@@ -54,7 +54,7 @@ jobs:
     # takes minutes and not seconds when the cache misses. `nix flake check`
     # builds 21 checks, and --max-jobs defaults to the core count. It uses the
     # wider runner with no more configuration.
-    runs-on: ubuntu-latest-32-core
+    runs-on: self-hosted
     timeout-minutes: 60
     steps:
       - name: Checkout code

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -57,7 +57,7 @@ jobs:
 
   emit-status:
     name: Emit review status
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: scan
     if: always()
     outputs:

--- a/.github/workflows/profile-artifact-check.yml
+++ b/.github/workflows/profile-artifact-check.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   check-profile-artifacts:
     name: Reject profile archives
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/publish-e2e-evidence.yml
+++ b/.github/workflows/publish-e2e-evidence.yml
@@ -21,7 +21,7 @@ jobs:
   publish:
     name: Publish inline E2E evidence
     if: github.event.workflow_run.event == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 10
     environment: gh-image
     steps:

--- a/.github/workflows/review-labels.yml
+++ b/.github/workflows/review-labels.yml
@@ -51,7 +51,7 @@ jobs:
   check:
     name: Review label gate
     if: inputs.ci_review || inputs.mcp_catalog || inputs.supply_chain
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 2
     outputs:
       ci_reviewed: ${{ steps.label-check.outputs.ci_reviewed }}

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -30,7 +30,7 @@ jobs:
     # cargo builds codegen units and test binaries in parallel across the
     # cores. This lane also builds the crate from the start when Cargo.toml
     # changes.
-    runs-on: ubuntu-latest-32-core
+    runs-on: self-hosted
     timeout-minutes: 30
     defaults:
       run:

--- a/.github/workflows/skills-index-freshness.yml
+++ b/.github/workflows/skills-index-freshness.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   check-freshness:
     if: github.repository == 'NousResearch/hermes-agent'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 10
     environment: trusted-automation
     steps:

--- a/.github/workflows/skills-index.yml
+++ b/.github/workflows/skills-index.yml
@@ -19,7 +19,7 @@ jobs:
   build-index:
     # Only run on the upstream repository, not on forks
     if: github.repository == 'NousResearch/hermes-agent'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 15
     environment: trusted-automation
     steps:
@@ -59,7 +59,7 @@ jobs:
   trigger-deploy:
     needs: build-index
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 15
     environment: trusted-automation
     steps:

--- a/.github/workflows/supply-chain-audit.yml
+++ b/.github/workflows/supply-chain-audit.yml
@@ -54,7 +54,7 @@ jobs:
   scan:
     name: Scan PR for critical supply chain risks
     if: inputs.scan
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 15
     outputs:
       review_status: ${{ steps.emit-status.outputs.review_status }}
@@ -180,7 +180,7 @@ jobs:
   dep-bounds:
     name: Check PyPI dependency upper bounds
     if: inputs.deps
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 15
     outputs:
       review_status: ${{ steps.emit-status.outputs.review_status }}
@@ -259,7 +259,7 @@ jobs:
     name: Aggregate review statuses
     needs: [scan, dep-bounds]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 15
     outputs:
       review_status: ${{ steps.merge.outputs.review_status }}

--- a/.github/workflows/tests-os.yml
+++ b/.github/workflows/tests-os.yml
@@ -58,10 +58,10 @@ jobs:
       matrix:
         include:
           - name: macOS-only tests
-            runner: macos-latest
+            runner: self-hosted
             marker: macos_only
           - name: Windows-only tests
-            runner: windows-latest-32-core
+            runner: self-hosted
             marker: windows_only
     steps:
       - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
     # 96 cores clear the floor that the slowest single test file sets (about
     # 82s). A second slice divides work that is already at that floor, and
     # adds a second setup.
-    runs-on: ubuntu-latest-96-core
+    runs-on: self-hosted
     timeout-minutes: 30
     steps:
       - name: Checkout code
@@ -126,7 +126,7 @@ jobs:
           NOUS_API_KEY: ""
 
   e2e:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 15
     steps:
       - name: Checkout code

--- a/.github/workflows/uv-lockfile-check.yml
+++ b/.github/workflows/uv-lockfile-check.yml
@@ -60,7 +60,7 @@ concurrency:
 jobs:
   check:
     name: uv lock --check
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 5
     outputs:
       review_status: ${{ steps.verify.outputs.review_status }}

--- a/.github/workflows/windows-venv-e2e.yml
+++ b/.github/workflows/windows-venv-e2e.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   venv-holder-e2e:
     name: venv-holder live E2E (windows-latest)
-    runs-on: windows-latest
+    runs-on: self-hosted
     timeout-minutes: 25
     steps:
       - name: Checkout code


### PR DESCRIPTION
Policy change for this fork's CI: only self-hosted runners are permitted; no GitHub-hosted Actions.

- Converts all fixed `runs-on:` entries (ubuntu-latest, ubuntu-latest-32/96-core, windows-latest*, macos-latest*) to `self-hosted` across all 32 workflow files.
- Matrix `runner:` values and the `install-e2e-run.yml` `runner` input default now resolve to `self-hosted`.
- OS-specific lanes (windows-venv-e2e, tests-os Windows/macOS markers, docker arm builds) now run wherever the self-hosted runner pool provides; lanes that need a specific OS/ARCH can be re-targeted later with runner labels.