### PR TITLE
fix(desktop): refresh Bot Chat transcript when a roster click fronts an already-open tab

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/bot-row-opens-canonical-chat.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/bot-row-opens-canonical-chat.test.ts
@@ -71,6 +71,24 @@ describe('a row click lands on the canonical chat, never a remembered side tab',
     })
   })
 
+  it('fronting an already-open Bot Chat refreshes its transcript in place', async () => {
+    // The front is presentation-only: the pane keeps whatever transcript it
+    // last painted, which can predate rows the bot wrote while the user was
+    // elsewhere (a cron delivery, a teammate's message_agent, another bot's
+    // turn). Fronting must force a registry open so forceResume re-pulls the
+    // latest rows instead of leaving a stale snapshot until the next turn
+    // (#99393 class; #95600 only covered the not-yet-open path).
+    host.focusOpenWorkspaceSession = vi.fn((_key: string, _probe: unknown, only?: readonly string[]) =>
+      only?.includes('bot-chat-tip') ? 'bot-chat-tip' : null
+    ) as never
+    $selectedStoredSessionId.set('bot-chat-tip')
+
+    await expect(openRosterBot(canonicalBot)).resolves.toBe(true)
+
+    expect(openBotCanonicalChat).toHaveBeenCalledWith(canonicalBot, expect.any(Function))
+    $selectedStoredSessionId.set(null)
+  })
+
   it('resolves the registry when only a side thread is open', async () => {
     // The shell would happily front 'side-thread' — the allowlist excludes it.
     host.focusOpenWorkspaceSession = vi.fn((_key: string, _probe: unknown, only?: readonly string[]) =>

--- a/apps/desktop/src/plugins/hermes-bots/roster-actions.ts
+++ b/apps/desktop/src/plugins/hermes-bots/roster-actions.ts
@@ -244,6 +244,14 @@ export async function openRosterBot(bot: RosterRow): Promise<boolean> {
     // the roster-activity refresh treat it exactly like a registry open.
     $openBotChat.set({ key, openedRegistryId: fronted.registryId, openedSessionId: fronted.storedSessionId })
 
+    // Fronting is presentation-only: the pane keeps whatever transcript it
+    // last painted, which can predate rows the bot wrote while the user was
+    // elsewhere (another bot's turn, a cron delivery, a teammate's
+    // message_agent). Force a registry open so forceResume re-pulls the
+    // latest transcript instead of leaving a stale snapshot until the next
+    // user turn (#99393 class; #95600 only covered the not-yet-open path).
+    refreshOpenBotChat(bot)
+
     return true
   }
 


### PR DESCRIPTION
## What does this PR do?

A roster click on a bot whose canonical **Bot Chat** is already open as a tab only *fronted* the tile — the pane kept whatever transcript it last painted, which can be several turns stale (rows the bot wrote while the user was elsewhere: another bot's turn, a cron delivery, a teammate's `message_agent`). The stale snapshot persisted until the next user turn.

The fronted branch of `openRosterBot` (roster-actions.ts) now re-runs `refreshOpenBotChat` — the existing #99393 reclaim mechanism — so the canonical registry open's `forceResume` re-pulls the latest transcript in place. This closes the gap where **#95600**'s `forceResume` only covered the *not-yet-open* registry path, and **#99439** only judged whether a tile's session still *exists* (not whether its cached transcript is *fresh*).

## Related Issue

Fixes #101430

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made
- `apps/desktop/src/plugins/hermes-bots/roster-actions.ts` — fronted branch calls `refreshOpenBotChat(bot)` after recording the claim, so an already-open Bot Chat reconciles its transcript with the backend on click.
- `apps/desktop/src/plugins/hermes-bots/bot-row-opens-canonical-chat.test.ts` — regression test: fronting an already-open Bot Chat now requests the canonical registry open (fails without the fix, verified via sabotage run).

## How to Test
1. Open Hermes Desktop in Bot Mode with two bots.
2. Chat with bot A; switch to bot B; have bot A receive rows in the background (cron / teammate / CLI).
3. Click bot A in the BOTS roster — its pane must show the latest turns immediately (previously stayed stale until the next user message).
4. Unit: `vitest run src/plugins/hermes-bots/` — 61 files / 571 tests pass on Windows.

## Checklist
### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass (N/A — desktop change; JS test suite run instead)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping
- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
