### PR TITLE
fix(cron): fail closed on explicit Telegram topics

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3577,6 +3577,8 @@ def _deliver_result(
                 thread_id = new_thread_id
                 opened_thread_id = new_thread_id
 
+        strict_thread_failed = False
+        route_via_dm_topic = False
         if live_adapter_ready:
             # Telegram topic routing (#22773, regression fixed #52060): a
             # ``telegram:<positive_chat_id>:<numeric_thread_id>`` cron target is
@@ -3604,6 +3606,7 @@ def _deliver_result(
             route_via_dm_topic = is_ambiguous_telegram_topic and _is_channel_dm_topic(
                 runtime_adapter, chat_id, loop, job["id"],
             )
+            media_metadata: dict[str, Any]
             if route_via_dm_topic:
                 # Genuine Bot API channel Direct-Messages topic (#22773 mode 2):
                 # routed via direct_messages_topic_id, no bare thread_id.
@@ -3635,6 +3638,13 @@ def _deliver_result(
                 media_metadata = {"notify": notify_delivery}
                 if thread_id:
                     media_metadata["thread_id"] = thread_id
+
+            # An exact Telegram cron topic is a delivery boundary, not a hint.
+            # Preserve the adapter's soft fallback for ordinary conversational
+            # sends, but make every topic-scoped cron delivery fail closed (#9168).
+            if platform == Platform.TELEGRAM and thread_id is not None:
+                route_metadata["topic_boundary"] = "strict"
+                media_metadata["topic_boundary"] = "strict"
 
             # Relay egress needs a tenant discriminator on the frame: the
             # connector's fail-closed guard resolves the workspace/guild from
@@ -3803,19 +3813,37 @@ def _deliver_result(
                                 else:
                                     err = "no response from adapter"
                                     shape = "None"
-                                msg = (
-                                    f"live adapter send to {platform_name}:{chat_id} "
-                                    f"returned unconfirmed result ({shape}, error={err})"
-                                )
-                                if transport is not None and transport.is_relay:
-                                    logger.warning("Job '%s': %s", job["id"], msg)
-                                else:
-                                    logger.warning(
-                                        "Job '%s': %s, falling back to standalone",
-                                        job["id"], msg,
+                                if (
+                                    send_raw_response
+                                    and send_raw_response.get("strict_thread_failure")
+                                ):
+                                    requested_thread_id = (
+                                        send_raw_response.get("requested_thread_id")
+                                        or thread_id
                                     )
-                                target_errors.append(msg)
-                                adapter_ok = False  # fall through to standalone path
+                                    msg = (
+                                        f"strict Telegram topic {requested_thread_id} for "
+                                        f"{platform_name}:{chat_id} was not found; "
+                                        f"delivery failed closed: {err}"
+                                    )
+                                    logger.warning("Job '%s': %s", job["id"], msg)
+                                    target_errors.append(msg)
+                                    adapter_ok = False
+                                    strict_thread_failed = True
+                                else:
+                                    msg = (
+                                        f"live adapter send to {platform_name}:{chat_id} "
+                                        f"returned unconfirmed result ({shape}, error={err})"
+                                    )
+                                    if transport is not None and transport.is_relay:
+                                        logger.warning("Job '%s': %s", job["id"], msg)
+                                    else:
+                                        logger.warning(
+                                            "Job '%s': %s, falling back to standalone",
+                                            job["id"], msg,
+                                        )
+                                    target_errors.append(msg)
+                                    adapter_ok = False  # fall through to standalone path
                             elif (
                                 send_raw_response
                                 and thread_id
@@ -3860,9 +3888,24 @@ def _deliver_result(
                     # Surface per-file failures into the run status (parity
                     # with the standalone lane): text delivered but an
                     # attachment didn't is a visible partial failure, not ok.
+                    strict_media_failed = bool(
+                        _media_errors
+                        and platform == Platform.TELEGRAM
+                        and thread_id is not None
+                    )
                     for _me in _media_errors:
                         _msg = f"{_me} (target {platform_name}:{chat_id})"
-                        delivery_errors.append(_msg)
+                        if strict_media_failed:
+                            target_errors.append(_msg)
+                        else:
+                            delivery_errors.append(_msg)
+                    if strict_media_failed:
+                        # Text may already have landed in the exact topic. Do not
+                        # report the target as delivered or retry the whole payload
+                        # through standalone: either would hide the attachment
+                        # failure or duplicate the text outside the requested lane.
+                        adapter_ok = False
+                        strict_thread_failed = True
                 elif timed_out and media_files:
                     msg = (
                         f"{len(media_files)} media attachment(s) not delivered to "
@@ -3964,7 +4007,10 @@ def _deliver_result(
                 err_msg = f"live adapter delivery to {platform_name}:{chat_id} failed: {e}"
                 if not any(err_msg in err for err in target_errors):
                     target_errors.append(err_msg)
-                if transport is not None and transport.is_relay:
+                if (
+                    (transport is not None and transport.is_relay)
+                    or route_via_dm_topic
+                ):
                     logger.warning("Job '%s': %s", job["id"], err_msg)
                 else:
                     logger.warning(
@@ -3973,6 +4019,24 @@ def _deliver_result(
                     )
 
         if not delivered:
+            if route_via_dm_topic and not strict_thread_failed:
+                # Standalone Telegram only knows ``message_thread_id``. A
+                # channel Direct-Messages topic uses ``direct_messages_topic_id``;
+                # changing fields on retry changes the destination semantics.
+                msg = (
+                    f"strict Telegram direct-messages topic {thread_id} for "
+                    f"{platform_name}:{chat_id} cannot be represented by the "
+                    "standalone sender; delivery failed closed"
+                )
+                logger.warning("Job '%s': %s", job["id"], msg)
+                target_errors.append(msg)
+                strict_thread_failed = True
+            if strict_thread_failed:
+                # The live adapter positively identified a strict routing
+                # boundary failure.  A standalone retry would repeat the same
+                # topic error or, under a soft sender, leak into the parent chat.
+                delivery_errors.extend(target_errors)
+                continue
             if transport is not None and transport.is_relay:
                 # Relay owns the logical destination and its connector owns the
                 # platform credential. A native retry could duplicate delivery
@@ -3983,6 +4047,33 @@ def _deliver_result(
                     )
                 delivery_errors.extend(target_errors)
                 continue
+            if (
+                not live_adapter_ready
+                and platform == Platform.TELEGRAM
+                and thread_id is not None
+            ):
+                from gateway.delivery import (
+                    _looks_like_int,
+                    looks_like_telegram_private_chat_id,
+                )
+
+                if (
+                    looks_like_telegram_private_chat_id(str(chat_id))
+                    and _looks_like_int(str(thread_id))
+                ):
+                    # Positive Telegram chat IDs can mean either an ordinary
+                    # private-chat forum lane (message_thread_id) or a channel
+                    # Direct-Messages topic (direct_messages_topic_id). Only
+                    # the live adapter can disambiguate those modes safely.
+                    msg = (
+                        f"Telegram topic {thread_id} for {platform_name}:{chat_id} "
+                        "cannot be safely disambiguated without a live adapter; "
+                        "delivery failed closed"
+                    )
+                    logger.warning("Job '%s': %s", job["id"], msg)
+                    target_errors.append(msg)
+                    delivery_errors.extend(target_errors)
+                    continue
             # If the interpreter is finalizing (gateway SIGTERM / restart /
             # OOM), scheduling any new delivery is futile — asyncio.run and a
             # fresh ThreadPoolExecutor both raise "cannot schedule new futures
@@ -4012,7 +4103,20 @@ def _deliver_result(
                 delivery_errors.extend(target_errors)
                 continue
             # Standalone path: run the async send in a fresh event loop (safe from any thread)
-            coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files)
+            topic_boundary = (
+                "strict"
+                if platform == Platform.TELEGRAM and thread_id is not None
+                else None
+            )
+            coro = _send_to_platform(
+                platform,
+                pconfig,
+                chat_id,
+                cleaned_delivery_content,
+                thread_id=thread_id,
+                media_files=media_files,
+                topic_boundary=topic_boundary,
+            )
             try:
                 result = asyncio.run(coro)
             except RuntimeError as run_err:
@@ -4052,7 +4156,15 @@ def _deliver_result(
                         future = pool.submit(
                             _fallback_context.run,
                             asyncio.run,
-                            _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files),
+                            _send_to_platform(
+                                platform,
+                                pconfig,
+                                chat_id,
+                                cleaned_delivery_content,
+                                thread_id=thread_id,
+                                media_files=media_files,
+                                topic_boundary=topic_boundary,
+                            ),
                         )
                         result = future.result(timeout=30)
                     finally:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -601,6 +601,15 @@ class _PollingLifecycleAbort(RuntimeError):
     """Internal control flow for polling startup fenced by teardown."""
 
 
+class _StrictTopicSendError(RuntimeError):
+    """Internal signal that an exact Telegram topic route failed twice."""
+
+    def __init__(self, error: Exception, requested_thread_id: int):
+        super().__init__(_redact_telegram_error_text(error))
+        self.original_error = error
+        self.requested_thread_id = requested_thread_id
+
+
 class TelegramAdapter(BasePlatformAdapter):
     """
     Telegram bot adapter.
@@ -1811,6 +1820,10 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         if not (metadata and metadata.get("telegram_dm_topic_reply_fallback")):
             return False
+        if metadata.get("topic_boundary") == "strict":
+            # A strict caller treats the topic as a privacy boundary. Retrying
+            # without its reply/topic routing would escape into the parent DM.
+            return False
         if not cls._is_bad_request_error(error):
             return False
         err_lower = str(error).lower()
@@ -1841,10 +1854,33 @@ class TelegramAdapter(BasePlatformAdapter):
         media_label: str,
         reset_media: Optional[Any] = None,
     ) -> Any:
-        """Retry stale private-topic media replies once without the topic anchor."""
+        """Apply strict same-topic retry or the legacy soft DM-anchor fallback."""
         try:
             return await send_fn(**send_kwargs)
         except Exception as send_err:
+            requested_thread_id = send_kwargs.get("message_thread_id")
+            if requested_thread_id is None:
+                requested_thread_id = send_kwargs.get("direct_messages_topic_id")
+            if (
+                (metadata or {}).get("topic_boundary") == "strict"
+                and requested_thread_id is not None
+                and self._is_thread_not_found_error(send_err)
+            ):
+                logger.warning(
+                    "[%s] Strict Telegram %s topic %s not found, retrying once with the same route",
+                    self.name,
+                    media_label,
+                    requested_thread_id,
+                )
+                if reset_media is not None:
+                    reset_media()
+                try:
+                    return await send_fn(**send_kwargs)
+                except Exception as retry_err:
+                    raise _StrictTopicSendError(
+                        retry_err,
+                        int(requested_thread_id),
+                    ) from retry_err
             if not self._should_retry_without_dm_topic_reply_anchor(
                 send_err,
                 metadata,
@@ -1865,6 +1901,19 @@ class TelegramAdapter(BasePlatformAdapter):
             retry_kwargs.pop("message_thread_id", None)
             retry_kwargs.pop("direct_messages_topic_id", None)
             return await send_fn(**retry_kwargs)
+
+    @staticmethod
+    def _strict_topic_failure_result(error: _StrictTopicSendError) -> SendResult:
+        return SendResult(
+            success=False,
+            error=str(error),
+            raw_response={
+                "requested_thread_id": error.requested_thread_id,
+                "strict_thread_failure": True,
+            },
+            retryable=False,
+            error_kind=classify_send_error(error.original_error),
+        )
 
     def _fallback_ips(self) -> list[str]:
         """Return validated fallback IPs from config (populated by _apply_env_overrides)."""
@@ -2319,16 +2368,40 @@ class TelegramAdapter(BasePlatformAdapter):
             # quietly drop the reply anchor instead of erroring.
             payload["reply_parameters"] = {"message_id": reply_to_id}
 
+        bot = self._bot
+        if bot is None:
+            return None
         try:
             # Take the raw Bot API result (dict under real PTB). Passing
             # return_type=Message would make PTB deserialize a Bot API 10.1
             # response shape it does not fully model yet; a post-delivery parse
             # error must not be mistaken for a sendable failure.
-            msg = await self._bot.do_api_request(
+            msg = await bot.do_api_request(
                 "sendRichMessage", api_kwargs=payload
             )
         except Exception as exc:
-            if self._is_rich_fallback_error(exc):
+            requested_thread_id = payload.get("message_thread_id")
+            if requested_thread_id is None:
+                requested_thread_id = payload.get("direct_messages_topic_id")
+            if (
+                (metadata or {}).get("topic_boundary") == "strict"
+                and requested_thread_id is not None
+                and self._is_thread_not_found_error(exc)
+            ):
+                logger.warning(
+                    "[%s] Strict sendRichMessage topic %s not found, retrying once with the same route",
+                    self.name,
+                    requested_thread_id,
+                )
+                try:
+                    msg = await bot.do_api_request(
+                        "sendRichMessage", api_kwargs=payload
+                    )
+                except Exception as retry_exc:
+                    return self._strict_topic_failure_result(
+                        _StrictTopicSendError(retry_exc, int(requested_thread_id))
+                    )
+            elif self._is_rich_fallback_error(exc):
                 if self._is_rich_capability_error(exc):
                     # Endpoint missing (old PTB/server) — latch rich off so
                     # every later send doesn't pay a doomed extra roundtrip.
@@ -2338,36 +2411,37 @@ class TelegramAdapter(BasePlatformAdapter):
                     self.name, _redact_telegram_error_text(exc),
                 )
                 return None
-            # Transient / network / unknown: the request may have reached
-            # Telegram. Do NOT legacy-resend (duplicate risk); surface a
-            # failure with retry semantics mirroring the legacy send() except.
-            err_str = str(exc).lower()
-            try:
-                from telegram.error import TimedOut as _TimedOut
-            except (ImportError, AttributeError):
-                _TimedOut = None
-            is_timeout = (_TimedOut and isinstance(exc, _TimedOut)) or "timed out" in err_str
-            is_connect_timeout = self._looks_like_connect_timeout(exc)
-            # Extract server-requested retry_after for flood control so the
-            # base retry layer honors Telegram's backoff instead of its own
-            # short exponential schedule.
-            _retry_after = getattr(exc, "retry_after", None)
-            if _retry_after is None:
-                import re as _re
-                _m = _re.search(r"retry\s+(?:in\s+)?(\d+)", err_str, _re.IGNORECASE)
-                if _m:
-                    _retry_after = float(_m.group(1))
-            safe_error = _redact_telegram_error_text(exc)
-            logger.warning(
-                "[%s] sendRichMessage transient failure (no legacy resend): %s",
-                self.name, safe_error,
-            )
-            return SendResult(
-                success=False,
-                error=safe_error,
-                retryable=(is_connect_timeout or not is_timeout),
-                retry_after=_retry_after,
-            )
+            else:
+                # Transient / network / unknown: the request may have reached
+                # Telegram. Do NOT legacy-resend (duplicate risk); surface a
+                # failure with retry semantics mirroring the legacy send() except.
+                err_str = str(exc).lower()
+                try:
+                    from telegram.error import TimedOut as _TimedOut
+                except (ImportError, AttributeError):
+                    _TimedOut = None
+                is_timeout = (_TimedOut and isinstance(exc, _TimedOut)) or "timed out" in err_str
+                is_connect_timeout = self._looks_like_connect_timeout(exc)
+                # Extract server-requested retry_after for flood control so the
+                # base retry layer honors Telegram's backoff instead of its own
+                # short exponential schedule.
+                _retry_after = getattr(exc, "retry_after", None)
+                if _retry_after is None:
+                    import re as _re
+                    _m = _re.search(r"retry\s+(?:in\s+)?(\d+)", err_str, _re.IGNORECASE)
+                    if _m:
+                        _retry_after = float(_m.group(1))
+                safe_error = _redact_telegram_error_text(exc)
+                logger.warning(
+                    "[%s] sendRichMessage transient failure (no legacy resend): %s",
+                    self.name, safe_error,
+                )
+                return SendResult(
+                    success=False,
+                    error=safe_error,
+                    retryable=(is_connect_timeout or not is_timeout),
+                    retry_after=_retry_after,
+                )
 
         message_id = None
         if isinstance(msg, dict):
@@ -5513,6 +5587,9 @@ class TelegramAdapter(BasePlatformAdapter):
             message_ids = []
             thread_id = self._metadata_thread_id(metadata)
             requested_thread_id = self._message_thread_id_for_send(thread_id)
+            direct_messages_topic_id = self._metadata_direct_messages_topic_id(metadata)
+            if requested_thread_id is None and direct_messages_topic_id is not None:
+                requested_thread_id = int(direct_messages_topic_id)
             used_thread_fallback = False
             
             try:
@@ -5605,17 +5682,57 @@ class TelegramAdapter(BasePlatformAdapter):
                                 raise
                         break  # success
                     except _NetErr as send_err:
+                        if (
+                            retried_thread_not_found
+                            and (metadata or {}).get("topic_boundary") == "strict"
+                            and requested_thread_id is not None
+                        ):
+                            return self._strict_topic_failure_result(
+                                _StrictTopicSendError(send_err, int(requested_thread_id))
+                            )
                         # BadRequest is a subclass of NetworkError in
                         # python-telegram-bot but represents permanent errors
                         # (not transient network issues). Detect and handle
                         # specific cases instead of blindly retrying.
                         if _BadReq and isinstance(send_err, _BadReq):
+                            if self._is_thread_not_found_error(send_err):
+                                strict_boundary = (metadata or {}).get("topic_boundary") == "strict"
+                                strict_route_id = (
+                                    effective_thread_id
+                                    if effective_thread_id is not None
+                                    else direct_messages_topic_id
+                                )
+                                if strict_boundary and strict_route_id is not None:
+                                    if not retried_thread_not_found:
+                                        retried_thread_not_found = True
+                                        logger.warning(
+                                            "[%s] Strict Telegram topic %s not found, retrying once with the same route",
+                                            self.name,
+                                            strict_route_id,
+                                        )
+                                        continue
+                                    safe_send_error = _redact_telegram_error_text(send_err)
+                                    return SendResult(
+                                        success=False,
+                                        error=safe_send_error,
+                                        raw_response={
+                                            "requested_thread_id": requested_thread_id,
+                                            "strict_thread_failure": True,
+                                        },
+                                        retryable=False,
+                                        error_kind=classify_send_error(send_err),
+                                    )
                             if self._is_thread_not_found_error(send_err) and effective_thread_id is not None:
                                 if private_dm_topic_send or (metadata and metadata.get("telegram_dm_topic_created_for_send")):
                                     return SendResult(
                                         success=False,
-                                        error=str(send_err),
+                                        error=_redact_telegram_error_text(send_err),
+                                        raw_response={
+                                            "requested_thread_id": requested_thread_id,
+                                            "strict_thread_failure": True,
+                                        },
                                         retryable=False,
+                                        error_kind=classify_send_error(send_err),
                                     )
                                 # Telegram has been observed to return a
                                 # one-off "thread not found" that recovers on
@@ -5630,12 +5747,8 @@ class TelegramAdapter(BasePlatformAdapter):
                                         self.name, effective_thread_id,
                                     )
                                     continue
-                                # Second failure: the thread is genuinely gone.
-                                # Retry without ``message_thread_id`` so the
-                                # message still reaches the chat, and prune
-                                # the stale binding so future inbound
-                                # messages aren't redirected back to it
-                                # (#31501).
+                                # Soft routing keeps the availability-oriented
+                                # fallback and stale-binding cleanup (#31501).
                                 logger.warning(
                                     "[%s] Thread %s not found, retrying without message_thread_id",
                                     self.name, effective_thread_id,
@@ -5709,6 +5822,14 @@ class TelegramAdapter(BasePlatformAdapter):
                         else:
                             raise
                     except Exception as send_err:
+                        if (
+                            retried_thread_not_found
+                            and (metadata or {}).get("topic_boundary") == "strict"
+                            and requested_thread_id is not None
+                        ):
+                            return self._strict_topic_failure_result(
+                                _StrictTopicSendError(send_err, int(requested_thread_id))
+                            )
                         retry_after = getattr(send_err, "retry_after", None)
                         if retry_after is not None or "retry after" in str(send_err).lower():
                             wait = float(retry_after) if retry_after is not None else 1.0
@@ -8152,6 +8273,8 @@ class TelegramAdapter(BasePlatformAdapter):
                         metadata=metadata,
                     )
             return SendResult(success=True, message_id=str(msg.message_id))
+        except _StrictTopicSendError as e:
+            return self._strict_topic_failure_result(e)
         except Exception as e:
             logger.error(
                 "[%s] Failed to send Telegram voice/audio, falling back to base adapter: %s",
@@ -8286,6 +8409,8 @@ class TelegramAdapter(BasePlatformAdapter):
                     "media group",
                     reset_media=_reset_opened_files,
                 )
+            except _StrictTopicSendError:
+                raise
             except Exception as e:
                 logger.warning(
                     "[%s] send_media_group failed (chunk %d/%d), falling back to per-image: %s",
@@ -8347,6 +8472,8 @@ class TelegramAdapter(BasePlatformAdapter):
                     reset_media=lambda: image_file.seek(0),
                 )
             return SendResult(success=True, message_id=str(msg.message_id))
+        except _StrictTopicSendError as e:
+            return self._strict_topic_failure_result(e)
         except Exception as e:
             error_str = str(e)
             # Dimension-related errors are the expected case for valid image
@@ -8445,6 +8572,8 @@ class TelegramAdapter(BasePlatformAdapter):
                     reset_media=lambda: f.seek(0),
                 )
             return SendResult(success=True, message_id=str(msg.message_id))
+        except _StrictTopicSendError as e:
+            return self._strict_topic_failure_result(e)
         except Exception as e:
             logger.warning(
                 "[%s] Failed to send document: %s",
@@ -8496,6 +8625,8 @@ class TelegramAdapter(BasePlatformAdapter):
                     reset_media=lambda: f.seek(0),
                 )
             return SendResult(success=True, message_id=str(msg.message_id))
+        except _StrictTopicSendError as e:
+            return self._strict_topic_failure_result(e)
         except Exception as e:
             logger.warning(
                 "[%s] Failed to send video: %s",
@@ -8551,6 +8682,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 "URL photo",
             )
             return SendResult(success=True, message_id=str(msg.message_id))
+        except _StrictTopicSendError as e:
+            return self._strict_topic_failure_result(e)
         except Exception as e:
             logger.warning(
                 "[%s] URL-based send_photo failed, trying file upload: %s",
@@ -8594,6 +8727,8 @@ class TelegramAdapter(BasePlatformAdapter):
                     "uploaded photo",
                 )
                 return SendResult(success=True, message_id=str(msg.message_id))
+            except _StrictTopicSendError as e2:
+                return self._strict_topic_failure_result(e2)
             except Exception as e2:
                 logger.error(
                     "[%s] File upload send_photo also failed: %s",
@@ -8642,6 +8777,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 "animation",
             )
             return SendResult(success=True, message_id=str(msg.message_id))
+        except _StrictTopicSendError as e:
+            return self._strict_topic_failure_result(e)
         except Exception as e:
             logger.error(
                 "[%s] Failed to send Telegram animation, falling back to photo: %s",

--- a/tests/cron/test_cron_live_delivery_confirmation.py
+++ b/tests/cron/test_cron_live_delivery_confirmation.py
@@ -109,7 +109,10 @@ def _job(thread_id=None):
 
 def _gateway_config(relay=False):
     config = MagicMock()
-    platforms = {Platform.TELEGRAM: PlatformConfig(enabled=True)}
+    platforms = {
+        Platform.TELEGRAM: PlatformConfig(enabled=True),
+        Platform.EMAIL: PlatformConfig(enabled=True),
+    }
     if relay:
         platforms[Platform.RELAY] = PlatformConfig(enabled=True)
     config.platforms = platforms
@@ -132,7 +135,16 @@ def _record_verification(job, unverified_targets):
     RECORDED_VERIFICATION.append((job["id"], list(unverified_targets)))
 
 
-def _run(job, content, send_result, relay=False, standalone_result=None, cron_cfg=None):
+def _run(
+    job,
+    content,
+    send_result,
+    relay=False,
+    standalone_result=None,
+    cron_cfg=None,
+    live=True,
+    dm_topic=False,
+):
     """Drive ``_deliver_result`` over the live lane with a stubbed router.
 
     Returns ``(error, router_calls, standalone_calls)``. ``cron_cfg`` extends
@@ -169,11 +181,147 @@ def _run(job, content, send_result, relay=False, standalone_result=None, cron_cf
          patch("cron.scheduler.load_config",
                return_value={"cron": {"wrap_response": False, **(cron_cfg or {})}}), \
          patch("cron.scheduler._record_delivery_verification", side_effect=_record_verification), \
+         patch("cron.scheduler._is_channel_dm_topic", return_value=dm_topic), \
          patch("gateway.delivery.DeliveryRouter", return_value=router), \
          patch("tools.send_message_tool._send_to_platform", _fake_send_to_platform), \
          patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
-        error = _deliver_result(job, content, adapters=_adapters(relay), loop=loop)
+        error = _deliver_result(
+            job,
+            content,
+            adapters=_adapters(relay) if live else None,
+            loop=loop if live else None,
+        )
     return error, router_calls, standalone_calls
+
+
+class TestStrictTopicFailure:
+    def test_strict_live_media_failure_is_not_logged_as_delivered(self, caplog):
+        with patch(
+            "gateway.platforms.base.BasePlatformAdapter.filter_media_delivery_paths",
+            side_effect=lambda paths: paths,
+        ), patch(
+            "cron.scheduler._send_media_via_adapter",
+            return_value=["media send failed for /tmp/report.pdf: topic unavailable"],
+        ), caplog.at_level(logging.INFO, logger="cron.scheduler"):
+            error, router_calls, standalone_calls = _run(
+                _job(thread_id="99"),
+                "Private report.\nMEDIA:/tmp/report.pdf",
+                _SendResult(message_id=1234),
+            )
+
+        assert len(router_calls) == 1
+        assert standalone_calls == []
+        assert error is not None
+        assert "media send failed" in error
+        assert "via live adapter" not in caplog.text
+
+    def test_direct_messages_topic_generic_failure_never_uses_standalone(self):
+        job = {
+            "id": "92e639af907f",
+            "name": "Private DM topic",
+            "deliver": "origin",
+            "origin": {
+                "platform": "telegram",
+                "chat_id": "123",
+                "thread_id": "99",
+            },
+        }
+        send_result = _SendResult(success=False, error="Telegram transport failed")
+
+        error, router_calls, standalone_calls = _run(
+            job,
+            "Private report.",
+            send_result,
+            dm_topic=True,
+        )
+
+        assert router_calls[0]["metadata"]["direct_messages_topic_id"] == "99"
+        assert router_calls[0]["metadata"]["topic_boundary"] == "strict"
+        assert standalone_calls == []
+        assert error is not None
+        assert "cannot be represented by the standalone sender" in error
+
+    def test_strict_topic_failure_does_not_abort_other_targets(self):
+        job = {
+            "id": "92e639af907f",
+            "name": "Private fan-out",
+            "deliver": f"telegram:{CHAT_ID}:99,email:ops@example.com",
+        }
+        send_result = _SendResult(
+            success=False,
+            raw_response={
+                "requested_thread_id": 99,
+                "strict_thread_failure": True,
+            },
+            error="Message thread not found",
+        )
+
+        error, router_calls, standalone_calls = _run(
+            job,
+            "Private report.",
+            send_result,
+        )
+
+        assert len(router_calls) == 1
+        assert [call["chat_id"] for call in standalone_calls] == ["ops@example.com"]
+        assert error is not None
+        assert "strict Telegram topic 99" in error
+
+    def test_ambiguous_private_topic_without_live_adapter_fails_closed(self):
+        job = {
+            "id": "92e639af907f",
+            "name": "Ambiguous private topic",
+            "deliver": "origin",
+            "origin": {
+                "platform": "telegram",
+                "chat_id": "123",
+                "thread_id": "99",
+            },
+        }
+
+        error, router_calls, standalone_calls = _run(
+            job,
+            "Private report.",
+            None,
+            live=False,
+        )
+
+        assert router_calls == []
+        assert standalone_calls == []
+        assert error is not None
+        assert "cannot be safely disambiguated without a live adapter" in error
+
+    def test_standalone_topic_delivery_carries_strict_boundary(self):
+        error, router_calls, standalone_calls = _run(
+            _job(thread_id="99"),
+            "Private report.",
+            None,
+            live=False,
+        )
+
+        assert error is None
+        assert router_calls == []
+        assert standalone_calls[0]["kwargs"]["topic_boundary"] == "strict"
+
+    def test_strict_topic_failure_does_not_retry_via_standalone(self):
+        send_result = _SendResult(
+            success=False,
+            raw_response={
+                "requested_thread_id": 99,
+                "strict_thread_failure": True,
+            },
+            error="Message thread not found",
+        )
+
+        error, router_calls, standalone_calls = _run(
+            _job(thread_id="99"), "Private report.", send_result,
+        )
+
+        assert router_calls[0]["metadata"]["topic_boundary"] == "strict"
+        assert standalone_calls == []
+        assert error is not None
+        assert "strict Telegram topic 99" in error
+        assert "Message thread not found" in error
 
 
 class TestFilteredResultIsNotDelivered:
@@ -287,6 +435,7 @@ class TestLiveDeliveryIsAFinalNotification:
         )
         metadata = router_calls[0]["metadata"]
         assert metadata["thread_id"] == "99"
+        assert metadata["topic_boundary"] == "strict"
         assert metadata["notify"] is True
 
     def test_media_route_metadata_carries_notify(self, tmp_path):

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -384,8 +384,170 @@ async def test_created_private_topic_thread_not_found_fails_without_root_fallbac
 
     assert result.success is False
     assert "thread not found" in str(result.error).lower()
+    assert result.raw_response == {
+        "requested_thread_id": 32343,
+        "strict_thread_failure": True,
+    }
     assert len(call_log) == 1
     assert call_log[0]["message_thread_id"] == 32343
+
+
+@pytest.mark.asyncio
+async def test_strict_created_private_topic_retries_same_thread_once():
+    adapter = _make_adapter()
+    call_log = []
+
+    async def mock_send_message(**kwargs):
+        call_log.append(dict(kwargs))
+        raise FakeBadRequest("Message thread not found")
+
+    adapter._bot = SimpleNamespace(send_message=mock_send_message)
+
+    result = await adapter.send(
+        chat_id="123",
+        content="created topic message",
+        metadata={
+            "thread_id": "32343",
+            "telegram_dm_topic_created_for_send": True,
+            "topic_boundary": "strict",
+        },
+    )
+
+    assert result.success is False
+    assert result.raw_response == {
+        "requested_thread_id": 32343,
+        "strict_thread_failure": True,
+    }
+    assert [call["message_thread_id"] for call in call_log] == [32343, 32343]
+
+
+@pytest.mark.asyncio
+async def test_strict_direct_messages_topic_failure_is_marked_for_scheduler():
+    adapter = _make_adapter()
+    call_log = []
+
+    async def mock_send_message(**kwargs):
+        call_log.append(dict(kwargs))
+        raise FakeBadRequest("Message thread not found")
+
+    adapter._bot = SimpleNamespace(send_message=mock_send_message)
+
+    result = await adapter.send(
+        chat_id="123",
+        content="weekly report",
+        metadata={
+            "direct_messages_topic_id": "99999",
+            "topic_boundary": "strict",
+            "notify": True,
+        },
+    )
+
+    assert result.success is False
+    assert result.raw_response == {
+        "requested_thread_id": 99999,
+        "strict_thread_failure": True,
+    }
+    assert len(call_log) == 2
+    assert all(call["direct_messages_topic_id"] == 99999 for call in call_log)
+
+
+@pytest.mark.asyncio
+async def test_strict_forum_topic_retries_same_thread_once_then_fails_closed():
+    """Strict forum sends must never escape to the parent chat."""
+    adapter = _make_adapter()
+    call_log = []
+
+    async def mock_send_message(**kwargs):
+        call_log.append(dict(kwargs))
+        raise FakeBadRequest("Message thread not found")
+
+    adapter._bot = SimpleNamespace(send_message=mock_send_message)
+
+    result = await adapter.send(
+        chat_id="-100123",
+        content="topic-only message",
+        metadata={"thread_id": "99999", "topic_boundary": "strict"},
+    )
+
+    assert result.success is False
+    assert result.retryable is False
+    assert result.raw_response == {
+        "requested_thread_id": 99999,
+        "strict_thread_failure": True,
+    }
+    assert [call["message_thread_id"] for call in call_log] == [99999, 99999]
+
+
+@pytest.mark.asyncio
+async def test_strict_text_retry_different_error_still_fails_as_strict_boundary():
+    adapter = _make_adapter()
+    call_log = []
+
+    async def mock_send_message(**kwargs):
+        call_log.append(dict(kwargs))
+        if len(call_log) == 1:
+            raise FakeBadRequest("Message thread not found")
+        raise RuntimeError("transport failed after exact-route retry")
+
+    adapter._bot = SimpleNamespace(send_message=mock_send_message)
+
+    result = await adapter.send(
+        chat_id="-100123",
+        content="topic-only message",
+        metadata={"thread_id": "99999", "topic_boundary": "strict"},
+    )
+
+    assert result.success is False
+    assert result.raw_response == {
+        "requested_thread_id": 99999,
+        "strict_thread_failure": True,
+    }
+    assert [call["message_thread_id"] for call in call_log] == [99999, 99999]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("chat_id", "routing_key"),
+    [
+        ("-100123", "message_thread_id"),
+        ("123", "direct_messages_topic_id"),
+    ],
+)
+async def test_strict_rich_topic_retries_same_api_once_then_fails_closed(
+    chat_id,
+    routing_key,
+):
+    adapter = _make_adapter()
+    adapter._rich_messages_enabled = True
+    call_log = []
+
+    async def mock_do_api_request(method, *, api_kwargs):
+        call_log.append((method, dict(api_kwargs)))
+        raise FakeBadRequest("Message thread not found")
+
+    adapter._bot = SimpleNamespace(do_api_request=mock_do_api_request)
+
+    metadata = {"topic_boundary": "strict"}
+    if routing_key == "message_thread_id":
+        metadata["thread_id"] = "99999"
+    else:
+        metadata["direct_messages_topic_id"] = "99999"
+
+    result = await adapter._try_send_rich(
+        chat_id=chat_id,
+        content="| a | b |\n|---|---|\n| 1 | 2 |",
+        reply_to=None,
+        metadata=metadata,
+    )
+
+    assert result is not None
+    assert result.success is False
+    assert result.raw_response == {
+        "requested_thread_id": 99999,
+        "strict_thread_failure": True,
+    }
+    assert [method for method, _ in call_log] == ["sendRichMessage", "sendRichMessage"]
+    assert all(payload[routing_key] == 99999 for _, payload in call_log)
 
 
 @pytest.mark.asyncio
@@ -436,6 +598,122 @@ async def test_native_media_dm_topic_reply_not_found_retry_drops_thread_id(
     assert call_log[1]["reply_to_message_id"] is None
     assert "message_thread_id" not in call_log[1]
     assert "direct_messages_topic_id" not in call_log[1]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("chat_id", "routing_key"),
+    [
+        ("-100123", "message_thread_id"),
+        ("123", "direct_messages_topic_id"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("method_name", "bot_method_name", "path_kw", "filename", "payload"),
+    [
+        ("send_image_file", "send_photo", "image_path", "photo.png", b"png-data"),
+        ("send_document", "send_document", "file_path", "report.txt", b"report-data"),
+        ("send_video", "send_video", "video_path", "clip.mp4", b"video-data"),
+        ("send_voice", "send_voice", "audio_path", "clip.ogg", b"ogg-data"),
+        ("send_voice", "send_audio", "audio_path", "clip.mp3", b"mp3-data"),
+    ],
+)
+async def test_strict_topic_media_retries_same_api_once_then_fails_closed(
+    tmp_path,
+    chat_id,
+    routing_key,
+    method_name,
+    bot_method_name,
+    path_kw,
+    filename,
+    payload,
+):
+    adapter = _make_adapter()
+    media_path = tmp_path / filename
+    media_path.write_bytes(payload)
+    call_log = []
+
+    def failing_send(label):
+        async def _send(**kwargs):
+            call_log.append((label, dict(kwargs)))
+            raise FakeBadRequest("Message thread not found")
+
+        return _send
+
+    adapter._bot = SimpleNamespace(
+        send_photo=failing_send("photo"),
+        send_document=failing_send("document"),
+        send_video=failing_send("video"),
+        send_voice=failing_send("voice"),
+        send_audio=failing_send("audio"),
+        send_message=failing_send("message"),
+    )
+
+    metadata = {"topic_boundary": "strict"}
+    if routing_key == "message_thread_id":
+        metadata["thread_id"] = "20197"
+    else:
+        metadata["direct_messages_topic_id"] = "20197"
+
+    result = await getattr(adapter, method_name)(
+        chat_id=chat_id,
+        **{path_kw: str(media_path)},
+        metadata=metadata,
+    )
+
+    assert result.success is False
+    assert result.raw_response == {
+        "requested_thread_id": 20197,
+        "strict_thread_failure": True,
+    }
+    assert [label for label, _ in call_log] == [
+        bot_method_name.removeprefix("send_"),
+        bot_method_name.removeprefix("send_"),
+    ]
+    assert all(kwargs.get(routing_key) == 20197 for _, kwargs in call_log)
+    other_routing_key = (
+        "direct_messages_topic_id"
+        if routing_key == "message_thread_id"
+        else "message_thread_id"
+    )
+    assert all(kwargs.get(other_routing_key) is None for _, kwargs in call_log)
+
+
+@pytest.mark.asyncio
+async def test_strict_media_retry_different_error_still_blocks_fallback(tmp_path):
+    adapter = _make_adapter()
+    media_path = tmp_path / "photo.png"
+    media_path.write_bytes(b"png-data")
+    call_log = []
+
+    async def mock_send_photo(**kwargs):
+        call_log.append(("photo", dict(kwargs)))
+        if len(call_log) == 1:
+            raise FakeBadRequest("Message thread not found")
+        raise RuntimeError("transport failed after exact-route retry")
+
+    async def unexpected_fallback(**kwargs):
+        call_log.append(("fallback", dict(kwargs)))
+        raise AssertionError("strict media must not change delivery API")
+
+    adapter._bot = SimpleNamespace(
+        send_photo=mock_send_photo,
+        send_document=unexpected_fallback,
+        send_message=unexpected_fallback,
+    )
+
+    result = await adapter.send_image_file(
+        chat_id="-100123",
+        image_path=str(media_path),
+        metadata={"thread_id": "20197", "topic_boundary": "strict"},
+    )
+
+    assert result.success is False
+    assert result.raw_response == {
+        "requested_thread_id": 20197,
+        "strict_thread_failure": True,
+    }
+    assert [label for label, _ in call_log] == ["photo", "photo"]
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_telegram_send_message_caption.py
+++ b/tests/tools/test_telegram_send_message_caption.py
@@ -84,6 +84,180 @@ def test_image_caption_rides_bubble_no_separate_text(monkeypatch: pytest.MonkeyP
         os.unlink(img)
 
 
+def test_strict_text_topic_retries_same_thread_once_and_never_general(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tools.send_message_tool import _send_telegram
+
+    _no_proxy(monkeypatch)
+    bot = _make_bot()
+    bot.send_message.side_effect = [
+        RuntimeError("Message thread not found"),
+        RuntimeError("transport failed after strict retry"),
+    ]
+    _install_telegram_mock(monkeypatch, MagicMock(return_value=bot))
+
+    result = asyncio.run(
+        _send_telegram(
+            "tok",
+            "-100123",
+            "private report",
+            thread_id="99999",
+            topic_boundary="strict",
+        )
+    )
+
+    assert result["success"] is False
+    assert result["raw_response"] == {
+        "requested_thread_id": 99999,
+        "strict_thread_failure": True,
+    }
+    assert "transport failed" in result["error"].lower()
+    assert bot.send_message.await_count == 2
+    assert [
+        call.kwargs.get("message_thread_id")
+        for call in bot.send_message.await_args_list
+    ] == [99999, 99999]
+
+
+def test_send_to_platform_propagates_strict_topic_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gateway.config import Platform
+    import tools.send_message_tool as smt
+
+    sender = AsyncMock(return_value={"success": True, "message_id": "1"})
+    monkeypatch.setattr(smt, "_send_telegram", sender)
+
+    result = asyncio.run(
+        smt._send_to_platform(
+            Platform.TELEGRAM,
+            SimpleNamespace(enabled=True, token="tok", extra={}),
+            "-100123",
+            "private report",
+            thread_id="99",
+            topic_boundary="strict",
+        )
+    )
+
+    assert result["success"] is True
+    call = sender.await_args
+    assert call is not None
+    assert call.kwargs["topic_boundary"] == "strict"
+
+
+def test_strict_media_topic_never_retries_in_general(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tools.send_message_tool import _send_telegram
+
+    _no_proxy(monkeypatch)
+    bot = _make_bot()
+    bot.send_photo.side_effect = [
+        RuntimeError("Message thread not found"),
+        RuntimeError("transport failed after strict retry"),
+    ]
+    _install_telegram_mock(monkeypatch, MagicMock(return_value=bot))
+    img = _tmpfile(".png")
+    try:
+        result = asyncio.run(
+            _send_telegram(
+                "tok",
+                "-100123",
+                "",
+                media_files=[(img, False)],
+                thread_id="99999",
+                topic_boundary="strict",
+            )
+        )
+
+        assert result["success"] is False
+        assert result["raw_response"] == {
+            "requested_thread_id": 99999,
+            "strict_thread_failure": True,
+        }
+        assert "transport failed" in result["error"].lower()
+        assert bot.send_photo.await_count == 2
+        assert [
+            call.kwargs["message_thread_id"]
+            for call in bot.send_photo.await_args_list
+        ] == [99999, 99999]
+    finally:
+        os.unlink(img)
+
+
+def test_strict_text_success_media_failure_is_not_reported_as_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tools.send_message_tool import _send_telegram
+
+    _no_proxy(monkeypatch)
+    bot = _make_bot()
+    bot.send_photo.side_effect = [
+        RuntimeError("Message thread not found"),
+        RuntimeError("transport failed after strict retry"),
+    ]
+    _install_telegram_mock(monkeypatch, MagicMock(return_value=bot))
+    img = _tmpfile(".png")
+    try:
+        result = asyncio.run(
+            _send_telegram(
+                "tok",
+                "-100123",
+                "x" * 1100,
+                media_files=[(img, False)],
+                thread_id="99999",
+                topic_boundary="strict",
+            )
+        )
+
+        assert bot.send_message.await_count == 1
+        assert bot.send_photo.await_count == 2
+        assert result["success"] is False
+        assert result["raw_response"] == {
+            "requested_thread_id": 99999,
+            "strict_thread_failure": True,
+        }
+    finally:
+        os.unlink(img)
+
+
+def test_strict_missing_media_caption_fallback_retries_same_topic_then_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tools.send_message_tool import _send_telegram
+
+    _no_proxy(monkeypatch)
+    bot = _make_bot()
+    bot.send_message.side_effect = [
+        RuntimeError("Message thread not found"),
+        RuntimeError("transport failed after strict retry"),
+    ]
+    _install_telegram_mock(monkeypatch, MagicMock(return_value=bot))
+
+    result = asyncio.run(
+        _send_telegram(
+            "tok",
+            "-100123",
+            "caption text",
+            media_files=[("/tmp/hermes-strict-missing-photo.png", False)],
+            thread_id="99999",
+            topic_boundary="strict",
+        )
+    )
+
+    assert bot.send_message.await_count == 2
+    assert [
+        call.kwargs["message_thread_id"]
+        for call in bot.send_message.await_args_list
+    ] == [99999, 99999]
+    assert result["success"] is False
+    assert result["raw_response"] == {
+        "requested_thread_id": 99999,
+        "strict_thread_failure": True,
+    }
+
+
 def test_multi_file_keeps_separate_text(monkeypatch: pytest.MonkeyPatch) -> None:
     from tools.send_message_tool import _send_telegram
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1109,7 +1109,17 @@ async def _send_via_adapter(
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False, args=None):
+async def _send_to_platform(
+    platform,
+    pconfig,
+    chat_id,
+    message,
+    thread_id=None,
+    media_files=None,
+    force_document=False,
+    args=None,
+    topic_boundary=None,
+):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -1203,6 +1213,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             thread_id=thread_id,
             disable_link_previews=disable_link_previews,
             force_document=force_document,
+            topic_boundary=topic_boundary,
         )
 
     # --- Discord: chunked delivery via the registry's standalone_sender_fn.
@@ -1556,7 +1567,28 @@ def _is_telegram_thread_not_found(error: Exception) -> bool:
     return "thread not found" in str(error).lower()
 
 
-async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False):
+def _strict_telegram_topic_failure(error: Exception, requested_thread_id: int) -> dict:
+    """Return an observable, redacted failure for an exact topic boundary."""
+    return {
+        "success": False,
+        "error": _sanitize_error_text(error),
+        "raw_response": {
+            "requested_thread_id": requested_thread_id,
+            "strict_thread_failure": True,
+        },
+    }
+
+
+async def _send_telegram(
+    token,
+    chat_id,
+    message,
+    media_files=None,
+    thread_id=None,
+    disable_link_previews=False,
+    force_document=False,
+    topic_boundary=None,
+):
     """Send via Telegram Bot API (one-shot, no polling needed).
 
     Applies markdown→MarkdownV2 formatting (same as the gateway adapter)
@@ -1688,20 +1720,38 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                         parse_mode=send_parse_mode, **text_kwargs
                     )
                 except Exception as md_error:
-                    # Thread not found — retry without message_thread_id so the
-                    # message still delivers (matching the gateway adapter's
-                    # fallback behaviour, issue #27012).
+                    # Strict topic boundaries retry once on the same topic for
+                    # Telegram's observed transient false negative, then fail
+                    # closed. Soft sends keep the availability-oriented parent
+                    # fallback (issue #27012, strict policy from #9168).
                     if _is_telegram_thread_not_found(md_error) and text_kwargs.get("message_thread_id") is not None:
-                        logger.warning(
-                            "Thread %s not found in _send_telegram, retrying without message_thread_id",
-                            text_kwargs.get("message_thread_id"),
-                        )
-                        text_kwargs.pop("message_thread_id", None)
-                        last_msg = await _send_telegram_message_with_retry(
-                            bot,
-                            chat_id=int_chat_id, text=chunk,
-                            parse_mode=send_parse_mode, **text_kwargs
-                        )
+                        if topic_boundary == "strict":
+                            logger.warning(
+                                "Strict thread %s not found in _send_telegram, retrying once with same message_thread_id",
+                                text_kwargs.get("message_thread_id"),
+                            )
+                            try:
+                                last_msg = await _send_telegram_message_with_retry(
+                                    bot,
+                                    chat_id=int_chat_id, text=chunk,
+                                    parse_mode=send_parse_mode, **text_kwargs
+                                )
+                            except Exception as retry_error:
+                                return _strict_telegram_topic_failure(
+                                    retry_error,
+                                    int(text_kwargs["message_thread_id"]),
+                                )
+                        else:
+                            logger.warning(
+                                "Thread %s not found in _send_telegram, retrying without message_thread_id",
+                                text_kwargs.get("message_thread_id"),
+                            )
+                            text_kwargs.pop("message_thread_id", None)
+                            last_msg = await _send_telegram_message_with_retry(
+                                bot,
+                                chat_id=int_chat_id, text=chunk,
+                                parse_mode=send_parse_mode, **text_kwargs
+                            )
                     elif "parse" in str(md_error).lower() or "markdown" in str(md_error).lower() or "html" in str(md_error).lower():
                         logger.warning(
                             "Parse mode %s failed in _send_telegram, falling back to plain text: %s",
@@ -1740,6 +1790,30 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                         )
                         _tg_caption = None  # delivered — don't re-caption a later file
                     except Exception as _cap_err:
+                        if (
+                            topic_boundary == "strict"
+                            and text_kwargs.get("message_thread_id") is not None
+                        ):
+                            if _is_telegram_thread_not_found(_cap_err):
+                                try:
+                                    last_msg = await _send_telegram_message_with_retry(
+                                        bot,
+                                        chat_id=int_chat_id,
+                                        text=_tg_caption,
+                                        parse_mode=send_parse_mode,
+                                        **text_kwargs,
+                                    )
+                                    _tg_caption = None
+                                    continue
+                                except Exception as retry_error:
+                                    return _strict_telegram_topic_failure(
+                                        retry_error,
+                                        int(text_kwargs["message_thread_id"]),
+                                    )
+                            return _strict_telegram_topic_failure(
+                                _cap_err,
+                                int(text_kwargs["message_thread_id"]),
+                            )
                         logger.warning(
                             "Telegram caption-fallback send failed for missing media: %s",
                             _sanitize_error_text(_cap_err),
@@ -1788,15 +1862,21 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                             )
                     except Exception as media_err:
                         if _is_telegram_thread_not_found(media_err) and media_kwargs.get("message_thread_id"):
-                            # Thread not found for media — retry without
-                            # message_thread_id (issue #27012).
-                            logger.warning(
-                                "Thread %s not found for media send, retrying without message_thread_id",
-                                media_kwargs["message_thread_id"],
-                            )
+                            if topic_boundary == "strict":
+                                logger.warning(
+                                    "Strict thread %s not found for media send, retrying once with same message_thread_id",
+                                    media_kwargs["message_thread_id"],
+                                )
+                            else:
+                                # Soft media keeps the availability-oriented
+                                # fallback (issue #27012).
+                                logger.warning(
+                                    "Thread %s not found for media send, retrying without message_thread_id",
+                                    media_kwargs["message_thread_id"],
+                                )
+                                media_kwargs.pop("message_thread_id", None)
                             # Re-seek the file since the first attempt consumed it
                             f.seek(0)
-                            media_kwargs.pop("message_thread_id", None)
                             if ext in _IMAGE_EXTS and not force_document:
                                 last_msg = await bot.send_photo(
                                     chat_id=int_chat_id, photo=f, **media_kwargs
@@ -1851,6 +1931,14 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                         else:
                             raise
             except Exception as e:
+                if (
+                    topic_boundary == "strict"
+                    and thread_kwargs.get("message_thread_id") is not None
+                ):
+                    return _strict_telegram_topic_failure(
+                        e,
+                        int(thread_kwargs["message_thread_id"]),
+                    )
                 warning = _sanitize_error_text(f"Failed to send media {media_path}: {e}")
                 logger.error(warning)
                 warnings.append(warning)

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -438,6 +438,15 @@ When scheduling jobs, you specify where the output goes:
 | `"telegram,discord"` | Fan out to a specific set of channels | Comma-separated list |
 | `"origin,all"` | Deliver to the origin **plus** every other connected channel | Combine any tokens |
 
+A Telegram topic target (`telegram:<chat_id>:<thread_id>`) is an exact delivery
+boundary. For forum topics Hermes retries the same topic once when Telegram
+reports it unavailable, then records the delivery as failed; it does **not**
+redirect the output to the parent/General chat. Private-chat topic sends likewise
+keep their exact routing and fail rather than falling back to the parent DM. Since
+a positive chat/topic pair is ambiguous between those modes, Hermes also fails
+closed when no live adapter is available to disambiguate it. Use
+`telegram:<chat_id>` when delivery to the parent chat is intentional.
+
 The agent's final response is automatically delivered to the configured `deliver:` target — the agent does not send messages itself, so there is nothing to call in the cron prompt.
 
 ### Delivery failures are a distinct status


### PR DESCRIPTION
## Problem

An explicit cron target such as `telegram:<chat_id>:<thread_id>` can currently lose its topic routing after Telegram reports `thread not found`. Depending on the delivery lane, Hermes may retry without the routing field, fall through to a different media API, or invoke the standalone sender. A topic-scoped report can therefore land in General or the parent chat while the job reports success.

## Approach

- Treat explicit topic-scoped Telegram cron targets as an exact internal boundary.
- Retry one time with the same Telegram API and the same routing field.
- Fail closed after the retry instead of removing `message_thread_id` / `direct_messages_topic_id`, changing media API, or using an incompatible standalone path.
- Return redacted, observable strict-failure metadata from live and standalone sends.
- Do not report text-plus-media delivery as successful when a strict attachment send fails.
- Continue processing the remaining destinations of a multi-target job.
- Preserve the existing availability-oriented fallback for non-strict conversational sends.

No new public configuration or dependency is introduced. The parent chat remains intentionally addressable as `telegram:<chat_id>`.

## Related work

This is a narrow reimplementation of the useful strict-routing intent from #9168 against the current plugin adapter and scheduler architecture. It follows the maintainer feedback there by avoiding the removed pre-plugin adapter, unsupported media APIs, prompt/session changes, and unrelated scope.

#57889 covers custom Bot API endpoint propagation and private-DM routing concerns, but its maintainer review explicitly rejects changing current cron routing and does not enforce an exact fail-closed boundary for explicit cron topics.

## Verification

- `scripts/run_tests.sh tests/gateway/test_telegram_thread_fallback.py tests/cron/test_cron_live_delivery_confirmation.py tests/tools/test_telegram_send_message_caption.py tests/tools/test_send_message_tool.py tests/tools/test_send_message_telegram_proxy.py`
  - 134 passed
- `scripts/run_tests.sh tests/cron/`
  - 1,172 passed, 1 platform-specific skip
- `uv run ruff check` on all changed Python files
- `git diff --cached --check`
- `uv run ty check` on affected files
  - 71 existing diagnostics versus 72 on the same `origin/main` baseline; none added
- Added-line security scan: clean

All delivery tests use mocks. No real Telegram messages or emails were sent.

## Risk

The behavior change is limited to explicit topic-scoped cron delivery. Those targets now prefer a visible failure over silently changing destination. Non-strict Telegram sends retain their existing fallback behavior.
