### PR TITLE
fix(desktop): harden fallback update progress window

### DIFF
--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -407,12 +407,29 @@ function Show-ProgressWindow {
         $form.Controls.Add($bar)
         $form.Controls.Add($title)
         $form.Controls.Add($sub)
+        # `cmd start /min` minimizes the whole PowerShell process; conhost
+        # on some systems ignores the STARTUPINFO show state and stays
+        # full-size on screen. Tuck the console away FIRST — MainWindowHandle
+        # is unambiguous only while this process owns just its console (once
+        # the card exists it may resolve to the card). SW_MINIMIZE = 6.
+        try {
+            if ($script:Win32) {
+                $consoleHwnd = (Get-Process -Id $PID).MainWindowHandle
+                if ($consoleHwnd -ne [System.IntPtr]::Zero) {
+                    [HermesHandoff.Win32]::ShowWindow($consoleHwnd, 6) | Out-Null
+                }
+            }
+        } catch {}
         $form.Show()
         # `cmd start /min` spawned us backgrounded, so the card comes up
         # behind everything without one explicit activation. Claim it ONCE
         # (so the user knows the update started), then never again — the
         # window is decoration and competes with nothing (no TopMost).
+        # NOTE: /min minimized the whole PowerShell process, so the WinForms
+        # window inherits the minimized state and Activate() is a no-op.
+        # SW_RESTORE (9) un-minimizes before claiming foreground.
         try {
+            if ($script:Win32) { [HermesHandoff.Win32]::ShowWindow($form.Handle, 9) | Out-Null }  # SW_RESTORE
             $form.Activate()
             if ($script:Win32) { [HermesHandoff.Win32]::SetForegroundWindow($form.Handle) | Out-Null }
         } catch {}

--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -70,6 +70,7 @@ try {
 [DllImport("user32.dll")] public static extern bool SetForegroundWindow(System.IntPtr hWnd);
 [DllImport("user32.dll")] public static extern bool AllowSetForegroundWindow(int dwProcessId);
 [DllImport("user32.dll")] public static extern bool ShowWindow(System.IntPtr hWnd, int nCmdShow);
+[DllImport("user32.dll")] public static extern bool IsIconic(System.IntPtr hWnd);
 '@ -ErrorAction Stop
     $script:Win32 = $true
 } catch { $script:Win32 = $false }
@@ -412,27 +413,45 @@ function Show-ProgressWindow {
         # full-size on screen. Tuck the console away FIRST — MainWindowHandle
         # is unambiguous only while this process owns just its console (once
         # the card exists it may resolve to the card). SW_MINIMIZE = 6.
+        # Only tuck when the console is already iconic (i.e. /min-spawned);
+        # a direct launch from the user's own terminal must not be minimized.
+        $script:ConsoleHwnd = [System.IntPtr]::Zero
         try {
             if ($script:Win32) {
                 $consoleHwnd = (Get-Process -Id $PID).MainWindowHandle
-                if ($consoleHwnd -ne [System.IntPtr]::Zero) {
+                if ($consoleHwnd -ne [System.IntPtr]::Zero -and [HermesHandoff.Win32]::IsIconic($consoleHwnd)) {
+                    $script:ConsoleHwnd = $consoleHwnd
                     [HermesHandoff.Win32]::ShowWindow($consoleHwnd, 6) | Out-Null
                 }
             }
-        } catch {}
-        $form.Show()
-        # `cmd start /min` spawned us backgrounded, so the card comes up
-        # behind everything without one explicit activation. Claim it ONCE
-        # (so the user knows the update started), then never again — the
-        # window is decoration and competes with nothing (no TopMost).
-        # NOTE: /min minimized the whole PowerShell process, so the WinForms
-        # window inherits the minimized state and Activate() is a no-op.
-        # SW_RESTORE (9) un-minimizes before claiming foreground.
+        } catch {
+            Write-Debug "console minimize skipped: $($_.Exception.Message)"
+        }
         try {
-            if ($script:Win32) { [HermesHandoff.Win32]::ShowWindow($form.Handle, 9) | Out-Null }  # SW_RESTORE
-            $form.Activate()
-            if ($script:Win32) { [HermesHandoff.Win32]::SetForegroundWindow($form.Handle) | Out-Null }
-        } catch {}
+            $form.Show()
+            # `cmd start /min` spawned us backgrounded, so the card comes up
+            # behind everything without one explicit activation. Claim it ONCE
+            # (so the user knows the update started), then never again — the
+            # window is decoration and competes with nothing (no TopMost).
+            # NOTE: /min minimized the whole PowerShell process, so the WinForms
+            # window inherits the minimized state and Activate() is a no-op.
+            # SW_RESTORE (9) un-minimizes before claiming foreground.
+            try {
+                if ($script:Win32) { [HermesHandoff.Win32]::ShowWindow($form.Handle, 9) | Out-Null }  # SW_RESTORE
+                $form.Activate()
+                if ($script:Win32) { [HermesHandoff.Win32]::SetForegroundWindow($form.Handle) | Out-Null }
+            } catch {
+                Write-Debug "progress card activation skipped: $($_.Exception.Message)"
+            }
+        } catch {
+            # Card failed to appear after we tucked the console: restore the
+            # console so the user isn't left with nothing on screen, then
+            # degrade to log-only via the outer handler.
+            if ($script:ConsoleHwnd -ne [System.IntPtr]::Zero) {
+                try { [HermesHandoff.Win32]::ShowWindow($script:ConsoleHwnd, 9) | Out-Null } catch { Write-Debug "console restore failed: $($_.Exception.Message)" }
+            }
+            throw
+        }
         [System.Windows.Forms.Application]::DoEvents()
         $script:Ui = [pscustomobject]@{ Form = $form; Bar = $bar; Title = $title; Sub = $sub; Timer = $null }
         $timer = New-Object System.Windows.Forms.Timer

--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -25,6 +25,7 @@
 #     [-RelaunchExe <path>] Hermes.exe to start when done (omit = no relaunch)
 #     [-NoUi]               headless (tests); default shows a progress window
 #     [-NoMarkerCleanup]    leave .hermes-update-in-progress in place (tests)
+#     [-ForceWinForms]      test-only: skip the browser shim and show the fallback card
 #
 # SAFETY POSTURE: both preflight gates FAIL CLOSED. A Desktop that never
 # exits, or a venv shim that never unlocks, aborts the hand-off without
@@ -49,6 +50,7 @@ param(
     [switch]$NoUi,
     [switch]$NoMarkerCleanup,
     [switch]$SelfTestUi,
+    [switch]$ForceWinForms,
     [switch]$SelfTestPipeDrain,
     [switch]$SelfTestMarker
 )
@@ -336,7 +338,7 @@ function Show-ProgressWindow {
     # claims attention once by appearing, then competes with nothing.
     $htmlPath = Get-UiHtmlPath
     $browser = Get-DefaultBrowserExe
-    if ($htmlPath -and $browser) {
+    if (-not $ForceWinForms -and $htmlPath -and $browser) {
         $server = Start-UiServer $htmlPath
         if ($server) {
             try {
@@ -408,6 +410,18 @@ function Show-ProgressWindow {
         $form.Controls.Add($bar)
         $form.Controls.Add($title)
         $form.Controls.Add($sub)
+        $timer = New-Object System.Windows.Forms.Timer
+        $timer.Interval = 1000
+        $timer.Add_Tick({
+            if ($script:Ui -and $script:Ui.Sub) {
+                $script:Ui.Sub.Text = Get-UiProgressLine
+            }
+        })
+        # Store cleanup state before Show(): if activation or the first
+        # message-pump pass fails, the catch below can close this form instead
+        # of leaving an unpumped orphan on screen.
+        $script:Ui = [pscustomobject]@{ Form = $form; Bar = $bar; Title = $title; Sub = $sub; Timer = $timer }
+        $form.WindowState = [System.Windows.Forms.FormWindowState]::Normal
         # `cmd start /min` minimizes the whole PowerShell process; conhost
         # on some systems ignores the STARTUPINFO show state and stays
         # full-size on screen. Tuck the console away FIRST — MainWindowHandle
@@ -429,6 +443,9 @@ function Show-ProgressWindow {
         }
         try {
             $form.Show()
+            # WinForms can inherit the minimized process state. Reset both the
+            # managed state and native HWND after Show() creates the handle.
+            $form.WindowState = [System.Windows.Forms.FormWindowState]::Normal
             # `cmd start /min` spawned us backgrounded, so the card comes up
             # behind everything without one explicit activation. Claim it ONCE
             # (so the user knows the update started), then never again — the
@@ -453,18 +470,25 @@ function Show-ProgressWindow {
             throw
         }
         [System.Windows.Forms.Application]::DoEvents()
-        $script:Ui = [pscustomobject]@{ Form = $form; Bar = $bar; Title = $title; Sub = $sub; Timer = $null }
-        $timer = New-Object System.Windows.Forms.Timer
-        $timer.Interval = 1000
-        $timer.Add_Tick({
-            if ($script:Ui -and $script:Ui.Sub) {
-                $script:Ui.Sub.Text = Get-UiProgressLine
-            }
-        })
-        $script:Ui.Timer = $timer
         $timer.Start()
     } catch {
         # Headless session / WinForms unavailable: degrade to log-only.
+        # `$script:Ui` is assigned before Show(), so setup failures after a
+        # visible form exists cannot strand a blank, unpumped card.
+        try {
+            if ($script:Ui -and $script:Ui.Timer) {
+                $script:Ui.Timer.Stop()
+                $script:Ui.Timer.Dispose()
+            }
+            if ($script:Ui -and $script:Ui.Form) {
+                $script:Ui.Form.Close()
+                $script:Ui.Form.Dispose()
+            }
+        } catch {}
+        if ($script:ConsoleHwnd -ne [System.IntPtr]::Zero) {
+            try { [HermesHandoff.Win32]::ShowWindow($script:ConsoleHwnd, 9) | Out-Null } catch { Write-Debug "console restore failed: $($_.Exception.Message)" }
+        }
+        Write-HandoffLog "WinForms progress window unavailable; continuing without UI"
         $script:Ui = $null
     }
 }
@@ -1198,7 +1222,7 @@ $script:TreeSafeToFinalize = $true
 if ($SelfTestUi) {
     New-Item -ItemType Directory -Path $LogDir -Force -ErrorAction SilentlyContinue | Out-Null
     Show-ProgressWindow
-    if (-not $script:UiServer) {
+    if (-not $ForceWinForms -and -not $script:UiServer) {
         $htmlPath = Get-UiHtmlPath
         if ($htmlPath) {
             $script:UiServer = Start-UiServer $htmlPath
@@ -1208,10 +1232,27 @@ if ($SelfTestUi) {
         Write-Host "SELF-TEST: shim at http://127.0.0.1:$($script:UiServer.Port)/"
     }
     Write-HandoffLog "SELF-TEST: shim simulation (no update will run)"
+    # The live Windows test launches through the production `cmd start /min`
+    # wrapper. Publish PID + the kernel process-creation token so cleanup can
+    # prove identity even if this short-lived PID is reused before OpenProcess.
+    if ($env:HERMES_SELFTEST_IDENTITY_PATH) {
+        try {
+            $self = [System.Diagnostics.Process]::GetCurrentProcess()
+            $identity = [ordered]@{
+                pid = $PID
+                creation_filetime = $self.StartTime.ToFileTimeUtc()
+            } | ConvertTo-Json -Compress
+            [System.IO.File]::WriteAllText($env:HERMES_SELFTEST_IDENTITY_PATH, $identity, [System.Text.Encoding]::ASCII)
+        } catch {}
+    }
     $hold = 6
     if ($env:HERMES_SELFTEST_HOLD_SECONDS) { $hold = [int]$env:HERMES_SELFTEST_HOLD_SECONDS }
     Publish-UiProgress "Testing quiet update"
-    Start-Sleep -Seconds $hold
+    $holdDeadline = (Get-Date).AddSeconds($hold)
+    while ((Get-Date) -lt $holdDeadline) {
+        if ($script:Ui) { [System.Windows.Forms.Application]::DoEvents() }
+        Start-Sleep -Milliseconds 50
+    }
     if ($env:HERMES_SELFTEST_FAIL) {
         Show-ErrorFinale "self-test error state"
     } else {

--- a/tests/test_desktop_update_windows_progress.py
+++ b/tests/test_desktop_update_windows_progress.py
@@ -15,6 +15,8 @@ import re
 import shutil
 import subprocess
 import time
+import ctypes
+from ctypes import wintypes
 from pathlib import Path
 from urllib.request import urlopen
 
@@ -24,6 +26,174 @@ pytestmark = pytest.mark.windows_only
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 WINDOWS_UPDATE_PS1 = REPO_ROOT / "scripts" / "desktop-update" / "windows.ps1"
+
+
+def _windows_child_env(tmp_path: Path) -> dict[str, str]:
+    """Preserve the Windows location variables the hermetic runner omits."""
+    env = os.environ.copy()
+    env["TEMP"] = str(tmp_path)
+    env["TMP"] = str(tmp_path)
+    if "SystemDrive" not in env and (system_root := env.get("SYSTEMROOT")):
+        env["SystemDrive"] = Path(system_root).drive
+    return env
+
+
+def _user32() -> ctypes.WinDLL:
+    user32 = ctypes.WinDLL("user32", use_last_error=True)
+    user32.GetWindowThreadProcessId.argtypes = [wintypes.HWND, ctypes.POINTER(wintypes.DWORD)]
+    user32.GetWindowThreadProcessId.restype = wintypes.DWORD
+    user32.IsWindowVisible.argtypes = [wintypes.HWND]
+    user32.IsWindowVisible.restype = wintypes.BOOL
+    user32.IsIconic.argtypes = [wintypes.HWND]
+    user32.IsIconic.restype = wintypes.BOOL
+    user32.GetClientRect.argtypes = [wintypes.HWND, ctypes.POINTER(_RECT)]
+    user32.GetClientRect.restype = wintypes.BOOL
+    user32.GetClassNameW.argtypes = [wintypes.HWND, wintypes.LPWSTR, ctypes.c_int]
+    user32.GetClassNameW.restype = ctypes.c_int
+    user32.GetWindowTextLengthW.argtypes = [wintypes.HWND]
+    user32.GetWindowTextLengthW.restype = ctypes.c_int
+    user32.GetWindowTextW.argtypes = [wintypes.HWND, wintypes.LPWSTR, ctypes.c_int]
+    user32.GetWindowTextW.restype = ctypes.c_int
+    user32.SendMessageTimeoutW.argtypes = [
+        wintypes.HWND,
+        wintypes.UINT,
+        wintypes.WPARAM,
+        wintypes.LPARAM,
+        wintypes.UINT,
+        wintypes.UINT,
+        ctypes.POINTER(ctypes.c_size_t),
+    ]
+    user32.SendMessageTimeoutW.restype = ctypes.c_size_t
+    return user32
+
+
+class _RECT(ctypes.Structure):
+    _fields_ = [
+        ("left", ctypes.c_long),
+        ("top", ctypes.c_long),
+        ("right", ctypes.c_long),
+        ("bottom", ctypes.c_long),
+    ]
+
+
+def _windows_for_pid(pid: int) -> list[int]:
+    """Return the visible top-level windows owned by exactly ``pid``."""
+    user32 = _user32()
+    windows: list[int] = []
+    callback_type = ctypes.WINFUNCTYPE(wintypes.BOOL, wintypes.HWND, wintypes.LPARAM)
+    user32.EnumWindows.argtypes = [callback_type, wintypes.LPARAM]
+    user32.EnumWindows.restype = wintypes.BOOL
+
+    @callback_type
+    def visit(hwnd: int, _lparam: int) -> bool:
+        owner = wintypes.DWORD()
+        user32.GetWindowThreadProcessId(hwnd, ctypes.byref(owner))
+        if owner.value == pid and user32.IsWindowVisible(hwnd):
+            windows.append(hwnd)
+        return True
+
+    assert user32.EnumWindows(visit, 0), ctypes.get_last_error()
+    return windows
+
+
+def _window_text(user32: ctypes.WinDLL, hwnd: int) -> str:
+    text_length = user32.GetWindowTextLengthW(hwnd)
+    text = ctypes.create_unicode_buffer(text_length + 1)
+    user32.GetWindowTextW(hwnd, text, len(text))
+    return text.value
+
+
+def _child_controls(hwnd: int) -> list[tuple[str, str, bool]]:
+    """Read the real WinForms child-control tree, not script text."""
+    user32 = _user32()
+    controls: list[tuple[str, str, bool]] = []
+    callback_type = ctypes.WINFUNCTYPE(wintypes.BOOL, wintypes.HWND, wintypes.LPARAM)
+    user32.EnumChildWindows.argtypes = [wintypes.HWND, callback_type, wintypes.LPARAM]
+    user32.EnumChildWindows.restype = wintypes.BOOL
+
+    @callback_type
+    def visit(child: int, _lparam: int) -> bool:
+        class_name = ctypes.create_unicode_buffer(256)
+        user32.GetClassNameW(child, class_name, len(class_name))
+        text_length = user32.GetWindowTextLengthW(child)
+        text = ctypes.create_unicode_buffer(text_length + 1)
+        user32.GetWindowTextW(child, text, len(text))
+        controls.append((class_name.value, text.value, bool(user32.IsWindowVisible(child))))
+        return True
+
+    assert user32.EnumChildWindows(hwnd, visit, 0), ctypes.get_last_error()
+    return controls
+
+
+def _kernel32() -> ctypes.WinDLL:
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.TerminateProcess.argtypes = [wintypes.HANDLE, wintypes.UINT]
+    kernel32.TerminateProcess.restype = wintypes.BOOL
+    kernel32.WaitForSingleObject.argtypes = [wintypes.HANDLE, wintypes.DWORD]
+    kernel32.WaitForSingleObject.restype = wintypes.DWORD
+    kernel32.GetExitCodeProcess.argtypes = [wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD)]
+    kernel32.GetExitCodeProcess.restype = wintypes.BOOL
+    kernel32.GetProcessTimes.argtypes = [
+        wintypes.HANDLE,
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+    ]
+    kernel32.GetProcessTimes.restype = wintypes.BOOL
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+    return kernel32
+
+
+def _open_self_test_process(
+    kernel32: ctypes.WinDLL,
+    pid: int,
+    expected_creation_filetime: int,
+) -> wintypes.HANDLE:
+    """Open the published child only when its kernel creation token matches."""
+    synchronize_query_terminate = 0x00100000 | 0x1000 | 0x0001
+    process = kernel32.OpenProcess(synchronize_query_terminate, False, pid)
+    if not process:
+        raise AssertionError(
+            f"could not open self-test PID {pid}: {ctypes.get_last_error()}"
+        )
+    try:
+        creation = wintypes.FILETIME()
+        exit_time = wintypes.FILETIME()
+        kernel_time = wintypes.FILETIME()
+        user_time = wintypes.FILETIME()
+        if not kernel32.GetProcessTimes(
+            process,
+            ctypes.byref(creation),
+            ctypes.byref(exit_time),
+            ctypes.byref(kernel_time),
+            ctypes.byref(user_time),
+        ):
+            raise AssertionError(ctypes.get_last_error())
+        actual_creation_filetime = (
+            int(creation.dwHighDateTime) << 32
+        ) | int(creation.dwLowDateTime)
+        if actual_creation_filetime != expected_creation_filetime:
+            raise AssertionError(
+                f"self-test PID {pid} was reused before its process handle was opened"
+            )
+        return process
+    except Exception:
+        kernel32.CloseHandle(process)
+        raise
+
+
+def _wait_for_process_exit(kernel32: ctypes.WinDLL, process: wintypes.HANDLE, timeout_ms: int) -> int | None:
+    """Return the exit code from the already-opened child process handle."""
+    if kernel32.WaitForSingleObject(process, timeout_ms) != 0:
+        return None
+    exit_code = wintypes.DWORD()
+    if not kernel32.GetExitCodeProcess(process, ctypes.byref(exit_code)):
+        return None
+    return int(exit_code.value)
 
 
 def _read_progress(url: str, deadline: float) -> dict[str, object]:
@@ -63,9 +233,7 @@ def test_progress_advances_while_the_orchestrator_blocks(tmp_path: Path) -> None
     assert powershell, "Windows updater tests require Windows PowerShell."
 
     output_path = tmp_path / "self-test-output.log"
-    env = os.environ.copy()
-    env["TEMP"] = str(tmp_path)
-    env["TMP"] = str(tmp_path)
+    env = _windows_child_env(tmp_path)
     # Generous hold: the assertions below must both land INSIDE it. 4s was
     # too tight for a slow runner — the second sample slid past the hold,
     # caught the cleared terminal state, and failed '' == 'Testing quiet
@@ -139,3 +307,110 @@ def test_progress_advances_while_the_orchestrator_blocks(tmp_path: Path) -> None
         if process.poll() is None:
             process.kill()
             process.wait(timeout=5)
+
+
+def test_minimized_production_handoff_restores_a_responsive_winforms_progress_window(
+    tmp_path: Path,
+) -> None:
+    """The real ``cmd start /min`` topology must not hide or freeze the fallback card."""
+    powershell = shutil.which("powershell.exe")
+    cmd = shutil.which("cmd.exe")
+    assert powershell and cmd, "Windows updater tests require cmd.exe and Windows PowerShell."
+
+    identity_path = tmp_path / "self-test-process.json"
+    env = _windows_child_env(tmp_path)
+    env["HERMES_SELFTEST_HOLD_SECONDS"] = "6"
+    env["HERMES_SELFTEST_IDENTITY_PATH"] = str(identity_path)
+
+    wrapper = subprocess.Popen(
+        [
+            cmd,
+            "/d",
+            "/s",
+            "/c",
+            "start",
+            "",
+            "/min",
+            powershell,
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(WINDOWS_UPDATE_PS1),
+            "-SelfTestUi",
+            "-ForceWinForms",
+        ],
+        env=env,
+    )
+    child_pid: int | None = None
+    child_creation_filetime: int | None = None
+    child_process: wintypes.HANDLE | None = None
+    child_exited = False
+    try:
+        assert wrapper.wait(timeout=10) == 0
+
+        deadline = time.monotonic() + 20
+        while time.monotonic() < deadline:
+            if identity_path.exists():
+                try:
+                    identity = json.loads(identity_path.read_text(encoding="ascii"))
+                    child_pid = int(identity["pid"])
+                    child_creation_filetime = int(identity["creation_filetime"])
+                    if child_pid <= 0 or child_creation_filetime <= 0:
+                        raise ValueError("invalid process identity")
+                except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+                    child_pid = None
+                    child_creation_filetime = None
+                    pass
+                else:
+                    break
+            time.sleep(0.1)
+        assert child_pid is not None and child_creation_filetime is not None, (
+            "self-test did not publish its PowerShell process identity"
+        )
+        kernel32 = _kernel32()
+        child_process = _open_self_test_process(
+            kernel32, child_pid, child_creation_filetime
+        )
+
+        deadline = time.monotonic() + 15
+        windows: list[int] = []
+        while time.monotonic() < deadline:
+            user32 = _user32()
+            windows = [hwnd for hwnd in _windows_for_pid(child_pid) if _window_text(user32, hwnd) == "Hermes"]
+            if windows:
+                break
+            time.sleep(0.1)
+        assert windows, f"no visible Hermes window owned by self-test PID {child_pid}"
+
+        user32 = _user32()
+        hwnd = windows[0]
+        assert _window_text(user32, hwnd) == "Hermes"
+        assert not user32.IsIconic(hwnd), "cmd start /min left the progress card minimized"
+        client = _RECT()
+        assert user32.GetClientRect(hwnd, ctypes.byref(client)), ctypes.get_last_error()
+        assert client.right > client.left and client.bottom > client.top
+
+        result = ctypes.c_size_t()
+        assert user32.SendMessageTimeoutW(hwnd, 0, 0, 0, 2, 2_000, ctypes.byref(result)), (
+            "Hermes progress card stopped processing window messages"
+        )
+
+        controls = _child_controls(hwnd)
+        visible_text = {text for _class_name, text, visible in controls if visible and text}
+        visible_classes = {class_name.lower() for class_name, _text, visible in controls if visible}
+        assert "Updating Hermes" in visible_text
+        assert any("Testing quiet update" in text for text in visible_text)
+        assert any("progress" in class_name for class_name in visible_classes)
+        exit_code = _wait_for_process_exit(kernel32, child_process, 15_000)
+        if exit_code is not None:
+            child_exited = True
+        assert exit_code == 0
+    finally:
+        if child_process:
+            try:
+                if not child_exited:
+                    kernel32.TerminateProcess(child_process, 1)
+                    kernel32.WaitForSingleObject(child_process, 5_000)
+            finally:
+                kernel32.CloseHandle(child_process)


### PR DESCRIPTION
## What changed

- Preserve the two original commits from #84025, including the guarded console minimization and `SW_RESTORE` fallback.
- Restore the WinForms card to a normal window state before and after `Show()` so `cmd start /min` cannot leave it minimized or blank.
- Keep setup and cleanup fail closed, restoring the console if card setup fails.
- Bind test-process cleanup to both PID and exact creation FILETIME.
- Add a real Windows regression test for visibility, iconic state, responsiveness, client area, and expected controls.

## Why

When the browser progress surface is unavailable, the Windows updater falls back to WinForms. The production handoff launches PowerShell through `cmd start /min`; the fallback can inherit that minimized state while the update continues normally, leaving only the PowerShell console visible.

This branch is built directly on the two commits from #84025, preserving their original authorship, and references the report in #84678. The final commit adds lifecycle safeguards and executable regression coverage. If maintainers prefer, that final commit can be folded into #84025 instead of merging this PR separately.

## How tested

- Windows updater slice: 14 passed.
- Focused real-window regression: 2 passed.
- PowerShell parser: passed.
- Ruff: passed.
- `scripts/check-windows-footguns.py --diff origin/main`: passed.
- Test launch uses the production `cmd start /min` topology and verifies a visible, non-iconic, responsive window with non-empty client bounds and expected controls.

## Platform impact

- Verified on Windows 11.
- The change is limited to `scripts/desktop-update/windows.ps1` and its Windows regression test.
- `-NoUi` and non-Windows paths are unchanged.

References #84678.
