### PR TITLE
fix(desktop): keep submitted prompt visible after Grok errors

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/agent-init-error.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/agent-init-error.test.tsx
@@ -1,7 +1,7 @@
 import { act, cleanup } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { textPart } from '@/lib/chat-messages'
+import { chatMessageText, textPart } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { $notifications, clearNotifications } from '@/store/notifications'
 
@@ -72,6 +72,26 @@ describe('useMessageStream agent-init error surfacing (#63078)', () => {
 
     // A global toast also fired (turn-ending errors are easy to miss inline).
     expect($notifications.get().some(n => n.kind === 'error' && n.message?.includes('was not sent'))).toBe(true)
+  })
+
+  it('keeps the optimistic prompt body after a Grok-shaped provider error (#101310)', () => {
+    mountStream()
+    seedOptimisticFirstMessage()
+
+    act(() =>
+      stream.handleEvent({
+        payload: { message: 'API call failed after 3 retries: capacity / broken pipe' },
+        session_id: SID,
+        type: 'error'
+      })
+    )
+
+    const state = stream.state()
+    const user = state.messages.find(m => m.id === 'user-123-abc')
+    expect(user).toBeTruthy()
+    expect(chatMessageText(user!)).toBe('first message of a new chat')
+    expect(state.messages.some(m => m.role === 'assistant' && m.error?.includes('API call failed'))).toBe(true)
+    expect(state.busy).toBe(false)
   })
 
   it('renders the pre-ready cancel error event (#65567 server emit) visibly', () => {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -708,10 +708,10 @@ export function useMessageStream({
               nextMessages = prev.map((message, messageIndex) =>
                 messageIndex === index ? completeMessage(message) : message
               )
-            } else if (finalText) {
+            } else if (finalText || completionError) {
               nextMessages = [...prev, newAssistantFromCompletion()]
             }
-          } else if (finalText) {
+          } else if (finalText || completionError) {
             nextMessages = [...prev, newAssistantFromCompletion()]
           }
         }

--- a/apps/desktop/src/app/session/hooks/use-message-stream/terminal-error-frame.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/terminal-error-frame.test.tsx
@@ -96,6 +96,31 @@ describe('terminal error message.complete frames', () => {
     expect(bubble?.errorSurface).toEqual({ layer: 'provider', code: 'rate_limit', retryable: true })
   })
 
+  it('still paints an error bubble when Grok fails before any delta (#101310)', async () => {
+    mountStream()
+    act(() => {
+      const current = stream.state()
+      stream.states.set(SID, {
+        ...current,
+        messages: [
+          { id: 'user-1', role: 'user', parts: [{ type: 'text', text: 'submitted prompt stays' }] },
+          ...current.messages
+        ],
+        busy: true,
+        awaitingResponse: true
+      })
+    })
+
+    await completeWithError({ error: 'API call failed after 3 retries: capacity', text: '' })
+
+    const state = getState()
+    const user = state.messages.find(m => m.id === 'user-1')
+    expect(user).toBeTruthy()
+    expect(chatMessageText(user!)).toBe('submitted prompt stays')
+    expect(lastAssistant()?.error).toContain('API call failed')
+    expect(state.busy).toBe(false)
+  })
+
   it('ignores a garbled error_surface payload (older/foreign backends)', async () => {
     mountStream()
     await start()

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -722,6 +722,15 @@ describe('reconcileResumeMessages', () => {
     expect(reconciled[1]).toMatchObject({ id: 'assistant-stream-live', pending: false })
     expect(chatMessageText(reconciled[1])).toBe('streamed body')
   })
+
+  it('keeps a non-empty optimistic user body over an empty hydrate twin (#101310)', () => {
+    const previous = [msg('user-123-abc', 'user', 'Grok please answer this submitted prompt')]
+    const next = [msg('user-stored-empty', 'user', '')]
+
+    const reconciled = reconcileResumeMessages(next, previous)
+
+    expect(chatMessageText(reconciled[0])).toBe('Grok please answer this submitted prompt')
+  })
 })
 
 describe('preserveLocalPendingTurnMessages', () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -330,6 +330,20 @@ export function reconcileResumeMessages(nextMessages: ChatMessage[], previousMes
     const previousTrimmed = previousVisibleText.trim()
     let preserved = message
 
+    // #101310: post-error hydrate can project an empty user twin at the same
+    // role-ordinal as the optimistic prompt (Grok fails before the submit is
+    // durable). Painting that shell drops the submitted text from the
+    // transcript until hover/copy still has it elsewhere. Keep the local body.
+    if (message.role === 'user' && previous.role === 'user' && !nextText && previousTrimmed) {
+      return {
+        ...message,
+        parts: previous.parts,
+        ...(message.attachmentRefs === undefined && previous.attachmentRefs?.length
+          ? { attachmentRefs: [...previous.attachmentRefs] }
+          : {})
+      }
+    }
+
     // #75825: resume can project an empty (or lagging) inflight assistant shell
     // at the same role-ordinal as the live stream row that still holds the
     // streamed text, reasoning and tool calls. Prefer that richer pending row

--- a/apps/desktop/src/components/assistant-ui/thread/grok-error-prompt-visibility.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/grok-error-prompt-visibility.test.tsx
@@ -1,0 +1,73 @@
+﻿import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { stubThreadEnvironment, stubThreadViewportSize } from '../test-utils'
+
+import { Thread } from '.'
+
+stubThreadEnvironment()
+stubThreadViewportSize()
+
+const createdAt = new Date('2026-05-01T00:00:00.000Z')
+const prompt = 'Grok please answer this submitted prompt'
+
+function userMsg(): ThreadMessage {
+  return {
+    id: 'user-1',
+    role: 'user',
+    content: [{ type: 'text', text: prompt }],
+    attachments: [],
+    createdAt,
+    metadata: { custom: {} }
+  } as ThreadMessage
+}
+
+function errMsg(): ThreadMessage {
+  return {
+    id: 'assistant-error-1',
+    role: 'assistant',
+    content: [],
+    status: { type: 'incomplete', reason: 'error', error: 'API call failed after 3 retries: capacity' },
+    createdAt,
+    metadata: { unstable_state: null, unstable_annotations: [], unstable_data: [], steps: [], custom: {} }
+  } as ThreadMessage
+}
+
+function Harness() {
+  const runtime = useExternalStoreRuntime<ThreadMessage>({
+    messages: [userMsg(), errMsg()],
+    isRunning: false,
+    onNew: async () => {}
+  })
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread />
+    </AssistantRuntimeProvider>
+  )
+}
+
+describe('grok error keeps user prompt painted (#101310)', () => {
+  it('keeps the submitted prompt readable without hover after a Grok-shaped error', () => {
+    const { container } = render(<Harness />)
+
+    expect(screen.getByText(prompt)).toBeTruthy()
+
+    const root = container.querySelector('[data-slot="aui_user-message-root"]') as HTMLElement
+    expect(root).toBeTruthy()
+    expect(root.textContent).toContain(prompt)
+
+    const bubble = container.querySelector('.composer-human-message') as HTMLElement
+    expect(bubble).toBeTruthy()
+    expect(bubble.textContent).toContain(prompt)
+
+    const actions = container.querySelector('[data-slot="aui_user-bubble-actions"]') as HTMLElement
+    expect(actions).toBeTruthy()
+    expect(actions.textContent).toContain(prompt)
+
+    const textEl = bubble.querySelector('.wrap-anywhere') as HTMLElement | null
+    expect(textEl?.textContent).toContain(prompt)
+    expect(textEl?.className ?? '').not.toMatch(/opacity-0/)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -443,7 +443,14 @@ export const UserMessage: FC<{
         }
         messageId={messageId}
       >
-        <ActionBarPrimitive.Root className="relative w-full max-w-full" data-slot="aui_user-bubble-actions">
+        <ActionBarPrimitive.Root
+          // The bubble body lives inside this root (Edit wraps the prompt). Never
+          // autohide — ActionBarRoot returns null when hidden, which would make
+          // the submitted prompt vanish until hover (#101310, same class as Copy).
+          autohide="never"
+          className="relative w-full max-w-full"
+          data-slot="aui_user-bubble-actions"
+        >
           <div className="human-message-with-todos-wrapper flex w-full flex-col gap-0">
             <ReactionPicker
               onOpenChange={setPickerOpen}

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1577,6 +1577,16 @@ body.guest-pointer-lock :is(webview, iframe) {
   mask-image: linear-gradient(to bottom, #000 55%, transparent);
 }
 
+/* #101310: after a provider error the turn has no streaming reply underneath,
+   so a clamped (or mask-faded) prompt reads as "send vanished until hover".
+   Lift the clamp for any turn that already carries an error alert. */
+[data-slot='aui_turn-pair']:has([role='alert']) .sticky-human-clamp {
+  max-height: none;
+  overflow: visible;
+  -webkit-mask-image: none;
+  mask-image: none;
+}
+
 /* Stick-to-bottom owns scrollTop while following. Once escaped, native anchoring
    is safe and keeps sticky human edits from shoving the viewport; data-editing
    enables that path before React swaps in the inline editor. */


### PR DESCRIPTION
## Why

After an xAI Grok provider failure, the already-submitted user prompt could disappear from the Desktop transcript until hover (the same reveal pattern as Copy). The send felt lost even though the text was still in memory.

Fixes #101310

## Scope

- `reconcileResumeMessages` keeps a non-empty local user body when hydrate projects an empty twin at the same role ordinal.
- `completeAssistantMessage` still appends an error assistant when a structured failure arrives with no streamed text.
- Sticky clamp lifts for turns that already show an error alert; user `ActionBarPrimitive.Root` sets `autohide=never` so the bubble body cannot unmount on hide.
- Focused tests: agent-init / terminal-error / reconcile / transcript paint.

Out of scope: #101321 Grok answer stacking (separate unit / open PRs such as #101376).

## Tradeoffs

Clamp still applies on healthy streaming turns. Only error turns lift it so a failed send stays readable without changing the long-prompt sticky behavior on success.

## Blast Radius

Desktop transcript only (`apps/desktop/**`). Hydrate reconcile is shared with resume/reconnect; the empty-user guard is narrow (empty next + non-empty previous at the same user ordinal).

## Verification

```
cd apps/desktop
npm run test:ui -- src/app/session/hooks/use-message-stream/agent-init-error.test.tsx src/app/session/hooks/use-message-stream/terminal-error-frame.test.tsx src/app/session/hooks/use-session-actions/utils.test.ts src/components/assistant-ui/thread/grok-error-prompt-visibility.test.tsx
```

Result: **122 passed**, exit **0**.