### PR TITLE
fix(skills): require complete frontmatter on background skill_manage create

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1067,6 +1067,12 @@ skills:
   # Set to 0 to disable.
   creation_nudge_interval: 15
 
+  # Require author/version/license/platforms on skill_manage create when the
+  # caller is a background_review / curator fork (is_background_review()).
+  # Default true: unattended creates must be auditable. Foreground creates
+  # still accept name+description only. Set false to opt out of the rail.
+  # require_background_create_frontmatter: true
+
   # External skill directories — share skills across tools/agents without
   # copying them into ~/.hermes/skills/.  Each path is expanded (~ and ${VAR})
   # and resolved to an absolute path.  External dirs are read-only: skill

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2345,6 +2345,12 @@ DEFAULT_CONFIG = {
         # External hub installs (trusted/community sources) are always
         # scanned regardless of this setting.
         "guard_agent_created": False,
+        # Background review / curator forks create skills unattended.
+        # When true (default), skill_manage create in those contexts must
+        # declare author, version, license, and platforms; missing fields
+        # are refused with a clear error. Foreground creates are unchanged.
+        # Turn off to restore the previous unattended-create behavior.
+        "require_background_create_frontmatter": True,
         # Advisory NVIDIA SkillEvaluator Tier 1 scan on hub installs
         # (`hermes skills install`). Runs ALONGSIDE the built-in skills
         # guard (which stays the enforcement layer) and only when the

--- a/tests/tools/test_skill_ledger.py
+++ b/tests/tools/test_skill_ledger.py
@@ -17,6 +17,10 @@ import pytest
 VALID_SKILL_CONTENT = """---
 name: my-skill
 description: test skill
+author: test-suite
+version: 1.0.0
+license: MIT
+platforms: [linux, macos, windows]
 ---
 
 # My Skill

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -525,8 +525,10 @@ class TestSkillManageDispatcher:
                  patch("tools.skill_usage.is_hub_installed", return_value=False), \
                  patch("tools.skill_usage.is_bundled",
                        side_effect=lambda skill_name: skill_name == "bundled"):
-                skill_manage(action="create", name="umbrella", content=VALID_SKILL_CONTENT)
-                skill_manage(action="create", name="bundled", content=VALID_SKILL_CONTENT)
+                skill_manage(action="create", name="umbrella",
+                             content=_skill_content("umbrella"))
+                skill_manage(action="create", name="bundled",
+                             content=_skill_content("bundled"))
                 raw = skill_manage(
                     action="delete",
                     name="bundled",
@@ -1068,6 +1070,10 @@ def _skill_content(name: str) -> str:
         "---\n"
         f"name: {name}\n"
         "description: A test skill for unit testing.\n"
+        "author: Hermes Agent\n"
+        "version: 1.0.0\n"
+        "license: MIT\n"
+        "platforms: [linux, macos]\n"
         "---\n\n"
         f"# {name}\n\n"
         "Step 1: Do the thing.\n"
@@ -1096,7 +1102,7 @@ class TestCuratorConsolidationDeleteGuard:
 
     def test_bare_prune_during_curator_pass_refused(self, tmp_path, monkeypatch):
         with _curator_pass(tmp_path, monkeypatch=monkeypatch) as skills_root:
-            _create_curator_skill("active-skill", VALID_SKILL_CONTENT)
+            _create_curator_skill("active-skill", _skill_content("active-skill"))
             result = _delete_skill("active-skill", absorbed_into="")
         assert result["success"] is False
         assert result.get("_fail_closed") is True
@@ -1191,3 +1197,161 @@ class TestCuratorConsolidationDeleteGuard:
             assert allowed["success"] is True, allowed
 
         _reset_background_review_read_marks()
+
+
+@contextmanager
+def _background_origin():
+    """Bind the write origin the background_review / curator forks use."""
+    from tools.skill_provenance import (
+        BACKGROUND_REVIEW,
+        reset_current_write_origin,
+        set_current_write_origin,
+    )
+
+    token = set_current_write_origin(BACKGROUND_REVIEW)
+    try:
+        yield
+    finally:
+        reset_current_write_origin(token)
+
+
+COMPLETE_SKILL_CONTENT = """\
+---
+name: complete-skill
+description: A test skill with full frontmatter.
+author: Hermes Agent
+version: 1.0.0
+license: MIT
+platforms: [linux, macos]
+---
+
+# Complete Skill
+
+Step 1: Do the thing.
+"""
+
+
+class TestBackgroundCreateFrontmatterGuard:
+    """#101402: unattended creates must declare author/version/license/platforms.
+
+    Foreground `skill_manage create` still accepts name+description only.
+    The guard is a different layer from a global skills.read_only lock
+    (see competing #64963): it fires only when is_background_review().
+    """
+
+    def test_background_create_refuses_bare_frontmatter(self, tmp_path):
+        with _skill_dir(tmp_path), _background_origin():
+            raw = skill_manage(
+                action="create", name="bare-bg", content=VALID_SKILL_CONTENT
+            )
+        result = json.loads(raw)
+        assert result["success"] is False
+        err = result["error"].lower()
+        assert "author" in err
+        assert "version" in err
+        assert "license" in err
+        assert "platforms" in err
+        # Discriminator vs weaker layers that could also refuse a write.
+        assert "read_only" not in err
+        assert "bundled" not in err
+        assert "_read_before_write_required" not in result
+        assert result.get("_missing_frontmatter_fields") == [
+            "author",
+            "version",
+            "license",
+            "platforms",
+        ]
+        assert not (tmp_path / "bare-bg" / "SKILL.md").exists()
+
+    def test_background_create_names_the_single_missing_field(self, tmp_path):
+        content = (
+            "---\n"
+            "name: almost\n"
+            "description: Missing only platforms.\n"
+            "author: Hermes Agent\n"
+            "version: 1.0.0\n"
+            "license: MIT\n"
+            "---\n\n"
+            "# Almost\n\n"
+            "Body.\n"
+        )
+        with _skill_dir(tmp_path), _background_origin():
+            raw = skill_manage(action="create", name="almost", content=content)
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "platforms" in result["error"].lower()
+        assert result.get("_missing_frontmatter_fields") == ["platforms"]
+        assert not (tmp_path / "almost" / "SKILL.md").exists()
+
+    def test_background_create_treats_blank_author_as_missing(self, tmp_path):
+        content = (
+            "---\n"
+            "name: blank-author\n"
+            "description: Author is whitespace only.\n"
+            "author: '   '\n"
+            "version: 1.0.0\n"
+            "license: MIT\n"
+            "platforms: [linux]\n"
+            "---\n\n"
+            "# Blank\n\n"
+            "Body.\n"
+        )
+        with _skill_dir(tmp_path), _background_origin():
+            raw = skill_manage(
+                action="create", name="blank-author", content=content
+            )
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "author" in result["error"].lower()
+        assert result.get("_missing_frontmatter_fields") == ["author"]
+        assert not (tmp_path / "blank-author" / "SKILL.md").exists()
+
+    def test_background_create_accepts_complete_frontmatter(self, tmp_path):
+        with _skill_dir(tmp_path), _background_origin():
+            raw = skill_manage(
+                action="create",
+                name="complete-skill",
+                content=COMPLETE_SKILL_CONTENT,
+            )
+        result = json.loads(raw)
+        assert result["success"] is True, result
+        assert (tmp_path / "complete-skill" / "SKILL.md").exists()
+
+    def test_foreground_create_still_allows_bare_frontmatter(self, tmp_path):
+        with _skill_dir(tmp_path):
+            raw = skill_manage(
+                action="create", name="bare-fg", content=VALID_SKILL_CONTENT
+            )
+        result = json.loads(raw)
+        assert result["success"] is True, result
+        assert (tmp_path / "bare-fg" / "SKILL.md").exists()
+
+    def test_escape_hatch_disables_the_background_create_rail(self, tmp_path):
+        with _skill_dir(tmp_path), _background_origin(), patch(
+            "tools.skill_manager_tool._background_create_frontmatter_required",
+            return_value=False,
+        ):
+            raw = skill_manage(
+                action="create", name="bare-escape", content=VALID_SKILL_CONTENT
+            )
+        result = json.loads(raw)
+        assert result["success"] is True, result
+        assert (tmp_path / "bare-escape" / "SKILL.md").exists()
+
+    def test_config_error_fails_closed_on_the_rail(self):
+        from tools.skill_manager_tool import _background_create_frontmatter_required
+
+        with patch("hermes_cli.config.load_config", side_effect=RuntimeError("boom")):
+            assert _background_create_frontmatter_required() is True
+
+    def test_quoted_false_disables_the_rail(self):
+        from tools.skill_manager_tool import _background_create_frontmatter_required
+
+        for quoted in ("false", "False", "0", "no", "off"):
+            with patch(
+                "hermes_cli.config.load_config",
+                return_value={
+                    "skills": {"require_background_create_frontmatter": quoted}
+                },
+            ):
+                assert _background_create_frontmatter_required() is False, quoted

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -142,6 +142,25 @@ def _guard_agent_created_enabled() -> bool:
         return False
 
 
+def _background_create_frontmatter_required() -> bool:
+    """Read skills.require_background_create_frontmatter (default True).
+
+    Background review / curator forks create skills unattended. Requiring
+    author/version/license/platforms on those creates is the default rail;
+    users who do not want it can turn the flag off, same config shape as
+    skills.guard_agent_created. Fail closed if config cannot be loaded.
+    """
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        return is_truthy_value(
+            cfg_get(cfg, "skills", "require_background_create_frontmatter"),
+            default=True,
+        )
+    except Exception:
+        return True
+
+
 def _security_scan_skill(skill_dir: Path) -> Optional[str]:
     """Scan a skill directory after write. Returns error string if blocked, else None.
 
@@ -467,6 +486,63 @@ def _background_review_write_guard(
             ),
         }
     return None
+
+
+_BACKGROUND_CREATE_REQUIRED_FIELDS = ("author", "version", "license", "platforms")
+
+
+def _frontmatter_field_missing(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return not value.strip()
+    if isinstance(value, (list, tuple)):
+        return not any(str(item).strip() for item in value)
+    return False
+
+
+def _missing_background_create_frontmatter_fields(content: str) -> List[str]:
+    fm, _ = _parse_frontmatter(content)
+    if not isinstance(fm, dict):
+        return list(_BACKGROUND_CREATE_REQUIRED_FIELDS)
+    return [
+        key for key in _BACKGROUND_CREATE_REQUIRED_FIELDS
+        if key not in fm or _frontmatter_field_missing(fm.get(key))
+    ]
+
+
+def _background_review_create_frontmatter_guard(
+    content: str,
+) -> Optional[Dict[str, Any]]:
+    """Refuse unattended creates that omit author/version/license/platforms.
+
+    Sibling of ``_background_review_write_guard``: that function protects
+    *existing* skills from autonomous mutation; this one protects the library
+    from malformed *new* sediment. Foreground creates are unchanged. Gated
+    by ``skills.require_background_create_frontmatter`` (default on).
+    """
+    try:
+        from tools.skill_provenance import is_background_review
+        if not is_background_review():
+            return None
+    except Exception:
+        return None
+    if not _background_create_frontmatter_required():
+        return None
+    missing = _missing_background_create_frontmatter_fields(content)
+    if not missing:
+        return None
+    listed = ", ".join(missing)
+    return {
+        "success": False,
+        "error": (
+            f"Refusing background skill_manage create: SKILL.md frontmatter "
+            f"is missing {listed}. Background review/curator forks must "
+            "declare author, version, license, and platforms so unattended "
+            "creates are auditable. Retry with a complete frontmatter block."
+        ),
+        "_missing_frontmatter_fields": missing,
+    }
 
 
 def _background_review_read_before_write_guard(
@@ -1017,6 +1093,10 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
     err = _validate_frontmatter(content, new_skill=True)
     if err:
         return {"success": False, "error": err}
+
+    create_guard = _background_review_create_frontmatter_guard(content)
+    if create_guard is not None:
+        return create_guard
 
     err = _validate_content_size(content)
     if err:


### PR DESCRIPTION
## Bug Description

`skill_manage create` accepts a bare `name` + `description` frontmatter. That is fine for a user-directed foreground turn. It is not fine for the unattended write lines: the background_review fork and the curator daemon fork (`is_background_review()`). Those creates land in the user's library with a blank author column and no `version` / `license` / `platforms` for later audits.

`_background_review_write_guard` already protects *existing* bundled / hub / user-owned skills from autonomous mutation. Nothing validated the *content* of a background create.

Related, not a duplicate: #64963 is a global `skills.read_only` lock on every write action. This PR is a different layer — background-create frontmatter completeness only.

## Root Cause

`_create_skill` / `_validate_frontmatter` require only `name` and `description`. `_background_review_preflight` skips `create` (there is no existing skill to ownership-check). Unattended forks therefore write malformed sediment with no tool-layer refusal.

## Fix

- New sibling of `_background_review_write_guard`: `_background_review_create_frontmatter_guard`, called from `_create_skill` after the existing frontmatter parse.
- When `is_background_review()` and `skills.require_background_create_frontmatter` is on (default), refuse creates missing `author` / `version` / `license` / `platforms` (blank values count as missing) with a clear error and `_missing_frontmatter_fields`.
- Foreground creates are unchanged.
- Escape hatch: `skills.require_background_create_frontmatter: false` (same `cfg_get` + `is_truthy_value` shape as `skills.guard_agent_created`). Config-load failure fails closed (rail stays on).

## How to Verify

1. Bind write origin `background_review`.
2. `skill_manage(action="create")` with only `name` + `description` → refused; no `SKILL.md` written; error names the missing fields.
3. Same create with `author` / `version` / `license` / `platforms` → succeeds.
4. Foreground create with bare frontmatter still succeeds.
5. `skills.require_background_create_frontmatter: false` restores the previous unattended-create behavior.

## Test Plan

- [x] Added `TestBackgroundCreateFrontmatterGuard` in `tests/tools/test_skill_manager_tool.py`
- [x] Discriminator: the three refusal tests fail when the field check is skipped (`assert True is False` — create still succeeds) and pass with the guard
- [x] Existing skill-manager / provenance tests still pass

```
HERMES_PYTHON=<venv>/bin/python ./scripts/run_tests.sh \
  tests/tools/test_skill_manager_tool.py \
  tests/tools/test_skill_provenance.py -q
# 2 files, 74 tests passed
```

RED on `origin/main` (and again with the field check sabotaged): background bare create succeeds, so the refusal tests fail with `assert True is False`. GREEN after the guard: 8/8 new tests pass, 71 in the file.

## Risk Assessment

Low — background create path only. Foreground create is byte-stable unless origin is `background_review`. The rail is on by default (the bug) and opt-out via config. Fail-closed on config errors.

Closes #101402
