### PR TITLE
fix(desktop): route macOS Cmd+Z through composer undo stack

### DIFF
--- a/apps/desktop/electron/edit-undo.test.ts
+++ b/apps/desktop/electron/edit-undo.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { installEditUndoShortcut, isEditHistoryChord } from './edit-undo'
+
+const chord = (over: Partial<Electron.Input> = {}): Electron.Input =>
+  ({
+    alt: false,
+    control: false,
+    key: 'z',
+    meta: false,
+    shift: false,
+    type: 'keyDown',
+    ...over
+  }) as Electron.Input
+
+describe('isEditHistoryChord', () => {
+  it('claims Cmd+Z / Ctrl+Z as undo', () => {
+    expect(isEditHistoryChord(chord({ meta: true }), true)).toBe('undo')
+    expect(isEditHistoryChord(chord({ control: true }), false)).toBe('undo')
+  })
+
+  it('claims Cmd+Shift+Z and Ctrl+Y as redo', () => {
+    expect(isEditHistoryChord(chord({ meta: true, shift: true }), true)).toBe('redo')
+    expect(isEditHistoryChord(chord({ control: true, key: 'y' }), false)).toBe('redo')
+  })
+
+  it('ignores Alt variants and unrelated keys', () => {
+    expect(isEditHistoryChord(chord({ alt: true, meta: true }), true)).toBeNull()
+    expect(isEditHistoryChord(chord({ key: 'a', meta: true }), true)).toBeNull()
+  })
+})
+
+describe('installEditUndoShortcut', () => {
+  it('prevents the chord and forwards undo/redo IPC', () => {
+    const handlers = new Map<string, (...args: unknown[]) => void>()
+    const send = vi.fn()
+    const webContents = {
+      isDestroyed: () => false,
+      off: vi.fn((channel: string) => handlers.delete(channel)),
+      on: vi.fn((channel: string, handler: (...args: unknown[]) => void) => {
+        handlers.set(channel, handler)
+      }),
+      send
+    }
+    const win = { webContents } as unknown as Electron.BrowserWindow
+
+    const uninstall = installEditUndoShortcut(win, () => true)
+    const handler = handlers.get('before-input-event')
+    expect(handler).toBeTypeOf('function')
+
+    const event = { preventDefault: vi.fn() }
+    handler?.(event, chord({ meta: true }))
+    expect(event.preventDefault).toHaveBeenCalled()
+    expect(send).toHaveBeenCalledWith('hermes:edit-undo')
+
+    send.mockClear()
+    event.preventDefault.mockClear()
+    handler?.(event, chord({ meta: true, shift: true }))
+    expect(send).toHaveBeenCalledWith('hermes:edit-redo')
+
+    uninstall()
+    expect(webContents.off).toHaveBeenCalledWith('before-input-event', handler)
+  })
+})

--- a/apps/desktop/electron/edit-undo.ts
+++ b/apps/desktop/electron/edit-undo.ts
@@ -1,0 +1,79 @@
+/**
+ * Claim ⌘Z / ⌘⇧Z (and Ctrl+Y) in the main process so macOS cannot run the
+ * native Edit-menu undo accelerator against Chromium's one-letter stack.
+ *
+ * Same hazard as ⌘W (electron#18295): a menu `{ role: 'undo' }` accelerator is
+ * consumed before the page sees the keystroke. The rich composer owns its own
+ * coalesced undo stack; native undo bypasses it. Menu items ship with no
+ * accelerator and call the same IPC as this hook (#101309).
+ *
+ * Returns an uninstall fn.
+ */
+
+export type EditHistoryAction = 'redo' | 'undo'
+
+export function isEditHistoryChord(
+  input: Pick<Electron.Input, 'alt' | 'control' | 'key' | 'meta' | 'shift'>,
+  isMac: boolean
+): EditHistoryAction | null {
+  const key = String(input.key || '').toLowerCase()
+  const primary = isMac ? input.meta : input.control
+
+  if (!primary || input.alt) {
+    return null
+  }
+
+  if (key === 'z' && !input.shift) {
+    return 'undo'
+  }
+
+  if (key === 'z' && input.shift) {
+    return 'redo'
+  }
+
+  // Ctrl+Y redo on non-Mac (and when a Mac user holds Ctrl).
+  if (key === 'y' && input.control && !input.meta && !input.shift) {
+    return 'redo'
+  }
+
+  return null
+}
+
+const IS_MAC = () => process.platform === 'darwin'
+
+export function installEditUndoShortcut(
+  window: Electron.BrowserWindow,
+  isMac: () => boolean = IS_MAC
+): () => void {
+  const { webContents } = window
+
+  if (!webContents || webContents.isDestroyed()) {
+    return () => {}
+  }
+
+  const handler = (event: Electron.Event, input: Electron.Input) => {
+    if (!webContents || webContents.isDestroyed() || input.type !== 'keyDown') {
+      return
+    }
+
+    const action = isEditHistoryChord(input, isMac())
+
+    if (!action) {
+      return
+    }
+
+    if (typeof event.preventDefault === 'function') {
+      event.preventDefault()
+    }
+
+    webContents.send(action === 'undo' ? 'hermes:edit-undo' : 'hermes:edit-redo')
+  }
+
+  webContents.on('before-input-event', handler)
+
+  return () => {
+    if (!webContents.isDestroyed()) {
+      webContents.off('before-input-event', handler)
+    }
+  }
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -179,6 +179,7 @@ import {
 } from './external-terminal'
 import { type FaviconIo, resolveFavicon } from './favicon'
 import { findGitBash as _findGitBash } from './find-git-bash'
+import { installEditUndoShortcut, type EditHistoryAction } from './edit-undo'
 import {
   installFindShortcut,
   installFoundInPageForwarder,
@@ -6419,6 +6420,22 @@ function sendClosePreviewRequested() {
   webContents.send('hermes:close-preview-requested')
 }
 
+function sendEditHistory(action: EditHistoryAction) {
+  const win = BrowserWindow.getFocusedWindow() || mainWindow
+
+  if (!win || win.isDestroyed()) {
+    return
+  }
+
+  const { webContents } = win
+
+  if (!webContents || webContents.isDestroyed()) {
+    return
+  }
+
+  webContents.send(action === 'undo' ? 'hermes:edit-undo' : 'hermes:edit-redo')
+}
+
 /**
  * Run a browser gesture on the guest page the user is actually in, if any.
  *
@@ -6712,8 +6729,13 @@ function buildApplicationMenu() {
   template.push({
     label: 'Edit',
     submenu: [
-      { role: 'undo' },
-      { role: 'redo' },
+      // NO accelerator: `{ role: 'undo' }` / `{ role: 'redo' }` register ⌘Z /
+      // ⌘⇧Z on macOS and the menu bar consumes them before the page sees the
+      // chord (electron#18295, same class as ⌘W). That ran Chromium's native
+      // one-letter undo and bypassed the composer's coalesced stack (#101309).
+      // Click still undoes via IPC; `installEditUndoShortcut` owns the chord.
+      { click: () => sendEditHistory('undo'), label: 'Undo' },
+      { click: () => sendEditHistory('redo'), label: 'Redo' },
       { type: 'separator' },
       { role: 'cut' },
       { role: 'copy' },
@@ -12964,6 +12986,13 @@ function wireCommonWindowHandlers(win, { zoom = true }: { zoom?: boolean } = {})
   installPreviewShortcut(win)
   installDevToolsShortcut(win)
   installBrowserNavGestures(win)
+
+  // macOS only: the application menu exists solely there, and `{ role: 'undo' }`
+  // was the accelerator that stole ⌘Z from the composer's stack (#101309).
+  // Windows / Linux leave Ctrl+Z on the renderer's keydown path.
+  if (IS_MAC) {
+    installEditUndoShortcut(win)
+  }
 
   // Claim Ctrl/Cmd+F in the main process — on Pop!_OS / GNOME-based Linux
   // distros the Ctrl+F keydown does not reach the renderer's `view.findInPage`

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -535,5 +535,20 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
     ipcRenderer.on('hermes:open-find-bar', listener)
 
     return () => ipcRenderer.removeListener('hermes:open-find-bar', listener)
+  },
+  // macOS Edit undo/redo (#101309): menu items have no accelerator;
+  // `before-input-event` claims ⌘Z / ⌘⇧Z and lands here so the rich composer
+  // stack (or native execCommand) can run.
+  onEditUndoRequested: callback => {
+    const listener = () => callback()
+    ipcRenderer.on('hermes:edit-undo', listener)
+
+    return () => ipcRenderer.removeListener('hermes:edit-undo', listener)
+  },
+  onEditRedoRequested: callback => {
+    const listener = () => callback()
+    ipcRenderer.on('hermes:edit-redo', listener)
+
+    return () => ipcRenderer.removeListener('hermes:edit-redo', listener)
   }
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-undo.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-undo.test.tsx
@@ -106,6 +106,33 @@ describe('useComposerUndo', () => {
     editor.remove()
   })
 
+  it('applies one stack step when keydown undo and historyUndo both fire', () => {
+    const { editor, ref } = makeEditor('base')
+    editor.focus()
+    placeCaretAtEnd(editor)
+
+    const { api, view } = mountUndo(ref, () => editor.textContent || '')
+
+    api.current!.recordUndoPoint()
+    editor.append(document.createTextNode(' one'))
+    api.current!.recordUndoPoint()
+    editor.append(document.createTextNode(' two'))
+    expect(editor.textContent).toBe('base one two')
+
+    expect(api.current!.undo()).toBe(true)
+    expect(editor.textContent).toBe('base one')
+
+    const event = new InputEvent('beforeinput', { bubbles: true, cancelable: true, inputType: 'historyUndo' })
+    editor.dispatchEvent(event)
+
+    // Same physical ⌘Z — do not take the next stack entry.
+    expect(event.defaultPrevented).toBe(true)
+    expect(editor.textContent).toBe('base one')
+
+    view.unmount()
+    editor.remove()
+  })
+
   it('ignores a historyUndo while another editor holds focus', () => {
     const { editor, ref } = makeEditor('mine')
     const { editor: other } = makeEditor('theirs')

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-undo.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-undo.ts
@@ -1,4 +1,4 @@
-import { type RefObject, useCallback, useEffect, useMemo } from 'react'
+import { type RefObject, useCallback, useEffect, useMemo, useRef } from 'react'
 
 import { caretOffsetInEditor, composerPlainText, placeCaretAtOffset, renderComposerContents } from '../rich-editor'
 import { type ComposerSnapshot, createComposerUndoHistory } from '../undo-history'
@@ -84,11 +84,35 @@ export function useComposerUndo({ editorRef, syncDraftFromEditor }: UseComposerU
   // conversation's text is worse than having no history at all.
   const resetUndoHistory = useCallback(() => history.reset(), [history])
 
-  // Electron's Edit menu ships `{ role: 'undo' }`, whose accelerator the macOS
-  // menu bar consumes before the web contents sees the keystroke (the same
-  // hazard main.ts documents for ⌘W). It fires the native editing command,
-  // which knows nothing about our stack. Claim it at the document level while
-  // the composer holds focus, so the menu item and the keystroke agree.
+  // One physical ⌘Z can arrive as both keydown (composer handler) and
+  // `beforeinput historyUndo` (Edit menu / main-process IPC). Apply a single
+  // stack step for that turn so burst undo cannot collapse twice.
+  const lastHistoryActionAt = useRef({ redo: 0, undo: 0 })
+
+  const runHistoryAction = useCallback(
+    (action: 'redo' | 'undo') => {
+      const now = performance.now()
+
+      if (now - lastHistoryActionAt.current[action] < 32) {
+        return false
+      }
+
+      const ran = action === 'undo' ? undo() : redo()
+
+      if (ran) {
+        lastHistoryActionAt.current[action] = now
+      }
+
+      return ran
+    },
+    [redo, undo]
+  )
+
+  // Electron's Edit menu used to ship `{ role: 'undo' }`, whose accelerator the
+  // macOS menu bar consumes before the web contents sees the keystroke (the
+  // same hazard main.ts documents for ⌘W). Main now forwards ⌘Z via IPC and
+  // the menu click shares that channel; this capture still claims a native
+  // `historyUndo` aimed at the focused composer so menu and keystroke agree.
   useEffect(() => {
     const onBeforeInput = (event: Event) => {
       const inputType = (event as InputEvent).inputType
@@ -104,16 +128,22 @@ export function useComposerUndo({ editorRef, syncDraftFromEditor }: UseComposerU
       event.preventDefault()
 
       if (inputType === 'historyUndo') {
-        undo()
+        runHistoryAction('undo')
       } else {
-        redo()
+        runHistoryAction('redo')
       }
     }
 
     document.addEventListener('beforeinput', onBeforeInput, true)
 
     return () => document.removeEventListener('beforeinput', onBeforeInput, true)
-  }, [editorRef, redo, undo])
+  }, [editorRef, runHistoryAction])
 
-  return { recordUndoPoint, redo, resetUndoHistory, undo, withUndoPoint }
+  return {
+    recordUndoPoint,
+    redo: () => runHistoryAction('redo'),
+    resetUndoHistory,
+    undo: () => runHistoryAction('undo'),
+    withUndoPoint
+  }
 }

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -82,7 +82,7 @@ import { SuggestionPills } from './suggestion-pills'
 import { extractClipboardImageBlobs, openDirectiveScope } from './text-utils'
 import { ComposerTriggerPopover } from './trigger-popover'
 import type { ChatBarProps } from './types'
-import { isRedoShortcut, isUndoShortcut } from './undo-history'
+import { isCoalescableTypingInput, isRedoShortcut, isUndoShortcut } from './undo-history'
 import { UrlDialog } from './url-dialog'
 import { chipTypedUrlOnSpace, linkifyUrls } from './url-refs'
 import { VoiceActivity, VoicePlaybackActivity } from './voice-activity'
@@ -491,7 +491,7 @@ export function ChatBar({
       return
     }
 
-    recordUndoPoint({ coalesce: inputType === 'insertText' || inputType === 'deleteContentBackward' })
+    recordUndoPoint({ coalesce: isCoalescableTypingInput(inputType) })
   }
 
   const handlePaste = (event: ClipboardEvent<HTMLDivElement>) => {

--- a/apps/desktop/src/app/chat/composer/perform-edit-history.test.ts
+++ b/apps/desktop/src/app/chat/composer/perform-edit-history.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { RICH_INPUT_SLOT } from './rich-editor'
+import { performEditHistory } from './perform-edit-history'
+
+describe('performEditHistory', () => {
+  afterEach(() => {
+    document.body.replaceChildren()
+    vi.restoreAllMocks()
+  })
+
+  it('dispatches historyUndo on the focused rich composer', () => {
+    const editor = document.createElement('div')
+    editor.contentEditable = 'true'
+    editor.tabIndex = 0
+    editor.dataset.slot = RICH_INPUT_SLOT
+    document.body.append(editor)
+    editor.focus()
+
+    const seen: string[] = []
+    editor.addEventListener('beforeinput', event => {
+      seen.push((event as InputEvent).inputType)
+      event.preventDefault()
+    })
+
+    expect(performEditHistory('undo')).toBe(true)
+    expect(seen).toEqual(['historyUndo'])
+  })
+
+  it('falls back to execCommand for ordinary fields', () => {
+    const input = document.createElement('input')
+    document.body.append(input)
+    input.focus()
+
+    const exec = vi.fn(() => true)
+    Object.defineProperty(document, 'execCommand', { configurable: true, value: exec, writable: true })
+
+    expect(performEditHistory('redo')).toBe(true)
+    expect(exec).toHaveBeenCalledWith('redo')
+  })
+})

--- a/apps/desktop/src/app/chat/composer/perform-edit-history.ts
+++ b/apps/desktop/src/app/chat/composer/perform-edit-history.ts
@@ -1,0 +1,22 @@
+import { RICH_INPUT_SLOT } from '@/app/chat/composer/rich-editor'
+
+/**
+ * Run one undo/redo step for whatever holds focus.
+ *
+ * The rich composer owns a coalesced stack claimed via `beforeinput`
+ * `historyUndo` / `historyRedo`. Ordinary `<input>` / `<textarea>` keep
+ * Chromium's native burst undo through `execCommand`.
+ */
+export function performEditHistory(action: 'redo' | 'undo'): boolean {
+  const active = document.activeElement
+
+  if (active instanceof HTMLElement && active.dataset.slot === RICH_INPUT_SLOT) {
+    const inputType = action === 'undo' ? 'historyUndo' : 'historyRedo'
+    const event = new InputEvent('beforeinput', { bubbles: true, cancelable: true, inputType })
+    active.dispatchEvent(event)
+
+    return event.defaultPrevented
+  }
+
+  return document.execCommand(action)
+}

--- a/apps/desktop/src/app/chat/composer/undo-history.test.ts
+++ b/apps/desktop/src/app/chat/composer/undo-history.test.ts
@@ -8,7 +8,12 @@ import {
   renderComposerContents,
   RICH_INPUT_SLOT
 } from './rich-editor'
-import { createComposerUndoHistory, isRedoShortcut, isUndoShortcut } from './undo-history'
+import {
+  createComposerUndoHistory,
+  isCoalescableTypingInput,
+  isRedoShortcut,
+  isUndoShortcut
+} from './undo-history'
 
 const key = (over: Partial<KeyboardEvent> = {}) =>
   ({ altKey: false, ctrlKey: false, key: 'z', metaKey: false, shiftKey: false, ...over }) as KeyboardEvent
@@ -43,6 +48,19 @@ describe('undo/redo shortcut recognition', () => {
     for (const chord of chords) {
       expect(isUndoShortcut(chord) && isRedoShortcut(chord)).toBe(false)
     }
+  })
+})
+
+describe('isCoalescableTypingInput', () => {
+  it('coalesces ordinary inserts and deletes, not paste/drop/history', () => {
+    expect(isCoalescableTypingInput('insertText')).toBe(true)
+    expect(isCoalescableTypingInput('insertReplacementText')).toBe(true)
+    expect(isCoalescableTypingInput('deleteContentBackward')).toBe(true)
+    expect(isCoalescableTypingInput('deleteContentForward')).toBe(true)
+    expect(isCoalescableTypingInput('insertFromPaste')).toBe(false)
+    expect(isCoalescableTypingInput('insertFromDrop')).toBe(false)
+    expect(isCoalescableTypingInput('historyUndo')).toBe(false)
+    expect(isCoalescableTypingInput('historyRedo')).toBe(false)
   })
 })
 
@@ -95,6 +113,17 @@ describe('composer undo history', () => {
     // One burst → one entry, back to the state before the burst started.
     expect(history.undo(snap('hel'))?.text).toBe('')
     expect(history.undo(snap(''))).toBeNull()
+  })
+
+  it('coalesces insertReplacementText into the same typing burst', () => {
+    let now = 1_000
+    const history = createComposerUndoHistory(200, () => now)
+
+    history.record(snap(''), { coalesce: isCoalescableTypingInput('insertText') })
+    now += 40
+    history.record(snap('teh'), { coalesce: isCoalescableTypingInput('insertReplacementText') })
+
+    expect(history.undo(snap('the'))?.text).toBe('')
   })
 
   it('starts a new entry once the typing pause exceeds the coalesce window', () => {

--- a/apps/desktop/src/app/chat/composer/undo-history.ts
+++ b/apps/desktop/src/app/chat/composer/undo-history.ts
@@ -29,6 +29,22 @@ const COALESCE_WINDOW_MS = 600
 
 const DEFAULT_LIMIT = 200
 
+/** True for ordinary typing / deleting `beforeinput` types that should share one
+ *  undo entry. Paste, drop, and history stay discrete. */
+export function isCoalescableTypingInput(inputType: string): boolean {
+  if (
+    inputType === 'insertFromPaste' ||
+    inputType === 'insertFromDrop' ||
+    inputType === 'insertFromYank' ||
+    inputType === 'historyUndo' ||
+    inputType === 'historyRedo'
+  ) {
+    return false
+  }
+
+  return inputType.startsWith('insert') || inputType.startsWith('delete')
+}
+
 export interface ComposerUndoHistory {
   /** Drop all history and start over from `snapshot`'s state (session swap). */
   reset: () => void

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
 
 import { closeActiveTab } from '@/app/chat/close-tab'
+import { performEditHistory } from '@/app/chat/composer/perform-edit-history'
 import { commandFocusedPreview } from '@/app/chat/right-rail/preview-nav'
 import { openSession } from '@/app/open-session'
 import { resolveDeepLinkAction } from '@/lib/deeplink-routes'
@@ -95,6 +96,23 @@ export function useDesktopIntegrations({
   // to us (close-preview-requested IPC) and we decide tab-vs-window.
   useEffect(() => {
     window.hermesDesktop?.setPreviewShortcutActive?.(true)
+  }, [])
+
+  // macOS Edit → Undo/Redo and the main-process ⌘Z intercept land here so the
+  // rich composer stack (or native execCommand for ordinary fields) runs
+  // instead of Chromium's one-letter undo (#101309).
+  useEffect(() => {
+    const offUndo = window.hermesDesktop?.onEditUndoRequested?.(() => {
+      performEditHistory('undo')
+    })
+    const offRedo = window.hermesDesktop?.onEditRedoRequested?.(() => {
+      performEditHistory('redo')
+    })
+
+    return () => {
+      offUndo?.()
+      offRedo?.()
+    }
   }, [])
 
   const restoredRef = useRef(false)

--- a/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
@@ -46,7 +46,7 @@ import {
 } from '@/app/chat/composer/rich-editor'
 import { detectTrigger, openDirectiveScope, textBeforeCaret, type TriggerState } from '@/app/chat/composer/text-utils'
 import { ComposerTriggerPopover } from '@/app/chat/composer/trigger-popover'
-import { isRedoShortcut, isUndoShortcut } from '@/app/chat/composer/undo-history'
+import { isCoalescableTypingInput, isRedoShortcut, isUndoShortcut } from '@/app/chat/composer/undo-history'
 import { chipTypedUrlOnSpace, linkifyUrls } from '@/app/chat/composer/url-refs'
 import {
   extractDroppedFiles,
@@ -590,7 +590,7 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
       return
     }
 
-    recordUndoPoint({ coalesce: inputType === 'insertText' || inputType === 'deleteContentBackward' })
+    recordUndoPoint({ coalesce: isCoalescableTypingInput(inputType) })
   }
 
   const handlePaste = (event: ClipboardEvent<HTMLDivElement>) => {

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -539,6 +539,10 @@ declare global {
       // renderer can still open the FindBar when the OS compositor has
       // already grabbed the chord (#81727, e.g. Pop!_OS / GNOME).
       onOpenFindBarRequested: (callback: () => void) => () => void
+      // macOS Edit undo/redo (#101309): main claims ⌘Z / ⌘⇧Z and menu clicks
+      // share these channels so the composer coalesced stack wins.
+      onEditUndoRequested: (callback: () => void) => () => void
+      onEditRedoRequested: (callback: () => void) => () => void
     }
   }
 }


### PR DESCRIPTION
﻿## Why

On macOS Desktop, Cmd+Z in the chat composer still undid one letter. The custom coalesced undo stack never saw the chord because Edit menu `{ role: "undo" }` registered the accelerator and the menu bar consumed it first (same class as Cmd+W / electron#18295). Chromium native undo ran instead.

## Scope

- `apps/desktop/electron/main.ts`: Edit Undo/Redo items have no accelerator; click sends IPC. macOS windows install `installEditUndoShortcut`.
- `apps/desktop/electron/edit-undo.ts`: `before-input-event` claims Cmd+Z / Cmd+Shift+Z / Ctrl+Y and forwards `hermes:edit-undo` / `hermes:edit-redo`.
- `apps/desktop/src/app/chat/composer/perform-edit-history.ts`: rich composer gets `historyUndo`/`historyRedo`; ordinary fields use `execCommand`.
- `isCoalescableTypingInput`: coalesce ordinary insert/delete types, not paste/drop/history.
- Same-tick debounce so keydown + `historyUndo` apply one stack step.

## Tradeoffs

macOS-only main-process intercept. Windows/Linux keep the renderer keydown path; the application menu is already null there.

## Blast Radius

macOS Edit Undo/Redo and Cmd+Z/Cmd+Shift+Z in the desktop shell. Rich composer uses the coalesced stack. Settings/search inputs keep native burst undo via `execCommand`. Guest webviews are untouched (their own webContents).

## Verification

```
cd apps/desktop
npm run test:ui -- src/app/chat/composer/undo-history.test.ts src/app/chat/composer/hooks/use-composer-undo.test.tsx src/app/chat/composer/perform-edit-history.test.ts
npm run test:desktop:platforms -- electron/edit-undo.test.ts
```

- UI: 31 passed, exit 0
- Electron: 4 passed, exit 0

No live packaged macOS Desktop run in this unit (Windows worktree).

Closes #101309
