### PR TITLE
fix(desktop): enable New Group Chat for local-plus-remote rosters

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/roster-pane.group-create-gate.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/roster-pane.group-create-gate.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+// #101543: New Group Chat must enable when the multi-source roster has ≥2
+// selectable (non-ghost) bots. The create dialog already uses that set; the
+// menu gate used to count only local-source rows via activeSourceRoster.
+
+const rosterPane = readFileSync(join(process.cwd(), 'src/plugins/hermes-bots/roster-pane.tsx'), 'utf8')
+const createDialog = readFileSync(join(process.cwd(), 'src/plugins/hermes-bots/create-dialog.tsx'), 'utf8')
+
+describe('New Group Chat menu gate', () => {
+  it('counts selectable bots across the full roster, matching the create dialog', () => {
+    expect(rosterPane).toMatch(/disabled=\{roster\.filter\(bot => !bot\?\.ghost\)\.length < 2\}/)
+    expect(rosterPane).not.toMatch(/disabled=\{activeSourceRoster\.length < 2\}/)
+    expect(createDialog).toMatch(/selectableRoster = roster\.filter\(bot => !bot\?\.ghost\)/)
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/roster-pane.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/roster-pane.tsx
@@ -760,7 +760,10 @@ export function BotsPane() {
                 <Codicon className="mr-1.5" name="hubot" />
                 {b.bot.newTitle}
               </DropdownMenuItem>
-              <DropdownMenuItem disabled={activeSourceRoster.length < 2} onSelect={() => setGroupCreateOpen(true)}>
+              <DropdownMenuItem
+                disabled={roster.filter(bot => !bot?.ghost).length < 2}
+                onSelect={() => setGroupCreateOpen(true)}
+              >
                 <Codicon className="mr-1.5" name="organization" />
                 {b.group.newTitle}
               </DropdownMenuItem>


### PR DESCRIPTION
## Why

With one local Bot and healthy Bots on registered remote connections, **New Group Chat** stayed disabled. The menu gate counted `activeSourceRoster`, which drops every `remoteSource` row. The create dialog already receives the full multi-source `roster` and treats non-ghost remotes as selectable members.

## Scope

- `apps/desktop/src/plugins/hermes-bots/roster-pane.tsx`: enable the menu item when `roster.filter(bot => !bot?.ghost).length >= 2`.
- `apps/desktop/src/plugins/hermes-bots/roster-pane.group-create-gate.test.ts`: source contract that the gate matches `CreateGroupChatDialog`'s selectable set.

Out of scope: gateway membership rules, dialog UX, and the stale pre-TSX patch in #96162 (conflicts against deleted `plugin.js`).

## Tradeoffs

Same one-line gate change #96162 intended, retargeted at `roster-pane.tsx` after the Bot Mode TSX conversion. Prefer this over rebasing that PR onto dead `plugin.js`.

## Blast Radius

Desktop Bot Mode roster **New…** menu only. Local-only fleets behave as before (still need ≥2 selectable bots). Ghost placeholders stay excluded.

## Verification

`
cd apps/desktop
npm run test:ui -- src/plugins/hermes-bots/roster-pane.group-create-gate.test.ts
`

- Before fix: 1 failed, exit 1
- After fix: 1 passed, exit 0

Fixes #101543
Supersedes the conflicting approach in #96162