### PR TITLE
fix(telegram): publish receive-path health after connect

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -824,6 +824,10 @@ class TelegramAdapter(BasePlatformAdapter):
         # While True, send() short-circuits to a failure so callers
         # (cron live-adapter branch) fall through to standalone delivery.
         self._send_path_degraded: bool = False
+        # Last receive-path health published to gateway_state.json, so the
+        # heartbeat writes only on a transition. None until connect() stamps
+        # the first state.
+        self._published_polling_degraded: Optional[bool] = None
         self._general_request_drain_lock = asyncio.Lock()
         # DM Topics: map of topic_name -> message_thread_id (populated at startup)
         self._dm_topics: Dict[str, int] = {}
@@ -903,9 +907,76 @@ class TelegramAdapter(BasePlatformAdapter):
     def _mark_connected(self) -> None:
         self._drop_delayed_deliveries = False
         super()._mark_connected()
+        # connect() has just published "connected"; the heartbeat republishes
+        # only when the receive path's health moves away from that.
+        self._published_polling_degraded = False
         # Drain anything held while we were down. PTB will not redeliver —
         # these events exist only in our hold queue now.
         self._schedule_held_inbound_redispatch()
+
+    def _publish_polling_health(self) -> None:
+        """Mirror receive-path health into the published platform state.
+
+        ``_mark_connected()`` stamps ``connected`` once, and nothing rewrites
+        it until the adapter disconnects or the recovery ladder escalates to a
+        fatal.  When polling dies in between — the ladder is still retrying, or
+        has itself wedged — ``gateway_state.json`` keeps reporting ``connected``
+        with ``error_code: null``, byte-for-byte what a healthy adapter
+        publishes, so an operator or dashboard cannot tell the two apart
+        (#101391: ~11h of false ``connected`` on one seat).
+
+        ``_send_path_degraded`` is already the adapter's own answer — set at
+        every polling-death site, cleared in ``_record_polling_progress()`` on a
+        confirmed ``getUpdates`` round-trip — and ``send()`` already fails
+        closed on it.  Publishing it costs the Bot API nothing and, unlike an
+        external ``getUpdates`` probe, cannot perturb the adapter it measures.
+        """
+        if getattr(self, "_polling_teardown_started", False):
+            return
+        # disconnect() clears _running before it raises the teardown fence, so
+        # this also keeps a mid-tick heartbeat from stamping health over the
+        # "disconnected" state that _mark_disconnected() just published.
+        if not getattr(self, "_running", False):
+            return
+        # A fatal (retryable or not) is the stronger verdict and owns the state.
+        if self.has_fatal_error:
+            return
+
+        degraded = bool(getattr(self, "_send_path_degraded", False))
+        if degraded == getattr(self, "_published_polling_degraded", None):
+            return
+        self._published_polling_degraded = degraded
+
+        if degraded:
+            # "retrying" is the existing vocabulary for alive-but-not-serving
+            # (GatewayRunner already publishes it around reconnects); no reader
+            # needs to learn a new state value to stop trusting this adapter.
+            self._write_runtime_status_safe(
+                "polling_degraded",
+                platform_state="retrying",
+                error_code=None,
+                error_message=(
+                    "Telegram polling is not delivering updates; background "
+                    "recovery in progress"
+                ),
+            )
+            logger.warning(
+                "[%s] Telegram receive path degraded; publishing platform "
+                "state 'retrying' until getUpdates progress is confirmed",
+                self.name,
+            )
+        else:
+            self._write_runtime_status_safe(
+                "connected",
+                platform_state="connected",
+                error_code=None,
+                error_message=None,
+            )
+            logger.warning(
+                "[%s] Telegram receive path recovered; publishing platform "
+                "state 'connected'",
+                self.name,
+            )
 
     def _mark_disconnected(self) -> None:
         self._drop_delayed_deliveries = True
@@ -3274,6 +3345,14 @@ class TelegramAdapter(BasePlatformAdapter):
                     return
                 if self.has_fatal_error:
                     return
+
+                # Reconcile the published platform state with the receive
+                # path's real health before probing (#101391). This loop is the
+                # only thing that runs for the whole lifetime of the polling
+                # connection and is not gated behind the recovery ladder, so a
+                # death the ladder never recovers from still becomes visible in
+                # gateway_state.json instead of staying "connected" forever.
+                self._publish_polling_health()
 
                 # Independent wedged-recovery watchdog (#66377): if the tracked
                 # recovery task has hung (any await no local bound covers), every

--- a/tests/gateway/test_telegram_polling_health_state.py
+++ b/tests/gateway/test_telegram_polling_health_state.py
@@ -1,0 +1,155 @@
+"""Published platform state must follow the receive path after connect.
+
+``_mark_connected()`` stamps ``platform_state: "connected"`` exactly once and
+nothing rewrites it until the adapter disconnects or the recovery ladder
+escalates to a fatal.  When Telegram polling dies in between — the ladder is
+still retrying, or has itself wedged — ``gateway_state.json`` keeps reporting
+``connected`` with ``error_code: null``, which is byte-for-byte what a healthy
+adapter publishes.  One seat measured ~11h of that false ``connected`` (#101391).
+
+``_send_path_degraded`` is already the adapter's own authoritative answer, and
+the polling heartbeat already runs for the whole lifetime of the connection, so
+these tests pin the heartbeat mirroring that flag into the published state.
+"""
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+
+
+def _make_adapter() -> TelegramAdapter:
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._bot = MagicMock()
+    adapter._bot.send_message = AsyncMock(return_value=MagicMock(message_id=42))
+    return adapter
+
+
+def _connected_adapter() -> TelegramAdapter:
+    """An adapter whose connect() already published a healthy ``connected``."""
+    adapter = _make_adapter()
+    adapter._running = True
+    adapter._send_path_degraded = False
+    adapter._published_polling_degraded = False
+    return adapter
+
+
+def _single_heartbeat_tick(monkeypatch) -> None:
+    """Let ``_polling_heartbeat_loop`` run exactly one tick, then unwind."""
+    ticks = {"n": 0}
+
+    async def _fake_sleep(_seconds):
+        ticks["n"] += 1
+        if ticks["n"] > 1:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(
+        "plugins.platforms.telegram.adapter.asyncio.sleep", _fake_sleep
+    )
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_publishes_degraded_after_polling_dies(monkeypatch):
+    """The reported bug: polling dies after a healthy connect and the published
+    state stays ``connected`` for the whole recovery window."""
+    adapter = _connected_adapter()
+    # Every polling-death site sets this (network error, conflict, wedged
+    # bootstrap, failed deleteWebhook). None of them publishes a state.
+    adapter._send_path_degraded = True
+    # No live PTB app -> the tick skips the get_me() probe and loops.
+    adapter._app = None
+    _single_heartbeat_tick(monkeypatch)
+
+    with patch.object(adapter, "_write_runtime_status_safe") as write_status:
+        await adapter._polling_heartbeat_loop()
+
+    write_status.assert_called_once()
+    _, kwargs = write_status.call_args
+    assert kwargs["platform_state"] == "retrying"
+    assert kwargs["error_message"]
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_is_silent_while_polling_stays_healthy(monkeypatch):
+    """A steady-state adapter must not rewrite the status file every 90s."""
+    adapter = _connected_adapter()
+    adapter._app = None
+    _single_heartbeat_tick(monkeypatch)
+
+    with patch.object(adapter, "_write_runtime_status_safe") as write_status:
+        await adapter._polling_heartbeat_loop()
+
+    write_status.assert_not_called()
+
+
+def test_publish_republishes_connected_once_polling_recovers():
+    """After the degraded state is published, a confirmed getUpdates round-trip
+    must move the published state back rather than leaving it wedged."""
+    adapter = _connected_adapter()
+    adapter._send_path_degraded = True
+    adapter._publish_polling_health()
+    assert adapter._published_polling_degraded is True
+
+    # _record_polling_progress clears the flag on a real round-trip.
+    adapter._send_path_degraded = False
+
+    with patch.object(adapter, "_write_runtime_status_safe") as write_status:
+        adapter._publish_polling_health()
+
+    write_status.assert_called_once()
+    _, kwargs = write_status.call_args
+    assert kwargs["platform_state"] == "connected"
+    assert kwargs["error_code"] is None
+    assert kwargs["error_message"] is None
+
+
+def test_publish_does_not_write_twice_for_the_same_health():
+    """Only transitions are published; the ladder can retry for hours."""
+    adapter = _connected_adapter()
+    adapter._send_path_degraded = True
+
+    with patch.object(adapter, "_write_runtime_status_safe") as write_status:
+        adapter._publish_polling_health()
+        adapter._publish_polling_health()
+        adapter._publish_polling_health()
+
+    write_status.assert_called_once()
+
+
+def test_publish_never_overwrites_a_fatal_verdict():
+    """``fatal``/retryable-fatal is a stronger verdict than degraded polling."""
+    adapter = _connected_adapter()
+    adapter._send_path_degraded = True
+    adapter._fatal_error_code = "telegram_network_error"
+    adapter._fatal_error_message = "ladder exhausted"
+
+    with patch.object(adapter, "_write_runtime_status_safe") as write_status:
+        adapter._publish_polling_health()
+
+    write_status.assert_not_called()
+
+
+def test_publish_never_overwrites_disconnected():
+    """disconnect() clears ``_running`` before it raises the teardown fence, so
+    a heartbeat mid-tick must not stamp health over ``disconnected``."""
+    adapter = _connected_adapter()
+    adapter._send_path_degraded = True
+    adapter._running = False
+
+    with patch.object(adapter, "_write_runtime_status_safe") as write_status:
+        adapter._publish_polling_health()
+
+    write_status.assert_not_called()
+
+
+def test_publish_is_inert_after_teardown_starts():
+    adapter = _connected_adapter()
+    adapter._send_path_degraded = True
+    adapter._polling_teardown_started = True
+
+    with patch.object(adapter, "_write_runtime_status_safe") as write_status:
+        adapter._publish_polling_health()
+
+    write_status.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

`gateway_state.json` could report `telegram.state = "connected"` with `error_code: null`
while the adapter had not delivered an update for hours. One seat measured ~11h of that
false `connected` before a manual gateway restart fixed it.

`_mark_connected()` stamps `connected` exactly once, and **nothing rewrites the platform
state until the adapter disconnects or the recovery ladder escalates to a fatal.** Every
polling-death site in between — `_handle_polling_network_error`,
`_schedule_polling_recovery`, a failed `deleteWebhook`, a teardown-raced generation — sets
`_send_path_degraded` and logs, but publishes nothing. So for the whole window between
"polling died" and "the ladder gave up" the published record is byte-for-byte what a
healthy adapter writes — and if the ladder never reaches its terminal escalation (the
reporter's own reading of the 11h silence), that window has no end.

`_send_path_degraded` is already the adapter's authoritative answer: set at every
polling-death site, cleared in `_record_polling_progress()` on a confirmed `getUpdates`
round-trip, and already trusted by `send()`, which fails closed on it. It was simply never
published.

The **polling heartbeat** is the one thing that runs for the full lifetime of the
connection and is not gated behind the recovery ladder, so it now reconciles the published
state with that flag on every tick, writing only on a transition:

- degraded → `platform_state="retrying"` with an explanatory `error_message`. `retrying` is
  the existing vocabulary for alive-but-not-serving (`GatewayRunner` already publishes it
  around reconnects), so no reader has to learn a new state value to stop trusting the
  adapter.
- recovered → `platform_state="connected"`.

Both transitions also log at `WARNING`, which addresses the issue's observability ask: a
journal capturing `WARNING` and above can now distinguish "connected and polling" from
"connected and deaf" without a Bot API probe. Publishing the in-process flag costs the Bot
API nothing and — unlike an external `getUpdates` probe, which the reporter showed can walk
a healthy adapter to a non-retryable fatal in ~2 minutes — cannot perturb the adapter it
measures.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A[Connect] -->|_mark_connected| B[Published: connected]
    B --> C{Polling alive?}
    C -->|getUpdates progressing| D[_send_path_degraded = False]
    C -->|network error / conflict / wedged| E[_send_path_degraded = True]

    E -.->|BEFORE: nothing published| F[Published stays connected<br/>for the whole recovery window]
    F -.->|ladder wedges| G[False connected forever<br/>11h measured]

    E -->|AFTER: heartbeat tick| H[Published: retrying<br/>plus WARNING log]
    D -->|AFTER: heartbeat tick| I[Published: connected<br/>plus WARNING log]

    H -->|ladder exhausted| J[_set_fatal_error owns the state]
    H -->|progress confirmed| I

    style F fill:#2a0208,stroke:#ff0038
    style G fill:#2a0208,stroke:#ff0038
```

## Related Issue

Refs #101391

## Relationship to #101406 — complementary, not a duplicate

@chelsealong's #101406 fixes the **connect-time** verdict: `_mark_connected(degraded=...)`
and the `gateway/run.py` reconnect-watcher second writer, so a connect that returns `True`
while polling never started does not publish `connected`.

This PR fixes the **post-connect** transition, which #101406 does not reach. With #101406
applied, an adapter that connects *healthy* (`_send_path_degraded == False` → `connected`
published) and then loses polling still publishes nothing: `_mark_connected()` does not
fire again and `_record_polling_progress()` never runs, so the state stays `connected` for
the entire recovery window. That is the scenario the reporter says actually produced the
11h observation ("the adapter began a generation and then lost it silently, rather than
taking the known degraded branch").

The two compose cleanly — both derive from the same `_send_path_degraded` flag and publish
the same `retrying`/`connected` vocabulary, so they agree by construction and neither
undoes the other. They touch different call sites (`_mark_connected` + `run.py` vs. the
heartbeat loop), and this PR's only overlap with theirs is the recovery direction, which it
must handle to be correct standalone. **Nothing here is taken from #101406 — I am not
proposing it be superseded.** If both land, recovery becomes instant instead of ≤90s.

One observation on #101406 offered for its author, not fixed here: it patches the reconnect
watcher's second writer but not the *startup* one at `gateway/run.py:14049`, which stamps
`connected` unconditionally once `connect()` returns `True`. A cold connect can still reach
the degraded branch via `_PollingLifecycleAbort`, a bootstrap conflict, or a network error,
and that writer would overwrite the adapter's own `retrying`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/telegram/adapter.py`
  - `_publish_polling_health()` — new; mirrors `_send_path_degraded` into the published
    platform state, writing only on a transition. Inert after teardown starts, while
    `_running` is False (`disconnect()` clears it *before* raising the teardown fence, so a
    mid-tick heartbeat cannot stamp health over `disconnected`), and while a fatal is set
    (`_set_fatal_error` owns the state outright).
  - `_polling_heartbeat_loop()` — calls it once per tick, after the teardown/fatal guards
    and before the probe, so it also runs when the wedged-recovery watchdog escalates.
  - `_mark_connected()` — seeds `_published_polling_degraded = False` to match the
    `connected` it just published, so a steady-state adapter never rewrites the file.
  - `__init__` — `_published_polling_degraded` transition tracker.
- `tests/gateway/test_telegram_polling_health_state.py` — new file, 7 tests.

No new `platform_state` value, no new `gateway_state.json` field, no other adapter touched,
and no public signature changed. Every consumer of the file (`gateway/readiness.py`,
`agent/monitoring/gateway_health*.py`, `hermes_cli/web_server.py`, `hermes_cli/claw.py`,
`gateway/control_socket.py`) is read-and-report — I checked that none rebuilds or restarts
an adapter based on the published state, so this makes the record truthful without changing
any control flow.

## How to Test

Environment note: `python-telegram-bot` is not installed here, so
`tests/gateway/test_telegram_rich_messages.py` cannot be collected and 46 tests in the
Telegram suite fail on **unmodified `main`** from cross-file isolation. Every number below
is therefore reported against a measured baseline on `origin/main` (`11942f6de5`), not in
absolute terms.

New tests:

```
$ python -m pytest tests/gateway/test_telegram_polling_health_state.py -q
7 passed
```

Proved they fail without the fix (`git stash` the adapter, keep the test file):

```
$ python -m pytest tests/gateway/test_telegram_polling_health_state.py -q
6 failed, 1 passed

FAILED test_heartbeat_publishes_degraded_after_polling_dies
  write_status.assert_called_once() -> Called 0 times.
```

That first failure **is** the bug: a polling death after a healthy connect publishes
nothing at all.

Focused regression run (the polling/connect/reconnect files this change can reach):

```
$ python -m pytest tests/gateway/test_telegram_polling_progress.py \
    tests/gateway/test_telegram_polling_stall_watchdog.py \
    tests/gateway/test_telegram_polling_health_confirmation.py \
    tests/gateway/test_telegram_send_path_health.py \
    tests/gateway/test_telegram_network_reconnect.py \
    tests/gateway/test_telegram_conflict.py tests/gateway/test_telegram_connect.py \
    tests/gateway/test_telegram_connect_success_visibility.py \
    tests/gateway/test_telegram_start_polling_timeout.py -q
76 passed
```

Runtime-status / adapter-classification suites: `208 passed, 1 failed`. The one failure is
`test_status.py::TestReadProcessCmdlinePsFallback::test_ps_fallback_when_proc_unavailable`,
a POSIX `ps` test that fails identically with the adapter stashed (verified) — it is this
Windows box, not this change.

Whole Telegram suite (`tests/gateway/test_telegram_*.py`,
`--continue-on-collection-errors -p no:randomly`):

```
baseline (origin/main):  46 failed, 556 passed
with this change:        46 failed, 563 passed   (+7 = exactly the new tests)
```

A second full run of the *patched* tree produced one additional failure,
`test_telegram_network_reconnect.py::test_disconnect_advances_past_cancellation_swallowing_lifecycle`,
which did **not** appear in the first patched run of the same code. It passes standalone,
and `test_telegram_network_reconnect.py` passes `36 passed` in full both with and without
this change — so it is the same order-dependent flakiness that produces the other 46, not a
regression. Flagging it rather than rounding it away.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (see the #101406
      section above — different call sites, complementary layer)
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant test files and compared them against a measured `main` baseline
- [x] I've added tests for my changes
- [ ] N/A — no config keys, docs, or tool schemas changed

**AI assistance disclosure:** this change was authored with an AI coding assistant (Claude),
with the diff, the baseline comparison, and the test runs reviewed before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ShTVU941HYygvypY9JMYE
