### PR TITLE
fix(gateway): stop truncating the command block on a bare / browse

### DIFF
--- a/tests/tui_gateway/test_slash_fuzzy.py
+++ b/tests/tui_gateway/test_slash_fuzzy.py
@@ -110,15 +110,61 @@ def test_rank_slash_completions_does_not_truncate_commands_when_browsing():
     # /queue sat past position 30 and never reached the client) while the
     # user-growable skill block keeps its cap.
     commands = [_item(f"/cmd{i}") for i in range(40)]
+    registry_names = frozenset(f"cmd{i}" for i in range(40))
 
     ranked = _rank_slash_completions(
         commands,
         lambda _name: 0,
         lambda _name: "user",
         browsing=True,
+        registry_command_names=registry_names,
     )
     assert len(ranked) == 40
     assert ranked[-1]["text"] == "/cmd39"
+
+
+def test_rank_slash_completions_still_caps_plugin_commands_when_browsing():
+    # Plugin-registered commands (kind: "command", same as registry
+    # commands) are an unbounded, user-installed source, unlike
+    # COMMAND_REGISTRY — a bare `/` must still bound them, or a large
+    # plugin install floods the browse list the way skills used to.
+    registry = [_item(f"/reg{i}") for i in range(40)]
+    plugins = [_item(f"/plugin{i}") for i in range(40)]
+    registry_names = frozenset(f"reg{i}" for i in range(40))
+
+    ranked = _rank_slash_completions(
+        registry + plugins,
+        lambda _name: 0,
+        lambda _name: "user",
+        browsing=True,
+        registry_command_names=registry_names,
+    )
+
+    texts = [item["text"] for item in ranked]
+    assert texts[:40] == [f"/reg{i}" for i in range(40)]
+    plugin_texts = texts[40:]
+    assert len(plugin_texts) == 30
+    assert plugin_texts == [f"/plugin{i}" for i in range(30)]
+
+
+def test_rank_slash_completions_defaults_to_the_real_command_registry():
+    # No registry_command_names override: this must wire up to the actual
+    # hermes_cli.commands.GATEWAY_KNOWN_COMMANDS, not just a test double.
+    # /help is a real registry command; /plugin* stands in for names a
+    # plugin registered (kind "command", but not in the registry) and
+    # must still be capped.
+    items = [_item("/help")] + [_item(f"/plugin{i}") for i in range(40)]
+
+    ranked = _rank_slash_completions(
+        items,
+        lambda _name: 0,
+        lambda _name: "user",
+        browsing=True,
+    )
+
+    texts = [item["text"] for item in ranked]
+    assert texts[0] == "/help"
+    assert len([t for t in texts if t.startswith("/plugin")]) == 30
 
 
 def test_rank_slash_completions_still_caps_commands_when_searching():

--- a/tests/tui_gateway/test_slash_fuzzy.py
+++ b/tests/tui_gateway/test_slash_fuzzy.py
@@ -105,6 +105,34 @@ def test_rank_slash_completions_uses_score_before_usage():
     assert [item["text"] for item in ranked_plain] == ["/notes", "/summarize"]
 
 
+def test_rank_slash_completions_does_not_truncate_commands_when_browsing():
+    # A bare `/` must surface every registry command (issue: /goal, /loop,
+    # /queue sat past position 30 and never reached the client) while the
+    # user-growable skill block keeps its cap.
+    commands = [_item(f"/cmd{i}") for i in range(40)]
+
+    ranked = _rank_slash_completions(
+        commands,
+        lambda _name: 0,
+        lambda _name: "user",
+        browsing=True,
+    )
+    assert len(ranked) == 40
+    assert ranked[-1]["text"] == "/cmd39"
+
+
+def test_rank_slash_completions_still_caps_commands_when_searching():
+    commands = [_item(f"/cmd{i}") for i in range(40)]
+
+    ranked = _rank_slash_completions(
+        commands,
+        lambda _name: 0,
+        lambda _name: "user",
+        browsing=False,
+    )
+    assert len(ranked) == 30
+
+
 def test_rank_slash_completions_ties_break_on_usage_then_name():
     a = _item("/beta", kind="skill")
     b = _item("/alpha", kind="skill")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -16132,6 +16132,7 @@ def _rank_slash_completions(
     *,
     browsing: bool,
     score_of=None,
+    registry_command_names: frozenset[str] | None = None,
 ) -> list[dict]:
     """Rank and bound slash completions the way the menu should read.
 
@@ -16158,6 +16159,14 @@ def _rank_slash_completions(
     BROWSING, so bundled skills with no recorded activity are dropped as
     noise. A typed query is SEARCHING, and a search that hides a match is
     broken — there nothing is pruned, the ranking only reorders.
+
+    Items with ``kind != "skill"`` are not all equally bounded, though:
+    plugin-registered commands (``PluginContext.register_command``) also
+    land in that bucket and, unlike ``COMMAND_REGISTRY``, are an unbounded,
+    user-installed source — the same flooding shape the skill cap exists to
+    prevent. ``registry_command_names`` (default: ``GATEWAY_KNOWN_COMMANDS``)
+    is the actual fixed set; only names in it skip the cap while browsing,
+    so a large plugin install still gets capped like the skill block.
     """
 
     def name_of(item: dict) -> str:
@@ -16180,11 +16189,19 @@ def _rank_slash_completions(
     else:
         skills.sort(key=lambda item: (-usage(name_of(item)), name_of(item)))
 
-    # Commands come from the bounded, curated registry (~150 entries), not
-    # from user-installed skills, which is what the cap exists to bound (see
-    # the 230-skill case above). Truncating the command block hid /goal,
-    # /loop and /queue from a bare `/` purely by registry position.
-    ranked_commands = commands if browsing else commands[:_SLASH_COMPLETION_LIMIT]
+    if browsing:
+        if registry_command_names is None:
+            from hermes_cli.commands import GATEWAY_KNOWN_COMMANDS
+
+            registry_command_names = GATEWAY_KNOWN_COMMANDS
+        fixed_commands = [c for c in commands if name_of(c) in registry_command_names]
+        other_commands = [
+            c for c in commands if name_of(c) not in registry_command_names
+        ]
+        ranked_commands = fixed_commands + other_commands[:_SLASH_COMPLETION_LIMIT]
+    else:
+        ranked_commands = commands[:_SLASH_COMPLETION_LIMIT]
+
     return ranked_commands + skills[:_SLASH_COMPLETION_LIMIT]
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -16180,7 +16180,12 @@ def _rank_slash_completions(
     else:
         skills.sort(key=lambda item: (-usage(name_of(item)), name_of(item)))
 
-    return commands[:_SLASH_COMPLETION_LIMIT] + skills[:_SLASH_COMPLETION_LIMIT]
+    # Commands come from the bounded, curated registry (~150 entries), not
+    # from user-installed skills, which is what the cap exists to bound (see
+    # the 230-skill case above). Truncating the command block hid /goal,
+    # /loop and /queue from a bare `/` purely by registry position.
+    ranked_commands = commands if browsing else commands[:_SLASH_COMPLETION_LIMIT]
+    return ranked_commands + skills[:_SLASH_COMPLETION_LIMIT]
 
 
 def _cli_exec_blocked(argv: list[str]) -> str | None:


### PR DESCRIPTION
## Summary

Fixes #101388.

Typing `/` alone in the desktop composer (and TUI) only ever showed the
first 30 registry commands, in registry order. Commands sitting later in
`hermes_cli.commands.COMMAND_REGISTRY` — `/goal`, `/subgoal`, `/loop`,
`/queue`, `/personality`, `/debug` — never appeared in the bare-`/` browse
list, even though they still worked when typed in full and still
autocompleted by prefix (`/go` → `/goal`).

### Root cause

`_rank_slash_completions` (`tui_gateway/server.py`) applies one shared
`_SLASH_COMPLETION_LIMIT = 30` cap to both the registry-command block and
the skill block:

```python
return commands[:_SLASH_COMPLETION_LIMIT] + skills[:_SLASH_COMPLETION_LIMIT]
```

The cap exists to bound the *skill* block — the docstring explains it was
added because a large skill install (~230 skills) could otherwise crowd out
the registry commands or bury a heavily-used skill under noise. But the same
cap was also applied to the *command* block, which was assumed to be a
small, fixed, curated registry (~150 entries total, not user-growable). On a
bare `/`, that shared cap silently dropped every command past position 30 in
registry order, with no relation to usage or importance.

### Fix

An earlier version of this fix exempted every completion item with
`kind != "skill"` from the cap while browsing. That was too broad:
plugin-registered slash commands (`hermes_cli.plugins.PluginContext
.register_command`) are also classified as `kind: "command"` by
`tui_gateway/methods_complete.py` — `kind` is `"skill"` only when the name
is in `get_skill_commands()`/`get_skill_bundles()`, so plugin commands fall
into the same bucket as `COMMAND_REGISTRY` entries. Unlike the registry,
plugin commands are an unbounded, user-installed source (no cap on plugin
count or commands-per-plugin), so exempting the whole `"command"` bucket
just moved the flooding hole from skills to plugin commands instead of
fixing it.

The fix now only exempts names that are actually in
`hermes_cli.commands.GATEWAY_KNOWN_COMMANDS` (the frozenset derived from
`COMMAND_REGISTRY` + aliases) from the browse cap. Everything else classified
as `kind: "command"` — including plugin-registered commands — keeps the
existing 30-item cap, same as skills:

```python
if browsing:
    if registry_command_names is None:
        from hermes_cli.commands import GATEWAY_KNOWN_COMMANDS
        registry_command_names = GATEWAY_KNOWN_COMMANDS
    fixed_commands = [c for c in commands if name_of(c) in registry_command_names]
    other_commands = [c for c in commands if name_of(c) not in registry_command_names]
    ranked_commands = fixed_commands + other_commands[:_SLASH_COMPLETION_LIMIT]
else:
    ranked_commands = commands[:_SLASH_COMPLETION_LIMIT]
```

`registry_command_names` is an injectable parameter (defaulting to the real
`GATEWAY_KNOWN_COMMANDS`) purely so tests can exercise it with a controlled
set; production callers don't pass it.

Note: this only fixes the gateway-side truncation. The separate
client-side `desktop=` availability filtering that issue #101062 covers is
untouched, as the issue itself calls out (different mechanism, same area).

## Test plan

`tests/tui_gateway/test_slash_fuzzy.py`:

- `test_rank_slash_completions_does_not_truncate_commands_when_browsing` —
  registry commands (40, all named in `registry_command_names`) are never
  truncated when browsing.
- `test_rank_slash_completions_still_caps_commands_when_searching` —
  unchanged: a typed search still caps at 30.
- `test_rank_slash_completions_still_caps_plugin_commands_when_browsing` —
  new. Mixes 40 registry-origin and 40 plugin-origin items (both
  `kind: "command"`); asserts all 40 registry commands survive uncapped
  while the plugin-origin commands are still capped at 30.
- `test_rank_slash_completions_defaults_to_the_real_command_registry` —
  new. Calls `_rank_slash_completions` with no `registry_command_names`
  override, using the real `/help` (in `GATEWAY_KNOWN_COMMANDS`) plus 40
  synthetic plugin-style names, to prove the default wiring reaches the
  actual registry and not just a test double.

Confirmed the new tests fail against the previous (`kind != "skill"`)
version of the fix:

```
$ git stash push -- tui_gateway/server.py   # revert to prior fix only
$ python3 -m pytest tests/tui_gateway/test_slash_fuzzy.py -q
3 failed, 10 passed
FAILED test_rank_slash_completions_does_not_truncate_commands_when_browsing (signature change)
FAILED test_rank_slash_completions_still_caps_plugin_commands_when_browsing (signature change)
FAILED test_rank_slash_completions_defaults_to_the_real_command_registry - AssertionError: assert 40 == 30

$ git stash pop                              # current fix restored
$ python3 -m pytest tests/tui_gateway/test_slash_fuzzy.py -q
13 passed in 0.66s
```

The load-bearing proof is
`test_rank_slash_completions_defaults_to_the_real_command_registry`:
against the prior fix it asserts `40 == 30` and fails — i.e. all 40
plugin-style commands leaked through uncapped — confirming the regression
the reviewer identified and that this version closes it.

Full `tests/tui_gateway/` suite (excluding one unrelated pre-existing
`ModuleNotFoundError: aiohttp` collection error from an optional
`messaging` extra not installed in this environment — unrelated to this
change):

```
$ python3 -m pytest tests/tui_gateway/ -q --ignore=tests/tui_gateway/test_hosted_room_two_gateway_scoped.py
973 passed in 81.97s
```

`ruff check tui_gateway/server.py tests/tui_gateway/test_slash_fuzzy.py` —
all checks passed.

## AI assistance disclosure

This change was written by an AI coding agent (Claude), including the root
cause analysis, the fix, and the added tests, with human oversight review
of the final diff before it was pushed. An independent AI review pass
caught that the first version of this fix under-scoped the cap exemption
(it would have re-exposed the same flooding bug for plugin-registered
commands instead of registry commands); this revision narrows the
exemption to the actual fixed command set.
