### PR TITLE
fix(anthropic): keep selected credentials source-affine

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -114,6 +114,8 @@ AUTH_TYPE_OAUTH = "oauth"
 AUTH_TYPE_API_KEY = "api_key"
 
 SOURCE_MANUAL = "manual"
+_ANTHROPIC_IMPLICIT_SINGLETON_SOURCES = frozenset({"claude_code", "hermes_pkce"})
+_ANTHROPIC_OAUTH_REFRESH_SKEW_MS = 120_000
 SOURCE_MANUAL_DEVICE_CODE = f"{SOURCE_MANUAL}:device_code"
 
 STRATEGY_FILL_FIRST = "fill_first"
@@ -323,6 +325,22 @@ def _next_priority(entries: List[PooledCredential]) -> int:
 def _is_manual_source(source: str) -> bool:
     normalized = (source or "").strip().lower()
     return normalized == SOURCE_MANUAL or normalized.startswith(f"{SOURCE_MANUAL}:")
+
+
+def _anthropic_oauth_expired_without_refresh(
+    expires_at_ms: Optional[int], refresh_token: Optional[str],
+) -> bool:
+    """Whether an Anthropic OAuth token is unusable without a refresh path."""
+    if expires_at_ms is None or str(refresh_token or "").strip():
+        return False
+    try:
+        expires_at_ms = int(expires_at_ms)
+    except (TypeError, ValueError):
+        return False
+    return (
+        expires_at_ms > 0
+        and expires_at_ms <= int(time.time() * 1000) + _ANTHROPIC_OAUTH_REFRESH_SKEW_MS
+    )
 
 
 def _exhausted_ttl(
@@ -2346,7 +2364,14 @@ class CredentialPool:
         if self.provider == "anthropic":
             if entry.expires_at_ms is None:
                 return False
-            return int(entry.expires_at_ms) <= int(time.time() * 1000) + 120_000
+            try:
+                expires_at_ms = int(entry.expires_at_ms)
+            except (TypeError, ValueError):
+                return False
+            return (
+                expires_at_ms > 0
+                and expires_at_ms <= int(time.time() * 1000) + _ANTHROPIC_OAUTH_REFRESH_SKEW_MS
+            )
         if self.provider == "openai-codex":
             return _codex_access_token_is_expiring(
                 entry.access_token,
@@ -2536,6 +2561,14 @@ class CredentialPool:
                     self._replace_entry(entry, cleared)
                     entry = cleared
                     cleared_any = True
+            if (
+                self.provider == "anthropic"
+                and entry.auth_type == AUTH_TYPE_OAUTH
+                and _anthropic_oauth_expired_without_refresh(
+                    entry.expires_at_ms, entry.refresh_token
+                )
+            ):
+                continue
             if refresh and self._entry_needs_refresh(entry):
                 if self.provider in ("openai-codex", "xai-oauth"):
                     # Defer single-use-token refresh to avoid holding the
@@ -2988,6 +3021,20 @@ class CredentialPool:
 
     def add_entry(self, entry: PooledCredential) -> PooledCredential:
         with self._lock:
+            removed_ids: List[str] = []
+            if self.provider == "anthropic" and _is_manual_source(entry.source):
+                removed_ids = [
+                    existing.id
+                    for existing in self._entries
+                    if (existing.source or "").strip().lower()
+                    in _ANTHROPIC_IMPLICIT_SINGLETON_SOURCES
+                ]
+                self._entries = [
+                    existing
+                    for existing in self._entries
+                    if (existing.source or "").strip().lower()
+                    not in _ANTHROPIC_IMPLICIT_SINGLETON_SOURCES
+                ]
             entry = replace(entry, priority=_next_priority(self._entries))
             self._entries.append(entry)
             borrowed_ids = getattr(self, "_borrowed_root_ids", None)
@@ -3005,7 +3052,7 @@ class CredentialPool:
                 self._entries = [e for e in self._entries if e.id not in borrowed_ids]
                 self._borrowed_root_ids = set()
             else:
-                self._persist()
+                self._persist(removed_ids=removed_ids)
             return entry
 
 
@@ -3128,6 +3175,20 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
             return False
 
     if provider == "anthropic":
+        # A manual credential is an explicit source choice.  Do not leave or
+        # re-seed implicit Claude Code / Hermes PKCE rows beside it.
+        if any(_is_manual_source(entry.source) for entry in entries):
+            retained = [
+                entry
+                for entry in entries
+                if (entry.source or "").strip().lower()
+                not in _ANTHROPIC_IMPLICIT_SINGLETON_SOURCES
+            ]
+            if len(retained) != len(entries):
+                entries[:] = retained
+                changed = True
+            return changed, active_sources
+
         # Only auto-discover external credentials (Claude Code, Hermes PKCE)
         # when the user has explicitly configured anthropic as their provider.
         # Without this gate, auxiliary client fallback chains silently read
@@ -3174,7 +3235,7 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
             # transient 401 could revive them.
             retained = [
                 entry for entry in entries
-                if entry.source not in {"hermes_pkce", "claude_code"}
+                if entry.source not in _ANTHROPIC_IMPLICIT_SINGLETON_SOURCES
             ]
             if len(retained) != len(entries):
                 entries[:] = retained
@@ -3191,6 +3252,10 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
             ("claude_code", read_claude_code_credentials()),
         ):
             if creds and creds.get("accessToken"):
+                if _anthropic_oauth_expired_without_refresh(
+                    creds.get("expiresAt"), creds.get("refreshToken")
+                ):
+                    continue
                 if _is_suppressed(provider, source_name):
                     continue
                 active_sources.add(source_name)

--- a/run_agent.py
+++ b/run_agent.py
@@ -6821,6 +6821,24 @@ class AIAgent:
         if base_url_host_matches(_base, "azure.com"):
             return False
 
+        # Credential-pool selection owns pool-bound credentials.  A global
+        # resolver can otherwise replace the selected entry with an unrelated
+        # singleton or env credential before the request is sent.
+        if getattr(self, "_credential_pool_entry_id", None) is not None:
+            return False
+
+        from agent.anthropic_adapter import _is_oauth_token
+
+        current_token = getattr(self, "_anthropic_api_key", None)
+        # Native API keys are static.  Only an unpooled OAuth session may use
+        # the legacy global resolver to pick up a rotated bearer token.
+        if (
+            not getattr(self, "_is_anthropic_oauth", False)
+            or not isinstance(current_token, str)
+            or not _is_oauth_token(current_token)
+        ):
+            return False
+
         try:
             from agent.anthropic_adapter import resolve_anthropic_token, build_anthropic_client
 
@@ -6835,13 +6853,13 @@ class AIAgent:
         if new_token == self._anthropic_api_key:
             return False
 
-        try:
-            self._anthropic_client.close()
-        except Exception:
-            pass
+        # Preflight refresh must preserve the OAuth auth scheme.  Pool
+        # recovery is the only path allowed to choose a different credential.
+        if not _is_oauth_token(new_token):
+            return False
 
         try:
-            self._anthropic_client = build_anthropic_client(
+            replacement_client = build_anthropic_client(
                 new_token,
                 getattr(self, "_anthropic_base_url", None),
                 timeout=get_provider_request_timeout(self.provider, self.model),
@@ -6850,13 +6868,16 @@ class AIAgent:
             logger.warning("Failed to rebuild Anthropic client after credential refresh: %s", exc)
             return False
 
+        old_client = self._anthropic_client
+        try:
+            old_client.close()
+        except Exception:
+            pass
+
+        self.api_key = new_token
         self._anthropic_api_key = new_token
-        # Update OAuth flag — token type may have changed (API key ↔ OAuth).
-        # Only treat as OAuth on native Anthropic; third-party endpoints using
-        # the Anthropic protocol must not trip OAuth paths (#1739 & third-party
-        # identity-injection guard).
-        from agent.anthropic_adapter import _is_oauth_token
-        self._is_anthropic_oauth = _is_oauth_token(new_token) if self.provider == "anthropic" else False
+        self._is_anthropic_oauth = True
+        self._anthropic_client = replacement_client
         return True
 
     def _apply_client_headers_for_base_url(

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -1218,6 +1218,255 @@ def test_load_pool_oauth_path_still_autodiscovers(tmp_path, monkeypatch):
     assert "claude_code" in sources
 
 
+@pytest.mark.parametrize(
+    ("source", "auth_type", "access_token", "refresh_token"),
+    [
+        ("manual", "api_key", "sk-ant-api03-manual", None),
+        ("manual:hermes_pkce", "oauth", "sk-ant-oat01-manual", "manual-refresh"),
+    ],
+)
+def test_adding_manual_anthropic_entry_removes_implicit_singletons(
+    tmp_path, monkeypatch, source, auth_type, access_token, refresh_token,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+    monkeypatch.setattr("hermes_cli.auth.is_provider_explicitly_configured", lambda _pid: True)
+    future = int(time.time() * 1000) + 3_600_000
+    monkeypatch.setattr(
+        "agent.anthropic_credentials.read_hermes_oauth_credentials",
+        lambda: {
+            "accessToken": "sk-ant-oat01-singleton-pkce",
+            "refreshToken": "pkce-refresh",
+            "expiresAt": future,
+        },
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_credentials.read_claude_code_credentials",
+        lambda: {
+            "accessToken": "sk-ant-oat01-singleton-claude",
+            "refreshToken": "claude-refresh",
+            "expiresAt": future,
+        },
+    )
+
+    from agent.credential_pool import PooledCredential, load_pool
+
+    pool = load_pool("anthropic")
+    assert {entry.source for entry in pool.entries()} == {"hermes_pkce", "claude_code"}
+
+    pool.add_entry(PooledCredential(
+        provider="anthropic",
+        id="manual-entry",
+        label="manual",
+        auth_type=auth_type,
+        priority=0,
+        source=source,
+        access_token=access_token,
+        refresh_token=refresh_token,
+    ))
+
+    assert {entry.source for entry in pool.entries()} == {source}
+    persisted = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert {entry["source"] for entry in persisted["credential_pool"]["anthropic"]} == {source}
+
+
+def test_manual_anthropic_entries_prevent_singleton_reseed_after_reload(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    future = int(time.time() * 1000) + 3_600_000
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {},
+            "credential_pool": {
+                "anthropic": [
+                    {
+                        "id": "manual-api",
+                        "label": "manual api",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-ant-api03-manual",
+                    },
+                    {
+                        "id": "manual-oauth",
+                        "label": "manual oauth",
+                        "auth_type": "oauth",
+                        "priority": 1,
+                        "source": "manual:dashboard_pkce",
+                        "access_token": "sk-ant-oat01-manual",
+                        "refresh_token": "manual-refresh",
+                        "expires_at_ms": future,
+                    },
+                    {
+                        "id": "singleton-pkce",
+                        "label": "pkce",
+                        "auth_type": "oauth",
+                        "priority": 2,
+                        "source": "hermes_pkce",
+                        "access_token": "sk-ant-oat01-pkce",
+                        "refresh_token": "pkce-refresh",
+                        "expires_at_ms": future,
+                    },
+                    {
+                        "id": "singleton-claude",
+                        "label": "claude",
+                        "auth_type": "oauth",
+                        "priority": 3,
+                        "source": "claude_code",
+                        "access_token": "sk-ant-oat01-claude",
+                        "refresh_token": "claude-refresh",
+                        "expires_at_ms": future,
+                    },
+                ],
+            },
+        },
+    )
+    reads = []
+    monkeypatch.setattr(
+        "agent.anthropic_credentials.read_hermes_oauth_credentials",
+        lambda: reads.append("hermes_pkce") or None,
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_credentials.read_claude_code_credentials",
+        lambda: reads.append("claude_code") or None,
+    )
+
+    from agent.credential_pool import load_pool
+
+    first = load_pool("anthropic")
+    second = load_pool("anthropic")
+    expected_sources = {"manual", "manual:dashboard_pkce"}
+    assert {entry.source for entry in first.entries()} == expected_sources
+    assert {entry.source for entry in second.entries()} == expected_sources
+    assert reads == []
+
+    persisted = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert {entry["source"] for entry in persisted["credential_pool"]["anthropic"]} == expected_sources
+
+
+def test_expired_nonrefreshable_anthropic_oauth_is_not_seeded_or_available(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+    monkeypatch.setattr("hermes_cli.auth.is_provider_explicitly_configured", lambda _pid: True)
+    within_refresh_skew = int(time.time() * 1000) + 60_000
+    monkeypatch.setattr(
+        "agent.anthropic_credentials.read_hermes_oauth_credentials",
+        lambda: {
+            "accessToken": "sk-ant-oat01-expiring-singleton",
+            "expiresAt": within_refresh_skew,
+        },
+    )
+    monkeypatch.setattr("agent.anthropic_credentials.read_claude_code_credentials", lambda: None)
+
+    from agent.credential_pool import CredentialPool, PooledCredential, load_pool
+
+    seeded = load_pool("anthropic")
+    assert not seeded.entries()
+
+    expired = PooledCredential(
+        provider="anthropic",
+        id="expired",
+        label="expired",
+        auth_type="oauth",
+        priority=0,
+        source="hermes_pkce",
+        access_token="sk-ant-oat01-expiring-pool",
+        expires_at_ms=within_refresh_skew,
+    )
+    static_setup = PooledCredential(
+        provider="anthropic",
+        id="static",
+        label="static setup token",
+        auth_type="oauth",
+        priority=1,
+        source="manual",
+        access_token="sk-ant-oat01-static",
+    )
+    available, _pending = CredentialPool("anthropic", [expired, static_setup])._available_entries(
+        clear_expired=False,
+        refresh=False,
+    )
+    assert [entry.id for entry in available] == ["static"]
+
+
+def test_unknown_expiry_anthropic_oauth_without_refresh_is_seeded_and_selectable(
+    tmp_path, monkeypatch,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    for name in ("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"):
+        monkeypatch.delenv(name, raising=False)
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+    monkeypatch.setattr("hermes_cli.auth.is_provider_explicitly_configured", lambda _pid: True)
+    monkeypatch.setattr(
+        "agent.anthropic_credentials.read_hermes_oauth_credentials",
+        lambda: {
+            "accessToken": "sk-ant-oat01-unknown-expiry",
+            "expiresAt": 0,
+        },
+    )
+    monkeypatch.setattr("agent.anthropic_credentials.read_claude_code_credentials", lambda: None)
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("anthropic")
+    assert [entry.source for entry in pool.entries()] == ["hermes_pkce"]
+
+    selected = pool.select()
+    assert selected is not None
+    assert selected.source == "hermes_pkce"
+
+
+def test_old_dead_manual_anthropic_oauth_prunes_before_singleton_reseed(
+    tmp_path, monkeypatch,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    for name in ("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"):
+        monkeypatch.delenv(name, raising=False)
+    now = time.time()
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {},
+            "credential_pool": {
+                "anthropic": [
+                    {
+                        "id": "old-dead-manual",
+                        "label": "old dead manual",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-ant-oat01-old-dead",
+                        "expires_at_ms": int(now * 1000) - 1,
+                        "last_status": "dead",
+                        "last_status_at": now - 24 * 60 * 60 - 1,
+                    },
+                ],
+            },
+        },
+    )
+    monkeypatch.setattr("hermes_cli.auth.is_provider_explicitly_configured", lambda _pid: True)
+    monkeypatch.setattr(
+        "agent.anthropic_credentials.read_hermes_oauth_credentials",
+        lambda: {
+            "accessToken": "sk-ant-oat01-reseeded-singleton",
+            "expiresAt": int(time.time() * 1000) + 3_600_000,
+        },
+    )
+    monkeypatch.setattr("agent.anthropic_credentials.read_claude_code_credentials", lambda: None)
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("anthropic")
+    assert pool.select() is None
+    assert not pool.entries()
+
+    reloaded = load_pool("anthropic")
+    assert [entry.source for entry in reloaded.entries()] == ["hermes_pkce"]
+    assert reloaded.select() is not None
+
+
 def test_least_used_strategy_selects_lowest_count(tmp_path, monkeypatch):
     """least_used strategy should select the credential with the lowest request_count."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -116,6 +116,44 @@ def test_auth_add_api_key_persists_manual_entry(tmp_path, monkeypatch):
     assert entry["access_token"] == "sk-or-manual"
 
 
+def test_auth_add_anthropic_api_key_removes_implicit_singleton_rows(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+    monkeypatch.setattr("hermes_cli.auth.is_provider_explicitly_configured", lambda _pid: True)
+    future = int(time.time() * 1000) + 3_600_000
+    monkeypatch.setattr(
+        "agent.anthropic_credentials.read_hermes_oauth_credentials",
+        lambda: {
+            "accessToken": "sk-ant-oat01-singleton-pkce",
+            "refreshToken": "pkce-refresh",
+            "expiresAt": future,
+        },
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_credentials.read_claude_code_credentials",
+        lambda: {
+            "accessToken": "sk-ant-oat01-singleton-claude",
+            "refreshToken": "claude-refresh",
+            "expiresAt": future,
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "anthropic"
+        auth_type = "api-key"
+        api_key = "sk-ant-api03-manual"
+        label = "manual"
+
+    auth_add_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert {
+        entry["source"] for entry in payload["credential_pool"]["anthropic"]
+    } == {"manual"}
+
+
 def test_auth_add_configured_provider_uses_canonical_pool_key(tmp_path, monkeypatch):
     """A keyed providers row must keep its runtime slug in the auth pool."""
     hermes_home = tmp_path / "hermes"

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5992,22 +5992,52 @@ class TestAnthropicCredentialRefresh:
             )
 
         agent._anthropic_client = old_client
+        agent.api_key = "sk-ant-oat01-stale-token"
         agent._anthropic_api_key = "sk-ant-oat01-stale-token"
         agent._anthropic_base_url = "https://api.anthropic.com"
         agent.provider = "anthropic"
+        agent._is_anthropic_oauth = True
+        agent._credential_pool_entry_id = None
+
+        events = []
+        old_client.close.side_effect = lambda: events.append("close")
+
+        def _build_replacement(*_args, **_kwargs):
+            events.append("build")
+            return new_client
 
         with (
             patch("agent.anthropic_adapter.resolve_anthropic_token", return_value="sk-ant-oat01-fresh-token"),
-            patch("agent.anthropic_adapter.build_anthropic_client", return_value=new_client) as rebuild,
+            patch("agent.anthropic_adapter.build_anthropic_client", side_effect=_build_replacement) as rebuild,
         ):
             assert agent._try_refresh_anthropic_client_credentials() is True
 
         old_client.close.assert_called_once()
+        assert events == ["build", "close"]
         rebuild.assert_called_once_with(
             "sk-ant-oat01-fresh-token", "https://api.anthropic.com", timeout=None,
         )
         assert agent._anthropic_client is new_client
+        assert agent.api_key == "sk-ant-oat01-fresh-token"
         assert agent._anthropic_api_key == "sk-ant-oat01-fresh-token"
+
+    def test_pool_bound_static_key_never_resolves_across_preflights(self, agent):
+        agent.api_mode = "anthropic_messages"
+        agent.provider = "anthropic"
+        agent.api_key = "sk-ant-api03-pool-bound"
+        agent._anthropic_api_key = agent.api_key
+        agent._anthropic_base_url = "https://api.anthropic.com"
+        agent._anthropic_client = MagicMock()
+        agent._is_anthropic_oauth = False
+        agent._credential_pool_entry_id = "pool-static"
+
+        with patch("agent.anthropic_adapter.resolve_anthropic_token") as resolve:
+            assert agent._try_refresh_anthropic_client_credentials() is False
+            assert agent._try_refresh_anthropic_client_credentials() is False
+
+        resolve.assert_not_called()
+        assert agent.api_key == "sk-ant-api03-pool-bound"
+        assert agent._anthropic_api_key == "sk-ant-api03-pool-bound"
 
 
     def test_anthropic_messages_create_preflights_refresh(self):
@@ -6953,39 +6983,38 @@ class TestNormalizeCodexDictArguments:
 
 
 # ---------------------------------------------------------------------------
-# OAuth flag and nudge counter fixes (salvaged from PR #1797)
+# OAuth scheme-affinity and nudge counter fixes (salvaged from PR #1797)
 # ---------------------------------------------------------------------------
 
 
-class TestOAuthFlagAfterCredentialRefresh:
-    """_is_anthropic_oauth must update when token type changes during refresh."""
+class TestOAuthSchemeAffinityAfterCredentialRefresh:
+    """Preflight refresh must preserve an agent's native Anthropic scheme."""
 
-    def test_oauth_flag_updates_api_key_to_oauth(self, agent):
-        """Refreshing from API key to OAuth token must set flag to True."""
+    def test_unpooled_static_key_never_resolves(self, agent):
         agent.api_mode = "anthropic_messages"
         agent.provider = "anthropic"
         agent._anthropic_api_key = "sk-ant-api-old"
+        agent.api_key = agent._anthropic_api_key
         agent._anthropic_client = MagicMock()
         agent._is_anthropic_oauth = False
+        agent._credential_pool_entry_id = None
 
-        with (
-            patch("agent.anthropic_adapter.resolve_anthropic_token",
-                  return_value="sk-ant-setup-oauth-token"),
-            patch("agent.anthropic_adapter.build_anthropic_client",
-                  return_value=MagicMock()),
-        ):
+        with patch("agent.anthropic_adapter.resolve_anthropic_token") as resolve:
             result = agent._try_refresh_anthropic_client_credentials()
 
-        assert result is True
-        assert agent._is_anthropic_oauth is True
+        assert result is False
+        resolve.assert_not_called()
+        assert agent.api_key == "sk-ant-api-old"
+        assert agent._anthropic_api_key == "sk-ant-api-old"
 
-    def test_oauth_flag_updates_oauth_to_api_key(self, agent):
-        """Refreshing from OAuth to API key must set flag to False."""
+    def test_unpooled_oauth_refresh_rejects_api_key(self, agent):
         agent.api_mode = "anthropic_messages"
         agent.provider = "anthropic"
         agent._anthropic_api_key = "sk-ant-setup-old"
+        agent.api_key = agent._anthropic_api_key
         agent._anthropic_client = MagicMock()
         agent._is_anthropic_oauth = True
+        agent._credential_pool_entry_id = None
 
         with (
             patch("agent.anthropic_adapter.resolve_anthropic_token",
@@ -6995,8 +7024,10 @@ class TestOAuthFlagAfterCredentialRefresh:
         ):
             result = agent._try_refresh_anthropic_client_credentials()
 
-        assert result is True
-        assert agent._is_anthropic_oauth is False
+        assert result is False
+        assert agent._is_anthropic_oauth is True
+        assert agent.api_key == "sk-ant-setup-old"
+        assert agent._anthropic_api_key == "sk-ant-setup-old"
 
 
 class TestFallbackSetsOAuthFlag:


### PR DESCRIPTION
## What does this PR do?

Preserve the Anthropic credential source the runtime actually selected.

Before this change, an agent could be bound to a manual API-key pool row while
the per-request global resolver substituted an auto-discovered Claude Code OAuth
token. The request then used one credential while pool bookkeeping still named
another. Separately, `hermes auth add anthropic` loaded the pool first, seeded
Claude Code/Hermes PKCE singleton rows, and persisted those implicit rows beside
the explicit manual credential.

This keeps request authentication and pool identity aligned without redesigning
credential persistence or 401 rotation.

## Related Issue

Fixes #75641

This subsumes the API-key guard proposed in #75697. It is distinct from #78950
(configurable global resolution order) and #65661 (configurable Keychain
lookup): neither binds a request to the selected pool row or fixes manual-add
persistence.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `run_agent.py`
  - Leave every pool-bound Anthropic credential under pool ownership instead of
    globally re-resolving it before each request.
  - Never refresh an unpooled static API key; keep an unpooled OAuth refresh
    OAuth-shaped and install the replacement client only after construction
    succeeds.
- `agent/credential_pool.py`
  - Treat a manual Anthropic entry as the explicit source choice: remove and
    suppress only implicit `claude_code` and `hermes_pkce` rows.
  - Exclude a known-expired/near-expiry OAuth token only when it has no refresh
    material; preserve `0`/unknown-expiry setup tokens and DEAD-row cleanup.
- Add focused pool, CLI, and request-preflight regressions.

## How to Test

1. Run:
   ```bash
   python -m pytest -q \
     tests/agent/test_credential_pool.py \
     tests/agent/test_anthropic_adapter.py \
     tests/hermes_cli/test_auth_commands.py \
     tests/run_agent/test_run_agent.py
   ```
2. Confirm `472 passed` (one unrelated existing `_BarrierDB.flush_token_counts`
   warning may appear).
3. Run Ruff on the five touched files and `git diff --check`.

No live provider call is required; the regressions use isolated temporary auth
stores and mocked Anthropic clients.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing option changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — platform-neutral runtime/pool logic
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

N/A. No credentials or live provider traffic are included.
