### PR TITLE
fix(gateway): normalize model identifiers before provider dispatch (#101424)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -402,6 +402,39 @@ def is_grok_46_family(model: str) -> bool:
     return name == "grok-4.6" or name.startswith("grok-4.6-")
 
 
+# OpenAI/Codex Responses models that ACCEPT the ``reasoning.effort`` dial
+# on api.openai.com /v1/responses.  The Responses API rejects ANY
+# reasoning field on non-reasoning models (gpt-4o*, gpt-4.1*, ...) with
+# 400 "Unsupported parameter: 'reasoning.effort' is not supported with
+# this model" (#101424).  Verified Aug 2026: the o-series and gpt-5
+# family accept the dial; everything else rejects it.  Conservative by
+# design, mirroring the grok allowlist above: a model not listed here
+# gets no effort dial rather than a 400.
+_OPENAI_EFFORT_CAPABLE_PREFIXES = (
+    "gpt-5",
+    "o1",
+    "o3",
+    "o4",
+    "o5",
+)
+
+
+def openai_responses_supports_reasoning_effort(model: str) -> bool:
+    """Return whether an OpenAI/Codex Responses model accepts
+    ``reasoning.effort``.
+
+    Allowlist by prefix, matching bare ``gpt-5.6`` / ``o4-mini`` and
+    aggregator-prefixed ``openai/gpt-5.6`` alike (mirrors
+    ``grok_supports_reasoning_effort``).
+    """
+    name = (model or "").strip().lower()
+    if not name:
+        return False
+    if "/" in name:
+        name = name.rsplit("/", 1)[-1]
+    return any(name.startswith(prefix) for prefix in _OPENAI_EFFORT_CAPABLE_PREFIXES)
+
+
 _CONTEXT_LENGTH_KEYS = (
     "context_length", "context_window", "context_size", "max_context_length", "max_position_embeddings",
     "max_model_len", "max_input_tokens", "max_sequence_length", "max_seq_len", "n_ctx_train", "n_ctx", "ctx_size",

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -224,9 +224,20 @@ def _resolve_reasoning(model: str, params: dict[str, Any]) -> tuple[Any, bool]:
         supported = ACTUAL_RELAY_EFFORTS
     else:
         declared = _profile_declared_efforts(params.get("provider"), model, params.get("base_url"))
-        if declared is not None and not declared:
-            reasoning_enabled = False
-        supported = declared or codex_supported_efforts(model)
+        if declared is not None:
+            if not declared:
+                reasoning_enabled = False
+            supported = declared or codex_supported_efforts(model)
+        else:
+            # OpenAI's native Responses surfaces reject the entire reasoning field for
+            # non-reasoning models; compatible third-party endpoints keep the legacy fallback.
+            from agent.model_metadata import openai_responses_supports_reasoning_effort
+
+            native_openai = (params.get("provider") or "").strip().lower() in (
+                "openai-api", "openai-codex")
+            if native_openai and not openai_responses_supports_reasoning_effort(model):
+                reasoning_enabled = False
+            supported = codex_supported_efforts(model)
     return clamp_effort(reasoning_effort, supported), reasoning_enabled
 
 

--- a/contributors/emails/yoaldrinjoseph@gmail.com
+++ b/contributors/emails/yoaldrinjoseph@gmail.com
@@ -1,0 +1,2 @@
+ALDRIN121
+# PR #101424 (gateway: normalize model identifiers before provider dispatch)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -333,6 +333,42 @@ def _resolve_request_runtime_agent_kwargs(provider: str, target_model: Optional[
         "credential_pool": runtime.get("credential_pool"), "max_tokens": max_tokens}
 
 
+_DEFAULT_MODEL_ALIAS = "default"
+
+
+def _providers_agree(left: str, right: str) -> bool:
+    """Return whether two provider slugs normalize to the same provider."""
+    a, b = (left or "").strip().lower(), (right or "").strip().lower()
+    if not a or not b:
+        return False
+    if a == b:
+        return True
+    try:
+        from hermes_cli.models import normalize_provider
+        return bool(normalize_provider(a)) and normalize_provider(a) == normalize_provider(b)
+    except Exception:
+        return False
+
+
+def _split_prefixed_model_identifier(model: str) -> tuple[str, str]:
+    """Split ``@provider:model`` or ``provider::model`` into routing hint and wire model."""
+    text = (model or "").strip()
+    if not text:
+        return "", text
+    provider, bare = "", text
+    if text.startswith("@"):
+        provider, sep, bare = text[1:].partition(":")
+        if not sep:
+            return "", text
+    elif "::" in text:
+        provider, sep, bare = text.partition("::")
+        if not sep:
+            return "", text
+    if provider and re.match(r"^[a-zA-Z0-9_.-]{2,64}$", provider) and bare.strip():
+        return provider, bare.strip()
+    return "", text
+
+
 def _request_agent_overrides(
     body: Any, *, virtual_model: Optional[str] = None, allow_bare_model: bool = True
 ) -> Dict[str, Any]:
@@ -341,16 +377,26 @@ def _request_agent_overrides(
     The virtual model (``hermes-agent``) means "gateway default". A bare ``model`` without
     ``provider`` is honored only when ``allow_bare_model`` (generic clients hardcode "gpt-4o";
     OpenAI-compatible handlers pass the ``direct_model_requests`` opt-in, Hermes-native
-    endpoints always allow it). An explicit ``provider`` is always honored.
+    endpoints always allow it). An explicit ``provider`` is always honored. Provider-prefixed
+    picker ids are reduced to the real wire model; a conflicting explicit provider is rejected
+    through ``request_error``.
     """
     if not isinstance(body, dict):
         return {}
     overrides: Dict[str, Any] = {}
     provider = _clean_request_string(body.get("provider"))
+    model = _clean_request_string(body.get("model"))
+    prefix_provider, prefixed_model = _split_prefixed_model_identifier(model)
+    if prefix_provider:
+        if provider and not _providers_agree(provider, prefix_provider):
+            overrides["request_error"] = (
+                f"model '{model}' is prefixed with provider '{prefix_provider}', which does not "
+                f"match the request's 'provider': '{provider}'. Drop the prefix or the 'provider' field.")
+            return overrides
+        model, provider = prefixed_model, provider or prefix_provider
     if provider:
         overrides["requested_provider"] = provider
-    model = _clean_request_string(body.get("model"))
-    if model and model != virtual_model and (provider or allow_bare_model):
+    if model and model not in (virtual_model, _DEFAULT_MODEL_ALIAS) and (provider or allow_bare_model):
         overrides["requested_model"] = model
     model_options = body.get("model_options")
     if isinstance(model_options, dict):
@@ -3023,7 +3069,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             route = stored_route or self._resolve_route(body.get("model"))
             session_model = stored_model if (stored_model and stored_route is None) else None
             agent_overrides = _request_agent_overrides(body, virtual_model=self._model_name)
-            selection_error = self._request_route_conflict_error(
+            selection_error = agent_overrides.get("request_error") or self._request_route_conflict_error(
                 session_id=session_id, gateway_session_key=gateway_session_key,
                 requested_model=agent_overrides.get("requested_model"),
                 requested_provider=agent_overrides.get("requested_provider"), route=route)

--- a/gateway/platforms/api_server_openai_routes.py
+++ b/gateway/platforms/api_server_openai_routes.py
@@ -385,7 +385,7 @@ class OpenAICompatRoutesMixin:
         route = self._resolve_route(model_alias)
         overrides = _request_agent_overrides(
             body, virtual_model=self._model_name, allow_bare_model=self._direct_model_requests)
-        err = self._request_route_conflict_error(
+        err = overrides.get("request_error") or self._request_route_conflict_error(
             session_id=session_id, gateway_session_key=gateway_session_key,
             requested_model=overrides.get("requested_model"),
             requested_provider=overrides.get("requested_provider"), route=route)

--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -398,7 +398,7 @@ async def _handle_runs(self, request: "web.Request", *, _api_server) -> "web.Res
     session_id = body.get("session_id") or stored_session_id
     route = self._resolve_route(body.get("model"))
     agent_overrides = _api_server._request_agent_overrides(body, virtual_model=self._model_name)
-    selection_error = self._request_route_conflict_error(
+    selection_error = agent_overrides.get("request_error") or self._request_route_conflict_error(
         session_id=session_id, gateway_session_key=gateway_session_key,
         requested_model=agent_overrides.get("requested_model"),
         requested_provider=agent_overrides.get("requested_provider"), route=route)

--- a/tests/agent/transports/test_101424_openai_reasoning_gate.py
+++ b/tests/agent/transports/test_101424_openai_reasoning_gate.py
@@ -1,0 +1,120 @@
+"""Tests for #101424: non-reasoning OpenAI models must not receive a
+``reasoning`` field on the codex/Responses transport.
+
+The Responses API 400s with "Unsupported parameter: 'reasoning.effort' is
+not supported with this model" when a non-reasoning model (gpt-4o*,
+gpt-4.1*, ...) receives any reasoning field.  Previously the transport's
+no-profile fallback sent the legacy effort vocabulary to every model;
+now the family allowlist suppresses the dial entirely for models that
+reject it, mirroring the grok effort-dial conservatism.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.transports import get_transport
+from agent.model_metadata import openai_responses_supports_reasoning_effort
+
+
+@pytest.fixture
+def transport():
+    import agent.transports.codex  # noqa: F401
+
+    return get_transport("codex_responses")
+
+
+class TestOpenaiFamilyAllowlist:
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "gpt-5",
+            "gpt-5.6",
+            "gpt-5-mini",
+            "o4-mini",
+            "o3",
+            "openai/gpt-5.6",  # aggregator-prefixed
+        ],
+    )
+    def test_reasoning_families_accept_effort(self, model):
+        assert openai_responses_supports_reasoning_effort(model) is True
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "gpt-4o-mini",
+            "gpt-4.1-mini",
+            "gpt-4.5",
+            "gpt-4o",
+            "chatgpt-4o-latest",
+            "openai/gpt-4o-mini",
+            "",  # unknown/blank -> conservative False
+            "some-byok-route",
+        ],
+    )
+    def test_non_reasoning_models_reject_effort(self, model):
+        assert openai_responses_supports_reasoning_effort(model) is False
+
+
+class TestNoProfileFallbackSuppressesNonReasoningModels:
+    def _kwargs(
+        self,
+        transport,
+        model,
+        provider="openai-api",
+        base_url="https://api.openai.com/v1",
+        reasoning_config=None,
+    ):
+        return transport.build_kwargs(
+            model=model,
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            base_url=base_url,
+            session_id="sid",
+            provider=provider,
+            reasoning_config=reasoning_config,
+        )
+
+    def test_openai_api_gpt_4o_mini_gets_no_reasoning_field(self, transport):
+        # openai-api registers no ProviderProfile -> no-profile fallback.
+        # gpt-4o-mini must NOT receive reasoning (it 400s on any such field).
+        kw = self._kwargs(transport, "gpt-4o-mini")
+        assert "reasoning" not in kw
+
+    def test_openai_codex_gpt_4o_mini_gets_no_reasoning_field(self, transport):
+        kw = self._kwargs(
+            transport,
+            "gpt-4o-mini",
+            provider="openai-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+        )
+        assert "reasoning" not in kw
+
+    def test_openai_api_gpt_5_family_still_gets_effort_dial(self, transport):
+        kw = self._kwargs(transport, "gpt-5.6", reasoning_config={"effort": "medium"})
+        assert kw["reasoning"]["effort"] == "medium"
+
+    def test_openai_compatible_byok_keeps_legacy_efforts(self, transport):
+        # A non-OpenAI provider riding the codex transport (BYOK endpoint,
+        # proxy, router without a catalog declaration) still sends the legacy
+        # vocabulary — the family gate is scoped to OpenAI's own surfaces.
+        kw = self._kwargs(
+            transport,
+            "gpt-4o-mini",
+            provider="some-byok-route",
+            base_url="https://generic.example.com/v1",
+            reasoning_config={"effort": "medium"},
+        )
+        assert kw["reasoning"]["effort"] == "medium"
+
+    def test_router_cold_cache_keeps_legacy_default(self, transport):
+        # Regression mirror of test_router_codex_efforts.py: no catalog ->
+        # no declaration -> legacy vocabulary for non-OpenAI providers.
+        kw = self._kwargs(
+            transport,
+            "grok-4.6",
+            provider="router",
+            base_url="https://api.router.com/v1",
+            reasoning_config={"effort": "xhigh"},
+        )
+        assert kw["reasoning"]["effort"] == "xhigh"

--- a/tests/gateway/test_101424_model_identifier_normalization.py
+++ b/tests/gateway/test_101424_model_identifier_normalization.py
@@ -1,0 +1,151 @@
+"""Tests for #101424: model-identifier normalization at the API surface.
+
+The WebUI model picker advertises ``@anthropic:claude-sonnet-5``-style ids
+(and the browser runtime uses ``anthropic::claude-sonnet-5``).  Neither
+form is a valid wire model id — the prefix is a routing hint — yet
+``_request_agent_overrides`` forwarded them verbatim, so the provider API
+404'd on the prefixed string.  ``default`` was also forwarded verbatim
+instead of resolving to the configured default model.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.platforms.api_server import (
+    _request_agent_overrides,
+    _split_prefixed_model_identifier,
+)
+
+
+# ---------------------------------------------------------------------------
+# _split_prefixed_model_identifier
+# ---------------------------------------------------------------------------
+
+
+class TestSplitPrefixedModelIdentifier:
+    @pytest.mark.parametrize(
+        ("model", "expected"),
+        [
+            # WebUI picker form
+            ("@anthropic:claude-sonnet-5", ("anthropic", "claude-sonnet-5")),
+            # browser-runtime / session form
+            ("anthropic::claude-sonnet-5", ("anthropic", "claude-sonnet-5")),
+            # bare ids pass through untouched
+            ("claude-sonnet-5", ("", "claude-sonnet-5")),
+            # vendor/slash ids are NOT this helper's job (normalize_model_for_provider)
+            ("openai/gpt-5", ("", "openai/gpt-5")),
+            ("", ("", "")),
+            (None, ("", "")),
+        ],
+    )
+    def test_forms(self, model, expected):
+        assert _split_prefixed_model_identifier(model) == expected
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            # @ without a colon, malformed slug, empty bare part
+            "@anthropicclaude-sonnet-5",
+            "@:claude-sonnet-5",
+            "@anthropic:",
+            "@an thropic:claude-sonnet-5",
+            "not-a-prefix@at-middle:claude",
+        ],
+    )
+    def test_malformed_never_split(self, model):
+        provider, bare = _split_prefixed_model_identifier(model)
+        assert provider == ""
+        assert bare == model
+
+
+# ---------------------------------------------------------------------------
+# _request_agent_overrides normalization
+# ---------------------------------------------------------------------------
+
+
+class TestPrefixedModelNormalization:
+    def test_matching_prefix_is_stripped_and_provider_kept(self):
+        overrides = _request_agent_overrides({
+            "provider": "anthropic",
+            "model": "@anthropic:claude-sonnet-5",
+        })
+        assert overrides["requested_provider"] == "anthropic"
+        assert overrides["requested_model"] == "claude-sonnet-5"
+        assert "request_error" not in overrides
+
+    def test_prefix_routes_when_no_explicit_provider(self):
+        overrides = _request_agent_overrides({"model": "@anthropic:claude-sonnet-5"})
+        assert overrides["requested_provider"] == "anthropic"
+        assert overrides["requested_model"] == "claude-sonnet-5"
+
+    def test_double_colon_form_is_split_too(self):
+        overrides = _request_agent_overrides({"model": "anthropic::claude-sonnet-5"})
+        assert overrides["requested_provider"] == "anthropic"
+        assert overrides["requested_model"] == "claude-sonnet-5"
+
+    def test_disagreeing_prefix_and_provider_is_an_error(self):
+        overrides = _request_agent_overrides({
+            "provider": "anthropic",
+            "model": "@openai:gpt-5",
+        })
+        assert "requested_model" not in overrides
+        assert "requested_provider" not in overrides
+        err = overrides.get("request_error") or ""
+        assert "anthropic" in err and "openai" in err
+
+    def test_bare_model_with_provider_still_passes_through(self):
+        # The issue's controlled experiment: bare name + provider works, and
+        # must keep working byte-for-byte.
+        overrides = _request_agent_overrides({
+            "provider": "anthropic",
+            "model": "claude-sonnet-5",
+        })
+        assert overrides["requested_provider"] == "anthropic"
+        assert overrides["requested_model"] == "claude-sonnet-5"
+
+    def test_model_options_still_carried(self):
+        overrides = _request_agent_overrides({
+            "provider": "anthropic",
+            "model": "@anthropic:claude-sonnet-5",
+            "model_options": {"reasoning_config": {"effort": "high"}},
+        })
+        assert overrides["model_options"] == {"reasoning_config": {"effort": "high"}}
+
+
+class TestDefaultAliasResolution:
+    def test_default_with_provider_resolves_to_gateway_default(self):
+        # "default" is a resolution instruction: no requested_model means the
+        # agent falls back to model.default from config; the provider still
+        # routes the request.
+        overrides = _request_agent_overrides({
+            "provider": "anthropic",
+            "model": "default",
+        })
+        assert overrides["requested_provider"] == "anthropic"
+        assert "requested_model" not in overrides
+
+    def test_prefixed_default_routes_on_prefix(self):
+        overrides = _request_agent_overrides({"model": "@anthropic:default"})
+        assert overrides["requested_provider"] == "anthropic"
+        assert "requested_model" not in overrides
+
+    def test_virtual_alias_still_means_default(self):
+        overrides = _request_agent_overrides(
+            {"model": "hermes-agent"}, virtual_model="hermes-agent"
+        )
+        assert "requested_model" not in overrides
+
+
+class TestBareModelGateUnchanged:
+    def test_bare_model_dropped_when_disallowed(self):
+        overrides = _request_agent_overrides(
+            {"model": "openai/gpt-5"}, allow_bare_model=False
+        )
+        assert "requested_model" not in overrides
+
+    def test_bare_model_honored_when_allowed(self):
+        overrides = _request_agent_overrides(
+            {"model": "openai/gpt-5"}, allow_bare_model=True
+        )
+        assert overrides["requested_model"] == "openai/gpt-5"


### PR DESCRIPTION
## What does this PR do?

Three symptoms, one root cause: model identifiers from the API surface reached the provider transport **verbatim**. The WebUI model picker advertises prefixed ids (`@anthropic:claude-sonnet-5`) so a selection is unambiguous across providers — but that prefix is a routing hint, not a wire model id, and the provider API 404'd on the prefixed string (`HTTP 404: model: "@anthropic:claude-sonnet-5"`, proven by the issue's controlled experiment: bare name completes, prefixed name fails). Two more symptoms shared the same gap: the literal `"default"` alias was forwarded instead of resolving to `model.default`, and `reasoning.effort` was injected for OpenAI models that reject any reasoning field.

**Fix 1 — normalize at the ingestion choke point.** `_request_agent_overrides()` is the single funnel for every external caller (`POST /v1/runs`, session chat sync/stream, `/v1/chat/completions`, `/v1/responses`). It now:
- splits provider-prefixed ids (`@anthropic:claude-sonnet-5` from the WebUI picker, `anthropic::claude-sonnet-5` from the browser runtime) into a routing provider + bare model, so a prefixed id behaves exactly like the working bare-model case;
- routes on the prefix when no explicit `provider` is given;
- returns a 400 `request_error` when a prefixed id disagrees with an explicit `provider` (callers surface it through the existing `selection_error` path) instead of silently misrouting;
- treats `"default"` as a resolution instruction — leaves `requested_model` unset so the agent falls back to `model.default` from config, while any prefix/explicit provider still routes the request.

**Fix 2 — gate `reasoning.effort` for OpenAI models that reject it.** The codex/Responses transport's no-profile fallback sent the legacy effort vocabulary to *every* model. Non-reasoning OpenAI families (`gpt-4o*`, `gpt-4.1*`, ...) 400 with "Unsupported parameter: 'reasoning.effort'". New `openai_responses_supports_reasoning_effort()` family allowlist (o-series + gpt-5, mirroring the existing `grok_supports_reasoning_effort` conservatism) suppresses the dial — scoped to OpenAI's own surfaces (`openai-api`, `openai-codex`) so OpenAI-compatible BYOK endpoints/proxies keep the legacy vocabulary they accept.

## Related Issue

Fixes #101424

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/api_server.py` — `_split_prefixed_model_identifier()` + `_providers_agree()` helpers; `_request_agent_overrides()` normalizes prefixed ids, routes on the prefix, resolves `default`, and reports prefix/provider disagreement via `request_error`; all five `selection_error` call sites surface it
- `gateway/platforms/api_server_runs.py` — same `request_error` surfacing in the `/v1/runs` handler
- `agent/transports/codex.py` — no-profile fallback consults the OpenAI family allowlist before sending legacy efforts (native OpenAI providers only)
- `agent/model_metadata.py` — `openai_responses_supports_reasoning_effort()` + `_OPENAI_EFFORT_CAPABLE_PREFIXES`
- `tests/gateway/test_101424_model_identifier_normalization.py` — new: prefix split forms, matching prefix stripped + provider kept, prefix routing, double-colon form, disagreement error, bare-model passthrough preserved, `default`/virtual-alias resolution, `model_options` passthrough, bare-model opt-in gate unchanged
- `tests/agent/transports/test_101424_openai_reasoning_gate.py` — new: family allowlist unit tests; no-profile fallback suppresses reasoning for gpt-4o-mini on `openai-api`/`openai-codex`; gpt-5 family keeps the effort dial; BYOK/router endpoints keep legacy efforts
- `contributors/emails/yoaldrinjoseph@gmail.com` — contributor mapping for the CI attribution gate

## How to Test

```
PYTHONPATH=. python -m pytest tests/gateway/test_101424_model_identifier_normalization.py tests/agent/transports/test_101424_openai_reasoning_gate.py -q        # 39 passed
PYTHONPATH=. python -m pytest tests/gateway/test_api_server.py tests/agent/transports/test_router_codex_efforts.py tests/gateway/test_api_server_runs.py tests/gateway/test_api_server_runs_extraction.py -q   # 237 passed (no regression)
```

Manual repro from the issue: `POST /v1/runs {"provider":"anthropic","model":"@anthropic:claude-sonnet-5","input":"hi"}` now dispatches with bare `claude-sonnet-5` and completes; `{"model":"default"}` resolves to the configured default; a `@openai:` model with `provider: anthropic` returns a clear 400 instead of a provider 404.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(gateway):`, `fix(agent):`, `test(...):`, `chore(contrib):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — targeted suites above green; full suite not run locally (no full dev venv), relied on the repo's existing test layout
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (arm64)
