### PR TITLE
fix(telegram): do not publish connected for a degraded, unconfirmed polling path

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3632,12 +3632,25 @@ class BasePlatformAdapter(ABC):
     def set_fatal_error_handler(self, handler: Callable[["BasePlatformAdapter"], Awaitable[None] | None]) -> None:
         self._fatal_error_handler = handler
 
-    def _mark_connected(self) -> None:
+    def _mark_connected(self, *, degraded: bool = False) -> None:
         self._running = True
         self._fatal_error_code = None
         self._fatal_error_message = None
         self._fatal_error_retryable = True
-        self._write_runtime_status_safe("connected", platform_state="connected", error_code=None, error_message=None)
+        if degraded:
+            # connect() succeeded but the adapter knows its send/receive path
+            # is not actually confirmed active yet (e.g. Telegram polling
+            # never proved a first getUpdates round-trip). Publishing
+            # "connected" here would be indistinguishable from a healthy
+            # adapter to anything reading gateway_state.json (#101391).
+            self._write_runtime_status_safe(
+                "connected_degraded",
+                platform_state="retrying",
+                error_code=None,
+                error_message="connected but not yet confirmed active; recovering in background",
+            )
+        else:
+            self._write_runtime_status_safe("connected", platform_state="connected", error_code=None, error_message=None)
 
     def _mark_disconnected(self) -> None:
         self._running = False

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16107,15 +16107,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         self._bind_voice_input_callback(adapter)
                         self.delivery_router.adapters = self.adapters
                         del self._failed_platforms[platform]
+                        # connect() returning True does not mean the adapter's
+                        # send/receive path is actually confirmed active --
+                        # Telegram's degraded-polling reconnect intentionally
+                        # returns True so the gateway stays up while its own
+                        # background ladder retries. Stamping "connected"
+                        # unconditionally here would silently undo the
+                        # adapter's own accurate status write (#101391).
+                        _degraded = getattr(adapter, "_send_path_degraded", False)
                         self._update_platform_runtime_status(
                             platform.value,
-                            platform_state="connected",
+                            platform_state="retrying" if _degraded else "connected",
                             error_code=None,
-                            error_message=None,
+                            error_message=(
+                                "connected but not yet confirmed active; recovering in background"
+                                if _degraded else None
+                            ),
                             needs_attention=False,
                             retrying_since=None,
                         )
-                        logger.info("✓ %s reconnected successfully", platform.value)
+                        logger.info(
+                            "%s %s reconnected%s",
+                            "⚠" if _degraded else "✓",
+                            platform.value,
+                            " in degraded mode (send/receive path not yet confirmed)" if _degraded else " successfully",
+                        )
 
                         # Final responses rejected while this adapter was down
                         # are still owned by this live process, so startup

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -902,7 +902,11 @@ class TelegramAdapter(BasePlatformAdapter):
 
     def _mark_connected(self) -> None:
         self._drop_delayed_deliveries = False
-        super()._mark_connected()
+        # _send_path_degraded is already true whenever this connect's
+        # polling generation has not proven a first getUpdates round-trip
+        # (set at generation start, cleared in _record_polling_progress) —
+        # publish that instead of an unconditional "connected" (#101391).
+        super()._mark_connected(degraded=getattr(self, "_send_path_degraded", False))
         # Drain anything held while we were down. PTB will not redeliver —
         # these events exist only in our hold queue now.
         self._schedule_held_inbound_redispatch()
@@ -2694,6 +2698,16 @@ class TelegramAdapter(BasePlatformAdapter):
             self._polling_conflict_recovery_generation = None
         else:
             self._polling_conflict_count = 0
+        # If connect() already published "connected" while polling was
+        # confirmed degraded (or the reconnect watcher stamped that state
+        # once connect() returned), gateway_state.json is still showing the
+        # pre-recovery status. This is the first proof getUpdates is
+        # actually flowing again, so flip it back now instead of leaving it
+        # wedged at "retrying" until the next disconnect/reconnect (#101391).
+        if self._send_path_degraded and getattr(self, "_running", False) and not self.has_fatal_error:
+            self._write_runtime_status_safe(
+                "connected", platform_state="connected", error_code=None, error_message=None,
+            )
         self._send_path_degraded = False
 
     def _observe_polling_request_result(self, request, generation, result):

--- a/tests/gateway/test_telegram_send_path_health.py
+++ b/tests/gateway/test_telegram_send_path_health.py
@@ -76,3 +76,49 @@ async def test_send_short_flood_still_retries_inline(monkeypatch):
     sleep.assert_awaited_once_with(2.0)
 
 
+def test_mark_connected_publishes_connected_when_healthy():
+    """A normal connect (never degraded) still publishes platform_state=connected."""
+    adapter = _make_adapter()
+    adapter._send_path_degraded = False
+
+    with patch.object(adapter, "_write_runtime_status_safe") as write_status:
+        adapter._mark_connected()
+
+    write_status.assert_called_once()
+    _, kwargs = write_status.call_args
+    assert kwargs["platform_state"] == "connected"
+
+
+def test_mark_connected_publishes_retrying_when_send_path_degraded():
+    """connect() can return True while polling never proved a first getUpdates
+    round-trip (the degraded branch, or a reconnect where require_progress is
+    skipped). _mark_connected() must not publish "connected" for that case --
+    it is indistinguishable from a healthy adapter to anything reading
+    gateway_state.json (#101391)."""
+    adapter = _make_adapter()
+    adapter._send_path_degraded = True
+
+    with patch.object(adapter, "_write_runtime_status_safe") as write_status:
+        adapter._mark_connected()
+
+    write_status.assert_called_once()
+    _, kwargs = write_status.call_args
+    assert kwargs["platform_state"] == "retrying"
+
+
+def test_record_polling_progress_republishes_connected_after_degraded_connect():
+    """Once getUpdates actually proves a round-trip after a degraded connect,
+    the previously-published "retrying" status must be corrected back to
+    "connected" -- otherwise it stays wedged until the next disconnect."""
+    adapter = _make_adapter()
+    generation, _event = adapter._begin_polling_generation()
+    # Simulate connect() having already run and published the degraded state.
+    adapter._running = True
+
+    with patch.object(adapter, "_write_runtime_status_safe") as write_status:
+        adapter._record_polling_progress(generation)
+
+    write_status.assert_called_once()
+    _, kwargs = write_status.call_args
+    assert kwargs["platform_state"] == "connected"
+    assert adapter._send_path_degraded is False


### PR DESCRIPTION
## What does this PR do?

`gateway_state.json` can report `telegram.state = "connected"` with
`error_code: null` for hours while the adapter is **not polling at all**.

`connect()` intentionally returns `True` when Telegram's polling starts in
degraded mode — either because `_start_polling_resilient()` explicitly
returned `False` (a network error or `409` conflict scheduled background
recovery), or because a reconnect's `require_progress=False` skips the
strict readiness gate and the polling generation never proves a first
`getUpdates` round-trip. This is deliberate: the gateway must stay up while
its own recovery ladder retries in the background.

The bug is that `_mark_connected()` published `platform_state: "connected"`
*unconditionally* on that return, and the reconnect watcher in
`gateway/run.py` stamped `"connected"` again immediately after `connect()`
returned `True` — so `gateway_state.json` was byte-identical to a healthy
adapter for as long as recovery took. One seat measured ~11h of a false
`"connected"` state (confirmed externally via the `getUpdates` 409/200
probe described in the issue) before a manual gateway restart fixed it.

`_send_path_degraded` already tracks exactly the condition we need — it's
set `True` at polling-generation start and cleared the moment
`_record_polling_progress()` sees a real `getUpdates` round-trip — so this
reuses that existing, already-correct signal instead of adding a new one:

- `BasePlatformAdapter._mark_connected()` takes a `degraded: bool = False`
  kwarg and publishes `platform_state: "retrying"` (with an explanatory
  `error_message`) instead of `"connected"` when set. Every other adapter
  is unaffected (default `False`).
- `TelegramAdapter._mark_connected()` passes its current
  `_send_path_degraded` through.
- The `gateway/run.py` reconnect-watcher success branch checks the same
  flag before overwriting the adapter's own status write with
  `"connected"` — otherwise the fix would be immediately undone by this
  second writer for every reconnect (`is_reconnect=True`) path, which is
  exactly the scenario the issue reports.
- `_record_polling_progress()` republishes `"connected"` the instant
  polling actually proves progress, so the state does not stay wedged at
  `"retrying"` until the next disconnect/reconnect cycle.

## Related Issue

Fixes #101391

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/base.py` — `_mark_connected(self, *, degraded: bool = False)`
  publishes `"retrying"` instead of `"connected"` when degraded.
- `plugins/platforms/telegram/adapter.py` — `_mark_connected()` passes
  `_send_path_degraded` through; `_record_polling_progress()` republishes
  `"connected"` once polling is confirmed healthy again.
- `gateway/run.py` — the reconnect-watcher success branch no longer
  overwrites a degraded adapter's status back to `"connected"`.
- `tests/gateway/test_telegram_send_path_health.py` — three new tests.

## How to Test

Ran directly (no CI wrapper available in this sandbox — `scripts/run_tests.sh`
needs the full `uv`-managed venv, which isn't installed here; ran `pytest`
against the affected modules after installing the missing runtime deps
`pyyaml`, `httpx`, `python-telegram-bot`, `wcwidth`):

```
$ python -m pytest tests/gateway/test_telegram_send_path_health.py -q
......                                                                   [100%]
6 passed in 0.46s
```

Proved the new tests fail without the fix (`git stash` the three source
files, keep the test file):

```
$ python -m pytest tests/gateway/test_telegram_send_path_health.py -q
....FF                                                                   [100%]
FAILED ...test_mark_connected_publishes_retrying_when_send_path_degraded
  AssertionError: assert 'connected' == 'retrying'
FAILED ...test_record_polling_progress_republishes_connected_after_degraded_connect
  AssertionError: Expected '_write_runtime_status_safe' to have been called once. Called 0 times.
2 failed, 4 passed in 0.61s
```

Full Telegram regression suite after the fix:

```
$ python -m pytest tests/gateway/test_telegram_*.py tests/test_telegram_polling_progress_ptb.py -q
640 passed, 2 skipped
```

(The 6 remaining `test_telegram_polling_progress_ptb.py` failures that show
up only when that file runs in the same session as several other Telegram
test files — never standalone — reproduce identically on unmodified
`upstream/main`, confirming they're pre-existing test-isolation flakiness
unrelated to this change, not a regression.)

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant test files and they pass
- [x] I've added tests for my changes
- [ ] N/A — no config keys, docs, or tool schemas changed

**AI assistance disclosure:** this change was authored with an AI coding
assistant (Claude), with the diff and test run reviewed before pushing.
