### PR TITLE
fix(tui): stop ctrl-modified keypresses from typing their letter into the composer

### DIFF
--- a/ui-tui/src/__tests__/textInputCtrlLetterLeak.test.tsx
+++ b/ui-tui/src/__tests__/textInputCtrlLetterLeak.test.tsx
@@ -1,0 +1,177 @@
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+
+import { renderSync } from '@hermes/ink'
+import React, { useState } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { TextInput } from '../components/textInput.js'
+
+class FakeInput extends EventEmitter {
+  chunks: string[] = []
+  isRaw = false
+  isTTY = true
+  readableLength = 0
+
+  read() {
+    const next = this.chunks.shift() ?? null
+    this.readableLength = this.chunks.length
+
+    return next
+  }
+
+  ref = vi.fn()
+
+  send(...chunks: string[]) {
+    this.chunks.push(...chunks)
+    this.readableLength = this.chunks.length
+
+    this.emit('readable')
+  }
+
+  setEncoding = vi.fn()
+
+  setRawMode = vi.fn((enabled: boolean) => {
+    this.isRaw = enabled
+  })
+
+  unref = vi.fn()
+}
+
+const settle = (ms = 0) => new Promise(resolve => setTimeout(resolve, ms))
+
+function makeStreams() {
+  const stdin = new FakeInput()
+  const stdout = new PassThrough()
+  const stderr = new PassThrough()
+
+  Object.assign(stdout, { columns: 80, isTTY: false, rows: 24 })
+  Object.assign(stderr, { columns: 80, isTTY: false, rows: 24 })
+
+  return { stderr, stdin, stdout }
+}
+
+// The dashboard gateway writes \x0c (Ctrl+L) to the chat PTY on every
+// reattach force-redraw (hermes_cli/pty_session.py TUI_FORCE_REDRAW).
+// hermes-ink parses it as {name: 'l', ctrl: true} and InputEvent surfaces
+// input='l'; without the ctrl guard in the composer's insert gate a literal
+// "l" lands at the cursor (#101393: every model-switcher reload appended
+// one "l" to the chat input).
+describe('TextInput ctrl-letter leak', () => {
+  it('does not insert a literal letter for the reattach force-redraw byte \\x0c (ctrl+l)', async () => {
+    const streams = makeStreams()
+    const changes: string[] = []
+
+    function Harness() {
+      const [value, setValue] = useState('')
+
+      return (
+        <TextInput
+          columns={80}
+          onChange={next => {
+            changes.push(next)
+            setValue(next)
+          }}
+          onSubmit={vi.fn()}
+          value={value}
+        />
+      )
+    }
+
+    const instance = renderSync(React.createElement(Harness), {
+      patchConsole: false,
+      stderr: streams.stderr as NodeJS.WriteStream,
+      stdin: streams.stdin as unknown as NodeJS.ReadStream,
+      stdout: streams.stdout as NodeJS.WriteStream
+    })
+
+    await settle()
+
+    streams.stdin.send('\x0c')
+    await settle(25)
+
+    streams.stdin.send('\x0c', '\x0c')
+    await settle(25)
+
+    expect(changes).toEqual([])
+
+    instance.unmount()
+  })
+
+  it('keeps existing draft text intact when \\x0c arrives mid-typing', async () => {
+    const streams = makeStreams()
+    const changes: string[] = []
+
+    function Harness() {
+      const [value, setValue] = useState('hello')
+
+      return (
+        <TextInput
+          columns={80}
+          onChange={next => {
+            changes.push(next)
+            setValue(next)
+          }}
+          onSubmit={vi.fn()}
+          value={value}
+        />
+      )
+    }
+
+    const instance = renderSync(React.createElement(Harness), {
+      patchConsole: false,
+      stderr: streams.stderr as NodeJS.WriteStream,
+      stdin: streams.stdin as unknown as NodeJS.ReadStream,
+      stdout: streams.stdout as NodeJS.WriteStream
+    })
+
+    await settle()
+
+    streams.stdin.send('\x0c')
+    await settle(25)
+
+    expect(changes).toEqual([])
+
+    instance.unmount()
+  })
+
+  it('still types a bare letter l and other ctrl-branch keys keep working', async () => {
+    const streams = makeStreams()
+    const changes: string[] = []
+
+    function Harness() {
+      const [value, setValue] = useState('')
+
+      return (
+        <TextInput
+          columns={80}
+          onChange={next => {
+            changes.push(next)
+            setValue(next)
+          }}
+          onSubmit={vi.fn()}
+          value={value}
+        />
+      )
+    }
+
+    const instance = renderSync(React.createElement(Harness), {
+      patchConsole: false,
+      stderr: streams.stderr as NodeJS.WriteStream,
+      stdin: streams.stdin as unknown as NodeJS.ReadStream,
+      stdout: streams.stdout as NodeJS.WriteStream
+    })
+
+    await settle()
+
+    streams.stdin.send('l')
+    await settle(25)
+
+    streams.stdin.send('\x0c')
+    await settle(25)
+
+    expect(changes).toEqual(['l'])
+
+    instance.unmount()
+  })
+})

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -1436,8 +1436,15 @@ export function TextInput({
       const range = selRange()
       const delFwd = k.delete || fwdDel.current
 
+      // A ctrl-modified keypress never types its letter into the composer:
+      // hermes-ink maps C0 controls to {name: <letter>, ctrl: true} (e.g. the
+      // gateway's PTY reattach force-redraw byte \x0c arrives as ctrl+'l'),
+      // and terminal convention is that Ctrl+<letter> is a shortcut or signal,
+      // not text — quoted-insert already has its own Ctrl+V path above.
       const isPrintableInput =
-        (event.keypress.isPasted || inp.length > 0) && PRINTABLE.test(inp.replace(BRACKET_PASTE, ''))
+        !k.ctrl &&
+        (event.keypress.isPasted || inp.length > 0) &&
+        PRINTABLE.test(inp.replace(BRACKET_PASTE, ''))
 
       if (!isPrintableInput) {
         flushKeyBurst()
@@ -1574,7 +1581,7 @@ export function TextInput({
         } else {
           ;({ cursor: c, value: v } = killToLineEnd(v, c))
         }
-      } else if (event.keypress.isPasted || inp.length > 0) {
+      } else if (event.keypress.isPasted || (inp.length > 0 && !k.ctrl)) {
         const bracketed = event.keypress.isPasted || inp.includes('[200~')
         const text = inp.replace(BRACKET_PASTE, '').replace(/\r\n/g, '\n').replace(/\r/g, '\n')
 


### PR DESCRIPTION
## What does this PR do?

Every PTY reattach of the dashboard chat typed a literal `l` at the composer cursor. Root cause chain:

1. On reattach, the gateway writes `TUI_FORCE_REDRAW = b"\x0c"` (Ctrl+L) into the chat PTY stdin (`hermes_cli/pty_session.py`, `attach(force_redraw=True)`).
2. hermes-ink parses `\x0c` as `{name: 'l', ctrl: true}`, and `InputEvent` surfaces `input = 'l'` for it (the Ink-compatibility rule `input = ctrl ? name : sequence`).
3. The composer's insert gate (`inp.length > 0` + printable check) did not exclude ctrl-modified keypresses, so the letter was typed into the input — with no keyboard key involved. On every model-switcher apply that reloads the chat page (the most common reattach path), the fresh empty composer gained one `l`; repeated reloads accumulated them.

Terminal convention is that Ctrl+`<letter>` is a shortcut or signal, never literal text — quoted-insert already has its own dedicated Ctrl+V path in the composer. This PR gates the insert path (and the matching `isPrintableInput` burst bookkeeping) on `!key.ctrl`. Paste events are unaffected (they never carry the ctrl modifier), and all existing Ctrl+letter actions (copy, cut, word-delete, kill-line, undo/redo, pass-throughs) branch before the insert path, so nothing else changes.

This also fixes the same leak for every other unbound Ctrl+letter reaching the composer (e.g. raw Ctrl+L / Ctrl+Z on macOS, where the action-modifier is Cmd and those keys previously fell through to typing `l` / `z`).

## Related Issue

Fixes #101393

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `ui-tui/src/components/textInput.tsx`: exclude `key.ctrl` from the printable-insert path (insert gate + `isPrintableInput`), so a ctrl-modified keypress never types its letter into the composer.
- `ui-tui/src/__tests__/textInputCtrlLetterLeak.test.tsx`: end-to-end regression tests that feed `\x0c` through the real stdin parse chain (FakeInput → tokenizer → InputEvent → composer) and assert no `l` lands in the value — on an empty draft, mid-typing, and mixed with a real keystroke.

## How to Test

1. `cd ui-tui && npx vitest run src/__tests__/textInputCtrlLetterLeak.test.tsx` — 3 tests pass. Observed result: on unpatched main the same suite fails with the literal `l` appearing in the composer value (red/green verified).
2. Full `npx vitest run` in `ui-tui`: no new failures vs. unpatched main at the same commit (baseline has pre-existing environment-related failures in `textInputFastEcho`, `createGatewayEventHandler`, `scrollBoxRendererBounds`, `virtualHistoryOffsetCache` — identical with and without this patch).
3. Manual (dashboard): open the browser dashboard chat, switch the model via the top-right model switcher and let the page reload — the chat input should stay empty. Before the fix, one `l` appeared at the cursor per reload.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A for this change (TypeScript-only; `ui-tui` vitest suite run instead, no new failures)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — fix is platform-neutral; macOS benefits most (raw Ctrl+letters previously leaked there)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ npx vitest run src/__tests__/textInputCtrlLetterLeak.test.tsx
 ✓ src/__tests__/textInputCtrlLetterLeak.test.tsx (3 tests) 162ms
 Test Files  1 passed (1)
      Tests  3 passed (3)
```