### PR TITLE
feat(mcp): add SourceMedium hosted MCP

### DIFF
--- a/optional-mcps/sourcemedium/manifest.yaml
+++ b/optional-mcps/sourcemedium/manifest.yaml
@@ -1,0 +1,41 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: sourcemedium
+description: >-
+  Analyze maintained ecommerce data from SourceMedium using read-only
+  warehouse, Shopify, Meta Ads, catalog, health, and documentation tools.
+source: https://sourcemedium.com/docs/ai-analyst/connect-an-ai-assistant
+
+# Official SourceMedium-hosted remote MCP. Hermes runs no local code.
+transport:
+  type: http
+  url: https://mcp.sourcemedium.com/mcp
+
+# SourceMedium supports native MCP OAuth 2.1 and Dynamic Client Registration.
+# Hermes handles discovery, PKCE, authorization, token exchange, and refresh.
+auth:
+  type: oauth
+
+# Composer-suggestion triggers (desktop brand pills).
+suggest:
+  keywords:
+    - sourcemedium
+    - source medium
+  hosts:
+    - sourcemedium.com
+
+post_install: |
+  On first connection, Hermes opens a browser to authorize SourceMedium.
+
+  You can start or repeat authorization with:
+
+    hermes mcp login sourcemedium
+
+  After authorization, restart the Hermes session so the SourceMedium
+  tools are loaded.
+
+  You can review or change the enabled tools with:
+
+    hermes mcp configure sourcemedium


### PR DESCRIPTION
## Summary

Adds SourceMedium's official hosted MCP server to the Nous-approved Hermes MCP catalog.

SourceMedium gives authorized customers read-only access to their maintained ecommerce data, including warehouse data, canonical metrics, data-model metadata, connected Shopify and Meta Ads sources, account health, and SourceMedium documentation.

## Integration

- Transport: Streamable HTTP
- Endpoint: https://mcp.sourcemedium.com/mcp
- Authentication: OAuth 2.1
- Client registration: Dynamic Client Registration / client metadata
- Authorization: SourceMedium organization membership and consent
- Local installation or bootstrap: none
- Credentials committed to the repository: none
- Mutating tools: none

## Security

The server is vendor-hosted and read-only. It cannot modify warehouse data, advertising campaigns, Shopify data, credentials, connections, or SourceMedium configuration.

Access is organization-scoped. The server enforces allowed datasets, source availability, query bounds, tenant isolation, and read-only SQL.

## Documentation

https://sourcemedium.com/docs/ai-analyst/connect-an-ai-assistant

## Verification

- Catalog manifest loads through `hermes_cli.mcp_catalog` with no catalog diagnostics.
- `scripts/run_tests.sh tests/hermes_cli/test_mcp_catalog.py -q` passes: 35 tests.
- The manifest resolves to `transport.type: http`, `auth.type: oauth`, and the official SourceMedium endpoint.

An interactive OAuth installation smoke test remains to be completed with a populated SourceMedium reviewer organization. Reviewer credentials can be provided privately if maintainers request them.
