### PR TITLE
fix(docker): stop cross-process reuse from ignoring mounts config changes

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -733,6 +733,7 @@ def test_labels_attribute_populated_after_init(monkeypatch):
         "hermes-task-id": "abc",
         "hermes-profile": "default",
         "hermes-egress": "off",
+        "hermes-mounts": docker_env._mounts_reuse_fingerprint(False, [], []),
     }
 
 
@@ -820,6 +821,16 @@ def _mock_subprocess_run_with_reuse(monkeypatch, ps_state: str | None,
                 return subprocess.CompletedProcess(
                     cmd, 0,
                     stdout=f"reused-cid\t{ps_state}\t<no value>\n",
+                    stderr="",
+                )
+            if sub == "inspect":
+                # By default the existing container's mounts label matches the
+                # dummy env's default config (persistent=False, no volumes,
+                # no extra args), so the reuse path keeps it.  Tests that need
+                # a mismatch stub this branch with their own mock.
+                return subprocess.CompletedProcess(
+                    cmd, 0,
+                    stdout=docker_env._mounts_reuse_fingerprint(False, [], []) + "\n",
                     stderr="",
                 )
             if sub == "start":
@@ -945,6 +956,180 @@ def test_reuse_starts_stopped_container_before_attaching(monkeypatch):
     assert not run_invocations, "should not docker run when reusing an exited container"
 
 
+def test_fresh_container_records_mounts_reuse_label(monkeypatch):
+    """``docker run`` must stamp the ``hermes-mounts`` fingerprint label so a
+    later cross-process reuse can detect mounts-config drift (#101368)."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
+    calls = _mock_subprocess_run_with_reuse(monkeypatch, ps_state=None)
+
+    volumes = ["C:/Users/me/Obsidian/LLM-Wiki:/obsidian-wiki"]
+    env = _make_dummy_env(
+        task_id="mounts-label",
+        persistent_filesystem=True,
+        volumes=volumes,
+    )
+
+    assert env._container_id == "fresh-cid"
+    expected = docker_env._mounts_reuse_fingerprint(True, volumes, [])
+    assert env._labels[docker_env._MOUNTS_LABEL_KEY] == expected
+    run_invocations = [
+        c for c in calls
+        if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"
+    ]
+    assert run_invocations, "expected a fresh docker run"
+    assert f"{docker_env._MOUNTS_LABEL_KEY}={expected}" in run_invocations[0][0], (
+        "docker run must carry the mounts fingerprint label"
+    )
+
+
+def test_reuse_rejects_container_created_with_different_mounts(monkeypatch):
+    """docker_volumes / docker_extra_args / container_persistent only take
+    effect at ``docker run`` time and are immutable afterwards, so attaching
+    to a container created under older values silently ignores the new config
+    (#101368).  Reuse must detect the drift via the ``hermes-mounts`` label,
+    remove the stale container, and start a fresh one that honors it."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
+    calls = []
+
+    def _run(cmd, **kwargs):
+        calls.append((list(cmd) if isinstance(cmd, list) else cmd, kwargs))
+        if isinstance(cmd, list) and len(cmd) >= 2:
+            sub = cmd[1]
+            if sub == "version":
+                return subprocess.CompletedProcess(cmd, 0, stdout="Docker version", stderr="")
+            if sub == "ps":
+                return subprocess.CompletedProcess(
+                    cmd, 0, stdout="stale-cid\trunning\t<no value>\n", stderr=""
+                )
+            if sub == "inspect":
+                # The container was created BEFORE the user added
+                # docker_volumes: its label reflects the volume-less config.
+                return subprocess.CompletedProcess(
+                    cmd, 0,
+                    stdout=docker_env._mounts_reuse_fingerprint(True, [], []) + "\n",
+                    stderr="",
+                )
+            if sub == "rm":
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+            if sub == "run":
+                return subprocess.CompletedProcess(cmd, 0, stdout="fresh-cid\n", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+
+    env = _make_dummy_env(
+        task_id="mounts-mismatch",
+        persistent_filesystem=True,
+        volumes=["C:/Users/me/Obsidian/LLM-Wiki:/obsidian-wiki"],
+    )
+
+    assert env._container_id == "fresh-cid", (
+        "a container created with different mounts must not be reused"
+    )
+    rm_invocations = [
+        c for c in calls
+        if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "rm"
+    ]
+    assert rm_invocations and rm_invocations[0][0][3] == "stale-cid", (
+        "the stale container must be removed so the next startup doesn't pick it up again"
+    )
+    run_invocations = [
+        c for c in calls
+        if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"
+    ]
+    assert run_invocations, "a fresh container honoring docker_volumes must be started"
+
+
+def test_reuse_replaces_unlabeled_container_when_mounts_configured(monkeypatch):
+    """Upgrade path: containers created before the ``hermes-mounts`` label
+    existed carry no label.  When the current config requests non-default
+    mounts, reuse must fail closed (remove + fresh) so the first startup
+    after upgrading actually honors docker_volumes (#101368)."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
+    calls = []
+
+    def _run(cmd, **kwargs):
+        calls.append((list(cmd) if isinstance(cmd, list) else cmd, kwargs))
+        if isinstance(cmd, list) and len(cmd) >= 2:
+            sub = cmd[1]
+            if sub == "version":
+                return subprocess.CompletedProcess(cmd, 0, stdout="Docker version", stderr="")
+            if sub == "ps":
+                return subprocess.CompletedProcess(
+                    cmd, 0, stdout="legacy-cid\trunning\t<no value>\n", stderr=""
+                )
+            if sub == "inspect":
+                # Legacy container: no hermes-mounts label at all.
+                return subprocess.CompletedProcess(cmd, 0, stdout="<no value>\n", stderr="")
+            if sub == "rm":
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+            if sub == "run":
+                return subprocess.CompletedProcess(cmd, 0, stdout="fresh-cid\n", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+
+    env = _make_dummy_env(
+        task_id="mounts-legacy",
+        persistent_filesystem=True,
+        volumes=["C:/Users/me/hermes-workspace:/host-media"],
+    )
+
+    assert env._container_id == "fresh-cid", (
+        "an unlabeled container must not be reused when mounts are configured"
+    )
+    rm_invocations = [
+        c for c in calls
+        if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "rm"
+    ]
+    assert rm_invocations, "the legacy container must be removed before the fresh run"
+
+
+def test_reuse_keeps_unlabeled_container_with_default_mounts(monkeypatch):
+    """The flip side of the upgrade path: a legacy container with no
+    ``hermes-mounts`` label is kept when the current config uses default
+    mounts, so upgrading doesn't churn every default-config user's
+    long-lived container (#101368)."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
+    calls = []
+
+    def _run(cmd, **kwargs):
+        calls.append((list(cmd) if isinstance(cmd, list) else cmd, kwargs))
+        if isinstance(cmd, list) and len(cmd) >= 2:
+            sub = cmd[1]
+            if sub == "version":
+                return subprocess.CompletedProcess(cmd, 0, stdout="Docker version", stderr="")
+            if sub == "ps":
+                return subprocess.CompletedProcess(
+                    cmd, 0, stdout="legacy-cid\trunning\t<no value>\n", stderr=""
+                )
+            if sub == "inspect":
+                return subprocess.CompletedProcess(cmd, 0, stdout="<no value>\n", stderr="")
+            if sub == "start":
+                return subprocess.CompletedProcess(cmd, 0, stdout="legacy-cid\n", stderr="")
+            if sub == "run":
+                return subprocess.CompletedProcess(cmd, 0, stdout="fresh-cid\n", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+
+    # Default mounts: persistent container, no volumes, no extra args.
+    env = _make_dummy_env(task_id="mounts-legacy-default", persistent_filesystem=True)
+
+    assert env._container_id == "legacy-cid", (
+        "default-config containers must keep being reused across the upgrade"
+    )
+    rm_invocations = [
+        c for c in calls
+        if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "rm"
+    ]
+    assert not rm_invocations, "no container should be removed for default mounts config"
+
+
 def test_failed_docker_run_cleans_up_orphaned_container(monkeypatch):
     """When ``docker run`` fails (e.g. exit 125), the partially-created
     container must be removed by name.
@@ -1042,11 +1227,23 @@ def test_find_reusable_handles_empty_label_string(monkeypatch):
                     stdout="safe-cid\trunning\t\n",
                     stderr="",
                 )
+            if cmd[1] == "inspect":
+                # Mounts label matching this env's config so the reuse path
+                # keeps the container (this test pins the ps parser, not the
+                # mounts guard).
+                return subprocess.CompletedProcess(
+                    cmd, 0,
+                    stdout=docker_env._mounts_reuse_fingerprint(True, [], []) + "\n",
+                    stderr="",
+                )
         return subprocess.CompletedProcess(cmd, 0, stdout="fresh-cid\n", stderr="")
 
     monkeypatch.setattr(docker_env.subprocess, "run", _run)
 
-    env = _make_dummy_env(task_id="empty-label")
+    # persistent_filesystem=True + no volumes/extra args = default mounts, so
+    # the unlabeled legacy container stays reusable (this test is about the
+    # ps-output parser, not the mounts guard).
+    env = _make_dummy_env(task_id="empty-label", persistent_filesystem=True)
     assert env._container_id == "safe-cid", (
         f"container with empty-string label should be reused, got {env._container_id!r}"
     )

--- a/tests/tools/test_docker_network_config.py
+++ b/tests/tools/test_docker_network_config.py
@@ -69,7 +69,15 @@ def _reuse_guard_harness(monkeypatch, *, existing_mode: str, network: bool):
             # missing label as "<no value>".
             Result.stdout = "existing-container-id\trunning\t<no value>\n"
         elif len(cmd) > 1 and cmd[1] == "inspect":
-            Result.stdout = f"{existing_mode}\n"
+            fmt = cmd[cmd.index("--format") + 1] if "--format" in cmd else ""
+            if "NetworkMode" in fmt:
+                Result.stdout = f"{existing_mode}\n"
+            else:
+                # Mounts-label probe: report a label matching this env's
+                # config so the harness exercises reuse, not rebuild.
+                Result.stdout = (
+                    docker_env._mounts_reuse_fingerprint(False, None, None) + "\n"
+                )
         elif len(cmd) > 1 and cmd[1] == "run":
             Result.stdout = "fresh-container-id\n"
         return Result()
@@ -110,7 +118,12 @@ def test_reuse_skips_inspect_when_network_enabled(monkeypatch):
     commands = _reuse_guard_harness(monkeypatch, existing_mode="none", network=True)
 
     # Default-network config never churns containers, even air-gapped ones
-    # (operators may have created them via docker_extra_args).
-    assert not any(cmd[1] == "inspect" for cmd in commands)
+    # (operators may have created them via docker_extra_args). The NetworkMode
+    # inspect belongs to the network guard and must not run; the mounts-label
+    # probe (#101368) is the one allowed inspect on the reuse path.
+    assert not any(
+        cmd[1] == "inspect" and any("NetworkMode" in str(p) for p in cmd)
+        for cmd in commands
+    ), "network guard must not inspect when network is enabled"
     assert not any(cmd[1] == "rm" for cmd in commands)
     assert not any(cmd[1] == "run" for cmd in commands)

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -44,6 +44,7 @@ _DOCKER_SEARCH_PATHS = [
 _docker_executable: Optional[str] = None  # resolved once, cached
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _EGRESS_LABEL_KEY = "hermes-egress"
+_MOUNTS_LABEL_KEY = "hermes-mounts"
 
 
 def _normalize_forward_env_names(forward_env: list[str] | None) -> list[str]:
@@ -599,6 +600,31 @@ def _egress_reuse_fingerprint(
             "volume_args": volume_args,
             "env_overrides": env_overrides,
             "host_args": host_args,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:24]
+
+
+def _mounts_reuse_fingerprint(
+    persistent: bool,
+    volumes: list,
+    extra_args: list,
+) -> str:
+    """Stable Docker-label value for the user-configured mount identity.
+
+    Cross-process reuse attaches to an existing container without re-running
+    ``docker run``, so any config that shapes the container's mounts/flags at
+    creation time — ``container_persistent``, ``docker_volumes``,
+    ``docker_extra_args`` — is silently dropped by the label-based reuse
+    probe unless it is part of the reuse label (issue #101368).
+    """
+    payload = json.dumps(
+        {
+            "persistent": bool(persistent),
+            "volumes": [str(v) for v in (volumes or [])],
+            "extra_args": [str(a) for a in (extra_args or [])],
         },
         sort_keys=True,
         separators=(",", ":"),
@@ -1413,11 +1439,15 @@ class DockerEnvironment(BaseEnvironment):
         # container-start time and never changes for the container's lifetime.
         profile_name = _container_identity(shared_container_key)
         task_label = _sanitize_label_value(task_id)
+        mounts_label = _mounts_reuse_fingerprint(
+            self._persistent, volumes, extra_args,
+        )
         label_args = [
             "--label", "hermes-agent=1",
             "--label", f"hermes-task-id={task_label}",
             "--label", f"hermes-profile={profile_name}",
             "--label", f"{_EGRESS_LABEL_KEY}={egress_label}",
+            "--label", f"{_MOUNTS_LABEL_KEY}={mounts_label}",
         ]
         # Save args for container recreation on "No such container" recovery.
         self._image = image
@@ -1430,6 +1460,7 @@ class DockerEnvironment(BaseEnvironment):
             "hermes-task-id": task_label,
             "hermes-profile": profile_name,
             _EGRESS_LABEL_KEY: egress_label,
+            _MOUNTS_LABEL_KEY: mounts_label,
         }
 
         # Cross-process container reuse (issue #20561 — docs claim "ONE long-lived
@@ -1474,6 +1505,46 @@ class DockerEnvironment(BaseEnvironment):
                         "(task=%s, profile=%s).",
                         container_id[:12], actual_mode or "unknown",
                         task_label, profile_name,
+                    )
+                    try:
+                        subprocess.run(
+                            [self._docker_exe, "rm", "-f", container_id],
+                            capture_output=True,
+                            text=True, encoding="utf-8", errors="replace",
+                            timeout=30,
+                            check=False,
+                            stdin=subprocess.DEVNULL,
+                        )
+                    except (subprocess.TimeoutExpired, OSError) as e:
+                        logger.warning("Failed to remove mismatched container %s: %s", container_id[:12], e)
+                    existing = None
+            if existing is not None:
+                container_id, _state = existing
+                # Mounts guard: docker_volumes / docker_extra_args /
+                # container_persistent only take effect at ``docker run``
+                # time and are immutable afterwards, so attaching to a
+                # container created under different values silently ignores
+                # the new config (issue #101368). On mismatch we remove the
+                # stale container and start fresh, mirroring the network-mode
+                # guard above. A container without the label predates this
+                # fingerprint: treat it as a mismatch only when the current
+                # config actually requests non-default mounts, so
+                # default-config users keep their long-lived container.
+                actual_mounts = self._container_mounts_label(container_id)
+                if actual_mounts is None:
+                    mounts_mismatch = (
+                        bool(volumes or extra_args) or not self._persistent
+                    )
+                else:
+                    mounts_mismatch = actual_mounts != mounts_label
+                if mounts_mismatch:
+                    logger.warning(
+                        "Existing container %s was created with different "
+                        "mounts config (docker_volumes/docker_extra_args/"
+                        "container_persistent changed) — removing it and "
+                        "starting fresh so the configured mounts take effect "
+                        "(task=%s, profile=%s).",
+                        container_id[:12], task_label, profile_name,
                     )
                     try:
                         subprocess.run(
@@ -1901,6 +1972,43 @@ class DockerEnvironment(BaseEnvironment):
             return None
         mode = result.stdout.strip()
         return mode or None
+
+    def _container_mounts_label(self, container_id: str) -> Optional[str]:
+        """Return the container's ``hermes-mounts`` label, or ``None`` when the
+        label is absent (container predates the fingerprint) or inspection
+        fails.
+
+        Used by the reuse path to detect containers created under different
+        docker_volumes / docker_extra_args / container_persistent settings;
+        see ``_mounts_reuse_fingerprint``.
+        """
+        try:
+            result = subprocess.run(
+                [
+                    self._docker_exe, "inspect",
+                    "--format",
+                    '{{index .Config.Labels "hermes-mounts"}}',
+                    container_id,
+                ],
+                capture_output=True,
+                text=True, encoding="utf-8", errors="replace",
+                timeout=10,
+                check=False,
+                stdin=subprocess.DEVNULL,
+            )
+        except (subprocess.TimeoutExpired, OSError) as e:
+            logger.debug("docker inspect mounts label failed: %s", e)
+            return None
+        if result.returncode != 0:
+            logger.debug(
+                "docker inspect mounts label returned %d: %s",
+                result.returncode, result.stderr.strip(),
+            )
+            return None
+        value = result.stdout.strip()
+        if not value or value == "<no value>":
+            return None
+        return value
 
     def _find_reusable_container(
         self,


### PR DESCRIPTION
## What does this PR do?

Cross-process container reuse (`terminal.docker_persist_across_processes`, default on) matches an existing container on `(hermes-task-id, hermes-profile, hermes-egress)` labels only. But `docker_volumes`, `docker_extra_args`, and `container_persistent` only take effect at `docker run` time, and reuse skips `docker run` entirely — so once a container exists, any change to those keys is silently ignored for as long as that container lives. The reporter's `docker inspect` output in #101368 shows exactly this: the ephemeral attempt (`container_persistent: false`) still shows the persistent-mode binds, because the probe attached to the container created under the earlier config.

This is statically provable from the reuse path (`_find_reusable_container` filters + the `docker run` skip in `DockerEnvironment.__init__`), which is why no runtime repro was needed.

The fix mirrors two existing patterns in the same code path:

- a `hermes-mounts` fingerprint label (persistent + volumes + extra_args), stamped at creation the same way `_egress_reuse_fingerprint` stamps the egress posture, and included in the recovery path's label replay (`self._labels`);
- before attaching to a reused container, the label is read via `docker inspect` and compared; on mismatch the stale container is removed and a fresh one is started — the same recovery shape as the NetworkMode guard right above it.

Containers created before this label existed (upgrade path) are treated as matching **unless** the current config requests non-default mounts, so default-config users keep their long-lived container and only affected configs get one rebuild.

## Related Issue

Fixes #101368

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/environments/docker.py`: added `_mounts_reuse_fingerprint()` (same shape as `_egress_reuse_fingerprint`) and the `hermes-mounts` label constant
- `tools/environments/docker.py`: stamp the label into `label_args` / `self._labels` at container creation
- `tools/environments/docker.py`: mounts guard on the reuse path — `_container_mounts_label()` reads the label via `docker inspect`; mismatch (or unlabeled container + non-default mounts) removes the stale container and starts fresh
- `tests/tools/test_docker_environment.py`: regression tests — fresh run stamps the label; mismatched / unlabeled-with-mounts containers are rebuilt; unlabeled default-config containers stay reused; reuse mock returns a matching label by default
- `tests/tools/test_docker_network_config.py`: guard harness now answers the mounts-label inspect distinctly from the NetworkMode inspect; the "no inspect when network enabled" pin now scopes to the NetworkMode inspect

## How to Test

1. `.venv/bin/python -m pytest tests/tools/test_docker_environment.py tests/tools/test_docker_network_config.py -q` — Observed result: 123 passed (67 + 56, includes the 5 new/updated mounts tests).
2. Also ran the adjacent suites touching this config surface: `tests/tools/test_container_cwd_sanitize.py tests/tools/test_terminal_config_env_sync.py tests/tools/test_modal_sandbox_fixes.py tests/tools/test_file_tools_container_config.py` — all pass alongside the two above.
3. End-to-end sanity for a Docker user: start with `terminal.backend: docker` (default mounts), let the shared container be created, then add `terminal.docker_volumes: ["/host/dir:/data"]` and restart — before this PR `docker inspect` shows no change; after it, the stale container is removed with a warning and the fresh one carries the `-v /host/dir:/data` bind (this also matches the reporter's implicit workaround: deleting the old container manually makes the volumes appear, which is the reuse-shorting mechanism this PR automates).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64); the fix is platform-neutral CLI plumbing (labels + `docker inspect`), and the reporter's Windows/WSL2 mounts syntax is covered by the test fixtures

### Documentation & Housekeeping

- [x] N/A — no config keys added or changed; the reuse contract now actually honors the documented ones
- [x] N/A — `cli-config.yaml.example` unchanged (no new keys)
- [x] N/A — no architecture/workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `docker inspect --format '{{index .Config.Labels "…"}}'` works on both Docker and Podman, and Windows drive-letter volume specs (`C:/a:/b`) are exercised in the new tests
- [x] N/A — no tool behavior/schema change
