### PR TITLE
feat(providers): an ACP provider can ship out of tree, and installed provider plugins are discovered (#74743 part 2, salvage #101346)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2709,6 +2709,71 @@ def anthropic_prompt_cache_policy(
 
 
 
+def _provider_supplied_client(agent, client_kwargs: dict) -> Any | None:
+    """Ask the registered ProviderProfile for a custom client, if any.
+
+    Resolves by provider name first, then by the ``base_url`` scheme prefix so a
+    runtime configured only by URL (``acp://…``) still reaches its profile.
+    A profile that raises is logged and skipped: a third-party plugin must not
+    be able to take the turn down, it can only fail to provide a client.
+    """
+    try:
+        from providers import get_provider_profile
+    except Exception:
+        return None
+
+    profile = None
+    provider_name = (getattr(agent, "provider", "") or "").strip()
+    if provider_name:
+        try:
+            profile = get_provider_profile(provider_name)
+        except Exception:
+            profile = None
+    if profile is None:
+        base_url = str(client_kwargs.get("base_url", "") or "").strip()
+        if base_url:
+            profile = _profile_for_base_url(base_url)
+    if profile is None:
+        return None
+
+    try:
+        return profile.create_client(**client_kwargs)
+    except Exception:
+        _ra().logger.warning(
+            "Provider profile %r failed to create a client; falling back to the "
+            "standard client path",
+            getattr(profile, "name", provider_name) or "?",
+            exc_info=True,
+        )
+        return None
+
+
+def _profile_for_base_url(base_url: str) -> Any | None:
+    """Find a registered profile whose own base_url matches ``base_url``.
+
+    Only used when the provider name did not resolve. Matches on exact base_url
+    so a non-HTTP scheme (``acp://copilot``) routes to its profile even when the
+    caller passed no provider name.
+    """
+    try:
+        from providers import list_providers
+    except Exception:
+        return None
+    target = base_url.rstrip("/").lower()
+    try:
+        candidates = list_providers()
+    except Exception:
+        return None
+    for candidate in candidates or []:
+        own = str(getattr(candidate, "base_url", "") or "").rstrip("/").lower()
+        # Prefix match, not equality: the replaced copilot-acp branch keyed on
+        # ``startswith("acp://copilot")``, so a base_url carrying a path or a
+        # user override under the same root must still resolve.
+        if own and (target == own or target.startswith(own + "/")):
+            return candidate
+    return None
+
+
 def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: bool) -> Any:
     from agent.auxiliary_client import _validate_base_url, _validate_proxy_env_urls
     from agent.ssl_verify import resolve_httpx_verify
@@ -2737,17 +2802,24 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     httpx_verify = resolve_httpx_verify(ca_bundle=ssl_ca_cert, ssl_verify=ssl_verify_cfg)
     _validate_proxy_env_urls()
     _validate_base_url(client_kwargs.get("base_url"))
-    if agent.provider == "copilot-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://copilot"):
-        from agent.copilot_acp_client import CopilotACPClient
-
-        client = CopilotACPClient(**client_kwargs)
+    # ── Provider-supplied client (registration seam) ──────────────────────
+    # A provider whose wire protocol is not OpenAI-over-HTTP supplies its own
+    # client from its ProviderProfile.create_client(). Consulted before the
+    # built-in ladder so a profile registered from ~/.hermes/plugins/ or a pip
+    # entry point can ship a transport without editing this function — that is
+    # what makes an out-of-tree ACP provider possible at all. Returning None
+    # (the default) falls through to the paths below, so every existing
+    # provider is unaffected.
+    provider_client = _provider_supplied_client(agent, client_kwargs)
+    if provider_client is not None:
         _ra().logger.info(
-            "Copilot ACP client created (%s, shared=%s) %s",
+            "%s client created from provider profile (%s, shared=%s) %s",
+            agent.provider,
             reason,
             shared,
             agent._client_log_context(),
         )
-        return client
+        return provider_client
     if agent.provider == "gemini":
         from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -749,6 +749,23 @@ def _run_protected_sync_provider_call(
         return outcome.get("result")
 
 
+def _client_declares(client_obj: Any, flag: str) -> bool:
+    """Whether ``client_obj`` (or its class) sets ``flag`` truthy.
+
+    Capability declaration instead of isinstance: a client shipped by an
+    out-of-tree provider profile can opt out of the transport/async wrappers
+    without this module importing it. Mirrors ``SUPPORTS_HERMES_TOOL_CALLS`` in
+    ``agent/background_review.py``. Absent attribute → False, so every ordinary
+    client keeps its existing behaviour.
+    """
+    if client_obj is None:
+        return False
+    try:
+        return bool(getattr(client_obj, flag, False))
+    except Exception:
+        return False
+
+
 def _safe_isinstance(obj: Any, maybe_type: Any) -> bool:
     """Return False instead of raising when a patched symbol is not a type."""
     try:
@@ -2833,7 +2850,9 @@ def _maybe_wrap_anthropic(
 
     Returns ``client_obj`` unchanged when:
 
-    - It's already an Anthropic/Codex/Gemini/CopilotACP wrapper.
+    - It's already a complete client — an Anthropic/Codex wrapper, or any
+      client declaring ``HERMES_SKIP_TRANSPORT_WRAP`` (the native and ACP
+      shims, in-tree or from a provider plugin).
     - The endpoint is an OpenAI-wire endpoint.
     - ``api_mode`` is explicitly set to a non-Anthropic transport.
     - The ``anthropic`` SDK is not installed (falls back to OpenAI wire).
@@ -2851,18 +2870,12 @@ def _maybe_wrap_anthropic(
     # Other specialized adapters we should never re-dispatch.
     if _safe_isinstance(client_obj, CodexAuxiliaryClient):
         return client_obj
-    try:
-        from agent.gemini_native_adapter import GeminiNativeClient
-        if _safe_isinstance(client_obj, GeminiNativeClient):
-            return client_obj
-    except ImportError:
-        pass
-    try:
-        from agent.copilot_acp_client import CopilotACPClient
-        if _safe_isinstance(client_obj, CopilotACPClient):
-            return client_obj
-    except ImportError:
-        pass
+    # A client that declares itself complete is never re-dispatched through a
+    # wire adapter. Declared as a class attribute rather than isinstance-checked
+    # so an out-of-tree provider's client is covered too — and so this hot path
+    # no longer imports the native/ACP client modules just to type-test.
+    if _client_declares(client_obj, "HERMES_SKIP_TRANSPORT_WRAP"):
+        return client_obj
 
     # Explicit non-anthropic api_mode wins over URL heuristics.
     if api_mode and api_mode != "anthropic_messages":
@@ -6660,12 +6673,10 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
             return AsyncGeminiNativeClient(sync_client), model
     except ImportError:
         pass
-    try:
-        from agent.copilot_acp_client import CopilotACPClient
-        if isinstance(sync_client, CopilotACPClient):
-            return sync_client, model
-    except ImportError:
-        pass
+    # Clients that are already usable from async code (the ACP shims drive a
+    # subprocess, not an HTTP connection pool) opt out of the async wrapper.
+    if _client_declares(sync_client, "HERMES_SKIP_ASYNC_WRAP"):
+        return sync_client, model
 
     async_kwargs = {
         "api_key": sync_client.api_key,
@@ -7479,34 +7490,55 @@ def resolve_provider_client(
             or _read_main_model_for_aux(),
             provider,
         )
-        if provider == "copilot-acp":
+        # Any external-process provider whose registered profile supplies a
+        # client is served here — keyed on the profile, not on a provider name,
+        # so an out-of-tree ACP provider reaches the auxiliary path (compression,
+        # vision, background review) exactly like the in-tree one.
+        _extproc_profile = None
+        try:
+            from providers import get_provider_profile as _get_provider_profile
+
+            _extproc_profile = _get_provider_profile(provider)
+        except Exception:
+            _extproc_profile = None
+        if _extproc_profile is not None:
             api_key = str(creds.get("api_key", "")).strip()
             base_url = str(creds.get("base_url", "")).strip()
             command = str(creds.get("command", "")).strip() or None
             args = list(creds.get("args") or [])
             if not final_model:
                 logger.warning(
-                    "resolve_provider_client: copilot-acp requested but no model "
-                    "was provided or configured"
+                    "resolve_provider_client: %s requested but no model "
+                    "was provided or configured",
+                    provider,
                 )
                 return None, None
             if not api_key or not base_url:
                 logger.warning(
-                    "resolve_provider_client: copilot-acp requested but external "
-                    "process credentials are incomplete"
+                    "resolve_provider_client: %s requested but external "
+                    "process credentials are incomplete",
+                    provider,
                 )
                 return None, None
-            from agent.copilot_acp_client import CopilotACPClient
-
-            client = CopilotACPClient(
-                api_key=api_key,
-                base_url=base_url,
-                command=command,
-                args=args,
-            )
-            logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
-            return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
-                    else (client, final_model))
+            try:
+                client = _extproc_profile.create_client(
+                    api_key=api_key,
+                    base_url=base_url,
+                    command=command,
+                    args=args,
+                )
+            except Exception:
+                logger.warning(
+                    "resolve_provider_client: profile %r failed to create an "
+                    "external-process client",
+                    provider,
+                    exc_info=True,
+                )
+                client = None
+            if client is not None:
+                logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
+                return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                        else (client, final_model))
         if provider not in _LOGGED_UNSUPPORTED_EXTPROC_KEYS:
             _LOGGED_UNSUPPORTED_EXTPROC_KEYS.add(provider)
             logger.debug("resolve_provider_client: external-process provider %s not "

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -358,6 +358,12 @@ class _ACPChatNamespace:
 class CopilotACPClient:
     """Minimal OpenAI-client-compatible facade for Copilot ACP."""
 
+    # Declared for agent/auxiliary_client.py: this shim drives an ACP subprocess
+    # over stdio, so it is already a complete client (never re-dispatch it
+    # through a wire adapter) and is safe to use from async code as-is.
+    HERMES_SKIP_TRANSPORT_WRAP = True
+    HERMES_SKIP_ASYNC_WRAP = True
+
     def __init__(
         self,
         *,

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -1102,6 +1102,11 @@ class _AsyncGeminiChatNamespace:
 class GeminiNativeClient:
     """Minimal OpenAI-SDK-compatible facade over Gemini's native REST API."""
 
+    # Declared for agent/auxiliary_client.py: already a complete client, so it
+    # is never re-dispatched through a wire adapter. (No HERMES_SKIP_ASYNC_WRAP
+    # — the async path has a real conversion, AsyncGeminiNativeClient.)
+    HERMES_SKIP_TRANSPORT_WRAP = True
+
     def __init__(
         self,
         *,

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -579,6 +579,24 @@ try:
     for _pp in _list_providers_for_registry():
         if _pp.name in PROVIDER_REGISTRY:
             continue
+        if _pp.auth_type == "external_process":
+            # An external-process provider (an ACP CLI driven over stdio) has no
+            # API-key env vars to resolve — its credentials come from
+            # resolve_external_process_provider_credentials(), keyed on this
+            # auth_type. Registering it here is what lets a provider shipped
+            # outside this tree pass resolve_provider()'s known-provider gate;
+            # without it, `hermes -m <that provider>` dies with
+            # "Unknown provider" before any client is ever built.
+            PROVIDER_REGISTRY[_pp.name] = ProviderConfig(
+                id=_pp.name,
+                name=_pp.display_name or _pp.name,
+                auth_type="external_process",
+                inference_base_url=_pp.base_url,
+            )
+            for _alias in _pp.aliases:
+                if _alias not in PROVIDER_REGISTRY:
+                    PROVIDER_REGISTRY[_alias] = PROVIDER_REGISTRY[_pp.name]
+            continue
         if _pp.auth_type != "api_key" or not _pp.env_vars:
             continue
         # Skip providers that need custom token resolution or are special-cased
@@ -8188,25 +8206,52 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
     if not base_url:
         base_url = pconfig.inference_base_url
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    # How to launch the CLI comes from the provider's own profile, so a provider
+    # shipped outside this tree describes its binary/args instead of inheriting
+    # another vendor's. copilot-acp's values live in its profile, which is why
+    # HERMES_COPILOT_ACP_COMMAND / COPILOT_CLI_PATH / HERMES_COPILOT_ACP_ARGS
+    # keep working unchanged.
+    profile = None
+    try:
+        from providers import get_provider_profile as _get_provider_profile
+
+        profile = _get_provider_profile(provider_id)
+    except Exception:
+        profile = None
+
+    command_env_vars = tuple(getattr(profile, "process_command_env_vars", ()) or ())
+    default_command = str(getattr(profile, "process_command", "") or "")
+    default_args = list(getattr(profile, "process_args", ()) or [])
+    args_env_var = str(getattr(profile, "process_args_env_var", "") or "")
+
+    command = ""
+    for _var in command_env_vars:
+        command = os.getenv(_var, "").strip()
+        if command:
+            break
+    if not command:
+        command = default_command
+
+    raw_args = os.getenv(args_env_var, "").strip() if args_env_var else ""
+    args = shlex.split(raw_args) if raw_args else list(default_args)
+
     resolved_command = shutil.which(command) if command else None
     if not resolved_command and not base_url.startswith("acp+tcp://"):
+        _hint = (
+            " or set " + "/".join(command_env_vars) if command_env_vars else ""
+        )
         raise AuthError(
-            f"Could not find the Copilot CLI command '{command}'. "
-            "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH.",
+            f"Could not find the '{provider_id}' CLI command "
+            f"'{command or '(none configured)'}'. Install it{_hint}.",
             provider=provider_id,
-            code="missing_copilot_cli",
+            code="missing_external_process_cli",
         )
 
     return {
         "provider": provider_id,
-        "api_key": "copilot-acp",
+        # Placeholder credential: the subprocess owns real auth. Keyed on the
+        # provider id so each external-process provider gets a distinct value.
+        "api_key": pconfig.id or provider_id,
         "base_url": base_url.rstrip("/"),
         "command": resolved_command or command,
         "args": args,

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1952,6 +1952,33 @@ def _resolve_explicit_runtime(
     return None
 
 
+def _is_external_process_provider(provider: str) -> bool:
+    """Whether ``provider`` is declared as an external-process (CLI) provider.
+
+    Reads the CLI provider registry first (which now absorbs registered
+    ProviderProfiles, in-tree and out), then falls back to the profile registry
+    directly so the check works before the CLI registry has been extended.
+    """
+    name = (provider or "").strip().lower()
+    if not name:
+        return False
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY
+
+        pconfig = PROVIDER_REGISTRY.get(name)
+        if pconfig is not None:
+            return pconfig.auth_type == "external_process"
+    except Exception:
+        pass
+    try:
+        from providers import get_provider_profile
+
+        profile = get_provider_profile(name)
+    except Exception:
+        return False
+    return profile is not None and getattr(profile, "auth_type", "") == "external_process"
+
+
 def resolve_runtime_provider(
     *,
     requested: Optional[str] = None,
@@ -2337,10 +2364,13 @@ def resolve_runtime_provider(
                 "requested_provider": requested_provider,
             }
 
-    if provider == "copilot-acp":
+    # External-process providers (an agent CLI driven over stdio, e.g. ACP).
+    # Keyed on the registered provider's auth_type rather than on one name, so a
+    # provider shipped outside this tree lands on the same credential path.
+    if _is_external_process_provider(provider):
         creds = resolve_external_process_provider_credentials(provider)
         return {
-            "provider": "copilot-acp",
+            "provider": provider,
             "api_mode": "chat_completions",
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),

--- a/plugins/model-providers/copilot-acp/__init__.py
+++ b/plugins/model-providers/copilot-acp/__init__.py
@@ -1,9 +1,15 @@
 """GitHub Copilot ACP provider profile.
 
-copilot-acp uses an external ACP subprocess — NOT the standard
-transport. api_mode="copilot_acp" is handled separately in run_agent.py.
-The profile captures auth + endpoint metadata for registry migration.
+copilot-acp does not speak OpenAI-over-HTTP: it drives an external ACP
+subprocess over stdio. The profile therefore supplies its own client through
+:meth:`ProviderProfile.create_client` instead of letting the core build an
+``openai.OpenAI``. That hook is the registration seam — this profile is its
+in-tree consumer, and an out-of-tree ACP provider registered from
+``~/.hermes/plugins/model-providers/`` or a pip entry point uses the exact same
+three lines without touching core.
 """
+
+from typing import Any
 
 from providers import register_provider
 from providers.base import ProviderProfile
@@ -11,6 +17,12 @@ from providers.base import ProviderProfile
 
 class CopilotACPProfile(ProviderProfile):
     """GitHub Copilot ACP — external process, no REST models endpoint."""
+
+    def create_client(self, **client_kwargs: Any) -> Any:
+        """Build the ACP stdio shim rather than an HTTP client."""
+        from agent.copilot_acp_client import CopilotACPClient
+
+        return CopilotACPClient(**client_kwargs)
 
     def fetch_models(
         self,

--- a/plugins/model-providers/copilot-acp/__init__.py
+++ b/plugins/model-providers/copilot-acp/__init__.py
@@ -42,6 +42,13 @@ copilot_acp = CopilotACPProfile(
     env_vars=(),  # Managed by ACP subprocess
     base_url="acp://copilot",  # ACP internal scheme
     auth_type="external_process",
+    # How to launch the CLI. Previously hardcoded in
+    # hermes_cli/auth.py::resolve_external_process_provider_credentials; the env
+    # var names are unchanged, so existing setups keep working.
+    process_command="copilot",
+    process_args=("--acp", "--stdio"),
+    process_command_env_vars=("HERMES_COPILOT_ACP_COMMAND", "COPILOT_CLI_PATH"),
+    process_args_env_var="HERMES_COPILOT_ACP_ARGS",
 )
 
 register_provider(copilot_acp)

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -108,6 +108,57 @@ def _user_plugins_dir() -> Path | None:
         return None
 
 
+def _installed_plugins_dir() -> Path | None:
+    """Return ``$HERMES_HOME/plugins/`` if it exists.
+
+    This is where ``hermes plugins install`` clones a plugin — flat, one
+    directory per plugin, NOT under ``model-providers/``. See
+    :func:`_discover_installed_provider_plugins`.
+    """
+    try:
+        from hermes_constants import get_hermes_home
+
+        d = get_hermes_home() / "plugins"
+        return d if d.is_dir() else None
+    except Exception:
+        return None
+
+
+def _declares_model_provider_kind(plugin_dir: Path) -> bool:
+    """Whether ``plugin_dir``'s manifest declares ``kind: model-provider``.
+
+    Only that kind is imported from the flat install directory — every other
+    plugin there belongs to ``PluginManager``, which owns its lifecycle and
+    consent flow. Parsed with PyYAML when available, falling back to a line
+    scan so provider discovery never hard-depends on it.
+    """
+    for filename in ("plugin.yaml", "plugin.yml"):
+        manifest = plugin_dir / filename
+        if not manifest.is_file():
+            continue
+        try:
+            text = manifest.read_text(encoding="utf-8", errors="replace")
+        except Exception:
+            return False
+        try:
+            import yaml
+
+            data = yaml.safe_load(text)
+            if isinstance(data, dict):
+                return str(data.get("kind", "")).strip() == "model-provider"
+        except Exception:
+            pass
+        for line in text.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("#") or ":" not in stripped:
+                continue
+            key, _, value = stripped.partition(":")
+            if key.strip() == "kind":
+                return value.strip().strip("\"'") == "model-provider"
+        return False
+    return False
+
+
 def _import_plugin_dir(plugin_dir: Path, source: str) -> None:
     """Import a single plugin directory so it self-registers.
 
@@ -274,6 +325,8 @@ def _discover_providers() -> None:
     Order:
       1. Bundled plugins at ``<repo>/plugins/model-providers/<name>/``
       2. User plugins at ``$HERMES_HOME/plugins/model-providers/<name>/``
+      2b. Plugins installed by ``hermes plugins install`` at
+          ``$HERMES_HOME/plugins/<name>/`` that declare ``kind: model-provider``
       3. Legacy per-file modules at ``providers/<name>.py`` (back-compat)
 
     Each step imports its plugins, which call ``register_provider()`` at
@@ -314,6 +367,25 @@ def _discover_providers() -> None:
     if user_dir is not None:
         for child in sorted(user_dir.iterdir()):
             if not child.is_dir() or child.name.startswith(("_", ".")):
+                continue
+            _import_plugin_dir(child, "user")
+
+    # 2b. Plugins installed by ``hermes plugins install`` / the plugin index.
+    #     Those clone into $HERMES_HOME/plugins/<name>/ — flat, NOT under
+    #     model-providers/ — so step 2 never sees them. PluginManager does not
+    #     import them either: it classifies ``kind: model-provider`` and routes
+    #     it here on purpose. Without this step the documented install path
+    #     silently half-works — the CLI reports success and the provider does
+    #     not exist. Only manifests declaring that kind are imported; every
+    #     other plugin in this directory belongs to PluginManager.
+    installed_dir = _installed_plugins_dir()
+    if installed_dir is not None:
+        for child in sorted(installed_dir.iterdir()):
+            if not child.is_dir() or child.name.startswith(("_", ".")):
+                continue
+            if child.name == "model-providers":
+                continue  # handled by step 2
+            if not _declares_model_provider_kind(child):
                 continue
             _import_plugin_dir(child, "user")
 

--- a/providers/base.py
+++ b/providers/base.py
@@ -223,6 +223,31 @@ class ProviderProfile:
         """
         return None
 
+    def create_client(self, **client_kwargs: Any) -> Any | None:
+        """Return a provider-specific client, or ``None`` for the standard one.
+
+        Most providers speak OpenAI-compatible HTTP and want the shared
+        ``openai.OpenAI`` client the core builds — they inherit this and return
+        ``None``. A provider whose wire protocol is not HTTP at all (the ACP
+        subprocess shims) or which needs a native SDK overrides this and
+        returns its own client object.
+
+        ``client_kwargs`` is the same mapping the core would have passed to
+        ``openai.OpenAI`` (``api_key``, ``base_url``, ``command``, ``args``,
+        timeouts, headers…). Unknown keys must be tolerated: the core adds to
+        this mapping over time, so an override should accept ``**kwargs`` and
+        pick what it needs rather than enumerate.
+
+        Returning ``None`` (the default) is always safe — the caller falls
+        through to its existing construction path.
+
+        This is the hook that lets a provider ship *outside* this tree: with it,
+        a profile registered from ``~/.hermes/plugins/model-providers/`` or a
+        pip entry point can supply its own transport without any core edit. See
+        ``plugins/model-providers/copilot-acp/`` for the in-tree example.
+        """
+        return None
+
     def fetch_models(
         self,
         *,

--- a/providers/base.py
+++ b/providers/base.py
@@ -78,6 +78,17 @@ class ProviderProfile:
     # top-level fields rather than ignoring them.
     supports_prompt_cache_key: bool = False
 
+    # ── External-process providers (auth_type="external_process") ──
+    # An agent CLI driven over stdio (ACP) rather than an HTTP endpoint. These
+    # describe how to launch it; hermes_cli/auth.py's
+    # resolve_external_process_provider_credentials() reads them instead of
+    # hardcoding one vendor's binary. Env vars are checked in order and win
+    # over the static defaults, so an operator can point at a custom build.
+    process_command: str = ""            # default binary, e.g. "copilot"
+    process_args: tuple = ()             # default argv tail, e.g. ("--acp", "--stdio")
+    process_command_env_vars: tuple = ()  # env overrides for the binary, in priority order
+    process_args_env_var: str = ""       # env override for argv (shlex-split)
+
     # ── Model catalog ─────────────────────────────────────────
     # fallback_models: curated list shown in /model picker when live fetch fails.
     # Only agentic models that support tool calling should appear here.

--- a/tests/agent/test_provider_client_seam.py
+++ b/tests/agent/test_provider_client_seam.py
@@ -1,0 +1,255 @@
+"""A provider profile can supply its own client — the registration seam.
+
+Most providers speak OpenAI-over-HTTP and want the client the core builds. A
+provider whose wire protocol is something else (the ACP subprocess shims) must
+be able to supply its own — and must be able to do so from *outside* this tree,
+otherwise every such integration has to edit ``create_openai_client`` by hand.
+
+These tests pin the hook, the two resolution paths into it (provider name and
+``base_url``), its failure isolation, and the capability flags that let such a
+client opt out of the transport/async wrappers without this code importing it.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+import providers as _providers  # noqa: E402
+from providers.base import ProviderProfile  # noqa: E402
+
+
+class _FakeClient:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+class _SeamProfile(ProviderProfile):
+    def create_client(self, **kwargs):
+        return _FakeClient(**kwargs)
+
+
+class _ExplodingProfile(ProviderProfile):
+    def create_client(self, **kwargs):
+        raise RuntimeError("plugin is broken")
+
+
+@pytest.fixture
+def registered():
+    """Register profiles for one test and restore the registry afterwards."""
+    _providers._discover_providers()
+    snapshot = (
+        dict(_providers._REGISTRY),
+        dict(_providers._ALIASES),
+        _providers._PROVIDER_LIST_CACHE,
+    )
+
+    def _register(profile):
+        _providers.register_provider(profile)
+        return profile
+
+    yield _register
+
+    _providers._REGISTRY.clear()
+    _providers._REGISTRY.update(snapshot[0])
+    _providers._ALIASES.clear()
+    _providers._ALIASES.update(snapshot[1])
+    _providers._PROVIDER_LIST_CACHE = snapshot[2]
+
+
+def _agent(provider: str = ""):
+    """The minimal agent surface create_openai_client touches."""
+    return SimpleNamespace(
+        provider=provider,
+        _client_log_context=lambda: "",
+        _build_keepalive_http_client=lambda *a, **k: None,
+    )
+
+
+# ── the hook itself ──────────────────────────────────────────────────────────
+
+
+def test_the_default_profile_supplies_no_client():
+    """Every ordinary provider inherits this and keeps the standard client."""
+    assert ProviderProfile(name="plain").create_client(api_key="k") is None
+
+
+def test_a_profile_can_supply_its_own_client(registered):
+    from agent.agent_runtime_helpers import _provider_supplied_client
+
+    registered(_SeamProfile(name="seam-test", base_url="acp://seam-test"))
+    client = _provider_supplied_client(_agent("seam-test"), {"api_key": "k"})
+    assert isinstance(client, _FakeClient)
+    assert client.kwargs == {"api_key": "k"}
+
+
+def test_an_alias_reaches_the_same_profile(registered):
+    from agent.agent_runtime_helpers import _provider_supplied_client
+
+    registered(_SeamProfile(name="seam-test", aliases=("seam",), base_url="acp://seam-test"))
+    assert isinstance(_provider_supplied_client(_agent("seam"), {}), _FakeClient)
+
+
+def test_the_base_url_resolves_the_profile_when_the_name_does_not(registered):
+    """A runtime configured only by URL still reaches its provider's client."""
+    from agent.agent_runtime_helpers import _provider_supplied_client
+
+    registered(_SeamProfile(name="seam-test", base_url="acp://seam-test"))
+    client = _provider_supplied_client(_agent(""), {"base_url": "acp://seam-test"})
+    assert isinstance(client, _FakeClient)
+    # Prefix, not equality — the branch this replaced keyed on startswith().
+    assert isinstance(
+        _provider_supplied_client(_agent(""), {"base_url": "acp://seam-test/x"}),
+        _FakeClient,
+    )
+    # A different scheme must not be captured.
+    assert _provider_supplied_client(_agent(""), {"base_url": "https://api.example/v1"}) is None
+
+
+def test_an_unregistered_provider_gets_no_client(registered):
+    from agent.agent_runtime_helpers import _provider_supplied_client
+
+    assert _provider_supplied_client(_agent("nothing-registered-here"), {}) is None
+
+
+def test_a_broken_plugin_cannot_take_the_turn_down(registered):
+    """A third-party profile that raises falls through to the standard path."""
+    from agent.agent_runtime_helpers import _provider_supplied_client
+
+    registered(_ExplodingProfile(name="seam-boom", base_url="acp://seam-boom"))
+    assert _provider_supplied_client(_agent("seam-boom"), {"api_key": "k"}) is None
+
+
+# ── the in-tree consumer ─────────────────────────────────────────────────────
+
+
+def test_copilot_acp_still_gets_its_acp_client():
+    """copilot-acp lost its hardcoded branch in create_openai_client; it must
+    still be constructed, now via its profile."""
+    from agent.copilot_acp_client import CopilotACPClient
+    from providers import get_provider_profile
+
+    profile = get_provider_profile("copilot-acp")
+    assert profile is not None
+    client = profile.create_client(api_key="copilot-acp", base_url="acp://copilot")
+    assert isinstance(client, CopilotACPClient)
+
+
+def test_copilot_acp_reaches_the_seam_by_name_and_by_url():
+    from agent.agent_runtime_helpers import _provider_supplied_client
+    from agent.copilot_acp_client import CopilotACPClient
+
+    by_name = _provider_supplied_client(
+        _agent("copilot-acp"), {"api_key": "copilot-acp", "base_url": "acp://copilot"}
+    )
+    assert isinstance(by_name, CopilotACPClient)
+    by_url = _provider_supplied_client(
+        _agent(""), {"api_key": "copilot-acp", "base_url": "acp://copilot"}
+    )
+    assert isinstance(by_url, CopilotACPClient)
+
+
+# ── the wiring, not just the helper ──────────────────────────────────────────
+
+
+def test_create_openai_client_actually_consults_the_profile(registered):
+    """Exercise the real construction entry point, not the helper it calls.
+
+    The helper being correct is worth nothing if ``create_openai_client`` stops
+    calling it — that is the regression this file exists to prevent.
+    """
+    from agent.agent_runtime_helpers import create_openai_client
+
+    registered(_SeamProfile(name="seam-test", base_url="acp://seam-test"))
+    client = create_openai_client(
+        _agent("seam-test"),
+        {"api_key": "k", "base_url": "acp://seam-test"},
+        reason="test",
+        shared=False,
+    )
+    assert isinstance(client, _FakeClient)
+
+
+def test_create_openai_client_still_builds_the_standard_client(registered):
+    """A provider with no profile hook is untouched by the seam."""
+    from openai import OpenAI
+
+    from agent.agent_runtime_helpers import create_openai_client
+
+    client = create_openai_client(
+        _agent("openai-api"),
+        {"api_key": "k", "base_url": "https://api.example/v1"},
+        reason="test",
+        shared=False,
+    )
+    assert isinstance(client, OpenAI)
+
+
+def test_create_openai_client_builds_the_copilot_acp_client():
+    """The in-tree consumer, through the same entry point its hardcoded branch
+    used to serve."""
+    from agent.agent_runtime_helpers import create_openai_client
+    from agent.copilot_acp_client import CopilotACPClient
+
+    client = create_openai_client(
+        _agent("copilot-acp"),
+        {"api_key": "copilot-acp", "base_url": "acp://copilot"},
+        reason="test",
+        shared=False,
+    )
+    assert isinstance(client, CopilotACPClient)
+
+
+# ── capability flags replacing the isinstance checks ─────────────────────────
+
+
+def test_clients_declaring_skip_flags_are_not_wrapped():
+    from agent.auxiliary_client import _client_declares
+
+    class _Final:
+        HERMES_SKIP_TRANSPORT_WRAP = True
+        HERMES_SKIP_ASYNC_WRAP = True
+
+    class _Plain:
+        pass
+
+    final = _Final()
+    assert _client_declares(final, "HERMES_SKIP_TRANSPORT_WRAP")
+    assert _client_declares(final, "HERMES_SKIP_ASYNC_WRAP")
+    # Absent attribute → False, so every ordinary client keeps its behaviour.
+    assert not _client_declares(_Plain(), "HERMES_SKIP_TRANSPORT_WRAP")
+    assert not _client_declares(None, "HERMES_SKIP_TRANSPORT_WRAP")
+
+
+def test_the_in_tree_clients_declare_what_their_isinstance_checks_used_to_say():
+    """copilot-acp skipped both wrappers; the Gemini native client skipped only
+    the transport one (its async path is a real conversion)."""
+    from agent.copilot_acp_client import CopilotACPClient
+    from agent.gemini_native_adapter import GeminiNativeClient
+
+    assert CopilotACPClient.HERMES_SKIP_TRANSPORT_WRAP is True
+    assert CopilotACPClient.HERMES_SKIP_ASYNC_WRAP is True
+    assert GeminiNativeClient.HERMES_SKIP_TRANSPORT_WRAP is True
+    assert getattr(GeminiNativeClient, "HERMES_SKIP_ASYNC_WRAP", False) is False
+
+
+def test_an_out_of_tree_client_is_covered_by_the_same_flags():
+    """The point of the flags: auxiliary_client never imports this class."""
+    from agent.auxiliary_client import _maybe_wrap_anthropic, _to_async_client
+
+    class _ThirdPartyClient:
+        HERMES_SKIP_TRANSPORT_WRAP = True
+        HERMES_SKIP_ASYNC_WRAP = True
+        api_key = "k"
+        base_url = "acp://third-party"
+
+    client = _ThirdPartyClient()
+    assert _maybe_wrap_anthropic(client, "m", "k", "acp://third-party") is client
+    assert _to_async_client(client, "m")[0] is client

--- a/tests/agent/test_provider_client_seam.py
+++ b/tests/agent/test_provider_client_seam.py
@@ -1,32 +1,28 @@
 """A provider profile can supply its own client — the registration seam.
 
-Most providers speak OpenAI-over-HTTP and want the client the core builds. A
-provider whose wire protocol is something else (the ACP subprocess shims) must
-be able to supply its own — and must be able to do so from *outside* this tree,
-otherwise every such integration has to edit ``create_openai_client`` by hand.
-
-These tests pin the hook, the two resolution paths into it (provider name and
-``base_url``), its failure isolation, and the capability flags that let such a
-client opt out of the transport/async wrappers without this code importing it.
+A provider whose wire protocol is not OpenAI-over-HTTP (the ACP subprocess
+shims) supplies its client via ``ProviderProfile.create_client()``, from inside
+or outside the tree. These tests pin the hook through the real entry point
+(``create_openai_client``), its failure isolation, and the capability flags
+that let such a client opt out of the auxiliary transport/async wrappers.
 """
 
 from __future__ import annotations
 
-import os
-import sys
 from types import SimpleNamespace
 
 import pytest
 
-_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-if _REPO_ROOT not in sys.path:
-    sys.path.insert(0, _REPO_ROOT)
-
-import providers as _providers  # noqa: E402
-from providers.base import ProviderProfile  # noqa: E402
+import providers as _providers
+from providers.base import ProviderProfile
 
 
 class _FakeClient:
+    HERMES_SKIP_TRANSPORT_WRAP = True
+    HERMES_SKIP_ASYNC_WRAP = True
+    api_key = "k"
+    base_url = "acp://seam-test"
+
     def __init__(self, **kwargs):
         self.kwargs = kwargs
 
@@ -45,18 +41,8 @@ class _ExplodingProfile(ProviderProfile):
 def registered():
     """Register profiles for one test and restore the registry afterwards."""
     _providers._discover_providers()
-    snapshot = (
-        dict(_providers._REGISTRY),
-        dict(_providers._ALIASES),
-        _providers._PROVIDER_LIST_CACHE,
-    )
-
-    def _register(profile):
-        _providers.register_provider(profile)
-        return profile
-
-    yield _register
-
+    snapshot = (dict(_providers._REGISTRY), dict(_providers._ALIASES), _providers._PROVIDER_LIST_CACHE)
+    yield _providers.register_provider
     _providers._REGISTRY.clear()
     _providers._REGISTRY.update(snapshot[0])
     _providers._ALIASES.clear()
@@ -65,7 +51,6 @@ def registered():
 
 
 def _agent(provider: str = ""):
-    """The minimal agent surface create_openai_client touches."""
     return SimpleNamespace(
         provider=provider,
         _client_log_context=lambda: "",
@@ -73,183 +58,47 @@ def _agent(provider: str = ""):
     )
 
 
-# ── the hook itself ──────────────────────────────────────────────────────────
+def _build(provider, base_url):
+    from agent.agent_runtime_helpers import create_openai_client
+
+    return create_openai_client(_agent(provider), {"api_key": "k", "base_url": base_url}, reason="t", shared=False)
 
 
-def test_the_default_profile_supplies_no_client():
-    """Every ordinary provider inherits this and keeps the standard client."""
-    assert ProviderProfile(name="plain").create_client(api_key="k") is None
-
-
-def test_a_profile_can_supply_its_own_client(registered):
-    from agent.agent_runtime_helpers import _provider_supplied_client
-
-    registered(_SeamProfile(name="seam-test", base_url="acp://seam-test"))
-    client = _provider_supplied_client(_agent("seam-test"), {"api_key": "k"})
-    assert isinstance(client, _FakeClient)
-    assert client.kwargs == {"api_key": "k"}
-
-
-def test_an_alias_reaches_the_same_profile(registered):
-    from agent.agent_runtime_helpers import _provider_supplied_client
+def test_an_out_of_tree_profile_supplies_the_client_through_create_openai_client(registered):
+    from openai import OpenAI
 
     registered(_SeamProfile(name="seam-test", aliases=("seam",), base_url="acp://seam-test"))
-    assert isinstance(_provider_supplied_client(_agent("seam"), {}), _FakeClient)
+    # By name, by alias, and by base_url prefix when no provider name is set.
+    assert isinstance(_build("seam-test", "acp://seam-test"), _FakeClient)
+    assert isinstance(_build("seam", "acp://seam-test"), _FakeClient)
+    assert isinstance(_build("", "acp://seam-test/x"), _FakeClient)
+    # No hook → the standard client, untouched by the seam.
+    assert isinstance(_build("openai-api", "https://api.example/v1"), OpenAI)
 
 
-def test_the_base_url_resolves_the_profile_when_the_name_does_not(registered):
-    """A runtime configured only by URL still reaches its provider's client."""
-    from agent.agent_runtime_helpers import _provider_supplied_client
-
-    registered(_SeamProfile(name="seam-test", base_url="acp://seam-test"))
-    client = _provider_supplied_client(_agent(""), {"base_url": "acp://seam-test"})
-    assert isinstance(client, _FakeClient)
-    # Prefix, not equality — the branch this replaced keyed on startswith().
-    assert isinstance(
-        _provider_supplied_client(_agent(""), {"base_url": "acp://seam-test/x"}),
-        _FakeClient,
-    )
-    # A different scheme must not be captured.
-    assert _provider_supplied_client(_agent(""), {"base_url": "https://api.example/v1"}) is None
-
-
-def test_an_unregistered_provider_gets_no_client(registered):
-    from agent.agent_runtime_helpers import _provider_supplied_client
-
-    assert _provider_supplied_client(_agent("nothing-registered-here"), {}) is None
-
-
-def test_a_broken_plugin_cannot_take_the_turn_down(registered):
-    """A third-party profile that raises falls through to the standard path."""
+def test_a_broken_plugin_falls_through_instead_of_taking_the_turn_down(registered):
     from agent.agent_runtime_helpers import _provider_supplied_client
 
     registered(_ExplodingProfile(name="seam-boom", base_url="acp://seam-boom"))
     assert _provider_supplied_client(_agent("seam-boom"), {"api_key": "k"}) is None
 
 
-# ── the in-tree consumer ─────────────────────────────────────────────────────
-
-
-def test_copilot_acp_still_gets_its_acp_client():
-    """copilot-acp lost its hardcoded branch in create_openai_client; it must
-    still be constructed, now via its profile."""
-    from agent.copilot_acp_client import CopilotACPClient
-    from providers import get_provider_profile
-
-    profile = get_provider_profile("copilot-acp")
-    assert profile is not None
-    client = profile.create_client(api_key="copilot-acp", base_url="acp://copilot")
-    assert isinstance(client, CopilotACPClient)
-
-
-def test_copilot_acp_reaches_the_seam_by_name_and_by_url():
-    from agent.agent_runtime_helpers import _provider_supplied_client
+def test_copilot_acp_still_gets_its_acp_client_via_its_profile():
     from agent.copilot_acp_client import CopilotACPClient
 
-    by_name = _provider_supplied_client(
-        _agent("copilot-acp"), {"api_key": "copilot-acp", "base_url": "acp://copilot"}
-    )
-    assert isinstance(by_name, CopilotACPClient)
-    by_url = _provider_supplied_client(
-        _agent(""), {"api_key": "copilot-acp", "base_url": "acp://copilot"}
-    )
-    assert isinstance(by_url, CopilotACPClient)
+    assert isinstance(_build("copilot-acp", "acp://copilot"), CopilotACPClient)
+    assert isinstance(_build("", "acp://copilot"), CopilotACPClient)
 
 
-# ── the wiring, not just the helper ──────────────────────────────────────────
-
-
-def test_create_openai_client_actually_consults_the_profile(registered):
-    """Exercise the real construction entry point, not the helper it calls.
-
-    The helper being correct is worth nothing if ``create_openai_client`` stops
-    calling it — that is the regression this file exists to prevent.
-    """
-    from agent.agent_runtime_helpers import create_openai_client
-
-    registered(_SeamProfile(name="seam-test", base_url="acp://seam-test"))
-    client = create_openai_client(
-        _agent("seam-test"),
-        {"api_key": "k", "base_url": "acp://seam-test"},
-        reason="test",
-        shared=False,
-    )
-    assert isinstance(client, _FakeClient)
-
-
-def test_create_openai_client_still_builds_the_standard_client(registered):
-    """A provider with no profile hook is untouched by the seam."""
-    from openai import OpenAI
-
-    from agent.agent_runtime_helpers import create_openai_client
-
-    client = create_openai_client(
-        _agent("openai-api"),
-        {"api_key": "k", "base_url": "https://api.example/v1"},
-        reason="test",
-        shared=False,
-    )
-    assert isinstance(client, OpenAI)
-
-
-def test_create_openai_client_builds_the_copilot_acp_client():
-    """The in-tree consumer, through the same entry point its hardcoded branch
-    used to serve."""
-    from agent.agent_runtime_helpers import create_openai_client
-    from agent.copilot_acp_client import CopilotACPClient
-
-    client = create_openai_client(
-        _agent("copilot-acp"),
-        {"api_key": "copilot-acp", "base_url": "acp://copilot"},
-        reason="test",
-        shared=False,
-    )
-    assert isinstance(client, CopilotACPClient)
-
-
-# ── capability flags replacing the isinstance checks ─────────────────────────
-
-
-def test_clients_declaring_skip_flags_are_not_wrapped():
-    from agent.auxiliary_client import _client_declares
-
-    class _Final:
-        HERMES_SKIP_TRANSPORT_WRAP = True
-        HERMES_SKIP_ASYNC_WRAP = True
-
-    class _Plain:
-        pass
-
-    final = _Final()
-    assert _client_declares(final, "HERMES_SKIP_TRANSPORT_WRAP")
-    assert _client_declares(final, "HERMES_SKIP_ASYNC_WRAP")
-    # Absent attribute → False, so every ordinary client keeps its behaviour.
-    assert not _client_declares(_Plain(), "HERMES_SKIP_TRANSPORT_WRAP")
-    assert not _client_declares(None, "HERMES_SKIP_TRANSPORT_WRAP")
-
-
-def test_the_in_tree_clients_declare_what_their_isinstance_checks_used_to_say():
-    """copilot-acp skipped both wrappers; the Gemini native client skipped only
-    the transport one (its async path is a real conversion)."""
+def test_skip_flags_replace_the_isinstance_checks_for_in_and_out_of_tree_clients():
+    from agent.auxiliary_client import _maybe_wrap_anthropic, _to_async_client
     from agent.copilot_acp_client import CopilotACPClient
     from agent.gemini_native_adapter import GeminiNativeClient
 
-    assert CopilotACPClient.HERMES_SKIP_TRANSPORT_WRAP is True
-    assert CopilotACPClient.HERMES_SKIP_ASYNC_WRAP is True
-    assert GeminiNativeClient.HERMES_SKIP_TRANSPORT_WRAP is True
-    assert getattr(GeminiNativeClient, "HERMES_SKIP_ASYNC_WRAP", False) is False
+    assert CopilotACPClient.HERMES_SKIP_TRANSPORT_WRAP and CopilotACPClient.HERMES_SKIP_ASYNC_WRAP
+    assert GeminiNativeClient.HERMES_SKIP_TRANSPORT_WRAP
+    assert not getattr(GeminiNativeClient, "HERMES_SKIP_ASYNC_WRAP", False)
 
-
-def test_an_out_of_tree_client_is_covered_by_the_same_flags():
-    """The point of the flags: auxiliary_client never imports this class."""
-    from agent.auxiliary_client import _maybe_wrap_anthropic, _to_async_client
-
-    class _ThirdPartyClient:
-        HERMES_SKIP_TRANSPORT_WRAP = True
-        HERMES_SKIP_ASYNC_WRAP = True
-        api_key = "k"
-        base_url = "acp://third-party"
-
-    client = _ThirdPartyClient()
-    assert _maybe_wrap_anthropic(client, "m", "k", "acp://third-party") is client
+    client = _FakeClient()  # never imported by auxiliary_client
+    assert _maybe_wrap_anthropic(client, "m", "k", "acp://seam-test") is client
     assert _to_async_client(client, "m")[0] is client

--- a/tests/hermes_cli/test_external_process_provider_seam.py
+++ b/tests/hermes_cli/test_external_process_provider_seam.py
@@ -1,0 +1,218 @@
+"""An external-process provider can ship from outside this tree.
+
+An ACP agent CLI is not an HTTP endpoint: it is a subprocess Hermes drives over
+stdio. Everything about launching it used to be spelled out for one vendor —
+the known-provider gate, the binary, the argv, the env var names. A provider
+registered from ``~/.hermes/plugins/model-providers/`` or a pip entry point
+therefore could not be reached at all: ``hermes -m <it>`` died with "Unknown
+provider" long before any client was built.
+
+This registers a provider the way a standalone package does — before importing
+any ``hermes_cli`` module, exactly as plugin discovery does — and walks the real
+resolution path end to end. ``copilot-acp`` is asserted alongside it at every
+step, so the generalisation cannot quietly change the in-tree provider.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import sys
+
+import pytest
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from providers import register_provider  # noqa: E402
+from providers.base import ProviderProfile  # noqa: E402
+
+
+class _AcmeClient:
+    HERMES_SKIP_TRANSPORT_WRAP = True
+    HERMES_SKIP_ASYNC_WRAP = True
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.api_key = kwargs.get("api_key")
+        self.base_url = kwargs.get("base_url")
+
+
+class _AcmeACPProfile(ProviderProfile):
+    def create_client(self, **kwargs):
+        return _AcmeClient(**kwargs)
+
+    def fetch_models(self, **kwargs):
+        return None
+
+
+# Registered at import time — the same moment a plugin's ``__init__.py`` or a
+# pip entry point runs, i.e. before hermes_cli.auth builds PROVIDER_REGISTRY.
+register_provider(
+    _AcmeACPProfile(
+        name="acme-acp",
+        aliases=("acme",),
+        display_name="Acme ACP",
+        api_mode="chat_completions",
+        base_url="acp://acme",
+        auth_type="external_process",
+        process_command="acme-cli",
+        process_args=("--acp",),
+        process_command_env_vars=("ACME_CLI_PATH",),
+        process_args_env_var="ACME_ACP_ARGS",
+    )
+)
+
+
+@pytest.fixture
+def fake_cli(tmp_path, monkeypatch):
+    """Put stub `acme-cli` and `copilot` binaries on PATH."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    for name in ("acme-cli", "copilot"):
+        exe = bindir / name
+        exe.write_text("#!/bin/sh\nexit 0\n")
+        exe.chmod(exe.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    monkeypatch.setenv("PATH", f"{bindir}{os.pathsep}{os.environ.get('PATH', '')}")
+    return bindir
+
+
+# ── the known-provider gate ──────────────────────────────────────────────────
+
+
+def test_the_provider_is_absorbed_into_the_cli_registry():
+    """Without this the resolver raises "Unknown provider" before anything else."""
+    from hermes_cli.auth import PROVIDER_REGISTRY
+
+    assert "acme-acp" in PROVIDER_REGISTRY
+    assert PROVIDER_REGISTRY["acme-acp"].auth_type == "external_process"
+    assert PROVIDER_REGISTRY["acme-acp"].inference_base_url == "acp://acme"
+    assert PROVIDER_REGISTRY["acme-acp"].name == "Acme ACP"
+    # Aliases resolve to the same config.
+    assert PROVIDER_REGISTRY["acme"] is PROVIDER_REGISTRY["acme-acp"]
+    # The in-tree one is declared explicitly and must not be shadowed.
+    assert PROVIDER_REGISTRY["copilot-acp"].auth_type == "external_process"
+
+
+def test_resolve_provider_accepts_the_name_and_its_alias():
+    from hermes_cli.auth import resolve_provider
+
+    assert resolve_provider("acme-acp") == "acme-acp"
+    assert resolve_provider("acme") == "acme-acp"
+
+
+# ── launching the CLI ────────────────────────────────────────────────────────
+
+
+def test_credentials_come_from_the_profile(fake_cli):
+    from hermes_cli.auth import resolve_external_process_provider_credentials
+
+    creds = resolve_external_process_provider_credentials("acme-acp")
+    assert creds["command"] == str(fake_cli / "acme-cli")
+    assert creds["args"] == ["--acp"]
+    assert creds["base_url"] == "acp://acme"
+    # Placeholder credential keyed on the provider, not a borrowed literal.
+    assert creds["api_key"] == "acme-acp"
+
+
+def test_copilot_launch_details_are_unchanged(fake_cli):
+    """These moved from hardcoded resolver code into copilot-acp's profile."""
+    from hermes_cli.auth import resolve_external_process_provider_credentials
+
+    creds = resolve_external_process_provider_credentials("copilot-acp")
+    assert creds["command"] == str(fake_cli / "copilot")
+    assert creds["args"] == ["--acp", "--stdio"]
+    assert creds["api_key"] == "copilot-acp"
+    assert creds["base_url"] == "acp://copilot"
+
+
+@pytest.mark.parametrize(
+    "provider,env_var,binary",
+    [
+        ("acme-acp", "ACME_CLI_PATH", "acme-cli"),
+        ("copilot-acp", "HERMES_COPILOT_ACP_COMMAND", "copilot"),
+        ("copilot-acp", "COPILOT_CLI_PATH", "copilot"),
+    ],
+)
+def test_the_binary_can_be_overridden_by_env(fake_cli, monkeypatch, provider, env_var, binary):
+    from hermes_cli.auth import resolve_external_process_provider_credentials
+
+    custom = fake_cli / f"custom-{binary}"
+    custom.write_text("#!/bin/sh\nexit 0\n")
+    custom.chmod(custom.stat().st_mode | stat.S_IEXEC)
+    monkeypatch.setenv(env_var, str(custom))
+    creds = resolve_external_process_provider_credentials(provider)
+    assert creds["command"] == str(custom)
+
+
+@pytest.mark.parametrize(
+    "provider,env_var",
+    [("acme-acp", "ACME_ACP_ARGS"), ("copilot-acp", "HERMES_COPILOT_ACP_ARGS")],
+)
+def test_the_args_can_be_overridden_by_env(fake_cli, monkeypatch, provider, env_var):
+    from hermes_cli.auth import resolve_external_process_provider_credentials
+
+    monkeypatch.setenv(env_var, "--acp=true --verbose")
+    assert resolve_external_process_provider_credentials(provider)["args"] == [
+        "--acp=true",
+        "--verbose",
+    ]
+
+
+def test_a_missing_binary_names_the_provider_and_its_env_override(monkeypatch, tmp_path):
+    from hermes_cli.auth import AuthError, resolve_external_process_provider_credentials
+
+    monkeypatch.setenv("PATH", str(tmp_path))
+    with pytest.raises(AuthError) as excinfo:
+        resolve_external_process_provider_credentials("acme-acp")
+    message = str(excinfo.value)
+    assert "acme-acp" in message
+    assert "ACME_CLI_PATH" in message
+
+
+def test_a_non_external_process_provider_is_still_rejected():
+    from hermes_cli.auth import AuthError, resolve_external_process_provider_credentials
+
+    with pytest.raises(AuthError):
+        resolve_external_process_provider_credentials("openai-api")
+
+
+# ── runtime resolution ───────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "requested,expected_base_url",
+    [
+        ("acme-acp", "acp://acme"),
+        ("acme", "acp://acme"),
+        ("copilot-acp", "acp://copilot"),
+    ],
+)
+def test_runtime_resolution_reaches_the_external_process_branch(
+    fake_cli, requested, expected_base_url
+):
+    """Previously keyed on the literal "copilot-acp", so anything else fell
+    through to the OpenRouter default instead of its own runtime."""
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    runtime = resolve_runtime_provider(requested=requested, target_model=requested)
+    assert runtime["base_url"] == expected_base_url
+    assert runtime["api_mode"] == "chat_completions"
+    assert runtime["source"] == "process"
+    assert runtime["command"]
+
+
+def test_the_client_is_built_from_the_profile(fake_cli):
+    from types import SimpleNamespace
+
+    from agent.agent_runtime_helpers import _provider_supplied_client
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    runtime = resolve_runtime_provider(requested="acme-acp", target_model="acme-acp")
+    agent = SimpleNamespace(provider=runtime["provider"], _client_log_context=lambda: "")
+    client = _provider_supplied_client(
+        agent, {"api_key": runtime["api_key"], "base_url": runtime["base_url"]}
+    )
+    assert isinstance(client, _AcmeClient)
+    assert client.base_url == "acp://acme"

--- a/tests/hermes_cli/test_external_process_provider_seam.py
+++ b/tests/hermes_cli/test_external_process_provider_seam.py
@@ -1,60 +1,36 @@
-"""An external-process provider can ship from outside this tree.
+"""An external-process (ACP) provider can ship from outside this tree.
 
-An ACP agent CLI is not an HTTP endpoint: it is a subprocess Hermes drives over
-stdio. Everything about launching it used to be spelled out for one vendor —
-the known-provider gate, the binary, the argv, the env var names. A provider
-registered from ``~/.hermes/plugins/model-providers/`` or a pip entry point
-therefore could not be reached at all: ``hermes -m <it>`` died with "Unknown
-provider" long before any client was built.
-
-This registers a provider the way a standalone package does — before importing
-any ``hermes_cli`` module, exactly as plugin discovery does — and walks the real
-resolution path end to end. ``copilot-acp`` is asserted alongside it at every
-step, so the generalisation cannot quietly change the in-tree provider.
+The known-provider gate, the binary, the argv and the env var names used to be
+spelled out for one vendor, so a profile registered from a plugin died with
+"Unknown provider" before any client was built. This registers a provider the
+way a standalone package does — before importing ``hermes_cli`` — and walks the
+real resolution path, asserting ``copilot-acp`` is unchanged alongside it.
 """
 
 from __future__ import annotations
 
 import os
 import stat
-import sys
 
 import pytest
 
-_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-if _REPO_ROOT not in sys.path:
-    sys.path.insert(0, _REPO_ROOT)
-
-from providers import register_provider  # noqa: E402
-from providers.base import ProviderProfile  # noqa: E402
-
-
-class _AcmeClient:
-    HERMES_SKIP_TRANSPORT_WRAP = True
-    HERMES_SKIP_ASYNC_WRAP = True
-
-    def __init__(self, **kwargs):
-        self.kwargs = kwargs
-        self.api_key = kwargs.get("api_key")
-        self.base_url = kwargs.get("base_url")
+from providers import register_provider
+from providers.base import ProviderProfile
 
 
 class _AcmeACPProfile(ProviderProfile):
     def create_client(self, **kwargs):
-        return _AcmeClient(**kwargs)
+        return ("acme-client", kwargs)
 
     def fetch_models(self, **kwargs):
         return None
 
 
-# Registered at import time — the same moment a plugin's ``__init__.py`` or a
-# pip entry point runs, i.e. before hermes_cli.auth builds PROVIDER_REGISTRY.
 register_provider(
     _AcmeACPProfile(
         name="acme-acp",
         aliases=("acme",),
         display_name="Acme ACP",
-        api_mode="chat_completions",
         base_url="acp://acme",
         auth_type="external_process",
         process_command="acme-cli",
@@ -67,152 +43,44 @@ register_provider(
 
 @pytest.fixture
 def fake_cli(tmp_path, monkeypatch):
-    """Put stub `acme-cli` and `copilot` binaries on PATH."""
     bindir = tmp_path / "bin"
     bindir.mkdir()
-    for name in ("acme-cli", "copilot"):
+    for name in ("acme-cli", "copilot", "custom-acme"):
         exe = bindir / name
         exe.write_text("#!/bin/sh\nexit 0\n")
-        exe.chmod(exe.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        exe.chmod(exe.stat().st_mode | stat.S_IEXEC)
     monkeypatch.setenv("PATH", f"{bindir}{os.pathsep}{os.environ.get('PATH', '')}")
     return bindir
 
 
-# ── the known-provider gate ──────────────────────────────────────────────────
+def test_an_out_of_tree_external_process_provider_resolves_end_to_end(fake_cli, monkeypatch):
+    from hermes_cli.auth import PROVIDER_REGISTRY, resolve_external_process_provider_credentials, resolve_provider
+    from hermes_cli.runtime_provider import resolve_runtime_provider
 
-
-def test_the_provider_is_absorbed_into_the_cli_registry():
-    """Without this the resolver raises "Unknown provider" before anything else."""
-    from hermes_cli.auth import PROVIDER_REGISTRY
-
-    assert "acme-acp" in PROVIDER_REGISTRY
-    assert PROVIDER_REGISTRY["acme-acp"].auth_type == "external_process"
-    assert PROVIDER_REGISTRY["acme-acp"].inference_base_url == "acp://acme"
-    assert PROVIDER_REGISTRY["acme-acp"].name == "Acme ACP"
-    # Aliases resolve to the same config.
     assert PROVIDER_REGISTRY["acme"] is PROVIDER_REGISTRY["acme-acp"]
-    # The in-tree one is declared explicitly and must not be shadowed.
-    assert PROVIDER_REGISTRY["copilot-acp"].auth_type == "external_process"
-
-
-def test_resolve_provider_accepts_the_name_and_its_alias():
-    from hermes_cli.auth import resolve_provider
-
-    assert resolve_provider("acme-acp") == "acme-acp"
+    assert PROVIDER_REGISTRY["acme-acp"].auth_type == "external_process"
     assert resolve_provider("acme") == "acme-acp"
 
-
-# ── launching the CLI ────────────────────────────────────────────────────────
-
-
-def test_credentials_come_from_the_profile(fake_cli):
-    from hermes_cli.auth import resolve_external_process_provider_credentials
-
     creds = resolve_external_process_provider_credentials("acme-acp")
-    assert creds["command"] == str(fake_cli / "acme-cli")
-    assert creds["args"] == ["--acp"]
-    assert creds["base_url"] == "acp://acme"
-    # Placeholder credential keyed on the provider, not a borrowed literal.
-    assert creds["api_key"] == "acme-acp"
+    assert (creds["command"], creds["args"], creds["api_key"]) == (str(fake_cli / "acme-cli"), ["--acp"], "acme-acp")
+
+    monkeypatch.setenv("ACME_CLI_PATH", str(fake_cli / "custom-acme"))
+    monkeypatch.setenv("ACME_ACP_ARGS", "--acp=true --verbose")
+    creds = resolve_external_process_provider_credentials("acme-acp")
+    assert (creds["command"], creds["args"]) == (str(fake_cli / "custom-acme"), ["--acp=true", "--verbose"])
+
+    runtime = resolve_runtime_provider(requested="acme", target_model="acme")
+    assert (runtime["provider"], runtime["base_url"], runtime["source"]) == ("acme-acp", "acp://acme", "process")
 
 
-def test_copilot_launch_details_are_unchanged(fake_cli):
-    """These moved from hardcoded resolver code into copilot-acp's profile."""
+def test_copilot_acp_launch_details_are_unchanged(fake_cli, monkeypatch):
     from hermes_cli.auth import resolve_external_process_provider_credentials
+    from hermes_cli.runtime_provider import resolve_runtime_provider
 
     creds = resolve_external_process_provider_credentials("copilot-acp")
     assert creds["command"] == str(fake_cli / "copilot")
-    assert creds["args"] == ["--acp", "--stdio"]
-    assert creds["api_key"] == "copilot-acp"
-    assert creds["base_url"] == "acp://copilot"
+    assert (creds["args"], creds["api_key"], creds["base_url"]) == (["--acp", "--stdio"], "copilot-acp", "acp://copilot")
 
-
-@pytest.mark.parametrize(
-    "provider,env_var,binary",
-    [
-        ("acme-acp", "ACME_CLI_PATH", "acme-cli"),
-        ("copilot-acp", "HERMES_COPILOT_ACP_COMMAND", "copilot"),
-        ("copilot-acp", "COPILOT_CLI_PATH", "copilot"),
-    ],
-)
-def test_the_binary_can_be_overridden_by_env(fake_cli, monkeypatch, provider, env_var, binary):
-    from hermes_cli.auth import resolve_external_process_provider_credentials
-
-    custom = fake_cli / f"custom-{binary}"
-    custom.write_text("#!/bin/sh\nexit 0\n")
-    custom.chmod(custom.stat().st_mode | stat.S_IEXEC)
-    monkeypatch.setenv(env_var, str(custom))
-    creds = resolve_external_process_provider_credentials(provider)
-    assert creds["command"] == str(custom)
-
-
-@pytest.mark.parametrize(
-    "provider,env_var",
-    [("acme-acp", "ACME_ACP_ARGS"), ("copilot-acp", "HERMES_COPILOT_ACP_ARGS")],
-)
-def test_the_args_can_be_overridden_by_env(fake_cli, monkeypatch, provider, env_var):
-    from hermes_cli.auth import resolve_external_process_provider_credentials
-
-    monkeypatch.setenv(env_var, "--acp=true --verbose")
-    assert resolve_external_process_provider_credentials(provider)["args"] == [
-        "--acp=true",
-        "--verbose",
-    ]
-
-
-def test_a_missing_binary_names_the_provider_and_its_env_override(monkeypatch, tmp_path):
-    from hermes_cli.auth import AuthError, resolve_external_process_provider_credentials
-
-    monkeypatch.setenv("PATH", str(tmp_path))
-    with pytest.raises(AuthError) as excinfo:
-        resolve_external_process_provider_credentials("acme-acp")
-    message = str(excinfo.value)
-    assert "acme-acp" in message
-    assert "ACME_CLI_PATH" in message
-
-
-def test_a_non_external_process_provider_is_still_rejected():
-    from hermes_cli.auth import AuthError, resolve_external_process_provider_credentials
-
-    with pytest.raises(AuthError):
-        resolve_external_process_provider_credentials("openai-api")
-
-
-# ── runtime resolution ───────────────────────────────────────────────────────
-
-
-@pytest.mark.parametrize(
-    "requested,expected_base_url",
-    [
-        ("acme-acp", "acp://acme"),
-        ("acme", "acp://acme"),
-        ("copilot-acp", "acp://copilot"),
-    ],
-)
-def test_runtime_resolution_reaches_the_external_process_branch(
-    fake_cli, requested, expected_base_url
-):
-    """Previously keyed on the literal "copilot-acp", so anything else fell
-    through to the OpenRouter default instead of its own runtime."""
-    from hermes_cli.runtime_provider import resolve_runtime_provider
-
-    runtime = resolve_runtime_provider(requested=requested, target_model=requested)
-    assert runtime["base_url"] == expected_base_url
-    assert runtime["api_mode"] == "chat_completions"
-    assert runtime["source"] == "process"
-    assert runtime["command"]
-
-
-def test_the_client_is_built_from_the_profile(fake_cli):
-    from types import SimpleNamespace
-
-    from agent.agent_runtime_helpers import _provider_supplied_client
-    from hermes_cli.runtime_provider import resolve_runtime_provider
-
-    runtime = resolve_runtime_provider(requested="acme-acp", target_model="acme-acp")
-    agent = SimpleNamespace(provider=runtime["provider"], _client_log_context=lambda: "")
-    client = _provider_supplied_client(
-        agent, {"api_key": runtime["api_key"], "base_url": runtime["base_url"]}
-    )
-    assert isinstance(client, _AcmeClient)
-    assert client.base_url == "acp://acme"
+    monkeypatch.setenv("COPILOT_CLI_PATH", str(fake_cli / "custom-acme"))
+    assert resolve_external_process_provider_credentials("copilot-acp")["command"] == str(fake_cli / "custom-acme")
+    assert resolve_runtime_provider(requested="copilot-acp", target_model="x")["base_url"] == "acp://copilot"

--- a/tests/providers/test_installed_plugin_discovery.py
+++ b/tests/providers/test_installed_plugin_discovery.py
@@ -1,0 +1,198 @@
+"""A provider installed by ``hermes plugins install`` must actually be found.
+
+``hermes plugins install owner/repo`` (and the plugin index behind
+``hermes plugins search``) clones into ``$HERMES_HOME/plugins/<name>/`` — flat,
+one directory per plugin. Provider discovery only ever scanned
+``$HERMES_HOME/plugins/model-providers/<name>/``, and ``PluginManager`` skips
+``kind: model-provider`` on purpose ("routed to their own discovery system").
+
+Nothing joined those two halves, so the documented install path half-worked: the
+CLI reported success and the provider silently did not exist. These tests pin
+the join, and pin that provider discovery still keeps its hands off every other
+plugin living in that same directory.
+"""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_PROFILE_SOURCE = textwrap.dedent(
+    """
+    from providers import register_provider
+    from providers.base import ProviderProfile
+
+    register_provider(ProviderProfile(
+        name="{name}",
+        aliases=("{name}-alias",),
+        base_url="acp://{name}",
+        auth_type="external_process",
+    ))
+    """
+)
+
+
+def _clear_provider_caches():
+    """Force providers/__init__.py to re-discover on the next lookup."""
+    import providers as _pkg
+
+    _pkg._REGISTRY.clear()
+    _pkg._ALIASES.clear()
+    _pkg._PROVIDER_LIST_CACHE = None
+    _pkg._discovered = False
+    for mod in list(sys.modules):
+        if mod.startswith("plugins.model_providers") or mod.startswith(
+            "_hermes_user_provider"
+        ):
+            del sys.modules[mod]
+
+
+def _write_plugin(directory: Path, *, name: str, kind: str, body: str | None = None):
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "plugin.yaml").write_text(
+        f"name: {name}\nkind: {kind}\nversion: 1.0.0\ndescription: test fixture\n",
+        encoding="utf-8",
+    )
+    (directory / "__init__.py").write_text(
+        body if body is not None else _PROFILE_SOURCE.format(name=name),
+        encoding="utf-8",
+    )
+    return directory
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _clear_provider_caches()
+    yield tmp_path
+    _clear_provider_caches()
+
+
+def test_a_plugin_installed_flat_is_discovered(hermes_home):
+    """The layout `hermes plugins install` actually produces."""
+    _write_plugin(
+        hermes_home / "plugins" / "installed-acp", name="installed-acp", kind="model-provider"
+    )
+    from providers import get_provider_profile
+
+    profile = get_provider_profile("installed-acp")
+    assert profile is not None
+    assert profile.base_url == "acp://installed-acp"
+    assert profile.auth_type == "external_process"
+
+
+def test_its_aliases_resolve_too(hermes_home):
+    _write_plugin(
+        hermes_home / "plugins" / "installed-acp", name="installed-acp", kind="model-provider"
+    )
+    from providers import get_provider_profile
+
+    assert get_provider_profile("installed-acp-alias") is not None
+
+
+def test_the_model_providers_layout_still_works(hermes_home):
+    """The pre-existing nested location must not regress."""
+    _write_plugin(
+        hermes_home / "plugins" / "model-providers" / "nested-acp",
+        name="nested-acp",
+        kind="model-provider",
+    )
+    from providers import get_provider_profile
+
+    assert get_provider_profile("nested-acp") is not None
+
+
+def test_both_layouts_coexist(hermes_home):
+    _write_plugin(
+        hermes_home / "plugins" / "installed-acp", name="installed-acp", kind="model-provider"
+    )
+    _write_plugin(
+        hermes_home / "plugins" / "model-providers" / "nested-acp",
+        name="nested-acp",
+        kind="model-provider",
+    )
+    from providers import get_provider_profile
+
+    assert get_provider_profile("installed-acp") is not None
+    assert get_provider_profile("nested-acp") is not None
+
+
+# ── discovery must not overreach ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("kind", ["standalone", "backend", "platform", "exclusive"])
+def test_other_plugin_kinds_are_left_to_the_plugin_manager(hermes_home, kind):
+    """Those belong to PluginManager, which owns their lifecycle and consent
+    flow. Importing them here would run third-party code behind its back.
+
+    The fixture registers a provider on import, so an unwanted import is
+    *visible* — a plugin that merely raised would be swallowed by
+    ``_import_plugin_dir``'s except and prove nothing.
+    """
+    _write_plugin(
+        hermes_home / "plugins" / f"other-{kind}",
+        name=f"other-{kind}",
+        kind=kind,
+        body=_PROFILE_SOURCE.format(name=f"other-{kind}"),
+    )
+    from providers import get_provider_profile, list_providers
+
+    assert get_provider_profile(f"other-{kind}") is None
+    assert not [p for p in list_providers() if p.name.startswith("other-")]
+
+
+def test_a_plugin_with_no_manifest_is_ignored(hermes_home):
+    directory = hermes_home / "plugins" / "manifestless"
+    directory.mkdir(parents=True)
+    # Registers on import, so an unwanted import shows up as a provider.
+    (directory / "__init__.py").write_text(
+        _PROFILE_SOURCE.format(name="manifestless"), encoding="utf-8"
+    )
+    from providers import get_provider_profile
+
+    assert get_provider_profile("manifestless") is None
+
+
+def test_an_unreadable_manifest_does_not_break_discovery(hermes_home):
+    """A malformed third-party manifest must not blank the whole registry."""
+    directory = hermes_home / "plugins" / "broken-manifest"
+    directory.mkdir(parents=True)
+    (directory / "plugin.yaml").write_text("kind: [this is: not valid\n", encoding="utf-8")
+    (directory / "__init__.py").write_text("", encoding="utf-8")
+    from providers import get_provider_profile, list_providers
+
+    assert len(list_providers()) > 20  # the bundled set is still there
+    assert get_provider_profile("copilot-acp") is not None
+
+
+def test_quoted_kind_values_are_accepted(hermes_home):
+    """The fallback line scan runs when PyYAML is unavailable; a quoted scalar
+    is valid YAML and must parse the same either way."""
+    directory = hermes_home / "plugins" / "quoted-acp"
+    directory.mkdir(parents=True)
+    (directory / "plugin.yaml").write_text(
+        'name: quoted-acp\nkind: "model-provider"\nversion: 1.0.0\n', encoding="utf-8"
+    )
+    (directory / "__init__.py").write_text(
+        _PROFILE_SOURCE.format(name="quoted-acp"), encoding="utf-8"
+    )
+    from providers import get_provider_profile
+
+    assert get_provider_profile("quoted-acp") is not None
+
+
+def test_discovery_survives_a_missing_hermes_home(tmp_path, monkeypatch):
+    """No $HERMES_HOME/plugins/ at all — the bundled set must still load."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "does-not-exist"))
+    _clear_provider_caches()
+    try:
+        from providers import get_provider_profile
+
+        assert get_provider_profile("copilot-acp") is not None
+    finally:
+        _clear_provider_caches()

--- a/tests/providers/test_installed_plugin_discovery.py
+++ b/tests/providers/test_installed_plugin_discovery.py
@@ -1,15 +1,10 @@
 """A provider installed by ``hermes plugins install`` must actually be found.
 
-``hermes plugins install owner/repo`` (and the plugin index behind
-``hermes plugins search``) clones into ``$HERMES_HOME/plugins/<name>/`` — flat,
-one directory per plugin. Provider discovery only ever scanned
-``$HERMES_HOME/plugins/model-providers/<name>/``, and ``PluginManager`` skips
-``kind: model-provider`` on purpose ("routed to their own discovery system").
-
-Nothing joined those two halves, so the documented install path half-worked: the
-CLI reported success and the provider silently did not exist. These tests pin
-the join, and pin that provider discovery still keeps its hands off every other
-plugin living in that same directory.
+The installer clones into ``$HERMES_HOME/plugins/<name>/`` (flat), provider
+discovery only scanned ``plugins/model-providers/<name>/``, and PluginManager
+skips ``kind: model-provider`` on purpose — so the documented install path
+reported success and registered nothing. These tests pin the join, and that
+discovery keeps its hands off every other plugin in that directory.
 """
 
 from __future__ import annotations
@@ -20,25 +15,18 @@ from pathlib import Path
 
 import pytest
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
-
 _PROFILE_SOURCE = textwrap.dedent(
     """
     from providers import register_provider
     from providers.base import ProviderProfile
 
-    register_provider(ProviderProfile(
-        name="{name}",
-        aliases=("{name}-alias",),
-        base_url="acp://{name}",
-        auth_type="external_process",
-    ))
+    register_provider(ProviderProfile(name="{name}", aliases=("{name}-alias",),
+                                      base_url="acp://{name}", auth_type="external_process"))
     """
 )
 
 
 def _clear_provider_caches():
-    """Force providers/__init__.py to re-discover on the next lookup."""
     import providers as _pkg
 
     _pkg._REGISTRY.clear()
@@ -46,23 +34,16 @@ def _clear_provider_caches():
     _pkg._PROVIDER_LIST_CACHE = None
     _pkg._discovered = False
     for mod in list(sys.modules):
-        if mod.startswith("plugins.model_providers") or mod.startswith(
-            "_hermes_user_provider"
-        ):
+        if mod.startswith(("plugins.model_providers", "_hermes_user_provider")):
             del sys.modules[mod]
 
 
-def _write_plugin(directory: Path, *, name: str, kind: str, body: str | None = None):
+def _write_plugin(directory: Path, *, name: str, manifest: str | None):
     directory.mkdir(parents=True, exist_ok=True)
-    (directory / "plugin.yaml").write_text(
-        f"name: {name}\nkind: {kind}\nversion: 1.0.0\ndescription: test fixture\n",
-        encoding="utf-8",
-    )
-    (directory / "__init__.py").write_text(
-        body if body is not None else _PROFILE_SOURCE.format(name=name),
-        encoding="utf-8",
-    )
-    return directory
+    if manifest is not None:
+        (directory / "plugin.yaml").write_text(manifest, encoding="utf-8")
+    # Registers a provider on import, so an unwanted import is *visible*.
+    (directory / "__init__.py").write_text(_PROFILE_SOURCE.format(name=name), encoding="utf-8")
 
 
 @pytest.fixture
@@ -73,126 +54,25 @@ def hermes_home(tmp_path, monkeypatch):
     _clear_provider_caches()
 
 
-def test_a_plugin_installed_flat_is_discovered(hermes_home):
-    """The layout `hermes plugins install` actually produces."""
-    _write_plugin(
-        hermes_home / "plugins" / "installed-acp", name="installed-acp", kind="model-provider"
-    )
+def test_flat_installed_model_provider_plugins_are_discovered_alongside_nested_ones(hermes_home):
+    _write_plugin(hermes_home / "plugins" / "installed-acp", name="installed-acp",
+                  manifest='name: installed-acp\nkind: "model-provider"\n')
+    _write_plugin(hermes_home / "plugins" / "model-providers" / "nested-acp", name="nested-acp",
+                  manifest="name: nested-acp\nkind: model-provider\n")
     from providers import get_provider_profile
 
-    profile = get_provider_profile("installed-acp")
-    assert profile is not None
-    assert profile.base_url == "acp://installed-acp"
-    assert profile.auth_type == "external_process"
-
-
-def test_its_aliases_resolve_too(hermes_home):
-    _write_plugin(
-        hermes_home / "plugins" / "installed-acp", name="installed-acp", kind="model-provider"
-    )
-    from providers import get_provider_profile
-
+    assert get_provider_profile("installed-acp").base_url == "acp://installed-acp"
     assert get_provider_profile("installed-acp-alias") is not None
-
-
-def test_the_model_providers_layout_still_works(hermes_home):
-    """The pre-existing nested location must not regress."""
-    _write_plugin(
-        hermes_home / "plugins" / "model-providers" / "nested-acp",
-        name="nested-acp",
-        kind="model-provider",
-    )
-    from providers import get_provider_profile
-
     assert get_provider_profile("nested-acp") is not None
 
 
-def test_both_layouts_coexist(hermes_home):
-    _write_plugin(
-        hermes_home / "plugins" / "installed-acp", name="installed-acp", kind="model-provider"
-    )
-    _write_plugin(
-        hermes_home / "plugins" / "model-providers" / "nested-acp",
-        name="nested-acp",
-        kind="model-provider",
-    )
-    from providers import get_provider_profile
-
-    assert get_provider_profile("installed-acp") is not None
-    assert get_provider_profile("nested-acp") is not None
-
-
-# ── discovery must not overreach ─────────────────────────────────────────────
-
-
-@pytest.mark.parametrize("kind", ["standalone", "backend", "platform", "exclusive"])
-def test_other_plugin_kinds_are_left_to_the_plugin_manager(hermes_home, kind):
-    """Those belong to PluginManager, which owns their lifecycle and consent
-    flow. Importing them here would run third-party code behind its back.
-
-    The fixture registers a provider on import, so an unwanted import is
-    *visible* — a plugin that merely raised would be swallowed by
-    ``_import_plugin_dir``'s except and prove nothing.
-    """
-    _write_plugin(
-        hermes_home / "plugins" / f"other-{kind}",
-        name=f"other-{kind}",
-        kind=kind,
-        body=_PROFILE_SOURCE.format(name=f"other-{kind}"),
-    )
+def test_other_plugins_in_the_flat_directory_are_left_to_the_plugin_manager(hermes_home):
+    _write_plugin(hermes_home / "plugins" / "other-standalone", name="other-standalone",
+                  manifest="name: other-standalone\nkind: standalone\n")
+    _write_plugin(hermes_home / "plugins" / "manifestless", name="manifestless", manifest=None)
+    _write_plugin(hermes_home / "plugins" / "broken-manifest", name="broken-manifest",
+                  manifest="kind: [this is: not valid\n")
     from providers import get_provider_profile, list_providers
 
-    assert get_provider_profile(f"other-{kind}") is None
-    assert not [p for p in list_providers() if p.name.startswith("other-")]
-
-
-def test_a_plugin_with_no_manifest_is_ignored(hermes_home):
-    directory = hermes_home / "plugins" / "manifestless"
-    directory.mkdir(parents=True)
-    # Registers on import, so an unwanted import shows up as a provider.
-    (directory / "__init__.py").write_text(
-        _PROFILE_SOURCE.format(name="manifestless"), encoding="utf-8"
-    )
-    from providers import get_provider_profile
-
-    assert get_provider_profile("manifestless") is None
-
-
-def test_an_unreadable_manifest_does_not_break_discovery(hermes_home):
-    """A malformed third-party manifest must not blank the whole registry."""
-    directory = hermes_home / "plugins" / "broken-manifest"
-    directory.mkdir(parents=True)
-    (directory / "plugin.yaml").write_text("kind: [this is: not valid\n", encoding="utf-8")
-    (directory / "__init__.py").write_text("", encoding="utf-8")
-    from providers import get_provider_profile, list_providers
-
-    assert len(list_providers()) > 20  # the bundled set is still there
-    assert get_provider_profile("copilot-acp") is not None
-
-
-def test_quoted_kind_values_are_accepted(hermes_home):
-    """The fallback line scan runs when PyYAML is unavailable; a quoted scalar
-    is valid YAML and must parse the same either way."""
-    directory = hermes_home / "plugins" / "quoted-acp"
-    directory.mkdir(parents=True)
-    (directory / "plugin.yaml").write_text(
-        'name: quoted-acp\nkind: "model-provider"\nversion: 1.0.0\n', encoding="utf-8"
-    )
-    (directory / "__init__.py").write_text(
-        _PROFILE_SOURCE.format(name="quoted-acp"), encoding="utf-8"
-    )
-    from providers import get_provider_profile
-
-    assert get_provider_profile("quoted-acp") is not None
-
-
-def test_discovery_survives_a_missing_hermes_home(tmp_path, monkeypatch):
-    """No $HERMES_HOME/plugins/ at all — the bundled set must still load."""
-    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "does-not-exist"))
-    _clear_provider_caches()
-    try:
-        from providers import get_provider_profile
-
-        assert get_provider_profile("copilot-acp") is not None
-    finally:
-        _clear_provider_caches()
+    assert not [p for p in list_providers() if p.name in ("other-standalone", "manifestless", "broken-manifest")]
+    assert get_provider_profile("copilot-acp") is not None  # bundled set still intact

--- a/website/docs/developer-guide/model-provider-plugin.md
+++ b/website/docs/developer-guide/model-provider-plugin.md
@@ -18,7 +18,8 @@ Model provider plugins are the third kind of **provider plugin**. The others are
 
 1. **Bundled plugins** — `<repo>/plugins/model-providers/<name>/` — ship with Hermes
 2. **User plugins** — `$HERMES_HOME/plugins/model-providers/<name>/` — drop in any directory; no restart required for subsequent sessions
-3. **Legacy single-file** — `<repo>/providers/<name>.py` — back-compat for out-of-tree editable installs
+3. **Installed plugins** — `$HERMES_HOME/plugins/<name>/` (where `hermes plugins install owner/repo` clones) — imported only when `plugin.yaml` declares `kind: model-provider`; every other kind there belongs to the general PluginManager
+4. **Legacy single-file** — `<repo>/providers/<name>.py` — back-compat for out-of-tree editable installs
 
 **User plugins override bundled plugins of the same name** because `register_provider()` is last-writer-wins. Drop a `$HERMES_HOME/plugins/model-providers/gmi/` directory to replace the built-in GMI profile without touching the repo.
 
@@ -141,7 +142,30 @@ class AcmeProfile(ProviderProfile):
         Bearer auth. Override for: custom auth (Anthropic), no REST endpoint
         (Bedrock → None), or public/unauthenticated catalogs (OpenRouter)."""
         return super().fetch_models(api_key=api_key, base_url=base_url, timeout=timeout)
+
+    def create_client(self, **client_kwargs):
+        """Supply your own client object instead of the shared openai.OpenAI.
+        Default returns None (= use the standard client). Override when the
+        wire protocol is not OpenAI-over-HTTP — e.g. an ACP subprocess shim.
+        client_kwargs is what the core would have passed to openai.OpenAI
+        (api_key, base_url, command, args, timeouts, headers…); accept **kwargs
+        and pick what you need. A raise is logged and falls back to the
+        standard client."""
+        return None
 ```
+
+## External-process (ACP) providers
+
+An agent CLI driven over stdio is not an HTTP endpoint. Set `auth_type="external_process"`, describe how to launch the binary, and supply the client with `create_client`. No core edits are needed — `hermes -m <name>`, `/model`, credential resolution, runtime resolution and the auxiliary client (compression, vision) all key on `auth_type`, not on the provider name. `plugins/model-providers/copilot-acp/` is the in-tree example.
+
+| Field | Purpose |
+|---|---|
+| `process_command` | Default binary, e.g. `"copilot"` |
+| `process_args` | Default argv tail, e.g. `("--acp", "--stdio")` |
+| `process_command_env_vars` | Env vars that override the binary, checked in order |
+| `process_args_env_var` | Env var that overrides argv (shlex-split) |
+
+The client your `create_client` returns receives `command` and `args` in `client_kwargs`. If it is already complete and async-safe, declare `HERMES_SKIP_TRANSPORT_WRAP = True` / `HERMES_SKIP_ASYNC_WRAP = True` as class attributes so the auxiliary client does not re-dispatch it through an HTTP wire adapter.
 
 ## Hook reference examples
 
@@ -198,7 +222,7 @@ Set `profile.api_mode` to match the default your provider ships — it acts as a
 | `oauth_external` | User signs in elsewhere, tokens land in `auth.json` | Anthropic OAuth, MiniMax OAuth, Qwen Portal, Nous Portal |
 | `copilot` | GitHub Copilot token refresh cycle | `copilot` plugin only |
 | `aws_sdk` | AWS SDK credential chain (IAM role, profile, env) | `bedrock` plugin only |
-| `external_process` | Auth handled by a subprocess the agent spawns | `copilot-acp` plugin only |
+| `external_process` | Auth handled by a subprocess the agent spawns (see [External-process providers](#external-process-acp-providers)) | `copilot-acp` plugin, out-of-tree ACP plugins |
 
 `auth_type` gates which codepaths treat your provider as a "simple api-key provider" — if it's not `api_key`, the PluginManager still records the manifest but Hermes' CLI-level automation (doctor checks, `--provider` flag, setup wizard delegation) may skip over it.
 


### PR DESCRIPTION
## Summary

An ACP/external-process model provider can now ship entirely outside the tree — a `ProviderProfile` plugin supplies its own client, its launch details, and passes every core gate — and a provider plugin installed with `hermes plugins install owner/repo` is actually discovered instead of silently doing nothing.

Salvage of #101346 by @AlexanderPrendota (part 2 of the #74743 split; part 1 was #95679). His three commits are cherry-picked with authorship preserved; on top we trimmed the tests to the invariants and added the developer-guide docs.

Root cause: `create_openai_client()` had no extension point for a non-HTTP client, and three core paths (`PROVIDER_REGISTRY` auto-extend, `resolve_external_process_provider_credentials`, `resolve_runtime_provider`) keyed on the literal `"copilot-acp"` / hardcoded `copilot --acp --stdio`. Separately, `hermes plugins install` clones flat into `~/.hermes/plugins/<name>/` while provider discovery only scanned `plugins/model-providers/` (#76372).

## Changes

- `providers/base.py`: `ProviderProfile.create_client(**kwargs)` hook (default `None` → standard client) + `process_command` / `process_args` / `process_command_env_vars` / `process_args_env_var` fields
- `agent/agent_runtime_helpers.py`: `create_openai_client` consults the profile (by name, then `base_url` prefix) before the built-in ladder; a raising plugin is logged and falls through
- `hermes_cli/auth.py`: registry auto-extend absorbs `external_process` profiles (+aliases); credential resolution reads the launch details from the profile; error names the provider and its own override var
- `hermes_cli/runtime_provider.py`: external-process branch keyed on `auth_type`, not the name
- `agent/auxiliary_client.py`: `isinstance(CopilotACPClient/GeminiNativeClient)` → `HERMES_SKIP_TRANSPORT_WRAP` / `HERMES_SKIP_ASYNC_WRAP` class flags (declared on both in-tree clients); external-process aux path builds via the profile
- `plugins/model-providers/copilot-acp/`: migrated onto the seam — same binary, argv, env vars (`HERMES_COPILOT_ACP_COMMAND` / `COPILOT_CLI_PATH` / `HERMES_COPILOT_ACP_ARGS`), same `copilot-acp` api_key placeholder
- `providers/__init__.py`: discovery also walks `$HERMES_HOME/plugins/<name>/` for manifests declaring `kind: model-provider`; every other kind stays with PluginManager
- `website/docs/developer-guide/model-provider-plugin.md`: `create_client`, external-process section, discovery step 3
- Tests: 41 → 8, pinning the before/after contracts (sabotage-checked: all fail without the source commits)

## Validation

Live repro, real imports against a temp `HERMES_HOME` with an out-of-tree `acme-acp` profile in the flat install layout:

| Step | Before (origin/main) | After |
|---|---|---|
| discovery | `None` | `AcmeProfile(...)` |
| registry gate | `KeyError: 'acme-acp'` | `external_process` |
| credentials | `AuthError: not an external-process provider` | `acme-cli --acp`, api_key `acme-acp` |
| runtime | `AuthError: Unknown provider 'acme-acp'` | `provider=acme-acp, base_url=acp://acme` |
| client | fell to OpenAI path | `_AcmeClient` |
| copilot-acp creds | `--acp --stdio` / `copilot-acp` | unchanged |

`tests/agent/test_provider_client_seam.py`, `tests/hermes_cli/test_external_process_provider_seam.py`, `tests/providers/test_installed_plugin_discovery.py`, plus existing `test_copilot_acp_client.py` and `test_plugin_discovery.py`: 29 passed.

## Credit

- @AlexanderPrendota — #101346 (this work)
- Flat-install discovery bug (#76372) was independently fixed from the installer side by @theQuert (#64277, earliest), @temga (#76387) and @RelaxJonh (#76554); the discovery-side fix here covers already-installed plugins too, so those close with this.
- @Aryan-Pardeshi — #84057 proposed the same generic `external_process` resolution for `auth.py`/`runtime_provider.py`.

Closes #76372.

## Infographic

![provider registration seam](https://v3b.fal.media/files/b/0aa8d511/tZ2WQvGklG42r0d56UuW__XN3YohYL.png)
