### PR TITLE
fix(agent): extend Windows bash hints with native-CLI flag and stderr-discipline rules

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1169,7 +1169,16 @@ _WINDOWS_BASH_SHELL_HINT = (
     "return, and a lone `\\n` is not delivered as a line terminator, so the "
     "child's prompt silently never returns. When a CLI offers a "
     "non-interactive path (flags, `--with-token`, config files, an OAuth "
-    "device flow polled with curl), prefer it over driving prompts."
+    "device flow polled with curl), prefer it over driving prompts. "
+    "Native Windows CLIs (`schtasks`, `taskkill`, `icacls`, `attrib`) take "
+    "SINGLE-slash flags (e.g. `schtasks /query /tn X /v /fo LIST`) — `//`-style "
+    "escaping is NOT needed here (MSYS conversion is already off) and is passed "
+    "literally, so `schtasks //query` dies with 'Invalid argument/option'. "
+    "If a native tool ever misbehaves under git-bash arg rewriting, prefix the "
+    "call with `MSYS_NO_PATHCONV=1`. Never send `2>/dev/null` on a discovery "
+    "query you will draw conclusions from: read its exit code and raw stderr "
+    "first — a mangled invocation with hidden stderr silently reads as "
+    "'nothing found'."
 )
 
 


### PR DESCRIPTION
## Summary

Extends the Windows environment hints (`agent/prompt_builder.py`, `_WINDOWS_BASH_SHELL_HINT`) — the block injected into every session's system prompt when the local terminal backend runs on native Windows (git-bash/MSYS) — with two rules that prevent recurring agent mistakes:

- **Single-slash flags for native Windows CLIs.** MSYS path conversion is disabled in Hermes's git-bash terminal, so `//`-style flag escaping is *not* collapsed and is passed literally to the child process. `schtasks //query` dies with `Invalid argument/option - '//query'`; the hint now tells agents to use `schtasks /query` and to reach for `MSYS_NO_PATHCONV=1` only if a native tool genuinely misbehaves under arg rewriting.
- **Don't silence stderr on discovery queries.** A mangled invocation with `2>/dev/null` hides the real error and reads as "nothing found" (e.g. concluding a scheduled task doesn't exist because `schtasks` failed silently). The hint says to read the exit code and raw stderr before drawing negative conclusions.

No runtime behavior changes — it is prompt-guidance only, so it is inert for non-Windows/remote-backend sessions and does not affect prompt caching (the hint is built at conversation start).

## Test Plan

- `python -m py_compile agent/prompt_builder.py` — passes.
- Module import confirms the two new clauses land in `_WINDOWS_BASH_SHELL_HINT`.
- The hint string is only emitted for local `win32` non-WSL terminal backends; this change is additive text inside that existing block.

## Notes

- This mirrors the repo's existing "Windows-Specific Quirks" documentation intent — the guidance now lives where the model actually reads it (the environment hints) instead of only in docs.