### PR TITLE
fix(bot-mode): derive group clarify/approval attention from $groupClarify instead of duplicating it into $groupNeedsYou

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/bot-row.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/bot-row.test.tsx
@@ -19,7 +19,7 @@ import type * as HermesSdk from '@hermes/plugin-sdk'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { BotRow } from './bot-row'
+import { BotRow, GroupRow } from './bot-row'
 import { translateBots } from './i18n-test-helper'
 import type { RosterRow } from './types'
 
@@ -173,5 +173,25 @@ describe('context-menu mutations hydrate the alias first', () => {
 
     expect(route.profile).toBe('worker')
     expect(params).toMatchObject({ name: 'backend-worker', ui_meta: { 'hermes-bots': { pinned: false } } })
+  })
+})
+
+describe('GroupRow renders its needs-you badge from the needsYou prop', () => {
+  const noopGroup = () => undefined
+
+  it('shows the question badge when needsYou is true', () => {
+    render(
+      <GroupRow active={false} group="Core" members={[]} needsYou={true} onDisband={noopGroup} onOpen={noopGroup} />
+    )
+
+    expect(screen.getByLabelText('Needs your input')).toBeTruthy()
+  })
+
+  it('hides the question badge when needsYou is false', () => {
+    render(
+      <GroupRow active={false} group="Core" members={[]} needsYou={false} onDisband={noopGroup} onOpen={noopGroup} />
+    )
+
+    expect(screen.queryByLabelText('Needs your input')).toBeNull()
   })
 })

--- a/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
@@ -94,7 +94,7 @@ import {
 } from './group-panes'
 import type { GroupComposerDraft, GroupDraftSetter } from './group-panes'
 import { sendToGroupChat, stopGroupThread } from './group-rounds'
-import { clearGroupClarify } from './group-turns'
+import { clearGroupClarify, renameGroupClarify } from './group-turns'
 import { botsText, useBots } from './i18n'
 import { displayName, slugify, stripPreviewMarkdown } from './labels'
 import { botRosterMeta, setBotsWorkspaceOwner } from './routing'
@@ -299,9 +299,9 @@ async function renameGroupChat(oldName: string, newName: string, members: GroupM
     $groupNeedsYou.set(needs)
   }
 
-  // Mirrored clarify cards key by group name; drop the old room's — the
-  // next poll re-mirrors any still-blocking question under the new name.
-  clearGroupClarify(oldName)
+  // Mirrored clarify cards key by group name; a pending prompt's attention
+  // must follow the room to its new name, not disappear.
+  renameGroupClarify(oldName, next)
 
   // Local memberships: swap the name inside each member's canonical groups
   // list (syncs cross-machine via ui_meta). Remote members' seating lives in

--- a/apps/desktop/src/plugins/hermes-bots/group-turns.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-turns.test.ts
@@ -359,10 +359,22 @@ describe('clarify and approvals (#90694)', () => {
   }
 
   it('holds the turn open while a member is blocked on clarify, then lands the reply', async () => {
+    let live: Awaited<ReturnType<typeof loadRoom>> | null = null
+    let sawPendingAttention = false
+
     const room = await loadRoom({
       clarifyUntil: { research: { payload: CLARIFY, until: 3 } },
+      // The mirror pass runs while the question is still blocking — this is
+      // the observable proof the gate inspected pending_clarify. Asserting
+      // on $groupNeedsYou/$groupClarify AFTER the turn lands proves nothing:
+      // the clarify has already resolved and its mirror is gone by then.
+      onResumePoll: () => {
+        sawPendingAttention = sawPendingAttention || live!.turns.groupHasPendingClarify(live!.chat.$groupClarify.get(), 'Core')
+      },
       turn: () => 'targeting staging'
     })
+
+    live = room
 
     const thread = room.rounds.sendToGroupChat(
       'Core',
@@ -379,10 +391,9 @@ describe('clarify and approvals (#90694)', () => {
     expect(replies).toHaveLength(1)
     expect(replies[0].text).toBe('targeting staging')
     expect(Object.keys(room.chat.$groupClarify.get())).toHaveLength(0)
-    // The mirror pass ran while the question was blocking, badging the room.
-    // A poll that never inspects pending_clarify leaves this unset — it is the
-    // observable proof the gate executed.
-    expect(room.chat.$groupNeedsYou.get().Core).toBe(true)
+    expect(sawPendingAttention).toBe(true)
+    // Resolved and mirrored away — nothing left to badge.
+    expect(room.turns.groupHasPendingClarify(room.chat.$groupClarify.get(), 'Core')).toBe(false)
   })
 
   it('mirrors a question, badges needs-you, and is idempotent per request', async () => {
@@ -397,16 +408,20 @@ describe('clarify and approvals (#90694)', () => {
     expect(mirrored[0].requestId).toBe('req-clarify-1')
     expect(mirrored[0].question).toBe('Which env should I target?')
     expect(mirrored[0].choices).toEqual(['staging', 'prod'])
-    expect(chat.$groupNeedsYou.get().Core).toBe(true)
+    // Badge is derived from $groupClarify, not a copy — nothing writes
+    // $groupNeedsYou here, so there is nothing to keep in sync.
+    expect(turns.groupHasPendingClarify(chat.$groupClarify.get(), 'Core')).toBe(true)
 
     // Same request again: no new entry, identity preserved.
     turns.syncGroupClarify('Core', member, { pending_clarify: CLARIFY })
 
     expect(Object.values(chat.$groupClarify.get())[0]).toBe(mirrored[0])
 
-    // Question resolved server-side: the mirror clears.
+    // Question resolved server-side: the mirror clears, and so does the
+    // derived badge — no separate cleanup path required.
     expect(turns.syncGroupClarify('Core', member, {})).toBe(false)
     expect(Object.keys(chat.$groupClarify.get())).toHaveLength(0)
+    expect(turns.groupHasPendingClarify(chat.$groupClarify.get(), 'Core')).toBe(false)
   })
 
   it('never mirrors a question for older backends without pending_clarify', async () => {
@@ -465,13 +480,124 @@ describe('clarify and approvals (#90694)', () => {
 
     expect(remaining).toHaveLength(1)
     expect(remaining[0].group).toBe('Other')
+    // The derived badge follows $groupClarify with no separate cleanup step.
+    expect(room.turns.groupHasPendingClarify(room.chat.$groupClarify.get(), 'Core')).toBe(false)
+    expect(room.turns.groupHasPendingClarify(room.chat.$groupClarify.get(), 'Other')).toBe(true)
+  })
+
+  it('keeps the derived badge lit until every clarify in the room is answered', async () => {
+    const room = await loadRoom()
+    const research: GroupMember = { name: 'research', title: '' }
+    const ops: GroupMember = { name: 'ops', title: '' }
+
+    room.turns.syncGroupClarify('Core', research, { pending_clarify: CLARIFY })
+    room.turns.syncGroupClarify('Core', ops, { pending_clarify: { ...CLARIFY, request_id: 'req-2' } })
+
+    expect(room.turns.groupHasPendingClarify(room.chat.$groupClarify.get(), 'Core')).toBe(true)
+
+    const [first, second] = Object.values(room.chat.$groupClarify.get())
+    await room.turns.answerGroupClarify(first, research, 'staging')
+
+    // One of two questions answered — the room still owes the user a reply.
+    expect(room.turns.groupHasPendingClarify(room.chat.$groupClarify.get(), 'Core')).toBe(true)
+
+    await room.turns.answerGroupClarify(second, ops, 'staging')
+
+    // Last pending clarify answered — nothing left to badge.
+    expect(room.turns.groupHasPendingClarify(room.chat.$groupClarify.get(), 'Core')).toBe(false)
+  })
+
+  // $groupNeedsYou (mention attention) and
+  // $groupClarify (pending clarify/approval attention) are independent
+  // sources — resolving one must never clear the other. The roster reads
+  // BOTH: groupNeedsYou[group] || groupHasPendingClarify(clarifies, group).
+  it('resolving the last clarify preserves independent @user mention attention', async () => {
+    const room = await loadRoom()
+    const research: GroupMember = { name: 'research', title: '' }
+
+    // A member addressing @user badges the room — independent of clarify.
+    room.chat.appendGroupChatEntry('Core', { kind: 'member', name: 'research' }, '@user deployment needs a call')
+    expect(room.chat.$groupNeedsYou.get().Core).toBe(true)
+
+    room.turns.syncGroupClarify('Core', research, { pending_clarify: CLARIFY })
+    expect(room.turns.groupHasPendingClarify(room.chat.$groupClarify.get(), 'Core')).toBe(true)
+
+    await room.turns.answerGroupClarify(Object.values(room.chat.$groupClarify.get())[0], research, 'staging')
+
+    // Clarify resolved — but the unrelated mention attention must survive.
+    expect(room.turns.groupHasPendingClarify(room.chat.$groupClarify.get(), 'Core')).toBe(false)
+    expect(room.chat.$groupNeedsYou.get().Core).toBe(true)
+  })
+
+  it('preserves pending clarify attention across a room rename', async () => {
+    const room = await loadRoom()
+    const research: GroupMember = { name: 'research', title: '' }
+
+    // Core has a pending clarify and no @user mention — attention is
+    // entirely clarify-derived, the case a plain group-key swap loses.
+    room.turns.syncGroupClarify('Core', research, { pending_clarify: CLARIFY })
+    expect(room.turns.groupHasPendingClarify(room.chat.$groupClarify.get(), 'Core')).toBe(true)
+    expect(room.chat.$groupNeedsYou.get().Core).toBeFalsy()
+
+    room.turns.renameGroupClarify('Core', 'Renamed')
+
+    // The prompt now belongs to the new name — not the old one.
+    expect(room.turns.groupHasPendingClarify(room.chat.$groupClarify.get(), 'Renamed')).toBe(true)
+    expect(room.turns.groupHasPendingClarify(room.chat.$groupClarify.get(), 'Core')).toBe(false)
+    const [prompt] = Object.values(room.chat.$groupClarify.get())
+    expect(prompt.group).toBe('Renamed')
+
+    // Resolving it under the new name clears attention there.
+    await room.turns.answerGroupClarify(prompt, research, 'staging')
+    expect(room.turns.groupHasPendingClarify(room.chat.$groupClarify.get(), 'Renamed')).toBe(false)
+  })
+
+  it('lets the renamed room\'s current prompt replace a stale mirror already at the destination', async () => {
+    const room = await loadRoom()
+
+    // Current prompt inserted FIRST, stale destination mirror SECOND — a
+    // single-pass rekey that iterates Object.entries in insertion order
+    // would let the stale entry (visited last) clobber the just-migrated
+    // current one. Two passes must let the live room win regardless of
+    // insertion order.
+    room.turns.syncGroupClarify('Core', { name: 'research', title: '' }, { pending_clarify: CLARIFY })
+    room.chat.$groupClarify.set({
+      ...room.chat.$groupClarify.get(),
+      'Renamed::research': {
+        at: Date.now(),
+        choices: [],
+        group: 'Renamed',
+        kind: 'clarify',
+        member: 'research',
+        memberKey: 'research',
+        multiSelect: false,
+        question: 'stale question',
+        questions: null,
+        requestId: 'req-stale',
+        sessionId: null
+      }
+    })
+
+    room.turns.renameGroupClarify('Core', 'Renamed')
+
+    const migrated = room.chat.$groupClarify.get()['Renamed::research']
+    expect(migrated.requestId).toBe(CLARIFY.request_id)
+    expect(Object.keys(room.chat.$groupClarify.get())).toEqual(['Renamed::research'])
   })
 
   it('holds the turn open on a command approval too', async () => {
+    let live: Awaited<ReturnType<typeof loadRoom>> | null = null
+    let sawPendingAttention = false
+
     const room = await loadRoom({
       approvalUntil: { research: { payload: APPROVAL, until: 3 } },
+      onResumePoll: () => {
+        sawPendingAttention = sawPendingAttention || live!.turns.groupHasPendingClarify(live!.chat.$groupClarify.get(), 'Core')
+      },
       turn: () => 'build cleaned'
     })
+
+    live = room
 
     const thread = room.rounds.sendToGroupChat(
       'Core',
@@ -488,7 +614,8 @@ describe('clarify and approvals (#90694)', () => {
     expect(replies).toHaveLength(1)
     expect(replies[0].text).toBe('build cleaned')
     expect(Object.keys(room.chat.$groupClarify.get())).toHaveLength(0)
-    expect(room.chat.$groupNeedsYou.get().Core).toBe(true)
+    expect(sawPendingAttention).toBe(true)
+    expect(room.turns.groupHasPendingClarify(room.chat.$groupClarify.get(), 'Core')).toBe(false)
   })
 
   it('mirrors an approval with its kind, command and server choices', async () => {

--- a/apps/desktop/src/plugins/hermes-bots/group-turns.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-turns.ts
@@ -9,7 +9,7 @@
 import { host } from '@hermes/plugin-sdk'
 
 import { recordGroupActivity } from './group-activity'
-import { $groupChats, $groupClarify, $groupNeedsYou, appendGroupChatEntry, updateGroupChat } from './group-chat'
+import { $groupChats, $groupClarify, appendGroupChatEntry, updateGroupChat } from './group-chat'
 import type { GroupChatRoom } from './group-chat'
 import { groupMemberKey, groupSessionOwner } from './group-membership'
 import { botConnectionRoute, requestForBot } from './routing'
@@ -493,16 +493,24 @@ export function syncGroupClarify(group: string, member: GroupMember, state: Grou
           questions: null
         }
   })
-  // A blocked member is a question for the human — badge the room.
-  $groupNeedsYou.set({
-    ...$groupNeedsYou.get(),
-    [group]: true
-  })
 
   return true
 }
 
-/** Drop every mirrored clarify belonging to `group` (disband/rename). */
+/** Whether `group` has any member currently blocked on a clarify or
+ *  approval, given a $groupClarify snapshot. Pure by design: the caller
+ *  (roster-pane) subscribes to $groupClarify itself via useValue and passes
+ *  the live snapshot in, so the subscription actually drives the
+ *  recalculation instead of existing only to force a re-render. $groupClarify
+ *  is the single source of truth for this kind of attention — nothing copies
+ *  it into a second boolean, so there is nothing to keep in sync when a
+ *  prompt resolves, is answered, or the room is disbanded/renamed. */
+export function groupHasPendingClarify(clarifies: Record<string, GroupPrompt>, group: string): boolean {
+  return Object.values(clarifies).some(entry => entry?.group === group)
+}
+
+/** Drop every mirrored clarify belonging to `group` (disband — the room is
+ *  gone, nothing to move the attention to). */
 export function clearGroupClarify(group: string) {
   const all = $groupClarify.get()
   const next: Record<string, GroupPrompt> = {}
@@ -513,6 +521,46 @@ export function clearGroupClarify(group: string) {
       changed = true
     } else {
       next[key] = value
+    }
+  }
+
+  if (changed) {
+    $groupClarify.set(next)
+  }
+}
+
+/** Re-key every mirrored clarify belonging to `oldName` onto `newName`
+ *  (rename). Unlike disband, the room still exists under its new name — a
+ *  pending clarify's attention must follow it, not disappear. Known gap:
+ *  an in-flight member turn captured `oldName` as its closure argument
+ *  (runGroupChatMemberTurnLeased) and keeps polling under that name, so a
+ *  poll that lands after this rename can still re-mirror a NEW entry under
+ *  oldName. That race predates this function and isn't fixed here. */
+export function renameGroupClarify(oldName: string, newName: string) {
+  const all = $groupClarify.get()
+  const next: Record<string, GroupPrompt> = {}
+  let changed = false
+
+  // Preserve every mirror that isn't being renamed. Iteration order matters:
+  // a single pass keyed by insertion order can let a STALE mirror already
+  // stranded at newName (left behind by the in-flight-poll race noted
+  // below) clobber the just-migrated CURRENT mirror if the stale entry
+  // happens to iterate after it. Copying unrelated entries first and
+  // writing the migrated ones last guarantees the live room's prompt
+  // always wins its destination key.
+  for (const [key, value] of Object.entries<GroupPrompt>(all)) {
+    if (value?.group !== oldName) {
+      next[key] = value
+    }
+  }
+
+  for (const value of Object.values<GroupPrompt>(all)) {
+    if (value?.group === oldName) {
+      changed = true
+      // Rebuild the key from the mirror's own memberKey rather than
+      // string-replacing oldName in place — a group name that happens to
+      // be a substring of the member key must not corrupt the rekey.
+      next[`${newName}::${value.memberKey}`] = { ...value, group: newName }
     }
   }
 

--- a/apps/desktop/src/plugins/hermes-bots/roster-attention.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/roster-attention.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * The needs-you attention badge the roster shows for a Group Chat row is
+ * derived from TWO independent stores: $groupNeedsYou (an @user mention)
+ * and $groupClarify (a pending clarify/approval, via groupHasPendingClarify).
+ * roster-pane.tsx subscribes to both and combines them with ||.
+ *
+ * This harness proves the REAL composition works end-to-end: real stores,
+ * real useValue subscriptions, and the real groupHasPendingClarify helper —
+ * not a re-implementation of the derive expression. Mutating a store here
+ * must be enough to flip what the harness renders, with no manual refresh.
+ */
+import { useValue } from '@hermes/plugin-sdk'
+import { act, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { $groupClarify, $groupNeedsYou } from './group-chat'
+import { groupHasPendingClarify } from './group-turns'
+import type { GroupPrompt } from './types'
+
+const GROUP = 'Core'
+
+function mockPrompt(overrides: Partial<GroupPrompt> = {}): GroupPrompt {
+  return {
+    at: Date.now(),
+    choices: ['staging', 'prod'],
+    group: GROUP,
+    kind: 'clarify',
+    member: 'research',
+    memberKey: 'research',
+    multiSelect: false,
+    question: 'Which env?',
+    questions: null,
+    requestId: 'req-1',
+    sessionId: null,
+    ...overrides
+  }
+}
+
+function AttentionHarness({ group }: { group: string }) {
+  const mentions = useValue($groupNeedsYou)
+  const clarifies = useValue($groupClarify)
+  const needsYou = Boolean(mentions[group]) || groupHasPendingClarify(clarifies, group)
+
+  return <div data-testid="attention">{String(needsYou)}</div>
+}
+
+describe('roster attention badge — real stores, real useValue, real helper', () => {
+  afterEach(() => {
+    $groupNeedsYou.set({})
+    $groupClarify.set({})
+  })
+
+  it('reflects a clarify being added and then removed', () => {
+    act(() => {
+      render(<AttentionHarness group={GROUP} />)
+    })
+
+    expect(screen.getByTestId('attention').textContent).toBe('false')
+
+    act(() => {
+      $groupClarify.set({ 'Core::research': mockPrompt() })
+    })
+
+    expect(screen.getByTestId('attention').textContent).toBe('true')
+
+    act(() => {
+      $groupClarify.set({})
+    })
+
+    expect(screen.getByTestId('attention').textContent).toBe('false')
+  })
+
+  it('keeps attention true when clarify clears but the mention persists', () => {
+    act(() => {
+      render(<AttentionHarness group={GROUP} />)
+    })
+
+    act(() => {
+      $groupNeedsYou.set({ [GROUP]: true })
+      $groupClarify.set({ 'Core::research': mockPrompt() })
+    })
+
+    expect(screen.getByTestId('attention').textContent).toBe('true')
+
+    // Clarify resolves — the unrelated mention must keep the badge lit.
+    act(() => {
+      $groupClarify.set({})
+    })
+
+    expect(screen.getByTestId('attention').textContent).toBe('true')
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/roster-pane.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/roster-pane.tsx
@@ -56,10 +56,11 @@ import {
   useRoster
 } from './data'
 import { EditProfileDialog } from './edit-profile-dialog'
-import { $groupChats, $groupChatWorkspace, $groupNeedsYou } from './group-chat'
+import { $groupChats, $groupChatWorkspace, $groupClarify, $groupNeedsYou } from './group-chat'
 import { disbandGroupChat, GroupChatWorkspace, openGroupChat } from './group-chat-view'
 import { groupChatMemberBots, groupChatNames, groupLastActivity } from './group-membership'
 import { $groupMainTabsRev, shouldRenderGroupChatInPane } from './group-panes'
+import { groupHasPendingClarify } from './group-turns'
 import { $showHiddenBots, isBotHidden, isBotPinned } from './hidden-bots'
 import { useBots } from './i18n'
 import { displayName } from './labels'
@@ -289,6 +290,7 @@ export function BotsPane() {
   // room beside a live main tab and stick).
   useValue($groupMainTabsRev)
   const groupNeedsYou = useValue($groupNeedsYou)
+  const groupClarify = useValue($groupClarify)
   const groupRooms = useValue($groupChats)
   const rememberedSources = useValue($lastSources)
   const rosterHydrated = useValue($rosterHydrated)
@@ -572,7 +574,7 @@ export function BotsPane() {
       group={row.name}
       key={`group:${row.name}`}
       members={row.members}
-      needsYou={Boolean(groupNeedsYou[row.name])}
+      needsYou={Boolean(groupNeedsYou[row.name]) || groupHasPendingClarify(groupClarify, row.name)}
       onDisband={setDeletingGroup}
       onOpen={openGroupChat}
     />


### PR DESCRIPTION
## What does this PR do?

The Group Chat roster's needs-you badge is written by two independent
sources: an `@user` mention (`appendGroupChatEntry`) and, until now,
`syncGroupClarify` whenever a member blocked on a clarify or approval.
Nothing kept these in sync, so answering a clarify, the server resolving
it, or disbanding/renaming the room could leave a stale badge lit with
nothing behind it -- or, with a naive fix, clear an unrelated still-
unresolved `@user` mention.

## Changes Made

- `syncGroupClarify` no longer writes `$groupNeedsYou`. `$groupClarify`
  is already the source of truth for pending clarify/approval attention.
- New `groupHasPendingClarify(clarifies, group)` derives that signal from
  a `$groupClarify` snapshot. It's pure by design: the caller
  (`roster-pane`) subscribes to `$groupClarify` itself via `useValue` and
  passes the live snapshot in, so the subscription actually drives
  recalculation.
- New `renameGroupClarify(oldName, newName)` re-keys a room's mirrored
  prompts onto its new name in two passes (unrelated entries first,
  migrated entries last), so a stale mirror already stranded at the
  destination key can never clobber the just-migrated current prompt.
- Roster reads `groupNeedsYou[group] || groupHasPendingClarify(...)` and
  subscribes to both stores.

## Related work

- #93993 handles the badge's *visibility* while the room is open; this PR
  is orthogonal -- it fixes the underlying attention *state*, which
  #93993 already says it preserves.

## Known limitation (not fixed here)

`runGroupChatMemberTurnLeased` captures its `group` argument in closure
and keeps polling under that name across the turn's lifetime. A rename
that lands mid-turn means the in-flight poll can still re-mirror a NEW
prompt under the old name after this PR's `renameGroupClarify` has
already migrated everything else. This race predates this PR and isn't
addressed here -- happy to file a follow-up issue if useful.

## How to Test

1. Block a member on a clarify/approval in a Group Chat.
2. Answer it from another chat/notification without opening the room --
   badge should clear.
3. Two members blocked at once: answering one leaves the badge lit;
   answering both clears it.
4. `@user`-mention a room, then separately trigger and resolve a
   clarify in the same room -- the mention badge must survive the
   clarify resolving.
5. Rename a room with a pending clarify -- attention follows the new
   name.

## Validation

- `tsc --noEmit`: clean
- `eslint` on changed files: clean
- `group-turns.test.ts`: 35/35 (multi-clarify, mention+clarify
  independence, server-side cleanup, rename migration, rename
  destination-collision -- red-green verified against the prior
  single-pass implementation)
- `group-rounds.test.ts` + `group-chat-view.test.ts`: 53/53 (regression)
- `bot-row.test.tsx`: 8/8, including 2 new `GroupRow` badge-render tests
- New `roster-attention.test.tsx`: 2/2, a subscription harness using the
  real stores, real `useValue`, and the real `groupHasPendingClarify`
  helper end-to-end (not a re-implementation of the derive expression)
