### PR TITLE
feat(slack): status and titles migrate to the Agent Sessions API before the Feb 2027 assistant_view removal

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -250,6 +250,48 @@ class _ThreadContextCache:
     messages: List[Dict[str, Any]] = field(default_factory=list)
 
 
+_AGENT_SESSIONS_SUPPORTED: Optional[bool] = None
+
+
+def _sdk_supports_agent_sessions() -> bool:
+    """Whether the installed slack-sdk ships the Agent Sessions API.
+
+    Slack is deprecating the Assistant messaging experience in February 2027:
+    ``assistant.threads.setStatus`` / ``assistant.threads.setTitle`` are
+    replaced by ``agents.sessions.setStatus`` / ``agents.sessions.rename``
+    (typed methods landed in slack-sdk 3.44.0). Checked on the SDK class —
+    never on a client instance, where mock auto-attributes would lie.
+    """
+    global _AGENT_SESSIONS_SUPPORTED
+    if _AGENT_SESSIONS_SUPPORTED is None:
+        try:
+            from slack_sdk.web.async_client import AsyncWebClient
+            _AGENT_SESSIONS_SUPPORTED = callable(
+                getattr(AsyncWebClient, "agents_sessions_setStatus", None)
+            )
+        except Exception:
+            _AGENT_SESSIONS_SUPPORTED = False
+    return _AGENT_SESSIONS_SUPPORTED
+
+
+def _session_status_method(client: Any):
+    """Return the status setter: Agent Sessions API when available, else legacy."""
+    if _sdk_supports_agent_sessions():
+        method = getattr(client, "agents_sessions_setStatus", None)
+        if method is not None:
+            return method
+    return client.assistant_threads_setStatus
+
+
+def _session_title_method(client: Any):
+    """Return the title setter: ``agents.sessions.rename`` when available, else legacy."""
+    if _sdk_supports_agent_sessions():
+        method = getattr(client, "agents_sessions_rename", None)
+        if method is not None:
+            return method
+    return client.assistant_threads_setTitle
+
+
 def slack_deps_present() -> bool:
     """PASSIVE probe: are slack-bolt/slack-sdk importable right now?
     Registry ``check_fn`` (status displays, config loading) — must never install. The active
@@ -2451,8 +2493,8 @@ class SlackAdapter(BasePlatformAdapter):
         self, chat_id: str, team_id: str, thread_ts: str, status: str, fail_label: str) -> None:
         """``assistant.threads.setStatus`` (empty ``status`` clears); failures are debug-logged."""
         try:
-            await self._get_client(chat_id, team_id=team_id).assistant_threads_setStatus(
-                channel_id=chat_id, thread_ts=thread_ts, status=status)
+            _set_status = _session_status_method(self._get_client(chat_id, team_id=team_id))
+            await _set_status(channel_id=chat_id, thread_ts=thread_ts, status=status)
         except Exception as e:
             logger.debug("[Slack] assistant.threads.setStatus %s: %s", fail_label, e)
 
@@ -3430,10 +3472,10 @@ class SlackAdapter(BasePlatformAdapter):
             return
         title = title[:77].rstrip() + "..." if len(title) > 80 else title
         try:
-            await self._get_client(channel_id, team_id=team_id).assistant_threads_setTitle(
-                channel_id=channel_id, thread_ts=thread_ts, title=title)
+            _set_title = _session_title_method(self._get_client(channel_id, team_id=team_id))
+            await _set_title(channel_id=channel_id, thread_ts=thread_ts, title=title)
         except Exception as e:
-            logger.debug("[Slack] assistant.threads.setTitle failed: %s", e)
+            logger.debug("[Slack] session title set failed: %s", e)
             return
         self._titled_assistant_threads.add(key)
         # Evict oldest thread_ts first so recently titled threads keep their guard.

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -99,6 +99,22 @@ _slack_mod.SLACK_AVAILABLE = True
 from plugins.platforms.slack.adapter import SlackAdapter  # noqa: E402
 
 
+@pytest.fixture(autouse=True)
+def _pin_legacy_assistant_threads_api():
+    """Pin the SDK capability probe to the legacy assistant.threads API.
+
+    The mocked slack_sdk module would make the class-attribute probe in
+    ``_sdk_supports_agent_sessions`` return a MagicMock auto-attribute
+    (always truthy), silently flipping every typing/title test onto the
+    Agent Sessions path. Tests that exercise the new path set the cached
+    flag to True explicitly.
+    """
+    prev = _slack_mod._AGENT_SESSIONS_SUPPORTED
+    _slack_mod._AGENT_SESSIONS_SUPPORTED = False
+    yield
+    _slack_mod._AGENT_SESSIONS_SUPPORTED = prev
+
+
 def _rich_text_blocks(*elements):
     return [{"type": "rich_text", "elements": list(elements)}]
 
@@ -5918,3 +5934,89 @@ class TestSlackAuthoredTextDeduplication:
         assert "Deploy failed" in payload
         assert "rollback" in payload
         assert "Roll back" in payload
+
+
+class TestAgentSessionsApiRouting:
+    """slack-sdk 3.44.0 Agent Sessions API (assistant_view deprecation Feb 2027).
+
+    When the installed slack-sdk ships agents.sessions.* typed methods, status
+    and title calls route through them; older SDKs keep using the legacy
+    assistant.threads.* methods (compat bridge on Slack's side).
+    """
+
+    def _adapter(self):
+        config = PlatformConfig(enabled=True, token="xoxb-fake-token")
+        a = SlackAdapter(config)
+        a._app = MagicMock()
+        a._app.client = AsyncMock()
+        return a
+
+    @pytest.mark.asyncio
+    async def test_typing_uses_agent_sessions_when_supported(self):
+        _slack_mod._AGENT_SESSIONS_SUPPORTED = True
+        a = self._adapter()
+        a._app.client.agents_sessions_setStatus = AsyncMock()
+        a._app.client.assistant_threads_setStatus = AsyncMock()
+        await a.send_typing("C123", metadata={"thread_id": "parent_ts"})
+        a._app.client.agents_sessions_setStatus.assert_called_once_with(
+            channel_id="C123",
+            thread_ts="parent_ts",
+            status="is thinking...",
+        )
+        a._app.client.assistant_threads_setStatus.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_typing_falls_back_to_legacy_without_sdk_support(self):
+        _slack_mod._AGENT_SESSIONS_SUPPORTED = False
+        a = self._adapter()
+        a._app.client.assistant_threads_setStatus = AsyncMock()
+        await a.send_typing("C123", metadata={"thread_id": "parent_ts"})
+        a._app.client.assistant_threads_setStatus.assert_called_once_with(
+            channel_id="C123",
+            thread_ts="parent_ts",
+            status="is thinking...",
+        )
+
+    @pytest.mark.asyncio
+    async def test_stop_typing_clears_via_agent_sessions(self):
+        _slack_mod._AGENT_SESSIONS_SUPPORTED = True
+        a = self._adapter()
+        a._app.client.agents_sessions_setStatus = AsyncMock()
+        a._app.client.assistant_threads_setStatus = AsyncMock()
+        await a.send_typing("C123", metadata={"thread_id": "parent_ts"})
+        a._app.client.agents_sessions_setStatus.reset_mock()
+        await a.stop_typing("C123", metadata={"thread_id": "parent_ts"})
+        a._app.client.agents_sessions_setStatus.assert_called_once_with(
+            channel_id="C123",
+            thread_ts="parent_ts",
+            status="",
+        )
+        a._app.client.assistant_threads_setStatus.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_thread_title_uses_agents_sessions_rename(self):
+        _slack_mod._AGENT_SESSIONS_SUPPORTED = True
+        a = self._adapter()
+        a.config.extra["assistant_thread_titles"] = True
+        a._app.client.agents_sessions_rename = AsyncMock()
+        a._app.client.assistant_threads_setTitle = AsyncMock()
+        await a._set_assistant_thread_title("D123", "171234.0001", "Summarize the incident")
+        a._app.client.agents_sessions_rename.assert_called_once_with(
+            channel_id="D123",
+            thread_ts="171234.0001",
+            title="Summarize the incident",
+        )
+        a._app.client.assistant_threads_setTitle.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_thread_title_legacy_without_sdk_support(self):
+        _slack_mod._AGENT_SESSIONS_SUPPORTED = False
+        a = self._adapter()
+        a.config.extra["assistant_thread_titles"] = True
+        a._app.client.assistant_threads_setTitle = AsyncMock()
+        await a._set_assistant_thread_title("D123", "171234.0001", "Summarize the incident")
+        a._app.client.assistant_threads_setTitle.assert_called_once_with(
+            channel_id="D123",
+            thread_ts="171234.0001",
+            title="Summarize the incident",
+        )

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -107,7 +107,7 @@ These are the most commonly missed scopes.
 | Scope | Purpose |
 |-------|---------|
 | `groups:read` | List and get info about private channels |
-| `assistant:write` | Render the working-state status line ("is thinking…") next to the bot name while it processes a message. Without this scope the `assistant.threads.setStatus` call fails silently and Slack shows its own rotating generic placeholders instead ("Finding answers…", "Reviewing findings…", …) — Hermes never controls the text. Required for `typing_status_text` to have any visible effect. |
+| `assistant:write` | Render the working-state status line ("is thinking…") next to the bot name while it processes a message. Without this scope the status call (`agents.sessions.setStatus` on slack-sdk 3.44+, `assistant.threads.setStatus` on older SDKs) fails silently and Slack shows its own rotating generic placeholders instead ("Finding answers…", "Reviewing findings…", …) — Hermes never controls the text. Required for `typing_status_text` to have any visible effect. |
 
 ---
 
@@ -498,7 +498,7 @@ platforms:
 | `platforms.slack.typing_status_text` | `"is thinking..."` | Text of the working-state status line shown while the agent processes a message. Requires the `assistant:write` scope — without it the status call fails silently and Slack renders its own generic placeholder, whatever this is set to. Set `typing_indicator: false` to disable the status line entirely. |
 
 :::note Where the status renders
-The custom status appears in the **footer beneath the reply composer** ("*BotName* is thinking…"), not inline in the message list. The inline "Generating response…" / "Finding answers…" lines Slack shows in the message area while an AI app works are **Slack's own rotating indicators** — `assistant.threads.setStatus` does not control those, and both can appear at the same time.
+The custom status appears in the **footer beneath the reply composer** ("*BotName* is thinking…"), not inline in the message list. The inline "Generating response…" / "Finding answers…" lines Slack shows in the message area while an AI app works are **Slack's own rotating indicators** — the status API (`agents.sessions.setStatus` / `assistant.threads.setStatus`) does not control those, and both can appear at the same time.
 :::
 
 The same key customizes Google Chat's visible working-state marker message


### PR DESCRIPTION
## Summary
Slack status lines and thread titles now go through the new Agent Sessions API (`agents.sessions.setStatus` / `agents.sessions.rename`) when the installed slack-sdk supports it, ahead of Slack's February 2027 removal of the Assistant messaging experience (`assistant_view`).

Slack announced the deprecation in its [changelog](https://docs.slack.dev/changelog): `assistant.threads.setStatus` → `agents.sessions.setStatus`, `assistant.threads.setTitle` → `agents.sessions.rename`, with a compat bridge until Feb 2027. slack-sdk 3.44.0 (released Aug 27 2026) shipped the typed methods with drop-in-compatible signatures (`channel_id` / `thread_ts` / `status|title`).

## Changes
- `plugins/platforms/slack/adapter.py`: SDK capability probe (`_sdk_supports_agent_sessions`, checked on the `AsyncWebClient` **class**, cached) + method resolvers; the three call sites (typing status set, status clear, thread title) route through `agents.sessions.*` when available, legacy `assistant.threads.*` otherwise
- Dependency pin: main already carries slack-sdk 3.44.1 (`pyproject.toml` / `tools/lazy_deps.py` / `uv.lock` are unchanged in this PR after rebase); the adapter resolves the Agent Sessions methods at call time and falls back to the legacy `assistant.threads.*` calls on older SDKs
- `tests/gateway/test_slack.py`: autouse fixture pins the probe to legacy under the mocked SDK (mock class attributes are always truthy); 5 new tests cover both routing paths for typing, clear, and title
- `website/docs/user-guide/messaging/slack.md`: scope table + status-line notes name both methods

## Validation
| | Before | After |
|---|---|---|
| SDK 3.44+ | `assistant.threads.setStatus/setTitle` (compat bridge, dies Feb 2027) | `agents.sessions.setStatus/rename` |
| SDK < 3.44 | legacy methods | legacy methods (unchanged) |
| `tests/gateway/test_slack.py` | 233 passed | 238 passed, 1 skipped |

**Deadline:** Slack removes `assistant_view` February 2027; this lands the migration 5 months early with a graceful fallback.

## Infographic

![Agent Sessions API migration mission patch](https://v3b.fal.media/files/b/0aa8d59d/QZ2Z-64M1buQNPk429GhK_lLnl8whV.png)