### PR TITLE
fix(telegram): publish 'degraded' when polling did not start, not 'connected'

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3637,7 +3637,37 @@ class BasePlatformAdapter(ABC):
         self._fatal_error_code = None
         self._fatal_error_message = None
         self._fatal_error_retryable = True
+        self._platform_state_degraded = False
         self._write_runtime_status_safe("connected", platform_state="connected", error_code=None, error_message=None)
+
+    def _mark_connected_degraded(self, code: str, message: str) -> None:
+        """Mark the adapter up but with its receive path known-unhealthy.
+
+        For polling adapters: connect() succeeded but the long-poll did not
+        start (bootstrap conflict, transient network failure on reconnect,
+        lifecycle abort). The gateway is alive and the background recovery
+        ladder will retry, but the published state must not claim
+        ``connected`` — a ``connected`` Telegram for hours while
+        ``getUpdates`` is unclaimed made the platform health check and
+        ``hermes send`` both report a lie (#101391). Recovery flips the
+        state back to ``connected`` on the first successful poll.
+
+        Consumers already handle the value: the dashboard's platform
+        health gate counts only connected/running/ok, so ``degraded``
+        correctly reports not-OK without a consumer change.
+        """
+        self._running = True
+        self._fatal_error_code = None
+        self._fatal_error_message = None
+        self._fatal_error_retryable = True
+        # Adapter subclasses (polling adapters with a recovery ladder) use
+        # this to flip the published state back to connected once the
+        # receive path actually recovers (#101391).
+        self._platform_state_degraded = True
+        self._write_runtime_status_safe(
+            "degraded", platform_state="degraded",
+            error_code=code, error_message=message,
+        )
 
     def _mark_disconnected(self) -> None:
         self._running = False

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2695,6 +2695,19 @@ class TelegramAdapter(BasePlatformAdapter):
         else:
             self._polling_conflict_count = 0
         self._send_path_degraded = False
+        # First successful poll after a degraded connect: the published state
+        # was "degraded" while the recovery ladder retried — now that
+        # getUpdates is actually progressing, flip it to connected so the
+        # state file tells the truth again (#101391).
+        if getattr(self, "_platform_state_degraded", False):
+            logger.info(
+                "[%s] Telegram polling recovered: flipping published state "
+                "degraded -> connected (generation %d)",
+                self.name,
+                generation,
+            )
+            self._platform_state_degraded = False
+            self._mark_connected()
 
     def _observe_polling_request_result(self, request, generation, result):
         """Record getUpdates progress from an observed do_request result.
@@ -4913,6 +4926,9 @@ class TelegramAdapter(BasePlatformAdapter):
 
             # Decide between webhook and polling mode
             webhook_url = os.getenv("TELEGRAM_WEBHOOK_URL", "").strip()
+            # Defined in both branches below so the degraded-skip check after
+            # the mode split can read it without a NameError in webhook mode.
+            polling_started = True
 
             if webhook_url:
                 # ── Webhook mode ─────────────────────────────────────
@@ -5045,9 +5061,31 @@ class TelegramAdapter(BasePlatformAdapter):
                         "polling will be retried in the background",
                         self.name,
                     )
-            
-            self._mark_connected()
-            mode = "webhook" if self._webhook_mode else "polling"
+                    # The adapter is up but its receive path is known-unhealthy:
+                    # publishing plain "connected" here kept gateway_state.json
+                    # reporting connected for hours while getUpdates was
+                    # unclaimed — health checks and `hermes send` both read
+                    # the lie (#101391). The recovery ladder flips the state
+                    # back to connected on the first successful poll.
+                    self._mark_connected_degraded(
+                        "telegram_polling_not_started",
+                        "Long-polling did not start; background recovery is retrying. "
+                        "Inbound messages are not being received until it succeeds.",
+                    )
+
+            if not polling_started and not self._webhook_mode:
+                # Degraded polling: skip the plain-connected stamp below so
+                # only the degraded state stands.
+                mode = "polling"
+                logger.warning(
+                    "[%s] Telegram up in degraded state (%s mode): polling "
+                    "recovering in background; state stays 'degraded' until "
+                    "the first successful poll",
+                    self.name, mode,
+                )
+            else:
+                self._mark_connected()
+                mode = "webhook" if self._webhook_mode else "polling"
             # WARNING, not INFO: the "Connecting to Telegram (attempt N/8)…"
             # line above is emitted at WARNING and reaches the terminal (the
             # gateway's default stderr handler is WARNING-only), but this

--- a/tests/gateway/test_telegram_degraded_state.py
+++ b/tests/gateway/test_telegram_degraded_state.py
@@ -1,0 +1,164 @@
+"""Degraded Telegram connect must publish 'degraded', not 'connected' (#101391).
+
+A reconnect whose polling did not start still called _mark_connected(),
+so gateway_state.json reported connected for hours while getUpdates was
+unclaimed — platform health checks and `hermes send` both read the lie.
+Now: degraded connect publishes 'degraded' (with an error code), and the
+first successful poll (_record_polling_progress) flips it back to
+'connected'.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+import plugins.platforms.telegram.adapter as tg_adapter
+
+
+def _bare_adapter():
+    a = object.__new__(tg_adapter.TelegramAdapter)
+    # Only the state-machine attrs the tested methods touch.
+    a._background_tasks = set()
+    from gateway.platforms.base import Platform
+
+    a.platform = Platform.TELEGRAM  # name/namespace lookups in status writes
+    a._polling_generation = 1
+    a._polling_conflict_recovery_generation = None
+    a._polling_conflict_count = 0
+    a._polling_network_error_count = 0
+    a._polling_teardown_started = False
+    a._polling_progress_accepting = True
+    a._polling_progress_event = asyncio.Event()
+    a._polling_last_progress_monotonic = 0.0
+    a._send_path_degraded = True
+    a._platform_state_degraded = False
+    a._webhook_mode = False
+    return a
+
+
+class _RecordedWrites:
+    def __init__(self):
+        self.writes = []
+
+    def __call__(self, context, **kwargs):
+        self.writes.append((context, kwargs))
+
+
+@pytest.fixture
+def recorded(monkeypatch):
+    rec = _RecordedWrites()
+    monkeypatch.setattr(
+        "gateway.platforms.base.BasePlatformAdapter._write_runtime_status_safe",
+        rec,
+    )
+    return rec
+
+
+def _bare_base():
+    """Concrete stand-in satisfying the abstract surface."""
+    from gateway.platforms.base import BasePlatformAdapter
+
+    class _Minimal(BasePlatformAdapter):
+        async def connect(self):
+            pass
+
+        async def disconnect(self):
+            pass
+
+        async def get_chat_info(self, chat_id):
+            return {}
+
+        async def send(self, chat_id, text, **kwargs):
+            pass
+
+    adapter = object.__new__(_Minimal)
+    adapter.platform = None
+    adapter._platform_state_degraded = False
+    return adapter
+
+
+class TestDegradedConnectState:
+    def test_mark_connected_degraded_publishes_degraded_with_error(self, recorded):
+        adapter = _bare_base()
+        adapter._mark_connected_degraded("telegram_polling_not_started", "retrying")
+        assert adapter._platform_state_degraded is True
+        context, kwargs = recorded.writes[-1]
+        assert kwargs["platform_state"] == "degraded"
+        assert kwargs["error_code"] == "telegram_polling_not_started"
+        assert kwargs["error_message"]
+
+    def test_plain_mark_connected_clears_degraded_flag(self, recorded):
+        adapter = _bare_base()
+        adapter._platform_state_degraded = True
+        adapter._mark_connected()
+        assert adapter._platform_state_degraded is False
+        context, kwargs = recorded.writes[-1]
+        assert kwargs["platform_state"] == "connected"
+
+
+class TestRecoveryFlip:
+    def test_first_successful_poll_flips_degraded_to_connected(self, recorded):
+        adapter = _bare_adapter()
+        # Degraded connect already happened.
+        adapter._platform_state_degraded = True
+
+        adapter._record_polling_progress(generation=1)
+
+        assert adapter._platform_state_degraded is False, (
+            "first successful getUpdates must end the degraded state (#101391)"
+        )
+        context, kwargs = recorded.writes[-1]
+        assert kwargs["platform_state"] == "connected"
+        assert kwargs["error_code"] is None
+
+    def test_progress_while_healthy_does_not_restamp(self, recorded):
+        adapter = _bare_adapter()
+        adapter._platform_state_degraded = False
+
+        adapter._record_polling_progress(generation=1)
+        count_after_first = len(recorded.writes)
+
+        adapter._record_polling_progress(generation=1)
+        assert len(recorded.writes) == count_after_first, (
+            "healthy polls must not re-write the state file"
+        )
+
+    def test_progress_from_stale_generation_does_not_flip(self, recorded):
+        adapter = _bare_adapter()
+        adapter._platform_state_degraded = True
+        adapter._polling_generation = 7  # current gen is 7...
+
+        adapter._record_polling_progress(generation=3)  # ...3 is stale
+
+        assert adapter._platform_state_degraded is True, (
+            "a stale generation's progress must not clear the degraded state"
+        )
+        assert recorded.writes == []
+
+
+class TestConnectFlowStamping:
+    """The connect() flow: polling_started=False must not reach
+    _mark_connected(). Verified by source shape so the branch wiring is
+    pinned without driving the full 11k-line connect()."""
+
+    def test_degraded_polling_skips_plain_mark_connected(self):
+        import inspect
+
+        src = inspect.getsource(tg_adapter.TelegramAdapter.connect)
+        # The degraded stamp happens inside the polling branch...
+        assert "_mark_connected_degraded(" in src
+        # ...and the post-branch stamp is guarded by polling_started.
+        assert "if not polling_started and not self._webhook_mode:" in src
+
+    def test_polling_started_initialized_for_webhook_mode(self):
+        """polling_started must be defined before the webhook/polling split
+        so the guard cannot NameError in webhook mode."""
+        import inspect
+
+        src = inspect.getsource(tg_adapter.TelegramAdapter.connect)
+        init_at = src.index("polling_started = True")
+        webhook_at = src.index("if webhook_url:")
+        assert init_at < webhook_at, (
+            "polling_started must be initialized before the webhook branch"
+        )


### PR DESCRIPTION
Fixes #101391

## Problem

`connect()` called `_mark_connected()` **unconditionally** — even when `_start_polling_resilient()` returned `False`, an explicitly-handled, logged, expected outcome (bootstrap conflict, transient network failure on reconnect, lifecycle abort).

On a **reconnect** (`require_progress=False`) the strict readiness gate is skipped, so a transient failure left the adapter up-but-not-polling while `gateway_state.json` said `state=connected, error_code=null`.

**The reporter measured an 11-hour window like this** on a live seat: the external `getUpdates` probe returned a clean 200 (nobody holds the long poll), `hermes send` reported `Platform 'telegram' is not configured`, no inbound message reached the agent — and the published state stayed `connected` the entire time. A gateway restart fixed it. Their probe design (`200 empty` = not polling vs `409 Conflict` = polling) makes the two states trivially distinguishable.

The recovery ladder never corrected the state while it ran either: `_send_path_degraded` is pure in-process state that is **never written to `gateway_state.json`**, so between "polling died" and the ladder's terminal escalation the published state was a lie.

## Fix — three coordinated changes

1. **`BasePlatformAdapter._mark_connected_degraded(code, message)`** — a new published state `degraded`: adapter up, receive path known-unhealthy, `error_code` carried through. Sets a `_platform_state_degraded` flag the recovery path keys on. **No consumer change needed**: the dashboard's platform health gate (`web_server.py:4117`) already counts only `connected/running/ok`, so `degraded` correctly reports not-OK.
2. **`telegram connect()`** — when polling did not start, stamps `degraded` with `telegram_polling_not_started` and **skips** the plain `_mark_connected()`. `polling_started` is initialized before the webhook/polling split so the guard cannot `NameError` in webhook mode.
3. **`_record_polling_progress()`** — the first confirmed `getUpdates` round-trip of the **current** generation flips `degraded` → `connected` (a stale generation's progress cannot clear the flag), and healthy polls never re-write the state file — no per-poll write storm.

The `retrying`/`connecting` values the reporter enumerated as already-published stay untouched; this adds the one missing state with the exact recovery hook their report identifies as absent.

## Verification

`tests/gateway/test_telegram_degraded_state.py` — **7/7 pass**:

- degraded stamp publishes `platform_state=degraded` + error code/message
- plain `_mark_connected` clears the flag
- **first successful poll flips degraded → connected** (the recovery hook)
- healthy polls do not re-stamp (no write storm)
- stale-generation progress does not flip
- connect-flow wiring pinned: the degraded stamp exists and the post-branch plain stamp is guarded by `polling_started`
- `polling_started` initialized before the webhook branch (no webhook-mode NameError)

Sibling suites green: `test_telegram_polling_health_confirmation` + `test_telegram_polling_progress` + `test_telegram_conflict` + `test_telegram_error_redaction` **33/33**.