### PR TITLE
Gateway /goal gate add no longer lets a non-admin reach the host shell (salvage #91677)

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2834,6 +2834,22 @@ class GatewaySlashCommandsMixin:
             if not gate_arg or gate_lower == "list":
                 return mgr.render_gates()
             if gate_lower.startswith("add "):
+                # SECURITY: a gate is persisted and later executed with
+                # shell=True at every goal turn boundary (run_gate), with no
+                # approval prompt. Letting an allowed but non-admin gateway
+                # sender choose that string is authenticated RCE under the
+                # Hermes process account — and with no admin list configured
+                # (the backward-compatible default) every allowed sender is
+                # treated as unrestricted. Gate ONLY this shell-creating
+                # operation behind a real, explicitly-configured admin (the
+                # same fail-closed check that guards cross-origin /resume);
+                # list/remove/clear stay open so a non-admin can still recover.
+                if not self._resume_caller_is_admin(event.source):
+                    return (
+                        "⛔ /goal gate add requires an explicitly configured "
+                        "gateway admin (allow_admin_from for DMs, "
+                        "group_allow_admin_from for groups)."
+                    )
                 command = gate_arg[len("add"):].strip()
                 try:
                     gate = mgr.add_gate(command)

--- a/tests/gateway/test_goal_gate_access.py
+++ b/tests/gateway/test_goal_gate_access.py
@@ -1,0 +1,131 @@
+"""Gateway authorization tests for shell-backed goal quality gates."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.session import SessionSource
+
+
+def _source(user_id: str = "user-1", *, chat_type: str = "dm") -> SessionSource:
+    return SessionSource(
+        platform=Platform.DISCORD,
+        user_id=user_id,
+        chat_id=f"{chat_type}-1",
+        chat_type=chat_type,
+    )
+
+
+def _runner(*, admins=(), group_admins=()):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={
+            Platform.DISCORD: PlatformConfig(
+                enabled=True,
+                extra={
+                    "allow_admin_from": list(admins),
+                    "group_allow_admin_from": list(group_admins),
+                },
+            )
+        }
+    )
+    manager = MagicMock()
+    manager.add_gate.return_value = SimpleNamespace(
+        command="touch /tmp/host-in-the-shell",
+        max_retries=3,
+        timeout_seconds=300,
+    )
+    runner._get_goal_manager_for_event = AsyncMock(
+        return_value=(manager, SimpleNamespace(session_id="session-1"))
+    )
+    return runner, manager
+
+
+def _event(user_id: str = "user-1", *, chat_type: str = "dm"):
+    event = MagicMock()
+    event.source = _source(user_id, chat_type=chat_type)
+    event.get_command_args.return_value = (
+        "gate add touch /tmp/host-in-the-shell"
+    )
+    return event
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("admins", "user_id"),
+    [
+        ((), "user-1"),
+        (("admin-1",), "user-1"),
+    ],
+)
+async def test_gateway_gate_add_requires_explicit_admin(admins, user_id):
+    """Allowed chat users must not turn /goal into an unrestricted host shell."""
+    from gateway.run import GatewayRunner
+
+    runner, manager = _runner(admins=admins)
+
+    result = await GatewayRunner._handle_goal_command(runner, _event(user_id))
+
+    assert "explicitly configured gateway admin" in result
+    manager.add_gate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_gateway_explicit_admin_can_add_goal_gate():
+    """The fix preserves the documented quality-gate capability for operators."""
+    from gateway.run import GatewayRunner
+
+    runner, manager = _runner(admins=("admin-1",))
+
+    result = await GatewayRunner._handle_goal_command(runner, _event("admin-1"))
+
+    assert "Gate added" in result
+    manager.add_gate.assert_called_once_with(
+        "touch /tmp/host-in-the-shell"
+    )
+
+
+@pytest.mark.asyncio
+async def test_gateway_group_gate_add_uses_group_admin_scope():
+    """DM admin status must not silently grant host-shell access in groups."""
+    from gateway.run import GatewayRunner
+
+    runner, manager = _runner(
+        admins=("dm-admin",),
+        group_admins=("group-admin",),
+    )
+
+    denied = await GatewayRunner._handle_goal_command(
+        runner,
+        _event("dm-admin", chat_type="group"),
+    )
+    allowed = await GatewayRunner._handle_goal_command(
+        runner,
+        _event("group-admin", chat_type="group"),
+    )
+
+    assert "explicitly configured gateway admin" in denied
+    assert "Gate added" in allowed
+    manager.add_gate.assert_called_once_with(
+        "touch /tmp/host-in-the-shell"
+    )
+
+
+@pytest.mark.asyncio
+async def test_gateway_non_admin_can_still_list_goal_gates():
+    """Non-admins retain read-only visibility into the active goal's gates."""
+    from gateway.run import GatewayRunner
+
+    runner, manager = _runner(admins=("admin-1",))
+    manager.render_gates.return_value = "- 1. $ scripts/run_tests.sh"
+    event = _event("user-1")
+    event.get_command_args.return_value = "gate list"
+
+    result = await GatewayRunner._handle_goal_command(runner, event)
+
+    assert result == "- 1. $ scripts/run_tests.sh"
+    manager.render_gates.assert_called_once_with()


### PR DESCRIPTION
## Summary
`/goal gate add` on the messaging gateway now requires an explicitly-configured gateway admin. A goal quality gate is a shell command that Hermes persists and later executes with `subprocess.run(shell=True)` at every goal turn boundary (`run_gate`), with no approval prompt. Gateway slash access is backward-compatible: with no `allow_admin_from` list configured (the default), every *allowed* chat user is treated as unrestricted — so an allowed but non-admin remote sender could add an arbitrary shell command and get **authenticated RCE as the Hermes process account**.

Root cause: the `gate add` dispatch persisted the caller-supplied string with zero admin check (`gateway/slash_commands.py`), and `run_gate()` runs it with `shell=True` (`hermes_cli/goals.py:528`).

## Changes
- `gateway/slash_commands.py`: gate **only** the shell-creating `gate add` operation behind the existing fail-closed explicit-admin check (`_resume_caller_is_admin` — the same one that guards cross-origin `/resume`, stricter than `is_admin` which returns True for every allowed caller when slash gating is off). `gate list` / `remove` / `clear` stay open so a non-admin can still inspect and recover. CLI/TUI/Desktop `gate add` is local (user already has host access) and is unchanged.
- `tests/gateway/test_goal_gate_access.py`: contributor's regression tests — default-open access denied, configured non-admin denied, DM admin allowed, group admin allowed, non-admin listing preserved.

Salvaged from #91677 by @unsupportedpastels, narrowed to the single shell-creating op and reusing the existing admin helper instead of renaming it. Their tests preserved.

## Validation
Live E2E through the real `GatewayRunner._handle_goal_command` (bare runner, real config, real dispatch):

| Caller / op | Before | After |
|---|---|---|
| non-admin, no admin list — `gate add` | **added + executed** (RCE) | denied |
| explicit admin — `gate add` | added | added (preserved) |
| non-admin — `gate list` | open | open (recovery) |
| non-admin — `gate remove` | open | open (recovery) |

Baseline confirmed on `origin/main`: no admin check on `gate add`. `run_gate` confirmed `shell=True`.

| Check | Result |
|---|---|
| `tests/gateway/test_goal_gate_access.py` + `tests/hermes_cli/test_goal_gates.py` | 23 passed |

## Infographic

![Goal gate add admin-gated](https://v3b.fal.media/files/b/0aa8d670/IoGD-gN7VEQTT8w9oQcOi_9vndcuvO.png)
