### PR TITLE
fix(tui_gateway): bridge configured service_tier onto request_overrides at build time

### DIFF
--- a/tests/test_tui_gateway_service_tier_build.py
+++ b/tests/test_tui_gateway_service_tier_build.py
@@ -1,0 +1,185 @@
+"""Build-time fast-tier bridging in ``tui_gateway`` ``_make_agent``.
+
+`agent.service_tier: fast` in config.yaml (and session-pinned
+``create_service_tier_override`` from ``session.create fast=true`` or the
+``config.set fast`` RPC) only ever reached ``AIAgent(service_tier=...)``.
+Every transport reads fast keys from ``agent.request_overrides`` —
+``agent/chat_completion_helpers.py`` gates ``fast_mode`` on
+``(agent.request_overrides or {}).get("speed") == "fast"`` and forwards
+``request_overrides=agent.request_overrides`` — so the configured tier was
+inert on every rebuilt session (deferred build, DB resume, ``/new``) while
+``session.info`` still reported fast enabled. The classic CLI
+(``hermes_cli/cli_agent_setup_mixin.py``) and the messaging gateway
+(``gateway/run.py``) bridge the tier through ``resolve_fast_mode_overrides``
+at build time; these tests pin the same contract for the desktop/TUI
+backend.
+"""
+
+import types
+
+import pytest
+
+import tui_gateway.server as server
+
+
+def _make_agent_capturing(monkeypatch, *, cfg, model, runtime, **make_kwargs):
+    """Run ``server._make_agent`` with a FakeAgent capturing ctor kwargs."""
+    captured = {}
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    merged_runtime = {
+        "provider": "openai",
+        "base_url": None,
+        "api_key": None,
+        "api_mode": None,
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+    }
+    merged_runtime.update(runtime or {})
+
+    monkeypatch.setattr(server, "_load_cfg", lambda: cfg)
+    monkeypatch.setattr(server, "_resolve_startup_runtime", lambda: (model, merged_runtime["provider"]))
+    monkeypatch.setattr(
+        server,
+        "_resolve_runtime_with_fallback",
+        lambda _kw: types.SimpleNamespace(
+            runtime=merged_runtime, used_fallback=False, selected_model=None
+        ),
+    )
+    monkeypatch.setattr(server, "_load_reasoning_config", lambda _m=None: None)
+    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda _p=None: set())
+    monkeypatch.setattr(server, "_resolve_agent_platform", lambda _p=None: "cli")
+    monkeypatch.setattr(server, "_agent_cbs", lambda _sid: {})
+    monkeypatch.setattr(server, "_load_provider_routing", lambda: {})
+    monkeypatch.setattr(server, "_load_fallback_model", lambda: None)
+    monkeypatch.setattr(server, "_parse_tui_skills_env", lambda: "")
+    monkeypatch.setattr(
+        "hermes_cli.config.resolve_ephemeral_system_prompt_from_config", lambda _cfg: None
+    )
+    monkeypatch.setattr(
+        "tui_gateway.synthetic_turn.maybe_build_synthetic_agent", lambda _key, _mo: None
+    )
+    monkeypatch.setattr("hermes_cli.mcp_startup.wait_for_mcp_discovery", lambda: None)
+    monkeypatch.setattr("tui_gateway.entry.wait_for_mcp_discovery", lambda: None)
+    monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+
+    agent = server._make_agent("sid", "key", context_cwd_is_launch_artifact=False, **make_kwargs)
+    return agent, captured
+
+
+def test_configured_fast_tier_reaches_request_overrides(monkeypatch):
+    """config.yaml `agent.service_tier: fast` must bridge onto request_overrides."""
+    agent, captured = _make_agent_capturing(
+        monkeypatch,
+        cfg={"agent": {"service_tier": "fast"}},
+        model="gpt-5.6",
+        runtime={"provider": "openai"},
+    )
+    assert captured["service_tier"] == "priority"
+    assert captured["request_overrides"] == {"service_tier": "priority"}
+    assert agent is not None
+
+
+def test_session_pinned_priority_reaches_request_overrides(monkeypatch):
+    """A pinned tier (session.create fast=true, stored row resume) bridges too."""
+    _agent, captured = _make_agent_capturing(
+        monkeypatch,
+        cfg={},
+        model="gpt-5.6",
+        runtime={"provider": "openai"},
+        service_tier_override="priority",
+    )
+    assert captured["service_tier"] == "priority"
+    assert captured["request_overrides"] == {"service_tier": "priority"}
+
+
+def test_pinned_normal_keeps_overrides_clear(monkeypatch):
+    """The explicit normal pin (`""`) must not resurrect stale overrides."""
+    _agent, captured = _make_agent_capturing(
+        monkeypatch,
+        cfg={"agent": {"service_tier": "fast"}},
+        model="gpt-5.6",
+        runtime={"provider": "openai"},
+        service_tier_override="",
+    )
+    assert captured["service_tier"] == ""
+    assert captured["request_overrides"] is None
+
+
+def test_auto_tier_not_pinned_into_overrides(monkeypatch):
+    """auto/cold windows are applied per request by agent.fast_mode, never pinned."""
+    _agent, captured = _make_agent_capturing(
+        monkeypatch,
+        cfg={"agent": {"service_tier": "auto"}},
+        model="gpt-5.6",
+        runtime={"provider": "openai"},
+    )
+    assert captured["service_tier"] == "auto"
+    assert captured["request_overrides"] is None
+
+
+def test_normal_tier_keeps_overrides_clear(monkeypatch):
+    _agent, captured = _make_agent_capturing(
+        monkeypatch,
+        cfg={"agent": {"service_tier": "normal"}},
+        model="gpt-5.6",
+        runtime={"provider": "openai"},
+    )
+    assert captured["service_tier"] is None
+    assert captured["request_overrides"] is None
+
+
+def test_anthropic_fast_model_gets_speed_override(monkeypatch):
+    _agent, captured = _make_agent_capturing(
+        monkeypatch,
+        cfg={"agent": {"service_tier": "fast"}},
+        model="claude-opus-4.8",
+        runtime={
+            "provider": "anthropic",
+            "base_url": "https://api.anthropic.com",
+        },
+    )
+    assert captured["service_tier"] == "priority"
+    assert captured["request_overrides"] == {"speed": "fast"}
+
+
+def test_unsupported_route_fails_open(monkeypatch):
+    """A route that must not see fast params (OpenRouter) builds the agent
+    without overrides rather than failing the whole session build."""
+    _agent, captured = _make_agent_capturing(
+        monkeypatch,
+        cfg={"agent": {"service_tier": "fast"}},
+        model="gpt-5.6",
+        runtime={
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+        },
+    )
+    assert captured["service_tier"] == "priority"
+    assert captured["request_overrides"] is None
+
+
+def test_resolve_failure_fails_open(monkeypatch):
+    """A crashing resolve must not take the session build down with it."""
+    import hermes_cli.models
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("registry unavailable")
+
+    monkeypatch.setattr(hermes_cli.models, "resolve_fast_mode_overrides", _boom)
+    _agent, captured = _make_agent_capturing(
+        monkeypatch,
+        cfg={"agent": {"service_tier": "fast"}},
+        model="gpt-5.6",
+        runtime={"provider": "openai"},
+    )
+    assert captured["service_tier"] == "priority"
+    assert captured["request_overrides"] is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9305,6 +9305,31 @@ def _make_agent(
                 raise RuntimeError("Auth fallback resolved without a model")
             model = resolution.selected_model
     _pr = _load_provider_routing()
+    tier = (
+        service_tier_override
+        if service_tier_override is not None
+        else _load_service_tier()
+    )
+    # Bridge the configured/pinned tier onto request_overrides at build time,
+    # like the classic CLI (cli_agent_setup_mixin) and the messaging gateway
+    # (gateway/run.py) do: transports read only agent.request_overrides, so
+    # agent.service_tier alone never reaches the wire. Without this a
+    # persisted agent.service_tier is inert for every rebuilt session
+    # (deferred build, session.create fast=true, DB resume, /new) while
+    # session.info still reports fast enabled. auto/cold stay None — their
+    # bounded window is applied per request by agent.fast_mode, not pinned.
+    fast_overrides = None
+    if tier == "priority":
+        try:
+            from hermes_cli.models import resolve_fast_mode_overrides
+
+            fast_overrides = resolve_fast_mode_overrides(
+                model,
+                provider=runtime.get("provider"),
+                base_url=runtime.get("base_url"),
+            )
+        except Exception:
+            fast_overrides = None
     agent = AIAgent(
         model=model,
         max_iterations=_cfg_max_turns(cfg, 500),
@@ -9326,11 +9351,8 @@ def _make_agent(
             if reasoning_config_override is not None
             else _load_reasoning_config(str(model or ""))
         ),
-        service_tier=(
-            service_tier_override
-            if service_tier_override is not None
-            else _load_service_tier()
-        ),
+        service_tier=tier,
+        request_overrides=fast_overrides,
         enabled_toolsets=_load_enabled_toolsets(_resolve_agent_platform(platform_override)),
         # OpenRouter provider-routing prefs (config.yaml `provider_routing`).
         # Mirrors the messaging gateway + CLI so the desktop/TUI honors the same


### PR DESCRIPTION
## What does this PR do?

`agent.service_tier` set in `config.yaml` (or pinned per session via `session.create fast=true` / the `config.set fast` RPC) only ever reached `AIAgent(service_tier=...)` on the desktop/TUI backend. Every transport reads the fast-tier keys from `agent.request_overrides` instead (`agent/chat_completion_helpers.py` gates `fast_mode` on `(agent.request_overrides or {}).get("speed") == "fast"` and forwards `request_overrides=agent.request_overrides`; same in `agent/transports/chat_completions.py` and `agent/transports/codex.py`), and nothing derives one from the other — so the tier was inert on every session rebuilt through `_make_agent` (deferred build, `session.create fast=true`, DB resume, `/new`) while `session.info` kept reporting fast enabled.

The classic CLI (`hermes_cli/cli_agent_setup_mixin.py`) and the messaging gateway (`gateway/run.py`) both bridge the configured tier through `resolve_fast_mode_overrides(model)` at build time. This PR gives `tui_gateway/server.py::__make_agent__` the same bridge:

- Only a `priority` tier (config `fast`/`priority`/`on`, or a pinned `priority` override) is pinned into `request_overrides` — `auto`/`cold` stay `None` because their bounded window is applied per request by `agent.fast_mode`, exactly like the CLI and gateway references.
- An explicit normal pin (`""`), an unsupported route (e.g. OpenRouter, which must not receive `service_tier`/`speed`), and a crashing `resolve_fast_mode_overrides` all fail open: the agent still builds, just without overrides.

## Related Issue

Fixes #101513

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py` (`_make_agent`): extract the tier resolution into a local, and when it is `priority` resolve fast-mode overrides via `resolve_fast_mode_overrides(model, provider=runtime["provider"], base_url=runtime["base_url"])` (wrapped in `try/except` → `None`, matching the CLI/gateway references) and pass them as `request_overrides=` to `AIAgent`. `service_tier=` keeps the exact previous value.
- `tests/test_tui_gateway_service_tier_build.py`: new regression tests driving `server._make_agent` with a capturing `FakeAgent` and the real `resolve_fast_mode_overrides` — configured `fast`, pinned `priority`, pinned normal, `auto`, `normal`, Anthropic `speed: fast` routing, unsupported-route fail-open, and resolve-crash fail-open.

## How to Test

1. `python -m pytest tests/test_tui_gateway_service_tier_build.py -q` — 8 passed with the fix; all 8 fail on unpatched `main` (verified via stash-style red/green).
2. Regression: `python -m pytest tests/test_tui_gateway_server.py tests/test_tui_gateway_event_replay.py tests/test_tui_gateway_loop_noise.py tests/test_tui_gateway_queue_on_busy.py tests/test_tui_gateway_ws.py tests/test_tui_gateway_server_crash_history.py -q` — 692 passed, 0 failed. Observed result: no regressions.
3. `ruff check tui_gateway/server.py tests/test_tui_gateway_service_tier_build.py` — All checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6 (arm64), Python 3.11

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ python -m pytest tests/test_tui_gateway_service_tier_build.py -q
8 passed, 6 warnings in 0.82s

# without the server.py change (red side of the red/green check):
8 failed, 6 warnings in 1.24s

$ python -m pytest tests/test_tui_gateway_server.py ... -q
692 passed, 6 warnings in 37.22s
```