### PR TITLE
fix(desktop): keep agent browser control after pop-out

### DIFF
--- a/apps/desktop/src/app/chat/browser-popout-shell.tsx
+++ b/apps/desktop/src/app/chat/browser-popout-shell.tsx
@@ -1,10 +1,11 @@
-import type { CSSProperties } from 'react'
+import { type CSSProperties, useEffect } from 'react'
 
 import { PanelEmpty } from '@/app/overlays/panel'
 import { TITLEBAR_HEIGHT } from '@/app/shell/titlebar'
 import { useI18n } from '@/i18n'
 import { windowBrowserTabId } from '@/store/windows'
 
+import { installPopoutPreviewResponder } from './right-rail/preview-popout-bridge'
 import { PreviewTilePane } from './right-rail/preview'
 
 /**
@@ -15,6 +16,10 @@ import { PreviewTilePane } from './right-rail/preview'
 export function BrowserPopoutShell() {
   const { t } = useI18n()
   const tabId = windowBrowserTabId()
+
+  // Serve drive_preview / read_preview for the chat window that still owns the
+  // active-session gate after this pane left the main renderer.
+  useEffect(() => installPopoutPreviewResponder(), [])
 
   return (
     <div

--- a/apps/desktop/src/app/chat/right-rail/preview-popout-bridge.test.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-popout-bridge.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const isBrowserWindow = vi.hoisted(() => vi.fn(() => false))
+const actOnActivePreview = vi.hoisted(() => vi.fn())
+const readActivePreview = vi.hoisted(() => vi.fn())
+const activePreviewScriptRunner = vi.hoisted(() => vi.fn(() => null))
+const activePreviewNav = vi.hoisted(() => vi.fn(() => null))
+
+type Listener = (event: MessageEvent) => void
+
+/** Same-origin BroadcastChannel never delivers to the posting window, so the
+ *  unit test needs a bus that fans out to every subscriber including the sender. */
+class LoopbackChannel {
+  static listeners = new Map<string, Set<Listener>>()
+
+  name: string
+
+  constructor(name: string) {
+    this.name = name
+    const set = LoopbackChannel.listeners.get(name) ?? new Set()
+    LoopbackChannel.listeners.set(name, set)
+  }
+
+  addEventListener(_type: 'message', listener: Listener) {
+    const set = LoopbackChannel.listeners.get(this.name) ?? new Set()
+    set.add(listener)
+    LoopbackChannel.listeners.set(this.name, set)
+  }
+
+  removeEventListener(_type: 'message', listener: Listener) {
+    LoopbackChannel.listeners.get(this.name)?.delete(listener)
+  }
+
+  postMessage(data: unknown) {
+    const snapshot = [...(LoopbackChannel.listeners.get(this.name) ?? [])]
+
+    for (const listener of snapshot) {
+      listener({ data } as MessageEvent)
+    }
+  }
+
+  close() {}
+}
+
+vi.stubGlobal('BroadcastChannel', LoopbackChannel)
+
+vi.mock('@/store/windows', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/store/windows')>()
+
+  return {
+    ...actual,
+    isBrowserWindow: () => isBrowserWindow()
+  }
+})
+
+vi.mock('./preview-act', () => ({
+  actOnActivePreview: (...args: unknown[]) => actOnActivePreview(...args)
+}))
+
+vi.mock('./preview-reader', () => ({
+  readActivePreview: (...args: unknown[]) => readActivePreview(...args)
+}))
+
+vi.mock('./preview-script-runner', () => ({
+  activePreviewScriptRunner: () => activePreviewScriptRunner()
+}))
+
+vi.mock('./preview-nav', () => ({
+  activePreviewNav: () => activePreviewNav()
+}))
+
+describe('preview pop-out bridge', () => {
+  afterEach(() => {
+    LoopbackChannel.listeners.clear()
+    vi.resetModules()
+    isBrowserWindow.mockReturnValue(false)
+    actOnActivePreview.mockReset()
+    readActivePreview.mockReset()
+    activePreviewScriptRunner.mockReturnValue(null)
+    activePreviewNav.mockReturnValue(null)
+  })
+
+  it('reports a live surface when a script runner is registered', async () => {
+    activePreviewScriptRunner.mockReturnValue(async () => null)
+    const { hasLivePreviewSurface } = await import('./preview-popout-bridge')
+
+    expect(hasLivePreviewSurface()).toBe(true)
+  })
+
+  it('round-trips an act request to the browser pop-out responder', async () => {
+    isBrowserWindow.mockReturnValue(true)
+    actOnActivePreview.mockResolvedValue({ acted: 'click', success: true })
+
+    const { installPopoutPreviewResponder, requestPopoutPreviewAct } = await import('./preview-popout-bridge')
+    const stop = installPopoutPreviewResponder()
+
+    try {
+      const result = await requestPopoutPreviewAct({ kind: 'click', ref: 'btn-1' })
+
+      expect(actOnActivePreview).toHaveBeenCalledWith({ kind: 'click', ref: 'btn-1' })
+      expect(result).toEqual({ acted: 'click', success: true })
+    } finally {
+      stop()
+    }
+  })
+})

--- a/apps/desktop/src/app/chat/right-rail/preview-popout-bridge.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-popout-bridge.ts
@@ -1,0 +1,178 @@
+/**
+ * Cross-window bridge for the popped-out Browser.
+ *
+ * Each Electron window is its own renderer, so the webview registries that
+ * drive_preview / read_preview use live only in the window that mounts the
+ * pane. After pop-out that is `?win=browser`, while the chat window still owns
+ * the active-session gate for agent tools. This channel lets the gated chat
+ * window ask the pop-out to run the live act/read and return the result.
+ */
+
+import type { PreviewActAction, PreviewActResult } from '@/lib/preview-act/act-in-page'
+import { isBrowserWindow } from '@/store/windows'
+
+import { actOnActivePreview } from './preview-act'
+import { activePreviewNav } from './preview-nav'
+import { readActivePreview, type PreviewReadOptions, type PreviewReadResult } from './preview-reader'
+import { activePreviewScriptRunner } from './preview-script-runner'
+
+const CHANNEL = 'hermes:preview-popout'
+
+const ACT_TIMEOUT_MS = 20_000
+const READ_TIMEOUT_MS = 8_000
+
+type ActPayload = Omit<PreviewActAction, 'kind'> & { kind: string }
+
+type BridgeRequest =
+  | { id: string; kind: 'act'; payload: ActPayload }
+  | { id: string; kind: 'read'; payload: PreviewReadOptions }
+
+type BridgeResponse =
+  | { id: string; kind: 'act'; result: PreviewActResult }
+  | { id: string; kind: 'read'; result: PreviewReadResult | null }
+  | { id: string; kind: 'error'; error: string }
+
+let channel: BroadcastChannel | null = null
+let responderInstalled = false
+let seq = 0
+
+function getChannel(): BroadcastChannel | null {
+  if (typeof BroadcastChannel === 'undefined') {
+    return null
+  }
+
+  if (!channel) {
+    channel = new BroadcastChannel(CHANNEL)
+  }
+
+  return channel
+}
+
+/** True when this renderer has a live webview (or nav handle) for the active tab. */
+export function hasLivePreviewSurface(): boolean {
+  return Boolean(activePreviewScriptRunner() || activePreviewNav())
+}
+
+function nextId(prefix: string): string {
+  seq += 1
+
+  return `${prefix}-${Date.now()}-${seq}`
+}
+
+function askPopout<T>(
+  request: BridgeRequest,
+  timeoutMs: number,
+  pick: (response: BridgeResponse) => T | undefined
+): Promise<T | null> {
+  const bus = getChannel()
+
+  if (!bus) {
+    return Promise.resolve(null)
+  }
+
+  return new Promise(resolve => {
+    const timer = window.setTimeout(() => {
+      bus.removeEventListener('message', onMessage)
+      resolve(null)
+    }, timeoutMs)
+
+    const onMessage = (event: MessageEvent<BridgeResponse | BridgeRequest>) => {
+      const data = event.data
+
+      // Ignore our own request echo (same-window tests / unusual hosts) and
+      // unrelated traffic. Only a response carries `result` or `error`.
+      if (!data || data.id !== request.id) {
+        return
+      }
+
+      if (!('result' in data) && data.kind !== 'error') {
+        return
+      }
+
+      window.clearTimeout(timer)
+      bus.removeEventListener('message', onMessage)
+
+      if (data.kind === 'error') {
+        resolve(null)
+
+        return
+      }
+
+      resolve(pick(data) ?? null)
+    }
+
+    bus.addEventListener('message', onMessage)
+    bus.postMessage(request)
+  })
+}
+
+/** Ask the browser pop-out to run drive_preview. Null when no pop-out answers. */
+export function requestPopoutPreviewAct(payload: ActPayload): Promise<PreviewActResult | null> {
+  return askPopout(
+    { id: nextId('act'), kind: 'act', payload },
+    ACT_TIMEOUT_MS,
+    response => (response.kind === 'act' ? response.result : undefined)
+  )
+}
+
+/** Ask the browser pop-out to run read_preview. Null when no pop-out answers. */
+export function requestPopoutPreviewRead(payload: PreviewReadOptions = {}): Promise<PreviewReadResult | null> {
+  return askPopout(
+    { id: nextId('read'), kind: 'read', payload },
+    READ_TIMEOUT_MS,
+    response => (response.kind === 'read' ? response.result : undefined)
+  )
+}
+
+/**
+ * Browser pop-out only: answer act/read requests from the chat window.
+ * Safe to call more than once; installs a single listener.
+ */
+export function installPopoutPreviewResponder(): () => void {
+  if (!isBrowserWindow() || responderInstalled) {
+    return () => {}
+  }
+
+  const bus = getChannel()
+
+  if (!bus) {
+    return () => {}
+  }
+
+  responderInstalled = true
+
+  const onMessage = (event: MessageEvent<BridgeRequest | BridgeResponse>) => {
+    const data = event.data
+
+    if (!data?.id || !('payload' in data) || (data.kind !== 'act' && data.kind !== 'read')) {
+      return
+    }
+
+    void (async () => {
+      try {
+        if (data.kind === 'act') {
+          const result = await actOnActivePreview(data.payload)
+          bus.postMessage({ id: data.id, kind: 'act', result } satisfies BridgeResponse)
+
+          return
+        }
+
+        const result = await readActivePreview(data.payload)
+        bus.postMessage({ id: data.id, kind: 'read', result } satisfies BridgeResponse)
+      } catch (error) {
+        bus.postMessage({
+          id: data.id,
+          kind: 'error',
+          error: error instanceof Error ? error.message : String(error)
+        } satisfies BridgeResponse)
+      }
+    })()
+  }
+
+  bus.addEventListener('message', onMessage)
+
+  return () => {
+    bus.removeEventListener('message', onMessage)
+    responderInstalled = false
+  }
+}

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $gateway } from '@/store/gateway'
+
+import { handleDesktopBridgeEvent } from './desktop-bridge'
+import type { GatewayEventContext } from './types'
+
+const hasLivePreviewSurface = vi.hoisted(() => vi.fn(() => false))
+const requestPopoutPreviewAct = vi.hoisted(() => vi.fn())
+const requestPopoutPreviewRead = vi.hoisted(() => vi.fn())
+const isBrowserWindow = vi.hoisted(() => vi.fn(() => false))
+const readActivePreview = vi.hoisted(() => vi.fn())
+
+vi.mock('@/store/windows', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/store/windows')>()
+
+  return {
+    ...actual,
+    isBrowserWindow: () => isBrowserWindow()
+  }
+})
+
+vi.mock('@/app/chat/right-rail/preview-popout-bridge', () => ({
+  hasLivePreviewSurface: () => hasLivePreviewSurface(),
+  requestPopoutPreviewAct: (...args: unknown[]) => requestPopoutPreviewAct(...args),
+  requestPopoutPreviewRead: (...args: unknown[]) => requestPopoutPreviewRead(...args)
+}))
+
+vi.mock('@/app/chat/right-rail/preview-reader', () => ({
+  readActivePreview: (...args: unknown[]) => readActivePreview(...args)
+}))
+
+function previewActContext({
+  explicitSid,
+  isActiveEvent
+}: {
+  explicitSid: string
+  isActiveEvent: boolean
+}): GatewayEventContext {
+  return {
+    event: { session_id: explicitSid || undefined, type: 'preview.act.request' },
+    explicitSid,
+    isActiveEvent,
+    payload: { action: 'elements', request_id: 'request-1' }
+  } as GatewayEventContext
+}
+
+function previewReadContext(): GatewayEventContext {
+  return {
+    event: { type: 'preview.read.request' },
+    explicitSid: '',
+    isActiveEvent: true,
+    payload: { request_id: 'read-1', start: 0, count: 100 }
+  } as GatewayEventContext
+}
+
+describe('preview action bridge routing', () => {
+  beforeEach(() => {
+    hasLivePreviewSurface.mockReturnValue(false)
+    isBrowserWindow.mockReturnValue(false)
+    requestPopoutPreviewAct.mockReset()
+    requestPopoutPreviewRead.mockReset()
+    readActivePreview.mockReset()
+  })
+
+  afterEach(() => {
+    $gateway.set(null)
+  })
+
+  it('leaves a scoped action request unanswered in a window showing another session', () => {
+    const request = vi.fn()
+    $gateway.set({ request } as never)
+
+    expect(handleDesktopBridgeEvent(previewActContext({ explicitSid: 'session-a', isActiveEvent: false }))).toBe(true)
+    expect(request).not.toHaveBeenCalled()
+  })
+
+  it('keeps the legacy fail-fast response for an unscoped inactive request', () => {
+    const request = vi.fn()
+    $gateway.set({ request } as never)
+
+    expect(handleDesktopBridgeEvent(previewActContext({ explicitSid: '', isActiveEvent: false }))).toBe(true)
+    expect(request).toHaveBeenCalledWith('preview.act.respond', {
+      request_id: 'request-1',
+      text: JSON.stringify({
+        error: 'The in-app browser only takes actions in the session the user is looking at.',
+        success: false
+      })
+    })
+  })
+
+  it('stays silent on preview.act in the browser pop-out window', () => {
+    const request = vi.fn()
+    $gateway.set({ request } as never)
+    isBrowserWindow.mockReturnValue(true)
+
+    expect(handleDesktopBridgeEvent(previewActContext({ explicitSid: 'session-a', isActiveEvent: false }))).toBe(true)
+    expect(request).not.toHaveBeenCalled()
+  })
+
+  it('forwards an active-session act to the pop-out when this window has no live surface', async () => {
+    const request = vi.fn()
+    $gateway.set({ request } as never)
+    hasLivePreviewSurface.mockReturnValue(false)
+    requestPopoutPreviewAct.mockResolvedValue({ acted: 'elements', success: true })
+
+    expect(handleDesktopBridgeEvent(previewActContext({ explicitSid: 'session-a', isActiveEvent: true }))).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(requestPopoutPreviewAct).toHaveBeenCalledWith(expect.objectContaining({ kind: 'elements' }))
+      expect(request).toHaveBeenCalledWith('preview.act.respond', {
+        request_id: 'request-1',
+        text: JSON.stringify({ acted: 'elements', success: true })
+      })
+    })
+  })
+
+  it('stays silent on preview.read in the browser pop-out window', () => {
+    const request = vi.fn()
+    $gateway.set({ request } as never)
+    isBrowserWindow.mockReturnValue(true)
+
+    expect(handleDesktopBridgeEvent(previewReadContext())).toBe(true)
+    expect(request).not.toHaveBeenCalled()
+    expect(readActivePreview).not.toHaveBeenCalled()
+  })
+
+  it('reads from the pop-out when the chat window has no live surface', async () => {
+    const request = vi.fn()
+    $gateway.set({ request } as never)
+    hasLivePreviewSurface.mockReturnValue(false)
+    requestPopoutPreviewRead.mockResolvedValue({
+      end: 4,
+      kind: 'url',
+      start: 0,
+      text: 'page',
+      title: 'Example',
+      total_chars: 4,
+      url: 'https://example.com'
+    })
+
+    expect(handleDesktopBridgeEvent(previewReadContext())).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(requestPopoutPreviewRead).toHaveBeenCalled()
+      expect(request).toHaveBeenCalledWith('preview.read.respond', {
+        request_id: 'read-1',
+        text: JSON.stringify({
+          end: 4,
+          kind: 'url',
+          start: 0,
+          text: 'page',
+          title: 'Example',
+          total_chars: 4,
+          url: 'https://example.com'
+        })
+      })
+    })
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts
@@ -1,3 +1,8 @@
+import {
+  hasLivePreviewSurface,
+  requestPopoutPreviewAct,
+  requestPopoutPreviewRead
+} from '@/app/chat/right-rail/preview-popout-bridge'
 import { readActivePreview } from '@/app/chat/right-rail/preview-reader'
 import { writeAgentTerminalChunk } from '@/app/right-sidebar/terminal/agent-terminal-stream'
 import { readActiveTerminal } from '@/app/right-sidebar/terminal/buffer'
@@ -10,6 +15,7 @@ import { recordAgentReaction } from '@/store/reactions-local'
 import { setMessages } from '@/store/session'
 import { $tipsEnabled, type ActiveTip, showTip } from '@/store/tips'
 import { $toursEnabled } from '@/store/tours'
+import { isBrowserWindow } from '@/store/windows'
 
 import type { GatewayEventContext } from './types'
 
@@ -45,7 +51,7 @@ const loadPreviewEngine = () => {
  *  (terminal/preview/window), agent terminal streaming, pane reveal, and
  *  message reactions. */
 export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
-  const { event, payload, isActiveEvent } = ctx
+  const { event, payload, explicitSid, isActiveEvent } = ctx
 
   if (event.type === 'terminal.read.request') {
     // read_terminal tool: serialize the renderer's xterm buffer and answer
@@ -69,18 +75,28 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
   if (event.type === 'preview.read.request') {
     // read_preview tool: serialize the active preview tab (a Browser
     // webview's page text is async) and answer. Empty text = nothing open.
+    // The popped-out Browser owns the live webview in another renderer, so
+    // that window stays silent on the gateway and answers via the pop-out
+    // bridge when the chat window has no local surface.
     const requestId = typeof payload?.request_id === 'string' ? payload.request_id : ''
 
     if (requestId) {
+      if (isBrowserWindow()) {
+        return true
+      }
+
       const start = typeof payload?.start === 'number' ? payload.start : undefined
       const count = typeof payload?.count === 'number' ? payload.count : undefined
 
-      void readActivePreview({ count, start }).then(result => {
+      void (async () => {
+        const local = hasLivePreviewSurface() ? await readActivePreview({ count, start }) : null
+        const result = local ?? (await requestPopoutPreviewRead({ count, start })) ?? (await readActivePreview({ count, start }))
+
         void $gateway.get()?.request('preview.read.respond', {
           request_id: requestId,
           text: result ? JSON.stringify(result) : ''
         })
-      })
+      })()
     }
 
     return true
@@ -91,10 +107,23 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
     // drive the pane's history. Dynamic import keeps the injected engine off
     // the boot path. Active session only: a background turn must never reach
     // into the page the user is working in (desktop AGENTS.md: offer, don't
-    // hijack).
+    // hijack). After pop-out the live webview is in `?win=browser`; that
+    // window stays silent here and serves acts through the pop-out bridge so
+    // the chat window keeps the session gate.
     const requestId = typeof payload?.request_id === 'string' ? payload.request_id : ''
 
     if (requestId) {
+      if (isBrowserWindow()) {
+        return true
+      }
+
+      // Every mounted desktop window can observe the same gateway event. A
+      // scoped mismatch belongs to another window, so answering here would race
+      // the owning window and could make a refusal win before its real result.
+      if (explicitSid && !isActiveEvent) {
+        return true
+      }
+
       const answer = (result: unknown) =>
         $gateway.get()?.request('preview.act.respond', {
           request_id: requestId,
@@ -102,23 +131,41 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
         })
 
       if (isActiveEvent) {
-        void loadPreviewEngine()
-          .then(run =>
-            run({
-              amount: payload?.amount,
-              key: payload?.key,
-              kind: payload?.action ?? '',
-              max: payload?.max,
-              ref: payload?.ref,
-              selector: payload?.selector,
-              submit: payload?.submit,
-              text: payload?.text,
-              to: payload?.to as PreviewActAction['to']
-            })
-          )
-          .then(answer, error =>
+        const action = {
+          amount: payload?.amount,
+          key: payload?.key,
+          kind: payload?.action ?? '',
+          max: payload?.max,
+          ref: payload?.ref,
+          selector: payload?.selector,
+          submit: payload?.submit,
+          text: payload?.text,
+          to: payload?.to as PreviewActAction['to']
+        }
+
+        void (async () => {
+          try {
+            if (hasLivePreviewSurface()) {
+              const run = await loadPreviewEngine()
+              answer(await run(action))
+
+              return
+            }
+
+            const remote = await requestPopoutPreviewAct(action)
+
+            if (remote) {
+              answer(remote)
+
+              return
+            }
+
+            const run = await loadPreviewEngine()
+            answer(await run(action))
+          } catch (error) {
             answer({ error: error instanceof Error ? error.message : String(error), success: false })
-          )
+          }
+        })()
       } else {
         void answer({
           error: 'The in-app browser only takes actions in the session the user is looking at.',


### PR DESCRIPTION
## Why

Popping the in-app Browser into its own window moved the live webview into another Electron renderer. The chat window kept the active-session gate for `drive_preview` / `read_preview`, but it no longer had the webview registries, so tool calls failed or raced a refusal from the pop-out. Agents should keep control of that page after pop-out.

## Scope

- `apps/desktop/src/app/chat/right-rail/preview-popout-bridge.ts` adds a BroadcastChannel handoff so the gated chat window can ask the pop-out to run act/read.
- `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts` forwards when the chat window has no live surface, stays silent in `?win=browser` on the gateway path, and leaves scoped inactive windows unanswered so they cannot win a refusal race.
- `apps/desktop/src/app/chat/browser-popout-shell.tsx` installs the pop-out responder.
- Focused tests cover routing and the channel round-trip.

Out of scope: tour tool routing, Electron main IPC, gateway/backend changes.

## Tradeoffs

BroadcastChannel keeps the change in the renderer and avoids new main-process IPC. Same-window hosts never deliver a BroadcastChannel message to the sender; the real pop-out is a second window, which is the case that matters.

## Blast radius

Desktop only. Docked Browser behavior is unchanged when a live surface exists locally. Background sessions still cannot drive the page from a non-active chat window. Related open work on idle-window refusal races (#101051 / #101016) overlaps the silence path for scoped inactive windows; this PR still needed the pop-out forward because the owning chat window was answering with no live page.

## Verification

```bash
cd apps/desktop
npx vitest run src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts src/app/chat/right-rail/preview-popout-bridge.test.ts
```

Result: 8 passed, exit 0.

Closes #101198
