### PR TITLE
feat(matrix): keep tool activity silent and sticky

### DIFF
--- a/gateway/matrix_activity_pane.py
+++ b/gateway/matrix_activity_pane.py
@@ -1,0 +1,147 @@
+"""Per-turn coordinator for Matrix's sticky activity pane."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Callable, Optional
+
+from gateway.matrix_tool_activity import matrix_tool_activity_bodies
+
+
+logger = logging.getLogger(__name__)
+
+
+class MatrixActivityPane:
+    """Serialize one turn's Matrix activity into a single editable root."""
+
+    def __init__(
+        self,
+        *,
+        adapter: Any,
+        chat_id: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[dict] = None,
+        coalescing_enabled: bool = True,
+    ) -> None:
+        self.adapter = adapter
+        self.chat_id = chat_id
+        self.reply_to = reply_to
+        self.metadata = dict(metadata or {})
+        self.coalescing_enabled = bool(coalescing_enabled)
+        self.root_event_id: Optional[str] = None
+        self.activity_lines: list[str] = []
+        self.footer: Optional[str] = None
+        self.lock = asyncio.Lock()
+        self.closed = False
+
+    async def append_activity(self, line: str) -> Any:
+        """Append one status/tool label and publish the complete snapshot."""
+
+        text = str(line or "").strip()
+        if not text:
+            return None
+        return await self._coordinate(lambda: self.activity_lines.append(text))
+
+    async def replace_activity(self, previous: str, replacement: str) -> Any:
+        """Replace the latest matching activity line, or append if absent."""
+
+        old = str(previous or "").strip()
+        new = str(replacement or "").strip()
+        if not new:
+            return None
+
+        def _mutate() -> None:
+            for index in range(len(self.activity_lines) - 1, -1, -1):
+                current = self.activity_lines[index]
+                if current == old or current.startswith(f"{old} (\u00d7"):
+                    self.activity_lines[index] = new
+                    return
+            self.activity_lines.append(new)
+
+        return await self._coordinate(_mutate)
+
+    async def set_footer(self, footer: str | None) -> Any:
+        """Replace the heartbeat footer and publish the complete snapshot."""
+
+        value = str(footer or "").strip() or None
+        return await self._coordinate(lambda: setattr(self, "footer", value))
+
+    async def close(self) -> None:
+        """Seal the pane after any in-flight publish; drop the live footer."""
+
+        async with self.lock:
+            if self.closed:
+                return
+            if self.footer is not None:
+                self.footer = None
+                if self.root_event_id:
+                    await self._transport_locked()
+            self.closed = True
+
+    async def _coordinate(self, mutate: Callable[[], None]) -> Any:
+        """Mutate, snapshot, render, and transport under one turn-local lock."""
+
+        async with self.lock:
+            if self.closed or not self.coalescing_enabled:
+                return None
+            mutate()
+            return await self._transport_locked()
+
+    async def _transport_locked(self) -> Any:
+        """Send or edit the current snapshot. Caller MUST hold ``self.lock``."""
+
+        lines = tuple(self.activity_lines)
+        footer = self.footer
+        body, formatted_body = matrix_tool_activity_bodies(lines, footer)
+        metadata = dict(self.metadata)
+        metadata["matrix_formatted_body"] = formatted_body
+        metadata["matrix_formatted_body_unprefixed"] = True
+        metadata["_interim_send"] = True
+
+        try:
+            if self.root_event_id is None:
+                result = await self._await_transport(
+                    self.adapter.send(
+                        chat_id=self.chat_id,
+                        content=body,
+                        reply_to=self.reply_to,
+                        metadata=metadata,
+                    )
+                )
+                if getattr(result, "success", False) and getattr(
+                    result, "message_id", None
+                ):
+                    self.root_event_id = str(result.message_id)
+                return result
+
+            kwargs = {
+                "chat_id": self.chat_id,
+                "message_id": self.root_event_id,
+                "content": body,
+                "metadata": metadata,
+            }
+            if getattr(self.adapter, "REQUIRES_EDIT_FINALIZE", False):
+                kwargs["finalize"] = True
+            return await self._await_transport(self.adapter.edit_message(**kwargs))
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.debug("Matrix activity pane transport failed", exc_info=True)
+            return None
+
+    async def _await_transport(self, awaitable: Any) -> Any:
+        """Finish the Matrix call even if the consumer task is cancelled."""
+
+        task = asyncio.ensure_future(awaitable)
+        try:
+            return await asyncio.shield(task)
+        except asyncio.CancelledError:
+            result = await task
+            if (
+                self.root_event_id is None
+                and getattr(result, "success", False)
+                and getattr(result, "message_id", None)
+            ):
+                self.root_event_id = str(result.message_id)
+            raise

--- a/gateway/matrix_tool_activity.py
+++ b/gateway/matrix_tool_activity.py
@@ -1,0 +1,38 @@
+"""Matrix Tool activity payload helpers (always-visible sticky list)."""
+
+from __future__ import annotations
+
+import html as _html
+import re
+from typing import Iterable, List, Sequence, Tuple
+
+
+def matrix_tool_activity_bodies(lines: Sequence[str] | Iterable[str]) -> Tuple[str, str]:
+    """Build plain body + HTML for Matrix tool progress.
+
+    Contract:
+    - plain body: ``🛠 Tool activity (N updates)`` only
+    - HTML: always-visible ``<p><strong>…</strong></p><ol><li>…</li></ol>``
+    - no fences, details, spoilers, or multi-line dumps
+    """
+    cleaned: List[str] = []
+    for line in lines:
+        s = str(line or "").strip()
+        if not s:
+            continue
+        if s in {"```", "~~~"} or set(s) <= {"`", "~", " "}:
+            continue
+        if s.startswith("```") or s.startswith("~~~"):
+            continue
+        s = s.splitlines()[0].strip()
+        s = re.sub(r"\s+", " ", s)
+        if len(s) > 160:
+            s = s[:157] + "..."
+        cleaned.append(s)
+    n = len(cleaned)
+    body = f"🛠 Tool activity ({n} update{'s' if n != 1 else ''})"
+    if not cleaned:
+        return body, f"<p><strong>{_html.escape(body)}</strong></p>"
+    items = "".join(f"<li>{_html.escape(item)}</li>" for item in cleaned)
+    html_body = f"<p><strong>{_html.escape(body)}</strong></p><ol>{items}</ol>"
+    return body, html_body

--- a/gateway/matrix_tool_activity.py
+++ b/gateway/matrix_tool_activity.py
@@ -7,12 +7,15 @@ import re
 from typing import Iterable, List, Sequence, Tuple
 
 
-def matrix_tool_activity_bodies(lines: Sequence[str] | Iterable[str]) -> Tuple[str, str]:
+def matrix_tool_activity_bodies(
+    lines: Sequence[str] | Iterable[str],
+    footer: str | None = None,
+) -> Tuple[str, str]:
     """Build plain body + HTML for Matrix tool progress.
 
     Contract:
-    - plain body: ``🛠 Tool activity (N updates)`` only
-    - HTML: always-visible ``<p><strong>…</strong></p><ol><li>…</li></ol>``
+    - tools-only plain body: ``🛠 Tool activity (N updates)``
+    - HTML: always-visible title, optional ordered list, optional footer
     - no fences, details, spoilers, or multi-line dumps
     """
     cleaned: List[str] = []
@@ -29,10 +32,19 @@ def matrix_tool_activity_bodies(lines: Sequence[str] | Iterable[str]) -> Tuple[s
         if len(s) > 160:
             s = s[:157] + "..."
         cleaned.append(s)
+    footer_text = str(footer or "").strip() or None
     n = len(cleaned)
-    body = f"🛠 Tool activity ({n} update{'s' if n != 1 else ''})"
-    if not cleaned:
-        return body, f"<p><strong>{_html.escape(body)}</strong></p>"
-    items = "".join(f"<li>{_html.escape(item)}</li>" for item in cleaned)
-    html_body = f"<p><strong>{_html.escape(body)}</strong></p><ol>{items}</ol>"
+    title = (
+        f"🛠 Tool activity ({n} update{'s' if n != 1 else ''})"
+        if cleaned
+        else "🛠 Tool activity"
+    )
+    body = f"{title} · {footer_text}" if footer_text else title
+    html_parts = [f"<p><strong>{_html.escape(title)}</strong></p>"]
+    if cleaned:
+        items = "".join(f"<li>{_html.escape(item)}</li>" for item in cleaned)
+        html_parts.append(f"<ol>{items}</ol>")
+    if footer_text:
+        html_parts.append(f"<p>{_html.escape(footer_text)}</p>")
+    html_body = "".join(html_parts)
     return body, html_body

--- a/gateway/matrix_tool_activity.py
+++ b/gateway/matrix_tool_activity.py
@@ -7,6 +7,9 @@ import re
 from typing import Iterable, List, Sequence, Tuple
 
 
+MAX_ACTIVITY_LINES = 16
+
+
 def matrix_tool_activity_bodies(
     lines: Sequence[str] | Iterable[str],
     footer: str | None = None,
@@ -33,9 +36,17 @@ def matrix_tool_activity_bodies(
             s = s[:157] + "..."
         cleaned.append(s)
     footer_text = str(footer or "").strip() or None
+    total = len(cleaned)
+    truncated = total > MAX_ACTIVITY_LINES
+    if truncated:
+        cleaned = cleaned[-MAX_ACTIVITY_LINES:]
     n = len(cleaned)
     title = (
-        f"🛠 Tool activity ({n} update{'s' if n != 1 else ''})"
+        (
+            f"🛠 Tool activity ({total} updates, latest {MAX_ACTIVITY_LINES} shown)"
+            if truncated
+            else f"🛠 Tool activity ({n} update{'s' if n != 1 else ''})"
+        )
         if cleaned
         else "🛠 Tool activity"
     )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -67,8 +67,8 @@ from agent.interrupt_compat import request_hard_interrupt
 from agent.turn_context import (
     compression_made_progress,
 )
+from gateway.matrix_activity_pane import MatrixActivityPane
 from hermes_cli.config import _is_ssh_remote_tilde_cwd, cfg_get
-from gateway.matrix_tool_activity import matrix_tool_activity_bodies
 from hermes_cli.fallback_config import get_fallback_chain
 
 # --- Agent cache tuning ---------------------------------------------------
@@ -1076,13 +1076,25 @@ def render_notice_line(notice) -> str:
     return str(getattr(notice, "text", "") or "").strip()
 
 
-async def _send_or_update_status_coro(adapter, chat_id, status_key, content, metadata):
+async def _send_or_update_status_coro(
+    adapter,
+    chat_id,
+    status_key,
+    content,
+    metadata,
+    matrix_activity_pane=None,
+):
     """Route a status message through adapter.send_or_update_status when supported.
 
     Issue #30045: adapters that implement send_or_update_status (currently
     Telegram) edit the previous bubble for the same status_key instead of
     appending a new one. Adapters without the method fall back to plain send.
     """
+    if (
+        matrix_activity_pane is not None
+        and matrix_activity_pane.coalescing_enabled
+    ):
+        return await matrix_activity_pane.append_activity(content)
     sender = getattr(adapter, "send_or_update_status", None)
     if callable(sender):
         return await sender(chat_id, status_key, content, metadata=metadata)
@@ -5363,6 +5375,13 @@ class TurnRunner:
             await self._send_native_task_card_progress(adapter)
             return
 
+        if (
+            ctx.matrix_activity_pane is not None
+            and ctx.matrix_activity_pane.coalescing_enabled
+        ):
+            await self._send_matrix_activity_progress()
+            return
+
         # Skip tool progress for platforms that don't support message
         # editing (e.g. iMessage/BlueBubbles) — each progress update
         # would become a separate message bubble, which is noisy.
@@ -5744,6 +5763,67 @@ class TurnRunner:
                 logger.error("Progress message error: %s", e)
                 await asyncio.sleep(1)
 
+    async def _send_matrix_activity_progress(self) -> None:
+        """Drain Matrix tool labels through the turn's shared activity pane."""
+
+        ctx = self._ctx
+        pane = ctx.matrix_activity_pane
+        if pane is None:
+            return
+
+        def _agent_interrupted() -> bool:
+            try:
+                agent = ctx.agent_holder[0] if ctx.agent_holder else None
+                return bool(
+                    agent is not None
+                    and getattr(agent, "is_interrupted", False)
+                )
+            except Exception:
+                return False
+
+        async def _publish(raw: Any) -> None:
+            if isinstance(raw, tuple) and raw and raw[0] == "__reset__":
+                # Matrix has one root for the whole turn, including across
+                # streamed content segment boundaries.
+                return
+            if (
+                isinstance(raw, tuple)
+                and len(raw) == 3
+                and raw[0] == "__dedup__"
+            ):
+                _, base_msg, count = raw
+                await pane.replace_activity(
+                    str(base_msg),
+                    f"{base_msg} (×{count + 1})",
+                )
+                return
+            await pane.append_activity(str(raw))
+
+        try:
+            while True:
+                if not ctx._run_still_current():
+                    return
+                try:
+                    raw = ctx.progress_queue.get_nowait()
+                except queue.Empty:
+                    await asyncio.sleep(0.1)
+                    continue
+                if not _agent_interrupted():
+                    await _publish(raw)
+        except asyncio.CancelledError:
+            while True:
+                try:
+                    raw = ctx.progress_queue.get_nowait()
+                except queue.Empty:
+                    break
+                except Exception:
+                    break
+                if not _agent_interrupted():
+                    await _publish(raw)
+            return
+        except Exception:
+            logger.debug("Matrix activity progress failed", exc_info=True)
+
     def voice_ack_callback(self, call_id, tool_name, args):
         """tool_start_callback: speak a one-time ack in the voice channel."""
         ctx = self._ctx
@@ -5938,15 +6018,34 @@ class TurnRunner:
                 _redact_gateway_user_facing_secrets(str(message or ""))[:160],
             )
             return
+        # Matrix coalesced pane: enqueue on the same progress queue as tool
+        # labels so list order matches production order, not loop scheduling.
+        if (
+            ctx.matrix_activity_pane is not None
+            and ctx.matrix_activity_pane.coalescing_enabled
+            and ctx.progress_queue is not None
+        ):
+            ctx.progress_queue.put(prepared_message)
+            return
         _fut = safe_schedule_threadsafe(
-            _send_or_update_status_coro(ctx._status_adapter, ctx._status_chat_id, event_type, prepared_message, ctx._status_thread_metadata),
+            _send_or_update_status_coro(
+                ctx._status_adapter,
+                ctx._status_chat_id,
+                event_type,
+                prepared_message,
+                ctx._status_thread_metadata,
+                ctx.matrix_activity_pane,
+            ),
             ctx._loop_for_step,
             logger=logger,
             log_message=f"status_callback ({event_type}) scheduling error",
         )
         if _fut is None:
             return
-        if ctx._cleanup_progress:
+        if ctx._cleanup_progress and not (
+            ctx.matrix_activity_pane is not None
+            and ctx.matrix_activity_pane.coalescing_enabled
+        ):
             def _track_status_id(fut) -> None:
                 try:
                     res = fut.result()
@@ -31709,6 +31808,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # exactly where the original closure's captured locals were bound.
         turn_ctx._progress_metadata = _progress_metadata
         turn_ctx._progress_reply_to = _progress_reply_to
+        _matrix_activity_adapter = self._adapter_for_source(source)
+        _matrix_activity_coalescing = bool(
+            tool_progress_enabled
+            and _matrix_activity_adapter is not None
+            and (
+                str(getattr(_matrix_activity_adapter, "name", "") or "").lower()
+                == "matrix"
+                or str(getattr(source.platform, "value", source.platform) or "").lower()
+                == "matrix"
+            )
+        )
+        if _matrix_activity_coalescing:
+            turn_ctx.matrix_activity_pane = MatrixActivityPane(
+                adapter=_matrix_activity_adapter,
+                chat_id=source.chat_id,
+                reply_to=_progress_reply_to,
+                metadata=_progress_metadata,
+                coalescing_enabled=True,
+            )
         send_progress_messages = turn_runner.send_progress_messages
         
         # We need to share the agent instance for interrupt support
@@ -32034,6 +32152,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 try:
                     _notify_res = None
+                    if (
+                        turn_ctx.matrix_activity_pane is not None
+                        and turn_ctx.matrix_activity_pane.coalescing_enabled
+                    ):
+                        await turn_ctx.matrix_activity_pane.set_footer(
+                            _heartbeat_text
+                        )
+                        continue
                     if _heartbeat_msg_id:
                         try:
                             _notify_res = await _notify_adapter.edit_message(
@@ -32625,6 +32751,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         )
                     elif first_response:
                         try:
+                            # This branch delivers the completed turn before
+                            # the outer finally block. Drain and seal Matrix's
+                            # pane first so a late heartbeat cannot edit it
+                            # after the separately-sent final answer.
+                            if turn_ctx.matrix_activity_pane is not None:
+                                await turn_ctx.matrix_activity_pane.close()
+                                if progress_task:
+                                    progress_task.cancel()
+                                    try:
+                                        await progress_task
+                                    except asyncio.CancelledError:
+                                        pass
+                                    progress_task = None
                             if _already_streamed:
                                 logger.info(
                                     "Queued follow-up for session %s: final text delivery confirmed; delivering explicit media before continuing.",
@@ -32854,6 +32993,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             "background turn task failed during cleanup",
                             exc_info=True,
                         )
+
+            if turn_ctx.matrix_activity_pane is not None:
+                await turn_ctx.matrix_activity_pane.close()
+                if (
+                    _cleanup_progress
+                    and turn_ctx.matrix_activity_pane.root_event_id
+                    and turn_ctx.matrix_activity_pane.root_event_id
+                    not in _cleanup_msg_ids
+                ):
+                    _cleanup_msg_ids.append(
+                        turn_ctx.matrix_activity_pane.root_event_id
+                    )
 
         # If streaming already delivered the response, mark it so the
         # caller's send() is skipped (avoiding duplicate messages).

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -68,6 +68,7 @@ from agent.turn_context import (
     compression_made_progress,
 )
 from hermes_cli.config import _is_ssh_remote_tilde_cwd, cfg_get
+from gateway.matrix_tool_activity import matrix_tool_activity_bodies
 from hermes_cli.fallback_config import get_fallback_chain
 
 # --- Agent cache tuning ---------------------------------------------------
@@ -5426,7 +5427,25 @@ class TurnRunner:
             except (TypeError, ValueError):
                 _edit_accepts_metadata = False
 
-        async def _edit_progress_message(message_id: str, content: str):
+        _is_matrix_progress = (
+            str(getattr(adapter, "name", "") or "").lower() == "matrix"
+            or str(getattr(ctx.source, "platform", "") or "").lower() == "matrix"
+            or str(getattr(getattr(ctx.source, "platform", None), "value", "") or "").lower() == "matrix"
+        )
+
+        def _matrix_tool_activity_bodies(lines: list) -> tuple[str, str]:
+            return matrix_tool_activity_bodies(lines)
+
+        def _progress_metadata_with_matrix_html(lines: list):
+            meta = dict(ctx._progress_metadata or {})
+            if _is_matrix_progress and lines:
+                body, html = _matrix_tool_activity_bodies(lines)
+                meta["matrix_formatted_body"] = html
+                meta["matrix_formatted_body_unprefixed"] = True
+                return meta, body
+            return meta, None
+
+        async def _edit_progress_message(message_id: str, content: str, lines: list | None = None):
             kwargs = {
                 "chat_id": ctx.source.chat_id,
                 "message_id": message_id,
@@ -5434,11 +5453,19 @@ class TurnRunner:
             }
             if getattr(adapter, "REQUIRES_EDIT_FINALIZE", False):
                 kwargs["finalize"] = True
-            if _edit_accepts_metadata:
+            if _is_matrix_progress and lines is not None:
+                meta, body = _progress_metadata_with_matrix_html(lines)
+                if body is not None:
+                    kwargs["content"] = body
+                kwargs["metadata"] = meta
+            elif _edit_accepts_metadata and ctx._progress_metadata:
                 kwargs["metadata"] = ctx._progress_metadata
             return await adapter.edit_message(**kwargs)
 
         def _progress_text(lines: list) -> str:
+            if _is_matrix_progress:
+                body, _html = _matrix_tool_activity_bodies(lines)
+                return body
             return "\n".join(str(line) for line in lines)
 
         def _split_progress_groups(lines: list) -> list[list]:
@@ -5464,12 +5491,18 @@ class TurnRunner:
             ):
                 ctx._cleanup_msg_ids.append(str(result.message_id))
 
-        async def _send_progress_text(text: str):
+        async def _send_progress_text(text: str, lines: list | None = None):
+            meta = ctx._progress_metadata
+            content = text
+            if _is_matrix_progress and lines is not None:
+                meta, body = _progress_metadata_with_matrix_html(lines)
+                if body is not None:
+                    content = body
             result = await adapter.send(
                 chat_id=ctx.source.chat_id,
-                content=text,
+                content=content,
                 reply_to=ctx._progress_reply_to,
-                metadata=ctx._progress_metadata,
+                metadata=meta,
             )
             _track_progress_result(result)
             return result
@@ -5483,6 +5516,9 @@ class TurnRunner:
                 the normal send/edit path for this tick.
                 """
             nonlocal progress_msg_id, progress_lines, can_edit
+            # Matrix keeps one sticky Tool activity pane.
+            if _is_matrix_progress:
+                return False
             if not progress_lines or not can_edit:
                 return False
             groups = _split_progress_groups(progress_lines)
@@ -5491,7 +5527,7 @@ class TurnRunner:
 
             first_text = _progress_text(groups[0])
             if progress_msg_id is not None:
-                result = await _edit_progress_message(progress_msg_id, first_text)
+                result = await _edit_progress_message(progress_msg_id, first_text, progress_lines)
                 if not result.success:
                     if getattr(result, "retryable", False):
                         logger.debug(
@@ -5503,12 +5539,12 @@ class TurnRunner:
                     # Fall back to the existing non-edit behavior below.
                     return False
             else:
-                result = await _send_progress_text(first_text)
+                result = await _send_progress_text(first_text, progress_lines)
                 if result.success and result.message_id:
                     progress_msg_id = result.message_id
 
             for group in groups[1:]:
-                result = await _send_progress_text(_progress_text(group))
+                result = await _send_progress_text(_progress_text(group), group)
                 if result.success and result.message_id:
                     progress_msg_id = result.message_id
 
@@ -5596,7 +5632,7 @@ class TurnRunner:
                 if can_edit and progress_msg_id is not None:
                     # Try to edit the existing progress message
                     full_text = "\n".join(progress_lines)
-                    result = await _edit_progress_message(progress_msg_id, full_text)
+                    result = await _edit_progress_message(progress_msg_id, full_text, progress_lines)
                     if not result.success:
                         _err = (getattr(result, "error", "") or "").lower()
                         # Transient network errors (ConnectError, timeouts)
@@ -5682,7 +5718,7 @@ class TurnRunner:
                             if can_edit and progress_lines and progress_msg_id:
                                 _pending_text = _progress_text(progress_lines)
                                 try:
-                                    await _edit_progress_message(progress_msg_id, _pending_text)
+                                    await _edit_progress_message(progress_msg_id, _pending_text, progress_lines)
                                 except Exception:
                                     pass
                             progress_msg_id = None
@@ -5700,7 +5736,7 @@ class TurnRunner:
                 if can_edit and progress_lines and progress_msg_id:
                     full_text = _progress_text(progress_lines)
                     try:
-                        await _edit_progress_message(progress_msg_id, full_text)
+                        await _edit_progress_message(progress_msg_id, full_text, progress_lines)
                     except Exception:
                         pass
                 return

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -42,6 +42,7 @@ class TurnContext:
     progress_mode: str = "off"
     progress_grouping: str = "grouped"
     tool_progress_enabled: bool = False
+    matrix_activity_pane: Any = None
 
     # --- queues ----------------------------------------------------------
     progress_queue: Any = None

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2228,6 +2228,8 @@ class MatrixAdapter(BasePlatformAdapter):
         last_event_id = None
         for i, chunk in enumerate(chunks):
             msg_content = self._build_text_message_content(chunk)
+            if metadata and metadata.get("_interim_send"):
+                msg_content["msgtype"] = "m.notice"
 
             # Prefer explicit Matrix HTML payload (always-visible Tool activity list).
             if i == 0 and metadata and metadata.get("matrix_formatted_body"):
@@ -2377,6 +2379,8 @@ class MatrixAdapter(BasePlatformAdapter):
 
         formatted = self.format_message(content)
         new_content = self._build_text_message_content(formatted)
+        msgtype = "m.notice" if metadata and metadata.get("_interim_send") else "m.text"
+        new_content["msgtype"] = msgtype
         # Prefer explicit Matrix HTML payload (always-visible Tool activity list).
         if metadata and metadata.get("matrix_formatted_body"):
             html = _sanitize_matrix_html(str(metadata.get("matrix_formatted_body") or ""))
@@ -2384,7 +2388,7 @@ class MatrixAdapter(BasePlatformAdapter):
                 new_content["format"] = "org.matrix.custom.html"
                 new_content["formatted_body"] = html
         msg_content: Dict[str, Any] = {
-            "msgtype": "m.text",
+            "msgtype": msgtype,
             "body": f"* {formatted}",
             "m.new_content": new_content,
         }

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2229,6 +2229,13 @@ class MatrixAdapter(BasePlatformAdapter):
         for i, chunk in enumerate(chunks):
             msg_content = self._build_text_message_content(chunk)
 
+            # Prefer explicit Matrix HTML payload (always-visible Tool activity list).
+            if i == 0 and metadata and metadata.get("matrix_formatted_body"):
+                html = _sanitize_matrix_html(str(metadata.get("matrix_formatted_body") or ""))
+                if html:
+                    msg_content["format"] = "org.matrix.custom.html"
+                    msg_content["formatted_body"] = html
+
             self._apply_relation_metadata(msg_content, reply_to=reply_to, metadata=metadata)
 
             try:
@@ -2353,12 +2360,29 @@ class MatrixAdapter(BasePlatformAdapter):
 
 
     async def edit_message(
-        self, chat_id: str, message_id: str, content: str, *, finalize: bool = False
+        self,
+        chat_id: str,
+        message_id: str,
+        content: str,
+        *,
+        finalize: bool = False,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        """Edit an existing message (via m.replace)."""
+        """Edit an existing message (via m.replace).
+
+        Returns the *original* target event id on success so gateway progress
+        keeps editing the same root pane. The replacement event id is available
+        under ``raw_response["replacement_event_id"]`` when needed.
+        """
 
         formatted = self.format_message(content)
         new_content = self._build_text_message_content(formatted)
+        # Prefer explicit Matrix HTML payload (always-visible Tool activity list).
+        if metadata and metadata.get("matrix_formatted_body"):
+            html = _sanitize_matrix_html(str(metadata.get("matrix_formatted_body") or ""))
+            if html:
+                new_content["format"] = "org.matrix.custom.html"
+                new_content["formatted_body"] = html
         msg_content: Dict[str, Any] = {
             "msgtype": "m.text",
             "body": f"* {formatted}",
@@ -2368,7 +2392,15 @@ class MatrixAdapter(BasePlatformAdapter):
             msg_content["m.mentions"] = new_content["m.mentions"]
         if "formatted_body" in new_content:
             msg_content["format"] = "org.matrix.custom.html"
-            msg_content["formatted_body"] = f'* {new_content["formatted_body"]}'
+            # Matrix replacement fallbacks MUST retain the outer ``* `` marker.
+            # Tool activity is the sole intentional exception because its stable
+            # pane HTML is already the complete client-facing replacement body.
+            # Keep that exception explicit so unrelated rich edits cannot inherit
+            # it merely by sharing the matrix_formatted_body metadata key.
+            if metadata and metadata.get("matrix_formatted_body_unprefixed"):
+                msg_content["formatted_body"] = new_content["formatted_body"]
+            else:
+                msg_content["formatted_body"] = f'* {new_content["formatted_body"]}'
         msg_content["m.relates_to"] = {
             "rel_type": "m.replace",
             "event_id": message_id,
@@ -2380,7 +2412,12 @@ class MatrixAdapter(BasePlatformAdapter):
                 EventType.ROOM_MESSAGE,
                 msg_content,
             )
-            return SendResult(success=True, message_id=str(event_id))
+            # Keep message_id as the original root so progress panes stay sticky.
+            return SendResult(
+                success=True,
+                message_id=str(message_id),
+                raw_response={"replacement_event_id": str(event_id)},
+            )
         except Exception as exc:
             return SendResult(success=False, error=str(exc))
 

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -320,6 +320,72 @@ def _make_adapter():
     return adapter
 
 
+class TestMatrixInterimNotificationPolicy:
+    @pytest.mark.asyncio
+    async def test_interim_send_uses_notice_but_final_stays_text(self):
+        """Tool/interim delivery is visible without changing final push semantics."""
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        adapter = object.__new__(MatrixAdapter)
+        adapter._encryption = False
+        adapter.format_message = lambda content: content
+        adapter.truncate_message = lambda content, _: [content]
+        adapter._build_text_message_content = (
+            lambda content: {"msgtype": "m.text", "body": content}
+        )
+        adapter._apply_relation_metadata = lambda *args, **kwargs: None
+        sent = []
+
+        async def send_message_event(_room, _event_type, content):
+            sent.append(content)
+            return f"${len(sent)}"
+
+        adapter._client = MagicMock()
+        adapter._client.send_message_event = send_message_event
+
+        await MatrixAdapter.send(
+            adapter,
+            "!room:example.org",
+            "Working…",
+            metadata={"_interim_send": True},
+        )
+        await MatrixAdapter.send(adapter, "!room:example.org", "Complete.")
+
+        assert sent[0]["msgtype"] == "m.notice"
+        assert sent[1]["msgtype"] == "m.text"
+
+    @pytest.mark.asyncio
+    async def test_interim_edit_keeps_replacement_event_silent(self):
+        """Updating the activity pane must not reintroduce a push event."""
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        adapter = object.__new__(MatrixAdapter)
+        adapter.format_message = lambda content: content
+        adapter._build_text_message_content = (
+            lambda content: {"msgtype": "m.text", "body": content}
+        )
+        sent = []
+
+        async def send_message_event(_room, _event_type, content):
+            sent.append(content)
+            return "$replacement"
+
+        adapter._client = MagicMock()
+        adapter._client.send_message_event = send_message_event
+
+        result = await MatrixAdapter.edit_message(
+            adapter,
+            "!room:example.org",
+            "$activity",
+            "Working…",
+            metadata={"_interim_send": True},
+        )
+
+        assert result.success
+        assert sent[0]["msgtype"] == "m.notice"
+        assert sent[0]["m.new_content"]["msgtype"] == "m.notice"
+
+
 # ---------------------------------------------------------------------------
 # Typing indicator
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_matrix_tool_activity_pane.py
+++ b/tests/gateway/test_matrix_tool_activity_pane.py
@@ -1,0 +1,174 @@
+"""Matrix Tool activity pane — first-principles contract tests."""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.matrix_tool_activity import matrix_tool_activity_bodies
+from gateway.platforms.base import SendResult
+from plugins.platforms.matrix.adapter import MatrixAdapter, _sanitize_matrix_html
+
+
+def test_matrix_body_is_counter_only():
+    body, html = matrix_tool_activity_bodies(
+        [
+            "🔍 Searching past sessions",
+            "💻 terminal: ls -la /tmp",
+            "```",
+            "💻 terminal\n```\nset -euo pipefail\n```",
+        ]
+    )
+    assert body == "🛠 Tool activity (3 updates)"
+    assert "```" not in body
+    assert "terminal" not in body  # plain body has no tool labels
+    assert body.count("\n") == 0
+
+
+def test_matrix_html_is_single_ol_no_fences_or_details():
+    body, html = matrix_tool_activity_bodies(
+        [
+            "🔍 Searching past sessions",
+            "```",
+            "💻 terminal: rg -n progress gateway/run.py",
+            "⚙️ hindsight_recall: resume website",
+        ]
+    )
+    assert body == "🛠 Tool activity (3 updates)"
+    assert html.count("<ol>") == 1
+    assert html.count("<li>") == 3
+    assert "<details>" not in html
+    assert "data-mx-spoiler" not in html
+    assert "<pre>" not in html
+    assert "```" not in html
+    assert "Searching past sessions" in html
+    assert html.count("Searching past sessions") == 1
+
+
+def test_plain_fallback_hides_arguments_and_rich_lines_are_bounded():
+    private_path = "/home/alice/private/customer-records.csv"
+    body, html = matrix_tool_activity_bodies(
+        [f"📖 read_file: {private_path} " + ("x" * 240) + "\nignored second line"]
+    )
+
+    assert body == "🛠 Tool activity (1 update)"
+    assert private_path not in body
+    assert private_path in html
+    assert "ignored second line" not in html
+    assert ("x" * 160) not in html
+    assert "..." in html
+
+
+def test_sanitize_keeps_ol_li_and_strips_details():
+    html = (
+        "<p><strong>🛠 Tool activity (1 update)</strong></p>"
+        "<ol><li>💻 terminal: ls</li></ol>"
+        "<details><summary>x</summary>secret</details>"
+    )
+    out = _sanitize_matrix_html(html)
+    assert "<ol>" in out and "<li>" in out
+    assert "terminal: ls" in out
+    assert "<details>" not in out
+    assert "<summary>" not in out
+
+
+@pytest.mark.asyncio
+async def test_matrix_send_and_edit_carry_html():
+    adapter = object.__new__(MatrixAdapter)
+    adapter._client = MagicMock()
+    adapter._encryption = False
+    adapter.format_message = lambda c: c
+    adapter.truncate_message = lambda c, n: [c]
+    adapter._build_text_message_content = lambda c: {"msgtype": "m.text", "body": c}
+    adapter._apply_relation_metadata = lambda *a, **k: None
+
+    sent = {}
+
+    async def _send_evt(room, etype, content):
+        sent.setdefault("events", []).append(content)
+        return f"$e{len(sent['events'])}"
+
+    adapter._client.send_message_event = _send_evt
+    body, html = matrix_tool_activity_bodies(["💻 terminal: ls", "📖 read_file: x"])
+
+    res = await MatrixAdapter.send(
+        adapter,
+        "!room:ex",
+        body,
+        metadata={
+            "matrix_formatted_body": html,
+            "matrix_formatted_body_unprefixed": True,
+        },
+    )
+    assert res.success
+    assert sent["events"][0]["format"] == "org.matrix.custom.html"
+    assert "<ol>" in sent["events"][0]["formatted_body"]
+
+    root_id = str(res.message_id or "")
+    res2 = await MatrixAdapter.edit_message(
+        adapter,
+        "!room:ex",
+        root_id,
+        body,
+        metadata={
+            "matrix_formatted_body": html,
+            "matrix_formatted_body_unprefixed": True,
+        },
+    )
+    assert res2.success
+    assert res2.message_id == root_id  # sticky root
+    edit = sent["events"][1]
+    assert edit["m.relates_to"]["rel_type"] == "m.replace"
+    assert edit["m.new_content"]["formatted_body"].startswith("<p>")
+    assert not edit["formatted_body"].startswith("*")
+    assert "```" not in edit["m.new_content"]["formatted_body"]
+    assert "<details>" not in edit["m.new_content"]["formatted_body"]
+
+
+@pytest.mark.asyncio
+async def test_unflagged_rich_edit_keeps_matrix_replacement_prefix():
+    adapter = object.__new__(MatrixAdapter)
+    sent = {}
+
+    async def _send_evt(room, etype, content):
+        sent["content"] = content
+        return "$replacement"
+
+    adapter._client = MagicMock(send_message_event=_send_evt)
+    adapter.format_message = lambda c: c
+    adapter._build_text_message_content = lambda c: {"msgtype": "m.text", "body": c}
+
+    result = await MatrixAdapter.edit_message(
+        adapter,
+        "!room:ex",
+        "$root",
+        "Updated content",
+        metadata={"matrix_formatted_body": "<p>Updated content</p>"},
+    )
+
+    assert result.success
+    assert sent["content"]["formatted_body"].startswith("* ")
+    assert not sent["content"]["m.new_content"]["formatted_body"].startswith("* ")
+
+
+def test_edit_message_accepts_metadata():
+    assert "metadata" in inspect.signature(MatrixAdapter.edit_message).parameters
+
+
+def test_matrix_one_line_label_contract_for_terminal():
+    """What progress_callback should enqueue for terminal on Matrix."""
+    cmd = "set -euo pipefail\nscp foo bar\n"
+    first = cmd.strip().splitlines()[0]
+    label = f"💻 terminal: {first[:80]}"
+    assert "```" not in label
+    assert "\n" not in label
+    assert label.startswith("💻 terminal:")
+
+
+def test_production_helper_is_single_source_for_run_py():
+    """gateway/run.py must import the production helper, not a forked copy."""
+    import gateway.run as run_mod
+    src = inspect.getsource(run_mod)
+    assert "from gateway.matrix_tool_activity import matrix_tool_activity_bodies" in src

--- a/tests/gateway/test_matrix_tool_activity_pane.py
+++ b/tests/gateway/test_matrix_tool_activity_pane.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 from unittest.mock import MagicMock
 
 import pytest
 
+from gateway.matrix_activity_pane import MatrixActivityPane
 from gateway.matrix_tool_activity import matrix_tool_activity_bodies
+from gateway.run import _send_or_update_status_coro
 from gateway.platforms.base import SendResult
 from plugins.platforms.matrix.adapter import MatrixAdapter, _sanitize_matrix_html
 
@@ -59,6 +62,36 @@ def test_plain_fallback_hides_arguments_and_rich_lines_are_bounded():
     assert "ignored second line" not in html
     assert ("x" * 160) not in html
     assert "..." in html
+
+
+def test_matrix_tools_and_footer_render_in_locked_order():
+    body, html = matrix_tool_activity_bodies(
+        ["🔍 Recall & inspect", "💻 terminal: a < b"],
+        "⏳ Working — 2 min & waiting <now>",
+    )
+
+    assert body == (
+        "🛠 Tool activity (2 updates) · "
+        "⏳ Working — 2 min & waiting <now>"
+    )
+    assert html == (
+        "<p><strong>🛠 Tool activity (2 updates)</strong></p>"
+        "<ol><li>🔍 Recall &amp; inspect</li>"
+        "<li>💻 terminal: a &lt; b</li></ol>"
+        "<p>⏳ Working — 2 min &amp; waiting &lt;now&gt;</p>"
+    )
+
+
+def test_matrix_footer_only_has_no_empty_list_or_zero_count():
+    body, html = matrix_tool_activity_bodies([], "⏳ Working — 1 min")
+
+    assert body == "🛠 Tool activity · ⏳ Working — 1 min"
+    assert html == (
+        "<p><strong>🛠 Tool activity</strong></p>"
+        "<p>⏳ Working — 1 min</p>"
+    )
+    assert "<ol>" not in html
+    assert "0 updates" not in html
 
 
 def test_sanitize_keeps_ol_li_and_strips_details():
@@ -167,8 +200,282 @@ def test_matrix_one_line_label_contract_for_terminal():
     assert label.startswith("💻 terminal:")
 
 
-def test_production_helper_is_single_source_for_run_py():
-    """gateway/run.py must import the production helper, not a forked copy."""
-    import gateway.run as run_mod
-    src = inspect.getsource(run_mod)
+def test_production_helper_is_single_source_for_pane():
+    """The coordinator must import the production helper, not fork rendering."""
+    import gateway.matrix_activity_pane as pane_mod
+
+    src = inspect.getsource(pane_mod)
     assert "from gateway.matrix_tool_activity import matrix_tool_activity_bodies" in src
+
+
+class _PaneAdapter:
+    name = "matrix"
+
+    def __init__(self):
+        self.sends = []
+        self.edits = []
+        self.send_results = []
+        self.edit_results = []
+        self.send_entered = None
+        self.send_release = None
+        self.edit_entered = None
+        self.edit_release = None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.sends.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": dict(metadata or {}),
+            }
+        )
+        if self.send_entered is not None:
+            self.send_entered.set()
+        if self.send_release is not None:
+            await self.send_release.wait()
+        if self.send_results:
+            return self.send_results.pop(0)
+        return SendResult(success=True, message_id="$root")
+
+    async def edit_message(
+        self, chat_id, message_id, content, *, finalize=False, metadata=None
+    ):
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+                "metadata": dict(metadata or {}),
+            }
+        )
+        if self.edit_entered is not None:
+            self.edit_entered.set()
+        if self.edit_release is not None:
+            await self.edit_release.wait()
+        if self.edit_results:
+            return self.edit_results.pop(0)
+        return SendResult(success=True, message_id=message_id)
+
+
+def _pane(adapter=None, *, enabled=True):
+    return MatrixActivityPane(
+        adapter=adapter or _PaneAdapter(),
+        chat_id="!room:example",
+        reply_to="$user",
+        metadata={"thread": "kept"},
+        coalescing_enabled=enabled,
+    )
+
+
+@pytest.mark.asyncio
+async def test_pane_tools_only_then_heartbeat_edits_original_root():
+    adapter = _PaneAdapter()
+    pane = _pane(adapter)
+
+    await pane.append_activity("💻 terminal: ls")
+    await pane.set_footer("⏳ Working — 1 min")
+
+    assert len(adapter.sends) == 1
+    assert len(adapter.edits) == 1
+    assert adapter.sends[0]["content"] == "🛠 Tool activity (1 update)"
+    assert adapter.sends[0]["metadata"]["_interim_send"] is True
+    assert adapter.edits[0]["message_id"] == "$root"
+    assert adapter.edits[0]["content"] == (
+        "🛠 Tool activity (1 update) · ⏳ Working — 1 min"
+    )
+
+
+@pytest.mark.asyncio
+async def test_pane_second_heartbeat_replaces_footer_then_tool_stays_above_it():
+    adapter = _PaneAdapter()
+    pane = _pane(adapter)
+
+    await pane.set_footer("⏳ Working — 1 min")
+    await pane.set_footer("⏳ Working — 2 min")
+    await pane.append_activity("📖 read_file: x")
+
+    assert len(adapter.sends) == 1
+    assert len(adapter.edits) == 2
+    final = adapter.edits[-1]
+    assert final["content"] == (
+        "🛠 Tool activity (1 update) · ⏳ Working — 2 min"
+    )
+    assert "1 min" not in final["metadata"]["matrix_formatted_body"]
+    assert final["metadata"]["matrix_formatted_body"].index("<ol>") < (
+        final["metadata"]["matrix_formatted_body"].index("⏳ Working")
+    )
+
+
+@pytest.mark.asyncio
+async def test_pane_status_then_tool_preserves_activity_order():
+    adapter = _PaneAdapter()
+    pane = _pane(adapter)
+
+    await pane.append_activity("🔍 Searching past sessions")
+    await pane.append_activity("💻 terminal: rg Matrix")
+
+    html = adapter.edits[-1]["metadata"]["matrix_formatted_body"]
+    assert html.index("Searching past sessions") < html.index("terminal: rg Matrix")
+
+
+@pytest.mark.asyncio
+async def test_concurrent_first_tool_and_heartbeat_send_exactly_one_root():
+    adapter = _PaneAdapter()
+    adapter.send_entered = asyncio.Event()
+    adapter.send_release = asyncio.Event()
+    pane = _pane(adapter)
+
+    tool_task = asyncio.create_task(pane.append_activity("💻 terminal: ls"))
+    await adapter.send_entered.wait()
+    heartbeat_task = asyncio.create_task(pane.set_footer("⏳ Working — 1 min"))
+    await asyncio.sleep(0)
+    adapter.send_release.set()
+    await asyncio.gather(tool_task, heartbeat_task)
+
+    assert len(adapter.sends) == 1
+    assert len(adapter.edits) == 1
+    assert adapter.edits[0]["message_id"] == "$root"
+    assert "terminal: ls" in adapter.edits[0]["metadata"]["matrix_formatted_body"]
+    assert "⏳ Working — 1 min" in adapter.edits[0]["metadata"]["matrix_formatted_body"]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_tool_and_heartbeat_edits_finish_with_both():
+    adapter = _PaneAdapter()
+    pane = _pane(adapter)
+    await pane.append_activity("🔍 recall")
+    adapter.edit_entered = asyncio.Event()
+    adapter.edit_release = asyncio.Event()
+
+    tool_task = asyncio.create_task(pane.append_activity("💻 terminal: ls"))
+    await adapter.edit_entered.wait()
+    heartbeat_task = asyncio.create_task(pane.set_footer("⏳ Working — 1 min"))
+    await asyncio.sleep(0)
+    adapter.edit_release.set()
+    await asyncio.gather(tool_task, heartbeat_task)
+
+    final_html = adapter.edits[-1]["metadata"]["matrix_formatted_body"]
+    assert "terminal: ls" in final_html
+    assert "⏳ Working — 1 min" in final_html
+
+
+@pytest.mark.asyncio
+async def test_failed_initial_send_retries_full_snapshot_on_later_update():
+    adapter = _PaneAdapter()
+    adapter.send_results = [
+        SendResult(success=False, error="offline"),
+        SendResult(success=True, message_id="$retry-root"),
+    ]
+    pane = _pane(adapter)
+
+    await pane.append_activity("🔍 recall")
+    assert pane.root_event_id is None
+    await pane.set_footer("⏳ Working — 1 min")
+
+    assert len(adapter.sends) == 2
+    assert len(adapter.edits) == 0
+    assert pane.root_event_id == "$retry-root"
+    retry_html = adapter.sends[-1]["metadata"]["matrix_formatted_body"]
+    assert "recall" in retry_html and "⏳ Working — 1 min" in retry_html
+
+
+@pytest.mark.asyncio
+async def test_edit_failure_keeps_root_and_never_sends_second_root():
+    adapter = _PaneAdapter()
+    adapter.edit_results = [
+        SendResult(success=False, error="temporary"),
+        SendResult(success=True, message_id="$root"),
+    ]
+    pane = _pane(adapter)
+
+    await pane.append_activity("🔍 recall")
+    await pane.set_footer("⏳ Working — 1 min")
+    await pane.append_activity("💻 terminal: ls")
+
+    assert len(adapter.sends) == 1
+    assert len(adapter.edits) == 2
+    assert pane.root_event_id == "$root"
+    assert "terminal: ls" in adapter.edits[-1]["metadata"]["matrix_formatted_body"]
+    assert "⏳ Working — 1 min" in adapter.edits[-1]["metadata"]["matrix_formatted_body"]
+
+
+@pytest.mark.asyncio
+async def test_transport_exception_is_fail_soft_and_snapshot_retries():
+    adapter = _PaneAdapter()
+    original_send = adapter.send
+    attempts = 0
+
+    async def _raise_once(*args, **kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("offline")
+        return await original_send(*args, **kwargs)
+
+    adapter.send = _raise_once
+    pane = _pane(adapter)
+
+    assert await pane.append_activity("🔍 recall") is None
+    await pane.append_activity("💻 terminal: ls")
+
+    assert pane.root_event_id == "$root"
+    html = adapter.sends[-1]["metadata"]["matrix_formatted_body"]
+    assert "recall" in html and "terminal: ls" in html
+
+
+@pytest.mark.asyncio
+async def test_close_blocks_later_heartbeat_edit():
+    adapter = _PaneAdapter()
+    pane = _pane(adapter)
+    await pane.append_activity("🔍 recall")
+
+    await pane.close()
+    await pane.set_footer("⏳ Working — too late")
+
+    assert pane.closed
+    assert len(adapter.sends) == 1
+    assert adapter.edits == []
+
+
+@pytest.mark.asyncio
+async def test_pane_metadata_is_unprefixed_but_standalone_status_is_not():
+    pane_adapter = _PaneAdapter()
+    pane = _pane(pane_adapter)
+    await pane.set_footer("⏳ Working — 1 min")
+
+    standalone_adapter = _PaneAdapter()
+    await _send_or_update_status_coro(
+        standalone_adapter,
+        "!room:example",
+        "recall",
+        "🔍 recall",
+        {"thread": "kept"},
+        None,
+    )
+
+    assert pane_adapter.sends[0]["metadata"][
+        "matrix_formatted_body_unprefixed"
+    ] is True
+    assert "matrix_formatted_body_unprefixed" not in (
+        standalone_adapter.sends[0]["metadata"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_disabled_pane_does_not_capture_status():
+    pane_adapter = _PaneAdapter()
+    pane = _pane(pane_adapter, enabled=False)
+    standalone_adapter = _PaneAdapter()
+
+    await _send_or_update_status_coro(
+        standalone_adapter,
+        "!room:example",
+        "recall",
+        "🔍 recall",
+        None,
+        pane,
+    )
+
+    assert pane_adapter.sends == []
+    assert len(standalone_adapter.sends) == 1

--- a/tests/gateway/test_matrix_tool_activity_pane.py
+++ b/tests/gateway/test_matrix_tool_activity_pane.py
@@ -64,6 +64,20 @@ def test_plain_fallback_hides_arguments_and_rich_lines_are_bounded():
     assert "..." in html
 
 
+def test_matrix_activity_keeps_a_bounded_recent_window():
+    max_lines = 16
+    lines = [f"tool update {index}" for index in range(max_lines + 1)]
+
+    body, html = matrix_tool_activity_bodies(lines)
+
+    assert body == (
+        f"🛠 Tool activity ({len(lines)} updates, latest {max_lines} shown)"
+    )
+    assert html.count("<li>") == max_lines
+    assert "tool update 0" not in html
+    assert f"tool update {max_lines}" in html
+
+
 def test_matrix_tools_and_footer_render_in_locked_order():
     body, html = matrix_tool_activity_bodies(
         ["🔍 Recall & inspect", "💻 terminal: a < b"],
@@ -198,14 +212,6 @@ def test_matrix_one_line_label_contract_for_terminal():
     assert "```" not in label
     assert "\n" not in label
     assert label.startswith("💻 terminal:")
-
-
-def test_production_helper_is_single_source_for_pane():
-    """The coordinator must import the production helper, not fork rendering."""
-    import gateway.matrix_activity_pane as pane_mod
-
-    src = inspect.getsource(pane_mod)
-    assert "from gateway.matrix_tool_activity import matrix_tool_activity_bodies" in src
 
 
 class _PaneAdapter:


### PR DESCRIPTION
## Summary
- Preserves contributor-authored sticky, turn-scoped Matrix tool/MCP activity pane via `m.replace`.
- Marks interim activity sends and replacement events as `m.notice`, while normal final responses remain `m.text`.
- Bounds rich activity history to the latest 16 entries to keep Matrix event payloads safe.

## Tests
- `scripts/run_tests.sh tests/gateway/test_matrix*.py tests/gateway/test_run_progress_topics.py tests/gateway/test_stream_final_contract.py` — 248 passed.
- `uv run ruff check gateway/matrix_activity_pane.py gateway/matrix_tool_activity.py gateway/run.py gateway/turn_context.py plugins/platforms/matrix/adapter.py tests/gateway/test_matrix.py tests/gateway/test_matrix_tool_activity_pane.py`

## Notes
- Rebased on current `upstream/main`.
- Regression tests were observed failing before the notice behavior and payload-cap implementations.
- Follow-up of #80467; incorporates the focused Matrix pane work from #61511 and #99040 while preserving original authorship.

Closes #80467
