### PR TITLE
fix(desktop): resolve remote group chat titles via botRosterMeta

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
@@ -97,7 +97,7 @@ import { sendToGroupChat, stopGroupThread } from './group-rounds'
 import { clearGroupClarify } from './group-turns'
 import { botsText, useBots } from './i18n'
 import { displayName, slugify, stripPreviewMarkdown } from './labels'
-import { botRosterMeta, setBotsWorkspaceOwner } from './routing'
+import { botRosterMeta, groupMemberDescriptorTitle, groupTranscriptSpeakerMeta, setBotsWorkspaceOwner } from './routing'
 import { bumpBotOpenGeneration, getPluginCtx, ID } from './shared'
 import type { Attachment, BotMeta, GroupChat, GroupMember, GroupMessage, RosterRow } from './types'
 
@@ -715,7 +715,7 @@ export function GroupChatWorkspace({ group, members, onBack, visible = true }: G
   const memberDescriptors = () =>
     members.map(b => ({
       ...b,
-      title: (b.remoteSource ? '' : allMeta[b.name]?.title) || b.title || ''
+      title: groupMemberDescriptorTitle(b, allMeta)
     }))
 
   // Activity disclosure: quiet, collapsed by default. The collapsed row shows
@@ -938,7 +938,8 @@ export function GroupChatWorkspace({ group, members, onBack, visible = true }: G
   // One log entry, rendered exactly as before conversation folding existed.
   const renderEntry = (entry: GroupMessage, index: number) => {
     const isUser = entry.from.kind === 'user'
-    const meta = isUser || entry.from.source ? null : allMeta[entry.from.name]
+    // Source-qualified speakers use owner-aware botRosterMeta (#101382 / #96432).
+    const meta = groupTranscriptSpeakerMeta(entry, members, allMeta)
 
     // Match this speaker back to its member descriptor so display
     // names and disambiguating handles come from the roster (the
@@ -974,8 +975,7 @@ export function GroupChatWorkspace({ group, members, onBack, visible = true }: G
 
     // Speaker avatar: same appearance pipeline as the roster
     // (custom image/pet, else deterministic shape+color face).
-    // Remote speakers have no local meta and get the
-    // deterministic face for their name — stable per bot.
+    // Source-qualified speakers use owner-aware botRosterMeta (#101382).
     // Non-null exactly when !isUser — the user's own lines carry no avatar.
     const appearance = isUser ? null : botAppearance(entry.from.name, meta)
     const image = appearance?.image ?? null

--- a/apps/desktop/src/plugins/hermes-bots/routing.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/routing.test.ts
@@ -21,6 +21,8 @@ import {
   beginAliasRouteIndex,
   botConnectionRoute,
   botRosterMeta,
+  groupMemberDescriptorTitle,
+  groupTranscriptSpeakerMeta,
   indexAliasRoutes,
   requestForBot,
   resolveBotConnectionRoute
@@ -284,5 +286,59 @@ describe('requestForBot rides the bot’s own source', () => {
     expect(error).toBeInstanceOf(Error)
     expect(typeof (error as Error).name).toBe('string')
     expect((error as Error).message).toBe('profile busy')
+  })
+})
+
+describe('group chat remote titles and avatars (#101382)', () => {
+  const localDefault = { name: 'default' } as RosterRow
+  const remoteSpider = {
+    connectionId: 'HermesDocker',
+    connectionLabel: 'HermesDocker',
+    name: 'spider',
+    remoteSource: true,
+    sourceScoped: true
+  } as RosterRow
+  const remoteDefault = {
+    connectionId: 'HermesDocker',
+    connectionLabel: 'HermesDocker',
+    name: 'default',
+    remoteSource: true,
+    sourceScoped: true
+  } as RosterRow
+  const allMeta = {
+    default: { image: 'local.png', title: 'Local Hermes' },
+    'HermesDocker::default': { image: 'remote-default.png', title: 'Remote Hermes' },
+    'HermesDocker::spider': { image: 'spider.png', title: '织网蛛' }
+  }
+
+  it('keeps the configured title on remote member descriptors', () => {
+    expect(groupMemberDescriptorTitle(remoteSpider, allMeta)).toBe('织网蛛')
+    expect(displayName(remoteSpider, botRosterMeta(remoteSpider, allMeta))).toBe('织网蛛')
+  })
+
+  it('gives user lines no bot meta', () => {
+    expect(groupTranscriptSpeakerMeta({ from: { kind: 'user', name: 'You' } }, [localDefault, remoteDefault], allMeta)).toBeNull()
+  })
+
+  it('keeps local meta for a local same-name speaker', () => {
+    const meta = groupTranscriptSpeakerMeta(
+      { from: { kind: 'member', name: 'default' } },
+      [localDefault, remoteDefault],
+      allMeta
+    )
+
+    expect(meta?.image).toBe('local.png')
+    expect(meta?.title).toBe('Local Hermes')
+  })
+
+  it('keeps owner meta for a remote same-name speaker instead of null or the local twin', () => {
+    const meta = groupTranscriptSpeakerMeta(
+      { from: { kind: 'member', name: 'default', source: 'HermesDocker' } },
+      [localDefault, remoteDefault],
+      allMeta
+    )
+
+    expect(meta?.image).toBe('remote-default.png')
+    expect(meta?.title).toBe('Remote Hermes')
   })
 })

--- a/apps/desktop/src/plugins/hermes-bots/routing.ts
+++ b/apps/desktop/src/plugins/hermes-bots/routing.ts
@@ -9,7 +9,7 @@
 
 import { host } from '@hermes/plugin-sdk'
 
-import type { BotMeta, ProfileRoute, RosterRow } from './types'
+import type { BotMeta, GroupMessageAuthor, ProfileRoute, RosterRow } from './types'
 
 export function botRouteKey(route: ProfileRoute): string {
   return `${route.connectionId}::${route.profile}`
@@ -421,4 +421,40 @@ export function botRosterMeta(bot: RosterRow, metaByName: Record<string, BotMeta
   }
 
   return own
+}
+
+/** Group Chat member-descriptor title (#101382). Same owner-aware lookup as
+ *  the sidebar — never clear remote titles just because `remoteSource` is set. */
+export function groupMemberDescriptorTitle(member: RosterRow, allMeta: Record<string, BotMeta>): string {
+  return String(botRosterMeta(member, allMeta)?.title || member.title || '')
+}
+
+/** Group Chat transcript speaker meta (#101382 / #96432). Owner-aware: a
+ *  source-qualified line looks up the matched member via botRosterMeta, never
+ *  `allMeta[name]` and never `null` just because `entry.from.source` is set. */
+export function groupTranscriptSpeakerMeta(
+  entry: { from?: GroupMessageAuthor } | null | undefined,
+  members: RosterRow[],
+  allMeta: Record<string, BotMeta>
+): BotMeta | null | undefined {
+  if (!entry?.from || entry.from.kind === 'user') {
+    return null
+  }
+
+  const member =
+    members.find(
+      bot =>
+        bot.name === entry.from?.name &&
+        (entry.from.source ? (bot.connectionLabel || bot.connectionId) === entry.from.source : !bot.remoteSource)
+    ) || null
+
+  if (member) {
+    return botRosterMeta(member, allMeta)
+  }
+
+  if (entry.from.source) {
+    return null
+  }
+
+  return allMeta?.[entry.from.name] || null
 }


### PR DESCRIPTION
## Why
Group Chat showed connection labels and default faces for remote bots, while the sidebar already showed each bot's configured `ui_meta.hermes-bots.title`. The room used a different meta path that cleared remote titles and forced transcript `meta` to `null` when `entry.from.source` was set.

## Scope
- `apps/desktop/src/plugins/hermes-bots/routing.ts`: add `groupMemberDescriptorTitle` and `groupTranscriptSpeakerMeta` (owner-aware via `botRosterMeta`).
- `apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx`: wire both helpers into member descriptors and `renderEntry`.
- `apps/desktop/src/plugins/hermes-bots/routing.test.ts`: focused coverage for remote titles and same-name local/remote speakers.

Related open transcript work: #96520 / #96519 (closes #96432). This PR also covers the member-descriptor title half called out on #101382.

## Tradeoffs
Adopt the same owner-aware helper shape as #96520 for the transcript path so the two landings stay mergeable. Prefer that over leaving remote names broken until the other PR merges.

## Blast Radius
Desktop Group Chat only. Local members keep `allMeta[name]` behavior. Remote members and source-qualified transcript lines pick up scoped meta keys (`connectionId::profile`). Prompt member lists that stamp `title` now carry the configured name for remote bots.

## Verification
Worktree: `C:\Users\falco\projects\hermes-agent-wt-u23`

```
cd apps/desktop
npx vitest run src/plugins/hermes-bots/routing.test.ts
```

- Before fix: 4 failed | 14 passed, exit 1 (helpers missing).
- After fix: **18 passed**, exit **0**.

No live `HERMES_HOME` / Electron group-chat session (standing order).

Fixes #101382