### PR TITLE
fix(tools): use _is_container_backend() in cwd-override guard (#101013)

### DIFF
--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1514,7 +1514,9 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
             # bypass the guard.  Valid in-container override paths (RL/benchmark
             # sandboxes that set cwd to /workspace, /root, etc.) are absolute
             # non-host paths and pass through untouched.
-            if env_type in _CONTAINER_BACKENDS and _is_unusable_container_cwd(cwd):
+            from tools.terminal_tool import _is_container_backend as _is_container_backend
+
+            if _is_container_backend(env_type) and _is_unusable_container_cwd(cwd):
                 if cwd != config["cwd"]:
                     logger.info(
                         "Ignoring host/relative cwd override %r for %s backend "


### PR DESCRIPTION
## Problem

`tools/file_tools.py` `_get_file_ops` guards the per-task cwd override with `env_type in _CONTAINER_BACKENDS` (a frozenset of hardcoded backend names). Eleven lines later, the same function classifies the backend with `_is_container_backend()` to decide whether to build `container_config`.

The two disagree for any container backend registered through the plugin system (with `is_container = True`): the guard never fires, while a container config is still built. This means a host cwd (e.g. `/Users/me/workspace`) reaches the container builder unsanitized for plugin-registered container backends.

## Fix

Replace the frozenset membership test `env_type in _CONTAINER_BACKENDS` with `_is_container_backend(env_type)` at the guard site, matching:
- The classifier used by the `container_config` builder 11 lines below
- The twin guard in `terminal_tool.py`
- The `_uses_container_paths()` helper in the same file

This is a one-line semantic change (plus moving the existing local import 15 lines earlier).

Fixes #101013