### PR TITLE
fix(discord): preserve voice receive across key rotation and DAVE activation

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -646,9 +646,9 @@ class VoiceReceiver:
         self._allowed_user_ids = allowed_user_ids or set()
         self._running = False
 
-        # Decryption
-        self._secret_key: Optional[bytes] = None
-        self._dave_session = None
+        # Decryption state is read live from the connection for every packet.
+        # discord.py rotates the key, SSRC, and DAVE session on reconnect while
+        # keeping the VoiceConnectionState object alive.
         self._bot_ssrc: int = 0
 
         # SSRC -> user_id mapping (populated from SPEAKING events)
@@ -675,9 +675,7 @@ class VoiceReceiver:
     def start(self):
         """Start listening for voice packets."""
         conn = self._vc._connection
-        self._secret_key = bytes(conn.secret_key)
-        self._dave_session = conn.dave_session
-        self._bot_ssrc = conn.ssrc
+        self._bot_ssrc = self._live_ssrc(conn)
 
         self._install_speaking_hook(conn)
         conn.add_socket_listener(self._on_packet)
@@ -749,9 +747,34 @@ class VoiceReceiver:
     # Packet handler (called from SocketReader thread)
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _live_ssrc(conn) -> int:
+        """Return the current bot SSRC, or zero during a voice handshake."""
+        try:
+            return int(conn.ssrc)
+        except (TypeError, ValueError):
+            return 0
+
+    @staticmethod
+    def _live_box(conn):
+        """Build an AEAD box for the current voice-session key.
+
+        The key is deliberately read per packet. discord.py replaces it on a
+        reconnect but retains the enclosing VoiceConnectionState object.
+        """
+        try:
+            key = bytes(conn.secret_key)
+        except (TypeError, ValueError):
+            return None
+        if len(key) != 32:
+            return None
+        import nacl.secret
+        return nacl.secret.Aead(key)
+
     def _on_packet(self, data: bytes):
         if not self._running or self._paused:
             return
+        conn = self._vc._connection
 
         # Log first few raw packets for debugging
         self._packet_debug_count += 1
@@ -775,7 +798,11 @@ class VoiceReceiver:
         first_byte = data[0]
         _, _, seq, timestamp, ssrc = struct.unpack_from(">BBHII", data, 0)
 
-        # Skip bot's own audio
+        # Skip bot's own audio. discord.py rotates SSRC on reconnect, so this
+        # must be read live alongside the key.
+        live_bot_ssrc = self._live_ssrc(conn)
+        if live_bot_ssrc:
+            self._bot_ssrc = live_bot_ssrc
         if ssrc == self._bot_ssrc:
             return
 
@@ -813,9 +840,10 @@ class VoiceReceiver:
         nonce[:4] = payload_with_nonce[-4:]
         encrypted = bytes(payload_with_nonce[:-4])
 
+        box = self._live_box(conn)
+        if box is None:
+            return
         try:
-            import nacl.secret  # noqa: E402 — delayed import, only in voice path
-            box = nacl.secret.Aead(self._secret_key)
             decrypted = box.decrypt(encrypted, header, bytes(nonce))
         except Exception as e:
             if self._packet_debug_count <= 10:
@@ -852,21 +880,23 @@ class VoiceReceiver:
                 return
 
         # --- DAVE E2EE decrypt ---
-        if self._dave_session:
+        dave = conn.dave_session
+        if dave is not None:
             with self._lock:
                 user_id = self._ssrc_to_user.get(ssrc, 0)
             if user_id:
                 try:
                     import davey
-                    decrypted = self._dave_session.decrypt(
+                    decrypted = dave.decrypt(
                         user_id, davey.MediaType.audio, decrypted
                     )
                 except Exception as e:
-                    # Unencrypted passthrough — use NaCl-decrypted data as-is
-                    if "Unencrypted" not in str(e):
-                        if self._packet_debug_count <= 10:
-                            logger.warning("DAVE decrypt failed for ssrc=%d: %s", ssrc, e)
-                        return
+                    # DAVE may be in passthrough mode, or its MLS group may not
+                    # yet have a decryptor for this SSRC. In either case retain
+                    # the NaCl-decrypted payload. If it is still E2EE bytes,
+                    # Opus decode rejects that packet and self-recovers.
+                    if self._packet_debug_count <= 10:
+                        logger.debug("DAVE decrypt passthrough for ssrc=%d: %s", ssrc, e)
             # If SSRC unknown (no SPEAKING event yet), skip DAVE and try
             # Opus decode directly — audio may be in passthrough mode.
             # Buffer will get a user_id when SPEAKING event arrives later.

--- a/tests/gateway/test_discord_voice_receiver_reconnect.py
+++ b/tests/gateway/test_discord_voice_receiver_reconnect.py
@@ -1,0 +1,126 @@
+"""Regression coverage for Discord voice reconnect and DAVE activation.
+
+Discord.py retains one VoiceConnectionState for a VoiceClient, but mutates its
+key, SSRC and DAVE session in place after a voice-server reconnect. The receiver
+must therefore not retain join-time snapshots.
+"""
+
+from __future__ import annotations
+
+import os
+import struct
+
+import nacl.secret
+import nacl.utils
+import discord
+
+from plugins.platforms.discord.adapter import VoiceReceiver
+
+
+class FakeConn:
+    def __init__(self) -> None:
+        self.secret_key = list(nacl.utils.random(32))
+        self.ssrc = 100
+        self.dave_session = None
+        self.hook = None
+        self.ws = discord.utils.MISSING
+        self.listeners = []
+
+    def add_socket_listener(self, callback):
+        self.listeners.append(callback)
+
+    def remove_socket_listener(self, callback):
+        self.listeners.remove(callback)
+
+    def rotate(self) -> None:
+        # Match discord.py VoiceConnectionState: mutate in place, do not replace.
+        self.secret_key = list(nacl.utils.random(32))
+        self.ssrc = 200
+
+
+class FakeVoiceClient:
+    def __init__(self) -> None:
+        self._connection = FakeConn()
+
+
+class DecoderMap(dict):
+    """Decoder substitute, so the tests exercise the receiver's decrypt path."""
+
+    def __missing__(self, ssrc):
+        class Decoder:
+            def decode(self, _payload):
+                return b"\0" * 3840
+
+        self[ssrc] = Decoder()
+        return self[ssrc]
+
+
+class StubDecoder:
+    def decode(self, _payload):
+        return b"\0" * 3840
+
+
+class DaveNotReady:
+    """The real davey error while MLS lacks a sender decryptor."""
+
+    def decrypt(self, *_args):
+        raise ValueError("Failed to decrypt: NoDecryptorForUser")
+
+
+def packet(conn: FakeConn, ssrc: int, sequence: int) -> bytes:
+    header = struct.pack(">BBHII", 0x80, 0x78, sequence, sequence * 960, ssrc)
+    nonce_suffix = struct.pack(">I", sequence)
+    nonce = bytearray(24)
+    nonce[:4] = nonce_suffix
+    encrypted = nacl.secret.Aead(bytes(conn.secret_key)).encrypt(
+        b"\xfc\xff\xfe" + os.urandom(32), header, bytes(nonce)
+    ).ciphertext
+    return header + encrypted + nonce_suffix
+
+
+def build_receiver():
+    vc = FakeVoiceClient()
+    receiver = VoiceReceiver(vc)
+    receiver._decoders = DecoderMap()
+    receiver._decoders[300] = StubDecoder()
+    receiver.start()
+    receiver.map_ssrc(300, 42)
+    return receiver, vc
+
+
+def buffered_bytes(receiver: VoiceReceiver) -> int:
+    with receiver._lock:
+        return sum(len(value) for value in receiver._buffers.values())
+
+
+def test_receiver_uses_new_key_and_ssrc_after_in_place_rotation():
+    receiver, vc = build_receiver()
+    receiver._on_packet(packet(vc._connection, 300, 1))
+    before_rotation = buffered_bytes(receiver)
+
+    vc._connection.rotate()
+    receiver._on_packet(packet(vc._connection, 300, 2))
+
+    assert buffered_bytes(receiver) > before_rotation
+    # The previous bot SSRC is no longer self-audio; the new one is.
+    receiver._on_packet(packet(vc._connection, 200, 3))
+    assert receiver._bot_ssrc == 200
+
+
+def test_dave_not_ready_falls_through_to_opus_not_a_permanent_drop():
+    receiver, vc = build_receiver()
+    vc._connection.dave_session = DaveNotReady()
+
+    receiver._on_packet(packet(vc._connection, 300, 1))
+
+    assert buffered_bytes(receiver) > 0
+
+
+def test_missing_key_during_handshake_does_not_crash_socket_reader():
+    receiver, vc = build_receiver()
+    encrypted_while_key_was_valid = packet(vc._connection, 300, 1)
+    vc._connection.secret_key = discord.utils.MISSING
+
+    # _on_packet should discard the transient frame cleanly, not throw in the
+    # long-lived SocketReader thread.
+    receiver._on_packet(encrypted_while_key_was_valid)


### PR DESCRIPTION
## Root cause
Discord.py mutates a long-lived VoiceConnectionState in place after a voice-server reconnect. VoiceReceiver had snapshotted the transport key, bot SSRC, and DAVE session once at join time, so it went deaf after rotation.

A first live-read approach exposed a second bug: DAVE MLS group formation can raise `NoDecryptorForUser`; treating that as fatal dropped all media immediately.

## Fix
- Read transport key, bot SSRC, and DAVE session from the live connection per packet.
- Treat transient/missing key frames as discard-only, never a SocketReader crash.
- Let DAVE passthrough/MLS-not-ready packets reach Opus instead of permanently dropping the receiver.

## Tests
`pytest tests/gateway/test_discord_voice_receiver_reconnect.py tests/gateway/test_voice_command.py tests/test_voice_max_recording_seconds.py -q`

Result: 83 passed. New regression coverage exercises in-place key/SSRC rotation, a late DAVE session yielding `NoDecryptorForUser`, and the mid-handshake `MISSING` key state.