### PR TITLE
fix(desktop): pin transcript bottom on session-switch backfill

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/list.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/list.test.ts
@@ -8,6 +8,7 @@ import {
   LIVE_TAIL_PARTS,
   liveTailStart,
   type MessageGroup,
+  prependRestoreFromBottom,
   resolveThreadScrollTarget,
   RUN_START_SNAP_THRESHOLD_PX,
   shouldClampTranscriptBudget,
@@ -363,5 +364,53 @@ describe('shouldRePinOnTranscriptReload', () => {
 
   it('pins on a cold-load arrival (same session, never settled non-empty)', () => {
     expect(shouldRePinOnTranscriptReload({ sessionSwitched: false, settledNonEmpty: false })).toBe(true)
+  })
+})
+
+describe('prependRestoreFromBottom', () => {
+  // Session-switch race (#101229): settle can flip loadSettled while scrollTop
+  // is still a mid-waypoint; auto-backfill must not re-apply that distance.
+  it('forces bottom on auto-backfill even when loadSettled and mid-scroll', () => {
+    expect(
+      prependRestoreFromBottom({
+        kind: 'auto-backfill',
+        loadSettled: true,
+        scrollHeight: 10_000,
+        scrollTop: 4_000
+      })
+    ).toBe(0)
+  })
+
+  it('forces bottom on auto-backfill before the settle loop finishes', () => {
+    expect(
+      prependRestoreFromBottom({
+        kind: 'auto-backfill',
+        loadSettled: false,
+        scrollHeight: 10_000,
+        scrollTop: 4_000
+      })
+    ).toBe(0)
+  })
+
+  it('preserves a settled user-expand reading position', () => {
+    expect(
+      prependRestoreFromBottom({
+        kind: 'user-expand',
+        loadSettled: true,
+        scrollHeight: 10_000,
+        scrollTop: 4_000
+      })
+    ).toBe(6_000)
+  })
+
+  it('forces bottom on user-expand while the load is still settling', () => {
+    expect(
+      prependRestoreFromBottom({
+        kind: 'user-expand',
+        loadSettled: false,
+        scrollHeight: 10_000,
+        scrollTop: 4_000
+      })
+    ).toBe(0)
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -154,6 +154,27 @@ export function shouldRePinOnTranscriptReload(opts: { sessionSwitched: boolean; 
   return opts.sessionSwitched || !opts.settledNonEmpty
 }
 
+/** Distance-from-bottom to re-apply after a prepend grows the DOM.
+ *
+ *  Auto-backfill is part of session load: the settle loop may already have
+ *  flipped `loadSettled` while scrollTop is still a mid-switch waypoint, so
+ *  measuring scrollHeight-scrollTop here parks the view partway (#101229).
+ *  Force bottom (0). Only a user-driven expand ("Show earlier") may preserve
+ *  a settled reading position.
+ */
+export function prependRestoreFromBottom(opts: {
+  kind: 'auto-backfill' | 'user-expand'
+  loadSettled: boolean
+  scrollHeight: number
+  scrollTop: number
+}): number {
+  if (opts.kind === 'auto-backfill' || !opts.loadSettled) {
+    return 0
+  }
+
+  return opts.scrollHeight - opts.scrollTop
+}
+
 export function subscribeToThreadForeground(shouldReanchor: () => boolean, onReanchor: () => void): () => void {
   let frameId: number | null = null
   let framePending = false
@@ -495,13 +516,18 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   const settledNonEmptyRef = useRef(false)
 
   // Record where the view should land once a prepend has grown the content,
-  // measured from the BOTTOM so the added height doesn't invalidate it. Only a
-  // settled load has an offset the user chose; mid-load the answer is simply
-  // the bottom.
-  const anchorBeforePrepend = useCallback(() => {
+  // measured from the BOTTOM so the added height doesn't invalidate it.
+  const anchorBeforePrepend = useCallback((kind: 'auto-backfill' | 'user-expand') => {
     const el = scrollRef.current
 
-    restoreFromBottomRef.current = el && loadSettledRef.current ? el.scrollHeight - el.scrollTop : 0
+    restoreFromBottomRef.current = el
+      ? prependRestoreFromBottom({
+          kind,
+          loadSettled: loadSettledRef.current,
+          scrollHeight: el.scrollHeight,
+          scrollTop: el.scrollTop
+        })
+      : 0
   }, [scrollRef])
 
   // Backfill from FIRST_PAINT_BUDGET to the full budget after the small
@@ -530,8 +556,9 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
       // it in the same commit the taller tree lands in — otherwise the view is
       // stranded near the TOP until use-stick-to-bottom's ResizeObserver
       // catches up a frame or two later (measured: an 11.5k px jump showing
-      // ~160ms of unrelated old turns, on every session load).
-      anchorBeforePrepend()
+      // ~160ms of unrelated old turns, on every session load). Always force
+      // bottom for auto-backfill; never capture a mid-switch waypoint.
+      anchorBeforePrepend('auto-backfill')
 
       // Functional max, not a plain set: an urgent "Show earlier" click can
       // land between scheduling and committing this transition, and a plain
@@ -749,7 +776,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
       return
     }
 
-    anchorBeforePrepend()
+    anchorBeforePrepend('user-expand')
     // Both paths grow the DOM budget by one pane page. Windowed rows are older
     // than the current page, so expand-without-grow paints nothing.
     setRenderBudget(budget => budget + paneBudget)


### PR DESCRIPTION
## Why

Switching sessions parks the transcript partway up instead of at the bottom. The settle loop can flip `loadSettled` while `scrollTop` is still a mid-switch waypoint. Auto-backfill then measured that distance and restored it after the prepend, so the view landed neither at the top nor at the bottom.

## Scope

- `apps/desktop/src/components/assistant-ui/thread/list.tsx`: add `prependRestoreFromBottom`; auto-backfill always restores offset `0`; `Show earlier` still preserves a settled reading position.
- `apps/desktop/src/components/assistant-ui/thread/list.test.ts`: cover the mid-settle auto-backfill race and the user-expand preserve path.

Does not change #101217 / PR #101223 (completion re-pin after a streamed turn).

## Tradeoffs

Forcing bottom on every auto-backfill step means a reader cannot keep a mid-load scroll during the first-paint→full-budget ramp. That ramp is load machinery, not a chosen reading position, so the trade is intentional.

## Blast Radius

Desktop transcript list only. `Show earlier` while settled still restores distance-from-bottom. Risk is low: the change narrows when we capture a non-zero restore offset.

## Verification

From `apps/desktop`:

```
npm run test:ui -- src/components/assistant-ui/thread/list.test.ts
```

Result: 39 passed, exit 0.

Fixes #101229

Made with [Cursor](https://cursor.com)