### PR TITLE
fix(tui): default follow_profile_config when create omits model

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -19250,12 +19250,44 @@ def test_session_create_records_ui_model_as_session_override(monkeypatch):
         normal_sess = server._sessions[normal["result"]["session_id"]]
         assert normal_sess["create_service_tier_override"] == ""
 
-        # No knobs → no overrides; the session builds from the profile default.
+        # No knobs → no model override; the session builds from the profile
+        # default and follows that profile on resume (#101514).
         plain = server._methods["session.create"]("r3", {"cols": 80})
         plain_sess = server._sessions[plain["result"]["session_id"]]
         assert plain_sess["model_override"] is None
         assert plain_sess["create_reasoning_override"] is None
         assert plain_sess["create_service_tier_override"] is None
+        assert plain_sess["follow_profile_config"] is True
+    finally:
+        server._sessions.clear()
+
+
+def test_session_create_defaults_follow_profile_config_without_model(monkeypatch):
+    """A create with no model must stamp follow_profile_config so resume does
+    not pin the row's stamped default (#101514). Explicit model or an explicit
+    follow flag still wins.
+    """
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
+    try:
+        plain = server._methods["session.create"]("r1", {"cols": 80, "title": "New Chat"})
+        assert server._sessions[plain["result"]["session_id"]]["follow_profile_config"] is True
+
+        pinned = server._methods["session.create"](
+            "r2", {"cols": 80, "model": "claude-sonnet-4.6", "provider": "anthropic"}
+        )
+        assert server._sessions[pinned["result"]["session_id"]]["follow_profile_config"] is False
+
+        forced = server._methods["session.create"](
+            "r3",
+            {"cols": 80, "model": "claude-sonnet-4.6", "follow_profile_config": True},
+        )
+        assert server._sessions[forced["result"]["session_id"]]["follow_profile_config"] is True
+
+        refused = server._methods["session.create"](
+            "r4", {"cols": 80, "follow_profile_config": False}
+        )
+        assert server._sessions[refused["result"]["session_id"]]["follow_profile_config"] is False
     finally:
         server._sessions.clear()
 

--- a/tests/tui_gateway/test_custom_provider_session_persistence.py
+++ b/tests/tui_gateway/test_custom_provider_session_persistence.py
@@ -704,6 +704,49 @@ class TestFollowProfileConfigRuntimeOverrides:
         server._ensure_session_db_row(session)
         assert captured["model_config"].get("follow_profile_config") is None
 
+    def test_persist_live_runtime_drops_follow_marker_after_model_pin(self, monkeypatch):
+        """After /model clears follow_profile_config, the next runtime persist
+        must drop the marker so resume restores the pin (#101514)."""
+        import tui_gateway.server as server
+
+        captured = {}
+
+        class FakeDB:
+            def get_session(self, _key):
+                return {
+                    "model_config": json.dumps(
+                        {
+                            "model": "old-model",
+                            "provider": "nous",
+                            "follow_profile_config": True,
+                        }
+                    )
+                }
+
+            def update_session_meta(self, _key, model_config_json, model):
+                captured["model_config"] = json.loads(model_config_json)
+                captured["model"] = model
+
+        agent = types.SimpleNamespace(
+            model="claude-sonnet-4.6",
+            provider="anthropic",
+            base_url="",
+            api_mode="",
+            reasoning_config=None,
+            service_tier=None,
+            _session_db=FakeDB(),
+        )
+        session = {
+            "session_key": "key-3",
+            "agent": agent,
+            "follow_profile_config": False,
+            "model_override": {"model": "claude-sonnet-4.6", "provider": "anthropic"},
+        }
+        server._persist_live_session_runtime(session)
+        assert captured["model_config"].get("follow_profile_config") is None
+        assert captured["model"] == "claude-sonnet-4.6"
+        assert captured["model_config"]["model"] == "claude-sonnet-4.6"
+
 
 # --- Regression: model column vs model_config desync (stale provider) ----------
 #

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -100,7 +100,18 @@ def _(rid, params: dict) -> dict:
             "pending_title": title or None,
             "pending_hidden": is_truthy_value(params.get("hidden", False)),
             "room_plumbing": is_truthy_value(params.get("room_plumbing", False)),
-            "follow_profile_config": is_truthy_value(params.get("follow_profile_config", False)),
+            # Default follow when create did not pin a model (#101514). Desktop
+            # already omits default-sourced model/provider so a new chat must
+            # keep tracking the profile; without this, _ensure_session_db_row
+            # stamps _resolve_model() and resume restores it as model_override,
+            # freezing the chat on the old default forever. Explicit
+            # follow_profile_config (Bot Mode) still wins; an explicit create
+            # model pins the chat instead.
+            "follow_profile_config": (
+                is_truthy_value(params.get("follow_profile_config"))
+                if "follow_profile_config" in params
+                else not bool(create_model)
+            ),
             "profile_home": str(profile_home) if profile_home is not None else None,
             "running": False,
             "session_key": key,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5852,6 +5852,12 @@ def _persist_live_session_runtime(session: dict | None) -> None:
             # normal and would otherwise erase the distinction on every live
             # metadata persist.
             model_config["service_tier"] = create_service_tier_override or "normal"
+        # Keep the follow_profile_config marker in sync with the live session.
+        # /model clears the flag; dropping it here lets resume restore the pin.
+        if session.get("follow_profile_config"):
+            model_config["follow_profile_config"] = True
+        else:
+            model_config.pop("follow_profile_config", None)
         model = str(getattr(agent, "model", "") or "").strip()
         if hasattr(db, "update_session_meta"):
             db.update_session_meta(session_key, json.dumps(model_config), model or None)
@@ -6752,6 +6758,11 @@ def _apply_model_switch(
             "api_key": result.api_key,
             "api_mode": result.api_mode,
         }
+        # An explicit /model pin must outrank the default follow_profile_config
+        # stamp from session.create (#101514). Clear the in-memory contract so
+        # _persist_live_session_runtime drops the marker from the row; otherwise
+        # resume keeps returning {} and the pin never sticks.
+        session["follow_profile_config"] = False
     if persist_global:
         _persist_model_switch(result)
     return {


### PR DESCRIPTION
## Why

A profile session created without an explicit model followed `model.default` only while it stayed live. After restart, `session.resume` restored the row's stamped default as `model_override`, so `_sync_agent_model_with_config` never ran again and profile config edits never reached that chat (#101514).

## Scope

- `tui_gateway/methods_session.py`: default `follow_profile_config` to true when `session.create` omits `model`; honor an explicit follow flag; keep an explicit create model as a pin.
- `tui_gateway/server.py`: clear the follow marker when `/model` pins, and drop it from the row in `_persist_live_session_runtime` so the pin survives resume.
- Focused regression coverage in `tests/test_tui_gateway_server.py` and `tests/tui_gateway/test_custom_provider_session_persistence.py`.

Out of scope: healing pre-existing unmarked rows (they keep stored-runtime restore); changing Bot Mode's explicit follow contract.

## Tradeoffs

New chats without a create-time model now follow the profile by default. That matches desktop (it already omits default-sourced model) and the issue expected behavior. An explicit create model or a later `/model` pin still persists across resume.

## Blast Radius

Touches gateway session create/resume and live runtime persist for desktop/TUI chats. Safe for Bot Mode (still sends `follow_profile_config: true`). Existing unmarked rows are unchanged.

## Verification

```
python -m pytest tests/tui_gateway/test_custom_provider_session_persistence.py::TestFollowProfileConfigRuntimeOverrides tests/test_tui_gateway_server.py::test_session_create_records_ui_model_as_session_override tests/test_tui_gateway_server.py::test_session_create_defaults_follow_profile_config_without_model -q --tb=short
```

Result: 10 passed, exit 0.

Fixes #101514