### PR TITLE
fix(auxiliary): fallback on statusless provider errors

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5035,6 +5035,24 @@ def _is_invalid_aux_response_error(exc: Exception) -> bool:
     )
 
 
+def _is_statusless_structured_provider_error(exc: Exception) -> bool:
+    """Detect a structured provider failure that has no HTTP status.
+
+    OpenAI-compatible relays may commit SSE with status 200, then send an
+    OpenAI-style ``error`` event. The SDK raises a status-less ``APIError`` and
+    preserves the event only on ``exc.body``. Any non-empty structured error in
+    that status-less shape is a route failure; ordinary HTTP errors keep their
+    existing status-based classifiers, and message text alone is insufficient.
+    """
+    status = getattr(exc, "status_code", None) or getattr(
+        getattr(exc, "response", None), "status_code", None
+    )
+    if status is not None:
+        return False
+    body = getattr(exc, "body", None)
+    return isinstance(body, dict) and bool(body.get("error"))
+
+
 def _evict_cached_clients(provider: str) -> None:
     """Drop cached auxiliary clients for a provider so fresh creds are used."""
     normalized = _normalize_aux_provider(provider)
@@ -10705,6 +10723,7 @@ def _call_llm_impl(
                     _is_payment_error(retry_err)
                     or _is_connection_error(retry_err)
                     or _is_auth_error(retry_err)
+                    or _is_statusless_structured_provider_error(retry_err)
                     or "max_tokens" in retry_err_str
                     or "unsupported_parameter" in retry_err_str
                 ):
@@ -10738,6 +10757,7 @@ def _call_llm_impl(
                         _is_payment_error(retry_err)
                         or _is_connection_error(retry_err)
                         or _is_auth_error(retry_err)
+                        or _is_statusless_structured_provider_error(retry_err)
                         or "max_tokens" in str(retry_err)
                         or "unsupported_parameter" in str(retry_err)
                     ):
@@ -10774,7 +10794,12 @@ def _call_llm_impl(
             except Exception as retry_err:
                 # If the max_tokens retry also hits a payment or connection
                 # error, fall through to the fallback chain below.
-                if not (_is_payment_error(retry_err) or _is_connection_error(retry_err) or _is_rate_limit_error(retry_err)):
+                if not (
+                    _is_payment_error(retry_err)
+                    or _is_connection_error(retry_err)
+                    or _is_rate_limit_error(retry_err)
+                    or _is_statusless_structured_provider_error(retry_err)
+                ):
                     raise
                 first_err = retry_err
 
@@ -11009,6 +11034,7 @@ def _call_llm_impl(
             or _is_rate_limit_error(first_err)
             or _is_model_incompatible_error(first_err)
             or _is_invalid_aux_response_error(first_err)
+            or _is_statusless_structured_provider_error(first_err)
         )
         # Respect explicit provider choice for transient errors (auth, request
         # validation, etc.) but allow fallback when the provider clearly cannot
@@ -11032,6 +11058,7 @@ def _call_llm_impl(
             or _is_rate_limit_error(first_err)
             or _is_model_incompatible_error(first_err)
             or _is_invalid_aux_response_error(first_err)
+            or _is_statusless_structured_provider_error(first_err)
         )
         if should_fallback and (is_auto or is_capacity_error):
             if _is_auth_error(first_err):
@@ -11051,6 +11078,8 @@ def _call_llm_impl(
                 reason = "model incompatible with route"
             elif _is_invalid_aux_response_error(first_err):
                 reason = "invalid provider response"
+            elif _is_statusless_structured_provider_error(first_err):
+                reason = "structured provider error"
             else:
                 reason = "connection error"
             logger.info("Auxiliary %s: %s on %s (%s), trying fallback",
@@ -11505,6 +11534,7 @@ async def _async_call_llm_impl(
                     _is_payment_error(retry_err)
                     or _is_connection_error(retry_err)
                     or _is_auth_error(retry_err)
+                    or _is_statusless_structured_provider_error(retry_err)
                     or "max_tokens" in retry_err_str
                     or "unsupported_parameter" in retry_err_str
                 ):
@@ -11539,6 +11569,7 @@ async def _async_call_llm_impl(
                         _is_payment_error(retry_err)
                         or _is_connection_error(retry_err)
                         or _is_auth_error(retry_err)
+                        or _is_statusless_structured_provider_error(retry_err)
                         or "max_tokens" in str(retry_err)
                         or "unsupported_parameter" in str(retry_err)
                     ):
@@ -11575,7 +11606,12 @@ async def _async_call_llm_impl(
             except Exception as retry_err:
                 # If the max_tokens retry also hits a payment or connection
                 # error, fall through to the fallback chain below.
-                if not (_is_payment_error(retry_err) or _is_connection_error(retry_err) or _is_rate_limit_error(retry_err)):
+                if not (
+                    _is_payment_error(retry_err)
+                    or _is_connection_error(retry_err)
+                    or _is_rate_limit_error(retry_err)
+                    or _is_statusless_structured_provider_error(retry_err)
+                ):
                     raise
                 first_err = retry_err
 
@@ -11776,6 +11812,7 @@ async def _async_call_llm_impl(
             or _is_rate_limit_error(first_err)
             or _is_model_incompatible_error(first_err)
             or _is_invalid_aux_response_error(first_err)
+            or _is_statusless_structured_provider_error(first_err)
         )
         # Capacity errors (payment/quota/connection/rate-limit) bypass the
         # explicit-provider gate — the provider cannot serve the request
@@ -11791,6 +11828,7 @@ async def _async_call_llm_impl(
             or _is_rate_limit_error(first_err)
             or _is_model_incompatible_error(first_err)
             or _is_invalid_aux_response_error(first_err)
+            or _is_statusless_structured_provider_error(first_err)
         )
         if should_fallback and (is_auto or is_capacity_error):
             if _is_auth_error(first_err):
@@ -11806,6 +11844,8 @@ async def _async_call_llm_impl(
                 reason = "model incompatible with route"
             elif _is_invalid_aux_response_error(first_err):
                 reason = "invalid provider response"
+            elif _is_statusless_structured_provider_error(first_err):
+                reason = "structured provider error"
             else:
                 reason = "connection error"
             logger.info("Auxiliary %s (async): %s on %s (%s), trying fallback",

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -5,6 +5,7 @@ import json
 import logging
 import time
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import patch, MagicMock, AsyncMock
 
 import pytest
@@ -26,6 +27,7 @@ from agent.auxiliary_client import (
     _is_rate_limit_error,
     _is_model_not_found_error,
     _is_model_incompatible_error,
+    _is_statusless_structured_provider_error,
     _refresh_nous_recommended_model,
     _normalize_aux_provider,
     _try_payment_fallback,
@@ -1627,6 +1629,235 @@ class TestCallLlmPaymentFallback:
         exc.status_code = 429
         return exc
 
+    def _make_statusless_structured_error(
+        self,
+        *,
+        error_type="server_error",
+        error_code="overloaded",
+        error_payload=None,
+    ):
+        import httpx
+        from openai import APIError
+
+        if error_payload is None:
+            error_payload = {
+                "message": "Upstream service temporarily overloaded.",
+                "type": error_type,
+                "code": error_code,
+            }
+        return APIError(
+            "Upstream service temporarily overloaded.",
+            request=httpx.Request("POST", "https://relay.example/v1/chat/completions"),
+            body={"error": error_payload},
+        )
+
+    def test_structured_statusless_provider_error_is_detected(self):
+        assert _is_statusless_structured_provider_error(self._make_statusless_structured_error()) is True
+        assert _is_statusless_structured_provider_error(
+            self._make_statusless_structured_error(
+                error_type="stream_error",
+                error_code="mid_stream_failure",
+            )
+        ) is True
+        assert _is_statusless_structured_provider_error(
+            self._make_statusless_structured_error(error_payload="service unavailable")
+        ) is True
+        assert _is_statusless_structured_provider_error(
+            self._make_statusless_structured_error(error_payload="")
+        ) is False
+
+        message_only = Exception("stream_error: mid_stream_failure")
+        assert _is_statusless_structured_provider_error(message_only) is False
+
+        class _StatusCodedStructuredError(Exception):
+            status_code = 503
+            body = {"error": {"type": "server_error"}}
+
+        assert _is_statusless_structured_provider_error(_StatusCodedStructuredError("unavailable")) is False
+
+    @pytest.mark.parametrize(
+        "error_payload",
+        [{"type": "server_error", "code": "overloaded"}, "service unavailable"],
+    )
+    def test_statusless_structured_error_triggers_configured_fallback(self, error_payload):
+        primary_client = MagicMock()
+        primary_client.base_url = "https://relay.example/v1"
+        primary_client.chat.completions.create.side_effect = self._make_statusless_structured_error(
+            error_payload=error_payload
+        )
+
+        fallback_client = MagicMock()
+        fallback_client.chat.completions.create.return_value = _DummyResponse("fallback response")
+
+        with patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(primary_client, "virtual-model"),
+        ), patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("custom", "virtual-model", "https://relay.example/v1", "test-key", None),
+        ), patch(
+            "agent.auxiliary_client._try_configured_fallback_chain",
+            return_value=(fallback_client, "fallback-model", "fallback_chain[0](openrouter)"),
+        ) as mock_chain, patch(
+            "agent.auxiliary_client._try_main_agent_model_fallback",
+            return_value=(None, None, ""),
+        ):
+            result = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarize"}],
+            )
+
+        assert result.choices[0].message.content == "fallback response"
+        assert primary_client.chat.completions.create.call_count == 1
+        assert mock_chain.call_args.kwargs["reason"] == "structured provider error"
+
+    @pytest.mark.parametrize(
+        "error_payload",
+        [{"type": "server_error", "code": "overloaded"}, "service unavailable"],
+    )
+    def test_async_statusless_structured_error_triggers_configured_fallback(self, error_payload):
+        import asyncio
+
+        primary_client = MagicMock()
+        primary_client.base_url = "https://relay.example/v1"
+        primary_client.chat.completions.create = AsyncMock(
+            side_effect=self._make_statusless_structured_error(error_payload=error_payload)
+        )
+
+        fallback_sync = MagicMock()
+        fallback_async = MagicMock()
+        fallback_async.chat.completions.create = AsyncMock(
+            return_value=_DummyResponse("async fallback response")
+        )
+
+        with patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(primary_client, "virtual-model"),
+        ), patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("custom", "virtual-model", "https://relay.example/v1", "test-key", None),
+        ), patch(
+            "agent.auxiliary_client._try_configured_fallback_chain",
+            return_value=(fallback_sync, "fallback-model", "fallback_chain[0](openrouter)"),
+        ) as mock_chain, patch(
+            "agent.auxiliary_client._try_main_agent_model_fallback",
+            return_value=(None, None, ""),
+        ), patch(
+            "agent.auxiliary_client._to_async_client",
+            return_value=(fallback_async, "fallback-model"),
+        ):
+            result = asyncio.run(
+                async_call_llm(
+                    task="compression",
+                    messages=[{"role": "user", "content": "summarize"}],
+                )
+            )
+
+        assert result.choices[0].message.content == "async fallback response"
+        assert primary_client.chat.completions.create.await_count == 1
+        assert mock_chain.call_args.kwargs["reason"] == "structured provider error"
+
+    @staticmethod
+    def _parameter_retry_case(kind: str) -> tuple[Exception, dict[str, Any]]:
+        class _UnsupportedParameterError(Exception):
+            status_code = 400
+
+        first_error = _UnsupportedParameterError(f"Unsupported parameter: {kind}")
+        if kind == "temperature":
+            return first_error, {"temperature": 0.1}
+        if kind == "response_format":
+            return first_error, {"extra_body": {"response_format": {"type": "json_object"}}}
+        return first_error, {"max_tokens": 128}
+
+    @pytest.mark.parametrize("kind", ["temperature", "response_format", "max_tokens"])
+    @pytest.mark.parametrize(
+        "error_payload",
+        [{"type": "server_error", "code": "overloaded"}, "service unavailable"],
+    )
+    def test_parameter_retry_structured_error_reaches_fallback(self, kind, error_payload):
+        first_error, call_kwargs = self._parameter_retry_case(kind)
+        primary_client = MagicMock()
+        primary_client.base_url = "https://relay.example/v1"
+        primary_client.chat.completions.create.side_effect = [
+            first_error,
+            self._make_statusless_structured_error(error_payload=error_payload),
+        ]
+        fallback_client = MagicMock()
+        fallback_client.chat.completions.create.return_value = _DummyResponse("retry fallback")
+
+        with patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(primary_client, "virtual-model"),
+        ), patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("custom", "virtual-model", "https://relay.example/v1", "test-key", None),
+        ), patch(
+            "agent.auxiliary_client._try_configured_fallback_chain",
+            return_value=(fallback_client, "fallback-model", "fallback_chain[0](openrouter)"),
+        ) as mock_chain, patch(
+            "agent.auxiliary_client._try_main_agent_model_fallback",
+            return_value=(None, None, ""),
+        ):
+            result = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarize"}],
+                **call_kwargs,
+            )
+
+        assert result.choices[0].message.content == "retry fallback"
+        assert primary_client.chat.completions.create.call_count == 2
+        assert mock_chain.call_args.kwargs["reason"] == "structured provider error"
+
+    @pytest.mark.parametrize("kind", ["temperature", "response_format", "max_tokens"])
+    @pytest.mark.parametrize(
+        "error_payload",
+        [{"type": "server_error", "code": "overloaded"}, "service unavailable"],
+    )
+    def test_async_parameter_retry_structured_error_reaches_fallback(self, kind, error_payload):
+        import asyncio
+
+        first_error, call_kwargs = self._parameter_retry_case(kind)
+        primary_client = MagicMock()
+        primary_client.base_url = "https://relay.example/v1"
+        primary_client.chat.completions.create = AsyncMock(
+            side_effect=[
+                first_error,
+                self._make_statusless_structured_error(error_payload=error_payload),
+            ]
+        )
+        fallback_sync = MagicMock()
+        fallback_async = MagicMock()
+        fallback_async.chat.completions.create = AsyncMock(
+            return_value=_DummyResponse("async retry fallback")
+        )
+
+        with patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(primary_client, "virtual-model"),
+        ), patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("custom", "virtual-model", "https://relay.example/v1", "test-key", None),
+        ), patch(
+            "agent.auxiliary_client._try_configured_fallback_chain",
+            return_value=(fallback_sync, "fallback-model", "fallback_chain[0](openrouter)"),
+        ) as mock_chain, patch(
+            "agent.auxiliary_client._try_main_agent_model_fallback",
+            return_value=(None, None, ""),
+        ), patch(
+            "agent.auxiliary_client._to_async_client",
+            return_value=(fallback_async, "fallback-model"),
+        ):
+            result = asyncio.run(
+                async_call_llm(
+                    task="compression",
+                    messages=[{"role": "user", "content": "summarize"}],
+                    **call_kwargs,
+                )
+            )
+
+        assert result.choices[0].message.content == "async retry fallback"
+        assert primary_client.chat.completions.create.await_count == 2
+        assert mock_chain.call_args.kwargs["reason"] == "structured provider error"
 
     def test_429_rate_limit_triggers_fallback(self, monkeypatch):
         """429 rate-limit errors should trigger fallback to next provider."""


### PR DESCRIPTION
## Summary

- classify status-less OpenAI-compatible auxiliary exceptions with a non-empty structured `body.error` as provider-route failures
- consult the configured auxiliary fallback chain in both sync and async paths, including after temperature, structured-output, and token-parameter retry rungs
- preserve existing handling for empty errors, message-only exceptions, and exceptions with an HTTP status

Fixes #101538.

## Why

An OpenAI-compatible SSE response can start with HTTP 200 and later emit a structured error event. The OpenAI SDK raises a plain `APIError` with the event stored on `exc.body`, but without `status_code`. Existing auxiliary classifiers therefore skip `auxiliary.<task>.fallback_chain`, even for an explicitly configured primary provider.

The classifier is structural and provider-agnostic. It does not match vendor names or arbitrary message text.

## Related but distinct

- #101018: HTTP 503 `model_not_found`
- #100526: stalled stream/watchdog behavior
- #101228: explicit-provider fallback for already-classified 401 errors
- #41245: HTTP 502/503/504 with a status code

This PR covers status-less SDK exceptions carrying a structured `body.error`.

## Test plan

- `scripts/run_tests.sh tests/agent/test_auxiliary_client.py -q`
  - 205 passed
- Ruff on `agent/auxiliary_client.py` and `tests/agent/test_auxiliary_client.py`
- `python -m compileall` on both changed files

Tests cover dictionary and string `body.error` payloads, empty and message-only negatives, status-coded negatives, sync and async fallback, and all three parameter-retry rungs.