### PR TITLE
fix(telegram): fence typing through final delivery

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -114,6 +114,16 @@ _HISTORY_MEDIA_LOOKUP_ADMISSION = threading.BoundedSemaphore(
     _HISTORY_MEDIA_LOOKUP_MAX_WORKERS
 )
 
+# Typing state belongs to a gateway runtime, not to one transport instance: a
+# Telegram reconnect can replace its adapter while an inbound task is alive.
+_TYPING_LEASE_GUARD = threading.RLock()
+_TYPING_LEASES: dict[str, tuple[str, str]] = {}
+_TYPING_LEASE_BY_SESSION: dict[tuple[str, str], str] = {}
+_TYPING_LEASE_CLOSING: set[str] = set()
+_TYPING_LEASE_LOCKS: weakref.WeakValueDictionary[
+    tuple[str, str, int], asyncio.Lock
+] = weakref.WeakValueDictionary()
+
 
 def _platform_name(platform) -> str:
     """Normalize a Platform enum / raw string into a lowercase name."""
@@ -167,6 +177,10 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) 
 def _mark_notify_metadata(metadata: dict | None) -> dict:
     """Clone metadata and mark a user-visible reply as notify-worthy."""
     notify_metadata = dict(metadata) if metadata else {}
+    # Typing leases are internal control-plane state. Final user-visible sends
+    # must not retain the token because Telegram's post-send typing re-arm is
+    # explicitly suppressed for notify replies.
+    notify_metadata.pop("_hermes_typing_lease_id", None)
     notify_metadata["notify"] = True
     return notify_metadata
 
@@ -5365,12 +5379,131 @@ class BasePlatformAdapter(ABC):
 
         return paths, cleaned
 
+    def _typing_lease_scope(self) -> str:
+        """Stable runtime scope shared by reconnect replacement adapters."""
+        platform = _platform_name(getattr(self, "platform", ""))
+        profile = str(getattr(self, "_owner_profile", None) or "default")
+        runner = getattr(self, "gateway_runner", None)
+        owner = runner if runner is not None else self
+        with _TYPING_LEASE_GUARD:
+            runtime_id = getattr(owner, "_typing_lease_runtime_id", None)
+            if not isinstance(runtime_id, str) or not runtime_id:
+                runtime_id = uuid.uuid4().hex
+                setattr(owner, "_typing_lease_runtime_id", runtime_id)
+        return f"{platform}:{profile}:{runtime_id}"
+
+    def _begin_typing_lease(self, chat_id: str, session_key: str) -> str:
+        """Grant a generation-safe lease shared across replacement adapters."""
+        scope = self._typing_lease_scope()
+        session_ref = (scope, str(session_key))
+        lease_id = uuid.uuid4().hex
+        with _TYPING_LEASE_GUARD:
+            previous = _TYPING_LEASE_BY_SESSION.get(session_ref)
+            if previous:
+                _TYPING_LEASES.pop(previous, None)
+                _TYPING_LEASE_CLOSING.discard(previous)
+            _TYPING_LEASES[lease_id] = (scope, str(chat_id))
+            _TYPING_LEASE_BY_SESSION[session_ref] = lease_id
+        return lease_id
+
+    def _typing_metadata_for_session(self, session_key: str, metadata=None):
+        """Return metadata stamped with the active inbound task's lease."""
+        if not getattr(self, "typing_send_requires_final_fence", False):
+            return metadata
+        lease_id = self._typing_lease_id_for_session(session_key)
+        if not lease_id:
+            return metadata
+        stamped = dict(metadata or {})
+        stamped["_hermes_typing_lease_id"] = lease_id
+        return stamped
+
+    def _typing_lease_id_for_session(self, session_key: str) -> str | None:
+        """Return the current private lease id without exposing it to egress."""
+        session_ref = (self._typing_lease_scope(), str(session_key))
+        with _TYPING_LEASE_GUARD:
+            return _TYPING_LEASE_BY_SESSION.get(session_ref)
+
+    def _typing_lease_allows(self, chat_id: str, metadata=None) -> bool:
+        """Whether metadata belongs to a live lease for this exact chat."""
+        lease_id = str((metadata or {}).get("_hermes_typing_lease_id") or "")
+        if not lease_id:
+            return False
+        expected = (self._typing_lease_scope(), str(chat_id))
+        with _TYPING_LEASE_GUARD:
+            return (
+                lease_id not in _TYPING_LEASE_CLOSING
+                and _TYPING_LEASES.get(lease_id) == expected
+            )
+
+    def _revoke_typing_lease(self, lease_id: str) -> None:
+        """Revoke one task's lease without disturbing a replacement task."""
+        with _TYPING_LEASE_GUARD:
+            _TYPING_LEASES.pop(lease_id, None)
+            _TYPING_LEASE_CLOSING.discard(lease_id)
+            for session_ref, current_lease in tuple(_TYPING_LEASE_BY_SESSION.items()):
+                if current_lease == lease_id:
+                    _TYPING_LEASE_BY_SESSION.pop(session_ref, None)
+
+    def _revoke_all_typing_leases(self) -> None:
+        """Fail-close all leases owned by this runtime during teardown."""
+        scope = self._typing_lease_scope()
+        with _TYPING_LEASE_GUARD:
+            lease_ids = [
+                lease_id
+                for lease_id, (lease_scope, _chat_id) in _TYPING_LEASES.items()
+                if lease_scope == scope
+            ]
+            for lease_id in lease_ids:
+                _TYPING_LEASES.pop(lease_id, None)
+                _TYPING_LEASE_CLOSING.discard(lease_id)
+            for session_ref, lease_id in tuple(_TYPING_LEASE_BY_SESSION.items()):
+                if session_ref[0] == scope or lease_id in lease_ids:
+                    _TYPING_LEASE_BY_SESSION.pop(session_ref, None)
+
+    async def _fence_all_typing_leases(self) -> None:
+        """Close and drain every runtime lease before shutdown returns."""
+        scope = self._typing_lease_scope()
+        with _TYPING_LEASE_GUARD:
+            leases = [
+                (lease_id, chat_id)
+                for lease_id, (lease_scope, chat_id) in _TYPING_LEASES.items()
+                if lease_scope == scope
+            ]
+            _TYPING_LEASE_CLOSING.update(lease_id for lease_id, _ in leases)
+        for lease_id, chat_id in leases:
+            async with self._typing_lease_lock(chat_id):
+                self._revoke_typing_lease(lease_id)
+
+    def _typing_lease_lock(self, chat_id: str) -> asyncio.Lock:
+        """Return the shared outbound typing lock for this runtime chat."""
+        key = (
+            self._typing_lease_scope(),
+            str(chat_id),
+            id(asyncio.get_running_loop()),
+        )
+        with _TYPING_LEASE_GUARD:
+            lock = _TYPING_LEASE_LOCKS.get(key)
+            if lock is None:
+                lock = asyncio.Lock()
+                _TYPING_LEASE_LOCKS[key] = lock
+            return lock
+
+    async def _fence_typing_lease_before_final(self, chat_id: str, lease_id: str) -> None:
+        """Close a lease, drain an admitted send, then revoke it."""
+        with _TYPING_LEASE_GUARD:
+            if lease_id not in _TYPING_LEASES:
+                return
+            _TYPING_LEASE_CLOSING.add(lease_id)
+        async with self._typing_lease_lock(chat_id):
+            self._revoke_typing_lease(lease_id)
+
     async def _keep_typing(
         self,
         chat_id: str,
         interval: float = 2.0,
         metadata=None,
         stop_event: asyncio.Event | None = None,
+        session_key: str | None = None,
     ) -> None:
         """
         Continuously send typing indicator until cancelled.
@@ -5402,10 +5535,27 @@ class BasePlatformAdapter(ABC):
                     return
                 if chat_id not in self._typing_paused:
                     try:
-                        await asyncio.wait_for(
-                            self.send_typing(chat_id, metadata=metadata),
-                            timeout=_send_typing_timeout,
+                        send_metadata = (
+                            self._typing_metadata_for_session(
+                                session_key, metadata
+                            )
+                            if session_key
+                            else metadata
                         )
+                        if getattr(self, "typing_send_requires_final_fence", False):
+                            # A fenced transport must not abandon a request
+                            # after it may have reached the platform. Final
+                            # delivery waits on the same per-chat lock.
+                            await self.send_typing(
+                                chat_id, metadata=send_metadata
+                            )
+                        else:
+                            await asyncio.wait_for(
+                                self.send_typing(
+                                    chat_id, metadata=send_metadata
+                                ),
+                                timeout=_send_typing_timeout,
+                            )
                     except asyncio.TimeoutError:
                         # Slow network — abandon this tick, keep the loop
                         # on schedule so the next send_typing fires fresh.
@@ -5462,6 +5612,8 @@ class BasePlatformAdapter(ABC):
     ) -> None:
         """Stop the refresh task and platform typing state as one operation."""
         self._typing_paused.add(chat_id)
+        stop_metadata = dict(metadata or {})
+        stop_metadata.pop("_hermes_typing_lease_id", None)
         try:
             if typing_task is not None and not typing_task.done():
                 typing_task.cancel()
@@ -5476,7 +5628,7 @@ class BasePlatformAdapter(ABC):
             attempts = max(1, stop_attempts)
             for attempt in range(attempts):
                 try:
-                    await self._stop_typing_with_metadata(chat_id, metadata)
+                    await self._stop_typing_with_metadata(chat_id, stop_metadata)
                 except Exception:
                     pass
                 if attempt < attempts - 1:
@@ -6510,7 +6662,14 @@ class BasePlatformAdapter(ABC):
         # Gated per-platform: when typing_indicator=False the refresh loop is
         # never spawned, so no "typing…" / "is thinking…" status is shown.
         # typing_task stays None; _stop_typing_refresh already no-ops on None.
-        _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
+        # Every typing producer for this inbound task shares one opaque lease.
+        # Revoke it before cleanup/callback work so a late progress callback
+        # cannot re-arm a platform-side typing status after final delivery.
+        typing_lease_id = self._begin_typing_lease(event.source.chat_id, session_key)
+        _thread_metadata = self._typing_metadata_for_session(
+            session_key,
+            _thread_metadata_for_source(event.source, _reply_anchor_for_event(event)),
+        )
         typing_task: Optional[asyncio.Task] = None
         if getattr(self.config, "typing_indicator", True):
             _keep_typing_kwargs: Dict[str, Any] = {"metadata": _thread_metadata}
@@ -6520,6 +6679,8 @@ class BasePlatformAdapter(ABC):
                 _keep_typing_sig = None
             if _keep_typing_sig is None or "stop_event" in _keep_typing_sig.parameters:
                 _keep_typing_kwargs["stop_event"] = interrupt_event
+            if _keep_typing_sig is None or "session_key" in _keep_typing_sig.parameters:
+                _keep_typing_kwargs["session_key"] = session_key
             typing_task = asyncio.create_task(
                 self._keep_typing(
                     event.source.chat_id,
@@ -6527,7 +6688,32 @@ class BasePlatformAdapter(ABC):
                 )
             )
 
+        owner_task = asyncio.current_task()
+
+        def _owns_session() -> bool:
+            registered_task = self._session_tasks.get(session_key)
+            if registered_task is not None:
+                return registered_task is owner_task
+            return self._active_sessions.get(session_key) is interrupt_event
+
+        async def _fence_typing_leases() -> None:
+            lease_ids = [typing_lease_id]
+            # Queued logical turns rotate the lease while remaining inside the
+            # same adapter task, so their successor must be fenced before the
+            # outer final egress. Once session ownership transfers, however,
+            # the registry points at a replacement turn and stale cleanup must
+            # never revoke that fresh lease.
+            if _owns_session():
+                current_lease_id = self._typing_lease_id_for_session(session_key)
+                if current_lease_id and current_lease_id not in lease_ids:
+                    lease_ids.append(current_lease_id)
+            for lease_id in lease_ids:
+                await self._fence_typing_lease_before_final(
+                    event.source.chat_id, lease_id
+                )
+
         async def _stop_typing_task() -> None:
+            await _fence_typing_leases()
             await self._stop_typing_refresh(
                 event.source.chat_id,
                 typing_task,
@@ -6708,11 +6894,18 @@ class BasePlatformAdapter(ABC):
                     except Exception as tts_err:
                         logger.warning("[%s] Auto-TTS failed: %s", self.name, tts_err)
 
+                # Synthesis is still active work and can take a while, so keep
+                # typing alive until immediately before the first visible final
+                # delivery. Then close the lease and drain any already-admitted
+                # Bot API action before voice, text, or attachments can egress.
+                await _fence_typing_leases()
+
                 # Play TTS audio before text (voice-first experience)
                 _tts_caption_delivered = False
                 _tts_cleanup_paths = {_tts_requested_path, *_tts_paths} - {None}
                 for _tts_index, _tts_path in enumerate(_tts_paths):
                     try:
+                        delivery_adapter = self._final_delivery_adapter(event.source)
                         # Caption eligibility and payload stay on the ORIGINAL
                         # reply text. The spoken script is for synthesis only:
                         # normalization can shrink a long reply below the
@@ -6723,12 +6916,12 @@ class BasePlatformAdapter(ABC):
                         telegram_tts_caption = None
                         if (
                             _tts_index == 0
-                            and self.platform == Platform.TELEGRAM
+                            and delivery_adapter.platform == Platform.TELEGRAM
                             and text_content
                             and text_content[:1024] == text_content
                         ):
                             telegram_tts_caption = text_content
-                        tts_result = await self.play_tts(
+                        tts_result = await delivery_adapter.play_tts(
                             chat_id=event.source.chat_id,
                             audio_path=_tts_path,
                             caption=telegram_tts_caption,
@@ -6888,9 +7081,10 @@ class BasePlatformAdapter(ABC):
 
                 # Send extracted images as native attachments
                 if images:
-                    logger.info("[%s] Extracted %d image(s) to send as attachments", self.name, len(images))
+                    delivery_adapter = self._final_delivery_adapter(event.source)
+                    logger.info("[%s] Extracted %d image(s) to send as attachments", delivery_adapter.name, len(images))
                     try:
-                        await self.send_multiple_images(
+                        await delivery_adapter.send_multiple_images(
                             chat_id=event.source.chat_id,
                             images=images,
                             metadata=_final_thread_metadata,
@@ -6930,9 +7124,10 @@ class BasePlatformAdapter(ABC):
                         _non_image_local.append(file_path)
 
                 if _image_paths:
+                    delivery_adapter = self._final_delivery_adapter(event.source)
                     try:
                         _batch = [(f"file://{_quote(p)}", "") for p in _image_paths]
-                        await self.send_multiple_images(
+                        await delivery_adapter.send_multiple_images(
                             chat_id=event.source.chat_id,
                             images=_batch,
                             metadata=_final_thread_metadata,
@@ -6951,9 +7146,10 @@ class BasePlatformAdapter(ABC):
                     if human_delay > 0:
                         await asyncio.sleep(human_delay)
                     try:
+                        delivery_adapter = self._final_delivery_adapter(event.source)
                         ext = Path(media_path).suffix.lower()
-                        if should_send_media_as_audio(self.platform, ext, is_voice=is_voice):
-                            media_result = await self.send_voice(
+                        if should_send_media_as_audio(delivery_adapter.platform, ext, is_voice=is_voice):
+                            media_result = await delivery_adapter.send_voice(
                                 chat_id=event.source.chat_id,
                                 audio_path=media_path,
                                 metadata=_final_thread_metadata,
@@ -6962,25 +7158,26 @@ class BasePlatformAdapter(ABC):
                         elif ext in _VIDEO_EXTS:
                             logger.info(
                                 "[%s] Sending video attachment (%s) to %s",
-                                self.name,
+                                delivery_adapter.name,
                                 ext,
                                 event.source.chat_id,
                             )
-                            media_result = await self.send_video(
+                            media_result = await delivery_adapter.send_video(
                                 chat_id=event.source.chat_id,
                                 video_path=media_path,
                                 metadata=_final_thread_metadata,
                             )
                         else:
-                            media_result = await self.send_document(
+                            media_result = await delivery_adapter.send_document(
                                 chat_id=event.source.chat_id,
                                 file_path=media_path,
                                 metadata=_final_thread_metadata,
                             )
 
                         if not media_result.success:
-                            logger.warning("[%s] Failed to send media (%s): %s", self.name, ext, media_result.error)
-                            await self._notify_media_delivery_failure(
+                            logger.warning("[%s] Failed to send media (%s): %s", delivery_adapter.name, ext, media_result.error)
+                            notification_adapter = self._final_delivery_adapter(event.source)
+                            await notification_adapter._notify_media_delivery_failure(
                                 event.source.chat_id,
                                 media_path,
                                 is_voice=is_voice,
@@ -6994,15 +7191,16 @@ class BasePlatformAdapter(ABC):
                     if human_delay > 0:
                         await asyncio.sleep(human_delay)
                     try:
+                        delivery_adapter = self._final_delivery_adapter(event.source)
                         ext = Path(file_path).suffix.lower()
                         if ext in _VIDEO_EXTS:
-                            file_result = await self.send_video(
+                            file_result = await delivery_adapter.send_video(
                                 chat_id=event.source.chat_id,
                                 video_path=file_path,
                                 metadata=_final_thread_metadata,
                             )
                         else:
-                            file_result = await self.send_document(
+                            file_result = await delivery_adapter.send_document(
                                 chat_id=event.source.chat_id,
                                 file_path=file_path,
                                 metadata=_final_thread_metadata,
@@ -7010,11 +7208,12 @@ class BasePlatformAdapter(ABC):
                         if not file_result.success:
                             logger.warning(
                                 "[%s] Failed to send local file (%s): %s",
-                                self.name,
+                                delivery_adapter.name,
                                 ext,
                                 file_result.error,
                             )
-                            await self._notify_media_delivery_failure(
+                            notification_adapter = self._final_delivery_adapter(event.source)
+                            await notification_adapter._notify_media_delivery_failure(
                                 event.source.chat_id,
                                 file_path,
                                 metadata=_final_thread_metadata,
@@ -7107,6 +7306,7 @@ class BasePlatformAdapter(ABC):
         except BaseException as e:
             await self._run_processing_hook("on_processing_complete", event, ProcessingOutcome.FAILURE)
             logger.error("[%s] Error handling message: %s", self.name, e, exc_info=True)
+            await _fence_typing_leases()
             # Send the error to the user so they aren't left with radio silence
             try:
                 error_type = type(e).__name__
@@ -7283,6 +7483,7 @@ class BasePlatformAdapter(ABC):
         whole shutdown path.  Stragglers are released from our tracking and
         allowed to finish unwinding on their own.
         """
+        await self._fence_all_typing_leases()
         # Loop until no new tasks appear.  Without this, a message
         # arriving during the `await asyncio.gather` below would spawn
         # a fresh _process_message_background task (added to

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5917,6 +5917,7 @@ class TurnRunner:
                         self._runner._build_stream_consumer_config(
                             ctx.source, _scfg, _adapter,
                             on_missing_cursor="raise",
+                            typing_metadata=ctx._status_thread_metadata,
                         )
                     )
                     _stream_consumer = GatewayStreamConsumer(
@@ -23208,7 +23209,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 not _streaming_tts_done
                 and self._should_send_voice_reply(event, response, agent_messages, already_sent=_already_sent)
             ):
-                await self._send_voice_reply(event, response)
+                await self._send_voice_reply(
+                    event, response, session_key=session_key
+                )
 
             # If streaming already delivered the response, extract and
             # deliver any MEDIA: files before returning None.  Streaming
@@ -24544,16 +24547,102 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """Return whether inbound voice/STT transcripts should be echoed to chat."""
         return bool(getattr(self.config, "stt_echo_transcripts", True))
 
-    async def _send_voice_reply(self, event: MessageEvent, text: str) -> None:
+    def _adapter_for_final_delivery(self, source, fallback=None):
+        """Resolve the live transport immediately before a new final payload.
+
+        A handler may outlive the adapter that accepted its inbound event.  Keep
+        the supplied adapter only as a fallback for runners without a current
+        registry entry; callers re-resolve before each independently unsent
+        payload so a second reconnect cannot strand later attachments.
+        """
+        try:
+            current = self._adapter_for_source(source)
+        except Exception:
+            logger.debug("Failed to resolve live adapter for final delivery", exc_info=True)
+            current = None
+        return current if current is not None else fallback
+
+    async def _send_voice_reply(
+        self,
+        event: MessageEvent,
+        text: str,
+        *,
+        session_key: Optional[str] = None,
+    ) -> None:
         """Generate TTS audio and send as a voice message before the text reply."""
         audio_path = None
         actual_paths: List[str] = []
+        adapter = None
+        lease_id = ""
+        synthesis_lease_started = False
+        lease_fenced = False
         try:
             from tools.tts_tool import text_to_speech_tool, _strip_markdown_for_tts
 
             tts_text = _strip_markdown_for_tts(text)
             if not tts_text:
                 return
+
+            adapter = self._adapter_for_source(event.source)
+
+            # Resolve the destination before synthesis. A streamed text final has
+            # already fenced its original typing lease, so Telegram needs a new
+            # short-lived lease while the potentially slow TTS work is running.
+            guild_id = self._get_guild_id(event)
+            play_in_voice_channel = getattr(adapter, "play_in_voice_channel", None)
+            is_in_voice_channel = getattr(adapter, "is_in_voice_channel", None)
+            send_voice = getattr(adapter, "send_voice", None)
+            in_voice_channel = bool(
+                guild_id
+                and callable(play_in_voice_channel)
+                and callable(is_in_voice_channel)
+                and is_in_voice_channel(guild_id)
+            )
+            reply_anchor = self._reply_anchor_for_event(event)
+            thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)
+            stamp_typing_lease = None
+            if session_key is not None:
+                stamp_typing_lease = getattr(
+                    adapter, "_typing_metadata_for_session", None
+                )
+                if callable(stamp_typing_lease):
+                    thread_meta = stamp_typing_lease(session_key, thread_meta)
+                    lease_id = str(
+                        (thread_meta or {}).get("_hermes_typing_lease_id") or ""
+                    )
+
+            requires_typing_fence = (
+                getattr(adapter, "typing_send_requires_final_fence", False) is True
+            )
+            if (
+                session_key is not None
+                and not lease_id
+                and requires_typing_fence
+                and not in_voice_channel
+                and callable(send_voice)
+            ):
+                begin_typing_lease = getattr(adapter, "_begin_typing_lease", None)
+                if callable(begin_typing_lease):
+                    lease_id = str(
+                        begin_typing_lease(event.source.chat_id, session_key)
+                    )
+                    synthesis_lease_started = bool(lease_id)
+                    if callable(stamp_typing_lease):
+                        thread_meta = stamp_typing_lease(session_key, thread_meta)
+                    elif lease_id:
+                        thread_meta = dict(thread_meta or {})
+                        thread_meta["_hermes_typing_lease_id"] = lease_id
+                    send_typing = getattr(adapter, "send_typing", None)
+                    if synthesis_lease_started and callable(send_typing):
+                        try:
+                            await send_typing(
+                                event.source.chat_id,
+                                metadata=thread_meta,
+                            )
+                        except Exception as exc:
+                            logger.debug(
+                                "Could not start auto-TTS typing indicator: %s", exc
+                            )
 
             # Platform-aware output path: platforms whose native voice
             # bubbles require Ogg/Opus (OPUS_VOICE_PLATFORMS — Telegram,
@@ -24585,40 +24674,56 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.warning("Auto voice reply TTS failed: %s", result.get("error"))
                 return
 
-            adapter = self._adapter_for_source(event.source)
+            # Mark the auto voice reply as notify-worthy. Mirrors the final-text
+            # path in gateway/platforms/base.py. Clone first so metadata shared
+            # with the typing indicator is not mutated.
+            if thread_meta is not None:
+                thread_meta = dict(thread_meta)
+                thread_meta["notify"] = True
+            else:
+                thread_meta = {"notify": True}
 
-            # If connected to a voice channel, play there instead of sending a file
-            guild_id = self._get_guild_id(event)
-            play_in_voice_channel = getattr(adapter, "play_in_voice_channel", None)
-            is_in_voice_channel = getattr(adapter, "is_in_voice_channel", None)
-            send_voice = getattr(adapter, "send_voice", None)
-            in_voice_channel = bool(
-                guild_id
-                and callable(play_in_voice_channel)
-                and callable(is_in_voice_channel)
-                and is_in_voice_channel(guild_id)
+            # Synthesis can outlive the ingress adapter. Fence through the live
+            # replacement, then re-resolve before every independently unsent
+            # file so another reconnect between files cannot route later audio
+            # through a disconnected transport.
+            delivery_adapter = GatewayRunner._adapter_for_final_delivery(self,
+                event.source, adapter
             )
-            reply_anchor = self._reply_anchor_for_event(event)
-            thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)
-            if not in_voice_channel and callable(send_voice):
-                # Mark the auto voice reply as notify-worthy.  Mirrors the
-                # final-text path in gateway/platforms/base.py which sets
-                # ``notify=True`` so platform adapters that gate push
-                # notifications (Telegram "important" mode) deliver the
-                # final voice reply as a normal notification instead of a
-                # silent message.  Clone first so we don't mutate metadata
-                # shared with concurrent typing-indicator state.
-                if thread_meta is not None:
-                    thread_meta = dict(thread_meta)
-                    thread_meta["notify"] = True
-                else:
-                    thread_meta = {"notify": True}
+            fence_typing = getattr(
+                delivery_adapter, "_fence_typing_lease_before_final", None
+            )
+            if lease_id and callable(fence_typing):
+                await fence_typing(event.source.chat_id, lease_id)
+                lease_fenced = True
+
             for actual_path in actual_paths:
-                if in_voice_channel:
-                    play_voice = cast(Callable[..., Awaitable[Any]], play_in_voice_channel)
+                delivery_adapter = GatewayRunner._adapter_for_final_delivery(self,
+                    event.source, adapter
+                )
+                delivery_play_in_voice_channel = getattr(
+                    delivery_adapter, "play_in_voice_channel", None
+                )
+                delivery_is_in_voice_channel = getattr(
+                    delivery_adapter, "is_in_voice_channel", None
+                )
+                delivery_send_voice = getattr(delivery_adapter, "send_voice", None)
+                delivery_in_voice_channel = bool(
+                    guild_id
+                    and callable(delivery_play_in_voice_channel)
+                    and callable(delivery_is_in_voice_channel)
+                    and delivery_is_in_voice_channel(guild_id)
+                )
+                if delivery_in_voice_channel:
+                    play_voice = cast(
+                        Callable[..., Awaitable[Any]],
+                        delivery_play_in_voice_channel,
+                    )
                     await play_voice(guild_id, actual_path)
-                elif callable(send_voice):
-                    send_voice_call = cast(Callable[..., Awaitable[Any]], send_voice)
+                elif callable(delivery_send_voice):
+                    send_voice_call = cast(
+                        Callable[..., Awaitable[Any]], delivery_send_voice
+                    )
                     send_kwargs: Dict[str, Any] = {
                         "chat_id": event.source.chat_id,
                         "audio_path": actual_path,
@@ -24634,6 +24739,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     os.unlink(p)
                 except OSError:
                     pass
+            if synthesis_lease_started and lease_id and not lease_fenced:
+                cleanup_adapter = GatewayRunner._adapter_for_final_delivery(self,
+                    event.source, adapter
+                )
+                fence_typing = getattr(
+                    cleanup_adapter, "_fence_typing_lease_before_final", None
+                )
+                if callable(fence_typing):
+                    try:
+                        await fence_typing(event.source.chat_id, lease_id)
+                    except Exception as exc:
+                        logger.debug(
+                            "Could not close auto-TTS typing lease: %s", exc
+                        )
 
     async def _deliver_media_from_response(
         self,
@@ -24715,43 +24834,86 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     non_image_media.append((media_path, is_voice))
 
             if image_paths:
+                delivery_adapter = GatewayRunner._adapter_for_final_delivery(self,
+                    event.source, adapter
+                )
                 try:
                     images = [(f"file://{_quote(p)}", "") for p in image_paths]
-                    await adapter.send_multiple_images(
+                    await delivery_adapter.send_multiple_images(
                         chat_id=event.source.chat_id,
                         images=images,
                         metadata=_thread_meta,
                     )
                 except Exception as e:
-                    logger.warning("[%s] Post-stream image batch delivery failed: %s", adapter.name, e)
+                    logger.warning(
+                        "[%s] Post-stream image batch delivery failed: %s",
+                        delivery_adapter.name,
+                        e,
+                    )
 
             for media_path, is_voice in non_image_media:
+                delivery_adapter = GatewayRunner._adapter_for_final_delivery(self,
+                    event.source, adapter
+                )
                 try:
                     ext = Path(media_path).suffix.lower()
                     if should_send_media_as_audio(event.source.platform, ext, is_voice=is_voice):
-                        await adapter.send_voice(
+                        await delivery_adapter.send_voice(
                             chat_id=event.source.chat_id,
                             audio_path=media_path,
                             metadata=_thread_meta,
                             is_voice=is_voice,
                         )
                     elif ext in _VIDEO_EXTS:
-                        await adapter.send_video(
+                        await delivery_adapter.send_video(
                             chat_id=event.source.chat_id,
                             video_path=media_path,
                             metadata=_thread_meta,
                         )
                     else:
-                        await adapter.send_document(
+                        await delivery_adapter.send_document(
                             chat_id=event.source.chat_id,
                             file_path=media_path,
                             metadata=_thread_meta,
                         )
                 except Exception as e:
-                    logger.warning("[%s] Post-stream media delivery failed: %s", adapter.name, e)
+                    logger.warning(
+                        "[%s] Post-stream media delivery failed: %s",
+                        delivery_adapter.name,
+                        e,
+                    )
 
         except Exception as e:
             logger.warning("Post-stream media extraction failed: %s", e)
+
+    @staticmethod
+    async def _edit_message_with_optional_metadata(
+        adapter,
+        *,
+        chat_id: str,
+        message_id: str,
+        content: str,
+        finalize: bool = False,
+        metadata: Optional[Dict[str, Any]] = None,
+    ):
+        """Edit a message without breaking legacy adapter signatures."""
+        kwargs = {
+            "chat_id": chat_id,
+            "message_id": message_id,
+            "content": content,
+            "finalize": finalize,
+        }
+        try:
+            params = inspect.signature(adapter.edit_message).parameters
+            accepts_kwargs = any(
+                param.kind is inspect.Parameter.VAR_KEYWORD
+                for param in params.values()
+            )
+            if metadata is not None and ("metadata" in params or accepts_kwargs):
+                kwargs["metadata"] = metadata
+        except (TypeError, ValueError):
+            pass
+        return await adapter.edit_message(**kwargs)
 
     async def _deliver_queued_first_response(
         self,
@@ -24765,8 +24927,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         stream_consumer=None,
     ) -> None:
         """Deliver a queued response using the normal text+attachment split."""
+        final_metadata = dict(metadata or {})
+        final_metadata["notify"] = True
+        delivery_adapter = GatewayRunner._adapter_for_final_delivery(
+            self, source, adapter
+        )
+        lease_id = final_metadata.get("_hermes_typing_lease_id")
+        fence = getattr(
+            delivery_adapter, "_fence_typing_lease_before_final", None
+        )
+        if lease_id and callable(fence):
+            await fence(source.chat_id, str(lease_id))
         if not text_already_delivered:
-            text_content = _strip_response_attachments_for_direct_send(response, adapter)
+            text_content = _strip_response_attachments_for_direct_send(
+                response, delivery_adapter
+            )
             if text_content:
                 # Reconcile-by-edit first (live finding, 2026-08-16 canary):
                 # when the stream consumer delivered/sealed a message but its
@@ -24784,11 +24959,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     and not getattr(stream_consumer, "_turn_split_delivery", False)
                 ):
                     try:
-                        _edit_res = await adapter.edit_message(
+                        _edit_res = await self._edit_message_with_optional_metadata(
+                            delivery_adapter,
                             chat_id=source.chat_id,
                             message_id=_sc_msg_id,
                             content=text_content,
                             finalize=True,
+                            metadata=final_metadata,
                         )
                         if getattr(_edit_res, "success", False):
                             _reconciled = True
@@ -24802,10 +24979,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             _qe,
                         )
                 if not _reconciled:
-                    await adapter.send(
+                    delivery_adapter = GatewayRunner._adapter_for_final_delivery(self,
+                        source, delivery_adapter
+                    )
+                    await delivery_adapter.send(
                         source.chat_id,
                         text_content,
-                        metadata=metadata,
+                        metadata=final_metadata,
                     )
 
         # Failed turns still deliver their (normalized failure) text above,
@@ -24823,9 +25003,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         await self._deliver_media_from_response(
             response,
             synthetic_event,
-            adapter,
-            thread_metadata=metadata,
+            delivery_adapter,
+            thread_metadata=final_metadata,
         )
+
+    @staticmethod
+    def _renew_followup_typing_lease(
+        adapter,
+        *,
+        chat_id: str,
+        session_key: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Give a queued Telegram turn a fresh private typing generation."""
+        if not getattr(adapter, "typing_send_requires_final_fence", False):
+            return metadata
+        begin_lease = getattr(adapter, "_begin_typing_lease", None)
+        stamp_lease = getattr(adapter, "_typing_metadata_for_session", None)
+        if not callable(begin_lease) or not callable(stamp_lease):
+            return metadata
+        begin_lease(chat_id, session_key)
+        return stamp_lease(session_key, metadata)
 
     async def _run_background_task(
         self,
@@ -30085,6 +30283,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         adapter: Any,
         *,
         on_missing_cursor: str,
+        typing_metadata: Optional[Dict[str, Any]] = None,
     ) -> "tuple[Any, Optional[Callable[[], None]]]":
         """Build the shared ``StreamConsumerConfig`` and the optional
         Telegram pause-typing closure used by both agent-run paths.
@@ -30102,12 +30301,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         from gateway.stream_consumer import StreamConsumerConfig
 
         _pause_typing_before_finalize = None
-        if source.platform == Platform.TELEGRAM and hasattr(adapter, "pause_typing_for_chat"):
-            def _pause_typing_before_finalize(
-                _adapter=adapter,
-                _chat_id=source.chat_id,
-            ) -> None:
-                _adapter.pause_typing_for_chat(_chat_id)
+        if source.platform == Platform.TELEGRAM:
+            lease_id = (typing_metadata or {}).get("_hermes_typing_lease_id")
+            fence = getattr(adapter, "_fence_typing_lease_before_final", None)
+            if lease_id and callable(fence):
+                async def _pause_typing_before_finalize(
+                    _fence=fence,
+                    _chat_id=source.chat_id,
+                    _lease_id=lease_id,
+                ) -> None:
+                    await _fence(_chat_id, _lease_id)
+            elif hasattr(adapter, "pause_typing_for_chat"):
+                def _pause_typing_before_finalize(
+                    _adapter=adapter,
+                    _chat_id=source.chat_id,
+                ) -> None:
+                    _adapter.pause_typing_for_chat(_chat_id)
         # Platforms that don't support editing sent messages
         # (e.g. QQ, WeChat) should skip streaming entirely —
         # without edit support, the consumer sends a partial
@@ -30275,6 +30484,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
 
         _thread_metadata: Optional[Dict[str, Any]] = self._thread_metadata_for_source(source, event_message_id)
+        _typing_adapter = self._adapter_for_source(source)
+        _stamp_typing_lease = getattr(_typing_adapter, "_typing_metadata_for_session", None)
+        if callable(_stamp_typing_lease):
+            _thread_metadata = _stamp_typing_lease(session_key, _thread_metadata)
 
         if _streaming_enabled:
             try:
@@ -30285,6 +30498,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         self._build_stream_consumer_config(
                             source, _scfg, _adapter,
                             on_missing_cursor="fallback",
+                            typing_metadata=_thread_metadata,
                         )
                     )
                     _stream_consumer = GatewayStreamConsumer(
@@ -31050,6 +31264,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # reply anchor; carry it so progress joins that thread.
             _progress_metadata = {"reply_to_message_id": event_message_id}
         _progress_metadata = _non_conversational_metadata(_progress_metadata, platform=source.platform)
+        _typing_lease_adapter = self._adapter_for_source(source)
+        _stamp_typing_lease = getattr(
+            _typing_lease_adapter, "_typing_metadata_for_session", None
+        )
+        if callable(_stamp_typing_lease):
+            _progress_metadata = _stamp_typing_lease(session_key, _progress_metadata)
         if _native_slack_task_cards:
             # chat.startStream in channels requires the recipient team/user
             # pair; harmless extras elsewhere, so stamp them whenever known.
@@ -31202,6 +31422,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _status_thread_metadata = {
                     "reply_to_message_id": event_message_id
                 }
+        if callable(_stamp_typing_lease):
+            _status_thread_metadata = _stamp_typing_lease(
+                session_key, _status_thread_metadata
+            )
 
         # Bridge extracted to TurnRunner._status_callback_sync; publish the
         # status wiring computed above onto the shared TurnContext at the
@@ -32164,12 +32388,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # Restart typing indicator so the user sees activity while
                 # the follow-up turn runs.  The outer _process_message_background
                 # typing task is still alive but may be stale.
-                _followup_adapter = self._adapter_for_source(source)
+                _followup_adapter = self._adapter_for_source(next_source)
                 if _followup_adapter:
                     try:
+                        _followup_typing_metadata = self._thread_metadata_for_source(
+                            next_source, next_message_id
+                        )
+                        _followup_typing_metadata = self._renew_followup_typing_lease(
+                            _followup_adapter,
+                            chat_id=next_source.chat_id,
+                            session_key=next_session_key,
+                            metadata=_followup_typing_metadata,
+                        )
                         await _followup_adapter.send_typing(
-                            source.chat_id,
-                            metadata=_status_thread_metadata,
+                            next_source.chat_id,
+                            metadata=_followup_typing_metadata,
                         )
                     except Exception:
                         pass
@@ -32377,11 +32610,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
                 elif _sc_msg_id and _sc_msg_id != "__no_edit__" and _sc_adapter is not None:
                     try:
-                        _reconcile_res = await _sc_adapter.edit_message(
+                        _reconcile_res = await self._edit_message_with_optional_metadata(
+                            _sc_adapter,
                             chat_id=source.chat_id,
                             message_id=_sc_msg_id,
                             content=_final,
                             finalize=True,
+                            metadata=_status_thread_metadata,
                         )
                         if getattr(_reconcile_res, "success", True):
                             response["already_sent"] = True
@@ -32411,11 +32646,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _sc_msg_id = _sc.message_id
                 if _sc_msg_id:
                     try:
-                        await _sc.adapter.edit_message(
+                        await self._edit_message_with_optional_metadata(
+                            _sc.adapter,
                             chat_id=source.chat_id,
                             message_id=_sc_msg_id,
                             content=response["final_response"],
                             finalize=True,
+                            metadata=_status_thread_metadata,
                         )
                         response["already_sent"] = True
                         logger.info(

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -555,6 +555,7 @@ class GatewayStreamConsumer:
         message_id: str,
         content: str,
         finalize: bool = False,
+        is_turn_final: bool = True,
     ):
         """Edit via the adapter, passing routing metadata when supported."""
         kwargs = {
@@ -566,16 +567,22 @@ class GatewayStreamConsumer:
         # must accept finalize= even when it is False (guarded by tests).
         kwargs["finalize"] = finalize
 
-        if self.metadata:
-            try:
-                params = inspect.signature(self.adapter.edit_message).parameters
+        try:
+            params = inspect.signature(self.adapter.edit_message).parameters
+            accepts_kwargs = any(
+                param.kind is inspect.Parameter.VAR_KEYWORD
+                for param in params.values()
+            )
+            if self.metadata:
                 if "metadata" in params or any(
                     param.kind is inspect.Parameter.VAR_KEYWORD
                     for param in params.values()
                 ):
                     kwargs["metadata"] = self.metadata
-            except (TypeError, ValueError):
-                pass
+            if "is_turn_final" in params or accepts_kwargs:
+                kwargs["is_turn_final"] = is_turn_final
+        except (TypeError, ValueError):
+            pass
         return await self.adapter.edit_message(**kwargs)
 
     def _append_accumulated(self, text: str) -> None:
@@ -1723,6 +1730,10 @@ class GatewayStreamConsumer:
                         and self._use_draft_streaming
                         and self._message_id is None
                     )
+                    if got_done and (
+                        self._accumulated or self._message_id is not None or self._already_sent
+                    ):
+                        await self._notify_before_finalize()
                     current_update_visible = await self._send_or_edit(
                         display_text,
                         finalize=(got_done or got_segment_break),
@@ -1739,8 +1750,6 @@ class GatewayStreamConsumer:
                         self._tool_progress_active = False
 
                 if got_done:
-                    if self._accumulated or self._message_id is not None or self._already_sent:
-                        await self._notify_before_finalize()
                     # Final edit without cursor. If progressive editing failed
                     # mid-stream, send a single continuation/fallback message
                     # here instead of letting the base gateway path send the
@@ -2943,7 +2952,10 @@ class GatewayStreamConsumer:
             result = await self.adapter.send(
                 chat_id=self.chat_id,
                 content=text,
-                metadata=self._metadata_for_send(final=True),
+                metadata=self._metadata_for_send(
+                    final=is_turn_final,
+                    expect_edits=not is_turn_final,
+                ),
             )
         except Exception as e:
             logger.debug("Fresh-final send failed, falling back to edit: %s", e)
@@ -3413,6 +3425,7 @@ class GatewayStreamConsumer:
                         message_id=self._message_id,
                         content=text,
                         finalize=finalize,
+                        is_turn_final=is_turn_final,
                     )
                     if result.success:
                         self._already_sent = True
@@ -3571,13 +3584,14 @@ class GatewayStreamConsumer:
             else:
                 # First message — send new, threaded to the original user message
                 # so it lands in the correct topic/thread.
+                turn_final = finalize and is_turn_final
                 result = await self.adapter.send(
                     chat_id=self.chat_id,
                     content=text,
                     reply_to=self._initial_reply_to_id,
                     metadata=self._metadata_for_send(
-                        final=finalize,
-                        expect_edits=not finalize,
+                        final=turn_final,
+                        expect_edits=not turn_final,
                     ),
                 )
                 if result.success:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -614,6 +614,9 @@ class TelegramAdapter(BasePlatformAdapter):
 
     # Telegram message limits
     MAX_MESSAGE_LENGTH = 4096
+    # A typing HTTP request can be server-visible even if client cancellation
+    # wins locally; final delivery therefore fences it instead of timing out.
+    typing_send_requires_final_fence = True
     supports_code_blocks = True  # Telegram MarkdownV2 renders fenced code blocks
     splits_long_messages = True  # send() chunks via truncate_message(MAX_MESSAGE_LENGTH)
     # Bot API 10.1 Rich Messages cap the raw markdown/html text at 32,768
@@ -5388,6 +5391,22 @@ class TelegramAdapter(BasePlatformAdapter):
         else:  # "first" (default)
             return chunk_index == 0
 
+    async def _fence_typing_before_final_delivery(
+        self,
+        chat_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+        *,
+        finalize: bool = False,
+        is_turn_final: Optional[bool] = None,
+    ) -> None:
+        """Fence a lease before any visible final Telegram operation."""
+        turn_final = finalize if is_turn_final is None else is_turn_final
+        if not turn_final and not (metadata or {}).get("notify"):
+            return
+        lease_id = (metadata or {}).get("_hermes_typing_lease_id")
+        if lease_id:
+            await self._fence_typing_lease_before_final(chat_id, str(lease_id))
+
     async def send(
         self,
         chat_id: str,
@@ -5419,6 +5438,7 @@ class TelegramAdapter(BasePlatformAdapter):
         # Skip whitespace-only text to prevent Telegram 400 empty-text errors.
         if not content or not content.strip():
             return SendResult(success=True, message_id=None)
+        await self._fence_typing_before_final_delivery(chat_id, metadata)
         
         try:
             # Bot API 10.1 rich fast-path: send the raw agent markdown via
@@ -5766,7 +5786,12 @@ class TelegramAdapter(BasePlatformAdapter):
         cached_id = self._status_message_ids.get(key)
         if cached_id is not None:
             result = await self.edit_message(
-                chat_id, cached_id, content, finalize=True, metadata=metadata,
+                chat_id,
+                cached_id,
+                content,
+                finalize=True,
+                is_turn_final=False,
+                metadata=metadata,
             )
             if result.success:
                 if result.message_id:
@@ -5779,6 +5804,23 @@ class TelegramAdapter(BasePlatformAdapter):
             self._status_message_ids[key] = str(result.message_id)
         return result
 
+    async def _rearm_typing_after_intermediate_edit(
+        self,
+        chat_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+        *,
+        finalize: bool = False,
+        is_turn_final: Optional[bool] = None,
+    ) -> None:
+        """Restore Telegram's action timer after a visible progress edit."""
+        turn_final = finalize if is_turn_final is None else is_turn_final
+        if turn_final or (metadata or {}).get("notify"):
+            return
+        try:
+            await self.send_typing(chat_id, metadata=metadata)
+        except Exception:
+            pass  # Typing failures are non-fatal
+
     async def edit_message(
         self,
         chat_id: str,
@@ -5786,6 +5828,7 @@ class TelegramAdapter(BasePlatformAdapter):
         content: str,
         *,
         finalize: bool = False,
+        is_turn_final: Optional[bool] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Edit a previously sent Telegram message.
@@ -5800,6 +5843,22 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         if not self._bot:
             return SendResult(success=False, error="Not connected")
+        await self._fence_typing_before_final_delivery(
+            chat_id,
+            metadata,
+            finalize=finalize,
+            is_turn_final=is_turn_final,
+        )
+
+        async def _finish_edit(result: SendResult) -> SendResult:
+            if result.success:
+                await self._rearm_typing_after_intermediate_edit(
+                    chat_id,
+                    metadata,
+                    finalize=finalize,
+                    is_turn_final=is_turn_final,
+                )
+            return result
 
         # Rich finalize (Bot API 10.1): when the completed content has
         # constructs the legacy MarkdownV2 edit degrades (tables → bullet
@@ -5816,7 +5875,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 chat_id, message_id, content, metadata=metadata,
             )
             if rich_result is not None:
-                return rich_result
+                return await _finish_edit(rich_result)
 
         # Pre-flight: if content already exceeds the limit, split-and-deliver
         # without round-tripping a doomed edit.  During streaming
@@ -5833,8 +5892,14 @@ class TelegramAdapter(BasePlatformAdapter):
             self._last_overflow_preview.pop(_preview_key, None)
         if utf16_len(content) > self.MAX_MESSAGE_LENGTH:
             if finalize:
-                return await self._edit_overflow_split(
-                    chat_id, message_id, content, finalize=finalize, metadata=metadata,
+                return await _finish_edit(
+                    await self._edit_overflow_split(
+                        chat_id,
+                        message_id,
+                        content,
+                        finalize=finalize,
+                        metadata=metadata,
+                    )
                 )
             content = self._truncate_stream_overflow_preview(content)
             _saturated_preview = True
@@ -5861,7 +5926,9 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
                 if _saturated_preview:
                     self._last_overflow_preview[_preview_key] = content
-                return SendResult(success=True, message_id=message_id)
+                return await _finish_edit(
+                    SendResult(success=True, message_id=message_id)
+                )
 
             formatted = self.format_message(content)
             try:
@@ -5874,7 +5941,9 @@ class TelegramAdapter(BasePlatformAdapter):
             except Exception as fmt_err:
                 # "Message is not modified" is a no-op, not an error
                 if "not modified" in str(fmt_err).lower():
-                    return SendResult(success=True, message_id=message_id)
+                    return await _finish_edit(
+                        SendResult(success=True, message_id=message_id)
+                    )
                 # Fallback: strip MarkdownV2 escapes and retry as clean plain text
                 safe_format_error = _redact_telegram_error_text(fmt_err)
                 logger.warning(
@@ -5888,12 +5957,16 @@ class TelegramAdapter(BasePlatformAdapter):
                     message_id=int(message_id),
                     text=_plain,
                 )
-            return SendResult(success=True, message_id=message_id)
+            return await _finish_edit(
+                SendResult(success=True, message_id=message_id)
+            )
         except Exception as e:
             err_str = str(e).lower()
             # "Message is not modified" — content identical, treat as success
             if "not modified" in err_str:
-                return SendResult(success=True, message_id=message_id)
+                return await _finish_edit(
+                    SendResult(success=True, message_id=message_id)
+                )
             # Reactive split-and-deliver: parse_mode formatting can inflate
             # the payload past the limit even when the raw text was under
             # (e.g. MarkdownV2 escapes).  Same fix as the pre-flight path.
@@ -5903,8 +5976,14 @@ class TelegramAdapter(BasePlatformAdapter):
                     self.name, utf16_len(content), self.MAX_MESSAGE_LENGTH,
                 )
                 if finalize:
-                    return await self._edit_overflow_split(
-                        chat_id, message_id, content, finalize=finalize, metadata=metadata,
+                    return await _finish_edit(
+                        await self._edit_overflow_split(
+                            chat_id,
+                            message_id,
+                            content,
+                            finalize=finalize,
+                            metadata=metadata,
+                        )
                     )
                 # Mid-stream: truncate and retry instead of splitting (#48648).
                 truncated = self._truncate_stream_overflow_preview(content)
@@ -5917,7 +5996,9 @@ class TelegramAdapter(BasePlatformAdapter):
                     text=truncated,
                 )
                 self._last_overflow_preview[_preview_key] = truncated
-                return SendResult(success=True, message_id=message_id)
+                return await _finish_edit(
+                    SendResult(success=True, message_id=message_id)
+                )
             # Flood control / RetryAfter — short waits are retried inline,
             # long waits return a failure immediately so streaming can fall back
             # to a normal final send instead of leaving a truncated partial.
@@ -5937,7 +6018,9 @@ class TelegramAdapter(BasePlatformAdapter):
                         message_id=int(message_id),
                         text=content,
                     )
-                    return SendResult(success=True, message_id=message_id)
+                    return await _finish_edit(
+                        SendResult(success=True, message_id=message_id)
+                    )
                 except Exception as retry_err:
                     safe_retry_error = _redact_telegram_error_text(retry_err)
                     logger.error(
@@ -8623,8 +8706,14 @@ class TelegramAdapter(BasePlatformAdapter):
         loop = asyncio.get_running_loop()
         retry_after = getattr(exc, "retry_after", None)
         try:
-            delay = float(retry_after) if retry_after is not None else self._telegram_typing_cooldown_seconds
-        except (TypeError, ValueError):
+            total_seconds = getattr(retry_after, "total_seconds", None)
+            if callable(total_seconds):
+                delay = float(total_seconds())
+            elif retry_after is not None:
+                delay = float(retry_after)
+            else:
+                delay = self._telegram_typing_cooldown_seconds
+        except (TypeError, ValueError, OverflowError):
             delay = self._telegram_typing_cooldown_seconds
         delay = max(1.0, min(delay, 300.0))
         self._telegram_typing_cooldown_until[str(chat_id)] = loop.time() + delay
@@ -8641,9 +8730,48 @@ class TelegramAdapter(BasePlatformAdapter):
         self._telegram_typing_cooldown_until.pop(str(chat_id), None)
         return False
 
+    async def _await_typing_transport(self, awaitable: Awaitable[Any]) -> Any:
+        """Drain an admitted typing request before propagating cancellation."""
+        transport_task = asyncio.ensure_future(awaitable)
+        caller_cancelled = False
+        transport_error: Optional[Exception] = None
+
+        while not transport_task.done():
+            try:
+                await asyncio.shield(transport_task)
+            except asyncio.CancelledError:
+                caller_cancelled = True
+            except Exception as exc:
+                transport_error = exc
+                break
+
+        if caller_cancelled:
+            # The result is intentionally consumed: cancellation wins for the
+            # caller, but only after Telegram's admitted request has returned.
+            try:
+                transport_task.result()
+            except BaseException:
+                pass
+            raise asyncio.CancelledError()
+        if transport_error is not None:
+            raise transport_error
+        return transport_task.result()
+
     async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
-        """Send typing indicator."""
-        if not self._bot or self._typing_in_cooldown(chat_id):
+        """Send typing indicator when the platform policy permits it."""
+        # This is the policy-enforcement boundary: progress, streaming, and
+        # queued-follow-up paths call send_typing() directly and therefore do
+        # not pass through base.py's _keep_typing() config gate.
+        if not getattr(self.config, "typing_indicator", True):
+            return
+        if not self._typing_lease_allows(chat_id, metadata):
+            return
+        if not self._bot:
+            replacement = self._replacement_telegram_adapter()
+            if replacement is not None:
+                await replacement.send_typing(chat_id, metadata=metadata)
+            return
+        if self._typing_in_cooldown(chat_id):
             return
 
         _is_dm_topic: bool = False
@@ -8652,11 +8780,21 @@ class TelegramAdapter(BasePlatformAdapter):
             _typing_thread = self._metadata_thread_id(metadata)
             _is_dm_topic = bool(metadata and metadata.get("telegram_dm_topic_reply_fallback"))
             message_thread_id = self._message_thread_id_for_typing(_typing_thread)
-            await self._bot.send_chat_action(
-                chat_id=normalize_telegram_chat_id(chat_id),
-                action="typing",
-                message_thread_id=message_thread_id,
-            )
+            async with self._typing_lease_lock(chat_id):
+                if (
+                    not getattr(self.config, "typing_indicator", True)
+                    or not self._typing_lease_allows(chat_id, metadata)
+                    or not self._bot
+                    or self._typing_in_cooldown(chat_id)
+                ):
+                    return
+                await self._await_typing_transport(
+                    self._bot.send_chat_action(
+                        chat_id=normalize_telegram_chat_id(chat_id),
+                        action="typing",
+                        message_thread_id=message_thread_id,
+                    )
+                )
             self._telegram_typing_cooldown_until.pop(str(chat_id), None)
         except Exception as e:
             # For DM topic lanes, Telegram may reject message_thread_id.
@@ -8664,10 +8802,20 @@ class TelegramAdapter(BasePlatformAdapter):
             # indicator at least appears in the main DM view.
             if _is_dm_topic and message_thread_id is not None:
                 try:
-                    await self._bot.send_chat_action(
-                        chat_id=normalize_telegram_chat_id(chat_id),
-                        action="typing",
-                    )
+                    async with self._typing_lease_lock(chat_id):
+                        if (
+                            not getattr(self.config, "typing_indicator", True)
+                            or not self._typing_lease_allows(chat_id, metadata)
+                            or not self._bot
+                            or self._typing_in_cooldown(chat_id)
+                        ):
+                            return
+                        await self._await_typing_transport(
+                            self._bot.send_chat_action(
+                                chat_id=normalize_telegram_chat_id(chat_id),
+                                action="typing",
+                            )
+                        )
                     self._telegram_typing_cooldown_until.pop(str(chat_id), None)
                     return
                 except Exception as fallback_exc:

--- a/tests/gateway/relay/test_relay_adapter.py
+++ b/tests/gateway/relay/test_relay_adapter.py
@@ -176,6 +176,26 @@ async def test_send_reattaches_dm_user_id_from_inbound_scope():
 
 
 @pytest.mark.asyncio
+async def test_private_typing_lease_is_not_serialized_to_relay():
+    t = _CaptureTransport()
+    a = RelayAdapter(
+        PlatformConfig(), make_desc(platform="discord"), transport=t
+    )
+    event = _make_event(chat_id="chan-1", scope_id="scope-9")
+    a._capture_scope(event)
+    session_key = "relay:scope-9:chan-1"
+    a._begin_typing_lease("chan-1", session_key)
+    metadata = a._typing_metadata_for_session(
+        session_key, {"thread_id": "thread-1"}
+    )
+
+    await a.send("chan-1", "reply", metadata=metadata)
+
+    assert t.sent["metadata"]["thread_id"] == "thread-1"
+    assert "_hermes_typing_lease_id" not in t.sent["metadata"]
+
+
+@pytest.mark.asyncio
 async def test_scoped_reply_reattaches_both_scope_id_and_user_id():
     """A scoped (guild) reply now re-attaches BOTH scope_id AND the authentic
     author user_id. scope_id is the connector's primary discriminator; user_id

--- a/tests/gateway/test_base_auto_tts_output_format.py
+++ b/tests/gateway/test_base_auto_tts_output_format.py
@@ -141,3 +141,42 @@ async def test_base_auto_tts_skips_playback_when_tool_reports_failure():
     adapter.play_tts.assert_not_awaited()
     # Text reply still goes out.
     assert adapter.sent and adapter.sent[0]["content"] == "reply text"
+
+
+@pytest.mark.asyncio
+async def test_base_auto_tts_fences_after_synthesis_before_voice_egress():
+    adapter = _DummyAdapter(Platform.TELEGRAM)
+    adapter._keep_typing = _hold_typing()
+    adapter._should_auto_tts_for_chat = lambda _chat_id: True
+    adapter.set_message_handler(
+        lambda _event: asyncio.sleep(0, result="x" * 2000)
+    )
+    event = _make_voice_event(Platform.TELEGRAM)
+    order = []
+
+    async def record_fence(chat_id, lease_id):
+        order.append("fence")
+
+    async def record_voice(**kwargs):
+        order.append("voice")
+        return SendResult(success=True, message_id="tts-1")
+
+    adapter._fence_typing_lease_before_final = AsyncMock(side_effect=record_fence)
+    adapter.play_tts = AsyncMock(side_effect=record_voice)
+
+    def fake_tts(*, text, output_path=None):
+        from pathlib import Path
+
+        order.append("synthesis")
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(output_path).write_bytes(b"fake audio")
+        return json.dumps({"success": True, "file_path": output_path})
+
+    with patch("tools.tts_tool.check_tts_requirements", return_value=True), patch(
+        "tools.tts_tool.text_to_speech_tool", side_effect=fake_tts
+    ):
+        await adapter._process_message_background(
+            event, build_session_key(event.source)
+        )
+
+    assert order[:3] == ["synthesis", "fence", "voice"]

--- a/tests/gateway/test_base_topic_sessions.py
+++ b/tests/gateway/test_base_topic_sessions.py
@@ -13,6 +13,8 @@ from gateway.session import SessionSource, build_session_key
 
 
 class DummyTelegramAdapter(BasePlatformAdapter):
+    typing_send_requires_final_fence = True
+
     def __init__(self):
         super().__init__(PlatformConfig(enabled=True, token="fake-token"), Platform.TELEGRAM)
         self._busy_text_mode = ""
@@ -119,12 +121,10 @@ class TestBasePlatformTopicSessions:
                 "metadata": {"thread_id": "17585", "notify": True},
             }
         ]
-        assert typing_calls == [
-            {
-                "chat_id": "-1001",
-                "metadata": {"thread_id": "17585"},
-            }
-        ]
+        assert len(typing_calls) == 1
+        assert typing_calls[0]["chat_id"] == "-1001"
+        assert typing_calls[0]["metadata"]["thread_id"] == "17585"
+        assert "_hermes_typing_lease_id" in typing_calls[0]["metadata"]
         assert {
             "chat_id": "-1001",
             "stopped": True,

--- a/tests/gateway/test_keep_typing_timeout.py
+++ b/tests/gateway/test_keep_typing_timeout.py
@@ -22,16 +22,22 @@ the bubble stays visible across provider stalls.
 """
 
 import asyncio
+import gc
+import weakref
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 
 from gateway.platforms.base import (
     BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
     Platform,
     PlatformConfig,
     SendResult,
 )
+from gateway.session import SessionSource, build_session_key
 
 
 class _StubAdapter(BasePlatformAdapter):
@@ -51,7 +57,289 @@ class _StubAdapter(BasePlatformAdapter):
         return {"id": chat_id, "type": "dm"}
 
 
-class TestKeepTypingTimeoutPerTick:
+class TestTypingLeaseGeneration:
+    def test_private_lease_metadata_is_not_stamped_for_unfenced_adapter(self):
+        adapter = _StubAdapter()
+        adapter.typing_send_requires_final_fence = False
+        adapter._begin_typing_lease("123", "session-1")
+
+        assert adapter._typing_metadata_for_session(
+            "session-1", {"thread_id": "topic-1"}
+        ) == {"thread_id": "topic-1"}
+
+    @pytest.mark.asyncio
+    async def test_lock_registry_does_not_retain_idle_chat(self):
+        adapter = _StubAdapter()
+        lock = adapter._typing_lease_lock("one-shot-chat")
+        lock_ref = weakref.ref(lock)
+
+        del lock
+        gc.collect()
+
+        assert lock_ref() is None
+
+    def test_replacement_adapter_recognizes_live_typing_lease(self):
+        runner = SimpleNamespace()
+        ingress = _StubAdapter()
+        ingress.gateway_runner = runner
+        lease_id = ingress._begin_typing_lease("123", "session-1")
+        replacement = _StubAdapter()
+        replacement.gateway_runner = runner
+
+        assert replacement._typing_lease_allows(
+            "123", {"_hermes_typing_lease_id": lease_id}
+        )
+
+    @pytest.mark.asyncio
+    async def test_distinct_gateway_runtimes_isolate_typing_leases(self):
+        first = _StubAdapter()
+        first.gateway_runner = SimpleNamespace()
+        second = _StubAdapter()
+        second.gateway_runner = SimpleNamespace()
+
+        first_lease = first._begin_typing_lease("123", "session-1")
+        first_metadata = {"_hermes_typing_lease_id": first_lease}
+        second._begin_typing_lease("123", "session-1")
+
+        assert first._typing_lease_allows("123", first_metadata)
+        await second._fence_all_typing_leases()
+        assert first._typing_lease_allows("123", first_metadata)
+        first._revoke_typing_lease(first_lease)
+
+    def test_replacement_turn_invalidates_prior_lease(self):
+        adapter = _StubAdapter()
+        adapter.typing_send_requires_final_fence = True
+        first = adapter._begin_typing_lease("123", "session-1")
+        old_metadata = adapter._typing_metadata_for_session("session-1", {})
+
+        second = adapter._begin_typing_lease("123", "session-1")
+        new_metadata = adapter._typing_metadata_for_session("session-1", {})
+
+        assert first != second
+        assert not adapter._typing_lease_allows("123", old_metadata)
+        assert adapter._typing_lease_allows("123", new_metadata)
+
+    @pytest.mark.asyncio
+    async def test_finalization_fence_closes_then_revokes_lease(self):
+        adapter = _StubAdapter()
+        lease_id = adapter._begin_typing_lease("123", "session-1")
+        metadata = {"_hermes_typing_lease_id": lease_id}
+        fence = getattr(adapter, "_fence_typing_lease_before_final", None)
+
+        assert callable(fence), "final delivery must fence admitted typing sends"
+        lock = adapter._typing_lease_lock("123")
+        await lock.acquire()
+        try:
+            fence_task = asyncio.create_task(
+                fence("123", lease_id)
+            )
+            await asyncio.sleep(0)
+            assert not adapter._typing_lease_allows("123", metadata)
+            assert not fence_task.done()
+        finally:
+            lock.release()
+        await fence_task
+        assert not adapter._typing_lease_allows("123", metadata)
+
+    @pytest.mark.asyncio
+    async def test_shutdown_revokes_live_typing_leases(self):
+        adapter = _StubAdapter()
+        lease_id = adapter._begin_typing_lease("123", "session-1")
+        metadata = {"_hermes_typing_lease_id": lease_id}
+
+        await adapter.cancel_background_tasks()
+
+        assert not adapter._typing_lease_allows("123", metadata)
+
+
+    @pytest.mark.asyncio
+    async def test_shutdown_drains_admitted_typing_action_before_returning(self):
+        adapter = _StubAdapter()
+        lease_id = adapter._begin_typing_lease("123", "session-1")
+        metadata = {"_hermes_typing_lease_id": lease_id}
+        lock = adapter._typing_lease_lock("123")
+        await lock.acquire()
+        try:
+            shutdown_task = asyncio.create_task(adapter.cancel_background_tasks())
+            await asyncio.sleep(0)
+            assert not adapter._typing_lease_allows("123", metadata)
+            assert not shutdown_task.done()
+        finally:
+            lock.release()
+        await shutdown_task
+
+    @pytest.mark.asyncio
+    async def test_outer_finalization_fences_successor_queued_turn_lease(self):
+        adapter = _StubAdapter()
+        adapter.typing_send_requires_final_fence = True
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="123",
+            chat_type="dm",
+        )
+        event = MessageEvent(
+            text="first",
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id="m1",
+        )
+        session_key = build_session_key(source)
+        successor = {}
+        successor_allowed_at_send = []
+
+        async def handler(_event):
+            successor["id"] = adapter._begin_typing_lease(
+                source.chat_id, session_key
+            )
+            return "queued final"
+
+        async def send(chat_id, content, reply_to=None, metadata=None):
+            successor_allowed_at_send.append(
+                adapter._typing_lease_allows(
+                    chat_id,
+                    {"_hermes_typing_lease_id": successor["id"]},
+                )
+            )
+            return SendResult(success=True, message_id="m1")
+
+        adapter._message_handler = handler
+        adapter.send = send
+
+        await adapter._process_message_background(event, session_key)
+
+        assert successor_allowed_at_send == [False]
+        assert not adapter._typing_lease_allows(
+            source.chat_id,
+            {"_hermes_typing_lease_id": successor["id"]},
+        )
+
+    @pytest.mark.asyncio
+    async def test_stale_task_cleanup_preserves_replacement_turn_lease(self):
+        adapter = _StubAdapter()
+        adapter.typing_send_requires_final_fence = True
+        adapter.config.typing_indicator = False
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="123",
+            chat_type="dm",
+        )
+        event = MessageEvent(
+            text="stale",
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id="m1",
+        )
+        session_key = build_session_key(source)
+        stale_guard = asyncio.Event()
+        adapter._active_sessions[session_key] = stale_guard
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def handler(_event):
+            started.set()
+            await release.wait()
+            return None
+
+        adapter._message_handler = handler
+        stale_task = asyncio.create_task(
+            adapter._process_message_background(event, session_key)
+        )
+        adapter._session_tasks[session_key] = stale_task
+        await started.wait()
+
+        replacement_guard = asyncio.Event()
+        replacement_task = asyncio.create_task(asyncio.sleep(0))
+        adapter._active_sessions[session_key] = replacement_guard
+        adapter._session_tasks[session_key] = replacement_task
+        replacement_lease = adapter._begin_typing_lease(
+            source.chat_id, session_key
+        )
+        replacement_metadata = {
+            "_hermes_typing_lease_id": replacement_lease
+        }
+        assert adapter._typing_lease_allows(
+            source.chat_id, replacement_metadata
+        )
+
+        release.set()
+        await stale_task
+        await replacement_task
+
+        assert adapter._active_sessions.get(session_key) is replacement_guard
+        assert adapter._typing_lease_allows(
+            source.chat_id, replacement_metadata
+        )
+        adapter._revoke_typing_lease(replacement_lease)
+
+    @pytest.mark.asyncio
+    async def test_keep_typing_refreshes_successor_generation(self, monkeypatch):
+        adapter = _StubAdapter()
+        adapter.typing_send_requires_final_fence = True
+        session_key = "session-1"
+        first_lease = adapter._begin_typing_lease("123", session_key)
+        first_metadata = adapter._typing_metadata_for_session(session_key, {})
+        successor_seen = asyncio.Event()
+        calls = []
+
+        async def record_typing(chat_id, metadata=None):
+            lease_id = (metadata or {}).get("_hermes_typing_lease_id")
+            calls.append(lease_id)
+            if lease_id != first_lease:
+                successor_seen.set()
+
+        monkeypatch.setattr(adapter, "send_typing", record_typing)
+        adapter.stop_typing = MagicMock(return_value=asyncio.sleep(0))
+        stop_event = asyncio.Event()
+        task = asyncio.create_task(
+            adapter._keep_typing(
+                "123",
+                interval=0.05,
+                metadata=first_metadata,
+                stop_event=stop_event,
+                session_key=session_key,
+            )
+        )
+        while not calls:
+            await asyncio.sleep(0)
+
+        successor_lease = adapter._begin_typing_lease("123", session_key)
+        await asyncio.wait_for(successor_seen.wait(), timeout=1.0)
+        stop_event.set()
+        await task
+
+        assert calls[0] == first_lease
+        assert successor_lease in calls[1:]
+
+    @pytest.mark.asyncio
+    async def test_fenced_typing_send_is_not_cancelled_by_heartbeat_timeout(self, monkeypatch):
+        adapter = _StubAdapter()
+        adapter.typing_send_requires_final_fence = True
+        started = asyncio.Event()
+        release = asyncio.Event()
+        cancelled = asyncio.Event()
+
+        async def blocked_send_typing(chat_id, metadata=None):
+            started.set()
+            try:
+                await release.wait()
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+        monkeypatch.setattr(adapter, "send_typing", blocked_send_typing)
+        adapter.stop_typing = MagicMock(return_value=asyncio.sleep(0))
+        stop_event = asyncio.Event()
+        task = asyncio.create_task(
+            adapter._keep_typing("123", interval=0.5, stop_event=stop_event)
+        )
+        await started.wait()
+        await asyncio.sleep(0.4)
+        assert not cancelled.is_set()
+
+        release.set()
+        stop_event.set()
+        await task
+
     @pytest.mark.asyncio
     async def test_slow_send_typing_does_not_block_cadence(self, monkeypatch):
         """A send_typing that hangs longer than the per-tick budget must be

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1289,7 +1289,7 @@ async def test_run_agent_queued_message_delivers_first_response_media(monkeypatc
             {
                 "chat_id": "discord-thread",
                 "images": [(media_path.as_uri(), "")],
-                "metadata": {"thread_id": "discord-thread"},
+                "metadata": {"thread_id": "discord-thread", "notify": True},
             }
         ],
     }
@@ -1330,7 +1330,7 @@ async def test_run_agent_queued_message_delivers_streamed_first_response_media(
         {
             "chat_id": "discord-thread",
             "images": [(media_path.as_uri(), "")],
-            "metadata": {"thread_id": "discord-thread"},
+            "metadata": {"thread_id": "discord-thread", "notify": True},
         }
     ]
 

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -157,6 +157,79 @@ class TestEditMessageFinalizeSignature:
             f"stream_consumer._send_or_edit passes it unconditionally"
         )
 
+    @pytest.mark.asyncio
+    async def test_turn_final_semantics_reach_supporting_adapter(self):
+        calls = []
+
+        class TurnAwareAdapter:
+            async def edit_message(
+                self,
+                chat_id,
+                message_id,
+                content,
+                *,
+                finalize=False,
+                is_turn_final=True,
+                metadata=None,
+            ):
+                calls.append(
+                    {
+                        "finalize": finalize,
+                        "is_turn_final": is_turn_final,
+                        "metadata": metadata,
+                    }
+                )
+                return SimpleNamespace(success=True, message_id=message_id)
+
+        metadata = {"_hermes_typing_lease_id": "lease-1"}
+        consumer = GatewayStreamConsumer(
+            TurnAwareAdapter(), "chat_1", metadata=metadata
+        )
+
+        await consumer._edit_message(
+            message_id="m1",
+            content="sealed intermediate segment",
+            finalize=True,
+            is_turn_final=False,
+        )
+
+        assert calls == [
+            {
+                "finalize": True,
+                "is_turn_final": False,
+                "metadata": metadata,
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_turn_final_semantics_are_omitted_for_legacy_adapter(self):
+        calls = []
+
+        class LegacyAdapter:
+            async def edit_message(
+                self,
+                chat_id,
+                message_id,
+                content,
+                *,
+                finalize=False,
+                metadata=None,
+            ):
+                calls.append({"finalize": finalize, "metadata": metadata})
+                return SimpleNamespace(success=True, message_id=message_id)
+
+        metadata = {"route": "thread-1"}
+        consumer = GatewayStreamConsumer(LegacyAdapter(), "chat_1", metadata=metadata)
+
+        await consumer._edit_message(
+            message_id="m1",
+            content="sealed intermediate segment",
+            finalize=True,
+            is_turn_final=False,
+        )
+
+        assert calls == [{"finalize": True, "metadata": metadata}]
+
 
 class TestSendOrEditMediaStripping:
     """Verify _send_or_edit strips MEDIA: before sending to the platform."""
@@ -295,17 +368,14 @@ class TestBeforeFinalizeHook:
             adapter,
             "chat_123",
             StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5),
-            on_before_finalize=lambda: events.append("pause"),
+            on_before_finalize=lambda: events.append("fence"),
         )
         consumer.on_delta("Hello")
         consumer.finish()
 
         await consumer.run()
 
-        assert events == ["send", "pause", "edit"]
-
-
-# ── Segment break (tool boundary) tests ──────────────────────────────────
+        assert events == ["fence", "send", "edit"]
 
 
 class TestSegmentBreakOnToolBoundary:

--- a/tests/gateway/test_stream_final_contract.py
+++ b/tests/gateway/test_stream_final_contract.py
@@ -266,3 +266,32 @@ class TestQueuedLaneReconcile:
         )
         assert adapter.edit_calls == []
         assert len(adapter.send_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_queued_first_response_marks_fallback_send_final(self):
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        adapter = _make_draft_adapter()
+        source = SimpleNamespace(chat_id="D1")
+        metadata = {"_hermes_typing_lease_id": "lease-1"}
+        await GatewayRunner._deliver_queued_first_response(
+            runner,
+            "final text",
+            source=source,
+            adapter=adapter,
+            metadata=metadata,
+            text_already_delivered=False,
+            deliver_media=False,
+            stream_consumer=SimpleNamespace(message_id=None, _turn_split_delivery=False),
+        )
+
+        assert adapter.send_calls == [
+            {
+                "content": "final text",
+                "metadata": {
+                    "_hermes_typing_lease_id": "lease-1",
+                    "notify": True,
+                },
+            }
+        ]

--- a/tests/gateway/test_telegram_typing_backoff.py
+++ b/tests/gateway/test_telegram_typing_backoff.py
@@ -1,7 +1,10 @@
 """Telegram typing indicator transient backoff tests."""
 
+import asyncio
 import sys
+from datetime import timedelta
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
@@ -9,14 +12,311 @@ import pytest
 _repo = str(Path(__file__).resolve().parents[2])
 if _repo not in sys.path:
     sys.path.insert(0, _repo)
-from gateway.config import PlatformConfig
+from gateway.config import Platform, PlatformConfig
+from gateway.stream_consumer import GatewayStreamConsumer
 from plugins.platforms.telegram.adapter import TelegramAdapter
 
 
 def _make_adapter():
     adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
     adapter._bot = AsyncMock()
+    adapter._test_typing_lease_id = adapter._begin_typing_lease("123", "test-session")
     return adapter
+
+
+def _active_turn_metadata(adapter, **extra):
+    return {"_hermes_typing_lease_id": adapter._test_typing_lease_id, **extra}
+
+
+@pytest.mark.asyncio
+async def test_late_typing_refresh_from_released_turn_is_blocked():
+    adapter = _make_adapter()
+
+    await adapter.send_typing(
+        "123", metadata={"_hermes_typing_lease_id": "finished-turn"}
+    )
+
+    adapter._bot.send_chat_action.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_typing_action_holds_finalization_fence_until_transport_returns():
+    adapter = _make_adapter()
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def blocked_action(**kwargs):
+        entered.set()
+        await release.wait()
+
+    adapter._bot.send_chat_action = AsyncMock(side_effect=blocked_action)
+    typing_task = asyncio.create_task(
+        adapter.send_typing("123", metadata=_active_turn_metadata(adapter))
+    )
+    await entered.wait()
+    fence_task = asyncio.create_task(
+        adapter._fence_typing_lease_before_final("123", adapter._test_typing_lease_id)
+    )
+    await asyncio.sleep(0)
+    assert not fence_task.done()
+
+    release.set()
+    await typing_task
+    await fence_task
+
+
+@pytest.mark.asyncio
+async def test_final_notify_send_fences_typing_before_visible_message():
+    adapter = _make_adapter()
+    order = []
+
+    async def record_fence(chat_id, lease_id):
+        order.append("fence")
+
+    async def record_send(**kwargs):
+        order.append("send")
+        return SimpleNamespace(message_id="final-1")
+
+    adapter._fence_typing_lease_before_final = AsyncMock(side_effect=record_fence)
+    adapter._bot.send_message = AsyncMock(side_effect=record_send)
+
+    await adapter.send(
+        "123", "final response", metadata=_active_turn_metadata(adapter, notify=True)
+    )
+
+    assert order[:2] == ["fence", "send"]
+
+
+@pytest.mark.asyncio
+async def test_final_edit_fences_typing_before_visible_edit():
+    adapter = _make_adapter()
+    order = []
+
+    async def record_fence(chat_id, lease_id):
+        order.append("fence")
+
+    async def record_edit(**kwargs):
+        order.append("edit")
+        return SimpleNamespace(message_id="final-1")
+
+    adapter._fence_typing_lease_before_final = AsyncMock(side_effect=record_fence)
+    adapter._bot.edit_message_text = AsyncMock(side_effect=record_edit)
+
+    await adapter.edit_message(
+        "123", "1", "final response", finalize=True,
+        metadata=_active_turn_metadata(adapter),
+    )
+
+    assert order[:2] == ["fence", "edit"]
+    adapter._bot.send_chat_action.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_intermediate_finalized_edit_preserves_lease_and_rearms_typing():
+    """Formatting-final is not necessarily the final delivery for the turn."""
+    adapter = _make_adapter()
+    order = []
+
+    async def record_fence(chat_id, lease_id):
+        order.append("fence")
+
+    async def record_edit(**kwargs):
+        order.append("edit")
+        return SimpleNamespace(message_id="1")
+
+    async def record_typing(**kwargs):
+        order.append("typing")
+
+    adapter._fence_typing_lease_before_final = AsyncMock(side_effect=record_fence)
+    adapter._bot.edit_message_text = AsyncMock(side_effect=record_edit)
+    adapter._bot.send_chat_action = AsyncMock(side_effect=record_typing)
+    metadata = _active_turn_metadata(adapter)
+
+    result = await adapter.edit_message(
+        "123",
+        "1",
+        "sealed intermediate segment",
+        finalize=True,
+        is_turn_final=False,
+        metadata=metadata,
+    )
+
+    assert result.success
+    assert order == ["edit", "typing"]
+    assert adapter._typing_lease_allows("123", metadata)
+
+
+@pytest.mark.asyncio
+async def test_status_edit_is_intermediate_and_preserves_typing_lease():
+    adapter = _make_adapter()
+    adapter._status_message_ids[("123", "compression")] = "1"
+    adapter._bot.edit_message_text = AsyncMock(
+        return_value=SimpleNamespace(message_id="1")
+    )
+    metadata = _active_turn_metadata(adapter)
+
+    result = await adapter.send_or_update_status(
+        "123", "compression", "still working", metadata=metadata
+    )
+
+    assert result.success
+    adapter._bot.send_chat_action.assert_awaited_once()
+    assert adapter._typing_lease_allows("123", metadata)
+
+
+@pytest.mark.asyncio
+async def test_first_formatting_final_send_preserves_and_rearms_typing():
+    adapter = _make_adapter()
+    adapter._bot.send_message = AsyncMock(
+        return_value=SimpleNamespace(message_id="1")
+    )
+    metadata = _active_turn_metadata(adapter)
+    consumer = GatewayStreamConsumer(adapter, "123", metadata=metadata)
+
+    delivered = await consumer._send_or_edit(
+        "sealed intermediate segment",
+        finalize=True,
+        is_turn_final=False,
+    )
+
+    assert delivered
+    adapter._bot.send_chat_action.assert_awaited_once()
+    assert adapter._typing_lease_allows("123", metadata)
+
+
+@pytest.mark.asyncio
+async def test_fresh_replacement_for_intermediate_segment_preserves_typing():
+    adapter = _make_adapter()
+    adapter._bot.send_message = AsyncMock(
+        return_value=SimpleNamespace(message_id="2")
+    )
+    adapter._bot.delete_message = AsyncMock()
+    metadata = _active_turn_metadata(adapter)
+    consumer = GatewayStreamConsumer(adapter, "123", metadata=metadata)
+    consumer._message_id = "1"
+    consumer._preview_message_ids = {"1"}
+
+    delivered = await consumer._try_fresh_final(
+        "sealed intermediate segment",
+        is_turn_final=False,
+    )
+
+    assert delivered
+    adapter._bot.send_chat_action.assert_awaited_once()
+    assert adapter._typing_lease_allows("123", metadata)
+
+
+@pytest.mark.asyncio
+async def test_intermediate_edit_rearms_typing_with_active_lease():
+    adapter = _make_adapter()
+    order = []
+
+    async def record_edit(**kwargs):
+        order.append("edit")
+        return SimpleNamespace(message_id="1")
+
+    async def record_typing(**kwargs):
+        order.append("typing")
+
+    adapter._bot.edit_message_text = AsyncMock(side_effect=record_edit)
+    adapter._bot.send_chat_action = AsyncMock(side_effect=record_typing)
+
+    result = await adapter.edit_message(
+        "123",
+        "1",
+        "progress update",
+        finalize=False,
+        metadata=_active_turn_metadata(adapter),
+    )
+
+    assert result.success
+    assert order == ["edit", "typing"]
+
+
+@pytest.mark.asyncio
+async def test_failed_intermediate_edit_does_not_rearm_typing():
+    adapter = _make_adapter()
+    adapter._bot.edit_message_text = AsyncMock(side_effect=ValueError("edit failed"))
+
+    result = await adapter.edit_message(
+        "123",
+        "1",
+        "progress update",
+        finalize=False,
+        metadata=_active_turn_metadata(adapter),
+    )
+
+    assert not result.success
+    adapter._bot.send_chat_action.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_disconnected_adapter_forwards_heartbeat_to_live_replacement():
+    ingress = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    replacement = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    replacement._bot = AsyncMock()
+    runner = SimpleNamespace(adapters={Platform.TELEGRAM: replacement})
+    ingress.gateway_runner = runner
+    replacement.gateway_runner = runner
+    lease_id = ingress._begin_typing_lease("123", "test-session")
+    metadata = {"_hermes_typing_lease_id": lease_id}
+    ingress._bot = None
+
+    await ingress.send_typing("123", metadata=metadata)
+
+    replacement._bot.send_chat_action.assert_awaited_once()
+    assert replacement._typing_lease_allows("123", metadata)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_intermediate_rearm_drains_before_final_fence():
+    adapter = _make_adapter()
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    adapter._bot.edit_message_text = AsyncMock(return_value=SimpleNamespace(message_id="1"))
+
+    async def blocked_typing(**kwargs):
+        entered.set()
+        await release.wait()
+
+    adapter._bot.send_chat_action = AsyncMock(side_effect=blocked_typing)
+    edit_task = asyncio.create_task(
+        adapter.edit_message(
+            "123",
+            "1",
+            "progress update",
+            finalize=False,
+            metadata=_active_turn_metadata(adapter),
+        )
+    )
+    await entered.wait()
+
+    edit_task.cancel()
+    fence_task = asyncio.create_task(
+        adapter._fence_typing_lease_before_final("123", adapter._test_typing_lease_id)
+    )
+    await asyncio.sleep(0)
+
+    assert not fence_task.done()
+
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await edit_task
+    await fence_task
+
+
+@pytest.mark.asyncio
+async def test_typing_disabled_never_calls_telegram_action():
+    adapter = TelegramAdapter(
+        PlatformConfig(enabled=True, token="test-token", typing_indicator=False)
+    )
+    adapter._bot = AsyncMock()
+    adapter._test_typing_lease_id = adapter._begin_typing_lease("123", "test-session")
+
+    await adapter.send_typing("123", metadata=_active_turn_metadata(adapter))
+
+    adapter._bot.send_chat_action.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -31,18 +331,38 @@ async def test_typing_transient_failure_enters_cooldown(monkeypatch):
 
     adapter._bot.send_chat_action = AsyncMock(side_effect=fail_once)
 
-    await adapter.send_typing("123")
-    await adapter.send_typing("123")
+    await adapter.send_typing("123", metadata=_active_turn_metadata(adapter))
+    await adapter.send_typing("123", metadata=_active_turn_metadata(adapter))
 
     assert adapter._bot.send_chat_action.await_count == 1
     assert adapter._telegram_typing_cooldown_until["123"] == pytest.approx(1030.0)
 
     now["value"] = 1031.0
     adapter._bot.send_chat_action = AsyncMock(return_value=None)
-    await adapter.send_typing("123")
+    await adapter.send_typing("123", metadata=_active_turn_metadata(adapter))
 
     assert adapter._bot.send_chat_action.await_count == 1
     assert "123" not in adapter._telegram_typing_cooldown_until
+
+
+@pytest.mark.asyncio
+async def test_typing_retry_after_timedelta_honors_server_delay(monkeypatch):
+    adapter = _make_adapter()
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.asyncio.get_running_loop",
+        lambda: type("Loop", (), {"time": lambda self: 1000.0})(),
+    )
+
+    class RetryAfterError(OSError):
+        retry_after = timedelta(seconds=90)
+
+    adapter._bot.send_chat_action = AsyncMock(
+        side_effect=RetryAfterError("retry after 90 seconds")
+    )
+
+    await adapter.send_typing("123", metadata=_active_turn_metadata(adapter))
+
+    assert adapter._telegram_typing_cooldown_until["123"] == pytest.approx(1090.0)
 
 
 @pytest.mark.asyncio
@@ -62,7 +382,10 @@ async def test_typing_dm_topic_fallback_success_does_not_cool_down(monkeypatch):
 
     await adapter.send_typing(
         "123",
-        metadata={"thread_id": "99", "telegram_dm_topic_reply_fallback": True},
+        metadata=_active_turn_metadata(
+            adapter,
+            thread_id="99", telegram_dm_topic_reply_fallback=True
+        ),
     )
 
     assert len(calls) == 2
@@ -79,8 +402,8 @@ async def test_typing_bad_thread_failure_does_not_cool_down(monkeypatch):
 
     adapter._bot.send_chat_action = AsyncMock(side_effect=bad_request)
 
-    await adapter.send_typing("123", metadata={"thread_id": "99"})
-    await adapter.send_typing("123", metadata={"thread_id": "99"})
+    await adapter.send_typing("123", metadata=_active_turn_metadata(adapter, thread_id="99"))
+    await adapter.send_typing("123", metadata=_active_turn_metadata(adapter, thread_id="99"))
 
     assert adapter._bot.send_chat_action.await_count == 2
     assert "123" not in adapter._telegram_typing_cooldown_until

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -11,7 +11,7 @@ import importlib
 import sys
 import types
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -22,6 +22,8 @@ from gateway.session import SessionSource, build_session_key
 
 
 class _MediaRoutingAdapter(BasePlatformAdapter):
+    typing_send_requires_final_fence = True
+
     def __init__(self):
         super().__init__(PlatformConfig(enabled=True, token="test"), Platform.TELEGRAM)
 
@@ -85,6 +87,161 @@ async def test_base_adapter_routes_voice_tagged_telegram_ogg_media_tag_to_voice_
         is_voice=True,
     )
     adapter.send_document.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reconnect_replacement_owns_all_unsent_final_media(tmp_path, monkeypatch):
+    stale = _MediaRoutingAdapter()
+    replacement = _MediaRoutingAdapter()
+    event = _event(thread_id="topic-1")
+    image = _allowed_media_path(tmp_path, monkeypatch, "result.png")
+    voice = _allowed_media_path(tmp_path, monkeypatch, "speech.ogg")
+    video = _allowed_media_path(tmp_path, monkeypatch, "clip.mp4")
+    document = _allowed_media_path(tmp_path, monkeypatch, "report.pdf")
+    stale._message_handler = AsyncMock(
+        return_value=(
+            "Final files\n[[audio_as_voice]]\n"
+            f"MEDIA:{image}\nMEDIA:{voice}\nMEDIA:{video}\nMEDIA:{document}"
+        )
+    )
+
+    runner = SimpleNamespace(_adapter_for_source=lambda _source: replacement)
+    stale.gateway_runner = runner
+    replacement.gateway_runner = runner
+    for adapter in (stale, replacement):
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="text"))
+        adapter.send_multiple_images = AsyncMock(return_value=None)
+        adapter.send_voice = AsyncMock(
+            return_value=SendResult(success=True, message_id="voice")
+        )
+        adapter.send_video = AsyncMock(
+            return_value=SendResult(success=True, message_id="video")
+        )
+        adapter.send_document = AsyncMock(
+            return_value=SendResult(success=True, message_id="document")
+        )
+
+    await stale._process_message_background(event, build_session_key(event.source))
+
+    stale.send.assert_not_awaited()
+    stale.send_multiple_images.assert_not_awaited()
+    stale.send_voice.assert_not_awaited()
+    stale.send_video.assert_not_awaited()
+    stale.send_document.assert_not_awaited()
+    replacement.send.assert_awaited_once()
+    replacement.send_multiple_images.assert_awaited_once()
+    replacement.send_voice.assert_awaited_once()
+    replacement.send_video.assert_awaited_once()
+    replacement.send_document.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_reconnect_replacement_owns_unsent_automatic_tts(tmp_path):
+    stale = _MediaRoutingAdapter()
+    replacement = _MediaRoutingAdapter()
+    event = _event(thread_id="topic-1")
+    event.message_type = MessageType.VOICE
+    stale._message_handler = AsyncMock(return_value="Voice final")
+    stale._should_auto_tts_for_chat = lambda _chat_id: True
+
+    runner = SimpleNamespace(_adapter_for_source=lambda _source: replacement)
+    stale.gateway_runner = runner
+    replacement.gateway_runner = runner
+    stale.play_tts = AsyncMock(
+        return_value=SendResult(success=True, message_id="stale-voice")
+    )
+    replacement.play_tts = AsyncMock(
+        return_value=SendResult(success=True, message_id="replacement-voice")
+    )
+    stale.send = AsyncMock(return_value=SendResult(success=True, message_id="stale-text"))
+    replacement.send = AsyncMock(
+        return_value=SendResult(success=True, message_id="replacement-text")
+    )
+    tts_path = tmp_path / "reply.ogg"
+    tts_path.write_bytes(b"audio")
+
+    with patch("tools.tts_tool.check_tts_requirements", return_value=True), patch(
+        "tools.tts_tool.text_to_speech_tool",
+        return_value=f'{{"file_path": "{tts_path}"}}',
+    ):
+        await stale._process_message_background(event, build_session_key(event.source))
+
+    stale.play_tts.assert_not_awaited()
+    stale.send.assert_not_awaited()
+    replacement.play_tts.assert_awaited_once()
+    # The short reply is the successful Telegram voice caption, so no duplicate
+    # text send should be necessary on either transport.
+    replacement.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_post_stream_media_re_resolves_between_payloads(tmp_path, monkeypatch):
+    first = _MediaRoutingAdapter()
+    replacement = _MediaRoutingAdapter()
+    event = _event(thread_id="topic-1")
+    voice = _allowed_media_path(tmp_path, monkeypatch, "speech.ogg")
+    document = _allowed_media_path(tmp_path, monkeypatch, "report.pdf")
+    current = {"adapter": first}
+    runner = object.__new__(GatewayRunner)
+    runner._adapter_for_source = lambda _source: current["adapter"]
+
+    async def send_voice_then_replace(**_kwargs):
+        current["adapter"] = replacement
+        return SendResult(success=True, message_id="voice")
+
+    first.send_voice = AsyncMock(side_effect=send_voice_then_replace)
+    first.send_document = AsyncMock(
+        return_value=SendResult(success=True, message_id="stale-document")
+    )
+    replacement.send_document = AsyncMock(
+        return_value=SendResult(success=True, message_id="replacement-document")
+    )
+
+    await runner._deliver_media_from_response(
+        f"[[audio_as_voice]]\nMEDIA:{voice}\nMEDIA:{document}",
+        event,
+        first,
+        thread_metadata={"thread_id": "topic-1"},
+    )
+
+    first.send_voice.assert_awaited_once()
+    first.send_document.assert_not_awaited()
+    replacement.send_document.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_queued_delivery_re_resolves_media_after_text(tmp_path, monkeypatch):
+    first = _MediaRoutingAdapter()
+    replacement = _MediaRoutingAdapter()
+    event = _event(thread_id="topic-1")
+    document = _allowed_media_path(tmp_path, monkeypatch, "queued.pdf")
+    current = {"adapter": first}
+    runner = object.__new__(GatewayRunner)
+    runner._adapter_for_source = lambda _source: current["adapter"]
+
+    async def send_text_then_replace(*_args, **_kwargs):
+        current["adapter"] = replacement
+        return SendResult(success=True, message_id="text")
+
+    first.send = AsyncMock(side_effect=send_text_then_replace)
+    first.send_document = AsyncMock(
+        return_value=SendResult(success=True, message_id="stale-document")
+    )
+    replacement.send_document = AsyncMock(
+        return_value=SendResult(success=True, message_id="replacement-document")
+    )
+
+    await runner._deliver_queued_first_response(
+        f"Queued final\nMEDIA:{document}",
+        source=event.source,
+        adapter=first,
+        metadata={"thread_id": "topic-1"},
+        event_message_id=event.message_id,
+    )
+
+    first.send.assert_awaited_once()
+    first.send_document.assert_not_awaited()
+    replacement.send_document.assert_awaited_once()
 
 
 def _fake_runner(thread_meta):
@@ -236,13 +393,122 @@ async def test_queued_followup_delivery_strips_media_tag_from_text_and_sends_ima
     adapter.send.assert_awaited_once_with(
         "chat-1",
         "Quote here",
-        metadata={"thread_id": "topic-1"},
+        metadata={"thread_id": "topic-1", "notify": True},
     )
     adapter.send_multiple_images.assert_awaited_once_with(
         chat_id="chat-1",
         images=[(f"file://{media_file.as_posix()}", "")],
-        metadata={"thread_id": "topic-1"},
+        metadata={"thread_id": "topic-1", "notify": True},
     )
+
+
+@pytest.mark.asyncio
+async def test_queued_delivery_fences_lease_before_text_and_media(
+    tmp_path, monkeypatch,
+):
+    event = _event(thread_id="topic-1")
+    media_file = _allowed_media_path(tmp_path, monkeypatch, "fenced.png")
+    runner = object.__new__(GatewayRunner)
+    adapter = SimpleNamespace(
+        name="test",
+        _fence_typing_lease_before_final=AsyncMock(),
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send=AsyncMock(return_value=SendResult(success=True, message_id="text")),
+        send_multiple_images=AsyncMock(return_value=None),
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+    metadata = {"_hermes_typing_lease_id": "lease-1"}
+
+    await GatewayRunner._deliver_queued_first_response(
+        runner,
+        f"Final text\nMEDIA:{media_file}",
+        source=event.source,
+        adapter=adapter,
+        metadata=metadata,
+        event_message_id=event.message_id,
+    )
+
+    adapter._fence_typing_lease_before_final.assert_awaited_once_with(
+        "chat-1", "lease-1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_queued_reconcile_supports_legacy_edit_signature_without_metadata():
+    event = _event(thread_id="topic-1")
+    runner = object.__new__(GatewayRunner)
+    edit_calls = []
+
+    async def legacy_edit_message(
+        chat_id, message_id, content, *, finalize=False
+    ):
+        edit_calls.append((chat_id, message_id, content, finalize))
+        return SendResult(success=True, message_id=message_id)
+
+    adapter = SimpleNamespace(
+        name="legacy",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        edit_message=legacy_edit_message,
+        send=AsyncMock(return_value=SendResult(success=True, message_id="duplicate")),
+    )
+    stream_consumer = SimpleNamespace(
+        message_id="preview-1",
+        _turn_split_delivery=False,
+    )
+
+    await GatewayRunner._deliver_queued_first_response(
+        runner,
+        "Final text",
+        source=event.source,
+        adapter=adapter,
+        metadata={"thread_id": "topic-1"},
+        event_message_id=event.message_id,
+        deliver_media=False,
+        stream_consumer=stream_consumer,
+    )
+
+    assert edit_calls == [
+        ("chat-1", "preview-1", "Final text", True)
+    ]
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_queued_followup_gets_successor_lease_for_typing():
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    adapter = TelegramAdapter(
+        PlatformConfig(enabled=True, token="test-token")
+    )
+    adapter._bot = AsyncMock()
+    session_key = "telegram:chat-1"
+    old_lease = adapter._begin_typing_lease("chat-1", session_key)
+    old_metadata = adapter._typing_metadata_for_session(session_key, {})
+    await adapter._fence_typing_lease_before_final("chat-1", old_lease)
+
+    successor_metadata = GatewayRunner._renew_followup_typing_lease(
+        adapter,
+        chat_id="chat-1",
+        session_key=session_key,
+        metadata={
+            "thread_id": "123",
+            "telegram_dm_topic_reply_fallback": True,
+        },
+    )
+
+    await adapter.send_typing("chat-1", metadata=old_metadata)
+    adapter._bot.send_chat_action.assert_not_awaited()
+
+    await adapter.send_typing("chat-1", metadata=successor_metadata)
+    adapter._bot.send_chat_action.assert_awaited_once()
+    assert successor_metadata["thread_id"] == "123"
+    assert successor_metadata["_hermes_typing_lease_id"] != old_lease
 
 
 @pytest.mark.asyncio
@@ -286,12 +552,12 @@ async def test_queued_followup_delivery_reuses_routing_metadata_for_media(
     adapter.send.assert_awaited_once_with(
         "chat-1",
         "Threaded image",
-        metadata=routing_metadata,
+        metadata={**routing_metadata, "notify": True},
     )
     adapter.send_multiple_images.assert_awaited_once_with(
         chat_id="chat-1",
         images=[(f"file://{media_file.as_posix()}", "")],
-        metadata=routing_metadata,
+        metadata={**routing_metadata, "notify": True},
     )
 
 
@@ -327,7 +593,7 @@ async def test_queued_followup_delivery_keeps_remote_image_url_in_text():
     adapter.send.assert_awaited_once_with(
         "chat-1",
         response,
-        metadata={"thread_id": "topic-1"},
+        metadata={"thread_id": "topic-1", "notify": True},
     )
     adapter.send_multiple_images.assert_not_awaited()
 
@@ -370,7 +636,7 @@ async def test_queued_followup_delivery_keeps_bare_local_path_in_text(
     adapter.send.assert_awaited_once_with(
         "chat-1",
         response,
-        metadata={"thread_id": "topic-1"},
+        metadata={"thread_id": "topic-1", "notify": True},
     )
     adapter.send_multiple_images.assert_not_awaited()
     adapter.send_document.assert_not_awaited()
@@ -409,7 +675,7 @@ async def test_queued_followup_delivery_preserves_protected_media_example():
     adapter.send.assert_awaited_once_with(
         "chat-1",
         response,
-        metadata={"thread_id": "topic-1"},
+        metadata={"thread_id": "topic-1", "notify": True},
     )
     adapter.send_multiple_images.assert_not_awaited()
     adapter.send_document.assert_not_awaited()

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -319,6 +319,32 @@ class TestSendVoiceReply:
         call_args = mock_adapter.send_voice.call_args
         assert call_args.kwargs.get("chat_id") == "123"
 
+    @pytest.mark.asyncio
+    async def test_auto_voice_reply_re_resolves_adapter_after_synthesis(self, runner):
+        from gateway.config import Platform
+
+        stale = AsyncMock()
+        stale.send_voice = AsyncMock()
+        replacement = AsyncMock()
+        replacement.send_voice = AsyncMock()
+        event = _make_event()
+        event.source.platform = Platform.TELEGRAM
+        runner.adapters[event.source.platform] = stale
+
+        def synthesize(**_kwargs):
+            runner.adapters[event.source.platform] = replacement
+            return json.dumps({"success": True, "file_path": "/tmp/test.ogg"})
+
+        with patch("tools.tts_tool.text_to_speech_tool", side_effect=synthesize), \
+             patch("tools.tts_tool._strip_markdown_for_tts", side_effect=lambda t: t), \
+             patch("os.path.isfile", return_value=True), \
+             patch("os.unlink"), \
+             patch("os.makedirs"):
+            await runner._send_voice_reply(event, "Hello replacement")
+
+        stale.send_voice.assert_not_awaited()
+        replacement.send_voice.assert_awaited_once()
+
 
     @pytest.mark.asyncio
     async def test_auto_voice_reply_uses_thread_metadata_helper(self, runner):
@@ -354,6 +380,101 @@ class TestSendVoiceReply:
             # mirrors the final-text path in gateway/platforms/base.py.
             "notify": True,
         }
+
+    @pytest.mark.asyncio
+    async def test_auto_voice_reply_fences_typing_before_transport(self, runner):
+        from gateway.config import Platform
+
+        order = []
+        mock_adapter = AsyncMock()
+        mock_adapter._typing_metadata_for_session = MagicMock(
+            side_effect=lambda session_key, metadata: {
+                **(metadata or {}),
+                "_hermes_typing_lease_id": "lease-1",
+            }
+        )
+        mock_adapter._fence_typing_lease_before_final = AsyncMock(
+            side_effect=lambda chat_id, lease_id: order.append(
+                ("fence", chat_id, lease_id)
+            )
+        )
+        mock_adapter.send_voice = AsyncMock(
+            side_effect=lambda **kwargs: order.append(
+                ("send", kwargs["chat_id"], kwargs["metadata"])
+            )
+        )
+        event = _make_event()
+        event.source.platform = Platform.TELEGRAM
+        runner.adapters[event.source.platform] = mock_adapter
+
+        tts_result = json.dumps({"success": True, "file_path": "/tmp/test.ogg"})
+        with patch("tools.tts_tool.text_to_speech_tool", return_value=tts_result), \
+             patch("tools.tts_tool._strip_markdown_for_tts", side_effect=lambda t: t), \
+             patch("os.path.isfile", return_value=True), \
+             patch("os.unlink"), \
+             patch("os.makedirs"):
+            await runner._send_voice_reply(
+                event, "Hello world", session_key="telegram:123"
+            )
+
+        assert order[0] == ("fence", "123", "lease-1")
+        assert order[1][0:2] == ("send", "123")
+        assert order[1][2]["_hermes_typing_lease_id"] == "lease-1"
+        assert order[1][2]["notify"] is True
+
+    @pytest.mark.asyncio
+    async def test_streamed_auto_voice_starts_synthesis_lease_until_egress(
+        self, runner
+    ):
+        from gateway.config import Platform, PlatformConfig
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        order = []
+        adapter = TelegramAdapter(
+            PlatformConfig(enabled=True, token="test-token")
+        )
+        adapter.gateway_runner = runner
+        adapter._bot = AsyncMock()
+        event = _make_event()
+        event.source.platform = Platform.TELEGRAM
+        runner.adapters[event.source.platform] = adapter
+        session_key = "telegram:123"
+
+        old_lease = adapter._begin_typing_lease("123", session_key)
+        await adapter._fence_typing_lease_before_final("123", old_lease)
+        assert adapter._typing_lease_id_for_session(session_key) is None
+
+        adapter._bot.send_chat_action = AsyncMock(
+            side_effect=lambda **kwargs: order.append("typing")
+        )
+        adapter.send_voice = AsyncMock(
+            side_effect=lambda **kwargs: order.append("voice")
+        )
+        real_fence = adapter._fence_typing_lease_before_final
+
+        async def record_fence(chat_id, lease_id):
+            order.append("fence")
+            await real_fence(chat_id, lease_id)
+
+        adapter._fence_typing_lease_before_final = AsyncMock(
+            side_effect=record_fence
+        )
+
+        def synthesize(**kwargs):
+            order.append("synthesis")
+            return json.dumps({"success": True, "file_path": "/tmp/test.ogg"})
+
+        with patch("tools.tts_tool.text_to_speech_tool", side_effect=synthesize), \
+             patch("tools.tts_tool._strip_markdown_for_tts", side_effect=lambda t: t), \
+             patch("os.path.isfile", return_value=True), \
+             patch("os.unlink"), \
+             patch("os.makedirs"):
+            await runner._send_voice_reply(
+                event, "Hello world", session_key=session_key
+            )
+
+        assert order[:4] == ["typing", "synthesis", "fence", "voice"]
+        assert adapter._typing_lease_id_for_session(session_key) is None
 
 
 # =====================================================================


### PR DESCRIPTION
## What changed

- Give each inbound turn a generation-safe typing lease that survives Telegram adapter replacement during reconnects while remaining isolated to one gateway runtime.
- Re-arm Telegram typing after successful progress/intermediate edits and formatting-final fresh sends while that lease is still active.
- Distinguish a formatting-final edit from turn-final delivery, preserving typing across sealed stream segments and status updates.
- Keep typing active during automatic TTS synthesis, then close the lease immediately before the first visible voice/text/media egress.
- Close the lease and drain any already-admitted `sendChatAction` before final user-visible text, edit, media, TTS, or queued-response delivery.
- Issue a successor lease for each queued logical turn and rotate the continuous heartbeat onto it so typing resumes after the prior response fence.
- Forward heartbeat ticks from a disconnected ingress adapter to the live reconnect replacement.
- Keep the private lease token inside Telegram's fenced lifecycle rather than serializing it through other platform or relay metadata.
- Make the drain cancellation-safe and revoke all live leases during adapter shutdown.
- Keep transient typing failures non-fatal while honoring Telegram `RetryAfter` values (including `timedelta`) and avoiding cooldown for the known bad-topic fallback path.

## Why

Stopping the refresh task before a final reply is necessary but not sufficient. A Telegram `sendChatAction` request can already have crossed the local cancellation boundary; if it completes after the final message, Telegram shows typing again with no later action to clear it.

Progress and intermediate edits create a second edge: Telegram may clear the indicator when the edit lands, but a long-running turn should resume typing until final delivery. That re-arm must never survive generation invalidation or race past the final response.

This patch makes final delivery a transport fence rather than only a task-cancellation boundary:

1. a turn-scoped lease controls admission;
2. Telegram typing sends hold a per-runtime/per-chat lock;
3. finalization closes the lease, waits for any admitted send to return, then revokes it;
4. the visible final delivery starts only after that fence.

## Related work / duplicate audit

Searched open issues and PRs using `telegram typing`, `typing indicator`, `sendChatAction`, `_keep_typing`, final-delivery, cancellation, and reconnect terms. The closest existing work is related but does not implement the complete transport fence in this patch:

- #20780, #21688, #29172, #52490, #64719, and #81646 stop, pause, or cancel the refresh task before final delivery. They establish the task-level boundary, but do not close admission and drain an already-started `sendChatAction` before visible egress.
- #33631 and #59326 suppress Telegram typing on specific terminal/footer/review-notice metadata paths. This patch preserves those terminal semantics while also handling intermediate re-arm, streaming, queued turns, TTS, and media.
- #66526 introduces a generic turn-completion lease so a cancellation-resistant refresher cannot survive cleanup. This patch overlaps that lease concept, but adds generation ownership, reconnect replacement, queued successor rotation, and the admitted-request drain needed for Telegram's no-cancel Bot API behavior.
- #99676 / #99643 address aggregate per-chat keep-alive rate and flood cooldown. That rate-control problem is distinct from final-delivery ordering; any shared `send_typing`/backoff touch points can be reconciled independently.
- #89615 reports idle-window Telegram typing. This patch addresses the late/stale refresh mechanisms it can reproduce, but does not claim to close every possible cause described in that issue.

The distinguishing regression is the residual transport race: a Bot API typing request may already have crossed local task cancellation and finish after the reply. The lease admission gate plus per-runtime/per-chat drain creates the missing happens-before relationship, while the broader lifecycle coverage prevents the fence from breaking progress edits, reconnects, queued responses, or automatic TTS/media delivery.

## How to test

Canonical focused suite:

```bash
scripts/run_tests.sh \
  tests/gateway/relay/test_relay_adapter.py \
  tests/gateway/test_base_auto_tts_output_format.py \
  tests/gateway/test_base_topic_sessions.py \
  tests/gateway/test_keep_typing_timeout.py \
  tests/gateway/test_run_progress_topics.py \
  tests/gateway/test_stream_consumer.py \
  tests/gateway/test_stream_final_contract.py \
  tests/gateway/test_telegram_typing_backoff.py \
  tests/gateway/test_tts_media_routing.py \
  tests/gateway/test_voice_command.py
```

Result: 251 passed, 7 skipped, 0 failed.

Full gateway regression suite:

```bash
scripts/run_tests.sh tests/gateway
```

Result: 7,545 passed, 46 skipped, 0 failed on Linux after rebasing onto current `origin/main`. The skipped cases are repository/host-specific tests, including the Windows-only lane cases. One timing-sensitive turn-lease test exceeded its one-second bound during the 56-worker run, passed the suite's automatic retry, and then passed all 13 cases in a direct isolated rerun.

Static checks:

```bash
ruff check <14 changed Python files>
git diff --check
```

Result: pass.

The regression tests cover:

- adapter replacement, stale-generation invalidation, and isolation between same-profile gateway runtimes;
- stale-adapter heartbeat forwarding and per-payload re-resolution of unsent text/TTS/media across repeated reconnect replacements;
- finalization draining an in-flight typing action;
- cancellation during intermediate re-arm;
- final text, edit, queued text/media, streaming, and TTS ordering;
- formatting-final stream/status edits and fresh sends that are not turn-final;
- typing remaining active during automatic TTS synthesis;
- queued-turn successor generations, continuous heartbeat rotation, and stale predecessor rejection;
- private lease metadata containment at relay egress;
- shutdown revocation/drain;
- inactive chat-lock reclamation;
- disabled typing and pause behavior;
- transient failures, topic fallback, and server-directed retry delays including `timedelta` values.

## Platforms tested

- Linux: automated gateway and Telegram adapter tests.
- Telegram: the precursor implementation of the same lease/fence design was exercised on a live bot during long-running model/tool work; the indicator remained active during work and stopped after final delivery.

## Scope

This does not change context compression, model-provider behavior, or Telegram credentials/configuration. Non-Telegram adapters retain the existing timeout-based typing cadence unless they explicitly opt into the final transport fence.