### PR TITLE
fix(gateway): bound stale DB contention and guard gateway from dashboard SIGKILL (#100968)

### DIFF
--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -434,6 +434,24 @@ def _kill_stale_dashboard_processes(
     if not pids:
         return {"matched": [], "killed": [], "failed": []}
 
+    # Defensive: never SIGKILL a live gateway even if its cmdline was
+    # mis-classified as a dashboard by the ps scan or the spawn ledger
+    # (e.g. a gateway startup that the Web Dashboard force-killed via
+    # SIGKILL leaves a stale gateway.pid/lock; the next gateway boot
+    # then hangs in state_db_data_migrations holding its progress lease
+    # until the watchdog times out — #100968). The dashboard kill path
+    # must own only dashboard/serve backends.
+    try:
+        from hermes_cli.gateway import find_gateway_pids
+
+        gateway_pids = set(find_gateway_pids(all_profiles=True))
+        if gateway_pids:
+            pids = [pid for pid in pids if pid not in gateway_pids]
+            if not pids:
+                return {"matched": [], "killed": [], "failed": []}
+    except Exception:
+        pass
+
     # Before killing, snapshot systemd cgroup info for each PID so we can
     # restart supervised services after the kill (the cgroup disappears
     # along with the process).  Only meaningful on Linux, and only when the

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -1063,6 +1063,19 @@ class SessionSchemaMixin:
         report_startup_progress(600.0, phase="state_db_init_schema")
 
         cursor = self._conn.cursor()
+        # Bound any file-level contention left by a SIGKILL'd predecessor
+        # (e.g. Web Dashboard force-killing a startup gateway mid-migration
+        # and leaving a hot WAL/SHM). Without a busy_timeout the migration
+        # SELECT/INSERT that hits SQLITE_BUSY raises immediately, but the
+        # watchdog lease it just acquired still delays the supervisor's
+        # respawn decision by up to 600s; with a short timeout the writer
+        # waits briefly and either succeeds after the stale lock clears or
+        # fails fast with a retriable busy error rather than hanging the
+        # startup phase indefinitely (#100968).
+        try:
+            cursor.execute("PRAGMA busy_timeout=5000")
+        except Exception:
+            pass
 
         cursor.executescript(SCHEMA_SQL)
 
@@ -1165,6 +1178,13 @@ class SessionSchemaMixin:
             # worst case is up to the lease duration of zombie time on a
             # wedged migration, accepted over per-chunk renewal complexity.
             report_startup_progress(600.0, phase="state_db_data_migrations")
+            # Also bound WAL contention from a SIGKILL'd predecessor that
+            # left a hot journal (#100968); see the matching pragma in
+            # _init_schema above.
+            try:
+                cursor.execute("PRAGMA busy_timeout=5000")
+            except Exception:
+                pass
             # Data migrations that can't be expressed declaratively (row
             # backfills, index changes tied to a specific version step) stay
             # in a version-gated chain. Column additions are handled by


### PR DESCRIPTION
Fixes #100968

**Problem:** Web Dashboard force-kills a startup gateway with SIGKILL mid-migration (state_db_data_migrations) leaving a hot WAL/SHM. Next gateway boot acquires the 600s progress lease then blocks on the stale file lock, delaying the watchdog respawn by the full lease and appearing to hold the lease indefinitely.

**Fix:**
- Set `PRAGMA busy_timeout=5000` on the migration cursors in both `state_db_init_schema` and `state_db_data_migrations` so contention from a SIGKILL'd predecessor is bounded (waits briefly or fails fast instead of hanging).
- Guard `_kill_stale_dashboard_processes` to never SIGKILL a live gateway even if its cmdline is mis-classified as dashboard/serve by the ps/ledger scan.

Test: existing `test_update_stale_dashboard` (42 passed) and `test_startup_watchdog` (53 passed) still green; syntax check passes.