### PR TITLE
feat(cron): add strict unattended policy boundary

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -614,6 +614,8 @@ def init_agent(
     pass_session_id: bool = False,
     requested_provider: str = None,
     capabilities: Optional[Dict[str, bool]] = None,
+    skip_tool_search_assembly: bool = False,
+    exclude_mcp_tools: bool = False,
 ):
     """
     Initialize the AI Agent.
@@ -1047,9 +1049,11 @@ def init_agent(
     agent._current_tool: str | None = None
     agent._api_call_count: int = 0
     # Opt-out flag for the between-turns MCP tool refresh (build_turn_context).
-    # Set on internal forks (e.g. background_review) that must keep ``tools[]``
-    # byte-identical to a parent for provider cache parity.
-    agent._skip_mcp_refresh = False
+    # Internal forks use this for cache parity; strict no-MCP agents use it as
+    # a capability boundary that must survive beyond the initial tool snapshot.
+    agent._skip_mcp_refresh = bool(exclude_mcp_tools)
+    agent._exclude_mcp_tools = bool(exclude_mcp_tools)
+    agent._skip_tool_search_assembly = bool(skip_tool_search_assembly)
     # Registry generation the current tool snapshot was derived from. Lets a
     # late/concurrent refresh reject a stale (older-generation) rebuild instead
     # of clobbering a newer one. Set adjacent to the tool snapshot below.
@@ -1626,6 +1630,8 @@ def init_agent(
         enabled_toolsets=enabled_toolsets,
         disabled_toolsets=disabled_toolsets,
         quiet_mode=agent.quiet_mode,
+        skip_tool_search_assembly=skip_tool_search_assembly,
+        exclude_mcp_tools=exclude_mcp_tools,
     )
     
     # Show tool configuration and store valid tool names for validation

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3715,6 +3715,9 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 skip_tool_request_middleware=True,
                 enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                 disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                exclude_mcp_tools=bool(
+                    getattr(agent, "_exclude_mcp_tools", False)
+                ),
                 tool_request_middleware_trace=list(_tool_middleware_trace),
             )
             if skip_tool_execution_middleware:

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -410,6 +410,9 @@ def _tool_search_scoped_names(agent) -> frozenset:
             disabled_toolsets=disabled,
             quiet_mode=True,
             skip_tool_search_assembly=True,
+            exclude_mcp_tools=bool(
+                getattr(agent, "_exclude_mcp_tools", False)
+            ),
         ) or []
         names = _ts.scoped_deferrable_names(scoped_defs)
     except Exception:
@@ -2542,6 +2545,9 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                             tool_request_middleware_trace=list(middleware_trace),
                             enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                             disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                            exclude_mcp_tools=bool(
+                                getattr(agent, "_exclude_mcp_tools", False)
+                            ),
                         )
 
                 (
@@ -2624,6 +2630,9 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                             tool_request_middleware_trace=list(middleware_trace),
                             enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                             disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                            exclude_mcp_tools=bool(
+                                getattr(agent, "_exclude_mcp_tools", False)
+                            ),
                         )
 
                 (

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -478,7 +478,16 @@ def fire_claim_fence(job_id: str, *, expected_owner: str):
 # as a filesystem path component under ``OUTPUT_DIR``; allowing it to be
 # updated lets an unsafe value (``../escape``, absolute path, nested) leak
 # into output writes/deletes.
-_IMMUTABLE_JOB_FIELDS = frozenset({"id"})
+_IMMUTABLE_JOB_FIELDS = frozenset(
+    {
+        "id",
+        "policy_id",
+        "strict_toolsets",
+        "no_mcp",
+        "no_fallback",
+        "created_paused",
+    }
+)
 
 
 def _job_output_dir(job_id: str) -> Path:
@@ -2350,6 +2359,12 @@ def create_job(
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
+    policy_id: Optional[str] = None,
+    strict_toolsets: bool = False,
+    no_mcp: bool = False,
+    no_fallback: bool = False,
+    start_paused: bool = False,
+    _operator_capability: object = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -2421,6 +2436,16 @@ def create_job(
     Returns:
         The created job dict
     """
+    from cron.policy import CronPolicyError, require_trusted_policy_operator
+
+    if policy_id is None and (strict_toolsets or no_mcp or no_fallback):
+        raise CronPolicyError(
+            "strict_toolsets, no_mcp, and no_fallback require a registered policy_id"
+        )
+    require_trusted_policy_operator(
+        {"policy_id": policy_id}, _operator_capability, "creation"
+    )
+
     parsed_schedule = parse_schedule(schedule)
 
     # Normalize repeat: treat 0 or negative values as None (infinite).
@@ -2446,8 +2471,14 @@ def create_job(
     normalized_base_url = _normalize_job_optional_text(base_url, strip_trailing_slash=True)
     normalized_script = str(script).strip() if isinstance(script, str) else None
     normalized_script = normalized_script or None
-    normalized_toolsets = [str(t).strip() for t in enabled_toolsets if str(t).strip()] if enabled_toolsets else None
-    normalized_toolsets = normalized_toolsets or None
+    normalized_strict_toolsets = bool(strict_toolsets)
+    normalized_toolsets = (
+        [str(t).strip() for t in enabled_toolsets if str(t).strip()]
+        if enabled_toolsets is not None
+        else None
+    )
+    if not normalized_strict_toolsets:
+        normalized_toolsets = normalized_toolsets or None
     normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
@@ -2500,8 +2531,9 @@ def create_job(
         no_agent=normalized_no_agent,
     )
 
-    next_run_at = compute_next_run(parsed_schedule)
-    if parsed_schedule.get("kind") == "once" and next_run_at is None:
+    normalized_start_paused = bool(start_paused)
+    next_run_at = None if normalized_start_paused else compute_next_run(parsed_schedule)
+    if parsed_schedule.get("kind") == "once" and next_run_at is None and not normalized_start_paused:
         run_at = parsed_schedule.get("run_at") or schedule
         logger.warning(
             "Rejecting one-shot cron job '%s': run_at %s is outside the %ss grace window",
@@ -2542,10 +2574,10 @@ def create_job(
             "times": repeat,  # None = forever
             "completed": 0
         },
-        "enabled": True,
-        "state": "scheduled",
-        "paused_at": None,
-        "paused_reason": None,
+        "enabled": not normalized_start_paused,
+        "state": "paused" if normalized_start_paused else "scheduled",
+        "paused_at": now if normalized_start_paused else None,
+        "paused_reason": "created paused" if normalized_start_paused else None,
         "created_at": now,
         "next_run_at": next_run_at,
         "last_run_at": None,
@@ -2562,6 +2594,16 @@ def create_job(
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
     }
+    if policy_id is not None:
+        job["policy_id"] = str(policy_id).strip()
+    if normalized_strict_toolsets:
+        job["strict_toolsets"] = True
+    if no_mcp:
+        job["no_mcp"] = True
+    if no_fallback:
+        job["no_fallback"] = True
+    if normalized_start_paused:
+        job["created_paused"] = True
     # Only persist attach_to_session when explicitly set, so existing jobs and
     # the common case stay byte-identical (absent key => fall back to the
     # global cron.mirror_delivery config, default off).
@@ -2571,6 +2613,10 @@ def create_job(
     # absent key = job follows config resolution (pre-feature behavior).
     if normalized_reasoning_effort is not None:
         job["reasoning_effort"] = normalized_reasoning_effort
+
+    from cron.policy import validate_job_policy
+
+    validate_job_policy(job)
 
     with _jobs_lock():
         jobs = load_jobs()
@@ -2643,7 +2689,12 @@ def list_jobs(include_disabled: bool = False) -> List[Dict[str, Any]]:
     return jobs
 
 
-def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+def update_job(
+    job_id: str,
+    updates: Dict[str, Any],
+    *,
+    _operator_capability: object = None,
+) -> Optional[Dict[str, Any]]:
     """Update a job by ID, refreshing derived schedule fields when needed."""
     # Block mutation of immutable fields. ``id`` in particular is a filesystem
     # path component under OUTPUT_DIR — letting an update change it leaks
@@ -2659,6 +2710,25 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
         for i, job in enumerate(jobs):
             if job["id"] != job_id:
                 continue
+
+            if job.get("policy_id") is not None:
+                containment_fields = {
+                    "enabled",
+                    "state",
+                    "paused_at",
+                    "paused_reason",
+                }
+                containment_pause = (
+                    set(updates or {}).issubset(containment_fields)
+                    and updates.get("enabled") is False
+                    and updates.get("state") == "paused"
+                )
+                if not containment_pause:
+                    from cron.policy import require_trusted_policy_operator
+
+                    require_trusted_policy_operator(
+                        job, _operator_capability, "update"
+                    )
 
             # Validate / normalize workdir if present in updates.  Empty string
             # or None both mean "clear the field" (restore old behaviour).
@@ -2823,6 +2893,10 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     "through update_job; use cron resume --run-now or --at."
                 )
 
+            from cron.policy import validate_policy_update
+
+            validate_policy_update(job, updated)
+
             jobs[i] = updated
             save_jobs(jobs)
             return _normalize_job_record(jobs[i])
@@ -2845,11 +2919,49 @@ def pause_job(job_id: str, reason: Optional[str] = None) -> Optional[Dict[str, A
     )
 
 
-def resume_job(job_id: str) -> Optional[Dict[str, Any]]:
+def quarantine_invalid_policy_job(
+    job_id: str, reason: str
+) -> Optional[Dict[str, Any]]:
+    """Disable an invalid policy record without allowing general mutation."""
+    from cron.policy import CronPolicyError, validate_job_policy
+
+    with _jobs_lock():
+        jobs = load_jobs()
+        for index, job in enumerate(jobs):
+            if job.get("id") != job_id:
+                continue
+            try:
+                validate_job_policy(job)
+            except CronPolicyError:
+                quarantined = dict(job)
+                quarantined.update(
+                    {
+                        "enabled": False,
+                        "state": "paused",
+                        "paused_at": _hermes_now().isoformat(),
+                        "paused_reason": reason,
+                        "next_run_at": None,
+                    }
+                )
+                jobs[index] = quarantined
+                save_jobs(jobs)
+                return _normalize_job_record(quarantined)
+            raise ValueError("refusing to quarantine a valid cron policy job")
+    return None
+
+
+def resume_job(
+    job_id: str, *, _operator_capability: object = None
+) -> Optional[Dict[str, Any]]:
     """Resume a paused job and compute the next future run from now. Accepts a job ID or name."""
     job = resolve_job_ref(job_id)
     if not job:
         return None
+
+    from cron.policy import require_trusted_policy_operator, validate_job_policy
+
+    require_trusted_policy_operator(job, _operator_capability, "resume")
+    validate_job_policy(job)
 
     next_run_at = compute_next_run(job["schedule"])
     if next_run_at is None and job["schedule"].get("kind") == "once":
@@ -2867,11 +2979,15 @@ def resume_job(job_id: str) -> Optional[Dict[str, Any]]:
             "paused_reason": None,
             "next_run_at": next_run_at,
         },
+        _operator_capability=_operator_capability,
     )
 
 
 def trigger_job(
-    job_id: str, extra_prompt: Optional[str] = None
+    job_id: str,
+    extra_prompt: Optional[str] = None,
+    *,
+    _operator_capability: object = None,
 ) -> Optional[Dict[str, Any]]:
     """Schedule a job to run on the next scheduler tick. Accepts a job ID or name.
 
@@ -2885,6 +3001,9 @@ def trigger_job(
     job = resolve_job_ref(job_id)
     if not job:
         return None
+    from cron.policy import require_trusted_policy_operator
+
+    require_trusted_policy_operator(job, _operator_capability, "trigger")
     if is_terminal_job(job):
         state = job.get("state")
         name = job.get("name", job_id)
@@ -2909,6 +3028,7 @@ def trigger_job(
             # clears any stale prompt from a previous trigger).
             "manual_run_prompt": (extra_prompt or None),
         },
+        _operator_capability=_operator_capability,
     )
 
 
@@ -2922,11 +3042,17 @@ def _claim_is_live(claim: Any, now: datetime, ttl_seconds: float) -> bool:
     return 0 <= age < ttl_seconds
 
 
-def rearm_oneshot(job_id: str, run_at: Any) -> Optional[Dict[str, Any]]:
+def rearm_oneshot(
+    job_id: str, run_at: Any, *, _operator_capability: object = None
+) -> Optional[Dict[str, Any]]:
     """Re-arm a completed one-shot as an explicit new occurrence."""
     job_ref = resolve_job_ref(job_id)
     if not job_ref:
         return None
+    from cron.policy import require_trusted_policy_operator, validate_job_policy
+
+    require_trusted_policy_operator(job_ref, _operator_capability, "re-arm")
+    validate_job_policy(job_ref)
     if isinstance(run_at, datetime):
         run_at = run_at.isoformat()
     parsed_schedule = parse_schedule(str(run_at))
@@ -2948,6 +3074,8 @@ def rearm_oneshot(job_id: str, run_at: Any) -> Optional[Dict[str, Any]]:
         for index, job in enumerate(jobs):
             if job.get("id") != job_ref["id"]:
                 continue
+            require_trusted_policy_operator(job, _operator_capability, "re-arm")
+            validate_job_policy(job)
             now = _hermes_now()
             if _claim_is_live(job.get("run_claim"), now, _oneshot_run_claim_ttl_seconds()):
                 raise ValueError("Cannot re-arm one-shot over a live run claim.")
@@ -2976,14 +3104,21 @@ def rearm_oneshot(job_id: str, run_at: Any) -> Optional[Dict[str, Any]]:
     return None
 
 
-def remove_job(job_id: str) -> bool:
+def remove_job(job_id: str, *, _operator_capability: object = None) -> bool:
     """Remove a job by ID or name."""
     job = resolve_job_ref(job_id)
     if not job:
         return False
+    from cron.policy import require_trusted_policy_operator
+
+    require_trusted_policy_operator(job, _operator_capability, "removal")
     canonical_id = job["id"]
     with _jobs_lock():
         jobs = load_jobs()
+        current = next((item for item in jobs if item.get("id") == canonical_id), None)
+        if current is None:
+            return False
+        require_trusted_policy_operator(current, _operator_capability, "removal")
         original_len = len(jobs)
         jobs = [j for j in jobs if j["id"] != canonical_id]
         if len(jobs) < original_len:
@@ -3585,22 +3720,50 @@ def _machine_id() -> str:
     return f"{host}:{os.getpid()}"
 
 
+def _notify_policy_quarantine() -> None:
+    """Best-effort reconciliation after a protected job is auto-paused."""
+    try:
+        from cron.scheduler import _notify_provider_jobs_changed
+
+        _notify_provider_jobs_changed()
+    except Exception:
+        logger.exception("Failed to notify cron provider after policy quarantine")
+
+
+def _is_policy_quarantined(job: Optional[Dict[str, Any]]) -> bool:
+    return bool(
+        job
+        and job.get("policy_id") is not None
+        and job.get("enabled") is False
+        and job.get("state") == "paused"
+        and str(job.get("paused_reason") or "").startswith(
+            "Auto-paused by scheduler:"
+        )
+    )
+
+
 def claim_job_for_fire(
     job_id: str,
     *,
     claim_ttl_seconds: int = 300,
     force: bool = False,
     return_job: bool = False,
+    _operator_capability: object = None,
 ) -> Union[bool, Dict[str, Any]]:
+    was_quarantined = _is_policy_quarantined(get_job(job_id))
     with _fire_job_lock(job_id) as acquired:
         if not acquired:
             return False
-        return _claim_job_for_fire_locked(
+        result = _claim_job_for_fire_locked(
             job_id,
             claim_ttl_seconds=claim_ttl_seconds,
             force=force,
             return_job=return_job,
+            _operator_capability=_operator_capability,
         )
+    if not was_quarantined and _is_policy_quarantined(get_job(job_id)):
+        _notify_policy_quarantine()
+    return result
 
 
 def _claim_job_for_fire_locked(
@@ -3609,6 +3772,7 @@ def _claim_job_for_fire_locked(
     claim_ttl_seconds: int = 300,
     force: bool = False,
     return_job: bool = False,
+    _operator_capability: object = None,
 ) -> Union[bool, Dict[str, Any]]:
     """Atomically claim a job for a single external 'fire' (multi-machine
     at-most-once). Returns True iff THIS caller won the claim.
@@ -3638,6 +3802,45 @@ def _claim_job_for_fire_locked(
         for job in jobs:
             if job["id"] != job_id:
                 continue
+            from cron.policy import (
+                CronPolicyError,
+                require_trusted_policy_operator,
+                validate_job_policy,
+            )
+
+            try:
+                validate_job_policy(job)
+            except CronPolicyError as exc:
+                logger.error(
+                    "Job '%s': quarantining invalid cron policy before fire claim — %s",
+                    job_id,
+                    exc,
+                )
+                job.update(
+                    {
+                        "enabled": False,
+                        "state": "paused",
+                        "paused_at": _hermes_now().isoformat(),
+                        "paused_reason": f"Auto-paused by scheduler: {exc}",
+                        "next_run_at": None,
+                    }
+                )
+                save_jobs(jobs)
+                return False
+            if force and job.get("policy_id") is not None:
+                require_trusted_policy_operator(
+                    job, _operator_capability, "manual fire"
+                )
+            if (
+                force
+                and job.get("policy_id") is not None
+                and not is_job_runnable(job)
+            ):
+                logger.error(
+                    "Job '%s': refusing forced activation of paused policy job",
+                    job_id,
+                )
+                return False
             if is_terminal_job(job) and not _is_recoverable_error_job(job):
                 return False
             # enabled + pause markers must both clear — a half-paused record
@@ -3815,11 +4018,17 @@ def get_due_jobs() -> List[Dict[str, Any]]:
     Note: firing once on catch-up flows through ``mark_job_run``, so a job with
     a ``repeat.times`` limit consumes one of its runs on that catch-up fire.
     """
+    quarantined_policy_ids: List[str] = []
     with _jobs_lock():
-        return _get_due_jobs_locked()
+        due = _get_due_jobs_locked(quarantined_policy_ids)
+    if quarantined_policy_ids:
+        _notify_policy_quarantine()
+    return due
 
 
-def _get_due_jobs_locked() -> List[Dict[str, Any]]:
+def _get_due_jobs_locked(
+    quarantined_policy_ids: Optional[List[str]] = None,
+) -> List[Dict[str, Any]]:
     """Inner implementation of get_due_jobs(); must be called with _jobs_lock held."""
     now = _hermes_now()
     raw_jobs = load_jobs()
@@ -3938,6 +4147,36 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
         # job this tick" so healthy siblings still run and their recovered
         # state still reaches save_jobs() below.
         try:
+            from cron.policy import validate_job_policy
+
+            try:
+                validate_job_policy(job)
+            except ValueError as exc:
+                logger.error(
+                    "Job '%s': quarantining invalid cron policy — %s",
+                    job.get("id", "?"),
+                    exc,
+                )
+                job_id = job.get("id")
+                for raw_job in raw_jobs:
+                    if raw_job.get("id") != job_id:
+                        continue
+                    raw_job.update(
+                        {
+                            "enabled": False,
+                            "state": "paused",
+                            "paused_at": now.isoformat(),
+                            "paused_reason": (
+                                f"Auto-paused by scheduler: {exc}"
+                            ),
+                            "next_run_at": None,
+                        }
+                    )
+                    needs_save = True
+                    if quarantined_policy_ids is not None and job_id:
+                        quarantined_policy_ids.append(job_id)
+                    break
+                continue
             if is_terminal_job(job) and not _is_recoverable_error_job(job):
                 continue
             if not job.get("enabled", True):

--- a/cron/policy.py
+++ b/cron/policy.py
@@ -1,0 +1,101 @@
+"""Registered fail-closed policies for restricted cron jobs."""
+
+from __future__ import annotations
+
+
+STRICT_UNATTENDED_POLICY_ID = "strict-unattended-v1"
+
+_CRON_OPERATOR_CAPABILITY = object()
+
+_POLICY_RUNTIME_PINS = frozenset({"enabled_toolsets", "provider", "model", "base_url"})
+
+
+class CronPolicyError(ValueError):
+    """Raised when a cron job violates its registered policy."""
+
+
+def cron_operator_capability() -> object:
+    """Return the non-serializable capability used by the direct CLI."""
+    return _CRON_OPERATOR_CAPABILITY
+
+
+def is_trusted_cron_operator(capability: object) -> bool:
+    """Validate direct CLI authority by object identity."""
+    return capability is _CRON_OPERATOR_CAPABILITY
+
+
+def require_trusted_policy_operator(job: dict, capability: object, action: str) -> None:
+    """Reject protected lifecycle actions without direct CLI authority."""
+    if job.get("policy_id") is not None and not is_trusted_cron_operator(capability):
+        raise CronPolicyError(
+            f"policy cron job {action} requires a trusted operator CLI"
+        )
+
+
+def validate_job_policy(job: dict) -> None:
+    """Validate a persisted cron job's registered policy, if any."""
+    policy_id = job.get("policy_id")
+    if policy_id is None:
+        return
+    if policy_id != STRICT_UNATTENDED_POLICY_ID:
+        raise CronPolicyError(f"unknown cron policy: {policy_id!r}")
+
+    required_true = (
+        "strict_toolsets",
+        "no_mcp",
+        "no_fallback",
+        "created_paused",
+    )
+    for field in required_true:
+        if job.get(field) is not True:
+            raise CronPolicyError(
+                f"policy {STRICT_UNATTENDED_POLICY_ID!r} requires {field}=true"
+            )
+
+    if not isinstance(job.get("enabled_toolsets"), list):
+        raise CronPolicyError(
+            f"policy {STRICT_UNATTENDED_POLICY_ID!r} requires an explicit enabled_toolsets list"
+        )
+    from toolsets import get_toolset, resolve_toolset
+
+    for toolset_name in job["enabled_toolsets"]:
+        if not isinstance(toolset_name, str) or not toolset_name.strip():
+            raise CronPolicyError(
+                f"policy {STRICT_UNATTENDED_POLICY_ID!r} has an invalid strict toolset name"
+            )
+        try:
+            known_toolset = get_toolset(toolset_name)
+            resolved_tools = resolve_toolset(toolset_name)
+        except Exception as exc:
+            raise CronPolicyError(
+                f"policy {STRICT_UNATTENDED_POLICY_ID!r} could not resolve strict toolset {toolset_name!r}"
+            ) from exc
+        if known_toolset is None:
+            raise CronPolicyError(
+                f"policy {STRICT_UNATTENDED_POLICY_ID!r} references unknown strict toolset {toolset_name!r}"
+            )
+        if "memory" in resolved_tools:
+            raise CronPolicyError(
+                f"policy {STRICT_UNATTENDED_POLICY_ID!r} forbids the persistent memory toolset"
+            )
+    for field in ("provider", "model"):
+        value = job.get(field)
+        if not isinstance(value, str) or not value.strip():
+            raise CronPolicyError(
+                f"policy {STRICT_UNATTENDED_POLICY_ID!r} requires a non-empty {field} pin"
+            )
+    if job.get("no_agent") is True:
+        raise CronPolicyError(
+            f"policy {STRICT_UNATTENDED_POLICY_ID!r} requires an agent-backed job"
+        )
+
+
+def validate_policy_update(before: dict, after: dict) -> None:
+    """Reject changes to capability and inference pins on policy jobs."""
+    validate_job_policy(before)
+    validate_job_policy(after)
+    if before.get("policy_id") is None:
+        return
+    for field in _POLICY_RUNTIME_PINS:
+        if before.get(field) != after.get(field):
+            raise CronPolicyError(f"policy field {field!r} cannot be updated")

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -618,7 +618,15 @@ def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
     surprise $4.63 run).
     """
     per_job = job.get("enabled_toolsets")
+    if job.get("strict_toolsets"):
+        if not isinstance(per_job, list):
+            from cron.policy import CronPolicyError
+
+            raise CronPolicyError("strict_toolsets requires an explicit enabled_toolsets list")
+        return [str(name) for name in per_job if str(name) != "no_mcp"]
     if per_job:
+        if job.get("no_mcp"):
+            return [str(name) for name in per_job if str(name) != "no_mcp"]
         return _merge_mcp_into_per_job_toolsets(list(per_job), cfg or {})
     try:
         from hermes_cli.tools_config import _get_platform_tools  # lazy: avoid heavy import at cron module load
@@ -5109,7 +5117,11 @@ def _guard_job_credential_exfil(job: dict) -> None:
 
 
 def _block_and_pause_job(
-    job_id: str, job_name: str, reason: str
+    job_id: str,
+    job_name: str,
+    reason: str,
+    *,
+    invalid_policy: bool = False,
 ) -> tuple[bool, str, str, Optional[str]]:
     """Fail a run closed and pause the job so it stops being scheduled.
 
@@ -5118,11 +5130,17 @@ def _block_and_pause_job(
     every tick forever. Pausing writes ``paused_at``/``paused_reason``, giving
     an auditable record of why the scheduler stopped it.
     """
-    from cron.jobs import pause_job
+    from cron.jobs import pause_job, quarantine_invalid_policy_job
 
     logger.error("Job '%s': %s", job_id, reason)
     try:
-        pause_job(job_id, f"Auto-paused by scheduler: {reason}")
+        if invalid_policy:
+            quarantine_invalid_policy_job(
+                job_id, f"Auto-paused by scheduler: {reason}"
+            )
+        else:
+            pause_job(job_id, f"Auto-paused by scheduler: {reason}")
+        _notify_provider_jobs_changed()
     except Exception:
         logger.exception("Job '%s': failed to auto-pause unrunnable job", job_id)
 
@@ -5727,6 +5745,20 @@ def run_job(
     """
     job_id = job["id"]
     job_name = str(job.get("name") or job.get("prompt") or job_id or "cron job")
+
+    from cron.policy import (
+        CronPolicyError,
+        STRICT_UNATTENDED_POLICY_ID,
+        validate_job_policy,
+    )
+
+    try:
+        validate_job_policy(job)
+    except CronPolicyError as exc:
+        logger.error("Job '%s': refusing invalid cron policy — %s", job_id, exc)
+        return _block_and_pause_job(
+            job_id, job_name, str(exc), invalid_policy=True
+        )
 
     # Fail closed on a corrupt config.yaml before any agent-driven work
     # (issue #81952): a cron fire is fully non-interactive, and continuing
@@ -6416,6 +6448,8 @@ def run_job(
             is_transient_net = _is_transient_provider_resolve_error(resolve_exc)
             if not (is_auth or is_transient_net):
                 raise RuntimeError(format_runtime_provider_error(resolve_exc)) from resolve_exc
+            if job.get("no_fallback"):
+                raise RuntimeError(format_runtime_provider_error(resolve_exc)) from resolve_exc
 
             primary_provider_for_drift = (
                 str(getattr(resolve_exc, "provider", "") or "").strip().lower()
@@ -6563,7 +6597,7 @@ def run_job(
                     f"config is pinned or restored. See #44585."
                 )
 
-        fallback_model = get_fallback_chain(_cfg) or None
+        fallback_model = None if job.get("no_fallback") else (get_fallback_chain(_cfg) or None)
         credential_pool = None
         runtime_provider = str(runtime.get("provider") or "").strip().lower()
         if runtime_provider:
@@ -6588,19 +6622,20 @@ def run_job(
         # ticks short-circuit on already-connected servers inside
         # register_mcp_servers(). Non-fatal on failure: a broken MCP server
         # shouldn't kill an otherwise-working cron job. See #4219.
-        try:
-            from tools.mcp_tool import discover_mcp_tools
-            _mcp_tools = discover_mcp_tools()
-            if _mcp_tools:
-                logger.info(
-                    "Job '%s': %d MCP tool(s) available",
-                    job_id, len(_mcp_tools),
+        if not job.get("no_mcp"):
+            try:
+                from tools.mcp_tool import discover_mcp_tools
+                _mcp_tools = discover_mcp_tools()
+                if _mcp_tools:
+                    logger.info(
+                        "Job '%s': %d MCP tool(s) available",
+                        job_id, len(_mcp_tools),
+                    )
+            except Exception as _mcp_exc:
+                logger.warning(
+                    "Job '%s': MCP initialization failed (non-fatal): %s",
+                    job_id, _mcp_exc,
                 )
-        except Exception as _mcp_exc:
-            logger.warning(
-                "Job '%s': MCP initialization failed (non-fatal): %s",
-                job_id, _mcp_exc,
-            )
 
         # Initialize the SQLite session store so cron job messages are
         # persisted and discoverable via session_search (same pattern as
@@ -6683,6 +6718,8 @@ def run_job(
             openrouter_min_coding_score=(_cfg.get("openrouter") or {}).get("min_coding_score"),
             enabled_toolsets=_resolve_cron_enabled_toolsets(job, _cfg),
             disabled_toolsets=_resolve_cron_disabled_toolsets(_cfg),
+            skip_tool_search_assembly=bool(job.get("strict_toolsets")),
+            exclude_mcp_tools=bool(job.get("no_mcp")),
             quiet_mode=True,
             # Cron jobs should always inherit the user's SOUL.md identity from
             # HERMES_HOME. When a workdir is configured, also inject project
@@ -6690,17 +6727,25 @@ def run_job(
             # Without a workdir, keep cwd context discovery disabled.
             skip_context_files=not bool(_job_workdir),
             load_soul_identity=True,
-            # Memory is enabled for cron agents like any other agent run:
-            # MEMORY.md / USER.md load into the system prompt and the memory
-            # tool follows normal toolset resolution, so jobs benefit from
-            # (and can update) the user's persistent memory.
-            skip_memory=False,
+            # Strict unattended policy jobs do not load or initialize the
+            # persistent memory/profile subsystem, preventing unrelated durable
+            # profile facts from entering the unattended model context.
+            skip_memory=(
+                job.get("policy_id") == STRICT_UNATTENDED_POLICY_ID
+            ),
             skip_background_review=True,  # Cron has no human-in-the-loop need for skill/memory review forks (~30K tok/event)
             platform="cron",
             session_id=_cron_session_id,
             session_db=_session_db,
         )
-        
+        # Keep the strict tool boundary as runtime state, not merely constructor
+        # arguments. This prevents between-turn MCP refresh or bridge scope
+        # rebuilding from widening the initial snapshot.
+        if job.get("policy_id") == STRICT_UNATTENDED_POLICY_ID:
+            agent._skip_mcp_refresh = True
+            agent._exclude_mcp_tools = True
+            agent._skip_tool_search_assembly = True
+
         # Run the agent with an *inactivity*-based timeout: the job can run
         # for hours if it's actively calling tools / receiving stream tokens,
         # but a hung API call or stuck tool with no activity for the configured
@@ -7973,6 +8018,8 @@ def create_job_with_scheduler_registration(**kwargs) -> dict:
     from cron.scheduler_provider import resolve_cron_scheduler
 
     job = create_job(**kwargs)
+    if not job.get("enabled") or job.get("next_run_at") is None:
+        return job
     try:
         resolve_cron_scheduler().register_job(job)
     except Exception as exc:

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -180,6 +180,7 @@ class CronScheduler(ABC):
         adapters: Any = None,
         loop: Any = None,
         force: bool = False,
+        _operator_capability: object = None,
     ) -> bool:
         """Run a single job NOW via the shared orchestrator. Called by the
         inbound fire webhook when an external scheduler signals a job is due.
@@ -193,12 +194,22 @@ class CronScheduler(ABC):
         the job itself failed. Returns False only if the claim was lost
         (another machine/retry won it) or the job no longer exists.
         """
-        claimed_job = self.claim_fire(job_id, force=force)
+        claimed_job = self.claim_fire(
+            job_id,
+            force=force,
+            _operator_capability=_operator_capability,
+        )
         if claimed_job is None:
             return False
         return self.fire_claimed(claimed_job, adapters=adapters, loop=loop)
 
-    def claim_fire(self, job_id: str, *, force: bool = False) -> dict | None:
+    def claim_fire(
+        self,
+        job_id: str,
+        *,
+        force: bool = False,
+        _operator_capability: object = None,
+    ) -> dict | None:
         """Durably claim one fire and create its audit attempt before dispatch.
 
         Webhook transports call this synchronously before acknowledging the
@@ -212,6 +223,8 @@ class CronScheduler(ABC):
         claim_kwargs = {"return_job": True}
         if force:
             claim_kwargs["force"] = True
+        if _operator_capability is not None:
+            claim_kwargs["_operator_capability"] = _operator_capability
         try:
             claimed_job = claim_job_for_fire(job_id, **claim_kwargs)
         except BaseException as exc:

--- a/docs/strict-unattended-cron.md
+++ b/docs/strict-unattended-cron.md
@@ -1,0 +1,98 @@
+# Strict unattended cron policy
+
+Hermes can create a scheduled agent under the registered
+`strict-unattended-v1` policy. This policy is intended for jobs that consume
+untrusted evidence without giving that evidence access to the Hermes control
+plane.
+
+## Security contract
+
+A policy job must persist all of these controls:
+
+- `created_paused=true`: its first jobs-store record was disabled and had no
+  next trigger;
+- `strict_toolsets=true`: `enabled_toolsets` is the complete tool allowlist;
+- `no_mcp=true`: the job does not initiate MCP discovery, previously
+  registered `mcp__*` schemas are removed from its tool surface, automatic
+  between-turn MCP refresh is disabled, and any defensive refresh,
+  progressive-disclosure scope rebuild, generic bridge catalog rebuild, recursive
+  bridge call, or direct dispatcher call preserves the MCP exclusion;
+- `no_fallback=true`: provider-resolution failover and the agent model fallback
+  chain are disabled;
+- persistent memory/profile loading is disabled for the run; every named
+  toolset is resolved fail-closed (including aggregate/alias and registered
+  plugin toolsets), and any resolved toolset containing the `memory` tool is
+  forbidden rather than allowed to override that isolation;
+- explicit `provider` and `model` pins.
+
+The policy ID and capability/runtime pins are immutable. Hermes validates the
+policy at create, update, resume, due-scan, fire-claim, and immediately before
+agent dispatch. Unknown or malformed persisted policies fail closed and are
+durably disabled with a diagnostic pause reason.
+
+Policy creation, activation, update, manual run, re-arm, and removal require the
+direct operator CLI on the supported model-facing and application ingress paths.
+Core `cron.jobs` mutation functions reject callers that do not carry the
+in-process capability, so REST, dashboard, console, model-tool, and ordinary
+wrapper calls fail closed; REST returns `403` for a protected mutation. The
+model-facing `cronjob` schema cannot serialize the capability. A policy job may
+pause itself as a containment action, but it cannot resume, mutate, remove,
+re-arm, or manually run itself. `force=True` requires the operator capability
+even when the job is already scheduled, and it cannot resurrect a paused policy
+job.
+
+The capability singleton is **not** an authority boundary against imported
+Python code. A same-process plugin is part of Hermes's trusted computing base
+and can import the singleton or mutate agent state. Likewise, a same-UID process
+can edit the job store. Do not describe this control as plugin isolation or an
+OS security boundary.
+
+Invalid-policy quarantine also asks the active scheduler provider to reconcile
+its registrations after the durable pause, preventing an external scheduler
+from remaining armed against a locally quarantined record.
+
+## Create paused
+
+Use an exact, minimal allowlist. Do not include `terminal`, file-write,
+process-control, cron-control, or external mutation toolsets in an evidence
+reviewer.
+
+```bash
+hermes cron create '0 7 * * *' \
+  'Review bounded evidence using only the fixed reader tool.' \
+  --name 'Restricted evidence review' \
+  --model 'provider/model' \
+  --provider 'provider' \
+  --policy-id strict-unattended-v1 \
+  --enabled-toolset fixed-reader \
+  --strict-toolsets \
+  --no-mcp \
+  --no-fallback \
+  --start-paused
+```
+
+Read the created job back and verify:
+
+- `enabled=false`;
+- `state="paused"`;
+- `next_run_at=null`;
+- all policy fields and pins match the intended values.
+
+Only then may an operator run `hermes cron resume <job-id>`.
+
+## Design boundary
+
+This policy is a model-capability boundary, not an operating-system sandbox.
+Processes running as the same OS user can still modify Hermes files directly.
+It also does not prove that model output is semantically correct.
+
+A truly unattended state-changing workflow must therefore keep commit/finalize
+authority out of the reviewing agent's process and tool surface. Put publication
+behind a separate trusted service or process with distinct OS credentials and
+authenticated, narrowly typed IPC; use fixed trusted code there to validate
+bounded, hash-bound output and apply an exact state transition. Fail closed on
+malformed evidence, incomplete coverage, policy drift, publisher failure, or
+readback mismatch. This policy alone is insufficient to authorize unattended
+publication.
+
+Legacy jobs without `policy_id` keep their existing behavior.

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1428,6 +1428,7 @@ try:
         resume_job as _cron_resume,
         trigger_job as _cron_trigger,
     )
+    from cron.policy import CronPolicyError as _CronPolicyError
     from cron.scheduler import (
         CronSchedulerRegistrationError as _CronSchedulerRegistrationError,
         create_job_with_scheduler_registration as _cron_create,
@@ -1444,6 +1445,9 @@ except ImportError:
     _cron_trigger = None
 
     class _CronSchedulerRegistrationError(RuntimeError):
+        pass
+
+    class _CronPolicyError(ValueError):
         pass
 
 
@@ -6875,6 +6879,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response({"error": "Job not found"}, status=404)
             _notify_cron_provider_jobs_changed()
             return web.json_response({"job": job})
+        except _CronPolicyError as e:
+            return web.json_response(
+                {"error": _redact_api_error_text(e)}, status=403
+            )
         except Exception as e:
             return web.json_response({"error": _redact_api_error_text(e)}, status=500)
 
@@ -6895,6 +6903,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response({"error": "Job not found"}, status=404)
             _notify_cron_provider_jobs_changed()
             return web.json_response({"ok": True})
+        except _CronPolicyError as e:
+            return web.json_response(
+                {"error": _redact_api_error_text(e)}, status=403
+            )
         except Exception as e:
             return web.json_response({"error": _redact_api_error_text(e)}, status=500)
 
@@ -6935,6 +6947,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response({"error": "Job not found"}, status=404)
             _notify_cron_provider_jobs_changed()
             return web.json_response({"job": job})
+        except _CronPolicyError as e:
+            return web.json_response(
+                {"error": _redact_api_error_text(e)}, status=403
+            )
         except Exception as e:
             return web.json_response({"error": _redact_api_error_text(e)}, status=500)
 
@@ -6979,6 +6995,10 @@ class APIServerAdapter(BasePlatformAdapter):
             if not job:
                 return web.json_response({"error": "Job not found"}, status=404)
             return web.json_response({"job": job})
+        except _CronPolicyError as e:
+            return web.json_response(
+                {"error": _redact_api_error_text(e)}, status=403
+            )
         except Exception as e:
             return web.json_response({"error": _redact_api_error_text(e)}, status=500)
 

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -44,8 +44,10 @@ def _normalize_skills(single_skill=None, skills: Optional[Iterable[str]] = None)
 
 
 def _cron_api(**kwargs):
+    from cron.policy import cron_operator_capability
     from tools.cronjob_tools import cronjob as cronjob_tool
 
+    kwargs["_operator_capability"] = cron_operator_capability()
     return json.loads(cronjob_tool(**kwargs))
 
 
@@ -803,6 +805,12 @@ def cron_create(args):
         monitor_url=getattr(args, "monitor_url", None),
         continuity=getattr(args, "continuity", None),
         reasoning_effort=getattr(args, "reasoning_effort", None),
+        policy_id=getattr(args, "policy_id", None),
+        enabled_toolsets=getattr(args, "enabled_toolsets", None),
+        strict_toolsets=getattr(args, "strict_toolsets", False),
+        no_mcp=getattr(args, "no_mcp", False),
+        no_fallback=getattr(args, "no_fallback", False),
+        start_paused=getattr(args, "start_paused", False),
     )
     if not result.get("success"):
         print(color(f"Failed to create job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -974,16 +982,23 @@ def cron_resume(args) -> int:
             return 1
         return _job_action("resume", args.job_id, "Resumed")
     from cron.jobs import AmbiguousJobReference, _hermes_now, rearm_oneshot
+    from cron.policy import cron_operator_capability
+    from cron.scheduler import _notify_provider_jobs_changed
 
     run_at = _hermes_now().isoformat() if args.run_now else args.run_at
     try:
-        job = rearm_oneshot(args.job_id, run_at)
+        job = rearm_oneshot(
+            args.job_id,
+            run_at,
+            _operator_capability=cron_operator_capability(),
+        )
     except (AmbiguousJobReference, ValueError) as exc:
         print(color(f"Failed to re-arm job: {exc}", Colors.RED))
         return 1
     if not job:
         print(color(f"Job not found: {args.job_id}", Colors.RED))
         return 1
+    _notify_provider_jobs_changed()
     print(color(f"Re-armed job: {job.get('name', args.job_id)} ({args.job_id})", Colors.GREEN))
     print(f"  Next run: {job.get('next_run_at')}")
     return 0

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -132,6 +132,40 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
             "monitors, incremental digests). First run is unchanged."
         ),
     )
+    cron_create.add_argument(
+        "--policy-id",
+        help="Registered immutable cron isolation policy.",
+    )
+    cron_create.add_argument(
+        "--enabled-toolset",
+        dest="enabled_toolsets",
+        action="append",
+        help="Exact allowed toolset for a strict job. Repeatable.",
+    )
+    cron_create.add_argument(
+        "--strict-toolsets",
+        action="store_true",
+        default=False,
+        help="Treat --enabled-toolset values as the complete allowlist.",
+    )
+    cron_create.add_argument(
+        "--no-mcp",
+        action="store_true",
+        default=False,
+        help="Do not discover, connect, or expose MCP servers for this job.",
+    )
+    cron_create.add_argument(
+        "--no-fallback",
+        action="store_true",
+        default=False,
+        help="Disable provider and model fallback for this job.",
+    )
+    cron_create.add_argument(
+        "--start-paused",
+        action="store_true",
+        default=False,
+        help="Persist the new job paused and without a next trigger.",
+    )
 
     # cron edit
     cron_edit = cron_subparsers.add_parser(

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -13346,6 +13346,8 @@ def _create_cron_job_sync(body: CronJobCreate, profile: Optional[str] = None):
 
 
 def _update_cron_job_sync(job_id: str, body: CronJobUpdate, profile: Optional[str] = None):
+    from cron.policy import CronPolicyError
+
     selected = profile or _find_cron_job_profile(job_id)
     if not selected:
         raise HTTPException(status_code=404, detail="Job not found")
@@ -13372,6 +13374,8 @@ def _update_cron_job_sync(job_id: str, body: CronJobUpdate, profile: Optional[st
         job = _mutate_cron_for_profile(profile_name, "update_job", job_id, updates)
     except HTTPException:
         raise
+    except CronPolicyError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     if not job:
@@ -13394,10 +13398,15 @@ def _pause_cron_job_sync(job_id: str, profile: Optional[str] = None):
 
 
 def _resume_cron_job_sync(job_id: str, profile: Optional[str] = None):
+    from cron.policy import CronPolicyError
+
     selected = profile or _find_cron_job_profile(job_id)
     if not selected:
         raise HTTPException(status_code=404, detail="Job not found")
-    job = _mutate_cron_for_profile(selected, "resume_job", job_id)
+    try:
+        job = _mutate_cron_for_profile(selected, "resume_job", job_id)
+    except CronPolicyError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
     return job
@@ -13412,6 +13421,12 @@ def _trigger_cron_job_sync(job_id: str, profile: Optional[str] = None):
     job = _call_cron_for_profile(selected, "resolve_job_ref", job_id)
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
+    from cron.policy import CronPolicyError, require_trusted_policy_operator
+
+    try:
+        require_trusted_policy_operator(job, None, "manual run")
+    except CronPolicyError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
     # Do not expose the job as due before claiming it: the built-in ticker and
     # external/manual fire paths share the same durable claim, so only one can
     # execute this selected run even if they race across processes. Active jobs
@@ -13442,11 +13457,15 @@ def _trigger_cron_job_sync(job_id: str, profile: Optional[str] = None):
 
 
 def _delete_cron_job_sync(job_id: str, profile: Optional[str] = None):
+    from cron.policy import CronPolicyError
+
     selected = profile or _find_cron_job_profile(job_id)
     if not selected:
         raise HTTPException(status_code=404, detail="Job not found")
     try:
         removed = _mutate_cron_for_profile(selected, "remove_job", job_id)
+    except CronPolicyError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     if not removed:

--- a/model_tools.py
+++ b/model_tools.py
@@ -325,6 +325,7 @@ def get_tool_definitions(
     disabled_toolsets: Optional[List[str]] = None,
     quiet_mode: bool = False,
     skip_tool_search_assembly: bool = False,
+    exclude_mcp_tools: bool = False,
 ) -> List[Dict[str, Any]]:
     """
     Get tool definitions for model API calls with toolset-based filtering.
@@ -337,9 +338,10 @@ def get_tool_definitions(
         quiet_mode: Suppress status prints.
         skip_tool_search_assembly: When True, return the pre-assembly tool list
             (raw schemas for every enabled tool). Used internally by the
-            tool_search / tool_describe bridge handlers so they can read the
-            real catalog, not the already-collapsed one. Public callers should
-            leave this False.
+            tool_search / tool_describe bridge handlers and strict cron jobs so
+            they can use the real catalog, not the already-collapsed one.
+        exclude_mcp_tools: Remove every MCP-prefixed schema even when a
+            previously registered MCP tool shares an allowed toolset name.
 
     Returns:
         Filtered list of OpenAI-format tool definitions.
@@ -371,6 +373,7 @@ def get_tool_definitions(
                 cfg_fp,
                 bool(os.environ.get("HERMES_KANBAN_TASK")),
                 bool(skip_tool_search_assembly),
+                bool(exclude_mcp_tools),
                 _is_delegated_child_context(),
                 _is_dispatcher_owned_worker(),
                 profile_scope,
@@ -386,8 +389,13 @@ def get_tool_definitions(
             # schemas are treated as read-only by all known callers.
             return list(cached)
 
-    result = _compute_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode,
-                                       skip_tool_search_assembly=skip_tool_search_assembly)
+    result = _compute_tool_definitions(
+        enabled_toolsets,
+        disabled_toolsets,
+        quiet_mode,
+        skip_tool_search_assembly=skip_tool_search_assembly,
+        exclude_mcp_tools=exclude_mcp_tools,
+    )
     if quiet_mode and cache_key is not None:
         # Cache the freshly-computed list, but hand callers a shallow copy so
         # downstream mutations (e.g. run_agent appending memory/LCM tool
@@ -419,6 +427,7 @@ def _compute_tool_definitions(
     disabled_toolsets: Optional[List[str]] = None,
     quiet_mode: bool = False,
     skip_tool_search_assembly: bool = False,
+    exclude_mcp_tools: bool = False,
 ) -> List[Dict[str, Any]]:
     """Uncached implementation of :func:`get_tool_definitions`."""
     # Determine which tool names the caller wants
@@ -506,8 +515,22 @@ def _compute_tool_definitions(
     # needed; plugins respect enabled_toolsets / disabled_toolsets like any
     # other toolset.
 
+    # Remove MCP names before registry availability checks: an MCP check_fn may
+    # perform discovery or connection work, so post-schema filtering alone is
+    # too late for a no-MCP caller.
+    if exclude_mcp_tools:
+        tools_to_include = {
+            name for name in tools_to_include if not str(name).startswith("mcp__")
+        }
+
     # Ask the registry for schemas (only returns tools whose check_fn passes)
     filtered_tools = registry.get_definitions(tools_to_include, quiet=quiet_mode)
+    if exclude_mcp_tools:
+        filtered_tools = [
+            tool
+            for tool in filtered_tools
+            if not str(tool.get("function", {}).get("name", "")).startswith("mcp__")
+        ]
 
     # The set of tool names that actually passed check_fn filtering.
     # Use this (not tools_to_include) for any downstream schema that references
@@ -1264,6 +1287,7 @@ def handle_function_call(
     tool_request_middleware_trace: Optional[List[Dict[str, Any]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     disabled_toolsets: Optional[List[str]] = None,
+    exclude_mcp_tools: bool = False,
 ) -> str:
     """
     Main function call dispatcher that routes calls to the tool registry.
@@ -1285,6 +1309,9 @@ def handle_function_call(
                        matching ``get_tool_definitions`` semantics.
         disabled_toolsets: The session's disabled toolsets, applied as a
                        subtraction when scoping the bridge catalog.
+        exclude_mcp_tools: Exclude MCP tools from bridge catalog reconstruction
+                       and recursive dispatch. Strict no-MCP sessions set this
+                       for every direct dispatcher call.
 
     Returns:
         Function result as a JSON string.
@@ -1301,6 +1328,11 @@ def handle_function_call(
     # the dispatch seam so every replay keeps working; new schemas only
     # advertise the new names, so fresh sessions never see the old ones.
     function_name = _LEGACY_TOOL_ALIASES.get(function_name, function_name)
+
+    if exclude_mcp_tools and str(function_name).startswith("mcp__"):
+        return tool_error(
+            f"'{function_name}' is not available in this session because MCP tools are disabled."
+        )
 
     # ── Tool Search bridge dispatch ──────────────────────────────────
     # tool_search and tool_describe are pure catalog reads — handle them
@@ -1348,7 +1380,9 @@ def handle_function_call(
             current_defs = get_tool_definitions(
                 enabled_toolsets=enabled_toolsets,
                 disabled_toolsets=disabled_toolsets,
-                quiet_mode=True, skip_tool_search_assembly=True,
+                quiet_mode=True,
+                skip_tool_search_assembly=True,
+                exclude_mcp_tools=exclude_mcp_tools,
             ) or []
         except Exception:
             current_defs = []
@@ -1410,6 +1444,7 @@ def handle_function_call(
                 tool_request_middleware_trace=list(_tool_middleware_trace),
                 enabled_toolsets=enabled_toolsets,
                 disabled_toolsets=disabled_toolsets,
+                exclude_mcp_tools=exclude_mcp_tools,
             )
 
     _tool_original_args = dict(function_args)

--- a/run_agent.py
+++ b/run_agent.py
@@ -569,6 +569,8 @@ class AIAgent:
         pass_session_id: bool = False,
         requested_provider: str = None,
         capabilities: Dict[str, bool] | None = None,
+        skip_tool_search_assembly: bool = False,
+        exclude_mcp_tools: bool = False,
     ):
         """Forwarder — see ``agent.agent_init.init_agent``."""
         if tool_delay is not None:
@@ -595,6 +597,8 @@ class AIAgent:
             max_iterations=max_iterations,
             enabled_toolsets=enabled_toolsets,
             disabled_toolsets=disabled_toolsets,
+            skip_tool_search_assembly=skip_tool_search_assembly,
+            exclude_mcp_tools=exclude_mcp_tools,
             save_trajectories=save_trajectories,
             verbose_logging=verbose_logging,
             quiet_mode=quiet_mode,

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -162,6 +162,27 @@ def test_force_fire_capability_detects_legacy_override():
     assert KeywordSink().supports_force_fire is True
 
 
+def test_force_fire_threads_operator_capability(monkeypatch):
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    provider = InProcessCronScheduler()
+    capability = object()
+    captured = {}
+
+    def claim(job_id, **kwargs):
+        captured.update(kwargs)
+        return {"id": job_id}
+
+    monkeypatch.setattr(provider, "claim_fire", claim)
+    monkeypatch.setattr(provider, "fire_claimed", lambda job, **kwargs: True)
+
+    assert provider.fire_due(
+        "job-id", force=True, _operator_capability=capability
+    )
+    assert captured["force"] is True
+    assert captured["_operator_capability"] is capability
+
+
 def test_inprocess_provider_ticks_and_stops():
     """The built-in provider drives cron.scheduler.tick(sync=False) on a loop
     and exits promptly when stop_event is set — same contract as the raw

--- a/tests/cron/test_unattended_policy.py
+++ b/tests/cron/test_unattended_policy.py
@@ -1,0 +1,1210 @@
+"""Security contract for strict unattended cron jobs."""
+
+import pytest
+
+
+def test_unknown_policy_id_fails_closed():
+    from cron.policy import CronPolicyError, validate_job_policy
+
+    with pytest.raises(CronPolicyError, match="unknown cron policy"):
+        validate_job_policy({"policy_id": "not-registered"})
+
+
+def _strict_policy_job():
+    from cron.policy import STRICT_UNATTENDED_POLICY_ID
+
+    return {
+        "policy_id": STRICT_UNATTENDED_POLICY_ID,
+        "strict_toolsets": True,
+        "no_mcp": True,
+        "no_fallback": True,
+        "created_paused": True,
+        "enabled_toolsets": ["safe"],
+        "provider": "openrouter",
+        "model": "example/model",
+        "no_agent": False,
+    }
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("strict_toolsets", False, "strict_toolsets=true"),
+        ("no_mcp", False, "no_mcp=true"),
+        ("no_fallback", False, "no_fallback=true"),
+        ("created_paused", False, "created_paused=true"),
+        ("enabled_toolsets", None, "explicit enabled_toolsets list"),
+        ("enabled_toolsets", ["memory"], "persistent memory toolset"),
+        ("enabled_toolsets", ["coding"], "persistent memory toolset"),
+        ("enabled_toolsets", ["not-registered"], "unknown strict toolset"),
+        ("provider", "", "non-empty provider pin"),
+        ("model", None, "non-empty model pin"),
+        ("no_agent", True, "agent-backed job"),
+    ],
+)
+def test_strict_policy_requires_every_isolation_control_and_pin(field, value, message):
+    from cron.policy import CronPolicyError, validate_job_policy
+
+    job = _strict_policy_job()
+    job[field] = value
+    with pytest.raises(CronPolicyError, match=message):
+        validate_job_policy(job)
+
+
+def test_valid_strict_policy_is_accepted():
+    from cron.policy import validate_job_policy
+
+    validate_job_policy(_strict_policy_job())
+
+
+def _operator_capability():
+    from cron.policy import cron_operator_capability
+
+    return cron_operator_capability()
+
+
+def _resume_policy_job(jobs_mod, job_id):
+    return jobs_mod.resume_job(job_id, _operator_capability=_operator_capability())
+
+
+def _update_policy_job(jobs_mod, job_id, updates):
+    return jobs_mod.update_job(
+        job_id, updates, _operator_capability=_operator_capability()
+    )
+
+
+def _point_store(jobs_mod, tmp_path, monkeypatch):
+    cron_dir = tmp_path / "cron"
+    monkeypatch.setattr(jobs_mod, "CRON_DIR", cron_dir)
+    monkeypatch.setattr(jobs_mod, "JOBS_FILE", cron_dir / "jobs.json")
+    monkeypatch.setattr(jobs_mod, "OUTPUT_DIR", cron_dir / "output")
+
+
+def _create_strict_policy_job(jobs_mod, *, operator_capability=None):
+    from cron.policy import (
+        STRICT_UNATTENDED_POLICY_ID,
+        cron_operator_capability,
+    )
+
+    if operator_capability is None:
+        operator_capability = cron_operator_capability()
+    return jobs_mod.create_job(
+        prompt="review bounded evidence",
+        schedule="every hour",
+        model="example/model",
+        provider="openrouter",
+        enabled_toolsets=["safe"],
+        policy_id=STRICT_UNATTENDED_POLICY_ID,
+        strict_toolsets=True,
+        no_mcp=True,
+        no_fallback=True,
+        start_paused=True,
+        _operator_capability=operator_capability,
+    )
+
+
+def test_core_rejects_policy_creation_without_operator_capability(
+    tmp_path, monkeypatch
+):
+    import cron.jobs as jobs_mod
+
+    _point_store(jobs_mod, tmp_path, monkeypatch)
+    with pytest.raises(ValueError, match="trusted operator"):
+        jobs_mod.create_job(
+            prompt="review bounded evidence",
+            schedule="every hour",
+            model="example/model",
+            provider="openrouter",
+            enabled_toolsets=[],
+            policy_id="strict-unattended-v1",
+            strict_toolsets=True,
+            no_mcp=True,
+            no_fallback=True,
+            start_paused=True,
+        )
+    assert jobs_mod.load_jobs() == []
+
+
+def test_core_rejects_policy_lifecycle_without_operator_capability(
+    tmp_path, monkeypatch
+):
+    import cron.jobs as jobs_mod
+    from cron.policy import cron_operator_capability
+
+    _point_store(jobs_mod, tmp_path, monkeypatch)
+    job = _create_strict_policy_job(
+        jobs_mod, operator_capability=cron_operator_capability()
+    )
+
+    with pytest.raises(ValueError, match="trusted operator"):
+        jobs_mod.update_job(job["id"], {"prompt": "untrusted change"})
+    with pytest.raises(ValueError, match="trusted operator"):
+        jobs_mod.resume_job(job["id"])
+    with pytest.raises(ValueError, match="trusted operator"):
+        jobs_mod.trigger_job(job["id"])
+    with pytest.raises(ValueError, match="trusted operator"):
+        jobs_mod.remove_job(job["id"])
+
+    paused = jobs_mod.pause_job(job["id"], reason="containment")
+    assert paused["state"] == "paused"
+    assert jobs_mod.get_job(job["id"])["prompt"] != "untrusted change"
+
+
+def test_strict_policy_is_first_persisted_as_non_runnable(tmp_path, monkeypatch):
+    import cron.jobs as jobs_mod
+
+    _point_store(jobs_mod, tmp_path, monkeypatch)
+
+    writes = []
+    real_save = jobs_mod.save_jobs
+
+    def capture_save(jobs):
+        writes.append([dict(job) for job in jobs])
+        real_save(jobs)
+
+    monkeypatch.setattr(jobs_mod, "save_jobs", capture_save)
+
+    job = _create_strict_policy_job(jobs_mod)
+
+    assert len(writes) == 1
+    first = writes[0][0]
+    assert first == job
+    assert first["enabled"] is False
+    assert first["state"] == "paused"
+    assert first["paused_at"]
+    assert first["next_run_at"] is None
+    assert first["created_paused"] is True
+
+
+def test_policy_fields_are_visible_in_operator_readback(tmp_path, monkeypatch):
+    import cron.jobs as jobs_mod
+    from tools.cronjob_tools import _format_job
+
+    _point_store(jobs_mod, tmp_path, monkeypatch)
+    job = _create_strict_policy_job(jobs_mod)
+
+    formatted = _format_job(job)
+
+    assert formatted["policy_id"] == "strict-unattended-v1"
+    assert formatted["strict_toolsets"] is True
+    assert formatted["no_mcp"] is True
+    assert formatted["no_fallback"] is True
+    assert formatted["created_paused"] is True
+    assert formatted["enabled_toolsets"] == ["safe"]
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "policy_id",
+        "strict_toolsets",
+        "no_mcp",
+        "no_fallback",
+        "created_paused",
+    ],
+)
+def test_policy_fields_are_immutable(field, tmp_path, monkeypatch):
+    import cron.jobs as jobs_mod
+
+    _point_store(jobs_mod, tmp_path, monkeypatch)
+    job = _create_strict_policy_job(jobs_mod)
+
+    with pytest.raises(ValueError, match="cannot be updated"):
+        jobs_mod.update_job(
+            job["id"], {field: None}, _operator_capability=_operator_capability()
+        )
+
+
+def test_resume_revalidates_tampered_policy_before_scheduling(tmp_path, monkeypatch):
+    import cron.jobs as jobs_mod
+    from cron.policy import CronPolicyError
+
+    _point_store(jobs_mod, tmp_path, monkeypatch)
+    job = _create_strict_policy_job(jobs_mod)
+    records = jobs_mod.load_jobs()
+    records[0]["no_mcp"] = False
+    jobs_mod.save_jobs(records)
+
+    with pytest.raises(CronPolicyError, match="no_mcp=true"):
+        jobs_mod.resume_job(job["id"], _operator_capability=_operator_capability())
+
+    stored = jobs_mod.get_job(job["id"])
+    assert stored["enabled"] is False
+    assert stored["state"] == "paused"
+    assert stored["next_run_at"] is None
+
+
+def test_valid_policy_can_be_resumed_after_paused_first_creation(tmp_path, monkeypatch):
+    import cron.jobs as jobs_mod
+
+    _point_store(jobs_mod, tmp_path, monkeypatch)
+    job = _create_strict_policy_job(jobs_mod)
+
+    resumed = _resume_policy_job(jobs_mod, job["id"])
+
+    assert resumed["enabled"] is True
+    assert resumed["state"] == "scheduled"
+    assert resumed["next_run_at"]
+    assert resumed["created_paused"] is True
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("enabled_toolsets", ["safe", "terminal"]),
+        ("provider", "anthropic"),
+        ("model", "other/model"),
+        ("base_url", "https://other.invalid/v1"),
+    ],
+)
+def test_policy_capability_and_runtime_pins_are_immutable(
+    field, value, tmp_path, monkeypatch
+):
+    import cron.jobs as jobs_mod
+
+    _point_store(jobs_mod, tmp_path, monkeypatch)
+    job = _create_strict_policy_job(jobs_mod)
+
+    with pytest.raises(ValueError, match=f"policy field {field!r} cannot be updated"):
+        _update_policy_job(jobs_mod, job["id"], {field: value})
+
+
+def test_update_revalidates_existing_policy_record(tmp_path, monkeypatch):
+    import cron.jobs as jobs_mod
+    from cron.policy import CronPolicyError
+
+    _point_store(jobs_mod, tmp_path, monkeypatch)
+    job = _create_strict_policy_job(jobs_mod)
+    records = jobs_mod.load_jobs()
+    records[0]["no_fallback"] = False
+    jobs_mod.save_jobs(records)
+
+    with pytest.raises(CronPolicyError, match="no_fallback=true"):
+        _update_policy_job(jobs_mod, job["id"], {"name": "must not persist"})
+
+    assert jobs_mod.get_job(job["id"])["name"] != "must not persist"
+
+
+def test_invalid_policy_fails_before_config_mcp_or_agent(monkeypatch):
+    from unittest.mock import patch
+
+    from cron.scheduler import run_job
+
+    job = {"id": "invalid-policy", "name": "invalid", "policy_id": "unknown"}
+    with (
+        patch(
+            "hermes_cli.config.require_parseable_user_config",
+            side_effect=AssertionError("config must not be read"),
+        ),
+        patch(
+            "tools.mcp_tool.discover_mcp_tools",
+            side_effect=AssertionError("MCP must not be discovered"),
+        ),
+        patch(
+            "run_agent.AIAgent",
+            side_effect=AssertionError("agent must not be constructed"),
+        ),
+    ):
+        success, _doc, _final, error = run_job(job)
+
+    assert success is False
+    assert "unknown cron policy" in error
+
+
+@pytest.mark.parametrize("enabled_toolsets", [["memory"], ["coding"]])
+def test_strict_memory_toolset_fails_before_agent_construction(
+    monkeypatch, enabled_toolsets
+):
+    from unittest.mock import patch
+
+    from cron.scheduler import run_job
+
+    job = _runnable_policy_job()
+    job["enabled_toolsets"] = enabled_toolsets
+    with patch(
+        "run_agent.AIAgent",
+        side_effect=AssertionError("agent must not initialize persistent memory"),
+    ):
+        success, _doc, _final, error = run_job(job)
+
+    assert success is False
+    assert "persistent memory toolset" in error
+
+
+def test_invalid_persisted_policy_is_auto_paused_with_diagnostic(tmp_path, monkeypatch):
+    import cron.jobs as jobs_mod
+    from cron.scheduler import run_job
+
+    _point_store(jobs_mod, tmp_path, monkeypatch)
+    job = _create_strict_policy_job(jobs_mod)
+    resumed = _resume_policy_job(jobs_mod, job["id"])
+    records = jobs_mod.load_jobs()
+    records[0]["policy_id"] = "tampered-policy"
+    jobs_mod.save_jobs(records)
+    notified = []
+    monkeypatch.setattr(
+        "cron.scheduler._notify_provider_jobs_changed",
+        lambda: notified.append(True),
+    )
+
+    success, _doc, _final, error = run_job(dict(records[0]))
+
+    assert success is False
+    assert "unknown cron policy" in error
+    stored = jobs_mod.get_job(resumed["id"])
+    assert stored["enabled"] is False
+    assert stored["state"] == "paused"
+    assert stored["next_run_at"] is None
+    assert "unknown cron policy" in stored["paused_reason"]
+    assert notified == [True]
+
+
+def test_due_scan_notifies_external_scheduler_after_policy_quarantine(
+    tmp_path, monkeypatch
+):
+    import cron.jobs as jobs_mod
+
+    _point_store(jobs_mod, tmp_path, monkeypatch)
+    job = _create_strict_policy_job(jobs_mod)
+    _resume_policy_job(jobs_mod, job["id"])
+    records = jobs_mod.load_jobs()
+    records[0]["policy_id"] = "tampered-policy"
+    records[0]["next_run_at"] = "2000-01-01T00:00:00+00:00"
+    jobs_mod.save_jobs(records)
+
+    notified = []
+    monkeypatch.setattr(
+        "cron.scheduler._notify_provider_jobs_changed",
+        lambda: notified.append(True),
+    )
+
+    assert jobs_mod.get_due_jobs() == []
+    assert notified == [True]
+
+
+def test_fire_claim_notifies_external_scheduler_after_policy_quarantine(
+    tmp_path, monkeypatch
+):
+    import cron.jobs as jobs_mod
+
+    _point_store(jobs_mod, tmp_path, monkeypatch)
+    job = _create_strict_policy_job(jobs_mod)
+    _resume_policy_job(jobs_mod, job["id"])
+    records = jobs_mod.load_jobs()
+    records[0]["no_mcp"] = False
+    jobs_mod.save_jobs(records)
+
+    notified = []
+    monkeypatch.setattr(
+        "cron.scheduler._notify_provider_jobs_changed",
+        lambda: notified.append(True),
+    )
+
+    assert jobs_mod.claim_job_for_fire(job["id"], force=False) is False
+    assert notified == [True]
+
+
+def test_due_scan_quarantines_invalid_policy_record(tmp_path, monkeypatch):
+    import cron.jobs as jobs_mod
+
+    _point_store(jobs_mod, tmp_path, monkeypatch)
+    job = _create_strict_policy_job(jobs_mod)
+    _resume_policy_job(jobs_mod, job["id"])
+    records = jobs_mod.load_jobs()
+    records[0]["policy_id"] = "tampered-policy"
+    records[0]["next_run_at"] = "2000-01-01T00:00:00+00:00"
+    jobs_mod.save_jobs(records)
+
+    assert jobs_mod.get_due_jobs() == []
+    stored = jobs_mod.get_job(job["id"])
+    assert stored["enabled"] is False
+    assert stored["state"] == "paused"
+    assert stored["next_run_at"] is None
+    assert "unknown cron policy" in stored["paused_reason"]
+
+
+def test_strict_no_mcp_toolsets_are_exact_even_when_global_mcp_exists(monkeypatch):
+    from cron.scheduler import _resolve_cron_enabled_toolsets
+
+    monkeypatch.setattr(
+        "hermes_cli.tools_config.enabled_mcp_server_names",
+        lambda _cfg: (_ for _ in ()).throw(
+            AssertionError("MCP config must not be read")
+        ),
+    )
+    job = {
+        "enabled_toolsets": ["safe"],
+        "strict_toolsets": True,
+        "no_mcp": True,
+    }
+
+    assert _resolve_cron_enabled_toolsets(job, {}) == ["safe"]
+
+
+def test_strict_empty_allowlist_does_not_expand_to_platform_defaults(monkeypatch):
+    from cron.scheduler import _resolve_cron_enabled_toolsets
+
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._get_platform_tools",
+        lambda *_args: (_ for _ in ()).throw(
+            AssertionError("platform defaults must not be read")
+        ),
+    )
+
+    assert (
+        _resolve_cron_enabled_toolsets(
+            {"enabled_toolsets": [], "strict_toolsets": True, "no_mcp": True}, {}
+        )
+        == []
+    )
+
+
+def _runnable_policy_job():
+    job = _strict_policy_job()
+    job.update({
+        "id": "strict-run",
+        "name": "strict run",
+        "prompt": "review bounded evidence",
+        "schedule": {"kind": "interval", "seconds": 3600},
+        "enabled": True,
+        "state": "scheduled",
+    })
+    return job
+
+
+def test_strict_run_skips_mcp_and_passes_exact_agent_controls(tmp_path):
+    from unittest.mock import MagicMock, patch
+
+    from cron.scheduler import run_job
+
+    discover = MagicMock(side_effect=AssertionError("MCP discovery forbidden"))
+    fake_db = MagicMock()
+    with (
+        patch("cron.scheduler._get_hermes_home", return_value=tmp_path),
+        patch("hermes_cli.config.require_parseable_user_config"),
+        patch("cron.scheduler._cron_preflight_enabled", return_value=False),
+        patch("cron.scheduler._guard_job_credential_exfil"),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "api_key": "test-key",
+                "base_url": "https://example.invalid/v1",
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+            },
+        ),
+        patch("cron.scheduler.get_fallback_chain", return_value=[{"provider": "x"}]),
+        patch("tools.mcp_tool.discover_mcp_tools", discover),
+        patch("hermes_state.get_shared_session_db", return_value=fake_db),
+        patch("run_agent.AIAgent") as agent_cls,
+    ):
+        agent_cls.return_value.run_conversation.return_value = {"final_response": "ok"}
+        success, _doc, final, error = run_job(_runnable_policy_job())
+
+    assert success is True
+    assert final == "ok"
+    assert error is None
+    discover.assert_not_called()
+    kwargs = agent_cls.call_args.kwargs
+    assert kwargs["enabled_toolsets"] == ["safe"]
+    assert kwargs["fallback_model"] is None
+    assert kwargs["skip_tool_search_assembly"] is True
+    assert kwargs["exclude_mcp_tools"] is True
+    assert kwargs["skip_memory"] is True
+    assert agent_cls.return_value._skip_mcp_refresh is True
+    assert agent_cls.return_value._exclude_mcp_tools is True
+    assert agent_cls.return_value._skip_tool_search_assembly is True
+
+
+def test_strict_refresh_reuses_initial_tool_isolation(monkeypatch):
+    import types
+
+    import model_tools
+    from tools.mcp_tool import refresh_agent_mcp_tools
+
+    def tool(name):
+        return {
+            "type": "function",
+            "function": {"name": name, "description": "", "parameters": {}},
+        }
+
+    calls = []
+
+    def definitions(**kwargs):
+        calls.append(kwargs)
+        if kwargs.get("exclude_mcp_tools") and kwargs.get("skip_tool_search_assembly"):
+            return [tool("strict_reader")]
+        return [tool("strict_reader"), tool("mcp__escape__write"), tool("tool_call")]
+
+    monkeypatch.setattr(model_tools, "get_tool_definitions", definitions)
+    agent = types.SimpleNamespace(
+        tools=[tool("strict_reader")],
+        valid_tool_names={"strict_reader"},
+        enabled_toolsets=["strict-reader"],
+        disabled_toolsets=[],
+        _exclude_mcp_tools=True,
+        _skip_tool_search_assembly=True,
+        _tool_snapshot_generation=-1,
+    )
+
+    assert refresh_agent_mcp_tools(agent) == set()
+    assert calls[-1]["exclude_mcp_tools"] is True
+    assert calls[-1]["skip_tool_search_assembly"] is True
+    assert agent.valid_tool_names == {"strict_reader"}
+
+
+def test_strict_tool_search_scope_excludes_mcp_rebuild(monkeypatch):
+    import types
+
+    import model_tools
+    from agent.tool_executor import _tool_search_scoped_names
+
+    captured = {}
+
+    def definitions(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(model_tools, "get_tool_definitions", definitions)
+    agent = types.SimpleNamespace(
+        enabled_toolsets=["strict-reader"],
+        disabled_toolsets=[],
+        _exclude_mcp_tools=True,
+        _skip_tool_search_assembly=True,
+    )
+
+    assert _tool_search_scoped_names(agent) == frozenset()
+    assert captured["exclude_mcp_tools"] is True
+    assert captured["skip_tool_search_assembly"] is True
+
+
+def test_aiagent_forwards_raw_tool_schema_mode():
+    from unittest.mock import patch
+
+    from run_agent import AIAgent
+
+    with patch("agent.agent_init.init_agent") as init:
+        AIAgent(
+            model="example/model",
+            skip_tool_search_assembly=True,
+            exclude_mcp_tools=True,
+        )
+
+    assert init.call_args.kwargs["skip_tool_search_assembly"] is True
+    assert init.call_args.kwargs["exclude_mcp_tools"] is True
+
+
+def test_aiagent_preserves_historical_positional_save_trajectories_slot():
+    from unittest.mock import patch
+
+    from run_agent import AIAgent
+
+    with patch("agent.agent_init.init_agent") as init:
+        AIAgent(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            "example/model",
+            5,
+            None,
+            ["safe"],
+            [],
+            True,
+        )
+
+    kwargs = init.call_args.kwargs
+    assert kwargs["save_trajectories"] is True
+    assert kwargs["skip_tool_search_assembly"] is False
+    assert kwargs["exclude_mcp_tools"] is False
+
+
+def test_cronjob_preserves_historical_positional_task_and_session_tail(monkeypatch):
+    import json
+
+    from tools.cronjob_tools import cronjob
+
+    monkeypatch.setattr("tools.cronjob_tools.list_jobs", lambda **_kwargs: [])
+    historical_args = (
+        ["list"]
+        + [None] * 23
+        + [
+            "legacy-task-id",
+            "legacy-session-id",
+        ]
+    )
+
+    result = json.loads(cronjob(*historical_args))
+
+    assert result["success"] is True
+    assert result["jobs"] == []
+
+
+def test_no_fallback_stops_after_primary_resolution_failure(tmp_path):
+    from unittest.mock import MagicMock, patch
+
+    from cron.scheduler import run_job
+    from hermes_cli.auth import AuthError
+
+    fallback = MagicMock(return_value=[{"provider": "anthropic", "model": "other"}])
+    with (
+        patch("cron.scheduler._get_hermes_home", return_value=tmp_path),
+        patch("hermes_cli.config.require_parseable_user_config"),
+        patch("cron.scheduler._cron_preflight_enabled", return_value=False),
+        patch("cron.scheduler._guard_job_credential_exfil"),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            side_effect=AuthError("primary unavailable"),
+        ),
+        patch("cron.scheduler.get_fallback_chain", fallback),
+        patch(
+            "tools.mcp_tool.discover_mcp_tools",
+            side_effect=AssertionError("MCP discovery forbidden"),
+        ),
+        patch(
+            "run_agent.AIAgent",
+            side_effect=AssertionError("agent must not be constructed"),
+        ),
+    ):
+        success, _doc, _final, error = run_job(_runnable_policy_job())
+
+    assert success is False
+    assert "primary unavailable" in error
+    fallback.assert_not_called()
+
+
+def _build_cron_parser():
+    import argparse
+
+    from hermes_cli.subcommands.cron import build_cron_parser
+
+    parser = argparse.ArgumentParser(prog="hermes")
+    subparsers = parser.add_subparsers(dest="command")
+    build_cron_parser(subparsers, cmd_cron=lambda _args: 0)
+    return parser
+
+
+def test_strict_policy_cli_flags_are_creation_only():
+    parser = _build_cron_parser()
+    args = parser.parse_args([
+        "cron",
+        "create",
+        "every hour",
+        "review",
+        "--policy-id",
+        "strict-unattended-v1",
+        "--enabled-toolset",
+        "safe",
+        "--enabled-toolset",
+        "web",
+        "--strict-toolsets",
+        "--no-mcp",
+        "--no-fallback",
+        "--start-paused",
+    ])
+
+    assert args.policy_id == "strict-unattended-v1"
+    assert args.enabled_toolsets == ["safe", "web"]
+    assert args.strict_toolsets is True
+    assert args.no_mcp is True
+    assert args.no_fallback is True
+    assert args.start_paused is True
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["cron", "edit", "job", "--policy-id", "x"])
+
+
+def test_cron_create_forwards_strict_policy_flags(monkeypatch):
+    from hermes_cli import cron as cron_cli
+
+    args = _build_cron_parser().parse_args([
+        "cron",
+        "create",
+        "every hour",
+        "review",
+        "--model",
+        "example/model",
+        "--provider",
+        "openrouter",
+        "--policy-id",
+        "strict-unattended-v1",
+        "--enabled-toolset",
+        "safe",
+        "--strict-toolsets",
+        "--no-mcp",
+        "--no-fallback",
+        "--start-paused",
+    ])
+    captured = {}
+
+    def fake_api(**kwargs):
+        captured.update(kwargs)
+        return {
+            "success": True,
+            "job_id": "job",
+            "name": "strict",
+            "schedule": "every hour",
+            "next_run_at": None,
+            "job": {},
+        }
+
+    monkeypatch.setattr(cron_cli, "_cron_api", fake_api)
+    monkeypatch.setattr(cron_cli, "_warn_if_gateway_not_running", lambda: None)
+
+    assert cron_cli.cron_create(args) == 0
+    assert captured["policy_id"] == "strict-unattended-v1"
+    assert captured["enabled_toolsets"] == ["safe"]
+    assert captured["strict_toolsets"] is True
+    assert captured["no_mcp"] is True
+    assert captured["no_fallback"] is True
+    assert captured["start_paused"] is True
+
+
+def test_operator_only_cron_api_forwards_policy_fields(monkeypatch):
+    import json
+    from unittest.mock import patch
+
+    from cron.policy import cron_operator_capability
+    from tools.cronjob_tools import cronjob
+
+    captured = {}
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return {
+            "id": "job",
+            "name": "strict",
+            "prompt": "review",
+            "skills": [],
+            "schedule_display": "every hour",
+            "repeat": {"times": None, "completed": 0},
+            "deliver": "local",
+            "next_run_at": None,
+            "enabled": False,
+            "state": "paused",
+        }
+
+    with patch(
+        "cron.scheduler.create_job_with_scheduler_registration",
+        side_effect=fake_create,
+    ):
+        result = json.loads(
+            cronjob(
+                action="create",
+                schedule="every hour",
+                prompt="review",
+                model="example/model",
+                provider="openrouter",
+                policy_id="strict-unattended-v1",
+                enabled_toolsets=["safe"],
+                strict_toolsets=True,
+                no_mcp=True,
+                no_fallback=True,
+                start_paused=True,
+                _operator_capability=cron_operator_capability(),
+            )
+        )
+
+    assert result["success"] is True
+    assert captured["policy_id"] == "strict-unattended-v1"
+    assert captured["enabled_toolsets"] == ["safe"]
+    assert captured["strict_toolsets"] is True
+    assert captured["no_mcp"] is True
+    assert captured["no_fallback"] is True
+    assert captured["start_paused"] is True
+
+
+def test_operator_create_preserves_empty_strict_allowlist():
+    import json
+    from unittest.mock import patch
+
+    from cron.policy import cron_operator_capability
+    from tools.cronjob_tools import cronjob
+
+    job = {
+        "id": "job",
+        "name": "strict",
+        "prompt": "review",
+        "skills": [],
+        "schedule_display": "every hour",
+        "repeat": {"times": None, "completed": 0},
+        "deliver": "local",
+        "next_run_at": None,
+        "enabled": False,
+        "state": "paused",
+    }
+    with patch(
+        "cron.scheduler.create_job_with_scheduler_registration", return_value=job
+    ) as create:
+        result = json.loads(
+            cronjob(
+                action="create",
+                schedule="every hour",
+                prompt="review",
+                model="example/model",
+                provider="openrouter",
+                policy_id="strict-unattended-v1",
+                enabled_toolsets=[],
+                strict_toolsets=True,
+                no_mcp=True,
+                no_fallback=True,
+                start_paused=True,
+                _operator_capability=cron_operator_capability(),
+            )
+        )
+
+    assert result["success"] is True
+    assert create.call_args.kwargs["enabled_toolsets"] == []
+
+
+def test_model_tool_cannot_create_registered_policy_job():
+    import json
+
+    from tools.cronjob_tools import cronjob
+
+    result = json.loads(
+        cronjob(
+            action="create",
+            schedule="every hour",
+            prompt="review",
+            policy_id="strict-unattended-v1",
+        )
+    )
+
+    assert result["success"] is False
+    assert "trusted operator" in result["error"]
+
+
+def test_cli_cron_api_marks_direct_operator_calls_trusted(monkeypatch):
+    import json
+
+    from cron.policy import is_trusted_cron_operator
+    from hermes_cli import cron as cron_cli
+
+    captured = {}
+
+    def fake_cronjob(**kwargs):
+        capability = kwargs.pop("_operator_capability", None)
+        captured.update(kwargs)
+        captured["trusted_scope"] = is_trusted_cron_operator(capability)
+        return json.dumps({"success": True})
+
+    monkeypatch.setattr("tools.cronjob_tools.cronjob", fake_cronjob)
+
+    assert cron_cli._cron_api(action="list")["success"] is True
+    assert captured["trusted_scope"] is True
+    assert "trusted_operator" not in captured
+
+
+def test_model_cannot_forge_trusted_operator_keyword():
+    import json
+
+    from tools.cronjob_tools import cronjob
+
+    result = json.loads(
+        cronjob(
+            action="create",
+            schedule="every hour",
+            prompt="review",
+            policy_id="strict-unattended-v1",
+            _operator_capability=True,
+        )
+    )
+
+    assert result["success"] is False
+    assert "trusted operator" in result["error"]
+
+
+@pytest.mark.parametrize(
+    "action", ["update", "resume", "run", "run_now", "trigger", "remove"]
+)
+def test_model_tool_cannot_mutate_or_activate_policy_job(action, tmp_path, monkeypatch):
+    import json
+
+    import cron.jobs as jobs_mod
+    from tools.cronjob_tools import cronjob
+
+    _point_store(jobs_mod, tmp_path, monkeypatch)
+    job = _create_strict_policy_job(jobs_mod)
+
+    result = json.loads(
+        cronjob(
+            action=action,
+            job_id=job["id"],
+            prompt="changed" if action == "update" else None,
+        )
+    )
+
+    assert result["success"] is False
+    assert "trusted operator" in result["error"]
+    assert jobs_mod.get_job(job["id"])["state"] == "paused"
+
+
+def test_cli_rearm_reconciles_external_scheduler(monkeypatch):
+    from types import SimpleNamespace
+
+    import cron.jobs as jobs_mod
+    import cron.scheduler as scheduler_mod
+    from hermes_cli.cron import cron_resume
+
+    monkeypatch.setattr(
+        jobs_mod,
+        "rearm_oneshot",
+        lambda *args, **kwargs: {
+            "id": "protected-job",
+            "name": "protected",
+            "next_run_at": "2030-01-01T00:00:00+00:00",
+        },
+    )
+    notified = []
+    monkeypatch.setattr(
+        scheduler_mod,
+        "_notify_provider_jobs_changed",
+        lambda: notified.append(True),
+    )
+
+    assert (
+        cron_resume(
+            SimpleNamespace(
+                job_id="protected-job",
+                run_at="2030-01-01T00:00:00+00:00",
+                run_now=False,
+            )
+        )
+        == 0
+    )
+    assert notified == [True]
+
+
+def test_paused_first_job_is_not_registered_with_external_scheduler(
+    tmp_path, monkeypatch
+):
+    import cron.jobs as jobs_mod
+    from cron.policy import STRICT_UNATTENDED_POLICY_ID
+    from cron.scheduler import create_job_with_scheduler_registration
+
+    _point_store(jobs_mod, tmp_path, monkeypatch)
+
+    class Provider:
+        def register_job(self, _job):
+            raise AssertionError("paused job must not be externally registered")
+
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler", lambda: Provider()
+    )
+
+    job = create_job_with_scheduler_registration(
+        prompt="review",
+        schedule="every hour",
+        model="example/model",
+        provider="openrouter",
+        enabled_toolsets=["safe"],
+        policy_id=STRICT_UNATTENDED_POLICY_ID,
+        strict_toolsets=True,
+        no_mcp=True,
+        no_fallback=True,
+        start_paused=True,
+        _operator_capability=_operator_capability(),
+    )
+
+    assert job["enabled"] is False
+    assert job["next_run_at"] is None
+
+
+def test_paused_policy_job_rejects_stale_due_time_and_nonforced_claim(
+    tmp_path, monkeypatch
+):
+    import cron.jobs as jobs_mod
+
+    _point_store(jobs_mod, tmp_path, monkeypatch)
+    job = _create_strict_policy_job(jobs_mod)
+    records = jobs_mod.load_jobs()
+    records[0]["next_run_at"] = "2000-01-01T00:00:00+00:00"
+    jobs_mod.save_jobs(records)
+    before = jobs_mod.get_job(job["id"])
+
+    assert all(item["id"] != job["id"] for item in jobs_mod.get_due_jobs())
+    assert jobs_mod.claim_job_for_fire(job["id"], force=False) is False
+    assert jobs_mod.get_job(job["id"]) == before
+
+
+def test_forced_fire_requires_operator_capability_after_resume(tmp_path, monkeypatch):
+    import cron.jobs as jobs_mod
+
+    _point_store(jobs_mod, tmp_path, monkeypatch)
+    job = _create_strict_policy_job(jobs_mod)
+    resumed = _resume_policy_job(jobs_mod, job["id"])
+    assert resumed["enabled"] is True
+
+    with pytest.raises(ValueError, match="trusted operator"):
+        jobs_mod.claim_job_for_fire(job["id"], force=True)
+    claimed = jobs_mod.claim_job_for_fire(
+        job["id"],
+        force=True,
+        _operator_capability=_operator_capability(),
+        return_job=True,
+    )
+    assert isinstance(claimed, dict)
+
+
+def test_provider_force_fire_requires_capability_for_resumed_policy_job(
+    tmp_path, monkeypatch
+):
+    import cron.executions as executions
+    import cron.jobs as jobs_mod
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    _point_store(jobs_mod, tmp_path, monkeypatch)
+    job = _create_strict_policy_job(jobs_mod)
+    _resume_policy_job(jobs_mod, job["id"])
+    monkeypatch.setattr(
+        executions,
+        "create_execution",
+        lambda _job_id, source: {"id": f"execution-{source}"},
+    )
+    monkeypatch.setattr(executions, "finish_execution", lambda *_args, **_kwargs: None)
+    provider = InProcessCronScheduler()
+    monkeypatch.setattr(provider, "fire_claimed", lambda *_args, **_kwargs: True)
+
+    with pytest.raises(ValueError, match="trusted operator"):
+        provider.fire_due(job["id"], force=True)
+
+    assert (
+        provider.fire_due(
+            job["id"],
+            force=True,
+            _operator_capability=_operator_capability(),
+        )
+        is True
+    )
+
+
+def test_forced_fire_cannot_reactivate_valid_paused_policy(tmp_path, monkeypatch):
+    import cron.jobs as jobs_mod
+
+    _point_store(jobs_mod, tmp_path, monkeypatch)
+    job = _create_strict_policy_job(jobs_mod)
+    claimed = jobs_mod.claim_job_for_fire(
+        job["id"], force=True, _operator_capability=_operator_capability()
+    )
+    assert claimed is False
+    stored = jobs_mod.get_job(job["id"])
+    assert stored["enabled"] is False
+    assert stored["state"] == "paused"
+
+
+def test_core_rearm_requires_operator_capability(tmp_path, monkeypatch):
+    import cron.jobs as jobs_mod
+
+    _point_store(jobs_mod, tmp_path, monkeypatch)
+    job = jobs_mod.create_job(
+        prompt="review bounded evidence",
+        schedule="in 1h",
+        model="example/model",
+        provider="openrouter",
+        enabled_toolsets=[],
+        policy_id="strict-unattended-v1",
+        strict_toolsets=True,
+        no_mcp=True,
+        no_fallback=True,
+        start_paused=True,
+        _operator_capability=_operator_capability(),
+    )
+
+    with pytest.raises(ValueError, match="trusted operator"):
+        jobs_mod.rearm_oneshot(job["id"], "in 2h")
+
+
+def test_tampered_policy_job_is_not_due_or_claimable(tmp_path, monkeypatch):
+    import cron.jobs as jobs_mod
+
+    _point_store(jobs_mod, tmp_path, monkeypatch)
+    job = _create_strict_policy_job(jobs_mod)
+    records = jobs_mod.load_jobs()
+    records[0].update({
+        "enabled": True,
+        "state": "scheduled",
+        "paused_at": None,
+        "next_run_at": "2000-01-01T00:00:00+00:00",
+        "no_mcp": False,
+    })
+    jobs_mod.save_jobs(records)
+
+    assert all(item["id"] != job["id"] for item in jobs_mod.get_due_jobs())
+    assert jobs_mod.claim_job_for_fire(job["id"], force=False) is False
+    stored = jobs_mod.get_job(job["id"])
+    assert stored["enabled"] is False
+    assert stored["state"] == "paused"
+    assert stored["next_run_at"] is None
+    assert "no_mcp=true" in stored["paused_reason"]
+
+
+def test_fire_claim_quarantines_invalid_policy_without_due_scan(tmp_path, monkeypatch):
+    import cron.jobs as jobs_mod
+
+    _point_store(jobs_mod, tmp_path, monkeypatch)
+    job = _create_strict_policy_job(jobs_mod)
+    _resume_policy_job(jobs_mod, job["id"])
+    records = jobs_mod.load_jobs()
+    records[0]["no_fallback"] = False
+    jobs_mod.save_jobs(records)
+
+    assert jobs_mod.claim_job_for_fire(job["id"], force=True) is False
+    stored = jobs_mod.get_job(job["id"])
+    assert stored["enabled"] is False
+    assert stored["state"] == "paused"
+    assert stored["next_run_at"] is None
+    assert "no_fallback=true" in stored["paused_reason"]
+
+
+def test_raw_strict_tool_schema_excludes_previously_registered_mcp_tool():
+    import model_tools
+    from tools.registry import registry
+
+    mcp_name = "mcp__collision_probe__read"
+    direct_name = "strict_collision_probe_read"
+    mcp_check_calls = []
+    registry.register(
+        name=mcp_name,
+        toolset="safe",
+        schema={
+            "name": mcp_name,
+            "description": "test MCP tool",
+            "parameters": {"type": "object", "properties": {}},
+        },
+        handler=lambda _args=None: "ok",
+        check_fn=lambda: mcp_check_calls.append(True) or True,
+    )
+    registry.register(
+        name=direct_name,
+        toolset="safe",
+        schema={
+            "name": direct_name,
+            "description": "test direct tool",
+            "parameters": {"type": "object", "properties": {}},
+        },
+        handler=lambda _args=None: "ok",
+    )
+    model_tools._clear_tool_defs_cache()
+    try:
+        definitions = model_tools.get_tool_definitions(
+            enabled_toolsets=["safe"],
+            quiet_mode=True,
+            skip_tool_search_assembly=True,
+            exclude_mcp_tools=True,
+        )
+    finally:
+        registry.deregister(mcp_name)
+        registry.deregister(direct_name)
+        model_tools._clear_tool_defs_cache()
+
+    names = {item["function"]["name"] for item in definitions}
+    assert mcp_check_calls == []
+    assert direct_name in names
+    assert mcp_name not in names
+    assert not any(tool_name.startswith("mcp__") for tool_name in names)
+    assert {"tool_search", "tool_describe", "tool_call"}.isdisjoint(names)

--- a/tests/gateway/test_api_server_jobs.py
+++ b/tests/gateway/test_api_server_jobs.py
@@ -398,6 +398,40 @@ class TestRunJob:
                 mock_trigger.assert_not_called()
 
 
+class TestProtectedPolicyLifecycle:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("method", "path", "target", "body"),
+        [
+            ("patch", f"/api/jobs/{VALID_JOB_ID}", "_cron_update", {"name": "x"}),
+            ("delete", f"/api/jobs/{VALID_JOB_ID}", "_cron_remove", None),
+            ("post", f"/api/jobs/{VALID_JOB_ID}/resume", "_cron_resume", None),
+            ("post", f"/api/jobs/{VALID_JOB_ID}/run", "_cron_trigger", {}),
+        ],
+    )
+    async def test_policy_rejection_is_forbidden_not_server_error(
+        self, adapter, method, path, target, body
+    ):
+        from cron.policy import CronPolicyError
+
+        app = _create_app(adapter)
+        rejecting = MagicMock(
+            side_effect=CronPolicyError(
+                "policy job lifecycle requires trusted operator authority"
+            )
+        )
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+                f"{_MOD}.{target}", rejecting
+            ):
+                response = await getattr(cli, method)(path, json=body)
+                payload = await response.json()
+
+        assert response.status == 403
+        assert "trusted operator" in payload["error"]
+        rejecting.assert_called_once()
+
+
 # ---------------------------------------------------------------------------
 # 17. test_auth_required
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_web_server_cron_profiles.py
+++ b/tests/hermes_cli/test_web_server_cron_profiles.py
@@ -612,6 +612,82 @@ async def test_trigger_cron_job_reports_lost_claim_as_conflict(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("enabled", "state"),
+    [(True, "scheduled"), (False, "paused")],
+)
+async def test_dashboard_rejects_manual_run_of_policy_jobs(
+    isolated_profiles,
+    monkeypatch,
+    enabled,
+    state,
+):
+    from hermes_cli import web_server
+
+    policy_job = {
+        "id": "strict-job",
+        "policy_id": "strict-unattended-v1",
+        "enabled": enabled,
+        "state": state,
+    }
+    monkeypatch.setattr(
+        web_server,
+        "_call_cron_for_profile",
+        lambda *_args, **_kwargs: policy_job,
+    )
+    monkeypatch.setattr(
+        web_server,
+        "_fire_cron_job_for_profile",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("dashboard must not fire protected policy jobs")
+        ),
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await web_server.trigger_cron_job(
+            policy_job["id"],
+            profile="worker_alpha",
+        )
+
+    assert exc.value.status_code == 403
+    assert "trusted operator" in exc.value.detail
+
+
+@pytest.mark.parametrize("operation", ["update", "resume", "delete"])
+def test_dashboard_policy_mutations_return_forbidden(monkeypatch, operation):
+    from cron.policy import CronPolicyError
+    from hermes_cli import web_server
+
+    monkeypatch.setattr(web_server, "_find_cron_job_profile", lambda _job_id: "default")
+    monkeypatch.setattr(
+        web_server,
+        "_call_cron_for_profile",
+        lambda *_args, **_kwargs: {"id": "strict-job", "policy_id": "strict-unattended-v1"},
+    )
+    monkeypatch.setattr(
+        web_server,
+        "_mutate_cron_for_profile",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            CronPolicyError("policy cron job mutation requires a trusted operator CLI")
+        ),
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        if operation == "update":
+            web_server._update_cron_job_sync(
+                "strict-job",
+                web_server.CronJobUpdate(updates={"name": "blocked"}),
+            )
+        elif operation == "resume":
+            web_server._resume_cron_job_sync("strict-job")
+        else:
+            web_server._delete_cron_job_sync("strict-job")
+
+    assert exc.value.status_code == 403
+    assert "trusted operator" in exc.value.detail
+
+
+@pytest.mark.asyncio
 async def test_trigger_cron_job_forces_paused_job_atomically(
     isolated_profiles,
     monkeypatch,

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2142,7 +2142,8 @@ class TestConcurrentToolExecution:
 
 
     def test_invoke_tool_dispatches_to_handle_function_call(self, agent):
-        """_invoke_tool should route regular tools through handle_function_call."""
+        """_invoke_tool forwards strict MCP exclusion to direct dispatch."""
+        agent._exclude_mcp_tools = True
         with patch("run_agent.handle_function_call", return_value="result") as mock_hfc:
             result = agent._invoke_tool("web_search", {"q": "test"}, "task-1")
             mock_hfc.assert_called_once_with(
@@ -2156,6 +2157,7 @@ class TestConcurrentToolExecution:
                 skip_tool_request_middleware=True,
                 enabled_toolsets=agent.enabled_toolsets,
                 disabled_toolsets=agent.disabled_toolsets,
+                exclude_mcp_tools=True,
                 tool_request_middleware_trace=[],
             )
             assert result == "result"

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -767,6 +767,65 @@ class TestDeferredCallSchemaProbe:
         assert result.get("ok") is True
         assert result.get("doc") == "abc"
 
+    def test_direct_bridge_dispatch_excludes_mcp_when_requested(self):
+        import model_tools
+        from tools.registry import registry
+
+        name = "mcp__strict_direct_probe__read"
+        toolset = "mcp-strict-direct-probe"
+        calls = []
+
+        def _handler(args, task_id=None, **kw):
+            calls.append(args)
+            return "DIRECT_MCP_REACHED"
+
+        registry.register(
+            name=name,
+            handler=_handler,
+            schema={
+                "name": name,
+                "description": "Unique strict direct MCP probe capability.",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            toolset=toolset,
+        )
+
+        search_result = model_tools.handle_function_call(
+            function_name="tool_search",
+            function_args={"queries": ["unique strict direct MCP probe"]},
+            enabled_toolsets=[toolset],
+            exclude_mcp_tools=True,
+        )
+        describe_result = model_tools.handle_function_call(
+            function_name="tool_describe",
+            function_args={"names": [name]},
+            enabled_toolsets=[toolset],
+            exclude_mcp_tools=True,
+        )
+        call_result = model_tools.handle_function_call(
+            function_name="tool_call",
+            function_args={"name": name, "arguments": {}},
+            enabled_toolsets=[toolset],
+            exclude_mcp_tools=True,
+        )
+        direct_result = model_tools.handle_function_call(
+            function_name=name,
+            function_args={},
+            enabled_toolsets=[toolset],
+            exclude_mcp_tools=True,
+        )
+
+        search_payload = json.loads(search_result)
+        describe_payload = json.loads(describe_result)
+        call_payload = json.loads(call_result)
+
+        assert all(name not in str(item) for item in search_payload.get("web", []))
+        assert describe_payload["tools"] == {}
+        assert describe_payload["not_found"] == [name]
+        assert "not available in this session" in call_payload["error"]
+        assert "DIRECT_MCP_REACHED" not in direct_result
+        assert calls == []
+
     def test_invalid_enum_is_blocked_before_dispatch(self):
         import model_tools
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -790,8 +790,14 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["monitor_state"] = job["monitor_state"]
     if job.get("no_agent"):
         result["no_agent"] = True
-    if job.get("enabled_toolsets"):
-        result["enabled_toolsets"] = job["enabled_toolsets"]
+    if job.get("policy_id") is not None:
+        result["policy_id"] = job["policy_id"]
+        result["strict_toolsets"] = job.get("strict_toolsets") is True
+        result["no_mcp"] = job.get("no_mcp") is True
+        result["no_fallback"] = job.get("no_fallback") is True
+        result["created_paused"] = job.get("created_paused") is True
+    if job.get("enabled_toolsets") or job.get("policy_id") is not None:
+        result["enabled_toolsets"] = job.get("enabled_toolsets") or []
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
     stored_refs = job.get("context_from") or []
@@ -1522,12 +1528,50 @@ def cronjob(
     reasoning_effort: Optional[str] = None,
     task_id: str = None,
     session_id: Optional[str] = None,
+    policy_id: Optional[str] = None,
+    strict_toolsets: bool = False,
+    no_mcp: bool = False,
+    no_fallback: bool = False,
+    start_paused: bool = False,
+    _operator_capability: object = None,
 ) -> str:
     """Unified cron job management tool."""
     del task_id  # unused but kept for handler signature compatibility
 
     try:
         normalized = (action or "").strip().lower()
+
+        from cron.policy import is_trusted_cron_operator
+
+        trusted_operator = is_trusted_cron_operator(_operator_capability)
+        protected_policy_request = bool(
+            policy_id or strict_toolsets or no_mcp or no_fallback or start_paused
+        )
+        if protected_policy_request and not trusted_operator:
+            return tool_error(
+                "Registered cron isolation policies may only be created by a trusted operator CLI.",
+                success=False,
+            )
+
+        protected_lifecycle_actions = {
+            "update",
+            "resume",
+            "run",
+            "run_now",
+            "trigger",
+            "remove",
+        }
+        if (
+            normalized in protected_lifecycle_actions
+            and job_id
+            and not trusted_operator
+        ):
+            target = resolve_job_ref(job_id)
+            if target and target.get("policy_id") is not None:
+                return tool_error(
+                    "Policy cron jobs may only be changed or activated by a trusted operator CLI.",
+                    success=False,
+                )
 
         if normalized == "create":
             if not schedule:
@@ -1624,7 +1668,7 @@ def cronjob(
                     base_url=_normalize_optional_job_value(base_url, strip_trailing_slash=True),
                     script=_normalize_optional_job_value(script),
                     context_from=context_from,
-                    enabled_toolsets=enabled_toolsets or None,
+                    enabled_toolsets=enabled_toolsets,
                     workdir=_normalize_optional_job_value(workdir),
                     no_agent=_no_agent,
                     attach_to_session=attach_to_session,
@@ -1636,6 +1680,12 @@ def cronjob(
                     # dispatch below: models do not make model-config
                     # decisions (standing policy).
                     reasoning_effort=reasoning_effort,
+                    policy_id=policy_id,
+                    strict_toolsets=bool(strict_toolsets),
+                    no_mcp=bool(no_mcp),
+                    no_fallback=bool(no_fallback),
+                    start_paused=bool(start_paused),
+                    _operator_capability=_operator_capability,
                 )
             except CronSchedulerRegistrationError as exc:
                 _partial = exc.to_dict()
@@ -1713,7 +1763,9 @@ def cronjob(
         job_id = job["id"]
 
         if normalized == "remove":
-            removed = remove_job(job_id)
+            removed = remove_job(
+                job_id, _operator_capability=_operator_capability
+            )
             if not removed:
                 return tool_error(f"Failed to remove job '{job_id}'", success=False)
             _notify_provider_jobs_changed_safe()
@@ -1736,7 +1788,9 @@ def cronjob(
             return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)
 
         if normalized == "resume":
-            updated = resume_job(job_id)
+            updated = resume_job(
+                job_id, _operator_capability=_operator_capability
+            )
             _notify_provider_jobs_changed_safe()
             return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)
 
@@ -1973,7 +2027,11 @@ def cronjob(
                     updates["enabled"] = True
             if not updates:
                 return tool_error("No updates provided.", success=False)
-            updated = update_job(job_id, updates)
+            updated = update_job(
+                job_id,
+                updates,
+                _operator_capability=_operator_capability,
+            )
             _notify_provider_jobs_changed_safe()
             _upd_result: Dict[str, Any] = {"success": True, "job": _format_job(updated)}
             # An update can switch a job into monitor / no_agent mode or

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -8373,6 +8373,12 @@ def refresh_agent_mcp_tools(
             enabled_toolsets=enabled,
             disabled_toolsets=disabled,
             quiet_mode=quiet_mode,
+            skip_tool_search_assembly=bool(
+                getattr(agent, "_skip_tool_search_assembly", False)
+            ),
+            exclude_mcp_tools=bool(
+                getattr(agent, "_exclude_mcp_tools", False)
+            ),
         )
         or []
     )


### PR DESCRIPTION
## Summary

Adds a registered `strict-unattended-v1` cron policy for scheduled agents that process untrusted evidence under an explicit, fail-closed model/control-plane boundary.

Key controls:

- paused-first persistence before any scheduler registration;
- immutable policy, model, provider, and isolation pins;
- exact explicit toolset allowlists, including a valid empty allowlist;
- fail-closed toolset resolution that rejects persistent-memory exposure through direct, aggregate, alias, or plugin toolsets;
- no MCP discovery, previously registered schemas, refresh, progressive/generic bridge catalog, recursive bridge dispatch, or direct `mcp__*` invocation;
- no provider/model fallback and no persistent memory/profile loading;
- core lifecycle authority checks for creation, update, resume, re-arm, manual force-fire, and removal;
- durable invalid-policy quarantine with scheduler-provider reconciliation;
- controlled REST/dashboard errors and compatibility-preserving public API parameter placement.

## Security boundary

This is an in-process model/control-plane policy boundary. It is **not** an OS, same-UID, or same-process-plugin security boundary and does not itself authorize unattended publication or other state-changing finalization. Those limitations are explicit in `docs/strict-unattended-cron.md`.

## Verification

Exact reviewed commit: `dd3dbabb12b23b3e00270dfbb01d41550f047b3e`

Canonical 22-file review aggregate over base `527da60844d4dced37879ea50259675371abe10e`:

`712a5061d241d467e53b61d615039e75e69ba1f9d32543bd5707e569f6fa430a`

Two independent adversarial reviewers recomputed this aggregate before and after review and returned `APPROVE` with no frozen-workspace drift or residue.

Local test results:

- strict warnings-as-errors policy/provider/direct-dispatch suite: **115 passed**;
- API, dashboard, plugin, cron-tool, MCP-refresh, and tool-search integration: **228 passed**;
- run-agent regression suite: **283 passed**;
- cron suite excluding one confirmed inherited order-dependent upstream test: **1,210 passed, 1 skipped, 1 deselected**;
- the deselected test passes alone: **1 passed**.

### Existing upstream test-order defect

At the tested base, the untouched upstream tree reproduces the same full-suite-order failure in:

`tests/cron/test_cron_multiplex_shared_route_delivery.py::test_satellite_routes_exact_target_through_primary_adapter`

Untouched baseline result: **1,141 passed, 1 failed, 1 skipped**. The test passes in isolation. This PR does not alter that test or attempt an unrelated fix.

Additional checks:

- Ruff lint passed for all changed Python files;
- AST parsing passed;
- `git diff --check` passed;
- added-line scans found no hardcoded secrets, shell execution, eval/exec, pickle, formatted SQL, or private workflow identifiers.

## Operational impact

No cron job, profile, production configuration, service, review cursor, vault content, or publication authority is activated by this PR.
