### PR TITLE
fix(tools): tools[] stays frozen for the session — prefix preserved, survives agent-cache eviction, /reload-mcp re-probes (salvage #100638)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -989,6 +989,7 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
     """
     stored_prompt = None
     stored_state = "missing"
+    session_row = None
     if conversation_history and agent._session_db:
         try:
             session_row = agent._session_db.get_session(agent.session_id)
@@ -1091,6 +1092,17 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
         # Continuing session — reuse the exact system prompt from the
         # previous turn so the Anthropic cache prefix matches.
         agent._cached_system_prompt = stored_prompt
+        # Same contract for tools[]: a fresh AIAgent for an existing session
+        # (gateway agent-cache eviction) re-probed every check_fn, so pin the
+        # array back to the order this session already sent (tools freeze).
+        try:
+            saved_tools = session_row.get("tool_names") if session_row else None
+            if saved_tools:
+                from tools.mcp_tool import restore_agent_tool_prefix
+
+                restore_agent_tool_prefix(agent, json.loads(saved_tools))
+        except Exception:
+            logger.debug("tool prefix restore skipped", exc_info=True)
         # Prompt-section callbacks are new-session-only. Recover their frozen
         # bytes from the persisted full prompt so a later compression rebuild
         # keeps them without evaluating plugin state in this resumed process.
@@ -1173,6 +1185,9 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
     if agent._session_db:
         try:
             agent._session_db.update_system_prompt(agent.session_id, agent._cached_system_prompt)
+            from tools.mcp_tool import persist_agent_tool_names
+
+            persist_agent_tool_names(agent)
         except Exception as exc:
             logger.warning(
                 "Session DB update_system_prompt failed for session %s: "

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -635,13 +635,18 @@ def build_turn_context(
     # Between-turns MCP refresh: an MCP server that finished connecting since
     # the previous turn (slow HTTP/OAuth servers routinely take 2-6s on a cold
     # connect, missing the bounded startup wait) lands in THIS turn's tool
-    # snapshot.  This is cache-safe by construction: it runs in the per-turn
+    # snapshot.  Timing is cache-safe by construction: it runs in the per-turn
     # prologue, before this turn's first API call assembles ``tools=``, so it
-    # only ever extends a fresh request prefix — it never mutates the cached
-    # prefix of an in-flight turn.  No-op when no MCP servers are registered
-    # (the common case, gated by the cheap ``has_registered_mcp_tools`` check)
-    # or when the tool set is unchanged (``refresh_agent_mcp_tools`` diffs by
-    # name and leaves the snapshot untouched on no-change).
+    # never mutates the prefix of an in-flight turn.  ``preserve_prefix`` makes
+    # the *content* cache-safe too (#100336): a plain rebuild re-derives the
+    # array from live availability, so a flapping ``check_fn`` silently drops a
+    # tool and a late arrival splices into sorted position — either one forks
+    # the tool block and re-prefills the whole history behind it, every turn it
+    # happens.  With the flag the live order is authoritative and the array
+    # only ever grows.  No-op when no MCP servers are registered (the common
+    # case, gated by the cheap ``has_registered_mcp_tools`` check) or when the
+    # tool set is unchanged (``refresh_agent_mcp_tools`` diffs by name and
+    # leaves the snapshot untouched on no-change).
     try:
         if not getattr(agent, "_skip_mcp_refresh", False):
             # Import-cost gate: ``tools.mcp_tool`` pulls in the whole ``mcp``
@@ -656,7 +661,9 @@ def build_turn_context(
             if "tools.mcp_tool" in _sys.modules:
                 from tools.mcp_tool import has_registered_mcp_tools, refresh_agent_mcp_tools
                 if has_registered_mcp_tools():
-                    refresh_agent_mcp_tools(agent, quiet_mode=True)
+                    refresh_agent_mcp_tools(
+                        agent, quiet_mode=True, preserve_prefix=True,
+                    )
     except Exception:
         logger.debug("between-turns MCP tool refresh skipped", exc_info=True)
 

--- a/cli.py
+++ b/cli.py
@@ -14764,7 +14764,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         sees the updated tools on the next turn.
         """
         try:
-            from tools.mcp_tool import shutdown_mcp_servers, discover_mcp_tools, _servers, _lock
+            from tools.mcp_tool import (
+                shutdown_mcp_servers, discover_mcp_tools, reprobe_tool_availability, _servers, _lock,
+            )
 
             # Capture old server names
             with _lock:
@@ -14776,6 +14778,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # Shutdown existing connections
             shutdown_mcp_servers()
 
+            # Explicit reload also re-probes tool availability (check_fn).
+            reprobe_tool_availability()
             # Reconnect (reads config.yaml fresh)
             new_tools = discover_mcp_tools()
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -26230,7 +26230,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return await self._execute_mcp_reload(event)
         try:
             from tools.mcp_tool import shutdown_mcp_servers, discover_mcp_tools, _servers, _lock
-            from tools.mcp_tool import _server_scope_keys
+            from tools.mcp_tool import _server_scope_keys, reprobe_tool_availability
             from tools.registry import registry
 
             reload_scope = registry.current_scope_key() if multiplex else None
@@ -26250,6 +26250,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             await self._run_in_executor_with_context(
                 lambda: shutdown_mcp_servers(scope=reload_scope)
             )
+            # Explicit reload also re-probes tool availability (check_fn).
+            reprobe_tool_availability()
 
             # Reconnect by discovering tools (reads config.yaml fresh)
             new_tools = await self._run_in_executor_with_context(discover_mcp_tools)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -9741,6 +9741,25 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             self._delete_unreferenced_system_prompts(conn)
         self._execute_write(_do)
 
+    def update_session_tool_names(
+        self, session_id: str, tool_names: Optional[List[str]]
+    ) -> None:
+        """Persist the session's resolved ``tools[]`` name order (JSON array).
+
+        Read back by ``tools.mcp_tool.restore_agent_tool_prefix`` when a fresh
+        ``AIAgent`` is rebuilt for an existing session (gateway agent-cache
+        eviction) so a flipped ``check_fn`` verdict can't fork the cached tool
+        prefix. ``None`` clears the pin.
+        """
+        payload = json.dumps(list(tool_names)) if tool_names is not None else None
+
+        def _do(conn):
+            conn.execute(
+                "UPDATE sessions SET tool_names = ? WHERE id = ?",
+                (payload, session_id),
+            )
+        self._execute_write(_do)
+
     def update_session_model(
         self, session_id: str, model: str, provider: Optional[str] = None
     ) -> None:

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -354,7 +354,7 @@ def _sql_session_last_active_by_id(session_id_expr: str) -> str:
     )
 
 
-SCHEMA_VERSION = 27
+SCHEMA_VERSION = 28
 
 
 # FTS storage-layout version, tracked INDEPENDENTLY of SCHEMA_VERSION in the
@@ -452,6 +452,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     pinned INTEGER NOT NULL DEFAULT 0,
     hidden INTEGER NOT NULL DEFAULT 0,
     last_read_at REAL,
+    tool_names TEXT,
     FOREIGN KEY (parent_session_id) REFERENCES sessions(id),
     FOREIGN KEY (system_prompt_hash) REFERENCES system_prompts(hash)
 );

--- a/tests/tools/test_refresh_agent_mcp_tools.py
+++ b/tests/tools/test_refresh_agent_mcp_tools.py
@@ -224,3 +224,65 @@ def test_wait_returns_instantly_when_no_discovery_thread(monkeypatch):
     t0 = time.time()
     mcp_startup.wait_for_mcp_discovery()
     assert time.time() - t0 < 0.2  # never blocks on the bound when nothing's pending
+
+
+# ---------------------------------------------------------------------------
+# preserve_prefix: the tool array is a cached request prefix (#100336)
+# ---------------------------------------------------------------------------
+
+
+def _registered(monkeypatch, names):
+    """Make the registry report exactly *names* as still registered."""
+    from tools import registry as registry_mod
+
+    entries = [types.SimpleNamespace(name=n) for n in names]
+    monkeypatch.setattr(
+        registry_mod.registry, "get_all_entries", lambda: entries, raising=False
+    )
+
+
+def _serve(monkeypatch, defs):
+    import model_tools
+
+    monkeypatch.setattr(model_tools, "get_tool_definitions", lambda **kw: list(defs))
+
+
+def test_preserve_prefix_carries_a_flapping_tool_forward(monkeypatch):
+    """A check_fn flip must not shrink a live session's tool prefix.
+
+    ``browser_navigate``'s availability probe fails this turn (headless box,
+    expired credential, docker blip) so ``get_tool_definitions`` omits it. The
+    tool is still *registered* — only its probe flapped — so the snapshot must
+    keep it, byte-for-byte, instead of forking the cached prefix.
+    """
+    agent = _agent(["read_file", "browser_navigate", "terminal"])
+    before = list(agent.tools)
+
+    _serve(monkeypatch, [_tool("read_file"), _tool("terminal")])
+    _registered(monkeypatch, ["read_file", "browser_navigate", "terminal"])
+
+    added = mcp_tool.refresh_agent_mcp_tools(agent, preserve_prefix=True)
+
+    assert added == set()
+    assert agent.tools == before
+    assert "browser_navigate" in agent.valid_tool_names
+
+
+def test_preserve_prefix_appends_late_arrivals_at_the_tail(monkeypatch):
+    """``get_definitions`` sorts by name, so a late tool can splice in at 0.
+
+    Under ``preserve_prefix`` the live order is authoritative and the new tool
+    extends the array, leaving every earlier byte where the provider cached it.
+    """
+    agent = _agent(["read_file", "terminal"])
+
+    # Sorted order would put the new tool first.
+    _serve(monkeypatch, [_tool("aaa_mcp_late"), _tool("read_file"), _tool("terminal")])
+    _registered(monkeypatch, ["aaa_mcp_late", "read_file", "terminal"])
+
+    added = mcp_tool.refresh_agent_mcp_tools(agent, preserve_prefix=True)
+
+    assert added == {"aaa_mcp_late"}
+    assert [t["function"]["name"] for t in agent.tools] == [
+        "read_file", "terminal", "aaa_mcp_late",
+    ]

--- a/tests/tools/test_refresh_agent_mcp_tools.py
+++ b/tests/tools/test_refresh_agent_mcp_tools.py
@@ -286,3 +286,54 @@ def test_preserve_prefix_appends_late_arrivals_at_the_tail(monkeypatch):
     assert [t["function"]["name"] for t in agent.tools] == [
         "read_file", "terminal", "aaa_mcp_late",
     ]
+
+
+# ---------------------------------------------------------------------------
+# tools[] freeze: eviction rebuild + the /reload-mcp re-probe hatch
+# ---------------------------------------------------------------------------
+
+
+def test_eviction_rebuild_restores_the_sessions_saved_tool_order(monkeypatch):
+    """A fresh AIAgent for an EXISTING session must keep the saved tools[] pin.
+
+    Gateway agent-cache eviction rebuilds the agent; ``agent_init`` re-probes
+    every ``check_fn`` and ``browser_navigate``'s flips false. The persisted
+    name list stands in for the missing predecessor: the tool is carried
+    forward from the registry schema, byte-for-byte in its old slot.
+    """
+    from tools import registry as registry_mod
+
+    saved = ["read_file", "browser_navigate", "terminal"]
+    entries = {n: types.SimpleNamespace(name=n, schema=_tool(n)["function"]) for n in saved}
+    monkeypatch.setattr(registry_mod.registry, "get_all_entries", lambda: list(entries.values()), raising=False)
+    monkeypatch.setattr(registry_mod.registry, "get_entry", lambda name, **kw: entries.get(name), raising=False)
+
+    rebuilt = _agent(["read_file", "terminal"])  # probe flipped: browser_navigate gone
+    changed = mcp_tool.restore_agent_tool_prefix(rebuilt, saved)
+
+    assert changed is True
+    assert [t["function"]["name"] for t in rebuilt.tools] == saved
+    assert rebuilt.valid_tool_names == set(saved)
+
+
+def test_reprobe_tool_availability_drops_cached_check_fn_verdicts(monkeypatch):
+    """/reload-mcp is the explicit hatch: a cached False must be re-probed."""
+    from tools import registry as registry_mod
+    import model_tools
+
+    verdict = {"ok": False}
+
+    def probe():
+        return verdict["ok"]
+
+    monkeypatch.setattr(registry_mod, "check_fn_cache_scope", lambda: "test-scope")
+    assert registry_mod._check_fn_cached(probe) is False
+    verdict["ok"] = True
+    assert registry_mod._check_fn_cached(probe) is False  # TTL cache replays stale verdict
+    with model_tools._tool_defs_cache_lock:
+        model_tools._tool_defs_cache[("sentinel",)] = []
+
+    mcp_tool.reprobe_tool_availability()
+
+    assert registry_mod._check_fn_cached(probe) is True
+    assert ("sentinel",) not in model_tools._tool_defs_cache

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -8344,6 +8344,7 @@ def refresh_agent_mcp_tools(
     disabled_override=None,
     quiet_mode: bool = True,
     content_aware: bool = False,
+    preserve_prefix: bool = False,
 ) -> set:
     """Re-derive an already-built agent's tool snapshot from the live registry.
 
@@ -8371,6 +8372,22 @@ def refresh_agent_mcp_tools(
     surface.  The new ``(tools, valid_tool_names)`` pair is published together
     under ``_agent_tools_lock`` so a concurrent reader never sees a
     cross-attribute half-swap.
+
+    ``preserve_prefix`` is for the callers that rebuild inside a live
+    conversation (the between-turns prologue).  There the tool array is a
+    cached request prefix: every provider that renders ``tools`` ahead of the
+    messages re-prefills the entire history behind any byte that moves.  A
+    plain rebuild moves two kinds of bytes — it drops a tool whose ``check_fn``
+    merely flapped (a headless browser probe, an expired credential, a docker
+    blip), and it splices a late-landing tool into sorted position, which can
+    be index 0.  With ``preserve_prefix`` the live order is authoritative:
+    existing tools keep their slot (schemas still refresh), a tool that is
+    still *registered* but momentarily unavailable is carried forward, a tool
+    that genuinely left the registry is still dropped, and new tools are
+    appended at the tail so the prefix only ever grows.  Carrying an
+    unavailable tool forward changes nothing about dispatch — ``check_fn``
+    gates exposure at snapshot time, never invocation, and every handler
+    already owns its own unavailability error.
 
     Returns the set of newly-added tool names (empty when nothing changed), so
     callers can decide whether to notify the user / re-emit session info.  The
@@ -8427,6 +8444,18 @@ def refresh_agent_mcp_tools(
     # this rebuild actually appended (matching agent_init's dedup-aware add).
     staged_engine_names = _reinject_post_build_tools(agent, new_defs, new_names)
 
+    # Snapshot registry membership OUTSIDE ``_agent_tools_lock`` — it is the
+    # only input ``preserve_prefix`` needs beyond the two tool lists, and
+    # taking ``registry._lock`` under the tools lock would be the first place
+    # in the process to nest those two.
+    registered_names: set = set()
+    if preserve_prefix:
+        try:
+            registered_names = {entry.name for entry in registry.get_all_entries()}
+        except Exception:  # noqa: BLE001
+            # Fail open to the plain rebuild rather than pinning a stale list.
+            preserve_prefix = False
+
     # Single atomic read-diff-publish so the returned ``added`` is consistent
     # with what was actually published, even under concurrent callers, and a
     # stale (older-generation) rebuild can't overwrite a newer published one.
@@ -8440,10 +8469,12 @@ def refresh_agent_mcp_tools(
         if snapshot_generation < published_gen:
             # A newer snapshot already won; our set is stale — drop it.
             return set()
-        current = {
-            t["function"]["name"]
-            for t in (getattr(agent, "tools", None) or [])
-        }
+        current_defs = list(getattr(agent, "tools", None) or [])
+        current = {t["function"]["name"] for t in current_defs}
+        if preserve_prefix:
+            new_defs, new_names = _merge_preserving_prefix(
+                current_defs, new_defs, registered_names,
+            )
         if new_names == current:
             # Same NAME set. For MCP-reload callers that is "no change" —
             # leave the live snapshot untouched (no churn). Content-aware
@@ -8479,6 +8510,40 @@ def refresh_agent_mcp_tools(
             engine_names.update(staged_engine_names)
         agent._tool_snapshot_generation = max(published_gen, snapshot_generation)
         return new_names - current
+
+
+def _merge_preserving_prefix(
+    current_defs: list, new_defs: list, registered_names: set,
+) -> tuple[list, set]:
+    """Fold a fresh tool snapshot into a live one without moving existing bytes.
+
+    The live tool array is a cached request prefix, so the merge is ordered by
+    ``current_defs``, not by the fresh list:
+
+    * a name in both keeps its slot and takes the fresh schema (dynamic
+      overrides — delegate_task limits, execute_code stubs — still land);
+    * a name only in the live list is carried forward when it is still
+      registered (its ``check_fn`` flapped) and dropped when it is not (the
+      MCP server or plugin genuinely went away);
+    * a name only in the fresh list is appended at the tail, so a late-landing
+      MCP tool extends the prefix instead of splicing into sorted position.
+    """
+    fresh = {}
+    for entry in new_defs:
+        name = (entry.get("function") or {}).get("name", "")
+        if name:
+            fresh[name] = entry
+
+    merged = []
+    for entry in current_defs:
+        name = (entry.get("function") or {}).get("name", "")
+        replacement = fresh.pop(name, None)
+        if replacement is not None:
+            merged.append(replacement)
+        elif name and name in registered_names:
+            merged.append(entry)
+    merged.extend(fresh.values())
+    return merged, {(t.get("function") or {}).get("name", "") for t in merged}
 
 
 def _reinject_post_build_tools(agent, tools_list: list, name_set: set) -> set:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -8509,7 +8509,83 @@ def refresh_agent_mcp_tools(
             engine_names.clear()
             engine_names.update(staged_engine_names)
         agent._tool_snapshot_generation = max(published_gen, snapshot_generation)
-        return new_names - current
+        added = new_names - current
+    # Every published snapshot re-pins the session's tool order so a later
+    # rebuild-for-existing-session (gateway agent-cache eviction) restores
+    # exactly these names — see ``restore_agent_tool_prefix``.
+    persist_agent_tool_names(agent)
+    return added
+
+
+def reprobe_tool_availability() -> None:
+    """Explicit ``/reload-mcp`` hatch out of the tools[] freeze.
+
+    Availability-gated tools (``check_fn``: Docker, HASS_TOKEN, OAuth…) are
+    frozen for the life of a session; a credential or daemon that appears
+    mid-session is only picked up when the user consciously asks. Drop the
+    ``check_fn`` verdict cache AND the ``get_tool_definitions`` memo (keyed on
+    registry generation, so it would otherwise replay the stale verdicts).
+    """
+    from model_tools import _clear_tool_defs_cache
+    from tools.registry import invalidate_check_fn_cache
+
+    invalidate_check_fn_cache()
+    _clear_tool_defs_cache()
+
+
+def persist_agent_tool_names(agent) -> None:
+    """Best-effort: write ``agent.tools`` names to the session row (freeze pin)."""
+    db = getattr(agent, "_session_db", None)
+    session_id = getattr(agent, "session_id", None)
+    if not db or not session_id:
+        return
+    try:
+        db.update_session_tool_names(
+            session_id,
+            [t["function"]["name"] for t in (getattr(agent, "tools", None) or [])],
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("tool_names persist skipped", exc_info=True)
+
+
+def restore_agent_tool_prefix(agent, saved_names: list) -> bool:
+    """Fold a freshly built agent's ``tools`` onto the session's saved order.
+
+    Closes the second door on the tools[] freeze: the gateway rebuilds a NEW
+    ``AIAgent`` for an existing session after agent-cache eviction, and
+    ``agent_init`` re-derives ``agent.tools`` from live ``check_fn`` probes
+    with no predecessor to preserve. The saved name list stands in for that
+    predecessor: a saved tool that is still registered but failed its probe
+    this time is carried forward from the registry's schema, a deregistered
+    one is dropped, and genuinely new tools append at the tail — the same
+    ``_merge_preserving_prefix`` rule the between-turns refresh uses.
+    Returns True when the snapshot was changed.
+    """
+    if not saved_names:
+        return False
+    from tools.registry import registry
+
+    fresh_defs = list(getattr(agent, "tools", None) or [])
+    fresh = {t["function"]["name"]: t for t in fresh_defs}
+    saved_defs = []
+    for name in saved_names:
+        entry_def = fresh.get(name)
+        if entry_def is None:
+            entry = registry.get_entry(name)
+            if entry is None:
+                continue
+            entry_def = {"type": "function", "function": {**entry.schema, "name": entry.name}}
+        saved_defs.append(entry_def)
+    registered_names = {entry.name for entry in registry.get_all_entries()}
+    merged, merged_names = _merge_preserving_prefix(saved_defs, fresh_defs, registered_names)
+    with _agent_tools_lock:
+        if merged == fresh_defs:
+            return False
+        agent.tools = merged
+        agent.valid_tool_names = merged_names
+    if [t["function"]["name"] for t in merged] != list(saved_names):
+        persist_agent_tool_names(agent)
+    return True
 
 
 def _merge_preserving_prefix(

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -133,7 +133,7 @@ def _(rid, params: dict) -> dict:
                 return _err(rid, 5019, f"compute-host reload_mcp failed: {exc}")
             return _ok(rid, {"status": "reloaded", "turn_isolation": True, "host_ack": ack})
 
-        from tools.mcp_tool import shutdown_mcp_servers, discover_mcp_tools
+        from tools.mcp_tool import shutdown_mcp_servers, discover_mcp_tools, reprobe_tool_availability
 
         def _refresh_session_agent() -> None:
             """Rebuild THIS session's cached tool snapshot from the live
@@ -184,6 +184,7 @@ def _(rid, params: dict) -> dict:
             loaded = _compute_mcp_rev()
             for _ in range(_MCP_RELOAD_MAX_PASSES):
                 shutdown_mcp_servers()
+                reprobe_tool_availability()
                 discover_mcp_tools()
                 after = _compute_mcp_rev()
                 if after == loaded:

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -115,7 +115,7 @@ Type `/` in the CLI to open the autocomplete menu. Built-in commands are case-in
 | `/blueprint [name] [slot=value ...]` (alias: `/bp`) | Set up an automation from a blueprint template. Bare `/blueprint` lists the catalog; `/blueprint <name>` starts a guided slot-filling flow on the next agent turn; `/blueprint <name> slot=value ...` creates the job directly. |
 | `/curator` | Background skill maintenance — `status`, `run`, `pin`, `archive`. See [Curator](/user-guide/features/curator). |
 | `/kanban <action>` | Drive the multi-profile, multi-project collaboration board without leaving chat. Full `hermes kanban` surface is available: `/kanban list`, `/kanban show t_abc`, `/kanban create "title" --assignee X`, `/kanban comment t_abc "text"`, `/kanban unblock t_abc`, `/kanban dispatch`, etc. Multi-board support included: `/kanban boards list`, `/kanban boards create <slug>`, `/kanban boards switch <slug>`, `/kanban --board <slug> <action>`. See [Kanban slash command](/user-guide/features/kanban#kanban-slash-command). |
-| `/reload-mcp` (alias: `/reload_mcp`) | Reload MCP servers from config.yaml |
+| `/reload-mcp` (alias: `/reload_mcp`) | Reload MCP servers from config.yaml and re-probe tool availability (credentials/daemons that appeared mid-session) |
 | `/reload-skills` (alias: `/reload_skills`) | Re-scan `~/.hermes/skills/` for newly installed or removed skills |
 | `/reload` | Reload `.env` variables into the running session (picks up new API keys without restarting) |
 | `/plugins` | List installed plugins and their status |
@@ -291,7 +291,7 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 | `/skills [pending\|approve\|reject\|diff\|approval]` | Review pending **skill** writes staged by the write-approval gate (`skills.write_approval`). Shows a one-line gist per staged write; `/skills diff <id>` is truncated for chat — read the full diff on the CLI or in `~/.hermes/pending/skills/<id>.json`. Only appears when the gate is on (or staged writes remain); search/install stay CLI-only. |
 | `/kanban <action>` | Drive the multi-profile, multi-project collaboration board from chat — identical argument surface to the CLI. Bypasses the running-agent guard, so `/kanban unblock t_abc`, `/kanban comment t_abc "…"`, `/kanban list --mine`, `/kanban boards switch <slug>`, etc. work mid-turn. `/kanban create …` auto-subscribes the originating chat to the new task's terminal events. See [Kanban slash command](/user-guide/features/kanban#kanban-slash-command). |
 | `/platform <list\|pause\|resume> [name]` | Operate a running gateway platform right from chat. `/platform list` shows every adapter and its state (running, paused-by-breaker, manually-paused); `/platform pause <name>` stops dispatching new messages to that adapter without unloading it; `/platform resume <name>` re-enables it and clears a tripped circuit breaker once the upstream is healthy. |
-| `/reload-mcp` (alias: `/reload_mcp`) | Reload MCP servers from config. |
+| `/reload-mcp` (alias: `/reload_mcp`) | Reload MCP servers from config and re-probe tool availability. |
 | `/verbose` | Cycle tool progress display. **Off by default on messaging** — enable with `display.tool_progress_command: true` in `config.yaml`. |
 | `/yolo` | Toggle YOLO mode — skip all dangerous command approval prompts. |
 | `/commands [page]` | Browse all commands and skills (paginated). |

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -644,7 +644,7 @@ If you change MCP config, use:
 /reload-mcp
 ```
 
-This reloads MCP servers from config and refreshes the available tool list. For runtime tool changes pushed by the server itself, see [Dynamic Tool Discovery](#dynamic-tool-discovery) above.
+This reloads MCP servers from config and refreshes the available tool list. It is also the explicit way to re-probe availability-gated tools (Docker, `HASS_TOKEN`, OAuth…): a session's tool set is otherwise frozen, so a credential or daemon that appears mid-session is only picked up on `/reload-mcp`, `/new`, or context compaction. For runtime tool changes pushed by the server itself, see [Dynamic Tool Discovery](#dynamic-tool-discovery) above.
 
 ### Toolsets
 


### PR DESCRIPTION
## Summary
Availability-gated tools (Docker, HASS_TOKEN, OAuth… `check_fn` probes) no longer appear/disappear mid-session: `tools[]` is frozen for the life of a session and changes only on `/new`, `/reload-mcp`, or compaction. Policy decision (Teknium, Sep 2 2026) closing #100336 defect (b); supersedes the flip-direction PRs #95053 / #84783.

Root cause: the between-turns MCP refresh republished `agent.tools` from live probe verdicts, and the gateway agent-cache eviction rebuilt a session's agent from live probes with no predecessor — either one silently forks the provider's cached prefix (measured 4,555-token shrink).

## Changes
- Door 1 (cherry-pick of #100638, @JoaoMarcos44): `refresh_agent_mcp_tools(preserve_prefix=True)` — `_merge_preserving_prefix` keeps live order, carries probe-flipped-but-still-registered tools forward, appends late arrivals at the tail
- Door 2: new `sessions.tool_names` JSON column (declarative reconciliation, schema 27→28); persisted where the system prompt is persisted and after each published refresh; on continuing-session rebuild the fresh definitions are folded onto the saved order with the SAME helper
- Hatch: `reprobe_tool_availability()` (invalidate check_fn cache + tool-defs cache) wired into CLI / gateway / TUI `/reload-mcp`; docs updated (slash-commands.md, features/mcp.md)
- 4 tests (2 from #100638, 2 new), all fail without the fix

## Validation (live, real registry + real SessionDB, tool with flipping check_fn)
| step | tools[] |
|---|---|
| turn 1 | [flappy, stable] |
| check_fn → False, between-turns refresh | [flappy, stable] (door 1) |
| eviction rebuild, raw | [stable] |
| eviction rebuild, restored | [flappy, stable] (door 2) |
| check_fn → True, no hatch | [stable] (TTL cache) |
| `/reload-mcp` | [flappy, stable] |

Dispatch never consults check_fn, so a carried-forward tool is invocable; its handler owns the unavailability error. Non-MCP sessions never hit the refresh path.

Credit: @JoaoMarcos44 (#100638, authorship preserved). Closes #100638.

## Infographic

![tools frozen](https://v3b.fal.media/files/b/0aa8d15e/YriJNDN2xAxPxsF7aCoNF_bXEhBVkm.png)
