### PR TITLE
fix(gateway): extend systemd startup deadline through state migration (salvage #75841)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -69,6 +69,7 @@ from agent.turn_context import (
 )
 from hermes_cli.config import _is_ssh_remote_tilde_cwd, cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
+from gateway.systemd_notify import SystemdStartupDeadline
 
 # --- Agent cache tuning ---------------------------------------------------
 # Bounds the per-session AIAgent cache to prevent unbounded growth in
@@ -33649,6 +33650,39 @@ def _looks_like_profile_conflict_from_cmdline(command: str, our_home) -> bool:
 
 
 
+async def _discover_mcp_and_start_runner(
+    runner: GatewayRunner,
+) -> tuple[bool, SystemdStartupDeadline]:
+    """Start the runner and keep its systemd startup deadline active."""
+    deadline = SystemdStartupDeadline(
+        config_enabled=runner.config.systemd_watchdog_seconds > 0
+    )
+    deadline.start()
+    try:
+        try:
+            await _discover_gateway_mcp_tools(runner.config)
+        except Exception as exc:
+            logger.debug("MCP tool discovery failed: %s", exc)
+        success = await runner.start()
+    except BaseException:
+        await deadline.stop()
+        raise
+    if not success:
+        await deadline.stop()
+    return success, deadline
+
+
+async def _complete_systemd_startup(
+    deadline: SystemdStartupDeadline,
+    runner: GatewayRunner,
+) -> None:
+    """Stop deadline extension immediately before the runtime READY signal."""
+    await deadline.stop()
+    start_watchdog = getattr(runner, "_start_systemd_watchdog", None)
+    if callable(start_watchdog):
+        start_watchdog()
+
+
 async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = False, verbosity: Optional[int] = 0) -> bool:
     """
     Start the gateway and run until interrupted.
@@ -34187,20 +34221,13 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
 
     _ensure_windows_gateway_venv_imports()
 
-    # MCP tool discovery — run in an executor so the asyncio event loop
-    # stays responsive even when a configured MCP server is slow or
-    # unreachable.  discover_mcp_tools() uses a blocking 120s wait
-    # internally; calling it from the loop thread would freeze platform
-    # heartbeats (Discord shard, Telegram polling) until it returned.
-    # See #16856.
+    # MCP discovery and adapter startup run under a renewable systemd startup
+    # deadline when the opt-in watchdog unit owns the notify environment.
     try:
-        await _discover_gateway_mcp_tools(runner.config)
-    except Exception as e:
-        logger.debug("MCP tool discovery failed: %s", e)
-
-    # Start the gateway
-    try:
-        success = await runner.start()
+        (
+            success,
+            systemd_startup_deadline,
+        ) = await _discover_mcp_and_start_runner(runner)
     except BaseException:
         _shutdown_gateway_health_export(runner)
         raise
@@ -34218,6 +34245,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     except Exception:
         pass
     if runner.should_exit_cleanly:
+        await systemd_startup_deadline.stop()
         _shutdown_gateway_health_export(runner)
         if runner.exit_reason:
             logger.error("Gateway exiting cleanly: %s", runner.exit_reason)
@@ -34232,6 +34260,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             raise SystemExit(runner.exit_code)
         return True
     if not runner._running:
+        await systemd_startup_deadline.stop()
         # Startup was intentionally aborted by restart/shutdown before entering
         # running mode; preserve that lifecycle path without starting cron.
         try:
@@ -34365,11 +34394,9 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     housekeeping_thread.start()
 
     # READY is emitted only after adapters, cron, and housekeeping have all
-    # reached their running boundary. Missing config/systemd runtime state
-    # leaves the watchdog disabled without changing gateway behavior.
-    start_watchdog = getattr(runner, "_start_systemd_watchdog", None)
-    if callable(start_watchdog):
-        start_watchdog()
+    # reached their running boundary. Stop startup extensions immediately
+    # before the runtime watchdog sends READY=1.
+    await _complete_systemd_startup(systemd_startup_deadline, runner)
 
     # Wait for shutdown
     await runner.wait_for_shutdown()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -33649,16 +33649,39 @@ def _looks_like_profile_conflict_from_cmdline(command: str, our_home) -> bool:
     return False
 
 
-
-async def _discover_mcp_and_start_runner(
-    runner: GatewayRunner,
-) -> tuple[bool, SystemdStartupDeadline]:
-    """Start the runner and keep its systemd startup deadline active."""
+async def _construct_runner_with_startup_deadline(
+    config: Optional[GatewayConfig],
+) -> tuple[GatewayRunner, SystemdStartupDeadline]:
+    """Start deadline renewal before the runner can open or migrate state.db."""
+    effective_config = (
+        config if config is not None else load_gateway_config_for_runner()
+    )
     deadline = SystemdStartupDeadline(
-        config_enabled=runner.config.systemd_watchdog_seconds > 0
+        config_enabled=effective_config.systemd_watchdog_seconds > 0
     )
     deadline.start()
     try:
+        runner = GatewayRunner(effective_config)
+    except BaseException:
+        await deadline.stop()
+        raise
+    return runner, deadline
+
+
+async def _discover_mcp_and_start_runner(
+    runner: GatewayRunner,
+    deadline: Optional[SystemdStartupDeadline] = None,
+) -> tuple[bool, SystemdStartupDeadline]:
+    """Start the runner while keeping its systemd startup deadline active."""
+    if deadline is None:
+        deadline = SystemdStartupDeadline(
+            config_enabled=runner.config.systemd_watchdog_seconds > 0
+        )
+        deadline.start()
+    try:
+        # Keep the event loop responsive while a configured MCP server is slow
+        # or unreachable. The deadline task can therefore continue notifying
+        # systemd throughout MCP discovery and sequential adapter startup.
         try:
             await _discover_gateway_mcp_tools(runner.config)
         except Exception as exc:
@@ -33683,7 +33706,13 @@ async def _complete_systemd_startup(
         start_watchdog()
 
 
-async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = False, verbosity: Optional[int] = 0) -> bool:
+async def _start_gateway_impl(
+    config: Optional[GatewayConfig] = None,
+    replace: bool = False,
+    verbosity: Optional[int] = 0,
+    *,
+    _systemd_startup_deadline_holder: Optional[List[SystemdStartupDeadline]] = None,
+) -> bool:
     """
     Start the gateway and run until interrupted.
     
@@ -33944,10 +33973,16 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         if _stderr_level < logging.getLogger().level:
             logging.getLogger().setLevel(_stderr_level)
 
-    runner = GatewayRunner(config)
+    runner, systemd_startup_deadline = (
+        await _construct_runner_with_startup_deadline(config)
+    )
+    if _systemd_startup_deadline_holder is not None:
+        # Register ownership before any post-construction setup can fail so the
+        # public wrapper's finally block covers every subsequent exit path.
+        _systemd_startup_deadline_holder.append(systemd_startup_deadline)
     # Multiplex: swap the launch-home file handlers for per-profile routers so
     # each profile's records land in its own logs/ (#82936). Must run after
-    # the runner resolved the (possibly None) config and after setup_logging.
+    # the runner resolved the effective config and after setup_logging.
     _enable_multiplex_log_routing(runner.config)
     # ``--replace`` is explicit startup authority, not a durable reconnect
     # policy. GatewayRunner scopes this bit to cold adapter connects and clears
@@ -34227,7 +34262,9 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         (
             success,
             systemd_startup_deadline,
-        ) = await _discover_mcp_and_start_runner(runner)
+        ) = await _discover_mcp_and_start_runner(
+            runner, deadline=systemd_startup_deadline
+        )
     except BaseException:
         _shutdown_gateway_health_export(runner)
         raise
@@ -34482,6 +34519,33 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         raise SystemExit(75)
 
     return True
+
+
+async def start_gateway(
+    config: Optional[GatewayConfig] = None,
+    replace: bool = False,
+    verbosity: Optional[int] = 0,
+) -> bool:
+    """Run the gateway while owning its startup deadline on every exit path.
+
+    ``_start_gateway_impl`` must keep the deadline alive across runner
+    construction, PID/lock setup, adapter startup, cron, and housekeeping.
+    Centralizing the final stop here makes every return, exception, and
+    cancellation after construction fail closed without duplicating cleanup at
+    each startup branch. Normal READY handoff already stops it; ``stop()`` is
+    intentionally idempotent, so this finalizer is then a no-op.
+    """
+    startup_deadlines: List[SystemdStartupDeadline] = []
+    try:
+        return await _start_gateway_impl(
+            config,
+            replace,
+            verbosity,
+            _systemd_startup_deadline_holder=startup_deadlines,
+        )
+    finally:
+        if startup_deadlines:
+            await startup_deadlines[-1].stop()
 
 
 def _guard_corrupt_user_config() -> None:

--- a/gateway/systemd_notify.py
+++ b/gateway/systemd_notify.py
@@ -57,6 +57,83 @@ def watchdog_interval_seconds() -> Optional[float]:
     return interval
 
 
+def _watchdog_pid_matches_current_process() -> bool:
+    """Reject a WATCHDOG_PID inherited from another process."""
+    raw_pid = os.environ.get("WATCHDOG_PID", "").strip()
+    if not raw_pid:
+        return True
+    try:
+        return int(raw_pid) == os.getpid()
+    except (TypeError, ValueError):
+        return False
+
+
+class SystemdStartupDeadline:
+    """Extend startup while a watchdog-enabled Type=notify unit initializes."""
+
+    def __init__(
+        self,
+        *,
+        config_enabled: bool = True,
+        interval_seconds: float = 30.0,
+        extend_seconds: int = 60,
+    ) -> None:
+        self._config_enabled = bool(config_enabled)
+        self._interval_seconds = max(0.01, float(interval_seconds))
+        self._extend_usec = max(1, int(extend_seconds * 1_000_000))
+        self._task: Optional[asyncio.Task[None]] = None
+
+    @property
+    def enabled(self) -> bool:
+        return (
+            self._config_enabled
+            and watchdog_interval_seconds() is not None
+            and _watchdog_pid_matches_current_process()
+        )
+
+    @property
+    def task(self) -> Optional[asyncio.Task[None]]:
+        return self._task
+
+    def start(self) -> bool:
+        """Start repeatedly extending systemd's startup deadline."""
+        if not self.enabled:
+            return False
+        if self._task is not None and not self._task.done():
+            return True
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return False
+        self._task = asyncio.create_task(
+            self._run(), name="hermes-systemd-startup-deadline"
+        )
+        return True
+
+    async def _run(self) -> None:
+        try:
+            while True:
+                notify(f"EXTEND_TIMEOUT_USEC={self._extend_usec}")
+                await asyncio.sleep(self._interval_seconds)
+        except asyncio.CancelledError:
+            return
+
+    async def stop(self) -> None:
+        """Cancel startup notifications without emitting runtime state."""
+        task = self._task
+        self._task = None
+        if task is None or task is asyncio.current_task():
+            return
+        if not task.done():
+            task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            pass
+
+
 class SystemdWatchdog:
     """Feed systemd while the asyncio event loop continues to make progress."""
 

--- a/gateway/systemd_notify.py
+++ b/gateway/systemd_notify.py
@@ -82,6 +82,7 @@ class SystemdStartupDeadline:
         self._interval_seconds = max(0.01, float(interval_seconds))
         self._extend_usec = max(1, int(extend_seconds * 1_000_000))
         self._task: Optional[asyncio.Task[None]] = None
+        self._owner_task: Optional[asyncio.Task[object]] = None
 
     @property
     def enabled(self) -> bool:
@@ -105,16 +106,32 @@ class SystemdStartupDeadline:
             asyncio.get_running_loop()
         except RuntimeError:
             return False
+        # Emit before returning: GatewayRunner construction and state migrations
+        # are synchronous and can block the event loop before _run gets a turn.
+        notify(f"EXTEND_TIMEOUT_USEC={self._extend_usec}")
         self._task = asyncio.create_task(
             self._run(), name="hermes-systemd-startup-deadline"
         )
+        self._owner_task = asyncio.current_task()
+        if self._owner_task is not None:
+            self._owner_task.add_done_callback(self._cancel_if_owner_done)
         return True
+
+    def _cancel_if_owner_done(self, owner: asyncio.Task[object]) -> None:
+        """Cancel orphaned renewal if startup exits before the READY handoff."""
+        if owner is not self._owner_task:
+            return
+        self._owner_task = None
+        task = self._task
+        self._task = None
+        if task is not None and not task.done():
+            task.cancel()
 
     async def _run(self) -> None:
         try:
             while True:
-                notify(f"EXTEND_TIMEOUT_USEC={self._extend_usec}")
                 await asyncio.sleep(self._interval_seconds)
+                notify(f"EXTEND_TIMEOUT_USEC={self._extend_usec}")
         except asyncio.CancelledError:
             return
 
@@ -122,16 +139,28 @@ class SystemdStartupDeadline:
         """Cancel startup notifications without emitting runtime state."""
         task = self._task
         self._task = None
+        owner = self._owner_task
+        self._owner_task = None
+        if owner is not None:
+            owner.remove_done_callback(self._cancel_if_owner_done)
         if task is None or task is asyncio.current_task():
             return
+        current = asyncio.current_task()
         if not task.done():
             task.cancel()
         try:
-            await task
+            # The owner may be cancelled while the child performs cancellation
+            # cleanup. Shield prevents that second cancellation from aborting
+            # the child and lets us distinguish owner cancellation below.
+            await asyncio.shield(task)
         except asyncio.CancelledError:
-            pass
+            if current is not None and current.cancelling():
+                raise
         except Exception:
             pass
+        # Deliver cancellation already queued for this caller after consuming
+        # only the child task's expected cancellation.
+        await asyncio.sleep(0)
 
 
 class SystemdWatchdog:
@@ -153,7 +182,11 @@ class SystemdWatchdog:
 
     @property
     def enabled(self) -> bool:
-        return self._config_enabled and self.interval_seconds is not None
+        return (
+            self._config_enabled
+            and self.interval_seconds is not None
+            and _watchdog_pid_matches_current_process()
+        )
 
     @property
     def unhealthy(self) -> bool:
@@ -238,16 +271,27 @@ class SystemdWatchdog:
         self._stopping = True
         task = self._task
         current = asyncio.current_task()
-        if task is not None and task is not current:
-            if not task.done():
-                task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
-            except Exception:
-                pass
-        self._task = None
-        if self.enabled and not self._stopping_notified:
-            notify("STOPPING=1")
-            self._stopping_notified = True
+        try:
+            if task is not None and task is not current:
+                if not task.done():
+                    task.cancel()
+                try:
+                    # Keep cancellation of this owner separate from the child
+                    # cancellation requested above; the child swallows its own
+                    # CancelledError as part of normal watchdog teardown.
+                    await asyncio.shield(task)
+                except asyncio.CancelledError:
+                    if current is not None and current.cancelling():
+                        raise
+                except Exception:
+                    pass
+                # Give a cancellation queued for this caller a checkpoint even
+                # when the child completed before the callback was delivered.
+                await asyncio.sleep(0)
+        finally:
+            # Cancellation must propagate without leaving stale watchdog state
+            # or skipping systemd's shutdown transition.
+            self._task = None
+            if self.enabled and not self._stopping_notified:
+                notify("STOPPING=1")
+                self._stopping_notified = True

--- a/tests/gateway/test_systemd_notify.py
+++ b/tests/gateway/test_systemd_notify.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import socket
 
 import pytest
@@ -53,6 +54,56 @@ def test_notify_uses_nonblocking_datagram_send(monkeypatch):
 
     assert notify_mod.notify("READY=1") is True
     assert calls[0] == ("setblocking", False)
+
+
+def test_startup_deadline_rejects_mismatched_watchdog_pid(monkeypatch):
+    monkeypatch.setenv("NOTIFY_SOCKET", "/tmp/hermes-test-notify")
+    monkeypatch.setenv("WATCHDOG_USEC", "1000000")
+    monkeypatch.setenv("WATCHDOG_PID", str(os.getpid() + 1))
+
+    from gateway.systemd_notify import SystemdStartupDeadline
+
+    assert SystemdStartupDeadline().enabled is False
+
+
+@pytest.mark.asyncio
+async def test_startup_deadline_repeats_until_stopped(monkeypatch):
+    calls: list[str] = []
+    monkeypatch.setenv("NOTIFY_SOCKET", "/tmp/hermes-test-notify")
+    monkeypatch.setenv("WATCHDOG_USEC", "1000000")
+    monkeypatch.setenv("WATCHDOG_PID", str(os.getpid()))
+
+    import gateway.systemd_notify as notify_mod
+
+    monkeypatch.setattr(
+        notify_mod, "notify", lambda message: calls.append(message) or True
+    )
+    deadline = notify_mod.SystemdStartupDeadline(
+        interval_seconds=0.01, extend_seconds=1
+    )
+
+    assert deadline.start() is True
+    await asyncio.sleep(0.025)
+    await deadline.stop()
+    count_after_stop = len(calls)
+    await asyncio.sleep(0.02)
+
+    assert calls.count("EXTEND_TIMEOUT_USEC=1000000") >= 2
+    assert len(calls) == count_after_stop
+    assert deadline.task is None
+
+
+@pytest.mark.asyncio
+async def test_startup_deadline_is_inert_when_config_disabled(monkeypatch):
+    monkeypatch.setenv("NOTIFY_SOCKET", "/tmp/hermes-test-notify")
+    monkeypatch.setenv("WATCHDOG_USEC", "1000000")
+
+    from gateway.systemd_notify import SystemdStartupDeadline
+
+    deadline = SystemdStartupDeadline(config_enabled=False)
+    assert deadline.enabled is False
+    assert deadline.start() is False
+    await deadline.stop()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_systemd_notify.py
+++ b/tests/gateway/test_systemd_notify.py
@@ -94,6 +94,81 @@ async def test_startup_deadline_repeats_until_stopped(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_startup_deadline_extends_before_start_returns(monkeypatch):
+    calls: list[str] = []
+    monkeypatch.setenv("NOTIFY_SOCKET", "/tmp/hermes-test-notify")
+    monkeypatch.setenv("WATCHDOG_USEC", "1000000")
+    monkeypatch.setenv("WATCHDOG_PID", str(os.getpid()))
+
+    import gateway.systemd_notify as notify_mod
+
+    monkeypatch.setattr(
+        notify_mod, "notify", lambda message: calls.append(message) or True
+    )
+    deadline = notify_mod.SystemdStartupDeadline(
+        interval_seconds=60, extend_seconds=1
+    )
+
+    assert deadline.start() is True
+    assert calls == ["EXTEND_TIMEOUT_USEC=1000000"]
+    await deadline.stop()
+
+
+@pytest.mark.asyncio
+async def test_startup_deadline_stop_propagates_caller_cancellation(monkeypatch):
+    monkeypatch.setenv("NOTIFY_SOCKET", "/tmp/hermes-test-notify")
+    monkeypatch.setenv("WATCHDOG_USEC", "1000000")
+    monkeypatch.setenv("WATCHDOG_PID", str(os.getpid()))
+
+    import gateway.systemd_notify as notify_mod
+
+    monkeypatch.setattr(notify_mod, "notify", lambda _message: True)
+    deadline = notify_mod.SystemdStartupDeadline()
+    assert deadline.start() is True
+
+    async def cancel_during_stop():
+        current = asyncio.current_task()
+        assert current is not None
+        asyncio.get_running_loop().call_soon(current.cancel)
+        await deadline.stop()
+
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.create_task(cancel_during_stop())
+
+    assert deadline.task is None
+
+
+@pytest.mark.asyncio
+async def test_startup_deadline_stops_when_owner_task_fails(monkeypatch):
+    calls: list[str] = []
+    deadlines = []
+    monkeypatch.setenv("NOTIFY_SOCKET", "/tmp/hermes-test-notify")
+    monkeypatch.setenv("WATCHDOG_USEC", "1000000")
+    monkeypatch.setenv("WATCHDOG_PID", str(os.getpid()))
+
+    import gateway.systemd_notify as notify_mod
+
+    monkeypatch.setattr(
+        notify_mod, "notify", lambda message: calls.append(message) or True
+    )
+
+    async def failing_startup_owner():
+        deadline = notify_mod.SystemdStartupDeadline(
+            interval_seconds=0.01, extend_seconds=1
+        )
+        deadlines.append(deadline)
+        assert deadline.start() is True
+        raise RuntimeError("pre-ready failure")
+
+    with pytest.raises(RuntimeError, match="pre-ready failure"):
+        await asyncio.create_task(failing_startup_owner())
+    await asyncio.sleep(0.03)
+
+    assert deadlines[0].task is None
+    assert calls == ["EXTEND_TIMEOUT_USEC=1000000"]
+
+
+@pytest.mark.asyncio
 async def test_startup_deadline_is_inert_when_config_disabled(monkeypatch):
     monkeypatch.setenv("NOTIFY_SOCKET", "/tmp/hermes-test-notify")
     monkeypatch.setenv("WATCHDOG_USEC", "1000000")
@@ -104,6 +179,40 @@ async def test_startup_deadline_is_inert_when_config_disabled(monkeypatch):
     assert deadline.enabled is False
     assert deadline.start() is False
     await deadline.stop()
+
+
+def test_runtime_watchdog_rejects_mismatched_watchdog_pid(monkeypatch):
+    monkeypatch.setenv("NOTIFY_SOCKET", "/tmp/hermes-test-notify")
+    monkeypatch.setenv("WATCHDOG_USEC", "1000000")
+    monkeypatch.setenv("WATCHDOG_PID", str(os.getpid() + 1))
+
+    from gateway.systemd_notify import SystemdWatchdog
+
+    assert SystemdWatchdog().enabled is False
+
+
+@pytest.mark.asyncio
+async def test_runtime_watchdog_stop_propagates_caller_cancellation(monkeypatch):
+    monkeypatch.setenv("NOTIFY_SOCKET", "/tmp/hermes-test-notify")
+    monkeypatch.setenv("WATCHDOG_USEC", "1000000")
+    monkeypatch.setenv("WATCHDOG_PID", str(os.getpid()))
+
+    import gateway.systemd_notify as notify_mod
+
+    monkeypatch.setattr(notify_mod, "notify", lambda _message: True)
+    watchdog = notify_mod.SystemdWatchdog()
+    assert watchdog.start() is True
+
+    async def cancel_during_stop():
+        current = asyncio.current_task()
+        assert current is not None
+        asyncio.get_running_loop().call_soon(current.cancel)
+        await watchdog.stop()
+
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.create_task(cancel_during_stop())
+
+    assert watchdog.task is None
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_systemd_watchdog_lifecycle.py
+++ b/tests/gateway/test_systemd_watchdog_lifecycle.py
@@ -8,7 +8,12 @@ from unittest.mock import patch
 import pytest
 
 from gateway.config import GatewayConfig
-from gateway.run import GatewayRunner, start_gateway
+from gateway.run import (
+    GatewayRunner,
+    _complete_systemd_startup,
+    _discover_mcp_and_start_runner,
+    start_gateway,
+)
 from tests.gateway.restart_test_helpers import make_restart_runner
 
 
@@ -50,5 +55,82 @@ def test_runner_starts_watchdog_only_after_running(monkeypatch):
     watchdog = _FakeWatchdog.instances[-1]
     assert watchdog.config_enabled is True
     assert watchdog.calls == ["start", "ready:Hermes Gateway running"]
+
+
+@pytest.mark.asyncio
+async def test_startup_deadline_stays_active_until_ready_boundary(monkeypatch):
+    order: list[str] = []
+
+    class _FakeDeadline:
+        def __init__(self, *, config_enabled):
+            order.append(f"deadline.init:{config_enabled}")
+
+        def start(self):
+            order.append("deadline.start")
+            return True
+
+        async def stop(self):
+            order.append("deadline.stop")
+
+    class _Runner:
+        config = GatewayConfig(systemd_watchdog_seconds=120)
+
+        async def start(self):
+            order.append("runner.start")
+            return True
+
+        def _start_systemd_watchdog(self):
+            order.append("watchdog.ready")
+            return True
+
+    monkeypatch.setattr("gateway.run.SystemdStartupDeadline", _FakeDeadline)
+    monkeypatch.setattr(
+        "tools.mcp_tool.discover_mcp_tools",
+        lambda: order.append("mcp.discover"),
+    )
+
+    runner = _Runner()
+    success, deadline = await _discover_mcp_and_start_runner(runner)
+    assert success is True
+    assert order == [
+        "deadline.init:True",
+        "deadline.start",
+        "mcp.discover",
+        "runner.start",
+    ]
+
+    await _complete_systemd_startup(deadline, runner)
+    assert order[-2:] == ["deadline.stop", "watchdog.ready"]
+
+
+@pytest.mark.asyncio
+async def test_startup_deadline_stops_when_runner_start_fails(monkeypatch):
+    order: list[str] = []
+
+    class _FakeDeadline:
+        def __init__(self, *, config_enabled):
+            order.append(f"deadline.init:{config_enabled}")
+
+        def start(self):
+            order.append("deadline.start")
+            return True
+
+        async def stop(self):
+            order.append("deadline.stop")
+
+    class _Runner:
+        config = GatewayConfig(systemd_watchdog_seconds=120)
+
+        async def start(self):
+            order.append("runner.start")
+            raise RuntimeError("startup failed")
+
+    monkeypatch.setattr("gateway.run.SystemdStartupDeadline", _FakeDeadline)
+    monkeypatch.setattr("tools.mcp_tool.discover_mcp_tools", lambda: None)
+
+    with pytest.raises(RuntimeError, match="startup failed"):
+        await _discover_mcp_and_start_runner(_Runner())
+
+    assert order[-1] == "deadline.stop"
 
 

--- a/tests/gateway/test_systemd_watchdog_lifecycle.py
+++ b/tests/gateway/test_systemd_watchdog_lifecycle.py
@@ -104,6 +104,38 @@ async def test_startup_deadline_stays_active_until_ready_boundary(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_startup_deadline_stops_when_runner_returns_false(monkeypatch):
+    order: list[str] = []
+
+    class _FakeDeadline:
+        def __init__(self, *, config_enabled):
+            order.append(f"deadline.init:{config_enabled}")
+
+        def start(self):
+            order.append("deadline.start")
+            return True
+
+        async def stop(self):
+            order.append("deadline.stop")
+
+    class _Runner:
+        config = GatewayConfig(systemd_watchdog_seconds=120)
+
+        async def start(self):
+            order.append("runner.start:false")
+            return False
+
+    monkeypatch.setattr("gateway.run.SystemdStartupDeadline", _FakeDeadline)
+    monkeypatch.setattr("tools.mcp_tool.discover_mcp_tools", lambda: None)
+
+    success, deadline = await _discover_mcp_and_start_runner(_Runner())
+
+    assert success is False
+    assert deadline is not None
+    assert order[-2:] == ["runner.start:false", "deadline.stop"]
+
+
+@pytest.mark.asyncio
 async def test_startup_deadline_stops_when_runner_start_fails(monkeypatch):
     order: list[str] = []
 

--- a/tests/gateway/test_systemd_watchdog_lifecycle.py
+++ b/tests/gateway/test_systemd_watchdog_lifecycle.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import inspect
+import os
 from unittest.mock import patch
 
 import pytest
@@ -11,6 +13,7 @@ from gateway.config import GatewayConfig
 from gateway.run import (
     GatewayRunner,
     _complete_systemd_startup,
+    _construct_runner_with_startup_deadline,
     _discover_mcp_and_start_runner,
     start_gateway,
 )
@@ -37,6 +40,138 @@ class _FakeWatchdog:
         self.calls.append("stop")
 
 
+class _FakeStartupDeadline:
+    def __init__(self):
+        self.stop_calls = 0
+
+    async def stop(self):
+        self.stop_calls += 1
+
+
+class _RunningStartupRunner:
+    def __init__(self):
+        self.config = GatewayConfig(systemd_watchdog_seconds=120)
+        self.adapters = {}
+        self.should_exit_cleanly = False
+        self.exit_reason = None
+        self.exit_code = None
+        self._running = True
+        self._draining = False
+        self._external_drain_active = False
+
+    def request_restart(self, *, detached, via_service):
+        return False
+
+    async def stop(self):
+        return None
+
+
+def _patch_start_gateway_shell(monkeypatch, tmp_path, runner, deadline):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("hermes_cli.resource_limits.apply_nofile_soft_limit", lambda: None)
+    monkeypatch.setattr("gateway.code_skew.record_boot_fingerprint", lambda: None)
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr("tools.skills_sync.sync_skills", lambda quiet=True: None)
+    monkeypatch.setattr(
+        "hermes_logging.setup_logging", lambda hermes_home, mode: tmp_path
+    )
+    monkeypatch.setattr(
+        "hermes_logging._add_rotating_handler", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        "hermes_cli.security_audit_startup.log_startup_security_warnings",
+        lambda **kwargs: None,
+    )
+
+    async def construct(_config):
+        return runner, deadline
+
+    monkeypatch.setattr(
+        "gateway.run._construct_runner_with_startup_deadline", construct
+    )
+    monkeypatch.setattr("gateway.run._run_planned_stop_watcher", lambda *args: None)
+    loop = asyncio.get_running_loop()
+    monkeypatch.setattr(loop, "add_signal_handler", lambda *args: None)
+    monkeypatch.setattr(loop, "set_exception_handler", lambda *args: None)
+
+
+@pytest.mark.asyncio
+async def test_start_gateway_stops_startup_deadline_on_early_false_return(
+    monkeypatch, tmp_path
+):
+    runner = _RunningStartupRunner()
+    deadline = _FakeStartupDeadline()
+    _patch_start_gateway_shell(monkeypatch, tmp_path, runner, deadline)
+    monkeypatch.setattr("gateway.status.acquire_gateway_runtime_lock", lambda: False)
+
+    assert await start_gateway(config=runner.config, verbosity=None) is False
+    assert deadline.stop_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_start_gateway_stops_deadline_when_post_construction_setup_fails(
+    monkeypatch, tmp_path
+):
+    runner = _RunningStartupRunner()
+    deadline = _FakeStartupDeadline()
+    _patch_start_gateway_shell(monkeypatch, tmp_path, runner, deadline)
+
+    def fail_log_routing(_config):
+        raise RuntimeError("log routing failed")
+
+    monkeypatch.setattr(
+        "gateway.run._enable_multiplex_log_routing", fail_log_routing
+    )
+
+    with pytest.raises(RuntimeError, match="log routing failed"):
+        await start_gateway(config=runner.config, verbosity=None)
+
+    assert deadline.stop_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_start_gateway_stops_startup_deadline_on_post_runner_exception(
+    monkeypatch, tmp_path
+):
+    runner = _RunningStartupRunner()
+    deadline = _FakeStartupDeadline()
+    _patch_start_gateway_shell(monkeypatch, tmp_path, runner, deadline)
+    monkeypatch.setattr("gateway.status.acquire_gateway_runtime_lock", lambda: True)
+    monkeypatch.setattr("gateway.status.write_pid_file", lambda: None)
+    monkeypatch.setattr("gateway.status.remove_pid_file", lambda: None)
+    monkeypatch.setattr("gateway.status.release_gateway_runtime_lock", lambda: None)
+
+    async def control_start(_self):
+        return False
+
+    monkeypatch.setattr("gateway.control_socket.GatewayControlServer.start", control_start)
+    monkeypatch.setattr("gateway.lifecycle_ledger.record_startup", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.nous_auth_keepalive.start_nous_auth_keepalive", lambda: None
+    )
+    monkeypatch.setattr("gateway.run._ensure_windows_gateway_venv_imports", lambda: None)
+
+    async def discover_and_start(_runner, *, deadline):
+        return True, deadline
+
+    monkeypatch.setattr(
+        "gateway.run._discover_mcp_and_start_runner", discover_and_start
+    )
+    monkeypatch.setattr("gateway.shutdown_flush.recover_pending_to_db", lambda: 0)
+
+    def fail_cron_resolution():
+        raise RuntimeError("cron resolution failed")
+
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler", fail_cron_resolution
+    )
+
+    with pytest.raises(RuntimeError, match="cron resolution failed"):
+        await start_gateway(config=runner.config, verbosity=None)
+
+    assert deadline.stop_calls == 1
+
+
 def _bare_runner(*, seconds: int, running: bool = True) -> GatewayRunner:
     runner = object.__new__(GatewayRunner)
     runner.config = GatewayConfig(systemd_watchdog_seconds=seconds)
@@ -55,6 +190,74 @@ def test_runner_starts_watchdog_only_after_running(monkeypatch):
     watchdog = _FakeWatchdog.instances[-1]
     assert watchdog.config_enabled is True
     assert watchdog.calls == ["start", "ready:Hermes Gateway running"]
+
+
+@pytest.mark.asyncio
+async def test_startup_deadline_covers_runner_construction(monkeypatch):
+    order: list[str] = []
+
+    class _FakeDeadline:
+        def __init__(self, *, config_enabled):
+            order.append(f"deadline.init:{config_enabled}")
+
+        def start(self):
+            order.append("deadline.start")
+            return True
+
+        async def stop(self):
+            order.append("deadline.stop")
+
+    class _Runner:
+        def __init__(self, config):
+            order.append("runner.init")
+            self.config = config
+
+    monkeypatch.setattr("gateway.run.SystemdStartupDeadline", _FakeDeadline)
+    monkeypatch.setattr("gateway.run.GatewayRunner", _Runner)
+
+    runner, deadline = await _construct_runner_with_startup_deadline(
+        GatewayConfig(systemd_watchdog_seconds=120)
+    )
+
+    assert runner.config.systemd_watchdog_seconds == 120
+    assert order == ["deadline.init:True", "deadline.start", "runner.init"]
+    await deadline.stop()
+
+
+@pytest.mark.asyncio
+async def test_startup_deadline_stops_when_runner_construction_fails(monkeypatch):
+    order: list[str] = []
+
+    class _FakeDeadline:
+        def __init__(self, *, config_enabled):
+            order.append(f"deadline.init:{config_enabled}")
+
+        def start(self):
+            order.append("deadline.start")
+            return True
+
+        async def stop(self):
+            order.append("deadline.stop")
+
+    class _Runner:
+        def __init__(self, config):
+            order.append("runner.init:failed")
+            raise RuntimeError("constructor failed")
+
+    monkeypatch.setattr("gateway.run.SystemdStartupDeadline", _FakeDeadline)
+    monkeypatch.setattr("gateway.run.GatewayRunner", _Runner)
+
+    with pytest.raises(RuntimeError, match="constructor failed"):
+        await _construct_runner_with_startup_deadline(
+            GatewayConfig(systemd_watchdog_seconds=120)
+        )
+
+    assert order == [
+        "deadline.init:True",
+        "deadline.start",
+        "runner.init:failed",
+        "deadline.stop",
+    ]
 
 
 @pytest.mark.asyncio
@@ -101,6 +304,55 @@ async def test_startup_deadline_stays_active_until_ready_boundary(monkeypatch):
 
     await _complete_systemd_startup(deadline, runner)
     assert order[-2:] == ["deadline.stop", "watchdog.ready"]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_ready_handoff_never_signals_ready(monkeypatch):
+    calls: list[str] = []
+    child_cancelled = asyncio.Event()
+    release_child = asyncio.Event()
+    monkeypatch.setenv("NOTIFY_SOCKET", "/tmp/hermes-test-notify")
+    monkeypatch.setenv("WATCHDOG_USEC", "1000000")
+    monkeypatch.setenv("WATCHDOG_PID", str(os.getpid()))
+
+    import gateway.systemd_notify as notify_mod
+
+    monkeypatch.setattr(
+        notify_mod, "notify", lambda message: calls.append(message) or True
+    )
+
+    class _SlowCancellationDeadline(notify_mod.SystemdStartupDeadline):
+        async def _run(self):
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                child_cancelled.set()
+                await release_child.wait()
+
+    deadline = _SlowCancellationDeadline(interval_seconds=60)
+    assert deadline.start() is True
+    child_task = deadline.task
+    assert child_task is not None
+
+    class _Runner:
+        def _start_systemd_watchdog(self):
+            calls.append("READY")
+            return True
+
+    handoff_task = asyncio.create_task(_complete_systemd_startup(deadline, _Runner()))
+    await asyncio.wait_for(child_cancelled.wait(), timeout=1)
+    assert handoff_task.done() is False
+    assert handoff_task.cancel() is True
+
+    with pytest.raises(asyncio.CancelledError):
+        await handoff_task
+
+    assert "READY" not in calls
+    assert deadline.task is None
+    release_child.set()
+    await child_task
+    assert child_task.done() is True
+    assert child_task.cancelled() is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

> **Safety status:** this draft is blocked. Public independent review of the exact remote HEAD `432cf497f769be77c02d66981a4231c08c06861d` found that renewal runs on the event loop and cannot renew while synchronous `GatewayRunner` construction blocks during a long `state.db` migration. Candidate follow-up fixes exist only on a separate local branch and have not been pushed. Do not merge this PR; GitHub CI has not started.

Salvage and current-main rebase of #75841 by @marcus-vibe, preserving both original commits and authorship.

A watchdog-enabled systemd `Type=notify` gateway currently sends `READY=1` only after MCP discovery, adapter startup, cron, and housekeeping are ready, but systemd's fixed startup deadline can expire first. This is reproducible on v0.21.0 with a multi-GB `state.db`: Hermes correctly grants `state_db_data_migrations` a 600-second progress lease while systemd still terminates the service after its 90-second `TimeoutStartSec`.

## Fix in this remote draft

- Add `SystemdStartupDeadline`, which renews the systemd startup deadline with `EXTEND_TIMEOUT_USEC` while startup is making progress.
- Start renewal before `GatewayRunner` can synchronously open or migrate `state.db`, and emit the first extension before `start()` returns.
- Enable startup and runtime watchdog notifications only when `WATCHDOG_PID` is absent or matches the current process.
- Keep the deadline active through runner construction, MCP discovery, sequential adapter startup, cron resolution, and housekeeping.
- Stop renewal on constructor/runner exceptions, `runner.start() -> False`, all clean/aborted/pre-READY exits, owner-task failure, and immediately before the runtime watchdog emits `READY=1`.
- Preserve caller cancellation so an aborted READY handoff can never continue into the runtime watchdog.
- Preserve no-op behavior outside the supported systemd notify/watchdog environment.

## Known remote blocker

`GatewayRunner(effective_config)` is synchronous. The initial extension is not sufficient when that construction blocks the event loop for longer than the extension interval: the async renewal task cannot run, and systemd can still time out. The public review includes a deterministic failing regression and an isolated transient-unit reproduction. The remote candidate must not be merged until that gap is fixed, tested, pushed as a successor, and independently reviewed.

## Recorded validation before the later blocker

- Focused systemd notify/lifecycle suite: **21 passed, 0 failed** before the independent stall regression was added.
- `ruff check` on all four changed files: passed.
- `py_compile` on both production modules: passed.
- `git diff --check`: passed.

The public blocker supersedes any earlier `PASS` or `safe_to_push` claim for this remote HEAD.

## Scope and risk

- Four files only: two production files and their focused tests.
- No config schema, dependency, credential, platform, or database changes.
- No change for non-systemd or watchdog-disabled gateways.

Original work and authorship: #75841 by @marcus-vibe.