### PR TITLE
Fix/dashboard turn isolation profile scope

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2964,6 +2964,32 @@ def _publish_rotated_compaction(
     old_title = agent._session_db.get_session_title(agent.session_id)
     new_session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
     from agent.context_compressor import _DB_PERSISTED_MARKER
+    # Blocker 2 (#99719): the continuation id B is now known but
+    # NOT yet durable. Under dashboard.turn_isolation the real
+    # active-session lease is held by the SERVING process on the
+    # old id A; the child's disabled sentinel transfer is a local
+    # no-op that never moves the registry. Before B is written,
+    # fire the optional pre-rotation re-anchor callback (installed
+    # by the compute-host child) so the CANONICAL owner atomically
+    # moves the registry lease A->B and acks. A RuntimeError or a
+    # falsy return means the owner did NOT commit -- ABORT the
+    # rotation (fall into the except below: parent stays live, the
+    # compacted snapshot is discarded) so the child never writes B
+    # unsynchronized. Only present/callable on the isolated child;
+    # the serving and classic in-process paths install nothing.
+    _pre_rotation_reanchor = getattr(
+        agent, "_pre_rotation_reanchor", None
+    )
+    if callable(_pre_rotation_reanchor):
+        if not _pre_rotation_reanchor(
+            old_session_id=old_session_id,
+            new_session_id=new_session_id,
+        ):
+            raise RuntimeError(
+                "active-session re-anchor was not committed by "
+                "the lease owner; aborting mid-turn rotation "
+                "(fail-closed, #99719)"
+            )
     agent._session_db.publish_compression_child(
         parent_session_id=old_session_id, child_session_id=new_session_id,
         source=agent.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"), model=agent.model,

--- a/tests/tui_gateway/test_compute_host_lease_reanchor.py
+++ b/tests/tui_gateway/test_compute_host_lease_reanchor.py
@@ -1,0 +1,377 @@
+"""Blocker 2 (#99719): mid-turn compression re-anchors the REAL active-session
+registry lease, not the child's disabled sentinel.
+
+Under ``dashboard.turn_isolation`` a named-profile turn is admitted once in the
+serving process (which holds the one real, file-locked active-session lease) and
+dispatched to a compute-host CHILD. When context compression rotates the session
+id A->B mid-turn INSIDE the child, the child's disabled sentinel
+``transfer_active_session`` is a local no-op that never touches the registry: the
+real lease stays on A while the child writes continuation B, so a second process
+can acquire B (double-writer, reopening the #99719 hole).
+
+The fix is a child-proposes / owner-transfers / owner-acks handshake fired at the
+pre-commit hook point (before ``publish_compression_child``): the child BLOCKS and
+sends a re-anchor request over a BUILT reverse-RPC; the serving owner atomically
+moves the real registry lease A->B (enabled ``transfer_active_session``) and acks;
+only then does the child publish B.
+
+R6  - B-refused-until-transfer: the owner's atomic transfer is what protects B.
+R7  - committed-transfer-then-lost-ack: a lost ack is reconciled by ONE bounded
+      status re-query (idempotent, outcome-recorded), never a double-writer.
+R7b - pre-commit nack: the rotation aborts to A (conversation_compression.py
+      5312-5329); B is never durably created.
+"""
+
+import io
+import os
+import tempfile
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tui_gateway import compute_host, server
+
+
+def _isolated_session(sid="sid", key="A", lease=None):
+    return {
+        "agent": None,
+        "session_key": key,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": True,
+        "_compute_host_active": True,
+        "attached_images": [],
+        "image_counter": 0,
+        "cols": 80,
+        "slash_worker": None,
+        "show_reasoning": False,
+        "tool_progress_mode": "all",
+        "_sid": sid,
+        "active_session_lease": lease,
+        "active_session_admission": (
+            {
+                "lease_id": getattr(lease, "lease_id", ""),
+                "session_id": key,
+                "generation": 0,
+            }
+            if lease is not None
+            else None
+        ),
+    }
+
+
+class TestR6BRefusedUntilTransfer:
+    def test_r6_b_refused_until_owner_transfers(self, monkeypatch, tmp_path):
+        # The owner (serving process) holds the real enabled lease on A. A
+        # distinct writer cannot take A. The child proposes a re-anchor A->B;
+        # the OWNER performs the atomic transfer_active_session A->B. Only AFTER
+        # that commit is B protected (a distinct writer claiming B is REFUSED)
+        # and A freed. FAILS on HEAD: the server-side reanchor handler does not
+        # exist, so B is never protected by an atomic owner-side transfer.
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        lease, refusal = server._claim_active_session_slot(
+            "A", live_session_id="sid", surface="tui"
+        )
+        assert lease is not None and lease.enabled and refusal is None
+
+        session = _isolated_session(lease=lease)
+        with server._sessions_lock:
+            server._sessions["sid"] = session
+        self.addfinalizer = None
+
+        try:
+            # A is protected against a distinct second writer.
+            s2, r2 = server._claim_active_session_slot(
+                "A", live_session_id="distinct-writer", surface="tui"
+            )
+            assert s2 is None and r2 is not None
+
+            # The child proposes; the owner atomically transfers A->B.
+            outcome = server._handle_active_session_reanchor(
+                {
+                    "type": "active_session.reanchor",
+                    "session_id": "sid",
+                    "request_id": "req-1",
+                    "old_id": "A",
+                    "new_id": "B",
+                    "lease_id": lease.lease_id,
+                    "generation": 0,
+                }
+            )
+            assert outcome["applied"] is True
+
+            # B is now protected; A is free.
+            b2, br = server._claim_active_session_slot(
+                "B", live_session_id="distinct-writer", surface="tui"
+            )
+            assert b2 is None and br is not None, "B not protected after transfer"
+
+            a3, ar = server._claim_active_session_slot(
+                "A", live_session_id="distinct-writer", surface="tui"
+            )
+            assert a3 is not None and ar is None, "A not freed after transfer"
+        finally:
+            with server._sessions_lock:
+                server._sessions.pop("sid", None)
+
+    def test_r6_idempotent_duplicate_returns_recorded_outcome(
+        self, monkeypatch, tmp_path
+    ):
+        # A duplicate proposal / status re-query for the same
+        # (request_id, generation) returns the recorded outcome WITHOUT a second
+        # transfer (same-id A->B is a no-op applied:true). FAILS on HEAD.
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        lease, _ = server._claim_active_session_slot(
+            "A", live_session_id="sid", surface="tui"
+        )
+        session = _isolated_session(lease=lease)
+        with server._sessions_lock:
+            server._sessions["sid"] = session
+        try:
+            first = server._handle_active_session_reanchor(
+                {
+                    "type": "active_session.reanchor",
+                    "session_id": "sid",
+                    "request_id": "req-dup",
+                    "old_id": "A",
+                    "new_id": "B",
+                    "lease_id": lease.lease_id,
+                    "generation": 0,
+                }
+            )
+            assert first["applied"] is True
+            status = server._handle_active_session_reanchor(
+                {
+                    "type": "active_session.reanchor.status",
+                    "session_id": "sid",
+                    "request_id": "req-dup",
+                    "lease_id": lease.lease_id,
+                    "generation": 0,
+                }
+            )
+            assert status["applied"] is True
+        finally:
+            with server._sessions_lock:
+                server._sessions.pop("sid", None)
+
+
+class TestR7CommittedTransferThenLostAck:
+    def test_r7_committed_transfer_then_lost_ack(self, monkeypatch, tmp_path):
+        # The server commits A->B under the file lock, then the ack is LOST. The
+        # child's ONE bounded status re-query for the same (request_id,
+        # generation) returns applied:true, so the child PROCEEDS to publish B;
+        # no third party can acquire B at any point. FAILS on HEAD: neither the
+        # timeout constant nor the child re-anchor method exists.
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(compute_host, "_REANCHOR_ACK_TIMEOUT_SECONDS", 0.2)
+
+        owner_lease, _ = server._claim_active_session_slot(
+            "A", live_session_id="sid", surface="tui"
+        )
+        assert owner_lease is not None and owner_lease.enabled
+
+        host = compute_host.ComputeHost(stdout=io.StringIO(), heartbeat_secs=0)
+        committed = {"done": False}
+
+        def _emit(frame):
+            msg = frame.get("message") or {} if frame.get("type") == "rpc" else {}
+            params = msg.get("params") or {}
+            kind = params.get("type")
+            if kind == "active_session.reanchor":
+                # Owner commits the real registry transfer, then DROPS the ack.
+                from hermes_cli.active_sessions import transfer_active_session
+
+                assert transfer_active_session(
+                    owner_lease, session_id="B", metadata={"live_session_id": "sid"}
+                )
+                committed["done"] = True
+                # ack lost: deliver nothing.
+            elif kind == "active_session.reanchor.status":
+                # The bounded status re-query is authoritative: committed.
+                host.handle_frame(
+                    {
+                        "type": "active_session.reanchor.ack",
+                        "request_id": params.get("request_id"),
+                        "generation": params.get("generation"),
+                        "applied": True,
+                    }
+                )
+
+        monkeypatch.setattr(host, "emit", _emit)
+        try:
+            applied = host._reanchor_active_session(
+                "sid",
+                "A",
+                "B",
+                {"lease_id": owner_lease.lease_id, "generation": 0},
+            )
+            assert applied is True
+            assert committed["done"]
+
+            # No third party can ever hold B (the real lease is on B).
+            b2, br = server._claim_active_session_slot(
+                "B", live_session_id="third-party", surface="tui"
+            )
+            assert b2 is None and br is not None, "third party acquired B"
+
+            # A is free (the lease moved off it).
+            a2, ar = server._claim_active_session_slot(
+                "A", live_session_id="third-party", surface="tui"
+            )
+            assert a2 is not None and ar is None
+        finally:
+            host.close()
+
+
+def _make_agent(session_db, session_id="A"):
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=session_db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.compression_in_place = False
+        return agent
+
+
+def _stub_compressor():
+    compressor = MagicMock()
+    compressor.compress.return_value = [
+        {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+        {"role": "user", "content": "tail question"},
+    ]
+    compressor.compression_count = 1
+    compressor.last_prompt_tokens = 0
+    compressor.last_completion_tokens = 0
+    compressor._last_summary_error = None
+    compressor._last_compress_aborted = False
+    return compressor
+
+
+class TestR7bPreCommitNackAborts:
+    def test_r7b_precommit_nack_aborts_rotation_to_A(self):
+        # A nacking _pre_rotation_reanchor (owner raised BEFORE the file-locked
+        # commit, so applied:false) must ABORT the rotation at
+        # conversation_compression.py:5312-5329: agent stays on A, B is never
+        # published. FAILS on HEAD: no pre-rotation hook exists, so the rotation
+        # proceeds and agent.session_id changes.
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = _make_agent(db, session_id="A")
+            agent.context_compressor = _stub_compressor()
+            agent._pre_rotation_reanchor = (
+                lambda old_session_id, new_session_id: False
+            )
+
+            original_sid = agent.session_id
+            published = {"n": 0}
+            orig_publish = db.publish_compression_child
+
+            def _count_publish(*a, **k):
+                published["n"] += 1
+                return orig_publish(*a, **k)
+
+            with patch.object(
+                db, "publish_compression_child", side_effect=_count_publish
+            ):
+                agent._compress_context(
+                    [{"role": "user", "content": f"m{i}"} for i in range(6)],
+                    "sys",
+                    approx_tokens=10_000,
+                )
+
+            assert agent.session_id == original_sid, "rotation not aborted on nack"
+            assert published["n"] == 0, "published B despite nack"
+
+    def test_r7b_hook_raise_aborts_rotation_to_A(self):
+        # A RuntimeError from the hook (e.g. ack timeout after the status
+        # re-query also failed) is equally fail-closed. FAILS on HEAD (no hook).
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = _make_agent(db, session_id="A")
+            agent.context_compressor = _stub_compressor()
+
+            def _raise(old_session_id, new_session_id):
+                raise RuntimeError("re-anchor ack timed out")
+
+            agent._pre_rotation_reanchor = _raise
+            original_sid = agent.session_id
+            published = {"n": 0}
+            orig_publish = db.publish_compression_child
+
+            def _count_publish(*a, **k):
+                published["n"] += 1
+                return orig_publish(*a, **k)
+
+            with patch.object(
+                db, "publish_compression_child", side_effect=_count_publish
+            ):
+                agent._compress_context(
+                    [{"role": "user", "content": f"m{i}"} for i in range(6)],
+                    "sys",
+                    approx_tokens=10_000,
+                )
+
+            assert agent.session_id == original_sid
+            assert published["n"] == 0
+
+
+class TestReanchorHookHappyPath:
+    def test_hook_fires_before_publish_and_allows_rotation(self):
+        # A truthy hook lets the rotation commit; the hook fires BEFORE
+        # publish_compression_child (the sole point where B is known but not yet
+        # durable). FAILS on HEAD (no hook, so ordering can't be observed).
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = _make_agent(db, session_id="A")
+            agent.context_compressor = _stub_compressor()
+
+            events = []
+            agent._pre_rotation_reanchor = (
+                lambda old_session_id, new_session_id: events.append(
+                    ("reanchor", old_session_id, new_session_id)
+                )
+                or True
+            )
+            orig_publish = db.publish_compression_child
+
+            def _record_publish(*a, **k):
+                events.append(("publish",))
+                return orig_publish(*a, **k)
+
+            original_sid = agent.session_id
+            with patch.object(
+                db, "publish_compression_child", side_effect=_record_publish
+            ):
+                agent._compress_context(
+                    [{"role": "user", "content": f"m{i}"} for i in range(6)],
+                    "sys",
+                    approx_tokens=10_000,
+                )
+
+            assert agent.session_id != original_sid, "rotation did not commit"
+            kinds = [e[0] for e in events]
+            assert "reanchor" in kinds and "publish" in kinds
+            assert kinds.index("reanchor") < kinds.index("publish"), (
+                "re-anchor hook must fire before publish_compression_child"
+            )
+            reanchor_event = next(e for e in events if e[0] == "reanchor")
+            assert reanchor_event[1] == original_sid
+            assert reanchor_event[2] == agent.session_id

--- a/tests/tui_gateway/test_compute_host_lease_reanchor.py
+++ b/tests/tui_gateway/test_compute_host_lease_reanchor.py
@@ -227,6 +227,117 @@ class TestR7CommittedTransferThenLostAck:
             host.close()
 
 
+class TestGenerationRefreshedAcrossRotations:
+    def test_second_rotation_quotes_refreshed_generation_and_commits(
+        self, monkeypatch, tmp_path
+    ):
+        # #99719 round-2: two SEQUENTIAL mid-turn rotations. The first re-anchor
+        # A->B commits; the owner bumps its generation 0->1 and forwards
+        # new_generation in the ack. The child must WRITE that back into the
+        # shared admission dict so the SECOND re-anchor B->C quotes generation=1
+        # (the refreshed value) and COMMITS. FAILS on HEAD: the ack drops
+        # new_generation and the admission snapshot stays 0, so the second
+        # rotation is nacked on a generation mismatch (quoted=0 current=1).
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(compute_host, "_REANCHOR_ACK_TIMEOUT_SECONDS", 0.2)
+
+        owner_lease, _ = server._claim_active_session_slot(
+            "A", live_session_id="sid", surface="tui"
+        )
+        assert owner_lease is not None and owner_lease.enabled
+
+        session = _isolated_session(lease=owner_lease)
+        with server._sessions_lock:
+            server._sessions["sid"] = session
+
+        host = compute_host.ComputeHost(stdout=io.StringIO(), heartbeat_secs=0)
+
+        # The shared admission object (session["_delegated_admission"] by ref).
+        admission = {"lease_id": owner_lease.lease_id, "generation": 0}
+
+        def _emit(frame):
+            msg = frame.get("message") or {} if frame.get("type") == "rpc" else {}
+            params = msg.get("params") or {}
+            kind = params.get("type")
+            if kind in ("active_session.reanchor", "active_session.reanchor.status"):
+                # Owner handles the proposal and forwards the ack (with the
+                # bumped new_generation, exactly like _emit_active_session_reanchor_ack).
+                outcome = server._handle_active_session_reanchor(params)
+                host.handle_frame(
+                    {
+                        "type": "active_session.reanchor.ack",
+                        "request_id": outcome.get("request_id"),
+                        "generation": outcome.get("generation"),
+                        "applied": bool(outcome.get("applied")),
+                        "new_generation": outcome.get("new_generation"),
+                    }
+                )
+
+        monkeypatch.setattr(host, "emit", _emit)
+        try:
+            # First rotation A->B commits; admission generation refreshes 0->1.
+            applied1 = host._reanchor_active_session("sid", "A", "B", admission)
+            assert applied1 is True
+            assert admission["generation"] == 1, "admission not refreshed after A->B"
+
+            # Second rotation B->C quotes the REFRESHED generation and commits.
+            applied2 = host._reanchor_active_session("sid", "B", "C", admission)
+            assert applied2 is True, "second rotation nacked on stale generation"
+            assert admission["generation"] == 2
+
+            # The registry lease moved B->C: C is protected, B is free.
+            c2, cr = server._claim_active_session_slot(
+                "C", live_session_id="third-party", surface="tui"
+            )
+            assert c2 is None and cr is not None, "C not protected after B->C"
+            b2, br = server._claim_active_session_slot(
+                "B", live_session_id="third-party", surface="tui"
+            )
+            assert b2 is not None and br is None, "B not freed after B->C"
+        finally:
+            host.close()
+            with server._sessions_lock:
+                server._sessions.pop("sid", None)
+
+
+class TestFailClosedHookInstall:
+    class _RejectingAgent:
+        # An agent object that refuses the re-anchor attribute assignment.
+        __slots__ = ()
+
+        def __setattr__(self, name, value):
+            raise AttributeError(f"cannot set {name}")
+
+    def test_install_raises_when_assignment_fails_with_admission(self):
+        # #99719: a session carrying a delegated admission whose agent rejects
+        # the hook assignment must FAIL CLOSED -- _install_pre_rotation_reanchor
+        # raises so the turn's outer except emits turn.error rather than
+        # proceeding hook-less (a mid-turn rotation would then reopen the
+        # double-writer window). FAILS on HEAD: the assignment error is swallowed
+        # (except Exception: pass) and the turn proceeds unprotected.
+        host = compute_host.ComputeHost(stdout=io.StringIO(), heartbeat_secs=0)
+        try:
+            session = {
+                "agent": self._RejectingAgent(),
+                "_delegated_admission": {"lease_id": "L", "generation": 0},
+            }
+            with pytest.raises(Exception):
+                host._install_pre_rotation_reanchor(server, "sid", session)
+        finally:
+            host.close()
+
+    def test_install_is_noop_without_admission(self):
+        # A session with NO delegated admission (serving/in-process path) is a
+        # clean no-op even if the agent would reject the assignment -- the early
+        # return fires before any attribute is touched, so no turn is failed.
+        host = compute_host.ComputeHost(stdout=io.StringIO(), heartbeat_secs=0)
+        try:
+            session = {"agent": self._RejectingAgent(), "_delegated_admission": None}
+            host._install_pre_rotation_reanchor(server, "sid", session)  # no raise
+        finally:
+            host.close()
+
+
 def _make_agent(session_db, session_id="A"):
     with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
         from run_agent import AIAgent

--- a/tests/tui_gateway/test_compute_host_turn_isolation_lease.py
+++ b/tests/tui_gateway/test_compute_host_turn_isolation_lease.py
@@ -1,0 +1,157 @@
+"""Turn-isolation active-session lease handoff (Design 1).
+
+With ``dashboard.turn_isolation`` on, a named-profile turn is admitted once in
+the SERVING (dashboard) process -- it claims the per-session lease there -- and
+then dispatched to a compute-host CHILD process to run. The child re-crosses the
+ownership chokepoint in ``_run_prompt_submit`` (the #94778 double-writer guard),
+but its rebuilt session dict does not carry the serving process's lease, and
+``_is_same_writer`` can never match across a process boundary (it requires
+``entry.pid == os.getpid()``). Without a handoff the child re-claims, sees the
+serving process's live entry, and refuses the turn:
+
+    Session ... already has a live owner (desktop, pid N, running 0m)
+
+Design 1 hands the admission to the child as a disabled lease SENTINEL: the
+serving process signals ``active_session_admitted`` in the turn frame, and the
+child installs a disabled ``ActiveSessionLease`` so the chokepoint recheck is a
+genuine no-op WITHOUT claiming a second registry slot and WITHOUT being able to
+release the serving process's real lease. The single admission (the serving
+process's) is preserved, so the double-writer guard is untouched.
+"""
+
+import threading
+
+import pytest
+
+from tui_gateway import server
+
+
+def _session(**overrides):
+    base = {
+        "session_key": "sess-key",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "cols": 80,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestTurnFrameAdmissionSignal:
+    def test_frame_marks_admitted_when_serving_process_holds_lease(self):
+        session = _session(active_session_lease=object())
+        frame = server._compute_host_turn_frame("rid", "sid", session, "hello")
+        assert frame["active_session_admitted"] is True
+
+    def test_frame_admission_false_without_lease(self):
+        session = _session()
+        frame = server._compute_host_turn_frame("rid", "sid", session, "hello")
+        assert frame["active_session_admitted"] is False
+
+
+class TestChildDelegatedLease:
+    def test_admitted_frame_makes_chokepoint_a_noop_without_reclaiming(
+        self, monkeypatch
+    ):
+        # The child must NOT try to claim a second registry slot when the
+        # serving process already admitted the turn.
+        def _boom(*args, **kwargs):
+            raise AssertionError(
+                "child re-claimed the active-session slot despite admission"
+            )
+
+        monkeypatch.setattr(server, "_claim_active_session_slot", _boom)
+
+        session = _session()
+        server._install_delegated_active_session_lease(
+            session, {"active_session_admitted": True, "session_key": "sess-key"}
+        )
+
+        # The chokepoint recheck sees a lease and returns None (admitted),
+        # never reaching the claim path above.
+        assert server._ensure_active_session_slot("sid", session) is None
+
+    def test_delegated_lease_release_is_a_noop(self, monkeypatch):
+        # Releasing the child's sentinel must NOT touch the registry -- that
+        # would drop the serving process's real lease out from under it.
+        session = _session()
+        server._install_delegated_active_session_lease(
+            session, {"active_session_admitted": True, "session_key": "sess-key"}
+        )
+        lease = session["active_session_lease"]
+
+        import hermes_cli.active_sessions as active_sessions
+
+        def _boom_release(_lease):
+            raise AssertionError("delegated lease reached the registry release")
+
+        # release() short-circuits on a disabled lease before calling the
+        # module-level release_active_session, so this stays untouched.
+        monkeypatch.setattr(active_sessions, "release_active_session", _boom_release)
+        lease.release()  # must not raise
+
+    def test_no_admission_installs_no_lease(self):
+        session = _session()
+        server._install_delegated_active_session_lease(
+            session, {"active_session_admitted": False, "session_key": "sess-key"}
+        )
+        assert session.get("active_session_lease") is None
+
+    def test_install_is_idempotent_and_preserves_a_real_lease(self):
+        real = object()
+        session = _session(active_session_lease=real)
+        server._install_delegated_active_session_lease(
+            session, {"active_session_admitted": True, "session_key": "sess-key"}
+        )
+        # A real lease already present is never overwritten by the sentinel.
+        assert session["active_session_lease"] is real
+
+    def test_release_slot_on_sentinel_never_touches_registry(self, monkeypatch):
+        # End-of-turn / finalize releases the session slot. For the delegated
+        # sentinel this must be a clean no-op: the serving process still owns
+        # the real registry entry.
+        import hermes_cli.active_sessions as active_sessions
+
+        session = _session()
+        server._install_delegated_active_session_lease(
+            session, {"active_session_admitted": True, "session_key": "sess-key"}
+        )
+
+        def _boom(_lease):
+            raise AssertionError("delegated lease reached the registry release")
+
+        monkeypatch.setattr(active_sessions, "release_active_session", _boom)
+        assert server._release_active_session_slot(session) is True
+        assert session.get("active_session_lease") is None
+
+    def test_compression_transfer_on_sentinel_never_claims_a_second_slot(
+        self, monkeypatch
+    ):
+        # Auto-compression rotates agent.session_id mid-turn, which fires
+        # _transfer_active_session_slot in the CHILD. The sentinel must take
+        # transfer_active_session's disabled-lease no-op branch -- never fall
+        # through to _claim_active_session_slot (a real second registry entry
+        # that would orphan the serving process's lease and break #94778).
+        session = _session()
+        server._install_delegated_active_session_lease(
+            session, {"active_session_admitted": True, "session_key": "old-key"}
+        )
+        sentinel = session["active_session_lease"]
+
+        def _boom_claim(*args, **kwargs):
+            raise AssertionError(
+                "compression transfer claimed a real second slot for a sentinel"
+            )
+
+        monkeypatch.setattr(server, "_claim_active_session_slot", _boom_claim)
+
+        assert (
+            server._transfer_active_session_slot(
+                "sid", session, new_session_id="new-key"
+            )
+            is True
+        )
+        # Same sentinel object, re-anchored to the new id; no real claim.
+        assert session["active_session_lease"] is sentinel
+        assert sentinel.session_id == "new-key"
+

--- a/tests/tui_gateway/test_compute_host_turn_isolation_lease.py
+++ b/tests/tui_gateway/test_compute_host_turn_isolation_lease.py
@@ -232,9 +232,21 @@ class TestCloseInterruptsActiveChildTurn:
             "lease released before the child turn was interrupted"
         )
 
-    def test_close_wait_is_bounded_when_child_never_settles(self, monkeypatch):
-        # If the child never reports done, close must not hang forever: the
-        # settle wait is bounded and teardown proceeds (with a warning).
+    def test_close_wait_is_bounded_but_lease_held_when_child_never_settles(
+        self, monkeypatch, tmp_path
+    ):
+        # INVERSION of the old cementing test (Blocker 1, #99719 single
+        # admission). The close/RPC path stays BOUNDED, but OWNERSHIP is not
+        # released at the grace deadline: while the isolated child may still be
+        # writing, the canonical lease is DETACHED-and-deferred, not dropped.
+        # A second distinct writer that races for the same session id is
+        # therefore still REFUSED after close returns. HEAD released the lease
+        # unconditionally at the deadline (the old assertion was
+        # ``active_session_lease is None``), so it FAILS this inversion.
+        import hermes_cli.active_sessions as active_sessions
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
         class _Supervisor:
             def interrupt(self, sid, request_id=None):
                 return True  # never clears `running`
@@ -251,10 +263,18 @@ class TestCloseInterruptsActiveChildTurn:
         # Shrink the grace so the test stays fast.
         monkeypatch.setattr(server, "_TURN_SETTLE_BEFORE_CLOSE_SECONDS", 0.1)
 
-        session = self._base_session()
-        server._install_delegated_active_session_lease(
-            session, {"active_session_admitted": True, "session_key": "session-key"}
+        # The SERVING process holds the one REAL enabled lease for the whole
+        # child turn (the child only carries the disabled sentinel).
+        lease, refusal = active_sessions.try_acquire_active_session(
+            session_id="session-key",
+            surface="tui",
+            config={},
+            metadata={"live_session_id": "sid"},
         )
+        assert refusal is None and lease is not None and lease.enabled
+
+        session = self._base_session()
+        session["active_session_lease"] = lease
         session["_sid"] = "sid"
 
         import time as _time
@@ -263,8 +283,30 @@ class TestCloseInterruptsActiveChildTurn:
         assert server._teardown_popped_session(session, end_reason="tui_close") is True
         elapsed = _time.monotonic() - start
         assert elapsed < 2.0, "close hung past the bounded settle grace"
-        # Lease still gets released (teardown proceeds despite the stuck child).
-        assert session.get("active_session_lease") is None
+
+        # OWNERSHIP is still HELD: the real lease was detached-and-deferred, and
+        # the registry still protects the id -- a distinct writer is REFUSED.
+        detached = getattr(server, "_detached_leases", {})
+        assert any(
+            rec is lease for rec in detached.values()
+        ), "canonical lease was not detached-and-deferred"
+        _second, second_refusal = active_sessions.try_acquire_active_session(
+            session_id="session-key",
+            surface="tui",
+            config={},
+            metadata={"live_session_id": "distinct-writer"},
+        )
+        assert second_refusal is not None, "lease dropped at the close deadline"
+
+        # Only after the simulated child exit / turn.end does ownership release.
+        server._release_detached_leases_for_dead_child()
+        third, third_refusal = active_sessions.try_acquire_active_session(
+            session_id="session-key",
+            surface="tui",
+            config={},
+            metadata={"live_session_id": "distinct-writer"},
+        )
+        assert third_refusal is None and third is not None
 
     def test_close_without_active_child_turn_does_not_interrupt(self, monkeypatch):
         calls = {"interrupt": 0}
@@ -291,3 +333,220 @@ class TestCloseInterruptsActiveChildTurn:
 
         server._teardown_popped_session(session, end_reason="tui_close")
         assert calls["interrupt"] == 0
+
+
+class TestDetachedLeaseDeferredRelease:
+    """Blocker 1 (#99719): the canonical lease is held until the isolated
+    child actually exits, not merely until a bounded close returns."""
+
+    def _isolated_session(self, sid="sid", key="session-key"):
+        return {
+            "agent": None,
+            "session_key": key,
+            "history": [],
+            "history_lock": threading.Lock(),
+            "history_version": 0,
+            "running": True,
+            "_compute_host_active": True,
+            "attached_images": [],
+            "image_counter": 0,
+            "cols": 80,
+            "slash_worker": None,
+            "show_reasoning": False,
+            "tool_progress_mode": "all",
+            "_sid": sid,
+        }
+
+    def _clear_detached(self):
+        with server._sessions_lock:
+            server._detached_leases.clear()
+
+    def test_r1_lease_held_until_child_death_real_registry(
+        self, monkeypatch, tmp_path
+    ):
+        # Child never settles; after the close grace a DISTINCT-writer second
+        # acquirer (a real _claim_active_session_slot against the file-locked
+        # JSONL) is REFUSED, and reacquisition succeeds ONLY after the
+        # simulated turn.end/child-exit. FAILS on HEAD (grace-deadline release).
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._clear_detached()
+
+        class _Supervisor:
+            def interrupt(self, sid, request_id=None):
+                return True  # never clears `running`
+
+        monkeypatch.setattr(
+            server, "_get_compute_host_supervisor", lambda _cfg=None: _Supervisor()
+        )
+        monkeypatch.setattr(
+            server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}}
+        )
+        monkeypatch.setattr(
+            server, "_session_uses_compute_host", lambda session, cfg=None: True
+        )
+        monkeypatch.setattr(server, "_TURN_SETTLE_BEFORE_CLOSE_SECONDS", 0.1)
+
+        lease, _ = server._claim_active_session_slot(
+            "session-key", live_session_id="sid", surface="tui"
+        )
+        assert lease is not None and lease.enabled
+
+        session = self._isolated_session()
+        session["active_session_lease"] = lease
+
+        server._teardown_popped_session(session, end_reason="tui_close")
+
+        # Second, distinct writer is refused while the child may still write.
+        second, refusal = server._claim_active_session_slot(
+            "session-key", live_session_id="distinct-writer", surface="tui"
+        )
+        assert second is None and refusal is not None
+
+        # turn.end / child-exit releases the detached lease -> reacquisition ok.
+        session["running"] = False
+        server._on_compute_host_turn_done(
+            "rid", "sid", session, {"type": "turn.end", "session_key": "session-key"}
+        )
+        third, refusal3 = server._claim_active_session_slot(
+            "session-key", live_session_id="distinct-writer", surface="tui"
+        )
+        assert third is not None and refusal3 is None
+
+    def test_r3_closing_shutdown_releases_detached_lease(
+        self, monkeypatch, tmp_path
+    ):
+        # Blocker 1a: with the supervisor _closing=True, an observed child exit
+        # must still release the detached lease (release call is AHEAD of the
+        # `if self._closing: return` guard). FAILS on HEAD (no such call).
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._clear_detached()
+        from tui_gateway.host_supervisor import HostSupervisor
+
+        released = {"n": 0}
+        real = server._release_detached_leases_for_dead_child
+
+        def _tracked(*a, **k):
+            released["n"] += 1
+            return real(*a, **k)
+
+        monkeypatch.setattr(
+            server, "_release_detached_leases_for_dead_child", _tracked
+        )
+
+        lease, _ = server._claim_active_session_slot(
+            "session-key", live_session_id="sid", surface="tui"
+        )
+        key = server._detach_lease_for_deferred_release("sid", lease)
+        assert key in server._detached_leases
+
+        sup = HostSupervisor(autostart=False, registry_path=tmp_path / "reg.json")
+        sup._closing = True
+
+        class _Proc:
+            def wait(self):
+                return 0
+
+        sup._wait_for_exit(_Proc())
+        assert released["n"] >= 1, "detached release skipped under _closing guard"
+        assert key not in server._detached_leases
+
+    def test_r4_reaper_does_not_drop_detached_lease(self, monkeypatch, tmp_path):
+        # Blocker 1b: the idle reaper unions detached lease_ids into `live`, so
+        # release_orphaned_leases KEEPS them. FAILS on HEAD (detached absent
+        # from _sessions -> swept on the ~300s tick).
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._clear_detached()
+        import hermes_cli.active_sessions as active_sessions
+
+        # Clear the live session map so the ONLY protection is the detached
+        # table union (otherwise the test would pass vacuously).
+        with server._sessions_lock:
+            server._sessions.clear()
+
+        lease, _ = server._claim_active_session_slot(
+            "session-key", live_session_id="sid", surface="tui"
+        )
+        server._detach_lease_for_deferred_release("sid", lease)
+
+        server._reclaim_orphaned_leases()
+
+        snapshot = active_sessions.active_session_registry_snapshot()
+        assert any(
+            e.get("lease_id") == lease.lease_id for e in snapshot
+        ), "reaper dropped the detached lease"
+
+    def test_r5_detach_is_single_critical_section_insert_before_remove(
+        self, monkeypatch, tmp_path
+    ):
+        # A reaper tick landing mid-detach must NEVER see the lease in neither
+        # _sessions nor _detached_leases. The detach is one _sessions_lock
+        # critical section that inserts into _detached_leases BEFORE removing
+        # from the session dict. FAILS on HEAD (no _detached_leases table).
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._clear_detached()
+
+        lease, _ = server._claim_active_session_slot(
+            "session-key", live_session_id="sid", surface="tui"
+        )
+        session = self._isolated_session()
+        session["active_session_lease"] = lease
+        with server._sessions_lock:
+            server._sessions["sid"] = session
+
+        observed = {"gap": False}
+
+        # Probe: the detach must run entirely under the lock, so any observer
+        # that acquires the lock sees a consistent state. Assert the invariant
+        # directly around the detach call: at no lock acquisition can the lease
+        # be absent from BOTH maps.
+        def _observe():
+            with server._sessions_lock:
+                in_sessions = (
+                    server._sessions.get("sid", {}).get("active_session_lease")
+                    is lease
+                )
+                in_detached = any(
+                    rec is lease for rec in server._detached_leases.values()
+                )
+                if not in_sessions and not in_detached:
+                    observed["gap"] = True
+
+        _observe()  # before detach: in _sessions
+        server._detach_lease_for_deferred_release("sid", lease, session=session)
+        _observe()  # after detach: in _detached_leases
+        assert not observed["gap"]
+        # The lease left the session dict but is now in the detached table.
+        assert session.get("active_session_lease") is None
+        assert any(rec is lease for rec in server._detached_leases.values())
+        with server._sessions_lock:
+            server._sessions.pop("sid", None)
+
+    def test_crash_path_reaches_detached_release(self, monkeypatch, tmp_path):
+        # _fail_pending_turns invokes on_complete, which for an isolated turn
+        # reaches _on_compute_host_turn_done -> detached release. Assert the
+        # crash callback releases the detached lease for the sid.
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._clear_detached()
+        from tui_gateway.host_supervisor import HostSupervisor
+
+        lease, _ = server._claim_active_session_slot(
+            "session-key", live_session_id="sid", surface="tui"
+        )
+        session = self._isolated_session()
+        session["running"] = False
+        key = server._detach_lease_for_deferred_release("sid", lease)
+
+        sink = []
+        sup = HostSupervisor(
+            autostart=False,
+            registry_path=tmp_path / "reg.json",
+            rpc_sink=sink.append,
+        )
+
+        def _on_complete(frame):
+            server._on_compute_host_turn_done("rid", "sid", session, frame)
+
+        sup._pending_turns["rid"] = ("sid", _on_complete)
+        sup._fail_pending_turns(reason="crash", message="host died")
+
+        assert key not in server._detached_leases

--- a/tests/tui_gateway/test_compute_host_turn_isolation_lease.py
+++ b/tests/tui_gateway/test_compute_host_turn_isolation_lease.py
@@ -155,3 +155,139 @@ class TestChildDelegatedLease:
         assert session["active_session_lease"] is sentinel
         assert sentinel.session_id == "new-key"
 
+
+class TestCloseInterruptsActiveChildTurn:
+    """Explicit session.close must interrupt an in-flight compute-host child
+    turn BEFORE releasing the serving process's real lease.
+
+    With the sentinel installed, the child's ownership chokepoint is a total
+    no-op, so safety rests on the serving process holding the real lease for the
+    whole child turn. The automatic reapers already gate on ``running`` (which
+    the serving process holds True from dispatch until the child reports done),
+    but explicit ``session.close`` tears down unconditionally and only waited on
+    the in-process ``_run_thread`` -- absent for an isolated turn. Without an
+    interrupt the lease drops while the child keeps writing, reopening a narrow
+    #94778 window for a sibling backend sharing HERMES_HOME.
+    """
+
+    def _base_session(self):
+        return {
+            "agent": None,
+            "session_key": "session-key",
+            "history": [],
+            "history_lock": threading.Lock(),
+            "history_version": 0,
+            "running": True,
+            "_compute_host_active": True,
+            "attached_images": [],
+            "image_counter": 0,
+            "cols": 80,
+            "slash_worker": None,
+            "show_reasoning": False,
+            "tool_progress_mode": "all",
+        }
+
+    def test_close_interrupts_child_before_releasing_lease(self, monkeypatch):
+        order = []
+        session_ref = {}
+
+        class _Supervisor:
+            def interrupt(self, sid, request_id=None):
+                order.append("interrupt")
+                # A real child reports the turn done, which clears `running`.
+                session_ref["session"]["running"] = False
+                return True
+
+        monkeypatch.setattr(
+            server, "_get_compute_host_supervisor", lambda _cfg=None: _Supervisor()
+        )
+        monkeypatch.setattr(
+            server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}}
+        )
+        monkeypatch.setattr(
+            server, "_session_uses_compute_host", lambda session, cfg=None: True
+        )
+
+        # A real release records its ordering relative to the interrupt.
+        real_release = server._release_active_session_slot
+
+        def _tracked_release(session):
+            order.append("release")
+            return real_release(session)
+
+        monkeypatch.setattr(server, "_release_active_session_slot", _tracked_release)
+
+        session = self._base_session()
+        session_ref["session"] = session
+        # A delegated sentinel stands in for the handed-off admission.
+        server._install_delegated_active_session_lease(
+            session, {"active_session_admitted": True, "session_key": "session-key"}
+        )
+        session["_sid"] = "sid"
+
+        server._teardown_popped_session(session, end_reason="tui_close")
+
+        assert "interrupt" in order, "child turn was not interrupted on close"
+        assert order.index("interrupt") < order.index("release"), (
+            "lease released before the child turn was interrupted"
+        )
+
+    def test_close_wait_is_bounded_when_child_never_settles(self, monkeypatch):
+        # If the child never reports done, close must not hang forever: the
+        # settle wait is bounded and teardown proceeds (with a warning).
+        class _Supervisor:
+            def interrupt(self, sid, request_id=None):
+                return True  # never clears `running`
+
+        monkeypatch.setattr(
+            server, "_get_compute_host_supervisor", lambda _cfg=None: _Supervisor()
+        )
+        monkeypatch.setattr(
+            server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}}
+        )
+        monkeypatch.setattr(
+            server, "_session_uses_compute_host", lambda session, cfg=None: True
+        )
+        # Shrink the grace so the test stays fast.
+        monkeypatch.setattr(server, "_TURN_SETTLE_BEFORE_CLOSE_SECONDS", 0.1)
+
+        session = self._base_session()
+        server._install_delegated_active_session_lease(
+            session, {"active_session_admitted": True, "session_key": "session-key"}
+        )
+        session["_sid"] = "sid"
+
+        import time as _time
+
+        start = _time.monotonic()
+        assert server._teardown_popped_session(session, end_reason="tui_close") is True
+        elapsed = _time.monotonic() - start
+        assert elapsed < 2.0, "close hung past the bounded settle grace"
+        # Lease still gets released (teardown proceeds despite the stuck child).
+        assert session.get("active_session_lease") is None
+
+    def test_close_without_active_child_turn_does_not_interrupt(self, monkeypatch):
+        calls = {"interrupt": 0}
+
+        class _Supervisor:
+            def interrupt(self, sid, request_id=None):
+                calls["interrupt"] += 1
+                return True
+
+        monkeypatch.setattr(
+            server, "_get_compute_host_supervisor", lambda _cfg=None: _Supervisor()
+        )
+        monkeypatch.setattr(
+            server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}}
+        )
+        monkeypatch.setattr(
+            server, "_session_uses_compute_host", lambda session, cfg=None: True
+        )
+
+        session = self._base_session()
+        session["running"] = False
+        session["_compute_host_active"] = False
+        session["_sid"] = "sid"
+
+        server._teardown_popped_session(session, end_reason="tui_close")
+        assert calls["interrupt"] == 0

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -25,6 +25,9 @@ def now_ns() -> int:
     return time.perf_counter_ns()
 
 
+logger = logging.getLogger(__name__)
+
+
 class _HostTransport:
     def __init__(self, emit: Callable[[dict[str, Any]], None]) -> None:
         self._emit = emit
@@ -88,6 +91,11 @@ class ComputeHost:
         # that already lets clarify/approval block mid-turn.
         self._reanchor_waiters: dict[tuple[str, int], threading.Event] = {}
         self._reanchor_results: dict[tuple[str, int], bool] = {}
+        # #99719 round-2: the owner bumps its generation to N+1 on a committed
+        # transfer and forwards it in the ack. Capture it so a SECOND mid-turn
+        # rotation quotes the REFRESHED generation instead of the stale
+        # install-time snapshot (which would be nacked on generation mismatch).
+        self._reanchor_new_generations: dict[tuple[str, int], int] = {}
         self._reanchor_lock = threading.Lock()
         self._heartbeat_secs = (
             float(heartbeat_secs) if heartbeat_secs is not None
@@ -405,6 +413,12 @@ class ComputeHost:
         key = (request_id, generation)
         with self._reanchor_lock:
             self._reanchor_results[key] = bool(frame.get("applied"))
+            new_generation = frame.get("new_generation")
+            if new_generation is not None:
+                try:
+                    self._reanchor_new_generations[key] = int(new_generation)
+                except (TypeError, ValueError):
+                    pass
             event = self._reanchor_waiters.get(key)
         if event is not None:
             event.set()
@@ -463,7 +477,12 @@ class ComputeHost:
             )
             if event.wait(timeout=_REANCHOR_ACK_TIMEOUT_SECONDS):
                 with self._reanchor_lock:
-                    return bool(self._reanchor_results.get(key, False))
+                    applied = bool(self._reanchor_results.get(key, False))
+                    if applied:
+                        new_gen = self._reanchor_new_generations.get(key)
+                        if new_gen is not None:
+                            admission["generation"] = new_gen
+                    return applied
 
             # Ack timed out. ONE bounded status re-query for the SAME key.
             event.clear()
@@ -485,13 +504,19 @@ class ComputeHost:
             )
             if event.wait(timeout=_REANCHOR_ACK_TIMEOUT_SECONDS):
                 with self._reanchor_lock:
-                    return bool(self._reanchor_results.get(key, False))
+                    applied = bool(self._reanchor_results.get(key, False))
+                    if applied:
+                        new_gen = self._reanchor_new_generations.get(key)
+                        if new_gen is not None:
+                            admission["generation"] = new_gen
+                    return applied
             # No committed answer at all -> fail the turn closed (do NOT write B).
             return False
         finally:
             with self._reanchor_lock:
                 self._reanchor_waiters.pop(key, None)
                 self._reanchor_results.pop(key, None)
+                self._reanchor_new_generations.pop(key, None)
 
     def _install_pre_rotation_reanchor(self, server: Any, sid: str, session: dict) -> None:
         """Wire the pre-rotation re-anchor callback onto the child's agent.
@@ -515,8 +540,20 @@ class ComputeHost:
 
         try:
             agent._pre_rotation_reanchor = _callback
-        except Exception:
-            pass
+        except Exception as exc:
+            # FAIL CLOSED (#99719): the session carries a delegated admission, so
+            # a mid-turn compression MUST re-anchor the real registry lease A->B
+            # before publishing B. If the hook cannot be installed, the turn
+            # would rotate hook-less and reopen the double-writer window the
+            # design closes. Raise so the caller's turn-outer except aborts the
+            # turn (turn.error) rather than proceeding unprotected.
+            logger.warning(
+                "failed to install pre-rotation re-anchor hook for sid=%s; "
+                "failing the turn closed: %s",
+                sid,
+                exc,
+            )
+            raise
 
     def _handle_reload_mcp(self, frame: dict[str, Any]) -> None:
         def body(server: Any, sid: str, request_id: Any) -> None:

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -291,6 +291,9 @@ class ComputeHost:
             session = self._build_server_session(server, frame, sid)
         if isinstance(frame.get("attached_images"), list):
             session["attached_images"] = list(frame.get("attached_images") or [])
+        # Re-adopt the serving process's admission on every reused turn
+        # (Design 1) -- the lease sentinel is per-turn frame state.
+        server._install_delegated_active_session_lease(session, frame)
         return session
 
     def _build_server_session(self, server: Any, frame: dict[str, Any], sid: str) -> dict:

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -46,6 +46,13 @@ class _HostTransport:
 # the whole budget would leave the flush racing that kill and persist nothing.
 _FLUSH_RESERVE_SECS = 1.0
 
+# Blocker 2 (#99719): the mid-turn compression re-anchor handshake blocks the
+# child worker on the owner's ack. Bounded so a lost/never-arriving ack cannot
+# wedge the turn: on timeout the child issues exactly ONE status re-query for
+# the SAME (request_id, generation) -- single-shot generation, never a fresh
+# proposal -- and fails the turn closed if that too returns no committed answer.
+_REANCHOR_ACK_TIMEOUT_SECONDS = 10.0
+
 # Fallback control.error text when a routed server method returns an error without a message.
 _CONTROL_FAILURES = {
     "session.save": "session save failed", "session.compress": "session compression failed"}
@@ -56,6 +63,7 @@ class ComputeHost:
     _FRAME_HANDLERS: dict[str, str] = {
         "turn.start": "_handle_turn_start", "interrupt": "_handle_interrupt",
         "respond": "_handle_respond", "reload_mcp": "_handle_reload_mcp",
+        "active_session.reanchor.ack": "_handle_reanchor_ack",
         "control": "_handle_control", "shutdown": "_handle_shutdown"}
 
     def __init__(
@@ -74,6 +82,13 @@ class ComputeHost:
         self._turn_futures: dict[concurrent.futures.Future, str] = {}
         self._turn_futures_lock = threading.Lock()
         self._transport = _HostTransport(self.emit)
+        # Blocker 2 (#99719): per-(request_id, generation) re-anchor ack Events.
+        # The blocked worker thread waits on the Event; the stdin reader thread
+        # sets the recorded result and wakes it -- the same cross-thread shape
+        # that already lets clarify/approval block mid-turn.
+        self._reanchor_waiters: dict[tuple[str, int], threading.Event] = {}
+        self._reanchor_results: dict[tuple[str, int], bool] = {}
+        self._reanchor_lock = threading.Lock()
         self._heartbeat_secs = (
             float(heartbeat_secs) if heartbeat_secs is not None
             else float(os.environ.get("HERMES_COMPUTE_HOST_HEARTBEAT_SECS") or "15"))
@@ -211,6 +226,15 @@ class ComputeHost:
         try:
             from tui_gateway import server
             session = self._ensure_server_session(server, frame)
+            # Blocker 2 (#99719): install the pre-rotation re-anchor callback on
+            # the child agent so a mid-turn auto-compression rotation A->B blocks
+            # (before publish_compression_child) on the serving owner atomically
+            # moving the REAL registry lease A->B. The disabled sentinel's own
+            # transfer is a local no-op that never touches the registry; without
+            # this the real lease would stay on A while the child writes B, so a
+            # second process could acquire B (double-writer). Only the isolated
+            # child installs it; serving/in-process paths install nothing.
+            self._install_pre_rotation_reanchor(server, sid, session)
             text = frame["text"] if "text" in frame else frame.get("prompt", "")
             inflight = frame["text"] if "text" in frame else frame.get("prompt")
             with session["history_lock"]:
@@ -366,6 +390,133 @@ class ComputeHost:
         if frame.get("model_override") is not None:
             session["model_override"] = frame.get("model_override")
         return session
+
+    def _handle_reanchor_ack(self, frame: dict[str, Any]) -> None:
+        """Route a Blocker-2 (#99719) re-anchor ack to the blocked worker.
+
+        Runs on the stdin reader thread. Records the boolean outcome keyed by
+        ``(request_id, generation)`` and wakes the worker waiting on the Event.
+        """
+        request_id = str(frame.get("request_id") or "")
+        try:
+            generation = int(frame.get("generation", 0) or 0)
+        except (TypeError, ValueError):
+            generation = 0
+        key = (request_id, generation)
+        with self._reanchor_lock:
+            self._reanchor_results[key] = bool(frame.get("applied"))
+            event = self._reanchor_waiters.get(key)
+        if event is not None:
+            event.set()
+
+    def _reanchor_active_session(
+        self,
+        sid: str,
+        old_id: str,
+        new_id: str,
+        admission: dict[str, Any],
+    ) -> bool:
+        """Propose the mid-turn registry re-anchor A->B and BLOCK on the ack.
+
+        Called from the pre-rotation-commit hook (before
+        publish_compression_child). Sends the proposal over the reverse-RPC,
+        blocks the worker thread on a per-(request_id, generation) Event, and
+        returns whether the owner committed the transfer.
+
+        Point-of-no-return handling (#99719 round-2): a committed transfer is
+        durable BEFORE the ack is emitted, so a lost/timed-out ack is NOT
+        treated as a failure. On timeout the child issues exactly ONE status
+        re-query for the SAME (request_id, generation) -- single-shot
+        generation, never a fresh proposal, never re-fetching a bumped N. Its
+        answer is authoritative: applied:true -> proceed to publish B (the
+        upsert is idempotent); applied:false -> abort to A. Only a status
+        re-query that ALSO returns no committed answer fails the turn closed.
+        """
+        request_id = uuid.uuid4().hex
+        try:
+            generation = int(admission.get("generation", 0) or 0)
+        except (TypeError, ValueError):
+            generation = 0
+        lease_id = str(admission.get("lease_id") or "")
+        key = (request_id, generation)
+        event = threading.Event()
+        with self._reanchor_lock:
+            self._reanchor_waiters[key] = event
+        try:
+            self.emit(
+                {
+                    "type": "rpc",
+                    "sid": sid,
+                    "message": {
+                        "method": "event",
+                        "params": {
+                            "type": "active_session.reanchor",
+                            "session_id": sid,
+                            "request_id": request_id,
+                            "old_id": old_id,
+                            "new_id": new_id,
+                            "lease_id": lease_id,
+                            "generation": generation,
+                        },
+                    },
+                }
+            )
+            if event.wait(timeout=_REANCHOR_ACK_TIMEOUT_SECONDS):
+                with self._reanchor_lock:
+                    return bool(self._reanchor_results.get(key, False))
+
+            # Ack timed out. ONE bounded status re-query for the SAME key.
+            event.clear()
+            self.emit(
+                {
+                    "type": "rpc",
+                    "sid": sid,
+                    "message": {
+                        "method": "event",
+                        "params": {
+                            "type": "active_session.reanchor.status",
+                            "session_id": sid,
+                            "request_id": request_id,
+                            "lease_id": lease_id,
+                            "generation": generation,
+                        },
+                    },
+                }
+            )
+            if event.wait(timeout=_REANCHOR_ACK_TIMEOUT_SECONDS):
+                with self._reanchor_lock:
+                    return bool(self._reanchor_results.get(key, False))
+            # No committed answer at all -> fail the turn closed (do NOT write B).
+            return False
+        finally:
+            with self._reanchor_lock:
+                self._reanchor_waiters.pop(key, None)
+                self._reanchor_results.pop(key, None)
+
+    def _install_pre_rotation_reanchor(self, server: Any, sid: str, session: dict) -> None:
+        """Wire the pre-rotation re-anchor callback onto the child's agent.
+
+        The callback (invoked by conversation_compression before
+        publish_compression_child) proposes the registry move A->B to the
+        serving owner and BLOCKS on the ack. Installed only when the session
+        carries a delegated admission record (the isolated-child path).
+        """
+        agent = session.get("agent")
+        if agent is None:
+            return
+        admission = session.get("_delegated_admission")
+        if not isinstance(admission, dict):
+            return
+
+        def _callback(old_session_id: str, new_session_id: str) -> bool:
+            return self._reanchor_active_session(
+                sid, old_session_id, new_session_id, admission
+            )
+
+        try:
+            agent._pre_rotation_reanchor = _callback
+        except Exception:
+            pass
 
     def _handle_reload_mcp(self, frame: dict[str, Any]) -> None:
         def body(server: Any, sid: str, request_id: Any) -> None:

--- a/tui_gateway/compute_host_bridge.py
+++ b/tui_gateway/compute_host_bridge.py
@@ -66,7 +66,17 @@ def _compute_host_turn_frame(
         "reasoning_config_override": session.get("create_reasoning_override"),
         "service_tier_override": session.get("create_service_tier_override"),
         "source": _session_source(session), "attached_images": attached_images,
-        "queued_prompt_generation": queued_prompt_generation}
+        "queued_prompt_generation": queued_prompt_generation,
+        # Turn-isolation lease handoff (Design 1). This turn was already admitted
+        # through the per-session ownership chokepoint in THIS (serving) process,
+        # which holds the real active-session lease. The compute-host child
+        # re-crosses that chokepoint in _run_prompt_submit but cannot recognise
+        # the serving process's lease across the process boundary
+        # (_is_same_writer requires an equal pid). Signal the admission so the
+        # child installs a disabled sentinel lease instead of re-claiming a
+        # second registry slot -- keeping exactly one admission and leaving the
+        # #94778 double-writer guard intact.
+        "active_session_admitted": session.get("active_session_lease") is not None}
 
 
 def _metadata_mirror(session: dict | None) -> dict:

--- a/tui_gateway/compute_host_bridge.py
+++ b/tui_gateway/compute_host_bridge.py
@@ -76,7 +76,36 @@ def _compute_host_turn_frame(
         # child installs a disabled sentinel lease instead of re-claiming a
         # second registry slot -- keeping exactly one admission and leaving the
         # #94778 double-writer guard intact.
+        #
+        # Blocker 2 (#99719): carry the QUALIFIED admission identity (the real
+        # lease_id, the admitted session id A, and a monotonic generation) so
+        # the child can quote it back verbatim when it proposes a mid-turn
+        # compression re-anchor A->B over the reverse-RPC handshake. The bare
+        # ``active_session_admitted`` boolean is derived from
+        # ``active_session_admission is not None`` for back-compat during
+        # rollout (consumer: _install_delegated_active_session_lease).
+        "active_session_admission": _turn_admission_record(session),
+        # Legacy boolean, DERIVED from the qualified record for back-compat
+        # during rollout (old consumers / frames still on the bare flag).
         "active_session_admitted": session.get("active_session_lease") is not None}
+
+
+def _turn_admission_record(session: dict) -> dict | None:
+    """Build the qualified admission record stamped into the turn frame.
+
+    ``None`` when the serving process holds no real lease for the session (the
+    old ``active_session_admitted is False`` case). Otherwise it carries the
+    authoritative ``lease_id``, the admitted session id, and a monotonic
+    ``generation`` the child quotes back verbatim in the re-anchor proposal.
+    """
+    lease = session.get("active_session_lease")
+    if lease is None:
+        return None
+    return {
+        "lease_id": str(getattr(lease, "lease_id", "") or ""),
+        "session_id": str(session.get("session_key") or ""),
+        "generation": int(session.get("_active_session_generation", 0) or 0),
+    }
 
 
 def _metadata_mirror(session: dict | None) -> dict:

--- a/tui_gateway/compute_host_bridge.py
+++ b/tui_gateway/compute_host_bridge.py
@@ -247,6 +247,7 @@ def _emit_active_session_reanchor_ack(params: dict, outcome: dict) -> None:
         "request_id": outcome.get("request_id"),
         "generation": outcome.get("generation"),
         "applied": bool(outcome.get("applied")),
+        "new_generation": outcome.get("new_generation"),
     }
     try:
         _get_compute_host_supervisor().send_frame(ack)

--- a/tui_gateway/compute_host_bridge.py
+++ b/tui_gateway/compute_host_bridge.py
@@ -217,6 +217,12 @@ def _on_compute_host_turn_done(rid: str, sid: str, session: dict, frame: dict) -
     info = _compute_host_session_info(session)
     if not frame.get("session_info_emitted"):
         _emit("session.info", sid, info)
+    # Blocker 1 (#99719): the child has reported this turn done (turn.end /
+    # turn.error, including the crash path via _fail_pending_turns' on_complete).
+    # It is no longer writing under sid, so release any lease detached-and-
+    # deferred at close/idle-reap. Idempotent keyed pop -- a no-op when nothing
+    # was detached (the common case).
+    _release_detached_leases_for_dead_child(sid)
     _drain_queued_prompt(rid, sid, session)
 
 

--- a/tui_gateway/compute_host_bridge.py
+++ b/tui_gateway/compute_host_bridge.py
@@ -127,6 +127,133 @@ def _compute_host_adopt_frame_meta(session: dict, frame: dict) -> None:
                                              int(frame.get("history_version") or 0))
 
 
+_reanchor_outcomes: dict[tuple[str, int], dict] = {}
+_reanchor_outcomes_lock = threading.Lock()
+
+
+def _handle_active_session_reanchor(params: dict) -> dict:
+    """Owner-side of the Blocker-2 (#99719) mid-turn re-anchor handshake.
+
+    Runs on the supervisor stdout-reader thread (the same thread as
+    _relay_compute_host_rpc). The child proposes moving the REAL registry lease
+    A->B before it commits continuation B. This handler validates the quoted
+    ``lease_id``+``generation`` against the real enabled lease it holds for the
+    session, then performs the SINGLE atomic transfer via the enabled
+    ``transfer_active_session`` path (the only registry writer -- no parallel
+    store).
+
+    Idempotent and outcome-recorded, keyed by ``(request_id, generation)``:
+    a first proposal transfers and records; a duplicate or a status re-query
+    returns the recorded outcome WITHOUT re-transferring (a same-id A->B is a
+    no-op that returns ``applied:true``). ``applied:false`` is emitted ONLY on
+    the handler's own exception raised BEFORE the file-locked commit;
+    ``applied:true`` only after the commit is durable -- so a committed transfer
+    is the point of no return and a lost ack never becomes a phantom lease.
+
+    MANDATE (#99719): this handler MUST NOT acquire ``session['history_lock']``
+    -- it needs only the lease object and the registry file lock inside
+    ``transfer_active_session`` -- so no cross-process lock cycle can form even
+    if a serving path regressed to holding history_lock across the child.
+    """
+    sid = str(params.get("session_id") or "")
+    request_id = str(params.get("request_id") or "")
+    try:
+        generation = int(params.get("generation", 0) or 0)
+    except (TypeError, ValueError):
+        generation = 0
+    key = (request_id, generation)
+
+    # Recorded-outcome fast path: duplicate proposal or status re-query.
+    with _reanchor_outcomes_lock:
+        recorded = _reanchor_outcomes.get(key)
+    if recorded is not None:
+        return dict(recorded)
+
+    # A status re-query with no recorded outcome means the original proposal was
+    # never processed here (e.g. the handler thread never ran). Report
+    # not-applied so the child fails closed rather than assuming a commit.
+    if params.get("type") == "active_session.reanchor.status":
+        return {"request_id": request_id, "generation": generation, "applied": False}
+
+    new_id = str(params.get("new_id") or "")
+    quoted_lease_id = str(params.get("lease_id") or "")
+    try:
+        session = _sessions.get(sid)
+        if session is None:
+            raise RuntimeError(f"no live session for re-anchor: sid={sid}")
+        lease = session.get("active_session_lease")
+        if lease is None or not getattr(lease, "enabled", False):
+            raise RuntimeError("serving process holds no enabled lease for re-anchor")
+        if quoted_lease_id and str(getattr(lease, "lease_id", "")) != quoted_lease_id:
+            raise RuntimeError("re-anchor lease_id mismatch (stale proposal)")
+        current_generation = int(session.get("_active_session_generation", 0) or 0)
+        if generation != current_generation:
+            raise RuntimeError(
+                f"re-anchor generation mismatch: quoted={generation} "
+                f"current={current_generation}"
+            )
+        if not new_id:
+            raise RuntimeError("re-anchor missing new session id")
+
+        from hermes_cli.active_sessions import transfer_active_session
+
+        # THE SINGLE ATOMIC TRANSFER POINT (enabled path, file-locked A->B).
+        # A same-id A->B (lease already on new_id) is a no-op that returns True.
+        committed = transfer_active_session(
+            lease,
+            session_id=new_id,
+            metadata={"live_session_id": sid},
+        )
+        if not committed:
+            raise RuntimeError("registry transfer did not commit")
+    except Exception as exc:
+        # Handler exception BEFORE the durable commit -> nack. Not recorded:
+        # nothing durable changed, so a later reconciliation is free to resolve
+        # the state, but the child aborts to A on this answer.
+        logger.warning(
+            "active-session re-anchor refused: sid=%s request_id=%s: %s",
+            sid,
+            request_id,
+            exc,
+        )
+        return {"request_id": request_id, "generation": generation, "applied": False}
+
+    # Committed and durable. Bump the generation so a stale racing proposal is
+    # nacked, and record the outcome so a duplicate/status re-query is a no-op.
+    session["_active_session_generation"] = current_generation + 1
+    outcome = {
+        "request_id": request_id,
+        "generation": generation,
+        "applied": True,
+        "new_generation": current_generation + 1,
+    }
+    with _reanchor_outcomes_lock:
+        _reanchor_outcomes[key] = dict(outcome)
+    return outcome
+
+
+def _emit_active_session_reanchor_ack(params: dict, outcome: dict) -> None:
+    """Send the correlated inbound ack down to the child (best effort).
+
+    The child's stdin reader routes ``active_session.reanchor.ack`` to the
+    blocked worker's per-(request_id, generation) Event. Delivery failure is
+    non-fatal: the child's bounded ack timeout drives a single status re-query,
+    and a committed transfer is already durable in the registry.
+    """
+    sid = str(params.get("session_id") or "")
+    ack = {
+        "type": "active_session.reanchor.ack",
+        "sid": sid,
+        "request_id": outcome.get("request_id"),
+        "generation": outcome.get("generation"),
+        "applied": bool(outcome.get("applied")),
+    }
+    try:
+        _get_compute_host_supervisor().send_frame(ack)
+    except Exception:
+        logger.debug("re-anchor ack delivery failed", exc_info=True)
+
+
 def _relay_compute_host_rpc(message: dict) -> bool:
     """Relay host events while retaining the clarify snapshot needed on resume."""
     params = message.get("params") if isinstance(message, dict) else None
@@ -139,6 +266,17 @@ def _relay_compute_host_rpc(message: dict) -> bool:
                             and session.get("_compute_host_turn_id") == params["turn_id"]):
                         session["_compute_host_activity_ns"] = params.get("activity_ns")
         return True  # Internal observation, not a client event or replay entry.
+    # Blocker 2 (#99719): the child's mid-turn compression re-anchor proposal is
+    # an INTERNAL request/reply, not a UI event. Handle it and its status
+    # re-query here and EARLY-RETURN -- it must NOT fall through to write_json
+    # below, which would leak the handshake frame to every connected UI client.
+    if isinstance(params, dict) and params.get("type") in (
+        "active_session.reanchor",
+        "active_session.reanchor.status",
+    ):
+        outcome = _handle_active_session_reanchor(params)
+        _emit_active_session_reanchor_ack(params, outcome)
+        return True
     kind = params.get("type") if isinstance(params, dict) else None
     if kind in {"clarify.request", "clarify.expire"}:
         session = _sessions.get(str(params.get("session_id") or ""))

--- a/tui_gateway/host_supervisor.py
+++ b/tui_gateway/host_supervisor.py
@@ -243,6 +243,18 @@ class HostSupervisor:
         self._send_frame(
             {"type": "interrupt", "sid": sid, "request_id": request_id or uuid.uuid4().hex})
 
+    def send_frame(self, frame: dict[str, Any]) -> None:
+        """Send a control/ack frame down to the running child (best effort).
+
+        Used for the Blocker-2 (#99719) reverse-RPC: the serving process
+        answers the child's mid-turn re-anchor proposal with an inbound
+        ``active_session.reanchor.ack`` frame the child's stdin reader routes to
+        its blocked worker. Never (re)starts the child -- if it is not running
+        there is no worker to ack, and the child fails closed on its own ack
+        timeout.
+        """
+        self._send_frame(frame)
+
     def _await_reply(self, frame: dict[str, Any], request_id: str, timeout: float) -> dict:
         """Send ``frame`` and block for the host reply carrying ``request_id``."""
         q: queue.Queue[dict] = queue.Queue(maxsize=1)

--- a/tui_gateway/host_supervisor.py
+++ b/tui_gateway/host_supervisor.py
@@ -190,6 +190,11 @@ class HostSupervisor:
             self._terminate_process(proc)
         finally:
             self._remove_registry()
+            # Blocker 1a (#99719): the child has exited / been terminated. Cover
+            # the path where shutdown() reaps the child itself rather than
+            # _wait_for_exit observing it -- release detached leases here too.
+            # Idempotent with the _wait_for_exit call (keyed pop).
+            self._release_detached_on_child_exit()
 
     def reconcile_startup_orphan(self) -> str:
         """Terminate a stale registered host, guarding against PID reuse."""
@@ -408,8 +413,34 @@ class HostSupervisor:
             if pending is not None and pending[1] is not None:
                 _call_logged(pending[1], frame, "compute host turn completion callback failed")
 
+    def _release_detached_on_child_exit(self) -> None:
+        """Release all leases the serving process detached for deferred release
+        because their isolated child (the one shared child this supervisor owns)
+        may still have been writing. On child exit that is no longer possible.
+
+        In-process call into the serving-process server module (the supervisor
+        runs in the same process). Idempotent keyed pop, so overlapping callers
+        (``_wait_for_exit`` and ``shutdown``) are safe. Imported lazily and
+        looked up at call time so tests can monkeypatch the release.
+        """
+        try:
+            from tui_gateway import server as _server
+
+            _server._release_detached_leases_for_dead_child()
+        except Exception:
+            logger.debug("detached-lease release on child exit failed", exc_info=True)
+
     def _wait_for_exit(self, proc: subprocess.Popen[str]) -> None:
         code = proc.wait()
+        # Blocker 1a (#99719): the shared child has EXITED. Any lease detached
+        # for deferred release (its write-exclusivity was owed to this child)
+        # must be released now, on EVERY observed exit -- closing or not. This
+        # runs AHEAD of the `_closing` early-return below because graceful
+        # shutdown sets `_closing=True` before the child exits, and turn.end
+        # never arrives for a dead child, so without this the detached lease
+        # would leak (the owning pid is the still-alive serving process, so
+        # _prune_dead cannot reclaim it) -> a self-inflicted DoS on the id.
+        self._release_detached_on_child_exit()
         if self._closing:
             return
         with self._lock:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -80,6 +80,16 @@ with contextlib.suppress(Exception):
 from tui_gateway.render import make_stream_renderer, render_diff, render_message  # noqa: F401
 
 _sessions: dict[str, dict] = {}
+# Blocker 1 (#99719): canonical active-session leases DETACHED from their
+# session dict at close/idle-reap while an isolated compute-host CHILD may still
+# be writing. The lease stays ENABLED and its registry entry keeps protecting
+# the session id until the child actually exits; release is deferred to the
+# per-turn done receipt / child-death paths. Keyed by "<sid>:<lease_id>". Guarded
+# by the EXISTING _sessions_lock (the same lock the idle reaper holds while it
+# reads _sessions to build `live`) -- no new lock, so the reaper can never observe
+# a lease that is in neither map (detach inserts here BEFORE removing from the
+# session dict, as one critical section).
+_detached_leases: dict[str, Any] = {}
 _methods: dict[str, callable] = {}
 _pending: dict[str, tuple[str, threading.Event]] = {}
 _pending_prompt_payloads: dict[str, tuple[str, dict]] = {}

--- a/tui_gateway/session_compression.py
+++ b/tui_gateway/session_compression.py
@@ -282,7 +282,26 @@ def _sync_session_key_after_compress(
     old_key = session.get("session_key", "") or ""
     if not new_session_id or new_session_id == old_key:
         return
-    if not _transfer_active_session_slot(sid, session, new_session_id=new_session_id):
+    lease = session.get("active_session_lease")
+    isolated_child = lease is not None and not getattr(lease, "enabled", True)
+    if isolated_child:
+        # Blocker 2 (#99719): for a compute-host isolated child the REAL
+        # registry lease was already moved A->B mid-turn by the re-anchor
+        # handshake (before publish_compression_child). The child holds only a
+        # disabled sentinel whose transfer is a local no-op, so a post-turn
+        # _transfer_active_session_slot here is redundant. Downgrade to
+        # assert-only: keep the sentinel's local id consistent, then fall
+        # through to sync session_key. Manual /compress runs in the serving
+        # process holding a real ENABLED lease, so it never takes this branch
+        # and its synchronous in-process transfer is unchanged.
+        try:
+            setattr(lease, "session_id", new_session_id)
+        except Exception:
+            pass
+        lease_reanchored = True
+    else:
+        lease_reanchored = _transfer_active_session_slot(sid, session, new_session_id=new_session_id)
+    if not lease_reanchored:
         logger.warning(
             "Compression session lease did not re-anchor: sid=%s old_session_id=%s new_session_id=%s",
             sid, old_key, new_session_id,

--- a/tui_gateway/session_lifecycle.py
+++ b/tui_gateway/session_lifecycle.py
@@ -57,6 +57,44 @@ def _ensure_active_session_slot(sid: str, session: dict) -> str | None:
     return limit_message
 
 
+def _install_delegated_active_session_lease(session: dict, frame: dict) -> None:
+    """Install a disabled sentinel lease for a turn admitted by the serving process.
+
+    Turn-isolation Design 1: a named-profile turn is admitted ONCE, in the
+    serving (dashboard/gateway) process, which claims the real active-session
+    lease. The turn is then dispatched to a compute-host child, whose rebuilt
+    session dict carries no lease. The child re-crosses the ownership chokepoint
+    in ``_run_prompt_submit`` (the #94778 double-writer guard) and would
+    otherwise re-claim -- and be refused, because ``_is_same_writer`` cannot
+    match across a process boundary (it requires an equal pid).
+
+    When the frame says the turn was already admitted, install a DISABLED
+    ``ActiveSessionLease`` so ``_ensure_active_session_slot`` short-circuits on
+    the ``active_session_lease is not None`` fast path -- no second registry
+    claim. The lease is disabled (``enabled=False``), so ``release()`` is a
+    no-op and ``transfer_active_session`` (fired when auto-compression rotates
+    the session id mid-turn) takes its disabled-lease no-op branch instead of
+    the fallback that would claim a real second slot in the child. It must NOT
+    be marked ``released``: a released lease trips ``transfer_active_session``'s
+    ``if lease.released`` early-return, which bypasses the disabled branch and
+    falls through to that real re-claim. A real lease already present (native,
+    non-isolated path) is never overwritten.
+    """
+    if not frame.get("active_session_admitted"):
+        return
+    if session.get("active_session_lease") is not None:
+        return
+    from hermes_cli.active_sessions import ActiveSessionLease
+
+    session["active_session_lease"] = ActiveSessionLease(
+        lease_id=f"delegated:{frame.get('session_key') or ''}",
+        session_id=str(frame.get("session_key") or ""),
+        surface="compute-host",
+        enabled=False,
+        released=False,
+    )
+
+
 def _lease_retry(attempts: int, fn) -> Exception | None:
     """Call ``fn`` up to ``attempts`` times (50ms*n backoff: registry writes contend across processes); last
     exception when every try failed, else None."""

--- a/tui_gateway/session_lifecycle.py
+++ b/tui_gateway/session_lifecycle.py
@@ -79,13 +79,25 @@ def _install_delegated_active_session_lease(session: dict, frame: dict) -> None:
     ``if lease.released`` early-return, which bypasses the disabled branch and
     falls through to that real re-claim. A real lease already present (native,
     non-isolated path) is never overwritten.
+
+    Blocker 2 (#99719): admission is now carried as the qualified
+    ``active_session_admission`` record ``{lease_id, session_id, generation}``.
+    The old bare ``active_session_admitted`` boolean is derived from
+    ``admission is not None`` for back-compat during rollout. The record is
+    stashed on the session (``_delegated_admission``) so the child can quote it
+    back verbatim in its mid-turn re-anchor proposal.
     """
-    if not frame.get("active_session_admitted"):
+    admission = frame.get("active_session_admission")
+    # Back-compat: derive from either the qualified record or the legacy bool.
+    admitted = admission is not None or bool(frame.get("active_session_admitted"))
+    if not admitted:
         return
     if session.get("active_session_lease") is not None:
         return
     from hermes_cli.active_sessions import ActiveSessionLease
 
+    if isinstance(admission, dict):
+        session["_delegated_admission"] = dict(admission)
     session["active_session_lease"] = ActiveSessionLease(
         lease_id=f"delegated:{frame.get('session_key') or ''}",
         session_id=str(frame.get("session_key") or ""),

--- a/tui_gateway/session_lifecycle.py
+++ b/tui_gateway/session_lifecycle.py
@@ -131,6 +131,87 @@ def _own_live_lease_ids(*, exclude=None) -> set[str]:
                 if (lease := session.get("active_session_lease")) is not None and lease is not exclude}
 
 
+def _release_active_session_lease(lease) -> bool:
+    """Release a bare lease object (no session dict), liveness-tracked leases get 3 tries; True when released."""
+    if lease is None:
+        return True
+    if (err := _lease_retry(3 if getattr(lease, "track_liveness", False) else 1, lambda: lease.release())) is not None:
+        logger.warning("Failed to release active session slot", exc_info=err)
+        return False
+    return bool(getattr(lease, "released", True) or not getattr(lease, "enabled", True))
+
+
+def _ownership_owed_to_live_child(session: dict | None) -> bool:
+    """True when the real lease must be HELD past close because an isolated
+    compute-host child may still be writing this session.
+
+    Blocker 1 (#99719): the child re-crosses the ownership chokepoint with only
+    a DISABLED sentinel; its write-exclusivity rests ENTIRELY on this serving
+    process holding the one real enabled lease for the whole turn. Releasing it
+    while ``running`` is still true (the child has not reported turn.end) drops
+    the registry entry out from under a live writer and reopens the
+    double-writer window. In that case ownership is DETACHED-and-deferred, not
+    released.
+    """
+    if not session:
+        return False
+    lease = session.get("active_session_lease")
+    if lease is None or not getattr(lease, "enabled", False):
+        return False
+    if not (session.get("running") or session.get("_compute_host_active")):
+        return False
+    try:
+        return bool(_session_uses_compute_host(session))
+    except Exception:
+        return False
+
+
+def _detached_lease_key(sid: str, lease) -> str:
+    return f"{sid}:{getattr(lease, 'lease_id', '')}"
+
+
+def _detach_lease_for_deferred_release(
+    sid: str, lease, *, session: dict | None = None
+) -> str:
+    """Move the still-enabled real lease out of the session dict into the
+    process-global detached table, as ONE critical section under
+    ``_sessions_lock`` that inserts into ``_detached_leases`` BEFORE removing it
+    from the session dict (insert-before-remove).
+
+    Returns the detached-table key. Idempotent for a given (sid, lease).
+    """
+    key = _detached_lease_key(sid, lease)
+    with _sessions_lock:
+        # Insert first: a reaper tick that acquires _sessions_lock between the
+        # two mutations must never find the lease in NEITHER map.
+        _detached_leases[key] = lease
+        if session is not None and session.get("active_session_lease") is lease:
+            session.pop("active_session_lease", None)
+    return key
+
+
+def _release_detached_leases_for_dead_child(sid: str | None = None) -> int:
+    """Release detached leases whose isolated child has exited.
+
+    Called from the per-turn done receipt (``_on_compute_host_turn_done`` for a
+    single sid), the child-death paths (``host_supervisor._wait_for_exit`` ahead
+    of the ``_closing`` guard, and ``shutdown()``), and the crash callback. When
+    ``sid`` is None every detached lease is released (whole-child exit). Each
+    release is an idempotent keyed pop, so overlapping callers are safe.
+    """
+    with _sessions_lock:
+        if sid is None:
+            popped = list(_detached_leases.items())
+            _detached_leases.clear()
+        else:
+            prefix = f"{sid}:"
+            keys = [k for k in _detached_leases if k.startswith(prefix)]
+            popped = [(k, _detached_leases.pop(k)) for k in keys]
+    for _key, lease in popped:
+        _release_active_session_lease(lease)
+    return len(popped)
+
+
 @contextlib.contextmanager
 def _other_runtime_lease_guard(session_id: str, session: dict):
     """Release this runtime and lock sibling ownership through the DB write. Yields True (another runtime owns
@@ -244,7 +325,21 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
         end_reason in _AUTOMATIC_SESSION_END_REASONS and _session_source(session).strip().lower() == "desktop")
     # Automatic Desktop cleanup releases its lease inside the lifecycle guard below; other paths keep force/end semantics.
     if not _desktop_automatic_cleanup:
-        _release_active_session_slot(session)
+        # Blocker 1 (#99719): do NOT release the canonical lease while an
+        # isolated compute-host child may still be writing this session. When
+        # ownership is still owed to a live child, DETACH-and-defer the enabled
+        # lease instead -- the registry entry keeps protecting the id until the
+        # child actually exits (turn.end / crash / child-death), reconciled with
+        # the idle reaper (which skips detached leases) and the child-death
+        # release paths. Otherwise a bounded close would drop the lease out from
+        # under a live writer and reopen the double-writer window.
+        if _ownership_owed_to_live_child(session):
+            lease = session.get("active_session_lease")
+            _detach_lease_for_deferred_release(
+                str(session.get("_sid") or ""), lease, session=session
+            )
+        else:
+            _release_active_session_slot(session)
     if (stop_event := session.get("_notif_stop")) is not None:
         stop_event.set()
     agent = session.get("agent")

--- a/tui_gateway/session_lifecycle.py
+++ b/tui_gateway/session_lifecycle.py
@@ -373,6 +373,38 @@ def _teardown_popped_session(session: dict | None, *, end_reason: str = "tui_clo
     """Finish a close after the caller has atomically detached the session."""
     if session is None:
         return False
+    # An isolated (compute-host) turn runs in a CHILD process, not in this
+    # process's _run_thread, so the settle-grace join below cannot see it. Its
+    # safety while running rests entirely on this serving process holding the
+    # real active-session lease (the child's own ownership chokepoint is a
+    # no-op via the delegated sentinel). _finalize_session releases that lease
+    # unconditionally, so interrupt the child FIRST -- otherwise the lease
+    # drops while the child keeps writing, reopening a narrow #94778 window for
+    # a sibling backend sharing HERMES_HOME. The automatic reapers already gate
+    # on `running`, so this only matters for an explicit close mid-turn.
+    if (
+        end_reason != "tui_shutdown"
+        and (session.get("running") or session.get("_compute_host_active"))
+        and _session_uses_compute_host(session)
+    ):
+        try:
+            _interrupt_session_turn(str(session.get("_sid") or ""), session)
+            # interrupt() is fire-and-forget (it just sends a frame to the
+            # child), so wait -- bounded by the same settle grace the in-process
+            # path uses for _run_thread -- for the child to report the turn done
+            # (_on_compute_host_turn_done clears `running`). This keeps the real
+            # lease held until the child actually stops writing, not merely until
+            # the interrupt was dispatched.
+            deadline = time.monotonic() + _TURN_SETTLE_BEFORE_CLOSE_SECONDS
+            while session.get("running") and time.monotonic() < deadline:
+                time.sleep(0.02)
+            if session.get("running"):
+                logger.warning(
+                    "compute-host turn still running after %.1fs close grace",
+                    _TURN_SETTLE_BEFORE_CLOSE_SECONDS,
+                )
+        except Exception:
+            logger.debug("failed to interrupt compute-host turn on close", exc_info=True)
     run_thread = session.get("_run_thread")
     if end_reason != "tui_shutdown" and run_thread is not None and run_thread is not threading.current_thread():
         try:

--- a/tui_gateway/session_reaper.py
+++ b/tui_gateway/session_reaper.py
@@ -225,7 +225,19 @@ def _reclaim_orphaned_leases() -> None:
     """Hand the registry the lease ids we still own so it can drop the rest."""
     try:
         from hermes_cli.active_sessions import release_orphaned_leases
-        if dropped := release_orphaned_leases(_own_live_lease_ids()):
+        with _sessions_lock:
+            live = _own_live_lease_ids()
+            # Blocker 1b (#99719): a lease DETACHED for deferred release is no
+            # longer in _sessions but its child may still be writing, so its
+            # registry entry must stay protected. Union the detached-table
+            # lease_ids under the SAME _sessions_lock hold so the reaper SKIPS
+            # them (never sweeps a detached lease). Held under one lock so the
+            # reaper cannot observe a lease mid-detach in neither map.
+            live |= {
+                getattr(lease, "lease_id", "")
+                for lease in _detached_leases.values()
+            }
+        if dropped := release_orphaned_leases(live):
             logger.info("Reclaimed %d orphaned active-session lease(s)", dropped)
     except Exception:
         logger.debug("orphaned lease reclaim failed", exc_info=True)


### PR DESCRIPTION
## What does this PR do?

Makes `dashboard.turn_isolation` actually work for named-profile agents whose terminal backend is `docker` (or `ssh`), and closes the two per-session write-exclusivity gaps found in review. Before this, opening such an agent's chat from the desktop dashboard failed to start at all; once it could start, a close or a mid-turn compression could drop the real active-session lease out from under the still-running isolated child, reopening the double-writer window that #99719 (salvaged Futahua/#94595) closed.

**Background.** With turn isolation on, a turn is admitted once in the serving (dashboard/gateway) process -- which claims the real per-session active-session lease -- and then dispatched to a compute-host **child process** to run. Four defects surfaced along that path. Two are fixed here; two were fixed independently upstream and by #101479 while this PR was open, so their commits were dropped (see the PR comment).

1. **The turn was refused outright.** The child re-crosses the ownership chokepoint in `_run_prompt_submit` (the #94778 double-writer guard), but its rebuilt session dict carries no lease, and `_is_same_writer` can never match across a process boundary (it requires an equal pid). So the child re-claimed, saw the serving process's live entry, and refused every isolated turn with `Session ... already has a live owner (pid N)`.

2. **The real lease could be dropped under a running child.** With the handoff in place the child's chokepoint is a no-op, so a running isolated turn's write-exclusivity rests entirely on the serving process holding the real lease for the turn's whole duration. Two paths broke that:
   - **explicit close** (`session.close`) tore down unconditionally and only waited on the in-process `_run_thread`, which does not exist for an isolated turn -- so closing a tab mid-turn released the lease while the child kept writing;
   - **a bounded close still released too early**: `_teardown_popped_session` waited a fixed grace and then released the lease *unconditionally* even when the child was still running.

3. **Mid-turn compression re-anchored the wrong lease.** When context compression rotates the session id `A -> B` inside the child, the child's disabled sentinel `transfer_active_session` is a local no-op that never touches the registry: the real lease stays on `A` while the child writes continuation `B`, so a second process can acquire `B`.

**Why this approach.** The handoff (fix 1) preserves the single-admission invariant exactly -- the child adopts the serving process's admission via a **disabled sentinel** lease rather than making a second claim -- so the #94778 double-writer guarantee is untouched. Fix 2 keeps the real lease alive for the child's real lifetime: closing interrupts the child first, and when ownership is still owed to a live child the still-enabled lease is *detached* for deferred release (released on the turn-done receipt or on child death) instead of dropped. Fix 3 makes compression re-anchor the *real* enabled lease via a correlated child-proposes / owner-transfers / owner-acks handshake, so `A -> B` is one atomic registry move that completes before the child publishes `B` (fail-closed on nack/timeout).

## Related Issue

<!-- No public issue for the isolation bring-up; the write-exclusivity gaps are the double-writer class tracked by #99719 / #94778. -->

Refs #99719, #94778

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py`
  - `_compute_host_turn_frame`: the turn frame carries a qualified `active_session_admission` record `{lease_id, session_id, generation}` (the legacy `active_session_admitted` bool is derived from it for back-compat).
  - `_install_delegated_active_session_lease`: the child installs a **disabled** sentinel `ActiveSessionLease` so `_ensure_active_session_slot` short-circuits on the fast path -- no second registry claim, and `release()` is a no-op so the child can never drop the serving process's real lease. The sentinel is `enabled=False` but **not** `released` (a released lease trips `transfer_active_session`'s early-return and falls through to a real re-claim on mid-turn compression). It also stamps the admission record the child quotes back during a re-anchor.
  - `_teardown_popped_session`: interrupt an in-flight compute-host child turn (bounded by the existing settle grace) before releasing the lease.
  - Deferred-release path: when ownership is still owed to a live child, the enabled lease is detached into a process-global `_detached_leases` table (insert-before-remove under `_sessions_lock`) instead of released; the idle reaper unions the detached ids into its `live` set so it never sweeps them. Release fires on `_on_compute_host_turn_done` (incl. the crash path) and on child death.
  - `_handle_active_session_reanchor` (invoked from `_relay_compute_host_rpc`, early-returns so the internal frame never leaks to the UI): validates the quoted `lease_id`+`generation`, performs the single atomic `transfer_active_session A -> B` (the only registry writer), idempotent + outcome-recorded by `(request_id, generation)`; `applied:false` only on a pre-commit exception, `applied:true` only after the durable commit; never takes `session['history_lock']`. Acks over the new `HostSupervisor.send_frame`.
- `tui_gateway/compute_host.py`: adopts the delegated sentinel on both the reused-session and fresh-build paths; `handle_frame` routes `active_session.reanchor.ack` to a per-`(request_id, generation)` event; `_reanchor_active_session` blocks the worker on it (same shape as clarify/approval), with a bounded `_REANCHOR_ACK_TIMEOUT_SECONDS` and exactly one status re-query on timeout, else fails the turn closed.
- `tui_gateway/host_supervisor.py`: `send_frame` writer; releases detached leases on every observed child exit ahead of the `_closing` guard and from `shutdown()`.
- `agent/conversation_compression.py`: invokes optional `agent._pre_rotation_reanchor(old, new)` immediately before `publish_compression_child`; a `RuntimeError`/falsy return aborts the rotation fail-closed (parent stays live, child never writes `B`).
- Tests: `tests/tui_gateway/test_compute_host_turn_isolation_lease.py` (handoff, no-reclaim, close-interrupts-before-release + bounded wait, hold-until-child-exit, reaper skips detached), `tests/tui_gateway/test_compute_host_lease_reanchor.py` (B-refused-until-transfer, committed-transfer-then-lost-ack, pre-commit-nack abort, generation refresh across rotations, fail-closed hook install).

## How to Test

1. Configure a named profile with `terminal.backend: docker` and `dashboard.turn_isolation: true`.
2. Open that profile's chat from the desktop dashboard and send a prompt that runs a shell command (e.g. `hostname && pwd && whoami`).
3. Before: the turn is refused (`already has a live owner`). After: the turn runs inside the profile's isolated compute-host child, and the command reports the **container's** hostname/user -- not the host's, and the default profile keeps resolving `terminal.backend: local` in its own process (no cross-profile leak).
4. Close the tab mid-turn, and force a mid-turn context compression: the real lease is never dropped under the running child, and a second process can never acquire the session id while the child is writing.
5. Automated:
   - `.venv-dev/bin/python -m pytest tests/tui_gateway/test_compute_host_turn_isolation_lease.py -q` — 16 passed.
   - `.venv-dev/bin/python -m pytest tests/tui_gateway/test_compute_host_lease_reanchor.py -q` — 9 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(gateway):` — six self-contained commits)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (two overlapping fixes were dropped — see the PR comment)
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **see note below**
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (aarch64, Python 3.13), docker backend, dashboard turn isolation, verified end-to-end against a live deployment

**Note on the full test run:** the tests added here pass, and each touched suite passes on its own. There is a **pre-existing** cross-file test-isolation issue on `upstream/main` (reproduced with these changes reverted): running certain `tests/tui_gateway/test_compute_host*` files before `tests/test_tui_gateway_server.py` in one invocation leaks global state and makes a few slow-agent-build tests fail (`IndexError` on a mocked threads list). It is unrelated to this PR.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings + inline comments) — or N/A
- [x] `cli-config.yaml.example`: N/A (no new config keys; `dashboard.turn_isolation` already exists)
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A (no architecture/workflow change)
- [x] Cross-platform impact: N/A (pure Python; no platform-specific calls)
- [x] Tool descriptions/schemas: N/A (no tool behavior change)
