### PR TITLE
fix(desktop): mint oauth ticket before cold-start unsigned hard-fail

### DIFF
--- a/apps/desktop/electron/backend-dial-claim.test.ts
+++ b/apps/desktop/electron/backend-dial-claim.test.ts
@@ -172,11 +172,26 @@ describe('main.ts wiring for #90812', () => {
   it('routes the roster-enumeration probe through the single-owner claim', () => {
     const handlerStart = mainSource.indexOf('async function enumerateRegistryAgentSources')
     expect(handlerStart).toBeGreaterThan(-1)
-    const body = mainSource.slice(handlerStart, handlerStart + 3_700)
+    const body = mainSource.slice(handlerStart, handlerStart + 4_200)
 
     expect(body).toContain('backendDialClaims.run(backendScopeKey(connection.id, null)')
     expect(body).toContain('ensureRegistryBackend(connection.id, null)')
     expect(body).toContain("getJsonForBackend(descriptor, '/api/profiles'")
+    // #101339: oauth remotes get a longer per-source deadline than the 10s default.
+    expect(body).toContain('rosterSourceEnumerationTimeoutMs(connection)')
+  })
+
+  it('mints the oauth ws-ticket before classifying an unsigned session (#101339)', () => {
+    const start = mainSource.indexOf('async function buildRemoteConnection(')
+    expect(start).toBeGreaterThan(-1)
+    const body = mainSource.slice(start, start + 2_800)
+
+    expect(body).toContain('ticket = await mintGatewayWsTicket(baseUrl, remoteHeaders)')
+    expect(body).toContain('shouldTreatOauthMintFailureAsUnsigned(')
+    // Preflight-only hard-fail must not return: Test succeeds by minting first.
+    expect(body).not.toMatch(
+      /oauthSessionIsLive\([\s\S]*?\)\s*&&\s*oauthGuardMayHardFail\([\s\S]*?\)\s*\{\s*throw makeUnsignedOauthError/
+    )
   })
 
   it('routes the connections update-all dispatch through the single-owner claim', () => {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -103,6 +103,7 @@ import {
   gatewayTicketFailure,
   gatewayWsUrlIpcResult,
   hostLabelFromBaseUrl,
+  isGatewayAuthRejection,
   localProfileEntry,
   modeIsRemoteLike,
   normalizeRemoteBaseUrl,
@@ -252,13 +253,14 @@ import {
 import { registerMcpOauthCallbackIpc } from './mcp-oauth-callback-ipc'
 import { createMediaProtocolHandler, MEDIA_PROTOCOL } from './media-protocol'
 import {
-  oauthGuardMayHardFail,
   oauthSessionIsLive,
   oauthTicketFailureAuthMessage,
   resolveGatedDownloadAuth,
   resolveJsonBody,
   resolveOauthRestAuth,
-  resolveReadinessProbeAuth
+  resolveReadinessProbeAuth,
+  rosterSourceEnumerationTimeoutMs,
+  shouldTreatOauthMintFailureAsUnsigned
 } from './native-auth-decisions'
 import {
   nativeRefreshUrl,
@@ -9803,28 +9805,12 @@ async function buildRemoteConnection(
   const host = remoteHost || hostLabelFromBaseUrl(baseUrl)
 
   if (authMode === 'oauth') {
-    // OAuth gateway: auth comes from EITHER a native bearer token (cookieless
-    // RFC 8252 flow) OR the session cookies in the OAuth partition. Liveness is
-    // NOT "is the access-token cookie present?" — Portal issues a 24h rotating
-    // refresh token (hermes #37247), and the gateway middleware transparently
-    // rotates a fresh ~15-min access token from it on the next authenticated
-    // request. So a session with an expired AT cookie but a live RT cookie is
-    // still perfectly connectable. We early-out only when NEITHER a native
-    // token NOR any cookie is present, then mint a ws-ticket (which itself
-    // prefers the native bearer) as the authoritative liveness check.
-    //
-    // The native-token check is essential: the native login stores bearer
-    // tokens (no cookie is ever set), so gating solely on hasLiveOauthSession
-    // here would reject a freshly-completed native sign-in and loop the UI back
-    // into "not signed in" even though mintGatewayWsTicket would succeed with
-    // the stored bearer.
-    if (
-      !oauthSessionIsLive(hasNativeSession(baseUrl), await hasLiveOauthSession(baseUrl)) &&
-      oauthGuardMayHardFail(await gatewayAuthProviders(baseUrl, remoteHeaders))
-    ) {
-      throw makeUnsignedOauthError()
-    }
-
+    // Authoritative liveness is the ws-ticket mint — the same path Settings →
+    // Connections → Test uses. Cookie-jar preflight alone false-negatives on
+    // cold start while a `persist:` partition is still hydrating, which used
+    // to skip the mint and drop remote roster rows until the user clicked
+    // Test (#101339). Mint first; only classify as unsigned after a confirmed
+    // auth rejection with no live session signal.
     let ticket
 
     try {
@@ -9841,6 +9827,18 @@ async function buildRemoteConnection(
 
       if (cloudError !== null) {
         throw cloudError
+      }
+
+      const sessionLive = oauthSessionIsLive(hasNativeSession(baseUrl), await hasLiveOauthSession(baseUrl))
+
+      if (
+        shouldTreatOauthMintFailureAsUnsigned({
+          cookieOrNativeSessionLive: sessionLive,
+          isAuthRejection: isGatewayAuthRejection(error),
+          providers: await gatewayAuthProviders(baseUrl, remoteHeaders)
+        })
+      ) {
+        throw makeUnsignedOauthError()
       }
 
       throw gatewayTicketFailure(
@@ -15222,9 +15220,13 @@ async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRe
   // the renderer painted stale rows for the entire outage (and the roster IPC
   // hung >30s in live repro). Bound each source's enumeration; a timeout is
   // reported like any other unreachable source and retried on the next poll.
-  const perSourceTimeoutMs = 10_000
-
-  const withEnumerationDeadline = async <T>(work: Promise<T>): Promise<T> => {
+  // OAuth remotes get a longer budget: mint + readiness + /api/profiles cannot
+  // fit inside 10s on cold start, which dropped remote groups until Test
+  // (no deadline) warmed the session (#101339).
+  const withEnumerationDeadline = async <T>(
+    work: Promise<T>,
+    perSourceTimeoutMs: number
+  ): Promise<T> => {
     let timer: ReturnType<typeof setTimeout> | null = null
 
     try {
@@ -15288,7 +15290,8 @@ async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRe
               backendDialClaims.run(backendScopeKey(connection.id, null), () =>
                 ensureRegistryBackend(connection.id, null)
               )
-            )
+            ),
+            rosterSourceEnumerationTimeoutMs(connection)
           )
 
           const body: any = await getJsonForBackend(descriptor, '/api/profiles', { timeoutMs: 8_000 })

--- a/apps/desktop/electron/native-auth-decisions.test.ts
+++ b/apps/desktop/electron/native-auth-decisions.test.ts
@@ -11,14 +11,18 @@ import assert from 'node:assert/strict'
 import { test } from 'vitest'
 
 import {
+  DEFAULT_ROSTER_SOURCE_TIMEOUT_MS,
   normalizeAdvertisedAuthProviders,
+  OAUTH_ROSTER_SOURCE_TIMEOUT_MS,
   oauthGuardMayHardFail,
   oauthSessionIsLive,
   oauthTicketFailureAuthMessage,
   resolveGatedDownloadAuth,
   resolveJsonBody,
   resolveOauthRestAuth,
-  resolveReadinessProbeAuth
+  resolveReadinessProbeAuth,
+  rosterSourceEnumerationTimeoutMs,
+  shouldTreatOauthMintFailureAsUnsigned
 } from './native-auth-decisions'
 
 // --- 1. body encoding (guards the double-JSON.stringify 422) ---
@@ -153,6 +157,54 @@ test('normalizeAdvertisedAuthProviders maps snake_case supports_password', () =>
 test('oauthTicketFailureAuthMessage is expired only with a decryptable native session', () => {
   assert.match(oauthTicketFailureAuthMessage(true), /session has expired/)
   assert.match(oauthTicketFailureAuthMessage(false), /not signed in/)
+})
+
+// --- 5b. mint-first unsigned classification (#101339 cold-start roster) ---
+
+test('shouldTreatOauthMintFailureAsUnsigned only when auth rejected and no live session', () => {
+  assert.equal(
+    shouldTreatOauthMintFailureAsUnsigned({
+      cookieOrNativeSessionLive: false,
+      isAuthRejection: true,
+      providers: [{ name: 'nous', supportsPassword: false }]
+    }),
+    true
+  )
+  // A live session signal means the mint failure is expired/transport, not "never signed in".
+  assert.equal(
+    shouldTreatOauthMintFailureAsUnsigned({
+      cookieOrNativeSessionLive: true,
+      isAuthRejection: true,
+      providers: [{ name: 'nous', supportsPassword: false }]
+    }),
+    false
+  )
+  // Transport blips must not become the Sign-in overlay.
+  assert.equal(
+    shouldTreatOauthMintFailureAsUnsigned({
+      cookieOrNativeSessionLive: false,
+      isAuthRejection: false,
+      providers: [{ name: 'nous', supportsPassword: false }]
+    }),
+    false
+  )
+  // Password-only gateways must not hard-fail as unsigned oauth.
+  assert.equal(
+    shouldTreatOauthMintFailureAsUnsigned({
+      cookieOrNativeSessionLive: false,
+      isAuthRejection: true,
+      providers: [{ name: 'basic', supportsPassword: true }]
+    }),
+    false
+  )
+})
+
+test('rosterSourceEnumerationTimeoutMs gives oauth remotes a longer dial budget', () => {
+  assert.equal(rosterSourceEnumerationTimeoutMs({ kind: 'remote', authMode: 'oauth' }), OAUTH_ROSTER_SOURCE_TIMEOUT_MS)
+  assert.equal(rosterSourceEnumerationTimeoutMs({ kind: 'cloud', authMode: 'oauth' }), OAUTH_ROSTER_SOURCE_TIMEOUT_MS)
+  assert.equal(rosterSourceEnumerationTimeoutMs({ kind: 'remote', authMode: 'token' }), DEFAULT_ROSTER_SOURCE_TIMEOUT_MS)
+  assert.equal(rosterSourceEnumerationTimeoutMs({ kind: 'local' }), DEFAULT_ROSTER_SOURCE_TIMEOUT_MS)
+  assert.equal(rosterSourceEnumerationTimeoutMs({ kind: 'ssh', authMode: 'oauth' }), DEFAULT_ROSTER_SOURCE_TIMEOUT_MS)
 })
 
 // --- 6. gated download auth (guards the Files-panel 401 on cookieless native) ---

--- a/apps/desktop/electron/native-auth-decisions.ts
+++ b/apps/desktop/electron/native-auth-decisions.ts
@@ -233,3 +233,50 @@ export function oauthGuardMayHardFail(providers: unknown): boolean {
 
   return !named.every(provider => provider.supportsPassword)
 }
+
+/**
+ * Decide whether a failed oauth ws-ticket mint should surface as "not signed
+ * in" (unsigned) rather than a generic ticket/transport failure.
+ *
+ * Cookie-jar preflight alone is NOT authoritative on Desktop cold start: a
+ * `persist:` partition can still be hydrating when hasLiveOauthSession first
+ * reads, so Settings → Connections → Test (which mints first) succeeds while
+ * roster dial (which used to hard-fail on a false-negative preflight) skipped
+ * the mint entirely (#101339). Only a confirmed auth rejection with no live
+ * session signal (and a guard-eligible provider set) is unsigned.
+ */
+export function shouldTreatOauthMintFailureAsUnsigned(options: {
+  cookieOrNativeSessionLive: boolean
+  isAuthRejection: boolean
+  providers?: unknown
+}): boolean {
+  if (options.cookieOrNativeSessionLive) {
+    return false
+  }
+
+  if (!options.isAuthRejection) {
+    return false
+  }
+
+  return oauthGuardMayHardFail(options.providers)
+}
+
+/** Per-source roster dial budget. OAuth remotes mint a ticket and run
+ *  readiness before /api/profiles; the historical 10s race dropped them on
+ *  cold start even when Test (no deadline) succeeded (#101339). */
+export const DEFAULT_ROSTER_SOURCE_TIMEOUT_MS = 10_000
+export const OAUTH_ROSTER_SOURCE_TIMEOUT_MS = 30_000
+
+export function rosterSourceEnumerationTimeoutMs(connection: {
+  authMode?: string | null
+  kind?: string | null
+}): number {
+  const kind = String(connection.kind || '')
+  const authMode = String(connection.authMode || '')
+
+  if ((kind === 'remote' || kind === 'cloud') && authMode === 'oauth') {
+    return OAUTH_ROSTER_SOURCE_TIMEOUT_MS
+  }
+
+  return DEFAULT_ROSTER_SOURCE_TIMEOUT_MS
+}

--- a/apps/desktop/src/app/settings/connections-registry.tsx
+++ b/apps/desktop/src/app/settings/connections-registry.tsx
@@ -35,6 +35,7 @@ import {
 } from '@/lib/icons'
 import { coerceRemoteUrlScheme } from '@/lib/remote-url'
 import { $activeConnectionId, setConnectionsRegistry } from '@/store/connections'
+import { refreshFleetRoster } from '@/store/fleet-roster'
 import { notify, notifyError } from '@/store/notifications'
 
 import { EmptyState, ListRow, Pill, SectionHeading, ToggleRow } from './primitives'
@@ -552,6 +553,10 @@ export function ConnectionsRegistrySection() {
 
         if (reachable) {
           notify({ title: conn.label, message: s.testOk })
+          // Test is the recovery path for cold-start oauth roster misses
+          // (#101339). Force the fleet rail to re-enumerate immediately —
+          // otherwise a stale incomplete snapshot can sit for up to 60s.
+          void refreshFleetRoster({ force: true })
         } else {
           notifyError(new Error(result.error || conn.label), s.testFailed)
         }

--- a/apps/desktop/src/store/fleet-roster.test.ts
+++ b/apps/desktop/src/store/fleet-roster.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  $fleetRoster,
+  _resetFleetRosterForTests,
+  fleetRosterIsComplete,
+  refreshFleetRoster
+} from './fleet-roster'
+
+describe('fleetRosterIsComplete (#101339)', () => {
+  it('treats missing or empty sources as complete (nothing to retry)', () => {
+    expect(fleetRosterIsComplete(null)).toBe(true)
+    expect(fleetRosterIsComplete({ agents: [], sources: [] } as never)).toBe(true)
+  })
+
+  it('is incomplete when a registered source is unreachable', () => {
+    expect(
+      fleetRosterIsComplete({
+        agents: [],
+        sources: [
+          { connectionId: 'local', kind: 'local', label: 'This device', reachable: true },
+          { connectionId: 'gw', kind: 'remote', label: 'Lab', reachable: false, error: 'roster enumeration timed out' }
+        ]
+      } as never)
+    ).toBe(false)
+  })
+
+  it('treats connect-on-demand as complete (deliberate skip, not a failed dial)', () => {
+    expect(
+      fleetRosterIsComplete({
+        agents: [],
+        sources: [{ connectionId: 'ssh-1', kind: 'ssh', label: 'Box', reachable: false, error: 'connect-on-demand' }]
+      } as never)
+    ).toBe(true)
+  })
+})
+
+describe('refreshFleetRoster incomplete-cache bypass (#101339)', () => {
+  afterEach(() => {
+    _resetFleetRosterForTests()
+    delete (window as { hermesDesktop?: unknown }).hermesDesktop
+  })
+
+  it('refetches within the stale window when the cached roster has an unreachable remote', async () => {
+    const getAgentRoster = vi
+      .fn()
+      .mockResolvedValueOnce({
+        agents: [],
+        sources: [
+          { connectionId: 'local', kind: 'local', label: 'This device', reachable: true },
+          { connectionId: 'gw', kind: 'remote', label: 'Lab', reachable: false, error: 'timed out' }
+        ]
+      })
+      .mockResolvedValueOnce({
+        agents: [{ connectionId: 'gw', profile: 'default', handle: 'default' }],
+        sources: [
+          { connectionId: 'local', kind: 'local', label: 'This device', reachable: true },
+          { connectionId: 'gw', kind: 'remote', label: 'Lab', reachable: true }
+        ]
+      })
+
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = { getAgentRoster }
+
+    await refreshFleetRoster()
+    expect(getAgentRoster).toHaveBeenCalledTimes(1)
+    expect($fleetRoster.get()?.sources?.[1]?.reachable).toBe(false)
+
+    await refreshFleetRoster()
+    expect(getAgentRoster).toHaveBeenCalledTimes(2)
+    expect($fleetRoster.get()?.sources?.[1]?.reachable).toBe(true)
+  })
+
+  it('still skips refetch within the stale window for a complete roster', async () => {
+    const getAgentRoster = vi.fn().mockResolvedValue({
+      agents: [],
+      sources: [{ connectionId: 'local', kind: 'local', label: 'This device', reachable: true }]
+    })
+
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = { getAgentRoster }
+
+    await refreshFleetRoster()
+    await refreshFleetRoster()
+    expect(getAgentRoster).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/store/fleet-roster.ts
+++ b/apps/desktop/src/store/fleet-roster.ts
@@ -15,6 +15,22 @@ const FLEET_ROSTER_STALE_MS = 60_000
 let fetchedAt = 0
 let inflight: null | Promise<void> = null
 
+/**
+ * True when every registered source answered with profiles (or is deliberately
+ * connect-on-demand). An incomplete snapshot — oauth remotes timing out on
+ * cold start (#101339) — must not sit in the 60s stale window and block focus
+ * retries after Settings → Test warms the session.
+ */
+export function fleetRosterIsComplete(roster: DesktopAgentRoster | null | undefined): boolean {
+  const sources = roster?.sources
+
+  if (!Array.isArray(sources) || sources.length === 0) {
+    return true
+  }
+
+  return sources.every(source => source?.reachable !== false || source?.error === 'connect-on-demand')
+}
+
 export async function refreshFleetRoster(options: { force?: boolean } = {}): Promise<void> {
   const bridge = window.hermesDesktop?.getAgentRoster
 
@@ -22,7 +38,14 @@ export async function refreshFleetRoster(options: { force?: boolean } = {}): Pro
     return
   }
 
-  if (!options.force && $fleetRoster.get() && Date.now() - fetchedAt < FLEET_ROSTER_STALE_MS) {
+  const current = $fleetRoster.get()
+
+  if (
+    !options.force &&
+    current &&
+    Date.now() - fetchedAt < FLEET_ROSTER_STALE_MS &&
+    fleetRosterIsComplete(current)
+  ) {
     return
   }
 


### PR DESCRIPTION
## Why
Registered remote OAuth gateways vanished from the Desktop fleet rail after restart until Settings → Connections → Test. Cookie-jar preflight on `buildRemoteConnection` hard-failed as unsigned while the `persist:` jar was still hydrating, so roster dial never minted a ws-ticket. Test mints first and succeeds. The 10s roster deadline also raced oauth mint + readiness.

## Scope
- `apps/desktop/electron/main.ts`: mint-first oauth dial; unsigned only via `shouldTreatOauthMintFailureAsUnsigned`; oauth roster sources use `rosterSourceEnumerationTimeoutMs` (30s).
- `apps/desktop/electron/native-auth-decisions.ts` (+ tests): pure helpers for mint-failure classification and roster budgets.
- `apps/desktop/src/store/fleet-roster.ts` (+ tests): incomplete snapshots (unreachable remotes) do not fill the 60s stale window.
- `apps/desktop/src/app/settings/connections-registry.tsx`: successful Test forces `refreshFleetRoster({ force: true })`.
- Source contract asserts in `backend-dial-claim.test.ts`.

Out of scope: gateway/backend auth, interactive re-login UX, SSH inventory.

## Tradeoffs
Mint-first can issue one extra network round-trip for a truly signed-out user before the unsigned overlay. That matches Test and avoids dropping a live session on cold start.

## Blast Radius
Desktop oauth remote/cloud connect and fleet roster refresh. Local/token/SSH paths keep the 10s roster budget. Safe when cookies are live: mint already ran on the previous path.

## Verification
Worktree `C:\Users\falco\projects\hermes-agent-wt-u22`:

```
cd apps/desktop
npm run test:desktop:platforms -- electron/native-auth-decisions.test.ts electron/backend-dial-claim.test.ts
# 37 passed, exit 0

npm run test:ui -- src/store/fleet-roster.test.ts
# 5 passed, exit 0
```

No live HERMES_HOME / packaged Electron run in this unit.

Fixes #101339