### PR TITLE
fix(desktop): add opacity-0 to hidden keep-alive pane layers

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -684,7 +684,7 @@ export function TreeGroup({
               return (
                 <div
                   aria-hidden={!isActive || undefined}
-                  className={cn('absolute inset-0 overflow-auto', !isActive && 'pointer-events-none invisible')}
+                  className={cn('absolute inset-0 overflow-auto', !isActive && 'pointer-events-none invisible opacity-0')}
                   key={paneId}
                   {...hiddenPaneProps(!isActive)}
                 >


### PR DESCRIPTION
## Description

After updating Hermes Desktop, switching between plugin/contrib panes (e.g. Notes ↔ Tokens) shows a brief flash of the outgoing pane's accent-colored content over the incoming pane.

## Root cause

In `apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx`, hidden keep-alive pane layers are kept mounted with `visibility: hidden` and `pointer-events: none` so scroll position and state survive tab round-trips. However, they do not set `opacity: 0`, so on some compositors the hidden layer can still paint for one frame during the tab switch, causing high-contrast/accent elements to leak over the new active pane.

This is the same root cause as #71406 / #71457 / #75134 / #79864, but it affects contrib/plugin panes rather than the terminal overlay specifically.

## Fix

Add `opacity-0` to the hidden layer's className so the compositor drops the hidden layer entirely while keeping the DOM mounted.

```tsx
className={cn('absolute inset-0 overflow-auto', !isActive && 'pointer-events-none invisible opacity-0')}
```

## Verification

Applied the change locally and rebuilt with `npm run pack`. Switching between Notes and Tokens panes no longer shows the flash.

## Related

Closes #101476
