### PR TITLE
fix(search): say when a content search could not read documents in scope

### DIFF
--- a/tests/tools/test_search_document_blindspot.py
+++ b/tests/tools/test_search_document_blindspot.py
@@ -1,0 +1,42 @@
+"""A content search that finds nothing must not imply the text is absent.
+
+search_files is ripgrep-backed and cannot see inside PDFs or Office documents,
+while read_file extracts them. On a folder of paperwork that mismatch produces
+a confident false negative: the search returns empty and the answer is in the
+PDF sitting next to it.
+"""
+
+import json
+
+from tools.file_tools import _unsearched_documents, search_tool
+
+
+def test_lists_documents_a_content_search_cannot_read(tmp_path):
+    (tmp_path / "notes.txt").write_text("nothing relevant here")
+    (tmp_path / "tickets.pdf").write_bytes(b"%PDF-1.4 binary")
+    (tmp_path / "sheet.xlsx").write_bytes(b"PK\x03\x04")
+
+    out = json.loads(search_tool(pattern="OATH", target="content", path=str(tmp_path)))
+    hint = out.get("_documents_not_searched", "")
+    assert "tickets.pdf" in hint and "sheet.xlsx" in hint
+    assert "read_file" in hint
+
+
+def test_no_hint_when_there_are_no_documents(tmp_path):
+    (tmp_path / "notes.txt").write_text("nothing relevant here")
+    out = json.loads(search_tool(pattern="OATH", target="content", path=str(tmp_path)))
+    assert "_documents_not_searched" not in out
+
+
+def test_no_hint_when_the_search_matched(tmp_path):
+    (tmp_path / "notes.txt").write_text("OATH appears here")
+    (tmp_path / "tickets.pdf").write_bytes(b"%PDF-1.4 binary")
+    out = json.loads(search_tool(pattern="OATH", target="content", path=str(tmp_path)))
+    assert "_documents_not_searched" not in out
+
+
+def test_scan_is_bounded_and_never_raises(tmp_path):
+    assert _unsearched_documents(str(tmp_path / "does-not-exist")) == []
+    for i in range(15):
+        (tmp_path / f"doc{i}.pdf").write_bytes(b"%PDF")
+    assert len(_unsearched_documents(str(tmp_path))) == 10  # capped

--- a/tests/tools/test_search_document_blindspot.py
+++ b/tests/tools/test_search_document_blindspot.py
@@ -40,3 +40,18 @@ def test_scan_is_bounded_and_never_raises(tmp_path):
     for i in range(15):
         (tmp_path / f"doc{i}.pdf").write_bytes(b"%PDF")
     assert len(_unsearched_documents(str(tmp_path))) == 10  # capped
+
+
+def test_hint_respects_file_glob(tmp_path):
+    """A search narrowed to source files must not point at excluded documents."""
+    (tmp_path / "notes.py").write_text("nothing relevant here")
+    (tmp_path / "tickets.pdf").write_bytes(b"%PDF-1.4 binary")
+
+    scoped = json.loads(search_tool(pattern="OATH", target="content",
+                                    path=str(tmp_path), file_glob="*.py"))
+    assert "_documents_not_searched" not in scoped
+
+    # A glob that selects documents is exactly when the blind spot bites.
+    on_docs = json.loads(search_tool(pattern="OATH", target="content",
+                                     path=str(tmp_path), file_glob="*.pdf"))
+    assert "tickets.pdf" in on_docs["_documents_not_searched"]

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2551,6 +2551,41 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         return tool_error(str(e))
 
 
+
+# Content search is ripgrep-backed and therefore blind to the text inside
+# PDFs and Office documents: `read_file` extracts them, `search_files` does
+# not. A folder of scanned-in paperwork answers "does anything here mention
+# OATH/ECB?" with an empty result set, and a model reasonably concludes the
+# answer is no — a confident false negative on exactly the corpus a document
+# search is most useful for. Naming the unsearched documents turns the silent
+# miss into a next step. Indexing them properly is a much larger change.
+_SEARCH_SCAN_CAP = 2000
+_SEARCH_HINT_MAX_FILES = 10
+
+
+def _unsearched_documents(root: str) -> list[str]:
+    """Extractable documents under ``root`` that a content search cannot see."""
+    from tools.read_extract import ANYDOC_EXTENSIONS, EXTRACTABLE_EXTENSIONS
+
+    exts = EXTRACTABLE_EXTENSIONS | ANYDOC_EXTENSIONS
+    found: list[str] = []
+    seen = 0
+    try:
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirnames[:] = [d for d in dirnames if not d.startswith(".")]
+            for name in filenames:
+                seen += 1
+                if seen > _SEARCH_SCAN_CAP:
+                    return found
+                if os.path.splitext(name)[1].lower() in exts:
+                    found.append(os.path.join(dirpath, name))
+                    if len(found) >= _SEARCH_HINT_MAX_FILES:
+                        return found
+    except OSError:
+        pass
+    return found
+
+
 def search_tool(pattern: str, target: str = "content", path: str = ".",
                 file_glob: str = None, limit: int = 50, offset: int = 0,
                 output_mode: str = "content", context: int = 0,
@@ -2643,6 +2678,23 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
                 f"You have run this exact search {count} times consecutively. "
                 "The results have not changed. Use the information you already have."
             )
+
+        # Zero content matches, but extractable documents sit in scope: say so
+        # rather than let an empty result read as "the text is not here".
+        if (
+            target == "content"
+            and not result_dict.get("error")
+            and not result_dict.get("matches")
+        ):
+            docs = _unsearched_documents(resolved_search_path)
+            if docs:
+                result_dict["_documents_not_searched"] = (
+                    "Content search does not read inside PDFs or Office documents. "
+                    f"{len(docs)} such file(s) in scope were NOT searched; the text "
+                    "you are looking for may be in one. Open them with read_file "
+                    "(it extracts them) before concluding the content is absent: "
+                    + ", ".join(docs)
+                )
 
         result_json = json.dumps(result_dict, ensure_ascii=False)
         # Hint when results were truncated — explicit next offset is clearer

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2563,8 +2563,16 @@ _SEARCH_SCAN_CAP = 2000
 _SEARCH_HINT_MAX_FILES = 10
 
 
-def _unsearched_documents(root: str) -> list[str]:
-    """Extractable documents under ``root`` that a content search cannot see."""
+def _unsearched_documents(root: str, file_glob: str = None) -> list[str]:
+    """Extractable documents under ``root`` that a content search cannot see.
+
+    ``file_glob`` is honoured so a search the caller already narrowed away from
+    documents (``*.py``) is not told to go read the PDFs it deliberately
+    excluded. A glob that *does* select documents (``*.pdf``) still reports —
+    that is the case where the blind spot bites hardest.
+    """
+    import fnmatch
+
     from tools.read_extract import ANYDOC_EXTENSIONS, EXTRACTABLE_EXTENSIONS
 
     exts = EXTRACTABLE_EXTENSIONS | ANYDOC_EXTENSIONS
@@ -2577,10 +2585,13 @@ def _unsearched_documents(root: str) -> list[str]:
                 seen += 1
                 if seen > _SEARCH_SCAN_CAP:
                     return found
-                if os.path.splitext(name)[1].lower() in exts:
-                    found.append(os.path.join(dirpath, name))
-                    if len(found) >= _SEARCH_HINT_MAX_FILES:
-                        return found
+                if os.path.splitext(name)[1].lower() not in exts:
+                    continue
+                if file_glob and not fnmatch.fnmatch(name, file_glob):
+                    continue
+                found.append(os.path.join(dirpath, name))
+                if len(found) >= _SEARCH_HINT_MAX_FILES:
+                    return found
     except OSError:
         pass
     return found
@@ -2686,7 +2697,7 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
             and not result_dict.get("error")
             and not result_dict.get("matches")
         ):
-            docs = _unsearched_documents(resolved_search_path)
+            docs = _unsearched_documents(resolved_search_path, file_glob)
             if docs:
                 result_dict["_documents_not_searched"] = (
                     "Content search does not read inside PDFs or Office documents. "


### PR DESCRIPTION
## What does this PR do?

`search_files` is ripgrep-backed and cannot read inside Office documents or PDFs, while `read_file` extracts them via `tools/read_extract.py`. A zero-match content search over a folder of documents is therefore indistinguishable from "the text is not here" — a confident false negative on exactly the corpus a document search is most useful for.

This names the extractable documents that were in scope but not searched, and points at `read_file`. It does **not** index them — that is a much larger change, and deliberately not this one. The goal is turning a silent miss into a next step.

## Related Issue

Fixes #101427

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/file_tools.py` — adds `_unsearched_documents(root, file_glob)`, walking for `EXTRACTABLE_EXTENSIONS | ANYDOC_EXTENSIONS`. Attaches `_documents_not_searched` to the result on a zero-match content search.
- `tests/tools/test_search_document_blindspot.py` — 5 tests.

Scoped to avoid noise:
- only on **zero matches**, only `target="content"`, never on an errored search
- honours `file_glob` — a search narrowed to `*.py` is not told to go read PDFs it excluded, while `*.pdf` still reports (that is when the blind spot bites hardest)
- skips dotted directories; scan capped at 2000 files, hint capped at 10 paths
- swallows `OSError`, so an unreadable tree degrades to no hint rather than a failed search

## How to Test

`.docx` needs no optional dependency (`EXTRACTABLE_EXTENSIONS = {".ipynb", ".docx", ".xlsx"}`).

1. Make a directory with a `.txt` that does not contain your term and a `.docx` whose body does.
2. `search_tool(pattern="OATH", target="content", path=d)` — on `main` returns `{"total_count": 0}` with no indication anything was skipped.
3. `read_file_tool(path=".../violations.docx")` — extracts the text, confirming the search missed a readable file.
4. On this branch, step 2 additionally returns `_documents_not_searched` naming the `.docx`.
5. Repeat step 4 with `file_glob="*.txt"` — no hint, since the caller excluded documents.

`pytest tests/tools/test_search_document_blindspot.py` — 5 passed.

## Checklist

- [x] Tests added
- [x] Rebased on current `main` (95f62ca)
- [x] Searched open and merged PRs/issues for duplicates — none found for this blind spot

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tfp5KBHuUhLg2fTFfEsje
