### PR TITLE
fix(api): start run sweeper only after successful bind

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3857,7 +3857,6 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             self._app["api_server_adapter"] = self
             if self.gateway_runner is not None:
                 self._app["gateway_runner"] = self.gateway_runner
-            self._track_background_task(asyncio.create_task(self._sweep_orphaned_runs()))
             # Network-accessible + unsandboxed local terminal backend = host-user RCE surface;
             # warn, don't refuse (the operator may have a firewall / strong key).
             if is_network_accessible(self._host):
@@ -3916,6 +3915,10 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
                     "config.yaml: platforms.api_server.port",
                     self.name, self._host, self._port, exc)
                 return False
+            # Start the permanent run-stream sweeper only after the server has
+            # bound successfully. Retryable bind failures discard this adapter;
+            # starting the task earlier would retain every failed instance.
+            self._track_background_task(asyncio.create_task(self._sweep_orphaned_runs()))
             self._mark_connected()
             logger.info(
                 "[%s] API server listening on http://%s:%d (model: %s)",

--- a/tests/gateway/test_api_server_bind_guard.py
+++ b/tests/gateway/test_api_server_bind_guard.py
@@ -4,8 +4,10 @@ Validates that is_network_accessible() correctly classifies addresses and
 that connect() refuses to start without API_SERVER_KEY.
 """
 
+import asyncio
+import errno
 import socket
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -170,3 +172,53 @@ class TestBindMechanics:
         finally:
             await first.disconnect()
             await second.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_retryable_bind_failure_does_not_start_sweeper(self):
+        """A failed bind must not leave the permanent run sweeper alive.
+
+        Non-EADDRINUSE bind errors remain retryable, so the reconnect watcher
+        repeatedly constructs and disposes fresh adapters. Starting the
+        permanent sweeper before the bind succeeds would retain every failed
+        adapter for the lifetime of the gateway.
+        """
+        adapter = self._make_adapter(8641)
+        sweep_started = asyncio.Event()
+        sweep_release = asyncio.Event()
+
+        async def blocked_sweeper():
+            sweep_started.set()
+            await sweep_release.wait()
+
+        try:
+            with (
+                patch.object(
+                    adapter,
+                    "_sweep_orphaned_runs",
+                    new=blocked_sweeper,
+                ),
+                patch(
+                    "gateway.platforms.api_server.web.TCPSite.start",
+                    new=AsyncMock(
+                        side_effect=OSError(
+                            errno.EADDRNOTAVAIL,
+                            "address unavailable",
+                        )
+                    ),
+                ) as start,
+            ):
+                result = await adapter.connect()
+
+            await asyncio.sleep(0)
+
+            start.assert_awaited_once_with()
+            assert result is False
+            assert adapter.has_fatal_error is False
+            assert adapter._runner is None
+            assert adapter._site is None
+            assert sweep_started.is_set() is False
+            assert adapter._background_tasks == set()
+        finally:
+            sweep_release.set()
+            await adapter.cancel_background_tasks()
+            await adapter.disconnect()


### PR DESCRIPTION
## What does this PR do?

Starts `_sweep_orphaned_runs()` only after `web.TCPSite.start()` binds successfully.

On a retryable bind failure, the reconnect watcher disposes the unused adapter. Starting the permanent sweeper before the bind meant the event loop retained each failed adapter through its still-running task. The new ordering leaves failed adapters with no permanent background task while preserving the successful startup path.

This is the focused extraction of the lifecycle fix identified by @Warrenpoobear in #22064, following the maintainer request to resubmit it from current `main` with only `gateway/platforms/api_server.py` and tests.

## Related Issue

Follow-up to #22064.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Move the API run-stream sweeper startup below the successful `TCPSite.start()` call.
- Add a deterministic regression test for a retryable bind failure.
- Verify the failed runner/site are cleaned up and no sweeper task is started.

## How to Test

1. Run:
   `scripts/run_tests.sh tests/gateway/test_api_server.py tests/gateway/test_api_server_bind_guard.py tests/gateway/test_api_server_runs.py tests/gateway/test_platform_reconnect_fd_leak.py tests/gateway/test_runner_startup_failures.py -q`
2. Confirm all 205 related tests pass.
3. Run `ruff check gateway/platforms/api_server.py tests/gateway/test_api_server_bind_guard.py` and `git diff --check`.

Full-suite note: `scripts/run_tests.sh` was also attempted. The run was stopped after 5 unrelated failures caused by the optional `anthropic` SDK not being installed in the local environment; the failures were confined to Anthropic-provider tests outside this PR's files. The focused 205-test gateway suite passes in full.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, lifecycle-only fix
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — asyncio/aiohttp lifecycle ordering is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

N/A — covered by the deterministic bind-failure regression test.
