### PR TITLE
fix(tools): name the semantic no-op in IDENTICAL_STRINGS_ERROR

### DIFF
--- a/tests/tools/test_file_tools_live.py
+++ b/tests/tools/test_file_tools_live.py
@@ -188,8 +188,8 @@ class TestPatchReplace:
         assert result.success is False
         assert result.error is not None
         assert "No edit was applied" in result.error
-        assert "existing text to replace in old_string" in result.error
-        assert "replacement text in new_string" in result.error
+        assert "change nothing" in result.error
+        assert "file_preview" in result.error
         assert Path(path).read_text() == "hello world\n"
 
     def test_multiline_patch(self, ops, tmp_path):

--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -31,6 +31,17 @@ class TestExactMatch:
         assert new == "abc"
         assert err == IDENTICAL_STRINGS_ERROR
 
+    def test_identical_strings_error_names_the_no_op(self):
+        # The message must state the edit changes nothing, so a model that
+        # typo'd both sides self-corrects instead of re-sending the call.
+        assert "change nothing" in IDENTICAL_STRINGS_ERROR
+
+    def test_identical_strings_error_directs_a_next_action(self):
+        # The message must not leave "re-send the arguments" as the only
+        # legible reading — it points at diffing against the file content.
+        assert "re-sending" in IDENTICAL_STRINGS_ERROR
+        assert "file_preview" in IDENTICAL_STRINGS_ERROR
+
     def test_multiline_exact(self):
         content = "line1\nline2\nline3"
         new, count, _, err = fuzzy_find_and_replace(content, "line1\nline2", "replaced")

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -58,9 +58,11 @@ UNICODE_MAP = {
 }
 
 IDENTICAL_STRINGS_ERROR = (
-    "No edit was applied because old_string and new_string are identical. "
-    "Provide the existing text to replace in old_string and the changed "
-    "replacement text in new_string."
+    "No edit was applied: new_string is identical to old_string, so the edit "
+    "would change nothing. This is not an argument-plumbing error — re-sending "
+    "the same call will fail identically. Diff your intended replacement "
+    "against the actual file text (file_preview) and fix whichever side "
+    "carries the typo."
 )
 
 


### PR DESCRIPTION
Reproduced the loop trigger on current main and reworded the error so the model self-corrects on failure #1 instead of re-sending the identical call until the tool-loop guardrail halts it.

## What changed

`IDENTICAL_STRINGS_ERROR` (`tools/fuzzy_match.py`) now names the semantic fact: the edit would change nothing, the anchor text was present, this is not an argument-plumbing error, and re-sending the same call will fail identically — and points at the next action (diff the intended replacement against the actual file text via `file_preview`). Previously the message read as a transport glitch ("old_string and new_string are identical. Provide the existing text..."), which trains byte-replay retry loops; #101519 observed 8 identical rejections across two turns.

The constant is the single source of truth: `test_identical_strings` asserts equality against it and survives the reword unchanged, and no other code in the repo greps for the old wording.

## Regression contract

Two behavior-contract tests on the constant (a framing contract, not a snapshot): the message must name the no-op ("change nothing") and must direct a next action other than re-send ("re-sending", "file_preview"). A future rewording that regresses the framing now fails CI.

Fixes #101519