### PR TITLE
fix(gateway): bind session_id in _set_session_env so HERMES_SESSION_ID reaches subprocesses on cached-agent turns

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -27438,6 +27438,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             user_name=str(context.source.user_name) if context.source.user_name else "",
             scope_id=str(getattr(context.source, "scope_id", "") or ""),
             session_key=context.session_key,
+            # Bind the session id too: without it the ContextVar is explicitly
+            # "" for the turn, and only the turn that constructs the AIAgent
+            # (set_current_session_id in agent_init) ever sets it — inside the
+            # executor-thread copy of that one turn's context. Every later turn
+            # on a cached agent copied the handler context where it was "",
+            # and _inject_session_context_env treats an explicitly-empty var as
+            # authoritative, so the terminal tool exported HERMES_SESSION_ID=""
+            # over the correct os.environ mirror. Compression rotations still
+            # rebind via _compress_context (#76354).
+            session_id=str(context.session_id) if context.session_id else "",
             message_id=str(context.source.message_id) if context.source.message_id else "",
             profile=getattr(context.source, "profile", "") or "",
             async_delivery=_async_delivery,

--- a/tests/gateway/test_session_env_session_id_bridge.py
+++ b/tests/gateway/test_session_env_session_id_bridge.py
@@ -1,0 +1,90 @@
+"""dt-570 (behemoth): HERMES_SESSION_ID must reach the terminal tool on every
+turn, not only on the turn that constructed the AIAgent.
+
+_set_session_env binds every HERMES_SESSION_* ContextVar per message; it never
+bound session_id, so _SESSION_ID was explicitly "" for the turn. AIAgent.__init__
+sets it (set_current_session_id) only inside the executor-thread context of the
+turn that built the agent; every later turn on a cached agent copies the handler
+context where the var is "" — and _inject_session_context_env treats an
+explicitly-empty ContextVar as authoritative, exporting HERMES_SESSION_ID="" to
+the shell even though the os.environ mirror holds the right id.
+"""
+import os
+from contextvars import copy_context
+
+from gateway.run import GatewayRunner
+from gateway.session import SessionContext, SessionSource
+from gateway.platforms.base import Platform
+from gateway.session_context import get_session_env
+from tools.environments.local import _inject_session_context_env
+
+
+def _context(session_id: str) -> SessionContext:
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="8073053805",
+        chat_name="Alexandru Bonea",
+        chat_type="dm",
+        user_id="8073053805",
+        user_name="Alexandru Bonea",
+        thread_id="18167",
+    )
+    return SessionContext(
+        source=source,
+        connected_platforms=[],
+        home_channels={},
+        session_key="agent:main:telegram:dm:8073053805:18167",
+        session_id=session_id,
+    )
+
+
+def test_set_session_env_binds_session_id(monkeypatch):
+    runner = object.__new__(GatewayRunner)
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+    tokens = runner._set_session_env(_context("20260829_151644_229db1da"))
+    try:
+        assert get_session_env("HERMES_SESSION_ID") == "20260829_151644_229db1da"
+        assert os.getenv("HERMES_SESSION_ID") is None  # contextvar path only
+    finally:
+        runner._clear_session_env(tokens)
+
+
+def test_reused_agent_turn_bridges_session_id_to_subprocess(monkeypatch):
+    """A turn on a cached agent: only _set_session_env runs (no AIAgent
+    construction). The shell env must still carry the session id."""
+    runner = object.__new__(GatewayRunner)
+    # The os.environ mirror written by an earlier turn's set_current_session_id.
+    monkeypatch.setenv("HERMES_SESSION_ID", "20260829_151644_229db1da")
+
+    def turn():
+        tokens = runner._set_session_env(_context("20260829_151644_229db1da"))
+        try:
+            env = {}
+            _inject_session_context_env(env)
+            return env
+        finally:
+            runner._clear_session_env(tokens)
+
+    # The gateway runs the turn in a copy of the handler context (executor).
+    env = copy_context().run(turn)
+    assert env.get("HERMES_SESSION_THREAD_ID") == "18167"
+    assert env.get("HERMES_SESSION_ID") == "20260829_151644_229db1da"
+
+
+def test_session_id_stays_task_local_across_sessions(monkeypatch):
+    """Two concurrent sessions never see each other's id (the leak guard the
+    bridge exists for still holds with session_id bound)."""
+    runner = object.__new__(GatewayRunner)
+    monkeypatch.setenv("HERMES_SESSION_ID", "foreign_session")
+
+    def turn(sid):
+        tokens = runner._set_session_env(_context(sid))
+        try:
+            env = {}
+            _inject_session_context_env(env)
+            return env.get("HERMES_SESSION_ID")
+        finally:
+            runner._clear_session_env(tokens)
+
+    assert copy_context().run(turn, "sess_a") == "sess_a"
+    assert copy_context().run(turn, "sess_b") == "sess_b"


### PR DESCRIPTION
## What does this PR do?

On the messaging gateway, `GatewayRunner._set_session_env` binds every `HERMES_SESSION_*` ContextVar per message except `session_id`, so `_SESSION_ID` is explicitly `""` for the turn. The only writer of that ContextVar is `set_current_session_id()` in `AIAgent.__init__`, which runs inside the executor-thread copy of the context of the one turn that constructs the agent. Every later turn on a cached agent copies the handler context where the var is `""`, and `_inject_session_context_env` (tools/environments/local.py) treats an explicitly-empty ContextVar as authoritative and does not fall back to `os.environ`. Result: the terminal tool exports `HERMES_SESSION_ID=""` to the shell on every turn after the first, even though the process mirror holds the right id.

Observed on Telegram: `echo $HERMES_SESSION_ID` prints nothing while `HERMES_SESSION_THREAD_ID`, `HERMES_SESSION_CHAT_ID`, `HERMES_SESSION_KEY` are all set. An MCP server that needs the harness session id (passed by the agent from its shell, since MCP stdio children get `_build_safe_env`) then receives an empty value or an invented one.

This is the same defect class already fixed for the TUI gateway in `tui_gateway/server.py::_set_session_context` (which binds the agent's `session_id`). The fix here is the same gesture: pass `session_id=context.session_id` to `set_session_vars`. `SessionContext.session_id` is populated by `build_session_context()` from the session entry, so the messaging gateway always knows it at binding time. No `session_key` fallback: an unidentified session stays blank rather than carrying a routing key as an id. Compression rotations still rebind through `_compress_context` (#76354), unchanged.

## Related Issue

No issue filed; the diagnosis is above.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` — `_set_session_env`: bind `session_id` from `context.session_id`.
- `tests/gateway/test_session_env_session_id_bridge.py` — three tests: the ContextVar is bound; a turn on a cached agent (only `_set_session_env`, no agent construction) bridges the id into the subprocess env; two sessions stay task-local (the leak guard still holds).

## How to Test

1. On `main`, run `pytest tests/gateway/test_session_env_session_id_bridge.py`: the three tests fail (`HERMES_SESSION_ID` comes out `""`).
2. With this patch they pass; `tests/gateway/test_session_env.py`, `tests/tools/test_local_env_session_leak.py`, `tests/tui_gateway/test_session_id_injection.py` still pass (`test_run_in_executor_with_context_preserves_session_env` fails on `main` before and after this change in my environment, unrelated).
3. Live: in a Telegram session, on the second message ask the agent to run `echo $HERMES_SESSION_ID`. Before: empty. After: the session id (`YYYYMMDD_HHMMSS_hash`).

## Checklist

- [x] Tests added
- [x] Existing related tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)