### PR TITLE
fix(desktop): allow window.open popups in preview webview

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
@@ -119,6 +119,29 @@ describe('PreviewPane console state', () => {
     forgetPreviewConsole(tabId)
   })
 
+  // Electron returns null from guest window.open() unless allowpopups is set.
+  // OAuth SDKs (Google Sign-In) bail when the popup handle is null (#100996).
+  it('marks the preview webview popup-capable for window.open()', async () => {
+    let rendered!: ReturnType<typeof render>
+    await act(async () => {
+      rendered = render(
+        <PreviewPane
+          target={{
+            kind: 'url',
+            label: 'Preview',
+            source: 'http://localhost:5174',
+            url: 'http://localhost:5174'
+          }}
+        />
+      )
+    })
+
+    const webview = rendered.container.querySelector('webview')
+
+    expect(webview).toBeInstanceOf(HTMLElement)
+    expect(webview?.hasAttribute('allowpopups')).toBe(true)
+  })
+
   // The bar is chrome for a LIVE page. A file peek, an artifact, and remote
   // HTML in a sandboxed iframe have no webview to navigate.
   it('shows the browser bar only for a live webview preview', async () => {

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -1023,6 +1023,9 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
     const webview = document.createElement('webview') as PreviewWebview
     webview.className = 'flex h-full w-full flex-1 bg-transparent'
     webview.setAttribute('partition', 'persist:hermes-preview')
+    // Without allowpopups, Electron returns null from guest window.open() and
+    // OAuth SDKs (Google Sign-In, etc.) fail silently. See #100996.
+    webview.setAttribute('allowpopups', '')
     webview.setAttribute('src', target.url)
     webview.setAttribute('webpreferences', 'contextIsolation=yes,nodeIntegration=no,sandbox=yes')
 


### PR DESCRIPTION
## Why

The in-app Browser preview `<webview>` omitted `allowpopups`. Electron then returns `null` from guest `window.open()`, so OAuth SDKs (Google Sign-In on TikTok login, etc.) fail with no visible popup. Fixes #100996.

## Scope

- `apps/desktop/src/app/chat/right-rail/preview-pane.tsx`: set `allowpopups` on the preview webview.
- `apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx`: assert the attribute stays set.

Does not add a guest `setWindowOpenHandler`. Open #82393 / #100733 deny guest popups and route elsewhere; that path still returns `null` to the page and would not restore OAuth. Open #101325 covers `target=_blank` separately.

## Tradeoffs

`allowpopups` lets Electron create real popup windows for guest `window.open()`. That is required for OAuth window handles. Hardened guest routing remains a follow-up if product wants in-app tabs or `openExternal` without breaking popup-based auth.

## Blast Radius

Only the desktop preview `<webview>`. Host window `setWindowOpenHandler` is unchanged. Sandbox / contextIsolation / nodeIntegration preferences are unchanged.

## Verification

```
cd apps/desktop
npm run test:ui -- src/app/chat/right-rail/preview-pane.test.tsx
```

18 passed, exit 0. No live Electron OAuth repro in this unit (timebox); the regression test locks the load-bearing attribute.

Made with [Cursor](https://cursor.com)