### PR TITLE
fix(opencode-free): exclude relay-advertised models upstream cannot serve; surface big-pickle

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -586,14 +586,23 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     # the floor (x-preview-f-free delisted 2026-08-26 — offline fallback must
     # not offer a model that 401s). deepseek-v4-flash-free and mimo-v2.5-free
     # are back on the live list.
+    # Floor = the models the relay currently advertises AND serves keyless
+    # (verified 2026-09-02 with real chat completions; the live path applies
+    # the same curated exclusion list, so this floor only matters when the
+    # relay is unreachable). Removed from the old floor because the relay
+    # advertises but cannot serve them — see
+    # _OPENCODE_FREE_KNOWN_DEAD_MODELS:
+    # deepseek-v4-flash-free (400 "Model is unavailable"),
+    # muse-spark-1.2-contributor-free (500 Internal server error),
+    # nemotron-3-ultra-free / nemotron-3.5-lightning-free (timeouts),
+    # hy3-free (absent from the live catalog). Re-add any of them if the
+    # relay starts serving them again — remove the id from
+    # _OPENCODE_FREE_KNOWN_DEAD_MODELS and it reappears on the next refresh.
     "opencode-free": [
-        "deepseek-v4-flash-free",
-        "hy3-free",
-        "mimo-v2.5-free",
         "laguna-s-2.1-free",
-        "nemotron-3-ultra-free",
-        "nemotron-3.5-lightning-free",
-        "muse-spark-1.2-contributor-free",
+        "mimo-v2.5-free",
+        "ling-3.0-flash-fin-free",
+        "big-pickle",
     ],
     # Synced against https://opencode.ai/docs/go/ + live GET /zen/go/v1/models
     # (2026-08-20).
@@ -5889,6 +5898,24 @@ _OPENCODE_KEYLESS_EXTRA_SLUGS = frozenset({"big-pickle"})
 # catalog even though the suffix looks free. ox-alpha-free is the Go relay's
 # subscription twin of the Zen keyless Ox Alpha (verified 2026-08-21).
 _OPENCODE_FREE_KEYED_SUFFIX_MODELS = frozenset({"ox-alpha-free"})
+# Advertised by the Zen relay's /models dump but its upstream cannot serve
+# them keyless — verified 2026-09-02 with repeated real chat completions:
+# deepseek-v4-flash-free 400s "Model is unavailable" (its promo ended and the
+# relay never de-listed it), muse-spark-1.2-contributor-free 500s,
+# nemotron-3-ultra-free / nemotron-3.5-lightning-free time out. Excluded from
+# the keyless picker rather than probed (probing trips the free relay's rate
+# limiter and burns the user's own quota). If the relay genuinely re-enables
+# one of these, remove it here — the model will reappear in the picker on the
+# next catalog refresh. Re-verify before removing: a real keyless chat
+# completion must return HTTP 200.
+_OPENCODE_FREE_KNOWN_DEAD_MODELS = frozenset(
+    {
+        "deepseek-v4-flash-free",
+        "muse-spark-1.2-contributor-free",
+        "nemotron-3-ultra-free",
+        "nemotron-3.5-lightning-free",
+    }
+)
 
 # In-process memo for _fetch_opencode_free_models(): (fetched_at, ids-or-None).
 # Direct provider_model_ids("opencode-free") callers (model validation, healing)
@@ -5986,11 +6013,21 @@ def _fetch_opencode_free_models(
     ids = [m["id"] for m in items if isinstance(m, dict) and isinstance(m.get("id"), str)]
     # Filter to the anonymous-servable free tier. The Zen dump can contain
     # keyed/Go IDs; only the verified free set belongs in the keyless picker.
+    # big-pickle has no -free suffix but is a keyless free slug (see
+    # _OPENCODE_KEYLESS_EXTRA_SLUGS) and has served non-OpenCode UAs since at
+    # least 2026-09-02, so surface it alongside the suffixed tier. Models in
+    # _OPENCODE_FREE_KNOWN_DEAD_MODELS are advertised by the relay but its
+    # upstream cannot serve them — exclude rather than probe: health-probing
+    # every refresh trips the free relay's rate limiter (429s) and burns the
+    # user's own free-tier quota (observed 2026-09-02).
     live_free = [
         mid
         for mid in ids
-        if mid.lower().endswith("-free")
-        and mid.lower() not in _OPENCODE_FREE_KEYED_SUFFIX_MODELS
+        if (
+            (mid.lower().endswith("-free") and mid.lower() not in _OPENCODE_FREE_KEYED_SUFFIX_MODELS)
+            or mid.lower() in _OPENCODE_KEYLESS_EXTRA_SLUGS
+        )
+        and mid.lower() not in _OPENCODE_FREE_KNOWN_DEAD_MODELS
     ]
     result = live_free if live_free else None
     _set_opencode_free_live_memo(result)


### PR DESCRIPTION
## Summary

The OpenCode Zen relay's `/zen/v1/models` dump advertises `*-free` models that its upstream cannot actually serve keyless, and `provider_model_ids("opencode-free")` trusts that advertisement, so dead models stay in the keyless model picker:

| Model | Failure (verified 2026-09-02, repeated real chat completions) |
|---|---|
| `deepseek-v4-flash-free` | HTTP 400 "Model is unavailable" — its promo ended, the relay never de-listed it |
| `muse-spark-1.2-contributor-free` | HTTP 500 Internal server error |
| `nemotron-3-ultra-free` / `nemotron-3.5-lightning-free` | Connection timeouts |

Picking any of them yields an immediate 400/500/timeout — the exact symptom users hit when selecting "OpenCode Free".

## Changes

1. **Add `_OPENCODE_FREE_KNOWN_DEAD_MODELS`** — relay-advertised but unservable slugs, excluded in `_fetch_opencode_free_models()`. This follows the codebase's existing pruning pattern for the free tier (e.g. `x-preview-f-free` was removed from the floor when delisted; `ox-alpha-free` is excluded as keyed). A curated exclusion list is deliberately preferred over health-probing on every refresh: probing trips the free relay's rate limiter (429s) and burns the user's own free-tier quota (observed during verification).
2. **Surface `big-pickle` in the keyless picker** — it is already a verified keyless free slug (`_OPENCODE_KEYLESS_EXTRA_SLUGS`, used by model validation via `is_opencode_zen_free_model`), but the suffix-only filter never listed it because it carries no `-free` suffix. It serves keyless chat completions with non-OpenCode user agents since at least 2026-09-02.
3. **Sync the offline floor** (`_PROVIDER_MODELS["opencode-free"]`) to the same verified-working set so an unreachable relay never offers the dead models either.

## Verification

- `provider_model_ids("opencode-free", force_refresh=True)` returns exactly `["laguna-s-2.1-free", "mimo-v2.5-free", "ling-3.0-flash-fin-free", "big-pickle"]` (~1s, live relay fetch).
- Each listed model was verified with real keyless chat completions (HTTP 200).
- Each excluded model was probed multiple times across several minutes (400/500/timeout persisted).

## Notes for maintainers

- The root cause is relay-side catalog hygiene (stale promo entries). If the relay genuinely re-enables any excluded model, remove it from `_OPENCODE_FREE_KNOWN_DEAD_MODELS` — it reappears on the next catalog refresh.
- `big-pickle`'s User-Agent policy changed at some point after 2026-08-21 (the old comment claimed it 429s every non-OpenCode CLI UA; it now serves keyless `HermesAgent/*` requests fine). Keeping the extra-slug surfacing means the picker and the validation path agree on the same keyless set.
