### PR TITLE
fix(state): converge concurrent WAL initialization

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -970,6 +970,15 @@ _WAL_INCOMPAT_MARKERS = (
     "disk i/o error",         # ZFS SHM corruption under concurrent connections
 )
 
+# A burst of fresh connections can all probe DELETE before one wins the
+# exclusive header transition to WAL. SQLite may return SQLITE_BUSY from
+# PRAGMA journal_mode=WAL immediately in that lock-upgrade race even when the
+# connection has a longer busy_timeout. Give the winner a short bounded window
+# to publish WAL, then let the losing connections converge by re-probing.
+_WAL_BUSY_CONVERGENCE_SECONDS = 1.0
+_WAL_BUSY_RETRY_MIN_SECONDS = 0.01
+_WAL_BUSY_RETRY_MAX_SECONDS = 0.05
+
 # Upper bound for the write-ahead log. SQLite defaults to -1 (unlimited),
 # which lets state.db-wal keep the high-water mark of the largest-ever
 # transaction forever. See _apply_wal_size_limit().
@@ -1195,6 +1204,53 @@ def _on_disk_journal_mode(conn: sqlite3.Connection) -> Optional[str]:
             "_on_disk_journal_mode: retries exhausted on disk read (%s)", last_exc
         )
     return None
+
+
+def _is_sqlite_busy(exc: sqlite3.OperationalError) -> bool:
+    """Return whether ``exc`` is SQLITE_BUSY (not SQLITE_LOCKED)."""
+    error_code = getattr(exc, "sqlite_errorcode", None)
+    if isinstance(error_code, int):
+        # Extended result codes retain the primary code in the low byte.
+        return error_code & 0xFF == sqlite3.SQLITE_BUSY
+    # Compatibility for runtimes/test doubles without sqlite_errorcode.
+    return str(exc).strip().lower() in {"database is locked", "database is busy"}
+
+
+def _set_wal_with_busy_convergence(conn: sqlite3.Connection):
+    """Set WAL while absorbing only the fresh-connection SQLITE_BUSY race.
+
+    A losing connection re-probes after BUSY: if a peer established WAL, that
+    is success; otherwise retry until one monotonic deadline. Exhaustion
+    re-raises SQLITE_BUSY. This never switches to DELETE and deliberately does
+    not retry SQLITE_LOCKED, WAL-incompatible storage errors, or other faults.
+    """
+    deadline = time.monotonic() + _WAL_BUSY_CONVERGENCE_SECONDS
+    last_busy: Optional[sqlite3.OperationalError] = None
+    while True:
+        try:
+            return conn.execute("PRAGMA journal_mode=WAL").fetchone()
+        except sqlite3.OperationalError as exc:
+            if not _is_sqlite_busy(exc):
+                raise
+            last_busy = exc
+
+        # Re-probe even if SQLite consumed the time budget waiting: a peer may
+        # have completed the WAL transition while this setter was blocked.
+        if _on_disk_journal_mode(conn) == "wal":
+            return ("wal",)
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            assert last_busy is not None
+            raise last_busy
+        time.sleep(
+            min(
+                remaining,
+                random.uniform(
+                    _WAL_BUSY_RETRY_MIN_SECONDS,
+                    _WAL_BUSY_RETRY_MAX_SECONDS,
+                ),
+            )
+        )
 
 
 def _apply_wal_size_limit(conn: sqlite3.Connection) -> None:
@@ -1524,7 +1580,7 @@ def apply_wal_with_fallback(
         # returned row, not the mere absence of an exception; otherwise we
         # report a false ``"wal"`` AND skip the fallback WARNING, leaving the
         # DB silently in DELETE (reader-blocks-writer) with no signal.
-        row = conn.execute("PRAGMA journal_mode=WAL").fetchone()
+        row = _set_wal_with_busy_convergence(conn)
         mode = str(row[0]).strip().lower() if row and row[0] is not None else ""
         if mode == "wal":
             if _upgrading_existing_db:

--- a/tests/test_hermes_state_wal_fallback.py
+++ b/tests/test_hermes_state_wal_fallback.py
@@ -114,6 +114,83 @@ class TestApplyWalWithFallback:
         assert cur.fetchone()[0].lower() == "wal"
         conn.close()
 
+    def test_busy_setter_converges_when_peer_establishes_wal(self, monkeypatch):
+        """A loser in the fresh-connection WAL race accepts the peer's WAL."""
+        attempts = [0]
+
+        class _Conn:
+            def execute(self, sql):
+                attempts[0] += 1
+                raise sqlite3.OperationalError("database is locked")
+
+        monkeypatch.setattr(
+            hermes_state, "_on_disk_journal_mode", lambda _conn: "wal"
+        )
+
+        assert hermes_state._set_wal_with_busy_convergence(_Conn()) == ("wal",)
+        assert attempts[0] == 1
+
+    def test_busy_setter_retries_when_mode_remains_delete(self, monkeypatch):
+        """If no peer won yet, one bounded retry may establish WAL locally."""
+        attempts = [0]
+
+        class _Cursor:
+            def fetchone(self):
+                return ("wal",)
+
+        class _Conn:
+            def execute(self, sql):
+                attempts[0] += 1
+                if attempts[0] == 1:
+                    raise sqlite3.OperationalError("database is locked")
+                return _Cursor()
+
+        monkeypatch.setattr(
+            hermes_state, "_on_disk_journal_mode", lambda _conn: "delete"
+        )
+        monkeypatch.setattr(hermes_state.time, "sleep", lambda _seconds: None)
+
+        assert hermes_state._set_wal_with_busy_convergence(_Conn()) == ("wal",)
+        assert attempts[0] == 2
+
+    def test_busy_setter_deadline_fails_closed_without_delete(self, monkeypatch):
+        """Persistent BUSY is bounded and never converted into a downgrade."""
+        calls = []
+        clock = iter([0.0, 2.0])
+
+        class _Conn:
+            def execute(self, sql):
+                calls.append(sql)
+                raise sqlite3.OperationalError("database is locked")
+
+        monkeypatch.setattr(
+            hermes_state, "_on_disk_journal_mode", lambda _conn: "delete"
+        )
+        monkeypatch.setattr(hermes_state.time, "monotonic", lambda: next(clock))
+
+        with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+            hermes_state._set_wal_with_busy_convergence(_Conn())
+
+        assert calls == ["PRAGMA journal_mode=WAL"]
+        assert not any("journal_mode=DELETE" in sql for sql in calls)
+
+    def test_sqlite_locked_is_not_retried_as_busy(self, monkeypatch):
+        """SQLITE_LOCKED is not the cross-connection convergence race."""
+        attempts = [0]
+
+        class _Conn:
+            def execute(self, sql):
+                attempts[0] += 1
+                raise sqlite3.OperationalError("database table is locked")
+
+        monkeypatch.setattr(
+            hermes_state, "_on_disk_journal_mode", lambda _conn: "delete"
+        )
+
+        with pytest.raises(sqlite3.OperationalError, match="database table is locked"):
+            hermes_state._set_wal_with_busy_convergence(_Conn())
+        assert attempts[0] == 1
+
     def test_falls_back_to_delete_on_locking_protocol(self, tmp_path, caplog):
         """NFS-style ``locking protocol`` error → DELETE mode + one ERROR."""
         conn, _ = _open_blocking(tmp_path / "nfs.db", isolation_level=None)


### PR DESCRIPTION
## What does this PR do?

Fixes a startup race in `apply_wal_with_fallback` (`hermes_state.py`): when several fresh connections open a database that is still in `DELETE` journal mode at the same time — a gateway plus dashboard plus CLI, or a burst of `SessionDB()` opens from the web server — they all issue `PRAGMA journal_mode=WAL`, and only one can win the exclusive header transition. SQLite answers the losers with `SQLITE_BUSY` **immediately** on this lock-upgrade path; the connection's `busy_timeout` is not consulted. Today that exception escapes `apply_wal_with_fallback` as `OperationalError: database is locked` and the open fails, even though a peer is establishing WAL at that very moment.

The fix adds `_set_wal_with_busy_convergence`: retry **only** `SQLITE_BUSY` (checked via `sqlite_errorcode`, with a message fallback for runtimes without it), with 10–50 ms jitter, inside one bounded monotonic window (1 s). After each BUSY it re-probes the on-disk journal mode, so a loser converges on the peer's WAL instead of hammering the pragma. Exhaustion re-raises the original `SQLITE_BUSY`. It never downgrades to `DELETE`, and it deliberately does not retry `SQLITE_LOCKED`, WAL-incompatible storage errors, or anything else — the NFS/SMB/ZFS fallback and the WAL-reset gate are untouched. This is the right shape because the failure is not "WAL unsupported here" (the fallback's domain) but "someone else is switching the file to WAL right now".

## Related Issue

No existing issue or PR covers this (searched issues and PRs for WAL initialization / concurrent openers / `database is locked` on `journal_mode`). Adjacent context: #55305 (concurrent-connection state.db corruption on ZFS) is a different failure class and already closed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py`: `_is_sqlite_busy`, `_set_wal_with_busy_convergence`, and the three tuning constants; `apply_wal_with_fallback` calls the convergence setter where it used to call the pragma directly.
- `tests/test_hermes_state_wal_fallback.py`: four tests for the contracts — peer-established WAL is accepted after one BUSY; a bounded retry may establish WAL locally; deadline exhaustion fails closed without ever issuing `journal_mode=DELETE`; `SQLITE_LOCKED` is not treated as the convergence race.

## How to Test

1. Reproduce the race on `main` (macOS, SQLite 3.53.1, Python 3.11): 16 processes each open a fresh connection to a new database, wait on a barrier, then call `apply_wal_with_fallback(conn)`. Over 40 trials, **81 of 640 opens raised `database is locked`**, with a maximum observed wait of 13 ms — the 5 s busy timeout never engaged. A bare `PRAGMA journal_mode=WAL` in the same harness fails 97–152 of 640 attempts on SQLite 3.53.1 and 3.53.4.
2. With this branch, the same measurement opens **640 of 640 in WAL**; maximum wait 54 ms.
3. `scripts/run_tests.sh -j 3 tests/test_hermes_state_wal_fallback.py tests/test_hermes_state.py tests/test_journal_mode_config.py tests/test_sqlite_wal_reset_gate.py` — all pass except the one pre-existing, unrelated `test_hermes_state.py` failure noted below.
4. `scripts/run_tests.sh -j 3` (full suite) on this branch: 3613 files, **43,399 passed**, 113 failed, 416 skipped, 1 flaky file (`tests/cron/test_script_claim_heartbeat.py`, passed on retry). Every one of the 32 files with failures was rerun on unpatched `main` (`254158f4`) in the same virtualenv and fails there with **identical counts** (host-specific: systemd-scope tests on macOS, `hermes update` flows, CUA driver / wake-word / voice hardware, Unix-socket path length under the parallel runner); none involve `hermes_state.py`'s WAL path. Full classification table available on request.

Pre-existing on `main` at `254158f4`, unrelated to this change and reproduced with the patch reverted: `tests/test_hermes_state.py::TestFTS5Search::test_search_projection_skips_context_enrichment_queries` fails on macOS (`context_query_count() == 0` where `1` is expected). Happy to follow up separately.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(state): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the test suite (`scripts/run_tests.sh`, the repo's parallel `pytest tests/` runner) — see "How to Test" for the one pre-existing unrelated failure on `main`
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.6.2 (Darwin 25.6.0), Apple silicon, Python 3.11.15, SQLite 3.53.1

### Documentation & Housekeeping

- [x] Documentation: N/A (behaviour is internal; docstrings updated in code)
- [x] `cli-config.yaml.example`: N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform: the retry is pure Python/sqlite3; the BUSY classification uses `sqlite_errorcode` (3.11+) with a message fallback for older runtimes.

Prepared with AI assistance (Claude); root cause, measurements and tests were run on the author's machine as described above.
