### PR TITLE
fix(skills): name rejected file_content key on skill_manage create

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -437,6 +437,57 @@ class TestSkillManageDispatcher:
         rec = usage.get("test-skill") or {}
         assert rec.get("created_by") in {None, "", False}
 
+    def test_create_file_content_names_rejected_key(self, tmp_path):
+        """#101418 — create with write_file's key must name it and the fix."""
+        with _skill_dir(tmp_path):
+            batch = json.loads(skill_manage(
+                action="", name="",
+                operations=[{
+                    "action": "create",
+                    "name": "x",
+                    "file_content": VALID_SKILL_CONTENT,
+                }],
+            ))
+            flat = json.loads(skill_manage(
+                action="create",
+                name="y",
+                file_content=VALID_SKILL_CONTENT,
+            ))
+            missing = json.loads(skill_manage(action="create", name="z"))
+
+        assert batch["success"] is False
+        assert "'file_content' is only valid for action='write_file'" in batch["error"]
+        assert "for 'create' pass 'content'" in batch["error"]
+        assert "rolled back" in batch["error"]
+        assert flat["success"] is False
+        assert "'file_content' is only valid for action='write_file'" in flat["error"]
+        assert "for 'create' pass 'content'" in flat["error"]
+        assert missing["success"] is False
+        assert "content is required for 'create'" in missing["error"]
+        assert "file_content" not in missing["error"]
+
+    def test_write_file_content_names_rejected_key(self, tmp_path):
+        """#101418 — write_file with create's key must name it and the fix."""
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            crossed = json.loads(skill_manage(
+                action="write_file",
+                name="my-skill",
+                file_path="references/a.md",
+                content="hello",
+            ))
+            missing = json.loads(skill_manage(
+                action="write_file",
+                name="my-skill",
+                file_path="references/a.md",
+            ))
+
+        assert crossed["success"] is False
+        assert "'content' is only valid for action='create' or 'patch'" in crossed["error"]
+        assert "for 'write_file' pass 'file_content'" in crossed["error"]
+        assert missing["success"] is False
+        assert missing["error"] == "file_content is required for 'write_file'."
+
     def test_successful_mutations_emit_lifecycle_with_correlation(self, tmp_path):
         with (
             _skill_dir(tmp_path),

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -732,6 +732,36 @@ def _record_success(action, name, result, *, file_path, absorbed_into, task_id,
         _maybe_debounced_sync_push(name)
 
 
+def _crossed_skill_payload_error(action, content, file_content):
+    """Name the rejected sibling key so the model can self-correct.
+
+    The operations-item schema advertises both ``content`` (create/patch)
+    and ``file_content`` (write_file). Models pick the wrong one and then
+    loop on a missing-key error that never names the key they sent
+    (#101418). Do not alias the fields — schema-alias-coverage forbids it.
+    """
+    has_content = bool(content)
+    has_file_content = file_content is not None
+    if action in {"create", "edit"} and not has_content and has_file_content:
+        return (
+            f"'file_content' is only valid for action='write_file'; "
+            f"for '{action}' pass 'content' with the full SKILL.md text "
+            f"(frontmatter + body)."
+        )
+    if action == "write_file" and file_content is None and has_content:
+        return (
+            "'content' is only valid for action='create' or 'patch'; "
+            "for 'write_file' pass 'file_content'."
+        )
+    if action == "patch" and not has_content and has_file_content:
+        return (
+            "'file_content' is only valid for action='write_file'; "
+            "for 'patch' pass 'content' (full rewrite) or "
+            "old_string/new_string (targeted replacement)."
+        )
+    return None
+
+
 def skill_manage(
     action: str, name: str, content: str = None, category: str = None, file_path: str = None,
     file_content: str = None, old_string: str = None, new_string: str = None,
@@ -762,6 +792,9 @@ def skill_manage(
         _pre = _find_skill(name)
         _ledger_before = _ledger.capture_before(
             _pre["path"] if _pre else None, complete_package=(action == "delete"), skill=name)
+    crossed = _crossed_skill_payload_error(action, content, file_content)
+    if crossed:
+        return tool_error(crossed, success=False)
     for arg, missing, message in _REQUIRED_ARGS.get(action, ()):
         if missing(args[arg]):
             return tool_error(message, success=False)
@@ -826,7 +859,8 @@ SKILL_MANAGE_SCHEMA = {
                             "description": (
                                 "Full SKILL.md text (YAML frontmatter + "
                                 "markdown body) for create, or a full "
-                                "rewrite on patch."
+                                "rewrite on patch. Not for write_file "
+                                "(that key is file_content)."
                             )
                         },
                         "category": {
@@ -860,7 +894,10 @@ SKILL_MANAGE_SCHEMA = {
                         },
                         "file_content": {
                             "type": "string",
-                            "description": "Content for write_file."
+                            "description": (
+                                "write_file only. create/patch use content, "
+                                "not this key."
+                            )
                         }
                     },
                     "required": ["name", "action"]


### PR DESCRIPTION
## What does this PR do?

`skill_manage` advertises both `content` (create/patch) and `file_content` (write_file) on the same operations item. Models often send `file_content` on `create`. Validation correctly required `content`, but the error never named the key that was sent, so the same malformed call could repeat for dozens of turns.

This change rejects the crossed keys with an error that names the rejected field and the correct one. It does not alias or copy `file_content` onto `content`.

## Related Issue

Fixes #101418

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/skill_manager_tool.py`: add `_crossed_skill_payload_error` and use it on create, edit, patch, and write_file when the sibling body key is present.
- `tools/skill_manager_tool.py`: schema descriptions for `content` and `file_content` state which action each key belongs to.
- `tests/tools/test_skill_manager_tool.py`: batch and flat `create` + `file_content` must name the rejected key; `write_file` + `content` must name `content`; a create with neither key still uses the existing required-content message.

## How to Test

1. Call `skill_manage` with `operations: [{action: "create", name: "x", file_content: "<valid SKILL.md>"}]`.
2. Confirm the error includes `'file_content' is only valid for action='write_file'` and `for 'create' pass 'content'`.
3. Repeat the same call with `content` instead of `file_content` and confirm create succeeds.
4. Call `skill_manage` create with neither body key and confirm the error is still `content is required for 'create'` (no `file_content` mention).
5. Run `scripts/run_tests.sh tests/tools/test_skill_manager_tool.py tests/tools/test_skill_manage_schema_diet.py tests/tools/test_skill_manage_batch.py -q`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before (create + `file_content`):

```
content is required for 'create'. Provide the full SKILL.md text (frontmatter + body). — batch aborted, all touched skills rolled back.
```

After:

```
'file_content' is only valid for action='write_file'; for 'create' pass 'content' with the full SKILL.md text (frontmatter + body). — batch aborted, all touched skills rolled back.
```

Create with `content` after the change: success.