### PR TITLE
fix(cron): retry proven pre-connect DNS failures

### DIFF
--- a/tests/cron/test_cron_delivery_dns_retry.py
+++ b/tests/cron/test_cron_delivery_dns_retry.py
@@ -1,0 +1,63 @@
+"""Cron standalone delivery retries only proven pre-connect DNS failures."""
+
+from __future__ import annotations
+
+import socket
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from cron.scheduler import _deliver_result
+from gateway.config import Platform
+from plugins.platforms.telegram import adapter as _telegram_adapter  # noqa: F401
+
+
+def _gateway_config():
+    platform_config = SimpleNamespace(enabled=True, token="test-token", extra={})
+    return SimpleNamespace(platforms={Platform.TELEGRAM: platform_config})
+
+
+def _job():
+    return {
+        "id": "dns-retry",
+        "name": "dns-retry",
+        "deliver": "origin",
+        "origin": {"platform": "telegram", "chat_id": "123"},
+    }
+
+
+def test_cron_delivery_retries_gaierror_before_connect():
+    bot = SimpleNamespace(send_message=AsyncMock())
+    bot.send_message.side_effect = [
+        socket.gaierror(socket.EAI_AGAIN, "Temporary failure in name resolution"),
+        socket.gaierror(socket.EAI_AGAIN, "Temporary failure in name resolution"),
+        SimpleNamespace(message_id=42),
+    ]
+
+    with (
+        patch("gateway.config.load_gateway_config", return_value=_gateway_config()),
+        patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}),
+        patch("telegram.Bot", return_value=bot),
+        patch("tools.send_message_tool.asyncio.sleep", new=AsyncMock()),
+    ):
+        result = _deliver_result(_job(), "daily report")
+
+    assert result is None
+    assert bot.send_message.await_count == 3
+
+
+def test_cron_delivery_does_not_retry_ambiguous_connection_error():
+    bot = SimpleNamespace(
+        send_message=AsyncMock(side_effect=ConnectionError("connection reset"))
+    )
+
+    with (
+        patch("gateway.config.load_gateway_config", return_value=_gateway_config()),
+        patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}),
+        patch("telegram.Bot", return_value=bot),
+        patch("tools.send_message_tool.asyncio.sleep", new=AsyncMock()) as sleep,
+    ):
+        result = _deliver_result(_job(), "daily report")
+
+    assert "Telegram send failed" in result
+    assert bot.send_message.await_count == 1
+    sleep.assert_not_awaited()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -10,6 +10,7 @@ import json
 import logging
 import os
 import re
+import socket
 import time
 
 
@@ -168,7 +169,26 @@ def _display_chat_id(platform_name: str, chat_id: str) -> str:
     return chat_id
 
 
+def _is_preconnect_dns_failure(exc: BaseException) -> bool:
+    """Return True only when an exception chain proves DNS failed pre-connect."""
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, socket.gaierror):
+            return True
+        current = current.__cause__ or current.__context__
+    return False
+
+
 def _telegram_retry_delay(exc: Exception, attempt: int) -> float | None:
+    # A gaierror is raised by getaddrinfo before a connection exists, so the
+    # current API call cannot have reached Telegram.  This is narrower than
+    # matching error text and therefore safe to retry without risking a
+    # duplicate message after an ambiguous/post-send failure.
+    if _is_preconnect_dns_failure(exc):
+        return (0.25, 1.0)[min(attempt, 1)]
+
     retry_after = getattr(exc, "retry_after", None)
     if retry_after is not None:
         try:


### PR DESCRIPTION
## What does this PR do?

Retries Telegram delivery only when the exception chain proves that DNS resolution failed before any connection existed (`socket.gaierror`). This closes a narrow reliability gap for standalone cron delivery while preserving the existing no-duplicate rule for ambiguous transport failures.

The check walks `__cause__` / `__context__` with cycle protection. A generic `ConnectionError` is deliberately not retried because the server may already have accepted the message.

## Related Issue

No linked issue.

Related but distinct work found during duplicate search:

- #84008 routes broader transient cron network errors through provider fallback; this PR changes only the Telegram transport retry classifier and requires a proven pre-connect DNS failure.
- #64085 retries pending cron result delivery; this PR covers the immediate standalone send path and does not add a delivery queue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Add a cycle-safe exception-chain classifier for `socket.gaierror` in `tools/send_message_tool.py`.
- Apply the existing bounded Telegram retry loop only for that proven pre-connect failure.
- Add regression coverage proving DNS failures retry and ambiguous `ConnectionError` does not.

## How to Test

1. Run `python -m pytest -q tests/cron/test_cron_delivery_dns_retry.py tests/tools/test_send_message_tool.py tests/tools/test_send_message_telegram_proxy.py tests/tools/test_send_message_cross_loop.py tests/tools/test_send_message_react.py tests/tools/test_send_message_slack.py tests/tools/test_send_message_target_parse.py tests/tools/test_send_message_plugin_extensibility.py tests/cron/test_scheduler.py tests/cron/test_cron_live_delivery_confirmation.py tests/cron/test_cron_relay_delivery_guards.py`.
2. Run `ruff check tools/send_message_tool.py tests/cron/test_cron_delivery_dns_retry.py`.
3. Run `python -m compileall -q tools/send_message_tool.py tests/cron/test_cron_delivery_dns_retry.py` and `git diff --check origin/main...HEAD`.

Verified on Ubuntu: 237 focused tests passed. Static, compile, and diff checks passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and documented the related non-duplicates above
- [x] My PR contains only changes related to this fix
- [ ] I've run the complete `pytest tests/ -q` suite; focused affected tests are reported above
- [x] I've added tests for the change
- [x] I've tested on Ubuntu

### Documentation & Housekeeping

- [x] Documentation is N/A; the behavior and safety boundary are documented in code/tests
- [x] `cli-config.yaml.example` is N/A; no config key changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` are N/A
- [x] Cross-platform impact considered: classifier and retry timing use Python stdlib only
- [x] Tool schema changes are N/A
