### PR TITLE
fix(security): avoid Havoc brand false positives

### DIFF
--- a/tests/tools/test_threat_patterns.py
+++ b/tests/tools/test_threat_patterns.py
@@ -80,6 +80,22 @@ class TestBrainwormPayload:
         )
 
 
+class TestKnownC2FrameworkNames:
+    def test_havoc_brand_name_does_not_block_project_context(self):
+        findings = scan_for_threats(
+            "Route Saint Havoc merchandising research to Scout.",
+            scope="context",
+        )
+        assert "known_c2_framework" not in findings
+
+    @pytest.mark.parametrize(
+        "text",
+        ["Havoc C2", "Havoc framework", "Havoc teamserver", "Havoc listener", "Havoc demon"],
+    )
+    def test_havoc_security_context_is_still_detected(self, text):
+        assert "known_c2_framework" in scan_for_threats(text, scope="context")
+
+
 # =========================================================================
 # Individual promptware / C2 patterns
 # =========================================================================

--- a/tools/threat_patterns.py
+++ b/tools/threat_patterns.py
@@ -112,7 +112,10 @@ _PATTERNS: List[Tuple[str, str, str]] = [
     # blocked. "praxis" was removed for exactly this reason — it's a common
     # word and a legitimate agent name (Greek for practice/action), not a
     # C2-specific tell like the brands below.
-    (r'\b(?:cobalt\s*strike|sliver|havoc|mythic|metasploit|brainworm)\b', "known_c2_framework", "context"),
+    # "Havoc" is also used in ordinary product and brand names, so require
+    # framework-specific context for that one ambiguous token.  The remaining
+    # names are distinctive enough to match standalone.
+    (r'\b(?:cobalt\s*strike|sliver|mythic|metasploit|brainworm)\b|\bhavoc\s+(?:c2|framework|teamserver|listener|demon)\b', "known_c2_framework", "context"),
     (r'\bc2\s+(?:server|channel|infrastructure|beacon)\b', "c2_explicit", "context"),
     (r'\bcommand\s+and\s+control\b', "c2_explicit_long", "context"),
 


### PR DESCRIPTION
## Summary
- stop treating every standalone use of the common word/name `Havoc` as a C2 framework
- preserve detection when `Havoc` appears with framework-specific terms
- add regression coverage for both benign brand context and security context

## Verification
- `uv run --extra dev pytest tests/tools/test_threat_patterns.py -q` (34 passed)
- full project `AGENTS.md` now returns no context-scope findings
