### PR TITLE
fix(tests): profile-routing test must not depend on eager log-file creation

### DIFF
--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -128,6 +128,21 @@ class TestSetupLogging:
         ) is True
 
         logger = logging.getLogger("cron.scheduler.profile-routing-test")
+
+        # The default home's agent.log must exist before the negative
+        # assertion can mean anything. On Windows the rotating handler is
+        # concurrent-log-handler's ConcurrentRotatingFileHandler (see the
+        # import alias in hermes_logging), which opens LAZILY — a handler
+        # that never emitted has not created its file, and read_text()
+        # would FileNotFoundError before the routing contract is checked.
+        # Emit one default-home record first so the file exists on every
+        # platform, then verify the routed record lands only in the
+        # profile home.
+        default_log = hermes_home / "logs" / "agent.log"
+        logger.info("profile-routing default-home probe record")
+        hermes_logging.flush_log_queue()
+        assert "default-home probe record" in default_log.read_text()
+
         token = set_hermes_home_override(profile_home)
         try:
             logger.info("profile-routed cron record")
@@ -138,9 +153,7 @@ class TestSetupLogging:
         assert "profile-routed cron record" in (
             profile_home / "logs" / "agent.log"
         ).read_text()
-        assert "profile-routed cron record" not in (
-            hermes_home / "logs" / "agent.log"
-        ).read_text()
+        assert "profile-routed cron record" not in default_log.read_text()
 
 
 


### PR DESCRIPTION
## Summary

`test_profile_routing_follows_context_home` fails on native Windows with `FileNotFoundError` before checking the routing contract:

```
FileNotFoundError: [Errno 2] No such file or directory: '...\hermes_test\logs\agent.log'
```

**Why:** the test's negative assertion (`assert record not in (hermes_home/"logs"/"agent.log").read_text()`) requires the default home's log file to **exist**. On Windows, the rotating handler is `concurrent-log-handler`'s `ConcurrentRotatingFileHandler` (the platform alias in `hermes_logging.py`, #44873), which opens **lazily** — a per-home handler that never emitted has not created its file. The routed record goes to the profile home; the default home's file never materializes; `read_text()` raises before the routing contract is verified.

The test only passed on POSIX because stdlib's `RotatingFileHandler` opens eagerly in `__init__` — an incidental platform behavior, not the contract under test. The routing itself was already **correct** on Windows (the record landed only in the profile home); only the test's file-existence assumption was platform-fragile.

## Fix

Emit one default-home probe record before the routing scenario, assert it landed, then run the scenario:

- the negative assertion now always reads a file that exists, on every platform
- the probe additionally proves the default home is live and receiving records — a **strictly stronger** check than before
- production code untouched

## Verification

Native Windows (Python 3.12):

```
tests/test_hermes_logging.py::TestSetupLogging::test_profile_routing_follows_context_home
before: 1 failed (FileNotFoundError)
after:  1 passed

whole file: 28 passed, 1 skipped
```

The one remaining failure (`test_managed_mode_initial_open_sets_group_writable`) is POSIX group-write permission semantics — separate issue, not touched here.

No issue referenced — nothing to close; self-contained test-robustness fix. Complementary to #96458's Windows-CI direction (this test is not in its file set).
