### PR TITLE
fix(desktop): pin and preserve the socket of a route-less Sessions-list tile

### DIFF
--- a/apps/desktop/src/store/gateway-foreground-retention.test.ts
+++ b/apps/desktop/src/store/gateway-foreground-retention.test.ts
@@ -175,3 +175,41 @@ describe('foreground tile retention vs. the live-work pruner (#93892)', () => {
     expect(gatewayMocks.closed).toEqual(['wss://homelab.invalid/api/ws?profile=bot'])
   })
 })
+
+describe('foreground retention for route-less (Sessions-list) tiles', () => {
+  // A session of a SECONDARY profile opened from the Sessions list persists as
+  // a tile with NO ownerRoute (the stored tile only carries
+  // anchor/dir/storedSessionId/workspaceMode). Neither foreground pin rung
+  // applies — addRouteScope needs an ownerRoute, addRuntimeScope needs the
+  // runtime in the connectionId-scoped event ledger — so a mounted tile pins
+  // nothing and the resume lease's finally disposes the socket it just dialed
+  // → backend reaps the runtime → reclaim → re-dial → … forever.
+
+  it('keeps the socket a tile dialed when the tile carries no ownerRoute (opened from the Sessions list)', async () => {
+    $sessionTiles.set([{ storedSessionId: 'stored-mara', runtimeId: undefined }])
+
+    await requestGatewayForAgent('local', 'mara', 'session.resume', { session_id: 'stored-mara' })
+
+    expect(gatewayMocks.closed).toEqual([])
+
+    // …and the live-work pruner agrees: an idle route-less tile is still a
+    // mounted foreground surface.
+    pruneSecondaryGateways(liveSessionScopes())
+    expect(gatewayMocks.closed).toEqual([])
+
+    // Tile gone: the pin does not latch — the next lease releases the socket.
+    $sessionTiles.set([])
+    await requestGatewayForAgent('local', 'mara', 'session.usage', { session_id: 'stored-mara' })
+    expect(gatewayMocks.closed).toEqual(['wss://local.invalid/api/ws?profile=mara'])
+  })
+
+  it('does not let a route-less tile of one profile pin another profile’s socket', async () => {
+    // Only the mara tile is mounted; a request for otto must not inherit mara's
+    // pin — the otto socket is idle garbage and closes on lease release.
+    $sessionTiles.set([{ storedSessionId: 'stored-mara', runtimeId: undefined }])
+
+    await requestGatewayForAgent('local', 'otto', 'session.usage', {})
+
+    expect(gatewayMocks.closed).toEqual(['wss://local.invalid/api/ws?profile=otto'])
+  })
+})

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -7,6 +7,7 @@ import { reconnectBackoffDelayMs } from '@/lib/reconnect-backoff'
 import { RECONNECT_ATTEMPT_TIMEOUT_MS, withTimeout } from '@/lib/with-timeout'
 import { markNativeNotifyBaseline } from '@/store/notify-baseline'
 import { setConnection, setGatewayState } from '@/store/session'
+import { recordSessionOwnerScope } from '@/store/session-owner-ledger'
 
 // ── Multi-profile gateway routing ──────────────────────────────────────────
 // Concurrent sessions across profiles need concurrent sockets: the renderer's
@@ -942,9 +943,17 @@ export async function requestGatewayForAgent<T>(
       await openSecondary(entry)
     }
 
-    return await (timeoutMs === undefined && signal === undefined
+    const result = await (timeoutMs === undefined && signal === undefined
       ? entry.gateway.request<T>(method, params)
       : entry.gateway.request<T>(method, params, timeoutMs, signal))
+
+    // Route-less tile rung — see session-owner-ledger. Only a resume carries
+    // the stored id a tile pins on (other RPCs key runtimes).
+    if (method === 'session.resume' && typeof params.session_id === 'string') {
+      recordSessionOwnerScope(params.session_id, scope)
+    }
+
+    return result
   } finally {
     entry.activeRequests = Math.max(0, entry.activeRequests - 1)
 

--- a/apps/desktop/src/store/session-owner-ledger.ts
+++ b/apps/desktop/src/store/session-owner-ledger.ts
@@ -1,0 +1,20 @@
+// Route-less (Sessions-list) tiles carry no ownerRoute until their resume
+// proves the owning backend, so neither foreground pin rung (route / runtime
+// event scope) can hold their socket open. This leaf records, per stored
+// session id, the composite gateway scope a session.resume dialed; the
+// foreground rung in session-states consults it to pin a mounted tile that
+// still has no ownerRoute. Otherwise the resume lease's finally disposes the
+// fresh socket and the backend reaps the runtime (reclaim → re-dial loop,
+// #93892 shape). The map is renderer-lifetime and keyed by stored id; the pin
+// still lives on the tile, so it never latches — this is only attribution.
+// Dependency-free leaf on purpose: the gateway must not import the
+// session/tile stores.
+const ownerScopeBySessionId = new Map<string, string>()
+
+export function recordSessionOwnerScope(sessionId: string, scope: string): void {
+  ownerScopeBySessionId.set(sessionId, scope)
+}
+
+export function sessionOwnerScopeFor(sessionId: string): string | undefined {
+  return ownerScopeBySessionId.get(sessionId)
+}

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -1,3 +1,4 @@
+import { registryBackendScopeKey } from '@hermes/shared'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ClientSessionState } from '@/app/types'
@@ -12,6 +13,7 @@ import {
 } from '@/components/pane-shell/workspace-scope'
 import { $activeGatewayProfile } from '@/store/profile'
 import { $activeSessionId, $connection, $selectedStoredSessionId, setSessions } from '@/store/session'
+import { recordSessionOwnerScope } from '@/store/session-owner-ledger'
 import type { SessionProfileRoute } from '@/store/session-request-router'
 import type { SessionTile } from '@/store/session-states'
 import type * as SessionStatesModule from '@/store/session-states'
@@ -259,6 +261,43 @@ describe('resetTileRuntimeBindings', () => {
     expect(workBot).toMatchObject({ runtimeId: 'runtime-work-live', storedSessionId: 'stored-work-bot' })
     expect(ordinarySession).not.toHaveProperty('runtimeId')
     expect(invalidateRuntimeBindings).toHaveBeenCalledWith(new Set(['stored-work-bot']))
+  })
+
+  it('keeps a route-less tile bound when a different profile\'s socket reconnects', () => {
+    // A Sessions-list tile opened for a secondary profile has no ownerRoute,
+    // but its resume recorded an owner scope in the ledger. An UNRELATED
+    // profile's reconnect must not drop the binding — dropping re-arms the
+    // tile's resume and remounts the composer, stealing focus on every
+    // sibling-socket reopen (e.g. a background roster poll).
+    const invalidateRuntimeBindings = vi.fn()
+    setSessionTileDelegate({ invalidateRuntimeBindings } as unknown as SessionTileDelegate)
+
+    recordSessionOwnerScope('stored-mara', registryBackendScopeKey('local', 'mara'))
+    $sessionTiles.set([{ storedSessionId: 'stored-mara', runtimeId: 'rt-mara' }])
+    const before = $sessionTiles.get()
+
+    resetTileRuntimeBindings({ connectionId: 'local', profile: 'otto' })
+
+    expect($sessionTiles.get()[0]?.runtimeId).toBe('rt-mara')
+    // A no-op keeps the array identity so subscribers do not re-render.
+    expect($sessionTiles.get()).toBe(before)
+    expect(invalidateRuntimeBindings).toHaveBeenCalledWith(new Set(['stored-mara']))
+  })
+
+  it('rebinds a route-less tile when its own profile\'s socket reconnects', () => {
+    // Guard against over-fixing: a ledger-known tile must not become
+    // un-resettable. Its OWN scope reconnecting still drops the binding so the
+    // tile re-resumes against the fresh runtime.
+    const invalidateRuntimeBindings = vi.fn()
+    setSessionTileDelegate({ invalidateRuntimeBindings } as unknown as SessionTileDelegate)
+
+    recordSessionOwnerScope('stored-mara', registryBackendScopeKey('local', 'mara'))
+    $sessionTiles.set([{ storedSessionId: 'stored-mara', runtimeId: 'rt-mara' }])
+
+    resetTileRuntimeBindings({ connectionId: 'local', profile: 'mara' })
+
+    expect($sessionTiles.get()[0]).not.toHaveProperty('runtimeId')
+    expect(invalidateRuntimeBindings).toHaveBeenCalledWith(new Set())
   })
 })
 

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -16,7 +16,7 @@
  * itself here as the delegate so tile UI stays dependency-light.
  */
 
-import { LOCAL_CONNECTION_ID, registryBackendScopeKey } from '@hermes/shared'
+import { backendScopePrefix, LOCAL_CONNECTION_ID, registryBackendScopeKey } from '@hermes/shared'
 import { atom, computed } from 'nanostores'
 
 import type { ClientSessionState } from '@/app/types'
@@ -1202,7 +1202,8 @@ export function setSessionTileWorkspaceScope(storedSessionId: string, scope: Ses
 }
 
 /** Drop live runtime bindings so every tile re-resumes — used on gateway
- *  reconnect, where a respawned backend re-mints (recycles) runtime ids.
+ *  reconnect, where a respawned backend re-mints (recycles) runtime ids;
+ *  tiles with a known live owner keep their binding.
  *  Also invalidates the wiring cache's stored→runtime map: clearing only the
  *  tile atoms left `resumeTile`'s warm path free to re-bind the same dead
  *  runtime id from the cache, so post-wake tiles repainted empty and never
@@ -1241,35 +1242,53 @@ export function resetTileRuntimeBindings(
           }
         : null
 
+  // Derive a tile's owner scope — an exact route stamps one directly; a
+  // route-less (Sessions-list) tile falls back to the resume-owner ledger,
+  // the SECOND rung that names who actually owns its socket.
+  const tileOwnerScope = (tile: SessionTile): string | undefined =>
+    tile.ownerRoute?.connectionId
+      ? registryBackendScopeKey(tile.ownerRoute.connectionId, tile.ownerRoute.targetProfile || tile.ownerRoute.profile)
+      : sessionOwnerScopeFor(tile.storedSessionId)
+
   const belongsToReconnectedRuntime = (tile: SessionTile): boolean => {
-    const route = tile.ownerRoute
+    const ownerScope = tileOwnerScope(tile)
+
+    if (!ownerScope) {
+      return false
+    }
 
     if (liveConnectionIds) {
       // Unknown restarted identity: a tile survives only when its owner is a
       // connection we know is still live — anything else rebinds on resume.
-      return !route?.connectionId || !liveConnectionIds.has(route.connectionId)
+      return ![...liveConnectionIds].some(id => ownerScope.startsWith(backendScopePrefix(id)))
     }
 
-    if (!reconnected?.connectionId || route?.connectionId !== reconnected.connectionId) {
+    if (!reconnected?.connectionId) {
       return false
     }
 
-    return !reconnected.profile || (route.targetProfile || route.profile) === reconnected.profile
+    // Compare on the scope key built from the reconnect side (never parse the
+    // scope string back); a profile-less reconnect re-mints the whole
+    // connection.
+    return reconnected.profile
+      ? ownerScope === registryBackendScopeKey(reconnected.connectionId, reconnected.profile)
+      : ownerScope.startsWith(backendScopePrefix(reconnected.connectionId))
   }
 
   const preservedStoredIds = new Set(
     tiles
       .filter(
-        // Any tile with an EXACT owner route — bot tabs always, and a
-        // sessions tile whose opener stamped one (a branch child on its
-        // parent's connection). Its runtime lives on that owner's socket,
-        // not the ambient gateway, so an unrelated connection's reconnect
-        // must not drop the binding: each drop re-arms the tile's resume,
-        // and a flapping sibling connection turns that into 4+ re-resumes
-        // inside the storm window — latching the "keeps losing its backend
-        // runtime" card over a session that is actually healthy.
+        // Any tile whose owner scope is known — an exact route (bot tabs
+        // always, a sessions tile whose opener stamped one), or the
+        // resume-owner ledger for a route-less Sessions-list tile. Its
+        // runtime lives on that owner's socket, not the ambient gateway, so
+        // an unrelated connection's reconnect must not drop the binding:
+        // each drop re-arms the tile's resume, and a flapping sibling
+        // connection turns that into 4+ re-resumes inside the storm window —
+        // latching the "keeps losing its backend runtime" card over a
+        // session that is actually healthy.
         tile =>
-          Boolean(tile.ownerRoute?.connectionId) &&
+          Boolean(tileOwnerScope(tile)) &&
           (!(reconnected || liveConnectionIds) || !belongsToReconnectedRuntime(tile))
       )
       .map(tile => tile.storedSessionId)

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -56,6 +56,7 @@ import {
   setBusy,
   setSessions
 } from './session'
+import { sessionOwnerScopeFor } from './session-owner-ledger'
 import { assertSessionOwnerResolved } from './session-owner-resolution'
 import {
   requestForSessionProfile,
@@ -243,6 +244,15 @@ export function foregroundSessionScopes(): Set<string> {
   for (const tile of $sessionTiles.get()) {
     addRuntimeScope(tile.runtimeId)
     addRouteScope(tile.ownerRoute)
+
+    // Route-less tile rung — see session-owner-ledger.
+    if (!tile.ownerRoute) {
+      const scope = sessionOwnerScopeFor(tile.storedSessionId)
+
+      if (scope) {
+        scopes.add(scope)
+      }
+    }
   }
 
   // Create → foreground holds. A hold whose scope the rungs above already


### PR DESCRIPTION
## What does this PR do?
Fixes a focus-loss / thread-reset storm in the desktop app when a tab shows a session that belongs to a **secondary profile** (one that is not the window's active profile), opened from the Sessions list.
Such a tile persists without `ownerRoute`, so nothing in the renderer named the socket it lives on. Two consequences, one root cause:
1. **Socket dispose loop (~2 s).** `foregroundSessionScopes()` never pinned the tile's secondary socket, so `requestGatewayForAgent`'s per-request lease disposed it at refcount 0 right after the resume. The backend orphan-reaped the runtime → `session.reclaimed` → `unbindTileRuntime` → the tile re-resumed → fresh dial → dispose → … forever. Visible as the thread resetting every ~2 s and the composer losing focus; `gui.log` shows `ws accepted` / `ws closed (client_disconnect, code=1005)` pairs every ~2 s on that profile's backend.
2. **Unbinding on unrelated reconnects.** `resetTileRuntimeBindings(scope)` runs on every reopen of *any* secondary socket (e.g. the Bots roster poll dialing each bot's profile every 5 s). Its preservation filter only recognised tiles stamped with an exact `ownerRoute`, so the route-less tile was un-bound and remounted its composer whenever a *different* profile's socket reopened.
The fix gives a route-less tile an owner the registry can reason about, without changing tile persistence: a dependency-free leaf (`session-owner-ledger.ts`, twin of the existing `sessionScopeByRuntimeId`) records the composite gateway scope a **successful** `session.resume` dialed, keyed by stored session id. `foregroundSessionScopes` pins that scope for a mounted tile with no `ownerRoute` (commit 1), and `resetTileRuntimeBindings` derives each tile's owner scope from its route *or* the ledger and compares it against the scope key built from the reconnect side (commit 2). The pin lives on the tile, so it releases the moment the tile closes — nothing latches, `retained` is untouched, and Bot-mode tiles (which carry `ownerRoute`) are unaffected. A ledger-known tile still drops its binding when its *own* owner reconnects.
Why not stamp `ownerRoute` on Sessions-list tiles at resume time instead? That would change the persisted semantics of every such tile (relaunch resume would go to a frozen route instead of re-resolving via the row) and only covers the resume door, whereas the lease disposes on every RPC. The ledger keeps the change to the two call sites that had the gap.
## Related Issue
Same bug class as #93892 (closed — that fix covered Bot-mode tiles, which carry an `ownerRoute`; this covers the route-less Sessions-list tile). No open issue found for the route-less case.
Refs #93892
## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)
## Changes Made
- `apps/desktop/src/store/session-owner-ledger.ts` (new, 20 lines) — `Map<storedSessionId, scope>`; `recordSessionOwnerScope` / `sessionOwnerScopeFor`. Leaf on purpose: `gateway.ts` must not import the session/tile stores (cycle).
- `apps/desktop/src/store/gateway.ts` — in `requestGatewayForAgent`, after a `session.resume` resolves, record the already-computed `scope` for `params.session_id`. Recording happens *after* the awaited request so a failed/mis-routed resume never attributes a session to a backend that did not answer.
- `apps/desktop/src/store/session-states.ts`
  - `foregroundSessionScopes`: for a tile without `ownerRoute`, add the ledger scope (route stays authoritative when present).
  - `resetTileRuntimeBindings`: `tileOwnerScope(tile)` (route, else ledger); `belongsToReconnectedRuntime` compares scope strings built from the reconnect side (exact key for a profile-scoped reopen, `backendScopePrefix` for a whole-connection one, `liveConnectionIds` membership via the same prefix). Filter keeps its original one-expression shape.
- `apps/desktop/src/store/gateway-foreground-retention.test.ts` — regression test (red on `main`): a route-less tile's socket survives the resume lease and the pruner, and is released once the tile closes; guard: a `mara` tile cannot pin an `otto` socket.
- `apps/desktop/src/store/session-states.test.ts` — regression test (red on `main`): a ledger-known route-less tile keeps its `runtimeId` and `$sessionTiles` identity when an unrelated profile reconnects; guard: its own profile reconnecting still drops the binding.
## How to Test
1. **Reproduce on `main`** (packaged or dev build, ≥2 local profiles): with profile A active, open a session of profile B from the Sessions list as a tab and leave it idle. Watch `~/.hermes/profiles/B/logs/gui.log`: `ws accepted` → `ws closed … client_disconnect(code=1005)` every ~2 s; the tab's thread resets and the composer drops focus. Then open the Bots tab: every 5 s every non-active profile dials once and the route-less tab remounts its composer.
2. **Unit tests** (both new regression tests fail on `main`, pass here):
   ```bash
   cd apps/desktop
   npx vitest run src/store/gateway-foreground-retention.test.ts src/store/session-states.test.ts
   npx vitest run src/store/      # 116 files / 1443 tests green
   npx eslint src/store/ && npx tsc -p . --noEmit
   ```
3. **Verify the fix live:** rebuild, repeat step 1. The B backend log shows one `ws accepted` for the tab and no churn; the tab keeps focus with the Bots tab and several secondary-profile tabs open. Closing the tab releases the socket (one `ws closed` on the next lease release).
## Checklist
### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(desktop): …`, two commits)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: renderer-only change (TypeScript); the desktop vitest suite for `src/store/` (1443 tests), eslint and `tsc` pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux (kernel 7.1.8), packaged desktop build from this branch, 8 local profiles
### Documentation & Housekeeping
- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (behavior restored to the documented invariant; code comments updated)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A: renderer store logic, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
## Screenshots / Logs
Before (profile `mara` backend, tab idle, one secondary-profile tab open):
```
16:32:58,086 ws accepted peer=127.0.0.1:56572
16:32:58,347 ws closed   peer=127.0.0.1:56572 reason=client_disconnect(code=1005) messages=2
16:33:00,209 ws accepted peer=127.0.0.1:56576
16:33:01,848 ws closed   peer=127.0.0.1:56576 reason=client_disconnect(code=1005) messages=9
16:33:03,368 ws accepted peer=127.0.0.1:43700
16:33:03,506 ws closed   peer=127.0.0.1:43700 reason=client_disconnect(code=1005) messages=2
```
After (same setup, rebuilt on this branch): a single `ws accepted` for the tab; 0 `client_disconnect` on `mara`/`ada`/`otto`/`silas`/`sloan`/`vera` over 15 minutes; user-reported focus losses correlated 1:1 with secondary reopens before the fix and stopped after it.
