### PR TITLE
feat(delegation): add bounded durable wait action

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -835,7 +835,7 @@ class ToolCallGuardrailController:
                 return None
             spawn_count = _subagent_spawn_count(args)
             if spawn_count == 0:
-                # Control action (list/steer/stop) — spawns nothing. Never
+                # Control action (list/steer/wait/stop) — spawns nothing. Never
                 # block: once the spawn cap is hit, steering/stopping the
                 # existing children is exactly what should still work.
                 return None
@@ -970,12 +970,12 @@ def _subagent_spawn_count(args: Mapping[str, Any]) -> int:
     delegate_task runs in one of two modes: a batch (``tasks`` is a non-empty
     list, one child per item) or a single task (``goal``). Count the batch size
     when present, otherwise 1, so the session subagent cap reflects real spawns
-    rather than delegate_task invocations. Control actions (list/steer/stop)
+    rather than delegate_task invocations. Control actions (list/steer/wait/stop)
     spawn nothing and must not consume the cap.
     """
     if isinstance(args, Mapping):
         action = str(args.get("action") or "").strip().lower()
-        if action in ("list", "steer", "stop"):
+        if action in ("list", "steer", "wait", "stop"):
             return 0
     tasks = args.get("tasks") if isinstance(args, Mapping) else None
     if isinstance(tasks, list) and tasks:

--- a/run_agent.py
+++ b/run_agent.py
@@ -9114,6 +9114,9 @@ class AIAgent:
             action=function_args.get("action"),
             subagent_id=function_args.get("subagent_id"),
             message=function_args.get("message"),
+            delegation_ids=function_args.get("delegation_ids"),
+            return_when=function_args.get("return_when"),
+            timeout_seconds=function_args.get("timeout_seconds"),
             parent_agent=self,
         )
 

--- a/tests/tools/test_delegate_wait.py
+++ b/tests/tools/test_delegate_wait.py
@@ -1,0 +1,185 @@
+"""Bounded model-facing waits over the existing durable delegation ledger."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from tools import async_delegation as ad
+from tools.delegate_tool import DELEGATE_TASK_SCHEMA, delegate_task
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    ad._reset_for_tests()
+    yield
+    ad._reset_for_tests()
+
+
+def _dispatch(delegation_id: str, parent: str) -> None:
+    ad._persist_dispatch(
+        {
+            "delegation_id": delegation_id,
+            "session_key": parent,
+            "parent_session_id": parent,
+            "origin_ui_session_id": "",
+            "dispatched_at": time.time(),
+            "goal": "test task",
+            "role": "leaf",
+            "model": "test-model",
+        }
+    )
+
+
+def _complete(
+    delegation_id: str,
+    summary: str = "done",
+    *,
+    status: str = "completed",
+) -> None:
+    now = time.time()
+    result = {"status": status, "summary": summary}
+    ad._persist_completion(
+        {
+            "type": "async_delegation",
+            "delegation_id": delegation_id,
+            "status": status,
+            "completed_at": now,
+        },
+        result,
+    )
+
+
+def test_wait_consumes_result_once_and_callback_loses():
+    _dispatch("deleg_one", "parent-one")
+    _complete("deleg_one")
+
+    first = ad.wait_for_delegations(
+        ["deleg_one"], parent_session_id="parent-one", timeout_seconds=1
+    )
+    assert first["status"] == "ready"
+    assert first["results"][0]["result"]["summary"] == "done"
+    assert ad.claim_completion_delivery("deleg_one", "callback-loser") is False
+
+    repeated = ad.wait_for_delegations(
+        ["deleg_one"], parent_session_id="parent-one", timeout_seconds=1
+    )
+    assert repeated["results"][0]["already_delivered"] is True
+    assert "result" not in repeated["results"][0]
+
+
+def test_wait_wakes_when_same_process_persists_completion():
+    _dispatch("deleg_wake", "parent-wake")
+    observed = []
+    waiter = threading.Thread(
+        target=lambda: observed.append(
+            ad.wait_for_delegations(
+                ["deleg_wake"],
+                parent_session_id="parent-wake",
+                timeout_seconds=2,
+                heartbeat_seconds=0.02,
+            )
+        )
+    )
+    waiter.start()
+    time.sleep(0.05)
+    assert waiter.is_alive()
+
+    _complete("deleg_wake", "woke")
+    waiter.join(timeout=1)
+
+    assert not waiter.is_alive()
+    assert observed[0]["results"][0]["result"]["summary"] == "woke"
+
+
+def test_wait_treats_timeout_as_terminal():
+    _dispatch("deleg_timeout", "parent-timeout")
+    _complete("deleg_timeout", "deadline exceeded", status="timeout")
+
+    result = ad.wait_for_delegations(
+        ["deleg_timeout"],
+        parent_session_id="parent-timeout",
+        timeout_seconds=1,
+    )
+
+    assert result["status"] == "ready"
+    assert result["results"][0]["state"] == "timeout"
+    assert result["results"][0]["result"]["summary"] == "deadline exceeded"
+
+
+def test_return_when_any_leaves_unfinished_result_available():
+    _dispatch("deleg_ready", "parent-any")
+    _dispatch("deleg_running", "parent-any")
+    _complete("deleg_ready", "first")
+
+    result = ad.wait_for_delegations(
+        ["deleg_ready", "deleg_running"],
+        parent_session_id="parent-any",
+        return_when="any",
+        timeout_seconds=1,
+    )
+
+    assert [item["delegation_id"] for item in result["results"]] == ["deleg_ready"]
+    assert result["still_running"] == ["deleg_running"]
+    assert ad.get_durable_delegation("deleg_running")["delivery_state"] == "pending"
+
+
+def test_wait_rejects_foreign_parent_without_consuming():
+    _dispatch("deleg_foreign", "real-parent")
+    _complete("deleg_foreign")
+
+    result = ad.wait_for_delegations(
+        ["deleg_foreign"], parent_session_id="other-parent", timeout_seconds=1
+    )
+
+    assert "not owned" in result["error"]
+    assert ad.get_durable_delegation("deleg_foreign")["delivery_state"] == "pending"
+
+
+def test_wait_accepts_owner_from_parent_compression_lineage():
+    _dispatch("deleg_before_compression", "parent-root")
+    _complete("deleg_before_compression", "lineage-visible")
+    session_db = SimpleNamespace(
+        get_compression_lineage=lambda _session_id: ["parent-root", "parent-tip"]
+    )
+    parent = SimpleNamespace(
+        session_id="parent-tip",
+        _session_db=session_db,
+        _interrupt_requested=False,
+    )
+
+    result = json.loads(
+        delegate_task(
+            action="wait",
+            delegation_ids=["deleg_before_compression"],
+            timeout_seconds=10,
+            parent_agent=parent,
+        )
+    )
+
+    assert result["results"][0]["result"]["summary"] == "lineage-visible"
+
+
+def test_wait_is_exposed_through_delegate_task_schema_and_handler():
+    _dispatch("deleg_model", "parent-model")
+    _complete("deleg_model", "model-visible")
+    parent = SimpleNamespace(session_id="parent-model", _interrupt_requested=False)
+
+    result = json.loads(
+        delegate_task(
+            action="wait",
+            delegation_ids=["deleg_model"],
+            timeout_seconds=10,
+            parent_agent=parent,
+        )
+    )
+
+    properties = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+    assert "wait" in properties["action"]["enum"]
+    assert properties["timeout_seconds"]["maximum"] == 3600
+    assert result["results"][0]["result"]["summary"] == "model-visible"

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -90,6 +90,20 @@ _MAX_DELIVERY_ATTEMPTS = 8
 _MAX_COMPLETION_REPLAY_AGE_S = 48 * 3600.0
 _DB_LOCK = threading.Lock()
 
+# Same-process completions wake model-facing waiters without model turns or
+# hot SQLite polling. A periodic durable re-check still covers completions
+# written by another process and restart recovery.
+_wait_condition = threading.Condition()
+_wait_generation = 0
+_WAIT_CLAIM_TTL_SECONDS = 300.0
+
+
+def _notify_waiters() -> None:
+    global _wait_generation
+    with _wait_condition:
+        _wait_generation += 1
+        _wait_condition.notify_all()
+
 # ---------------------------------------------------------------------------
 # Stale-delegation detection (progress-based, on by default)
 # ---------------------------------------------------------------------------
@@ -330,6 +344,7 @@ def _persist_completion(event: Dict[str, Any], result: Dict[str, Any]) -> None:
             (event.get("status", "completed"), event.get("completed_at", now), now,
              json.dumps(event), json.dumps(result), event["delegation_id"]),
         )
+    _notify_waiters()
 
 
 def _note_delivery_attempt(delegation_id: str) -> None:
@@ -394,6 +409,8 @@ def recover_abandoned_delegations() -> int:
                 (now, now, json.dumps(event), json.dumps(result), delegation_id),
             )
             recovered += 1
+    if recovered:
+        _notify_waiters()
     return recovered
 
 
@@ -461,7 +478,10 @@ def mark_completion_delivered(delegation_id: str) -> bool:
                WHERE delegation_id=? AND delivery_state!='delivered'""",
             (now, now, delegation_id),
         )
-        return cur.rowcount == 1
+        changed = cur.rowcount == 1
+    if changed:
+        _notify_waiters()
+    return changed
 
 
 def claim_completion_delivery(delegation_id: str, claim_id: str) -> bool:
@@ -520,15 +540,19 @@ def release_completion_delivery(delegation_id: str, claim_id: str) -> bool:
                 "marking terminally dropped (result remains queryable).",
                 delegation_id, _MAX_DELIVERY_ATTEMPTS,
             )
-            return True
-        cur = conn.execute(
-            """UPDATE async_delegations SET delivery_claim=NULL,
-                      delivery_claimed_at=NULL, updated_at=?
-               WHERE delegation_id=? AND delivery_state='pending'
-                 AND delivery_claim=?""",
-            (now, delegation_id, claim_id),
-        )
-        return cur.rowcount == 1
+            changed = True
+        else:
+            cur = conn.execute(
+                """UPDATE async_delegations SET delivery_claim=NULL,
+                          delivery_claimed_at=NULL, updated_at=?
+                   WHERE delegation_id=? AND delivery_state='pending'
+                     AND delivery_claim=?""",
+                (now, delegation_id, claim_id),
+            )
+            changed = cur.rowcount == 1
+    if changed:
+        _notify_waiters()
+    return changed
 
 
 def drop_completion_delivery(delegation_id: str, claim_id: str) -> bool:
@@ -550,7 +574,10 @@ def drop_completion_delivery(delegation_id: str, claim_id: str) -> bool:
                  AND delivery_claim=?""",
             (now, delegation_id, claim_id),
         )
-        return cur.rowcount == 1
+        changed = cur.rowcount == 1
+    if changed:
+        _notify_waiters()
+    return changed
 
 
 def complete_completion_delivery(delegation_id: str, claim_id: str) -> bool:
@@ -565,7 +592,10 @@ def complete_completion_delivery(delegation_id: str, claim_id: str) -> bool:
                  AND delivery_claim=?""",
             (now, now, delegation_id, claim_id),
         )
-        return cur.rowcount == 1
+        changed = cur.rowcount == 1
+    if changed:
+        _notify_waiters()
+    return changed
 
 
 def complete_event_delivery(evt: Dict[str, Any], claim_id: str) -> None:
@@ -595,6 +625,244 @@ def get_durable_delegation(delegation_id: str) -> Optional[Dict[str, Any]]:
         "delivery_state": row[5], "delivery_attempts": row[6],
         "origin_session_id": row[7] or "",
     }
+
+
+_ACTIVE_DURABLE_STATES = frozenset({"running", "finalizing"})
+
+
+def _consume_wait_results(
+    delegation_ids: List[str],
+    *,
+    parent_session_ids: set[str],
+    return_when: str,
+) -> Dict[str, Any]:
+    """Atomically arbitrate in-loop consumption against callback delivery."""
+    placeholders = ",".join("?" for _ in delegation_ids)
+    now = time.time()
+    stale_before = now - _WAIT_CLAIM_TTL_SECONDS
+    with _DB_LOCK:
+        conn = _connect()
+        try:
+            # Schema initialization may run idempotent DDL. Start the ownership
+            # and consumption decision in a fresh immediate transaction.
+            conn.commit()
+            conn.execute("BEGIN IMMEDIATE")
+            rows = conn.execute(
+                f"""SELECT delegation_id, parent_session_id, origin_session,
+                           state, result_json, delivery_state,
+                           delivery_claim, delivery_claimed_at
+                      FROM async_delegations
+                     WHERE delegation_id IN ({placeholders})""",
+                tuple(delegation_ids),
+            ).fetchall()
+            by_id = {row[0]: row for row in rows}
+            missing = [item for item in delegation_ids if item not in by_id]
+            if missing:
+                conn.rollback()
+                return {
+                    "error": "Unknown delegation id(s); no result was consumed.",
+                    "unknown_delegation_ids": missing,
+                }
+
+            foreign = []
+            for item in delegation_ids:
+                row = by_id[item]
+                owner = str(row[1] or row[2] or "")
+                if not owner or owner not in parent_session_ids:
+                    foreign.append(item)
+            if foreign:
+                conn.rollback()
+                return {
+                    "error": (
+                        "Delegation id(s) are not owned by this parent session; "
+                        "no result was consumed."
+                    ),
+                    "foreign_delegation_ids": foreign,
+                }
+
+            def _claim_in_flight(row) -> bool:
+                return (
+                    row[5] == "pending"
+                    and bool(row[6])
+                    and (row[7] or 0) >= stale_before
+                )
+
+            terminal = [
+                item
+                for item in delegation_ids
+                if by_id[item][3] not in _ACTIVE_DURABLE_STATES
+                and not _claim_in_flight(by_id[item])
+            ]
+            ready = (
+                len(terminal) == len(delegation_ids)
+                if return_when == "all"
+                else bool(terminal)
+            )
+            if not ready:
+                conn.commit()
+                return {
+                    "_ready": False,
+                    "still_running": [
+                        item for item in delegation_ids if item not in terminal
+                    ],
+                }
+
+            selected = list(delegation_ids) if return_when == "all" else terminal
+            entries: List[Dict[str, Any]] = []
+            for item in selected:
+                row = by_id[item]
+                entry: Dict[str, Any] = {
+                    "delegation_id": item,
+                    "state": row[3],
+                }
+                if row[5] == "delivered":
+                    # The callback path or an earlier wait already exposed the
+                    # full payload. Never replay it into the model.
+                    entry["already_delivered"] = True
+                else:
+                    cur = conn.execute(
+                        """UPDATE async_delegations
+                              SET delivery_state='delivered', delivered_at=?,
+                                  updated_at=?, delivery_claim=NULL,
+                                  delivery_claimed_at=NULL
+                            WHERE delegation_id=?
+                              AND (delivery_state='dropped'
+                                   OR (delivery_state='pending'
+                                       AND (delivery_claim IS NULL
+                                            OR delivery_claimed_at < ?)))""",
+                        (now, now, item, stale_before),
+                    )
+                    if cur.rowcount != 1:
+                        conn.rollback()
+                        return {
+                            "_ready": False,
+                            "still_running": list(delegation_ids),
+                        }
+                    entry["result"] = json.loads(row[4]) if row[4] else None
+                entries.append(entry)
+
+            conn.commit()
+            return {
+                "_ready": True,
+                "results": entries,
+                "still_running": [
+                    item for item in delegation_ids if item not in selected
+                ],
+            }
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+
+def wait_for_delegations(
+    delegation_ids: List[str],
+    *,
+    parent_session_id: str,
+    parent_session_lineage: Optional[List[str]] = None,
+    return_when: str = "all",
+    timeout_seconds: float = 30.0,
+    interrupt_fn: Optional[Callable[[], bool]] = None,
+    progress_fn: Optional[Callable[[Dict[str, Any]], None]] = None,
+    heartbeat_seconds: float = 5.0,
+) -> Dict[str, Any]:
+    """Wait once at a dependency boundary and consume durable results."""
+    ids = list(
+        dict.fromkeys(
+            str(item or "").strip()
+            for item in delegation_ids or []
+            if str(item or "").strip()
+        )
+    )
+    if not ids:
+        return {"error": "action='wait' requires at least one delegation_id."}
+    if not parent_session_id:
+        return {"error": "action='wait' requires a durable parent session."}
+    parent_session_ids = {
+        str(item or "").strip()
+        for item in [parent_session_id, *(parent_session_lineage or [])]
+        if str(item or "").strip()
+    }
+    if return_when not in {"all", "any"}:
+        return {"error": "return_when must be 'all' or 'any'."}
+    try:
+        timeout = max(0.0, float(timeout_seconds))
+    except (TypeError, ValueError):
+        return {"error": "timeout_seconds must be a number."}
+
+    started = time.monotonic()
+    deadline = started + timeout
+    heartbeat = max(0.01, float(heartbeat_seconds))
+    next_heartbeat = started + heartbeat
+    with _wait_condition:
+        generation = _wait_generation
+
+    while True:
+        if interrupt_fn is not None and interrupt_fn():
+            return {
+                "status": "interrupted",
+                "timed_out": False,
+                "results": [],
+                "still_running": ids,
+                "elapsed_seconds": round(time.monotonic() - started, 3),
+            }
+
+        snapshot = _consume_wait_results(
+            ids,
+            parent_session_ids=parent_session_ids,
+            return_when=return_when,
+        )
+        if snapshot.get("error"):
+            return snapshot
+        if snapshot.get("_ready"):
+            snapshot.pop("_ready", None)
+            snapshot.update(
+                {
+                    "status": "ready",
+                    "timed_out": False,
+                    "elapsed_seconds": round(time.monotonic() - started, 3),
+                }
+            )
+            _notify_waiters()
+            return snapshot
+
+        now_mono = time.monotonic()
+        if now_mono >= deadline:
+            return {
+                "status": "waiting",
+                "timed_out": True,
+                "results": [],
+                "still_running": snapshot.get("still_running", ids),
+                "elapsed_seconds": round(now_mono - started, 3),
+            }
+
+        # Condition notifications give same-process completions immediate
+        # wakeup. The one-second ceiling rechecks the durable ledger for a
+        # writer in another process without involving another model turn.
+        wake_at = min(deadline, next_heartbeat, now_mono + 1.0)
+        with _wait_condition:
+            _wait_condition.wait_for(
+                lambda: _wait_generation != generation,
+                timeout=max(0.0, wake_at - time.monotonic()),
+            )
+            generation = _wait_generation
+
+        now_mono = time.monotonic()
+        if now_mono >= next_heartbeat:
+            if progress_fn is not None:
+                try:
+                    progress_fn(
+                        {
+                            "delegation_ids": list(ids),
+                            "return_when": return_when,
+                            "elapsed_seconds": round(now_mono - started, 1),
+                            "still_running": snapshot.get("still_running", ids),
+                        }
+                    )
+                except Exception:
+                    logger.debug("delegate wait progress callback failed", exc_info=True)
+            next_heartbeat = now_mono + heartbeat
 
 
 def _get_executor(max_workers: int) -> ThreadPoolExecutor:

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -457,7 +457,7 @@ def _is_descendant_of(child_agent: Any, parent_agent: Any, max_hops: int = 8) ->
 
 # Model-facing control actions accepted by delegate_task(action=...).
 # "spawn" (or omitted) keeps the historical spawn semantics.
-_CONTROL_ACTIONS = frozenset({"list", "steer", "stop"})
+_CONTROL_ACTIONS = frozenset({"list", "steer", "wait", "stop"})
 
 
 def _resolve_session_lineage(session_id: Optional[str], parent_agent: Any) -> str:
@@ -525,8 +525,12 @@ def _handle_control_action(
     subagent_id: Optional[str],
     message: Optional[str],
     parent_agent: Any,
+    *,
+    delegation_ids: Optional[List[str]] = None,
+    return_when: Optional[str] = None,
+    timeout_seconds: Optional[float] = None,
 ) -> str:
-    """Synchronous control plane for delegate_task: list/steer/stop.
+    """Synchronous control plane for delegate_task: list/steer/wait/stop.
 
     Runs in-turn (never backgrounded) and only over subagents descended from
     *parent_agent* — the same registry the TUI overlay drives, but scoped so
@@ -569,6 +573,76 @@ def _handle_control_action(
                 "completion messages — there is nothing to steer or stop."
             )
         return json.dumps(payload, ensure_ascii=False)
+
+    if action == "wait":
+        ids = delegation_ids if isinstance(delegation_ids, list) else []
+        ids = list(
+            dict.fromkeys(str(item or "").strip() for item in ids if str(item or "").strip())
+        )
+        if not ids:
+            return tool_error(
+                "action='wait' requires non-empty delegation_ids from a spawn "
+                "dispatch response."
+            )
+        if len(ids) > 50:
+            return tool_error("action='wait' accepts at most 50 delegation_ids.")
+        mode = str(return_when or "all").strip().lower()
+        if mode not in {"all", "any"}:
+            return tool_error("return_when must be 'all' or 'any'.")
+        raw_timeout = 30 if timeout_seconds is None else timeout_seconds
+        try:
+            timeout = float(raw_timeout)
+        except (TypeError, ValueError):
+            return tool_error("timeout_seconds must be a number from 10 to 3600.")
+        if not 10 <= timeout <= 3600:
+            return tool_error("timeout_seconds must be from 10 to 3600.")
+        parent_session_id = str(getattr(parent_agent, "session_id", "") or "")
+        if not parent_session_id:
+            return tool_error(
+                "action='wait' requires a durable parent session identity."
+            )
+        parent_session_lineage = [parent_session_id]
+        session_db = getattr(parent_agent, "_session_db", None)
+        get_lineage = getattr(session_db, "get_compression_lineage", None)
+        if callable(get_lineage):
+            try:
+                lineage = get_lineage(parent_session_id)
+                if isinstance(lineage, (list, tuple)):
+                    parent_session_lineage = [str(item) for item in lineage if item]
+            except Exception:
+                pass
+
+        def _interrupted() -> bool:
+            return bool(getattr(parent_agent, "_interrupt_requested", False))
+
+        def _progress(info: Dict[str, Any]) -> None:
+            touch = getattr(parent_agent, "_touch_activity", None)
+            if callable(touch):
+                touch("waiting for delegated results")
+            callback = getattr(parent_agent, "tool_progress_callback", None)
+            if callable(callback):
+                remaining = len(info.get("still_running") or [])
+                preview = (
+                    f"Waiting for {remaining} delegated result"
+                    f"{'s' if remaining != 1 else ''} "
+                    f"({info.get('elapsed_seconds', 0):g}s elapsed)"
+                )
+                callback("tool.progress", "delegate_task", preview, info)
+
+        from tools.async_delegation import wait_for_delegations
+
+        result = wait_for_delegations(
+            ids,
+            parent_session_id=parent_session_id,
+            parent_session_lineage=parent_session_lineage,
+            return_when=mode,
+            timeout_seconds=timeout,
+            interrupt_fn=_interrupted,
+            progress_fn=_progress,
+        )
+        if result.get("error"):
+            return tool_error(result.pop("error"), **result)
+        return json.dumps(result, ensure_ascii=False)
 
     # steer / stop need a resolvable, owned target.
     sid = (subagent_id or "").strip()
@@ -636,7 +710,9 @@ def _handle_control_action(
             "message; re-delegate a follow-up task if more work is needed."
         )
 
-    return tool_error(f"Unknown action '{action}'. Use spawn, list, steer, or stop.")
+    return tool_error(
+        f"Unknown action '{action}'. Use spawn, list, steer, wait, or stop."
+    )
 
 
 def _extract_output_tail(
@@ -3932,6 +4008,9 @@ def delegate_task(
     action: Optional[str] = None,
     subagent_id: Optional[str] = None,
     message: Optional[str] = None,
+    delegation_ids: Optional[List[str]] = None,
+    return_when: Optional[str] = None,
+    timeout_seconds: Optional[float] = None,
     parent_agent=None,
     credentials_cfg: Optional[Dict[str, Any]] = None,
 ) -> str:
@@ -3947,6 +4026,7 @@ def delegate_task(
       - action='list'  -> live children of this conversation's spawn tree
       - action='steer' -> queue course-correction text into a running child
                           (subagent_id + message)
+      - action='wait'  -> wait for durable delegation results needed by this turn
       - action='stop'  -> interrupt a running child early (subagent_id)
 
     The 'role' parameter controls whether a child can further delegate:
@@ -3959,17 +4039,23 @@ def delegate_task(
     if parent_agent is None:
         return tool_error("delegate_task requires a parent agent context.")
 
-    # ── Control plane: list/steer/stop run synchronously and return here.
+    # ── Control plane: list/steer/wait/stop run synchronously and return here.
     # They never spawn, so they bypass the pause gate, depth limit, and the
     # async dispatch machinery entirely.
     normalized_action = (action or "").strip().lower()
     if normalized_action in _CONTROL_ACTIONS:
         return _handle_control_action(
-            normalized_action, subagent_id, message, parent_agent
+            normalized_action,
+            subagent_id,
+            message,
+            parent_agent,
+            delegation_ids=delegation_ids,
+            return_when=return_when,
+            timeout_seconds=timeout_seconds,
         )
     if normalized_action and normalized_action != "spawn":
         return tool_error(
-            f"Unknown action '{action}'. Use spawn (default), list, steer, or stop."
+            f"Unknown action '{action}'. Use spawn (default), list, steer, wait, or stop."
         )
 
     # Operator-controlled kill switch — lets the TUI freeze new fan-out
@@ -4632,21 +4718,24 @@ def delegate_task(
             n = len(_goals)
             note = (
                 "Subagent is running in the background. You and the user can "
-                "keep working; its full result re-enters the conversation as a "
-                "new message when it finishes. Do not wait or poll — just "
-                "continue."
+                "keep working. If its result is required for this turn, finish "
+                "independent work and call action='wait' once with this "
+                "delegation_id; otherwise its result re-enters later as a new "
+                "completion message."
                 if n == 1 else
                 f"{n} subagents are running in parallel in the background. You "
-                f"and the user can keep working; they wait on each other and "
-                f"their consolidated results re-enter the conversation as a "
-                f"single message once ALL of them finish. Do not wait or poll "
-                f"— just continue."
+                f"and the user can keep working; they join inside this durable "
+                f"delegation group. Call action='wait' once with this "
+                f"delegation_id before dependent synthesis, or let the "
+                f"consolidated result re-enter later as a completion message."
             )
             payload = {
                 "status": "dispatched",
                 "mode": "background",
                 "count": n,
                 "delegation_id": dispatch["delegation_id"],
+                "state": "running",
+                "result_policy": "wait_or_notify",
                 "goals": _goals,
                 "note": note,
             }
@@ -4660,7 +4749,8 @@ def delegate_task(
                     "same tool: delegate_task(action='list') to see live "
                     "children, action='steer' with subagent_id + message to "
                     "redirect one, action='stop' with subagent_id to end one "
-                    "early."
+                    "early, or action='wait' with delegation_ids to consume "
+                    "required results before dependent synthesis."
                 )
             if live_paths:
                 payload["live_transcripts"] = list(live_paths)
@@ -5127,12 +5217,12 @@ def _build_top_level_description() -> str:
         "terminal session, and toolset, and only its final summary returns to "
         "you. Pass every task in `tasks` — one entry spawns one subagent, "
         "several run in parallel (limit in the tasks description).\n\n"
-        "Runs in the background: dispatch returns immediately with live "
-        "transcript paths, and the completed result (one consolidated message, "
-        "results in task order) re-enters the conversation on its own. Do NOT "
-        "wait or poll; continue other work. While children run, `action` "
-        "(list/steer/stop) controls them live — steer when a transcript shows "
-        "a child drifting.\n\n"
+        "Runs in the background: dispatch returns immediately with a durable "
+        "delegation id and live transcript paths. Continue independent work, "
+        "then use action='wait' once if the result is required for this turn; "
+        "do not repeatedly wait or poll. Otherwise the completed result "
+        "re-enters later on its own. While "
+        "children run, `action` (list/steer/wait/stop) controls them live.\n\n"
         "USE FOR: reasoning-heavy subtasks, work that would flood your context "
         "with intermediate data, or independent parallel workstreams.\n"
         "DO NOT USE FOR (use these instead):\n"
@@ -5289,16 +5379,40 @@ DELEGATE_TASK_SCHEMA = {
             # re-add to the schema.
             "action": {
                 "type": "string",
-                "enum": ["spawn", "list", "steer", "stop"],
+                "enum": ["spawn", "list", "steer", "wait", "stop"],
                 "description": (
                     "Default 'spawn'. Live control of running children: "
                     "'list' = ids/goals/status/transcripts; 'steer' = queue "
                     "course-correction text into one child (subagent_id + "
-                    "message) without stopping it; 'stop' = end one child "
+                    "message) without stopping it; 'wait' = consume durable "
+                    "delegation results needed by this turn (delegation_ids); "
+                    "'stop' = end one child "
                     "early (subagent_id; partial result still returns). "
-                    "Control actions return immediately; goal/tasks are "
+                    "Wait is bounded; other control actions return immediately; goal/tasks are "
                     "ignored unless spawning."
                 ),
+            },
+            "delegation_ids": {
+                "type": "array",
+                "items": {"type": "string"},
+                "maxItems": 50,
+                "description": (
+                    "Durable delegation ids for action='wait', returned by spawn. "
+                    "Results are visible only to their owning parent session."
+                ),
+            },
+            "return_when": {
+                "type": "string",
+                "enum": ["all", "any"],
+                "default": "all",
+                "description": "For action='wait', return after all or any supplied result is ready.",
+            },
+            "timeout_seconds": {
+                "type": "number",
+                "minimum": 10,
+                "maximum": 3600,
+                "default": 30,
+                "description": "Bounded action='wait' duration; unfinished results remain available.",
             },
             "subagent_id": {
                 "type": "string",
@@ -5379,6 +5493,9 @@ registry.register(
         action=args.get("action"),
         subagent_id=args.get("subagent_id"),
         message=args.get("message"),
+        delegation_ids=args.get("delegation_ids"),
+        return_when=args.get("return_when"),
+        timeout_seconds=args.get("timeout_seconds"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,


### PR DESCRIPTION
## What does this PR do?

Adds `delegate_task(action="wait")` as a bounded, model-facing dependency barrier over Hermes' existing durable `async_delegations` SQLite ledger.

A parent can wait for one or more delegation IDs with `return_when="all"|"any"` for 10–3600 seconds. Ownership is checked against the parent session and its compression lineage. Result delivery is arbitrated in one immediate SQLite transaction, so a callback and an in-turn wait cannot both inject the same completion into the model context.

Same-process completions wake a condition variable immediately; a bounded durable recheck covers cross-process completion and restart recovery without repeated model turns.

## Related Issue

No linked issue.

Related but distinct open PRs:

- #87201 waits on the live in-memory descendant registry and suppresses repeated `list` payloads. This PR waits on the existing durable completion ledger and arbitrates exactly-once consumption against callback delivery.
- #72301 adds a per-spawn foreground barrier. This PR preserves background dispatch and lets a later dependency boundary wait on returned durable IDs, including `all` / `any` selection.
- #90055 adds a much larger durable lifecycle/control repository. This PR adds no new table or tool and intentionally reuses the current `async_delegations` delivery state.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Extend `delegate_task` schema and runtime wiring with `action=wait`, `delegation_ids`, `return_when`, and `timeout_seconds`.
- Treat wait as a control action that consumes no spawn quota.
- Add durable ownership checks across compression lineage.
- Atomically arbitrate wait/callback completion delivery and preserve unfinished results for `return_when=any`.
- Treat terminal `timeout` child results as ready while keeping a wait-call timeout non-destructive.
- Add condition wakeups and periodic durable rechecks without hot model polling.
- Update background-dispatch guidance to use one wait only at a real dependency boundary.

## How to Test

1. Run the focused delegation, ledger, guardrail, and compression-lineage suite listed below.
2. Run `ruff check agent/tool_guardrails.py run_agent.py tools/async_delegation.py tools/delegate_tool.py tests/tools/test_delegate_wait.py`.
3. Run `python -m compileall -q` for those files and `git diff --check origin/main...HEAD`.

Focused verification on Ubuntu: 346 passed, 1 macOS-only test skipped. Ruff, compile, and diff checks passed. The focused command covered `test_delegate_wait`, existing async/delegate control tests, restored ownership, gateway delivery-ledger tests, session binding, compression rotation/lineage, and run-agent guardrails.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and documented the behavioral differences above
- [x] My PR contains only changes related to this feature
- [ ] I've run the complete `pytest tests/ -q` suite; focused affected tests are reported above
- [x] I've added tests for the change
- [x] I've tested on Ubuntu

### Documentation & Housekeeping

- [x] The model-facing schema, descriptions, and inline contract documentation are updated
- [x] `cli-config.yaml.example` is N/A; no config key changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` are N/A
- [x] Cross-platform impact considered; one existing macOS-only focused test was skipped on Linux
- [x] Tool descriptions and schema are updated
