### PR TITLE
fix(gateway): cache inbound attachments in the routed profile's scope

### DIFF
--- a/gateway/inbound_media_scope.py
+++ b/gateway/inbound_media_scope.py
@@ -1,0 +1,212 @@
+"""Re-home inbound attachments into the routed profile's cache.
+
+Platform adapters download and cache an inbound attachment *before* the
+gateway knows which multiplexed profile owns the turn, so the bytes land in
+the cache of the process/launch Hermes home.  The turn then runs inside
+``_profile_runtime_scope``, where ``get_cache_directory_mounts()`` — and the
+sandbox bind mounts built from it — resolve the *profile's* cache instead.
+
+The two halves disagree in the worst possible way: the agent is handed a path
+that exists, is mounted, and is empty, so it reports "file not found" and asks
+for a re-send that lands in the same unmounted directory.  Host-side vision
+reads fail the same way from the other end, because
+``tools/image_source._media_cache_roots()`` only authorises paths under the
+*active* home (#101134).
+
+This module moves those files into the active profile's matching cache
+directory at the one point where the routed profile is known and no media
+consumer (vision, STT, document notes) has run yet.  Single-profile gateways
+resolve the same home twice and return before touching disk.
+
+Path form: entries are rewritten to **host** paths.  That is the coordinate
+system every host-side consumer already needs (STT opens the file, vision
+resolves it against the cache roots), and the document-note builder in
+``gateway/run.py`` performs the single host→sandbox translation under the
+routed scope.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+from pathlib import Path, PurePosixPath
+from typing import Any, Dict, List, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+
+def _is_existing_file(path: Path) -> bool:
+    """``path.is_file()`` that survives an unreadable parent directory.
+
+    ``pathlib`` swallows ``ENOENT``/``ENOTDIR`` but not ``EACCES``, and the
+    sandbox-form paths this module inspects start at ``/root`` — mode 0700 for
+    a gateway that does not run as root.  Probing one would raise instead of
+    answering ``False``.
+    """
+    try:
+        return path.is_file()
+    except OSError:
+        return False
+
+
+def _source_host_path(
+    entry: str,
+    source_mounts: Sequence[Dict[str, str]],
+) -> Optional[Path]:
+    """Return the host file named by *entry*, or ``None`` if it is not one.
+
+    Accepts both coordinate systems: a host path (what the cache primitives
+    return) and a sandbox path minted by ``to_agent_visible_cache_path`` under
+    the source home (what ``CachedMedia`` used to carry, and what an
+    out-of-tree adapter may still push into ``media_urls``).
+    """
+    if not entry:
+        return None
+    candidate = Path(entry)
+    if _is_existing_file(candidate):
+        return candidate
+    posix_entry = PurePosixPath(entry)
+    for mount in source_mounts:
+        try:
+            rel = posix_entry.relative_to(mount["container_path"])
+        except ValueError:
+            continue
+        translated = Path(mount["host_path"]) / Path(str(rel))
+        if _is_existing_file(translated):
+            return translated
+    return None
+
+
+def _relocate(source: Path, destination: Path) -> None:
+    """Move *source* onto *destination*, falling back to copy across devices."""
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        os.replace(source, destination)
+        return
+    except OSError:
+        # Cross-device rename, or a Windows handle still open on the source.
+        shutil.copy2(source, destination)
+    try:
+        source.unlink()
+    except OSError:
+        # The copy landed; leaving the original behind is untidy, not broken.
+        logger.debug("inbound media source not removable: %s", source, exc_info=True)
+
+
+def _rehome_one(
+    entry: str,
+    source_mounts: Sequence[Dict[str, str]],
+    destination_roots: Dict[str, str],
+) -> Optional[str]:
+    """Return the relocated host path for *entry*, or ``None`` to keep it."""
+    host_path = _source_host_path(entry, source_mounts)
+    if host_path is None:
+        return None
+    for mount in source_mounts:
+        try:
+            rel = host_path.relative_to(Path(mount["host_path"]))
+        except ValueError:
+            continue
+        destination_root = destination_roots.get(mount["container_path"])
+        if not destination_root:
+            return None
+        root = Path(destination_root)
+        destination = root / rel
+        try:
+            # ``rel`` comes from relative_to, so it cannot escape on its own;
+            # a symlinked cache entry still can.
+            destination.resolve().relative_to(root.resolve())
+        except (OSError, ValueError):
+            return None
+        if _is_existing_file(destination):
+            # Same file name already staged for this profile (a redelivered
+            # event): keep the staged copy rather than clobbering it.
+            return str(destination)
+        _relocate(host_path, destination)
+        return str(destination)
+    return None
+
+
+def rehome_media_paths(paths: Sequence[str]) -> List[str]:
+    """Return *paths* with adapter-cached files moved into the active profile.
+
+    Entries that are not adapter-cached files, or that already live under the
+    active home's cache, are returned untouched — which also makes the whole
+    pass idempotent.
+    """
+    from hermes_constants import (
+        get_hermes_home,
+        get_process_hermes_home,
+        hermes_home_key,
+    )
+    from tools.credential_files import get_cache_directory_mounts
+
+    active_home = Path(get_hermes_home())
+    source_home = Path(get_process_hermes_home())
+    if hermes_home_key(active_home) == hermes_home_key(source_home):
+        return list(paths)
+
+    source_mounts = get_cache_directory_mounts(home=source_home)
+    destination_roots = {
+        mount["container_path"]: mount["host_path"]
+        for mount in get_cache_directory_mounts(home=active_home)
+    }
+
+    rewritten: List[str] = []
+    for entry in paths:
+        try:
+            moved = _rehome_one(entry, source_mounts, destination_roots)
+        except OSError:
+            logger.warning(
+                "Could not move inbound attachment into the routed profile "
+                "cache; the agent may not be able to open it",
+                exc_info=True,
+            )
+            moved = None
+        rewritten.append(moved or entry)
+    return rewritten
+
+
+def _rewrite_baked_paths(
+    event: Any,
+    original: Sequence[str],
+    rewritten: Sequence[str],
+) -> None:
+    """Repoint paths an adapter already interpolated into ``event.text``.
+
+    ``CachedMedia.context_note()`` is appended to the observed-group
+    transcript at ingress, naming the pre-move location.
+    """
+    text = getattr(event, "text", None)
+    if not text:
+        return
+    from tools.credential_files import to_agent_visible_cache_path
+
+    for old, new in zip(original, rewritten):
+        if old == new or old not in text:
+            continue
+        text = text.replace(old, to_agent_visible_cache_path(new))
+    event.text = text
+
+
+def rehome_event_media(event: Any) -> None:
+    """Move one inbound event's cached attachments into the active profile.
+
+    Call from inside the routed profile's runtime scope, before any consumer
+    reads ``event.media_urls`` or ``event.text``.
+    """
+    original = list(getattr(event, "media_urls", None) or [])
+    if not original:
+        return
+    try:
+        rewritten = rehome_media_paths(original)
+    except Exception:
+        # Never fail an inbound turn over cache placement: the worst case is
+        # the pre-fix behaviour.
+        logger.debug("inbound media rehome failed", exc_info=True)
+        return
+    if rewritten == original:
+        return
+    event.media_urls = rewritten
+    _rewrite_baked_paths(event, original, rewritten)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2356,14 +2356,19 @@ def cleanup_document_cache(max_age_hours: int = 24) -> int:
 class CachedMedia:
     """Result of caching one attachment's bytes."""
 
-    path: str                 # absolute cache path, agent-visible (sandbox-translated)
+    path: str                 # absolute cache path, HOST side (not translated)
     media_type: str           # MIME type recorded on the MessageEvent
     kind: str                 # "image" | "video" | "audio" | "document"
     display_name: str         # human-readable name for transcript notes
 
     def context_note(self) -> str:
         """One-line transcript annotation pointing the agent at the file."""
-        return f"[{self.kind} '{self.display_name}' saved at: {self.path}]"
+        from tools.credential_files import to_agent_visible_cache_path
+
+        return (
+            f"[{self.kind} '{self.display_name}' saved at: "
+            f"{to_agent_visible_cache_path(self.path)}]"
+        )
 
 
 def _resolve_media_ext(filename: str, mime_type: str) -> str:
@@ -2401,9 +2406,15 @@ def cache_media_bytes(
     document and surfaced to the agent (arbitrary types get
     ``application/octet-stream``); only images that fail validation
     (``cache_image_from_bytes`` raises ValueError) return None.
-    """
-    from tools.credential_files import to_agent_visible_cache_path
 
+    The returned path is the HOST path, matching every other inbound cache
+    primitive (``cache_image_from_bytes`` and friends). Translating to the
+    sandbox coordinate here used to make ``event.media_urls`` a mixed-format
+    field — photos host-form, documents container-form — with no marker saying
+    which was which, and it baked a mount table resolved outside the routed
+    profile's scope into the path (#101134). Sandbox translation now happens
+    once, at the point of use, under the scope that owns the turn.
+    """
     ext = _resolve_media_ext(filename, mime_type)
     mime = (mime_type or "").lower()
     display = re.sub(r"[^\w.\- ]", "_", filename) if filename else (ext.lstrip(".") or "file")
@@ -2423,18 +2434,18 @@ def cache_media_bytes(
         except ValueError:
             return None
         out_mime = mime if mime.startswith("image/") else SUPPORTED_IMAGE_DOCUMENT_TYPES.get(img_ext, "image/jpeg")
-        return CachedMedia(to_agent_visible_cache_path(path), out_mime, "image", display)
+        return CachedMedia(path, out_mime, "image", display)
 
     if is_video:
         vid_ext = ext if ext in SUPPORTED_VIDEO_TYPES else ".mp4"
         path = cache_video_from_bytes(data, ext=vid_ext)
-        return CachedMedia(to_agent_visible_cache_path(path), SUPPORTED_VIDEO_TYPES.get(vid_ext, "video/mp4"), "video", display)
+        return CachedMedia(path, SUPPORTED_VIDEO_TYPES.get(vid_ext, "video/mp4"), "video", display)
 
     if is_audio:
         aud_ext = ext if ext in _AUDIO_EXTS else ".ogg"
         path = cache_audio_from_bytes(data, ext=aud_ext)
         out_mime = mime if mime.startswith("audio/") else _AUDIO_MIME_TYPES[aud_ext]
-        return CachedMedia(to_agent_visible_cache_path(path), out_mime, "audio", display)
+        return CachedMedia(path, out_mime, "audio", display)
 
     # Any other file type is cached and surfaced to the agent as a local path
     # so it can be inspected with terminal / read_file / etc. Authorization to
@@ -2449,7 +2460,7 @@ def cache_media_bytes(
         out_mime = SUPPORTED_DOCUMENT_TYPES[ext]
     else:
         out_mime = mime if mime else "application/octet-stream"
-    return CachedMedia(to_agent_visible_cache_path(path), out_mime, "document", display or fallback_name)
+    return CachedMedia(path, out_mime, "document", display or fallback_name)
 
 
 class MessageType(Enum):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20327,6 +20327,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         list is empty, the ``_enrich_message_with_vision`` text path has
         already run and images are represented in-text.
         """
+        # Inbound attachments were cached by the adapter before profile
+        # routing picked this turn's profile, so under multiplexing they can
+        # sit in the process home's cache while this scope -- and the sandbox
+        # mounts built from it -- point at the profile's own cache (#101134).
+        # Move them here, before vision / STT / the document notes below
+        # read media_urls.
+        from gateway.inbound_media_scope import rehome_event_media
+
+        rehome_event_media(event)
+
         history = history or []
         _pending_stt_prepared = hasattr(event, "_gateway_pending_stt_text")
         message_text = (
@@ -20570,6 +20580,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # Translate host cache path to in-container path if running under Docker backend.
                 # This ensures the agent receives a path it can open inside its sandbox, as the
                 # cache directories are auto-mounted at /root/.hermes/cache/* by get_cache_directory_mounts().
+                # Both halves resolve get_hermes_home(), so this must stay inside the routed
+                # profile's scope AND the bytes must already have been moved into that profile's
+                # cache by rehome_event_media() above -- otherwise the mount table and the file
+                # disagree and the sandbox path names an empty directory (#101134).
                 agent_path = to_agent_visible_cache_path(path)
 
                 inline_flags = getattr(event, "media_text_inlined", None) or []

--- a/tests/gateway/test_inbound_media_profile_scope.py
+++ b/tests/gateway/test_inbound_media_profile_scope.py
@@ -1,0 +1,227 @@
+"""Regression: inbound attachments must land in the routed profile's cache (#101134).
+
+A platform adapter downloads and caches an attachment before the gateway knows
+which multiplexed profile owns the turn, so the bytes go to the process/launch
+home's cache.  The turn then runs under ``_profile_runtime_scope``, where the
+cache mount table — and the Docker bind mounts built from it — resolve the
+*profile's* cache.  The agent was handed ``/root/.hermes/cache/documents/x.pdf``:
+a path that exists, is mounted, and is empty.
+
+Covered here:
+
+* documents and photos are moved into the active profile's cache;
+* the sandbox path the agent is told about now names a directory that actually
+  holds the file;
+* the pass is idempotent, single-profile gateways never touch disk, and a
+  failed move degrades to the pre-fix path instead of dropping the attachment;
+* ``event.media_urls`` carries one coordinate system (host paths), which is
+  the second, independent defect the issue reports.
+"""
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.inbound_media_scope import (
+    _is_existing_file,
+    rehome_event_media,
+    rehome_media_paths,
+)
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+@pytest.fixture
+def homes(tmp_path, monkeypatch):
+    """A process/launch home plus a routed profile home, with the profile bound."""
+    process_home = tmp_path / "hermes"
+    profile_home = process_home / "profiles" / "profile-a"
+    for home in (process_home, profile_home):
+        (home / "cache" / "documents").mkdir(parents=True)
+        (home / "cache" / "images").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(process_home))
+    token = set_hermes_home_override(str(profile_home))
+    try:
+        yield SimpleNamespace(process=process_home, profile=profile_home)
+    finally:
+        reset_hermes_home_override(token)
+
+
+def _stage(home: Path, kind: str, name: str, body: bytes = b"%PDF-1.4 body") -> Path:
+    path = home / "cache" / kind / name
+    path.write_bytes(body)
+    return path
+
+
+class TestRehomeMediaPaths:
+    def test_document_moves_into_the_routed_profile_cache(self, homes):
+        staged = _stage(homes.process, "documents", "report.pdf")
+
+        (rehomed,) = rehome_media_paths([str(staged)])
+
+        assert Path(rehomed) == homes.profile / "cache" / "documents" / "report.pdf"
+        assert Path(rehomed).read_bytes() == b"%PDF-1.4 body"
+        assert not staged.exists(), "the process-home copy must not linger"
+
+    def test_agent_visible_path_names_the_mounted_directory(self, homes, monkeypatch):
+        """The bug in one assertion: sandbox path + profile mount must agree."""
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        from tools.credential_files import to_agent_visible_cache_path
+
+        staged = _stage(homes.process, "documents", "report.pdf")
+
+        # Pre-fix: translating the process-home path under the profile scope
+        # yields a sandbox path whose bind-mounted host directory is empty.
+        pre_fix = to_agent_visible_cache_path(str(staged))
+        assert pre_fix == str(staged), "process-home file is outside the profile mounts"
+
+        (rehomed,) = rehome_media_paths([str(staged)])
+        agent_path = to_agent_visible_cache_path(rehomed)
+
+        assert agent_path == "/root/.hermes/cache/documents/report.pdf"
+        # ...and the directory Docker mounts at that path now holds the file.
+        assert (homes.profile / "cache" / "documents" / "report.pdf").is_file()
+
+    def test_image_becomes_readable_by_the_host_vision_path(self, homes, monkeypatch):
+        """`_media_cache_roots()` only authorises the ACTIVE home's cache."""
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        from tools.image_source import _permitted_host_read_target
+
+        staged = _stage(homes.process, "images", "img_abc.jpg", b"\xff\xd8\xff body")
+        ctx = SimpleNamespace()
+
+        assert _permitted_host_read_target(staged, ctx) is None
+
+        (rehomed,) = rehome_media_paths([str(staged)])
+
+        assert _permitted_host_read_target(Path(rehomed), ctx) is not None
+
+    def test_sandbox_form_entries_are_translated_before_moving(self, homes, monkeypatch):
+        """An out-of-tree adapter may still push a container-form path."""
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        staged = _stage(homes.process, "documents", "legacy.pdf")
+        container_form = "/root/.hermes/cache/documents/legacy.pdf"
+
+        (rehomed,) = rehome_media_paths([container_form])
+
+        assert Path(rehomed) == homes.profile / "cache" / "documents" / "legacy.pdf"
+        assert not staged.exists()
+
+    def test_second_pass_is_a_no_op(self, homes):
+        staged = _stage(homes.process, "documents", "report.pdf")
+
+        once = rehome_media_paths([str(staged)])
+        twice = rehome_media_paths(once)
+
+        assert twice == once
+        assert Path(once[0]).is_file()
+
+    def test_single_profile_gateway_leaves_paths_alone(self, tmp_path, monkeypatch):
+        home = tmp_path / "hermes"
+        (home / "cache" / "documents").mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        staged = _stage(home, "documents", "report.pdf")
+
+        assert rehome_media_paths([str(staged)]) == [str(staged)]
+        assert staged.is_file()
+
+    def test_unknown_paths_are_returned_untouched(self, homes, tmp_path):
+        outside = tmp_path / "elsewhere" / "notes.txt"
+        outside.parent.mkdir(parents=True)
+        outside.write_text("x", encoding="utf-8")
+
+        assert rehome_media_paths([str(outside), "https://example.com/a.png"]) == [
+            str(outside),
+            "https://example.com/a.png",
+        ]
+        assert outside.is_file()
+
+    def test_move_failure_keeps_the_original_path(self, homes, monkeypatch):
+        staged = _stage(homes.process, "documents", "report.pdf")
+
+        def _boom(*_args, **_kwargs):
+            raise PermissionError("locked")
+
+        monkeypatch.setattr("gateway.inbound_media_scope.os.replace", _boom)
+        monkeypatch.setattr("gateway.inbound_media_scope.shutil.copy2", _boom)
+
+        assert rehome_media_paths([str(staged)]) == [str(staged)]
+        assert staged.is_file(), "a failed move must not lose the attachment"
+
+    def test_probe_survives_an_unreadable_parent(self, monkeypatch):
+        """`/root` is 0700: pathlib re-raises EACCES instead of answering False."""
+        denied = Path("/root/.hermes/cache/documents/x.pdf")
+
+        def _raise(_self):
+            raise PermissionError(13, "Permission denied")
+
+        monkeypatch.setattr(type(denied), "is_file", _raise, raising=False)
+
+        assert _is_existing_file(denied) is False
+
+
+class TestRehomeEventMedia:
+    def test_rewrites_media_urls_and_the_baked_transcript_note(self, homes, monkeypatch):
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        staged = _stage(homes.process, "documents", "report.pdf")
+        event = SimpleNamespace(
+            media_urls=[str(staged)],
+            text=f"[document 'report.pdf' saved at: {staged}] hi",
+        )
+
+        rehome_event_media(event)
+
+        assert event.media_urls == [
+            str(homes.profile / "cache" / "documents" / "report.pdf")
+        ]
+        assert "/root/.hermes/cache/documents/report.pdf" in event.text
+        assert str(staged) not in event.text
+
+    def test_event_without_media_is_untouched(self, homes):
+        event = SimpleNamespace(media_urls=[], text="hello")
+        rehome_event_media(event)
+        assert event.media_urls == []
+        assert event.text == "hello"
+
+
+class TestMediaUrlsCoordinateSystem:
+    """The second, independent defect: media_urls held two path forms."""
+
+    @pytest.fixture(autouse=True)
+    def _docker_cache(self, tmp_path, monkeypatch):
+        home = tmp_path / "hermes"
+        (home / "cache" / "documents").mkdir(parents=True)
+        (home / "cache" / "images").mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        return home
+
+    def test_document_and_photo_agree_on_the_host_form(self):
+        from gateway.platforms.base import cache_media_bytes, cache_image_from_bytes
+
+        png = bytes.fromhex(
+            "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4"
+            "890000000d49444154789c6360000002000154a24f5f0000000049454e44ae426082"
+        )
+        document = cache_media_bytes(
+            b"%PDF-1.4 body", filename="report.pdf", mime_type="application/pdf"
+        )
+        photo_direct = cache_image_from_bytes(png, ext=".png")
+        photo_dispatch = cache_media_bytes(png, filename="p.png", mime_type="image/png")
+
+        assert document is not None and photo_dispatch is not None
+        for path in (document.path, photo_dispatch.path, photo_direct):
+            assert os.path.isabs(path)
+            assert not path.startswith("/root/.hermes"), "container form leaked"
+            assert Path(path).is_file()
+
+    def test_context_note_still_renders_the_sandbox_path(self):
+        from gateway.platforms.base import cache_media_bytes
+
+        cached = cache_media_bytes(
+            b"%PDF-1.4 body", filename="report.pdf", mime_type="application/pdf"
+        )
+
+        assert cached is not None
+        assert "/root/.hermes/cache/documents/" in cached.context_note()

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -436,18 +436,25 @@ _CACHE_DIRS: list[tuple[str, str]] = [
 
 def get_cache_directory_mounts(
     container_base: str = "/root/.hermes",
+    home: Optional[Path] = None,
 ) -> List[Dict[str, str]]:
     """Return mount entries for each cache directory that exists on disk.
 
     Used by Docker to create bind mounts.  Each entry has ``host_path`` and
     ``container_path`` keys.  The host path is resolved via
     ``get_hermes_dir()`` for backward compatibility with old directory layouts.
+
+    ``home`` names an explicit Hermes home instead of the ambient one.  A
+    multiplexed gateway holds two homes at once — the process/launch home the
+    platform adapters cached into and the routed profile's home the turn runs
+    under — and needs both tables in the same call stack to move inbound
+    attachments between them (see ``gateway.inbound_media_scope``).
     """
     from hermes_constants import get_hermes_dir
 
     mounts: List[Dict[str, str]] = []
     for new_subpath, old_name in _CACHE_DIRS:
-        host_dir = get_hermes_dir(new_subpath, old_name)
+        host_dir = get_hermes_dir(new_subpath, old_name, home=home)
         if not host_dir.is_dir():
             # Create missing staging dirs instead of skipping them: Docker
             # snapshots this mount list at container CREATION, so a dir that


### PR DESCRIPTION
## What does this PR do?

An inbound document or photo sent to a non-default profile on a multiplexed gateway is now cached inside that profile's scope, so the path the agent is given names a directory that actually holds the file.

### Symptom

With `gateway.multiplex_profiles` and `terminal.backend: docker`, a PDF sent to a secondary profile is downloaded into the process/launch home's cache, while that profile's container bind-mounts its own `profiles/<name>/cache/<type>`. The agent receives `/root/.hermes/cache/documents/<name>.pdf` — a path that exists, is mounted, and is empty — and reports `File not found`. Re-sending can never work: every re-send lands in the same unmounted directory. Photos fail from the other end: `tools/image_source._media_cache_roots()` only authorises host reads under the *active* home, so the read is redirected into the sandbox where the file is not present.

### Impact

Every document and photo routed to a non-default profile is unreachable to that profile's agent, and the failure is reported to the user as a missing file rather than a bug. `hermes doctor` is clean; nothing at config level is wrong.

### Bug Cause

**Trigger:** any inbound attachment on a gateway with `gateway.multiplex_profiles` enabled, whenever the turn's routed profile differs from the home the adapter cached under.

**Causal chain:**

1. `_handle_media_message` (and every sibling adapter ingress) downloads and caches the bytes *before* the gateway resolves `source.profile`, so `get_hermes_home()` still answers the process/launch home.
2. The turn then enters `_profile_runtime_scope(profile_home)`, where `get_cache_directory_mounts()` — and the Docker bind mounts built from it — resolve the profile's cache.
3. `to_agent_visible_cache_path()` and the container mount table therefore agree on a sandbox path but resolve different host directories.

**Why it is wrong:** the file location and the mount table are both derived from `get_hermes_home()`, but at two different times under two different scopes. Nothing reconciles them, and a syntactically valid path silently points into an empty mount.

**Working sibling / contrast:** a single-profile gateway resolves the same home in both places, so the downloaded file and the mounted directory already coincide.

**Ruled out:** `get_cache_directory_mounts()` is not omitting cache directories — it creates and returns the active profile's mounts correctly. The defect is *where the bytes were written* before that profile became active.

### A second, independent defect

`event.media_urls` was a mixed-format field. `cache_media_bytes` returned a sandbox-translated path while `cache_image_from_bytes` (and every other inbound cache primitive) returned a host path, with no marker saying which was which — so a document arrived in container form and a photo in host form on the same list. Any consumer assuming one form silently mishandled the other half; host-side STT on an audio *document* could never open its file.

### Fix

- `gateway/inbound_media_scope.py` moves adapter-cached files into the active profile's matching cache directory at the single point where the routed profile is known and no media consumer (vision, STT, document notes) has run yet. It covers every mounted cache class — documents, images, audio, videos, screenshots, web, delegation, spillover, and the flat `images/` and `attachments/` staging dirs — with no adapter-specific branches, is idempotent, and short-circuits before touching disk when the two homes resolve equal. Any failure keeps the original path, so the worst case equals the pre-fix behaviour.
- Sandbox-form probes are `EACCES`-safe: `/root` is `drwx------`, and `pathlib` swallows `ENOENT`/`ENOTDIR` but re-raises `EACCES`, so a naive `is_file()` on the container form raises instead of answering `False`.
- `CachedMedia.path` now carries the **host** path, matching every other inbound cache primitive, and `context_note()` translates at render time — so `event.media_urls` has one coordinate system and the sandbox string the agent sees is byte-identical.
- `get_cache_directory_mounts()` accepts an explicit `home`, the seam `get_hermes_dir()` already documents for callers that hold more than one home in a single call stack.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A[Inbound Attachment] -->|Adapter Ingress| B[Download and Cache]
    B -->|Profile Not Yet Routed| C[Process Home Cache]
    C -->|Turn Enters Profile Scope| D{Homes Agree?}
    D -->|Yes: Single Profile| E[Path Kept Untouched]
    D -->|No: Multiplexed| F[Move Into Profile Cache]
    F -->|Relocation Failure| E
    F -->|Relocation Success| G[Host Path Rewritten]
    G -->|Single Translation Point| H[Sandbox Path Under Profile Mount]
    E --> H
    H -->|Agent Opens File| I[Vision / STT / Document Note]
```

## Related Issue

Fixes #101134

Prior art: #101153 attempted a gateway-side relocation and was closed unmerged by its author. This lands on a different seam — a shared helper at the preprocessing choke point, plus the coordinate-system fix at its source — and additionally covers audio and video, which the workaround described in the issue left in the shared folder.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/inbound_media_scope.py` — new: move adapter-cached inbound media into the routed profile's cache; idempotent, fail-soft, `EACCES`-safe.
- `gateway/run.py` — call it once at the top of `_prepare_inbound_message_text`, before vision / STT / document notes read `media_urls`; correct the stale mount comment the issue cites.
- `gateway/platforms/base.py` — `CachedMedia.path` is the host path; `context_note()` translates at render time.
- `tools/credential_files.py` — `get_cache_directory_mounts(home=...)`.
- `tests/gateway/test_inbound_media_profile_scope.py` — 13 regression tests.

## How to Test

```bash
scripts/run_tests.sh tests/gateway/test_inbound_media_profile_scope.py -q --tb=short
```

Result: **13 passed**.

Adjacent suites, run before and after the change on the same machine, produce an identical failure set (5 pre-existing Windows-only failures: path-separator assertions, symlink privileges, an env-var length limit):

```bash
scripts/run_tests.sh tests/gateway/test_document_cache.py tests/gateway/test_media_cache.py \
  tests/gateway/test_buzz_adapter.py tests/tools/test_credential_files.py -q
# 5 failed, 266 passed - identical ids before and after
```

Fully green after the change:

```bash
scripts/run_tests.sh tests/gateway/test_telegram_documents.py tests/gateway/test_mixed_attachment_routing.py \
  tests/gateway/test_image_input_routing_runtime.py tests/gateway/test_native_image_buffer_isolation.py \
  tests/gateway/test_queued_native_image_session_key.py tests/gateway/test_discord_attachment_download.py \
  tests/tools/test_image_source.py -q
# 50 passed, 1 skipped

scripts/run_tests.sh tests/gateway/test_document_context_note.py tests/gateway/test_video_context_note.py \
  tests/gateway/test_teams.py tests/gateway/test_telegram_audio_vs_voice.py tests/gateway/test_reply_to_injection.py \
  tests/gateway/test_shared_group_sender_prefix.py tests/gateway/test_context_ref_expansion_runtime.py \
  tests/agent/test_gateway_turn_sidecar.py -q
# 57 passed
```

Manual check on a multiplexed Docker deployment:

1. Send a PDF from a chat routed to a secondary profile.
2. `ls ~/.hermes/cache/documents/` — empty; `ls ~/.hermes/profiles/<name>/cache/documents/` — holds the file.
3. `docker exec <container> ls /root/.hermes/cache/documents/` — holds the file, and the agent opens the path it was given.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests
- [x] I've added tests for my changes
- [x] Cross-platform impact considered: host paths go through `pathlib`, sandbox paths stay POSIX via `PurePosixPath`/`posixpath`

### Documentation & Housekeeping

- [x] Documentation update is N/A; the rationale lives in the new module's docstring and in the corrected in-tree comment at the translation site
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` updates are N/A; no workflow contract changed
- [x] Tool descriptions and schemas are N/A; no model tool contract changed


