### PR TITLE
feat(models): Gemini 3.8 Flash now pickable on Nous Portal + OpenRouter

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -102,6 +102,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("openai/gpt-5.4-mini",                    ""),
     # Google
     ("google/gemini-3.1-pro-preview",          ""),
+    ("google/gemini-3.8-flash",                ""),
     ("google/gemini-3.7-flash",                ""),
     # xAI
     ("x-ai/grok-4.6",                          ""),
@@ -285,6 +286,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "openai/gpt-5.4-mini",
         # Google
         "google/gemini-3.1-pro-preview",
+        "google/gemini-3.8-flash",
         "google/gemini-3.7-flash",
         # xAI
         "x-ai/grok-4.6",

--- a/plugins/model-providers/openrouter/__init__.py
+++ b/plugins/model-providers/openrouter/__init__.py
@@ -249,7 +249,7 @@ openrouter = OpenRouterProfile(
         "anthropic/claude-sonnet-4.6",
         "openai/gpt-5.4",
         "deepseek/deepseek-chat",
-        "google/gemini-3.7-flash",
+        "google/gemini-3.8-flash",
         "qwen/qwen3-plus",
     ),
 )

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-09-01T18:20:04Z",
+  "updated_at": "2026-09-02T16:31:43Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -82,6 +82,10 @@
         },
         {
           "id": "google/gemini-3.1-pro-preview",
+          "description": ""
+        },
+        {
+          "id": "google/gemini-3.8-flash",
           "description": ""
         },
         {
@@ -260,6 +264,9 @@
         },
         {
           "id": "google/gemini-3.1-pro-preview"
+        },
+        {
+          "id": "google/gemini-3.8-flash"
         },
         {
           "id": "google/gemini-3.7-flash"


### PR DESCRIPTION
## Summary
`google/gemini-3.8-flash` is now pickable on Nous Portal and OpenRouter, slotted above `gemini-3.7-flash` (kept).

## Changes
- `hermes_cli/models.py`: add `google/gemini-3.8-flash` to `OPENROUTER_MODELS` and `_PROVIDER_MODELS["nous"]`, directly above 3.7-flash (newest-first).
- `plugins/model-providers/openrouter/__init__.py`: `fallback_models` bumped 3.7 → 3.8.
- `website/static/api/model-catalog.json`: regenerated via `scripts/build_model_catalog.py`.

Scoped to the two named providers — vertex/gemini/kilocode/gmi curated lists, `setup.py` samples, and aux defaults deliberately untouched.

## Validation
| Check | Result |
|---|---|
| Live test completion, Nous Portal | 200, `model` echoes `google/gemini-3.8-flash`, billed $5.25e-05 (also listed in `/v1/models`) |
| Live test completion, OpenRouter | 200, `model` echoes `google/gemini-3.8-flash`, billed $4.875e-05 |
| OpenRouter metadata | 1,048,576 ctx / 65,536 max output / same per-token rates as 3.7-flash |
| `DEFAULT_CONTEXT_LENGTHS` | resolves via existing `gemini` → 1,048,576 (matches live) — no new entry |
| `resolve_billing_route` (nous, openrouter) | `official_models_api` on both — pricing snapshot skipped |
| Curated-fallback E2E (net denied, keys stripped) | 3.8 present above 3.7, no dupes, both providers |
| Targeted catalog suites (6 files) | 189 passed |
| Dupe-PR sweep (`gemini-3.8-flash`, `gemini 3.8`) | none open or closed — this is the first |

## Infographic

![Nous Portal added support for Gemini 3.8 Flash](https://v3b.fal.media/files/b/0aa8d4c4/QImlCxqg3rD9q7UCBoTKp_PbTJHCzW.png)
