### PR TITLE
docs: add Obsidian control-plane user story

### DIFF
--- a/website/src/data/userStories.json
+++ b/website/src/data/userStories.json
@@ -3584,5 +3584,16 @@
     "headline": "Recursively built a Supabase-backed CRM dashboard where each build reuses prior components",
     "quote": "Used the Hermes Desktop App to recursively generate a CRM dashboard where each build reuses components from prior generations; it can also build full videos using official HyperFrame skills — HTML-native, full control over scenes, animations, and rendering.",
     "size": "sm"
+  },
+  {
+    "id": "blog-marc-bara-obsidian-control-plane",
+    "source": "blog",
+    "author": "Marc Bara (Medium)",
+    "url": "https://medium.com/@marc.bara.iniesta/obsidian-as-a-durable-control-plane-for-sequential-hermes-jobs-6a60bf8a593c",
+    "date": "2026-09-02",
+    "category": "dev-workflow",
+    "headline": "Independent Hermes cron jobs coordinate through an Obsidian control note",
+    "quote": "Obsidian works as the control plane here: the one artifact every job has to read from and write to, and the one place I have to look to know what happened.",
+    "size": "md"
   }
 ]


### PR DESCRIPTION
## Summary
- Adds one Medium-backed Hermes user story from Marc Bara.
- Links the public article and its companion Gist, which documents the reusable control-note pattern.

## Scope
The procurement radar is explicitly a synthetic worked example. The entry describes the documented pattern of independent Hermes cron jobs coordinating through an Obsidian control note; it does not claim this is a built-in Hermes feature or a production remediation system.

## Validation
- Parsed website/src/data/userStories.json and asserted exactly one new entry.
- corepack npm@11.17.0 run build:fast completed successfully. Docusaurus also reported broken-link warnings for /docs/llms.txt and /docs/llms-full.txt.