### PR TITLE
fix(desktop): stabilize Bot Mode owner switches

### DIFF
--- a/apps/desktop/src/app/chat/chat-swap-overlay.test.tsx
+++ b/apps/desktop/src/app/chat/chat-swap-overlay.test.tsx
@@ -3,7 +3,7 @@
 // that GlyphSpinner was rewritten to remove. It now renders GlyphSpinner, so
 // what needs pinning is that no timer comes back, that the label still survives
 // the fade-out, and that the spinner stops animating once the swap is done.
-import { cleanup, render, screen } from '@testing-library/react'
+import { act, cleanup, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ChatSwapOverlay } from './chat-swap-overlay'
@@ -66,5 +66,24 @@ describe('ChatSwapOverlay', () => {
     expect(screen.getByText(/turqoise/)).toBeTruthy()
     // ...and the spinner stops, the way clearing the interval used to stop it.
     expect(container.querySelector('.glyph-spinner')?.getAttribute('data-paused')).toBe('true')
+  })
+
+  it('keeps the Bot Mode cover opaque through one settled transcript paint before fading', () => {
+    const { container, rerender } = render(<ChatSwapOverlay botMode profile="persephone" />)
+    const overlay = container.querySelector('[data-slot="chat-swap-overlay"]')
+
+    rerender(<ChatSwapOverlay botMode profile={null} />)
+
+    // Keep one fully painted cover between transcript commit/scroll restoration
+    // and the fade. Starting the fade in this same render exposes giant restored
+    // histories before their first stable frame.
+    expect(overlay?.className).toContain('opacity-100')
+    expect(overlay?.hasAttribute('data-glass-opaque')).toBe(true)
+
+    act(() => vi.advanceTimersByTime(16))
+    expect(overlay?.className).toContain('opacity-100')
+
+    act(() => vi.advanceTimersByTime(16))
+    expect(overlay?.className).toContain('opacity-0')
   })
 })

--- a/apps/desktop/src/app/chat/chat-swap-overlay.test.tsx
+++ b/apps/desktop/src/app/chat/chat-swap-overlay.test.tsx
@@ -72,6 +72,9 @@ describe('ChatSwapOverlay', () => {
     const { container, rerender } = render(<ChatSwapOverlay botMode profile="persephone" />)
     const overlay = container.querySelector('[data-slot="chat-swap-overlay"]')
 
+    expect(overlay?.className).toContain('opacity-100')
+    expect(overlay?.className).not.toContain('transition-opacity')
+
     rerender(<ChatSwapOverlay botMode profile={null} />)
 
     // Keep one fully painted cover between transcript commit/scroll restoration
@@ -85,5 +88,6 @@ describe('ChatSwapOverlay', () => {
 
     act(() => vi.advanceTimersByTime(16))
     expect(overlay?.className).toContain('opacity-0')
+    expect(overlay?.className).toContain('transition-opacity')
   })
 })

--- a/apps/desktop/src/app/chat/chat-swap-overlay.test.tsx
+++ b/apps/desktop/src/app/chat/chat-swap-overlay.test.tsx
@@ -68,7 +68,7 @@ describe('ChatSwapOverlay', () => {
     expect(container.querySelector('.glyph-spinner')?.getAttribute('data-paused')).toBe('true')
   })
 
-  it('keeps the Bot Mode cover opaque through one settled transcript paint before fading', () => {
+  it('keeps the Bot Mode cover opaque until a blocked transcript commit settles, including the fade', () => {
     const { container, rerender } = render(<ChatSwapOverlay botMode profile="persephone" />)
     const overlay = container.querySelector('[data-slot="chat-swap-overlay"]')
 
@@ -77,11 +77,17 @@ describe('ChatSwapOverlay', () => {
 
     rerender(<ChatSwapOverlay botMode profile={null} />)
 
-    // Keep one fully painted cover between transcript commit/scroll restoration
-    // and the fade. Starting the fade in this same render exposes giant restored
-    // histories before their first stable frame.
+    // Keep the cover up long enough for a large transcript commit to begin. If
+    // that commit blocks the main thread, the timer and fade cannot run until
+    // the transcript has finished laying out.
     expect(overlay?.className).toContain('opacity-100')
     expect(overlay?.hasAttribute('data-glass-opaque')).toBe(true)
+
+    act(() => vi.advanceTimersByTime(499))
+    expect(overlay?.className).toContain('opacity-100')
+
+    act(() => vi.advanceTimersByTime(1))
+    expect(overlay?.className).toContain('opacity-100')
 
     act(() => vi.advanceTimersByTime(16))
     expect(overlay?.className).toContain('opacity-100')
@@ -89,5 +95,7 @@ describe('ChatSwapOverlay', () => {
     act(() => vi.advanceTimersByTime(16))
     expect(overlay?.className).toContain('opacity-0')
     expect(overlay?.className).toContain('transition-opacity')
+    expect(overlay?.className).toContain('bg-(--ui-chat-surface-background)')
+    expect(overlay?.hasAttribute('data-glass-opaque')).toBe(true)
   })
 })

--- a/apps/desktop/src/app/chat/chat-swap-overlay.test.tsx
+++ b/apps/desktop/src/app/chat/chat-swap-overlay.test.tsx
@@ -50,6 +50,7 @@ describe('ChatSwapOverlay', () => {
     const overlay = container.querySelector('[data-slot="chat-swap-overlay"]')
 
     expect(overlay?.className).toContain('bg-(--ui-chat-surface-background)')
+    expect(overlay?.hasAttribute('data-glass-opaque')).toBe(true)
     expect(screen.queryByText(/persephone/i)).toBeNull()
     expect(screen.getByText(/Bot Chat/i)).toBeTruthy()
   })

--- a/apps/desktop/src/app/chat/chat-swap-overlay.test.tsx
+++ b/apps/desktop/src/app/chat/chat-swap-overlay.test.tsx
@@ -39,6 +39,21 @@ describe('ChatSwapOverlay', () => {
     expect(screen.getByText(/turqoise/)).toBeTruthy()
   })
 
+  it('conceals the interim session shell and raw profile name in Bot Mode', () => {
+    const { container } = render(
+      <div>
+        <span>New session</span>
+        <ChatSwapOverlay botMode profile="persephone" />
+      </div>
+    )
+
+    const overlay = container.querySelector('[data-slot="chat-swap-overlay"]')
+
+    expect(overlay?.className).toContain('bg-(--ui-chat-surface-background)')
+    expect(screen.queryByText(/persephone/i)).toBeNull()
+    expect(screen.getByText(/Bot Chat/i)).toBeTruthy()
+  })
+
   it('keeps the last profile name through the fade-out, with the glyph frozen', () => {
     const { container, rerender } = render(<ChatSwapOverlay profile="turqoise" />)
 

--- a/apps/desktop/src/app/chat/chat-swap-overlay.test.tsx
+++ b/apps/desktop/src/app/chat/chat-swap-overlay.test.tsx
@@ -22,7 +22,7 @@ describe('ChatSwapOverlay', () => {
     vi.useRealTimers()
   })
 
-  it('animates the glyph without any timer', () => {
+  it('animates the glyph without any repeating timer', () => {
     const { container } = render(<ChatSwapOverlay profile="turqoise" />)
 
     expect(container.querySelector('.glyph-spinner__strip')).toBeTruthy()
@@ -55,6 +55,19 @@ describe('ChatSwapOverlay', () => {
     expect(screen.getByText(/Bot Chat/i)).toBeTruthy()
   })
 
+  it('keeps the modal wake label quiet for a fast Bot Mode switch', () => {
+    const { container } = render(<ChatSwapOverlay botMode profile="persephone" />)
+    const status = container.querySelector('[data-slot="chat-swap-status"]')
+
+    expect(status?.className).toContain('opacity-0')
+
+    act(() => vi.advanceTimersByTime(299))
+    expect(status?.className).toContain('opacity-0')
+
+    act(() => vi.advanceTimersByTime(1))
+    expect(status?.className).toContain('opacity-100')
+  })
+
   it('keeps the last profile name through the fade-out, with the glyph frozen', () => {
     const { container, rerender } = render(<ChatSwapOverlay profile="turqoise" />)
 
@@ -68,7 +81,7 @@ describe('ChatSwapOverlay', () => {
     expect(container.querySelector('.glyph-spinner')?.getAttribute('data-paused')).toBe('true')
   })
 
-  it('keeps the Bot Mode cover opaque until a blocked transcript commit settles, including the fade', () => {
+  it('keeps the Bot Mode cover opaque through six transcript paint frames', () => {
     const { container, rerender } = render(<ChatSwapOverlay botMode profile="persephone" />)
     const overlay = container.querySelector('[data-slot="chat-swap-overlay"]')
 
@@ -77,25 +90,31 @@ describe('ChatSwapOverlay', () => {
 
     rerender(<ChatSwapOverlay botMode profile={null} />)
 
-    // Keep the cover up long enough for a large transcript commit to begin. If
-    // that commit blocks the main thread, the timer and fade cannot run until
-    // the transcript has finished laying out.
+    // If a large transcript commit blocks the main thread, neither animation
+    // frame can run until it has finished laying out.
     expect(overlay?.className).toContain('opacity-100')
     expect(overlay?.hasAttribute('data-glass-opaque')).toBe(true)
 
-    act(() => vi.advanceTimersByTime(499))
-    expect(overlay?.className).toContain('opacity-100')
-
-    act(() => vi.advanceTimersByTime(1))
-    expect(overlay?.className).toContain('opacity-100')
-
-    act(() => vi.advanceTimersByTime(16))
-    expect(overlay?.className).toContain('opacity-100')
+    for (let frame = 0; frame < 5; frame += 1) {
+      act(() => vi.advanceTimersByTime(16))
+      expect(overlay?.className).toContain('opacity-100')
+    }
 
     act(() => vi.advanceTimersByTime(16))
     expect(overlay?.className).toContain('opacity-0')
     expect(overlay?.className).toContain('transition-opacity')
     expect(overlay?.className).toContain('bg-(--ui-chat-surface-background)')
     expect(overlay?.hasAttribute('data-glass-opaque')).toBe(true)
+  })
+
+  it('releases the Bot Mode cover after paint settles without a fixed half-second delay', () => {
+    const { container, rerender } = render(<ChatSwapOverlay botMode profile="persephone" />)
+    const overlay = container.querySelector('[data-slot="chat-swap-overlay"]')
+
+    rerender(<ChatSwapOverlay botMode profile={null} />)
+
+    act(() => vi.advanceTimersByTime(96))
+
+    expect(overlay?.className).toContain('opacity-0')
   })
 })

--- a/apps/desktop/src/app/chat/chat-swap-overlay.tsx
+++ b/apps/desktop/src/app/chat/chat-swap-overlay.tsx
@@ -4,6 +4,8 @@ import { GlyphSpinner } from '@/components/ui/glyph-spinner'
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
 
+const BOT_MODE_SETTLE_DELAY_MS = 500
+
 // Shown over the conversation while the live gateway swaps to another profile's
 // backend (lazily spawned). Keeps the last profile name through the fade-out so
 // the label doesn't blank. Purely visual — pointer-events-none.
@@ -25,22 +27,31 @@ export function ChatSwapOverlay({ botMode = false, profile }: { botMode?: boolea
     }
 
     // The message store can settle before React commits and scroll-restores a
-    // giant transcript. Preserve one fully painted cover, then begin the fade;
-    // otherwise the browser exposes the transcript's intermediate layout.
+    // giant transcript. Wait long enough for that render to start, then keep
+    // one fully painted cover after the main thread becomes available again.
+    // A long transcript blocks this timer, which is intentional: the cover
+    // remains opaque until the expensive commit has actually finished.
     let secondFrame: number | undefined
+    let firstFrame: number | undefined
 
-    const firstFrame = window.requestAnimationFrame(() => {
-      secondFrame = window.requestAnimationFrame(() => setCovering(false))
-    })
+    const settleTimer = window.setTimeout(() => {
+      firstFrame = window.requestAnimationFrame(() => {
+        secondFrame = window.requestAnimationFrame(() => setCovering(false))
+      })
+    }, botMode ? BOT_MODE_SETTLE_DELAY_MS : 0)
 
     return () => {
-      window.cancelAnimationFrame(firstFrame)
+      window.clearTimeout(settleTimer)
+
+      if (firstFrame !== undefined) {
+        window.cancelAnimationFrame(firstFrame)
+      }
 
       if (secondFrame !== undefined) {
         window.cancelAnimationFrame(secondFrame)
       }
     }
-  }, [covering, profile])
+  }, [botMode, covering, profile])
 
   const coverVisible = Boolean(profile) || (botMode && covering)
 
@@ -49,10 +60,10 @@ export function ChatSwapOverlay({ botMode = false, profile }: { botMode?: boolea
       aria-hidden
       className={cn(
         'pointer-events-none absolute inset-0 z-50 flex items-center justify-center',
-        botMode && coverVisible ? 'bg-(--ui-chat-surface-background)' : '',
+        botMode ? 'bg-(--ui-chat-surface-background)' : '',
         coverVisible ? 'opacity-100' : 'opacity-0 transition-opacity duration-150 ease-out'
       )}
-      data-glass-opaque={botMode && coverVisible ? '' : undefined}
+      data-glass-opaque={botMode ? '' : undefined}
       data-slot="chat-swap-overlay"
     >
       <div className="flex items-center gap-2 bg-[color-mix(in_srgb,var(--dt-card)_92%,transparent)] px-4 py-2 font-mono text-[0.8125rem] text-foreground shadow-composer">

--- a/apps/desktop/src/app/chat/chat-swap-overlay.tsx
+++ b/apps/desktop/src/app/chat/chat-swap-overlay.tsx
@@ -25,6 +25,7 @@ export function ChatSwapOverlay({ botMode = false, profile }: { botMode?: boolea
         botMode && profile ? 'bg-(--ui-chat-surface-background)' : '',
         profile ? 'opacity-100' : 'opacity-0'
       )}
+      data-glass-opaque={botMode && profile ? '' : undefined}
       data-slot="chat-swap-overlay"
     >
       <div className="flex items-center gap-2 bg-[color-mix(in_srgb,var(--dt-card)_92%,transparent)] px-4 py-2 font-mono text-[0.8125rem] text-foreground shadow-composer">

--- a/apps/desktop/src/app/chat/chat-swap-overlay.tsx
+++ b/apps/desktop/src/app/chat/chat-swap-overlay.tsx
@@ -48,9 +48,9 @@ export function ChatSwapOverlay({ botMode = false, profile }: { botMode?: boolea
     <div
       aria-hidden
       className={cn(
-        'pointer-events-none absolute inset-0 z-50 flex items-center justify-center transition-opacity duration-150 ease-out',
+        'pointer-events-none absolute inset-0 z-50 flex items-center justify-center',
         botMode && coverVisible ? 'bg-(--ui-chat-surface-background)' : '',
-        coverVisible ? 'opacity-100' : 'opacity-0'
+        coverVisible ? 'opacity-100' : 'opacity-0 transition-opacity duration-150 ease-out'
       )}
       data-glass-opaque={botMode && coverVisible ? '' : undefined}
       data-slot="chat-swap-overlay"

--- a/apps/desktop/src/app/chat/chat-swap-overlay.tsx
+++ b/apps/desktop/src/app/chat/chat-swap-overlay.tsx
@@ -10,22 +10,49 @@ import { cn } from '@/lib/utils'
 export function ChatSwapOverlay({ botMode = false, profile }: { botMode?: boolean; profile: string | null }) {
   const { t } = useI18n()
   const [label, setLabel] = useState<null | string>(profile)
+  const [covering, setCovering] = useState(Boolean(profile))
 
   useEffect(() => {
     if (profile) {
       setLabel(profile)
+      setCovering(true)
+
+      return
     }
-  }, [profile])
+
+    if (!covering) {
+      return
+    }
+
+    // The message store can settle before React commits and scroll-restores a
+    // giant transcript. Preserve one fully painted cover, then begin the fade;
+    // otherwise the browser exposes the transcript's intermediate layout.
+    let secondFrame: number | undefined
+
+    const firstFrame = window.requestAnimationFrame(() => {
+      secondFrame = window.requestAnimationFrame(() => setCovering(false))
+    })
+
+    return () => {
+      window.cancelAnimationFrame(firstFrame)
+
+      if (secondFrame !== undefined) {
+        window.cancelAnimationFrame(secondFrame)
+      }
+    }
+  }, [covering, profile])
+
+  const coverVisible = Boolean(profile) || (botMode && covering)
 
   return (
     <div
       aria-hidden
       className={cn(
         'pointer-events-none absolute inset-0 z-50 flex items-center justify-center transition-opacity duration-150 ease-out',
-        botMode && profile ? 'bg-(--ui-chat-surface-background)' : '',
-        profile ? 'opacity-100' : 'opacity-0'
+        botMode && coverVisible ? 'bg-(--ui-chat-surface-background)' : '',
+        coverVisible ? 'opacity-100' : 'opacity-0'
       )}
-      data-glass-opaque={botMode && profile ? '' : undefined}
+      data-glass-opaque={botMode && coverVisible ? '' : undefined}
       data-slot="chat-swap-overlay"
     >
       <div className="flex items-center gap-2 bg-[color-mix(in_srgb,var(--dt-card)_92%,transparent)] px-4 py-2 font-mono text-[0.8125rem] text-foreground shadow-composer">

--- a/apps/desktop/src/app/chat/chat-swap-overlay.tsx
+++ b/apps/desktop/src/app/chat/chat-swap-overlay.tsx
@@ -7,7 +7,7 @@ import { cn } from '@/lib/utils'
 // Shown over the conversation while the live gateway swaps to another profile's
 // backend (lazily spawned). Keeps the last profile name through the fade-out so
 // the label doesn't blank. Purely visual — pointer-events-none.
-export function ChatSwapOverlay({ profile }: { profile: string | null }) {
+export function ChatSwapOverlay({ botMode = false, profile }: { botMode?: boolean; profile: string | null }) {
   const { t } = useI18n()
   const [label, setLabel] = useState<null | string>(profile)
 
@@ -22,8 +22,10 @@ export function ChatSwapOverlay({ profile }: { profile: string | null }) {
       aria-hidden
       className={cn(
         'pointer-events-none absolute inset-0 z-50 flex items-center justify-center transition-opacity duration-150 ease-out',
+        botMode && profile ? 'bg-(--ui-chat-surface-background)' : '',
         profile ? 'opacity-100' : 'opacity-0'
       )}
+      data-slot="chat-swap-overlay"
     >
       <div className="flex items-center gap-2 bg-[color-mix(in_srgb,var(--dt-card)_92%,transparent)] px-4 py-2 font-mono text-[0.8125rem] text-foreground shadow-composer">
         {/* Was a local 80ms setInterval + setState braille ticker — the same
@@ -34,7 +36,7 @@ export function ChatSwapOverlay({ profile }: { profile: string | null }) {
             `paused` restores the old "no ticking once the swap is done"
             behaviour while the overlay fades out still mounted. */}
         <GlyphSpinner className="w-3 justify-start text-(--ui-accent)" paused={!profile} spinner="braille" />
-        {t.composer.wakingProfile(label ?? '')}
+        {t.composer.wakingProfile(botMode ? t.composer.botChat : (label ?? ''))}
       </div>
     </div>
   )

--- a/apps/desktop/src/app/chat/chat-swap-overlay.tsx
+++ b/apps/desktop/src/app/chat/chat-swap-overlay.tsx
@@ -1,10 +1,8 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { GlyphSpinner } from '@/components/ui/glyph-spinner'
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
-
-const BOT_MODE_SETTLE_DELAY_MS = 500
 
 // Shown over the conversation while the live gateway swaps to another profile's
 // backend (lazily spawned). Keeps the last profile name through the fade-out so
@@ -13,42 +11,76 @@ export function ChatSwapOverlay({ botMode = false, profile }: { botMode?: boolea
   const { t } = useI18n()
   const [label, setLabel] = useState<null | string>(profile)
   const [covering, setCovering] = useState(Boolean(profile))
+  const [statusVisible, setStatusVisible] = useState(!botMode && Boolean(profile))
+  const overlayRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     if (profile) {
       setLabel(profile)
       setCovering(true)
 
-      return
+      if (!botMode) {
+        setStatusVisible(true)
+
+        return
+      }
+
+      // Warm Bot Chat switches normally paint in well under this threshold.
+      // Keep the opaque ownership guard immediate, but do not flash a modal
+      // "Waking up" card for a transition that completes almost at once. A
+      // genuinely cold wake still gets status once the delay elapses.
+      setStatusVisible(false)
+      const statusTimer = window.setTimeout(() => setStatusVisible(true), 300)
+
+      return () => window.clearTimeout(statusTimer)
     }
+
+    setStatusVisible(false)
 
     if (!covering) {
       return
     }
 
-    // The message store can settle before React commits and scroll-restores a
-    // giant transcript. Wait long enough for that render to start, then keep
-    // one fully painted cover after the main thread becomes available again.
-    // A long transcript blocks this timer, which is intentional: the cover
-    // remains opaque until the expensive commit has actually finished.
-    let secondFrame: number | undefined
-    let firstFrame: number | undefined
+    // The session stores can settle before React commits, the tab becomes
+    // visible and a large transcript finishes its keep-alive catch-up. Keep a
+    // short paint-frame floor, then require two quiet frames after the last DOM
+    // mutation in this chat surface. This covers the raw-session flash without
+    // putting the old fixed 500ms sleep back on every warm switch.
+    let frame: number | undefined
+    let frames = 0
+    let quietFrames = 0
+    const surface = overlayRef.current?.closest('[data-chat-surface]')
+    const observer = surface
+      ? new MutationObserver(() => {
+          quietFrames = 0
+        })
+      : null
+
+    observer?.observe(surface!, { attributes: true, characterData: true, childList: true, subtree: true })
 
     const settleTimer = window.setTimeout(() => {
-      firstFrame = window.requestAnimationFrame(() => {
-        secondFrame = window.requestAnimationFrame(() => setCovering(false))
-      })
-    }, botMode ? BOT_MODE_SETTLE_DELAY_MS : 0)
+      const settle = () => {
+        frames += 1
+        quietFrames += 1
+
+        if (frames >= 6 && quietFrames >= 2) {
+          setCovering(false)
+
+          return
+        }
+
+        frame = window.requestAnimationFrame(settle)
+      }
+
+      frame = window.requestAnimationFrame(settle)
+    }, 0)
 
     return () => {
       window.clearTimeout(settleTimer)
+      observer?.disconnect()
 
-      if (firstFrame !== undefined) {
-        window.cancelAnimationFrame(firstFrame)
-      }
-
-      if (secondFrame !== undefined) {
-        window.cancelAnimationFrame(secondFrame)
+      if (frame !== undefined) {
+        window.cancelAnimationFrame(frame)
       }
     }
   }, [botMode, covering, profile])
@@ -65,8 +97,15 @@ export function ChatSwapOverlay({ botMode = false, profile }: { botMode?: boolea
       )}
       data-glass-opaque={botMode ? '' : undefined}
       data-slot="chat-swap-overlay"
+      ref={overlayRef}
     >
-      <div className="flex items-center gap-2 bg-[color-mix(in_srgb,var(--dt-card)_92%,transparent)] px-4 py-2 font-mono text-[0.8125rem] text-foreground shadow-composer">
+      <div
+        className={cn(
+          'flex items-center gap-2 bg-[color-mix(in_srgb,var(--dt-card)_92%,transparent)] px-4 py-2 font-mono text-[0.8125rem] text-foreground shadow-composer transition-opacity duration-100',
+          statusVisible ? 'opacity-100' : 'opacity-0'
+        )}
+        data-slot="chat-swap-status"
+      >
         {/* Was a local 80ms setInterval + setState braille ticker — the same
             mechanism class (per-tick DOM mutation scheduling style recalc)
             that GlyphSpinner was rewritten to remove. `braille` is exactly the

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -14,6 +14,7 @@ import { Backdrop } from '@/components/Backdrop'
 import { COMPOSER_HEART_CONFIG, HeartField } from '@/components/chat/vibe-hearts'
 import { usePaneVisible } from '@/components/pane-shell/pane-visibility'
 import { $sessionTileDragging, $sessionTileEdgeHover } from '@/components/pane-shell/tree/store'
+import { $workspaceMode } from '@/components/pane-shell/workspace-scope'
 import { PromptOverlays } from '@/components/prompt-overlays'
 import { Button } from '@/components/ui/button'
 import { ErrorState } from '@/components/ui/error-state'
@@ -398,6 +399,7 @@ const ChatViewContent = memo(function ChatViewContent({
   const composerScope = useComposerScope()
   const composerSurfaceId = useComposerSurfaceId()
   const isPrimary = view.kind === 'primary'
+  const workspaceMode = useStore($workspaceMode)
   const activeSessionId = useStore(view.$runtimeId)
   const storedId = useStore(view.$storedId)
   // Multi-pane dimming: only the focused surface paints at full strength, so
@@ -714,7 +716,7 @@ const ChatViewContent = memo(function ChatViewContent({
           {/* A session drag hovering an EDGE hands the visual to the zone
               target; the link overlay shows only for the center region. */}
           <ChatDropOverlay kind={overlayKind} />
-          <ChatSwapOverlay profile={gatewaySwapTarget} />
+          <ChatSwapOverlay botMode={workspaceMode === 'bots'} profile={gatewaySwapTarget} />
           {/* Paint-first wake (#89843): transcript is live, profile gate still
               settling in the background — subtle badge, not an overlay. */}
           {isPrimary && !gatewaySwapTarget && <ChatSyncBadge profile={hydrationSyncProfile} />}

--- a/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
@@ -1,8 +1,12 @@
-import { cleanup, render } from '@testing-library/react'
+import { act, cleanup, render } from '@testing-library/react'
 import type { MutableRefObject } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { $resumeExhaustedSessionId, setResumeExhaustedSessionId } from '@/store/session'
+import {
+  $resumeExhaustedSessionId,
+  $sessionResumeSettlement,
+  setResumeExhaustedSessionId
+} from '@/store/session'
 import type { SessionProfileRoute } from '@/store/session-request-router'
 import { markSelectionRestore } from '@/store/session-states'
 
@@ -46,6 +50,7 @@ function RouteResumeHarness({
 describe('useRouteResume', () => {
   afterEach(() => {
     cleanup()
+    $sessionResumeSettlement.set(null)
     vi.restoreAllMocks()
   })
 
@@ -138,6 +143,51 @@ describe('useRouteResume', () => {
     rerender(<RouteResumeHarness {...props} sessionResumeRequest={{ sequence: 1, sessionId: 'session-1' }} />)
 
     expect(resumeSession).toHaveBeenCalledWith('session-1', true)
+  })
+
+  it('publishes the explicit resume settlement only after its authoritative refresh completes', async () => {
+    let finishResume: (() => void) | undefined
+
+    const resumeSession = vi.fn(
+      () =>
+        new Promise<void>(resolve => {
+          finishResume = resolve
+        })
+    )
+
+    const activeSessionIdRef: MutableRefObject<null | string> = { current: null }
+    const selectedStoredSessionIdRef: MutableRefObject<null | string> = { current: null }
+
+    const props = {
+      activeSessionId: null,
+      activeSessionIdRef,
+      creatingSessionRef: { current: false },
+      currentView: 'chat',
+      freshDraftReady: true,
+      gatewayState: 'open',
+      locationPathname: '/session-1',
+      resumeSession,
+      routedSessionId: 'session-1',
+      runtimeIdByStoredSessionIdRef: { current: new Map<string, string>() },
+      selectedStoredSessionId: null,
+      selectedStoredSessionIdRef,
+      startFreshSessionDraft: vi.fn()
+    }
+
+    const { rerender } = render(<RouteResumeHarness {...props} />)
+
+    rerender(
+      <RouteResumeHarness
+        {...props}
+        sessionResumeRequest={{ sequence: 41, sessionId: 'session-1' }}
+      />
+    )
+
+    expect($sessionResumeSettlement.get()).toBeNull()
+
+    await act(async () => finishResume?.())
+
+    expect($sessionResumeSettlement.get()).toMatchObject({ sequence: 41, sessionId: 'session-1' })
   })
 
   it('self-heals a stranded routed session (null selected/active, same pathname, not a fresh draft)', () => {

--- a/apps/desktop/src/app/session/hooks/use-route-resume.ts
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.ts
@@ -1,7 +1,7 @@
 import { type MutableRefObject, useEffect, useRef } from 'react'
 
 import { isNewChatRoute } from '@/app/routes'
-import { type SessionResumeRequest, setResumeExhaustedSessionId } from '@/store/session'
+import { markSessionResumeSettled, type SessionResumeRequest, setResumeExhaustedSessionId } from '@/store/session'
 import type { SessionProfileRoute } from '@/store/session-request-router'
 import { markSelectionRestore } from '@/store/session-states'
 
@@ -183,10 +183,19 @@ export function useRouteResume({
         const ownerRoute =
           sessionResumeRequest?.sessionId === routedSessionId ? sessionResumeRequest.ownerRoute : undefined
 
-        if (ownerRoute) {
-          void resumeSession(routedSessionId, true, ownerRoute)
-        } else {
-          void resumeSession(routedSessionId, true)
+        const resume = ownerRoute
+          ? resumeSession(routedSessionId, true, ownerRoute)
+          : resumeSession(routedSessionId, true)
+
+        if (explicitlyRequested && sessionResumeRequest) {
+          // The caller that issued this exact sequence may be holding an
+          // opaque wake cover over a warm cached transcript. Publish a receipt
+          // only after resumeSession's authoritative REST refresh (or its
+          // terminal fallback) has fully settled.
+          void resume.then(
+            () => markSessionResumeSettled(sessionResumeRequest),
+            () => markSessionResumeSettled(sessionResumeRequest)
+          )
         }
       }
 

--- a/apps/desktop/src/components/pane-shell/workspace-scope.ts
+++ b/apps/desktop/src/components/pane-shell/workspace-scope.ts
@@ -46,6 +46,15 @@ export type WorkspaceNewSessionTarget =
 /** Sessions uses its established ambient behavior (`null`). */
 export const $workspaceNewSessionTarget = atom<WorkspaceNewSessionTarget | null>(null)
 
+// Monotonic semantic-scope token. Async navigation captures this before it
+// dials another owner and commits only if no intervening workspace action
+// changed the surface. Equivalent scope publications stay true no-ops.
+let workspaceScopeRevision = 0
+
+export function getWorkspaceScopeRevision(): number {
+  return workspaceScopeRevision
+}
+
 /** Display name per exact owner key, published by the workspace that owns the
  *  key (Bot Mode: the roster's display name). Presentation only — never a
  *  session title, which for a canonical Bot Chat is an identity the backend
@@ -121,6 +130,8 @@ export function setWorkspaceScope(
   ) {
     return false
   }
+
+  workspaceScopeRevision += 1
 
   batch(() => {
     $workspaceMode.set(mode)

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1833,6 +1833,7 @@ export const ar = defineLocale({
   },
   composer: {
     message: 'الرسالة',
+    botChat: 'دردشة البوت',
     wakingProfile: profile => `جار إيقاظ ${profile}`,
     placeholderStarting: 'جار بدء Hermes...',
     placeholderReconnecting: 'جار إعادة الاتصال...',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2484,6 +2484,7 @@ export const en: Translations = {
 
   composer: {
     message: 'Message',
+    botChat: 'Bot Chat',
     wakingProfile: profile => `Waking up ${profile}…`,
     placeholderStarting: 'Starting Hermes...',
     placeholderReconnecting: 'Reconnecting to Hermes…',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2147,6 +2147,7 @@ export const ja = defineLocale({
 
   composer: {
     message: 'メッセージ',
+    botChat: 'ボットチャット',
     wakingProfile: profile => `${profile} を起動中…`,
     placeholderStarting: 'Hermes を起動中...',
     placeholderReconnecting: 'Hermes に再接続中…',

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -2520,6 +2520,7 @@ export const ru = defineLocale({
   },
   composer: {
     message: 'Сообщение',
+    botChat: 'Чат с ботом',
     wakingProfile: profile => `Пробуждаем ${profile}…`,
     placeholderStarting: 'Запуск Hermes...',
     placeholderReconnecting: 'Переподключение к Hermes…',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2128,6 +2128,7 @@ export interface Translations {
 
   composer: {
     message: string
+    botChat: string
     wakingProfile: (profile: string) => string
     placeholderStarting: string
     placeholderReconnecting: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2068,6 +2068,7 @@ export const zhHant = defineLocale({
 
   composer: {
     message: '訊息',
+    botChat: '機器人聊天',
     wakingProfile: profile => `正在喚醒 ${profile}…`,
     placeholderStarting: '正在啟動 Hermes...',
     placeholderReconnecting: '正在重新連線至 Hermes…',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2649,6 +2649,7 @@ export const zh: Translations = {
 
   composer: {
     message: '消息',
+    botChat: '机器人聊天',
     wakingProfile: profile => `正在唤醒 ${profile}…`,
     placeholderStarting: '正在启动 Hermes…',
     placeholderReconnecting: '正在重新连接 Hermes…',

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -435,6 +435,20 @@ describe('toChatMessages', () => {
     ])
   })
 
+  it('projects an untyped legacy auto-continue row instead of flashing its internal note as a user bubble', () => {
+    const messages = toChatMessages([
+      {
+        role: 'user',
+        content:
+          '[System note: Your previous turn was interrupted mid-run — the app or its backend process stopped before the turn could finish.]\n\nkeep going',
+        timestamp: 1
+      }
+    ])
+
+    expect(messages.map(message => message.role)).toEqual(['system'])
+    expect(messages.map(chatMessageText)).toEqual(['resumed interrupted turn'])
+  })
+
   // A backend older than this app serves display_metadata as unparsed JSON
   // text. Indexing into that string used to throw and fail the whole resume.
   it.each([

--- a/apps/desktop/src/lib/chat-messages/hydration.ts
+++ b/apps/desktop/src/lib/chat-messages/hydration.ts
@@ -18,6 +18,7 @@ import type { ChatMessage, ChatMessagePart } from './types'
 const ATTACHED_CONTEXT_MARKER_RE = /(?:^|\n)--- Attached Context ---\s*\n/
 const CONTEXT_WARNINGS_MARKER_RE = /(?:^|\n)--- Context Warnings ---[\s\S]*$/
 const CONTEXT_REF_RE = /@(file|folder|url|image|tool|terminal):(?:"[^"\n]+"|'[^'\n]+'|`[^`\n]+`|\S+)/g
+const LEGACY_AUTO_CONTINUE_PREFIX = '[System note: Your previous turn was interrupted mid-run'
 
 function displayContentForMessage(role: SessionMessage['role'], content: unknown): string {
   const textContent = textFromUnknown(content)
@@ -91,21 +92,33 @@ function messageReactions(metadata: SessionMessage['display_metadata']): Message
   )
 }
 
-function timelineDisplayContent(message: SessionMessage, content: string): string {
-  if (message.display_kind === 'model_switch') {
+function legacyDisplayKind(role: SessionMessage['role'], content: string): SessionMessage['display_kind'] {
+  if (role === 'user' && content.trimStart().startsWith(LEGACY_AUTO_CONTINUE_PREFIX)) {
+    return 'auto_continue'
+  }
+
+  return undefined
+}
+
+function timelineDisplayContent(
+  displayKind: SessionMessage['display_kind'],
+  displayMetadata: SessionMessage['display_metadata'],
+  content: string
+): string {
+  if (displayKind === 'model_switch') {
     return 'model changed'
   }
 
-  if (message.display_kind === 'auto_continue') {
+  if (displayKind === 'auto_continue') {
     return 'resumed interrupted turn'
   }
 
-  if (message.display_kind === 'personality_switch') {
+  if (displayKind === 'personality_switch') {
     return 'personality changed'
   }
 
-  if (message.display_kind === 'async_delegation_complete') {
-    const count = timelineTaskCount(message.display_metadata)
+  if (displayKind === 'async_delegation_complete') {
+    const count = timelineTaskCount(displayMetadata)
 
     return count === undefined
       ? 'background agent work finished'
@@ -194,16 +207,19 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
         ? message.display_content
         : message.content || message.text || message.context || message.name
 
+    const visibleContent = displayContentForMessage(message.role, content)
+    const displayKind = message.display_kind ?? legacyDisplayKind(message.role, visibleContent)
+
     const rawDisplayContent = transcriptContent(
-      message.display_kind,
-      timelineDisplayContent(message, displayContentForMessage(message.role, content))
+      displayKind,
+      timelineDisplayContent(displayKind, message.display_metadata, visibleContent)
     )
 
     const displayRole =
-      message.display_kind === 'model_switch' ||
-      message.display_kind === 'async_delegation_complete' ||
-      message.display_kind === 'auto_continue' ||
-      message.display_kind === 'personality_switch'
+      displayKind === 'model_switch' ||
+      displayKind === 'async_delegation_complete' ||
+      displayKind === 'auto_continue' ||
+      displayKind === 'personality_switch'
         ? 'system'
         : message.role
 

--- a/apps/desktop/src/plugins/hermes-bots/bot-row-opens-canonical-chat.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/bot-row-opens-canonical-chat.test.ts
@@ -28,7 +28,7 @@ vi.mock('./canonical-chat', () => ({
 }))
 
 const { host } = await import('@hermes/plugin-sdk')
-const { $openBotChat, $selectedBot } = await import('./bot-state')
+const { $openBotChat, $selectedBot, $selectedRosterKey } = await import('./bot-state')
 const { openRosterBot, trackInboundActivity } = await import('./roster-actions')
 const { $selectedStoredSessionId } = await import('@/store/session')
 
@@ -40,6 +40,7 @@ beforeEach(() => {
   openBotCanonicalChat.mockResolvedValue({ openedId: 'bot-chat-tip', registryId: 'bot-chat' })
   $openBotChat.set(null)
   $selectedBot.set('')
+  $selectedRosterKey.set('')
 })
 
 describe('a row click lands on the canonical chat, never a remembered side tab', () => {
@@ -79,16 +80,43 @@ describe('a row click lands on the canonical chat, never a remembered side tab',
 
     await expect(openRosterBot(canonicalBot)).resolves.toBe(true)
 
-    expect(openBotCanonicalChat).toHaveBeenCalledWith(canonicalBot, expect.any(Function))
+    expect(openBotCanonicalChat).toHaveBeenCalledWith(canonicalBot, expect.any(Function), expect.any(Function))
     expect($openBotChat.get()?.openedSessionId).toBe('bot-chat-tip')
+  })
+
+  it('commits the roster owner only after its canonical chat owns the center', async () => {
+    let releaseSource!: () => void
+
+    const sourceReady = new Promise<void>(resolve => {
+      releaseSource = resolve
+    })
+
+    prepareBotSource.mockReturnValueOnce(sourceReady)
+    $selectedBot.set('omega')
+    $selectedRosterKey.set('local::omega')
+
+    const opening = openRosterBot(canonicalBot)
+
+    await vi.waitFor(() => expect(prepareBotSource).toHaveBeenCalledOnce())
+    expect($selectedBot.get()).toBe('omega')
+    expect($selectedRosterKey.get()).toBe('local::omega')
+
+    releaseSource()
+    await expect(opening).resolves.toBe(true)
+    expect($selectedBot.get()).toBe('alpha')
+    expect($selectedRosterKey.get()).toBe('local::alpha')
   })
 
   it('a failed open records no claim', async () => {
     openBotCanonicalChat.mockRejectedValueOnce(new Error('gateway away'))
+    $selectedBot.set('omega')
+    $selectedRosterKey.set('local::omega')
 
     await expect(openRosterBot(bot)).resolves.toBe(false)
 
     expect($openBotChat.get()).toBeNull()
+    expect($selectedBot.get()).toBe('omega')
+    expect($selectedRosterKey.get()).toBe('local::omega')
   })
 })
 

--- a/apps/desktop/src/plugins/hermes-bots/bot-row-opens-canonical-chat.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/bot-row-opens-canonical-chat.test.ts
@@ -54,7 +54,7 @@ describe('a row click lands on the canonical chat, never a remembered side tab',
     delete host.focusOpenWorkspaceSession
   })
 
-  it('fronts an open Bot Chat tab without a registry round-trip, side tabs excluded', async () => {
+  it('re-opens an already-open Bot Chat through the atomic canonical path, side tabs excluded', async () => {
     const focus = vi.fn((_key: string, _probe: unknown, only?: readonly string[]) =>
       only?.includes('bot-chat-tip') ? 'bot-chat-tip' : null
     )
@@ -63,8 +63,8 @@ describe('a row click lands on the canonical chat, never a remembered side tab',
 
     await expect(openRosterBot(canonicalBot)).resolves.toBe(true)
 
-    expect(focus).toHaveBeenCalledWith('bot:alpha', expect.any(Function), ['bot-chat', 'bot-chat-tip'])
-    expect(openBotCanonicalChat).not.toHaveBeenCalled()
+    expect(focus).not.toHaveBeenCalled()
+    expect(openBotCanonicalChat).toHaveBeenCalledWith(canonicalBot, expect.any(Function), expect.any(Function))
     expect($openBotChat.get()).toEqual({
       key: 'local::alpha',
       openedRegistryId: 'bot-chat',
@@ -72,6 +72,33 @@ describe('a row click lands on the canonical chat, never a remembered side tab',
     })
   })
 
+  it('keeps the previous roster owner until an already-open Bot Chat finishes reopening', async () => {
+    let releaseOpen!: (opened: { openedId: string; registryId: string }) => void
+
+    const reopened = new Promise<{ openedId: string; registryId: string }>(resolve => {
+      releaseOpen = resolve
+    })
+
+    host.focusOpenWorkspaceSession = vi.fn((_key: string, _probe: unknown, only?: readonly string[]) =>
+      only?.includes('bot-chat-tip') ? 'bot-chat-tip' : null
+    ) as never
+    openBotCanonicalChat.mockReturnValueOnce(reopened)
+    $selectedBot.set('omega')
+    $selectedRosterKey.set('local::omega')
+
+    const opening = openRosterBot(canonicalBot)
+
+    await vi.waitFor(() => expect(openBotCanonicalChat).toHaveBeenCalledOnce())
+    const ownerWhileReopening = $selectedBot.get()
+    const rosterKeyWhileReopening = $selectedRosterKey.get()
+
+    releaseOpen({ openedId: 'bot-chat-tip', registryId: 'bot-chat' })
+    await expect(opening).resolves.toBe(true)
+    expect(ownerWhileReopening).toBe('omega')
+    expect(rosterKeyWhileReopening).toBe('local::omega')
+    expect($selectedBot.get()).toBe('alpha')
+    expect($selectedRosterKey.get()).toBe('local::alpha')
+  })
   it('resolves the registry when only a side thread is open', async () => {
     // The shell would happily front 'side-thread' — the allowlist excludes it.
     host.focusOpenWorkspaceSession = vi.fn((_key: string, _probe: unknown, only?: readonly string[]) =>

--- a/apps/desktop/src/plugins/hermes-bots/canonical-chat.ts
+++ b/apps/desktop/src/plugins/hermes-bots/canonical-chat.ts
@@ -81,7 +81,8 @@ export function isCanonicalChatOnScreen(
 async function openStoredBotChat(
   owner: RosterRow | string,
   storedId: string,
-  summary: CanonicalChatRow
+  summary: CanonicalChatRow,
+  onWorkspaceCommit: (() => void) | null = null
 ): Promise<string> {
   if (!storedId || typeof host.openSession !== 'function') {
     throw new Error('This Hermes Desktop version cannot open stored sessions')
@@ -132,6 +133,7 @@ async function openStoredBotChat(
     forceResume: true,
     hydrationTimeoutMs,
     keepAllProfilesScope: true,
+    ...(onWorkspaceCommit ? { onWorkspaceCommit } : {}),
     workspaceMode: 'bots',
     workspaceOwnerKey: ownerKey,
     retryHydrationTimeoutOnce: true,
@@ -236,6 +238,7 @@ async function findExistingCanonicalChat(owner: RosterRow | string): Promise<Can
 
 interface CreateCanonicalChatOptions {
   kickoff?: boolean
+  onWorkspaceCommit?: (() => void) | null
   openingStillCurrent?: (() => boolean) | null
 }
 
@@ -289,7 +292,7 @@ function kickoffText(): string {
  *  rail in a bot chat until the next click re-opened it scoped. */
 export function createCanonicalChat(
   owner: RosterRow | string,
-  { kickoff = false, openingStillCurrent = null }: CreateCanonicalChatOptions = {}
+  { kickoff = false, onWorkspaceCommit = null, openingStillCurrent = null }: CreateCanonicalChatOptions = {}
 ): Promise<null | string> {
   const { bot, name, key, route } = botOwner(owner)
   const inflight = canonicalCreations.get(key)
@@ -307,6 +310,7 @@ export function createCanonicalChat(
       profile: name,
       intent: 'main',
       keepAllProfilesScope: route ? true : false,
+      ...(onWorkspaceCommit ? { onWorkspaceCommit } : {}),
       workspaceMode: 'bots',
       workspaceOwnerKey: botWorkspaceOwnerKey(bot),
       tabTitle: CANONICAL_CHAT_TITLE
@@ -339,7 +343,7 @@ export function createCanonicalChat(
       if (typeof host.openSession === 'function' && canNavigate()) {
         // The exact-lookup gateway reports the compression-lineage tip as
         // resolved_id; open the tip, the registry row stays the identity.
-        await openStoredBotChat(owner, existing.resolved_id || existing.id, existing)
+        await openStoredBotChat(owner, existing.resolved_id || existing.id, existing, onWorkspaceCommit)
       }
 
       return existing.id
@@ -402,7 +406,7 @@ export function createCanonicalChat(
             // round-trip after the user clicked another bot, and every sibling
             // open here is staleness-probed for exactly that reason.
             if (typeof host.openSession === 'function' && canNavigate()) {
-              await openStoredBotChat(owner, winner.resolved_id || winner.id, winner)
+              await openStoredBotChat(owner, winner.resolved_id || winner.id, winner, onWorkspaceCommit)
             }
 
             return winner.id
@@ -484,7 +488,8 @@ export function createCanonicalChat(
  *  bot's chat opens without re-homing Desktop's chrome. */
 export async function openBotCanonicalChat(
   owner: RosterRow | string,
-  openingStillCurrent: (() => boolean) | null = null
+  openingStillCurrent: (() => boolean) | null = null,
+  onWorkspaceCommit: (() => void) | null = null
 ): Promise<{ openedId: string; registryId: string } | null> {
   const existing = await findExistingCanonicalChat(owner)
 
@@ -494,7 +499,7 @@ export async function openBotCanonicalChat(
     }
 
     const openedId = existing.resolved_id || existing.id
-    await openStoredBotChat(owner, openedId, existing)
+    await openStoredBotChat(owner, openedId, existing, onWorkspaceCommit)
 
     // Both identities matter downstream: the durable registry row names the
     // chat; the resolved lineage tip is what actually takes session focus.
@@ -507,6 +512,7 @@ export async function openBotCanonicalChat(
   }
 
   const created = await createCanonicalChat(owner, {
+    onWorkspaceCommit,
     openingStillCurrent
   })
 

--- a/apps/desktop/src/plugins/hermes-bots/roster-actions.ts
+++ b/apps/desktop/src/plugins/hermes-bots/roster-actions.ts
@@ -11,7 +11,7 @@
 import { ackStoredSessionId, atom, haptic, host, markSessionUnreadFinished } from '@hermes/plugin-sdk'
 
 import { $openBotChat, $selectedBot, rosterWatermarks, saveSelectedRosterBot } from './bot-state'
-import { CANONICAL_CHAT_TITLE, notifyBotOpenFailure, openBotCanonicalChat, prepareBotSource } from './canonical-chat'
+import { notifyBotOpenFailure, openBotCanonicalChat, prepareBotSource } from './canonical-chat'
 import { $botMeta, botActivitySession, botRosterKey, botSelectionKey, newBotChat } from './data'
 import { $groupChats, $groupChatWorkspace } from './group-chat'
 import { openGroupChat } from './group-chat-view'
@@ -130,54 +130,14 @@ function refreshOpenBotChat(bot: RosterRow) {
   })
 }
 
-/** Front the bot's canonical Bot Chat when it is ALREADY open as a tab —
- *  presentation only, no registry round-trip. Returns the fronted stored id,
- *  or null when the chat is not on screen (or this shell cannot tell) and the
- *  caller must resolve the registry.
- *
- *  Only the canonical chat qualifies: a tile whose stored id is the roster's
- *  server-resolved `canonical_session` (registry row or its lineage tip). An
- *  earlier version fronted whatever bots-workspace tab the user last had
- *  active — a `+` side thread persisted in Local Storage across restarts and
- *  won every click forever while the row kept previewing the Bot Chat, so
- *  sidebar and center described two different conversations ("[Bots] -
- *  Sessions is not in sync again"). Side tabs stay open; they never answer a
- *  click aimed at the bot. Canonical-titled tiles at a foreign id are stale
- *  (hermes-agent#90102) and are discarded. Without `canonical_session` (older
- *  gateway) nothing can be verified, so nothing is fronted. */
-function focusExistingBotTab(bot: RosterRow): null | { registryId: string; storedSessionId: string } {
-  if (typeof host.focusOpenWorkspaceSession !== 'function') {
-    return null
-  }
-
-  const canonical = bot?.canonical_session
-  const canonicalIds = [canonical?.id, canonical?.resolved_id].filter(Boolean).map(String)
-
-  if (canonicalIds.length === 0) {
-    return null
-  }
-
-  const isStaleTile = (tile: { storedSessionId: string; workspaceTabTitle?: string }) =>
-    typeof tile.workspaceTabTitle === 'string' &&
-    tile.workspaceTabTitle === CANONICAL_CHAT_TITLE &&
-    !canonicalIds.includes(String(tile.storedSessionId))
-
-  try {
-    const focused = host.focusOpenWorkspaceSession(botWorkspaceOwnerKey(bot), isStaleTile, canonicalIds)
-
-    return typeof focused === 'string' && focused
-      ? { registryId: String(canonical!.id), storedSessionId: focused }
-      : null
-  } catch {
-    return null
-  }
-}
-
 /** Select one exact roster owner and open its canonical Bot Chat — the same
  *  session the row previews. Resolution always goes through the owner
- *  profile's "Bot Chat" title registry: an already-open canonical tab is
- *  fronted (focusExistingBotTab), otherwise openBotCanonicalChat resolves and
- *  opens it in place; side tabs the user opened with `+` stay open beside it. A click never fronts a side tab: an
+ *  profile's "Bot Chat" title registry, then openBotCanonicalChat opens it in
+ *  place through the SDK's hydrated workspace handoff. This is intentional
+ *  even when the tab is already mounted: the presentation-only focus helper
+ *  changed the roster owner while the previous bot still painted in the
+ *  center, and it kept a stale transcript until a later refresh. Side tabs the
+ *  user opened with `+` stay open beside it. A click never fronts a side tab: an
  *  earlier "return to the last open tab" shortcut left the center on a `+`
  *  thread (persisted in Local Storage across restarts) while the row kept
  *  previewing the Bot Chat — sidebar and center described two different
@@ -251,18 +211,6 @@ export async function openRosterBot(bot: RosterRow): Promise<boolean> {
   // which the selection listener alone would file against the wrong profile —
   // a bot open deliberately leaves the gateway on the launch profile.
   ackStoredSessionId(botCanonicalSessionId(bot), bot.name)
-
-  const fronted = focusExistingBotTab(bot)
-
-  if (fronted) {
-    // The canonical chat is on screen: no source activation, no registry
-    // round-trip. Both identities are recorded so the reclaim listener and
-    // the roster-activity refresh treat it exactly like a registry open.
-    commitRosterBot()
-    $openBotChat.set({ key, openedRegistryId: fronted.registryId, openedSessionId: fronted.storedSessionId })
-
-    return true
-  }
 
   try {
     // Activation selects this row's source only. Canonical identity is resolved

--- a/apps/desktop/src/plugins/hermes-bots/roster-actions.ts
+++ b/apps/desktop/src/plugins/hermes-bots/roster-actions.ts
@@ -200,9 +200,23 @@ export async function openRosterBot(bot: RosterRow): Promise<boolean> {
       }
     : null
 
+  let ownerCommitted = false
+
+  const commitRosterBot = () => {
+    if (ownerCommitted) {
+      return
+    }
+
+    // One synchronous owner handoff. The SDK invokes this immediately before
+    // a newly opened session navigates; an already-open tab invokes it after
+    // focus succeeds. Until then every visible owner surface stays on the
+    // previously committed bot.
+    setBotsWorkspaceOwner(botWorkspaceOwnerKey(bot), bot)
+    saveSelectedRosterBot(bot)
+    ownerCommitted = true
+  }
+
   haptic('tap')
-  saveSelectedRosterBot(bot)
-  setBotsWorkspaceOwner(botWorkspaceOwnerKey(bot), bot)
   const dismissedGroup = dismissGroupChatForBotOpen()
 
   if (!dismissedGroup) {
@@ -244,6 +258,7 @@ export async function openRosterBot(bot: RosterRow): Promise<boolean> {
     // The canonical chat is on screen: no source activation, no registry
     // round-trip. Both identities are recorded so the reclaim listener and
     // the roster-activity refresh treat it exactly like a registry open.
+    commitRosterBot()
     $openBotChat.set({ key, openedRegistryId: fronted.registryId, openedSessionId: fronted.storedSessionId })
 
     return true
@@ -268,7 +283,7 @@ export async function openRosterBot(bot: RosterRow): Promise<boolean> {
   }
 
   try {
-    const opened = await openBotCanonicalChat(bot, () => generation === getBotOpenGeneration())
+    const opened = await openBotCanonicalChat(bot, () => generation === getBotOpenGeneration(), commitRosterBot)
 
     if (generation !== getBotOpenGeneration()) {
       return false
@@ -282,6 +297,9 @@ export async function openRosterBot(bot: RosterRow): Promise<boolean> {
       // durable registry row, and matching focus against the registry id
       // alone released this claim on the first click of every compressed
       // Bot Chat.
+      // Older SDKs ignore onWorkspaceCommit; commit here as the compatibility
+      // fallback after their open promise succeeds.
+      commitRosterBot()
       $openBotChat.set({
         key,
         openedRegistryId: opened.registryId,
@@ -309,6 +327,7 @@ export async function openRosterBot(bot: RosterRow): Promise<boolean> {
     return false
   }
 
+  commitRosterBot()
   $openBotChat.set({
     key,
     openedRegistryId: ''

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -79,6 +79,7 @@ import {
   $gatewayState,
   $messages,
   $selectedStoredSessionId,
+  $sessionResumeSettlement,
   $sessions,
   getSessionOwnerHints,
   rememberedSessionProfile,
@@ -394,6 +395,7 @@ function waitForFocusedSessionHydration({
   isCurrent,
   profile,
   requireActiveProfile,
+  resumeRequest,
   storedSessionId,
   timeoutMs
 }: {
@@ -402,6 +404,7 @@ function waitForFocusedSessionHydration({
   isCurrent?: () => boolean
   profile: string
   requireActiveProfile: boolean
+  resumeRequest?: null | { sequence: number; sessionId: string }
   storedSessionId: string
   timeoutMs: number
 }): Promise<void> {
@@ -454,6 +457,12 @@ function waitForFocusedSessionHydration({
 
       const runtimeReady = mainMatches ? Boolean($activeSessionId.get()) : tileMatches ? Boolean(tileRuntimeId) : false
 
+      const settlement = $sessionResumeSettlement.get()
+
+      const freshResumeSettled =
+        !resumeRequest ||
+        (settlement?.sessionId === resumeRequest.sessionId && settlement.sequence >= resumeRequest.sequence)
+
       const historyPainted = mainMatches
         ? Boolean($messages.get().length)
         : tileMatches
@@ -472,7 +481,7 @@ function waitForFocusedSessionHydration({
       // immediately. Only an expected-EMPTY chat still waits for the runtime
       // — with no transcript to paint, a bound runtime is the only proof the
       // surface is real rather than a stuck loader.
-      const hydrated = expectHistory ? historyPainted : runtimeReady
+      const hydrated = (expectHistory ? historyPainted : runtimeReady) && freshResumeSettled
 
       if ((mainMatches || tileMatches) && hydrated) {
         if (profileMatches) {
@@ -509,6 +518,7 @@ function waitForFocusedSessionHydration({
     unbinds.push($selectedStoredSessionId.listen(check))
     unbinds.push($activeSessionId.listen(check))
     unbinds.push($messages.listen(check))
+    unbinds.push($sessionResumeSettlement.listen(check))
     unbinds.push($focusedStoredSessionId.listen(check))
     unbinds.push($focusedRuntimeId.listen(check))
     unbinds.push($focusedSessionState.listen(check))
@@ -1022,6 +1032,8 @@ export const host = {
           // an already-mounted tile would paint the idle snapshot and never
           // pull messages that arrived while the panel WS was down (#96183).
           // Refresh the tile transcript in place instead.
+          let resumeRequest: null | { sequence: number; sessionId: string } = null
+
           if (options.awaitHydration && (options.forceResume || !surfaceHealthy)) {
             const existingTile = $sessionTiles.get().some(tile => tile.storedSessionId === storedSessionId)
             const tileDelegate = existingTile ? sessionTileDelegate() : null
@@ -1030,10 +1042,10 @@ export const host = {
               try {
                 await tileDelegate.resumeTile(storedSessionId, { refreshTranscript: true })
               } catch {
-                requestSessionResume(storedSessionId, ownerRoute || undefined)
+                resumeRequest = requestSessionResume(storedSessionId, ownerRoute || undefined)
               }
             } else {
-              requestSessionResume(storedSessionId, ownerRoute || undefined)
+              resumeRequest = requestSessionResume(storedSessionId, ownerRoute || undefined)
             }
           }
 
@@ -1043,6 +1055,10 @@ export const host = {
               generation,
               isCurrent: openingStillCurrent,
               profile: targetProfile,
+              // A forced refresh must outlive a merely non-empty warm cache.
+              // Its receipt is published only after resumeSession finishes
+              // reconciling the persisted display transcript.
+              resumeRequest: options.forceResume ? resumeRequest : null,
               // A background dial never moves $activeGatewayProfile, so gating
               // hydration on it would wait for something that is not coming.
               requireActiveProfile: ownerRoute ? false : plan.requireActiveProfileForHydration,

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -35,6 +35,7 @@ import {
 import {
   $workspaceMode,
   $workspaceOwnerKey,
+  getWorkspaceScopeRevision,
   setWorkspaceScope as publishWorkspaceScope,
   setWorkspaceOwnerLabel,
   type WorkspaceNewSessionTarget
@@ -346,6 +347,11 @@ export interface PluginOpenSessionOptions {
   hydrationTimeoutMs?: number
   intent?: OpenSessionIntent
   keepAllProfilesScope?: boolean
+  /** Runs in the same synchronous commit as a Bot workspace handoff, after
+   *  the new owner scope is published and before its session navigates. A
+   *  caller with local selection stores can update them without exposing an
+   *  async frame where the sidebar and center name different owners. */
+  onWorkspaceCommit?: () => void
   profile?: null | string
   route?: PluginProfileRoute
   workspaceMode?: WorkspaceMode
@@ -817,6 +823,8 @@ export const host = {
    *  also scope chrome onto that profile and collapse the sidebar. */
   openSession: async (storedSessionId: string, options: PluginOpenSessionOptions = {}): Promise<void> => {
     const generation = ++openSessionGeneration
+    const initialWorkspaceScopeRevision = getWorkspaceScopeRevision()
+    let workspaceScopeCommitted = options.workspaceMode !== 'bots'
 
     // A new wake owns the syncing affordance — a lingering badge from an
     // earlier paint-first wake must not survive into this one.
@@ -848,18 +856,12 @@ export const host = {
 
     const expectHistory = options.expectHistory ?? false
 
-    if (options.workspaceMode === 'bots') {
-      publishWorkspaceScope(
-        'bots',
-        options.workspaceOwnerKey ?? null,
-        ownerRoute ? { kind: 'route', route: ownerRoute } : null
-      )
-    }
-
     const openingStillCurrent = () =>
       generation === openSessionGeneration &&
       (options.workspaceMode !== 'bots' ||
-        ($workspaceMode.get() === 'bots' && $workspaceOwnerKey.get() === (options.workspaceOwnerKey ?? null)))
+        (workspaceScopeCommitted
+          ? $workspaceMode.get() === 'bots' && $workspaceOwnerKey.get() === (options.workspaceOwnerKey ?? null)
+          : getWorkspaceScopeRevision() === initialWorkspaceScopeRevision))
 
     const plan = planPluginOpenSession({
       activeProfile: $activeGatewayProfile.get(),
@@ -929,6 +931,20 @@ export const host = {
 
       if (!openingStillCurrent()) {
         throw new Error('Session open was superseded by a newer selection.')
+      }
+
+      // Commit the owner only once its backend is ready and the core open can
+      // follow synchronously. Publishing this before the dial made the Bot
+      // row, center, routines and `+` target describe two different owners
+      // for the whole remote-activation window.
+      if (options.workspaceMode === 'bots') {
+        publishWorkspaceScope(
+          'bots',
+          options.workspaceOwnerKey ?? null,
+          ownerRoute ? { kind: 'route', route: ownerRoute } : null
+        )
+        workspaceScopeCommitted = true
+        options.onWorkspaceCommit?.()
       }
 
       // Only a cross-connection (explicit route) open forces the all-profiles
@@ -1225,7 +1241,14 @@ export const host = {
     workspaceOwnerKey: string,
     isStaleTile?: (tile: { storedSessionId: string; workspaceTabTitle?: string }) => boolean,
     onlyStoredIds?: readonly string[]
-  ): null | string => focusWorkspaceOwnerSessionTile(workspaceOwnerKey, isStaleTile, onlyStoredIds),
+  ): null | string => {
+    // A direct re-front is a newer navigation intent even when it returns to
+    // the owner already committed in workspace scope. Cancel a slow wake for
+    // another bot so it cannot land after this click and steal the center.
+    openSessionGeneration += 1
+
+    return focusWorkspaceOwnerSessionTile(workspaceOwnerKey, isStaleTile, onlyStoredIds)
+  },
 
   /** Reactive on-screen visibility of a contributed pane: true while it is in
    *  the layout tree, not dismissed/hidden, its zone un-minimized, AND holding

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -408,6 +408,8 @@ function waitForFocusedSessionHydration({
   storedSessionId: string
   timeoutMs: number
 }): Promise<void> {
+  const targetTileVisibility = $paneVisible(`session-tile:${storedSessionId}`)
+
   return new Promise((resolve, reject) => {
     let settled = false
     const unbinds: Array<() => void> = []
@@ -445,17 +447,17 @@ function waitForFocusedSessionHydration({
       const profileMatches = !requireActiveProfile || normalizeProfileKey($activeGatewayProfile.get()) === profile
       const mainMatches = $selectedStoredSessionId.get() === storedSessionId
       const storedTile = $sessionTiles.get().find(tile => tile.storedSessionId === storedSessionId)
-      const tileMatches = $focusedStoredSessionId.get() === storedSessionId || Boolean(storedTile)
       const focusedTileMatches = $focusedStoredSessionId.get() === storedSessionId
+      const visibleTileMatches = focusedTileMatches || Boolean(storedTile && targetTileVisibility.get())
+      const displayMatches = mainMatches || visibleTileMatches
       const tileRuntimeId = focusedTileMatches ? $focusedRuntimeId.get() : (storedTile?.runtimeId ?? null)
-
       const tileState = focusedTileMatches
         ? $focusedSessionState.get()
-        : tileRuntimeId
+        : visibleTileMatches && tileRuntimeId
           ? $sessionStates.get()[tileRuntimeId]
           : undefined
 
-      const runtimeReady = mainMatches ? Boolean($activeSessionId.get()) : tileMatches ? Boolean(tileRuntimeId) : false
+      const runtimeReady = mainMatches ? Boolean($activeSessionId.get()) : visibleTileMatches && Boolean(tileRuntimeId)
 
       const settlement = $sessionResumeSettlement.get()
 
@@ -465,7 +467,7 @@ function waitForFocusedSessionHydration({
 
       const historyPainted = mainMatches
         ? Boolean($messages.get().length)
-        : tileMatches
+        : visibleTileMatches
           ? Boolean(tileState?.messages.length)
           : false
 
@@ -481,9 +483,18 @@ function waitForFocusedSessionHydration({
       // immediately. Only an expected-EMPTY chat still waits for the runtime
       // — with no transcript to paint, a bound runtime is the only proof the
       // surface is real rather than a stuck loader.
-      const hydrated = (expectHistory ? historyPainted : runtimeReady) && freshResumeSettled
+      // A display-authoritative transcript paint is the history-bearing wake
+      // contract (#89510, #101227): keep the forced refresh running so
+      // background turns reconcile, but do not hide readable history behind
+      // that slower RPC. The warm path already suppresses unproven runtime
+      // tails until persisted-display authority lands (#97293), while the
+      // cold durable tail is scoped to this exact connection/profile/session
+      // and is deliberately display-only. Expected-empty chats have no paint
+      // to prove the surface, so they still wait for both runtime binding and
+      // the requested refresh settlement.
+      const hydrated = expectHistory ? historyPainted : runtimeReady && freshResumeSettled
 
-      if ((mainMatches || tileMatches) && hydrated) {
+      if (displayMatches && hydrated) {
         if (profileMatches) {
           finish()
 
@@ -524,6 +535,7 @@ function waitForFocusedSessionHydration({
     unbinds.push($focusedSessionState.listen(check))
     unbinds.push($sessionTiles.listen(check))
     unbinds.push($sessionStates.listen(check))
+    unbinds.push(targetTileVisibility.listen(check))
     unbinds.push($workspaceMode.listen(check))
     unbinds.push($workspaceOwnerKey.listen(check))
 
@@ -973,8 +985,11 @@ export const host = {
       }
 
       if (options.awaitHydration) {
-        // Keep the target-specific overlay visible through transcript hydration,
-        // not merely through the gateway/profile activation that precedes it.
+        // A destination transcript can be warm in a BACKGROUND tile while the
+        // center still paints the bot being left. Cover that ownership gap;
+        // the waiter releases it as soon as the exact destination is the
+        // selected/focused surface with history. Merely finding a cached tile
+        // is not display proof (#93604, #97293).
         $gatewaySwapTarget.set(targetProfile)
       }
 

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -59,6 +59,7 @@ vi.mock('@/store/session-states', async () => {
     $stalledSessionIds: atom([]),
     $workingSessionIds: atom([]),
     dropTilesForProfile: vi.fn(),
+    focusWorkspaceOwnerSessionTile: vi.fn(),
     sessionTileDelegate: vi.fn(() => null)
   }
 })
@@ -151,12 +152,13 @@ const {
   $focusedStoredSessionId,
   $sessionStates,
   $sessionTiles,
+  focusWorkspaceOwnerSessionTile,
   sessionTileDelegate
 } = await import('@/store/session-states')
 
 const { dropTilesForProfile } = await import('@/store/session-states')
 
-const { setWorkspaceScope } = await import('@/components/pane-shell/workspace-scope')
+const { $workspaceOwnerKey, setWorkspaceScope } = await import('@/components/pane-shell/workspace-scope')
 
 const {
   $activeSessionId,
@@ -636,6 +638,76 @@ describe('profile-aware plugin session opens', () => {
     })
   })
 
+  it('keeps the current Bot owner committed while the next owner is still dialing', async () => {
+    let releaseDial: (() => void) | undefined
+    const timeline: string[] = []
+
+    vi.mocked(openGatewayForAgent).mockImplementationOnce(
+      () =>
+        new Promise<void>(resolve => {
+          releaseDial = resolve
+        })
+    )
+    vi.mocked(openSessionCore).mockImplementationOnce(() => {
+      timeline.push('open')
+    })
+    setWorkspaceScope('bots', 'bot:source-a::alpha')
+
+    const opening = host.openSession('beta-chat', {
+      route: {
+        connectionId: 'source-b',
+        mode: 'remote',
+        profile: 'beta',
+        targetProfile: 'beta'
+      },
+      onWorkspaceCommit: () => timeline.push('commit'),
+      workspaceMode: 'bots',
+      workspaceOwnerKey: 'bot:source-b::beta'
+    })
+
+    await vi.waitFor(() => expect(openGatewayForAgent).toHaveBeenCalledOnce())
+    expect($workspaceOwnerKey.get()).toBe('bot:source-a::alpha')
+    expect(timeline).toEqual([])
+
+    releaseDial?.()
+    await opening
+    expect($workspaceOwnerKey.get()).toBe('bot:source-b::beta')
+    expect(timeline).toEqual(['commit', 'open'])
+    expect(openSessionCore).toHaveBeenCalledOnce()
+  })
+
+  it('does not let a late wake steal focus after the user re-fronts the current Bot', async () => {
+    let releaseDial: (() => void) | undefined
+
+    vi.mocked(openGatewayForAgent).mockImplementationOnce(
+      () =>
+        new Promise<void>(resolve => {
+          releaseDial = resolve
+        })
+    )
+    vi.mocked(focusWorkspaceOwnerSessionTile).mockReturnValueOnce('alpha-chat')
+    setWorkspaceScope('bots', 'bot:source-a::alpha')
+
+    const opening = host.openSession('beta-chat', {
+      route: {
+        connectionId: 'source-b',
+        mode: 'remote',
+        profile: 'beta',
+        targetProfile: 'beta'
+      },
+      workspaceMode: 'bots',
+      workspaceOwnerKey: 'bot:source-b::beta'
+    })
+
+    await vi.waitFor(() => expect(openGatewayForAgent).toHaveBeenCalledOnce())
+    expect(host.focusOpenWorkspaceSession('bot:source-a::alpha')).toBe('alpha-chat')
+    releaseDial?.()
+
+    await expect(opening).rejects.toThrow(/superseded/i)
+    expect($workspaceOwnerKey.get()).toBe('bot:source-a::alpha')
+    expect(openSessionCore).not.toHaveBeenCalled()
+  })
+
   it('finishes hydration on the focused Bot tile without moving the Sessions gateway', async () => {
     const route = {
       connectionId: 'source-a',
@@ -714,6 +786,7 @@ describe('profile-aware plugin session opens', () => {
           releaseDial = resolve
         })
     )
+    setWorkspaceScope('bots', 'bot:source-a::alpha')
 
     const opening = host.openSession('late-bot-chat', {
       awaitHydration: true,

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -19,6 +19,7 @@ vi.mock('@/store/notifications', () => ({ notify: vi.fn(), notifyError: vi.fn() 
 vi.mock('@/store/system-actions', () => ({ runGatewayRestart: vi.fn() }))
 vi.mock('@/store/session', async () => {
   const { atom } = await import('nanostores')
+  let resumeSequence = 0
 
   type LineageRow = { _lineage_root_id?: null | string; id: string }
 
@@ -32,12 +33,17 @@ vi.mock('@/store/session', async () => {
     $messages: atom([]),
     $messagingSessions: atom([]),
     $selectedStoredSessionId: atom(null),
+    $sessionResumeSettlement: atom(null),
     $sessions: atom([]),
     $unreadFinishedSessionIds: atom([]),
     lineageAliases: (storedId: string) => [storedId],
     rememberedSessionProfile: (_sessions: unknown, _sessionId: null | string, activeProfile: null | string) =>
       (activeProfile ?? '').trim() || 'default',
-    requestSessionResume: vi.fn(),
+    requestSessionResume: vi.fn((sessionId: string, ownerRoute?: unknown) => ({
+      ...(ownerRoute ? { ownerRoute } : {}),
+      sequence: ++resumeSequence,
+      sessionId
+    })),
     sessionMatchesStoredId: (session: LineageRow, storedSessionId: string) =>
       session.id === storedSessionId || session._lineage_root_id === storedSessionId,
     sessionPinId: (session: LineageRow) => session._lineage_root_id ?? session.id,
@@ -164,6 +170,7 @@ const {
   $activeSessionId,
   $messages,
   $selectedStoredSessionId,
+  $sessionResumeSettlement,
   requestSessionResume,
   setSessionOwnerHint,
   setResumeExhaustedSessionId
@@ -196,6 +203,7 @@ afterEach(() => {
   setMockAtom($activeSessionId, null)
   setMockAtom($selectedStoredSessionId, null)
   setMockAtom($messages, [])
+  setMockAtom($sessionResumeSettlement, null)
   $profiles.set([profile('cached-only')])
   setWorkspaceScope('sessions')
   delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
@@ -956,7 +964,7 @@ describe('profile-aware plugin session opens', () => {
     expect(requestSessionResume).not.toHaveBeenCalled()
   })
 
-  it('forces a resume on an explicit bot switch even when a cached transcript looks healthy (#93604)', async () => {
+  it('keeps a forced Bot Chat wake covered until the fresh resume settles (#93604)', async () => {
     // Bot-switch shape from the field: the previous visit left a non-empty
     // snapshot in the session-states cache, so the surface passes every
     // health check while painting STALE messages. The heuristic alone skips
@@ -966,18 +974,30 @@ describe('profile-aware plugin session opens', () => {
     setMockAtom($activeSessionId, 'runtime-stale-snapshot')
     setMockAtom($messages, [{ id: 'stale-history', parts: [], role: 'assistant' }] as never)
 
+    let resolved = false
+
     const opening = host.openSession('bot-chat', {
       profile: 'hyoseob',
       awaitHydration: true,
       expectHistory: true,
       forceResume: true,
       hydrationTimeoutMs: 1_000
+    }).then(() => {
+      resolved = true
     })
 
     await Promise.resolve()
     expect(requestSessionResume).toHaveBeenCalledWith('bot-chat', undefined)
+    expect(resolved).toBe(false)
+    expect($gatewaySwapTarget.get()).toBe('hyoseob')
+
+    const resumeRequest = vi.mocked(requestSessionResume).mock.results.at(-1)?.value
+
+    expect(resumeRequest).toBeTruthy()
+    setMockAtom($sessionResumeSettlement, resumeRequest)
 
     await opening
+    expect(resolved).toBe(true)
     expect($gatewaySwapTarget.get()).toBeNull()
   })
 

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -10,8 +10,26 @@ vi.mock('@/app/chat/session-view', async () => {
 vi.mock('@/app/open-session', () => ({ openSession: vi.fn() }))
 vi.mock('@/components/pane-shell/tree/store', async () => {
   const { atom } = await import('nanostores')
+  const visibilityByPane = new Map<string, ReturnType<typeof atom<boolean>>>()
 
-  return { $narrowViewport: atom(false) }
+  const paneVisibility = (paneId: string) => {
+    const existing = visibilityByPane.get(paneId)
+
+    if (existing) {
+      return existing
+    }
+
+    const visible = atom(false)
+    visibilityByPane.set(paneId, visible)
+
+    return visible
+  }
+
+  return {
+    $narrowViewport: atom(false),
+    $paneVisible: vi.fn(paneVisibility),
+    setPaneVisibleForTest: (paneId: string, visible: boolean) => paneVisibility(paneId).set(visible)
+  }
 })
 vi.mock('@/contrib/events', () => ({ onGatewayEvent: vi.fn() }))
 vi.mock('@/hermes', () => ({ deleteProfile: vi.fn(), getLogs: vi.fn(), getStatus: vi.fn(), hermesApi: vi.fn() }))
@@ -164,6 +182,10 @@ const {
 
 const { dropTilesForProfile } = await import('@/store/session-states')
 
+const { setPaneVisibleForTest } = (await import('@/components/pane-shell/tree/store')) as unknown as {
+  setPaneVisibleForTest(paneId: string, visible: boolean): void
+}
+
 const { $workspaceOwnerKey, setWorkspaceScope } = await import('@/components/pane-shell/workspace-scope')
 
 const {
@@ -204,6 +226,8 @@ afterEach(() => {
   setMockAtom($selectedStoredSessionId, null)
   setMockAtom($messages, [])
   setMockAtom($sessionResumeSettlement, null)
+  setPaneVisibleForTest('session-tile:bot-chat', false)
+  setPaneVisibleForTest('session-tile:restored-bot-chat', false)
   $profiles.set([profile('cached-only')])
   setWorkspaceScope('sessions')
   delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
@@ -780,6 +804,7 @@ describe('profile-aware plugin session opens', () => {
         storedSessionId: 'restored-bot-chat'
       }
     } as never)
+    setPaneVisibleForTest('session-tile:restored-bot-chat', true)
 
     await opening
     expect($focusedStoredSessionId.get()).toBeNull()
@@ -946,6 +971,7 @@ describe('profile-aware plugin session opens', () => {
     setMockAtom($sessionTiles, [{ storedSessionId: 'bot-chat' }] as never)
     setMockAtom($focusedStoredSessionId, 'bot-chat')
     setMockAtom($focusedRuntimeId, 'runtime-bot-chat')
+    setPaneVisibleForTest('session-tile:bot-chat', true)
     setMockAtom($focusedSessionState, { messages: [{ id: 'stale-history', parts: [], role: 'assistant' }] } as never)
 
     const opening = host.openSession('bot-chat', {
@@ -964,15 +990,83 @@ describe('profile-aware plugin session opens', () => {
     expect(requestSessionResume).not.toHaveBeenCalled()
   })
 
-  it('keeps a forced Bot Chat wake covered until the fresh resume settles (#93604)', async () => {
-    // Bot-switch shape from the field: the previous visit left a non-empty
-    // snapshot in the session-states cache, so the surface passes every
-    // health check while painting STALE messages. The heuristic alone skips
-    // the resume; the explicit-navigation caller must be able to force it.
+  it('keeps a painted background Bot Chat covered until that exact tile is visible', async () => {
+    let finishRefresh: (() => void) | undefined
+    const resumeTile = vi.fn(
+      () =>
+        new Promise<string>(resolve => {
+          finishRefresh = () => resolve('runtime-bot-chat')
+        })
+    )
+
+    vi.mocked(sessionTileDelegate).mockReturnValue({ resumeTile } as never)
+    $activeGatewayProfile.set('hyoseob')
+    setMockAtom($sessionTiles, [{ runtimeId: 'runtime-bot-chat', storedSessionId: 'bot-chat' }] as never)
+    setMockAtom($selectedStoredSessionId, 'previous-chat')
+    setMockAtom($activeSessionId, 'runtime-previous')
+    setMockAtom($messages, [{ id: 'previous-history', parts: [], role: 'assistant' }] as never)
+    setMockAtom($focusedStoredSessionId, 'previous-chat')
+    setMockAtom($focusedRuntimeId, 'runtime-previous')
+    setMockAtom($focusedSessionState, {
+      messages: [{ id: 'previous-history', parts: [], role: 'assistant' }],
+      storedSessionId: 'previous-chat'
+    } as never)
+    setMockAtom($sessionStates, {
+      'runtime-bot-chat': {
+        messages: [{ id: 'painted-history', parts: [], role: 'assistant' }],
+        storedSessionId: 'bot-chat',
+        transcriptProvenance: {
+          connectionId: 'local',
+          coverage: 'latest-page',
+          lineageRootId: null,
+          profile: 'hyoseob',
+          source: 'persisted-display',
+          storedSessionId: 'bot-chat'
+        }
+      }
+    } as never)
+
+    let resolved = false
+
+    const opening = host.openSession('bot-chat', {
+      profile: 'hyoseob',
+      awaitHydration: true,
+      expectHistory: true,
+      forceResume: true,
+      hydrationTimeoutMs: 1_000,
+      workspaceMode: 'bots',
+      workspaceOwnerKey: 'hyoseob'
+    }).then(() => {
+      resolved = true
+    })
+
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect($gatewaySwapTarget.get()).toBe('hyoseob')
+    expect(resolved).toBe(false)
+
+    finishRefresh?.()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    // A cached destination tile existing in the background does not prove the
+    // center has switched away from the previous bot yet.
+    expect($gatewaySwapTarget.get()).toBe('hyoseob')
+    expect(resolved).toBe(false)
+
+    setPaneVisibleForTest('session-tile:bot-chat', true)
+
+    await opening
+    expect(resumeTile).toHaveBeenCalledWith('bot-chat', { refreshTranscript: true })
+    expect($gatewaySwapTarget.get()).toBeNull()
+  })
+
+  it('keeps a forced Bot Chat wake covered until a display transcript paints (#93604, #97293)', async () => {
+    // The warm path has suppressed an unproven runtime tail, so the target is
+    // selected and runtime-bound but has no display-authoritative transcript.
+    // A refresh settlement alone must not uncover an empty/raw session shell.
     $activeGatewayProfile.set('hyoseob')
     setMockAtom($selectedStoredSessionId, 'bot-chat')
     setMockAtom($activeSessionId, 'runtime-stale-snapshot')
-    setMockAtom($messages, [{ id: 'stale-history', parts: [], role: 'assistant' }] as never)
+    setMockAtom($messages, [])
 
     let resolved = false
 
@@ -996,8 +1090,68 @@ describe('profile-aware plugin session opens', () => {
     expect(resumeRequest).toBeTruthy()
     setMockAtom($sessionResumeSettlement, resumeRequest)
 
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(resolved).toBe(false)
+    expect($gatewaySwapTarget.get()).toBe('hyoseob')
+
+    setMockAtom($messages, [{ id: 'persisted-history', parts: [], role: 'assistant' }] as never)
+
     await opening
     expect(resolved).toBe(true)
+    expect($gatewaySwapTarget.get()).toBeNull()
+  })
+
+  it('reveals painted Bot Chat history while its forced refresh continues (#89510, #101227)', async () => {
+    // A verified warm/cold transcript paint is already scoped to this exact
+    // stored Bot Chat. Refreshing it remains necessary for background turns,
+    // but that revalidation must not hold readable history behind the wake
+    // cover — the paint-first contract keeps the refresh off the critical path.
+    $activeGatewayProfile.set('hyoseob')
+    setMockAtom($selectedStoredSessionId, 'bot-chat')
+    setMockAtom($activeSessionId, 'runtime-cached')
+    setMockAtom($messages, [{ id: 'painted-history', parts: [], role: 'assistant' }] as never)
+    setMockAtom($sessionStates, {
+      'runtime-cached': {
+        messages: [{ id: 'painted-history', parts: [], role: 'assistant' }],
+        storedSessionId: 'bot-chat',
+        transcriptProvenance: {
+          connectionId: 'local',
+          coverage: 'latest-page',
+          lineageRootId: null,
+          profile: 'hyoseob',
+          source: 'persisted-display',
+          storedSessionId: 'bot-chat'
+        }
+      }
+    } as never)
+
+    let resolved = false
+
+    const opening = host.openSession('bot-chat', {
+      profile: 'hyoseob',
+      awaitHydration: true,
+      expectHistory: true,
+      forceResume: true,
+      hydrationTimeoutMs: 1_000
+    }).then(() => {
+      resolved = true
+    })
+
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    const resumeRequest = vi.mocked(requestSessionResume).mock.results.at(-1)?.value
+
+    expect(resumeRequest).toBeTruthy()
+    const resolvedOnPaint = resolved
+
+    // Let the old implementation finish too, so the intentionally failing
+    // assertion below leaves no pending timer or promise behind.
+    if (!resolvedOnPaint) {
+      setMockAtom($sessionResumeSettlement, resumeRequest)
+    }
+
+    await opening
+    expect(resolvedOnPaint).toBe(true)
     expect($gatewaySwapTarget.get()).toBeNull()
   })
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -876,6 +876,12 @@ export interface SessionResumeRequest {
 }
 let sessionResumeRequestSequence = 0
 export const $sessionResumeRequest = atom<SessionResumeRequest | null>(null)
+// Receipt for the latest explicit resume request whose full async refresh has
+// settled. A non-empty cached transcript is not this receipt: warm activation
+// can paint it immediately, then replace it with the persisted display
+// transcript seconds later. Bot Chat wake UI uses this edge to stay covered
+// through that authoritative refresh instead of exposing the intermediate DOM.
+export const $sessionResumeSettlement = atom<SessionResumeRequest | null>(null)
 // ── Exact session owner hints ───────────────────────────────────────────────
 // The (connectionId, profile[, targetProfile, mode]) route a session was
 // created / resumed / opened on, keyed by stored id. Bounded LRU and
@@ -1277,11 +1283,14 @@ export const setMessages = (next: Updater<ChatMessage[]>) => updateAtom($message
 export const setFreshDraftReady = (next: Updater<boolean>) => updateAtom($freshDraftReady, next)
 export const setResumeFailedSessionId = (next: Updater<string | null>) => updateAtom($resumeFailedSessionId, next)
 
-export const requestSessionResume = (sessionId: string, ownerRoute?: SessionOwnerRoute) => {
+export const requestSessionResume = (
+  sessionId: string,
+  ownerRoute?: SessionOwnerRoute
+): null | SessionResumeRequest => {
   const id = sessionId.trim()
 
   if (!id) {
-    return
+    return null
   }
 
   // A chat on its way out must never be re-selected. The push path
@@ -1291,18 +1300,33 @@ export const requestSessionResume = (sessionId: string, ownerRoute?: SessionOwne
   // not found" for a chat the user deliberately removed. Filtering at the
   // producer means no consumer has to re-derive "is this id doomed".
   if (isSessionRemovalPending(id)) {
-    return
+    return null
   }
 
   if (ownerRoute) {
     setSessionOwnerHint(id, ownerRoute)
   }
 
-  $sessionResumeRequest.set({
+  const request: SessionResumeRequest = {
     ...(ownerRoute ? { ownerRoute: { ...ownerRoute } } : {}),
     sequence: ++sessionResumeRequestSequence,
     sessionId: id
-  })
+  }
+
+  $sessionResumeRequest.set(request)
+
+  return request
+}
+
+export const markSessionResumeSettled = (request: SessionResumeRequest) => {
+  const current = $sessionResumeSettlement.get()
+
+  if (!current || request.sequence > current.sequence) {
+    $sessionResumeSettlement.set({
+      ...request,
+      ...(request.ownerRoute ? { ownerRoute: { ...request.ownerRoute } } : {})
+    })
+  }
 }
 
 export const setResumeExhaustedSessionId = (next: Updater<string | null>) => updateAtom($resumeExhaustedSessionId, next)


### PR DESCRIPTION
## What does this PR do?

Prevents Bot Mode from exposing the wrong transcript, raw hydration state, or internal session labels while switching between bot owners, while keeping an already-warm Bot Chat fast enough that it does not flash a modal `Waking up Bot Chat...` card.

The visible flash was a client-side ownership/hydration race, not chat loss:

1. `openRosterBot` could publish the destination bot before its backend and canonical **Bot Chat** were ready.
2. An already-open Bot Chat used a focus-only shortcut, so the roster/task dock could name one bot while the center still painted another bot's cached transcript.
3. A cached background tile was treated as displayed even when that exact pane was not visible.
4. The session stores could settle before React committed the target transcript and before a large keep-alive tree finished its DOM catch-up.
5. `ChatSwapOverlay` was transparent under Bot Mode/Glass Mode, so `New session`, profile slugs, summaries, or the previous bot's transcript could paint during that gap.
6. Legacy interrupted-turn rows without `display_kind` could briefly render their private `[System note: ...]` payload as a user bubble.

The fix stages owner publication until the destination route is ready, makes every roster click reopen and hydrate the exact canonical Bot Chat, accepts painted history only from the main transcript or the exact visible target tile, rejects stale/superseded wakes, and classifies legacy auto-continue rows before first paint.

For perceived speed, history-bearing chats remain paint-first: a slow forced `session.resume` refresh continues in the background instead of blocking usable cached history. The opaque ownership guard appears immediately, but its status card is delayed for 300 ms, so normal warm switches do not show `Waking up Bot Chat...`. When hydration settles, the guard waits for at least six animation frames and two DOM-quiet frames instead of imposing the previous fixed 500 ms hold.

## Related Issue and PRs

Addresses the Bot Mode session-routing/focus-switch class tracked in #94726 (§3).

This is a targeted continuation of the existing Desktop Bot Mode work:

- #89510 established paint-first Bot Mode hydration and the durable transcript cache.
- #97293 fixed the broader session-switch transcript-flicker class.
- #101227 made cold resume paint the REST transcript before a slow `session.resume` settles.
- #101431 is related but distinct: it refreshes the already-open focus-only branch. This PR removes that bypass and also covers atomic owner publication, exact visible-pane proof, stale async navigation, hydration masking, DOM-quiescent release, and legacy internal-row concealment. No commit from #101431 is included here.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/roster-actions.ts` and `canonical-chat.ts`: route every roster click through the canonical hydrated-open path and commit the bot owner only at the navigation handoff.
- `apps/desktop/src/components/pane-shell/workspace-scope.ts`, `src/sdk/index.ts`, and `src/store/session.ts`: add sequence-scoped navigation/resume receipts; only the main transcript, focused tile, or exact visibly active target tile can satisfy paint readiness.
- `apps/desktop/src/app/chat/chat-swap-overlay.tsx` and `src/app/chat/index.tsx`: render an immediate Bot Mode-opaque cover, suppress the status card for sub-300 ms warm swaps, and release only after a short paint-frame floor plus DOM quiescence.
- `apps/desktop/src/lib/chat-messages/hydration.ts`: mirror the backend's fixed legacy auto-continue prefix inference before the first renderer frame.
- `apps/desktop/src/i18n/{en,ja,zh,zh-hant,ar,ru}.ts` plus `types.ts`: localize the stable `Bot Chat` cover label in every Desktop locale.
- Add behavioral regressions for pending, failed, superseded, warm-cache, background-tile, already-open, hydration-shell, delayed-status, DOM-settlement, and untyped legacy-auto-continue cases.

## How to Test

1. In **BOTS**, open Gamer Boy and then Alfred (or any two bots with different transcript sizes).
2. On a warm switch, the destination bubbles should appear immediately without a visible `Waking up Bot Chat...` card. The opaque guard may exist for a few paint frames but must not expose the previous transcript.
3. On a genuinely cold wake lasting over 300 ms, the localized `Waking up Bot Chat...` card may appear. `New session`, profile slugs such as `persephone`, raw summaries, and the previous bot's transcript must never appear underneath it.
4. When the guard clears, the selected roster row, center transcript, composer target, and scheduled-jobs owner must all identify the same bot.
5. Repeat with both Bot Chats already open, then rapidly click A → B → A. Only the newest navigation intent may settle.
6. Reopen a Bot Chat containing an interrupted-turn auto-continue row. The private `[System note: ...]` payload must never render as a user bubble; only the quiet `resumed interrupted turn` timeline event may appear.

Focused command used:

```bash
cd apps/desktop
npm test -- --run \
  src/app/chat/chat-swap-overlay.test.tsx \
  src/app/session/hooks/use-route-resume.test.tsx \
  src/lib/chat-messages.test.ts \
  src/plugins/hermes-bots/bot-row-opens-canonical-chat.test.ts \
  src/sdk/profile-routing.test.ts
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — this is a renderer-only change; no Python path is changed by this PR. An earlier canonical Python-suite run passed more than 41,000 assertions but retained unrelated platform failures and large-file timeouts.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2 (25F84), Apple silicon; the exact package was installed on two Apple-silicon Macs

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior is documented at the changed seams and in behavioral regressions
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no project workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — renderer/store-only TypeScript with no new platform API; the Windows footgun rules do not apply to the changed files
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool behavior changed

## Verification

- Final PR head `3d2f96248f5a` is rebased onto upstream `593aa74c6182`; all ten commits use `fix(desktop): ...`, all branch authors resolve through the contributor-attribution audit, and the 21-file diff contains only Desktop source, locale, and test files.
- Red-before proof: the new background-tile and six-frame/DOM-settlement regressions fail on the previous implementation, then pass with this refinement. The earlier upstream-only test application produced **21 failures / 135 passes** across the full bug class.
- Focused final-head run: **5 files / 160 tests passed**.
- Full final-head Desktop run: **858 files / 9,228 tests passed, 2 files / 2 tests failed, 2 files / 6 tests skipped**. The two failures are `electron/managed-ssh-update.test.ts` (POSIX launcher status 127) and `electron/remote-lifecycle.test.ts` (short-lived process recognition); the same two files/failures reproduce on an untouched upstream checkout, where the other 117 tests pass.
- Final-head `npm run typecheck`, `npm run lint -- --quiet`, `git diff --check origin/main...HEAD`, `scripts/audit_pr_attribution.py`, and production `npm run pack` pass.
- Local macOS package is ad-hoc signed and passes `codesign --verify --deep --strict`. Install stamp: `3d2f96248f5a`; `app.asar` SHA-256: `49f8117a7b73b0e533e8d93a15fa9d0d043d563d2363cf28de2e7ce8799fb69f`.
- That exact stamped package is installed and relaunched on the Personal Mac mini and AI-MAC-MINI; both hashes match, both processes are live, and both renderer debug endpoints respond.
- Computer Use plus frame/mutation instrumentation on the Personal Mac mini exercised the exact Gamer Boy → Alfred path. On both warm switches the status card stayed hidden. For Alfred, the target marker painted while the guard was opaque, the guard released 58 ms later after quiet frames, and no Gamer Boy marker, `Session Arc Summary`, or `persephone` content appeared during any uncovered post-switch frame.
- The final Personal Mac screenshot remains in **BOTS** and shows Alfred's bubble transcript. No message was sent.

## Screenshots / Logs

The deterministic regressions and exact counts above are the review artifacts. The live visual check used private local conversations, so no user transcript screenshot is attached to the public PR.
