### PR TITLE
fix(desktop): keep transcript across cold reconnect empty REST

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -2466,6 +2466,7 @@ describe('resumeSession warm-cache mapping integrity', () => {
     cleanup()
     setActiveSessionId(null)
     setResumeFailedSessionId(null)
+    setSelectedStoredSessionId(null)
     setMessages([])
     setSessions([])
     vi.mocked(getSession).mockReset()
@@ -3585,6 +3586,96 @@ describe('resumeSession warm-cache mapping integrity', () => {
     const renderedMessages = JSON.stringify(resumedState?.messages)
     expect(renderedMessages).toContain('still here after wake')
     expect(renderedMessages).toContain('still here after wake too')
+  })
+
+  it('keeps the on-screen transcript across cold reconnect when REST returns empty (#100970)', async () => {
+    // Sleep/wake and VPS blips call resetTileRuntimeBindings, which drops the
+    // stored→runtime map and forces a cold session.resume. The concurrent REST
+    // prefetch can race a remote state.db and return []. That empty page must
+    // not wipe completed turns still painted in $messages, and omit_messages
+    // resume must graft onto that view instead of reconciling against [].
+    const liveMessages = [
+      {
+        id: 'user-completed',
+        role: 'user' as const,
+        parts: [{ type: 'text' as const, text: 'completed turn before disconnect' }]
+      },
+      {
+        id: 'assistant-completed',
+        role: 'assistant' as const,
+        parts: [{ type: 'text' as const, text: 'completed answer before disconnect' }]
+      },
+      {
+        id: 'user-active',
+        role: 'user' as const,
+        parts: [{ type: 'text' as const, text: 'active turn still running' }]
+      },
+      {
+        id: 'assistant-stream-1',
+        role: 'assistant' as const,
+        pending: true,
+        parts: [{ type: 'text' as const, text: 'partial tool output before lid close' }]
+      }
+    ]
+
+    setSessions([storedSession({ id: 'stored-A', message_count: 4, title: 'VPS chat' })])
+    setSelectedStoredSessionId('stored-A')
+    setMessages(liveMessages)
+
+    vi.mocked(getLatestSessionMessages).mockResolvedValue({ messages: [], session_id: 'stored-A' } as never)
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.resume') {
+        return {
+          session_id: 'rt-A-reborn',
+          session_key: 'stored-A',
+          resumed: params?.session_id,
+          message_count: 4,
+          messages: [],
+          messages_omitted: true,
+          running: true,
+          inflight: {
+            user: 'active turn still running',
+            assistant: 'partial tool output before lid close',
+            streaming: true
+          },
+          info: {}
+        } as never
+      }
+
+      return {} as never
+    })
+
+    let resumedState: ClientSessionState | undefined
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+
+    render(
+      <ResumeHarness
+        onReady={ready => (resume = ready)}
+        onStateUpdate={(_sessionId, next) => (resumedState = next)}
+        requestGateway={requestGateway}
+        selectedStoredSessionId="stored-A"
+        runtimeIdByStoredSessionIdRef={{ current: new Map() }}
+        sessionStateByRuntimeIdRef={{ current: new Map() }}
+      />
+    )
+    await waitFor(() => expect(resume).not.toBeNull())
+    await resume!('stored-A', true)
+
+    expect(requestGateway).toHaveBeenCalledWith(
+      'session.resume',
+      expect.objectContaining({ omit_messages: true, session_id: 'stored-A' })
+    )
+
+    const painted = JSON.stringify($messages.get())
+    const cached = JSON.stringify(resumedState?.messages)
+    expect(painted).toContain('completed turn before disconnect')
+    expect(painted).toContain('completed answer before disconnect')
+    expect(painted).toContain('partial tool output before lid close')
+    expect(cached).toContain('completed turn before disconnect')
+    expect(cached).toContain('completed answer before disconnect')
+    expect($activeSessionId.get()).toBe('rt-A-reborn')
+    expect($resumeFailedSessionId.get()).toBeNull()
   })
 
   it('keeps the complete persisted transcript when activating a compressed running session', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -1579,19 +1579,25 @@ export function useSessionActions({
             ? preserveLocalPendingTurnMessages(viewMessagesForReconcile(), resumeStartMessages)
             : viewMessagesForReconcile()
 
-          // Tail page + previously backfilled prefix (same-session re-resume).
-          const graftedPrefetch = graftRefreshedTailOntoBackfill(
-            toChatMessages(prefetchedResult.messages),
-            previousMessages
-          )
+          // An empty REST page is not proof the transcript is empty — a just-
+          // reconnected VPS can race state.db and return zero rows while the
+          // view still holds the live conversation (#100970). Same guard as the
+          // warm activate path: only trust an empty page when the view is empty.
+          if (prefetchedResult.messages.length || previousMessages.length === 0) {
+            // Tail page + previously backfilled prefix (same-session re-resume).
+            const graftedPrefetch = graftRefreshedTailOntoBackfill(
+              toChatMessages(prefetchedResult.messages),
+              previousMessages
+            )
 
-          prefetchedTranscriptMessages = graftedPrefetch
-          localSnapshot = reconcileAuthoritativeChatMessages(graftedPrefetch, previousMessages)
-          prefetchApplied = true
-          prefetchedStoredSessionId = prefetchedResult.session_id || storedSessionId
+            prefetchedTranscriptMessages = graftedPrefetch
+            localSnapshot = reconcileAuthoritativeChatMessages(graftedPrefetch, previousMessages)
+            prefetchApplied = true
+            prefetchedStoredSessionId = prefetchedResult.session_id || storedSessionId
 
-          if (!chatMessageArraysEquivalent($messages.get(), localSnapshot)) {
-            setMessages(localSnapshot)
+            if (!chatMessageArraysEquivalent($messages.get(), localSnapshot)) {
+              setMessages(localSnapshot)
+            }
           }
         }
 
@@ -1659,7 +1665,14 @@ export function useSessionActions({
             ? preserveLocalPendingTurnMessages(currentMessages, resumeStartMessages)
             : currentMessages
 
-          const resumedMessages = reconcileAuthoritativeMessages(resumed.messages, previousMessages, resumed)
+          // Cold resume requests omit_messages; reconciling against [] would
+          // rebuild the thread from an empty authority and drop completed turns
+          // that are still on screen after reconnect invalidated the warm map.
+          const resumedMessages = resumed.messages_omitted
+            ? appendLiveSessionProjection(previousMessages, resumed)
+            : resumed.messages.length || resumed.inflight || resumed.queued
+              ? reconcileAuthoritativeMessages(resumed.messages, previousMessages, resumed)
+              : previousMessages
 
           return chatMessageArraysEquivalent(currentMessages, resumedMessages) ? currentMessages : resumedMessages
         })()


### PR DESCRIPTION
## Why

Mac Desktop clients on a remote VPS lose the active chat after a network drop or lid close. Reconnect clears warm runtime bindings and cold-resumes with `omit_messages`. A racing empty REST page then wiped completed and in-flight turns from the view (#100970).

Related #101408 / #101531 cover transport rebind / detach. This change only stops the transcript wipe on the cold same-session reconnect path.

## Scope

- `apps/desktop/src/app/session/hooks/use-session-actions/index.ts`: skip empty REST prefetch when the view still has messages; treat `messages_omitted` cold resumes like warm activate (graft onto the on-screen transcript).
- `apps/desktop/src/app/session/hooks/use-session-actions.test.tsx`: regression for cold reconnect with empty REST + omitted resume payload.

Out of scope: gateway backlog replay, new sequence-id protocol, tile detach fixes already covered by #101531.

## Tradeoffs

Trust the on-screen transcript when REST returns zero rows after reconnect, instead of treating empty as authoritative. A genuinely empty session still fails the existing `sessionShouldHaveTranscript` latch when both sources agree the view is empty.

## Blast Radius

Desktop primary-chat resume after primary reconnect / sleep-wake. Session switches that already clear the view keep the empty-page path. No gateway or REST API changes.

## Verification

Worktree: `C:\Users\falco\projects\hermes-agent-wt-u28`

```
cd apps/desktop
npm run test:ui -- src/app/session/hooks/use-session-actions.test.tsx -t "keeps the on-screen transcript across cold reconnect"
```

- Result: 1 passed | 97 skipped, exit 0

```
npm run test:ui -- src/app/session/hooks/use-session-actions.test.tsx
```

- Result: 98 passed, exit 0

Closes #100970
