### PR TITLE
fix(desktop): wrap transcript output instead of horizontal scroll

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-table.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-table.tsx
@@ -154,11 +154,10 @@ export function ResizableMarkdownTable({ children, className, ...props }: Compon
   }, [])
 
   return (
-    <div className="aui-md-table my-2 max-w-full overflow-x-auto rounded-[0.375rem] border border-(--ui-stroke-tertiary)">
+    <div className="aui-md-table my-2 max-w-full overflow-x-hidden rounded-[0.375rem] border border-(--ui-stroke-tertiary)">
       <table
         className={cn(
-          'm-0 w-full min-w-[18rem] border-collapse text-[0.8125rem] [&_tr]:border-b [&_tr]:border-(--ui-stroke-tertiary) last:[&_tr]:border-0',
-          widths && 'table-fixed [&_td]:wrap-anywhere',
+          'm-0 w-full table-fixed border-collapse text-[0.8125rem] [&_td]:wrap-anywhere [&_th]:wrap-anywhere [&_tr]:border-b [&_tr]:border-(--ui-stroke-tertiary) last:[&_tr]:border-0',
           className
         )}
         onDoubleClick={onDoubleClick}
@@ -191,9 +190,9 @@ export function ResizableMarkdownTh({ children, className, ...props }: Component
       )}
       {...props}
     >
-      {/* Truncation lives on an inner box, not the cell: the grab band straddles
-          the cell's edge, so a clipping `<th>` would cut half of it off. */}
-      <span className="block overflow-hidden text-ellipsis whitespace-nowrap">{children}</span>
+      {/* Header text wraps; the grab band still sits on this inner box so a
+          clipping `<th>` would not cut the seam handle in half. */}
+      <span className="block wrap-anywhere">{children}</span>
       {/* Invisible grab band straddling the seam, with the hairline revealed on
           hover — the pane sash treatment (`tree-split.tsx`) scaled to a header
           row. The table carries no vertical rules otherwise, so the line only

--- a/apps/desktop/src/components/assistant-ui/thread/user-message-text.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message-text.test.tsx
@@ -56,6 +56,10 @@ describe('a sent reference renders as the chip the composer showed', () => {
   it('leaves a fenced block alone', () => {
     render(<UserMessageText text={'before\n```ts\nconst x = 1\n```\nafter'} />)
 
-    expect(document.querySelector('[data-slot="aui_user-fence"]')?.textContent).toBe('const x = 1\n')
+    const fence = document.querySelector('[data-slot="aui_user-fence"]')
+    expect(fence?.textContent).toBe('const x = 1\n')
+    expect(fence?.className).toContain('overflow-x-hidden')
+    expect(fence?.className).toContain('whitespace-pre-wrap')
+    expect(fence?.className).not.toContain('overflow-x-auto')
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/user-message-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message-text.tsx
@@ -127,11 +127,11 @@ export const UserMessageText: FC<UserMessageTextProps> = ({ className, text }) =
         if (segment.kind === 'fence') {
           return (
             <pre
-              className="my-1.5 max-w-full overflow-x-auto rounded-md border border-(--ui-stroke-tertiary) bg-[color-mix(in_srgb,currentColor_5%,transparent)] px-2.5 py-2 font-mono text-[0.86em] leading-snug"
+              className="my-1.5 max-w-full overflow-x-hidden whitespace-pre-wrap wrap-anywhere rounded-md border border-(--ui-stroke-tertiary) bg-[color-mix(in_srgb,currentColor_5%,transparent)] px-2.5 py-2 font-mono text-[0.86em] leading-snug"
               data-slot="aui_user-fence"
               key={`fence-${segmentIndex}`}
             >
-              <code className="block whitespace-pre">{segment.code}</code>
+              <code className="block whitespace-pre-wrap wrap-anywhere">{segment.code}</code>
             </pre>
           )
         }

--- a/apps/desktop/src/components/chat/code-card.tsx
+++ b/apps/desktop/src/components/chat/code-card.tsx
@@ -36,7 +36,7 @@ function CodeCardBody({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       className={cn(
-        'font-mono text-[0.7rem] leading-relaxed text-foreground/90 [&_pre]:m-0 [&_pre]:overflow-x-auto [&_pre]:scrollbar-overlay [&_pre]:bg-transparent! [&_pre]:px-2 [&_pre]:py-1.5 [&_pre]:font-mono [&_pre]:leading-relaxed',
+        'font-mono text-[0.7rem] leading-relaxed text-foreground/90 [&_pre]:m-0 [&_pre]:overflow-x-hidden [&_pre]:whitespace-pre-wrap [&_pre]:wrap-anywhere [&_pre]:bg-transparent! [&_pre]:px-2 [&_pre]:py-1.5 [&_pre]:font-mono [&_pre]:leading-relaxed [&_code]:whitespace-pre-wrap [&_code]:wrap-anywhere',
         className
       )}
       data-slot="code-card-body"

--- a/apps/desktop/src/components/chat/compact-markdown.tsx
+++ b/apps/desktop/src/components/chat/compact-markdown.tsx
@@ -20,9 +20,9 @@ const TAG_CLASSES = {
   li: 'marker:text-muted-foreground/60',
   ol: 'mb-2 list-decimal pl-5 last:mb-0',
   p: 'mb-1.5 leading-relaxed last:mb-0',
-  pre: 'mb-2 overflow-x-auto rounded-md border border-(--ui-stroke-tertiary) bg-background/70 p-2 font-mono text-[0.7rem] leading-[1.55] last:mb-0',
-  td: 'px-2 py-1 align-top leading-snug',
-  th: 'px-2 py-1 text-left text-[0.62rem] font-semibold uppercase tracking-[0.08em] text-muted-foreground/80',
+  pre: 'mb-2 overflow-x-hidden whitespace-pre-wrap wrap-anywhere rounded-md border border-(--ui-stroke-tertiary) bg-background/70 p-2 font-mono text-[0.7rem] leading-[1.55] last:mb-0',
+  td: 'px-2 py-1 align-top leading-snug wrap-anywhere',
+  th: 'px-2 py-1 text-left text-[0.62rem] font-semibold uppercase tracking-[0.08em] text-muted-foreground/80 wrap-anywhere',
   thead: 'bg-muted/40',
   ul: 'mb-2 list-disc pl-5 last:mb-0'
 } as const
@@ -66,10 +66,10 @@ function MarkdownCode({ className, ...rest }: ComponentProps<'code'>) {
 
 function MarkdownTable({ className, ...rest }: ComponentProps<'table'>) {
   return (
-    <div className="mb-2 max-w-full overflow-x-auto rounded-md border border-(--ui-stroke-tertiary) last:mb-0">
+    <div className="mb-2 max-w-full overflow-x-hidden rounded-md border border-(--ui-stroke-tertiary) last:mb-0">
       <table
         className={cn(
-          'w-full border-collapse text-[0.72rem] [&_tr]:border-b [&_tr]:border-(--ui-stroke-tertiary) last:[&_tr]:border-0',
+          'w-full table-fixed border-collapse text-[0.72rem] [&_tr]:border-b [&_tr]:border-(--ui-stroke-tertiary) last:[&_tr]:border-0',
           className
         )}
         {...rest}

--- a/apps/desktop/src/components/chat/expandable-block.test.tsx
+++ b/apps/desktop/src/components/chat/expandable-block.test.tsx
@@ -24,7 +24,7 @@ afterEach(() => {
 })
 
 describe('ExpandableBlock', () => {
-  it('lets horizontal scroll through and keeps the last line selectable', () => {
+  it('clips horizontal overflow and keeps the last line selectable', () => {
     vi.stubGlobal('ResizeObserver', TestResizeObserver)
 
     const { container } = render(
@@ -37,14 +37,14 @@ describe('ExpandableBlock', () => {
     const toggle = screen.getByRole('button', { name: /expand|collapse/i })
     const fade = toggle.parentElement!
 
-    // Inner container allows horizontal scroll so wide code gets a scrollbar:
-    // platform overlay (`scrollbar-overlay`), not the always-on classic gutter.
-    expect(inner.className).toContain('overflow-x-auto')
+    // Vertical scroll only. Wide code wraps inside the card; no nested X bar.
+    expect(inner.className).toContain('overflow-x-hidden')
+    expect(inner.className).toContain('overflow-y-auto')
     expect(inner.className).toContain('scrollbar-overlay')
+    expect(inner.className).not.toContain('overflow-x-auto')
 
     // The full-width fade is a pure cue: it spans the bottom edge but must not
-    // intercept pointer events, so the scrollbar drag and text selection on the
-    // last line pass through to the content underneath.
+    // intercept pointer events, so text selection on the last line passes through.
     expect(fade.className).toContain('pointer-events-none')
     expect(fade.className).toContain('inset-x-0')
 

--- a/apps/desktop/src/components/chat/expandable-block.tsx
+++ b/apps/desktop/src/components/chat/expandable-block.tsx
@@ -35,7 +35,8 @@ export function ExpandableBlock({ children, className }: ExpandableBlockProps) {
         className={cn(
           // `scrollbar-overlay` opts out of the app-wide classic thin gutters so
           // this scroller keeps platform overlay bars (no always-on track).
-          'scrollbar-overlay overflow-y-auto overflow-x-auto',
+          // Clip X: wide fences wrap inside the card; only Y may scroll.
+          'scrollbar-overlay overflow-y-auto overflow-x-hidden',
           expanded ? 'max-h-[40dvh]' : 'max-h-[7.5rem]',
           className
         )}
@@ -45,11 +46,9 @@ export function ExpandableBlock({ children, className }: ExpandableBlockProps) {
       </div>
       {overflowing && (
         // The fade is a pure overflow cue and must not intercept pointer events:
-        // it spans the full bottom edge (over the horizontal scrollbar of a wide
-        // code block AND the block's last line), so making it clickable killed
-        // both sideways scrolling and text selection. Keep the fade
-        // `pointer-events-none` and pin the only clickable target — a compact
-        // toggle — to the right edge, clear of the draggable scrollbar track.
+        // it spans the full bottom edge over the block's last line, so making it
+        // clickable killed text selection. Keep the fade `pointer-events-none`
+        // and pin the only clickable target — a compact toggle — to the right.
         <div className="pointer-events-none absolute inset-x-0 bottom-0 flex h-7 justify-end bg-linear-to-t from-[var(--expandable-fade-from,var(--ui-chat-surface-background))] to-transparent">
           <button
             aria-expanded={expanded}

--- a/apps/desktop/src/components/chat/shiki-highlighter.tsx
+++ b/apps/desktop/src/components/chat/shiki-highlighter.tsx
@@ -105,14 +105,14 @@ const PlainCode: FC<{ code: string }> = ({ code }) => {
   const chunks = useMemo(() => chunkByLines(code, CHUNK_LINES), [code])
 
   if (chunks.length === 1) {
-    return <code className="block whitespace-pre">{code}</code>
+    return <code className="block whitespace-pre-wrap wrap-anywhere">{code}</code>
   }
 
   return (
     <>
       {chunks.map((chunk, index) => (
         <code
-          className="block whitespace-pre [content-visibility:auto]"
+          className="block whitespace-pre-wrap wrap-anywhere [content-visibility:auto]"
           key={index}
           style={{ containIntrinsicSize: `auto ${chunk.lines * EST_LINE_PX}px` }}
         >

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1888,9 +1888,17 @@ body.guest-pointer-lock :is(webview, iframe) {
 
 /* react-shiki nests its own `pre.shiki` inside our `.aui-shiki` Pre, so the
    code card's `[&_pre]` padding lands on both and doubles the inset. The outer
-   Pre already carries the card's padding — zero the inner one. */
+   Pre already carries the card's padding — zero the inner one. Soft-wrap so
+   long tokens never force a nested horizontal scrollbar in the transcript. */
 [data-slot='aui_assistant-message-content'] .aui-md .aui-shiki .shiki {
   padding: 0 !important;
+  white-space: pre-wrap !important;
+  overflow-wrap: anywhere;
+}
+
+[data-slot='aui_assistant-message-content'] .aui-md .aui-shiki code {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 [data-slot='aui_assistant-message-content'] .aui-md .aui-md-table {


### PR DESCRIPTION
## Why

Assistant output in the Desktop transcript grew nested horizontal scrollbars. Long fences, tables, and tool markdown forced sideways pan, so the thread was hard to read. #101311 asks for vertical scroll only, with wrap inside each card.

Related open PRs (#70520, #70561) touch prose/table containment and keep fenced-code X scroll. This change removes that X scroll on the smoking-gun surfaces.

## Scope

- `ExpandableBlock`: `overflow-x-hidden` (was `overflow-x-auto`)
- `CodeCardBody` + `PlainCode` + Shiki CSS: soft-wrap long tokens
- `CompactMarkdown` pre/table and user-bubble fences: same wrap rule
- `ResizableMarkdownTable`: `table-fixed`, wrap cells, no `min-w-[18rem]` X push
- Tests: `expandable-block.test.tsx`, `user-message-text.test.tsx`

Out of scope: bot group-chat plugin fences (#91857), code word-wrap toggle feature (#87952), terminal/diff `whitespace-pre` surfaces.

## Tradeoffs

Code no longer pans sideways. Very long unbroken tokens wrap with `overflow-wrap: anywhere`, which can look denser than a horizontal scrollbar. That matches the issue acceptance criteria.

## Blast Radius

Desktop chat transcript only (assistant markdown, code cards, tool compact markdown, user fences). Thread viewport stays `overflow-x-hidden`. Tall blocks still expand/collapse and scroll vertically.

## Verification

`
cd apps/desktop
npm run test:ui -- src/components/chat/expandable-block.test.tsx src/components/assistant-ui/thread/user-message-text.test.tsx src/components/chat/shiki-highlighter.test.ts
`

Result: 3 files, 14 passed, exit 0.

Fixes #101311
Also covers the same containment mechanism as #70451 for code/expandable/table output (partial overlap with open #70520).

Made with [Cursor](https://cursor.com)