### PR TITLE
fix(desktop): stop Grok answers stacking and honor hidden thinking

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-hermes-config.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.test.ts
@@ -17,6 +17,7 @@ import {
   setCurrentReasoningEffort,
   setDefaultReasoningEffort
 } from '@/store/session'
+import { $showReasoning, setShowReasoningFromConfig } from '@/store/reasoning-disclosure'
 
 import { deferred } from '../../../test/deferred'
 
@@ -41,7 +42,26 @@ describe('useHermesConfig refreshHermesConfig', () => {
     setCurrentReasoningEffort('')
     setDefaultReasoningEffort('')
     setTerminalFontFamilyFromConfig('')
+    setShowReasoningFromConfig(false)
     persistString(WORKSPACE_CWD_KEY, null)
+  })
+
+  it('publishes display.show_reasoning so the renderer can hide thinking and tools', async () => {
+    mockConfig({ display: { show_reasoning: true } })
+    const { result } = renderHook(() => useHermesConfig({ activeSessionIdRef: { current: null } }))
+
+    await act(async () => {
+      await result.current.refreshHermesConfig()
+    })
+
+    expect($showReasoning.get()).toBe(true)
+
+    mockConfig({ display: { show_reasoning: 'false' } })
+    await act(async () => {
+      await result.current.refreshHermesConfig()
+    })
+
+    expect($showReasoning.get()).toBe(false)
   })
 
   // Regression: the composer keeps a manual model pick sticky, which skips the

--- a/apps/desktop/src/app/session/hooks/use-hermes-config.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.ts
@@ -5,6 +5,7 @@ import { getHermesConfig, getHermesConfigDefaults } from '@/hermes'
 import { BUILTIN_PERSONALITIES, normalizePersonalityValue, personalityNamesFromConfig } from '@/lib/chat-runtime'
 import { normalize } from '@/lib/text'
 import { setDisplayTimestampsFromConfig } from '@/store/display-timestamps'
+import { setShowReasoningFromConfig } from '@/store/reasoning-disclosure'
 import {
   getComposerSelectionGeneration,
   getCurrentModelSource,
@@ -138,6 +139,7 @@ export function useHermesConfig({ activeSessionIdRef }: HermesConfigOptions) {
         }
 
         setDisplayTimestampsFromConfig(config.display?.timestamps)
+        setShowReasoningFromConfig(config.display?.show_reasoning)
         setTerminalFontFamilyFromConfig(config.terminal?.font_family)
 
         if (!canPublish()) {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/message-stream.ts
@@ -120,13 +120,24 @@ export function handleMessageStreamEvent(ctx: GatewayEventContext): boolean {
         return state
       }
 
+      const messages = state.streamId
+        ? state.messages.map(message =>
+            message.id === state.streamId ? { ...message, pending: false } : message
+          )
+        : state.messages
+
       return {
         ...state,
+        messages,
         busy: true,
         awaitingResponse: true,
         sawAssistantPayload: false,
         interrupted: false,
         interimBoundaryPending: false,
+        // A message.start begins a distinct backend turn. Never let a dropped
+        // completion from the prior turn make its streaming bubble the target
+        // for this turn's first delta (#99416).
+        streamId: null,
         // Backend accepted the turn — the no-payload settle gate below may
         // now treat a running=false heartbeat as a real turn end.
         turnLive: true,

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -15,6 +15,7 @@ import {
   reasoningPart,
   renderMediaTags,
   sealOpenToolParts,
+  stripReplayedAssistantHistory,
   upsertToolPart
 } from '@/lib/chat-messages'
 import type { ErrorSurface } from '@/lib/error-surface'
@@ -586,7 +587,18 @@ export function useMessageStream({
         }
 
         const streamId = state.streamId
-        const finalText = renderMediaTags(text).trim()
+        const rawFinalText = renderMediaTags(text).trim()
+        const priorAssistantTexts = state.messages
+          .filter(
+            message =>
+              message.role === 'assistant' &&
+              !message.hidden &&
+              !message.interim &&
+              !message.pending &&
+              message.id !== streamId
+          )
+          .map(message => chatMessageText(message))
+        const finalText = stripReplayedAssistantHistory(rawFinalText, priorAssistantTexts)
         // Structured failure from the terminal frame wins over the legacy text
         // heuristic ("Error: <provider detail>" texts don't match the regexes).
         const completionError = failure?.error ?? completionErrorText(finalText)

--- a/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
@@ -105,6 +105,37 @@ describe('useMessageStream interim text sealing', () => {
     expect(hydrateFromStoredSession).toHaveBeenCalledWith(3, 'stored-session-1', SID)
   })
 
+  it('starts a fresh bubble after an uncompleted prior stream (#99416)', async () => {
+    mountStream()
+    await start()
+    await delta('first answer')
+
+    // A transport gap can lose the terminal frame. The next backend turn
+    // must not append its deltas to this abandoned stream bubble.
+    await start()
+    await delta('second answer')
+    await complete('second answer')
+
+    expect(assistantMessages()).toEqual(['first answer', 'second answer'])
+  })
+
+  it('does not prefix the next Grok turn with prior assistant replies (#99416)', async () => {
+    mountStream()
+    await start()
+    await delta('Answer one.')
+    await complete('Answer one.')
+
+    await start()
+    await delta('Answer one.\n\nAnswer two.')
+    await complete('Answer one.\n\nAnswer two.')
+
+    await start()
+    await delta('Answer one.\n\nAnswer two.\n\nAnswer three.')
+    await complete('Answer one.\n\nAnswer two.\n\nAnswer three.')
+
+    expect(assistantMessages()).toEqual(['Answer one.', 'Answer two.', 'Answer three.'])
+  })
+
   it('marks sealed interim bubbles interim and leaves the final reply unmarked', async () => {
     mountStream()
     await start()

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.test.tsx
@@ -9,6 +9,7 @@ import { cleanup, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import { $displayTimestamps } from '@/store/display-timestamps'
+import { $showReasoning } from '@/store/reasoning-disclosure'
 
 import { stubThreadEnvironment } from '../test-utils'
 
@@ -18,6 +19,7 @@ import { Thread } from '.'
 
 // Timeline timestamps render only when `display.timestamps` is enabled.
 $displayTimestamps.set(true)
+$showReasoning.set(true)
 
 const createdAt = new Date('2026-05-01T00:00:00.000Z')
 const completedAt = createdAt.getTime() / 1000 + 1.25
@@ -142,5 +144,15 @@ describe('message timeline timestamps', () => {
     )
 
     expect(stamps.filter(stamp => stamp === formatTimelineRange(startedAt, completedAt))).toHaveLength(1)
+  })
+})
+
+describe('answer-only transcript (#85110 / #49664)', () => {
+  it('hides thinking chrome when display.show_reasoning is off', async () => {
+    $showReasoning.set(false)
+    render(<Harness />)
+    await screen.findByText('done')
+    expect(screen.queryByText('checked carefully')).toBeNull()
+    $showReasoning.set(true)
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
@@ -24,7 +24,7 @@ import { generatedImageFromResult } from '@/lib/generated-images'
 import { separateGluedReasoningBlocks } from '@/lib/reasoning-blocks'
 import { useEnterAnimation } from '@/lib/use-enter-animation'
 import { cn } from '@/lib/utils'
-import { $reasoningCollapsedByDefault } from '@/store/reasoning-disclosure'
+import { $reasoningCollapsedByDefault, $showReasoning } from '@/store/reasoning-disclosure'
 
 type TimelineToolCallProps = ToolCallMessagePartProps & { completedAt?: number; timestamp?: number }
 
@@ -301,7 +301,9 @@ const ReasoningAccordionGroup: FC<{ children?: ReactNode; endIndex: number; star
     }, undefined)
   )
 
-  if (!hasContent) {
+  const showReasoning = useStore($showReasoning)
+
+  if (!hasContent || !showReasoning) {
     return null
   }
 

--- a/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
@@ -17,6 +17,7 @@ import {
 } from 'react'
 
 import { useSessionView } from '@/app/chat/session-view'
+import { $showReasoning } from '@/store/reasoning-disclosure'
 import { AnsiText } from '@/components/assistant-ui/ansi-text'
 import { TimelineTimestamp } from '@/components/assistant-ui/thread/timeline-timestamp'
 import { useElapsedSeconds } from '@/components/chat/activity-timer'
@@ -993,6 +994,12 @@ export const ToolGroupSlot: FC<PropsWithChildren<{ endIndex: number; startIndex:
   endIndex,
   startIndex
 }) => {
+  const showReasoning = useStore($showReasoning)
+
+  if (!showReasoning) {
+    return null
+  }
+
   // Joined rather than returned as an array: assistant-ui compares selector
   // results with `Object.is` and re-runs them on every store update, so a
   // fresh array would re-render the whole group on every text delta.

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -10,6 +10,7 @@ import {
   collectUnspokenTurnSpeech,
   completeOpenTimelineParts,
   mergeFinalAssistantText,
+  stripReplayedAssistantHistory,
   preserveLocalAssistantErrors,
   reasoningPart,
   renderMediaTags,
@@ -1437,5 +1438,20 @@ describe('sealOpenToolParts', () => {
     const messages = [assistantWithParts([done])]
 
     expect(sealOpenToolParts(messages)).toBe(messages)
+  })
+})
+
+describe('stripReplayedAssistantHistory', () => {
+  it('drops stacked prior answers from the next Grok final (#99416)', () => {
+    expect(
+      stripReplayedAssistantHistory('Answer one.\n\nAnswer two.\n\nAnswer three.', [
+        'Answer one.',
+        'Answer two.'
+      ])
+    ).toBe('Answer three.')
+  })
+
+  it('leaves a final that does not replay history', () => {
+    expect(stripReplayedAssistantHistory('Brand new.', ['Answer one.'])).toBe('Brand new.')
   })
 })

--- a/apps/desktop/src/lib/chat-messages/index.ts
+++ b/apps/desktop/src/lib/chat-messages/index.ts
@@ -9,6 +9,7 @@ export {
   dedupeRepeatedTextInParts,
   mergeFinalAssistantText,
   reasoningPart,
+  stripReplayedAssistantHistory,
   renderMediaTags,
   textPart
 } from './parts'

--- a/apps/desktop/src/lib/chat-messages/parts.ts
+++ b/apps/desktop/src/lib/chat-messages/parts.ts
@@ -150,6 +150,31 @@ export function dedupeRepeatedTextInParts(parts: ChatMessagePart[]): ChatMessage
  * - Keeps all other part types (tool-call, image, etc.).
  * - Appends the final text as a new text part.
  */
+/**
+ * Drop prior assistant replies that Grok/xAI (and similar) re-send as a prefix
+ * of the next turn's final text. Walk oldest→newest so three stacked answers
+ * collapse to the new one instead of quadratic bloat (#99416).
+ */
+export function stripReplayedAssistantHistory(finalText: string, priorAssistantTexts: string[]): string {
+  let text = finalText.trim()
+
+  if (!text) {
+    return finalText
+  }
+
+  for (const prior of priorAssistantTexts) {
+    const prefix = prior.trim()
+
+    if (!prefix || prefix.length > 32 * 1024 || text.length <= prefix.length || !text.startsWith(prefix)) {
+      continue
+    }
+
+    text = text.slice(prefix.length).replace(/^\s+/, '')
+  }
+
+  return text || finalText
+}
+
 export function mergeFinalAssistantText(
   parts: ChatMessagePart[],
   finalText: string,

--- a/apps/desktop/src/store/reasoning-disclosure.ts
+++ b/apps/desktop/src/store/reasoning-disclosure.ts
@@ -12,3 +12,16 @@ $reasoningCollapsedByDefault.subscribe(value => persistBoolean(REASONING_COLLAPS
 export function setReasoningCollapsedByDefault(value: boolean) {
   $reasoningCollapsedByDefault.set(value)
 }
+
+/**
+ * `display.show_reasoning` — Settings → Chat → Reasoning Blocks.
+ *
+ * Off by default, matching gateway/CLI (`display.show_reasoning: false`).
+ * When false the transcript is answer-only: no Thinking disclosure and no
+ * tool-run chrome (#49664, #85110). Quoted YAML `'false'` is off.
+ */
+export const $showReasoning = atom(false)
+
+export function setShowReasoningFromConfig(value: unknown): void {
+  $showReasoning.set(value === true || value === 'true' || value === 1 || value === '1')
+}

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -347,6 +347,7 @@ export interface HermesConfig {
     skin?: string
     interim_assistant_messages?: boolean
     timestamps?: boolean
+    show_reasoning?: boolean | string
   }
   desktop?: {
     repo_scan_enabled?: boolean


### PR DESCRIPTION
## Bug Description

On Hermes Desktop with Grok (xAI OAuth):

- Each new assistant reply kept previous answers in the same bubble (new text on top of old). By turn three the thread was unusable.
- Thinking / tool-run chrome stayed visible even with Settings → Chat → Reasoning Blocks off (`display.show_reasoning: false`).

Fixes #99416
Fixes #85110
Fixes #49664

Related but narrower open PRs this supersedes in scope: #99468 (streamId reset only), #49725 (reasoning toggle; predates current `message-parts.tsx` layout).

## Root Cause

1. `message.start` did not clear `streamId`, so `mutateStream` appended the next turn's deltas onto the previous live bubble.
2. Grok complete payloads often replay prior answers as a prefix; finalize wrote that prefix into the new bubble.
3. `display.show_reasoning` was persisted from Settings but the transcript renderer never read it (`ReasoningAccordionGroup` / `ToolGroupSlot` gated only on content, not the setting).

## Fix

- Null `streamId` on `message.start` and mark the abandoned bubble not-pending.
- `stripReplayedAssistantHistory` on complete, using sealed non-interim prior assistant texts (does not disturb same-turn interim settle).
- `$showReasoning` atom filled from config; Thinking disclosures and tool-run groups render only when it is on. Default off, matching CLI/gateway.

## How to Verify

1. Desktop + Grok xAI OAuth. Three short prompts. Each assistant bubble is only that turn's answer.
2. Settings → Chat → Reasoning Blocks off. New turn with tools/thinking: transcript shows the answer only (no Thinking row, no "Ran N commands").
3. Turn Reasoning Blocks on: thinking + tools return.

## Test Plan

- [x] `interim-sealing.test.tsx` — fresh bubble after abandoned stream; three Grok-style stacked finals collapse to one answer each (19 passed)
- [x] `chat-messages.test.ts` — prefix strip unit tests
- [x] `use-hermes-config.test.ts` — publishes `display.show_reasoning` (quoted `'false'` is off)
- [x] `assistant-message.test.tsx` — hides reasoning chrome when the flag is off
- [ ] Manual: macOS Desktop × Grok OAuth, thinking on/off

## Risk Assessment

Medium — streaming settle is load-bearing. Prefix strip ignores interim/pending bubbles so #63679 / #74560 interim-seal tests stay green (verified). Hiding tools when reasoning is off matches the answer-only request in #85110; users who want tools without thinking would need a later split setting.
