### PR TITLE
fix(desktop): isolate local composer model by profile

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -812,6 +812,30 @@ describe('createBackendSessionForSend profile routing', () => {
     })
   })
 
+  it('does not ship a prior profile manual pick after activating another profile', async () => {
+    vi.mocked(ensureGatewayProfile).mockImplementationOnce(async profile => {
+      const target = String(profile)
+      setConnection({ baseUrl: '', connectionId: 'local', mode: 'local', profile: target } as never)
+      setCurrentModel('mimo-v2.5-pro')
+      setCurrentProvider('xiaomi')
+      setCurrentModelSource('default')
+      $activeGatewayProfile.set(target)
+    })
+
+    const params = await createWith(() => {
+      $activeGatewayProfile.set('default')
+      $newChatProfile.set('dev')
+      setConnection({ baseUrl: '', connectionId: 'local', mode: 'local', profile: 'default' } as never)
+      setCurrentModel('deepseek-v4-pro')
+      setCurrentProvider('deepseek')
+      setCurrentModelSource('manual')
+    })
+
+    expect(params).toMatchObject({ profile: 'dev' })
+    expect(params).not.toHaveProperty('model')
+    expect(params).not.toHaveProperty('provider')
+  })
+
   // An unset source is the first-run/cleared state — nothing the user picked,
   // so it must not pin the session either.
   it('omits the model when no selection source is recorded', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -289,29 +289,42 @@ async function desktopSessionCreateParams(
   cwd: string,
   capturedRoute = resolveNewChatOwnerRoute()
 ): Promise<Record<string, unknown>> {
-  // Treat Send as the linearization point for the visible selector state. The
-  // profile handshake below can yield long enough for background config/model
-  // refreshes to finish; reading atoms afterward would silently create the
-  // session with a different selection than the one the user submitted.
   // Settings → Model while a session is live leaves $currentModel painted with
   // the live agent (applySavedMainModel) and only flips the source to 'default'.
   // Shipping that stale value as an override pins every new chat to the old
   // model. Omit model/provider unless the source is 'manual'.
-  const isManualSelection = getCurrentModelSource() === 'manual'
+  const readManualSelection = () => {
+    const isManualSelection = getCurrentModelSource() === 'manual'
 
-  const selection = {
-    effort: $currentReasoningEffort.get().trim(),
-    fast: $currentFastMode.get(),
-    model: isManualSelection ? $currentModel.get().trim() : '',
-    provider: isManualSelection ? $currentProvider.get().trim() : ''
+    return {
+      effort: $currentReasoningEffort.get().trim(),
+      fast: $currentFastMode.get(),
+      model: isManualSelection ? $currentModel.get().trim() : '',
+      provider: isManualSelection ? $currentProvider.get().trim() : ''
+    }
   }
 
+  // Treat Send as the linearization point for the visible selector state when
+  // the create stays on the same profile. The handshake below can yield long
+  // enough for background config/model refreshes to finish; reading atoms
+  // afterward on a same-profile create would silently rewrite the submitted
+  // pick. When the create activates a different profile, re-read after the
+  // handshake so a prior profile's sticky manual pair cannot ride along
+  // (#101091).
+  const profileAtSubmit = normalizeProfileKey($activeGatewayProfile.get())
+  let selection = readManualSelection()
+
   const profile = capturedRoute?.profile || $newChatProfile.get() || normalizeProfileKey($activeGatewayProfile.get())
+  const targetProfile = normalizeProfileKey(profile)
 
   if (capturedRoute) {
     await ensureGatewayAgent(capturedRoute.connectionId, profile)
   } else {
     await ensureGatewayProfile(profile)
+  }
+
+  if (targetProfile !== profileAtSubmit) {
+    selection = readManualSelection()
   }
 
   return {

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -521,10 +521,17 @@ export async function ensureGatewayProfile(profile: string | null | undefined): 
     // ONE publication frame. batch() defers Nanostores' notifications to the
     // end of the callback, so the profile pointer and the connection
     // descriptor become visible together; a null descriptor (no bridge, or a
-    // failed best-effort lookup) keeps the previous one — fail open.
+    // failed best-effort lookup) keeps the previous one — fail open. Stamp the
+    // activated profile onto the descriptor and (when a connection id exists)
+    // the composer owner so local multi-profile switches cannot keep sharing a
+    // sticky model/provider pair (#101091).
     batch(() => {
       if (connection) {
-        setConnection(connection)
+        setConnection({ ...connection, profile: target })
+
+        if (connection.connectionId) {
+          setComposerSelectionOwner(connection.connectionId, target)
+        }
       } else {
         clearComposerSelectionOwner()
       }

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -115,18 +115,44 @@ describe('composer model persistence scope', () => {
     expect($currentProvider.get()).toBe('xai-oauth')
   })
 
-  it('keeps inferred local-primary connections on the historical bare keys', () => {
+  it('keeps manual model selections isolated across local profiles', () => {
+    const localProfile = (profile: string) =>
+      ({ baseUrl: '', connectionId: 'local', mode: 'local', profile }) as never
+
+    setConnection(localProfile('default'))
+    setCurrentModel('deepseek-v4-pro')
+    setCurrentProvider('deepseek')
+    setCurrentModelSource('manual')
+
+    setConnection(localProfile('dev'))
+    expect($currentModel.get()).toBe('')
+    expect($currentProvider.get()).toBe('')
+
+    setCurrentModel('mimo-v2.5-pro')
+    setCurrentProvider('xiaomi')
+    setCurrentModelSource('manual')
+
+    setConnection(localProfile('default'))
+    expect($currentModel.get()).toBe('deepseek-v4-pro')
+    expect($currentProvider.get()).toBe('deepseek')
+
+    setConnection(localProfile('dev'))
+    expect($currentModel.get()).toBe('mimo-v2.5-pro')
+    expect($currentProvider.get()).toBe('xiaomi')
+  })
+
+  it('does not migrate bare legacy composer keys into a local profile namespace', () => {
     setComposerSelectionOwner('remote', 'default')
     window.localStorage.setItem('hermes.desktop.composer.model', 'legacy-model')
     window.localStorage.setItem('hermes.desktop.composer.provider', 'legacy-provider')
 
     setConnection({ baseUrl: '', connectionId: 'local', mode: 'local', profile: 'default' } as never)
 
-    expect($currentModel.get()).toBe('legacy-model')
-    expect($currentProvider.get()).toBe('legacy-provider')
+    expect($currentModel.get()).toBe('')
+    expect($currentProvider.get()).toBe('')
     setCurrentModel('next-model')
-    expect(window.localStorage.getItem('hermes.desktop.composer.model')).toBe('next-model')
-    expect(window.localStorage.getItem('hermes.desktop.composer.model.registry.local.default')).toBeNull()
+    expect(window.localStorage.getItem('hermes.desktop.composer.model')).toBe('legacy-model')
+    expect(window.localStorage.getItem('hermes.desktop.composer.model.registry.local.default')).toBe('next-model')
   })
 
   it('uses the live registry owner when the connection descriptor is stale', () => {

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -26,9 +26,10 @@ const WORKSPACE_CWD_KEY = 'hermes.desktop.workspace-cwd'
 // The composer's model/effort/fast is sticky UI state, NOT the profile default
 // (that lives in Settings → Model). Persisting it in localStorage makes a pick
 // follow across Cmd+N and app restarts instead of snapping back to the default.
-// Model/provider/source are scoped to the remote (connection, profile) owner so
-// a provider authenticated on one profile cannot contaminate another profile's
-// session.create. Local/single-backend users retain the historical bare keys.
+// Model/provider/source are scoped to the (connection, profile) owner — including
+// local multi-profile — so a sticky pick on one profile cannot contaminate
+// another profile's session.create (#101091). Legacy bare keys are not migrated:
+// ownership is unknowable.
 const COMPOSER_MODEL_KEY = 'hermes.desktop.composer.model'
 const COMPOSER_PROVIDER_KEY = 'hermes.desktop.composer.provider'
 const COMPOSER_MODEL_SOURCE_KEY = 'hermes.desktop.composer.model-source'
@@ -46,18 +47,19 @@ function composerScopeForConnection(connection: HermesConnection | null): string
     return null
   }
 
-  // Electron may infer the sole `local` registry id onto the ordinary primary
-  // descriptor. That remains the legacy single-backend path: only an explicit
-  // registry-scoped route earns a new namespace.
-  if (connection.mode !== 'remote' && !connection.registryScoped) {
-    return ''
-  }
+  const profile = (connection.profile || 'default').trim() || 'default'
 
+  // Registry identities (including an explicit `local` id Electron may infer onto
+  // the primary descriptor) isolate by (connectionId, profile).
   if (connection.connectionId) {
-    return `.registry.${encodeURIComponent(connection.connectionId)}.${encodeURIComponent(connection.profile || 'default')}`
+    return `.registry.${encodeURIComponent(connection.connectionId)}.${encodeURIComponent(profile)}`
   }
 
-  return connectionScopeSuffix(connection)
+  if (connection.mode === 'remote') {
+    return connectionScopeSuffix(connection)
+  }
+
+  return `.local.${encodeURIComponent(profile)}`
 }
 
 function composerSelectionKey(base: string): string | null {


### PR DESCRIPTION
## Why

Desktop let sticky composer `{provider, model, source}` state share bare localStorage keys across local profiles. Switching from a DeepSeek profile to a Xiaomi profile could still ship `deepseek-v4-pro` on `session.create`, and the runtime then mixed that model with the Xiaomi credential/base URL (`HTTP 400: Unsupported model`). Fixes #101091.

## Scope

- `composerScopeForConnection` now namespaces local (and inferred `local` registry) selections by `(connectionId, profile)` instead of the historical bare keys. Bare legacy keys are not migrated.
- `ensureGatewayProfile` stamps the activated profile onto the connection descriptor and composer owner when a connection id is present.
- `desktopSessionCreateParams` keeps the pre-await snapshot for same-profile creates, then re-reads after activation when the create targets a different profile so a prior sticky pair cannot ride along.
- Regression coverage in `session.test.ts` and `use-session-actions.test.tsx`.

Out of scope: gateway `session.create` validation and model-inventory injection into the wrong provider row (backend seams named in the issue).

## Tradeoffs

Same-profile creates still snapshot before the gateway handshake so an in-flight default refresh cannot rewrite the submitted pick. Cross-profile creates intentionally re-read after activation.

## Blast Radius

Local multi-profile Desktop users lose bare-key sticky composer state on upgrade (keys are not migrated). Remote / registry-scoped owners already used namespaced keys and are unchanged in behavior. New chats for a different local profile no longer inherit the previous profile's manual model override.

## Verification

```
cd apps/desktop
npx vitest run src/store/session.test.ts src/app/session/hooks/use-session-actions.test.tsx
```
Exit 0 (203 passed).

```
npx vitest run src/store/profile-agent-activation.test.ts
```
Exit 0 (13 passed).

`package-lock.json` from workspace install was reverted and not committed.