### PR TITLE
fix(desktop): restore remote agent roster after startup

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -333,6 +333,7 @@ import {
 import { missingRendererAssets } from './renderer-bundle'
 import { loadRendererLoadErrorPage } from './renderer-load-error-page'
 import { attachRendererConsoleCapture, formatRendererBoundaryReport } from './renderer-log'
+import { createRosterRecoverySignals } from './roster-recovery'
 import {
   classifyStoredSecret,
   readSecretStoragePolicy,
@@ -11128,6 +11129,16 @@ function broadcastConnectionsChanged(payload: { connectionId: string; reason: 'r
   }
 }
 
+function broadcastAgentRosterChanged(payload: { connectionId: string }) {
+  for (const win of BrowserWindow.getAllWindows()) {
+    const { webContents } = win
+
+    if (webContents && !webContents.isDestroyed()) {
+      webContents.send('hermes:agents:roster-changed', payload)
+    }
+  }
+}
+
 async function waitForBackendExit(child, timeoutMs = 5000) {
   if (!child || child.exitCode !== null || child.signalCode !== null) {
     return
@@ -15121,6 +15132,7 @@ ipcMain.handle('hermes:connections:test', async (_event, id) => {
 const sshRosterCache = new Map<string, string[]>()
 const sshInventoryAttemptedAt = new Map<string, number>()
 const SSH_INVENTORY_RETRY_MS = 60_000
+const rosterRecoverySignals = createRosterRecoverySignals(broadcastAgentRosterChanged)
 
 // Stable backend identity per registered connection: the `install_id` its
 // /api/status reports (absent on backends older than the field). Enumeration
@@ -15231,7 +15243,11 @@ async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRe
       return await Promise.race([
         work,
         new Promise<never>((_resolve, reject) => {
-          timer = setTimeout(() => reject(new Error('roster enumeration timed out')), perSourceTimeoutMs)
+          timer = setTimeout(() => {
+            const error: any = new Error('roster enumeration timed out')
+            error.code = 'roster_enumeration_timeout'
+            reject(error)
+          }, perSourceTimeoutMs)
         })
       ])
     } finally {
@@ -15243,6 +15259,8 @@ async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRe
 
   return Promise.all(
     registry.connections.map(async connection => {
+      let pendingDial: Promise<any> | null = null
+
       let raw: {
         connection: typeof connection
         error?: string
@@ -15283,13 +15301,12 @@ async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRe
           // Claim-guarded (#90812): this ~5s roster poll can race a renderer's
           // own reconnect dial for the same connection; coalescing avoids
           // bootstrapping a second SSH tunnel / remote dashboard.
-          const descriptor: any = await withEnumerationDeadline(
-            Promise.resolve(
-              backendDialClaims.run(backendScopeKey(connection.id, null), () =>
-                ensureRegistryBackend(connection.id, null)
-              )
+          pendingDial = Promise.resolve(
+            backendDialClaims.run(backendScopeKey(connection.id, null), () =>
+              ensureRegistryBackend(connection.id, null)
             )
           )
+          const descriptor: any = await withEnumerationDeadline(pendingDial)
 
           const body: any = await getJsonForBackend(descriptor, '/api/profiles', { timeoutMs: 8_000 })
 
@@ -15349,6 +15366,14 @@ async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRe
           }
         }
       } catch (error: any) {
+        // The UI deadline is intentionally shorter than a remote readiness
+        // dial. Let that dial finish in the background, then tell renderers to
+        // refetch once instead of leaving the startup roster partial until a
+        // manual connection Test/focus cycle.
+        if (error?.code === 'roster_enumeration_timeout' && pendingDial) {
+          rosterRecoverySignals.afterPendingDial(connection.id, pendingDial)
+        }
+
         raw = { connection, profiles: null, error: String(error?.message || error) }
       }
 

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -30,6 +30,12 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   getGatewayWsUrlFor: payload => ipcRenderer.invoke('hermes:gateway:ws-url-for', payload),
   // Union agent roster across every registered connection.
   getAgentRoster: () => ipcRenderer.invoke('hermes:agents:roster'),
+  onAgentRosterChanged: callback => {
+    const listener = (_event, payload) => callback(payload)
+    ipcRenderer.on('hermes:agents:roster-changed', listener)
+
+    return () => ipcRenderer.removeListener('hermes:agents:roster-changed', listener)
+  },
   openSessionWindow: (sessionId, opts) => ipcRenderer.invoke('hermes:window:openSession', sessionId, opts),
   openSessionInTerminal: (sessionId, opts) => ipcRenderer.invoke('hermes:window:openInTerminal', sessionId, opts),
   openWindow: () => ipcRenderer.invoke('hermes:window:openInstance'),

--- a/apps/desktop/electron/roster-recovery.test.ts
+++ b/apps/desktop/electron/roster-recovery.test.ts
@@ -1,0 +1,61 @@
+import { expect, it } from 'vitest'
+
+import { createRosterRecoverySignals } from './roster-recovery'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+
+  return { promise, reject, resolve }
+}
+
+it('signals once when repeated consumers observe the same recovering connection', async () => {
+  const notifications: string[] = []
+  const recovery = createRosterRecoverySignals(signal => notifications.push(signal.connectionId))
+  const dial = deferred<void>()
+
+  recovery.afterPendingDial('homelab', dial.promise)
+  recovery.afterPendingDial('homelab', dial.promise)
+  dial.resolve()
+  await dial.promise
+  await Promise.resolve()
+
+  expect(notifications).toEqual(['homelab'])
+})
+
+it('does not signal when the background dial fails', async () => {
+  const notifications: string[] = []
+  const recovery = createRosterRecoverySignals(signal => notifications.push(signal.connectionId))
+  const dial = deferred<void>()
+
+  recovery.afterPendingDial('homelab', dial.promise)
+  dial.reject(new Error('offline'))
+  await expect(dial.promise).rejects.toThrow(/offline/)
+  await Promise.resolve()
+
+  expect(notifications).toEqual([])
+})
+
+it('allows a later recovery attempt after an earlier dial settles', async () => {
+  const notifications: string[] = []
+  const recovery = createRosterRecoverySignals(signal => notifications.push(signal.connectionId))
+  const first = deferred<void>()
+  const second = deferred<void>()
+
+  recovery.afterPendingDial('homelab', first.promise)
+  first.reject(new Error('offline'))
+  await expect(first.promise).rejects.toThrow(/offline/)
+  await Promise.resolve()
+
+  recovery.afterPendingDial('homelab', second.promise)
+  second.resolve()
+  await second.promise
+  await Promise.resolve()
+
+  expect(notifications).toEqual(['homelab'])
+})

--- a/apps/desktop/electron/roster-recovery.ts
+++ b/apps/desktop/electron/roster-recovery.ts
@@ -1,0 +1,31 @@
+export interface RosterRecoverySignal {
+  connectionId: string
+}
+
+/**
+ * Publish one recovery signal when an enumeration dial that outlived its UI
+ * deadline eventually succeeds. Repeated roster consumers can observe the
+ * same pending dial, so connection id is the single-flight key.
+ */
+export function createRosterRecoverySignals(notify: (signal: RosterRecoverySignal) => void) {
+  const pending = new Map<string, Promise<void>>()
+
+  return {
+    afterPendingDial(connectionId: string, dial: Promise<unknown>): void {
+      if (pending.has(connectionId)) {
+        return
+      }
+
+      const tracked = dial
+        .then(() => notify({ connectionId }))
+        .catch(() => undefined)
+        .finally(() => {
+          if (pending.get(connectionId) === tracked) {
+            pending.delete(connectionId)
+          }
+        })
+
+      pending.set(connectionId, tracked)
+    }
+  }
+}

--- a/apps/desktop/src/app/chat/sidebar/use-fleet-roster.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/use-fleet-roster.test.ts
@@ -1,0 +1,39 @@
+import { renderHook } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+
+import { refreshFleetRoster } from '@/store/fleet-roster'
+
+import { useFleetRoster } from './use-fleet-roster'
+
+vi.mock('@/store/fleet-roster', () => ({
+  refreshFleetRoster: vi.fn(async () => undefined)
+}))
+
+afterEach(() => {
+  vi.clearAllMocks()
+  delete (window as { hermesDesktop?: unknown }).hermesDesktop
+})
+
+it('force-refreshes when Electron reports a completed startup roster dial', () => {
+  const rosterChanged = { current: null as null | (() => void) }
+
+  const unsubscribe = vi.fn()
+
+  ;(window as { hermesDesktop?: unknown }).hermesDesktop = {
+    onAgentRosterChanged: vi.fn(callback => {
+      rosterChanged.current = callback
+
+      return unsubscribe
+    })
+  }
+
+  const view = renderHook(() => useFleetRoster(true))
+
+  vi.mocked(refreshFleetRoster).mockClear()
+  expect(rosterChanged.current).not.toBeNull()
+  rosterChanged.current?.()
+  expect(refreshFleetRoster).toHaveBeenCalledWith({ force: true })
+
+  view.unmount()
+  expect(unsubscribe).toHaveBeenCalledOnce()
+})

--- a/apps/desktop/src/app/chat/sidebar/use-fleet-roster.ts
+++ b/apps/desktop/src/app/chat/sidebar/use-fleet-roster.ts
@@ -28,11 +28,13 @@ export function useFleetRoster(enabled: boolean): void {
     window.addEventListener('focus', onFocus)
     document.addEventListener('visibilitychange', onVisibility)
     const offRegistry = window.hermesDesktop?.connections?.onChanged?.(() => void refreshFleetRoster({ force: true }))
+    const offRoster = window.hermesDesktop?.onAgentRosterChanged?.(() => void refreshFleetRoster({ force: true }))
 
     return () => {
       window.removeEventListener('focus', onFocus)
       document.removeEventListener('visibilitychange', onVisibility)
       offRegistry?.()
+      offRoster?.()
     }
   }, [enabled])
 }

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -32,6 +32,9 @@ declare global {
       }) => Promise<GatewayWsUrlResult>
       // Union agent roster across every registered connection.
       getAgentRoster?: () => Promise<DesktopAgentRoster>
+      // A source whose startup enumeration exceeded the UI deadline finished
+      // connecting in the background; consumers should refetch once.
+      onAgentRosterChanged?: (callback: (payload: { connectionId: string }) => void) => () => void
       // Credential-free routes across the union connection registry. The
       // optional profile list is used only by the single-local v1 fallback;
       // endpoint and auth material never crosses the IPC boundary.

--- a/apps/desktop/src/store/fleet-roster.test.ts
+++ b/apps/desktop/src/store/fleet-roster.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+
+import type { DesktopAgentRoster } from '@/global'
+
+import { _resetFleetRosterForTests, refreshFleetRoster } from './fleet-roster'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+
+  const promise = new Promise<T>(resolvePromise => {
+    resolve = resolvePromise
+  })
+
+  return { promise, resolve }
+}
+
+const emptyRoster: DesktopAgentRoster = { agents: [], sources: [] }
+
+beforeEach(() => {
+  _resetFleetRosterForTests()
+})
+
+afterEach(() => {
+  delete (window as { hermesDesktop?: unknown }).hermesDesktop
+})
+
+it('queues a forced recovery refresh behind an in-flight startup enumeration', async () => {
+  const startup = deferred<DesktopAgentRoster>()
+
+  const getAgentRoster = vi.fn().mockImplementationOnce(() => startup.promise).mockResolvedValue(emptyRoster)
+
+  ;(window as { hermesDesktop?: unknown }).hermesDesktop = { getAgentRoster }
+
+  const initialRefresh = refreshFleetRoster()
+  const recoveryRefresh = refreshFleetRoster({ force: true })
+
+  expect(getAgentRoster).toHaveBeenCalledTimes(1)
+  startup.resolve(emptyRoster)
+  await Promise.all([initialRefresh, recoveryRefresh])
+  await vi.waitFor(() => expect(getAgentRoster).toHaveBeenCalledTimes(2))
+})

--- a/apps/desktop/src/store/fleet-roster.ts
+++ b/apps/desktop/src/store/fleet-roster.ts
@@ -14,6 +14,7 @@ const FLEET_ROSTER_STALE_MS = 60_000
 
 let fetchedAt = 0
 let inflight: null | Promise<void> = null
+let forceAfterInflight = false
 
 export async function refreshFleetRoster(options: { force?: boolean } = {}): Promise<void> {
   const bridge = window.hermesDesktop?.getAgentRoster
@@ -27,6 +28,8 @@ export async function refreshFleetRoster(options: { force?: boolean } = {}): Pro
   }
 
   if (inflight) {
+    forceAfterInflight ||= options.force === true
+
     return inflight
   }
 
@@ -42,6 +45,11 @@ export async function refreshFleetRoster(options: { force?: boolean } = {}): Pro
     })
     .finally(() => {
       inflight = null
+
+      if (forceAfterInflight) {
+        forceAfterInflight = false
+        void refreshFleetRoster({ force: true })
+      }
     })
 
   return inflight
@@ -52,4 +60,5 @@ export function _resetFleetRosterForTests(): void {
   $fleetRoster.set(null)
   fetchedAt = 0
   inflight = null
+  forceAfterInflight = false
 }


### PR DESCRIPTION
## What does this PR do?

Desktop now restores registered remote agents automatically when a cold-start roster enumeration reaches its 10-second UI deadline but the OAuth-backed connection finishes recovering in the background. The bounded enumeration deadline remains intact, while a one-shot recovery event refreshes the Sessions fleet roster without requiring Settings -> Connections -> Test.

### Symptom

After restarting Desktop with registered OAuth remote gateways, the Sessions fleet rail can show only local agents even though the remote gateways are reachable. Remote agents appear only after a manual connection Test or another later refresh.

### Impact

Users with slow-to-restore remote OAuth connections cannot select their remote agents from the Sessions sidebar after startup until they perform manual recovery steps.

### Bug Cause

**Trigger:** `apps/desktop/electron/main.ts` / `enumerateRegistryAgentSources()` when `ensureRegistryBackend()` exceeds the per-source 10-second enumeration deadline.

**Causal chain:**
1. Desktop starts a remote registry dial that validates or refreshes the saved OAuth session and waits for backend readiness.
2. The fleet enumeration returns a partial roster after 10 seconds, while the remote dial continues and can recover successfully in the background.
3. `refreshFleetRoster()` treats that partial response as a successful fetch and caches it; the sidebar deliberately has no periodic polling, so the completed remote dial is not published to the rail.

**Why it is wrong:** A UI latency bound was also acting as the final roster result. The later successful connection changed backend availability without invalidating the renderer cache.

**Working sibling / contrast:** The Settings connection Test waits for its HTTP and WebSocket auth legs directly and is not discarded by the roster's 10-second presentation deadline. A later roster refresh can then reuse the recovered descriptor.

**Ruled out:** The remote gateway itself being unreachable does not explain the report because `/api/status` remains accessible and the existing dial continues after the roster deadline. The fix does not weaken auth or reuse a one-time WebSocket ticket.

### Fix

- Track timed-out registry dials and emit one `hermes:agents:roster-changed` event only when a background dial eventually succeeds.
- Subscribe the Sessions fleet rail to that event and force one refresh.
- Queue the forced refresh if the original startup fetch is still settling, so the recovery signal cannot be lost to the in-flight request guard.
- Keep failures silent and preserve the existing per-source timeout and non-periodic polling contract.

## Related Issue
N/A
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/main.ts` - publish a deduplicated roster recovery event after a timed-out dial later succeeds.
- `apps/desktop/electron/roster-recovery.ts` - single-flight the background recovery notification per connection.
- `apps/desktop/electron/preload.ts` and `apps/desktop/src/global.d.ts` - expose the typed recovery subscription.
- `apps/desktop/src/store/fleet-roster.ts` - queue a forced refresh behind an in-flight startup enumeration.
- `apps/desktop/src/app/chat/sidebar/use-fleet-roster.ts` - refresh the fleet rail on recovery.
- Added behavior tests for notification deduplication, failed dials, in-flight refresh ordering, and hook subscription cleanup.

## How to Test

1. Register an OAuth remote gateway whose cold-start readiness takes longer than 10 seconds.
2. Restart Desktop and leave the Sessions sidebar open without testing the connection manually.
3. Verify the local roster renders within the existing deadline and the remote agents appear automatically when the background dial becomes ready.
4. Automated checks run locally on Windows 11:

```bash
npx eslint electron/main.ts electron/preload.ts electron/roster-recovery.ts electron/roster-recovery.test.ts src/global.d.ts src/store/fleet-roster.ts src/store/fleet-roster.test.ts src/app/chat/sidebar/use-fleet-roster.ts src/app/chat/sidebar/use-fleet-roster.test.ts
npx vitest run --project electron electron/roster-recovery.test.ts
npx vitest run --project ui src/store/fleet-roster.test.ts src/app/chat/sidebar/use-fleet-roster.test.ts
npm run typecheck
```

The full UI suite reported 7088 passing tests and four unrelated failures. Two sidebar test failures reproduced unchanged on a clean `main`; the other two files passed when rerun in isolation.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant Desktop tests and type checks
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update is N/A; this changes internal startup recovery behavior
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no architecture or workflow contract changed
- [x] I've considered cross-platform impact; the event and promise coordination are platform-neutral
- [x] Tool description/schema updates are N/A; no model tool behavior changed

## Screenshots / Logs

N/A - this is startup timing and cache-recovery behavior covered by automated tests.
