### PR TITLE
GitSpawn RCE no longer executes from a malicious repo's .git/config (GHSA-7x36-8jrh-v4pw)

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -12,7 +12,12 @@ from pathlib import Path
 from typing import Awaitable, Callable
 
 from agent.model_metadata import estimate_tokens_rough
-from hermes_cli._subprocess_compat import IS_WINDOWS, windows_hide_flags
+from hermes_cli._subprocess_compat import (
+    IS_WINDOWS,
+    harden_git_argv,
+    noninteractive_git_env,
+    windows_hide_flags,
+)
 from hermes_cli.sizefmt import format_bytes
 
 from abc import ABC, abstractmethod
@@ -425,12 +430,13 @@ def _expand_git_reference(
     _popen_kwargs = {"creationflags": windows_hide_flags()} if IS_WINDOWS else {}
     try:
         result = subprocess.run(
-            ["git", *args],
+            ["git", *harden_git_argv(args)],
             cwd=cwd,
             capture_output=True,
             text=True, encoding='utf-8', errors='replace',
             timeout=30,
             stdin=subprocess.DEVNULL,
+            env=noninteractive_git_env(),
             **_popen_kwargs,
         )
     except subprocess.TimeoutExpired:

--- a/cli.py
+++ b/cli.py
@@ -1837,6 +1837,10 @@ def _setup_worktree(repo_root: str = None, sync_base: bool = True,
     """
     import subprocess
 
+    from hermes_cli._subprocess_compat import (
+        noninteractive_git_env as _noninteractive_git_env,
+    )
+
     repo_root = repo_root or _git_repo_root()
     if not repo_root:
         _cprint("\033[31m✗ --worktree requires being inside a git repository.\033[0m")
@@ -1910,6 +1914,7 @@ def _setup_worktree(repo_root: str = None, sync_base: bool = True,
         result = subprocess.run(
             ["git", *_wt_add_cfg, "worktree", "add", str(wt_path), "-b", branch_name, base_ref],
             capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=120, cwd=repo_root,
+            stdin=subprocess.DEVNULL, env=_noninteractive_git_env(),
         )
         if result.returncode != 0:
             # If branching from the resolved remote ref failed for any reason
@@ -1925,6 +1930,7 @@ def _setup_worktree(repo_root: str = None, sync_base: bool = True,
                 result = subprocess.run(
                     ["git", "worktree", "add", str(wt_path), "-b", branch_name, base_ref],
                     capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=120, cwd=repo_root,
+                    stdin=subprocess.DEVNULL, env=_noninteractive_git_env(),
                 )
             if result.returncode != 0:
                 _cleanup_failed_worktree_add(repo_root, wt_path, branch_name)

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -47,8 +47,63 @@ __all__ = [
     "bounded_git_probe",
     "bounded_probe_run",
     "noninteractive_git_env",
+    "NO_DRIVER_DIFF_FLAGS",
     "pid_is_hermes",
 ]
+
+# Flags that neutralize *attribute-scoped* diff drivers on any diff-rendering
+# git command (``diff``, ``log -p``, ``show``, ``blame``). A malicious repo can
+# name a driver in ``.gitattributes`` (``* diff=evil``) and point it at an
+# arbitrary program via ``[diff "evil"] command=/textconv=`` in ``.git/config``.
+# Because the attacker chooses the driver name, ``GIT_CONFIG_KEY`` overrides in
+# ``noninteractive_git_env`` cannot enumerate and disable it — only these
+# command-line flags do. ``--no-ext-diff`` kills ``command=``; ``--no-textconv``
+# kills ``textconv=``. Both are required (verified empirically: each alone
+# leaves the other live). Smudge/clean filters are neutralized by the env
+# layer's ``core.hooksPath`` + running against the index without checkout.
+NO_DRIVER_DIFF_FLAGS = ("--no-ext-diff", "--no-textconv")
+
+# Subcommands that render diffs and therefore invoke ``.gitattributes``-scoped
+# diff/textconv drivers. Only these accept ``NO_DRIVER_DIFF_FLAGS`` — ``status``
+# and friends reject the flags (``unknown option``), so the helper must gate on
+# this set rather than blanket-prepending.
+_DIFF_RENDERING_SUBCOMMANDS = frozenset({"diff", "show", "log", "blame"})
+
+
+def harden_git_argv(args: Sequence[str]) -> list[str]:
+    """Return a copy of subcommand-first git *args* with diff-driver flags
+    inserted for diff-rendering subcommands.
+
+    *args* is the argument list WITHOUT the leading ``"git"`` (e.g.
+    ``["diff", "HEAD"]`` or ``["-c", "core.quotePath=false", "diff", ...]``).
+    The first non-option token is treated as the subcommand; if it is one of
+    :data:`_DIFF_RENDERING_SUBCOMMANDS`, :data:`NO_DRIVER_DIFF_FLAGS` is
+    inserted immediately after it. Non-diff subcommands are returned unchanged.
+
+    Pair with :func:`noninteractive_git_env`: the env layer disables
+    fsmonitor/hooks/pager/editor/credential sinks, this closes the one class
+    (attacker-named attribute drivers) env overrides cannot reach.
+    """
+    out = list(args)
+    # Options that consume the FOLLOWING token as their value, so that value is
+    # never mistaken for the subcommand (``-C diff`` is a path; ``-c diff=x`` is
+    # a config pair — neither is the diff subcommand).
+    _value_opts = {"-C", "-c", "--git-dir", "--work-tree", "--namespace", "--exec-path"}
+    i = 0
+    while i < len(out):
+        tok = out[i]
+        if tok in _value_opts:
+            i += 2
+            continue
+        if tok.startswith("-"):
+            i += 1
+            continue
+        if tok in _DIFF_RENDERING_SUBCOMMANDS:
+            return out[: i + 1] + list(NO_DRIVER_DIFF_FLAGS) + out[i + 1 :]
+        # First non-option token is the subcommand; if it isn't a diff renderer
+        # there is nothing to harden.
+        return out
+    return out
 
 
 IS_WINDOWS = sys.platform == "win32"
@@ -610,6 +665,7 @@ def bounded_probe_run(
     *,
     timeout: float,
     errors: str = "replace",
+    env: "Mapping[str, str] | None" = None,
 ) -> "subprocess.CompletedProcess[str] | None":
     """Deadlock-safe ``subprocess.run(argv, capture_output=True, timeout=...)``
     for fail-open probe call sites. Returns a ``CompletedProcess`` when the
@@ -647,6 +703,7 @@ def bounded_probe_run(
             text=True,
             encoding="utf-8",
             errors=errors,
+            env=dict(env) if env is not None else None,
             **_popen_kwargs,
         )
     except Exception:
@@ -674,6 +731,20 @@ def bounded_git_probe(argv: Sequence[str], *, timeout: float) -> str:
     ``subprocess.run(["git", ...], timeout=...)`` at fail-open probe call sites
     (``tui_gateway.git_probe.run_git``, ``agent.coding_context._git``).
 
+    **Security (GHSA-7x36-8jrh-v4pw):** these probes run automatically against
+    whatever directory the session sits in — the coding-workspace snapshot and
+    the gateway project-tree build fire ``git status`` / ``git branch`` before
+    any tool call, approval, or trust prompt. An index refresh executes the
+    repository-configured ``core.fsmonitor`` program, and other config keys
+    (hooks, pager, editor, credential helper) are execution sinks too. A repo
+    delivered as files with its ``.git`` directory intact (a shared zip, sync
+    folder, or USB stick — ``git clone`` never transfers ``.git/config``) would
+    otherwise get host code execution as the user. Every probe now runs under
+    :func:`noninteractive_git_env`, which pins those keys to inert values via
+    ``GIT_CONFIG_*`` and ignores global/system config. Diff-rendering callers
+    additionally pass :data:`NO_DRIVER_DIFF_FLAGS` (attribute-scoped drivers
+    can't be disabled through env overrides).
+
     Why not ``subprocess.run``: on Windows, ``run()``'s post-timeout cleanup
     calls an *unbounded* ``communicate()`` after killing git. Killing the
     PATH-resolved launcher can leave a suspended descendant ``git.exe`` holding
@@ -698,7 +769,7 @@ def bounded_git_probe(argv: Sequence[str], *, timeout: float) -> str:
     openai/codex#36793). ``process_group`` only changes which group the child
     belongs to; it does not detach the terminal or alter the fast path.
     """
-    result = bounded_probe_run(argv, timeout=timeout)
+    result = bounded_probe_run(argv, timeout=timeout, env=noninteractive_git_env())
     if result is None or result.returncode != 0:
         return ""
     return (result.stdout or "").strip()

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -365,6 +365,10 @@ def noninteractive_git_env(
       instead of prompting for credentials.
     * ``GCM_INTERACTIVE=Never`` — Git Credential Manager (the default
       credential helper on Windows installs) never pops its own dialog.
+    * isolated git config — inherited ``GIT_CONFIG_*`` overrides, global/system
+      config, pagers, editors, fsmonitor, external diff, and hooks are disabled
+      for the child process. A user's repo/global config should not be able to
+      hang or mutate Hermes's internal plumbing calls.
 
     ``GIT_ASKPASS`` / ``SSH_ASKPASS`` are deliberately left alone: when the
     user has a *working* askpass helper or ssh-agent configured, auth should
@@ -381,6 +385,43 @@ def noninteractive_git_env(
     env = dict(base if base is not None else os.environ)
     env["GIT_TERMINAL_PROMPT"] = "0"
     env["GCM_INTERACTIVE"] = "Never"
+
+    # Do not inherit caller-supplied config injection. We rebuild the
+    # GIT_CONFIG_COUNT block below so ambient -c values cannot re-enable
+    # pagers, hooks, fsmonitor, editors, or credential prompts.
+    for key in list(env):
+        if (
+            key == "GIT_CONFIG_PARAMETERS"
+            or key.startswith("GIT_CONFIG_KEY_")
+            or key.startswith("GIT_CONFIG_VALUE_")
+        ):
+            env.pop(key, None)
+    env.pop("GIT_CONFIG_COUNT", None)
+
+    devnull = os.devnull
+    env["GIT_CONFIG_GLOBAL"] = devnull
+    env["GIT_CONFIG_SYSTEM"] = devnull
+    env["GIT_CONFIG_NOSYSTEM"] = "1"
+    env["GIT_PAGER"] = "cat"
+    env["PAGER"] = "cat"
+    env["GIT_EDITOR"] = "true"
+
+    config_overrides = {
+        "credential.helper": "",
+        "core.askPass": "",
+        "core.fsmonitor": "false",
+        "core.untrackedCache": "false",
+        "core.hooksPath": devnull,
+        "core.pager": "cat",
+        "core.editor": "true",
+        "sequence.editor": "true",
+        "diff.external": "",
+    }
+    env["GIT_CONFIG_COUNT"] = str(len(config_overrides))
+    for idx, (key, value) in enumerate(config_overrides.items()):
+        env[f"GIT_CONFIG_KEY_{idx}"] = key
+        env[f"GIT_CONFIG_VALUE_{idx}"] = value
+
     return env
 
 

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -42,6 +42,8 @@ from dataclasses import dataclass, field, asdict
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
+from hermes_cli._subprocess_compat import noninteractive_git_env
+
 logger = logging.getLogger(__name__)
 
 
@@ -494,6 +496,7 @@ def workspace_fingerprint(cwd: Optional[str] = None) -> str:
             ["git", "rev-parse", "HEAD"],
             capture_output=True, text=True, encoding="utf-8", errors="replace",
             timeout=10, cwd=workdir,
+            stdin=subprocess.DEVNULL, env=noninteractive_git_env(),
         )
         if head.returncode != 0:
             return ""
@@ -501,6 +504,7 @@ def workspace_fingerprint(cwd: Optional[str] = None) -> str:
             ["git", "status", "--porcelain"],
             capture_output=True, text=True, encoding="utf-8", errors="replace",
             timeout=30, cwd=workdir,
+            stdin=subprocess.DEVNULL, env=noninteractive_git_env(),
         )
         if status.returncode != 0:
             return ""

--- a/hermes_cli/web_git.py
+++ b/hermes_cli/web_git.py
@@ -19,7 +19,7 @@ import shutil
 import subprocess
 from pathlib import Path
 
-from hermes_cli._subprocess_compat import noninteractive_git_env
+from hermes_cli._subprocess_compat import harden_git_argv, noninteractive_git_env
 
 _GIT_TIMEOUT = 30
 _GH_TIMEOUT = 30
@@ -42,7 +42,7 @@ def _git(cwd: str, args: list[str], *, timeout: int = _GIT_TIMEOUT) -> tuple[int
     the real auth error in the toast instead."""
     try:
         proc = subprocess.run(
-            ["git", *args],
+            ["git", *harden_git_argv(args)],
             cwd=cwd,
             capture_output=True,
             text=True, encoding='utf-8', errors='replace',

--- a/tests/hermes_cli/test_noninteractive_git.py
+++ b/tests/hermes_cli/test_noninteractive_git.py
@@ -56,6 +56,47 @@ class TestNoninteractiveGitEnv:
         env = noninteractive_git_env({"GIT_TERMINAL_PROMPT": "1"})
         assert env["GIT_TERMINAL_PROMPT"] == "0"
 
+    def test_strips_ambient_git_config_injection(self):
+        env = noninteractive_git_env(
+            {
+                "GIT_CONFIG_COUNT": "2",
+                "GIT_CONFIG_KEY_0": "core.pager",
+                "GIT_CONFIG_VALUE_0": "less",
+                "GIT_CONFIG_KEY_1": "core.hooksPath",
+                "GIT_CONFIG_VALUE_1": ".git/hooks",
+                "GIT_CONFIG_PARAMETERS": "'core.pager=less'",
+            }
+        )
+
+        assert env["GIT_CONFIG_COUNT"] != "2"
+        assert "GIT_CONFIG_PARAMETERS" not in env
+        values = {
+            env[f"GIT_CONFIG_KEY_{idx}"]: env[f"GIT_CONFIG_VALUE_{idx}"]
+            for idx in range(int(env["GIT_CONFIG_COUNT"]))
+        }
+        assert values["core.pager"] == "cat"
+        assert values["core.hooksPath"] == os.devnull
+        assert values["credential.helper"] == ""
+
+    def test_disables_pagers_hooks_editors_and_user_config(self):
+        env = noninteractive_git_env({})
+        values = {
+            env[f"GIT_CONFIG_KEY_{idx}"]: env[f"GIT_CONFIG_VALUE_{idx}"]
+            for idx in range(int(env["GIT_CONFIG_COUNT"]))
+        }
+
+        assert env["GIT_CONFIG_GLOBAL"] == os.devnull
+        assert env["GIT_CONFIG_SYSTEM"] == os.devnull
+        assert env["GIT_CONFIG_NOSYSTEM"] == "1"
+        assert env["GIT_PAGER"] == "cat"
+        assert env["PAGER"] == "cat"
+        assert env["GIT_EDITOR"] == "true"
+        assert values["core.fsmonitor"] == "false"
+        assert values["core.hooksPath"] == os.devnull
+        assert values["core.editor"] == "true"
+        assert values["sequence.editor"] == "true"
+        assert values["diff.external"] == ""
+
 
 # ---------------------------------------------------------------------------
 # 2. Real-git E2E: 401 remote fails fast instead of prompting

--- a/tests/security/test_gitspawn_config_injection.py
+++ b/tests/security/test_gitspawn_config_injection.py
@@ -1,0 +1,200 @@
+"""GitSpawn / GHSA-7x36-8jrh-v4pw regression suite.
+
+A repository delivered as files (zip, sync folder, USB) can carry a
+``.git/config`` that names a command in an execution-sink git setting —
+``core.fsmonitor``, ``core.hooksPath`` hooks, or an attribute-scoped
+``[diff "x"] command=/textconv=`` driver. Hermes gathers workspace context by
+running git against the session directory automatically, before any prompt,
+approval, or trust gate, so an unhardened probe would execute that command on
+the host as the user.
+
+These tests build a real malicious repo and assert that every automatic
+context-gathering git path Hermes runs neutralizes every sink. They use a real
+``git`` and skip if it is unavailable.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hermes_cli._subprocess_compat import (
+    NO_DRIVER_DIFF_FLAGS,
+    harden_git_argv,
+    noninteractive_git_env,
+)
+
+_HAS_GIT = shutil.which("git") is not None
+pytestmark = pytest.mark.skipif(not _HAS_GIT, reason="git not installed")
+
+
+# ---------------------------------------------------------------------------
+# 1. harden_git_argv unit contract
+# ---------------------------------------------------------------------------
+
+
+class TestHardenGitArgv:
+    def test_diff_gets_flags_after_subcommand(self):
+        assert harden_git_argv(["diff", "HEAD"]) == [
+            "diff", *NO_DRIVER_DIFF_FLAGS, "HEAD",
+        ]
+
+    def test_show_log_blame_are_hardened(self):
+        for sub in ("show", "log", "blame"):
+            out = harden_git_argv([sub, "x"])
+            assert out[0] == sub
+            assert out[1:3] == list(NO_DRIVER_DIFF_FLAGS)
+
+    def test_status_is_not_touched(self):
+        # status rejects --no-ext-diff (`unknown option`), so it must pass through.
+        assert harden_git_argv(["status", "--porcelain=2", "--branch"]) == [
+            "status", "--porcelain=2", "--branch",
+        ]
+
+    def test_worktree_and_other_subcommands_untouched(self):
+        assert harden_git_argv(["worktree", "add", "x"]) == ["worktree", "add", "x"]
+        assert harden_git_argv(["rev-parse", "HEAD"]) == ["rev-parse", "HEAD"]
+
+    def test_global_options_are_skipped_when_finding_subcommand(self):
+        out = harden_git_argv(["-C", "/repo", "diff", "HEAD"])
+        assert out == ["-C", "/repo", "diff", *NO_DRIVER_DIFF_FLAGS, "HEAD"]
+
+    def test_dash_c_value_is_not_mistaken_for_subcommand(self):
+        # ``-C diff`` is a path; the real subcommand is status → no flags.
+        assert harden_git_argv(["-C", "diff", "status"]) == ["-C", "diff", "status"]
+        # ``-c diff=x`` is a config pair; the real subcommand is status.
+        assert harden_git_argv(["-c", "diff=x", "status"]) == ["-c", "diff=x", "status"]
+
+    def test_config_pair_before_diff_still_hardens(self):
+        out = harden_git_argv(["-c", "core.quotePath=false", "diff", "--numstat"])
+        assert out == [
+            "-c", "core.quotePath=false", "diff", *NO_DRIVER_DIFF_FLAGS, "--numstat",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# 2. Real-git E2E: every automatic path neutralizes every sink
+# ---------------------------------------------------------------------------
+
+
+def _make_malicious_repo(tmp: Path) -> tuple[Path, Path]:
+    """Build a repo whose .git/config arms fsmonitor, a checkout hook, and an
+    attribute-scoped external-diff + textconv driver. Returns (repo, marker_stem):
+    a fired sink leaves ``<marker_stem>.<sink>`` on disk."""
+    repo = tmp / "poc"
+    clean = {
+        **os.environ,
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_CONFIG_SYSTEM": os.devnull,
+        "GIT_CONFIG_NOSYSTEM": "1",
+    }
+    subprocess.run(["git", "init", "-q", str(repo)], check=True, env=clean)
+    (repo / "README").write_text("hi\n")
+    ident = ["-c", "user.email=a@b", "-c", "user.name=a"]
+    subprocess.run(["git", "-C", str(repo), *ident, "add", "."], check=True, env=clean)
+    subprocess.run(["git", "-C", str(repo), *ident, "commit", "-qm", "init"], check=True, env=clean)
+
+    marker = tmp / "MARKER"
+    hooks = repo / "evil-hooks"
+    hooks.mkdir()
+    hook = hooks / "post-checkout"
+    hook.write_text(f"#!/bin/sh\ntouch {marker}.hook\n")
+    hook.chmod(0o755)
+    with (repo / ".git" / "config").open("a") as f:
+        f.write(f'[core]\n\tfsmonitor = "touch {marker}.fsmonitor"\n\thooksPath = {hooks}\n')
+        f.write(f'[diff "evil"]\n\tcommand = "touch {marker}.extdiff"\n')
+        f.write(f'\ttextconv = "sh -c \'touch {marker}.textconv; cat\'"\n')
+    (repo / ".gitattributes").write_text("* diff=evil\n")
+    (repo / "README").write_text("changed\n")  # dirty working tree so diffs run
+    return repo, marker
+
+
+def _fired(marker: Path) -> list[str]:
+    out = []
+    for sink in ("fsmonitor", "hook", "extdiff", "textconv"):
+        p = Path(f"{marker}.{sink}")
+        if p.exists():
+            out.append(sink)
+            p.unlink()
+    return out
+
+
+@pytest.fixture()
+def malicious_repo(tmp_path):
+    repo, marker = _make_malicious_repo(tmp_path)
+    yield repo, marker
+
+
+def test_baseline_unhardened_git_fires_sinks(malicious_repo):
+    """Sanity: without hardening the payload actually fires — proves the repo
+    is armed and the test can detect a regression."""
+    repo, marker = malicious_repo
+    subprocess.run(["git", "-C", str(repo), "diff", "HEAD"], capture_output=True)
+    fired = _fired(marker)
+    assert "fsmonitor" in fired and "extdiff" in fired, fired
+
+
+def test_coding_workspace_snapshot_is_safe(malicious_repo):
+    import agent.coding_context as cc
+    repo, marker = malicious_repo
+    cc.build_coding_workspace_block(cwd=repo)
+    assert _fired(marker) == []
+
+
+def test_gateway_git_probe_is_safe(malicious_repo):
+    from tui_gateway import git_probe
+    repo, marker = malicious_repo
+    git_probe.branch(str(repo))
+    git_probe.run_git(str(repo), "status", "--porcelain")
+    assert _fired(marker) == []
+
+
+def test_working_diff_is_safe(malicious_repo):
+    from tools.working_diff import collect_working_diff
+    repo, marker = malicious_repo
+    collect_working_diff(str(repo), "working")
+    assert _fired(marker) == []
+
+
+def test_goals_fingerprint_is_safe(malicious_repo):
+    from hermes_cli.goals import workspace_fingerprint
+    repo, marker = malicious_repo
+    workspace_fingerprint(str(repo))
+    assert _fired(marker) == []
+
+
+def test_web_git_diff_is_safe(malicious_repo):
+    from hermes_cli import web_git
+    repo, marker = malicious_repo
+    web_git._git(str(repo), ["status", "--porcelain=v2", "-z"])
+    web_git._git_out(str(repo), ["diff", "HEAD"])
+    assert _fired(marker) == []
+
+
+def test_context_reference_diff_is_safe(malicious_repo):
+    from agent import context_references as cr
+    repo, marker = malicious_repo
+    ref = type("R", (), {"raw": "@diff"})()
+    cr._expand_git_reference(ref, repo, ["diff", "HEAD"], "git diff")
+    assert _fired(marker) == []
+
+
+def test_subagent_worktree_add_is_safe(malicious_repo, tmp_path):
+    from tools import subagent_worktree as sw
+    repo, marker = malicious_repo
+    sw._run_git(["worktree", "add", str(tmp_path / "wt1"), "-b", "safe1"], str(repo))
+    assert _fired(marker) == []
+
+
+def test_noninteractive_env_pins_fsmonitor_and_hooks():
+    env = noninteractive_git_env({})
+    values = {
+        env[f"GIT_CONFIG_KEY_{i}"]: env[f"GIT_CONFIG_VALUE_{i}"]
+        for i in range(int(env["GIT_CONFIG_COUNT"]))
+    }
+    assert values["core.fsmonitor"] == "false"
+    assert values["core.hooksPath"] == os.devnull

--- a/tools/subagent_worktree.py
+++ b/tools/subagent_worktree.py
@@ -44,6 +44,8 @@ import uuid
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from hermes_cli._subprocess_compat import harden_git_argv, noninteractive_git_env
+
 logger = logging.getLogger(__name__)
 
 _GIT_TIMEOUT = 30
@@ -52,15 +54,24 @@ _BRANCH_NAMESPACE = "hermes-subagent"
 
 
 def _run_git(args, cwd: str, timeout: int = _GIT_TIMEOUT):
-    """Run a git command, capturing output. Never raises on non-zero exit."""
+    """Run a git command, capturing output. Never raises on non-zero exit.
+
+    Runs under :func:`noninteractive_git_env` (GHSA-7x36-8jrh-v4pw): worktree
+    isolation runs automatically for delegated subagents against whatever repo
+    the parent sits in, and ``worktree add`` runs checkout hooks. Disabling the
+    fsmonitor/hooks/pager/credential config sinks keeps a malicious ``.git/config``
+    from executing on the host.
+    """
     return subprocess.run(
-        ["git", *args],
+        ["git", *harden_git_argv(args)],
         cwd=cwd,
         capture_output=True,
         text=True,
         encoding="utf-8",
         errors="replace",
         timeout=timeout,
+        stdin=subprocess.DEVNULL,
+        env=noninteractive_git_env(),
     )
 
 

--- a/tools/working_diff.py
+++ b/tools/working_diff.py
@@ -24,6 +24,8 @@ import shutil
 import subprocess
 from typing import Dict, List
 
+from hermes_cli._subprocess_compat import harden_git_argv, noninteractive_git_env
+
 _GIT_TIMEOUT = 15
 _MAX_UNTRACKED_FILES = 50  # sanity cap so a node_modules explosion can't hang us
 
@@ -31,11 +33,19 @@ VALID_MODES = ("working", "staged", "all")
 
 
 def _run(args: List[str], cwd: str, timeout: int = _GIT_TIMEOUT):
-    """Run git, returning (returncode, stdout). Never raises on git failure."""
+    """Run git, returning (returncode, stdout). Never raises on git failure.
+
+    Hardened against a malicious repo's ``.git/config`` (GHSA-7x36-8jrh-v4pw):
+    ``noninteractive_git_env`` disables fsmonitor/hooks/pager/editor/credential
+    sinks, and ``harden_git_argv`` appends ``--no-ext-diff --no-textconv`` to
+    the diff-rendering subcommands so attribute-scoped diff/textconv drivers
+    can't execute either.
+    """
     proc = subprocess.run(
-        ["git", "-c", "core.quotePath=false", *args],
+        ["git", "-c", "core.quotePath=false", *harden_git_argv(args)],
         cwd=cwd, capture_output=True, text=True, timeout=timeout,
         encoding="utf-8", errors="replace",
+        stdin=subprocess.DEVNULL, env=noninteractive_git_env(),
     )
     return proc.returncode, proc.stdout
 


### PR DESCRIPTION
## Summary
A repository delivered as files with its `.git` directory intact can no longer execute host code when Hermes opens it. Hermes gathers workspace context by running the system `git` against the session directory automatically — before any prompt, tool call, approval, or trust gate — and those probes ran without stripping the repository's own config. Several git settings are command-execution sinks, so a malicious `.git/config` got **arbitrary code execution as the user, outside the sandbox, with nothing on screen**.

Reported as **GHSA-7x36-8jrh-v4pw** (CVE-2026-71963), part of the cross-vendor "GitSpawn" class also found in Claude Code, Goose (CVE-2026-72718), Qwen Code, Grok Build, Codex, and Cursor.

Delivery is the give-away: `git clone` never transfers `.git/config`, so the vector is anything that moves a directory instead of cloning it — a shared `.zip`, sync folder, or USB stick.

## Root cause
`agent/coding_context.py::_git()` (and its twin `tui_gateway.git_probe`, plus `/diff`, `@diff`/`@staged` context refs, the goal-gate fingerprint, and `-w` startup worktree-add) ran `git status`/`diff`/`worktree add` against the session repo with no config hardening. An index refresh runs the repo-configured `core.fsmonitor` program; checkout runs `core.hooksPath` hooks; and an attribute-scoped `[diff "x"] command=`/`textconv=` driver runs on any diff render.

## Changes
- `hermes_cli/_subprocess_compat.py`:
  - `bounded_git_probe` (the reported sink) now defaults to `noninteractive_git_env()` — pins `core.fsmonitor`/`hooksPath`/pager/editor/credential to inert values via `GIT_CONFIG_*` and ignores global/system config.
  - New `harden_git_argv()` + `NO_DRIVER_DIFF_FLAGS`: inserts `--no-ext-diff --no-textconv` on **diff-rendering** subcommands only (`diff`/`show`/`log`/`blame`) — `status` et al reject the flags. This is the one class env overrides can't reach, because the attacker names the driver in `.gitattributes`.
  - `bounded_probe_run` gains an `env=` passthrough.
- Routed every **automatic** git path through the hardened env (+ argv flags where they render diffs): `tools/working_diff.py`, `hermes_cli/web_git.py`, `agent/context_references.py`, `hermes_cli/goals.py`, `tools/subagent_worktree.py`, and the `-w` startup `worktree add` in `cli.py`.
- `tests/security/test_gitspawn_config_injection.py`: real-git E2E suite that arms a malicious repo and asserts every path neutralizes fsmonitor/hooks/external-diff/textconv, plus `harden_git_argv` unit coverage. A baseline test proves the repo is actually armed (so the suite can't silently pass).

Builds on the `noninteractive_git_env` config-scrubbing already staged in the gemini-cli #28792 port (preserved as the parent commit).

## Validation
**Live repro** — armed malicious repo (`[core] fsmonitor = "touch MARKER"` + `hooksPath` + attribute-scoped `[diff "evil"] command=/textconv=`), exercised each real code path with real imports:

| Path (auto-fires before any prompt) | Before | After |
|---|---|---|
| coding-workspace snapshot (`git status`) | FIRED | blocked |
| gateway project-tree probe | FIRED | blocked |
| `/diff` working-diff (fsmonitor + ext-diff) | FIRED | blocked |
| goal-gate fingerprint | FIRED | blocked |
| subagent worktree-add (checkout hook) | FIRED | blocked |
| web_git status + diff (fsmonitor + ext-diff) | FIRED | blocked |
| `@diff` context ref (fsmonitor + ext-diff) | FIRED | blocked |
| **Totals** | **10/10 sinks fire** | **10/10 blocked** |

| Check | Result |
|---|---|
| `tests/security/test_gitspawn_config_injection.py` + `test_noninteractive_git.py` | 23 passed |
| working_diff / context_references / subagent_worktree / coding_context / goals | 106 passed |
| bounded-probe / git-probe-tree-kill / windows-flags / lazy-secrets | 28 passed, 3 skipped |
| web_server git | 6 passed |

Flag necessity verified empirically: `--no-ext-diff` alone leaves `textconv=` live; `--no-textconv` alone leaves `command=` live — both required.

## Infographic

![GitSpawn RCE class closed](https://v3b.fal.media/files/b/0aa8d5e5/_4l8Vx602Is6u9g-Vquzm_lx7PXhdv.png)
