### PR TITLE
fix(cli): keep passive update checks noninteractive

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -241,11 +241,15 @@ def _is_full_sha(value: Optional[str]) -> bool:
 
 def _upstream_main_sha() -> Optional[str]:
     """Tip SHA of upstream main via HTTPS ls-remote (no auth, no prompts)."""
+    from hermes_cli._subprocess_compat import noninteractive_git_env
+
     try:
         result = subprocess.run(
             ["git", "ls-remote", _UPSTREAM_REPO_URL, "refs/heads/main"],
             capture_output=True, text=True, encoding="utf-8", errors="replace",
             timeout=10,
+            stdin=subprocess.DEVNULL,
+            env=noninteractive_git_env(),
         )
     except Exception:
         return None
@@ -277,6 +281,8 @@ def _check_via_rev(local_rev: str) -> Optional[int]:
 
 def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     """Count commits behind origin/main in a local checkout."""
+    from hermes_cli._subprocess_compat import noninteractive_git_env
+
     origin_url = _git_stdout(["remote", "get-url", "origin"], cwd=repo_dir)
     if _is_official_ssh_remote(origin_url):
         head_rev = _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir)
@@ -348,6 +354,8 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
             fetch_args,
             capture_output=True, timeout=10,
             cwd=str(repo_dir),
+            stdin=subprocess.DEVNULL,
+            env=noninteractive_git_env(),
         )
         fetch_ok = fetch_proc.returncode == 0
     except Exception:

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -23,7 +23,10 @@ def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
     (repo_dir / ".git").mkdir()
 
     cache_file = tmp_path / ".update_check"
-    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3, "ver": __version__}))
+    cache_file.write_text(
+        json.dumps({"ts": time.time(), "behind": 3, "ver": __version__}),
+        encoding="utf-8",
+    )
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     with patch("hermes_cli.banner.subprocess.run") as mock_run:
@@ -58,6 +61,21 @@ def test_prefetch_non_blocking():
         assert banner._update_result == 5
 
 
+def test_upstream_main_sha_disables_git_prompts(monkeypatch):
+    """The passive HTTPS probe must never inherit the interactive terminal."""
+    from hermes_cli import banner
+
+    completed = MagicMock(returncode=1, stdout="", stderr="auth required")
+    run = MagicMock(return_value=completed)
+    monkeypatch.setattr(banner.subprocess, "run", run)
+
+    assert banner._upstream_main_sha() is None
+    kwargs = run.call_args.kwargs
+    assert kwargs["stdin"] is banner.subprocess.DEVNULL
+    assert kwargs["env"]["GIT_TERMINAL_PROMPT"] == "0"
+    assert kwargs["env"]["GCM_INTERACTIVE"] == "Never"
+
+
 def test_check_via_local_git_fetch_failure_returns_none(tmp_path, monkeypatch):
     """When git fetch fails and the stale origin/main ref is not ahead,
     _check_via_local_git must return None (#82166).
@@ -90,8 +108,12 @@ def test_check_via_local_git_fetch_failure_returns_none(tmp_path, monkeypatch):
     stale_zero_proc.returncode = 0
     stale_zero_proc.stdout = "0"
 
+    fetch_kwargs = None
+
     def mock_run(args, **kwargs):
+        nonlocal fetch_kwargs
         if args[:2] == ["git", "fetch"]:
+            fetch_kwargs = kwargs
             return failed_proc
         if args[:2] == ["git", "rev-list"]:
             return stale_zero_proc
@@ -104,6 +126,10 @@ def test_check_via_local_git_fetch_failure_returns_none(tmp_path, monkeypatch):
     assert result is None, (
         "Fetch failure with stale 0-behind must return None, not 'up to date'"
     )
+    assert fetch_kwargs is not None
+    assert fetch_kwargs["stdin"] is banner.subprocess.DEVNULL
+    assert fetch_kwargs["env"]["GIT_TERMINAL_PROMPT"] == "0"
+    assert fetch_kwargs["env"]["GCM_INTERACTIVE"] == "Never"
 
 
 def test_check_via_local_git_fetch_failure_keeps_positive_stale_count(tmp_path, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Passive update checks can invoke Git against a public HTTPS remote while inheriting the terminal. If a proxy or transient GitHub response requests authentication, Git asks for a GitHub username and blocks Hermes startup even though the repository is public.

This change applies the existing non-interactive Git contract to both passive network probes in `hermes_cli/banner.py`:

- detach subprocess stdin with `subprocess.DEVNULL`
- set `GIT_TERMINAL_PROMPT=0` and `GCM_INTERACTIVE=Never` through `noninteractive_git_env()`
- retain the existing fail-closed behavior when the upstream probe or local fetch is unavailable

This is the passive-banner counterpart to merged PR #73709. PR #73751 covers explicit `hermes update` operations instead. It overlaps the passive-probe portion of #64478, but deliberately excludes that PR's unrelated OAuth and update-count changes, which have unresolved review findings.

## Related Issue

No issue exists; reproduced directly on current `main`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/banner.py`: make the hard-coded upstream `ls-remote` and local-checkout fetch non-interactive and unable to read terminal stdin.
- `tests/hermes_cli/test_update_check.py`: assert both passive call sites disable terminal and Git Credential Manager prompts.
- `tests/hermes_cli/test_update_check.py`: make the touched cache fixture's JSON encoding explicit for Windows compatibility.

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_update_check.py`.
2. Run `uvx ruff==0.15.10 check hermes_cli/banner.py tests/hermes_cli/test_update_check.py`.
3. Run `python3 scripts/check-windows-footguns.py` with the two changed files staged.
4. Redirect the hard-coded upstream URL to a local HTTP endpoint that returns `401`; `_upstream_main_sha()` should return `None` immediately without prompting.

Verified on Linux Mint 22.3 with Python 3.11.15:

- focused suite: 7 passed
- Ruff: passed
- Windows-footgun scan: passed
- real Git/HTTP 401 reproduction: returned `None` in 0.038 seconds without prompting
- independent review: passed with no blocking findings

Full canonical-suite validation was completed on the exact pushed head. The first run reported 81 failures across 20 files; a fresh canonical retry left 80 failures across 19 files. Running that exact 19-file set against an untouched detached `origin/main` worktree at `afc3d9d34` reproduced the same 80 failures in the same files. The one non-repeating failure (`tests/gateway/test_turn_lease.py`) passed on retry. This establishes the remaining failures as base/environment failures rather than regressions from this two-file PR. The focused update-check suite remains 7/7 passing.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux Mint 22.3, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior-only bug fix
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable; this removes an invisible blocking credential prompt from a passive subprocess path.
