### PR TITLE
Stop compacted chats from rendering as an empty transcript

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -13561,6 +13561,56 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         return self._execute_write(_do)
 
+    def _dedupe_display_generations(self, rows):
+        """Collapse compaction generations so each message appears once.
+
+        Compaction epochs copy the protected tail into each new generation, so
+        one logical message can exist as several rows (identical
+        role/content/timestamp) with different ``active`` flags and ids. A
+        display read must surface each exactly once: prefer the live row, then
+        the newest generation.
+
+        This is the ONE definition shared by every display projection —
+        :meth:`get_messages` (REST), :meth:`get_resume_conversations` and
+        :meth:`get_ancestor_display_prefix` (gateway resume), and
+        :meth:`get_messages_as_conversation` (warm-session payload) — so the
+        surfaces cannot disagree about the same transcript. *rows* must already
+        be ordered by ``id``; the returned list keeps that order.
+        """
+        seen: Dict[Tuple[Any, ...], Any] = {}
+        for row in rows:
+            dedupe_content = row["content"]
+            if row["role"] == "user":
+                from agent.context_compressor import split_user_originated_turn
+
+                candidate = {
+                    "role": "user",
+                    "content": self._decode_content(row["content"]),
+                    "display_kind": row["display_kind"],
+                    "display_metadata": self._decode_display_metadata(
+                        row["display_metadata"]
+                    ),
+                }
+                handoff, live_view = split_user_originated_turn(candidate)
+                if handoff is not None and live_view is not None:
+                    dedupe_content = self._encode_content(live_view.get("content"))
+            # Tool fields participate in the dedupe key: compaction copies them
+            # verbatim, so identical tool messages across generations still
+            # collapse, while distinct tool calls that happen to share
+            # role/content/timestamp are never merged.
+            key = (
+                row["role"],
+                dedupe_content,
+                row["timestamp"],
+                row["tool_call_id"],
+                row["tool_calls"],
+                row["tool_name"],
+            )
+            cur = seen.get(key)
+            if cur is None or (row["active"], row["id"]) > (cur["active"], cur["id"]):
+                seen[key] = row
+        return sorted(seen.values(), key=lambda r: r["id"])
+
     def get_messages(
         self,
         session_id: str,
@@ -13625,14 +13675,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if after_id is not None:
             params.append(after_id)
         if include_compacted:
-            # Compaction epochs copy the protected tail into each new
-            # generation, so the same logical message can exist as several
-            # rows (identical role/content/timestamp) with different active
-            # flags and ids. A display read must surface each message exactly
-            # once: prefer the live row, then the newest generation. Read the
-            # full display set (a session's rows are bounded; the UI-level
-            # 500-row cap lives in the endpoint, not here), dedupe in Python,
-            # then apply paging.
+            # Read the full display set (a session's rows are bounded; the
+            # UI-level 500-row cap lives in the endpoint, not here), dedupe
+            # generations, then apply paging.
             with self._read_ctx() as conn:
                 cursor = conn.execute(
                     "SELECT * FROM messages WHERE session_id = ?" + active_clause
@@ -13640,41 +13685,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     [session_id],
                 )
                 all_rows = cursor.fetchall()
-            seen: dict = {}
-            for row in all_rows:
-                dedupe_content = row["content"]
-                if row["role"] == "user":
-                    from agent.context_compressor import split_user_originated_turn
-
-                    candidate = {
-                        "role": "user",
-                        "content": self._decode_content(row["content"]),
-                        "display_kind": row["display_kind"],
-                        "display_metadata": self._decode_display_metadata(
-                            row["display_metadata"]
-                        ),
-                    }
-                    handoff, live_view = split_user_originated_turn(candidate)
-                    if handoff is not None and live_view is not None:
-                        dedupe_content = self._encode_content(
-                            live_view.get("content")
-                        )
-                # Tool fields participate in the dedupe key: compaction copies
-                # them verbatim, so identical tool messages across generations
-                # still collapse, while distinct tool calls that happen to
-                # share role/content/timestamp are never merged.
-                key = (
-                    row["role"],
-                    dedupe_content,
-                    row["timestamp"],
-                    row["tool_call_id"],
-                    row["tool_calls"],
-                    row["tool_name"],
-                )
-                cur = seen.get(key)
-                if cur is None or (row["active"], row["id"]) > (cur["active"], cur["id"]):
-                    seen[key] = row
-            rows = sorted(seen.values(), key=lambda r: r["id"])
+            rows = self._dedupe_display_generations(all_rows)
             if latest:
                 rows = rows[::-1]
             rows = rows[offset:]
@@ -13916,6 +13927,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         include_inactive: bool = False,
         repair_alternation: bool = False,
         include_row_ids: bool = False,
+        include_compacted: bool = False,
     ) -> List[Dict[str, Any]]:
         """
         Load messages in the OpenAI conversation format (role + content dicts).
@@ -13924,6 +13936,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         By default only active messages are returned. Pass
         ``include_inactive=True`` to load soft-deleted (rewound) rows
         as well. See :meth:`rewind_to_message`.
+
+        ``include_compacted=True`` additionally loads rows preserved by
+        in-place compaction (``active=0, compacted=1``), deduped by
+        :meth:`_dedupe_display_generations`. DISPLAY reads want this; the
+        model-fed restore must NOT pass it, or a resumed session regrows the
+        very history compaction just summarized away.
 
         ``repair_alternation=True`` runs ``repair_message_sequence`` over the
         loaded list before returning it. Callers that restore a session for
@@ -13939,7 +13957,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if include_ancestors and not self._is_explicit_branch_session(session_id):
             session_ids = self._session_lineage_root_to_tip(session_id)
 
-        active_clause = "" if include_inactive else " AND active = 1"
+        if include_inactive:
+            active_clause = ""
+        elif include_compacted:
+            active_clause = " AND (active = 1 OR compacted = 1)"
+        else:
+            active_clause = " AND active = 1"
         with self._read_ctx() as conn:
             placeholders = ",".join("?" for _ in session_ids)
             rows = conn.execute(
@@ -13957,6 +13980,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 tuple(session_ids),
             ).fetchall()
 
+        if include_compacted:
+            rows = self._dedupe_display_generations(rows)
+
         return self._rows_to_conversation(
             rows,
             session_id=session_id,
@@ -13967,12 +13993,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
     # Columns every conversation projection decodes. Shared by
     # get_messages_as_conversation and get_resume_conversations so a single
-    # SELECT can feed both the model-fed and display views.
+    # SELECT can feed both the model-fed and display views. ``active`` rides
+    # along so a display read can split the compaction-archived rows from the
+    # live set (and feed _dedupe_display_generations) without a second query.
     _CONVERSATION_ROW_COLUMNS = (
         "id, role, content, tool_call_id, tool_calls, tool_name, effect_disposition, "
         "finish_reason, reasoning, reasoning_content, reasoning_details, "
         "codex_reasoning_items, codex_message_items, platform_message_id, observed, "
-        "_compressed_summary, timestamp, "
+        "_compressed_summary, timestamp, active, "
         "api_content, display_kind, display_metadata"
     )
 
@@ -14183,6 +14211,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
           copied transcript; including the live parent's rows would let messages
           written to the original after the fork leak into the branch.
 
+        The display projection also includes rows preserved by IN-PLACE
+        compaction (``active=0, compacted=1``), deduped by
+        :meth:`_dedupe_display_generations`. Without them a compacted
+        conversation resumes showing only its summary plus the carried-forward
+        tail — the user's own turns read as deleted even though every row is
+        still on disk, and the REST transcript read (which has always included
+        them) disagreed with this one about the same session (#92080).
+
         The display fetch already reads a superset of the model fetch (the tip
         rows are part of the lineage), so serving both from one lineage SELECT
         halves the resume's DB work versus two separate calls, with byte-identical
@@ -14193,7 +14229,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             placeholders = ",".join("?" for _ in session_ids)
             rows = conn.execute(
                 f"SELECT session_id, {self._CONVERSATION_ROW_COLUMNS} "
-                f"FROM messages WHERE session_id IN ({placeholders}) AND active = 1 "
+                f"FROM messages WHERE session_id IN ({placeholders}) "
+                # Compaction-archived rows (active=0, compacted=1) are display
+                # history; Undo/Rewind rows (active=0, compacted=0) are not.
+                "AND (active = 1 OR compacted = 1) "
                 # ORDER BY id (insertion order) — see get_messages_as_conversation
                 # for why timestamp ordering is unsafe.
                 "ORDER BY id",
@@ -14202,8 +14241,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         # Tip rows are exactly the model-fed set (get_messages_as_conversation
         # with session_ids=[session_id]); filtering the lineage fetch preserves
-        # their relative id order.
-        tip_rows = [r for r in rows if r["session_id"] == session_id]
+        # their relative id order. The model projection stays active-only — it
+        # is the compressed working context and must not regrow the history
+        # compaction just summarized away.
+        tip_rows = [r for r in rows if r["session_id"] == session_id and r["active"]]
         model_history = self._rows_to_conversation(
             tip_rows,
             session_id=session_id,
@@ -14216,7 +14257,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             include_summary_markers=True,
         )
         display_history = self._rows_to_conversation(
-            rows,
+            self._dedupe_display_generations(rows),
             session_id=session_id,
             include_ancestors=True,
             repair_alternation=False,
@@ -14242,19 +14283,27 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     def get_resume_message_count(
         self, session_id: str, *, tip_only: bool = False
     ) -> int:
-        """Count active rows that a resume would materialize.
+        """Count the rows that a resume would materialize.
 
-        ``tip_only=True`` counts only the tip segment — the set a model-history
-        restore loads (``get_messages_as_conversation`` without ancestors, or
-        the deferred Desktop resume that pages the display transcript over
-        REST and never materializes the ancestor prefix in memory).
+        ``tip_only=True`` counts the tip segment's ACTIVE rows — the set a
+        model-history restore loads (``get_messages_as_conversation`` without
+        ancestors, or the deferred Desktop resume that pages the display
+        transcript over REST and never materializes the ancestor prefix in
+        memory).
+
+        Otherwise this counts the full-lineage DISPLAY set — active rows plus
+        the compaction-archived rows ``get_resume_conversations`` now loads
+        for the transcript. Counting only active rows here would let a
+        heavily-compacted conversation pass a limit sized for a handful of
+        live rows and then materialize tens of thousands.
         """
         session_ids = [session_id] if tip_only else self._resume_lineage_ids(session_id)
+        active_clause = "active = 1" if tip_only else "(active = 1 OR compacted = 1)"
         placeholders = ",".join("?" for _ in session_ids)
         with self._read_ctx() as conn:
             row = conn.execute(
                 f"SELECT COUNT(*) FROM messages "
-                f"WHERE session_id IN ({placeholders}) AND active = 1",
+                f"WHERE session_id IN ({placeholders}) AND {active_clause}",
                 tuple(session_ids),
             ).fetchone()
         return int(row[0] if row else 0)
@@ -14272,15 +14321,20 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         (``sessions.max_resume_messages``); 0 disables the guard and returns
         the (bounded) count without raising.
 
-        ``tip_only=True`` bounds only the tip segment, for callers that never
-        materialize the ancestor lineage in memory (tip-only model restore,
-        deferred Desktop resume whose display history is REST-paginated). A
+        ``tip_only=True`` bounds only the tip segment's ACTIVE rows, for
+        callers that never materialize the ancestor lineage or the
+        compaction archive in memory (tip-only model restore, deferred
+        Desktop resume whose display history is REST-paginated). A
         heavily-compressed conversation — 85 compaction segments and ~29k
         lineage rows behind a ~700-row tip — is exactly the shape compression
         is supposed to produce; counting its whole lineage against a limit
         sized for in-memory materialization rejected the healthiest sessions
         (Desktop Bot Chat stuck on "Waking up…" with code 4130) while the
         process would only ever have held the tip.
+
+        The full (non-``tip_only``) bound counts the DISPLAY set — active plus
+        compaction-archived rows — because that is what
+        ``get_resume_conversations`` materializes for the transcript.
         """
         if max_messages is None:
             max_messages = resolved_max_resume_messages()
@@ -14293,12 +14347,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # exact pathological work the disable exists to avoid.
             return 0
         session_ids = [session_id] if tip_only else self._resume_lineage_ids(session_id)
+        active_clause = "active = 1" if tip_only else "(active = 1 OR compacted = 1)"
         placeholders = ",".join("?" for _ in session_ids)
         with self._read_ctx() as conn:
             row = conn.execute(
                 "SELECT COUNT(*) FROM ("
                 f"SELECT 1 FROM messages WHERE session_id IN ({placeholders}) "
-                "AND active = 1 LIMIT ?"
+                f"AND {active_clause} LIMIT ?"
                 ")",
                 (*session_ids, max_messages + 1),
             ).fetchone()
@@ -14374,10 +14429,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             placeholders = ",".join("?" for _ in session_ids)
             rows = conn.execute(
                 f"SELECT session_id, {self._CONVERSATION_ROW_COLUMNS} "
-                f"FROM messages WHERE session_id IN ({placeholders}) AND active = 1 "
+                f"FROM messages WHERE session_id IN ({placeholders}) "
+                # Display read: compaction-archived rows included, Undo/Rewind
+                # rows excluded (see get_resume_conversations).
+                "AND (active = 1 OR compacted = 1) "
                 "ORDER BY id",
                 tuple(session_ids),
             ).fetchall()
+        rows = self._dedupe_display_generations(rows)
         ancestor_ids = {
             int(row["id"])
             for row in rows

--- a/tests/hermes_state/test_display_projection_parity.py
+++ b/tests/hermes_state/test_display_projection_parity.py
@@ -1,0 +1,213 @@
+"""Every display projection of a compacted session must agree.
+
+In-place compaction archives earlier turns as ``active=0, compacted=1`` rows.
+They are durable display history — the user's own conversation, still on disk.
+#80680 taught the REST transcript read to include them, but three GATEWAY
+display projections kept filtering ``active = 1``:
+
+- ``get_resume_conversations()``   — what ``session.resume`` ships
+- ``get_ancestor_display_prefix()`` — the ancestor lineage prefix
+- ``get_messages_as_conversation()`` — the warm-session payload on tab switch
+
+So the same conversation read four ways gave two different answers: REST showed
+everything, the gateway cut the transcript off at the compaction boundary. The
+user sees their chat "vanish" down to a summary plus a couple of carried-forward
+turns, and a resumed agent that cannot see its own completed work starts it over
+(#92080, #93618, #68321).
+
+These tests assert the INVARIANT — all display reads of one session return the
+same transcript — rather than any particular row count, and pin the two things
+that must NOT grow with it: the model-fed projection stays compressed, and
+soft-deleted Undo/Rewind rows stay hidden.
+"""
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    return SessionDB(tmp_path / "state.db")
+
+
+def _compact_in_place(db, sid, *, epochs=3, turns=4, tail_count=2):
+    """Drive *sid* through repeated in-place compaction, like a long chat."""
+    db.create_session(sid, source="desktop")
+    for epoch in range(epochs):
+        for i in range(turns):
+            db.append_message(sid, "user", f"e{epoch} user {i}")
+            db.append_message(sid, "assistant", f"e{epoch} assistant {i}")
+        live = db.get_messages_as_conversation(sid)
+        db.archive_and_compact(
+            sid,
+            [{"role": "user", "content": f"[summary {epoch}]"}] + live[-tail_count:],
+            tail_count=tail_count,
+        )
+    return sid
+
+
+def _texts(messages):
+    return [(m["role"], m["content"]) for m in messages]
+
+
+def _rest_display(db, sid):
+    """The read that was already correct — the parity reference."""
+    return [
+        {"role": m["role"], "content": m["content"]}
+        for m in db.get_messages(sid, include_compacted=True)
+    ]
+
+
+class TestDisplayProjectionParity:
+    def test_resume_display_matches_the_rest_transcript(self, db):
+        sid = _compact_in_place(db, "chat")
+
+        _, display = db.get_resume_conversations(sid)
+
+        assert _texts(display) == _texts(_rest_display(db, sid))
+
+    def test_warm_session_display_matches_the_rest_transcript(self, db):
+        """The read behind ``_live_visible_history`` (switching back to a tab)."""
+        sid = _compact_in_place(db, "chat")
+
+        warm = db.get_messages_as_conversation(
+            sid, include_ancestors=True, include_row_ids=True, include_compacted=True
+        )
+
+        assert _texts(warm) == _texts(_rest_display(db, sid))
+
+    def test_pre_compaction_turns_survive_in_the_resume_transcript(self, db):
+        """The user's own first turn is still there after several compactions."""
+        sid = _compact_in_place(db, "chat")
+
+        _, display = db.get_resume_conversations(sid)
+
+        assert ("user", "e0 user 0") in _texts(display)
+        assert ("assistant", "e0 assistant 0") in _texts(display)
+
+    def test_display_read_dedupes_carried_forward_tail(self, db):
+        """Each logical message appears once, not once per compaction epoch."""
+        sid = _compact_in_place(db, "chat", epochs=4, tail_count=2)
+
+        _, display = db.get_resume_conversations(sid)
+        seen = _texts(display)
+
+        assert len(seen) == len(set(seen))
+
+
+class TestModelProjectionStaysCompressed:
+    def test_model_history_excludes_archived_rows(self, db):
+        """Compaction must still do its job: the model gets the compressed set."""
+        sid = _compact_in_place(db, "chat")
+
+        model, display = db.get_resume_conversations(sid)
+
+        assert len(model) < len(display)
+        assert ("user", "e0 user 0") not in _texts(model)
+
+    def test_model_history_matches_the_active_only_read(self, db):
+        sid = _compact_in_place(db, "chat")
+
+        model, _ = db.get_resume_conversations(sid)
+        active_only = db.get_messages_as_conversation(sid, repair_alternation=True)
+
+        assert _texts(model) == _texts(active_only)
+
+
+class TestSoftDeletedRowsStayHidden:
+    def test_rewound_rows_are_excluded_from_the_display_projections(self, db):
+        """Undo/Rewind rows (active=0, compacted=0) are NOT display history."""
+        sid = "chat"
+        db.create_session(sid, source="desktop")
+        db.append_message(sid, "user", "kept")
+        db.append_message(sid, "assistant", "kept reply")
+        db.append_message(sid, "user", "taken back")
+        db.append_message(sid, "assistant", "taken back reply")
+
+        rewind_target = next(
+            m for m in reversed(db.get_messages(sid)) if m["role"] == "user"
+        )
+        db.rewind_to_message(sid, rewind_target["id"])
+
+        _, display = db.get_resume_conversations(sid)
+        warm = db.get_messages_as_conversation(
+            sid, include_ancestors=True, include_compacted=True
+        )
+
+        for projection in (display, warm):
+            contents = [c for _, c in _texts(projection)]
+            assert "taken back" not in contents
+            assert "kept" in contents
+
+
+class TestAncestorPrefix:
+    def test_prefix_includes_a_compacted_ancestor_s_archived_rows(self, db):
+        """A compression ROTATION's parent still shows its pre-compaction turns."""
+        parent, child = "parent", "child"
+        db.create_session(parent, source="desktop")
+        for i in range(3):
+            db.append_message(parent, "user", f"P user {i}")
+            db.append_message(parent, "assistant", f"P assistant {i}")
+        db.archive_and_compact(parent, [{"role": "user", "content": "[parent summary]"}])
+
+        db.create_session(child, source="desktop", parent_session_id=parent)
+        db.append_message(child, "user", "C user 0")
+        db.append_message(child, "assistant", "C assistant 0")
+
+        prefix = db.get_ancestor_display_prefix(child)
+        _, display = db.get_resume_conversations(child)
+
+        assert ("user", "P user 0") in _texts(prefix)
+        assert ("user", "P user 0") in _texts(display)
+        # The child's own turns belong to the tip, never the ancestor prefix.
+        assert ("user", "C user 0") not in _texts(prefix)
+
+    def test_explicit_branch_has_no_ancestor_prefix(self, db):
+        """A /branch copy owns its transcript; the live parent must not leak in."""
+        sid = _compact_in_place(db, "chat")
+        db.create_session(
+            "branch",
+            source="desktop",
+            parent_session_id=sid,
+            model_config={"_branched_from": sid},
+        )
+        db.append_message("branch", "user", "branch turn")
+
+        assert db.get_ancestor_display_prefix("branch") == []
+
+        _, display = db.get_resume_conversations("branch")
+        assert _texts(display) == [("user", "branch turn")]
+
+
+class TestResumeGuardBoundsWhatResumeLoads:
+    def test_guard_counts_the_rows_the_display_read_materializes(self, db):
+        """The guard must not undercount: it bounds an in-memory materialization."""
+        sid = _compact_in_place(db, "chat", epochs=4)
+
+        _, display = db.get_resume_conversations(sid)
+
+        assert db.get_resume_message_count(sid) >= len(display)
+
+    def test_guard_rejects_a_lineage_over_the_limit(self, db):
+        from hermes_state import SessionResumeTooLargeError
+
+        sid = _compact_in_place(db, "chat", epochs=4)
+
+        with pytest.raises(SessionResumeTooLargeError):
+            db.assert_resume_safe(sid, max_messages=2)
+
+    def test_tip_only_guard_still_bounds_only_the_live_tip(self, db):
+        """The #4130 carve-out: a healthy compacted chat must stay resumable.
+
+        A well-compressed conversation is exactly the shape compression is
+        meant to produce. Counting its archive against a tip-sized budget is
+        what stranded Bot Chats on "Waking up…"; ``tip_only`` callers never
+        materialize the archive, so they keep the active-only bound.
+        """
+        sid = _compact_in_place(db, "chat", epochs=4)
+
+        tip_count = db.get_resume_message_count(sid, tip_only=True)
+
+        assert tip_count < db.get_resume_message_count(sid)
+        assert db.assert_resume_safe(sid, max_messages=tip_count, tip_only=True)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11388,7 +11388,16 @@ def _live_visible_history(session: dict, db, in_memory_fallback: list[dict]) -> 
     key = session.get("session_key")
     if db is not None and key:
         try:
-            display = db.get_messages_as_conversation(key, include_ancestors=True, include_row_ids=True)
+            display = db.get_messages_as_conversation(
+                key,
+                include_ancestors=True,
+                include_row_ids=True,
+                # Display read: a compacted session's archived turns are still
+                # the user's conversation. Without them a warm switch repainted
+                # the chat as just the summary + tail while the REST transcript
+                # showed everything (#92080).
+                include_compacted=True,
+            )
             return _reconcile_display_with_live(display, in_memory_fallback)
         except Exception:
             logger.debug("live display projection read failed", exc_info=True)


### PR DESCRIPTION
A compacted conversation renders as its summary plus a couple of carried-forward turns, and the rest of the chat looks deleted. It isn't — every row is still on disk. Three of the four display read paths just stopped reporting them.

In-place compaction soft-archives earlier turns as `active=0, compacted=1`. That is durable display history, not a delete, and the REST transcript read has included it since #80680. But the gateway's display projections still filtered `active = 1`:

- `get_resume_conversations()` — what `session.resume` ships
- `get_ancestor_display_prefix()` — the ancestor lineage prefix
- `_live_visible_history()` — the payload a tab switch repaints from

So the same session read two ways gave two different answers. On a chat with 300 turns and six compaction epochs, REST returns 306 messages and the gateway returns 5.

The second-order cost is worse than the missing scrollback: an agent resumed onto a truncated transcript cannot see work it already finished, so it starts it over. That is the "it compacted, then redid completed work, and burned $10" report.

## The fix

The REST read carried the generation-dedupe policy inline, which is exactly why the other three drifted from it. This extracts it into one `_dedupe_display_generations()` and points every display projection at it, so the surfaces can no longer disagree about the same transcript.

The model-fed history stays active-only. Compaction still compresses the working context — it just stops erasing the user's record of it. The resume size guard moves with the display read for the same reason: it bounds an in-memory materialization, and counting active rows would now wave a session through and then load tens of thousands. The `tip_only` bound stays active-only, preserving the #4130 carve-out that keeps well-compressed Bot Chats resumable.

## Verification

Reproduced against a real `SessionDB`, no mocks. All four display reads now agree at 306 where three previously returned 5.

| read path | before | after |
| --- | --- | --- |
| REST `get_messages(include_compacted)` | 306 | 306 |
| `session.resume` display_history | 5 | 306 |
| `get_ancestor_display_prefix` | 1 | 13 |
| warm-session `_live_visible_history` | 5 | 306 |

The new tests are mutation-verified: six fail against the unfixed read paths.

Pathological shape from the resume guard's own docstring — 85 compaction segments, 32k rows on disk behind a 41-row tip — loads in 1.07s at 35 MB peak.

560 pass in `tests/hermes_state/` + `test_hermes_state.py` + `test_compression_watermark_commit.py` + `test_session_db_read_path_split.py`; `test_tui_gateway_server.py` green. Two FTS failures in `test_hermes_state.py` and 15 in `tests/gateway/` (Discord, systemd, AF_UNIX path length) reproduce identically on clean `main`.

Fixes #92080. Also addresses the disappearing-transcript half of #93618 and #68321, and the `needs-repro` item under #94726 §3.

Worth noting for #93618: the reporter landed on "data drift, reset your `state.db`" as the workaround. That reads as a fix because a freshly-created bot has not compacted yet — resetting the store buys time until the new chat crosses the threshold, then the same truncation returns.
