### PR TITLE
fix(desktop): add manage_launcher_entry opt-out so hermes.desktop edits survive every launch

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -4034,6 +4034,14 @@ DEFAULT_CONFIG = {
         # Ignored on macOS/Windows. Bridged to the HERMES_DESKTOP_PASSWORD_STORE
         # env var the Electron app reads, so an explicit env var still wins.
         "password_store": "auto",
+        # Linux only: whether `hermes desktop` rewrites the XDG launcher
+        # entry (~/.local/share/applications/hermes.desktop) on every
+        # launch. The entry is content-compared first, so a rewrite only
+        # happens when the generated form actually differs from what is on
+        # disk — but that check IS the clobber: a user's hand-edited entry
+        # silently reverts on the next launch. Set False to stop touching
+        # an entry that already exists (a missing entry is still created).
+        "manage_launcher_entry": True,
         # macOS only: optional persistent code-signing identity (a cert in the
         # login keychain — a self-signed "Code Signing" cert from Keychain
         # Access works; no Apple Developer account needed) used to re-sign

--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -759,6 +759,29 @@ def _install_icon_to_hicolor(icon: Path) -> bool:
         return False
 
 
+def _launcher_entry_management_enabled() -> bool:
+    """Whether config.yaml allows rewriting an EXISTING launcher entry.
+
+    ``desktop.manage_launcher_entry: false`` opts out of the every-launch
+    rewrite: a hand-edited ``hermes.desktop`` is then left alone instead
+    of silently reverting (#101097's clobber complaint). A MISSING entry
+    is still created regardless — the opt-out protects user edits, not
+    first-run presence. Any config error reads as enabled (default).
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        desktop_cfg = (load_config_readonly() or {}).get("desktop") or {}
+        raw = desktop_cfg.get("manage_launcher_entry", True)
+        if isinstance(raw, bool):
+            return raw
+        if isinstance(raw, str):
+            return raw.strip().lower() not in ("false", "0", "no", "off")
+        return True
+    except Exception:
+        return True
+
+
 def install_desktop_entry(project_root: Path) -> Optional[Path]:
     """Write (or refresh) the Hermes desktop entry. Return its path.
 
@@ -769,6 +792,12 @@ def install_desktop_entry(project_root: Path) -> Optional[Path]:
         return None
 
     entry_path = desktop_entry_path()
+
+    # Opt-out honored only for an entry that already exists: the flag
+    # stops the every-launch clobber, not first-run creation.
+    if entry_path.is_file() and not _launcher_entry_management_enabled():
+        return entry_path
+
     icon = icon_path(project_root)
     # Prefer the themed name: the icon is COPIED into the user's hicolor
     # tree, so the entry outlives the checkout (moving/archiving the

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -1099,3 +1099,105 @@ def test_install_resizes_decodable_png_to_panel_sizes(
     assert not stale.exists()
     assert struct.unpack(">II", dest_24.read_bytes()[16:24]) == (24, 24)
     assert struct.unpack(">II", dest_256.read_bytes()[16:24]) == (256, 256)
+
+
+# ---------------------------------------------------------------------------
+# desktop.manage_launcher_entry opt-out (#101097)
+# ---------------------------------------------------------------------------
+
+
+def _stub_manage_flag(monkeypatch, value) -> None:
+    monkeypatch.setattr(
+        lde,
+        "_launcher_entry_management_enabled",
+        lambda: value,
+    )
+
+
+def test_optout_leaves_existing_entry_untouched(tmp_path, xdg_home, monkeypatch):
+    """`manage_launcher_entry: false` must not clobber a hand-edited entry."""
+    root = _make_project(tmp_path)
+    _stub_install(tmp_path, monkeypatch)
+    entry_path = xdg_home / "applications" / "hermes.desktop"
+    entry_path.parent.mkdir(parents=True, exist_ok=True)
+    entry_path.write_text(
+        "[Desktop Entry]\nType=Application\nName=Hermes (custom)\n"
+        'Exec=/usr/bin/special-wrapper desktop\n',
+        encoding="utf-8",
+    )
+    _stub_manage_flag(monkeypatch, False)
+
+    entry = lde.install_desktop_entry(root)
+
+    # The user's edit survives the launch instead of silently reverting.
+    assert entry == entry_path
+    assert "special-wrapper" in entry_path.read_text(encoding="utf-8")
+
+
+def test_optout_still_creates_missing_entry(tmp_path, xdg_home, monkeypatch):
+    """The opt-out protects user edits, not first-run presence: with no
+    entry on disk a launch still installs one."""
+    root = _make_project(tmp_path)
+    _stub_install(tmp_path, monkeypatch)
+    _stub_manage_flag(monkeypatch, False)
+
+    entry = lde.install_desktop_entry(root)
+
+    assert entry is not None
+    assert entry.is_file()
+    values = _parse(entry.read_text(encoding="utf-8"))
+    assert values["Name"] == "Hermes"
+
+
+def test_default_management_rewrites_changed_entry(tmp_path, xdg_home, monkeypatch):
+    """Default (True): a differing on-disk entry is still rewritten —
+    the opt-out only changes behavior for an EXISTING entry."""
+    root = _make_project(tmp_path)
+    _stub_install(tmp_path, monkeypatch)
+    entry_path = xdg_home / "applications" / "hermes.desktop"
+    entry_path.parent.mkdir(parents=True, exist_ok=True)
+    entry_path.write_text(
+        "[Desktop Entry]\nType=Application\nName=Hermes (custom)\n",
+        encoding="utf-8",
+    )
+    _stub_manage_flag(monkeypatch, True)
+
+    entry = lde.install_desktop_entry(root)
+
+    values = _parse(entry_path.read_text(encoding="utf-8"))
+    assert values["Name"] == "Hermes"
+
+
+def test_manage_flag_reads_config_desktop_section(tmp_path, monkeypatch):
+    """The gate reads `desktop.manage_launcher_entry` from config.yaml,
+    accepting bools and common string forms; config errors stay enabled."""
+    import hermes_cli.linux_desktop_entry as mod
+
+    def _with_config(cfg):
+        fake_load = lambda: cfg  # noqa: E731
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly", fake_load, raising=False
+        )
+
+    _with_config({"desktop": {"manage_launcher_entry": False}})
+    assert mod._launcher_entry_management_enabled() is False
+
+    _with_config({"desktop": {"manage_launcher_entry": "false"}})
+    assert mod._launcher_entry_management_enabled() is False
+
+    _with_config({"desktop": {"manage_launcher_entry": True}})
+    assert mod._launcher_entry_management_enabled() is True
+
+    _with_config({"desktop": {"manage_launcher_entry": "yes"}})
+    assert mod._launcher_entry_management_enabled() is True
+
+    _with_config({"desktop": {}})
+    assert mod._launcher_entry_management_enabled() is True
+
+    def boom():
+        raise RuntimeError("unreadable config")
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly", boom, raising=False
+    )
+    assert mod._launcher_entry_management_enabled() is True

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -292,6 +292,15 @@ Running `hermes uninstall --gui` from a **source checkout** (a `hermes desktop` 
 
 To launch via the CLI, simply run `hermes desktop`. By default it installs workspace Node dependencies, builds the current OS's unpacked Electron app, then launches that packaged artifact.
 
+On Linux, every launch also (re)writes the XDG launcher entry at `~/.local/share/applications/hermes.desktop` so Hermes shows up in the application menu with its icon. If you hand-edit that file and want your edits to survive, opt out of the rewrite:
+
+```yaml
+desktop:
+  manage_launcher_entry: false
+```
+
+A missing entry is still created; the flag only stops `hermes desktop` from rewriting an entry that already exists.
+
 | Flag                 | Description                                                                               |
 | -------------------- | ----------------------------------------------------------------------------------------- |
 | `--skip-build`       | Skip npm install/package and launch the existing unpacked app from `apps/desktop/release` |


### PR DESCRIPTION
## Summary

Fixes the remaining half of #101097.

On Linux, `hermes desktop` rewrites the XDG launcher entry (`~/.local/share/applications/hermes.desktop`) on **every launch**. There is no opt-out, so any hand edit to the entry is silently reverted the next time the app opens — the issue's point 3 ("Make the on-launch rewrite opt-out-able (and less clobbery)").

Two notes on scope:

- The issue's other two suggested fixes (don't `.resolve()` the venv interpreter; prefer the stable bash wrapper) are **already fixed on main**: `_running_interpreter()` keeps the lexical venv path when a `pyvenv.cfg` sits above it, and `_resolve_hermes_bin_for_desktop_entry()` skips checkout-internal `argv[0]` in favor of the PATH-installed wrapper. Only the clobber behavior remains.
- The existing idempotency check (skip the write when content is unchanged) does not help here: content-compare against the *generated* form is exactly what reverts a user's edit.

## Change

- Add `desktop.manage_launcher_entry` (default `true`) to config defaults.
- `install_desktop_entry()` now returns early, leaving the on-disk entry untouched, when the flag is false **and an entry already exists**. A missing entry is still created, so the opt-out protects user edits without costing first-run menu presence.
- Config read is best-effort inside the module (keeps it import-light for the uninstaller path); any config error falls back to current behavior.

## How to opt out

```yaml
desktop:
  manage_launcher_entry: false
```

## Testing

- `tests/hermes_cli/test_linux_desktop_entry.py`: 4 new tests covering (a) an existing hand-edited entry is left untouched under the opt-out, (b) a missing entry is still created, (c) default behavior still rewrites a differing entry, (d) the flag parses bool/string forms and fails open on config errors.
- Full suites pass: `test_linux_desktop_entry.py` (50 passed), `test_gui_command.py` (47 passed), `ruff check` clean on touched files.
- `tests/hermes_cli/test_config_loader_e2e.py::test_behavioral_read...` fails identically on clean `main` (pre-existing, unrelated).

Fixes #101097