### PR TITLE
fix(terminal): serialize list/dict terminal scope values as JSON

### DIFF
--- a/tests/tools/test_terminal_scope_multiplex.py
+++ b/tests/tools/test_terminal_scope_multiplex.py
@@ -182,3 +182,64 @@ def test_tui_and_cron_boundaries_bind_and_reset(tmp_path):
     with install_and_reset_profile_terminal_scope(home):  # cron fire helper
         assert terminal_env("TERMINAL_ENV") == "local"
     assert get_terminal_scope() is None
+
+
+def test_scope_serializes_list_dict_config_as_json(tmp_path):
+    """#101465: config.yaml list/dict terminal values must mirror as JSON.
+
+    Consumers (terminal_tool's _parse_env_var) json.loads these mirrors;
+    str() would emit a Python repr ("['X']") and the docker-backend
+    requirement check would fail, disabling terminal tools for profiles
+    served through the multiplexed dashboard."""
+    from tools.terminal_scope import (
+        build_profile_terminal_scope,
+        install_and_reset_profile_terminal_scope,
+    )
+
+    home = _profile(
+        tmp_path,
+        "cee",
+        "terminal:\n"
+        "  backend: docker\n"
+        "  docker_forward_env:\n"
+        "    - EMAIL_HOME_ADDRESS\n"
+        "  docker_volumes:\n"
+        "    - /data:/data:ro\n"
+        "  docker_env:\n"
+        "    Gateway: upstream-proxy\n"
+        "  docker_extra_args:\n"
+        "    - --pids-limit\n"
+        "    - '256'\n"
+        "  timeout: 240\n",
+    )
+    scope = build_profile_terminal_scope(home)
+    assert json.loads(scope["TERMINAL_DOCKER_FORWARD_ENV"]) == ["EMAIL_HOME_ADDRESS"]
+    assert json.loads(scope["TERMINAL_DOCKER_VOLUMES"]) == ["/data:/data:ro"]
+    assert json.loads(scope["TERMINAL_DOCKER_ENV"]) == {"Gateway": "upstream-proxy"}
+    assert json.loads(scope["TERMINAL_DOCKER_EXTRA_ARGS"]) == ["--pids-limit", "256"]
+    # Scalars keep the plain str() mirror.
+    assert scope["TERMINAL_TIMEOUT"] == "240"
+
+    import tools.terminal_tool as tt
+
+    with install_and_reset_profile_terminal_scope(home):
+        cfg = tt._get_env_config()
+    assert cfg["env_type"] == "docker"
+    assert cfg["docker_forward_env"] == ["EMAIL_HOME_ADDRESS"]
+    assert cfg["docker_env"] == {"Gateway": "upstream-proxy"}
+    assert cfg["docker_volumes"] == ["/data:/data:ro"]
+
+
+def test_scope_keeps_dotenv_json_strings_verbatim(tmp_path):
+    """.env TERMINAL_* values are already JSON strings; they must pass
+    through unchanged (no double-encoding, no repr)."""
+    from tools.terminal_scope import build_profile_terminal_scope
+
+    home = _profile(
+        tmp_path,
+        "dee",
+        dotenv='TERMINAL_DOCKER_VOLUMES=["/v:/v:rw"]\nTERMINAL_ENV=docker\n',
+    )
+    scope = build_profile_terminal_scope(home)
+    assert scope["TERMINAL_DOCKER_VOLUMES"] == '["/v:/v:rw"]'
+    assert json.loads(scope["TERMINAL_DOCKER_VOLUMES"]) == ["/v:/v:rw"]

--- a/tools/terminal_scope.py
+++ b/tools/terminal_scope.py
@@ -27,6 +27,7 @@ Two contracts distinguish this from a plain override dict:
 
 from __future__ import annotations
 
+import json
 import logging
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
@@ -172,7 +173,15 @@ def build_profile_terminal_scope(hermes_home: "Any") -> Dict[str, str]:
 
         env_var = TERMINAL_CONFIG_ENV_MAP.get(cfg_key)
         if env_var:
-            scope[env_var] = str(value)
+            # Consumers parse these mirrors with json.loads (terminal_tool's
+            # _parse_env_var), so list/dict values must serialize as JSON —
+            # str() would emit a Python repr like "['X']" and break every
+            # docker-backend requirement check. Mirrors
+            # hermes_cli.config._terminal_env_value().
+            if isinstance(value, (list, dict)):
+                scope[env_var] = json.dumps(value)
+            else:
+                scope[env_var] = str(value)
 
     # 1) Defined defaults — the total baseline.
     for cfg_key, value in defaults.items():


### PR DESCRIPTION
## What does this PR do?

`build_profile_terminal_scope()` mirrored a profile's `config.yaml` `terminal:` values into `TERMINAL_*` env vars with `str()`, so any non-empty list/dict value (e.g. `docker_forward_env: [EMAIL_HOME_ADDRESS]`) produced a Python repr like "['EMAIL_HOME_ADDRESS']" instead of valid JSON. `tools/terminal_tool.py` parses those mirrors with `json.loads` (via `_parse_env_var`), so for a docker-backend profile served through the multiplexed/unified dashboard the terminal requirement check failed and terminal tools became unavailable entirely.

The fix serializes list/dict values with `json.dumps` in the shared `_apply()` projection, which is exactly what the single-profile CLI path (`hermes_cli.config._terminal_env_value`, used by `apply_terminal_config_to_env`) already does — the two paths now agree. The `.env`-derived path is intentionally unchanged: those values are already JSON strings.

## Related Issue

Fixes #101465

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/terminal_scope.py` — in `build_profile_terminal_scope()`'s `_apply()`: list/dict values now mirror via `json.dumps` instead of `str()` (covers both the defaults projection and `config.yaml` explicit keys); scalars keep `str()`.
- `tests/tools/test_terminal_scope_multiplex.py` — added `test_scope_serializes_list_dict_config_as_json` (regression: scope mirrors must be valid JSON and `terminal_tool._get_env_config()` must succeed for a docker profile with list/dict terminal config) and `test_scope_keeps_dotenv_json_strings_verbatim` (the `.env` path stays verbatim).

## How to Test

1. Build a profile whose `config.yaml` contains `terminal: {backend: docker, docker_forward_env: [EMAIL_HOME_ADDRESS]}` and run `build_profile_terminal_scope(home)['TERMINAL_DOCKER_FORWARD_ENV']`.
   - Before: "['EMAIL_HOME_ADDRESS']" (Python repr; `json.loads` raises JSONDecodeError).
   - After: "[\"EMAIL_HOME_ADDRESS\"]" — Observed result: `json.loads` succeeds.
2. Inside `install_and_reset_profile_terminal_scope(home)`, call `tools.terminal_tool._get_env_config()`.
   - Before: raises `ValueError: Invalid value for TERMINAL_DOCKER_FORWARD_ENV ...`.
   - After: returns `docker_forward_env == ['EMAIL_HOME_ADDRESS']` — should pass.
3. `pytest tests/tools/test_terminal_scope_multiplex.py tests/tools/test_terminal_config_env_sync.py tests/tools/test_terminal_env_bridge.py -q` — Observed result: 29 passed. The new regression test also fails on the pre-fix code (verified via stash).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11.15

### Documentation & Housekeeping

- [x] N/A — docstrings in the touched function already describe the projection; behavior now matches the documented JSON contract
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow changes
- [x] N/A — pure Python serialization change, no platform-specific behavior
- [x] N/A — no tool behavior/schema changes

## For New Skills

N/A — not a skill.

## Screenshots / Logs

```
$ pytest tests/tools/test_terminal_scope_multiplex.py -q
10 passed, 6 warnings in 1.39s
```