### PR TITLE
fix(bedrock): repair trailing-assistant tail on the Converse wire (ConverseStream prefill 400)

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -516,6 +516,7 @@ def convert_tools_to_converse(tools: List[Dict]) -> List[Dict]:
 # #9486.
 _EMPTY_TEXT_PLACEHOLDER = "(empty)"
 _PLACEHOLDER_BLOCK = {"text": _EMPTY_TEXT_PLACEHOLDER}
+_NO_PREFILL_USER_TAIL = "Continue from the previous assistant message."
 
 
 def _safe_text(text) -> str:
@@ -535,6 +536,110 @@ def _image_block_from_data_url(url: str) -> Dict:
     except Exception:
         raw_bytes = data.encode("utf-8")
     return {"image": {"format": media_type.split("/")[-1] if "/" in media_type else "jpeg", "source": {"bytes": raw_bytes}}}
+
+
+def model_rejects_assistant_prefill(model: str) -> bool:
+    """Return whether *model* hard-rejects a trailing assistant message.
+
+    Claude Sonnet/Opus/Haiku 4.6+ and the Fable family answer a trailing
+    assistant message with a non-retryable ValidationException ("This model
+    does not support assistant message prefill. The conversation must end
+    with a user message."), which bricks the session: the model never gets
+    another request through to recover.
+
+    Older Claude models accept the prefill and Hermes uses it deliberately
+    (conversation_loop.py appends a `_thinking_prefill` assistant turn to
+    continue a thinking-only response), so the gate must stay narrow —
+    repairing the tail for a model that tolerates prefill would silently
+    change semantics the agent loop depends on.
+
+    Matching is done on the bare family name so Bedrock's regional inference
+    profiles ("eu.anthropic.claude-sonnet-5", "apac.anthropic.…") and plain
+    model IDs resolve identically.
+    """
+    if not model or not isinstance(model, str):
+        return False
+    name = model.rsplit("/", 1)[-1].lower()
+    # Strip Bedrock's region prefix + vendor namespace: "eu.anthropic.claude-…"
+    if "anthropic." in name:
+        name = name.split("anthropic.", 1)[1]
+    if "claude-fable" in name:
+        return True
+    match = re.search(r"claude-(?:sonnet|opus|haiku)-(\d+)(?:[-.](\d+))?", name)
+    if not match:
+        return False
+    major = int(match.group(1))
+    minor = int(match.group(2) or 0)
+    return (major, minor) >= (4, 6)
+
+
+def ensure_converse_user_tail(kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    """Return wire kwargs whose conversation cannot end in assistant prefill.
+
+    Repairs the tail on the outgoing wire payload only; the stored transcript
+    is never mutated (a shallow copy carries a fresh messages list).
+
+    Two tails are deliberately left alone:
+
+    * anything but a plain assistant tail (a user tail is already valid), and
+    * an assistant tail whose content contains a `toolUse` block. Bedrock
+      requires the very next message to carry the matching `toolResult`;
+      injecting a synthetic user turn there trades one ValidationException
+      for another ("Expected toolResult blocks…"). Those tails need real tool
+      results, not a fake continuation.
+    """
+    messages = kwargs.get("messages")
+    if not isinstance(messages, list) or not messages:
+        return kwargs
+    if not model_rejects_assistant_prefill(kwargs.get("modelId") or ""):
+        return kwargs
+    last = messages[-1]
+    if not isinstance(last, dict) or last.get("role") != "assistant":
+        return kwargs
+    content = last.get("content")
+    if isinstance(content, list) and any(
+        isinstance(block, dict) and "toolUse" in block for block in content
+    ):
+        return kwargs
+
+    repaired = dict(kwargs)
+    repaired["messages"] = list(messages) + [{
+        "role": "user",
+        "content": [{"text": _NO_PREFILL_USER_TAIL}],
+    }]
+    return repaired
+
+
+def _normalize_assistant_tool_tail(content_blocks: List[Dict]) -> List[Dict]:
+    """Drop streamed prefill *text* that got merged in after a toolUse block.
+
+    Hermes merges consecutive assistant turns to keep Bedrock's strict
+    alternation. When a turn is interrupted mid-stream, a bare preamble
+    assistant message can land *after* the turn that already carries the
+    tool calls, and the merge appends its text behind the `toolUse` blocks.
+    Bedrock rejects that ordering, so the stray text is dropped.
+
+    Only `text` blocks are dropped. `reasoningContent` after a `toolUse` is
+    legitimate — interleaved thinking emits reasoning between tool calls and
+    those blocks carry signatures Bedrock replays; dropping them breaks
+    interleaved thinking (regression caught by
+    TestNormalizeConverseResponse::test_interleaved_reasoning_and_tools_keep_exact_order).
+    """
+    if not any(isinstance(block, dict) and "toolUse" in block for block in content_blocks):
+        return content_blocks
+
+    normalized: List[Dict] = []
+    tool_use_seen = False
+    for block in content_blocks:
+        is_dict = isinstance(block, dict)
+        if is_dict and "toolUse" in block:
+            tool_use_seen = True
+            normalized.append(block)
+        elif tool_use_seen and is_dict and set(block) == {"text"}:
+            continue
+        else:
+            normalized.append(block)
+    return normalized
 
 
 def _convert_content_to_converse(content) -> List[Dict]:
@@ -653,7 +758,13 @@ def convert_messages_to_converse(messages: List[Dict]) -> Tuple[Optional[List[Di
             append_turn("user", [{"toolResult": {
                 "toolUseId": msg.get("tool_call_id", ""), "content": [{"text": _safe_text(result_content)}]}}])
         elif role == "assistant":
-            append_turn("assistant", _assistant_blocks(msg, content) or [dict(_PLACEHOLDER_BLOCK)])
+            blocks = _assistant_blocks(msg, content) or [dict(_PLACEHOLDER_BLOCK)]
+            if converse_msgs and converse_msgs[-1]["role"] == "assistant":
+                converse_msgs[-1]["content"] = _normalize_assistant_tool_tail(
+                    converse_msgs[-1]["content"] + blocks
+                )
+            else:
+                converse_msgs.append({"role": "assistant", "content": _normalize_assistant_tool_tail(blocks)})
         elif role == "user":
             append_turn("user", _convert_content_to_converse(content))
     if converse_msgs and converse_msgs[0]["role"] != "user":
@@ -880,7 +991,7 @@ def build_converse_kwargs(
         kwargs["guardrailConfig"] = guardrail_config
     if not inference_config:
         del kwargs["inferenceConfig"]  # optional on the wire; don't send {}
-    return kwargs
+    return ensure_converse_user_tail(kwargs)
 
 
 def call_converse(

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -652,12 +652,17 @@ def _bedrock_converse_call(api_kwargs: dict, *, stream: bool, on_stream_denied=N
     #97281) drops the marker and resends once inside the same attempt; a streaming IAM
     denial hands off to ``on_stream_denied(client, kwargs, exc)``; a stale connection
     evicts the cached client so the outer retry builds a fresh pool. Streaming returns the
-    event stream; non-streaming an OpenAI-shaped SimpleNamespace."""
-    from agent.bedrock_adapter import (_get_bedrock_runtime_client, invalidate_runtime_client,
-        is_stale_connection_error, is_streaming_access_denied_error, normalize_converse_response,
-        recover_from_cache_point_rejection)
+    event stream; non-streaming an OpenAI-shaped SimpleNamespace.
+
+    ``ensure_converse_user_tail`` repairs a trailing-assistant-prefill tail on the wire
+    payload before either verb is called — Claude 4.6+/Fable hard-400 with a
+    non-retryable ValidationException otherwise, bricking the session (#101401)."""
+    from agent.bedrock_adapter import (_get_bedrock_runtime_client, ensure_converse_user_tail,
+        invalidate_runtime_client, is_stale_connection_error, is_streaming_access_denied_error,
+        normalize_converse_response, recover_from_cache_point_rejection)
     region = api_kwargs.pop("__bedrock_region__", "us-east-1")
     api_kwargs.pop("__bedrock_converse__", None)
+    api_kwargs = ensure_converse_user_tail(api_kwargs)
     client = _get_bedrock_runtime_client(region)
     method = client.converse_stream if stream else client.converse
     finish = (lambda raw: raw.get("stream", [])) if stream else normalize_converse_response

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -255,6 +255,139 @@ class TestConvertMessagesToConverse:
         # Empty string should get a space placeholder
         assert msgs[0]["content"][0]["text"].strip() != "" or msgs[0]["content"][0]["text"] == " "
 
+    def test_wire_guard_repairs_trailing_assistant_without_mutating_input(self):
+        from agent.bedrock_adapter import ensure_converse_user_tail
+
+        kwargs = {
+            "modelId": "eu.anthropic.claude-sonnet-5",
+            "messages": [
+                {"role": "user", "content": [{"text": "Hello"}]},
+                {"role": "assistant", "content": [{"text": "Hi"}]},
+            ],
+        }
+
+        repaired = ensure_converse_user_tail(kwargs)
+
+        assert kwargs["messages"][-1]["role"] == "assistant"
+        assert repaired["messages"][-1] == {
+            "role": "user",
+            "content": [{"text": "Continue from the previous assistant message."}],
+        }
+
+    def test_wire_guard_leaves_tool_use_tail_alone(self):
+        """A toolUse tail needs a real toolResult, not a synthetic user turn.
+
+        Repairing it would swap "does not support assistant message prefill"
+        for "Expected toolResult blocks" — still a non-retryable 400.
+        """
+        from agent.bedrock_adapter import ensure_converse_user_tail
+
+        kwargs = {
+            "modelId": "eu.anthropic.claude-sonnet-5",
+            "messages": [
+                {"role": "user", "content": [{"text": "Run it"}]},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"text": "Starting."},
+                        {"toolUse": {"toolUseId": "t1", "name": "terminal", "input": {}}},
+                    ],
+                },
+            ],
+        }
+
+        assert ensure_converse_user_tail(kwargs) is kwargs
+
+    def test_wire_guard_leaves_prefill_tolerant_model_alone(self):
+        """Pre-4.6 Claude accepts prefill and the agent loop relies on it.
+
+        conversation_loop.py appends a `_thinking_prefill` assistant turn to
+        continue a thinking-only response; repairing that tail here would
+        silently break the mechanism on models that never rejected it.
+        """
+        from agent.bedrock_adapter import ensure_converse_user_tail
+
+        for model_id in (
+            "anthropic.claude-3-5-sonnet-20241022-v2:0",
+            "anthropic.claude-sonnet-4-5-v1:0",
+            "meta.llama3-70b-instruct-v1:0",
+        ):
+            kwargs = {
+                "modelId": model_id,
+                "messages": [
+                    {"role": "user", "content": [{"text": "Hello"}]},
+                    {"role": "assistant", "content": [{"text": "Hi"}]},
+                ],
+            }
+            assert ensure_converse_user_tail(kwargs) is kwargs, model_id
+
+    def test_wire_guard_passes_through_user_tail(self):
+        from agent.bedrock_adapter import ensure_converse_user_tail
+
+        kwargs = {
+            "modelId": "eu.anthropic.claude-sonnet-5",
+            "messages": [{"role": "user", "content": [{"text": "Hello"}]}],
+        }
+        assert ensure_converse_user_tail(kwargs) is kwargs
+
+    def test_prefill_rejecting_model_gate_matrix(self):
+        from agent.bedrock_adapter import model_rejects_assistant_prefill
+
+        rejects = [
+            "eu.anthropic.claude-sonnet-5",
+            "eu.anthropic.claude-opus-5",
+            "anthropic.claude-sonnet-4-6-20260101-v1:0",
+            "anthropic.claude-opus-4.6",
+            "us.anthropic.claude-fable-5",
+            "anthropic.claude-haiku-4-6-v1:0",
+        ]
+        tolerates = [
+            "anthropic.claude-3-5-sonnet-20241022-v2:0",
+            "anthropic.claude-sonnet-4-5-v1:0",
+            "anthropic.claude-opus-4-1-v1:0",
+            "meta.llama3-70b-instruct-v1:0",
+            "amazon.nova-pro-v1:0",
+            "",
+            None,
+        ]
+        assert [model_rejects_assistant_prefill(m) for m in rejects] == [True] * len(rejects)
+        assert [model_rejects_assistant_prefill(m) for m in tolerates] == [False] * len(tolerates)
+
+    def test_text_after_tool_use_is_removed_as_assistant_prefill(self):
+        from agent.bedrock_adapter import convert_messages_to_converse
+
+        messages = [
+            {"role": "user", "content": "Run both tools"},
+            {
+                "role": "assistant",
+                "content": "Starting.",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "first", "arguments": "{}"},
+                    },
+                    {
+                        "id": "call_2",
+                        "type": "function",
+                        "function": {"name": "second", "arguments": "{}"},
+                    },
+                ],
+            },
+            {"role": "assistant", "content": "Streamed prefill fragment."},
+            {"role": "tool", "tool_call_id": "call_1", "content": "one"},
+            {"role": "tool", "tool_call_id": "call_2", "content": "two"},
+        ]
+
+        _system, converted = convert_messages_to_converse(messages)
+        assistant_blocks = converted[1]["content"]
+
+        assert [next(iter(block)) for block in assistant_blocks] == [
+            "text",
+            "toolUse",
+            "toolUse",
+        ]
+
 
 # ---------------------------------------------------------------------------
 # Response normalization: Converse → OpenAI


### PR DESCRIPTION
## Symptom

On Bedrock's native Converse path, Claude Sonnet/Opus 4.6+ and the Fable family reject a trailing assistant message with a non-retryable `ValidationException`:

```
An error occurred (ValidationException) when calling the ConverseStream operation:
The model returned the following errors: This model does not support assistant
message prefill. The conversation must end with a user message.
```

Because the 400 is non-retryable, the session is bricked: every subsequent turn fails identically and the model never gets a request through to recover. Observed repeatedly during normal desktop use on `eu.anthropic.claude-sonnet-5` and `eu.anthropic.claude-opus-5`.

The trailing assistant message is not intentional prefill. Streamed preamble/status text is persisted as an assistant message as it arrives, so an interrupt (gateway restart, `/stop`, crash) legitimately leaves the transcript ending on a plain assistant turn.

## Relationship to #79145

#79145 fixes the same class of defect for `agent/anthropic_adapter.py` and `agent/transports/chat_completions.py`. Bedrock's native Converse path is a **third transport** that neither patch touches — `convert_messages_to_converse` / `build_converse_kwargs` build their own wire payload:

```console
$ git grep -n -iE "prefill|assistant.?tail|ensure_user_tail" main -- \
      agent/bedrock_adapter.py agent/transports/bedrock.py agent/anthropic_message_convert.py
$ # (no output)
```

This PR is therefore complementary, not a duplicate. It also avoids the over-application that AI triage flagged on #79145's chat-completions gate, by making the model gate version-aware from the start.

## Fix

`agent/bedrock_adapter.py`:

- **`model_rejects_assistant_prefill(model)`** — version-aware gate matching `sonnet`/`opus`/`haiku` >= 4.6 and `claude-fable`. Bedrock's regional inference profiles (`eu.anthropic.claude-sonnet-5`, `apac.anthropic.…`) and bare model IDs resolve identically. Older Claude models keep prefill semantics deliberately: the agent loop depends on them — `conversation_loop.py` appends a `_thinking_prefill` assistant turn to continue a thinking-only response, so repairing that tail unconditionally would silently break the mechanism on models that never rejected it.
- **`ensure_converse_user_tail(kwargs)`** — appends a synthetic `"Continue from the previous assistant message."` user turn when the wire tail is a plain assistant message. Applied in `build_converse_kwargs` and at both Bedrock call sites in `agent/chat_completion_helpers.py` (`client.converse` and `client.converse_stream`), since the streaming path assembles its kwargs separately.
  Assistant tails containing a `toolUse` block are deliberately left alone: Bedrock requires the next message to carry the matching `toolResult`, so repairing those would swap one non-retryable 400 for another (`Expected toolResult blocks…`).
- **`_normalize_assistant_tool_tail(content_blocks)`** — when consecutive assistant turns are merged for Bedrock's strict alternation, an interrupted turn's preamble text can land *behind* the `toolUse` blocks, an ordering Bedrock rejects. Those stray blocks are dropped — `text` only. `reasoningContent` after a `toolUse` is legitimate (interleaved thinking emits reasoning between tool calls, and those blocks carry signatures that get replayed).

Invariants: the stored transcript is never mutated (the repair returns a shallow copy with a fresh messages list), role alternation is preserved, and prompt-cache prefixes are unaffected since the change is strictly at the tail.

## Tests

`tests/agent/test_bedrock_adapter.py`:

- gate matrix — rejecting families (incl. regional profiles and both `4-6`/`4.6` spellings), prefill-tolerant Claude, non-Claude, empty and `None`
- plain assistant tail repaired without mutating the caller's kwargs
- `toolUse` tails and prefill-tolerant models passed through unchanged (identity-asserted)
- text-after-`toolUse` dropped while interleaved reasoning order is preserved

```console
$ python -m pytest tests/agent/test_bedrock_adapter.py -q
86 passed

$ python -m pytest tests/agent/ -k "bedrock or converse" -q
153 passed, 1 skipped, 6017 deselected
```

Each new guard was mutation-probed — removing the `toolUse` guard, the model gate, or the text-only restriction each turns exactly one test red, and no other:

| mutation | result |
| --- | --- |
| drop `toolUse` guard | `test_wire_guard_leaves_tool_use_tail_alone` fails, 85 pass |
| drop model gate | `test_wire_guard_leaves_prefill_tolerant_model_alone` fails, 85 pass |
| drop `text`-only restriction in `_normalize_assistant_tool_tail` | `test_interleaved_reasoning_and_tools_keep_exact_order` fails, 85 pass |

That last row is worth calling out: an earlier draft of this change dropped *every* block after a `toolUse`, which silently broke interleaved thinking. The existing test caught it, and the restriction to `text` blocks is what keeps reasoning signatures intact.
