### PR TITLE
fix(desktop): keep Dark mode across Bot Mode new chat

### DIFF
--- a/apps/desktop/src/themes/context.tsx
+++ b/apps/desktop/src/themes/context.tsx
@@ -70,6 +70,7 @@ const normalizeMode = (value: string | null): ThemeMode =>
 // unassigned profiles and pre-per-profile installs stay on the global value.
 // Named assigns also mirror into the global slot so a Bot Mode gateway hop onto
 // a never-themed bot inherits the look the user just picked (#101216).
+// Persists from stored (write-on-read). Idempotent. No-op when records disagree.
 const promoteUnanimousLegacy = (record: string, legacy: string): void => {
   if (storedString(legacy) != null) {
     return

--- a/apps/desktop/src/themes/context.tsx
+++ b/apps/desktop/src/themes/context.tsx
@@ -68,8 +68,32 @@ const normalizeMode = (value: string | null): ThemeMode =>
 // it *is* the legacy global slot, so it reads/writes the global directly. Named
 // profiles get their own entry and fall back to that global until assigned, so
 // unassigned profiles and pre-per-profile installs stay on the global value.
+// Named assigns also mirror into the global slot so a Bot Mode gateway hop onto
+// a never-themed bot inherits the look the user just picked (#101216).
+const promoteUnanimousLegacy = (record: string, legacy: string): void => {
+  if (storedString(legacy) != null) {
+    return
+  }
+
+  const values = Object.values(storedStringRecord(record)).filter(Boolean)
+
+  if (values.length === 0) {
+    return
+  }
+
+  const unique = [...new Set(values)]
+
+  if (unique.length === 1) {
+    persistString(legacy, unique[0])
+  }
+}
+
 const profilePref = <T extends string>(record: string, legacy: string, normalize: (v: string | null) => T) => {
-  const stored = (profile: string): string | null => storedStringRecord(record)[profile] ?? storedString(legacy)
+  const stored = (profile: string): string | null => {
+    promoteUnanimousLegacy(record, legacy)
+
+    return storedStringRecord(record)[profile] ?? storedString(legacy)
+  }
 
   return {
     /** The pick as written, un-normalized. */
@@ -80,6 +104,7 @@ const profilePref = <T extends string>(record: string, legacy: string, normalize
         persistString(legacy, value)
       } else {
         persistStringRecord(record, { ...storedStringRecord(record), [profile]: value })
+        persistString(legacy, value)
       }
     }
   }

--- a/apps/desktop/src/themes/profile-theme.test.ts
+++ b/apps/desktop/src/themes/profile-theme.test.ts
@@ -64,3 +64,26 @@ describe('a profile that has never chosen a mode', () => {
     expect(modePref.resolve('default')).toBe('light')
   })
 })
+
+// #101216: named-profile assign must seed the global fallback so a Bot Mode
+// gateway hop onto a never-themed bot does not resolve `system`.
+describe('named-profile appearance seeds the global fallback (#101216)', () => {
+  beforeEach(() => window.localStorage.clear())
+
+  it('lets a never-themed bot profile inherit Dark set on the launch profile', () => {
+    modePref.assign('forge', 'dark')
+    expect(modePref.resolve('atlas')).toBe('dark')
+  })
+
+  it('keeps an explicit per-profile override over the global fallback', () => {
+    modePref.assign('forge', 'dark')
+    modePref.assign('atlas', 'light')
+    expect(modePref.resolve('forge')).toBe('dark')
+    expect(modePref.resolve('atlas')).toBe('light')
+  })
+
+  it('promotes a unanimous pre-existing per-profile mode into the empty global slot', () => {
+    window.localStorage.setItem('hermes-desktop-profile-modes-v1', JSON.stringify({ forge: 'dark' }))
+    expect(modePref.resolve('atlas')).toBe('dark')
+  })
+})

--- a/apps/desktop/src/themes/profile-theme.test.ts
+++ b/apps/desktop/src/themes/profile-theme.test.ts
@@ -82,6 +82,12 @@ describe('named-profile appearance seeds the global fallback (#101216)', () => {
     expect(modePref.resolve('atlas')).toBe('light')
   })
 
+  it('lets a never-themed profile inherit the last named-profile assign', () => {
+    modePref.assign('forge', 'dark')
+    modePref.assign('atlas', 'light')
+    expect(modePref.resolve('never-themed')).toBe('light')
+  })
+
   it('promotes a unanimous pre-existing per-profile mode into the empty global slot', () => {
     window.localStorage.setItem('hermes-desktop-profile-modes-v1', JSON.stringify({ forge: 'dark' }))
     expect(modePref.resolve('atlas')).toBe('dark')


### PR DESCRIPTION
## Why

Bot Mode **New chat with this bot** activates the bot gateway profile. That profile usually has no appearance of its own. When the launch profile is not `default`, Settings → Appearance Dark only wrote the per-profile record, so the hop resolved `system` and a light OS flipped the window to Light (#101216).

## Scope

- `apps/desktop/src/themes/context.tsx` — `profilePref.assign` mirrors named-profile picks into the global slot; `promoteUnanimousLegacy` fills an empty global slot when every per-profile value agrees.
- `apps/desktop/src/themes/profile-theme.test.ts` — covers inherit, override, and promote for the #101216 path.

Out of scope: `$appearanceProfile` decoupling (issue suggestion 1), Theme Scope Shared (#96271), Appearance caption copy.

## Tradeoffs

Mirroring into the global slot means the last named-profile Appearance pick becomes the fallback for never-themed profiles. Explicit per-profile overrides still win. This is smaller than teaching ThemeProvider to ignore Bot Mode gateway activations.

## Blast Radius

Desktop theme/mode persistence only. Users with one unanimous mode across profiles get that mode on never-themed bots and on cold launch after a bot hop. Installs with conflicting per-profile modes keep those overrides and do not auto-promote.

## Verification

```
cd apps/desktop
npx vitest run src/themes/profile-theme.test.ts src/themes/context.test.tsx
```

20 passed, exit 0.
