### PR TITLE
fix(desktop): route local Bot Mode RPCs to the named profile gateway

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/cron-rpc-error.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/cron-rpc-error.test.ts
@@ -13,12 +13,12 @@
 import type * as HermesSdk from '@hermes/plugin-sdk'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const request = vi.fn()
+const requestLocalProfileGateway = vi.fn()
 
 vi.mock('@hermes/plugin-sdk', async importOriginal => {
   const sdk = await importOriginal<typeof HermesSdk>()
 
-  return { ...sdk, host: { ...sdk.host, request } }
+  return { ...sdk, host: { ...sdk.host, requestLocalProfileGateway } }
 })
 
 const { loadRoutines } = await import('./cron')
@@ -31,7 +31,7 @@ function react19Format(error: { message?: unknown; name?: unknown }) {
 
 /** The rejection `requestForBot` hands back, after coercion. */
 async function rejectionFrom(thrown: unknown) {
-  request.mockRejectedValue(thrown)
+  requestLocalProfileGateway.mockRejectedValue(thrown)
 
   return requestForBot({ name: 'research' }, 'cron.manage', {}).then(
     () => {
@@ -47,7 +47,7 @@ beforeEach(() => {
 
 describe('a rejection always reaches React with a string name', () => {
   it('coerces a plain JSON-RPC object whose name is an error code', async () => {
-    request.mockRejectedValue({ code: -32603, message: 'cron.manage failed', name: 32000 })
+    requestLocalProfileGateway.mockRejectedValue({ code: -32603, message: 'cron.manage failed', name: 32000 })
 
     const error = await loadRoutines('research').then(
       () => {

--- a/apps/desktop/src/plugins/hermes-bots/cross-connection-bots.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/cross-connection-bots.test.ts
@@ -20,9 +20,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { GroupMember, ProfileRoute, RosterRow } from './types'
 
-const { overrides, request, requestProfile } = vi.hoisted(() => ({
+const { overrides, request, requestLocalProfileGateway, requestProfile } = vi.hoisted(() => ({
   overrides: {} as Record<string, unknown>,
   request: vi.fn(),
+  requestLocalProfileGateway: vi.fn(),
   requestProfile: vi.fn()
 }))
 
@@ -30,6 +31,7 @@ vi.mock('@hermes/plugin-sdk', async importOriginal => {
   const sdk = await importOriginal<typeof HermesSdk>()
 
   overrides.request = request
+  overrides.requestLocalProfileGateway = requestLocalProfileGateway
   overrides.requestProfile = requestProfile
 
   return {
@@ -60,6 +62,7 @@ const aliasBot = {
 beforeEach(() => {
   vi.clearAllMocks()
   request.mockResolvedValue({})
+  requestLocalProfileGateway.mockResolvedValue({})
   requestProfile.mockResolvedValue({})
 })
 
@@ -91,7 +94,7 @@ describe('every source-scoped row resolves to an immutable owner', () => {
 })
 
 describe('requestForBot dispatches on the owner, not the active gateway', () => {
-  it('sends source-scoped rows through requestProfile and local rows through request', async () => {
+  it('sends source-scoped rows through requestProfile and local rows through requestLocalProfileGateway', async () => {
     await requestForBot({ name: 'local-bot' }, 'session.create', { title: 'x' })
     await requestForBot({ connectionId: 'local', name: 'local-bot', sourceScoped: true }, 'session.create', {
       title: 'x'
@@ -100,7 +103,10 @@ describe('requestForBot dispatches on the owner, not the active gateway', () => 
       text: 'hi'
     })
 
-    expect(request.mock.calls.map(([method]) => method)).toEqual(['session.create'])
+    expect(requestLocalProfileGateway.mock.calls.map(([profile, method]) => [profile, method])).toEqual([
+      ['local-bot', 'session.create']
+    ])
+    expect(request).not.toHaveBeenCalled()
     // A registered LOCAL source still uses the explicit descriptor.
     expect(requestProfile.mock.calls.map(([route, method]) => [route.connectionId, method])).toEqual([
       ['local', 'session.create'],

--- a/apps/desktop/src/plugins/hermes-bots/routing.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/routing.test.ts
@@ -30,6 +30,7 @@ import type { ProfileRoute, RosterRow } from './types'
 const { hostMock } = vi.hoisted(() => ({
   hostMock: {
     request: vi.fn(),
+    requestLocalProfileGateway: vi.fn(),
     requestProfile: vi.fn(),
     state: { connectionId: { get: vi.fn(() => 'local') } }
   }
@@ -277,12 +278,25 @@ describe('requestForBot rides the bot’s own source', () => {
   it('coerces a JSON-RPC rejection into an Error with a string name (#94471)', async () => {
     // React 19 formats query errors with `(error.name || '').trim()`; a
     // numeric JSON-RPC `name` crashed the Routines pane and hid the cause.
-    hostMock.request.mockRejectedValue({ code: -32000, message: 'profile busy', name: -32000 })
+    hostMock.requestLocalProfileGateway.mockRejectedValue({ code: -32000, message: 'profile busy', name: -32000 })
 
     const error = await requestForBot({ name: 'ops' }, 'cron.list', {}).catch((thrown: unknown) => thrown)
 
     expect(error).toBeInstanceOf(Error)
     expect(typeof (error as Error).name).toBe('string')
     expect((error as Error).message).toBe('profile busy')
+  })
+
+  it('pins an unscoped local bot to its own profile gateway, not the active socket (#101422)', async () => {
+    hostMock.requestLocalProfileGateway.mockResolvedValue({ ok: true })
+
+    await requestForBot({ name: 'default' }, 'session.create', { profile: 'default', title: 'Bot Chat' })
+    await requestForBot({ name: 'default' }, 'prompt.submit', { session_id: 'rt-1', text: 'hi' })
+
+    expect(hostMock.requestLocalProfileGateway.mock.calls.map(([profile, method]) => [profile, method])).toEqual([
+      ['default', 'session.create'],
+      ['default', 'prompt.submit']
+    ])
+    expect(hostMock.request).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/plugins/hermes-bots/routing.ts
+++ b/apps/desktop/src/plugins/hermes-bots/routing.ts
@@ -196,7 +196,9 @@ export function botBackendProfileScope(route: null | ProfileRoute | undefined, f
 }
 
 /** Gateway RPC on the bot's OWN source. Source-scoped rows always use the
- * explicit descriptor, including a registered local source. */
+ * explicit descriptor, including a registered local source. Unscoped local
+ * rows ride `requestLocalProfileGateway` so a foregrounded orchestrator
+ * cannot mint or prompt against the wrong HERMES_HOME (#101422). */
 export async function requestForBot<T = unknown>(
   bot: Partial<RosterRow> | null | undefined,
   method: string,
@@ -219,7 +221,13 @@ export async function requestForBot<T = unknown>(
     }
   }
 
+  const profile = String(bot?.name || 'default').trim() || 'default'
+
   try {
+    if (typeof host.requestLocalProfileGateway === 'function') {
+      return await host.requestLocalProfileGateway(profile, method, params)
+    }
+
     return await host.request(method, params)
   } catch (error) {
     throw asRpcError(error, `Gateway request ${method} failed`)

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -50,6 +50,7 @@ import {
   openGatewayForProfile,
   requestGatewayForAgent,
   requestGatewayForProfile,
+  requestLocalProfileGateway,
   retainGatewayForAgent,
   retainGatewayForRelay,
   retireLocalProfileGateways
@@ -1283,6 +1284,20 @@ export const host = {
     params: Record<string, unknown> = {},
     timeoutMs?: number
   ): Promise<T> => requestPluginProfile<T>(route, method, params, timeoutMs),
+
+  /** Gateway JSON-RPC for a LOCAL profile by name, without using the active
+   *  socket and without the multi-source string gate on `requestProfile`.
+   *  Bot Mode's unscoped rows use this so `default` is not hijacked by a
+   *  foregrounded orchestrator (#101422). Feature-detect on older hosts. */
+  requestLocalProfileGateway: async <T>(
+    profile: string,
+    method: string,
+    params: Record<string, unknown> = {},
+    timeoutMs?: number
+  ): Promise<T> =>
+    timeoutMs === undefined
+      ? requestLocalProfileGateway<T>(profile, method, params)
+      : requestLocalProfileGateway<T>(profile, method, params, timeoutMs),
 
   /** Pin a route's pooled gateway socket open across repeated `requestProfile`
    *  calls (#93594: the bot-relay drain loop was dialing and tearing down a

--- a/apps/desktop/src/store/gateway-profile-request.test.ts
+++ b/apps/desktop/src/store/gateway-profile-request.test.ts
@@ -636,6 +636,34 @@ describe('attached shared-remote group turns (#96493)', () => {
     expect(primary.request).not.toHaveBeenCalled()
   })
 
+  it('never collapses a local registry profile onto the primary, even when the probe fails (#101422)', async () => {
+    const primary = makePrimary()
+    setPrimaryGateway(primary as never, 'orchestrator')
+    setPrimaryGatewayConnection({ connectionId: 'local' })
+    ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
+      getConnection: vi.fn(async (profile: null | string) =>
+        profile === 'orchestrator'
+          ? { port: 4242, profile: 'orchestrator', token: 'primary-token' }
+          : { port: 5151, profile, token: 'secondary-token' }
+      ),
+      getConnectionFor: vi.fn(async () => {
+        throw new Error('Timed out connecting to profile "default"')
+      }),
+      getGatewayWsUrlFor: vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) => ({
+        ok: true as const,
+        wsUrl: `ws://${connectionId}/${profile}`
+      })),
+      touchBackend: vi.fn(async () => undefined)
+    }
+    await ensureGatewayForProfile('orchestrator')
+
+    await expect(requestGatewayForAgent('local', 'default', 'session.create', { title: 'Bot Chat' })).rejects.toThrow(
+      /Timed out connecting/
+    )
+
+    expect(primary.request).not.toHaveBeenCalled()
+  })
+
   it('reuses the primary when the shared-remote probe fails instead of dialing a ghost secondary', async () => {
     const primary = makePrimary()
     setPrimaryGateway(primary as never, 'default')

--- a/apps/desktop/src/store/gateway-profile-request.test.ts
+++ b/apps/desktop/src/store/gateway-profile-request.test.ts
@@ -636,34 +636,6 @@ describe('attached shared-remote group turns (#96493)', () => {
     expect(primary.request).not.toHaveBeenCalled()
   })
 
-  it('never collapses a local registry profile onto the primary, even when the probe fails (#101422)', async () => {
-    const primary = makePrimary()
-    setPrimaryGateway(primary as never, 'orchestrator')
-    setPrimaryGatewayConnection({ connectionId: 'local' })
-    ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
-      getConnection: vi.fn(async (profile: null | string) =>
-        profile === 'orchestrator'
-          ? { port: 4242, profile: 'orchestrator', token: 'primary-token' }
-          : { port: 5151, profile, token: 'secondary-token' }
-      ),
-      getConnectionFor: vi.fn(async () => {
-        throw new Error('Timed out connecting to profile "default"')
-      }),
-      getGatewayWsUrlFor: vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) => ({
-        ok: true as const,
-        wsUrl: `ws://${connectionId}/${profile}`
-      })),
-      touchBackend: vi.fn(async () => undefined)
-    }
-    await ensureGatewayForProfile('orchestrator')
-
-    await expect(requestGatewayForAgent('local', 'default', 'session.create', { title: 'Bot Chat' })).rejects.toThrow(
-      /Timed out connecting/
-    )
-
-    expect(primary.request).not.toHaveBeenCalled()
-  })
-
   it('reuses the primary when the shared-remote probe fails instead of dialing a ghost secondary', async () => {
     const primary = makePrimary()
     setPrimaryGateway(primary as never, 'default')
@@ -706,3 +678,46 @@ describe('attached shared-remote group turns (#96493)', () => {
     expect(secondaryGateways).toHaveLength(0)
   })
 })
+
+describe('local profile connection failures', () => {
+  it.each(['request', 'retain', 'open', 'ensure'] as const)(
+    '%s does not reuse a foreign primary when the local profile cannot be resolved',
+    async operation => {
+      const primary = makePrimary()
+
+      setPrimaryGateway(primary as never, 'secondary-profile')
+      setPrimaryGatewayConnection({ connectionId: 'local' })
+      const failure = new Error('Timed out connecting to profile "default"')
+
+      const getConnectionFor = vi.fn(async () => {
+        throw failure
+      })
+
+      ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
+        getConnection: vi.fn(async () => ({ connectionId: 'local', port: 4242, profile: 'secondary-profile' })),
+        getConnectionFor,
+        touchBackend: vi.fn(async () => undefined)
+      }
+      await ensureGatewayForProfile('secondary-profile')
+
+      if (operation === 'ensure') {
+        expect(await ensureGatewayForAgent('local', 'default')).toBe(false)
+      } else {
+        const pending =
+          operation === 'request'
+            ? requestGatewayForAgent('local', 'default', 'session.create', { title: 'local-only' })
+            : operation === 'retain'
+              ? retainGatewayForAgent('local', 'default')
+              : openGatewayForAgent('local', 'default')
+
+        await expect(pending).rejects.toBe(failure)
+      }
+
+      expect(getConnectionFor).toHaveBeenCalledWith({ connectionId: 'local', profile: 'default' })
+      expect(primary.request).not.toHaveBeenCalled()
+      expect(secondaryGateways.every(gateway => gateway.request.mock.calls.length === 0)).toBe(true)
+      expect($gateway.get()).toBe(primary)
+    }
+  )
+})
+

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -1,4 +1,4 @@
-import { type ConnectionState, type GatewayEvent, registryBackendScopeKey, resolveGatewayWsUrl } from '@hermes/shared'
+import { type ConnectionState, type GatewayEvent, LOCAL_CONNECTION_ID, registryBackendScopeKey, resolveGatewayWsUrl } from '@hermes/shared'
 import { atom } from 'nanostores'
 
 import type { HermesConnection } from '@/global'
@@ -307,6 +307,14 @@ async function isAttachedSharedRemote(connectionId: null | string, profile: stri
   const key = normKey(profile)
 
   if (!id || !g.primaryConnectionId || id !== g.primaryConnectionId) {
+    return false
+  }
+
+  // The local registry source is a pool of per-profile HERMES_HOME backends,
+  // never a one-host-many-profiles remote. Collapsing onto the primary here
+  // made Bot Mode's `default` row mint and prompt on whatever local profile
+  // was foregrounded (orchestrator) (#101422).
+  if (id === LOCAL_CONNECTION_ID) {
     return false
   }
 
@@ -880,6 +888,25 @@ export async function requestGatewayForProfile<T>(
   } finally {
     route.release()
   }
+}
+
+/**
+ * Bot Mode door for a LOCAL (non-cross-connection) profile.
+ *
+ * Unlike `host.request` (active gateway) and `host.requestProfile`'s string
+ * overload (throws when more than one registry source exists), this always
+ * resolves the named profile's own socket via `requestGatewayForProfile`.
+ * That is what keeps `default` reachable when another profile (e.g.
+ * orchestrator) is foregrounded (#101422).
+ */
+export async function requestLocalProfileGateway<T>(
+  profile: string,
+  method: string,
+  params: Record<string, unknown> = {},
+  timeoutMs?: number,
+  signal?: AbortSignal
+): Promise<T> {
+  return requestGatewayForProfile<T>(profile, method, params, timeoutMs, signal)
 }
 
 /**


### PR DESCRIPTION
## Why

Clicking the Desktop `default` bot while another local profile (for example orchestrator) is foregrounded minted sessions and ran `prompt.submit` on the active gateway. The default model never answered. Fixes #101422.

## Scope

- `requestForBot` unscoped fallthrough now uses `host.requestLocalProfileGateway(profile, …)` instead of `host.request`.
- New `requestLocalProfileGateway` in `store/gateway.ts` and `sdk/index.ts` (thin door over `requestGatewayForProfile`, bypasses the multi-source string gate on `requestProfile`).
- `isAttachedSharedRemote` returns false for `LOCAL_CONNECTION_ID` so a failed local probe cannot collapse onto the primary.
- Focused tests in routing, cross-connection-bots, cron-rpc-error, and gateway-profile-request.
- `describe('local profile connection failures')` covers request, retain, open, and ensure. The request-only `#101422` case was removed so the request path is not asserted twice.

## Tradeoffs

Did not bypass `sharedPrimaryRoute` for global-remote profiles. A second dial at a shared descriptor breaks SSH tunnels. Named-profile routing already isolates local pooled backends when `getConnection` returns a pool descriptor.

## Blast Radius

Bot Mode local/unscoped RPCs and registry-local `requestGatewayForAgent` calls. Shared-remote probe-failure collapse is unchanged for non-local connection ids. Safe for single-profile users: `requestGatewayForProfile` still uses the primary socket when the name matches `primaryProfile`.

## Verification

```
cd apps/desktop
node ../../node_modules/vitest/vitest.mjs run --project ui src/store/gateway-profile-request.test.ts --no-cache
```

Result on `083d86a7681dcc409f2147e407a4e57aa4911224`: **25 passed**, exit **0**. Filter `-t 'local profile connection failures'`: **4 passed**, 21 skipped. Shared-remote probe-failure fallback remains in the same file and passed. No production routing rewrite. No live HERMES_HOME / packaged Electron run in this unit.