### PR TITLE
fix(mcp): _stdio_children_dead() returns True when a child is alive

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2988,15 +2988,13 @@ class MCPServerTask:
         if not pids or self._is_http():
             return False
         for pid in pids:
-            # windows-footgun: ok — psutil.pid_exists handles Windows; the
-            # os.kill probe below only runs when psutil is unavailable.
+            # psutil.pid_exists is the liveness probe — os.kill signal
+            # permission is irrelevant to whether a pid exists.
             import psutil
 
-            if not psutil.pid_exists(pid):
-                continue  # this one is dead
-            return True  # alive (signal permission irrelevant for liveness)
-            return False  # at least one child alive
-        return True
+            if psutil.pid_exists(pid):
+                return False  # at least one child alive → not all dead
+        return True  # every tracked child has exited
 
     async def _watch_stdio_children(self) -> None:
         """Poll child liveness while a stdio RPC is in flight (#81995).


### PR DESCRIPTION
## Problem

Every stdio MCP tool call fails instantly with:

```
MCP stdio subprocess for '<server>' has exited; failing the call fast instead of waiting 300s
```

…even when the server child process is alive and healthy. Restarting Hermes, reloading MCP, or `pkill`-ing the child does not help — the failure recurs in every fresh session.

## Root cause

`MCPClient._stdio_children_dead()` (`tools/mcp_tool.py`) is documented as "True when every stdio child we spawned has exited", and the fast-fail gate (~line 6125) raises the error above whenever it returns True. But the loop's returns were inverted:

```python
for pid in pids:
    if not psutil.pid_exists(pid):
        continue  # this one is dead
    return True   # ← fires when the child is ALIVE
    return False  # ← unreachable dead code
return True
```

`return True` runs on the first *alive* pid, so the method reports "all children dead" whenever any child exists. The fast-fail path then aborts every stdio call before the RPC is even issued. The `return False` on the following line is unreachable, and the trailing `return True` is only reached when the `pids` list is empty of alive entries (i.e. actually all dead) — so the two code paths return the same value.

## Fix

Return `False` as soon as an alive child is found; fall through to `return True` only when all tracked children have exited:

```python
for pid in pids:
    if psutil.pid_exists(pid):
        return False  # at least one child alive → not all dead
return True  # every tracked child has exited
```

## Verification

- `python -m py_compile tools/mcp_tool.py` passes.
- Isolated logic check of the corrected loop: alive pid → `False`, dead pid → `True`, empty list → `False`.
- Real-world: with the patch applied and Hermes restarted, stdio MCP tools (Obelus, Obsidian, SlideForge) respond normally again.
