### PR TITLE
fix(updater): stop macOS launchd restarts from idling after revival

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -17,6 +17,7 @@ import subprocess
 import sys
 import textwrap
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -304,7 +305,11 @@ def _request_gateway_self_restart(pid: int) -> bool:
     return True
 
 
-def _graceful_restart_via_sigusr1(pid: int, drain_timeout: float) -> bool:
+def _graceful_restart_via_sigusr1(
+    pid: int,
+    drain_timeout: float,
+    completion_probe: Callable[[], bool] | None = None,
+) -> bool:
     """Send SIGUSR1 to a gateway PID and wait for it to exit gracefully.
 
     SIGUSR1 is wired in gateway/run.py to ``request_restart(via_service=True)``,
@@ -326,9 +331,10 @@ def _graceful_restart_via_sigusr1(pid: int, drain_timeout: float) -> bool:
             ``resolve_restart_exit_wait_budget(...)``.
 
     Returns:
-        True if the PID was signalled and exited within the timeout.
-        False if SIGUSR1 couldn't be sent or the process didn't exit in
-        time (caller should fall back to a harder restart path).
+        True if the PID was signalled and exited within the timeout, or if an
+        optional caller-specific completion probe observed the handoff.
+        False if SIGUSR1 couldn't be sent or neither completion condition was
+        reached in time (caller should fall back to a harder restart path).
     """
     if not hasattr(signal, "SIGUSR1"):
         return False
@@ -343,17 +349,30 @@ def _graceful_restart_via_sigusr1(pid: int, drain_timeout: float) -> bool:
         return False
 
     # Drain-wait: delegate to the shared PID-exit helper (0.5s poll, bounded).
-    return _wait_for_pid_exit(pid, max(drain_timeout, 1.0))
+    if completion_probe is None:
+        return _wait_for_pid_exit(pid, max(drain_timeout, 1.0))
+    return _wait_for_pid_exit(
+        pid,
+        max(drain_timeout, 1.0),
+        completion_probe=completion_probe,
+    )
 
 
-def _wait_for_pid_exit(pid: int, timeout: float) -> bool:
+def _wait_for_pid_exit(
+    pid: int,
+    timeout: float,
+    *,
+    completion_probe: Callable[[], bool] | None = None,
+) -> bool:
     """Wait up to ``timeout`` seconds for ``pid`` to leave the process table.
 
     ``launchctl bootstrap`` of a label whose previous instance is still draining
     fails with EIO ("already loaded"), so callers that tear the gateway down
     must wait for the old process to actually exit before re-bootstrapping.
 
-    Returns True once the PID is gone (or was never alive), False on timeout.
+    Returns True once the PID is gone (or was never alive), or when an
+    optional caller-specific completion probe succeeds. Returns False on
+    timeout.
     """
     if pid <= 0:
         return True
@@ -370,6 +389,8 @@ def _wait_for_pid_exit(pid: int, timeout: float) -> bool:
     deadline = _time.monotonic() + max(timeout, 0.0)
     while True:
         if not _pid_exists(pid):
+            return True
+        if completion_probe is not None and completion_probe():
             return True
         if _time.monotonic() >= deadline:
             return False
@@ -6048,11 +6069,32 @@ def launchd_restart():
             # updater's live output most of all, where a silent stop here
             # reads as "update stuck" (#44515).
             wait_budget = _get_restart_exit_wait_budget()
+            old_launchd_pid = None
+            try:
+                _loaded, old_launchd_pid = _launchd_print_service_pid(domain, label)
+            except (OSError, subprocess.TimeoutExpired):
+                # This pre-signal probe only enables the fast path. If it is
+                # unavailable, preserve the established old-PID exit wait.
+                pass
+
+            def launchd_replacement_running() -> bool:
+                if old_launchd_pid is None:
+                    return False
+                try:
+                    _loaded, service_pid = _launchd_print_service_pid(domain, label)
+                except (OSError, subprocess.TimeoutExpired):
+                    return False
+                return bool(service_pid and service_pid != old_launchd_pid)
+
             print(
                 f"→ Stopping gateway (PID {pid}) — draining in-flight runs "
                 f"(up to {wait_budget:.0f}s)..."
             )
-            if _graceful_restart_via_sigusr1(pid, wait_budget):
+            if _graceful_restart_via_sigusr1(
+                pid,
+                wait_budget,
+                completion_probe=launchd_replacement_running,
+            ):
                 # The gateway exited with the planned-restart code. When
                 # launchd is actually supervising this label, KeepAlive
                 # revives it — do NOT kickstart (the replacement may already
@@ -6064,7 +6106,10 @@ def launchd_restart():
                 # PID appears before trusting KeepAlive — mirrors the systemd
                 # branch's replacement observation.
                 if _wait_for_launchd_service_pid(
-                    label, pid, timeout=15.0, domain=domain
+                    label,
+                    old_launchd_pid if old_launchd_pid is not None else pid,
+                    timeout=15.0,
+                    domain=domain,
                 ):
                     print("✓ Service restart requested")
                     _clear_launchd_unsupported_marker()

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1029,7 +1029,10 @@ class TestGatewaySystemServiceRouting:
         monkeypatch.setattr(
             gateway_cli,
             "_graceful_restart_via_sigusr1",
-            lambda pid, timeout: calls.append(("graceful", pid, timeout)) or True,
+            lambda pid, timeout, completion_probe=None: calls.append(
+                ("graceful", pid, timeout)
+            )
+            or True,
         )
         monkeypatch.setattr(
             gateway_cli,
@@ -1044,6 +1047,11 @@ class TestGatewaySystemServiceRouting:
             ),
         )
         monkeypatch.setattr(gateway_cli, "_clear_launchd_unsupported_marker", lambda: None)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_launchd_print_service_pid",
+            lambda domain, label: (True, 600),
+        )
         # KeepAlive revives the label on a fresh PID — replacement observed.
         monkeypatch.setattr(
             gateway_cli,
@@ -1091,7 +1099,9 @@ class TestGatewaySystemServiceRouting:
         )
         monkeypatch.setattr(gateway_cli, "_get_restart_exit_wait_budget", lambda: 27.0)
         monkeypatch.setattr(
-            gateway_cli, "_graceful_restart_via_sigusr1", lambda pid, timeout: True
+            gateway_cli,
+            "_graceful_restart_via_sigusr1",
+            lambda pid, timeout, completion_probe=None: True,
         )
         monkeypatch.setattr(
             gateway_cli,
@@ -1106,6 +1116,11 @@ class TestGatewaySystemServiceRouting:
             ),
         )
         monkeypatch.setattr(gateway_cli, "_clear_launchd_unsupported_marker", lambda: None)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_launchd_print_service_pid",
+            lambda domain, label: (True, 600),
+        )
 
         gateway_cli.launchd_restart()
 

--- a/tests/hermes_cli/test_launchd_restart_replacement.py
+++ b/tests/hermes_cli/test_launchd_restart_replacement.py
@@ -1,0 +1,63 @@
+"""Launchd restart handoff regressions."""
+
+from types import SimpleNamespace
+
+import hermes_cli.gateway as gateway_cli
+
+
+def test_launchd_restart_accepts_replacement_while_old_child_lingers(monkeypatch):
+    """A fresh launchd service PID completes the graceful handoff promptly.
+
+    launchd supervises the stderr wrapper while ``get_running_pid()`` reports
+    its gateway child. The old child can remain reportable after KeepAlive has
+    already replaced the wrapper, so waiting only for that child burns the full
+    drain budget despite a successful restart.
+    """
+    now = [0.0]
+    service_pids = [700, 700, 701]
+    calls = []
+
+    monkeypatch.setattr(gateway_cli.signal, "SIGUSR1", 10, raising=False)
+    monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+    monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda *a, **k: 654)
+    monkeypatch.setattr("gateway.status._pid_exists", lambda _pid: True)
+    monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
+    monkeypatch.setattr(
+        gateway_cli,
+        "probe_gateway_loop_liveness",
+        lambda pid, **kw: gateway_cli.GATEWAY_LOOP_ALIVE,
+    )
+    monkeypatch.setattr(gateway_cli, "_get_restart_exit_wait_budget", lambda: 27.0)
+    monkeypatch.setattr(
+        gateway_cli,
+        "_launchd_print_service_pid",
+        lambda domain, label: (
+            True,
+            service_pids.pop(0) if len(service_pids) > 1 else service_pids[0],
+        ),
+    )
+    monkeypatch.setattr(gateway_cli.time, "monotonic", lambda: now[0])
+    monkeypatch.setattr(
+        gateway_cli.time,
+        "sleep",
+        lambda seconds: now.__setitem__(0, now[0] + seconds),
+    )
+    monkeypatch.setattr(
+        gateway_cli.os,
+        "kill",
+        lambda pid, sig: calls.append(("signal", pid, sig)),
+    )
+    monkeypatch.setattr(
+        gateway_cli.subprocess,
+        "run",
+        lambda *a, **k: calls.append(("kickstart", a[0]))
+        or SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+    monkeypatch.setattr(gateway_cli, "_clear_launchd_unsupported_marker", lambda: None)
+
+    gateway_cli.launchd_restart()
+
+    assert ("signal", 654, 10) in calls
+    assert not any(call[0] == "kickstart" for call in calls)
+    assert now[0] < 27.0


### PR DESCRIPTION
## What does this PR do?

Stops `hermes update` from idling for the entire gateway drain budget after launchd has already revived the gateway. The restart wait now recognizes a changed launchd service PID as a completed handoff while retaining the existing bounded force-restart fallback.

### Symptom

On a launchd-supervised macOS fleet, the old gateway exits and a replacement starts, but the updater can remain blocked in the graceful drain poll for 8-20 minutes.

### Impact

Affected macOS updates appear hung and delay completion for every supervised gateway fleet restart even though the new gateway is already running.

### Bug Cause

**Trigger:** `hermes_cli/gateway.py:6072` / `launchd_restart()` waiting after SIGUSR1.

**Causal chain:**
1. The updater signals the gateway child PID and waits for that PID to disappear.
2. launchd completes the KeepAlive handoff and exposes a new direct service PID, but the generic drain wait observes only the old child PID.
3. If that old child remains reportable, the updater consumes the full restart-exit budget before checking launchd and appears hung.

**Why it is wrong:** A changed launchd service PID is stronger evidence that the supervised restart completed than the stale liveness result for the old gateway child, but the wait ignored that signal.

**Working sibling / contrast:** The existing post-drain launchd path already accepts a fresh service PID and avoids a redundant `kickstart -k`; this change makes the same signal visible during the drain wait.

**Ruled out:** The later replacement check is capped at 15 seconds and cannot account for the reported multi-minute delay. The shared PID helper also already treats zombies as exited, so another zombie-only check would not close the observed gap.

### Fix

Add an optional completion probe to the bounded PID-exit wait. The launchd restart path snapshots the pre-signal service PID and uses a changed service PID to finish the graceful handoff promptly, then verifies the replacement against the same launchd-level identity.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/gateway.py` - observe launchd replacement PIDs during the graceful drain wait and compare service-level identities consistently.
- `tests/hermes_cli/test_launchd_restart_replacement.py` - reproduce a lingering old child alongside a fresh launchd service PID.
- `tests/hermes_cli/test_gateway_service.py` - keep existing launchd restart contracts aligned with the completion probe.

## How to Test

1. On macOS with a launchd-supervised gateway, run `hermes update --yes --gateway` and observe that the restart phase advances as soon as `launchctl print` exposes a fresh service PID.
2. Automated regression test run locally:

```bash
scripts/run_tests.sh tests/hermes_cli/test_launchd_restart_replacement.py -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant regression test and it passes
- [x] I've added tests for my changes
- [x] I've tested the deterministic process-state seam on Windows 11; macOS real-environment verification remains required

### Documentation & Housekeeping

- [x] Relevant documentation is N/A; behavior and rationale are covered by docstrings and tests
- [x] `cli-config.yaml.example` is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A; no architecture or workflow changed
- [x] Cross-platform impact was considered; the new callback is optional and only launchd supplies it
- [x] Tool descriptions and schemas are N/A

## Screenshots / Logs

N/A - this changes a process restart wait and has automated regression coverage.
