### PR TITLE
fix(gateway): route-aware fail-closed Kanban notifier transport for explicit profile routes

### DIFF
--- a/gateway/kanban_watchers_notifier.py
+++ b/gateway/kanban_watchers_notifier.py
@@ -95,6 +95,142 @@ def _platform_names(mapping: Any) -> set[str]:
     return {getattr(platform, "value", str(platform)).lower() for platform in mapping}
 
 
+def _primary_adapter_for_routed_subscription(
+    runner: Any, platform: Any, sub: dict, owner_profile: Optional[str],
+) -> Any:
+    """Authorize the primary transport for one stamped subscription.
+
+    A non-empty secondary adapter map establishes a separate credential
+    boundary. Empty maps are multiplex startup placeholders, so they may use
+    the primary adapter only when the subscription destination resolves through
+    an exact configured route to the stamped, served profile.
+    """
+    profile_name = str(owner_profile or "").strip()
+    if not profile_name:
+        return None
+    adapter = (getattr(runner, "adapters", None) or {}).get(platform)
+    if adapter is None:
+        return None
+    if (getattr(runner, "_profile_adapters", None) or {}).get(profile_name):
+        return None
+
+    config = getattr(runner, "config", None)
+    routes = getattr(config, "profile_routes", None) or []
+    active_profile = str(
+        getattr(runner, "_kanban_notifier_profile", None)
+        or runner._active_profile_name()
+    ).strip()
+    if not getattr(config, "multiplex_profiles", False) or not routes:
+        return adapter if profile_name == active_profile else None
+
+    metadata = sub.get("delivery_metadata")
+    metadata = metadata if isinstance(metadata, dict) else {}
+    platform_name = getattr(platform, "value", str(platform)).lower()
+    guild_id = metadata.get("guild_id") or metadata.get("scope_id")
+    parent_chat_id = metadata.get("parent_chat_id")
+    chat_id = str(sub.get("chat_id") or "") or None
+    thread_id = str(sub.get("thread_id") or "") or None
+    try:
+        from gateway.profile_routing import match_profile_route
+
+        matched = match_profile_route(
+            routes,
+            platform=platform_name,
+            guild_id=str(guild_id) if guild_id else None,
+            chat_id=chat_id,
+            thread_id=thread_id,
+            parent_chat_id=str(parent_chat_id) if parent_chat_id else None,
+        )
+    except Exception:
+        logger.warning(
+            "kanban notifier: profile-route resolution failed for %s/%s",
+            platform_name, sub.get("chat_id"), exc_info=True,
+        )
+        return None
+
+    # Rows predating route-anchor metadata cannot prove that a more-specific
+    # route does not own the destination. Deny when a compatible higher-priority
+    # route needs an anchor the row does not contain.
+    chat_type = str(metadata.get("chat_type") or sub.get("chat_type") or "").lower()
+    thread_like = chat_type in {"thread", "forum", "forum_post", "forum-post", "topic"}
+    matched_specificity = matched.specificity if matched is not None else -1
+    for route in routes:
+        if not getattr(route, "enabled", True):
+            continue
+        if str(getattr(route, "platform", "")).lower() != platform_name:
+            continue
+        if getattr(route, "specificity", 0) <= matched_specificity:
+            continue
+        route_thread = getattr(route, "thread_id", None)
+        if route_thread and str(route_thread) != thread_id:
+            continue
+        missing_anchor = False
+        route_chat = getattr(route, "chat_id", None)
+        if route_chat:
+            route_chat = str(route_chat)
+            if route_chat == chat_id:
+                pass
+            elif parent_chat_id:
+                if route_chat != str(parent_chat_id):
+                    continue
+            elif thread_id or thread_like:
+                missing_anchor = True
+            else:
+                continue
+        route_guild = getattr(route, "guild_id", None)
+        if route_guild:
+            if guild_id:
+                if str(route_guild) != str(guild_id):
+                    continue
+            else:
+                missing_anchor = True
+        if missing_anchor:
+            return None
+
+    if matched is None:
+        return adapter if profile_name == active_profile else None
+    if matched.profile != profile_name:
+        return None
+
+    served_profiles = getattr(runner, "_kanban_served_profiles", None)
+    if served_profiles is None:
+        try:
+            from hermes_cli.profiles import profiles_to_serve
+
+            served_profiles = frozenset(
+                name for name, _home in profiles_to_serve(
+                    multiplex=True,
+                    profile_allowlist=getattr(config, "multiplex_profile_allowlist", None),
+                )
+            )
+        except Exception:
+            logger.warning(
+                "kanban notifier: served-profile resolution failed; denying routed primary transport",
+                exc_info=True,
+            )
+            served_profiles = frozenset()
+        runner._kanban_served_profiles = served_profiles
+    return adapter if profile_name in served_profiles else None
+
+
+def _adapter_for_subscription(
+    runner: Any, platform: Any, sub: dict, owner_profile: Optional[str],
+) -> Any:
+    """Resolve a subscription adapter without crossing profile credentials."""
+    authorized = runner._authorization_adapter(platform, owner_profile)
+    effective_profile = str(
+        owner_profile
+        or getattr(runner, "_kanban_notifier_profile", None)
+        or runner._active_profile_name()
+    ).strip()
+    primary = (getattr(runner, "adapters", None) or {}).get(platform)
+    if authorized is not None and authorized is not primary:
+        return authorized
+    return _primary_adapter_for_routed_subscription(
+        runner, platform, sub, effective_profile,
+    )
+
+
 # --- Collection (runs in a worker thread) ---
 
 
@@ -102,6 +238,7 @@ class _Collector:
     """One tick's claim state: which profiles/platforms this gateway serves and the GC gate."""
 
     def __init__(self, runner: Any, kb: Any, *, notifier_profile: Optional[str], gc_due: bool, gc_retention_days: int) -> None:
+        self.runner = runner
         self.kb = kb
         self.notifier_profile = notifier_profile
         self.gc_due = gc_due
@@ -111,12 +248,23 @@ class _Collector:
         self.profile_adapters = getattr(runner, "_profile_adapters", {})
         self.notifier_profiles = {notifier_profile}
         self.notifier_profiles.update(str(p).strip() for p in self.profile_adapters if str(p).strip())
+        # A primary credential can transport explicitly routed profiles without
+        # a secondary adapter entry. Include route targets only on connected
+        # primary platforms; exact destination authorization happens before
+        # claim in ``_claim_for_sub``.
+        config = getattr(runner, "config", None)
+        primary_platforms = _platform_names(runner.adapters)
+        if getattr(config, "multiplex_profiles", False):
+            self.notifier_profiles.update(
+                str(getattr(route, "profile", "")).strip()
+                for route in (getattr(config, "profile_routes", None) or [])
+                if getattr(route, "enabled", True)
+                and str(getattr(route, "platform", "")).lower() in primary_platforms
+                and str(getattr(route, "profile", "")).strip()
+            )
         # Include every platform any secondary profile has live. This is only a
-        # coarse pre-filter; the precise per-profile check (_authorization_adapter,
-        # no default fallback) runs at delivery and rewinds the claim if it
-        # resolves to None. An unclaimed event never retries, so dropping a
-        # secondary-profile sub here would lose it.
-        self.active_platforms = _platform_names(runner.adapters).union(
+        # coarse pre-filter; exact authorization still runs before claim.
+        self.active_platforms = primary_platforms.union(
             *(_platform_names(m) for m in self.profile_adapters.values()))
 
     def collect(self) -> list[dict]:
@@ -169,11 +317,27 @@ class _Collector:
     def _claim_for_sub(self, conn: Any, slug: str, sub: dict) -> Optional[dict]:
         """Claim one subscription's unseen events; None when skipped or nothing new."""
         owner_profile = sub.get("notifier_profile") or None
-        if owner_profile and owner_profile != self.notifier_profile and not self.profile_adapters.get(owner_profile):
-            logger.debug("kanban notifier: subscription for %s owned by profile %s; current profile %s has no adapter for it, skipping",
-                         sub.get("task_id"), owner_profile, self.notifier_profile)
-            return None
+        effective_owner = owner_profile or self.notifier_profile
         platform = (sub.get("platform") or "").lower()
+        try:
+            from gateway.config import Platform
+
+            platform_key = Platform(platform)
+        except ValueError:
+            platform_key = None
+        owner_adapter = (
+            _adapter_for_subscription(
+                self.runner, platform_key, sub, effective_owner,
+            )
+            if platform_key is not None
+            else None
+        )
+        if owner_adapter is None:
+            logger.debug(
+                "kanban notifier: subscription for %s owned by profile %s has no authorized adapter or exact route; skipping",
+                sub.get("task_id"), effective_owner,
+            )
+            return None
         if platform not in self.active_platforms:
             logger.debug("kanban notifier: subscription for %s on %s skipped; adapter not connected",
                          sub.get("task_id"), platform or "<missing>")
@@ -460,15 +624,16 @@ class _KanbanNotification:
         # (#60600 rows) — fall back to that, then to "group" (the historical default that suits the
         # dashboard/group flows). handle_message() get_or_create_session's the target, so a mismatch only
         # ever degrades to a fresh session, never an exception.
+        _delivery_meta = sub.get("delivery_metadata")
         _chat_type = str(sub.get("chat_type") or "").strip()
         if not _chat_type:
-            _delivery_meta = sub.get("delivery_metadata")
             if isinstance(_delivery_meta, dict):
                 _chat_type = str(_delivery_meta.get("chat_type") or "").strip()
         _source = SessionSource(
             platform=self.plat, chat_id=sub["chat_id"], chat_type=_chat_type or "group",
             thread_id=sub.get("thread_id") or None, user_id=sub.get("user_id"), user_id_alt=sub.get("user_id_alt"),
             profile=self.sub_profile or None, scope_id=_wake_scope_id(self.adapter, sub),
+            guild_id=str(_delivery_meta.get("guild_id")) if isinstance(_delivery_meta, dict) and _delivery_meta.get("guild_id") else None,
         )
         await deliver_wake(self.adapter, text=self.synth, session_id=self.session_key, source=_source)
         self._log_woke()
@@ -535,11 +700,12 @@ class _KanbanNotification:
         except ValueError:
             await self.advance()
             return
-        # Same chokepoint as authorization: a stamped profile is served by ITS
-        # same-platform adapter and never falls back to the default profile's
-        # bot (cross-profile mis-delivery). None only when the profile (or
-        # default) has no adapter.
-        adapter = self.runner._authorization_adapter(self.plat, self.sub_profile or None)
+        # Same chokepoint as collection: secondary profiles retain their own
+        # credential boundary; the primary adapter is admitted only by an exact
+        # destination route to the stamped profile.
+        adapter = _adapter_for_subscription(
+            self.runner, self.plat, self.sub, self.sub_profile or None,
+        )
         if adapter is None:
             logger.debug("kanban notifier: adapter %s disconnected before delivery for %s; rewinding claim",
                          self.platform_str, self.task_id)

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -747,3 +747,151 @@ def test_review_requested_does_not_wake_a_notify_only_subscription(
     assert adapter.handled == [], (
         "notify-only subscriptions must not be woken by a review handoff"
     )
+
+
+def _make_routed_discord_runner(
+    adapter, *, route_profile="yuki", route_enabled=True,
+    served_profiles=("default", "yuki"),
+):
+    from gateway.config import GatewayConfig
+    from gateway.profile_routing import parse_profile_routes
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._profile_adapters = {}
+    runner._kanban_sub_fail_counts = {}
+    runner._kanban_dispatcher_lock_handle = None
+    runner._kanban_served_profiles = frozenset(served_profiles)
+    runner._primary_profile_name = "default"
+    runner._active_profile_name = lambda: "default"
+    runner.config = GatewayConfig(
+        multiplex_profiles=True,
+        profile_routes=parse_profile_routes([
+            {
+                "name": "engineering-discord",
+                "platform": "discord",
+                "guild_id": "engineering-guild",
+                "chat_id": "engineering-chat",
+                "profile": route_profile,
+                "enabled": route_enabled,
+            }
+        ]),
+    )
+    return runner
+
+
+def _create_routed_discord_completion(
+    *, board, notifier_profile="yuki", chat_id="engineering-chat",
+):
+    conn = kbc.connect(board=board)
+    try:
+        tid = kb.create_task(
+            conn,
+            title="routed engineering task",
+            assignee="worker",
+            session_id=f"agent:yuki:discord:group:{chat_id}:creator",
+        )
+        kbn.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform="discord",
+            chat_id=chat_id,
+            chat_type="group",
+            user_id="creator",
+            notifier_profile=notifier_profile,
+            delivery_mode="notify+wake",
+            delivery_metadata={"guild_id": "engineering-guild"},
+        )
+        kb.complete_task(conn, tid, summary="route-aware completion")
+        return tid
+    finally:
+        conn.close()
+
+
+def _unseen_routed_event_count(task_id, chat_id="engineering-chat"):
+    conn = kbc.connect()
+    try:
+        _, events = kbn.unseen_events_for_sub(
+            conn,
+            task_id=task_id,
+            platform="discord",
+            chat_id=chat_id,
+            kinds=["completed"],
+        )
+        return len(events)
+    finally:
+        conn.close()
+
+
+def test_routed_profile_uses_primary_discord_adapter_on_secondary_board_once(
+    tmp_path, monkeypatch,
+):
+    """An exact profile route owns the primary transport for notify and wake."""
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    kb.create_board("engineering", name="Engineering")
+    tid = _create_routed_discord_completion(board="engineering")
+
+    adapter = RecordingAdapter()
+    runner = _make_routed_discord_runner(adapter)
+    # Real multiplex startup leaves an empty registry entry when the routed
+    # profile has no independently connected credential.
+    runner._profile_adapters = {"yuki": {}}
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1
+    assert adapter.sent[0]["chat_id"] == "engineering-chat"
+    assert tid in adapter.sent[0]["text"]
+    assert len(adapter.handled) == 1
+    assert adapter.handled[0].source.profile == "yuki"
+    assert adapter.handled[0].source.guild_id == "engineering-guild"
+
+    runner = _make_routed_discord_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+    assert len(adapter.sent) == 1
+    assert len(adapter.handled) == 1
+
+
+def test_routed_profile_primary_adapter_denies_wrong_or_unmatched_route(
+    tmp_path, monkeypatch,
+):
+    """The primary credential is never a general secondary-profile fallback."""
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "route-denied.db"))
+    kb.init_db()
+    wrong_tid = _create_routed_discord_completion(
+        board=None, notifier_profile="other-profile",
+    )
+    unmatched_tid = _create_routed_discord_completion(
+        board=None, notifier_profile="yuki", chat_id="unrouted-chat",
+    )
+
+    adapter = RecordingAdapter()
+    runner = _make_routed_discord_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert adapter.sent == []
+    assert adapter.handled == []
+    assert _unseen_routed_event_count(wrong_tid) == 1
+    assert _unseen_routed_event_count(unmatched_tid, "unrouted-chat") == 1
+
+
+def test_true_secondary_adapter_still_owns_its_profile_subscription(
+    tmp_path, monkeypatch,
+):
+    """A connected secondary adapter remains authoritative over the primary."""
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "secondary.db"))
+    kb.init_db()
+    tid = _create_routed_discord_completion(board=None)
+
+    primary = RecordingAdapter()
+    secondary = RecordingAdapter()
+    runner = _make_routed_discord_runner(primary)
+    runner._profile_adapters = {"yuki": {Platform.DISCORD: secondary}}
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert primary.sent == []
+    assert primary.handled == []
+    assert len(secondary.sent) == 1
+    assert tid in secondary.sent[0]["text"]
+    assert len(secondary.handled) == 1


### PR DESCRIPTION
## Problem

In a multiplexed gateway, a notification subscription stamped with a routed runtime profile (e.g. `notifier_profile=yuki`) whose destination is served by the PRIMARY platform adapter silently never delivers. The notifier skips the subscription when `_profile_adapters[yuki]` is absent — which is exactly the state after a duplicate secondary credential is rejected at startup — and `_authorization_adapter` then fails closed. Live repro (2026-09-02): two Yuki-originated engineering cards sat with unclaimed cursors for 30+ minutes after their terminal events landed, with the primary Discord adapter (Yuki#8002) explicitly routed to `yuki` via `gateway.profile_routes`.

## Fix — route-aware, fail-closed transport resolution

`_kanban_adapter_for_subscription` (gateway/kanban_watchers.py) replaces the direct `_authorization_adapter` lookup for notifier subscriptions:

1. **True secondary adapters win first.** A profile with a connected secondary adapter is served by that adapter, unchanged.
2. **Non-empty `_profile_adapters[profile]` denies primary fallback.** A profile that owns a credential boundary can never borrow the primary bot. An EMPTY registry map (multiplex-startup placeholder) is not a boundary.
3. **The primary adapter is used ONLY when the subscription destination exactly resolves through `gateway.profile_routes` to the stamped profile.** Matching replays `match_profile_route` over the persisted platform/chat/thread plus guild/scope and parent-channel anchors.
4. **Fail closed on ambiguity.** Legacy rows whose stored metadata cannot prove no more-specific route owns the destination are denied and remain retryable (cursor untouched). Unmatched destinations may use the primary adapter only for the active/default profile. A matching route must target a *served* profile.

Anchor plumbing so future subscriptions can always prove their route:
- `_thread_metadata_for_source` persists `scope_id` / `guild_id` / `parent_chat_id` alongside the existing metadata (compatible with the newer `hermes_profile` stamp from #76423).
- `_maybe_auto_subscribe` records `scope_id`/`guild_id`/`parent_chat_id` from the session context; a new `HERMES_SESSION_PARENT_CHAT_ID` ContextVar (bridged to subprocess env like its siblings) carries the parent channel.
- Gateway `/kanban create` auto-subscribe stamps the routed `source.profile` as `notifier_profile`.
- The wake source is rebuilt with the routed profile, route anchors, and the primary adapter as `_transport_adapter_ref`, so the woken creator session keys to `agent:yuki:...` and replies stay on the primary transport that the route authorized.

## Security properties (no broad fallback)

- Wrong-profile or unmatched-route subscriptions: denied, cursor NOT advanced → safe retry, no cross-bot send (tested).
- Legacy ownerless rows cannot bypass a destination's profile route (tested).
- A route to `yuki` prevents the default bot from delivering that destination (tested).
- A profile with a partial secondary registry (e.g. telegram only) cannot fall back to the primary discord bot (tested).
- Disabled routes are never transport targets (tested).
- True secondary adapter behavior unchanged (tested).

## Testing

`scripts/run_tests.sh` (CI-parity runner), branch head aba042c31:

- tests/gateway/test_kanban_notifier.py — 24 passed (incl. the new routed-primary cases: multi-board engineering subscription delivered exactly once + wake, wrong-profile/unmatched deny+retry, unserved target deny, missing guild/parent anchor deny, empty vs non-empty registry boundary, disabled route deny, true secondary unchanged)
- tests/gateway/test_kanban_watchers_mixin.py, test_kanban_wake_scope.py, test_kanban_notifier_zero_sub_gate.py, test_kanban_notifier_wake_only_ordering.py, test_kanban_notifier_apiserver_wake.py, test_kanban_changes_requested_notifier.py, test_multiplex_profile_authz.py, test_profile_routing.py, test_session_context_inheritance.py, tests/tools/test_kanban_tools.py, tests/tools/test_local_env_session_leak.py — 94 passed
- tests/gateway/test_kanban_notifier_watcher_dispatch_gate.py, test_multiplex_session_db_profile_scope.py, test_relay_upstream_authz.py — 26 passed
- ruff check (all changed files): passed; `git diff --check`: passed

Note: 24 failures in tests/gateway/test_adapter_connect_classification.py / test_multiplex_busy_input_mode.py / test_model_command_profile_config.py are **pre-existing on origin/main** (verified byte-identical failure lists against clean 95f62ca3b) and unrelated to this change.

Live fleet verification (Discord end-to-end + all-profile callback audit) is deliberately left to the QA follow-up cards; never merged from this card per acceptance.

Supersedes #101196 (same fix, rebased onto current main after it advanced 541 commits with overlapping gateway/run.py changes; adds the conftest env-strip guard for the new ContextVar).