### PR TITLE
fix(preview): guard drive_preview type action against unfocused DOM

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-act.test.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-act.test.ts
@@ -113,12 +113,21 @@ describe('actOnActivePreview (drive_preview tool)', () => {
     const send = vi.fn()
 
     cleanups.push(
-      registerPreviewScriptRunner(tabId, async code =>
-        code.includes('"kind":"locate"')
-          ? JSON.stringify({ acted: 'looking at button "Save"', point: { x: 120, y: 80 }, success: true })
-          : // `hit` is the page's witness that the real pointerdown arrived.
-            JSON.stringify({ elements: [], hit: { tag: 'BUTTON', trusted: true }, success: true })
-      )
+      registerPreviewScriptRunner(tabId, async code => {
+        if (code.includes('"kind":"locate"')) {
+          return JSON.stringify({ acted: 'looking at button "Save"', point: { x: 120, y: 80 }, success: true })
+        }
+
+        // The focus probe from driveAction verifies that activeElement is
+        // editable after clicking. Return a happy answer so the type action
+        // proceeds without hitting the Jira-case guard.
+        if (code.includes('activeElement')) {
+          return JSON.stringify({ focused: true, tag: 'INPUT' })
+        }
+
+        // `hit` is the page's witness that the real pointerdown arrived.
+        return JSON.stringify({ elements: [], hit: { tag: 'BUTTON', trusted: true }, success: true })
+      })
     )
     cleanups.push(registerPreviewInput(tabId, { focus: vi.fn(), send }))
 
@@ -176,6 +185,36 @@ describe('actOnActivePreview (drive_preview tool)', () => {
     // agent was trying to reveal, or worse, activate it.
     expect(types).not.toContain('mouseDown')
     expect(result.acted).toBe('hovered over button "Save"')
+  })
+
+  it('refuses to type when the click did not focus an editable (Jira async editor mount)', async () => {
+    const tabId = openBrowserTab()
+    const send = vi.fn()
+
+    cleanups.push(
+      registerPreviewScriptRunner(tabId, async code => {
+        if (code.includes('"kind":"locate"')) {
+          return JSON.stringify({ acted: 'looking at div "Comment area"', point: { x: 120, y: 80 }, success: true, typable: true })
+        }
+
+        // The focus probe: the click mounted the editor but focus stayed on body.
+        if (code.includes('activeElement')) {
+          return JSON.stringify({ focused: false, tag: 'BODY' })
+        }
+
+        // Read-back should never be reached — the action fails before typing.
+        return JSON.stringify({ elements: [], hit: { tag: 'BUTTON', trusted: true }, success: true })
+      })
+    )
+    cleanups.push(registerPreviewInput(tabId, { focus: vi.fn(), send }))
+
+    const result = await actOnActivePreview({ kind: 'type', ref: '@e1', text: 'Scope decision.' })
+
+    // No keystrokes sent — the focus check catches the unfocused target before typeText.
+    expect(send.mock.calls.filter(([event]) => event.type === 'char')).toHaveLength(0)
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('not focused')
+    expect(result.error).toContain('BODY')
   })
 
   // The witness only speaks for verbs that put the button down. Demanding one

--- a/apps/desktop/src/app/chat/right-rail/preview-act.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-act.ts
@@ -372,6 +372,31 @@ async function driveAction(
 
     input.focus()
     await clickAt(input)
+
+    // Verify that DOM focus actually landed on an editable — if the click only
+    // mounted the editor (Jira ProseMirror, React async), DOM focus stays on
+    // body and every character becomes a page shortcut.
+    const probe = await runJson(
+      run,
+      `(function() {
+        var ae = document.activeElement;
+        var tag = ae ? ae.tagName : '';
+        var ok = tag === 'INPUT' || tag === 'TEXTAREA' || (ae && ae.isContentEditable === true);
+        return JSON.stringify({ focused: ok, tag: tag });
+      })()`
+    )
+
+    if (probe.kind === 'answered') {
+      const check = probe.result as { focused?: boolean; tag?: string }
+
+      if (!check.focused) {
+        return {
+          error: `The target is not focused (activeElement is ${check.tag || '?'}), so typing would be delivered as page shortcuts instead of text. Click the target again to ensure the editor is mounted, or locate a different element.`,
+          success: false
+        }
+      }
+    }
+
     // Select-all inside the now-focused field, so typing replaces what is there
     // the way it would for a person. NOT a triple-click: that is a pointer
     // gesture and selects the paragraph under the cursor whenever the target


### PR DESCRIPTION
Fixes #101508

When `drive_preview` with `kind: type` clicks a lazy-mounted editor (Jira ProseMirror, React `contentEditable`), the locate-click mounts the editor component but leaves `document.activeElement` on `body`. Every character then fires as a page shortcut instead of text entry — exactly what the reporter saw (assignee flip, Create dialog, typed text vanishing).

**Before typing**, the action now probes `activeElement.isContentEditable` or `INPUT`/`TEXTAREA` and fails with a clear error if the target is not focused. This covers async editors that won't be ready until the next tick or a re-click.

**Test coverage**:
- New Jira-scenario spec simulates the click-and-probe path when focus stays on `BODY` (asserts no keystrokes sent and error message includes "not focused").
- Existing type test now answers the probe (happy path) — refactored `withDrivenPane` fixture to return `{ focused: true, tag: 'INPUT' }` when the probe runs.

All 17 specs pass in `preview-act.test.ts`.

This is a narrow guard (one `await runJson` probe + early return on failure) with zero impact to the success path — the probe only rejects when DOM focus genuinely did not land on an editable, in which case *every* keystroke would have been a shortcut.
