### PR TITLE
fix(desktop): keep Windows drive letters when decoding file: preview paths

### DIFF
--- a/apps/desktop/src/lib/local-preview.test.ts
+++ b/apps/desktop/src/lib/local-preview.test.ts
@@ -133,6 +133,13 @@ describe('remote HTML previews', () => {
     expect(localPreviewTarget('//srv/share/report #1?.html')?.url).toBe('file:////srv/share/report%20%231%3F.html')
   })
 
+  it('decodes a Windows drive file URL without a leading slash pathname', () => {
+    expect(localPreviewTarget('file:///C:/Users/demo/AppData/Local/hermes/images/upload_x.png')).toMatchObject({
+      path: 'C:/Users/demo/AppData/Local/hermes/images/upload_x.png',
+      previewKind: 'image'
+    })
+  })
+
   it('opens ordinary targets without staging them', async () => {
     const openPreviewInBrowser = vi.fn(async () => undefined)
     const saveImageBuffer = vi.fn()

--- a/apps/desktop/src/lib/local-preview.ts
+++ b/apps/desktop/src/lib/local-preview.ts
@@ -1,6 +1,7 @@
 import DOMPurify from 'dompurify'
 
 import { isDesktopFsRemoteMode, readDesktopFileDataUrl, readDesktopFileText } from '@/lib/desktop-fs'
+import { filePathFromMediaPath } from '@/lib/media'
 import type { PreviewTarget } from '@/store/preview'
 
 const HTML_EXTENSIONS = new Set(['.htm', '.html'])
@@ -191,12 +192,8 @@ export function localPreviewTarget(rawTarget: string, cwd?: string | null): Prev
 
   let path = raw
 
-  if (/^file:\/\//i.test(raw)) {
-    try {
-      path = decodeURIComponent(new URL(raw).pathname)
-    } catch {
-      path = raw.replace(/^file:\/\//i, '')
-    }
+  if (/^file:/i.test(raw)) {
+    path = filePathFromMediaPath(raw)
   } else if (!raw.startsWith('/') && cwd) {
     path = joinPath(cwd, raw)
   }

--- a/apps/desktop/src/lib/media.remote.test.ts
+++ b/apps/desktop/src/lib/media.remote.test.ts
@@ -43,6 +43,16 @@ describe('filePathFromMediaPath', () => {
   it('decodes a file:// URL with encoded characters', () => {
     expect(filePathFromMediaPath('file:///tmp/a%20b.png')).toBe('/tmp/a b.png')
   })
+
+  it('strips the WHATWG leading slash from a Windows drive file URL', () => {
+    expect(filePathFromMediaPath('file:///C:/Users/demo/AppData/Local/hermes/images/upload_x.png')).toBe(
+      'C:/Users/demo/AppData/Local/hermes/images/upload_x.png'
+    )
+    expect(filePathFromMediaPath('file:///c:/Users/demo/a%20b.png')).toBe('c:/Users/demo/a b.png')
+    expect(filePathFromMediaPath('/C:/Users/demo/AppData/Local/hermes/images/upload_x.png')).toBe(
+      'C:/Users/demo/AppData/Local/hermes/images/upload_x.png'
+    )
+  })
 })
 
 describe('mediaExternalUrl', () => {
@@ -151,6 +161,32 @@ describe('resolveMediaDisplaySrc', () => {
     await expect(resolveMediaDisplaySrc('/Users/me/project/a b.png')).resolves.toBe('data:image/png;base64,ZHVtbXk=')
     expect(api).toHaveBeenCalledWith({
       path: '/api/fs/read-data-url?path=%2FUsers%2Fme%2Fproject%2Fa%20b.png',
+      profile: 'remote-work'
+    })
+  })
+
+  it('does not send a WHATWG-mangled /C:/ path to a remote Windows gateway', async () => {
+    vi.stubGlobal('window', { hermesDesktop: { api } })
+    $connection.set({ mode: 'remote', profile: 'remote-work' } as never)
+
+    await expect(
+      resolveMediaDisplaySrc('file:///C:/Users/demo/AppData/Local/hermes/images/upload_x.png')
+    ).resolves.toBe('data:image/png;base64,ZHVtbXk=')
+    expect(api).toHaveBeenCalledWith({
+      path: '/api/fs/read-data-url?path=C%3A%2FUsers%2Fdemo%2FAppData%2FLocal%2Fhermes%2Fimages%2Fupload_x.png',
+      profile: 'remote-work'
+    })
+  })
+
+  it('does not send a WHATWG /C:/ pathname to the remote fs bridge', async () => {
+    vi.stubGlobal('window', { hermesDesktop: { api } })
+    $connection.set({ mode: 'remote', profile: 'remote-work' } as never)
+
+    await expect(
+      resolveMediaDisplaySrc('file:///C:/Users/demo/AppData/Local/hermes/images/upload_x.png')
+    ).resolves.toBe('data:image/png;base64,ZHVtbXk=')
+    expect(api).toHaveBeenCalledWith({
+      path: '/api/fs/read-data-url?path=C%3A%2FUsers%2Fdemo%2FAppData%2FLocal%2Fhermes%2Fimages%2Fupload_x.png',
       profile: 'remote-work'
     })
   })

--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -172,15 +172,26 @@ export function mediaPathFromMarkdownHref(href?: string): string | null {
   }
 }
 
+// WHATWG URL.pathname for file:///C:/Users/... is "/C:/Users/...". That
+// leading slash is neither a Windows path nor POSIX, and remote /api/fs
+// reads 404 when the gateway host is Windows.
+const WHATWG_WINDOWS_DRIVE_PATHNAME = /^\/([A-Za-z]:)(\/.*)?$/
+
+export function stripWhatwgWindowsDrivePrefix(pathname: string): string {
+  const match = pathname.match(WHATWG_WINDOWS_DRIVE_PATHNAME)
+
+  return match ? `${match[1]}${match[2] || '/'}` : pathname
+}
+
 export function filePathFromMediaPath(path: string): string {
   if (!path.startsWith('file:')) {
-    return path
+    return stripWhatwgWindowsDrivePrefix(path)
   }
 
   try {
-    return decodeURIComponent(new URL(path).pathname)
+    return stripWhatwgWindowsDrivePrefix(decodeURIComponent(new URL(path).pathname))
   } catch {
-    return path.replace(/^file:\/\//, '')
+    return stripWhatwgWindowsDrivePrefix(path.replace(/^file:\/\//, ''))
   }
 }
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2425,6 +2425,19 @@ _FS_MIME_TYPES = {
 }
 
 
+# WHATWG file URL pathname for a Windows drive is "/C:/Users/...".
+# Path.is_absolute() is false for that shape on Windows, so _fs_path
+# previously joined it to cwd and 404'd a file that existed.
+_WHATWG_WINDOWS_DRIVE_PATHNAME = re.compile(r"^/([A-Za-z]:)(/.*)?$")
+
+
+def _normalize_whatwg_windows_drive_pathname(raw: str) -> str:
+    match = _WHATWG_WINDOWS_DRIVE_PATHNAME.match(raw)
+    if match:
+        return f"{match.group(1)}{match.group(2) or '/'}"
+    return raw
+
+
 def _fs_path(raw_path: str) -> Path:
     raw = str(raw_path or "").strip()
     if not raw:
@@ -2437,7 +2450,12 @@ def _fs_path(raw_path: str) -> Path:
             if parsed.netloc and parsed.netloc not in {"", "localhost"}:
                 raise ValueError
             raw = urllib.request.url2pathname(parsed.path)
+        raw = _normalize_whatwg_windows_drive_pathname(raw)
         candidate = Path(raw).expanduser()
+        if re.match(r"^[A-Za-z]:[/\\]", raw):
+            # Drive-letter paths are absolute on Windows. On POSIX, Path
+            # treats them as relative and would otherwise join process cwd.
+            return candidate.resolve(strict=False) if candidate.is_absolute() else Path(raw)
         if not candidate.is_absolute():
             candidate = Path.cwd() / candidate
         return candidate.resolve(strict=False)

--- a/tests/hermes_cli/test_web_server_fs.py
+++ b/tests/hermes_cli/test_web_server_fs.py
@@ -45,6 +45,30 @@ def test_fs_list_sorts_and_hides_noise(client, tmp_path):
     assert all(entry["name"] not in {".git", "node_modules"} for entry in entries)
 
 
+def test_normalize_whatwg_windows_drive_pathname_strips_leading_slash():
+    assert (
+        web_server._normalize_whatwg_windows_drive_pathname(
+            "/C:/Users/demo/AppData/Local/hermes/images/upload_x.png"
+        )
+        == "C:/Users/demo/AppData/Local/hermes/images/upload_x.png"
+    )
+    assert web_server._normalize_whatwg_windows_drive_pathname("/tmp/a.png") == "/tmp/a.png"
+    assert (
+        web_server._normalize_whatwg_windows_drive_pathname(
+            r"C:\Users\demo\upload_x.png"
+        )
+        == r"C:\Users\demo\upload_x.png"
+    )
+
+
+def test_fs_path_does_not_join_whatwg_windows_drive_to_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    resolved = web_server._fs_path("/C:/Users/demo/AppData/Local/hermes/images/upload_x.png")
+    assert "C:" in str(resolved)
+    assert tmp_path not in resolved.parents
+    assert resolved.name == "upload_x.png"
+
+
 def test_fs_read_data_url_rejects_over_cap(client, tmp_path, monkeypatch):
     monkeypatch.setattr(web_server, "_FS_DATA_URL_MAX_BYTES", 3)
     target = tmp_path / "image.png"


### PR DESCRIPTION
## What does this PR do?

Remote Desktop preview of files on a Windows gateway 404s because the renderer turns `file:///C:/Users/...` into `/C:/Users/...` via `URL.pathname`. That shape is not a Windows path: `_fs_path()` treats it as relative on Windows, joins process cwd, and returns File not found for a file that exists. This keeps Windows drive letters when decoding `file:` URLs (and already-decoded `/C:/...` strings) and normalizes the same shape in the FS API so third-party clients are covered too.

## Related Issue

Fixes #101411

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/lib/media.ts` — strip the WHATWG leading slash from Windows drive pathnames in `filePathFromMediaPath`
- `apps/desktop/src/lib/local-preview.ts` — decode `file:` preview targets through the same helper
- `hermes_cli/web_server.py` — `_fs_path()` normalizes `/C:/...` to `C:/...` and does not join it to cwd
- Tests in `apps/desktop/src/lib/media.remote.test.ts`, `local-preview.test.ts`, and `tests/hermes_cli/test_web_server_fs.py`

## How to Test

1. `cd apps/desktop && npx vitest run src/lib/media.remote.test.ts src/lib/local-preview.test.ts` — 43 passed, including `file:///C:/...` → `C:/...` and remote `/api/fs/read-data-url?path=C%3A%2F...`
2. `scripts/run_tests.sh tests/hermes_cli/test_web_server_fs.py -q` — 7 passed, including `_fs_path("/C:/Users/...")` not under process cwd
3. On a Windows gateway: paste or open a workspace file in Desktop remote preview; the pane should load instead of `404 File not found`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5) — Desktop + targeted vitest/pytest; Windows gateway topology not re-run here

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
file:///C:/Users/demo/AppData/Local/hermes/images/upload_x.png => C:/Users/demo/AppData/Local/hermes/images/upload_x.png
npx vitest run src/lib/media.remote.test.ts src/lib/local-preview.test.ts
  Test Files  2 passed (2)
  Tests       43 passed (43)
scripts/run_tests.sh tests/hermes_cli/test_web_server_fs.py -q
  === Summary: 1 files, 7 tests passed, 0 failed ===
```