### PR TITLE
fix(cli): canonicalize venv-derived fields out of launchd staleness comparison

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4265,13 +4265,32 @@ def _normalize_launchd_plist_for_comparison(text: str) -> str:
     invoking shell so user-installed tools remain reachable under launchd.
     That makes raw text comparison unstable across shells, so ignore the PATH
     payload when deciding whether the installed plist is stale.
+
+    The interpreter in ``ProgramArguments`` and the ``VIRTUAL_ENV`` value
+    resolve from whichever venv's ``hermes`` invoked the CLI (a git install can
+    carry both ``venv`` and ``.venv``), so canonicalize them too — otherwise a
+    plist written by ``gateway start`` is perpetually stale under
+    ``gateway status`` and no restart can ever clear the warning (#101498).
     """
     import re
 
     normalized = _normalize_service_definition(text)
-    return re.sub(
+    normalized = re.sub(
         r"(<key>PATH</key>\s*<string>)(.*?)(</string>)",
         r"\1__HERMES_PATH__\3",
+        normalized,
+        flags=re.S,
+    )
+    # Both the stderr wrapper and the inner ``gateway run`` command are spelled
+    # "<string>…/bin/python</string>" followed by "<string>-m</string>".
+    normalized = re.sub(
+        r"(<string>)([^<]*python[^<]*)(</string>\s*<string>-m</string>)",
+        r"\1__HERMES_PYTHON__\3",
+        normalized,
+    )
+    return re.sub(
+        r"(<key>VIRTUAL_ENV</key>\s*<string>)(.*?)(</string>)",
+        r"\1__HERMES_VENV__\3",
         normalized,
         flags=re.S,
     )

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -343,6 +343,53 @@ class TestGeneratedSystemdUnits:
 
         assert "SoftResourceLimits" not in plist
 
+    def test_launchd_plist_is_current_across_invoking_venvs(self, tmp_path, monkeypatch):
+        """The staleness answer must not depend on which venv's hermes runs the
+        CLI (#101498).
+
+        A git install can carry both ``venv`` (what ``hermes`` on PATH resolves
+        to) and ``.venv`` (the canonical runtime): ``gateway start`` writes the
+        plist from one venv, then ``gateway status`` compares from the other.
+        Before the fix the interpreter in ProgramArguments and the VIRTUAL_ENV
+        payload leaked the invoking venv, so `start` could never clear what
+        `status` reported."""
+        canonical_venv = tmp_path / ".venv"
+        launcher_venv = tmp_path / "venv"
+        for venv in (canonical_venv, launcher_venv):
+            bin_dir = venv / "bin"
+            bin_dir.mkdir(parents=True)
+            (bin_dir / "python").write_text("#!/bin/sh\n")
+
+        # `gateway start` writes the plist while the canonical runtime is active.
+        monkeypatch.setattr(gateway_cli, "_detect_venv_dir", lambda: canonical_venv)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+
+        # `gateway status` later compares in-process under the PATH-launcher venv.
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "_detect_venv_dir", lambda: launcher_venv)
+
+        assert gateway_cli.launchd_plist_is_current() is True
+
+    def test_launchd_plist_staleness_survives_venv_canonicalization(self, tmp_path, monkeypatch):
+        """Canonicalizing the invoking venv out of the comparison must not mask
+        real drift: a plist whose ThrottleInterval differs from the generated
+        one is still stale."""
+        monkeypatch.setattr(
+            gateway_cli, "_detect_venv_dir", lambda: tmp_path / ".venv"
+        )
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(
+            gateway_cli.generate_launchd_plist().replace(
+                "<key>ThrottleInterval</key>\n    <integer>30</integer>",
+                "<key>ThrottleInterval</key>\n    <integer>10</integer>",
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        assert gateway_cli.launchd_plist_is_current() is False
+
 
 
 class TestGatewayStopCleanup:


### PR DESCRIPTION
## What does this PR do?

`hermes gateway status` reports "⚠ Service definition is stale relative to the current Hermes install" forever on git installs that carry two venvs (`venv` on PATH plus the canonical `.venv`): the plist is written under one interpreter, then `gateway status` regenerates the expected plist from whichever venv's `hermes` invoked the CLI. Because `_normalize_launchd_plist_for_comparison()` normalized the PATH payload but not the venv-derived interpreter paths (in `ProgramArguments`) or the `VIRTUAL_ENV` value, the comparison could never agree across venvs — no amount of `gateway start` could clear the warning.

This PR canonicalizes those invocation-dependent fields out of the staleness comparison, exactly like PATH already was: interpreter strings (both the stderr-timestamp wrapper and the inner `gateway run` command, both spelled `<string>…/bin/python</string><string>-m</string>`) and the `VIRTUAL_ENV` env value are replaced with placeholders before comparing. Substantive drift (any other key/value difference) still flags the plist as stale.

## Related Issue

Fixes #101498

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/gateway.py`: `_normalize_launchd_plist_for_comparison()` now also canonicalizes the interpreter strings inside `ProgramArguments` and the `VIRTUAL_ENV` environment value, mirroring the existing PATH placeholder treatment.
- `tests/hermes_cli/test_gateway_service.py`: added `test_launchd_plist_is_current_across_invoking_venvs` (a plist written from `.venv` compares as current when regenerated from `venv`) and `test_launchd_plist_staleness_survives_venv_canonicalization` (a real value drift — `ThrottleInterval` — is still reported stale).

## How to Test

1. `pytest tests/hermes_cli/test_gateway_service.py -k "launchd_plist" -q` → 8 passed. Observed result: with the fix the cross-venv test passes; on unpatched `main` it fails (`assert False is True`), confirming it pins the reported behavior.
2. `pytest tests/hermes_cli/ -k "gateway" -q` → 871 passed, 28 skipped. The single failure in `test_update_launchd_fleet_restart.py::TestGetServicePidsScoping` also fails on clean upstream `main` (6ef6691960) with this PR's changes fully reverted — pre-existing and unrelated.
3. `ruff check hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py` → All checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (full `tests/hermes_cli/` gateway suite + `test_gateway_service.py` as detailed in How to Test)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin 25.4.0, arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the normalization contract is documented in the function docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the comparison path is macOS-launchd only; systemd/Windows flows are untouched
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
