### PR TITLE
fix(mcp): honor oauth.scope as a DCR privilege ceiling

### DIFF
--- a/tests/tools/test_mcp_oauth_scope_ceiling.py
+++ b/tests/tools/test_mcp_oauth_scope_ceiling.py
@@ -1,0 +1,175 @@
+"""oauth.scope is a hard ceiling through SDK discovery and DCR (#101467)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("mcp.client.auth.oauth2", reason="MCP SDK OAuth required")
+
+
+CONFIGURED = "user:read company:read recognition:read rewards:read recognition:write"
+ADVERTISED = ["user:read", "company:read", "billing:administer", "finance:administer"]
+
+
+def _set_interactive_stdin(monkeypatch) -> None:
+    mock_stdin = MagicMock()
+    mock_stdin.isatty.return_value = True
+    monkeypatch.setattr("tools.mcp_oauth.sys.stdin", mock_stdin)
+
+
+def test_configured_scope_survives_sdk_assignment(tmp_path, monkeypatch, caplog):
+    from tools.mcp_oauth import HermesTokenStorage, _build_client_metadata, _configure_callback_port
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    cfg = {"scope": CONFIGURED, "redirect_port": 0}
+    storage = HermesTokenStorage("bonusly")
+    _configure_callback_port(cfg, storage)
+    metadata = _build_client_metadata(cfg)
+
+    assert metadata.scope == CONFIGURED
+    metadata.scope = " ".join(ADVERTISED)
+    assert metadata.scope == CONFIGURED
+    assert "keeping configured oauth.scope" in caplog.text
+
+
+def test_unset_scope_still_accepts_sdk_assignment(tmp_path, monkeypatch):
+    from tools.mcp_oauth import HermesTokenStorage, _build_client_metadata, _configure_callback_port
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    cfg = {"redirect_port": 0}
+    storage = HermesTokenStorage("open")
+    _configure_callback_port(cfg, storage)
+    metadata = _build_client_metadata(cfg)
+
+    metadata.scope = " ".join(ADVERTISED)
+    assert metadata.scope == " ".join(ADVERTISED)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("configured_scope", "expected_scope"),
+    [
+        (CONFIGURED, CONFIGURED),
+        (None, " ".join(ADVERTISED)),
+    ],
+)
+async def test_registration_honors_configured_scope_ceiling(
+    tmp_path, monkeypatch, configured_scope, expected_scope
+):
+    from tools.mcp_tool import sdk_httpx
+
+    httpx = sdk_httpx()
+    from tools.mcp_oauth import (
+        HermesTokenStorage,
+        _build_client_metadata,
+        _configure_callback_port,
+    )
+    from tools.mcp_oauth_manager import _HERMES_PROVIDER_CLS, reset_manager_for_tests
+
+    assert _HERMES_PROVIDER_CLS is not None
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    reset_manager_for_tests()
+
+    cfg = {"redirect_port": 0}
+    if configured_scope is not None:
+        cfg["scope"] = configured_scope
+    storage = HermesTokenStorage("scoped-registration")
+    _configure_callback_port(cfg, storage)
+    metadata = _build_client_metadata(cfg)
+    provider = _HERMES_PROVIDER_CLS(
+        server_name="scoped-registration",
+        server_url="https://mcp.example.com/mcp",
+        client_metadata=metadata,
+        storage=storage,
+        redirect_handler=_noop_redirect,
+        callback_handler=_noop_callback,
+    )
+
+    flow = provider.async_auth_flow(
+        httpx.Request("POST", "https://mcp.example.com/mcp")
+    )
+    outbound = await flow.__anext__()
+    outbound = await flow.asend(
+        httpx.Response(
+            401,
+            request=outbound,
+            headers={
+                "www-authenticate": (
+                    'Bearer resource_metadata="https://mcp.example.com/'
+                    '.well-known/oauth-protected-resource"'
+                )
+            },
+        )
+    )
+
+    for _ in range(8):
+        url = str(outbound.url)
+        if url.endswith("/oauth/register"):
+            registration = json.loads(outbound.content)
+            assert registration["scope"] == expected_scope
+            await flow.aclose()
+            return
+
+        if url.endswith("/.well-known/oauth-protected-resource"):
+            response = httpx.Response(
+                200,
+                request=outbound,
+                json={
+                    "resource": "https://mcp.example.com/mcp",
+                    "authorization_servers": ["https://auth.example.com"],
+                    "scopes_supported": ADVERTISED,
+                    "bearer_methods_supported": ["header"],
+                },
+            )
+        elif "/.well-known/oauth-authorization-server" in url:
+            response = httpx.Response(
+                200,
+                request=outbound,
+                json={
+                    "issuer": "https://auth.example.com",
+                    "authorization_endpoint": "https://auth.example.com/oauth/authorize",
+                    "token_endpoint": "https://auth.example.com/oauth/token",
+                    "registration_endpoint": "https://auth.example.com/oauth/register",
+                    "response_types_supported": ["code"],
+                    "grant_types_supported": ["authorization_code", "refresh_token"],
+                    "code_challenge_methods_supported": ["S256"],
+                    "token_endpoint_auth_methods_supported": ["none"],
+                    "scopes_supported": ADVERTISED,
+                },
+            )
+        else:
+            response = httpx.Response(404, request=outbound)
+
+        outbound = await flow.asend(response)
+
+    await flow.aclose()
+    raise AssertionError("OAuth flow never reached dynamic client registration")
+
+
+def test_manager_rebuilds_provider_when_scope_tightens(tmp_path, monkeypatch):
+    from tools.mcp_oauth_manager import MCPOAuthManager, reset_manager_for_tests
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+    reset_manager_for_tests()
+    manager = MCPOAuthManager()
+    url = "https://mcp.example.com/mcp"
+
+    wide = manager.get_or_build_provider("mesh", url, {"scope": "openid read write"})
+    tight = manager.get_or_build_provider("mesh", url, {"scope": "openid read"})
+
+    assert tight is not wide
+    assert tight.context.client_metadata.scope == "openid read"
+    tight.context.client_metadata.scope = "openid read write"
+    assert tight.context.client_metadata.scope == "openid read"
+
+
+async def _noop_redirect(_url: str) -> None:
+    return None
+
+
+async def _noop_callback() -> tuple[str, str | None]:
+    raise AssertionError("callback handler should not be invoked")

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -33,7 +33,7 @@ Configuration in config.yaml::
         oauth:                                  # all fields optional
           client_id: "pre-registered-id"        # skip dynamic registration
           client_secret: "secret"               # confidential clients only
-          scope: "read write"                   # default: server-provided
+          scope: "read write"                   # hard ceiling; default: server-provided
           redirect_port: 0                      # 0 = auto-pick free port
           redirect_uri: "https://proxy/callback"  # default: loopback callback
           redirect_host: "localhost"            # loopback hostname (WAF-safe)
@@ -1687,6 +1687,60 @@ def apply_oauth_provider_defaults(
     return cfg
 
 
+_PinnedOAuthClientMetadata: Any = None
+
+
+def _pin_explicit_scope(
+    metadata: "OAuthClientMetadata", scope: str
+) -> "OAuthClientMetadata":
+    """Return metadata whose configured scope cannot be widened by the SDK.
+
+    The MCP SDK's ``async_auth_flow`` Step 3 assigns
+    ``client_metadata.scope = get_client_metadata_scopes(...)``. That helper
+    never sees the caller's value: if protected-resource metadata advertises
+    ``scopes_supported``, it requests the entire list. Hermes documents
+    ``oauth.scope`` as a working knob, so an explicit value is a least-privilege
+    ceiling for registration and authorization — not a hint the SDK may drop.
+
+    The subclass otherwise serializes like the SDK model. Narrowing after pin
+    (including ``insufficient_scope`` step-up that would add scopes) is refused
+    on purpose; widen the config if the operator needs more privilege.
+    """
+    global _PinnedOAuthClientMetadata
+
+    metadata_type = type(metadata)
+    cached = _PinnedOAuthClientMetadata
+    if cached is None or getattr(cached, "__bases__", (None,))[0] is not metadata_type:
+
+        class _ExplicitScopeMetadata(metadata_type):
+            def __setattr__(self, name: str, value: Any) -> None:
+                if (
+                    name == "scope"
+                    and self.__dict__.get("_hermes_explicit_scope") is not None
+                ):
+                    pinned = self.__dict__["_hermes_explicit_scope"]
+                    if value != pinned:
+                        logger.warning(
+                            "MCP OAuth: SDK overwrote client_metadata.scope "
+                            "(%r) with %r; keeping configured oauth.scope %r",
+                            pinned,
+                            value,
+                            pinned,
+                        )
+                    return
+                super().__setattr__(name, value)
+
+        _ExplicitScopeMetadata.__name__ = "PinnedOAuthClientMetadata"
+        _ExplicitScopeMetadata.__qualname__ = "PinnedOAuthClientMetadata"
+        _ExplicitScopeMetadata.__module__ = __name__
+        _PinnedOAuthClientMetadata = _ExplicitScopeMetadata
+
+    dumped = metadata.model_dump(by_alias=True, mode="json", exclude_none=True)
+    pinned = _PinnedOAuthClientMetadata.model_validate(dumped)
+    object.__setattr__(pinned, "_hermes_explicit_scope", scope)
+    return pinned
+
+
 def _build_client_metadata(cfg: dict) -> "OAuthClientMetadata":
     """Build OAuthClientMetadata from the oauth config dict.
 
@@ -1728,12 +1782,16 @@ def _build_client_metadata(cfg: dict) -> "OAuthClientMetadata":
         metadata_kwargs["scope"] = scope
 
     try:
-        return OAuthClientMetadata.model_validate(metadata_kwargs)
+        metadata = OAuthClientMetadata.model_validate(metadata_kwargs)
     except Exception:
         # mcp 1.x metadata models predate SEP-837 and reject the unknown
         # field — retry without it rather than failing the whole flow.
         metadata_kwargs.pop("application_type", None)
-        return OAuthClientMetadata.model_validate(metadata_kwargs)
+        metadata = OAuthClientMetadata.model_validate(metadata_kwargs)
+
+    # Empty string is treated as unset (same as today): pin only a real scope
+    # so we do not register with an explicit empty scope field.
+    return _pin_explicit_scope(metadata, scope) if scope else metadata
 
 
 def _invalidate_tokens_on_client_change(

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -642,8 +642,8 @@ class MCPOAuthManager:
         """Return a cached OAuth provider for ``server_name`` or build one.
 
         Idempotent: repeat calls with the same name return the same instance.
-        If ``server_url`` changes for a given name, the cached entry is
-        discarded and a fresh provider is built.
+        If ``server_url`` or ``oauth.scope`` changes for a given name, the
+        cached entry is discarded and a fresh provider is built.
 
         Returns None if the MCP SDK's OAuth support is unavailable.
         """
@@ -656,6 +656,17 @@ class MCPOAuthManager:
                     server_name, entry.server_url, server_url,
                 )
                 entry = None
+
+            if entry is not None:
+                old_scope = (entry.oauth_config or {}).get("scope")
+                new_scope = (oauth_config or {}).get("scope")
+                if old_scope != new_scope:
+                    logger.info(
+                        "MCP OAuth '%s': oauth.scope changed from %r to %r, "
+                        "discarding cached provider",
+                        server_name, old_scope, new_scope,
+                    )
+                    entry = None
 
             if entry is None:
                 entry = _ProviderEntry(

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -370,10 +370,13 @@ mcp_servers:
     url: "https://mcp.example.com/mcp"
     auth: oauth
     oauth:
+      scope: "user:read company:read"                           # least-privilege ceiling
       client_metadata_url: "https://example.com/my-cimd.json"  # self-hosted document
       cimd: false                                              # force DCR
       user_agent: "My-MCP-Client/1.0"                          # token-request User-Agent
 ```
+
+`oauth.scope` is a **hard ceiling** for Dynamic Client Registration and the authorize request. The MCP SDK otherwise requests every scope listed in the server's `scopes_supported`. When this key is set, Hermes keeps that value even if discovery advertises a wider list, and logs a warning if the SDK tries to overwrite it. Omit the key to keep the SDK's default (all advertised scopes).
 
 `client_metadata_url` must be an HTTPS URL with a path (no bare origin, no fragment, no userinfo, no `.`/`..` segments) that returns `200` and `Content-Type: application/json` with **no redirect** — authorization servers are forbidden from following redirects when fetching it. Hermes still pins its callback to the same `27890`–`27894` range, so a self-hosted document must declare all ten loopback URIs (`http://127.0.0.1:<port>/callback` and `http://localhost:<port>/callback` for each port), and its `client_id` must be its own URL.
 

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -267,7 +267,11 @@ mcp_servers:
   linear:
     url: "https://mcp.linear.app/mcp"
     auth: oauth
+    oauth:
+      scope: "read"   # optional ceiling; omit to request every advertised scope
 ```
+
+`oauth.scope` is the privilege ceiling Hermes registers and authorizes with. Hosted servers often advertise administrative scopes in `scopes_supported`; without this key the MCP SDK requests that full list. Set a narrow subset when you do not want the consent screen (or the issued token) to include those extras.
 
 On first connect, Hermes prints an authorize URL, opens your browser when possible, and waits for the OAuth callback on a local loopback port. Tokens are cached at `~/.hermes/mcp-tokens/<server>.json` with 0o600 perms; subsequent runs reuse them silently until refresh fails.
 


### PR DESCRIPTION
## What does this PR do?

The MCP SDK overwrites `client_metadata.scope` during discovery with every entry in the server's `scopes_supported`. Hermes already copied `oauth.scope` into client metadata, then registered and authorized for the full advertised list. An operator who configured five Bonusly scopes still registered all 37, including `billing:administer` and `finance:administer`.

This treats an explicit `oauth.scope` as a privilege ceiling: SDK assignment cannot widen it, a warning names both values if the SDK tries, and a cached provider is rebuilt when the configured scope changes.

## Related Issue

Fixes #101467

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/mcp_oauth.py` — pin configured scope on `OAuthClientMetadata`; warn if the SDK tries to replace it
- `tools/mcp_oauth_manager.py` — discard the cached provider when `oauth.scope` changes
- `tests/tools/test_mcp_oauth_scope_ceiling.py` — assignment, DCR registration, and cache rebuild
- `website/docs/reference/mcp-config-reference.md` and `website/docs/user-guide/features/mcp.md` — document `oauth.scope`

## How to Test

1. Configure an OAuth MCP server whose protected-resource metadata advertises `scopes_supported`, and set `oauth.scope` to a narrower subset.
2. Run `hermes mcp login <server>`, or drive `async_auth_flow` through discovery until `POST /oauth/register`.
3. Confirm the register body and `$HERMES_HOME/mcp-tokens/<server>.client.json` contain only the configured scopes, not the full advertised list.

```text
scripts/run_tests.sh tests/tools/test_mcp_oauth_scope_ceiling.py tests/tools/test_mcp_oauth.py tests/tools/test_mcp_oauth_manager.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
GET https://bonus.ly/.well-known/oauth-protected-resource -> 200
prm_scopes 37

# before
REGISTER_SCOPE user:read company:read user:write user:administer … billing:administer finance:administer …
WIDENED True

# after
REGISTER_SCOPE user:read company:read recognition:read rewards:read recognition:write
KEPT_CEILING True

scripts/run_tests.sh tests/tools/test_mcp_oauth_scope_ceiling.py tests/tools/test_mcp_oauth.py tests/tools/test_mcp_oauth_manager.py -q
# 5 + 72 surrounding OAuth tests passed
```