### PR TITLE
fix(desktop): hydrate gateway registry from ProfileRail on mount

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/profile-rail-connect.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-rail-connect.test.tsx
@@ -65,6 +65,7 @@ vi.mock('@/store/connections', () => ({
   $activeConnectionId: atom(null),
   $connectionsRegistry: atom(null),
   $hasMultipleConnections: atom(false),
+  refreshConnectionsRegistry: vi.fn(async () => null),
   selectConnection: vi.fn()
 }))
 

--- a/apps/desktop/src/app/chat/sidebar/profile-rail-fleet.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-rail-fleet.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { atom } from 'nanostores'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -85,12 +85,35 @@ vi.mock('@/store/profile', () => ({
   sortByProfileOrder: (profiles: unknown[]) => profiles
 }))
 
-vi.mock('@/store/connections', () => ({
-  $activeConnectionId: atom<null | string>(null),
-  $connectionsRegistry: atom<DesktopConnectionsRegistry | null>(null),
-  $hasMultipleConnections: atom(false),
-  selectConnection: (...args: unknown[]) => selectConnection(...args)
-}))
+vi.mock('@/store/connections', () => {
+  const $activeConnectionId = atom<null | string>(null)
+  const $connectionsRegistry = atom<DesktopConnectionsRegistry | null>(null)
+  const $hasMultipleConnections = atom(false)
+
+  return {
+    $activeConnectionId,
+    $connectionsRegistry,
+    $hasMultipleConnections,
+    selectConnection: (...args: unknown[]) => selectConnection(...args),
+    // Mirrors the real store: list() → publish registry → flip multi-gateway.
+    refreshConnectionsRegistry: vi.fn(async () => {
+      const listed = await (
+        window as {
+          hermesDesktop?: { connections?: { list?: () => Promise<DesktopConnectionsRegistry> } }
+        }
+      ).hermesDesktop?.connections?.list?.()
+
+      if (!listed) {
+        return null
+      }
+
+      $connectionsRegistry.set(listed)
+      $hasMultipleConnections.set(listed.connections.length > 1)
+
+      return listed
+    })
+  }
+})
 
 vi.mock('@/store/profile-share', () => ({
   runExportProfileFlow: vi.fn(),
@@ -118,6 +141,7 @@ vi.mock('../../profiles/rename-profile-dialog', () => ({ RenameProfileDialog: ()
 const connectionsStore = await import('@/store/connections')
 const hasMultipleConnections = connectionsStore.$hasMultipleConnections as ReturnType<typeof atom<boolean>>
 const activeConnectionId = connectionsStore.$activeConnectionId as ReturnType<typeof atom<null | string>>
+const refreshConnectionsRegistry = vi.mocked(connectionsStore.refreshConnectionsRegistry)
 
 const connectionsRegistry = connectionsStore.$connectionsRegistry as ReturnType<
   typeof atom<DesktopConnectionsRegistry | null>
@@ -220,6 +244,31 @@ describe('ProfileRail fleet mode', () => {
     expect(screen.queryByRole('group', { name: /^Profiles on/ })).toBeNull()
     expect(container.querySelector('[data-slot="profile-rail-divider"]')).toBeNull()
     expect(screen.getByRole('button', { name: 'Manage gateways…' })).toBeTruthy()
+  })
+
+  it('hydrates a null registry on mount so every gateway paints without Settings (#101257)', async () => {
+    // Cold boot with SSH/remote primary: registry atom still null, rail must
+    // not wait for Settings → Gateway (or the statusbar switcher) to publish it.
+    activeConnectionId.set('pandora')
+    profiles.set([{ is_default: true, name: 'default' }])
+    const list = vi.fn().mockResolvedValue(registry)
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = { connections: { list }, getAgentRoster }
+
+    const container = await renderFleet()
+
+    await waitFor(() => {
+      expect(refreshConnectionsRegistry).toHaveBeenCalled()
+      expect(list).toHaveBeenCalled()
+      expect(connectionsRegistry.get()).toEqual(registry)
+      expect(hasMultipleConnections.get()).toBe(true)
+    })
+
+    await waitFor(() => {
+      const groups = Array.from(container.querySelectorAll('[data-slot="profile-rail-gateway"]')).map(node =>
+        node.getAttribute('data-connection-id')
+      )
+      expect(groups).toEqual(['local', 'pandora', 'vps'])
+    })
   })
 
   it('lays every other gateway on the strip as an at-rest group, in switcher order', async () => {

--- a/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
@@ -61,6 +61,7 @@ import {
   $activeConnectionId,
   $connectionsRegistry,
   $hasMultipleConnections,
+  refreshConnectionsRegistry,
   selectConnection
 } from '@/store/connections'
 import { $fleetRoster, refreshFleetRoster } from '@/store/fleet-roster'
@@ -322,6 +323,16 @@ export function ProfileRail() {
   // use-profile-rail-refresh-on-active.ts for the extracted (and tested)
   // wiring.
   useProfileRailRefreshOnActive()
+
+  // Own the initial registry load so fleet mode does not wait on Settings →
+  // Gateway or the statusbar switcher (#101257).
+  useEffect(() => {
+    if ($connectionsRegistry.get() !== null) {
+      return
+    }
+
+    void refreshConnectionsRegistry().catch(() => undefined)
+  }, [])
 
   // Which profiles carry a per-profile remote override (connection.json
   // profiles.<name>) — refreshed whenever the profile list changes so the


### PR DESCRIPTION
## Why

With a remote/SSH gateway as primary, cold boot painted only that gateway on the profile rail until the user opened Settings → Gateway. The registry already had every connection. The rail read `` but never loaded it, so fleet mode waited on another surface to publish the snapshot.

## Scope

- `ProfileRail` calls `refreshConnectionsRegistry()` on mount when the registry atom is still null.
- Extends `profile-rail-fleet.test.tsx` for the null-registry hydrate path (#101257).
- Adds the mock stub in `profile-rail-connect.test.tsx`.

Out of scope: main-process connect-on-demand deferral, boot-path hydration in `use-gateway-boot`, statusbar `ConnectionSwitcher` behavior.

## Tradeoffs

Hydrate from the rail (smallest consumer fix) instead of gateway boot. Boot hydration would cover more readers; the rail is what users see broken, and the acceptance test targets that surface.

## Blast Radius

Desktop profile rail only. Best-effort IPC `connections.list`; failures leave the prior single-gateway paint. No backend spawn for deferred local gateways.

## Verification

`
cd apps/desktop
npm run test:ui -- src/app/chat/sidebar/profile-rail-fleet.test.tsx src/app/chat/sidebar/profile-rail-connect.test.tsx
`

14 passed, exit 0.

Closes #101257

Made with [Cursor](https://cursor.com)