### PR TITLE
fix(desktop): a saved comment crop shows its own marker, and only its own

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-annotate-host.test.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-annotate-host.test.ts
@@ -57,4 +57,56 @@ describe('preview annotate host', () => {
       y: 20 - ANNOTATE_CROP_PAD
     })
   })
+
+  it('brackets the shot so the crop is taken with only this comment marked', async () => {
+    const order: string[] = []
+
+    const executeJavaScript = vi.fn(async (code: string) => {
+      order.push(code.includes('beginCapture') ? 'begin' : 'end')
+
+      return true
+    })
+
+    const capture = vi.fn(async () => {
+      order.push('capture')
+
+      return 'data:image/png;base64,AA=='
+    })
+
+    await captureAnnotateCrop({ capture, executeJavaScript }, { height: 16, width: 40, x: 10, y: 20 })
+
+    expect(order).toEqual(['begin', 'capture', 'end'])
+  })
+
+  it('restores saved pins even when the capture fails', async () => {
+    const executeJavaScript = vi.fn(async (code: string) => {
+      void code
+
+      return true
+    })
+
+    const capture = vi.fn(async () => {
+      throw new Error('capture exploded')
+    })
+
+    await expect(
+      captureAnnotateCrop({ capture, executeJavaScript }, { height: 16, width: 40, x: 10, y: 20 })
+    ).rejects.toThrow('capture exploded')
+
+    expect(executeJavaScript.mock.calls.some(([code]) => String(code).includes('endCapture'))).toBe(true)
+  })
+
+  it('still captures when the overlay cannot be reached', async () => {
+    const capture = vi.fn(async () => 'data:image/png;base64,AA==')
+
+    const executeJavaScript = vi.fn(async (code: string) => {
+      void code
+
+      throw new Error('guest is gone')
+    })
+
+    await expect(
+      captureAnnotateCrop({ capture, executeJavaScript }, { height: 16, width: 40, x: 10, y: 20 })
+    ).resolves.toContain('data:image/png')
+  })
 })

--- a/apps/desktop/src/app/chat/right-rail/preview-annotate-host.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-annotate-host.ts
@@ -95,6 +95,15 @@ export async function hideAnnotateDraft(guest: PreviewAnnotateGuest): Promise<vo
   `)
 }
 
+/** Guest calls are best-effort dressing: never let one fail the capture. */
+async function tryGuest(guest: PreviewAnnotateGuest, code: string): Promise<void> {
+  try {
+    await guest.executeJavaScript(code)
+  } catch {
+    // The overlay may be mid-teardown or the guest gone. Shoot anyway.
+  }
+}
+
 export async function captureAnnotateCrop(
   guest: PreviewAnnotateGuest,
   rect: AnnotatePinChrome['rect']
@@ -103,5 +112,15 @@ export async function captureAnnotateCrop(
     throw new Error('preview capture is unavailable')
   }
 
-  return guest.capture(padRect(rect))
+  // Bracket the shot: the overlay hides saved pins and waits for a paint, so
+  // the crop carries this comment's marker and no neighbour's. `endCapture`
+  // runs even when the capture throws, or one failed crop leaves every saved
+  // pin invisible on the page.
+  await tryGuest(guest, 'window.__hermesAnnotate ? window.__hermesAnnotate.beginCapture() : null')
+
+  try {
+    return await guest.capture(padRect(rect))
+  } finally {
+    await tryGuest(guest, 'window.__hermesAnnotate && window.__hermesAnnotate.endCapture()')
+  }
 }

--- a/apps/desktop/src/lib/preview-annotate/in-page.test.ts
+++ b/apps/desktop/src/lib/preview-annotate/in-page.test.ts
@@ -224,6 +224,56 @@ describe('annotateInPage overlay', () => {
     api.teardown()
   })
 
+  it('shows the draft marker before a capture can photograph it', async () => {
+    const api = annotateInPage(document)
+    api.install()
+    api.showDraft({ height: 24, width: 80, x: 10, y: 10 }, 2)
+
+    const ready = await api.beginCapture()
+    const shadow = document.querySelector('hermes-annotate')!.shadowRoot!
+    const draft = shadow.querySelector('[data-annotate-outline="draft"]') as HTMLElement
+    const marker = draft.querySelector('[data-annotate-marker]')
+
+    expect(ready).toBe(true)
+    expect(draft.style.display).toBe('block')
+    expect(marker?.getAttribute('data-annotate-marker')).toBe('2')
+    api.teardown()
+  })
+
+  it('hides saved pins during a capture so a neighbour marker cannot land in the crop', async () => {
+    const api = annotateInPage(document)
+    api.install()
+    api.showPins([
+      { kind: 'element', number: 1, rect: { height: 24, width: 80, x: 10, y: 10 } },
+      { kind: 'element', number: 2, rect: { height: 24, width: 80, x: 10, y: 40 } }
+    ])
+    api.showDraft({ height: 24, width: 80, x: 10, y: 70 }, 3)
+
+    const shadow = document.querySelector('hermes-annotate')!.shadowRoot!
+    const pins = () => shadow.querySelector('[data-annotate-pin="1"]')!.parentElement as HTMLElement
+
+    expect(pins().style.display).not.toBe('none')
+
+    await api.beginCapture()
+
+    expect(pins().style.display).toBe('none')
+    // The draft's own marker must survive — it is the point of the crop.
+    expect(
+      (shadow.querySelector('[data-annotate-outline="draft"]') as HTMLElement).style.display
+    ).toBe('block')
+
+    api.endCapture()
+
+    expect(pins().style.display).toBe('block')
+    api.teardown()
+  })
+
+  it('refuses to dress a capture when the overlay is gone', async () => {
+    const api = annotateInPage(document)
+
+    expect(await api.beginCapture()).toBe(false)
+  })
+
   it('owns wheel scrolling instead of also allowing the native wheel action', () => {
     const scroller = document.createElement('div')
     scroller.style.overflowY = 'auto'

--- a/apps/desktop/src/lib/preview-annotate/in-page.ts
+++ b/apps/desktop/src/lib/preview-annotate/in-page.ts
@@ -40,6 +40,8 @@ export interface AnnotatePinChrome {
 }
 
 export interface AnnotateInPage {
+  beginCapture: () => Promise<boolean>
+  endCapture: () => void
   getMarkerNumbers: () => number[]
   getOutlineColor: () => string
   hideDraft: () => void
@@ -732,6 +734,58 @@ export function annotateInPage(doc: Document): AnnotateInPage {
     }
   }
 
+  /**
+   * Two frames. `executeJavaScript` resolving only means the style property is
+   * set — the compositor has not drawn it yet, and `capturePage` grabs whatever
+   * is on screen. Capturing straight after `showDraft` therefore photographs
+   * the page one frame before the marker exists, which is why saved crops came
+   * back outlined but unnumbered. One rAF schedules us before the next paint;
+   * the second lands after it.
+   */
+  const afterPaint = (): Promise<void> =>
+    new Promise(resolve => {
+      if (!win) {
+        resolve()
+
+        return
+      }
+
+      win.requestAnimationFrame(() => win.requestAnimationFrame(() => resolve()))
+    })
+
+  /**
+   * Dress the page for one crop: the draft's own marker, nothing else.
+   *
+   * Saved pins live in the page, so a neighbour's marker lands inside this
+   * crop whenever the two elements sit within the crop padding of each other —
+   * a comment on a heading came back carrying the marker of the comment on the
+   * paragraph below it, and "Image 2 marks the target in blue" then pointed at
+   * a 1. Hover chrome is transient but would be captured just the same.
+   */
+  const beginCapture = async (): Promise<boolean> => {
+    if (!host || !host.isConnected) {
+      return false
+    }
+
+    if (pinsLayer) {
+      style(pinsLayer, { display: 'none' })
+    }
+
+    if (hoverBox) {
+      style(hoverBox, { display: 'none' })
+    }
+
+    await afterPaint()
+
+    return true
+  }
+
+  const endCapture = () => {
+    if (pinsLayer) {
+      style(pinsLayer, { display: 'block' })
+    }
+  }
+
   const teardown = () => {
     unbind()
     emit({ type: 'end' })
@@ -750,6 +804,8 @@ export function annotateInPage(doc: Document): AnnotateInPage {
   }
 
   return {
+    beginCapture,
+    endCapture,
     getMarkerNumbers: () => {
       if (!shadow) {
         return []


### PR DESCRIPTION
## Summary

Follow-up to #101455. Left two comments on one page in the in-app browser and looked at the PNGs that landed in the composer — both were wrong, in two different ways.

| | Expected | Actual |
|---|---|---|
| Comment 1 (`p.sub`) | blue outline + marker **1** | outline, **no marker at all** |
| Comment 2 (`h1`) | blue outline + marker **2** | outline + marker **1** — the *other* comment's |

Both crops say `Image N marks the target in blue` in the prompt, so the agent is told to look for a number that is either absent or belongs to a different element.

Measured rather than eyeballed — counting `#2F80ED` pixels in the marker zone of each attachment:

```
Comment_1  827x129   blue px in top-left marker zone: 135   (a painted badge is ~1200)
Comment_2  946x199   blue px in top-left marker zone: 139
```

Neither crop has a badge at its own origin. Comment 2's `1` is a *neighbour's* pin that drifted into frame.

## Cause 1 — the shot beat the paint

`showDraft` sets the marker's style and its `executeJavaScript` resolves. Resolving means the property is set; it does not mean the compositor has drawn it. `capturePage` then grabs the frame *before* the marker exists.

`beginCapture` now waits two animation frames — the first schedules before the next paint, the second lands after it — so the shot is taken with the marker on screen.

## Cause 2 — neighbouring pins are still on the page

Saved pins are real elements in the overlay. Crops are padded by `ANNOTATE_CROP_PAD` (12px), so any saved pin within that distance of the new element is inside the frame. Comment 1 sat directly under Comment 2's heading, so its marker rode along — and it is the only marker in that crop, which is exactly how the agent gets pointed at the wrong element.

`beginCapture` hides the saved-pin layer and hover chrome for the duration of the shot; `endCapture` restores them.

## Failure modes

- Restore runs in a `finally`, so a capture that throws cannot leave every saved pin invisible on the page.
- The guest calls are best-effort (`tryGuest`): a torn-down overlay or a dead guest degrades to the old unbracketed shot instead of failing the capture. Covered by a test.

## Validation

| Check | Result |
|---|---|
| `npx vitest run src/app/chat/right-rail src/lib/preview-annotate` | 161/161 passed |
| `npx tsc --noEmit -p tsconfig.json` | clean |
| `npx eslint` (touched files) | 0 problems |
| **Reverse-mutation check** | reverting just the fix behaviour fails 3 of the new tests — they bind to the bug, not to the implementation |

The three that fail against merged `main`:
- `hides saved pins during a capture so a neighbour marker cannot land in the crop`
- `brackets the shot so the crop is taken with only this comment marked`
- `restores saved pins even when the capture fails`

Not in scope: per-pin deletion (#101412).