### PR TITLE
fix(desktop): rebind mounted sessions after ws reconnect

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
@@ -65,6 +65,8 @@ describe('useSessionTileDelegate resumeTile', () => {
   beforeEach(() => {
     setSessions([])
     vi.mocked(getLatestSessionMessages).mockClear()
+    vi.mocked(requestGatewayForAgent).mockReset()
+    vi.mocked(requestGatewayForProfile).mockReset()
   })
 
   afterEach(() => {
@@ -180,18 +182,91 @@ describe('useSessionTileDelegate resumeTile', () => {
     expect(ambientRequest).not.toHaveBeenCalled()
   })
 
-  it('reuses a warm binding that still carries a transcript', async () => {
+  it('rebinds a warm binding via session.activate before reuse (#101408)', async () => {
     const stateA = { busy: false, messages: [{ id: 'm1' }], storedSessionId: 'stored-a' }
     const runtimeIdByStoredSessionIdRef = { current: new Map([['stored-a', 'runtime-a']]) }
     const sessionStateByRuntimeIdRef = { current: new Map([['runtime-a', stateA]]) }
-    const requestGateway = vi.fn(async () => ({}) as never)
+    const ambientRequest = vi.fn(async () => ({}) as never)
 
-    renderTile(requestGateway, { runtimeIdByStoredSessionIdRef, sessionStateByRuntimeIdRef })
+    setSessions([row({ id: 'stored-a', profile: 'default' })])
+    vi.mocked(requestGatewayForProfile).mockResolvedValueOnce({ session_id: 'runtime-a' } as never)
+
+    renderTile(ambientRequest, { runtimeIdByStoredSessionIdRef, sessionStateByRuntimeIdRef })
     const runtimeId = await sessionTileDelegate()!.resumeTile('stored-a')
 
     expect(runtimeId).toBe('runtime-a')
-    expect(requestGateway).not.toHaveBeenCalled()
+    expect(requestGatewayForProfile).toHaveBeenCalledWith(
+      'default',
+      'session.activate',
+      {
+        session_id: 'runtime-a',
+        cols: 96,
+        omit_messages: true
+      },
+      undefined,
+      undefined
+    )
     expect(getLatestSessionMessages).not.toHaveBeenCalled()
+  })
+
+  it('restores a pending approval from warm session.activate (#101408)', async () => {
+    const stateA = { busy: true, messages: [{ id: 'm1' }], storedSessionId: 'stored-appr', needsInput: false }
+    const runtimeIdByStoredSessionIdRef = { current: new Map([['stored-appr', 'runtime-appr']]) }
+    const sessionStateByRuntimeIdRef = { current: new Map([['runtime-appr', stateA]]) }
+    const updateSessionState = vi.fn((_id, updater) => {
+      const next = updater(stateA)
+      sessionStateByRuntimeIdRef.current.set('runtime-appr', next)
+
+      return next
+    })
+
+    setSessions([row({ id: 'stored-appr', profile: 'default' })])
+    vi.mocked(requestGatewayForProfile).mockResolvedValueOnce({
+      pending_approval: {
+        allow_permanent: true,
+        command: 'rm -rf /',
+        description: 'dangerous command',
+        request_id: 'req-1'
+      },
+      session_id: 'runtime-appr'
+    } as never)
+
+    const { clearApprovalRequest, sessionApprovalRequest } = await import('@/store/prompts')
+    clearApprovalRequest('runtime-appr')
+
+    renderTile(vi.fn(async () => ({}) as never), {
+      runtimeIdByStoredSessionIdRef,
+      sessionStateByRuntimeIdRef,
+      updateSessionState
+    })
+    await sessionTileDelegate()!.resumeTile('stored-appr')
+
+    expect(sessionApprovalRequest('runtime-appr').get()?.command).toBe('rm -rf /')
+    expect(updateSessionState).toHaveBeenCalled()
+  })
+
+  it('falls through to cold resume when warm activate proves the runtime dead (#101408)', async () => {
+    // Reconnect busy-reconcile can re-seed the stored→runtime map while the
+    // gateway still parks the session on the drop sentinel. Activate 404s;
+    // cold resume must rebind a live runtime instead of painting the dead one.
+    setSessions([row({ id: 'stored-reseed', profile: 'default' })])
+
+    const liveState = { busy: true, messages: [{ id: 'm1' }], storedSessionId: 'stored-reseed' }
+    const runtimeIdByStoredSessionIdRef = { current: new Map([['stored-reseed', 'runtime-dead']]) }
+    const sessionStateByRuntimeIdRef = { current: new Map([['runtime-dead', liveState]]) }
+
+    vi.mocked(requestGatewayForProfile)
+      .mockRejectedValueOnce(new Error('session not found'))
+      .mockResolvedValueOnce({ session_id: 'runtime-fresh' } as never)
+
+    renderTile(vi.fn(async () => ({}) as never), { runtimeIdByStoredSessionIdRef, sessionStateByRuntimeIdRef })
+    const runtimeId = await sessionTileDelegate()!.resumeTile('stored-reseed')
+
+    expect(runtimeId).toBe('runtime-fresh')
+    expect(requestGatewayForProfile.mock.calls.map(call => call[1])).toEqual([
+      'session.activate',
+      'session.resume'
+    ])
   })
 
   it('merges persisted messages into a warm tile on explicit reopen (#96183)', async () => {
@@ -206,6 +281,8 @@ describe('useSessionTileDelegate resumeTile', () => {
     const updateSessionState = vi.fn((_id, updater) => updater(stateA))
     const requestGateway = vi.fn(async () => ({}) as never)
 
+    setSessions([row({ id: 'stored-a', profile: 'default' })])
+    vi.mocked(requestGatewayForProfile).mockResolvedValueOnce({ session_id: 'runtime-a' } as never)
     vi.mocked(getLatestSessionMessages).mockResolvedValueOnce({
       messages: [
         { id: 'm1', content: 'old', role: 'user' },
@@ -218,14 +295,27 @@ describe('useSessionTileDelegate resumeTile', () => {
     const runtimeId = await sessionTileDelegate()!.resumeTile('stored-a', { refreshTranscript: true })
 
     expect(runtimeId).toBe('runtime-a')
-    expect(requestGateway).not.toHaveBeenCalled()
+    expect(requestGatewayForProfile).toHaveBeenCalledWith(
+      'default',
+      'session.activate',
+      {
+        session_id: 'runtime-a',
+        cols: 96,
+        omit_messages: true
+      },
+      undefined,
+      undefined
+    )
     expect(getLatestSessionMessages).toHaveBeenCalled()
     expect(updateSessionState).toHaveBeenCalled()
 
-    const updater = updateSessionState.mock.calls[0][1] as (state: typeof stateA) => {
+    const updater = updateSessionState.mock.calls.find(call => call[0] === 'runtime-a')?.[1] as (
+      state: typeof stateA
+    ) => {
       messages: Array<{ parts?: Array<{ text?: string }> }>
     }
 
+    expect(updater).toBeTypeOf('function')
     const next = updater(stateA)
     const texts = next.messages.flatMap(message => (message.parts ?? []).map(part => part.text ?? ''))
 

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
@@ -8,7 +8,9 @@ import {
 } from '@/hermes'
 import { translateNow } from '@/i18n/runtime'
 import { type ChatMessage, toChatMessages } from '@/lib/chat-messages'
+import { isMissingRpcMethod } from '@/lib/gateway-rpc'
 import { notify } from '@/store/notifications'
+import { setApprovalRequest } from '@/store/prompts'
 import {
   isReadOnlyRuntimeId,
   readOnlyRuntimeIdFor,
@@ -218,15 +220,61 @@ export function useSessionTileDelegate({
         // warm snapshot is whatever the tile last painted, and cron bot-chat
         // deliveries that landed while the panel's WS was down never arrive
         // as realtime events (#96183).
+        //
+        // Cache warmth is not transport attachment (#101408). After a WS drop
+        // the map can be re-seeded by reconnect busy-reconcile while the
+        // gateway still holds the session on the drop sentinel — returning
+        // here without session.activate left the tile looking live and
+        // silently dropping typed input. Always rebind first; fall through
+        // to cold resume when activate proves the runtime dead.
+        const rebindWarmRuntime = async (runtimeId: string): Promise<'ok' | 'missing' | 'dead'> => {
+          try {
+            const activated = await requestForStoredSession<SessionResumeResponse>(storedSessionId, 'session.activate', {
+              session_id: runtimeId,
+              cols: 96,
+              omit_messages: true
+            })
+
+            const pending = activated?.pending_approval
+
+            if (pending) {
+              setApprovalRequest({
+                allowPermanent: pending.allow_permanent !== false,
+                choices: pending.choices,
+                command: pending.command ?? '',
+                description: pending.description ?? 'dangerous command',
+                requestId: typeof pending.request_id === 'string' ? pending.request_id : undefined,
+                sessionId: runtimeId,
+                smartDenied: pending.smart_denied === true
+              })
+              updateSessionState(runtimeId, state => ({ ...state, needsInput: true }), storedSessionId)
+            }
+
+            return 'ok'
+          } catch (error) {
+            if (isMissingRpcMethod(error)) {
+              return 'missing'
+            }
+
+            return 'dead'
+          }
+        }
+
         if (
           existing &&
           cached?.storedSessionId === storedSessionId &&
           (cached.busy || cached.messages.length > 0) &&
           !refreshTranscript
         ) {
-          publishSessionState(existing, cached)
+          const rebind = await rebindWarmRuntime(existing)
 
-          return existing
+          if (rebind !== 'dead') {
+            publishSessionState(existing, sessionStateByRuntimeIdRef.current.get(existing) ?? cached)
+
+            return existing
+          }
+
+          runtimeIdByStoredSessionIdRef.current.delete(storedSessionId)
         }
 
         // Resolve the owning profile before binding a runtime. A tile can open a
@@ -243,17 +291,31 @@ export function useSessionTileDelegate({
 
         const prefetchPromise = getLatestSessionMessages(storedSessionId, restScope).catch(() => null)
 
-        if (existing && cached?.storedSessionId === storedSessionId && (cached.busy || cached.messages.length > 0)) {
-          const prefetch = await prefetchPromise
-          const merged = mergeTileTranscript(cached.messages, prefetch?.messages)
+        const warmAfterAwait = runtimeIdByStoredSessionIdRef.current.get(storedSessionId)
+        const warmCached = warmAfterAwait ? sessionStateByRuntimeIdRef.current.get(warmAfterAwait) : undefined
 
-          if (!chatMessageArraysEquivalent(cached.messages, merged)) {
-            updateSessionState(existing, state => ({ ...state, messages: merged }), storedSessionId)
-          } else {
-            publishSessionState(existing, cached)
+        if (
+          warmAfterAwait &&
+          warmCached?.storedSessionId === storedSessionId &&
+          (warmCached.busy || warmCached.messages.length > 0)
+        ) {
+          const rebind = await rebindWarmRuntime(warmAfterAwait)
+
+          if (rebind !== 'dead') {
+            const prefetch = await prefetchPromise
+            const latest = sessionStateByRuntimeIdRef.current.get(warmAfterAwait) ?? warmCached
+            const merged = mergeTileTranscript(latest.messages, prefetch?.messages)
+
+            if (!chatMessageArraysEquivalent(latest.messages, merged)) {
+              updateSessionState(warmAfterAwait, state => ({ ...state, messages: merged }), storedSessionId)
+            } else {
+              publishSessionState(warmAfterAwait, latest)
+            }
+
+            return warmAfterAwait
           }
 
-          return existing
+          runtimeIdByStoredSessionIdRef.current.delete(storedSessionId)
         }
 
         // #94724 no-owner recovery: dispatching the resume through the same
@@ -320,12 +382,26 @@ export function useSessionTileDelegate({
         }
 
         const info = resumed?.info
+        const pending = resumed?.pending_approval
+
+        if (pending) {
+          setApprovalRequest({
+            allowPermanent: pending.allow_permanent !== false,
+            choices: pending.choices,
+            command: pending.command ?? '',
+            description: pending.description ?? 'dangerous command',
+            requestId: typeof pending.request_id === 'string' ? pending.request_id : undefined,
+            sessionId: runtimeId,
+            smartDenied: pending.smart_denied === true
+          })
+        }
 
         updateSessionState(
           runtimeId,
           state => ({
             ...state,
             busy: Boolean(info?.running),
+            needsInput: Boolean(pending) || state.needsInput,
             // Persist the session's own model/provider from resume so the tile
             // pill does not wait on a chrome-scoped catalog read (#93892).
             ...(typeof info?.model === 'string' ? { model: info.model } : {}),

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -3894,7 +3894,7 @@ describe('resumeSession warm-cache mapping integrity', () => {
     expect(JSON.stringify(resumedState?.messages)).toContain('partial answer')
   })
 
-  it('keeps a warm runtime and optimistic turn on a transient activation timeout', async () => {
+  it('falls through to session.resume when warm activate times out (#101408)', async () => {
     const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
       current: new Map([['stored-A', 'rt-A']])
     }
@@ -3912,9 +3912,23 @@ describe('resumeSession warm-cache mapping integrity', () => {
       current: new Map([['rt-A', state]])
     }
 
+    setSessions([storedSession({ id: 'stored-A', message_count: 1 })])
+
     const requestGateway = vi.fn(async (method: string) => {
       if (method === 'session.activate') {
         throw new Error('request timed out: session.activate')
+      }
+
+      if (method === 'session.resume') {
+        return {
+          info: {},
+          message_count: 1,
+          messages: [{ content: 'do not lose me', role: 'user', timestamp: 1 }],
+          resumed: 'stored-A',
+          running: false,
+          session_id: 'rt-fresh',
+          session_key: 'stored-A'
+        } as never
       }
 
       return {} as never
@@ -3932,9 +3946,8 @@ describe('resumeSession warm-cache mapping integrity', () => {
     await waitFor(() => expect(resume).not.toBeNull())
     await resume!('stored-A', true)
 
-    expect(requestGateway.mock.calls.map(([method]) => method)).not.toContain('session.resume')
-    expect(runtimeIdByStoredSessionIdRef.current.get('stored-A')).toBe('rt-A')
-    expect(sessionStateByRuntimeIdRef.current.get('rt-A')?.messages[0]?.id).toBe('user-optimistic')
+    expect(requestGateway.mock.calls.map(([method]) => method)).toContain('session.resume')
+    await waitFor(() => expect($activeSessionId.get()).toBe('rt-fresh'))
   })
 
   it('never publishes a tail-only warm cache before the full persisted history', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -1425,14 +1425,18 @@ export function useSessionActions({
             }
 
             if (!isSessionGoneError(error)) {
-              publishDegradedWarmCache()
-
-              return
+              // #101408: a timeout / transport blip during reconnect storm used
+              // to publish the warm cache and return — the pane looked live
+              // while the gateway still held the session on the drop sentinel,
+              // so typed input never reached `prompt accepted` until a remount.
+              // Drop only the stored→runtime mapping and fall through to
+              // session.resume, which rebinds the transport on this socket.
+              runtimeIdByStoredSessionIdRef.current.delete(storedSessionId)
+            } else {
+              runtimeIdByStoredSessionIdRef.current.delete(storedSessionId)
+              sessionStateByRuntimeIdRef.current.delete(cachedRuntimeId)
+              dropSessionState(cachedRuntimeId)
             }
-
-            runtimeIdByStoredSessionIdRef.current.delete(storedSessionId)
-            sessionStateByRuntimeIdRef.current.delete(cachedRuntimeId)
-            dropSessionState(cachedRuntimeId)
           } finally {
             releaseTranscriptView()
           }


### PR DESCRIPTION
﻿## Why
After a desktop WebSocket drop (1006), reconnect could leave a mounted pane painted from warm cache while the gateway still held that session on the drop sentinel. Typed input never reached `prompt accepted`, and a pending `approval.pending` frame was lost until the user remounted the chat (#101408).

## Scope
- `use-session-tile-delegate.ts`: warm `resumeTile` always runs `session.activate` (restores `pending_approval`); falls through to cold `session.resume` when activate proves the runtime dead.
- `use-session-actions/index.ts`: a timed-out / transient warm `session.activate` falls through to cold `session.resume` instead of returning on degraded cache.
- Focused tests for both paths.

Out of scope: gateway orphan-reap / transport ownership changes.

## Tradeoffs
Warm tile reuse now pays one `session.activate` round-trip. That matches the primary resume path and is the cheapest way to prove transport attachment.

## Blast Radius
Desktop renderer only (`apps/desktop`). Affects tiled sessions and primary warm reconnect. Safe failure mode is cold resume.

## Verification
```
cd apps/desktop
npm run test:ui -- src/app/contrib/hooks/use-session-tile-delegate.test.ts
# 14 passed, exit 0

npm run test:ui -- src/app/session/hooks/use-session-actions.test.tsx -t "falls through to session.resume when warm activate times out"
# 1 passed, exit 0
```

Closes #101408
