### PR TITLE
fix(weixin): accept is_voice kwarg in send_voice — audio attachments silently dropped (#101380)

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -2137,7 +2137,16 @@ class WeixinAdapter(BasePlatformAdapter):
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        is_voice: bool = False,
     ) -> SendResult:
+        """Deliver audio to Weixin as a file attachment.
+
+        ``is_voice`` mirrors the shared ``BasePlatformAdapter.send_voice``
+        keyword set (the gateway media router passes it for MEDIA: audio).
+        Weixin has no proven native voice-bubble path, so every audio send
+        takes the attachment fallback below and the flag is accepted for
+        signature compatibility and ignored.
+        """
         if not self._send_session or not self._token:
             return SendResult(success=False, error="Not connected")
 

--- a/tests/gateway/test_weixin_send_voice_is_voice_kwarg.py
+++ b/tests/gateway/test_weixin_send_voice_is_voice_kwarg.py
@@ -1,0 +1,72 @@
+"""Regression tests: WeixinAdapter.send_voice must accept the router's is_voice kwarg.
+
+The gateway media dispatch loop (``gateway/platforms/base.py``) calls
+``self.send_voice(chat_id=..., audio_path=..., metadata=..., is_voice=...)``
+whenever ``should_send_media_as_audio`` routes an audio ``MEDIA:`` attachment
+to the voice sender. An adapter whose ``send_voice`` accepts neither
+``is_voice`` nor ``**kwargs`` raises ``TypeError`` at argument-binding time,
+and the dispatch loop's ``except Exception`` handler swallows it — so the
+audio silently never arrives.
+
+Matrix was fixed for this in #99712 and Mattermost/LINE in #100021; these
+tests pin the same contract for Weixin.
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.platforms.weixin import WeixinAdapter
+
+
+def test_send_voice_accepts_is_voice_kwarg():
+    params = inspect.signature(WeixinAdapter.send_voice).parameters
+    assert "is_voice" in params or any(
+        p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()
+    ), (
+        "gateway media router calls send_voice(is_voice=...); "
+        "WeixinAdapter must accept it"
+    )
+
+
+@pytest.mark.asyncio
+async def test_router_kwarg_set_binds_and_sends_attachment():
+    """The exact kwarg set from the base.py dispatch loop must bind and deliver."""
+    adapter = WeixinAdapter.__new__(WeixinAdapter)
+    adapter._send_session = object()
+    adapter._token = "token"
+    adapter._send_file = AsyncMock(return_value="msg-1")
+
+    # A TypeError here is the regression: argument binding failed before any
+    # send was attempted. Any other outcome means the kwarg was accepted.
+    result = await adapter.send_voice(
+        chat_id="C1",
+        audio_path="/tmp/speech.ogg",
+        metadata=None,
+        is_voice=True,
+    )
+
+    assert result.success is True
+    assert result.message_id == "msg-1"
+    adapter._send_file.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_disconnected_adapter_still_returns_controlled_failure():
+    """is_voice must not disturb the not-connected guard."""
+    adapter = WeixinAdapter.__new__(WeixinAdapter)
+    adapter._send_session = None
+    adapter._token = None
+
+    result = await adapter.send_voice(
+        chat_id="C1",
+        audio_path="/tmp/speech.ogg",
+        metadata=None,
+        is_voice=True,
+    )
+
+    assert result.success is False
+    assert result.error == "Not connected"


### PR DESCRIPTION
## What does this PR do?

Audio attachments sent through the gateway media dispatch loop never arrive on Weixin (personal WeChat / iLink), silently.

`gateway/platforms/base.py` calls the voice sender with an `is_voice` flag:

```python
media_result = await self.send_voice(
    chat_id=event.source.chat_id,
    audio_path=media_path,
    metadata=_final_thread_metadata,
    is_voice=is_voice,
)
```

`WeixinAdapter.send_voice` accepted neither `is_voice` nor a `**kwargs` catch-all, so the call raised `TypeError` at argument-binding time — before any upload was attempted. The dispatch loop's `except Exception` handler logs a warning and continues, so the text part of the reply is delivered while the audio vanishes with nothing user-visible.

**Why this approach:** the fix accepts the flag explicitly (`is_voice: bool = False`) rather than adding `**kwargs`, matching the shape already used by #100021 for mattermost/line, and documents in the docstring that Weixin ignores it. Weixin has no proven native voice-bubble path, so every audio send already takes the existing file-attachment fallback — no delivery behaviour changes, the signature contract is simply honoured.

Same defect class as #99712 (matrix) and #100018 / #100021 (mattermost, line). Weixin was the remaining adapter with no issue or PR covering it. An AST scan of every `send_voice` definition on `origin/main` @ `87ad7aa0b`:

```
call sites passing is_voice= : 4   (base.py:5039, 7020, 7025, 7051)
send_voice defs accepting it : 16
send_voice defs that TypeError: 4
   gateway/platforms/weixin.py:2133              <- this PR
   plugins/platforms/line/adapter.py:1461        <- #100021
   plugins/platforms/matrix/adapter.py:2581      <- #99712
   plugins/platforms/mattermost/adapter.py:496   <- #100021
```

This PR deliberately touches **only** weixin, to avoid overlapping with the open PRs for the other three.

## Related Issue

Fixes #101380

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/weixin.py` — `WeixinAdapter.send_voice` accepts `is_voice: bool = False`; added a docstring recording that the flag is accepted for router-signature compatibility and ignored, because Weixin always takes the file-attachment fallback.
- `tests/gateway/test_weixin_send_voice_is_voice_kwarg.py` (new) — three regression tests: the signature accepts the kwarg, the exact router kwarg set binds and reaches `_send_file`, and the not-connected guard still returns a controlled `SendResult`.

## How to Test

1. **Reproduce on unpatched `main`** — no credentials or network needed:

   ```bash
   python3 - <<'PY'
   import asyncio, sys
   sys.path.insert(0, ".")
   from gateway.platforms.weixin import WeixinAdapter

   inst = WeixinAdapter.__new__(WeixinAdapter)
   try:
       asyncio.run(WeixinAdapter.send_voice(
           inst, chat_id="C1", audio_path="/tmp/x.ogg",
           metadata=None, is_voice=True))
   except TypeError as e:
       print(f"WeixinAdapter: {e}")
   PY
   ```

   Prints `WeixinAdapter.send_voice() got an unexpected keyword argument 'is_voice'`.

2. **Red/green on the new tests** — on unpatched `main` all three fail with that `TypeError`; with this patch:

   ```
   $ pytest tests/gateway/test_weixin_send_voice_is_voice_kwarg.py -q
   3 passed
   ```

3. **No regressions in the media router or the existing weixin suites:**

   ```
   $ pytest tests/gateway/test_tts_media_routing.py -q
   10 passed

   $ pytest tests/gateway/test_weixin.py tests/gateway/test_weixin_typing.py \
            tests/gateway/test_weixin_secret_scope.py \
            tests/gateway/test_weixin_send_voice_is_voice_kwarg.py -q
   43 passed, 2 failed
   ```

   The 2 failures are `test_send_file_uses_post_for_upload_full_url_and_hex_encoded_aes_key` and `test_send_file_sets_voice_metadata_for_silk_payload`, both `AttributeError: 'NoneType' object has no attribute 'AES'`. They fail identically on unmodified `upstream/main` in the same environment (a minimal venv missing a pycryptodome-related import) — pre-existing and unrelated to this change.

4. **End-to-end:** with TTS enabled on a Weixin channel, a reply containing a `MEDIA:` audio attachment now delivers the audio as a file attachment instead of silently dropping it.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the targeted suites listed under "How to Test" (new tests, media router, all weixin suites) rather than the whole tree; my environment can't install the full dependency set. Relying on CI for the complete run.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian GNU/Linux 13 (trixie), x86_64, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring added on `send_voice`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python signature change, no OS-specific behaviour
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before (unpatched `main`, exact router kwarg set):

```
WeixinAdapter: WeixinAdapter.send_voice() got an unexpected keyword argument 'is_voice'
```

After:

```
$ pytest tests/gateway/test_weixin_send_voice_is_voice_kwarg.py -q
...                                                                      [100%]
3 passed in 0.41s
```
