### PR TITLE
fix(kanban): improve lane-header collapse controls and focus visibility

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -161,6 +161,7 @@
     "@rolldown/plugin-babel": "0.2.3",
     "@testing-library/dom": "10.4.1",
     "@testing-library/react": "16.3.2",
+    "@testing-library/user-event": "^14.6.7",
     "@types/babel__core": "7.20.5",
     "@types/d3-force": "3.0.10",
     "@types/hast": "3.0.5",

--- a/apps/desktop/src/plugins/kanban/board.test.tsx
+++ b/apps/desktop/src/plugins/kanban/board.test.tsx
@@ -1,0 +1,155 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { $lanesByProfile } from './api'
+import { Column } from './board'
+import type { KanbanTask } from './types'
+
+const kanbanText = {
+  collapse: (label: string) => `Collapse ${label}`,
+  empty: 'Empty',
+  expand: (label: string) => `Expand ${label}`,
+  newTaskIn: (label: string) => `New task in ${label}`
+}
+
+const { emptyAtom, lanesByProfile } = vi.hoisted(() => ({
+  emptyAtom: { get: () => null, set: () => undefined },
+  lanesByProfile: { get: () => false, set: () => undefined }
+}))
+
+vi.mock('@hermes/plugin-sdk', () => ({
+  Codicon: ({
+    name,
+    size: _size,
+    spinning: _spinning,
+    ...props
+  }: {
+    name: string
+    size?: string
+    spinning?: boolean
+  }) => <span data-codicon={name} {...props} />,
+  Tip: ({ children, label }: { children: ReactNode; label: string }) => <span data-tip={label}>{children}</span>,
+  cn: (...values: unknown[]) => values.filter(value => typeof value === 'string' && value.length > 0).join(' '),
+  useValue: (store: { get: () => unknown }) => store.get()
+}))
+
+vi.mock('./api', () => ({
+  $boardSlug: emptyAtom,
+  $collapsedLanes: emptyAtom,
+  $introDismissed: emptyAtom,
+  $lanesByProfile: lanesByProfile,
+  BOARDS_KEY: [],
+  PROFILES_KEY: [],
+  boardKey: vi.fn(),
+  bulkTasks: vi.fn(),
+  createTask: vi.fn(),
+  deleteTask: vi.fn(),
+  estimateNew: vi.fn(),
+  fetchBoard: vi.fn(),
+  fetchBoards: vi.fn(),
+  fetchProfiles: vi.fn(),
+  patchTask: vi.fn()
+}))
+
+vi.mock('./ui', () => ({
+  columnHelp: vi.fn(() => 'Ready lane help'),
+  columnLabel: vi.fn(() => 'Ready'),
+  isLockedTarget: vi.fn(() => false),
+  useKanban: () => kanbanText
+}))
+
+vi.mock('./board-switcher', () => ({ BoardSwitcher: () => null }))
+vi.mock('./drawer', () => ({ TaskDrawer: () => null }))
+vi.mock('./model-override', () => ({
+  EMPTY_OVERRIDE: {},
+  ModelOverrideField: () => null,
+  overrideCreateFields: () => ({})
+}))
+vi.mock('./orchestration', () => ({ OrchestrationPanel: () => null }))
+
+afterEach(() => {
+  cleanup()
+  $lanesByProfile.set(false)
+  vi.clearAllMocks()
+})
+
+const column = { name: 'ready', tasks: [] as KanbanTask[] }
+
+function renderColumn(collapsed: boolean, onToggle = vi.fn()) {
+  return {
+    onToggle,
+    ...render(
+      <Column
+        collapsed={collapsed}
+        column={column}
+        columns={['ready']}
+        onAdd={vi.fn()}
+        onDelete={vi.fn()}
+        onDropTask={vi.fn()}
+        onMove={vi.fn()}
+        onOpen={vi.fn()}
+        onToggle={onToggle}
+        onToggleSelect={vi.fn()}
+        selected={new Set()}
+      />
+    )
+  }
+}
+
+describe('kanban column lane controls', () => {
+  it('renders one full-width native collapse button for an expanded lane header', () => {
+    const { container, onToggle } = renderColumn(false)
+    const collapse = screen.getByRole('button', { name: 'Collapse Ready' })
+
+    expect(collapse.getAttribute('type')).toBe('button')
+    expect(collapse.classList.contains('h-5')).toBe(true)
+    expect(collapse.classList.contains('w-full')).toBe(true)
+    expect(container.querySelector('header')).toBeNull()
+    expect(collapse.querySelector('button')).toBeNull()
+    expect(collapse.contains(screen.getByText('Ready'))).toBe(true)
+    expect(collapse.textContent).toContain('0')
+    expect(collapse.querySelector('[data-codicon="chevron-left"]')).toBeTruthy()
+    expect(screen.getByText('Ready').closest('[data-tip]')?.getAttribute('data-tip')).toBe('Ready lane help')
+
+    fireEvent.click(collapse)
+
+    expect(onToggle).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves the collapsed rail as a full-height native expand button', () => {
+    const { onToggle } = renderColumn(true)
+    const expand = screen.getByRole('button', { name: 'Expand Ready' })
+
+    expect(expand.getAttribute('type')).toBe('button')
+    expect(expand.classList.contains('h-full')).toBe(true)
+
+    fireEvent.click(expand)
+
+    expect(onToggle).toHaveBeenCalledTimes(1)
+  })
+
+  it('collapsed rail button has keyboard focus-visible highlight matching the project pattern', () => {
+    renderColumn(true)
+    const expand = screen.getByRole('button', { name: 'Expand Ready' })
+    const cls = expand.className
+
+    expect(cls).toContain('focus-visible:bg-(--chrome-action-hover)')
+    expect(cls).toContain('focus-visible:text-foreground')
+    expect(cls).toContain('focus-visible:outline-none')
+    expect(cls).toContain('focus-visible:ring-2')
+    expect(cls).toContain('focus-visible:ring-ring/40')
+  })
+
+  it('does not need custom keyboard handlers for Enter or Space', () => {
+    const { onToggle } = renderColumn(false)
+    const collapse = screen.getByRole('button', { name: 'Collapse Ready' })
+
+    fireEvent.keyDown(collapse, { key: 'Enter' })
+    fireEvent.keyUp(collapse, { key: 'Enter' })
+    fireEvent.keyDown(collapse, { key: ' ' })
+    fireEvent.keyUp(collapse, { key: ' ' })
+
+    expect(onToggle).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/plugins/kanban/board.test.tsx
+++ b/apps/desktop/src/plugins/kanban/board.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import type { ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -141,15 +142,16 @@ describe('kanban column lane controls', () => {
     expect(cls).toContain('focus-visible:ring-ring/40')
   })
 
-  it('does not need custom keyboard handlers for Enter or Space', () => {
+  it('activates natively on Enter and Space via keyboard', async () => {
+    const user = userEvent.setup()
     const { onToggle } = renderColumn(false)
     const collapse = screen.getByRole('button', { name: 'Collapse Ready' })
 
-    fireEvent.keyDown(collapse, { key: 'Enter' })
-    fireEvent.keyUp(collapse, { key: 'Enter' })
-    fireEvent.keyDown(collapse, { key: ' ' })
-    fireEvent.keyUp(collapse, { key: ' ' })
+    collapse.focus()
+    await user.keyboard('{Enter}')
+    expect(onToggle).toHaveBeenCalledTimes(1)
 
-    expect(onToggle).not.toHaveBeenCalled()
+    await user.keyboard(' ')
+    expect(onToggle).toHaveBeenCalledTimes(2)
   })
 })

--- a/apps/desktop/src/plugins/kanban/board.tsx
+++ b/apps/desktop/src/plugins/kanban/board.tsx
@@ -333,7 +333,7 @@ function Card({
 
 // ── column ───────────────────────────────────────────────────────────────────
 
-function Column({
+export function Column({
   collapsed,
   column,
   columns,
@@ -420,7 +420,7 @@ function Column({
         {...dragHandlers}
         aria-label={k.expand(label)}
         className={cn(
-          'flex h-full w-8 shrink-0 flex-col items-center gap-1.5 rounded-lg p-2 transition-colors hover:bg-(--ui-bg-quinary)',
+          'flex h-full w-8 shrink-0 flex-col items-center gap-1.5 rounded-lg p-2 transition-colors hover:bg-(--ui-bg-quinary) focus-visible:bg-(--chrome-action-hover) focus-visible:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40',
           wash
         )}
         onClick={onToggle}
@@ -444,7 +444,12 @@ function Column({
       {...dragHandlers}
       className={cn('group/col flex h-full w-64 shrink-0 flex-col rounded-lg p-2 transition-colors', wash)}
     >
-      <header className="mb-1.5 flex h-5 items-center gap-1.5 px-1">
+      <button
+        aria-label={k.collapse(label)}
+        className="group/lane mb-1.5 flex h-5 w-full items-center gap-1.5 rounded px-1 text-left transition-colors hover:bg-(--chrome-action-hover) focus-visible:bg-(--chrome-action-hover) focus-visible:text-foreground"
+        onClick={onToggle}
+        type="button"
+      >
         <span className="size-1.5 rounded-full" style={{ backgroundColor: meta.tone }} />
         <Tip label={columnHelp(k, column.name)}>
           <span className="cursor-help text-[0.6875rem] font-medium uppercase tracking-wide text-(--ui-text-tertiary)">
@@ -452,15 +457,10 @@ function Column({
           </span>
         </Tip>
         <span className="text-[0.625rem] tabular-nums text-(--ui-text-quaternary)">{column.tasks.length}</span>
-        <button
-          aria-label={k.collapse(label)}
-          className="ml-auto grid size-5 place-items-center rounded text-(--ui-text-tertiary) opacity-0 transition-opacity hover:bg-(--chrome-action-hover) hover:text-foreground focus-visible:opacity-100 group-hover/col:opacity-100"
-          onClick={onToggle}
-          type="button"
-        >
+        <span className="ml-auto grid size-5 place-items-center rounded text-(--ui-text-tertiary) opacity-0 transition-opacity hover:bg-(--chrome-action-hover) hover:text-foreground group-hover/col:opacity-100 group-focus-within/lane:opacity-100">
           <Codicon name="chevron-left" size="0.75rem" />
-        </button>
-      </header>
+        </span>
+      </button>
       <div className="relative flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto">
         {lanes
           ? lanes.map(([assignee, tasks]) => (

--- a/apps/desktop/src/plugins/kanban/board.tsx
+++ b/apps/desktop/src/plugins/kanban/board.tsx
@@ -457,7 +457,7 @@ export function Column({
           </span>
         </Tip>
         <span className="text-[0.625rem] tabular-nums text-(--ui-text-quaternary)">{column.tasks.length}</span>
-        <span className="ml-auto grid size-5 place-items-center rounded text-(--ui-text-tertiary) opacity-0 transition-opacity hover:bg-(--chrome-action-hover) hover:text-foreground group-hover/col:opacity-100 group-focus-within/lane:opacity-100">
+        <span className="ml-auto grid size-5 place-items-center rounded text-(--ui-text-tertiary) opacity-0 transition-opacity hover:bg-(--chrome-action-hover) hover:text-foreground group-hover/col:opacity-100 group-focus-visible/lane:opacity-100">
           <Codicon name="chevron-left" size="0.75rem" />
         </span>
       </button>

--- a/package-lock.json
+++ b/package-lock.json
@@ -147,6 +147,7 @@
         "@rolldown/plugin-babel": "0.2.3",
         "@testing-library/dom": "10.4.1",
         "@testing-library/react": "16.3.2",
+        "@testing-library/user-event": "^14.6.7",
         "@types/babel__core": "7.20.5",
         "@types/d3-force": "3.0.10",
         "@types/hast": "3.0.5",
@@ -6370,6 +6371,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.7",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.7.tgz",
+      "integrity": "sha512-MPCpX8bxe8zS+JmmTwLp8jd0dy1rAm60Te/SL8JrQM3qvQJcBOs1d7IefJMyZzqM3EWBrDn/LWDt1BCGu4ASfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@types/aria-query": {


### PR DESCRIPTION
## Summary
- make Kanban lane headers native full-width collapse/expand controls
- preserve collapsed rails with a visible keyboard focus state
- add focused component coverage for expanded and collapsed lane controls

## Testing
- `npx vitest run --project ui src/plugins/kanban/board.test.tsx` — 4 passed
- `npm run typecheck` — passed
- `npm run lint` — passed with 0 errors and 125 existing warnings
- `npm run test:ui` — stopped after 13 minutes without producing a result; inconclusive
- Manual Windows acceptance on Tennant — Tab and Shift+Tab focus highlight confirmed
