### PR TITLE
fix(kanban): make listing read-only

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1743,9 +1743,10 @@ def _cmd_list(args: argparse.Namespace) -> int:
     if args.mine and not assignee:
         assignee = _profile_author()
     with kb.connect_closing() as conn:
-        # Cheap "mini-dispatch": recompute ready so list output reflects
-        # dependencies that may have cleared since the last dispatcher tick.
-        kb.recompute_ready(conn)
+        # No "mini-dispatch" here: listing is a read. Promoting eligible
+        # tasks belongs to the dispatcher and to the lifecycle writes that
+        # clear a dependency, so `kanban list` never moves a card between
+        # lanes or appends a `promoted` event for it.
         tasks = kb.list_tasks(
             conn,
             assignee=assignee,

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -57,6 +57,39 @@ def test_kanban_list_json_includes_session_id(kanban_home):
     )
 
 
+def test_kanban_list_does_not_promote_ready_tasks(kanban_home):
+    """`hermes kanban list` is a read, not a "mini-dispatch".
+
+    The command ran ``recompute_ready`` before rendering, so listing the
+    board moved eligible ``todo`` cards into ``ready`` and logged a
+    ``promoted`` event for each. Promotion is the dispatcher's job (and
+    that of the lifecycle writes which clear a dependency); looking at the
+    board must leave every card in the lane it was already in.
+    """
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="eligible", assignee="alice")
+        # create_task promotes a parentless card itself; put it back in the
+        # lane recompute_ready would pull it out of.
+        conn.execute("UPDATE tasks SET status = 'todo' WHERE id = ?", (tid,))
+        conn.commit()
+        promotions_before = conn.execute(
+            "SELECT COUNT(*) FROM task_events "
+            "WHERE task_id = ? AND kind = 'promoted'",
+            (tid,),
+        ).fetchone()[0]
+
+    payload = json.loads(kc.run_slash("list --json"))
+    assert [row["status"] for row in payload if row["id"] == tid] == ["todo"]
+
+    with kb.connect() as conn:
+        assert kb.get_task(conn, tid).status == "todo"
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_events "
+            "WHERE task_id = ? AND kind = 'promoted'",
+            (tid,),
+        ).fetchone()[0] == promotions_before
+
+
 def test_kanban_show_text_renders_graph_with_open_connection(kanban_home):
     with kb.connect_closing() as conn:
         parent_id = kb.create_task(conn, title="parent task")

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -111,6 +111,73 @@ def test_list_filters_tasks(monkeypatch, worker_env):
     assert tenant_ids == [c]
 
 
+def _board_snapshot(conn) -> dict[str, list[str]]:
+    """Every row of every table, order-independent and type-safe.
+
+    Repr-sorting sidesteps both SQLite's unspecified scan order and
+    Python's refusal to compare ``None`` with a string, so an unchanged
+    database compares equal without pinning a row order the schema never
+    promised.
+    """
+    tables = [
+        row[0] for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' "
+            "AND name NOT LIKE 'sqlite_%' ORDER BY name"
+        ).fetchall()
+    ]
+    return {
+        name: sorted(repr(tuple(r)) for r in conn.execute(f"SELECT * FROM {name}"))
+        for name in tables
+    }
+
+
+def test_list_does_not_write_to_the_board(monkeypatch, worker_env):
+    """Listing is discovery, not dispatch.
+
+    ``kanban_list`` ran ``recompute_ready`` before rendering, so merely
+    looking at the board promoted every eligible ``todo`` card to ``ready``
+    and appended a ``promoted`` event for it — an orchestrator could not
+    read the board without changing it, and the lane a card was in depended
+    on who had listed it last. Eligibility promotion belongs to the
+    dispatcher and to the lifecycle writes that clear a dependency.
+    """
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    from hermes_cli import kanban_db as kb
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="eligible", assignee="factory")
+        # create_task promotes a parentless card itself; put it back in the
+        # lane recompute_ready would pull it out of.
+        conn.execute("UPDATE tasks SET status = 'todo' WHERE id = ?", (tid,))
+        conn.commit()
+        before = _board_snapshot(conn)
+    finally:
+        conn.close()
+
+    from tools import kanban_tools as kt
+    payload = json.loads(kt._handle_list({"limit": 10}))
+
+    # The card is listed as it actually sits, not as a promotion would leave it.
+    listed = {t["id"]: t for t in payload["tasks"]}
+    assert listed[tid]["status"] == "todo"
+    # The counter stays in the response for callers that read it, and a read
+    # surface has nothing to count.
+    assert payload["promoted"] == 0
+
+    conn = kb.connect()
+    try:
+        assert _board_snapshot(conn) == before, "kanban_list wrote to the database"
+        assert kb.get_task(conn, tid).status == "todo"
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_events "
+            "WHERE task_id = ? AND kind = 'promoted'",
+            (tid,),
+        ).fetchone()[0] == 0
+    finally:
+        conn.close()
+
+
 def test_complete_happy_path(worker_env):
     from tools import kanban_tools as kt
     out = kt._handle_complete({

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -623,9 +623,10 @@ def _handle_list(args: dict, **kw) -> str:
     try:
         kb, conn = _connect(board=board)
         try:
-            # Match CLI list: dependencies that cleared since the last
-            # dispatcher tick should be visible to orchestrators immediately.
-            promoted = kb.recompute_ready(conn)
+            # Listing is a read. Promoting eligible tasks belongs to the
+            # dispatcher and to the lifecycle writes that clear a
+            # dependency, so discovering work never moves a card between
+            # lanes or appends a `promoted` event for it.
             # Fetch one extra row so model-facing output can report that
             # a bounded listing was truncated without dumping the board.
             rows = kb.list_tasks(
@@ -647,7 +648,10 @@ def _handle_list(args: dict, **kw) -> str:
                     min(limit * 2, KANBAN_LIST_MAX_LIMIT)
                     if truncated and limit < KANBAN_LIST_MAX_LIMIT else None
                 ),
-                "promoted": promoted,
+                # Kept so existing callers keep reading a field that is
+                # still there; a read surface promotes nothing, so it is
+                # now always zero.
+                "promoted": 0,
             })
         finally:
             conn.close()
@@ -1744,8 +1748,8 @@ KANBAN_LIST_SCHEMA = {
         "status, tenant, include_archived, and limit. Returns compact rows "
         "with ids, title, status, assignee, priority, parent/child ids, and "
         "counts. Bounded to 50 rows by default, 200 max, with truncation "
-        "metadata. Also recomputes ready tasks before listing, matching the "
-        "CLI. Orchestrator-only — dispatcher-spawned task workers never see "
+        "metadata. Read-only: listing never changes a task's lane. "
+        "Orchestrator-only — dispatcher-spawned task workers never see "
         "this tool."
     ),
     "parameters": {


### PR DESCRIPTION
## What does this PR do?

Listing Kanban cards mutates the board. Both listing surfaces run
`recompute_ready()` before rendering, as a deliberate cheap "mini-dispatch":

- `hermes_cli/kanban.py::_cmd_list` — `hermes kanban list`
- `tools/kanban_tools.py::_handle_list` — the `kanban_list` agent tool

So any eligible `todo` card is promoted to `ready` and given a `promoted`
event *because somebody looked at the board*. A card's lane therefore depends
on who listed it last, and the event log records promotions no dispatcher tick
ever made — which is misleading when you are reading that log to work out why a
task started.

Promotion already happens everywhere it should: `dispatch_once()` runs
`recompute_ready()` on every tick, and each lifecycle write that can clear a
dependency (`complete_task`, `unblock_task`, `archive_task`, `link_tasks` /
`unlink_tasks`) recomputes on its own. Removing the call from the two read
surfaces changes **what a reader observes, not when a task actually becomes
eligible** — a card is promoted by the next dispatcher tick instead of by the
person looking at it.

`kanban_list`'s response keeps its `promoted` key, so any caller that reads it
still finds it; with nothing left to promote on a read path it is now always
`0`. Making listing read-only does not require removing a public response
field, so this PR does not remove one.

## Related Issue

No issue — found while reading the two list surfaces.

**Possible overlap: #81823** ("fix(kanban): keep list queries non-mutating",
opened 2026-08-08, still open and unreviewed) makes the same core change to the
same two functions. I found it after writing this, and I am flagging it rather
than quietly competing with it. For whoever triages:

- That PR also adds sticky-block handling in `hermes_cli/kanban_db.py`. `main`
  has since grown `_has_sticky_block()` inside `recompute_ready()`
  independently, so that part now looks redundant.
- Both PRs keep `"promoted": 0` in the tool response for compatibility. This
  one is the narrower change: the two `recompute_ready()` calls, the schema
  description, and tests.

If #81823 is the one you want, please close this — no objection at all.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban.py` — `_cmd_list` no longer calls `kb.recompute_ready(conn)`.
- `tools/kanban_tools.py` — `_handle_list` no longer calls `kb.recompute_ready(conn)`.
  Its response still carries `"promoted"`, now a constant `0`, so existing callers
  keep the key they have always read. `KANBAN_LIST_SCHEMA`'s description no longer
  advertises the recompute and says the tool is read-only instead.
- `tests/hermes_cli/test_kanban_cli.py` — `test_kanban_list_does_not_promote_ready_tasks`.
- `tests/tools/test_kanban_tools.py` — `test_list_does_not_write_to_the_board`, which
  compares a full row-level snapshot of every table before and after the call, and
  asserts the response still reports `promoted == 0`.

## How to Test

Both new tests fail on `main` for exactly the right reason (`assert 'ready' == 'todo'`,
and the tool response reporting `promoted == 1`) and pass with the fix.

1. Create a card and put it in `todo` with no parents — i.e. eligible for promotion:
   ```python
   from hermes_cli import kanban_db as kb
   kb.init_db()
   conn = kb.connect()
   tid = kb.create_task(conn, title="real-path card", assignee="alice")
   conn.execute("UPDATE tasks SET status='todo' WHERE id=?", (tid,))
   conn.commit(); conn.close()
   ```
2. `hermes kanban list` — before: the card renders as `ready`. After: it renders as `todo`.
   ```
   ◻ t_d282e262  todo      alice                 real-path card
   ```
3. Re-read the card and its events. Before: `status == 'ready'` and one `promoted`
   event. After: `status == 'todo'` and zero `promoted` events.
4. Same for the tool: `json.loads(kanban_tools._handle_list({'limit': 10}))` leaves the
   card in `todo` and returns `promoted == 0` — before the fix that same call returns
   `promoted == 1` and leaves the card in `ready`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — see the overlap with #81823 noted above
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **not the full suite.** I ran the
  Kanban tool, CLI, dispatcher and lifecycle-promotion suites:
  `pytest tests/tools/test_kanban_tools.py tests/hermes_cli/test_kanban_cli.py
  tests/hermes_cli/test_kanban_blocked_sticky.py tests/hermes_cli/test_kanban_promote.py
  tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_lifecycle_hooks.py
  tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_dispatch_lock.py
  tests/hermes_cli/test_kanban_dispatch_tick_hook.py tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py -q`
  → **106 passed, 2 skipped**. Leaving the rest to CI.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.6.0), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no docs
  page described the recompute. The two in-code comments that did are updated.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A; no platform-specific code paths.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — `KANBAN_LIST_SCHEMA`'s
  description now says listing is read-only instead of advertising the recompute.
