### PR TITLE
fix(agent): fall back to message.thinking for chat_completions reasoning

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -4511,8 +4511,13 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             if hasattr(chunk, "usage") and chunk.usage:
                 usage_obj = chunk.usage
 
-            # Accumulate reasoning content
-            reasoning_text = getattr(delta, "reasoning_content", None) or getattr(delta, "reasoning", None)
+            # Accumulate reasoning content. Merge Gateway and similar
+            # OpenAI-compat shims stream it as ``thinking`` (#101392).
+            reasoning_text = (
+                getattr(delta, "reasoning_content", None)
+                or getattr(delta, "reasoning", None)
+                or getattr(delta, "thinking", None)
+            )
             if reasoning_text:
                 # Summary-part models (gpt-5.x and other Responses relays) send
                 # one complete markdown block per delta with no separator, so

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -1066,15 +1066,21 @@ class ChatCompletionsTransport(ProviderTransport):
             )
 
         # Preserve reasoning fields separately.  DeepSeek/Moonshot use
-        # ``reasoning_content``; others use ``reasoning``.  Downstream code
-        # (_extract_reasoning, thinking-prefill retry) reads both distinctly,
-        # so keep them apart in provider_data rather than merging.
-        reasoning = getattr(msg, "reasoning", None)
+        # ``reasoning_content``; others use ``reasoning``. Merge Gateway and
+        # similar OpenAI-compat shims use ``thinking`` (#101392) — fold it
+        # into ``reasoning`` since it's the same plain-text-reasoning shape.
+        # Downstream code (_extract_reasoning, thinking-prefill retry) reads
+        # ``reasoning``/``reasoning_content`` distinctly, so keep those two
+        # apart in provider_data rather than merging.
+        reasoning = getattr(msg, "reasoning", None) or getattr(msg, "thinking", None)
         reasoning_content = getattr(msg, "reasoning_content", None)
-        if reasoning_content is None and hasattr(msg, "model_extra"):
+        if hasattr(msg, "model_extra"):
             model_extra = getattr(msg, "model_extra", None) or {}
-            if isinstance(model_extra, dict) and "reasoning_content" in model_extra:
-                reasoning_content = model_extra["reasoning_content"]
+            if isinstance(model_extra, dict):
+                if reasoning_content is None and "reasoning_content" in model_extra:
+                    reasoning_content = model_extra["reasoning_content"]
+                if reasoning is None and "thinking" in model_extra:
+                    reasoning = model_extra["thinking"]
 
         provider_data: Dict[str, Any] = {}
         if reasoning_content is not None:

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -614,6 +614,26 @@ class TestChatCompletionsNormalize:
         assert nr.provider_data == {"reasoning_content": ""}
         assert nr.reasoning_content == ""
 
+    def test_thinking_field_falls_back_to_reasoning(self, transport):
+        """Merge Gateway and similar OpenAI-compat shims return reasoning as
+        ``message.thinking`` rather than ``reasoning``/``reasoning_content``
+        (#101392) — it should still surface as ``reasoning``."""
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content="42",
+                    tool_calls=None,
+                    reasoning=None,
+                    reasoning_content=None,
+                    thinking="17*23 is 391",
+                ),
+                finish_reason="stop",
+            )],
+            usage=None,
+        )
+        nr = transport.normalize_response(r)
+        assert nr.reasoning == "17*23 is 391"
+
 
 
     def test_refusal_none_is_noop(self, transport):

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -15,7 +15,7 @@ import pytest
 
 def _make_stream_chunk(
     content=None, tool_calls=None, finish_reason=None,
-    model=None, reasoning_content=None, usage=None,
+    model=None, reasoning_content=None, usage=None, thinking=None,
 ):
     """Build a mock streaming chunk matching OpenAI's ChatCompletionChunk shape."""
     delta = SimpleNamespace(
@@ -23,6 +23,7 @@ def _make_stream_chunk(
         tool_calls=tool_calls,
         reasoning_content=reasoning_content,
         reasoning=None,
+        thinking=thinking,
     )
     choice = SimpleNamespace(
         index=0,
@@ -646,6 +647,43 @@ class TestReasoningStreaming:
         assert text_deltas == ["The answer is 42"]
         assert response.choices[0].message.reasoning_content == "Let me think about this"
         assert response.choices[0].message.content == "The answer is 42"
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_reasoning_callback_fires_for_thinking_field(self, mock_close, mock_create):
+        """Merge Gateway and similar OpenAI-compat shims stream reasoning as
+        ``delta.thinking`` rather than ``reasoning``/``reasoning_content``
+        (#101392) — it should still reach the reasoning callback."""
+        from run_agent import AIAgent
+
+        chunks = [
+            _make_stream_chunk(thinking="17*23 is "),
+            _make_stream_chunk(thinking="391"),
+            _make_stream_chunk(content="391"),
+            _make_stream_chunk(finish_reason="stop"),
+        ]
+
+        reasoning_deltas = []
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter(chunks)
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            reasoning_callback=lambda t: reasoning_deltas.append(t),
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        agent._interruptible_streaming_api_call({})
+
+        assert reasoning_deltas == ["17*23 is ", "391"]
 
 
 # ── Test: _has_stream_consumers ──────────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

The `chat_completions` transport only recognizes reasoning returned under `reasoning` / `reasoning_content` (and their `model_extra` equivalents). Merge Gateway — and other OpenAI-compatible shims that follow the same convention — return reasoning as `message.thinking` (non-streaming) / `delta.thinking` (streaming) instead. Because neither ingestion site checked that field, the reasoning text was silently dropped: never streamed live, never shown in the post-turn reasoning box, and never persisted to `state.db`, even though the gateway produced and billed it.

This extends both fallback chains to also check `thinking`, using the same pattern already used for `reasoning_content`'s `model_extra` fallback.

Scope note: the issue's "Proposed Fix" section also describes a second step — persisting and echoing back `thinking_signature` for signed multi-turn replay. That's a materially larger, separate change (a new persistence + replay contract), so it's left out of this minimal fix, which addresses the primary bug: reasoning text reaching display/persistence at all.

## Related Issue

Fixes #101392

## Changes Made

- `agent/transports/chat_completions.py`: `normalize_response()` now falls back to `msg.thinking` / `model_extra["thinking"]` when `reasoning` is absent.
- `agent/chat_completion_helpers.py`: the streaming delta loop in `interruptible_streaming_api_call()` now also checks `delta.thinking` when accumulating reasoning text.
- `tests/agent/transports/test_chat_completions.py`: new test proving `normalize_response()` surfaces `thinking` as `reasoning`.
- `tests/run_agent/test_streaming.py`: new test proving the streaming reasoning callback fires for `thinking` deltas.

## How to Test

1. Configure a custom `chat_completions` provider whose responses include `message.thinking` (e.g. Merge Gateway per the issue's repro).
2. Send a message that triggers reasoning.
3. Before this fix: no reasoning displayed/streamed/persisted. After: reasoning streams live and appears in `state.db`.

Verified with the added regression tests — confirmed each fails on the pre-fix code and passes after (via `git checkout HEAD~1 -- <file>`, rerun, then restore):

```
$ scripts/run_tests.sh tests/agent/transports/test_chat_completions.py tests/run_agent/test_streaming.py -q
...
3 failed, 33 passed, 4 skipped in 7.50s   # pre-existing failures, unrelated to this change
```

The 3 failures are `TestAnthropicStreamCallbacks` tests that raise `ImportError: The 'anthropic' package is required...` — reproduced identically on unmodified `main` with the same (minimal) dev environment; the `anthropic` extra isn't installed here. All tests touching the changed code paths pass:

```
$ uv run pytest tests/agent/transports/test_chat_completions.py tests/run_agent/test_streaming.py -q
...
3 failed, 92 passed, 4 skipped in 8.58s
```

Lint:

```
$ uv run ruff check agent/transports/chat_completions.py agent/chat_completion_helpers.py tests/agent/transports/test_chat_completions.py tests/run_agent/test_streaming.py
All checks passed!
```

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run the test suite for the touched modules and all relevant tests pass
- [x] I've added tests for my changes
- [ ] I've tested on my platform — no live Merge Gateway credentials available in this environment; verified via unit tests with mocked chunks/messages carrying `thinking`, matching the issue's documented shape

## Disclosure

This patch was written with AI assistance (Claude Code / Anthropic), reviewed and verified by the submitter before opening.
