### PR TITLE
fix(update): preserve launchd-owned dashboard backends

### DIFF
--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -191,6 +191,219 @@ def _hermes_home_for_pid(pid: int) -> str | None:
     return None
 
 
+def _is_hermes_backend_launchd_label(label: str) -> bool:
+    """True only for the launchd label families used by Hermes backends."""
+    if not label or label.startswith("application."):
+        return False
+    if not all(
+        char.isascii() and (char.isalnum() or char in "._-") for char in label
+    ):
+        return False
+    for base in ("ai.hermes.dashboard", "ai.hermes.serve"):
+        if label == base:
+            return True
+        prefix = f"{base}-"
+        if label.startswith(prefix) and len(label) > len(prefix):
+            return True
+    return False
+
+
+def _launchd_label_for_pid(pid: int) -> str | None:
+    """Return launchd's job label from *pid*'s own environment on macOS.
+
+    ``psutil`` is a pinned core dependency (see ``pyproject.toml``); failures
+    here mean the process disappeared or macOS denied the environment query,
+    not that callers should substitute an argv-only ownership guess.
+    """
+    if sys.platform != "darwin":
+        return None
+    try:
+        import psutil
+
+        label = str(
+            psutil.Process(pid).environ().get("XPC_SERVICE_NAME") or ""
+        ).strip()
+    except Exception:
+        return None
+    return label if _is_hermes_backend_launchd_label(label) else None
+
+
+def _launchd_pid_is_verified_ancestor(
+    launchd_pid: int, candidate_pid: int
+) -> bool | None:
+    """Return launchd ancestry, or ``None`` when it cannot be queried safely.
+
+    ``psutil`` is pinned in Hermes' core dependencies.  The indeterminate
+    result therefore represents process churn or an access/query failure and
+    must be handled fail-closed rather than as proof that the PIDs are
+    unrelated.
+    """
+    if launchd_pid <= 0 or candidate_pid <= 0 or launchd_pid == candidate_pid:
+        return False
+    try:
+        import psutil
+
+        return any(
+            int(parent.pid) == launchd_pid
+            for parent in psutil.Process(candidate_pid).parents()
+        )
+    except Exception:
+        return None
+
+
+def _launchd_owner_for_pid(
+    pid: int,
+) -> tuple[str, str | None, int | None, bool] | None:
+    """Return launchd ownership data for a Hermes backend candidate.
+
+    Ownership is based on launchd's job identity, not the process command.
+    The PID's own ``XPC_SERVICE_NAME`` supplies the exact label, then
+    domain-qualified ``launchctl print`` probes must report either the same
+    PID (the fast path) or a verified ancestor wrapper of the candidate.
+    The final bool is true when the exact job is loaded but not running, or is
+    running under a different, non-ancestor PID: *pid* is then a stale same-job
+    process that must exit before launchd is restarted, and must never be
+    replayed from argv.
+
+    When every launchctl probe is indeterminate, only an accepted Hermes
+    backend label is enough to fail closed: cleanup leaves the process alone
+    and never falls into argv-only manual respawn.
+    """
+    if sys.platform != "darwin":
+        return None
+    label = _launchd_label_for_pid(pid)
+    if label is None or not _is_hermes_backend_launchd_label(label):
+        return None
+
+    try:
+        uid = os.getuid()
+    except AttributeError:  # pragma: no cover - guarded by the darwin check
+        return None
+
+    query_incomplete = False
+    conclusive_job_query = False
+    stale_same_job: tuple[str, str | None, int | None, bool] | None = None
+    for domain in (f"gui/{uid}", f"user/{uid}"):
+        try:
+            result = subprocess.run(
+                ["launchctl", "print", f"{domain}/{label}"],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=5,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            query_incomplete = True
+            continue
+        if result.returncode != 0:
+            query_incomplete = True
+            continue
+        try:
+            from hermes_cli.gateway import _parse_launchd_pid_from_print_output
+
+            launchd_pid = _parse_launchd_pid_from_print_output(result.stdout or "")
+        except Exception:
+            query_incomplete = True
+            continue
+        conclusive_job_query = True
+        if launchd_pid == pid:
+            return label, domain, launchd_pid, False
+        if launchd_pid is not None:
+            ancestor = _launchd_pid_is_verified_ancestor(launchd_pid, pid)
+            if ancestor is True:
+                return label, domain, launchd_pid, False
+            if ancestor is None:
+                # The exact Hermes job is loaded, but we cannot prove whether
+                # its PID owns this candidate.  Protect the process and make
+                # reconciliation unrecovered; never reinterpret uncertainty as
+                # an unrelated manual process eligible for argv replay.
+                return label, None, launchd_pid, False
+        if stale_same_job is None or stale_same_job[2] is None:
+            # A successful print with no PID means the exact job is loaded but
+            # not running.  The labelled candidate is stale same-job state:
+            # stop it first so it releases its port, then let launchd start the
+            # registered job rather than replaying argv without plist state.
+            stale_same_job = label, domain, launchd_pid, True
+
+    if stale_same_job is not None:
+        return stale_same_job
+
+    # A successfully queried exact job (running or merely loaded) returned
+    # above. Fail closed only when every probe was indeterminate, so a possible
+    # owner can never enter argv-only respawn.
+    if query_incomplete and not conclusive_job_query:
+        return label, None, None, False
+    return None
+
+
+def _restart_launchd_owned_dashboard(
+    label: str,
+    old_pid: int,
+    domain: str | None,
+    *,
+    loaded_pid: int | None,
+) -> bool:
+    """Restart a launchd-owned backend and verify a fresh supervised PID."""
+    if domain is None:
+        uid = os.getuid()
+        print(
+            f"    ⚠ launchd-labelled PID {old_pid} ({label}) could not be "
+            "safely related to a loaded job in "
+            f"gui/{uid} or user/{uid}; left it running; launchd ownership "
+            "could not be confirmed"
+        )
+        print(f"      Inspect with: launchctl print gui/{uid}/{label}")
+        print(f"                    launchctl print user/{uid}/{label}")
+        return False
+    target = f"{domain}/{label}"
+    if loaded_pid is not None:
+        updater_pid = os.getpid()
+        updater_is_descendant = (
+            True
+            if loaded_pid == updater_pid
+            else _launchd_pid_is_verified_ancestor(loaded_pid, updater_pid)
+        )
+        if loaded_pid == updater_pid or updater_is_descendant is not False:
+            relationship = (
+                "is the loaded job PID or descends from it"
+                if loaded_pid == updater_pid or updater_is_descendant is True
+                else "could not be proven unrelated to it"
+            )
+            print(
+                f"    ⚠ refusing to kickstart launchd-labelled job {target}: "
+                f"updater PID {updater_pid} {relationship}; left unrecovered"
+            )
+            return False
+    try:
+        from hermes_cli.gateway import (
+            _launchd_kickstart,
+            _wait_for_launchd_service_pid,
+        )
+
+        _launchd_kickstart(label, domain)
+        if not _wait_for_launchd_service_pid(
+            label, old_pid, timeout=30.0, domain=domain
+        ):
+            print(
+                f"    ⚠ launchd job {target} (previous PID {old_pid}) did not "
+                "report a fresh PID after restart"
+            )
+            print(f"      Retry with: launchctl kickstart -k {target}")
+            return False
+    except (
+        FileNotFoundError,
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        OSError,
+    ) as e:
+        print(f"    ⚠ failed to restart launchd job {target} (PID {old_pid}): {e}")
+        print(f"      Retry with: launchctl kickstart -k {target}")
+        return False
+    print(f"    ✓ restarted launchd job {target} (previous PID {old_pid})")
+    return True
+
+
 def _is_ephemeral_port_zero_backend(argv: list[str]) -> bool:
     """True for Desktop-style ``serve|dashboard --port 0`` backends (#78821).
 
@@ -372,8 +585,11 @@ def _kill_stale_dashboard_processes(
     Windows: ``taskkill /PID <pid> /F`` since there's no clean SIGTERM
     equivalent for background console apps.
 
-    Manually-started dashboards are not auto-restarted because we don't know
-    the original launch args (--host, --port, --insecure, --tui, --no-open).
+    With ``restart_managed=False`` (the explicit stop path), launchd ownership
+    classification and every restart remain disabled: matching processes keep
+    the pre-existing stop-only behavior. Manually-started dashboards are not
+    auto-restarted because we don't know the original launch args (--host,
+    --port, --insecure, --tui, --no-open).
     When ``restart_managed`` is true (the ``hermes update`` path), a detected
     ``hermes-dashboard.service`` is restarted through systemd; any OTHER
     killed PID that was supervised by a systemd unit (custom unit names —
@@ -434,6 +650,82 @@ def _kill_stale_dashboard_processes(
     if not pids:
         return {"matched": [], "killed": [], "failed": []}
 
+    # A fixed-port ``hermes serve`` can be a user LaunchAgent.  macOS has no
+    # systemd cgroup metadata, so treating every such PID as manual used to
+    # kill it and replay argv outside launchd, dropping the plist environment
+    # and racing KeepAlive on the same port.  Resolve exact launchd job/PID
+    # ownership before any argv capture or signal.  Only launchd may restart
+    # an owned process; an indeterminate XPC-identified owner is left alone.
+    matched_pids = list(pids)
+    launchd_owned_pids: set[int] = set()
+    launchd_protected_pids: set[int] = set()
+    launchd_stale_pids: set[int] = set()
+    launchd_unrecovered: list[int] = []
+    deferred_launchd_jobs: dict[
+        tuple[str, str], tuple[int | None, list[int], list[int]]
+    ] = {}
+    if restart_managed and sys.platform == "darwin":
+        launchd_owned: dict[int, tuple[str, str | None, int | None, bool]] = {}
+        for pid in pids:
+            owner = _launchd_owner_for_pid(pid)
+            if owner is not None:
+                launchd_owned[pid] = owner
+        if launchd_owned:
+            launchd_owned_pids = set(launchd_owned)
+            launchd_jobs: dict[
+                tuple[str, str | None], tuple[int | None, list[int], list[int]]
+            ] = {}
+            for pid, (label, domain, loaded_pid, stale_same_job) in launchd_owned.items():
+                current_loaded_pid, owned_pids, stale_pids = launchd_jobs.setdefault(
+                    (label, domain), (loaded_pid, [], [])
+                )
+                owned_pids.append(pid)
+                if stale_same_job:
+                    stale_pids.append(pid)
+                    launchd_stale_pids.add(pid)
+                else:
+                    launchd_protected_pids.add(pid)
+                launchd_jobs[(label, domain)] = (
+                    current_loaded_pid or loaded_pid,
+                    owned_pids,
+                    stale_pids,
+                )
+            print()
+            print(
+                f"⟲ Reconciling {len(launchd_owned)} launchd-labelled "
+                "dashboard process(es)"
+            )
+            for (label, domain), (
+                loaded_pid,
+                owned_pids,
+                stale_pids,
+            ) in launchd_jobs.items():
+                if domain is not None and stale_pids:
+                    # The stale same-job process may still own the fixed port.
+                    # Defer one kickstart until the normal POSIX path confirms
+                    # every stale candidate has exited; never snapshot argv.
+                    deferred_launchd_jobs[(label, domain)] = (
+                        loaded_pid,
+                        owned_pids,
+                        stale_pids,
+                    )
+                    continue
+                if not _restart_launchd_owned_dashboard(
+                    label,
+                    loaded_pid or owned_pids[0],
+                    domain,
+                    loaded_pid=loaded_pid,
+                ):
+                    launchd_unrecovered.extend(owned_pids)
+            pids = [pid for pid in pids if pid not in launchd_protected_pids]
+            if not pids:
+                return {
+                    "matched": matched_pids,
+                    "killed": [],
+                    "failed": [],
+                    "unrecovered": launchd_unrecovered,
+                }
+
     # Before killing, snapshot systemd cgroup info for each PID so we can
     # restart supervised services after the kill (the cgroup disappears
     # along with the process).  Only meaningful on Linux, and only when the
@@ -445,6 +737,8 @@ def _kill_stale_dashboard_processes(
     pid_home: dict[int, str | None] = {}
     if restart_managed and sys.platform != "win32":
         for pid in pids:
+            if pid in launchd_stale_pids:
+                continue
             cg_path = _m()._get_pid_cgroup_path(pid)
             pid_cgroup[pid] = cg_path
             pid_service[pid] = _m()._get_systemd_service_for_pid(pid)
@@ -469,12 +763,24 @@ def _kill_stale_dashboard_processes(
                 not in already_restarted_units
             ]
             if not pids:
+                if launchd_owned_pids:
+                    return {
+                        "matched": [
+                            pid
+                            for pid in matched_pids
+                            if pid in launchd_owned_pids
+                        ],
+                        "killed": [],
+                        "failed": [],
+                        "unrecovered": launchd_unrecovered,
+                    }
                 return {"matched": [], "killed": [], "failed": []}
 
     print()
     print(f"⟲ Stopping {len(pids)} dashboard process(es) ({reason})")
 
     killed: list[int] = []
+    confirmed_exited: set[int] = set()
     failed: list[tuple[int, str]] = []
 
     if sys.platform == "win32":
@@ -528,6 +834,7 @@ def _kill_stale_dashboard_processes(
             except ProcessLookupError:
                 # Already gone — count as killed.
                 killed.append(pid)
+                confirmed_exited.add(pid)
             except (PermissionError, OSError) as e:
                 failed.append((pid, str(e)))
 
@@ -547,6 +854,7 @@ def _kill_stale_dashboard_processes(
                     still_pending.append(pid)
                 else:
                     killed.append(pid)
+                    confirmed_exited.add(pid)
             pending = still_pending
 
         # SIGKILL any survivors.
@@ -556,6 +864,7 @@ def _kill_stale_dashboard_processes(
                 killed.append(pid)
             except ProcessLookupError:
                 killed.append(pid)
+                confirmed_exited.add(pid)
             except (PermissionError, OSError) as e:
                 failed.append((pid, str(e)))
 
@@ -563,6 +872,56 @@ def _kill_stale_dashboard_processes(
         print(f"    ✓ stopped PID {pid}")
     for pid, err_msg in failed:
         print(f"    ✗ failed to stop PID {pid}: {err_msg}")
+
+    # A stale process carrying an exact loaded Hermes job label must release
+    # its fixed port before launchd is kicked. Grouping by domain/label keeps
+    # the restart at most once even when the scan found multiple candidates.
+    for (label, domain), (
+        loaded_pid,
+        owned_pids,
+        stale_pids,
+    ) in deferred_launchd_jobs.items():
+        # SIGKILL delivery is not the same as exit. Wait for any force-killed
+        # stale process to disappear before launchd can contend for its port.
+        unconfirmed = {
+            pid for pid in stale_pids if pid in killed and pid not in confirmed_exited
+        }
+        if unconfirmed:
+            import time as _time
+
+            from gateway.status import _pid_exists
+
+            deadline = _time.monotonic() + 3.0
+            while unconfirmed:
+                unconfirmed = {pid for pid in unconfirmed if _pid_exists(pid)}
+                if not unconfirmed or _time.monotonic() >= deadline:
+                    break
+                _time.sleep(0.1)
+            confirmed_exited.update(
+                pid
+                for pid in stale_pids
+                if pid in killed and pid not in unconfirmed
+            )
+
+        if any(pid not in confirmed_exited for pid in stale_pids):
+            launchd_unrecovered.extend(
+                pid for pid in owned_pids if pid not in launchd_unrecovered
+            )
+            print(
+                f"    ⚠ did not restart launchd job {domain}/{label}; "
+                "its stale same-job process is still running"
+            )
+            continue
+        old_pid = loaded_pid or stale_pids[0]
+        if not _restart_launchd_owned_dashboard(
+            label,
+            old_pid,
+            domain,
+            loaded_pid=loaded_pid,
+        ):
+            launchd_unrecovered.extend(
+                pid for pid in owned_pids if pid not in launchd_unrecovered
+            )
 
     # Restart what we just killed (update path only).  Two categories:
     #  - systemd-supervised PIDs: restart the owning unit.  Without this, a
@@ -573,12 +932,14 @@ def _kill_stale_dashboard_processes(
     #    Filtered so Desktop ``serve|dashboard --port 0`` backends are not
     #    resurrected and duplicates collapse to one per profile (#78821).
     restarted_services: list[str] = []
-    unrecovered: list[int] = []
+    unrecovered: list[int] = list(launchd_unrecovered)
     if killed and restart_managed:
         failed_restarts: list[tuple[str, str]] = []
         seen_services: set[str] = set()
         respawn_candidates: list[tuple[int, list[str], str | None]] = []
         for pid in killed:
+            if pid in launchd_stale_pids:
+                continue
             svc_name = pid_service.get(pid)
             if svc_name:
                 if svc_name in seen_services:
@@ -607,8 +968,16 @@ def _kill_stale_dashboard_processes(
             if failed_cmds:
                 unrecovered.extend(p for p in killed if pid_cmdline.get(p) in failed_cmds)
 
-        if failed_restarts or unrecovered:
-            print("  Restart anything not auto-restarted when you're ready:")
+        non_launchd_unrecovered = [
+            pid for pid in unrecovered if pid not in launchd_owned_pids
+        ]
+        if non_launchd_unrecovered:
+            rendered_pids = ", ".join(str(pid) for pid in non_launchd_unrecovered)
+            print(
+                "  Restart anything not auto-restarted for non-launchd dashboard "
+                "process(es)"
+                f" (PID {rendered_pids}) when you're ready:"
+            )
             print("    hermes dashboard --port <port>")
     elif killed:
         unrecovered = list(killed)
@@ -616,7 +985,9 @@ def _kill_stale_dashboard_processes(
         print("    hermes dashboard --port <port>")
 
     return {
-        "matched": list(pids),
+        "matched": [
+            pid for pid in matched_pids if pid in launchd_owned_pids or pid in pids
+        ],
         "killed": list(killed),
         "failed": list(failed),
         "unrecovered": list(unrecovered),
@@ -1120,4 +1491,3 @@ def _reap_orphaned_desktop_local_serves(
             pass
 
     return {"matched": matched, "killed": killed, "failed": failed}
-

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -384,6 +384,802 @@ class TestWindowsWmicEncoding:
             assert _find_stale_dashboard_pids() == []
 
 
+class TestLaunchdOwnedBackendRestart:
+    """A macOS LaunchAgent remains the sole owner of its fixed-port serve."""
+
+    def _live(self):
+        return sys.modules["hermes_cli.main"]
+
+    @pytest.mark.parametrize("xpc_environment", [{}, {"XPC_SERVICE_NAME": "0"}])
+    def test_missing_or_zero_xpc_label_is_not_launchd_owned(
+        self, monkeypatch, xpc_environment
+    ):
+        import psutil
+
+        from hermes_cli import dashboard_procs
+
+        process = MagicMock()
+        process.environ.return_value = xpc_environment
+        monkeypatch.setattr(psutil, "Process", lambda pid: process)
+        monkeypatch.setattr(dashboard_procs.sys, "platform", "darwin")
+        run = MagicMock()
+        monkeypatch.setattr(dashboard_procs.subprocess, "run", run)
+
+        assert dashboard_procs._launchd_label_for_pid(4321) is None
+        assert dashboard_procs._launchd_owner_for_pid(4321) is None
+        run.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "label",
+        [
+            "../ai.hermes.serve",
+            "ai/hermes",
+            "ai\\hermes",
+            "ai.hermes.gateway",
+            "com.example.hermes.serve",
+            "application.com.microsoft.VSCode.1.2",
+            "application.ai.hermes.serve",
+            "application.anything",
+            "ai.hermes.serve-",
+        ],
+    )
+    def test_non_backend_xpc_label_never_reaches_launchctl(self, monkeypatch, label):
+        import psutil
+
+        from hermes_cli import dashboard_procs
+
+        process = MagicMock()
+        process.environ.return_value = {"XPC_SERVICE_NAME": label}
+        monkeypatch.setattr(psutil, "Process", lambda pid: process)
+        monkeypatch.setattr(dashboard_procs.sys, "platform", "darwin")
+        run = MagicMock()
+        monkeypatch.setattr(dashboard_procs.subprocess, "run", run)
+
+        assert dashboard_procs._launchd_label_for_pid(4321) is None
+        assert dashboard_procs._launchd_owner_for_pid(4321) is None
+        run.assert_not_called()
+
+    def test_vscode_inherited_label_with_ancestor_never_triggers_kickstart(
+        self, monkeypatch
+    ):
+        import psutil
+        import signal
+
+        from hermes_cli import dashboard_procs, gateway
+
+        live = self._live()
+        candidate_pid = 4321
+        vscode_pid = 9999
+        process = MagicMock()
+        process.environ.return_value = {
+            "XPC_SERVICE_NAME": "application.com.microsoft.VSCode.1.2"
+        }
+        process.parents.return_value = [MagicMock(pid=vscode_pid)]
+        monkeypatch.setattr(psutil, "Process", lambda pid: process)
+        monkeypatch.setattr(dashboard_procs.sys, "platform", "darwin")
+        launchctl = MagicMock(
+            return_value=MagicMock(
+                returncode=0, stdout=f"\tpid = {vscode_pid}\n", stderr=""
+            )
+        )
+        monkeypatch.setattr(dashboard_procs.subprocess, "run", launchctl)
+        kickstart = MagicMock()
+        monkeypatch.setattr(gateway, "_launchd_kickstart", kickstart)
+
+        with patch.object(live, "_restart_managed_dashboard_service", return_value=False), \
+             patch.object(dashboard_procs, "_lock_owned_serve_pids", return_value=set()), \
+             patch.object(live, "_find_stale_dashboard_pids", return_value=[candidate_pid]), \
+             patch.object(live, "_get_pid_cgroup_path", return_value=None), \
+             patch.object(live, "_get_systemd_service_for_pid", return_value=None), \
+             patch.object(
+                 live,
+                 "_dashboard_cmdline_for_pid",
+                 return_value=["hermes", "serve", "--port", "9119"],
+             ), \
+             patch.object(live, "_respawn_dashboard_processes", return_value=[]) as respawn, \
+             patch("gateway.status._pid_exists", return_value=False), \
+             patch.object(dashboard_procs.os, "kill") as kill, \
+             patch("time.sleep"):
+            result = _kill_stale_dashboard_processes(restart_managed=True)
+
+        launchctl.assert_not_called()
+        kickstart.assert_not_called()
+        kill.assert_called_once_with(candidate_pid, signal.SIGTERM)
+        respawn.assert_called_once_with([["hermes", "serve", "--port", "9119"]])
+        assert result["killed"] == [candidate_pid]
+
+    @pytest.mark.parametrize(
+        "label",
+        [
+            "ai.hermes.dashboard",
+            "ai.hermes.dashboard-default",
+            "ai.hermes.serve",
+            "ai.hermes.serve-work",
+        ],
+    )
+    def test_only_hermes_backend_label_families_are_accepted(self, label):
+        from hermes_cli import dashboard_procs
+
+        assert dashboard_procs._is_hermes_backend_launchd_label(label)
+
+    def test_exact_launchd_job_pid_is_fast_path(self, monkeypatch):
+        from hermes_cli import dashboard_procs
+
+        label = "ai.hermes.serve"
+        calls: list[list[str]] = []
+
+        def fake_run(argv, **kwargs):
+            calls.append(list(argv))
+            return MagicMock(
+                returncode=0,
+                stdout="\tpid = 4321\n",
+                stderr="",
+            )
+
+        monkeypatch.setattr(dashboard_procs.sys, "platform", "darwin")
+        monkeypatch.setattr(
+            dashboard_procs, "_launchd_label_for_pid", lambda pid: label
+        )
+        monkeypatch.setattr(dashboard_procs.os, "getuid", lambda: 501, raising=False)
+        monkeypatch.setattr(dashboard_procs.subprocess, "run", fake_run)
+        ancestor = MagicMock()
+        monkeypatch.setattr(
+            dashboard_procs, "_launchd_pid_is_verified_ancestor", ancestor
+        )
+
+        assert dashboard_procs._launchd_owner_for_pid(4321) == (
+            label,
+            "gui/501",
+            4321,
+            False,
+        )
+        assert calls == [
+            ["launchctl", "print", f"gui/501/{label}"],
+        ]
+        ancestor.assert_not_called()
+
+    def test_loaded_job_ancestor_owns_dashboard_child(self, monkeypatch):
+        import psutil
+
+        from hermes_cli import dashboard_procs
+
+        label = "ai.hermes.serve"
+        process = MagicMock()
+        process.parents.return_value = [MagicMock(pid=9999)]
+        monkeypatch.setattr(psutil, "Process", lambda pid: process)
+        monkeypatch.setattr(dashboard_procs.sys, "platform", "darwin")
+        monkeypatch.setattr(
+            dashboard_procs, "_launchd_label_for_pid", lambda pid: label
+        )
+        monkeypatch.setattr(dashboard_procs.os, "getuid", lambda: 501, raising=False)
+        monkeypatch.setattr(
+            dashboard_procs.subprocess,
+            "run",
+            lambda *args, **kwargs: MagicMock(
+                returncode=0, stdout="\tpid = 9999\n", stderr=""
+            ),
+        )
+
+        assert dashboard_procs._launchd_owner_for_pid(4321) == (
+            label,
+            "gui/501",
+            9999,
+            False,
+        )
+
+    def test_different_nonancestor_pid_is_stale_same_job_on_domain_error(
+        self, monkeypatch
+    ):
+        import psutil
+
+        from hermes_cli import dashboard_procs
+
+        label = "ai.hermes.serve"
+        process = MagicMock()
+        process.parents.return_value = []
+        results = iter(
+            [
+                MagicMock(returncode=0, stdout="\tpid = 9999\n", stderr=""),
+                subprocess.TimeoutExpired("launchctl", 5),
+            ]
+        )
+
+        def fake_run(*args, **kwargs):
+            result = next(results)
+            if isinstance(result, Exception):
+                raise result
+            return result
+
+        monkeypatch.setattr(psutil, "Process", lambda pid: process)
+        monkeypatch.setattr(dashboard_procs.sys, "platform", "darwin")
+        monkeypatch.setattr(
+            dashboard_procs, "_launchd_label_for_pid", lambda pid: label
+        )
+        monkeypatch.setattr(dashboard_procs.os, "getuid", lambda: 501, raising=False)
+        monkeypatch.setattr(dashboard_procs.subprocess, "run", fake_run)
+
+        assert dashboard_procs._launchd_owner_for_pid(4321) == (
+            label,
+            "gui/501",
+            9999,
+            True,
+        )
+
+    def test_loaded_job_without_pid_is_stale_same_job(self, monkeypatch):
+        from hermes_cli import dashboard_procs
+
+        label = "ai.hermes.serve"
+        results = iter(
+            [
+                MagicMock(
+                    returncode=0,
+                    stdout="\tstate = exited\n\tlast exit code = 0\n",
+                    stderr="",
+                ),
+                MagicMock(returncode=113, stdout="", stderr="Could not find service"),
+            ]
+        )
+
+        monkeypatch.setattr(dashboard_procs.sys, "platform", "darwin")
+        monkeypatch.setattr(
+            dashboard_procs, "_launchd_label_for_pid", lambda pid: label
+        )
+        monkeypatch.setattr(dashboard_procs.os, "getuid", lambda: 501, raising=False)
+        monkeypatch.setattr(
+            dashboard_procs.subprocess, "run", lambda *args, **kwargs: next(results)
+        )
+
+        assert dashboard_procs._launchd_owner_for_pid(4321) == (
+            label,
+            "gui/501",
+            None,
+            True,
+        )
+
+    def test_ancestor_query_exception_fails_closed(self, monkeypatch):
+        import psutil
+
+        from hermes_cli import dashboard_procs
+
+        label = "ai.hermes.serve"
+        process = MagicMock()
+        process.parents.side_effect = RuntimeError("ancestry unavailable")
+        monkeypatch.setattr(psutil, "Process", lambda pid: process)
+        monkeypatch.setattr(dashboard_procs.sys, "platform", "darwin")
+        monkeypatch.setattr(
+            dashboard_procs, "_launchd_label_for_pid", lambda pid: label
+        )
+        monkeypatch.setattr(dashboard_procs.os, "getuid", lambda: 501, raising=False)
+        monkeypatch.setattr(
+            dashboard_procs.subprocess,
+            "run",
+            lambda *args, **kwargs: MagicMock(
+                returncode=0, stdout="\tpid = 9999\n", stderr=""
+            ),
+        )
+
+        assert dashboard_procs._launchd_owner_for_pid(4321) == (
+            label,
+            None,
+            9999,
+            False,
+        )
+
+    def test_restart_uses_real_gateway_helpers_and_waits_for_fresh_pid(
+        self, monkeypatch
+    ):
+        from hermes_cli import dashboard_procs
+
+        label = "ai.hermes.serve"
+        old_pid = 4321
+        calls: list[tuple[list[str], dict[str, object]]] = []
+        print_results = iter(
+            [
+                subprocess.CompletedProcess(
+                    ["launchctl"], 0, stdout="\tpid = 4321\n", stderr=""
+                ),
+                subprocess.CompletedProcess(
+                    ["launchctl"], 0, stdout="\tpid = 9876\n", stderr=""
+                ),
+            ]
+        )
+
+        def fake_run(argv, **kwargs):
+            calls.append((list(argv), dict(kwargs)))
+            if argv[1:3] == ["kickstart", "-k"]:
+                return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+            return next(print_results)
+
+        # Both real gateway helpers call this one launchctl boundary.
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            dashboard_procs,
+            "_launchd_pid_is_verified_ancestor",
+            lambda ancestor_pid, candidate_pid: False,
+        )
+
+        assert dashboard_procs._restart_launchd_owned_dashboard(
+            label, old_pid, "gui/501", loaded_pid=old_pid
+        )
+        assert calls == [
+            (
+                ["launchctl", "kickstart", "-k", f"gui/501/{label}"],
+                {
+                    "check": True,
+                    "capture_output": True,
+                    "text": True,
+                    "encoding": "utf-8",
+                    "errors": "replace",
+                    "timeout": 90,
+                },
+            ),
+            (
+                ["launchctl", "print", f"gui/501/{label}"],
+                {
+                    "capture_output": True,
+                    "text": True,
+                    "encoding": "utf-8",
+                    "errors": "replace",
+                    "timeout": 5,
+                },
+            ),
+            (
+                ["launchctl", "print", f"gui/501/{label}"],
+                {
+                    "capture_output": True,
+                    "text": True,
+                    "encoding": "utf-8",
+                    "errors": "replace",
+                    "timeout": 5,
+                },
+            ),
+        ]
+
+    def test_launchd_pid_never_enters_manual_kill_or_respawn(self, monkeypatch):
+        from hermes_cli import dashboard_procs, gateway
+
+        live = self._live()
+        label = "ai.hermes.serve"
+        loaded_pid = 4000
+        kickstart = MagicMock()
+        wait_for_pid = MagicMock(return_value=True)
+        monkeypatch.setattr(dashboard_procs.sys, "platform", "darwin")
+        monkeypatch.setattr(gateway, "_launchd_kickstart", kickstart)
+        monkeypatch.setattr(gateway, "_wait_for_launchd_service_pid", wait_for_pid)
+        monkeypatch.setattr(
+            dashboard_procs,
+            "_launchd_pid_is_verified_ancestor",
+            lambda ancestor_pid, candidate_pid: False,
+        )
+
+        with patch.object(live, "_restart_managed_dashboard_service", return_value=False), \
+             patch.object(live, "_find_stale_dashboard_pids", return_value=[4321]), \
+             patch.object(live, "_dashboard_cmdline_for_pid") as cmdline, \
+             patch.object(live, "_respawn_dashboard_processes") as respawn, \
+             patch.object(
+                 dashboard_procs,
+                 "_launchd_owner_for_pid",
+                 return_value=(label, "gui/501", loaded_pid, False),
+             ), \
+             patch.object(dashboard_procs.os, "kill") as kill:
+            result = _kill_stale_dashboard_processes(restart_managed=True)
+
+        kickstart.assert_called_once_with(label, "gui/501")
+        wait_for_pid.assert_called_once_with(
+            label, loaded_pid, timeout=30.0, domain="gui/501"
+        )
+        cmdline.assert_not_called()
+        kill.assert_not_called()
+        respawn.assert_not_called()
+        assert result == {
+            "matched": [4321],
+            "killed": [],
+            "failed": [],
+            "unrecovered": [],
+        }
+
+    @pytest.mark.parametrize(
+        ("loaded_pid", "updater_pid", "ancestor_result"),
+        [
+            (5000, 5000, False),
+            (5000, 6000, True),
+        ],
+    )
+    def test_updater_owned_by_loaded_job_is_never_kickstarted(
+        self,
+        monkeypatch,
+        capsys,
+        loaded_pid,
+        updater_pid,
+        ancestor_result,
+    ):
+        from hermes_cli import dashboard_procs, gateway
+
+        live = self._live()
+        label = "ai.hermes.serve"
+        candidate_pid = 4321
+        monkeypatch.setattr(dashboard_procs.sys, "platform", "darwin")
+        monkeypatch.setattr(dashboard_procs.os, "getpid", lambda: updater_pid)
+        monkeypatch.setattr(
+            dashboard_procs,
+            "_launchd_pid_is_verified_ancestor",
+            lambda ancestor_pid, candidate_pid: ancestor_result,
+        )
+        kickstart = MagicMock()
+        wait_for_pid = MagicMock()
+        monkeypatch.setattr(gateway, "_launchd_kickstart", kickstart)
+        monkeypatch.setattr(gateway, "_wait_for_launchd_service_pid", wait_for_pid)
+
+        with patch.object(live, "_restart_managed_dashboard_service", return_value=False), \
+             patch.object(dashboard_procs, "_lock_owned_serve_pids", return_value=set()), \
+             patch.object(live, "_find_stale_dashboard_pids", return_value=[candidate_pid]), \
+             patch.object(
+                 dashboard_procs,
+                 "_launchd_owner_for_pid",
+                 return_value=(label, "gui/501", loaded_pid, False),
+             ), \
+             patch.object(live, "_dashboard_cmdline_for_pid") as cmdline, \
+             patch.object(live, "_respawn_dashboard_processes") as respawn, \
+             patch.object(dashboard_procs.os, "kill") as kill:
+            result = _kill_stale_dashboard_processes(restart_managed=True)
+
+        kickstart.assert_not_called()
+        wait_for_pid.assert_not_called()
+        cmdline.assert_not_called()
+        respawn.assert_not_called()
+        kill.assert_not_called()
+        assert result["unrecovered"] == [candidate_pid]
+        out = capsys.readouterr().out
+        assert f"refusing to kickstart launchd-labelled job gui/501/{label}" in out
+        assert "left unrecovered" in out
+
+    def test_indeterminate_xpc_owner_without_plist_fails_closed(
+        self, monkeypatch, capsys
+    ):
+        from hermes_cli import dashboard_procs
+
+        live = self._live()
+        label = "ai.hermes.serve"
+        monkeypatch.setattr(dashboard_procs.sys, "platform", "darwin")
+        monkeypatch.setattr(
+            dashboard_procs, "_launchd_label_for_pid", lambda pid: label
+        )
+        monkeypatch.setattr(dashboard_procs.os, "getuid", lambda: 501, raising=False)
+
+        with patch.object(live, "_restart_managed_dashboard_service", return_value=False), \
+             patch.object(live, "_find_stale_dashboard_pids", return_value=[4321]), \
+             patch.object(live, "_dashboard_cmdline_for_pid") as cmdline, \
+             patch.object(live, "_respawn_dashboard_processes") as respawn, \
+             patch.object(
+                 dashboard_procs.subprocess,
+                 "run",
+                 side_effect=subprocess.TimeoutExpired("launchctl", 5),
+             ), \
+             patch.object(dashboard_procs.os, "kill") as kill:
+            result = _kill_stale_dashboard_processes(restart_managed=True)
+
+        cmdline.assert_not_called()
+        kill.assert_not_called()
+        respawn.assert_not_called()
+        assert result["unrecovered"] == [4321]
+        out = capsys.readouterr().out
+        assert "PID 4321" in out
+        assert f"launchctl print gui/501/{label}" in out
+        assert f"launchctl print user/501/{label}" in out
+        assert "left it running; launchd ownership could not be confirmed" in out
+        assert "launchd recovery" not in out
+        assert "hermes dashboard --port" not in out
+
+    def test_failed_launchd_restart_is_unrecovered(self, monkeypatch, capsys):
+        from hermes_cli import dashboard_procs, gateway
+
+        live = self._live()
+        label = "ai.hermes.serve"
+        monkeypatch.setattr(dashboard_procs.sys, "platform", "darwin")
+        monkeypatch.setattr(gateway, "_launchd_kickstart", MagicMock())
+        monkeypatch.setattr(
+            gateway, "_wait_for_launchd_service_pid", MagicMock(return_value=False)
+        )
+        monkeypatch.setattr(
+            dashboard_procs,
+            "_launchd_pid_is_verified_ancestor",
+            lambda ancestor_pid, candidate_pid: False,
+        )
+
+        with patch.object(live, "_restart_managed_dashboard_service", return_value=False), \
+             patch.object(live, "_find_stale_dashboard_pids", return_value=[4321]), \
+             patch.object(
+                 dashboard_procs,
+                 "_launchd_owner_for_pid",
+                 return_value=(label, "gui/501", 4321, False),
+             ), \
+             patch.object(dashboard_procs.os, "kill") as kill:
+            result = _kill_stale_dashboard_processes(restart_managed=True)
+
+        kill.assert_not_called()
+        assert result["unrecovered"] == [4321]
+        out = capsys.readouterr().out
+        assert "previous PID 4321" in out
+        assert f"launchctl kickstart -k gui/501/{label}" in out
+        assert "hermes dashboard --port" not in out
+
+    def test_non_darwin_never_enters_launchd_owner_or_restart_path(
+        self, monkeypatch
+    ):
+        from hermes_cli import dashboard_procs
+
+        live = self._live()
+        monkeypatch.setattr(dashboard_procs.sys, "platform", "linux")
+
+        with patch.object(live, "_restart_managed_dashboard_service", return_value=False), \
+             patch.object(live, "_find_stale_dashboard_pids", return_value=[4321]), \
+             patch.object(live, "_get_pid_cgroup_path", return_value=None), \
+             patch.object(
+                 live,
+                 "_get_systemd_service_for_pid",
+                 return_value="hermes-dashboard.service",
+             ), \
+             patch.object(dashboard_procs, "_launchd_owner_for_pid") as owner, \
+             patch.object(
+                 dashboard_procs, "_restart_launchd_owned_dashboard"
+             ) as restart, \
+             patch.object(dashboard_procs.os, "kill") as kill:
+            result = _kill_stale_dashboard_processes(
+                restart_managed=True,
+                already_restarted_units={"hermes-dashboard"},
+            )
+
+        owner.assert_not_called()
+        restart.assert_not_called()
+        kill.assert_not_called()
+        assert result == {"matched": [], "killed": [], "failed": []}
+
+    def test_launchd_failure_survives_already_restarted_systemd_filter(
+        self, monkeypatch
+    ):
+        from hermes_cli import dashboard_procs
+
+        live = self._live()
+        monkeypatch.setattr(dashboard_procs.sys, "platform", "darwin")
+
+        def owner(pid):
+            if pid == 4321:
+                return "ai.hermes.serve", "gui/501", 4321, False
+            return None
+
+        with patch.object(live, "_restart_managed_dashboard_service", return_value=False), \
+             patch.object(live, "_find_stale_dashboard_pids", return_value=[4321, 4322]), \
+             patch.object(live, "_get_pid_cgroup_path", return_value=None), \
+             patch.object(
+                 live,
+                 "_get_systemd_service_for_pid",
+                 return_value="hermes-dashboard.service",
+             ), \
+             patch.object(dashboard_procs, "_launchd_owner_for_pid", side_effect=owner), \
+             patch.object(
+                 dashboard_procs, "_restart_launchd_owned_dashboard", return_value=False
+             ), \
+             patch.object(dashboard_procs.os, "kill") as kill:
+            result = _kill_stale_dashboard_processes(
+                restart_managed=True,
+                already_restarted_units={"hermes-dashboard"},
+            )
+
+        kill.assert_not_called()
+        assert result["matched"] == [4321]
+        assert result["unrecovered"] == [4321]
+
+    def test_same_launchd_job_is_not_restarted_twice(self, monkeypatch):
+        from hermes_cli import dashboard_procs
+
+        live = self._live()
+        label = "ai.hermes.serve"
+        monkeypatch.setattr(dashboard_procs.sys, "platform", "darwin")
+
+        with patch.object(live, "_restart_managed_dashboard_service", return_value=False), \
+             patch.object(live, "_find_stale_dashboard_pids", return_value=[4321, 4322]), \
+             patch.object(
+                 dashboard_procs,
+                 "_launchd_owner_for_pid",
+                 return_value=(label, "gui/501", 4000, False),
+             ), \
+             patch.object(
+                 dashboard_procs, "_restart_launchd_owned_dashboard", return_value=True
+             ) as restart, \
+             patch.object(dashboard_procs.os, "kill") as kill:
+            result = _kill_stale_dashboard_processes(restart_managed=True)
+
+        restart.assert_called_once_with(
+            label, 4000, "gui/501", loaded_pid=4000
+        )
+        kill.assert_not_called()
+        assert result["unrecovered"] == []
+
+    def test_stale_same_job_exits_before_single_kickstart_and_never_respawns(
+        self, monkeypatch
+    ):
+        import signal
+
+        from hermes_cli import dashboard_procs
+
+        live = self._live()
+        label = "ai.hermes.serve-work"
+        stale_pid = 4321
+        loaded_pid = 9999
+        events: list[tuple[object, ...]] = []
+
+        def fake_kill(pid, sig):
+            events.append(("kill", pid, sig))
+            assert pid == stale_pid
+
+        def fake_exists(pid):
+            assert pid == stale_pid
+            events.append(("exit-confirmed", pid))
+            return False
+
+        def fake_restart(restart_label, old_pid, domain, **kwargs):
+            assert restart_label == label
+            assert kwargs == {"loaded_pid": loaded_pid}
+            assert old_pid == loaded_pid
+            assert domain == "gui/501"
+            events.append(("kickstart", old_pid))
+            return True
+
+        def owner(pid):
+            return label, "gui/501", loaded_pid, pid == stale_pid
+
+        monkeypatch.setattr(dashboard_procs.sys, "platform", "darwin")
+
+        with patch.object(live, "_restart_managed_dashboard_service", return_value=False), \
+             patch.object(dashboard_procs, "_lock_owned_serve_pids", return_value=set()), \
+             patch.object(
+                 live,
+                 "_find_stale_dashboard_pids",
+                 return_value=[loaded_pid, stale_pid],
+             ), \
+             patch.object(live, "_get_pid_cgroup_path") as cgroup, \
+             patch.object(live, "_get_systemd_service_for_pid") as service, \
+             patch.object(live, "_dashboard_cmdline_for_pid") as cmdline, \
+             patch.object(live, "_respawn_dashboard_processes") as respawn, \
+             patch.object(
+                 dashboard_procs,
+                 "_launchd_owner_for_pid",
+                 side_effect=owner,
+             ), \
+             patch.object(
+                 dashboard_procs,
+                 "_restart_launchd_owned_dashboard",
+                 side_effect=fake_restart,
+             ) as restart, \
+             patch("gateway.status._pid_exists", side_effect=fake_exists), \
+             patch.object(dashboard_procs.os, "kill", side_effect=fake_kill), \
+             patch("time.monotonic", side_effect=[0.0, 4.0, 4.0]), \
+             patch("time.sleep"):
+            result = _kill_stale_dashboard_processes(restart_managed=True)
+
+        assert events == [
+            ("kill", stale_pid, signal.SIGTERM),
+            ("kill", stale_pid, signal.SIGKILL),
+            ("exit-confirmed", stale_pid),
+            ("kickstart", loaded_pid),
+        ]
+        restart.assert_called_once_with(
+            label, loaded_pid, "gui/501", loaded_pid=loaded_pid
+        )
+        cgroup.assert_not_called()
+        service.assert_not_called()
+        cmdline.assert_not_called()
+        respawn.assert_not_called()
+        assert result == {
+            "matched": [loaded_pid, stale_pid],
+            "killed": [stale_pid],
+            "failed": [],
+            "unrecovered": [],
+        }
+
+    def test_loaded_but_not_running_job_kickstarts_only_after_stale_exit(
+        self, monkeypatch, capsys
+    ):
+        import signal
+
+        from hermes_cli import dashboard_procs, gateway
+
+        live = self._live()
+        label = "ai.hermes.serve-work"
+        stale_pid = 4321
+        events: list[tuple[object, ...]] = []
+
+        def fake_kill(pid, sig):
+            events.append(("kill", pid, sig))
+
+        def fake_exists(pid):
+            events.append(("exit-confirmed", pid))
+            return False
+
+        def fake_kickstart(restart_label, domain):
+            events.append(("kickstart", restart_label, domain))
+
+        def fake_wait(restart_label, old_pid, *, timeout, domain):
+            events.append(("fresh-pid-wait", old_pid))
+            return True
+
+        monkeypatch.setattr(dashboard_procs.sys, "platform", "darwin")
+        monkeypatch.setattr(gateway, "_launchd_kickstart", fake_kickstart)
+        monkeypatch.setattr(gateway, "_wait_for_launchd_service_pid", fake_wait)
+
+        with patch.object(live, "_restart_managed_dashboard_service", return_value=False), \
+             patch.object(dashboard_procs, "_lock_owned_serve_pids", return_value=set()), \
+             patch.object(live, "_find_stale_dashboard_pids", return_value=[stale_pid]), \
+             patch.object(live, "_get_pid_cgroup_path") as cgroup, \
+             patch.object(live, "_get_systemd_service_for_pid") as service, \
+             patch.object(live, "_dashboard_cmdline_for_pid") as cmdline, \
+             patch.object(live, "_respawn_dashboard_processes") as respawn, \
+             patch.object(
+                 dashboard_procs,
+                 "_launchd_owner_for_pid",
+                 return_value=(label, "gui/501", None, True),
+             ), \
+             patch("gateway.status._pid_exists", side_effect=fake_exists), \
+             patch.object(dashboard_procs.os, "kill", side_effect=fake_kill), \
+             patch("time.monotonic", side_effect=[0.0, 1.0]), \
+             patch("time.sleep"):
+            result = _kill_stale_dashboard_processes(restart_managed=True)
+
+        assert events == [
+            ("kill", stale_pid, signal.SIGTERM),
+            ("exit-confirmed", stale_pid),
+            ("kickstart", label, "gui/501"),
+            ("fresh-pid-wait", stale_pid),
+        ]
+        cgroup.assert_not_called()
+        service.assert_not_called()
+        cmdline.assert_not_called()
+        respawn.assert_not_called()
+        assert result == {
+            "matched": [stale_pid],
+            "killed": [stale_pid],
+            "failed": [],
+            "unrecovered": [],
+        }
+        assert "launchd-labelled dashboard process(es)" in capsys.readouterr().out
+
+    def test_stale_same_job_that_cannot_exit_is_never_kickstarted(
+        self, monkeypatch, capsys
+    ):
+        from hermes_cli import dashboard_procs
+
+        live = self._live()
+        label = "ai.hermes.dashboard"
+        stale_pid = 4321
+        loaded_pid = 9999
+        monkeypatch.setattr(dashboard_procs.sys, "platform", "darwin")
+
+        with patch.object(live, "_restart_managed_dashboard_service", return_value=False), \
+             patch.object(dashboard_procs, "_lock_owned_serve_pids", return_value=set()), \
+             patch.object(live, "_find_stale_dashboard_pids", return_value=[stale_pid]), \
+             patch.object(
+                 dashboard_procs,
+                 "_launchd_owner_for_pid",
+                 return_value=(label, "gui/501", loaded_pid, True),
+             ), \
+             patch.object(
+                 dashboard_procs, "_restart_launchd_owned_dashboard"
+             ) as restart, \
+             patch.object(
+                 dashboard_procs.os,
+                 "kill",
+                 side_effect=PermissionError("denied"),
+             ), \
+             patch.object(live, "_respawn_dashboard_processes") as respawn:
+            result = _kill_stale_dashboard_processes(restart_managed=True)
+
+        restart.assert_not_called()
+        respawn.assert_not_called()
+        assert result["killed"] == []
+        assert result["failed"] == [(stale_pid, "denied")]
+        assert result["unrecovered"] == [stale_pid]
+        assert "stale same-job process is still running" in capsys.readouterr().out
+
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX kill + systemd restart")
 class TestSupervisedBackendRestart:
     """After the kill, systemd-supervised PIDs get their owning unit


### PR DESCRIPTION
## Summary

Fix macOS `hermes update` cleanup incorrectly treating a launchd-managed fixed-port `hermes serve` backend as a manual process.

Previously the updater could:

1. stop the launchd-owned backend;
2. respawn only its argv with `start_new_session=True`;
3. lose the LaunchAgent environment (including dashboard authentication and toolset isolation);
4. race the real KeepAlive job for the same port.

The result is an unmanaged PPID-1 listener, repeated `EX_TEMPFAIL` from the intended LaunchAgent, and authenticated Desktop requests failing despite the public status endpoint responding.

## Fix

- Recognize only narrowly scoped Hermes backend launchd labels.
- Verify ownership using the exact XPC service label plus `launchctl print` PID identity.
- Support launchd wrapper parents without accepting arbitrary inherited `application.*` labels.
- Restart confirmed managed jobs through launchd, preserving the plist environment.
- Require a fresh supervised PID before reporting success.
- Fail closed on indeterminate Hermes-label ownership; never argv-respawn that candidate.
- Retire stale same-job listeners before one deferred launchd kickstart, preventing same-port races.
- Refuse self-kickstart when the updater belongs to the managed job.
- Keep existing manual fixed-port, port-0, SSH-owned, foreign-home, systemd, and Windows paths unchanged.

## Tests

Focused regression suite:

```text
99 passed, 3 skipped
```

Coverage includes:

- exact launchd PID ownership;
- wrapper/descendant ownership;
- inherited VS Code `application.*` label rejection;
- loaded-but-not-running jobs;
- stale same-job listener ordering and failure paths;
- single restart per launchd job;
- kickstart/fresh-PID helper integration;
- indeterminate fail-closed behavior;
- non-darwin, systemd, manual, port-0, SSH and foreign-home preservation.

Additional checks:

- `git diff --check` passed.
- Ruff rule checks passed for both changed files.
