### PR TITLE
fix(mcp): warn when a granted OAuth token exceeds the configured oauth.scope

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -160,6 +160,99 @@ class TestHermesTokenStorage:
         import asyncio
         assert asyncio.run(storage.get_tokens()) is None
 
+    # -- oauth.scope not honoured warning (#101467) --------------------------
+
+    @staticmethod
+    def _token_with_scope(scope):
+        mock_token = MagicMock()
+        payload = {
+            "access_token": "abc123",
+            "token_type": "Bearer",
+        }
+        if scope is not None:
+            payload["scope"] = scope
+        mock_token.model_dump.return_value = payload
+        return mock_token
+
+    def test_granted_scope_exceeding_configured_warns(self, tmp_path, monkeypatch, caplog):
+        """A granted scope wider than the configured oauth.scope must warn.
+
+        Regression for #101467: the MCP SDK overwrites client_metadata.scope
+        with every server-advertised scope before registration, silently
+        discarding the configured narrow scope. The warning is the only
+        Hermes-side signal the knob was ignored.
+        """
+        import logging
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage(
+            "bonusly", configured_scope="user:read recognition:write"
+        )
+
+        with caplog.at_level(logging.WARNING, logger="tools.mcp_oauth"):
+            asyncio.run(
+                storage.set_tokens(
+                    self._token_with_scope(
+                        "user:read recognition:write billing:administer user:administer"
+                    )
+                )
+            )
+
+        assert "was NOT honoured" in caplog.text
+        assert "billing:administer" in caplog.text
+        assert "user:read recognition:write" in caplog.text
+
+    def test_sdk_appended_offline_access_does_not_warn(self, tmp_path, monkeypatch, caplog):
+        """offline_access is appended by the SDK itself (SEP-2207), not a leak."""
+        import logging
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("srv", configured_scope="read write")
+
+        with caplog.at_level(logging.WARNING, logger="tools.mcp_oauth"):
+            asyncio.run(
+                storage.set_tokens(self._token_with_scope("read write offline_access"))
+            )
+
+        assert "was NOT honoured" not in caplog.text
+
+    def test_granted_subset_of_configured_does_not_warn(self, tmp_path, monkeypatch, caplog):
+        """A server narrowing the grant is the AS's prerogative, not this bug."""
+        import logging
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("srv", configured_scope="read write admin")
+
+        with caplog.at_level(logging.WARNING, logger="tools.mcp_oauth"):
+            asyncio.run(storage.set_tokens(self._token_with_scope("read")))
+
+        assert "was NOT honoured" not in caplog.text
+
+    def test_no_configured_scope_never_warns(self, tmp_path, monkeypatch, caplog):
+        import logging
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("srv")
+
+        with caplog.at_level(logging.WARNING, logger="tools.mcp_oauth"):
+            asyncio.run(
+                storage.set_tokens(self._token_with_scope("read write admin"))
+            )
+
+        assert "was NOT honoured" not in caplog.text
+
+    def test_configured_scope_without_granted_scope_does_not_warn(self, tmp_path, monkeypatch, caplog):
+        """No scope on the token (server omitted it) — nothing to compare."""
+        import logging
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("srv", configured_scope="read write")
+
+        with caplog.at_level(logging.WARNING, logger="tools.mcp_oauth"):
+            asyncio.run(storage.set_tokens(self._token_with_scope(None)))
+
+        assert "was NOT honoured" not in caplog.text
+
 
 # ---------------------------------------------------------------------------
 # build_oauth_auth

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -465,9 +465,16 @@ class HermesTokenStorage:
         HERMES_HOME/mcp-tokens/<server_name>.cimd-off      -- CIMD refused here
     """
 
-    def __init__(self, server_name: str, *, hermes_home: str | Path | None = None):
+    def __init__(
+        self,
+        server_name: str,
+        *,
+        hermes_home: str | Path | None = None,
+        configured_scope: str | None = None,
+    ):
         self._server_name = _safe_filename(server_name)
         self._hermes_home = Path(hermes_home) if hermes_home is not None else None
+        self._configured_scope = configured_scope
 
     def _tokens_path(self) -> Path:
         return _get_token_dir(self._hermes_home) / f"{self._server_name}.json"
@@ -542,7 +549,46 @@ class HermesTokenStorage:
                 # rather than fail persistence.
                 pass
         _write_json(self._tokens_path(), payload)
+        self._warn_if_scope_not_honoured(payload.get("scope"))
         logger.debug("OAuth tokens saved for %s", self._server_name)
+
+    def _warn_if_scope_not_honoured(self, granted_scope: str | None) -> None:
+        """Warn when the granted token exceeds the configured ``oauth.scope``.
+
+        The MCP SDK unconditionally overwrites ``client_metadata.scope`` with
+        every scope advertised by the server (WWW-Authenticate scope, then PRM
+        ``scopes_supported``, then AS ``scopes_supported``) before client
+        registration, so a configured narrow scope is silently discarded and
+        the client requests — and is granted — maximum privilege
+        (modelcontextprotocol/python-sdk#2317). Until that lands upstream,
+        this is the only Hermes-side signal that the knob did nothing.
+
+        ``offline_access`` is excluded from the comparison: the SDK appends it
+        itself (SEP-2207) whenever the AS supports it and the client has the
+        ``refresh_token`` grant, which Hermes always requests.
+        """
+        if not self._configured_scope or not granted_scope:
+            return
+        try:
+            configured = set(self._configured_scope.split())
+            granted = set(granted_scope.split())
+        except AttributeError:
+            return
+        extras = granted - configured - {"offline_access"}
+        if not extras:
+            return
+        logger.warning(
+            "MCP OAuth '%s': configured oauth.scope=%r was NOT honoured — the "
+            "granted token additionally carries %r (full grant: %r). The MCP "
+            "SDK replaces the configured scope with every scope the server "
+            "advertises before registration (modelcontextprotocol/python-sdk#2317). "
+            "Check the consent screen actually shown; the token may hold more "
+            "privilege than configured.",
+            self._server_name,
+            self._configured_scope,
+            " ".join(sorted(extras)),
+            granted_scope,
+        )
 
     # -- client info -------------------------------------------------------
 
@@ -1911,7 +1957,7 @@ def build_oauth_auth(
     apply_oauth_provider_defaults(
         cfg, server_name=server_name, server_url=server_url
     )
-    storage = HermesTokenStorage(server_name)
+    storage = HermesTokenStorage(server_name, configured_scope=cfg.get("scope"))
 
     if not _is_interactive() and not storage.has_cached_tokens():
         raise OAuthNonInteractiveError(

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -725,7 +725,7 @@ class MCPOAuthManager:
         apply_oauth_provider_defaults(
             cfg, server_name=server_name, server_url=entry.server_url
         )
-        storage = HermesTokenStorage(server_name)
+        storage = HermesTokenStorage(server_name, configured_scope=cfg.get("scope"))
 
         from tools.mcp_dashboard_oauth import get_dashboard_oauth_flow
 


### PR DESCRIPTION
## What does this PR do?

`mcp_servers.<name>.oauth.scope` is documented as a working config key, and Hermes does pass it into `OAuthClientMetadata` — but the MCP SDK unconditionally overwrites `client_metadata.scope` with every scope the server advertises (WWW-Authenticate scope, then PRM `scopes_supported`, then AS `scopes_supported`) in `mcp/client/auth/oauth2.py` `Step 3: Apply scope selection strategy`, before client registration. The result: every OAuth MCP connector requests — and is granted — maximum privilege, and the operator's narrow scope is silently discarded (no error, no warning).

The override lives inside the SDK's `async_auth_flow`, past every hook Hermes has, so a behavioural fix on our side would mean monkey-patching the SDK (version-coupled patch burden). Upstream fix is tracked as modelcontextprotocol/python-sdk#2317 (open since 2026-03-20).

This PR implements the warning option from the issue: `HermesTokenStorage.set_tokens` now compares the granted token's `scope` against the configured `oauth.scope` and logs a loud warning naming both whenever the grant carries scopes outside the configuration. The token's granted scope is the final authority — it reflects what the consent screen actually granted, after registration and the authorize round-trip — and `set_tokens` is the one Hermes-owned seam the SDK always calls on the way through.

`offline_access` is excluded from the comparison: the SDK appends it itself (SEP-2207) whenever the AS supports it and the client has the `refresh_token` grant, which Hermes always requests — flagging it would warn on every server.

Why warn-only and not re-assert: re-asserting the configured scope after the SDK's selection would require patching SDK internals, and (as noted in the issue discussion) some registration endpoints may reject scopes absent from `scopes_supported`. A warning cannot break any server; it removes the "silent" part that made this hard to attribute, and it fires exactly when the operator's least-privilege intent was not honoured.

## Related Issue

Fixes #101467

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_oauth.py` — `HermesTokenStorage.__init__` accepts a new keyword-only `configured_scope` (default `None`, fully backwards compatible); `set_tokens` calls the new `_warn_if_scope_not_honoured` helper which logs a warning when the granted scope set exceeds the configured set (minus `offline_access`).
- `tools/mcp_oauth.py` — `build_oauth_auth` passes the effective configured scope (`cfg.get("scope")` after `apply_oauth_provider_defaults`, so provider defaults like Figma's `mcp:connect` are covered too) into the storage.
- `tools/mcp_oauth_manager.py` — the manager's parallel provider-construction path passes the same `configured_scope` into its `HermesTokenStorage`.
- `tests/tools/test_mcp_oauth.py` — five regression tests: exceeding grant warns (naming both scopes), SDK-appended `offline_access` does not warn, server-narrowed grant does not warn, no configured scope never warns, missing granted scope does not warn.

## How to Test

1. `.venv/bin/python -m pytest tests/tools/test_mcp_oauth.py -q` — all pass, including the five new `#101467` tests.
2. Red/green proof: with the source change stashed, `test_granted_scope_exceeding_configured_warns` FAILS (the silent-discard behaviour the issue reports); with the change applied it passes.
3. Full MCP OAuth family: `.venv/bin/python -m pytest tests/tools/test_mcp_oauth.py tests/tools/test_mcp_oauth_manager.py tests/tools/test_mcp_oauth_bidirectional.py tests/tools/test_mcp_oauth_cold_load_expiry.py tests/tools/test_mcp_oauth_metadata.py tests/tools/test_mcp_oauth_user_agent.py tests/tools/test_mcp_dashboard_oauth.py tests/tools/test_mcp_cimd.py -q` — Observed result: 158 passed, 0 failed.
4. `ruff check tools/mcp_oauth.py tools/mcp_oauth_manager.py tests/tools/test_mcp_oauth.py` — All checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (helper docstring documents the behaviour and the upstream reference)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no new config key; the warning concerns the existing `oauth.scope` key)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure Python logging change, no platform surface)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
