### PR TITLE
fix(kanban): dependency blocks are edge-bound and non-respawning

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -675,6 +675,15 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
             "triage to break unblock loops. Omit for a generic block."
         ),
     )
+    p_block.add_argument(
+        "--dependency-ids", nargs="+", default=None, metavar="TASK_ID",
+        help=(
+            "With --kind dependency: task ids to link as parents in the same "
+            "transaction as the block. The block is refused when there is no "
+            "live parent edge to wait on (parentless or all-parents-done "
+            "tasks would respawn immediately)."
+        ),
+    )
 
     p_schedule = sub.add_parser("schedule", help="Park one or more tasks in Scheduled (waiting on time, not human input)")
     p_schedule.add_argument("task_id")
@@ -2452,23 +2461,40 @@ def _cmd_edit(args: argparse.Namespace) -> int:
 def _cmd_block(args: argparse.Namespace) -> int:
     reason = " ".join(args.reason).strip() if args.reason else None
     kind = getattr(args, "kind", None)
+    dependency_ids = getattr(args, "dependency_ids", None)
     author = _profile_author()
     ids = [args.task_id] + list(getattr(args, "ids", None) or [])
     failed: list[str] = []
     with kb.connect_closing() as conn:
         for tid in ids:
-            if reason:
-                kb.add_comment(conn, tid, author, f"BLOCKED: {reason}")
-            if not kb.block_task(
-                conn,
-                tid,
-                reason=reason,
-                kind=kind,
-                expected_run_id=_worker_run_id_for(tid),
-            ):
+            try:
+                ok = kb.block_task(
+                    conn,
+                    tid,
+                    reason=reason,
+                    kind=kind,
+                    expected_run_id=_worker_run_id_for(tid),
+                    dependency_ids=dependency_ids,
+                )
+            except ValueError as exc:
+                # Refused by validation (kind/dependency_ids misuse, or the
+                # dependency respawn-guard: no live parent edge to wait on).
+                # Deliberately NO comment: a refused block must not leave a
+                # misleading "BLOCKED:" note on a task that is not blocked.
+                failed.append(tid)
+                print(str(exc), file=sys.stderr)
+                continue
+            if not ok:
                 failed.append(tid)
                 print(f"cannot block {tid}", file=sys.stderr)
             else:
+                # The transition succeeded; only now is it safe to record the
+                # block reason as a durable comment. (Moving this before the
+                # transition would stamp "BLOCKED:" on a refused dependency
+                # block — the misleading state the respawn-guard exists to
+                # prevent.)
+                if reason:
+                    kb.add_comment(conn, tid, author, f"BLOCKED: {reason}")
                 # Report where the task actually landed — dependency blocks go
                 # to todo, and a tripped unblock-loop breaker routes to triage.
                 landed = kb.get_task(conn, tid)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3838,34 +3838,45 @@ def set_reasoning_effort(
 # ---------------------------------------------------------------------------
 
 def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
+    with write_txn(conn):
+        _link_tasks_locked(conn, parent_id, child_id)
+
+
+def _link_tasks_locked(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
+    """Shared edge-write logic for ``link_tasks`` — NO transaction of its own.
+
+    Callers must already hold a write transaction (``link_tasks`` opens one;
+    ``block_task`` reuses it inside its own txn so adding edges and parking
+    the task commit atomically). Runs the same self/unknown/cycle validation
+    as ``link_tasks``.
+    """
     if parent_id == child_id:
         raise ValueError("a task cannot depend on itself")
-    with write_txn(conn):
-        missing = _find_missing_parents(conn, [parent_id, child_id])
-        if missing:
-            raise ValueError(f"unknown task(s): {', '.join(missing)}")
-        if _would_cycle(conn, parent_id, child_id):
-            raise ValueError(
-                f"linking {parent_id} -> {child_id} would create a cycle"
-            )
+    missing = _find_missing_parents(conn, [parent_id, child_id])
+    if missing:
+        raise ValueError(f"unknown task(s): {', '.join(missing)}")
+    if _would_cycle(conn, parent_id, child_id):
+        raise ValueError(
+            f"linking {parent_id} -> {child_id} would create a cycle"
+        )
+    conn.execute(
+        "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
+        (parent_id, child_id),
+    )
+    # If child was ready but parent is not yet done, demote child to todo.
+    parent_status = conn.execute(
+        "SELECT status FROM tasks WHERE id = ?", (parent_id,)
+    ).fetchone()["status"]
+    if parent_status != "done":
         conn.execute(
-            "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
-            (parent_id, child_id),
+            "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'ready'",
+            (child_id,),
         )
-        # If child was ready but parent is not yet done, demote child to todo.
-        parent_status = conn.execute(
-            "SELECT status FROM tasks WHERE id = ?", (parent_id,)
-        ).fetchone()["status"]
-        if parent_status != "done":
-            conn.execute(
-                "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'ready'",
-                (child_id,),
-            )
-        _append_event(
-            conn, child_id, "linked",
-            {"parent": parent_id, "child": child_id},
-        )
-        _inherit_notify_subs(conn, child_id, (parent_id,))
+    _append_event(
+        conn, child_id, "linked",
+        {"parent": parent_id, "child": child_id},
+    )
+    _inherit_notify_subs(conn, child_id, (parent_id,))
 
 
 def _would_cycle(conn: sqlite3.Connection, parent_id: str, child_id: str) -> bool:
@@ -4623,6 +4634,22 @@ def _parents_satisfied(conn: sqlite3.Connection, task_id: str) -> bool:
         "AND p.status NOT IN ('done', 'archived') LIMIT 1",
         (task_id,),
     ).fetchone() is None
+
+
+def _live_dependency_edges(conn: sqlite3.Connection, task_id: str) -> int:
+    """Number of parent edges whose parent is NOT yet terminal.
+
+    Zero means the parent gate has nothing to wait on: a task parked in
+    ``todo`` without a live parent is promoted straight back to ``ready``
+    by :func:`recompute_ready` on the next tick.
+    """
+    row = conn.execute(
+        "SELECT COUNT(*) AS n FROM task_links l "
+        "JOIN tasks p ON p.id = l.parent_id "
+        "WHERE l.child_id = ? AND p.status NOT IN ('done', 'archived')",
+        (task_id,),
+    ).fetchone()
+    return int(row["n"]) if row is not None else 0
 
 
 def claim_task(
@@ -6261,6 +6288,7 @@ def block_task(
     reason: Optional[str] = None,
     kind: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    dependency_ids: Optional[Iterable[str]] = None,
 ) -> bool:
     """Transition ``running``/``ready`` → ``blocked`` (or route elsewhere).
 
@@ -6273,6 +6301,21 @@ def block_task(
       ``todo`` so the existing parent-gating / ``recompute_ready`` machinery
       promotes it automatically once its parents finish. No human, no cron, no
       retry storm. This is Dale's "Type 2 — dependency blocked".
+      Precondition: the task must have at least one parent edge whose parent
+      is not yet terminal. With no live edge there is nothing for the parent
+      gate to wait on, and ``recompute_ready`` promotes zero-parent ``todo``
+      tasks straight back to ``ready`` on the next tick — the respawn loop
+      this routing exists to prevent. In that case ``ValueError`` is raised
+      with the actionable code ``dependency_edge_missing`` and nothing is
+      written; link the blocking task first (``link_tasks``), or use a
+      human-visible kind.
+
+      ``dependency_ids`` (optional, ``kind='dependency'`` only) links the
+      named tasks as parents inside THIS block's write transaction — the
+      edges and the todo park commit atomically, reusing ``link_tasks``'
+      self/unknown/cycle validation. If any id is invalid the whole call
+      raises ``ValueError`` and rolls back. Edges whose parents are already
+      terminal count as no live edge, so the respawn guard still applies.
 
     * ``needs_input`` / ``capability`` / ``None`` — "truly blocked" (Dale's
       "Type 1"). Lands in ``blocked`` for a human. BUT: each time such a task
@@ -6293,13 +6336,43 @@ def block_task(
         raise ValueError(
             f"block kind must be one of {sorted(VALID_BLOCK_KINDS)} or None"
         )
+    dep_ids: list[str] = []
+    if dependency_ids is not None:
+        seen_ids: set[str] = set()
+        for raw_id in dependency_ids:
+            dep_id = str(raw_id).strip()
+            if dep_id and dep_id not in seen_ids:
+                seen_ids.add(dep_id)
+                dep_ids.append(dep_id)
+        if dep_ids and kind != "dependency":
+            raise ValueError(
+                "dependency_ids is only valid with kind='dependency' — the "
+                "other block kinds route to a human, not a parent gate"
+            )
     recurrences = 0
     with write_txn(conn):
         cur_row = conn.execute(
-            "SELECT status, block_kind, block_recurrences FROM tasks WHERE id = ?",
+            "SELECT status, block_kind, block_recurrences, current_run_id "
+            "FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
         if cur_row is None:
+            return False
+        # Blockable source states only — the original WHERE contract. The
+        # dependency branch's park filter below accepts 'todo' as well (a
+        # ready task can be demoted by its own link step), so the state
+        # machine must reject every other entry state up front.
+        if cur_row["status"] not in ("running", "ready"):
+            return False
+        # Validate the expected run BEFORE any write (including the
+        # dependency edge links below). A stale ``expected_run_id`` must
+        # refuse the whole call with zero side effects: linking parents but
+        # then failing the park UPDATE would commit a half-blocked state
+        # (edges present, task still running).
+        if expected_run_id is not None and (
+            cur_row["current_run_id"] is None
+            or int(cur_row["current_run_id"]) != int(expected_run_id)
+        ):
             return False
         source_status = (
             _retry_status_for_run(conn, task_id)
@@ -6319,6 +6392,36 @@ def block_task(
         # here (rather than ``blocked``) is what keeps a cron from ever seeing
         # a dependency-wait as something to "unblock".
         if kind == "dependency":
+            # Caller-supplied parents are linked inside THIS transaction so
+            # the edges and the todo park commit atomically. This reuses
+            # ``link_tasks``' self/unknown/cycle validation verbatim; any
+            # ValueError rolls back the whole block (no partial edges).
+            for dep_id in dep_ids:
+                _link_tasks_locked(conn, dep_id, task_id)
+            # Respawn-guard: a dependency block is only meaningful when there
+            # is a live parent edge to wait on. Without one (no edges at all,
+            # or every parent already terminal), ``recompute_ready`` promotes
+            # this ``todo`` back to ``ready`` on the very next tick and the
+            # task respawns — the exact loop this routing exists to prevent.
+            # Refuse the transition instead of parking a task nothing gates.
+            if _live_dependency_edges(conn, task_id) == 0:
+                raise ValueError(
+                    f"dependency_edge_missing: cannot block {task_id} with "
+                    f"kind='dependency' — it has no live parent edge to wait "
+                    f"on (a parentless or already-satisfied todo is "
+                    f"re-promoted to ready on the next recompute, respawning "
+                    f"the worker). Link the blocking task first (kanban link "
+                    f"<parent> <child> or pass dependency_ids), or block "
+                    f"with a human-visible kind instead."
+                )
+            # ``_link_tasks_locked`` demotes a ready child to todo (the same
+            # contract link_tasks applies). That demote is ours, so the park
+            # transition must still match it.
+            park_filter = (
+                "AND status IN ('running', 'ready', 'todo')"
+                if source_status == "ready"
+                else "AND status IN ('running', 'ready')"
+            )
             cur = conn.execute(
                 """
                 UPDATE tasks
@@ -6328,8 +6431,8 @@ def block_task(
                        worker_pid    = NULL,
                        block_kind    = ?
                  WHERE id = ?
-                   AND status IN ('running', 'ready')
-                """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
+                """ + park_filter
+                + ("" if expected_run_id is None else " AND current_run_id = ?"),
                 (kind, task_id) if expected_run_id is None
                 else (kind, task_id, int(expected_run_id)),
             )

--- a/tests/hermes_cli/test_kanban_block_kinds.py
+++ b/tests/hermes_cli/test_kanban_block_kinds.py
@@ -101,6 +101,263 @@ def test_dependency_then_parent_done_promotes(kanban_home: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Respawn guard: a dependency block without a live parent edge is refused
+# ---------------------------------------------------------------------------
+
+
+def test_dependency_block_without_edges_refused(kanban_home: Path) -> None:
+    """No parent edges at all: block_task(kind='dependency') must fail closed.
+
+    A parentless todo is re-promoted to ready by recompute_ready on the next
+    tick, so parking one in todo respawns the worker immediately.
+    """
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn)
+        with pytest.raises(ValueError) as excinfo:
+            kb.block_task(conn, tid, reason="wait", kind="dependency")
+        # The refusal must carry the actionable dependency_edge_missing code.
+        assert "dependency_edge_missing" in str(excinfo.value)
+        # Nothing was written: the task is still running, no todo park, no
+        # dependency_wait event.
+        task = kb.get_task(conn, tid)
+        assert task.status == "running"
+        assert task.block_kind != "dependency"
+        assert not [
+            e for e in kb.list_events(conn, tid) if e.kind == "dependency_wait"
+        ]
+        # And no phantom re-promotion can happen: recompute_ready must not
+        # move it either.
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, tid).status == "running"
+
+
+def test_dependency_block_all_parents_terminal_refused(
+    kanban_home: Path,
+) -> None:
+    """Every parent already done/archived: fail closed instead of respawning."""
+    with kb.connect_closing() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="worker")
+        child = _running_task(conn, title="child")
+        kb.link_tasks(conn, parent_id=parent, child_id=child)
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (parent,))
+        kb.claim_task(conn, parent, claimer="worker")
+        kb.complete_task(conn, parent, result="done")
+        with pytest.raises(ValueError):
+            kb.block_task(conn, child, reason="wait", kind="dependency")
+        assert kb.get_task(conn, child).status == "running"
+
+
+def test_dependency_block_live_parent_still_parks(kanban_home: Path) -> None:
+    """A live (non-terminal) parent edge keeps the documented todo parking."""
+    with kb.connect_closing() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="worker")
+        child = _running_task(conn, title="child")
+        kb.link_tasks(conn, parent_id=parent, child_id=child)
+        assert kb.block_task(conn, child, reason="wait", kind="dependency")
+        assert kb.get_task(conn, child).status == "todo"
+        # The parked child does NOT respawn while its parent is unfinished:
+        # recompute_ready must keep it in todo.
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, child).status == "todo"
+
+
+def test_dependency_block_links_new_parents_transactionally(
+    kanban_home: Path,
+) -> None:
+    """dependency_ids add edges inside the block's own write txn."""
+    with kb.connect_closing() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="worker")
+        child = _running_task(conn, title="child")
+        assert kb.block_task(
+            conn, child, reason="wait", kind="dependency",
+            dependency_ids=[parent],
+        )
+        assert kb.get_task(conn, child).status == "todo"
+        assert kb.parent_ids(conn, child) == [parent]
+        events = [e for e in kb.list_events(conn, child) if e.kind == "linked"]
+        assert events, "expected a linked event for the new edge"
+        # Finish the parent: the parked child auto-resumes (the happy path).
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (parent,))
+        kb.claim_task(conn, parent, claimer="worker")
+        kb.complete_task(conn, parent, result="done")
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, child).status == "ready"
+
+
+def test_dependency_block_new_parent_terminal_still_refused(
+    kanban_home: Path,
+) -> None:
+    """Linking an already-done parent yields no live edge -> fail closed."""
+    with kb.connect_closing() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="worker")
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (parent,))
+        kb.claim_task(conn, parent, claimer="worker")
+        kb.complete_task(conn, parent, result="done")
+        child = _running_task(conn, title="child")
+        with pytest.raises(ValueError):
+            kb.block_task(
+                conn, child, reason="wait", kind="dependency",
+                dependency_ids=[parent],
+            )
+        assert kb.get_task(conn, child).status == "running"
+
+
+def test_dependency_block_rejects_invalid_dependency_ids(
+    kanban_home: Path,
+) -> None:
+    """Self, unknown, and cyclic dependency_ids fail with no partial write."""
+    with kb.connect_closing() as conn:
+        child = _running_task(conn, title="child")
+        # Self-dependency.
+        with pytest.raises(ValueError):
+            kb.block_task(
+                conn, child, reason="wait", kind="dependency",
+                dependency_ids=[child],
+            )
+        # Unknown task id.
+        with pytest.raises(ValueError):
+            kb.block_task(
+                conn, child, reason="wait", kind="dependency",
+                dependency_ids=["t_nonexistent"],
+            )
+        # Cycle: child's child pointing back at child.
+        grandchild = kb.create_task(conn, title="grandchild", assignee="worker")
+        kb.link_tasks(conn, parent_id=child, child_id=grandchild)
+        with pytest.raises(ValueError):
+            kb.block_task(
+                conn, child, reason="wait", kind="dependency",
+                dependency_ids=[grandchild],
+            )
+        # No partial state: still running, no edges, no todo park.
+        assert kb.get_task(conn, child).status == "running"
+        assert kb.parent_ids(conn, child) == []
+
+
+def test_dependency_ids_require_dependency_kind(kanban_home: Path) -> None:
+    """dependency_ids only make sense with kind='dependency'."""
+    with kb.connect_closing() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="worker")
+        child = _running_task(conn, title="child")
+        with pytest.raises(ValueError):
+            kb.block_task(
+                conn, child, reason="wait", kind="needs_input",
+                dependency_ids=[parent],
+            )
+        assert kb.get_task(conn, child).status == "running"
+        assert kb.parent_ids(conn, child) == []
+
+
+def test_dependency_block_stale_expected_run_writes_nothing(
+    kanban_home: Path,
+) -> None:
+    """A stale expected_run_id must refuse the whole call atomically.
+
+    Regression: edge links used to run before the run-id check, so a stale
+    run could commit parents while the park UPDATE matched nothing — leaving
+    a half-blocked task. The run id is now validated before any write.
+    """
+    with kb.connect_closing() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="worker")
+        child = _running_task(conn, title="child")
+        run = kb.latest_run(conn, child)
+        assert run is not None
+        stale_run_id = run.id + 999
+        assert not kb.block_task(
+            conn, child, reason="wait", kind="dependency",
+            expected_run_id=stale_run_id,
+            dependency_ids=[parent],
+        )
+        # Zero side effects: state, edges, and events all unchanged.
+        assert kb.get_task(conn, child).status == "running"
+        assert kb.parent_ids(conn, child) == []
+        assert not [
+            e for e in kb.list_events(conn, child)
+            if e.kind in ("linked", "dependency_wait", "blocked")
+        ]
+
+
+def test_dependency_promotion_idempotent_across_recomputes(
+    kanban_home: Path,
+) -> None:
+    """Repeated parent completion / recompute calls must not double-promote.
+
+    Once the parent finishes, the child promotes exactly once; extra
+    recompute_ready ticks and a second complete_task call are no-ops.
+    """
+    with kb.connect_closing() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="worker")
+        child = _running_task(conn, title="child")
+        kb.link_tasks(conn, parent_id=parent, child_id=child)
+        kb.block_task(conn, child, reason="wait", kind="dependency")
+        assert kb.get_task(conn, child).status == "todo"
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (parent,))
+        kb.claim_task(conn, parent, claimer="worker")
+        kb.complete_task(conn, parent, result="done")
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, child).status == "ready"
+        # Repeat the promotion pass: no duplicate promotion, no status churn.
+        promoted_again = kb.recompute_ready(conn)
+        assert kb.get_task(conn, child).status == "ready"
+        assert promoted_again == 0, (
+            "child already promoted; a second recompute must be a no-op"
+        )
+        # Re-completing the finished parent must not re-park or re-promote.
+        assert not kb.complete_task(conn, parent, result="done again")
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, child).status == "ready"
+
+
+def test_cli_dependency_block_refusal_leaves_no_blocked_comment(
+    kanban_home: Path,
+) -> None:
+    """CLI: a refused dependency block must not stamp a BLOCKED comment.
+
+    Regression: ``hermes kanban block`` wrote the comment before validating
+    the transition, so a respawn-guard refusal left a misleading
+    ``BLOCKED:`` note on a task that was never blocked.
+    """
+    import argparse
+
+    from hermes_cli import kanban as kc
+
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn)
+        args = argparse.Namespace(
+            task_id=tid,
+            reason=["waiting on nothing"],
+            kind="dependency",
+            ids=None,
+            dependency_ids=None,
+        )
+        rc = kc._cmd_block(args)
+        assert rc == 1, "refused dependency block must exit non-zero"
+        assert kb.get_task(conn, tid).status == "running"
+        comments = kb.list_comments(conn, tid)
+        assert not [c for c in comments if "BLOCKED" in (c.body or "")], (
+            "refused block must not leave a misleading BLOCKED comment"
+        )
+        # A successful block still records the comment.
+        parent = kb.create_task(conn, title="parent", assignee="worker")
+        args_ok = argparse.Namespace(
+            task_id=tid,
+            reason=["waiting on parent"],
+            kind="dependency",
+            ids=None,
+            dependency_ids=[parent],
+        )
+        assert kc._cmd_block(args_ok) == 0
+        assert kb.get_task(conn, tid).status == "todo"
+        comments = kb.list_comments(conn, tid)
+        assert [c for c in comments if "BLOCKED" in (c.body or "")], (
+            "successful block must record its reason"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Completion resets loop memory
 # ---------------------------------------------------------------------------
 

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -846,6 +846,11 @@ def _handle_block(args: dict, **kw) -> str:
         return tool_error("reason is required — explain what input you need")
     reason = redact_sensitive_text(str(reason), force=True)
     kind = args.get("kind")
+    dependency_ids = args.get("dependency_ids")
+    if dependency_ids is not None:
+        if not isinstance(dependency_ids, (list, tuple)):
+            return tool_error("dependency_ids must be a list of task ids")
+        dependency_ids = [str(x) for x in dependency_ids]
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)
@@ -884,6 +889,7 @@ def _handle_block(args: dict, **kw) -> str:
                 reason=reason,
                 kind=kind,
                 expected_run_id=_worker_run_id(tid),
+                dependency_ids=dependency_ids,
             )
             if not ok:
                 return tool_error(
@@ -1912,6 +1918,19 @@ KANBAN_BLOCK_SCHEMA = {
                     "Why you're blocked. 'dependency' waits in todo and "
                     "resumes automatically; the others surface to a human. "
                     "Omit only if none apply."
+                ),
+            },
+            "dependency_ids": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "kind='dependency' only: task ids this task is waiting "
+                    "on. Linked as parents in the same transaction as the "
+                    "block. The block is refused (error code "
+                    "dependency_edge_missing) when there is no live parent "
+                    "edge to wait on — either pass the blockers here or link "
+                    "them first; a dependency block without a live edge "
+                    "would just respawn."
                 ),
             },
             "board": _board_schema_prop(),


### PR DESCRIPTION
## What

`block_task(kind="dependency")` is now edge-bound: it refuses to park a task in `todo` unless there is a live (non-terminal) parent edge to wait on, and it can accept the blocking tasks atomically via a new `dependency_ids` parameter. This stops the unlinked dependency respawn loop.

## Why

A dependency block routed the task to `todo` regardless of whether any parent edge existed. `recompute_ready` promotes zero-parent `todo` tasks straight back to `ready` on the next tick, so an unlinked dependency block respawned the worker almost immediately — the exact loop the dependency routing was built to prevent. Tasks in that state also never surface to a human and never self-recover.

## Scope

Four files, write path only (no schema migration; the `tasks` table is untouched):

- `hermes_cli/kanban_db.py`
  - `block_task(kind="dependency")` fails closed with the actionable code `dependency_edge_missing` when there is no live parent edge (no edges at all, or every parent already `done`/`archived`). Nothing is written; the task keeps its current status.
  - New optional `dependency_ids` parameter: links the named tasks as parents inside the block's own write transaction, reusing `link_tasks`' self/unknown/cycle validation (`_link_tasks_locked`), so edges and the `todo` park commit atomically. Any invalid id rolls back the whole call.
  - `expected_run_id` is validated before any write: a stale run id can no longer commit parent edges while the park `UPDATE` matches nothing.
  - Entry states validated up front (`running`/`ready` only), matching the original `WHERE` contract.
- `tools/kanban_tools.py` — `kanban_block` tool gains `dependency_ids` (array of task ids, `kind="dependency"` only) with schema documentation; `ValueError` surfaces as a tool error with the actionable code.
- `hermes_cli/kanban.py` — `hermes kanban block --dependency-ids TASK_ID...`; the `BLOCKED:` comment is now written only after the transition succeeds, so a refused block leaves no misleading comment.
- `tests/hermes_cli/test_kanban_block_kinds.py` — +9 tests (below).

## Backward compatibility

- Dependency blocks with a live unfinished parent keep the documented behavior: park in `todo`, auto-resume when the parent completes (`test_dependency_then_parent_done_promotes` still green).
- Other block kinds (`needs_input`, `capability`, `transient`, untyped), the unblock-loop breaker (`block_recurrences`/triage routing), and `unblock_task` semantics are unchanged.
- No new callers of `recompute_ready`; no DB migration; no API rename. `dependency_ids` is optional everywhere.
- MCP/dashboard/plugin surfaces that call `block_task` without `kind="dependency"` are unaffected; the two dashboard paths pass no `kind` and keep generic blocking.

## Required test coverage (all added in this PR)

1. Zero-respawn guarantee: parentless `kind="dependency"` block raises `dependency_edge_missing`, writes nothing (status, edges, events unchanged), and `recompute_ready` never promotes it.
2. Linked parent not finished: still parks in `todo`, and repeated `recompute_ready` does not respawn it.
3. Linked parent completed (live-edge precondition only): block fails closed instead of respawning.
4. Transactional `dependency_ids`: edge + park commit together; auto-resume on parent completion.
5. `dependency_ids` on an already-done parent: fail closed.
6. Self/unknown/cyclic `dependency_ids`: rejected with no partial writes.
7. Stale `expected_run_id`: zero edges/events, state unchanged.
8. Idempotent promotion: repeated recompute/complete cycles do not double-promote.
9. CLI regression: refused dependency block leaves no `BLOCKED:` comment; successful block still records it.

## Test commands

```
pytest tests/hermes_cli/test_kanban_block_kinds.py -q
pytest tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_promote.py tests/hermes_cli/test_kanban_blocked_sticky.py tests/hermes_cli/test_kanban_project_link.py tests/hermes_cli/test_kanban_parent_reopen_invalidation.py tests/hermes_cli/test_kanban_review_lifecycle.py tests/hermes_cli/test_kanban_review_lifecycle_complete.py tests/tools/test_kanban_tools.py tests/hermes_cli/test_kanban_swarm.py tests/hermes_cli/test_kanban_specify.py tests/tools/test_kanban_comment_injection.py tests/tools/test_kanban_redaction.py tests/tools/test_delegate_kanban_isolation.py tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py tests/hermes_cli/test_kanban_specify_db.py tests/hermes_cli/test_kanban_write_txn_busy_retry.py tests/hermes_cli/test_kanban_reclaim_claim_lock_guard.py -q
```

Local evidence (Python 3.11.9, Windows): block-kinds suite 12/12 passed; broader regression selection 125 passed / 1 skipped with zero new failures (remaining failures in `test_kanban_notify.py`, `test_kanban_core_functionality.py::test_gateway_dispatcher_*`, `test_kanban_db.py` symlink/worktree/subprocess-timeout tests reproduce identically on the unmodified base `11f932c9` — missing optional deps (`fastapi`, `acp`, `concurrent_log_handler`) and Windows symlink privileges, unrelated to this change).

## Follow-up candidate (out of scope here)

`unblock_task` on a dependency-parked task already re-gates via `_landing_status_after_parents`, and `recompute_ready` demotes wrongly-promoted rows back to `todo`; no repair needed for this PR. A future improvement would be a `hermes kanban recompute` repair pass for any pre-existing parked tasks without edges, if any exist in live boards.
