### PR TITLE
fix(tui): reserve three-row composer input height

### DIFF
--- a/ui-tui/src/__tests__/textInputWrap.test.ts
+++ b/ui-tui/src/__tests__/textInputWrap.test.ts
@@ -2,7 +2,14 @@ import { wrapAnsi } from '@hermes/ink'
 import { describe, expect, it } from 'vitest'
 
 import { offsetFromPosition } from '../components/textInput.js'
-import { composerPromptWidth, cursorLayout, inputVisualHeight, stableComposerColumns } from '../lib/inputMetrics.js'
+import {
+  COMPOSER_INPUT_MIN_ROWS,
+  composerInputHeight,
+  composerPromptWidth,
+  cursorLayout,
+  inputVisualHeight,
+  stableComposerColumns
+} from '../lib/inputMetrics.js'
 
 // Helper: compute the "end of text" position that wrap-ansi would render
 // the input to. This is what Ink's <Text wrap="wrap"> uses, so cursorLayout
@@ -98,6 +105,16 @@ describe('input metrics helpers', () => {
     expect(inputVisualHeight('one\ntwo', 40)).toBe(2)
     // Multi-line wrap case sanity
     expect(inputVisualHeight('hello world', 8)).toBe(2)
+  })
+
+  it('reserves at least three composer rows for empty and single-line drafts (#100842)', () => {
+    expect(COMPOSER_INPUT_MIN_ROWS).toBe(3)
+    expect(composerInputHeight('', 80)).toBe(3)
+    expect(composerInputHeight('hi', 80)).toBe(3)
+    expect(composerInputHeight('abcdefgh', 8)).toBe(3)
+    expect(composerInputHeight('one\ntwo\nthree', 40)).toBe(3)
+    expect(composerInputHeight('one\ntwo\nthree\nfour', 40)).toBe(4)
+    expect(composerInputHeight('hello world', 8)).toBe(Math.max(3, inputVisualHeight('hello world', 8)))
   })
 
   it('counts the prompt gap as its own cell', () => {

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -16,8 +16,8 @@ import { PLACEHOLDER } from '../content/placeholders.js'
 import { prevRenderedMsg } from '../domain/blockLayout.js'
 import {
   COMPOSER_PROMPT_GAP_WIDTH,
+  composerInputHeight,
   composerPromptWidth,
-  inputVisualHeight,
   stableComposerColumns
 } from '../lib/inputMetrics.js'
 import { PerfPane } from '../lib/perfPane.js'
@@ -291,7 +291,7 @@ const ComposerPane = memo(function ComposerPane({
   const promptWidth = composerPromptWidth(promptText)
   const promptBlank = ' '.repeat(promptWidth)
   const inputColumns = stableComposerColumns(composer.cols, promptWidth, TERMUX_TUI_MODE)
-  const inputHeight = inputVisualHeight(composer.input, inputColumns)
+  const inputHeight = composerInputHeight(composer.input, inputColumns)
   const inputMouseRef = useRef<null | TextInputMouseApi>(null)
 
   const captureInputDrag = (e: GutterMouseEvent) => {

--- a/ui-tui/src/lib/inputMetrics.ts
+++ b/ui-tui/src/lib/inputMetrics.ts
@@ -170,6 +170,13 @@ export function inputVisualHeight(value: string, columns: number) {
   return cursorLayout(value, value.length, columns).line + 1
 }
 
+/** Floor for the composer box so empty drafts are not a single ~20px cell. */
+export const COMPOSER_INPUT_MIN_ROWS = 3
+
+export function composerInputHeight(value: string, columns: number) {
+  return Math.max(COMPOSER_INPUT_MIN_ROWS, inputVisualHeight(value, columns))
+}
+
 export function composerPromptWidth(promptText: string) {
   return Math.max(1, stringWidth(promptText)) + COMPOSER_PROMPT_GAP_WIDTH
 }


### PR DESCRIPTION
## Why

The Ink composer sized its box to content height only. An empty or single-line draft collapsed to one terminal row (~20px in the dashboard xterm embed), which made multi-line typing hard to read. Issue #100842 asks for at least 2–3 visible lines.

## Scope

- `composerInputHeight` / `COMPOSER_INPUT_MIN_ROWS` in `ui-tui/src/lib/inputMetrics.ts`
- `ComposerPane` in `ui-tui/src/components/appLayout.tsx` uses the floored height
- Focused coverage in `ui-tui/src/__tests__/textInputWrap.test.ts`
- Out of scope: dashboard xterm `fontSize` still ignores Hermes Teal (Large) `baseSize`

## Tradeoffs

Always reserve three rows, including empty drafts. That costs two transcript rows for more typing room. Content above three rows still grows as before.

## Blast Radius

Native `hermes --tui` and the dashboard Chat embed (same Ink composer). Layout shifts by two blank composer rows when the draft is short. Cursor and wrap math stay on `inputVisualHeight`.

## Verification

Worktree `hermes-agent-wt-u16`.

```
cd ui-tui
npm run build:ink
npm test -- src/__tests__/textInputWrap.test.ts src/__tests__/cursorDriftRegression.test.ts
```

- Result: **24 passed**, exit **0**

```
npm test
```

- Result: **1723 passed**, **10 failed**, exit **1**
- Failures are pre-existing Windows host noise (`notepad.exe` editor resolution, VS Code path separators). Untouched by this diff.

Closes #100842

Made with [Cursor](https://cursor.com)