### PR TITLE
fix(agent): resolve dated Anthropic snapshot ids in pricing lookup (#101145)

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1196,6 +1196,13 @@ def _lookup_official_docs_pricing(route: BillingRoute) -> Optional[PricingEntry]
             entry = _OFFICIAL_DOCS_PRICING.get((route.provider, normalized))
             if entry:
                 return entry
+        # Dated snapshot ids (e.g. claude-haiku-4-5-20251001) don't match
+        # the undated family entry in the pricing table (#101145).
+        undated = re.sub(r"-\d{8}$", "", model)
+        if undated != model:
+            entry = _OFFICIAL_DOCS_PRICING.get((route.provider, undated))
+            if entry:
+                return entry
     # Bedrock cross-region inference profiles carry a region prefix
     # (us./global./eu./...) that the bare pricing keys don't have.
     if route.provider == "bedrock":


### PR DESCRIPTION
## Problem

Dated Anthropic model snapshot ids (e.g. `claude-haiku-4-5-20251001`) do not resolve to the undated family entry (`claude-haiku-4-5`) in `_OFFICIAL_DOCS_PRICING`. The session books `$0.00` estimated cost silently.

```python
get_pricing_entry("claude-haiku-4-5", provider="anthropic")             # -> entry, $1.00/MTok
get_pricing_entry("claude-haiku-4-5-20251001", provider="anthropic")    # -> None (before fix)
```

## Fix

Add a fallback in `_lookup_official_docs_pricing` that strips the trailing `-YYYYMMDD` suffix and retries the lookup when both the direct and normalized lookups miss. This is inside the existing `if route.provider == "anthropic":` guard, so it only applies to Anthropic models.

The regex `r"-\d{8}$"` matches exactly 8 trailing digits after a hyphen, which is the Anthropic snapshot date format. No false positives for model names ending in version numbers (those use dots, not hyphens).

## Testing

```python
# Before fix:
assert get_pricing_entry("claude-haiku-4-5-20251001", provider="anthropic") is None

# After fix:
entry = get_pricing_entry("claude-haiku-4-5-20251001", provider="anthropic")
assert entry is not None
assert entry.input_cost_per_million > 0
```

Fixes #101145