### PR TITLE
fix(desktop): route Bot voice TTS through the owner profile

### DIFF
--- a/apps/desktop/src/api/system.ts
+++ b/apps/desktop/src/api/system.ts
@@ -184,9 +184,13 @@ export function transcribeAudio(dataUrl: string, mimeType?: string): Promise<Aud
   })
 }
 
-export function speakText(text: string): Promise<AudioSpeakResponse> {
+export function speakText(
+  text: string,
+  scope?: { connectionId?: null | string; profile?: null | string }
+): Promise<AudioSpeakResponse> {
   return hermesApi<AudioSpeakResponse>({
-    ...profileScoped(),
+    ...profileScoped(scope?.profile),
+    ...(scope?.connectionId ? { connectionId: scope.connectionId } : {}),
     path: '/api/audio/speak',
     method: 'POST',
     body: { text },

--- a/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.ts
@@ -43,7 +43,7 @@ export function useAutoSpeakReplies({
   const enabled = useStore($autoSpeakReplies)
   // Wake on THIS composer's transcript: a tile subscribed to the primary's
   // would never fire on its own replies (and would fire on someone else's).
-  const { $messages } = useComposerScope()
+  const { $messages, ownerConnectionId, ownerProfile } = useComposerScope()
   const latest = useRef({ conversationActive, failureLabel, markSpoken, pendingReply })
   latest.current = { conversationActive, failureLabel, markSpoken, pendingReply }
 
@@ -75,9 +75,12 @@ export function useAutoSpeakReplies({
       // ran in every window, so peers just stay quiet.
       void ownsAmbientCue(`speak:${reply.id}`).then(owns => {
         if (owns) {
-          void playSpeechText(reply.text, { messageId: reply.id, source: 'read-aloud' }).catch(error =>
-            notifyError(error, failureLabel)
-          )
+          void playSpeechText(reply.text, {
+            messageId: reply.id,
+            source: 'read-aloud',
+            ...(ownerProfile ? { profile: ownerProfile } : {}),
+            ...(ownerConnectionId ? { connectionId: ownerConnectionId } : {})
+          }).catch(error => notifyError(error, failureLabel))
         }
       })
     }
@@ -87,5 +90,5 @@ export function useAutoSpeakReplies({
     const stops = [$messages.subscribe(speakLatest), $voicePlayback.listen(speakLatest)]
 
     return () => stops.forEach(f => f())
-  }, [$messages, enabled, sessionId])
+  }, [$messages, enabled, ownerConnectionId, ownerProfile, sessionId])
 }

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
@@ -62,7 +62,7 @@ export function useComposerVoice({
 }: UseComposerVoiceArgs) {
   const { t } = useI18n()
   // A tile's composer speaks ITS transcript, not the primary chat's.
-  const { $messages } = useComposerScope()
+  const { $messages, ownerConnectionId, ownerProfile } = useComposerScope()
   const [voiceConversationActive, setVoiceConversationActive] = useState(false)
   const ownsWakeIndicatorRef = useRef(false)
   const voiceStartRequest = useStore($voiceConversationStartRequest)
@@ -155,7 +155,11 @@ export function useComposerVoice({
     pendingResponse: pendingTurnResponse,
     // Before the conversation opens the mic, wait for any in-flight wake.pause
     // to finish releasing the capture device (see wakePauseBarrierRef).
-    beforeMicOpen: () => wakePauseBarrierRef.current ?? undefined
+    beforeMicOpen: () => wakePauseBarrierRef.current ?? undefined,
+    voiceScope:
+      ownerProfile || ownerConnectionId
+        ? { connectionId: ownerConnectionId, profile: ownerProfile }
+        : undefined
   })
 
   // eslint-disable-next-line no-restricted-syntax -- ownership token used only by unmount cleanup

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -39,6 +39,8 @@ interface VoiceConversationOptions {
   /** Awaited right before the mic is opened. Used to let the wake-word listener
    *  fully release the capture device first, so the two never contend. */
   beforeMicOpen?: () => Promise<void> | void
+  /** Bot / tile owner TTS scope. Overrides ambient active gateway profile. */
+  voiceScope?: { connectionId?: string; profile?: string }
 }
 
 /** How long a barge-triggered interrupt may take to settle before we submit
@@ -55,7 +57,8 @@ export function useVoiceConversation({
   onTranscribeAudio,
   pendingResponse,
   consumePendingResponse,
-  beforeMicOpen
+  beforeMicOpen,
+  voiceScope
 }: VoiceConversationOptions) {
   const { t } = useI18n()
   const voiceCopy = t.notifications.voice
@@ -92,11 +95,17 @@ export function useVoiceConversation({
   }, [onStopWord])
 
   const beforeMicOpenRef = useRef(beforeMicOpen)
+  const voiceScopeRef = useRef(voiceScope)
 
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
     beforeMicOpenRef.current = beforeMicOpen
   }, [beforeMicOpen])
+
+  // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
+  useEffect(() => {
+    voiceScopeRef.current = voiceScope
+  }, [voiceScope])
 
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
@@ -459,7 +468,10 @@ export function useVoiceConversation({
         // this is a safety net for read-aloud-style entries into the loop.
         ensureBargeMonitor()
 
-        const playback = playSpeechText(response.text, { source: 'voice-conversation' })
+        const playback = playSpeechText(response.text, {
+          source: 'voice-conversation',
+          ...voiceScopeRef.current
+        })
         // playSpeechText performs its normal cleanup synchronously before
         // returning. Capture the sequence after that internal increment so
         // only a later, external stop suppresses the next listen cycle.
@@ -500,7 +512,10 @@ export function useVoiceConversation({
       ensureBargeMonitor()
 
       void (async () => {
-        const session = await startSpeechStream({ source: 'voice-conversation' })
+        const session = await startSpeechStream({
+          source: 'voice-conversation',
+          ...voiceScopeRef.current
+        })
 
         // The session may resolve after the loop moved on (barge, disable).
         if (responseIdRef.current !== responseId) {

--- a/apps/desktop/src/app/chat/composer/scope.tsx
+++ b/apps/desktop/src/app/chat/composer/scope.tsx
@@ -25,8 +25,13 @@ export interface ComposerScope {
   attachments: ComposerAttachmentScope
   /** This scope's transcript. Read it imperatively (input-history browse) to
    *  keep streaming out of the composer's renders; subscribe only off-render
-   *  (auto-speak) where the reply edge is the whole point. */
+   *  (auto-speak) where the reply edge is the whole path. */
   $messages: ReadableAtom<ChatMessage[]>
+  /** Bot / tile owner registry connection for voice TTS routing (#100864). */
+  ownerConnectionId?: string
+  /** Bot / tile owner profile for voice TTS routing (#100864). Falls back to
+   *  the ambient active gateway profile when omitted. */
+  ownerProfile?: string
   /** Focus-bus routing key (`'main'` | `'tile:<id>'`). */
   target: ComposerTarget
 }

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -61,7 +61,7 @@ import { ChatSwapOverlay, ChatSyncBadge } from './chat-swap-overlay'
 import { ChatBar, ChatBarFallback } from './composer'
 import { requestComposerInsert } from './composer/focus'
 import { droppedFileInlineRefs } from './composer/inline-refs'
-import { ComposerSurfaceProvider, useComposerScope, useComposerSurfaceId } from './composer/scope'
+import { ComposerScopeProvider, ComposerSurfaceProvider, useComposerScope, useComposerSurfaceId } from './composer/scope'
 import type { ChatBarState } from './composer/types'
 import { type DroppedFile, partitionDroppedFiles } from './hooks/use-composer-actions'
 import { type DragKind, useFileDropZone } from './hooks/use-file-drop-zone'
@@ -442,6 +442,46 @@ const ChatViewContent = memo(function ChatViewContent({
   const selectedSessionId = useStore(view.$storedId)
   const sessions = useStore($sessions)
   const resumeExhaustedSessionId = useStore($resumeExhaustedSessionId)
+  const connection = useStore($connection)
+  const connectionId = connection?.connectionId || (connection?.mode === 'local' ? 'local' : '')
+
+  // Bot Mode keeps chrome on the launch profile (`keepAllProfilesScope`) while
+  // the chat's ownerRoute names the Bot. Prefer that owner for voice TTS so
+  // playback matches the Bot's own profile config (#100864). Tiles already
+  // stamp owner* onto ComposerScope; primary surfaces resolve the hint here.
+  const ownerHint = selectedSessionId
+    ? (getSessionOwnerHint(
+        selectedSessionId,
+        connectionId ? { connectionId, profile: activeGatewayProfile } : undefined
+      ) ?? getSessionOwnerHint(selectedSessionId))
+    : undefined
+
+  const voiceOwnerScope = useMemo(() => {
+    if (composerScope.ownerProfile || composerScope.ownerConnectionId) {
+      return composerScope
+    }
+
+    const ownerProfile =
+      ownerHint?.targetProfile || ownerHint?.profile || modelOptionsProfile || undefined
+    const ownerConnectionId = ownerHint?.connectionId || modelOptionsOwnerConnectionId || undefined
+
+    if (!ownerProfile && !ownerConnectionId) {
+      return composerScope
+    }
+
+    return {
+      ...composerScope,
+      ...(ownerConnectionId ? { ownerConnectionId } : {}),
+      ...(ownerProfile ? { ownerProfile } : {})
+    }
+  }, [
+    composerScope,
+    modelOptionsOwnerConnectionId,
+    modelOptionsProfile,
+    ownerHint?.connectionId,
+    ownerHint?.profile,
+    ownerHint?.targetProfile
+  ])
 
   // Durable composer/queue scope (lineage root) so auto-compression tip rotation
   // does not wipe an in-progress draft or orphan /queue entries. For the
@@ -628,6 +668,7 @@ const ChatViewContent = memo(function ChatViewContent({
   const overlayKind: DragKind = dragKind === 'files' ? 'files' : sessionDragging && !sessionEdgeHover ? 'session' : null
 
   return (
+    <ComposerScopeProvider value={voiceOwnerScope}>
     <div
       className={cn(
         'relative isolate flex h-full min-w-0 flex-col overflow-hidden bg-(--ui-chat-surface-background)',
@@ -758,5 +799,6 @@ const ChatViewContent = memo(function ChatViewContent({
         )}
       </ChatRuntimeBoundary>
     </div>
+    </ComposerScopeProvider>
   )
 })

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -224,9 +224,19 @@ function TileChat({
       $awaitingInput: sessionAwaitingInput(runtimeId),
       $messages: view.$messages,
       attachments,
+      ownerConnectionId: ownerRoute?.connectionId || undefined,
+      ownerProfile: ownerRoute?.targetProfile || ownerRoute?.profile || undefined,
       target: `tile:${storedSessionId}`
     }),
-    [attachments, runtimeId, storedSessionId, view.$messages]
+    [
+      attachments,
+      ownerRoute?.connectionId,
+      ownerRoute?.profile,
+      ownerRoute?.targetProfile,
+      runtimeId,
+      storedSessionId,
+      view.$messages
+    ]
   )
 
   // Tile actions must keep the persisted owner route. The ambient gateway hook

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -11,6 +11,7 @@ import { type FC, type ReactNode, useCallback, useMemo, useState } from 'react'
 import { useInRouterContext, useNavigate } from 'react-router'
 
 import { useSessionView } from '@/app/chat/session-view'
+import { useComposerScope } from '@/app/chat/composer/scope'
 import { SETTINGS_ROUTE } from '@/app/routes'
 import { ChangedFilesCard } from '@/components/assistant-ui/thread/changed-files-card'
 import {
@@ -686,6 +687,7 @@ const ReadAloudButton: FC<{ getText: () => string; messageId: string }> = ({ get
   const copy = t.assistant.thread
   const voicePlayback = useStore($voicePlayback)
   const view = useSessionView()
+  const { ownerConnectionId, ownerProfile } = useComposerScope()
   const sessionId = useStore(view.$runtimeId)
 
   const readAloudStatus =
@@ -705,12 +707,17 @@ const ReadAloudButton: FC<{ getText: () => string; messageId: string }> = ({ get
     }
 
     try {
-      await playSpeechText(text, { messageId, source: 'read-aloud' })
+      await playSpeechText(text, {
+        messageId,
+        source: 'read-aloud',
+        ...(ownerProfile ? { profile: ownerProfile } : {}),
+        ...(ownerConnectionId ? { connectionId: ownerConnectionId } : {})
+      })
       markAssistantIdSpoken(sessionId, view.$messages.get(), messageId)
     } catch (error) {
       notifyError(error, copy.readAloudFailed)
     }
-  }, [copy.readAloudFailed, getText, messageId, sessionId, view.$messages])
+  }, [copy.readAloudFailed, getText, messageId, ownerConnectionId, ownerProfile, sessionId, view.$messages])
 
   return (
     <TooltipIconButton

--- a/apps/desktop/src/hermes-profile-scope.test.ts
+++ b/apps/desktop/src/hermes-profile-scope.test.ts
@@ -80,4 +80,12 @@ describe('backend action helpers are profile-scoped', () => {
       expect(call[0].profile).toBe('jarvis')
     }
   })
+
+  it('lets speakText pin a Bot owner profile over the ambient active profile (#100864)', () => {
+    setApiRequestProfile('launch-profile')
+
+    void speakText('hello', { profile: 'bot-rachel' })
+
+    expect(lastProfile()).toBe('bot-rachel')
+  })
 })

--- a/apps/desktop/src/lib/voice-client-direct.test.ts
+++ b/apps/desktop/src/lib/voice-client-direct.test.ts
@@ -77,6 +77,33 @@ describe('fetchVoiceClientConfig', () => {
     expect(api).toHaveBeenCalledTimes(2)
   })
 
+  it('honors an explicit Bot owner profile over the ambient active gateway profile (#100864)', async () => {
+    const api = mockDesktopApi({ ok: true, stt: directStt, tts: relay })
+    setApiRequestConnection('local')
+    setApiRequestProfile('launch-profile')
+
+    await fetchVoiceClientConfig({ profile: 'bot-rachel', connectionId: 'local' })
+
+    expect(api).toHaveBeenCalledTimes(1)
+
+    const request = api.mock.calls[0][0] as { connectionId?: string; path: string; profile?: string }
+    expect(request.path).toBe('/api/audio/voice-config')
+    expect(request.profile).toBe('bot-rachel')
+    expect(request.connectionId).toBe('local')
+  })
+
+  it('keeps distinct Bot profile configs in separate cache entries', async () => {
+    const api = mockDesktopApi({ ok: true, stt: directStt, tts: relay })
+    setApiRequestProfile('launch-profile')
+
+    await fetchVoiceClientConfig({ profile: 'bot-rachel' })
+    await fetchVoiceClientConfig({ profile: 'bot-adam' })
+
+    expect(api).toHaveBeenCalledTimes(2)
+    expect((api.mock.calls[0][0] as { profile?: string }).profile).toBe('bot-rachel')
+    expect((api.mock.calls[1][0] as { profile?: string }).profile).toBe('bot-adam')
+  })
+
   it('resolves null on an older backend without the endpoint', async () => {
     Object.defineProperty(window, 'hermesDesktop', {
       configurable: true,

--- a/apps/desktop/src/lib/voice-client-direct.ts
+++ b/apps/desktop/src/lib/voice-client-direct.ts
@@ -61,8 +61,25 @@ const CONFIG_TTL_MS = 60_000
 let cached: { key: string; at: number; config: VoiceClientConfig } | null = null
 let inflight: { key: string; promise: Promise<null | VoiceClientConfig> } | null = null
 
-function scopeKey(): string {
-  return `${getApiRequestConnection() ?? 'local'}::${getApiRequestProfile() ?? 'default'}`
+/** Optional pin for Bot chats whose owner profile differs from the ambient
+ *  gateway profile (`keepAllProfilesScope`). Undefined fields fall back to
+ *  `getApiRequestConnection` / `getApiRequestProfile`. */
+export interface VoiceClientScope {
+  connectionId?: null | string
+  profile?: null | string
+}
+
+function resolveScope(scope?: VoiceClientScope): { connectionId: null | string; profile: null | string } {
+  return {
+    connectionId: scope?.connectionId !== undefined ? scope.connectionId : getApiRequestConnection(),
+    profile: scope?.profile !== undefined ? scope.profile : getApiRequestProfile()
+  }
+}
+
+function scopeKey(scope?: VoiceClientScope): string {
+  const resolved = resolveScope(scope)
+
+  return `${resolved.connectionId ?? 'local'}::${resolved.profile ?? 'default'}`
 }
 
 /** Drop cached credentials (used by tests; scope changes rotate the key). */
@@ -71,8 +88,9 @@ export function clearVoiceClientConfigCache(): void {
   inflight = null
 }
 
-export async function fetchVoiceClientConfig(): Promise<null | VoiceClientConfig> {
-  const key = scopeKey()
+export async function fetchVoiceClientConfig(scope?: VoiceClientScope): Promise<null | VoiceClientConfig> {
+  const key = scopeKey(scope)
+  const resolved = resolveScope(scope)
 
   if (cached && cached.key === key && Date.now() - cached.at < CONFIG_TTL_MS) {
     return cached.config
@@ -87,8 +105,12 @@ export async function fetchVoiceClientConfig(): Promise<null | VoiceClientConfig
       // hermesApi carries connectionScoped(); profileScoped() adds the
       // profile — the same routing every relay audio call uses, so the
       // config comes from the backend the user is actually talking to.
+      // An explicit Bot owner scope overrides the ambient active profile
+      // (#100864): Bot Mode keeps chrome on the launch profile while the
+      // chat's TTS must resolve against the Bot's own profile config.
       const response = await hermesApi<{ ok: boolean } & VoiceClientConfig>({
-        ...profileScoped(),
+        ...profileScoped(resolved.profile),
+        ...(resolved.connectionId ? { connectionId: resolved.connectionId } : {}),
         path: '/api/audio/voice-config'
       })
 
@@ -272,8 +294,8 @@ export async function transcribeAudioClientDirect(audio: Blob): Promise<null | s
 // ---------------------------------------------------------------------------
 
 /** Resolve the profile's TTS config when it is client-callable, else null. */
-export async function directTtsConfig(): Promise<DirectTtsConfig | null> {
-  const config = await fetchVoiceClientConfig()
+export async function directTtsConfig(scope?: VoiceClientScope): Promise<DirectTtsConfig | null> {
+  const config = await fetchVoiceClientConfig(scope)
 
   return config?.tts && config.tts.mode === 'direct' ? config.tts : null
 }

--- a/apps/desktop/src/lib/voice-playback.routing.test.ts
+++ b/apps/desktop/src/lib/voice-playback.routing.test.ts
@@ -119,4 +119,16 @@ describe('resolveSpeakStreamUrl', () => {
 
     await expect(pending).resolves.toBeNull()
   })
+
+  it('prefers an explicit Bot owner profile over the ambient active profile (#100864)', async () => {
+    setApiRequestConnection('local')
+    setApiRequestProfile('launch-profile')
+
+    const url = await resolveSpeakStreamUrl({ connectionId: 'local', profile: 'bot-rachel' })
+
+    expect(url).toContain('profile=bot-rachel')
+    expect(url).not.toContain('profile=launch-profile')
+    expect(getConnectionFor).toHaveBeenCalledWith({ connectionId: 'local', profile: 'bot-rachel' })
+    expect(getConnection).not.toHaveBeenCalled()
+  })
 })

--- a/apps/desktop/src/lib/voice-playback.ts
+++ b/apps/desktop/src/lib/voice-playback.ts
@@ -72,8 +72,19 @@ function currentState(
 }
 
 export interface VoicePlaybackOptions {
+  /** Bot / tile owner registry connection. Overrides ambient when set. */
+  connectionId?: null | string
   messageId?: string | null
+  /** Bot / tile owner profile. Overrides ambient active gateway profile (#100864). */
+  profile?: null | string
   source: VoicePlaybackSource
+}
+
+function voiceClientScope(options?: Pick<VoicePlaybackOptions, 'connectionId' | 'profile'>) {
+  return {
+    ...(options?.connectionId !== undefined ? { connectionId: options.connectionId } : {}),
+    ...(options?.profile !== undefined ? { profile: options.profile } : {})
+  }
 }
 
 export function stopVoicePlayback() {
@@ -105,7 +116,9 @@ export function stopVoicePlayback() {
 
 /** Exported for tests: the (connection, profile) routing contract below is
  *  exactly what broke in the desktop-remote voice report — keep it pinned. */
-export async function resolveSpeakStreamUrl(): Promise<null | string> {
+export async function resolveSpeakStreamUrl(
+  scope?: Pick<VoicePlaybackOptions, 'connectionId' | 'profile'>
+): Promise<null | string> {
   const desktop = window.hermesDesktop
 
   if (!desktop?.getConnection) {
@@ -123,8 +136,13 @@ export async function resolveSpeakStreamUrl(): Promise<null | string> {
     // replies would synthesize with the local (often unconfigured) TTS
     // instead of the profile the user is actually talking to (#90051-adjacent
     // desktop-remote voice report, Aug 2026).
-    const profile = getApiRequestProfile()
-    const connectionId = getApiRequestConnection()
+    //
+    // Bot Mode (#100864): an explicit owner scope wins over the ambient
+    // active gateway profile so each Bot speaks with its own TTS config.
+    const profile =
+      scope?.profile !== undefined ? scope.profile : getApiRequestProfile()
+    const connectionId =
+      scope?.connectionId !== undefined ? scope.connectionId : getApiRequestConnection()
 
     // Both awaits below are IPC round-trips into the main process with no
     // timeout of their own (#93454) — a wedged main-process round-trip
@@ -522,7 +540,8 @@ function openSpeechStream(wsUrl: string, options: VoicePlaybackOptions): SpeechS
  * `playSpeechText`).
  */
 export async function startSpeechStream(options: VoicePlaybackOptions): Promise<null | SpeechStreamSession> {
-  const direct = await directTtsConfig().catch(() => null)
+  const scope = voiceClientScope(options)
+  const direct = await directTtsConfig(scope).catch(() => null)
 
   if (direct) {
     stopVoicePlayback()
@@ -539,7 +558,7 @@ export async function startSpeechStream(options: VoicePlaybackOptions): Promise<
     return session
   }
 
-  const wsUrl = await resolveSpeakStreamUrl()
+  const wsUrl = await resolveSpeakStreamUrl(scope)
 
   if (!wsUrl) {
     return null
@@ -573,7 +592,7 @@ async function playSpeechDataUrl(
   options: VoicePlaybackOptions,
   isCurrent: () => boolean
 ): Promise<boolean> {
-  const response = await speakText(speakableText)
+  const response = await speakText(speakableText, voiceClientScope(options))
 
   if (!isCurrent()) {
     return false
@@ -669,7 +688,8 @@ export async function playSpeechText(text: string, options: VoicePlaybackOptions
   try {
     // Ladder: client-direct synthesis (profile's own TTS, no gateway audio
     // hop) → streaming WS relay → POST data-URL fallback.
-    const direct = await directTtsConfig().catch(() => null)
+    const scope = voiceClientScope(options)
+    const direct = await directTtsConfig(scope).catch(() => null)
 
     if (direct && isCurrent()) {
       const session = openClientDirectSpeechSession(direct, options)
@@ -693,7 +713,7 @@ export async function playSpeechText(text: string, options: VoicePlaybackOptions
       return false
     }
 
-    const streamUrl = await resolveSpeakStreamUrl()
+    const streamUrl = await resolveSpeakStreamUrl(scope)
 
     if (streamUrl && isCurrent()) {
       const outcome = await playSpeechStream(streamUrl, speakableText, options)


### PR DESCRIPTION
## Why

Bot Mode keeps chrome on the launch profile (keepAllProfilesScope) while each Bot chat's ownerRoute names the Bot profile. Voice playback still resolved TTS through the ambient active gateway profile, so every Bot spoke with the same voice.

## Scope

- VoicePlaybackOptions accepts optional profile / connectionId and threads them through etchVoiceClientConfig, directTtsConfig, esolveSpeakStreamUrl, and speakText.
- Bot tiles stamp ownerProfile / ownerConnectionId onto ComposerScope; primary ChatView falls back to the session owner hint.
- Voice conversation, auto-speak, and read-aloud pass that owner scope into playback.
- Focused tests pin Bot owner overrides for voice-config, speak-stream, and speak.

Out of scope: STT transcription routing, gateway TTS loader changes.

## Blast Radius

Desktop Bot and tile voice playback only. Non-Bot chats omit the owner pin and keep the previous ambient profile path.

## Verification

```
cd apps/desktop
npx vitest run src/lib/voice-client-direct.test.ts src/lib/voice-playback.routing.test.ts src/hermes-profile-scope.test.ts
```

Exit 0. 33 passed.

Closes #100864