### PR TITLE
feat(desktop): user-selectable HUD orientation

### DIFF
--- a/apps/desktop/src/app/hud/hud-shell.tsx
+++ b/apps/desktop/src/app/hud/hud-shell.tsx
@@ -3,6 +3,7 @@ import { type CSSProperties, useCallback, useEffect, useRef, useState } from 're
 import { useNavigate } from 'react-router'
 
 import { chatMessageText } from '@/lib/chat-messages'
+import { $hudOrientation } from '@/store/hud'
 import { $activeSessionAwaitingInput } from '@/store/prompts'
 import { $busy, $messages } from '@/store/session'
 
@@ -38,10 +39,6 @@ const HUD_DIM_MS = Math.round(HUD_FADE_MS * 1.5)
  *  while the last of the text is still going — it reads as the transcript being
  *  drawn down into the bar rather than the two dissolving in lockstep. */
 const HUD_COLLAPSE_MS = Math.round(HUD_FADE_MS * 0.66)
-
-/** Composer on top, transcript always hanging below it — Spotlight's shape,
- *  rather than flipping to follow the screen edge the HUD is parked against. */
-const HUD_THREAD_ALWAYS_BELOW = true
 
 const composerHasFocus = () => document.activeElement?.closest(`[data-slot="${RICH_INPUT_SLOT}"]`) != null
 
@@ -217,11 +214,14 @@ export function HudShell() {
   useReportHudSession()
   useHudGoto(useNavigate())
 
-  // Which screen EDGE the window is parked against. Parked tight to the top,
-  // the composer flips to the window's top edge and the thread grows DOWN
-  // (data-hud-edge). Computed here from window.screenY — no IPC: the renderer
-  // always knows where its window is. Polled because the DOM has no
-  // window-move event; 300ms is imperceptible for a layout flip.
+  // Which layout the window shows, published to CSS as `data-hud-edge`:
+  // 'top' = composer hugs the window's TOP edge and the band hangs below it;
+  // 'bottom' = composer hugs the BOTTOM edge and the band grows upward.
+  // Driven by the persisted orientation preference ($hudOrientation):
+  // - 'composer-top' / 'composer-bottom' pin the bar to that edge directly.
+  // - 'auto' is edge-aware, computed here from window.screenY — no IPC: the
+  //   renderer always knows where its window is. Polled because the DOM has
+  //   no window-move event; 300ms is imperceptible for a layout flip.
   //
   // EDGE-tight, not a midpoint rule: the first cut compared topGap<bottomGap,
   // which flips the layout the moment the window crosses the vertical center
@@ -229,9 +229,26 @@ export function HudShell() {
   // flips to 'top' only when the HUD is actually parked against the top, and
   // back once it clearly leaves — the gap between the two thresholds is
   // hysteresis so the layout can't flutter while it's dragged along the line.
-  const [edge, setEdge] = useState<'bottom' | 'top'>('top')
+  const orientation = useStore($hudOrientation)
+  // Seeded from the pinned choice so a reopened HUD paints its layout on the
+  // first frame; 'auto' seeds the bottom (composer) layout, which the
+  // measurement corrects a moment later.
+  const [edge, setEdge] = useState<'bottom' | 'top'>(orientation === 'composer-top' ? 'top' : 'bottom')
 
   useEffect(() => {
+    // A pinned orientation wins outright — no measurement, no flip.
+    if (orientation === 'composer-top') {
+      setEdge('top')
+
+      return
+    }
+
+    if (orientation === 'composer-bottom') {
+      setEdge('bottom')
+
+      return
+    }
+
     // Measured on the WINDOW, and flush-only. Flipping is what lets the bar
     // reach the top of the screen at all: the window's top edge can sit against
     // the menu bar, and the flip moves the composer to that edge. Keying it off
@@ -243,15 +260,6 @@ export function HudShell() {
     const FLIP_OFF = 4
 
     const measure = () => {
-      // TRYING IT: the bar stays on top and the transcript always hangs below,
-      // wherever the HUD is parked. Flip the constant to re-enable the
-      // edge-aware layout (the CSS for both orientations is still here).
-      if (HUD_THREAD_ALWAYS_BELOW) {
-        setEdge('top')
-
-        return
-      }
-
       // availTop ≈ menu bar / notch inset on macOS; screenY is in full-screen
       // coordinates, so "parked at the top" means screenY ≈ availTop, not 0.
       const availTop = (window.screen as { availTop?: number }).availTop ?? 0
@@ -268,7 +276,7 @@ export function HudShell() {
       clearInterval(timer)
       window.removeEventListener('resize', measure)
     }
-  }, [])
+  }, [orientation])
 
   const rootRef = useRef<HTMLDivElement | null>(null)
 

--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -42,6 +42,7 @@ import {
   setNested,
   voiceFieldVisible
 } from './helpers'
+import { HudSettings } from './hud-settings'
 import { MemoryConnect } from './memory/connect'
 import { ProviderConfigPanel } from './memory/provider-config-panel'
 import { ModelSettings, ModelSettingsSkeleton } from './model-settings'
@@ -389,8 +390,8 @@ function ConfigSettingsInner({
         </div>
       )}
       {/* Device-local desktop prefs (not config.yaml) — they live here since
-          keeping the machine awake and the global Quick Entry chord are both
-          power-user, this-computer-only knobs. */}
+          keeping the machine awake, the global Quick Entry chord, and the HUD
+          layout are all power-user, this-computer-only knobs. */}
       {activeSectionId === 'advanced' && (
         <>
           <ToggleRow
@@ -406,6 +407,7 @@ function ConfigSettingsInner({
             onChange={setDisableF12}
           />
           <QuickEntrySettings />
+          <HudSettings />
         </>
       )}
       {/* Device-local attach/preview byte cap (main-process IPC guard). Chat is

--- a/apps/desktop/src/app/settings/hud-settings.tsx
+++ b/apps/desktop/src/app/settings/hud-settings.tsx
@@ -1,0 +1,47 @@
+import { useStore } from '@nanostores/react'
+
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { useI18n } from '@/i18n'
+import { $hudOrientation, HUD_ORIENTATIONS, type HudOrientation, setHudOrientation } from '@/store/hud'
+
+import { CONTROL_TEXT } from './constants'
+import { ListRow } from './primitives'
+
+/**
+ * HUD mode — device-local layout rows.
+ *
+ * The orientation choice is pure renderer presentation (the window layout is
+ * computed in the HUD's own renderer, see app/hud/hud-shell), so unlike Quick
+ * Entry there is no main-process round-trip: the store owns it, persists it to
+ * localStorage, and the live HUD picks it up reactively while open.
+ */
+export function HudSettings() {
+  const { t } = useI18n()
+  const c = t.settings.config
+  const orientation = useStore($hudOrientation)
+
+  const labelFor = (value: HudOrientation) =>
+    value === 'auto' ? c.hudOrientationAuto : value === 'composer-top' ? c.hudOrientationTop : c.hudOrientationBottom
+
+  return (
+    <ListRow
+      action={
+        <Select onValueChange={value => setHudOrientation(value as HudOrientation)} value={orientation}>
+          <SelectTrigger className={CONTROL_TEXT}>
+            <SelectValue />
+          </SelectTrigger>
+
+          <SelectContent>
+            {HUD_ORIENTATIONS.map(value => (
+              <SelectItem key={value} value={value}>
+                {labelFor(value)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      }
+      description={c.hudOrientationDesc}
+      title={c.hudOrientationTitle}
+    />
+  )
+}

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -732,7 +732,13 @@ export const en: Translations = {
       attachmentSizeDesc:
         'How big a local file Desktop will load for previews and image attach, in MB. Default is 16. Remote non-image attach uses a separate 256 MB cap. Setting this very high loads the whole file into memory and can freeze or crash the app.',
       attachmentSizeUnit: 'MB',
-      attachmentSizeLabel: 'Max preview / image load size in megabytes'
+      attachmentSizeLabel: 'Max preview / image load size in megabytes',
+      hudOrientationTitle: 'HUD orientation',
+      hudOrientationDesc:
+        'Where the composer bar sits in HUD mode relative to the transcript. Follow screen edge flips the layout when the HUD is parked against the top of the screen.',
+      hudOrientationAuto: 'Follow screen edge',
+      hudOrientationTop: 'Composer on top',
+      hudOrientationBottom: 'Composer on bottom'
     },
     quickEntry: {
       enabledTitle: 'Quick Entry',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -614,6 +614,11 @@ export interface Translations {
       attachmentSizeDesc: string
       attachmentSizeUnit: string
       attachmentSizeLabel: string
+      hudOrientationTitle: string
+      hudOrientationDesc: string
+      hudOrientationAuto: string
+      hudOrientationTop: string
+      hudOrientationBottom: string
     }
     quickEntry: {
       enabledTitle: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -933,7 +933,12 @@ export const zh: Translations = {
       attachmentSizeDesc:
         '桌面端为预览和图片附件加载本地文件的大小上限（MB）。默认为 16。远程非图片附件使用单独的 256 MB 上限。设置过大会将整个文件读入内存，可能导致应用卡死或崩溃。',
       attachmentSizeUnit: 'MB',
-      attachmentSizeLabel: '预览 / 图片加载大小上限（MB）'
+      attachmentSizeLabel: '预览 / 图片加载大小上限（MB）',
+      hudOrientationTitle: 'HUD 方向',
+      hudOrientationDesc: 'HUD 模式下输入栏相对于对话记录的位置。选择“跟随屏幕边缘”时，HUD 停靠到屏幕顶部会自动翻转布局。',
+      hudOrientationAuto: '跟随屏幕边缘',
+      hudOrientationTop: '输入栏在顶部',
+      hudOrientationBottom: '输入栏在底部'
     },
     quickEntry: {
       enabledTitle: '快速输入',

--- a/apps/desktop/src/store/hud.test.ts
+++ b/apps/desktop/src/store/hud.test.ts
@@ -4,7 +4,7 @@ import { $activeGatewayProfile } from '@/store/profile'
 import { $sessions } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
-import { $hudActive, $hudSession, openHud, resetHudLayout } from './hud'
+import { $hudActive, $hudOrientation, $hudSession, openHud, resetHudLayout, setHudOrientation } from './hud'
 
 const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
 const initialHermesDesktop = desktopWindow.hermesDesktop
@@ -45,6 +45,47 @@ describe('resetHudLayout', () => {
     resetHudLayout()
 
     expect(resetLayout).toHaveBeenCalledOnce()
+  })
+})
+
+describe('hud orientation', () => {
+  const ORIENTATION_KEY = 'hermes.desktop.hud.orientation'
+
+  afterEach(() => {
+    window.localStorage.removeItem(ORIENTATION_KEY)
+    setHudOrientation('composer-top')
+  })
+
+  it('boots on the shipped composer-top layout when nothing is stored', async () => {
+    window.localStorage.removeItem(ORIENTATION_KEY)
+    vi.resetModules()
+
+    const { $hudOrientation: fresh } = await import('./hud')
+
+    expect(fresh.get()).toBe('composer-top')
+  })
+
+  it('boots on the persisted choice, and falls back on junk', async () => {
+    window.localStorage.setItem(ORIENTATION_KEY, JSON.stringify('composer-bottom'))
+    vi.resetModules()
+
+    const { $hudOrientation: restored } = await import('./hud')
+
+    expect(restored.get()).toBe('composer-bottom')
+
+    window.localStorage.setItem(ORIENTATION_KEY, '{corrupt')
+    vi.resetModules()
+
+    const { $hudOrientation: fallback } = await import('./hud')
+
+    expect(fallback.get()).toBe('composer-top')
+  })
+
+  it('persists the choice so a reopened HUD restores it', () => {
+    setHudOrientation('composer-bottom')
+
+    expect($hudOrientation.get()).toBe('composer-bottom')
+    expect(JSON.parse(window.localStorage.getItem(ORIENTATION_KEY) ?? '')).toBe('composer-bottom')
   })
 })
 

--- a/apps/desktop/src/store/hud.ts
+++ b/apps/desktop/src/store/hud.ts
@@ -15,6 +15,7 @@
 
 import { atom } from 'nanostores'
 
+import { readJson, writeJson } from '@/lib/storage'
 import { requestComposerDraftSync } from '@/store/composer'
 import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import { $sessions, rememberedSessionProfile } from '@/store/session'
@@ -42,6 +43,46 @@ export const $hudSession = atom<null | string>(null)
 /** True when the shell exposes HUD mode (desktop only). */
 export const canUseHud = (): boolean =>
   typeof window !== 'undefined' && typeof window.hermesDesktop?.hud?.open === 'function'
+
+// ── Orientation ──────────────────────────────────────────────────────────────
+
+/** Where the composer sits relative to the transcript band.
+ *  - `auto`: edge-aware — the band grows AWAY from the screen edge the HUD is
+ *    parked against (parked at the top the composer hugs the top and the
+ *    transcript hangs below; anywhere else the composer sits at the bottom
+ *    and the transcript grows upward). This was the layout until the
+ *    always-below experiment pinned it.
+ *  - `composer-top`: the Spotlight shape — composer pinned to the window's
+ *    top edge, transcript always hanging below, wherever the HUD is parked.
+ *  - `composer-bottom`: mirrored — composer pinned to the bottom edge,
+ *    transcript always above it. */
+export type HudOrientation = 'auto' | 'composer-top' | 'composer-bottom'
+
+export const HUD_ORIENTATIONS: readonly HudOrientation[] = ['auto', 'composer-top', 'composer-bottom']
+
+/** Device-local presentation preference — purely this window's layout, so it
+ *  lives in localStorage (the renderer owns it), scoped under one key. */
+const HUD_ORIENTATION_KEY = 'hermes.desktop.hud.orientation'
+
+const isHudOrientation = (value: unknown): value is HudOrientation =>
+  typeof value === 'string' && (HUD_ORIENTATIONS as readonly string[]).includes(value)
+
+/** The user's orientation choice. The default is `composer-top` — the shipped
+ *  Spotlight shape is preserved verbatim for everyone who never opens the
+ *  setting; `auto` restores the original edge-aware layout and
+ *  `composer-bottom` pins the bar to the bottom edge. */
+export const $hudOrientation = atom<HudOrientation>(readPersistedHudOrientation())
+
+function readPersistedHudOrientation(): HudOrientation {
+  const stored = readJson<unknown>(HUD_ORIENTATION_KEY)
+
+  return isHudOrientation(stored) ? stored : 'composer-top'
+}
+
+export function setHudOrientation(orientation: HudOrientation): void {
+  $hudOrientation.set(orientation)
+  writeJson(HUD_ORIENTATION_KEY, orientation)
+}
 
 export function openHud(sessionId?: null | string): void {
   const api = window.hermesDesktop?.hud


### PR DESCRIPTION
Closes #101493

## What

Replaces the hardcoded `HUD_THREAD_ALWAYS_BELOW = true` experiment flag (landed in 4500b43914, with a `// TRYING IT` comment) with a user-selectable **HUD orientation** preference in **Settings → Advanced**:

- **Composer on top** (default) — the shipped Spotlight shape, byte-for-byte unchanged for anyone who never opens the setting
- **Composer on bottom** — chat bar pinned to the bottom edge, transcript above it (the pre-Aug-8 parked-at-bottom default, now pinned explicitly)
- **Follow screen edge** — restores the original edge-aware flip that the flag disabled

## Why

The flag pinned everyone into one orientation mid-experiment while both orientations' CSS still ships in every build (`styles.css`, "Edge flip" section). HUD users who dock the bar at the bottom of the screen get a layout mirrored from what their parking position wants, with no escape hatch. See #101493 for the full write-up.

## How

- `store/hud.ts`: `HudOrientation` type + `$hudOrientation` nanostore, persisted to `localStorage` under `hermes.desktop.hud.orientation` with a strict allowlist validator (malformed/unknown stored values fall back to `composer-top`). Renderer-owned presentation, so no main-process round-trip — same authority split as other device-local layout prefs.
- `app/hud/hud-shell.tsx`: the pinned orientations set `data-hud-edge` directly; `auto` runs the existing edge-aware measurement (unchanged hysteresis logic). The live HUD reacts to the change without a reopen; the effect now depends on `[orientation]`. The `edge` initial state is seeded from the persisted choice so a reopened HUD paints the right layout on its first frame.
- `app/settings/hud-settings.tsx` + wired into the `advanced` section of `config-settings.tsx` next to Quick Entry, using the existing `ListRow` + `Select` primitives.
- i18n strings in `en.ts` (+ `types.ts`), and `zh.ts` (it declares the `config` block exhaustively, so it must carry them too).

## Tests

- 3 new store tests (boot default with empty storage, persisted restore + corrupt-value fallback via `vi.resetModules()`, persistence round-trip) — `src/store/hud.test.ts`
- `tsc -p .` clean, `eslint` clean on all touched files
- Full desktop suite: **859 files / 9188 tests passed** (6 skipped)

## Not included

- zh-hant/ja/ru/ar locales fall back to English for the new keys via `defineLocale`'s merge (only `zh.ts` *requires* them). A follow-up translation sweep can pick them up.
- The wider HUD settings page from #83210 — this row sits in Advanced for now and would move cleanly into that page if/when it lands.
