### PR TITLE
fix(terminal): JSON-serialize list/dict values in profile terminal scope

### DIFF
--- a/tests/tools/test_terminal_scope_multiplex.py
+++ b/tests/tools/test_terminal_scope_multiplex.py
@@ -183,3 +183,60 @@ def test_tui_and_cron_boundaries_bind_and_reset(tmp_path):
     with install_and_reset_profile_terminal_scope(home):  # cron fire helper
         assert terminal_env("TERMINAL_ENV") == "local"
     assert get_terminal_scope() is None
+
+
+def test_config_list_and_dict_values_are_json_not_repr(tmp_path):
+    """config.yaml list/dict terminal keys must be JSON so terminal_tool's
+    json.loads path succeeds. str() produces Python repr and drops the tool."""
+    from tools.terminal_scope import build_profile_terminal_scope
+
+    home = _profile(
+        tmp_path,
+        "docker-lists",
+        "\n".join(
+            [
+                "terminal:",
+                "  backend: docker",
+                "  docker_forward_env:",
+                "    - EMAIL_HOME_ADDRESS",
+                "  docker_volumes:",
+                "    - /tmp/a:/data",
+                "  docker_env:",
+                "    FOO: bar",
+                "  docker_extra_args:",
+                "    - --network=host",
+                "",
+            ]
+        ),
+    )
+    scope = build_profile_terminal_scope(home)
+    assert json.loads(scope["TERMINAL_DOCKER_FORWARD_ENV"]) == ["EMAIL_HOME_ADDRESS"]
+    assert json.loads(scope["TERMINAL_DOCKER_VOLUMES"]) == ["/tmp/a:/data"]
+    assert json.loads(scope["TERMINAL_DOCKER_ENV"]) == {"FOO": "bar"}
+    assert json.loads(scope["TERMINAL_DOCKER_EXTRA_ARGS"]) == ["--network=host"]
+
+    import gateway.run as gw
+    import tools.terminal_tool as tt
+
+    with gw._profile_runtime_scope(home):
+        cfg = tt._get_env_config()
+        assert cfg["docker_forward_env"] == ["EMAIL_HOME_ADDRESS"]
+        assert cfg["docker_volumes"] == ["/tmp/a:/data"]
+        assert cfg["docker_env"] == {"FOO": "bar"}
+        assert cfg["docker_extra_args"] == ["--network=host"]
+
+
+def test_dotenv_json_strings_stay_json_strings(tmp_path):
+    """The .env path already stores JSON text; str() must keep that payload."""
+    from tools.terminal_scope import build_profile_terminal_scope
+
+    home = _profile(
+        tmp_path,
+        "dotenv-json",
+        "terminal:\n  backend: docker\n",
+        'TERMINAL_DOCKER_FORWARD_ENV=["EMAIL_HOME_ADDRESS"]\n'
+        'TERMINAL_DOCKER_VOLUMES=["/tmp/a:/data"]\n',
+    )
+    scope = build_profile_terminal_scope(home)
+    assert json.loads(scope["TERMINAL_DOCKER_FORWARD_ENV"]) == ["EMAIL_HOME_ADDRESS"]
+    assert json.loads(scope["TERMINAL_DOCKER_VOLUMES"]) == ["/tmp/a:/data"]

--- a/tools/terminal_scope.py
+++ b/tools/terminal_scope.py
@@ -93,7 +93,7 @@ def build_profile_terminal_scope(hermes_home: "Any") -> Dict[str, str]:
     ``config.yaml`` ``terminal:``. Total by construction, so a bound scope never widens back to
     ambient authority. Raises :class:`TerminalPolicyUnavailable` if a present file is unreadable.
     """
-    from hermes_cli.config import TERMINAL_CONFIG_ENV_MAP
+    from hermes_cli.config import TERMINAL_CONFIG_ENV_MAP, _terminal_env_value
     from hermes_cli.config_defaults import DEFAULT_CONFIG
 
     home = Path(hermes_home)
@@ -106,7 +106,10 @@ def build_profile_terminal_scope(hermes_home: "Any") -> Dict[str, str]:
                 continue
             env_var = TERMINAL_CONFIG_ENV_MAP.get(cfg_key)
             if env_var:
-                scope[env_var] = str(value)
+                # List/dict config values must be JSON (same contract as
+                # apply_terminal_config_to_env). str() yields Python repr, which
+                # json.loads in terminal_tool rejects.
+                scope[env_var] = _terminal_env_value(value)
 
     _apply({**_TOOL_LEVEL_DEFAULTS, **(DEFAULT_CONFIG.get("terminal") or {})})
     env_path = home / ".env"


### PR DESCRIPTION
## What does this PR do?

`build_profile_terminal_scope()` serialized `config.yaml` `terminal:` list/dict values with `str()`, producing Python repr (`['EMAIL_HOME_ADDRESS']`) instead of JSON. `tools/terminal_tool.py` then `json.loads()` those env values, so any multiplexed/dashboard profile with non-empty `docker_forward_env` / `docker_volumes` / `docker_env` / `docker_extra_args` failed `check_terminal_requirements` and lost the terminal tool.

The config.yaml path now uses the same `_terminal_env_value()` helper as `apply_terminal_config_to_env()` (`json.dumps` for list/dict). The `.env` path is unchanged: those values are already JSON text.

## Related Issue

Fixes #101465

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/terminal_scope.py` — `_apply()` writes list/dict config values through `_terminal_env_value()` so the multiplex scope matches the CLI env-bridge contract
- `tests/tools/test_terminal_scope_multiplex.py` — list/dict `config.yaml` keys parse via `json.loads` and `_get_env_config()`; `.env` JSON strings stay intact

## How to Test

1. Write a profile `config.yaml` with `terminal.backend: docker` and `docker_forward_env: [EMAIL_HOME_ADDRESS]`.
2. Call `build_profile_terminal_scope(profile_home)`. Confirm `TERMINAL_DOCKER_FORWARD_ENV` is `["EMAIL_HOME_ADDRESS"]` and `json.loads` succeeds (not Python repr).
3. Install that scope and call `_get_env_config()`; `docker_forward_env` should be the list. Repeat for `docker_volumes`, `docker_env`, and `docker_extra_args`.
4. `HERMES_PYTHON=<venv python> scripts/run_tests.sh tests/tools/test_terminal_scope_multiplex.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Pre-fix:

```
TERMINAL_DOCKER_FORWARD_ENV repr: "['EMAIL_HOME_ADDRESS']"
json.loads FAILED: JSONDecodeError Expecting value: line 1 column 2 (char 1)
Invalid value for TERMINAL_DOCKER_FORWARD_ENV: "['EMAIL_HOME_ADDRESS']" (expected valid JSON).
check_terminal_requirements returned: False
```

Post-fix:

```
raw ["EMAIL_HOME_ADDRESS"]
json.loads ['EMAIL_HOME_ADDRESS']
docker_forward_env ['EMAIL_HOME_ADDRESS']
```

`scripts/run_tests.sh tests/tools/test_terminal_scope_multiplex.py -q` — 10 passed
`scripts/run_tests.sh tests/tools/test_parse_env_var.py tests/tools/test_terminal_requirements.py tests/tools/test_terminal_config_env_sync.py -q` — 29 passed