### PR TITLE
fix(update): hermes update no longer hangs on a GitHub username prompt during outages (salvage #73751, #101421)

### DIFF
--- a/contributors/emails/robbert_camps@hotmail.com
+++ b/contributors/emails/robbert_camps@hotmail.com
@@ -1,0 +1,1 @@
+RobbertC5

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -241,11 +241,15 @@ def _is_full_sha(value: Optional[str]) -> bool:
 
 def _upstream_main_sha() -> Optional[str]:
     """Tip SHA of upstream main via HTTPS ls-remote (no auth, no prompts)."""
+    from hermes_cli._subprocess_compat import noninteractive_git_env
+
     try:
         result = subprocess.run(
             ["git", "ls-remote", _UPSTREAM_REPO_URL, "refs/heads/main"],
             capture_output=True, text=True, encoding="utf-8", errors="replace",
             timeout=10,
+            stdin=subprocess.DEVNULL,
+            env=noninteractive_git_env(),
         )
     except Exception:
         return None
@@ -277,6 +281,8 @@ def _check_via_rev(local_rev: str) -> Optional[int]:
 
 def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     """Count commits behind origin/main in a local checkout."""
+    from hermes_cli._subprocess_compat import noninteractive_git_env
+
     origin_url = _git_stdout(["remote", "get-url", "origin"], cwd=repo_dir)
     if _is_official_ssh_remote(origin_url):
         head_rev = _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir)
@@ -348,6 +354,8 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
             fetch_args,
             capture_output=True, timeout=10,
             cwd=str(repo_dir),
+            stdin=subprocess.DEVNULL,
+            env=noninteractive_git_env(),
         )
         fetch_ok = fetch_proc.returncode == 0
     except Exception:

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -55,6 +55,22 @@ def _m():
     return main
 
 
+def _no_prompt_git_kwargs() -> dict:
+    """``subprocess.run`` kwargs for the updater's network git calls.
+
+    GitHub answers anonymous fetches with HTTP 401 during outages (and for
+    unreachable repos); git then prompts ``Username for 'https://github.com':``
+    on the inherited terminal and the update sits there forever. Disable the
+    prompt so the fetch fails fast into ``_classify_fetch_failure``. Only the
+    *prompt* is disabled — a configured credential helper / askpass still
+    runs, so a private-fork origin keeps authenticating non-interactively.
+    """
+    env = dict(os.environ)
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    env["GCM_INTERACTIVE"] = "Never"
+    return {"stdin": subprocess.DEVNULL, "env": env}
+
+
 _UPDATE_RUNTIME_RELOAD_MODULES = (
     "hermes_constants",
     "tools.environments.local",
@@ -3263,6 +3279,7 @@ def _sync_fork_with_upstream(git_cmd: list[str], cwd: Path) -> bool:
             cwd=cwd,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
+            **_no_prompt_git_kwargs(),
         )
         return result.returncode == 0
     except Exception:
@@ -3358,6 +3375,7 @@ def _sync_with_upstream_if_needed(
             cwd=cwd,
             capture_output=True,
             check=True,
+            **_no_prompt_git_kwargs(),
         )
     except subprocess.CalledProcessError:
         print("  ✗ Failed to fetch upstream. Skipping upstream sync.")
@@ -3397,6 +3415,7 @@ def _sync_with_upstream_if_needed(
             git_cmd + ["pull", "--ff-only", "upstream", "main"],
             cwd=cwd,
             check=True,
+            **_no_prompt_git_kwargs(),
         )
     except subprocess.CalledProcessError:
         print(
@@ -4539,7 +4558,17 @@ def _classify_fetch_failure(stderr: str) -> str:
         )
     if "Could not resolve host" in stderr or "unable to access" in stderr:
         return "✗ Network error — cannot reach the remote repository."
-    if "Authentication failed" in stderr or "could not read Username" in stderr:
+    if "could not read Username" in stderr or "terminal prompts disabled" in stderr:
+        # Anonymous fetch of a public repo got HTTP 401. GitHub does this
+        # during outages (and for renamed/private repos) — it is not a
+        # credentials problem on the user's side.
+        return (
+            "✗ GitHub rejected the anonymous fetch (asked for a login) — this"
+            " usually means a GitHub outage; try again in a few minutes"
+            " (https://www.githubstatus.com). If it persists, check"
+            " `git remote -v` points at a public repo."
+        )
+    if "Authentication failed" in stderr:
         return "✗ Authentication failed — check your git credentials or SSH key."
     return "✗ Failed to fetch updates from origin."
 
@@ -4646,6 +4675,7 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
                 cwd=_m().PROJECT_ROOT,
                 capture_output=True,
                 text=True, encoding="utf-8", errors="replace",
+                **_no_prompt_git_kwargs(),
             )
         if fetch_result is not None and fetch_result.returncode == 0:
             upstream_exists = True
@@ -4658,6 +4688,7 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
                 cwd=_m().PROJECT_ROOT,
                 capture_output=True,
                 text=True, encoding="utf-8", errors="replace",
+                **_no_prompt_git_kwargs(),
             )
             upstream_exists = False
             compare_branch = f"origin/{branch}"
@@ -4669,6 +4700,7 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
             cwd=_m().PROJECT_ROOT,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
+            **_no_prompt_git_kwargs(),
         )
         upstream_exists = False
         compare_branch = f"origin/{branch}"
@@ -8591,6 +8623,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             cwd=_m().PROJECT_ROOT,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
+            **_no_prompt_git_kwargs(),
         )
         if fetch_result.returncode != 0:
             _print_fetch_failure(fetch_result.stderr)

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -23,7 +23,10 @@ def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
     (repo_dir / ".git").mkdir()
 
     cache_file = tmp_path / ".update_check"
-    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3, "ver": __version__}))
+    cache_file.write_text(
+        json.dumps({"ts": time.time(), "behind": 3, "ver": __version__}),
+        encoding="utf-8",
+    )
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     with patch("hermes_cli.banner.subprocess.run") as mock_run:
@@ -58,6 +61,21 @@ def test_prefetch_non_blocking():
         assert banner._update_result == 5
 
 
+def test_upstream_main_sha_disables_git_prompts(monkeypatch):
+    """The passive HTTPS probe must never inherit the interactive terminal."""
+    from hermes_cli import banner
+
+    completed = MagicMock(returncode=1, stdout="", stderr="auth required")
+    run = MagicMock(return_value=completed)
+    monkeypatch.setattr(banner.subprocess, "run", run)
+
+    assert banner._upstream_main_sha() is None
+    kwargs = run.call_args.kwargs
+    assert kwargs["stdin"] is banner.subprocess.DEVNULL
+    assert kwargs["env"]["GIT_TERMINAL_PROMPT"] == "0"
+    assert kwargs["env"]["GCM_INTERACTIVE"] == "Never"
+
+
 def test_check_via_local_git_fetch_failure_returns_none(tmp_path, monkeypatch):
     """When git fetch fails and the stale origin/main ref is not ahead,
     _check_via_local_git must return None (#82166).
@@ -90,8 +108,12 @@ def test_check_via_local_git_fetch_failure_returns_none(tmp_path, monkeypatch):
     stale_zero_proc.returncode = 0
     stale_zero_proc.stdout = "0"
 
+    fetch_kwargs = None
+
     def mock_run(args, **kwargs):
+        nonlocal fetch_kwargs
         if args[:2] == ["git", "fetch"]:
+            fetch_kwargs = kwargs
             return failed_proc
         if args[:2] == ["git", "rev-list"]:
             return stale_zero_proc
@@ -104,6 +126,10 @@ def test_check_via_local_git_fetch_failure_returns_none(tmp_path, monkeypatch):
     assert result is None, (
         "Fetch failure with stale 0-behind must return None, not 'up to date'"
     )
+    assert fetch_kwargs is not None
+    assert fetch_kwargs["stdin"] is banner.subprocess.DEVNULL
+    assert fetch_kwargs["env"]["GIT_TERMINAL_PROMPT"] == "0"
+    assert fetch_kwargs["env"]["GCM_INTERACTIVE"] == "Never"
 
 
 def test_check_via_local_git_fetch_failure_keeps_positive_stale_count(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_update_fetch_failure_classifier.py
+++ b/tests/hermes_cli/test_update_fetch_failure_classifier.py
@@ -51,6 +51,16 @@ class TestClassifyFetchFailure:
         )
         assert msg.startswith("✗ Network error")
 
+    def test_username_prompt_401_reports_github_not_user_credentials(self):
+        # What GitHub's HTTP 401 looks like once the terminal prompt is
+        # disabled — must NOT be blamed on the user's credentials.
+        msg = update_cmd._classify_fetch_failure(
+            "fatal: could not read Username for 'https://github.com':"
+            " terminal prompts disabled"
+        )
+        assert "GitHub" in msg and "outage" in msg
+        assert "check your git credentials" not in msg
+
     def test_auth_failure(self):
         msg = update_cmd._classify_fetch_failure(
             "fatal: Authentication failed for 'https://github.com/x.git/'"
@@ -75,3 +85,37 @@ class TestPrintFetchFailure:
         update_cmd._print_fetch_failure("")
         out = capsys.readouterr().out.strip().splitlines()
         assert out == ["✗ Failed to fetch updates from origin."]
+
+
+def test_update_network_git_calls_never_prompt_for_credentials():
+    """Every `git fetch`/`pull`/`push` in the updater runs with prompts disabled.
+
+    Live incident (Sep 2026): a GitHub-side 401 made `hermes update` sit on
+    ``Username for 'https://github.com':`` instead of failing with a diagnosis.
+    """
+    import inspect
+    import os
+    import re
+    import subprocess
+
+    kw = update_cmd._no_prompt_git_kwargs()
+    assert kw["stdin"] is subprocess.DEVNULL
+    assert kw["env"]["GIT_TERMINAL_PROMPT"] == "0"
+    # Only the prompt is disabled — credential helpers / askpass stay
+    # configured so a private-fork origin still authenticates.
+    assert "GIT_CONFIG_COUNT" not in kw["env"] or kw["env"]["GIT_CONFIG_COUNT"] == os.environ.get("GIT_CONFIG_COUNT")
+
+    src = inspect.getsource(update_cmd)
+    # Every subprocess.run(...) whose argv is a fetch/pull must spread the kwargs.
+    calls = []
+    for m in re.finditer(r"subprocess\.run\(", src):
+        depth, i = 1, m.end()
+        while depth:
+            depth += {"(": 1, ")": -1}.get(src[i], 0)
+            i += 1
+        call = src[m.start():i]
+        if re.search(r'git_cmd \+ \["(fetch|pull|push)"', call):
+            calls.append(call)
+    assert calls, "expected network git calls in update_cmd"
+    missing = [c for c in calls if "_no_prompt_git_kwargs()" not in c]
+    assert not missing, missing


### PR DESCRIPTION
## Summary
`hermes update` no longer hangs on `Username for 'https://github.com':` when GitHub answers the anonymous fetch with HTTP 401 (outages, renamed/private repos); it fails fast with a GitHub-side diagnosis instead of looking like Hermes demands a GitHub login.

Root cause: the updater's `git fetch`/`pull`/`push` calls inherited the interactive terminal, so a 401 made git prompt for credentials and block forever. The passive banner probe (`ls-remote` / background fetch) had the same gap.

Same class as #73751 by @Frowtek (pre-dates the `main.py` → `update_cmd.py` decomposition, no longer applies); passive-banner half salvaged from #101421 by @RobbertC5 (cherry-picked, authorship preserved).

## Changes
- `hermes_cli/update_cmd.py`: `_no_prompt_git_kwargs()` (`GIT_TERMINAL_PROMPT=0`, `GCM_INTERACTIVE=Never`, `stdin=DEVNULL`) applied to all 7 network git calls (apply path fetch, `--check` upstream/origin fetches, fork-sync fetch/pull/push). Credential helpers / askpass are left configured so private-fork origins still authenticate.
- `_classify_fetch_failure`: `could not read Username` / `terminal prompts disabled` now reports "GitHub rejected the anonymous fetch — usually an outage" instead of "check your git credentials".
- `hermes_cli/banner.py` (@RobbertC5): passive `_upstream_main_sha` + `_check_via_local_git` fetch run under `noninteractive_git_env()`.
- Tests: classifier case for the 401 shape; one invariant test that every `fetch`/`pull`/`push` `subprocess.run` in the updater spreads the no-prompt kwargs (sabotage-verified: fails when one site is stripped).

## Validation
Live A/B — real `_cmd_update_check()` under a controlling PTY against a local origin returning HTTP 401:

| | Before (origin/main) | After |
|---|---|---|
| Behavior | `→ Fetching from origin...` then `Username for 'http://…':` — hung 15s+ (killed) | exits rc=1 in 0.2s |
| Message | (prompt) | `✗ GitHub rejected the anonymous fetch (asked for a login) — this usually means a GitHub outage; try again in a few minutes (https://www.githubstatus.com). If it persists, check git remote -v points at a public repo.` + raw git line |

`tests/hermes_cli/test_update_fetch_failure_classifier.py test_noninteractive_git.py test_update_check.py`: 25 passed. ruff clean.

## Infographic

![hermes update no longer hangs on a login prompt](https://v3b.fal.media/files/b/0aa8d890/FURksus10Dt5hnI6xCzrV_Eg5Vr7ad.png)
