### PR TITLE
fix(gateway): drain async delegations before restart

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9437,12 +9437,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return len(self._running_agents)
 
     def _active_work_count(self) -> int:
-        """All agent work the gateway must expose and drain as one total."""
+        """All agent work the gateway must expose and drain as one total.
+
+        Async delegations are daemon-thread work owned by this process. A
+        planned restart must wait for them too; otherwise the requesting chat
+        turn can finish, the restart proceeds, and completed child work is
+        discarded when the process exits.
+        """
+        try:
+            from tools.async_delegation import active_count
+
+            async_delegations = max(0, int(active_count()))
+        except Exception:
+            logger.debug(
+                "Active async-delegation count unavailable during drain",
+                exc_info=True,
+            )
+            async_delegations = 0
         return (
             self._running_agent_count()
             + self._active_cron_job_count()
             + self._active_api_run_count()
             + self._active_deferred_agent_worker_count()
+            + async_delegations
         )
 
     def _active_cron_job_count(self) -> int:

--- a/tests/gateway/test_restart_after_turn.py
+++ b/tests/gateway/test_restart_after_turn.py
@@ -53,3 +53,17 @@ def test_load_restart_after_turn_timeout_preserves_zero(tmp_path, monkeypatch):
 
     monkeypatch.setenv("HERMES_RESTART_AFTER_TURN_TIMEOUT", "0")
     assert GatewayRunner._load_restart_after_turn_timeout() == 0.0
+
+
+def test_active_work_count_includes_async_delegations(monkeypatch):
+    """A planned restart must not kill detached subagents after the parent turn."""
+    import tools.async_delegation as async_delegation
+
+    runner = object.__new__(GatewayRunner)
+    monkeypatch.setattr(runner, "_running_agent_count", lambda: 0)
+    monkeypatch.setattr(runner, "_active_cron_job_count", lambda: 0)
+    monkeypatch.setattr(runner, "_active_api_run_count", lambda: 0)
+    monkeypatch.setattr(runner, "_active_deferred_agent_worker_count", lambda: 0)
+    monkeypatch.setattr(async_delegation, "active_count", lambda: 1)
+
+    assert runner._active_work_count() == 1


### PR DESCRIPTION
## Summary
- count active `delegate_task(background=true)` runs as gateway work
- make planned restart/update drains wait for detached subagents instead of killing their daemon threads after the parent chat turn ends
- add regression coverage for the active-work count

## Root cause
A planned update waited for the requesting chat turn, then restarted while its detached delegation was still running. The daemon-thread child died with the gateway, and startup recovery could only report `Delegation owner exited before recording a terminal result; outcome unknown.`

## Verification
- `uv run --with pytest pytest tests/gateway/test_restart_after_turn.py tests/tools/test_async_delegation.py tests/agent/test_proactive_tool_result_pruning.py tests/agent/test_proactive_prune_restart_safety.py tests/tui_gateway/test_compression_config_hot_reload.py -q`
- 65 passed, 1 skipped
- `git diff --check`