### PR TITLE
fix(kanban): suppress stop-guard nudge when the task is already terminal

### DIFF
--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -19,6 +19,15 @@ from typing import Any, Iterable, Optional
 
 _TERMINAL_KANBAN_TOOLS = frozenset({"kanban_complete", "kanban_block"})
 
+# Board statuses that are terminal for the purposes of this guard. A task in
+# one of these can no longer be completed or blocked by THIS session, so the
+# nudge ("Task ... is still running — call kanban_complete/kanban_block")
+# would be factually wrong and, on models that comply, can even cause an
+# improper board mutation attempt. ``review`` is deliberately NOT terminal:
+# a reviewer session must still end with ``kanban_complete`` /
+# ``kanban_request_changes``.
+_TERMINAL_TASK_STATUSES = frozenset({"done", "archived"})
+
 _DEFAULT_MAX_ATTEMPTS = 2
 
 
@@ -66,6 +75,34 @@ def session_called_kanban_terminal(messages: Iterable[dict] | None) -> bool:
     return False
 
 
+def _live_task_is_terminal(task_id: str) -> bool:
+    """True only on a POSITIVE live read of a terminal board status.
+
+    Consults the board DB (resolved the same way every other kanban surface
+    resolves it — ``HERMES_KANBAN_DB`` / ``HERMES_KANBAN_BOARD`` env, then
+    the default board). Fail-open by design: any failure to consult the
+    board — import error, unreadable DB, missing task row — returns ``False``
+    so the caller still nudges. Over-suppressing the nudge on a board we
+    cannot read would hide genuine protocol violations from workers whose
+    task really is still running.
+    """
+    try:
+        from hermes_cli import kanban_db
+
+        conn = kanban_db.connect()
+        try:
+            row = conn.execute(
+                "SELECT status FROM tasks WHERE id = ?", (task_id,)
+            ).fetchone()
+        finally:
+            conn.close()
+    except Exception:
+        return False
+    if row is None:
+        return False
+    return str(row["status"]) in _TERMINAL_TASK_STATUSES
+
+
 def build_kanban_stop_nudge(
     *,
     messages: Iterable[dict] | None = None,
@@ -76,7 +113,9 @@ def build_kanban_stop_nudge(
     """Return a synthetic follow-up when a kanban worker exits without a terminal tool.
 
     Returns ``None`` when the guard should not fire (not a kanban worker,
-    already completed/blocked, or nudge budget exhausted).
+    already completed/blocked, nudge budget exhausted, or the task's LIVE
+    board status is already terminal — e.g. a session that inherited
+    ``HERMES_KANBAN_TASK`` from a card another run completed).
     """
     if not kanban_stop_nudge_enabled():
         return None
@@ -86,6 +125,11 @@ def build_kanban_stop_nudge(
         return None
 
     tid = (task_id or os.environ.get("HERMES_KANBAN_TASK") or "").strip() or "this task"
+    # Suppress only on a positive live read: the session env can outlive the
+    # card it names (child processes inherit it; sessions resume after
+    # completion). Never suppress merely because the board is unreadable.
+    if tid != "this task" and _live_task_is_terminal(tid):
+        return None
     return (
         "[System: You are a Hermes kanban worker. A plain-text reply is NOT a "
         "terminal state for the board.\n\n"

--- a/tests/agent/test_kanban_stop.py
+++ b/tests/agent/test_kanban_stop.py
@@ -13,13 +13,14 @@ from agent.kanban_stop import (
 
 @pytest.fixture
 def clear_kanban_env(monkeypatch):
-    for var in ("HERMES_KANBAN_TASK", "HERMES_KANBAN_STOP_NUDGE"):
+    for var in (
+        "HERMES_KANBAN_TASK",
+        "HERMES_KANBAN_STOP_NUDGE",
+        "HERMES_KANBAN_DB",
+        "HERMES_KANBAN_BOARD",
+    ):
         monkeypatch.delenv(var, raising=False)
     return monkeypatch
-
-
-
-
 
 
 def test_env_can_disable(clear_kanban_env):
@@ -29,7 +30,8 @@ def test_env_can_disable(clear_kanban_env):
     assert build_kanban_stop_nudge(messages=[]) is None
 
 
-def test_nudge_when_no_terminal_tool(clear_kanban_env):
+def test_nudge_when_no_terminal_tool(clear_kanban_env, tmp_path):
+    clear_kanban_env.setenv("HERMES_KANBAN_DB", str(tmp_path / "board.db"))
     clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_46be8aa5")
     messages = [
         {"role": "user", "content": "work kanban task"},
@@ -74,8 +76,75 @@ def test_no_nudge_after_kanban_complete(clear_kanban_env):
     assert build_kanban_stop_nudge(messages=messages) is None
 
 
+# ── Live board-status suppression (stale-nag fix) ────────────────────
+#
+# The guard used to fire on HERMES_KANBAN_TASK alone. A session that
+# inherited the task env from an already-terminal card (e.g. a child
+# process spawned by a worker, or a session resumed after the task
+# completed) was nagged to "call kanban_complete / kanban_block" against
+# a done card — the nudge's "still `running`" claim was a hardcoded
+# template string, never checked against the board. These tests pin the
+# fix: the nudge is suppressed ONLY on a positive live read of a
+# terminal status, and fails open (nudge still fires) whenever the
+# board cannot be consulted.
 
 
+def _make_board(clear_kanban_env, tmp_path, status):
+    """Create a real board with one task in ``status``; return its id."""
+    from hermes_cli import kanban_db
+
+    db = tmp_path / "board.db"
+    clear_kanban_env.setenv("HERMES_KANBAN_DB", str(db))
+    conn = kanban_db.connect()
+    try:
+        tid = kanban_db.create_task(
+            conn, title="probe", assignee="w", initial_status="running",
+        )
+        if status != "running":
+            with kanban_db.write_txn(conn):
+                conn.execute(
+                    "UPDATE tasks SET status = ? WHERE id = ?", (status, tid),
+                )
+    finally:
+        conn.close()
+    return tid
+
+
+@pytest.mark.parametrize("terminal", ["done", "archived"])
+def test_no_nudge_when_task_is_terminal_live(
+    clear_kanban_env, tmp_path, terminal
+):
+    tid = _make_board(clear_kanban_env, tmp_path, terminal)
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", tid)
+    # No terminal tool call in-session: the OLD code nagged here.
+    assert build_kanban_stop_nudge(messages=[], attempts=0) is None
+
+
+def test_nudge_still_fires_when_task_is_running_live(clear_kanban_env, tmp_path):
+    tid = _make_board(clear_kanban_env, tmp_path, "running")
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", tid)
+    nudge = build_kanban_stop_nudge(messages=[], attempts=0)
+    assert nudge is not None
+    assert tid in nudge
+
+
+def test_nudge_fails_open_when_board_unreadable(clear_kanban_env, tmp_path):
+    # A directory is not a database: connect() must raise, and the
+    # guard must fall back to nudging (never over-suppress on error).
+    clear_kanban_env.setenv("HERMES_KANBAN_DB", str(tmp_path))
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_zzz")
+    assert build_kanban_stop_nudge(messages=[], attempts=0) is not None
+
+
+def test_nudge_fails_open_when_task_missing(clear_kanban_env, tmp_path):
+    from hermes_cli import kanban_db
+
+    db = tmp_path / "board.db"
+    clear_kanban_env.setenv("HERMES_KANBAN_DB", str(db))
+    conn = kanban_db.connect()
+    conn.close()
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_nope")
+    assert build_kanban_stop_nudge(messages=[], attempts=0) is not None
 
 
 # ── Integration: agent nudge + dispatcher bounded retry ──────────────
@@ -84,7 +153,3 @@ def test_no_nudge_after_kanban_complete(clear_kanban_env):
 # without a terminal call, the dispatcher's bounded retry (streak of 3)
 # handles it.  See also tests/hermes_cli/test_kanban_core_functionality.py
 # for the dispatcher-side streak tests.
-
-
-
-


### PR DESCRIPTION
fix(kanban): suppress stop-guard nudge when the task is already terminal

## The bug

`build_kanban_stop_nudge` in `agent/kanban_stop.py` fired on
`HERMES_KANBAN_TASK` alone — no board-state check anywhere:

- `kanban_stop_nudge_enabled()` (lines 25-35) returns True whenever the
  env var is set.
- The only suppression is `session_called_kanban_terminal(messages)`
  (lines 85-86) — scoped to THIS conversation's tool history.

A session that inherits the env var from an already-terminal card was
therefore nagged with "Task `X` is still `running` — call
kanban_complete / kanban_block". That claim is a hardcoded template
string (lines 92-93); it never queries the board. Two ways this hits
every deployment with workers that spawn children:

1. A kanban worker spawns a child `hermes chat` process (e2e probes,
   model checks). The child inherits `HERMES_KANBAN_TASK` +
   `HERMES_KANBAN_CLAIM_LOCK`, and if it ever ends a turn with plain
   text, the stop guard nudges it into "finishing" the PARENT's card.
   Observed in the wild (2026-09-02): a reviewer's e2e probe child
   fired `kanban_complete` mid-review on a card it did not own the
   phase for — the kernel accepted it because the call came from the
   claim-lock holder's process tree.
2. A card completed, then a stale session (env still set) ends a turn
   with plain text → the nag fires against a done card. On our
   deployment this produced 5 duplicate no-op worker sessions in one
   afternoon, each demanding completion of a card that had been done
   for 30+ minutes.

## The fix

Suppress the nudge ONLY on a positive live read of a terminal board
status (`done`, `archived`). `review` is deliberately NOT terminal — a
reviewer session must still end with a terminal call. Every failure to
consult the board fails open (nudge still fires): import error,
unreadable DB, missing task row — so genuine protocol violations on
running tasks keep their guard, and over-suppression stays impossible.

The live check reuses the standard board resolution
(`HERMES_KANBAN_DB` / `HERMES_KANBAN_BOARD` env — the dispatcher
already injects these into workers, no new env vars), issues a single
read-only `SELECT status FROM tasks WHERE id = ?` outside any
transaction, and keeps the O(1) hot path for genuinely running tasks
(one extra point query at turn-end, only after the model tried to stop).

## Tests

Extended `tests/agent/test_kanban_stop.py` (TDD: both new terminal
cases RED against unfixed `main`, GREEN with the fix, same harness):

- `test_no_nudge_when_task_is_terminal_live[done|archived]` — real
  board via `kanban_db.connect()` + `create_task()` + status flip;
  asserts `build_kanban_stop_nudge(...) is None`.
- `test_nudge_still_fires_when_task_is_running_live` — guards against
  over-suppression.
- `test_nudge_fails_open_when_board_unreadable` / `..._task_missing` —
  the nudge MUST fire when the board can't be consulted.

All 8 pass with the fix; the 2 new cases fail on unfixed `main`.
Ruff clean.