### PR TITLE
fix(tools): serialize terminal-scope list/dict config values as JSON (#101465)

### DIFF
--- a/tests/tools/test_terminal_scope_multiplex.py
+++ b/tests/tools/test_terminal_scope_multiplex.py
@@ -142,6 +142,32 @@ def test_profile_omitting_keys_gets_defaults_not_launch_values(tmp_path):
     assert json.loads(os.environ["TERMINAL_DOCKER_VOLUMES"])  # A unchanged
 
 
+def test_config_yaml_list_and_dict_values_serialize_as_json(tmp_path):
+    """#101465: config.yaml ``terminal:`` list/dict values must reach the
+    scope as valid JSON (what terminal_tool parses with ``json.loads``),
+    not Python ``repr`` from ``str()`` — which failed the parse and disabled
+    the terminal tool entirely for docker-backend profiles."""
+    import gateway.run as gw
+    import tools.terminal_tool as tt
+
+    home = _profile(
+        tmp_path, "bee",
+        "terminal:\n"
+        "  backend: docker\n"
+        "  docker_forward_env:\n"
+        "    - EMAIL_HOME_ADDRESS\n"
+        "    - SHELL\n"
+        "  docker_env:\n"
+        "    FOO: bar\n"
+    )
+    with gw._profile_runtime_scope(home):
+        cfg = tt._get_env_config()
+        assert cfg["env_type"] == "docker"
+        assert cfg["docker_forward_env"] == ["EMAIL_HOME_ADDRESS", "SHELL"]
+        assert cfg["docker_env"] == {"FOO": "bar"}
+    assert get_terminal_scope() is None
+
+
 def test_malformed_profile_config_refuses_execution(tmp_path):
     """Unresolvable policy → refusal scope; terminal_tool refuses instead of
     running under the launch process's ambient policy (fail closed)."""

--- a/tools/terminal_scope.py
+++ b/tools/terminal_scope.py
@@ -27,6 +27,7 @@ Two contracts distinguish this from a plain override dict:
 
 from __future__ import annotations
 
+import json
 import logging
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
@@ -172,7 +173,15 @@ def build_profile_terminal_scope(hermes_home: "Any") -> Dict[str, str]:
 
         env_var = TERMINAL_CONFIG_ENV_MAP.get(cfg_key)
         if env_var:
-            scope[env_var] = str(value)
+            if isinstance(value, (list, dict, tuple)):
+                # JSON-consuming keys (docker_forward_env, docker_volumes,
+                # docker_env, docker_extra_args) are parsed downstream with
+                # ``json.loads`` (#101465); str() would emit Python repr,
+                # which fails to parse and disables the terminal tool.
+                scope[env_var] = json.dumps(list(value) if isinstance(
+                    value, tuple) else value)
+            else:
+                scope[env_var] = str(value)
 
     # 1) Defined defaults — the total baseline.
     for cfg_key, value in defaults.items():


### PR DESCRIPTION
## What does this PR do?

`build_profile_terminal_scope()` (`tools/terminal_scope.py`) applied `str()` to every `config.yaml` `terminal:` value. For the JSON-consuming keys — `docker_forward_env`, `docker_volumes`, `docker_env`, `docker_extra_args` — that put **Python repr** (e.g. `"['EMAIL_HOME_ADDRESS']"`) into the scope, while `tools/terminal_tool.py` parses those values with `json.loads` (`_parse_env_var(..., json.loads, "valid JSON")`, terminal_tool.py:1813-1816). The parse failed, `check_terminal_requirements` returned `False`, and **any `terminal.backend: docker` profile served through the multiplexed/unified dashboard lost the terminal tool entirely**.

Fix: list/dict/tuple values are serialized with `json.dumps()`; scalar values keep the existing `str()` behavior (no change to int/bool/str keys).

Reproduction on current `main` (before this change):

```python
from tools.terminal_scope import build_profile_terminal_scope
scope = build_profile_terminal_scope(Path("<profile with terminal.docker_forward_env: [EMAIL_HOME_ADDRESS]>"))
scope["TERMINAL_DOCKER_FORWARD_ENV"]  # "['EMAIL_HOME_ADDRESS']"
json.loads(scope["TERMINAL_DOCKER_FORWARD_ENV"])  # JSONDecodeError
```

## Related Issue

Fixes #101465

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/terminal_scope.py` — `_apply()` now emits `json.dumps()` for list/dict/tuple config values so JSON-consuming keys parse downstream; `import json` added.
- `tests/tools/test_terminal_scope_multiplex.py` — regression test: a docker profile with `docker_forward_env` (list) and `docker_env` (dict) in `config.yaml`, driven through the real `gw._profile_runtime_scope` boundary, asserting `terminal_tool._get_env_config()` yields the parsed list/dict (behavior contract, not a snapshot).

## Validation

- Reproduced the failure on `main` (repr string, `json.loads` raises) before the fix; both parse cleanly after.
- `scripts/run_tests.sh tests/tools/test_terminal_scope_multiplex.py` — 9/9 pass (8 preserved + 1 new).
- `scripts/run_tests.sh tests/tools/` — the only failures are 10 files unrelated to terminal/scope (daytona, video-gen surface matrix, search, voice, web-config, …); verified identical on a clean `main` stash (same 4 sampled files: 50 failed on baseline without this change).