### PR TITLE
fix(reasoning): extend stale-timeout floor to Z.AI GLM reasoning models

### DIFF
--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -131,6 +131,19 @@ _REASONING_STALE_TIMEOUT_FLOORS: tuple[tuple[str, int], ...] = (
     # reasoning variants.
     ("ox-alpha", 300),
     ("x-preview-f-free", 300),
+    # Z.AI GLM — GLM 4.5+ and GLM 5.x reasoning models.  GLM emits
+    # ``reasoning_content`` in a separate delta field before final content
+    # (same wire shape as DeepSeek R1/V4), and long-horizon reasoning turns
+    # on GLM 5.x routinely exceed the 90s non-streaming default during the
+    # thinking phase — the stale watchdog kills the call mid-think and the
+    # user sees "Non-streaming API call timed out after 90s with no
+    # response".  ``glm-4`` / ``glm-5`` cover the reasoning families
+    # (glm-4.5, glm-4.6, glm-5, glm-5.3, …) via the separator right-anchor;
+    # plain ``glm-4``-era instruct models share the prefix and inherit the
+    # floor, which is the safe direction (a longer wait on a hung stream
+    # vs. killing a healthy reasoning stream mid-think).
+    ("glm-4", 600),
+    ("glm-5", 600),
     # Thinking Machines Inkling (thinkingmachines/inkling[-small][:free]
     # on OpenRouter).  Reasoning model (OpenRouter supported_parameters
     # includes "reasoning"); 1M context — same tier as the Grok

--- a/tests/agent/test_reasoning_stale_timeout_floor.py
+++ b/tests/agent/test_reasoning_stale_timeout_floor.py
@@ -56,6 +56,11 @@ import pytest
     ("deepseek/deepseek-v4-flash", 600.0),
     ("deepseek/deepseek-v4-pro", 600.0),
     ("deepseek-v4-flash-free", 600.0),   # catalog -free variant inherits via separator anchor
+    # Z.AI GLM reasoning families (glm-4.5/4.6, glm-5.x) — reasoning_content
+    # delta + multi-minute thinking phase, same tier as DeepSeek V4.
+    ("zai/glm-5.3", 600.0),
+    ("glm-4.6-air", 600.0),
+    ("glm-4.5-flash", 600.0),
     # Qwen QwQ + Qwen3 thinking variants (qwen3 family entry matches all).
     ("qwen/qwq-32b-preview", 300.0),
     ("qwen/qwen3-235b-a22b-thinking", 180.0),


### PR DESCRIPTION
**Problem**

GLM 4.5+/5.x reasoning models emit `reasoning_content` in a separate delta field before final content (same wire shape as DeepSeek R1/V4). Long-horizon reasoning turns routinely exceed the 90s non-streaming stale default during the thinking phase, so the stale watchdog kills the call mid-think: `RuntimeError: Non-streaming API call timed out after 90s with no response`. Same symptom class as #52217 (Nemotron / o-series), which this table already addresses.

Observed in production against an on-prem GLM 5.3 endpoint: growing failure streaks on prompt-heavy cron jobs until the per-model `stale_timeout_seconds: 600` config workaround was applied.

**Fix**

Adds `glm-4` / `glm-5` family entries to `_REASONING_STALE_TIMEOUT_FLOORS` at the 600s deep-reasoning tier (alongside deepseek-v4, o1, nemotron-3-ultra). The separator right-anchor covers glm-4.5, glm-4.6, glm-5, glm-5.3 and future variants; instruct variants sharing the prefix inherit the floor, which is the safe direction (longer wait on a hung stream vs. killing a healthy reasoning stream mid-think).

**Testing**

- `tests/agent/test_reasoning_stale_timeout_floor.py`: 3 new parametrized cases (`zai/glm-5.3`, `glm-4.6-air`, `glm-4.5-flash` — aggregator-prefix stripping + separator inheritance). All 41 tests pass.
- Module doctests: 12/12 pass.
- No behavior change for non-GLM models (table lookup returns None unchanged).