### PR TITLE
fix(tools): treat ttl_ms=0 as no TTL hint in MCP schema cache (#101007)

### DIFF
--- a/tools/mcp_schema_cache.py
+++ b/tools/mcp_schema_cache.py
@@ -83,7 +83,7 @@ def get_cached_entry(server_name: str, fingerprint: str) -> Optional[dict]:
         return None
     ttl_ms = entry.get("ttl_ms")
     written_at = entry.get("written_at")
-    if isinstance(ttl_ms, (int, float)) and isinstance(written_at, (int, float)):
+    if isinstance(ttl_ms, (int, float)) and ttl_ms > 0 and isinstance(written_at, (int, float)):
         if (time.time() - written_at) * 1000.0 >= float(ttl_ms):
             return None
     return entry


### PR DESCRIPTION
## Problem

MCP servers that don't provide a TTL hint report `ttlMs: 0` in their `tools/list` response. The schema cache stores this as `ttl_ms: 0`, and `get_cached_entry()` treats it as immediately expired (0ms TTL). This means:

1. `lazy: true` in config never engages — every startup eagerly connects to all MCP servers
2. No log line indicates why lazy was skipped
3. Removing the `ttl_ms` key from the cache JSON manually fixes it (old never-expires behavior)

```python
# Current behavior (broken):
ttl_ms = 0
(time.time() - written_at) * 1000.0 >= float(ttl_ms)  # always True when ttl_ms=0
# -> cache miss on every startup

# After fix:
ttl_ms > 0  # guard skips the expiry check when ttl_ms is 0
# -> entry treated as "no TTL hint" (never expires from TTL alone)
```

## Fix

Add `ttl_ms > 0` guard to the TTL expiry check in `get_cached_entry()`. Per SEP-2549 semantics, `ttl_ms` of 0 (or absent) means "no TTL hint" — the entry should keep the old never-expires behavior.

One-line change: `isinstance(ttl_ms, (int, float)) and isinstance(...)` → `isinstance(ttl_ms, (int, float)) and ttl_ms > 0 and isinstance(...)`.

## Testing

1. Set `lazy: true` on any MCP server
2. Run `hermes chat -q hi --oneshot -Q` twice
3. Second run should log `registered N lazy tool(s) from schema cache` instead of eagerly connecting

Fixes #101007