### PR TITLE
fix(skills): skip unchanged GitHub bundle downloads

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -558,6 +558,62 @@ class TestCheckForSkillUpdates:
         assert results[0]["name"] == "demo-skill"
         assert results[0]["status"] == "update_available"
 
+    def test_skips_bundle_fetch_when_immutable_revision_is_unchanged(self):
+        lock = MagicMock()
+        lock.list_installed.return_value = [{
+            "name": "demo-skill",
+            "source": "github",
+            "identifier": "owner/repo/demo-skill",
+            "content_hash": "installed-hash",
+            "install_path": "demo-skill",
+            "metadata": {"source_revision": "abc123"},
+        }]
+
+        source = MagicMock(spec=SkillSource)
+        source.source_id.return_value = "github"
+        source.current_revision.return_value = "abc123"
+        source.fetch.side_effect = AssertionError("unchanged revision must not fetch bundle")
+
+        results = check_for_skill_updates(lock=lock, sources=[source])
+
+        assert results == [{
+            "name": "demo-skill",
+            "identifier": "owner/repo/demo-skill",
+            "source": "github",
+            "status": "up_to_date",
+            "current_hash": "installed-hash",
+            "latest_hash": "installed-hash",
+        }]
+        source.fetch.assert_not_called()
+
+    def test_fetches_bundle_when_immutable_revision_changed(self):
+        lock = MagicMock()
+        lock.list_installed.return_value = [{
+            "name": "demo-skill",
+            "source": "github",
+            "identifier": "owner/repo/demo-skill",
+            "content_hash": "oldhash",
+            "install_path": "demo-skill",
+            "metadata": {"source_revision": "abc123"},
+        }]
+
+        source = MagicMock(spec=SkillSource)
+        source.source_id.return_value = "github"
+        source.current_revision.return_value = "def456"
+        source.fetch.return_value = SkillBundle(
+            name="demo-skill",
+            files={"SKILL.md": "new content"},
+            source="github",
+            identifier="owner/repo/demo-skill",
+            trust_level="community",
+        )
+
+        results = check_for_skill_updates(lock=lock, sources=[source])
+
+        assert results[0]["status"] == "update_available"
+        source.fetch.assert_called_once_with("owner/repo/demo-skill")
+
+
 class TestCreateSourceRouter:
 
     def test_url_source_runs_before_github_source(self):

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -558,7 +558,7 @@ class TestCheckForSkillUpdates:
         assert results[0]["name"] == "demo-skill"
         assert results[0]["status"] == "update_available"
 
-    def test_skips_bundle_fetch_when_immutable_revision_is_unchanged(self):
+    def test_skips_bundle_fetch_when_skill_tree_is_unchanged(self):
         lock = MagicMock()
         lock.list_installed.return_value = [{
             "name": "demo-skill",
@@ -571,8 +571,8 @@ class TestCheckForSkillUpdates:
 
         source = MagicMock(spec=SkillSource)
         source.source_id.return_value = "github"
-        source.current_revision.return_value = "abc123"
-        source.fetch.side_effect = AssertionError("unchanged revision must not fetch bundle")
+        source.is_revision_content_current.return_value = True
+        source.fetch.side_effect = AssertionError("unchanged skill tree must not fetch bundle")
 
         results = check_for_skill_updates(lock=lock, sources=[source])
 
@@ -586,7 +586,7 @@ class TestCheckForSkillUpdates:
         }]
         source.fetch.assert_not_called()
 
-    def test_fetches_bundle_when_immutable_revision_changed(self):
+    def test_fetches_bundle_when_skill_tree_changed(self):
         lock = MagicMock()
         lock.list_installed.return_value = [{
             "name": "demo-skill",
@@ -599,7 +599,7 @@ class TestCheckForSkillUpdates:
 
         source = MagicMock(spec=SkillSource)
         source.source_id.return_value = "github"
-        source.current_revision.return_value = "def456"
+        source.is_revision_content_current.return_value = False
         source.fetch.return_value = SkillBundle(
             name="demo-skill",
             files={"SKILL.md": "new content"},
@@ -612,6 +612,36 @@ class TestCheckForSkillUpdates:
 
         assert results[0]["status"] == "update_available"
         source.fetch.assert_called_once_with("owner/repo/demo-skill")
+
+    def test_github_revision_comparison_ignores_unrelated_tree_changes(self):
+        source = GitHubSource(auth=MagicMock(spec=GitHubAuth))
+        source._tree_cache["owner/repo"] = ("main", [
+            {"path": "skills/demo/SKILL.md", "type": "blob", "mode": "100644", "sha": "same"},
+            {"path": "skills/other/SKILL.md", "type": "blob", "mode": "100644", "sha": "new"},
+        ])
+        source._tree_revisions["owner/repo"] = "new-revision"
+        source._revision_tree_cache[("owner/repo", "old-revision")] = [
+            {"path": "skills/demo/SKILL.md", "type": "blob", "mode": "100644", "sha": "same"},
+            {"path": "skills/other/SKILL.md", "type": "blob", "mode": "100644", "sha": "old"},
+        ]
+
+        assert source.is_revision_content_current(
+            "owner/repo/skills/demo", "old-revision"
+        ) is True
+
+    def test_github_revision_comparison_detects_skill_tree_change(self):
+        source = GitHubSource(auth=MagicMock(spec=GitHubAuth))
+        source._tree_cache["owner/repo"] = ("main", [
+            {"path": "skills/demo/SKILL.md", "type": "blob", "mode": "100644", "sha": "new"},
+        ])
+        source._tree_revisions["owner/repo"] = "new-revision"
+        source._revision_tree_cache[("owner/repo", "old-revision")] = [
+            {"path": "skills/demo/SKILL.md", "type": "blob", "mode": "100644", "sha": "old"},
+        ]
+
+        assert source.is_revision_content_current(
+            "owner/repo/skills/demo", "old-revision"
+        ) is False
 
 
 class TestCreateSourceRouter:

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -558,7 +558,76 @@ class TestCheckForSkillUpdates:
         assert results[0]["name"] == "demo-skill"
         assert results[0]["status"] == "update_available"
 
-    def test_skips_bundle_fetch_when_skill_tree_is_unchanged(self):
+    def test_complete_github_bundle_records_revision_fast_path_proof(self):
+        source = GitHubSource(auth=MagicMock(spec=GitHubAuth))
+        source._tree_cache["owner/repo"] = ("main", [
+            {
+                "path": "demo-skill/SKILL.md",
+                "type": "blob",
+                "mode": "100644",
+                "sha": "skill-md",
+            },
+            {
+                "path": "demo-skill/references/guide.md",
+                "type": "blob",
+                "mode": "100644",
+                "sha": "guide",
+            },
+        ])
+        source._tree_revisions["owner/repo"] = "a" * 40
+        source._fetch_file_content = MagicMock(return_value="---\nname: demo-skill\n---\n")
+        source._fetch_file_bytes = MagicMock(return_value=b"guide")
+
+        bundle = source.fetch("owner/repo/demo-skill")
+
+        assert bundle is not None
+        assert bundle.metadata["source_tree_complete"] is True
+
+    def test_partial_github_bundle_does_not_enable_revision_fast_path(self):
+        source = GitHubSource(auth=MagicMock(spec=GitHubAuth))
+        source._tree_cache["owner/repo"] = ("main", [
+            {
+                "path": "demo-skill/SKILL.md",
+                "type": "blob",
+                "mode": "100644",
+                "sha": "skill-md",
+            },
+            {
+                "path": "demo-skill/references/guide.md",
+                "type": "blob",
+                "mode": "100644",
+                "sha": "guide",
+            },
+        ])
+        source._tree_revisions["owner/repo"] = "a" * 40
+        source._fetch_file_content = MagicMock(return_value="---\nname: demo-skill\n---\n")
+        source._fetch_file_bytes = MagicMock(return_value=None)
+
+        partial_bundle = source.fetch("owner/repo/demo-skill")
+
+        assert partial_bundle is not None
+        assert partial_bundle.metadata["source_tree_complete"] is False
+
+        lock = MagicMock()
+        lock.list_installed.return_value = [{
+            "name": "demo-skill",
+            "source": "github",
+            "identifier": "owner/repo/demo-skill",
+            "content_hash": bundle_content_hash(partial_bundle),
+            "install_path": "demo-skill",
+            "metadata": partial_bundle.metadata,
+        }]
+        checker = MagicMock(spec=SkillSource)
+        checker.source_id.return_value = "github"
+        checker.is_revision_content_current.return_value = True
+        checker.fetch.return_value = partial_bundle
+
+        check_for_skill_updates(lock=lock, sources=[checker])
+
+        checker.is_revision_content_current.assert_not_called()
+        checker.fetch.assert_called_once_with("owner/repo/demo-skill")
+
+    def test_legacy_revision_without_completeness_marker_falls_back_to_fetch(self):
         lock = MagicMock()
         lock.list_installed.return_value = [{
             "name": "demo-skill",
@@ -567,6 +636,35 @@ class TestCheckForSkillUpdates:
             "content_hash": "installed-hash",
             "install_path": "demo-skill",
             "metadata": {"source_revision": "abc123"},
+        }]
+        source = MagicMock(spec=SkillSource)
+        source.source_id.return_value = "github"
+        source.is_revision_content_current.return_value = True
+        source.fetch.return_value = SkillBundle(
+            name="demo-skill",
+            files={"SKILL.md": "same content"},
+            source="github",
+            identifier="owner/repo/demo-skill",
+            trust_level="community",
+        )
+
+        check_for_skill_updates(lock=lock, sources=[source])
+
+        source.is_revision_content_current.assert_not_called()
+        source.fetch.assert_called_once_with("owner/repo/demo-skill")
+
+    def test_skips_bundle_fetch_when_skill_tree_is_unchanged(self):
+        lock = MagicMock()
+        lock.list_installed.return_value = [{
+            "name": "demo-skill",
+            "source": "github",
+            "identifier": "owner/repo/demo-skill",
+            "content_hash": "installed-hash",
+            "install_path": "demo-skill",
+            "metadata": {
+                "source_revision": "abc123",
+                "source_tree_complete": True,
+            },
         }]
 
         source = MagicMock(spec=SkillSource)
@@ -594,7 +692,10 @@ class TestCheckForSkillUpdates:
             "identifier": "owner/repo/demo-skill",
             "content_hash": "oldhash",
             "install_path": "demo-skill",
-            "metadata": {"source_revision": "abc123"},
+            "metadata": {
+                "source_revision": "abc123",
+                "source_tree_complete": True,
+            },
         }]
 
         source = MagicMock(spec=SkillSource)

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -796,6 +796,7 @@ class GitHubSource(SkillSource):
             return None
 
         files: Dict[str, Union[str, bytes]] = {"SKILL.md": skill_md}
+        source_tree_complete = tree is not None
         if tree is not None:
             # Download the FULL skill directory, not just SKILL.md-linked
             # paths. Link-driven fetching silently dropped every support file
@@ -828,6 +829,7 @@ class GitHubSource(SkillSource):
                     return None
                 content = self._fetch_file_bytes(repo, item_path, ref=pinned_ref)
                 if content is None:
+                    source_tree_complete = False
                     logger.warning("Failed to fetch referenced skill support "
                                    "file; continuing without it: %s", item_path)
                     continue
@@ -879,6 +881,7 @@ class GitHubSource(SkillSource):
                     if revision else f"https://github.com/{repo}/{skill_path}"
                 ),
                 "source_revision": revision,
+                "source_tree_complete": source_tree_complete,
             },
         )
 
@@ -4572,7 +4575,12 @@ def check_for_skill_updates(
                 if isinstance(metadata, dict)
                 else ""
             )
-            if revision:
+            tree_complete = (
+                metadata.get("source_tree_complete") is True
+                if isinstance(metadata, dict)
+                else False
+            )
+            if revision and tree_complete:
                 revision_checks.append((entry.get("identifier", ""), revision))
         if revision_checks:
             try:
@@ -4607,7 +4615,12 @@ def check_for_skill_updates(
             if isinstance(metadata, dict)
             else ""
         )
-        if recorded_revision:
+        source_tree_complete = (
+            metadata.get("source_tree_complete") is True
+            if isinstance(metadata, dict)
+            else False
+        )
+        if recorded_revision and source_tree_complete:
             revision_matches = False
             for src in candidate_sources:
                 try:

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -605,6 +605,10 @@ class SkillSource(ABC):
         """Unique identifier for this source (e.g. 'github', 'clawhub')."""
         ...
 
+    def current_revision(self, identifier: str) -> Optional[str]:
+        """Return an immutable upstream revision when the source exposes one."""
+        return None
+
     def trust_level_for(self, identifier: str) -> str:
         """Determine trust level for a skill from this source."""
         return "community"
@@ -868,6 +872,17 @@ class GitHubSource(SkillSource):
                 "source_revision": revision,
             },
         )
+
+    def current_revision(self, identifier: str) -> Optional[str]:
+        """Return the repository tree revision without downloading a bundle."""
+        parts = identifier.split("/", 2)
+        if len(parts) < 3:
+            return None
+
+        repo = f"{parts[0]}/{parts[1]}"
+        if self._get_repo_tree(repo) is None:
+            return None
+        return self._tree_revisions.get(repo)
 
     def inspect(self, identifier: str) -> Optional[SkillMeta]:
         """Fetch just the SKILL.md metadata for preview."""
@@ -4465,6 +4480,33 @@ def check_for_skill_updates(
                 "status": "unavailable",
             })
             continue
+
+        metadata = entry.get("metadata")
+        recorded_revision = (
+            metadata.get("source_revision", "")
+            if isinstance(metadata, dict)
+            else ""
+        )
+        if recorded_revision:
+            revision_matches = False
+            for src in candidate_sources:
+                try:
+                    revision_matches = src.current_revision(identifier) == recorded_revision
+                except Exception:
+                    revision_matches = False
+                if revision_matches:
+                    break
+            if revision_matches:
+                current_hash = entry.get("content_hash", "")
+                results.append({
+                    "name": entry.get("name", ""),
+                    "identifier": identifier,
+                    "source": source_name,
+                    "status": "up_to_date",
+                    "current_hash": current_hash,
+                    "latest_hash": current_hash,
+                })
+                continue
 
         bundle = None
         for src in candidate_sources:

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -605,8 +605,16 @@ class SkillSource(ABC):
         """Unique identifier for this source (e.g. 'github', 'clawhub')."""
         ...
 
-    def current_revision(self, identifier: str) -> Optional[str]:
-        """Return an immutable upstream revision when the source exposes one."""
+    def is_revision_content_current(
+        self, identifier: str, recorded_revision: str
+    ) -> Optional[bool]:
+        """Return whether an immutable revision still has current skill content."""
+        return None
+
+    def prepare_revision_checks(
+        self, identifiers_and_revisions: List[Tuple[str, str]]
+    ) -> None:
+        """Optionally prefetch shared metadata for a batch of revision checks."""
         return None
 
     def trust_level_for(self, identifier: str) -> str:
@@ -701,6 +709,7 @@ class GitHubSource(SkillSource):
         # Survives within a single search/install flow, avoiding redundant API calls.
         self._tree_cache: Dict[str, Tuple[str, List[dict]]] = {}
         self._tree_revisions: Dict[str, str] = {}
+        self._revision_tree_cache: Dict[Tuple[str, str], List[dict]] = {}
         # Per-repo cache of the optional skills.sh.json grouping sidecar,
         # mapping skill_name -> human-readable grouping title. ``None`` means
         # "fetched, no sidecar"; a missing key means "not fetched yet".
@@ -873,16 +882,62 @@ class GitHubSource(SkillSource):
             },
         )
 
-    def current_revision(self, identifier: str) -> Optional[str]:
-        """Return the repository tree revision without downloading a bundle."""
+    def is_revision_content_current(
+        self, identifier: str, recorded_revision: str
+    ) -> Optional[bool]:
+        """Compare one skill subtree across Git revisions without blob downloads."""
         parts = identifier.split("/", 2)
         if len(parts) < 3:
             return None
 
         repo = f"{parts[0]}/{parts[1]}"
-        if self._get_repo_tree(repo) is None:
+        skill_path = parts[2].rstrip("/")
+        current_tree = self._get_repo_tree(repo)
+        if current_tree is None:
             return None
-        return self._tree_revisions.get(repo)
+        if self._tree_revisions.get(repo) == recorded_revision:
+            return True
+
+        recorded_tree = self._get_repo_tree_at_revision(repo, recorded_revision)
+        if recorded_tree is None:
+            return None
+        recorded_fingerprint = self._skill_tree_fingerprint(recorded_tree, skill_path)
+        if not recorded_fingerprint:
+            return None
+        return self._skill_tree_fingerprint(current_tree[1], skill_path) == recorded_fingerprint
+
+    def prepare_revision_checks(
+        self, identifiers_and_revisions: List[Tuple[str, str]]
+    ) -> None:
+        """Fetch unique current and historical repo trees concurrently."""
+        from concurrent.futures import ThreadPoolExecutor
+
+        repos: set[str] = set()
+        historical: set[Tuple[str, str]] = set()
+        for identifier, revision in identifiers_and_revisions:
+            parts = identifier.split("/", 2)
+            if len(parts) < 3:
+                continue
+            repo = f"{parts[0]}/{parts[1]}"
+            repos.add(repo)
+            historical.add((repo, revision))
+
+        if not repos:
+            return
+        self.auth.get_headers()
+        with ThreadPoolExecutor(max_workers=min(len(repos), 8)) as pool:
+            list(pool.map(self._get_repo_tree, sorted(repos)))
+
+        historical = {
+            item for item in historical
+            if self._tree_revisions.get(item[0]) != item[1]
+        }
+        if historical:
+            with ThreadPoolExecutor(max_workers=min(len(historical), 8)) as pool:
+                list(pool.map(
+                    lambda item: self._get_repo_tree_at_revision(*item),
+                    sorted(historical),
+                ))
 
     def inspect(self, identifier: str) -> Optional[SkillMeta]:
         """Fetch just the SKILL.md metadata for preview."""
@@ -1025,6 +1080,52 @@ class GitHubSource(SkillSource):
             self._tree_revisions[repo] = revision
         self._tree_cache[repo] = (default_branch, entries)
         return (default_branch, entries)
+
+    def _get_repo_tree_at_revision(
+        self, repo: str, revision: str
+    ) -> Optional[List[dict]]:
+        """Fetch and cache a recursive tree at an immutable Git revision."""
+        cache_key = (repo, revision)
+        if cache_key in self._revision_tree_cache:
+            return self._revision_tree_cache[cache_key]
+        if re.fullmatch(r"[0-9a-fA-F]{40}", revision) is None:
+            return None
+
+        response = self._github_get(
+            f"https://api.github.com/repos/{repo}/git/trees/{revision}",
+            params={"recursive": "1"},
+            timeout=30,
+        )
+        if response is None or response.status_code != 200:
+            return None
+        try:
+            tree_data = response.json()
+        except ValueError:
+            return None
+        if tree_data.get("truncated"):
+            return None
+        entries = tree_data.get("tree", [])
+        if not isinstance(entries, list):
+            return None
+        self._revision_tree_cache[cache_key] = entries
+        return entries
+
+    @staticmethod
+    def _skill_tree_fingerprint(
+        entries: List[dict], skill_path: str
+    ) -> Tuple[Tuple[str, str, str, str], ...]:
+        """Return path and Git-object identity for entries inside one skill."""
+        prefix = f"{skill_path.rstrip('/')}/"
+        return tuple(sorted(
+            (
+                str(item.get("path", ""))[len(prefix):],
+                str(item.get("type", "")),
+                str(item.get("mode", "")),
+                str(item.get("sha", "")),
+            )
+            for item in entries
+            if str(item.get("path", "")).startswith(prefix)
+        ))
 
     def _check_rate_limit_response(self, resp: "httpx.Response") -> None:
         """Flag the instance as rate-limited when GitHub returns 403 + exhausted quota."""
@@ -4460,6 +4561,25 @@ def check_for_skill_updates(
     if sources is None:
         sources = create_source_router(auth=auth)
 
+    for source in sources:
+        revision_checks: List[Tuple[str, str]] = []
+        for entry in installed:
+            if not _source_matches(source, entry.get("source", "")):
+                continue
+            metadata = entry.get("metadata")
+            revision = (
+                metadata.get("source_revision", "")
+                if isinstance(metadata, dict)
+                else ""
+            )
+            if revision:
+                revision_checks.append((entry.get("identifier", ""), revision))
+        if revision_checks:
+            try:
+                source.prepare_revision_checks(revision_checks)
+            except Exception:
+                pass
+
     results: List[dict] = []
     for entry in installed:
         identifier = entry.get("identifier", "")
@@ -4491,7 +4611,9 @@ def check_for_skill_updates(
             revision_matches = False
             for src in candidate_sources:
                 try:
-                    revision_matches = src.current_revision(identifier) == recorded_revision
+                    revision_matches = src.is_revision_content_current(
+                        identifier, recorded_revision
+                    ) is True
                 except Exception:
                     revision_matches = False
                 if revision_matches:


### PR DESCRIPTION
## What does this PR do?

Makes no-op `hermes skills check` / `hermes skills update` fast for GitHub-backed skills. The lockfile already records an immutable Git revision. Hermes now compares the installed skill's Git subtree at that revision with the current subtree and skips downloading `SKILL.md` plus every support file when the skill itself did not change — even if unrelated skills in the same tap repository did.

Current and historical repository trees are fetched once per unique revision with bounded concurrency. The existing full-bundle hash path remains the fallback when a source has no revision capability, tree metadata is unavailable, or the skill subtree changed.

## Related Issue

Fixes #101454

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tools/skills_hub.py`: add optional revision-comparison and batch-preparation source capabilities.
- `tools/skills_hub.py`: compare GitHub skill subtrees by path, type, mode, and blob SHA; cache current and historical trees.
- `tools/skills_hub.py`: prefetch unique Git trees concurrently, then short-circuit unchanged skills before full bundle fetch.
- `tools/skills_hub.py`: record proof that every eligible tree blob downloaded, and allow the revision fast path only for proven-complete installs; legacy and partial installs retain the full fetch path.
- `tests/tools/test_skills_hub.py`: prove unchanged subtrees skip fetches, changed subtrees retain the full hash path, and unrelated repository changes do not invalidate a skill.
- `tests/tools/test_skills_hub.py`: prove partial and legacy installs cannot short-circuit update checks.

## How to Test

1. Install multiple skills from the same GitHub tap across several repository revisions.
2. Run `hermes skills check` after unrelated tap changes.
3. Confirm unchanged skill subtrees remain `up_to_date` without bundle fetches; change one skill and confirm that skill uses the normal bundle hash path.

Focused verification on macOS:

```text
118 passed in 2.83s
ruff: All checks passed
py_compile: passed
real profile benchmark: 456.6s before → 191.8s after with several genuinely changed/unavailable skills still taking the fallback path
```

The local full-suite attempt stopped during collection because the live runtime venv does not include the repository dev dependency `pytest_asyncio`; GitHub CI is the authoritative full-suite run.

## Checklist

### Code

- [x] I've read the Contributing Guide and repository `AGENTS.md`
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing issues/PRs
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (local dev dependency unavailable; CI pending)
- [x] I've added tests for my changes
- [x] I've tested on macOS

### Documentation & Housekeeping

- [x] Documentation update: N/A; no user-facing contract changed
- [x] `cli-config.yaml.example`: N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no workflow changed
- [x] Cross-platform impact considered: source logic is platform-independent
- [x] Tool descriptions/schemas: N/A
