### PR TITLE
fix(desktop): surface projects.create server errors in the create sheet

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/project-dialog.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/project-dialog.test.tsx
@@ -1,4 +1,5 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { JsonRpcGatewayError } from '@hermes/shared'
 import type * as Nanostores from 'nanostores'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -9,11 +10,11 @@ afterEach(cleanup)
 vi.mock('@/i18n', () => ({
   useI18n: () => ({
     t: {
-      common: { cancel: 'Cancel', save: 'Save' },
+      common: { cancel: 'Cancel', close: 'Close', save: 'Save' },
       sidebar: {
         projects: {
           addFolder: 'Add folder',
-          create: 'Create',
+          create: 'Create project',
           createDesc: 'Create a new project',
           createFailed: 'Failed to create project',
           createTitle: 'New project',
@@ -38,13 +39,15 @@ vi.mock('@/i18n', () => ({
 // store (backend calls, project list, etc.) which is irrelevant to the Tip fix.
 // vi.mock factories are hoisted above the rest of the file, so the atom must
 // be created inside vi.hoisted to exist by the time the factory runs.
-const { $projectDialog } = vi.hoisted(() => {
+const { $projectDialog, createProject, pickProjectFolder } = vi.hoisted(() => {
   const { atom } = require('nanostores') as typeof Nanostores
 
   return {
     $projectDialog: atom<{ mode: 'create' | 'rename' | 'add-folder'; name?: string; projectId?: string } | null>({
       mode: 'create'
-    })
+    }),
+    createProject: vi.fn(),
+    pickProjectFolder: vi.fn(async () => '/home/hermes/.hermes/projects/agent-from-scratch')
   }
 })
 
@@ -52,14 +55,10 @@ vi.mock('@/store/projects', () => ({
   $projectDialog,
   addProjectFolder: vi.fn(),
   closeProjectDialog: vi.fn(),
-  createProject: vi.fn(),
+  createProject,
   generateProjectIdea: vi.fn(),
-  pickProjectFolder: vi.fn(async () => '/Users/test/my-folder'),
+  pickProjectFolder,
   renameProject: vi.fn()
-}))
-
-vi.mock('@/store/notifications', () => ({
-  notifyError: vi.fn()
 }))
 
 vi.mock('@/lib/project-idea-templates', () => ({
@@ -83,5 +82,48 @@ describe('ProjectDialog', () => {
 
     const button = await screen.findByRole('button', { name: 'Remove folder' })
     expect(tipTrigger(button)).toBeTruthy()
+  })
+
+  it('keeps the sheet open and shows the server RPC message when create fails', async () => {
+    createProject.mockRejectedValueOnce(
+      new JsonRpcGatewayError(
+        "folder already belongs to project 'agent-from-scratch' (p_abc); switch to it instead of creating a duplicate",
+        { code: 5063 }
+      )
+    )
+
+    render(<ProjectDialog />)
+
+    fireEvent.change(screen.getByPlaceholderText('Project name'), {
+      target: { value: 'agent-from-scratch' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Add folder' }))
+    await screen.findByRole('button', { name: 'Remove folder' })
+    fireEvent.click(screen.getByRole('button', { name: 'Create project' }))
+
+    expect(
+      await screen.findByText(
+        "folder already belongs to project 'agent-from-scratch' (p_abc); switch to it instead of creating a duplicate"
+      )
+    ).toBeTruthy()
+    expect(screen.queryByText(/Hermes RPC request failed \(5063\)/)).toBeNull()
+    expect(screen.getByRole('button', { name: 'Create project' })).toBeTruthy()
+  })
+
+  it('shows the opaque code fallback only when the gateway omitted a message', async () => {
+    createProject.mockRejectedValueOnce(new JsonRpcGatewayError('', { code: 5063 }))
+
+    render(<ProjectDialog />)
+
+    fireEvent.change(screen.getByPlaceholderText('Project name'), {
+      target: { value: 'agent-from-scratch' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Add folder' }))
+    await screen.findByRole('button', { name: 'Remove folder' })
+    fireEvent.click(screen.getByRole('button', { name: 'Create project' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Hermes RPC request failed (5063)')).toBeTruthy()
+    })
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/project-dialog.tsx
+++ b/apps/desktop/src/app/chat/sidebar/project-dialog.tsx
@@ -16,9 +16,9 @@ import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Tip } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
+import { formatGatewayRpcError } from '@/lib/gateway-rpc'
 import { type ProjectIdeaTemplate, randomIdeaTemplates } from '@/lib/project-idea-templates'
 import { cn } from '@/lib/utils'
-import { notifyError } from '@/store/notifications'
 import {
   $projectDialog,
   addProjectFolder,
@@ -45,6 +45,7 @@ export function ProjectDialog() {
   const [templates, setTemplates] = useState<ProjectIdeaTemplate[]>([])
   const [generatingIdea, setGeneratingIdea] = useState(false)
   const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<null | string>(null)
   const nameRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
@@ -55,6 +56,7 @@ export function ProjectDialog() {
       setTemplates(randomIdeaTemplates())
       setGeneratingIdea(false)
       setSubmitting(false)
+      setError(null)
 
       if (mode !== 'add-folder') {
         window.setTimeout(() => nameRef.current?.select(), 0)
@@ -69,19 +71,21 @@ export function ProjectDialog() {
   }
 
   // One submit beat for every flow: guard re-entry, run the write, close on
-  // success, surface a toast on failure. Callers pass only the write.
+  // success, keep the sheet open with the server error on failure so mobile
+  // still sees the actionable message (not only an opaque RPC code toast).
   const runSubmit = async (write: () => Promise<unknown>) => {
     if (submitting) {
       return
     }
 
     setSubmitting(true)
+    setError(null)
 
     try {
       await write()
       closeProjectDialog()
     } catch (err) {
-      notifyError(err, p.createFailed)
+      setError(formatGatewayRpcError(err, p.createFailed))
     } finally {
       setSubmitting(false)
     }
@@ -103,9 +107,10 @@ export function ProjectDialog() {
         return
       }
 
+      setError(null)
       setFolders(prev => (prev.includes(dir) ? prev : [...prev, dir]))
     } catch (err) {
-      notifyError(err, p.createFailed)
+      setError(formatGatewayRpcError(err, p.createFailed))
     }
   }
 
@@ -150,7 +155,12 @@ export function ProjectDialog() {
 
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
-      <DialogContent className="max-w-md" onInteractOutside={event => event.preventDefault()}>
+      <DialogContent
+        banner={error}
+        bannerTone="error"
+        className="max-w-md"
+        onInteractOutside={event => event.preventDefault()}
+      >
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           {mode === 'create' && <DialogDescription>{p.createDesc}</DialogDescription>}

--- a/apps/desktop/src/lib/gateway-rpc.test.ts
+++ b/apps/desktop/src/lib/gateway-rpc.test.ts
@@ -1,6 +1,7 @@
+import { JsonRpcGatewayError } from '@hermes/shared'
 import { describe, expect, it } from 'vitest'
 
-import { isMissingPendingPromptRequest, isMissingRpcMethod } from './gateway-rpc'
+import { formatGatewayRpcError, isMissingPendingPromptRequest, isMissingRpcMethod } from './gateway-rpc'
 
 describe('isMissingRpcMethod', () => {
   it('detects JSON-RPC method-not-found errors', () => {
@@ -12,6 +13,26 @@ describe('isMissingRpcMethod', () => {
   it('ignores unrelated failures', () => {
     expect(isMissingRpcMethod(new Error('Hermes gateway is not connected'))).toBe(false)
     expect(isMissingRpcMethod(new Error('no such project'))).toBe(false)
+  })
+})
+
+describe('formatGatewayRpcError', () => {
+  it('prefers the server message on projects.create 5063 failures', () => {
+    expect(
+      formatGatewayRpcError(
+        new JsonRpcGatewayError(
+          "folder already belongs to project 'demo' (p_1); switch to it instead of creating a duplicate",
+          { code: 5063 }
+        ),
+        'Could not create project'
+      )
+    ).toBe("folder already belongs to project 'demo' (p_1); switch to it instead of creating a duplicate")
+  })
+
+  it('falls back to an opaque code label only when the message is empty', () => {
+    expect(formatGatewayRpcError(new JsonRpcGatewayError('', { code: 5063 }), 'Could not create project')).toBe(
+      'Hermes RPC request failed (5063)'
+    )
   })
 })
 

--- a/apps/desktop/src/lib/gateway-rpc.ts
+++ b/apps/desktop/src/lib/gateway-rpc.ts
@@ -1,8 +1,37 @@
+import { JsonRpcGatewayError } from '@hermes/shared'
+
 /** True when a JSON-RPC call failed because the backend predates the method. */
 export function isMissingRpcMethod(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error)
 
   return /method not found|-32601|unknown method|no such method/i.test(message)
+}
+
+/** User-facing text for a gateway RPC failure. Prefer the server message; keep
+ *  the numeric code only as a diagnostic suffix when the message is missing or
+ *  already the opaque `Hermes RPC request failed (N)` fallback. */
+export function formatGatewayRpcError(error: unknown, fallback = 'request failed'): string {
+  if (error instanceof JsonRpcGatewayError) {
+    const message = typeof error.message === 'string' ? error.message.trim() : ''
+
+    if (message) {
+      return message
+    }
+
+    if (typeof error.code === 'number') {
+      return `Hermes RPC request failed (${error.code})`
+    }
+  }
+
+  if (error instanceof Error && error.message.trim()) {
+    return error.message.trim()
+  }
+
+  if (typeof error === 'string' && error.trim()) {
+    return error.trim()
+  }
+
+  return fallback
 }
 
 /** REST twin of isMissingRpcMethod: the route does not exist on this backend.

--- a/apps/desktop/src/lib/json-rpc-gateway-url-guard.test.ts
+++ b/apps/desktop/src/lib/json-rpc-gateway-url-guard.test.ts
@@ -126,4 +126,60 @@ describe('JsonRpcGatewayClient structured errors', () => {
       vi.unstubAllGlobals()
     }
   })
+
+  it('keeps an empty server message from becoming a silent failure when a code is present', async () => {
+    class RespondingSocket {
+      static OPEN = 1
+      readyState = 0
+      private messageHandler: ((event: { data: string }) => void) | null = null
+
+      addEventListener = vi.fn((type: string, handler: (event?: { data: string }) => void) => {
+        if (type === 'open') {
+          setTimeout(() => {
+            this.readyState = RespondingSocket.OPEN
+            handler()
+          }, 0)
+        }
+
+        if (type === 'message') {
+          this.messageHandler = handler as (event: { data: string }) => void
+        }
+      })
+      removeEventListener = vi.fn()
+      close = vi.fn()
+      send = vi.fn((raw: string) => {
+        const req = JSON.parse(raw) as { id: string }
+        queueMicrotask(() => {
+          this.messageHandler?.({
+            data: JSON.stringify({
+              jsonrpc: '2.0',
+              id: req.id,
+              error: { code: 5063, message: '   ' }
+            })
+          })
+        })
+      })
+    }
+
+    vi.stubGlobal('WebSocket', RespondingSocket)
+
+    try {
+      const client = new JsonRpcGatewayClient({
+        requestTimeoutMs: 5_000,
+        socketFactory: () => new RespondingSocket() as unknown as WebSocket
+      })
+
+      await client.connect('ws://127.0.0.1:1234/api/ws?token=t')
+
+      await expect(client.request('projects.create', { name: 'x' })).rejects.toEqual(
+        expect.objectContaining({
+          name: 'JsonRpcGatewayError',
+          code: 5063,
+          message: 'Hermes RPC request failed (5063)'
+        })
+      )
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
 })

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -424,9 +424,41 @@ describe('createProject', () => {
     const result = await createProject({ folders: ['/srv/demo'], name: 'Demo', use: true })
 
     expect(result).toEqual(created)
-    expect(request).toHaveBeenCalledWith('projects.create', expect.objectContaining({ name: 'Demo' }))
+    expect(request).toHaveBeenCalledWith(
+      'projects.create',
+      expect.objectContaining({
+        name: 'Demo',
+        folders: ['/srv/demo'],
+        primary_path: '/srv/demo'
+      })
+    )
     expect($sidebarAgentsGrouped.get()).toBe(true)
     expect($activeProjectId.get()).toBe('p_new')
+  })
+
+  it('sends the selected host folder as primary_path when creating from a remote pick', async () => {
+    const hostFolder = '/home/hermes/.hermes/projects/agent-from-scratch'
+    const created = { folders: [], id: 'p_host', name: 'agent-from-scratch', primary_path: hostFolder }
+    const request = vi.fn(async (method: string) => {
+      if (method === 'projects.create') {
+        return { project: created }
+      }
+
+      return { active_id: 'p_host', projects: [created], scoped_session_ids: [] }
+    })
+
+    activeGateway.mockReturnValue({ connectionState: 'open', request } as never)
+
+    await createProject({ folders: [hostFolder], name: 'agent-from-scratch', use: true })
+
+    expect(request).toHaveBeenCalledWith(
+      'projects.create',
+      expect.objectContaining({
+        folders: [hostFolder],
+        name: 'agent-from-scratch',
+        primary_path: hostFolder
+      })
+    )
   })
 
   it('marks the backend stale and surfaces a friendly error when projects.create is missing', async () => {

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -858,12 +858,18 @@ export async function createProject(input: CreateProjectInput): Promise<ProjectI
   let res: { project: ProjectInfo | null }
 
   try {
+    const folders = input.folders ?? []
+    // Remote/mobile folder picks often omit primaryPath; the gateway still
+    // defaults to folders[0], but send it explicitly so older cores and the
+    // duplicate-primary-path check see the same path the user selected.
+    const primaryPath = input.primaryPath ?? folders[0]
+
     res = await gatewayRequest<{ project: ProjectInfo | null }>(
       'projects.create',
       projectParams({
         name: input.name,
-        folders: input.folders ?? [],
-        primary_path: input.primaryPath,
+        folders,
+        primary_path: primaryPath,
         slug: input.slug,
         description: input.description,
         icon: input.icon,

--- a/apps/shared/src/json-rpc-gateway.ts
+++ b/apps/shared/src/json-rpc-gateway.ts
@@ -449,9 +449,17 @@ export class JsonRpcGatewayClient {
       this.clearPending(frame.id)
 
       if (frame.error) {
+        const code = typeof frame.error.code === 'number' ? frame.error.code : undefined
+        const message =
+          typeof frame.error.message === 'string' && frame.error.message.trim()
+            ? frame.error.message.trim()
+            : code !== undefined
+              ? `Hermes RPC request failed (${code})`
+              : 'Hermes RPC failed'
+
         call.reject(
-          new JsonRpcGatewayError(frame.error.message || 'Hermes RPC failed', {
-            code: typeof frame.error.code === 'number' ? frame.error.code : undefined,
+          new JsonRpcGatewayError(message, {
+            code,
             data: frame.error.data
           })
         )


### PR DESCRIPTION
## Why
Mobile create-project failed with an opaque `Hermes RPC request failed (5063)` while the gateway already returned an actionable `ValueError` message. The create sheet stayed open but never showed that text.

## Scope
- `ProjectDialog` keeps the sheet open and renders the server message in the dialog banner.
- `formatGatewayRpcError` prefers `JsonRpcGatewayError.message`.
- `JsonRpcGatewayClient` only uses the opaque code fallback when the wire message is empty/whitespace.
- `createProject` sends `primary_path` from the selected host folder when the caller omits it.
- Focused tests for banner copy, RPC formatting, empty-message fallback, and remote-folder payload shape.

Out of scope: gateway/projects_db duplicate-path policy changes.

## Tradeoffs
Inline banner replaces the create-flow toast so the error stays on the sheet the user is already looking at. Toast remains available elsewhere via `notifyError`.

## Blast Radius
Desktop create/rename/add-folder project dialog and shared JSON-RPC error construction. Safe when the gateway includes a message; opaque code text remains only as an empty-message fallback.

## Verification
Worktree: `C:\Users\falco\projects\hermes-agent-wt-u25`

```
cd apps/desktop
npm test -- src/app/chat/sidebar/project-dialog.test.tsx src/lib/gateway-rpc.test.ts src/lib/json-rpc-gateway-url-guard.test.ts src/store/projects.test.ts
```

Result: 58 passed, exit 0.

Fixes https://github.com/NousResearch/hermes-agent/issues/99961