### PR TITLE
fix(bot-mode): deliver local DMs into Desktop-owned Bot Chat (#101060)

### DIFF
--- a/tests/tools/test_bot_live_owner_delivery.py
+++ b/tests/tools/test_bot_live_owner_delivery.py
@@ -1,0 +1,167 @@
+"""Reliable Bot Chat delivery through an existing live session owner."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from hermes_cli.active_sessions import try_acquire_active_session
+from hermes_state import SessionDB
+from tools import bot_live_delivery
+
+
+def test_find_canonical_live_owner_uses_profile_registry(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("canonical", source="desktop")
+    db.set_session_title("canonical", "Bot Chat")
+    db.set_session_hidden("canonical", True)
+    lease, refusal = try_acquire_active_session(
+        session_id="canonical",
+        surface="desktop",
+        config={},
+        metadata={"live_session_id": "live-target"},
+        registry_home=tmp_path,
+    )
+    assert lease is not None and refusal is None
+
+    assert bot_live_delivery.find_canonical_live_owner(tmp_path) == "canonical"
+
+
+def test_find_canonical_live_owner_ignores_cli_owner(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("canonical", source="cli")
+    db.set_session_title("canonical", "Bot Chat")
+    db.set_session_hidden("canonical", True)
+    lease, refusal = try_acquire_active_session(
+        session_id="canonical",
+        surface="cli",
+        config={},
+        metadata={"live_session_id": "classic-cli"},
+        registry_home=tmp_path,
+    )
+    assert lease is not None and refusal is None
+
+    assert bot_live_delivery.find_canonical_live_owner(tmp_path) is None
+
+
+def test_find_canonical_live_owner_returns_none_when_session_is_idle(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("canonical", source="desktop")
+    db.set_session_title("canonical", "Bot Chat")
+    db.set_session_hidden("canonical", True)
+
+    assert bot_live_delivery.find_canonical_live_owner(tmp_path) is None
+
+
+def test_live_owner_claim_and_terminal_receipt_round_trip(tmp_path):
+    result = {}
+
+    def sender():
+        result.update(
+            bot_live_delivery.deliver_to_live_owner(
+                tmp_path,
+                "canonical",
+                "Message from agent: hello",
+                owner_wait_seconds=1,
+                receipt_wait_seconds=1,
+            )
+        )
+
+    thread = threading.Thread(target=sender)
+    thread.start()
+
+    claimed = None
+    deadline = time.monotonic() + 1
+    while claimed is None and time.monotonic() < deadline:
+        claimed = bot_live_delivery.claim_pending_delivery(tmp_path, "canonical")
+        if claimed is None:
+            time.sleep(0.01)
+
+    assert claimed is not None
+    assert claimed["message"] == "Message from agent: hello"
+    bot_live_delivery.complete_delivery(
+        tmp_path,
+        claimed["id"],
+        status="settled",
+        reply="received",
+    )
+    thread.join(timeout=2)
+
+    assert result == {
+        "status": "delivered",
+        "delivery_id": claimed["id"],
+        "reply": "received",
+    }
+
+
+def test_live_owner_busy_timeout_is_definitively_not_delivered(tmp_path):
+    result = bot_live_delivery.deliver_to_live_owner(
+        tmp_path,
+        "canonical",
+        "wait for owner",
+        owner_wait_seconds=0.02,
+        receipt_wait_seconds=1,
+        poll_seconds=0.005,
+    )
+
+    assert result["status"] == "not_delivered"
+    assert result["reason"] == "target_busy"
+    assert bot_live_delivery.claim_pending_delivery(tmp_path, "canonical") is None
+
+
+def test_claimed_delivery_timeout_is_transport_ambiguous(tmp_path):
+    result = {}
+
+    def sender():
+        result.update(
+            bot_live_delivery.deliver_to_live_owner(
+                tmp_path,
+                "canonical",
+                "claimed but receipt lost",
+                owner_wait_seconds=1,
+                receipt_wait_seconds=0.02,
+                poll_seconds=0.005,
+            )
+        )
+
+    thread = threading.Thread(target=sender)
+    thread.start()
+    deadline = time.monotonic() + 1
+    claimed = None
+    while claimed is None and time.monotonic() < deadline:
+        claimed = bot_live_delivery.claim_pending_delivery(tmp_path, "canonical")
+        if claimed is None:
+            time.sleep(0.005)
+    assert claimed is not None
+    thread.join(timeout=2)
+
+    assert result["status"] == "ambiguous"
+    assert result["reason"] == "delivery_timeout"
+
+
+def test_claim_pending_delivery_uses_created_at_fifo_not_uuid_order(tmp_path):
+    pending_dir, _claimed_dir, _replies_dir = bot_live_delivery._paths(
+        tmp_path, "canonical"
+    )
+    now = time.time()
+    requests = [
+        ("f" * 32, now - 2, "older"),
+        ("0" * 32, now - 1, "newer"),
+    ]
+    for delivery_id, created_at, message in requests:
+        bot_live_delivery._atomic_json(
+            pending_dir / f"{delivery_id}.json",
+            {
+                "id": delivery_id,
+                "session_id": "canonical",
+                "message": message,
+                "created_at": created_at,
+                "owner_deadline": now + 30,
+            },
+        )
+
+    first = bot_live_delivery.claim_pending_delivery(tmp_path, "canonical")
+    second = bot_live_delivery.claim_pending_delivery(tmp_path, "canonical")
+
+    assert first is not None and first["message"] == "older"
+    assert second is not None and second["message"] == "newer"

--- a/tests/tools/test_bot_live_owner_delivery.py
+++ b/tests/tools/test_bot_live_owner_delivery.py
@@ -109,6 +109,44 @@ def test_live_owner_busy_timeout_is_definitively_not_delivered(tmp_path):
     assert bot_live_delivery.claim_pending_delivery(tmp_path, "canonical") is None
 
 
+def test_expired_pending_claim_makes_sender_result_not_delivered(tmp_path):
+    result = {}
+
+    def sender():
+        result.update(
+            bot_live_delivery.deliver_to_live_owner(
+                tmp_path,
+                "canonical",
+                "expired before owner could claim",
+                owner_wait_seconds=0.05,
+                receipt_wait_seconds=1,
+                poll_seconds=0.001,
+            )
+        )
+
+    thread = threading.Thread(target=sender)
+    thread.start()
+    pending_dir, _claimed_dir, _replies_dir = bot_live_delivery._paths(
+        tmp_path, "canonical"
+    )
+    deadline = time.monotonic() + 1
+    pending = next(pending_dir.glob("*.json"), None)
+    while pending is None and time.monotonic() < deadline:
+        time.sleep(0.001)
+        pending = next(pending_dir.glob("*.json"), None)
+    assert pending is not None
+    payload = bot_live_delivery._read_json(pending)
+    assert payload is not None
+    payload["owner_deadline"] = time.time() - 1
+    bot_live_delivery._atomic_json(pending, payload)
+
+    assert bot_live_delivery.claim_pending_delivery(tmp_path, "canonical") is None
+    thread.join(timeout=2)
+
+    assert result["status"] == "not_delivered"
+    assert result["reason"] == "target_busy"
+
+
 def test_claimed_delivery_timeout_is_transport_ambiguous(tmp_path):
     result = {}
 

--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -445,11 +445,61 @@ def test_delivery_runner_surfaces_live_owner_refusal(tmp_path, capsys):
     assert "NOT delivered" in payload["error"]
 
 
+def test_delivery_runner_hands_off_to_live_owner(tmp_path, monkeypatch, capsys):
+    """#101060: when Desktop owns Bot Chat, local delivery uses the live-owner
+    handoff instead of the fenced-out CLI subprocess."""
+    dm_file = tmp_path / "message.txt"
+    dm_file.write_text("Message from 🤖 forge (@forge): ping", encoding="utf-8")
+    profile_home = tmp_path / "profiles" / "ops"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        bot_mode_dm,
+        "_hermes_root",
+        lambda home: tmp_path,
+    )
+    calls = []
+
+    def fake_find(home):
+        assert Path(home) == profile_home
+        return "canonical"
+
+    def fake_deliver(home, session_id, content, **kwargs):
+        calls.append((Path(home), session_id, content, kwargs))
+        return {"status": "delivered", "delivery_id": "a" * 32, "reply": "pong"}
+
+    monkeypatch.setattr(
+        "tools.bot_live_delivery.find_canonical_live_owner", fake_find
+    )
+    monkeypatch.setattr(
+        "tools.bot_live_delivery.deliver_to_live_owner", fake_deliver
+    )
+    spawned = []
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: spawned.append(a) or None
+    )
+
+    returncode = bot_mode_dm._run_delivery(
+        ["hermes", "-p", "ops", "chat", "-c", "Bot Chat"],
+        str(dm_file),
+        stdin_file=False,
+    )
+
+    assert returncode == 0
+    assert not spawned
+    assert calls and calls[0][1] == "canonical"
+    assert "ping" in calls[0][2]
+    assert capsys.readouterr().out.strip() == "pong"
+    assert not dm_file.exists()
+
+
 def test_query_file_delivery_closes_stdin_for_initial_attempt_and_retry(
     tmp_path, monkeypatch
 ):
     dm_file = tmp_path / "message.txt"
     dm_file.write_text("secret", encoding="utf-8")
+    (tmp_path / "profiles" / "researcher").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     calls = []
     responses = [
         subprocess.CompletedProcess([], 1, stdout="", stderr="HTTP 429 rate limit"),

--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -390,7 +390,7 @@ def test_delivery_runner_keeps_file_for_child_then_unlinks(tmp_path, stdin_file)
     assert not dm_file.exists()
 
 
-def test_delivery_runner_unlinks_when_child_launch_raises(tmp_path, monkeypatch):
+def test_delivery_runner_retains_payload_when_child_launch_raises(tmp_path, monkeypatch):
     dm_file = tmp_path / "message.txt"
     dm_file.write_text("secret", encoding="utf-8")
 
@@ -400,10 +400,10 @@ def test_delivery_runner_unlinks_when_child_launch_raises(tmp_path, monkeypatch)
     monkeypatch.setattr(subprocess, "run", boom)
     with pytest.raises(RuntimeError, match="child launch failed"):
         bot_mode_dm._run_delivery(["hermes"], str(dm_file), stdin_file=False)
-    assert not dm_file.exists()
+    assert dm_file.exists()
 
 
-def test_delivery_runner_preserves_child_failure_and_unlinks(tmp_path):
+def test_delivery_runner_preserves_child_failure_and_payload(tmp_path):
     dm_file = tmp_path / "message.txt"
     dm_file.write_text("secret", encoding="utf-8")
     child = tmp_path / "fail.py"
@@ -419,7 +419,38 @@ def test_delivery_runner_preserves_child_failure_and_unlinks(tmp_path):
     )
 
     assert returncode == 7
-    assert not dm_file.exists()
+    assert dm_file.exists()
+
+
+def test_non_delivered_payload_is_retained_and_replay_returns_cached_receipt(
+    tmp_path, monkeypatch, capsys
+):
+    dm_file = tmp_path / "message.txt"
+    dm_file.write_text("secret", encoding="utf-8")
+    calls = []
+
+    def failed_transport(*args, **kwargs):
+        calls.append((args, kwargs))
+        return subprocess.CompletedProcess(
+            args[0],
+            1,
+            stdout="",
+            stderr="Session abc already has a live owner (desktop, pid 1).",
+        )
+
+    monkeypatch.setattr(subprocess, "run", failed_transport)
+
+    assert bot_mode_dm._run_delivery(["hermes"], str(dm_file), stdin_file=False) == 1
+    first = json.loads(capsys.readouterr().out)
+    assert dm_file.exists()
+    assert first["reason"] == "target_busy"
+    assert first["payload_file"] == str(dm_file)
+    assert first["retry_command"]
+
+    assert bot_mode_dm._run_delivery(["hermes"], str(dm_file), stdin_file=False) == 1
+    second = json.loads(capsys.readouterr().out)
+    assert second == first
+    assert len(calls) == 1
 
 
 def test_delivery_runner_surfaces_live_owner_refusal(tmp_path, capsys):
@@ -562,7 +593,7 @@ def test_delivery_main_runs_valid_cli_and_unlinks(tmp_path, mode):
     assert not dm_file.exists()
 
 
-def test_delivery_main_maps_launch_exception_to_one_and_unlinks(tmp_path, monkeypatch):
+def test_delivery_main_maps_launch_exception_to_one_and_retains_payload(tmp_path, monkeypatch):
     dm_file = tmp_path / "message.txt"
     dm_file.write_text("secret", encoding="utf-8")
 
@@ -576,7 +607,7 @@ def test_delivery_main_maps_launch_exception_to_one_and_unlinks(tmp_path, monkey
         )
         == 1
     )
-    assert not dm_file.exists()
+    assert dm_file.exists()
 
 
 @pytest.mark.parametrize("stdin_file", [False, True])

--- a/tests/tui_gateway/test_auto_continue.py
+++ b/tests/tui_gateway/test_auto_continue.py
@@ -181,12 +181,14 @@ def test_interrupt_racing_marker_write_cannot_leave_recovery_state(
     session = _session(agent=agent, running=True)
     _patch_local_interrupt(monkeypatch, session)
 
-    def write_after_stop(home, key, prompt, *, attempts=0):
+    def write_after_stop(home, key, prompt, *, attempts=0, auto_continue=True):
         response = server._methods["session.interrupt"](
             "stop-during-write", {"session_id": "runtime-race"}
         )
         assert response["result"]["status"] == "interrupted"
-        record_turn_start(home, key, prompt, attempts=attempts)
+        record_turn_start(
+            home, key, prompt, attempts=attempts, auto_continue=auto_continue
+        )
 
     monkeypatch.setattr(server, "record_turn_start", write_after_stop)
 
@@ -399,6 +401,20 @@ def test_hosted_room_marker_is_left_to_the_driver(schedule_env, marker_home):
     assert result is None
     assert not schedule_env
     assert read_turn_marker(marker_home, "session-key") is not None
+
+
+def test_dm_marker_is_not_auto_continued(schedule_env, marker_home):
+    record_turn_start(
+        marker_home,
+        "session-key",
+        "Message from agent: do not replay this DM",
+        auto_continue=False,
+    )
+
+    result = server._maybe_schedule_auto_continue("sid", _session(), "session-key")
+
+    assert result is None
+    assert not schedule_env
 
 
 def test_stale_marker_is_cleared_not_continued(schedule_env, marker_home, monkeypatch):

--- a/tests/tui_gateway/test_bot_live_owner_delivery.py
+++ b/tests/tui_gateway/test_bot_live_owner_delivery.py
@@ -1,0 +1,67 @@
+"""TUI/Desktop live-owner intake for durable Bot Chat deliveries."""
+
+from __future__ import annotations
+
+import threading
+
+from tui_gateway import server
+
+
+def _session(*, running=False):
+    return {
+        "session_key": "canonical",
+        "profile_home": "C:/profiles/target",
+        "history_lock": threading.Lock(),
+        "running": running,
+        "transport": None,
+    }
+
+
+def test_idle_owner_claims_delivery_and_commits_terminal_receipt(monkeypatch):
+    session = _session()
+    claimed = {
+        "id": "a" * 32,
+        "session_id": "canonical",
+        "message": "Message from agent: hello",
+    }
+    completions = []
+    monkeypatch.setattr(
+        "tools.bot_live_delivery.claim_pending_delivery",
+        lambda home, session_id: claimed,
+    )
+    monkeypatch.setattr(
+        "tools.bot_live_delivery.complete_delivery",
+        lambda home, delivery_id, **payload: completions.append(
+            (str(home), delivery_id, payload)
+        ),
+    )
+
+    def run_prompt(rid, sid, live, text, **kwargs):
+        assert text == claimed["message"]
+        assert live["running"] is True
+        kwargs["terminal_callback"]({"status": "settled", "text": "received"})
+        return True
+
+    monkeypatch.setattr(server, "_run_prompt_submit", run_prompt)
+    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+
+    assert server._poll_bot_live_delivery_once("live-sid", session) is True
+    assert completions == [
+        (
+            "C:/profiles/target",
+            "a" * 32,
+            {"status": "settled", "reply": "received", "error": "", "reason": ""},
+        )
+    ]
+
+
+def test_busy_owner_leaves_request_unclaimed_for_bounded_sender_timeout(monkeypatch):
+    session = _session(running=True)
+    claims = []
+    monkeypatch.setattr(
+        "tools.bot_live_delivery.claim_pending_delivery",
+        lambda *args: claims.append(args),
+    )
+
+    assert server._poll_bot_live_delivery_once("live-sid", session) is False
+    assert claims == []

--- a/tests/tui_gateway/test_bot_live_owner_delivery.py
+++ b/tests/tui_gateway/test_bot_live_owner_delivery.py
@@ -65,3 +65,32 @@ def test_busy_owner_leaves_request_unclaimed_for_bounded_sender_timeout(monkeypa
 
     assert server._poll_bot_live_delivery_once("live-sid", session) is False
     assert claims == []
+
+
+def test_receipt_write_failure_does_not_fail_dm_turn(monkeypatch):
+    session = _session()
+    claimed = {
+        "id": "a" * 32,
+        "session_id": "canonical",
+        "message": "Message from agent: hello",
+    }
+    monkeypatch.setattr(
+        "tools.bot_live_delivery.claim_pending_delivery", lambda *args: claimed
+    )
+    monkeypatch.setattr(
+        "tools.bot_live_delivery.complete_delivery",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("disk full")),
+    )
+
+    completed = []
+
+    def run_prompt(rid, sid, live, text, **kwargs):
+        kwargs["terminal_callback"]({"status": "settled", "text": "received"})
+        completed.append(text)
+        return True
+
+    monkeypatch.setattr(server, "_run_prompt_submit", run_prompt)
+    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+
+    assert server._poll_bot_live_delivery_once("live-sid", session) is True
+    assert completed == [claimed["message"]]

--- a/tools/bot_live_delivery.py
+++ b/tools/bot_live_delivery.py
@@ -1,0 +1,248 @@
+"""Durable handoff of Bot Chat turns to an existing live owner.
+
+A sender writes one request under the target profile's runtime directory.
+The live TUI/Desktop owner atomically claims it and writes one terminal
+receipt. The rename boundary distinguishes a request that was never
+delivered from one whose transport outcome is no longer knowable.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+DELIVERY_DIR_NAME = "bot_live_delivery"
+
+# Surfaces that run tui_gateway's idle poller and can claim pending DMs.
+_LIVE_OWNER_SURFACES = frozenset({"desktop", "tui"})
+
+
+def _owner_can_consume(entry: dict[str, Any]) -> bool:
+    meta = entry.get("metadata") or {}
+    if meta.get("bot_live_delivery_consumer") is True:
+        return True
+    return str(entry.get("surface") or "").strip().lower() in _LIVE_OWNER_SURFACES
+
+
+def find_canonical_live_owner(profile_home: Path | str) -> str | None:
+    """Return the canonical Bot Chat id when a Desktop/TUI owner holds it."""
+    from hermes_cli.active_sessions import active_session_registry_snapshot
+    from hermes_state import SessionDB
+
+    home = Path(profile_home)
+    db = SessionDB(db_path=home / "state.db")
+    try:
+        row = db.get_session_by_title("Bot Chat")
+    finally:
+        db.close()
+    session_id = str((row or {}).get("id") or "")
+    if not session_id:
+        return None
+    try:
+        owners = active_session_registry_snapshot(registry_home=home)
+    except Exception:
+        return None
+    return session_id if any(
+        str(entry.get("session_id") or "") == session_id and _owner_can_consume(entry)
+        for entry in owners
+    ) else None
+
+
+def _session_dir(profile_home: Path | str, session_id: str) -> Path:
+    key = hashlib.sha256(str(session_id).encode("utf-8")).hexdigest()[:32]
+    return Path(profile_home) / "runtime" / DELIVERY_DIR_NAME / key
+
+
+def _paths(profile_home: Path | str, session_id: str) -> tuple[Path, Path, Path]:
+    base = _session_dir(profile_home, session_id)
+    pending = base / "pending"
+    claimed = base / "claimed"
+    replies = base / "replies"
+    for directory in (pending, claimed, replies):
+        directory.mkdir(parents=True, exist_ok=True)
+    return pending, claimed, replies
+
+
+def _atomic_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.stem}-", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            json.dump(payload, stream, ensure_ascii=False, sort_keys=True)
+        os.replace(tmp, path)
+    finally:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def deliver_to_live_owner(
+    profile_home: Path | str,
+    session_id: str,
+    message: str,
+    *,
+    owner_wait_seconds: float,
+    receipt_wait_seconds: float,
+    poll_seconds: float = 0.05,
+) -> dict[str, Any]:
+    """Submit one message and wait for the live owner's durable terminal receipt."""
+    pending_dir, claimed_dir, replies_dir = _paths(profile_home, session_id)
+    delivery_id = uuid.uuid4().hex
+    pending = pending_dir / f"{delivery_id}.json"
+    claimed = claimed_dir / pending.name
+    reply_path = replies_dir / pending.name
+    created = time.time()
+    owner_deadline = created + max(0.0, float(owner_wait_seconds))
+    _atomic_json(
+        pending,
+        {
+            "id": delivery_id,
+            "session_id": str(session_id),
+            "message": str(message),
+            "created_at": created,
+            "owner_deadline": owner_deadline,
+        },
+    )
+
+    sleep_for = max(0.001, float(poll_seconds))
+    while time.time() < owner_deadline:
+        receipt = _read_json(reply_path)
+        if receipt is not None:
+            return _finish_result(delivery_id, receipt, claimed, reply_path)
+        if claimed.exists():
+            break
+        time.sleep(sleep_for)
+    else:
+        # Winning this rename proves the owner never claimed the request. If it
+        # loses, the owner crossed the claim boundary and only a receipt can say
+        # whether the message entered the session.
+        cancelled = pending.with_suffix(".cancelled")
+        try:
+            os.replace(pending, cancelled)
+        except FileNotFoundError:
+            pass
+        else:
+            cancelled.unlink(missing_ok=True)
+            return {
+                "status": "not_delivered",
+                "reason": "target_busy",
+                "delivery_id": delivery_id,
+            }
+
+    receipt_deadline = time.time() + max(0.0, float(receipt_wait_seconds))
+    while time.time() < receipt_deadline:
+        receipt = _read_json(reply_path)
+        if receipt is not None:
+            return _finish_result(delivery_id, receipt, claimed, reply_path)
+        time.sleep(sleep_for)
+    return {
+        "status": "ambiguous",
+        "reason": "delivery_timeout",
+        "delivery_id": delivery_id,
+    }
+
+
+def _finish_result(
+    delivery_id: str,
+    receipt: dict[str, Any],
+    claimed_path: Path,
+    reply_path: Path,
+) -> dict[str, Any]:
+    claimed_path.unlink(missing_ok=True)
+    reply_path.unlink(missing_ok=True)
+    status = str(receipt.get("status") or "")
+    if status == "settled":
+        return {
+            "status": "delivered",
+            "delivery_id": delivery_id,
+            "reply": str(receipt.get("reply") or ""),
+        }
+    return {
+        "status": "not_delivered" if status in {"failed", "cancelled"} else "ambiguous",
+        "reason": str(receipt.get("reason") or "unknown"),
+        "delivery_id": delivery_id,
+        "error": str(receipt.get("error") or ""),
+    }
+
+
+def claim_pending_delivery(
+    profile_home: Path | str, session_id: str
+) -> dict[str, Any] | None:
+    """Atomically claim the oldest unexpired request for one live session."""
+    pending_dir, claimed_dir, _replies_dir = _paths(profile_home, session_id)
+    now = time.time()
+    candidates: list[tuple[float, str, Path, dict[str, Any]]] = []
+    for pending in pending_dir.glob("*.json"):
+        payload = _read_json(pending)
+        if payload is None or payload.get("session_id") != str(session_id):
+            pending.unlink(missing_ok=True)
+            continue
+        try:
+            owner_deadline = float(payload.get("owner_deadline"))
+            created_at = float(payload.get("created_at"))
+        except (TypeError, ValueError):
+            pending.unlink(missing_ok=True)
+            continue
+        delivery_id = str(payload.get("id") or "")
+        if delivery_id != pending.stem or owner_deadline <= now:
+            pending.unlink(missing_ok=True)
+            continue
+        candidates.append((created_at, delivery_id, pending, payload))
+
+    for _created_at, _delivery_id, pending, payload in sorted(candidates):
+        claimed = claimed_dir / pending.name
+        try:
+            os.replace(pending, claimed)
+        except FileNotFoundError:
+            continue
+        return payload
+    return None
+
+
+def complete_delivery(
+    profile_home: Path | str,
+    delivery_id: str,
+    *,
+    status: str,
+    reply: str = "",
+    error: str = "",
+    reason: str = "",
+) -> None:
+    """Persist the live owner's terminal result for the waiting sender."""
+    safe_id = str(delivery_id or "")
+    if len(safe_id) != 32 or any(ch not in "0123456789abcdef" for ch in safe_id):
+        raise ValueError("invalid delivery id")
+    # Delivery ids are globally random, so locate the receipt directory without
+    # trusting caller-provided session/path data.
+    root = Path(profile_home) / "runtime" / DELIVERY_DIR_NAME
+    matches = list(root.glob(f"*/claimed/{safe_id}.json"))
+    if len(matches) != 1:
+        raise FileNotFoundError(f"claimed delivery not found: {safe_id}")
+    claimed = matches[0]
+    replies = claimed.parent.parent / "replies"
+    _atomic_json(
+        replies / claimed.name,
+        {
+            "id": safe_id,
+            "status": str(status),
+            "reply": str(reply),
+            "error": str(error),
+            "reason": str(reason),
+            "completed_at": time.time(),
+        },
+    )

--- a/tools/bot_live_delivery.py
+++ b/tools/bot_live_delivery.py
@@ -64,7 +64,8 @@ def _paths(profile_home: Path | str, session_id: str) -> tuple[Path, Path, Path]
     pending = base / "pending"
     claimed = base / "claimed"
     replies = base / "replies"
-    for directory in (pending, claimed, replies):
+    expired = base / "expired"
+    for directory in (pending, claimed, replies, expired):
         directory.mkdir(parents=True, exist_ok=True)
     return pending, claimed, replies
 
@@ -106,6 +107,7 @@ def deliver_to_live_owner(
     pending = pending_dir / f"{delivery_id}.json"
     claimed = claimed_dir / pending.name
     reply_path = replies_dir / pending.name
+    expired_path = pending_dir.parent / "expired" / pending.name
     created = time.time()
     owner_deadline = created + max(0.0, float(owner_wait_seconds))
     _atomic_json(
@@ -135,7 +137,12 @@ def deliver_to_live_owner(
         try:
             os.replace(pending, cancelled)
         except FileNotFoundError:
-            pass
+            if expired_path.exists():
+                return {
+                    "status": "not_delivered",
+                    "reason": "target_busy",
+                    "delivery_id": delivery_id,
+                }
         else:
             cancelled.unlink(missing_ok=True)
             return {
@@ -185,6 +192,7 @@ def claim_pending_delivery(
 ) -> dict[str, Any] | None:
     """Atomically claim the oldest unexpired request for one live session."""
     pending_dir, claimed_dir, _replies_dir = _paths(profile_home, session_id)
+    expired_dir = pending_dir.parent / "expired"
     now = time.time()
     candidates: list[tuple[float, str, Path, dict[str, Any]]] = []
     for pending in pending_dir.glob("*.json"):
@@ -199,8 +207,14 @@ def claim_pending_delivery(
             pending.unlink(missing_ok=True)
             continue
         delivery_id = str(payload.get("id") or "")
-        if delivery_id != pending.stem or owner_deadline <= now:
+        if delivery_id != pending.stem:
             pending.unlink(missing_ok=True)
+            continue
+        if owner_deadline <= now:
+            try:
+                os.replace(pending, expired_dir / pending.name)
+            except FileNotFoundError:
+                pass
             continue
         candidates.append((created_at, delivery_id, pending, payload))
 

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -576,8 +576,42 @@ def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool) -> int:
     compression lever; no fresh session is ever minted. Auth/quota/config
     failures never retry. Peer transports (stdin mode) retry on their own
     gateway's deliver path, not here.
+
+    When the target's canonical Bot Chat already has a Desktop/TUI owner
+    (#101060), the one-shot CLI would be fenced out by the single-owner
+    lease. Hand the message to that owner via ``tools.bot_live_delivery``
+    instead so the DM lands as a normal turn in the open chat.
     """
     try:
+        if not stdin_file and len(argv) >= 3 and argv[1] == "-p":
+            from tools.bot_live_delivery import (
+                deliver_to_live_owner,
+                find_canonical_live_owner,
+            )
+            from tools.bot_relay import turn_wait_seconds
+
+            ambient_home = Path(
+                os.getenv("HERMES_HOME") or os.path.expanduser("~/.hermes")
+            )
+            root = _hermes_root(ambient_home)
+            profile = str(argv[2])
+            profile_home = root if profile == "default" else root / "profiles" / profile
+            live_session_id = find_canonical_live_owner(profile_home)
+            if live_session_id:
+                content = Path(dm_file).read_text(encoding="utf-8")
+                outcome = deliver_to_live_owner(
+                    profile_home,
+                    live_session_id,
+                    content,
+                    owner_wait_seconds=turn_wait_seconds(),
+                    receipt_wait_seconds=600,
+                )
+                if outcome.get("status") == "delivered":
+                    print(str(outcome.get("reply") or ""))
+                    return 0
+                print(json.dumps(outcome, ensure_ascii=False))
+                return 1
+
         with _delivery_lock(argv, stdin_file=stdin_file):
             if stdin_file:
                 # Keep the file open until the transport exits; cleanup occurs

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -41,6 +41,7 @@ the same wake shape every Bot Mode agent already knows.
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import json
 import logging
 import os
@@ -533,6 +534,39 @@ def _unlink_dm_file(path: str) -> None:
         pass
 
 
+def _delivery_id_from_payload(path: str) -> str:
+    return hashlib.sha256(str(Path(path).resolve()).encode("utf-8")).hexdigest()[:32]
+
+
+def _delivery_receipt_path(path: str) -> Path:
+    return Path(f"{path}.receipt.json")
+
+
+def _read_delivery_receipt(path: str) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(_delivery_receipt_path(path).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _write_delivery_receipt(
+    path: str, argv: list[str], *, stdin_file: bool, reason: str, error: str
+) -> dict[str, Any]:
+    receipt = {
+        "status": "not_delivered" if reason == "target_busy" else "ambiguous",
+        "reason": reason or "unknown",
+        "error": error,
+        "delivery_id": _delivery_id_from_payload(path),
+        "payload_file": path,
+        "retry_command": _delivery_command(argv, path, stdin_file=stdin_file),
+    }
+    _delivery_receipt_path(path).write_text(
+        json.dumps(receipt, ensure_ascii=False, sort_keys=True), encoding="utf-8"
+    )
+    return receipt
+
+
 def _delivery_lock(argv: list[str], *, stdin_file: bool):
     """Per-profile turn lock context for a LOCAL teammate delivery (#93091).
 
@@ -563,7 +597,7 @@ def _delivery_lock(argv: list[str], *, stdin_file: bool):
 
 
 def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool) -> int:
-    """Run one DM transport and remove its plaintext file after consumption.
+    """Run one DM transport and remove its plaintext file only after delivery.
 
     The turn execution window (not the enqueue) holds the target profile's
     cross-process lock, so two deliveries into one profile queue instead of
@@ -577,11 +611,22 @@ def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool) -> int:
     failures never retry. Peer transports (stdin mode) retry on their own
     gateway's deliver path, not here.
 
+    Failed deliveries retain the payload and a durable typed receipt so a
+    re-run reports the original outcome instead of sending the DM twice.
+
     When the target's canonical Bot Chat already has a Desktop/TUI owner
     (#101060), the one-shot CLI would be fenced out by the single-owner
     lease. Hand the message to that owner via ``tools.bot_live_delivery``
     instead so the DM lands as a normal turn in the open chat.
     """
+    cached_receipt = _read_delivery_receipt(dm_file)
+    if cached_receipt is not None:
+        print(json.dumps(cached_receipt, ensure_ascii=False))
+        return 0 if cached_receipt.get("status") == "delivered" else 1
+
+    delivered = False
+    failure_reason = "unknown"
+    failure_error = ""
     try:
         if not stdin_file and len(argv) >= 3 and argv[1] == "-p":
             from tools.bot_live_delivery import (
@@ -608,8 +653,10 @@ def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool) -> int:
                 )
                 if outcome.get("status") == "delivered":
                     print(str(outcome.get("reply") or ""))
+                    delivered = True
                     return 0
-                print(json.dumps(outcome, ensure_ascii=False))
+                failure_reason = str(outcome.get("reason") or "unknown")
+                failure_error = str(outcome.get("error") or "")
                 return 1
 
         with _delivery_lock(argv, stdin_file=stdin_file):
@@ -617,7 +664,9 @@ def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool) -> int:
                 # Keep the file open until the transport exits; cleanup occurs
                 # after subprocess.run returns, not merely after stdin reaches EOF.
                 with open(dm_file, "r", encoding="utf-8") as stream:
-                    return subprocess.run(argv, stdin=stream, check=False).returncode
+                    returncode = subprocess.run(argv, stdin=stream, check=False).returncode
+                    delivered = returncode == 0
+                    return returncode
             proc = subprocess.run(
                 [*argv, "--query-file", dm_file],
                 check=False,
@@ -648,11 +697,11 @@ def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool) -> int:
                 # surface (Desktop). The turn never ran, so tell the sender
                 # plainly instead of leaking a raw lease error + exit code.
                 who = argv[argv.index("-p") + 1] if "-p" in argv[:-1] else "the teammate"
-                print(json.dumps({
-                    "error": f"Delivery failed: @{who}'s Bot Chat is open on another "
-                             "surface right now, so your message was NOT delivered. Try again later.",
-                    "reason": "target_busy",
-                }))
+                failure_reason = "target_busy"
+                failure_error = (
+                    f"Delivery failed: @{who}'s Bot Chat is open on another surface "
+                    "right now, so your message was NOT delivered. Try again later."
+                )
                 return 1
             if proc.stdout:
                 sys.stdout.write(proc.stdout)
@@ -660,9 +709,32 @@ def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool) -> int:
             if proc.stderr:
                 sys.stderr.write(proc.stderr)
                 sys.stderr.flush()
+            delivered = proc.returncode == 0
+            if not delivered:
+                from tools.bot_failure_reasons import classify_agent_error
+
+                failure_error = (proc.stderr or proc.stdout or "").strip()[-500:]
+                failure_reason = classify_agent_error(failure_error)
             return proc.returncode
+    except Exception as exc:
+        failure_error = str(exc)
+        raise
     finally:
-        _unlink_dm_file(dm_file)
+        if delivered:
+            _unlink_dm_file(dm_file)
+            _delivery_receipt_path(dm_file).unlink(missing_ok=True)
+        else:
+            try:
+                receipt = _write_delivery_receipt(
+                    dm_file,
+                    argv,
+                    stdin_file=stdin_file,
+                    reason=failure_reason,
+                    error=failure_error,
+                )
+                print(json.dumps(receipt, ensure_ascii=False))
+            except Exception:
+                logger.warning("failed to retain undelivered DM payload", exc_info=True)
 
 
 def _delivery_command(argv: list[str], dm_file: str, *, stdin_file: bool) -> str:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -693,7 +693,10 @@ def _claim_active_session_slot(
             session_id=session_key,
             surface=surface,
             config=_load_cfg(),
-            metadata={"live_session_id": live_session_id},
+            metadata={
+                "live_session_id": live_session_id,
+                "bot_live_delivery_consumer": True,
+            },
             registry_home=profile_home,
             track_liveness=track_liveness,
         )
@@ -837,7 +840,10 @@ def _transfer_active_session_slot(
         if transfer_active_session(
             lease,
             session_id=new_session_id,
-            metadata={"live_session_id": sid},
+            metadata={
+                "live_session_id": sid,
+                "bot_live_delivery_consumer": True,
+            },
         ):
             return True
     except Exception:
@@ -12593,6 +12599,73 @@ def _collect_kanban_notifications(session: dict) -> list:
     return texts
 
 
+def _poll_bot_live_delivery_once(sid: str, session: dict) -> bool:
+    """Claim and start one Bot DM addressed to this live session owner.
+
+    Local ``message_agent`` deliveries that would otherwise die on the
+    single-owner lease (#101060) write a pending request under the profile
+    runtime dir; idle Desktop/TUI owners drain one at a time here and run it
+    through ``_run_prompt_submit`` so the DM lands in the open Bot Chat.
+    """
+    with session["history_lock"]:
+        if session.get("running") or session.get("_closing"):
+            return False
+
+        from tools.bot_live_delivery import (
+            claim_pending_delivery,
+            complete_delivery,
+        )
+
+        profile_home = session.get("profile_home") or _session_home(session)
+        session_key = str(session.get("session_key") or "")
+        claimed = claim_pending_delivery(profile_home, session_key)
+        if claimed is None:
+            return False
+        session["running"] = True
+
+    delivery_id = str(claimed["id"])
+
+    def terminal_receipt(terminal: dict[str, Any]) -> None:
+        status = str(terminal.get("status") or "failed")
+        error = str(terminal.get("error") or "")
+        reason = ""
+        if status == "cancelled":
+            reason = "cancelled"
+        elif status != "settled":
+            from tools.bot_failure_reasons import classify_agent_error
+
+            reason = classify_agent_error(error)
+        complete_delivery(
+            profile_home,
+            delivery_id,
+            status=status,
+            reply=str(terminal.get("text") or "") if status == "settled" else "",
+            error=error,
+            reason=reason,
+        )
+
+    rid = f"__bot_dm__{delivery_id}"
+    _emit("message.start", sid)
+    started = _run_prompt_submit(
+        rid,
+        sid,
+        session,
+        claimed["message"],
+        terminal_callback=terminal_receipt,
+    )
+    if not started:
+        with session["history_lock"]:
+            session["running"] = False
+        complete_delivery(
+            profile_home,
+            delivery_id,
+            status="failed",
+            error="live session owner could not start the delivery turn",
+            reason="unknown",
+        )
+    return started
+
+
 def _notification_poller_loop(
     stop_event: threading.Event, sid: str, session: dict
 ) -> None:
@@ -12618,6 +12691,10 @@ def _notification_poller_loop(
     _last_loop_poll = 0.0
     while not stop_event.is_set() and not session.get("_finalized"):
         _now = time.monotonic()
+        try:
+            _poll_bot_live_delivery_once(sid, session)
+        except Exception:
+            logger.debug("Bot live-owner delivery poll failed", exc_info=True)
         # ── /loop wakeup driver ──────────────────────────────────────
         # Fire a due /loop tick for THIS session while it's idle. Same
         # claim-under-lock pattern as the kanban dispatch below. Active

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10313,6 +10313,8 @@ def _maybe_schedule_auto_continue(sid: str, session: dict, session_key: str) -> 
     marker = read_turn_marker(home, session_key)
     if marker is None:
         return None
+    if not marker.get("auto_continue", True):
+        return None
     enabled, freshness_secs, max_attempts = _auto_continue_config()
     age = time.time() - marker["started_at"]
     if not enabled or age > freshness_secs or marker["attempts"] >= max_attempts:
@@ -12635,14 +12637,20 @@ def _poll_bot_live_delivery_once(sid: str, session: dict) -> bool:
             from tools.bot_failure_reasons import classify_agent_error
 
             reason = classify_agent_error(error)
-        complete_delivery(
-            profile_home,
-            delivery_id,
-            status=status,
-            reply=str(terminal.get("text") or "") if status == "settled" else "",
-            error=error,
-            reason=reason,
-        )
+        try:
+            complete_delivery(
+                profile_home,
+                delivery_id,
+                status=status,
+                reply=str(terminal.get("text") or "") if status == "settled" else "",
+                error=error,
+                reason=reason,
+            )
+        except Exception:
+            logger.warning(
+                "bot DM terminal receipt could not be persisted; sender will time out",
+                exc_info=True,
+            )
 
     rid = f"__bot_dm__{delivery_id}"
     _emit("message.start", sid)
@@ -12656,13 +12664,19 @@ def _poll_bot_live_delivery_once(sid: str, session: dict) -> bool:
     if not started:
         with session["history_lock"]:
             session["running"] = False
-        complete_delivery(
-            profile_home,
-            delivery_id,
-            status="failed",
-            error="live session owner could not start the delivery turn",
-            reason="unknown",
-        )
+        try:
+            complete_delivery(
+                profile_home,
+                delivery_id,
+                status="failed",
+                error="live session owner could not start the delivery turn",
+                reason="unknown",
+            )
+        except Exception:
+            logger.warning(
+                "bot DM failed-start receipt could not be persisted; sender will time out",
+                exc_info=True,
+            )
     return started
 
 
@@ -13367,7 +13381,13 @@ def _run_prompt_submit(
             # race where Stop lands first and therefore clears no file yet.
             with session["history_lock"]:
                 session["_active_turn_marker_key"] = marker_key
-            record_turn_start(marker_home, marker_key, marker_text, attempts=marker_attempt)
+            record_turn_start(
+                marker_home,
+                marker_key,
+                marker_text,
+                attempts=marker_attempt,
+                auto_continue=terminal_callback is None,
+            )
             with session["history_lock"]:
                 marker_cancelled = bool(session.get("_turn_cancel_requested"))
             if marker_cancelled:

--- a/tui_gateway/turn_marker.py
+++ b/tui_gateway/turn_marker.py
@@ -95,7 +95,12 @@ def _store(path: Path, entries: dict[str, dict]) -> None:
 
 
 def record_turn_start(
-    home: Path | str, session_key: str, prompt: str, *, attempts: int = 0
+    home: Path | str,
+    session_key: str,
+    prompt: str,
+    *,
+    attempts: int = 0,
+    auto_continue: bool = True,
 ) -> None:
     """Persist the marker for a turn that is about to run.
 
@@ -108,6 +113,7 @@ def record_turn_start(
     now = time.time()
     entry = {
         "attempts": max(0, int(attempts)),
+        "auto_continue": bool(auto_continue),
         "prompt": prompt[:_MAX_PROMPT_CHARS],
         "started_at": now,
     }
@@ -156,4 +162,9 @@ def read_turn_marker(home: Path | str, session_key: str) -> dict[str, Any] | Non
         attempts = max(0, int(entry.get("attempts") or 0))
     except (TypeError, ValueError):
         return None
-    return {"attempts": attempts, "prompt": prompt, "started_at": started_at}
+    return {
+        "attempts": attempts,
+        "auto_continue": bool(entry.get("auto_continue", True)),
+        "prompt": prompt,
+        "started_at": started_at,
+    }


### PR DESCRIPTION
## Why

`message_agent` between local profiles still used a one-shot CLI turn into the canonical Bot Chat. When Desktop already held that session lease, the runner exited 1 after the tool had already returned `status: sent`, so the DM never appeared and the sender treated dispatch as success. #101293 fixed the Desktop-relay path via in-process `prompt.submit`; the local CLI path stayed broken (reconfirmed on #101060).

## Scope

- `tools/bot_live_delivery.py`: durable pending/claim/receipt handoff under the target profile runtime dir.
- `tools/bot_mode_dm.py` `_run_delivery`: when a Desktop/TUI owner holds Bot Chat, deliver through that handoff instead of the fenced CLI; keep `target_busy` when no owner claims in time.
- `tui_gateway/server.py`: idle notification poller claims one pending DM and runs it through `_run_prompt_submit` with a terminal receipt; new leases mark `bot_live_delivery_consumer`.
- Focused tests for find/claim/receipt, poller intake, and the `_run_delivery` handoff path.

Out of scope: changing the async `sent` ack shape, peer/A2A transports, cron `deliver=bot-chat` (see #100319).

## Tradeoffs

Reuses the #100544 live-owner handoff idea in a smaller form rather than inventing a second Desktop-only RPC. Accepts Desktop/TUI surface owners without requiring a prior consumer flag so already-open Bot Chats work after upgrade. CLI owners stay on the existing subprocess path.

## Blast Radius

Local Bot Mode teammate DMs when the target Bot Chat is open in Desktop/TUI. Relay deliveries already covered by #101293 stay unchanged. Idle poller adds a cheap filesystem probe per session tick.

## Verification

```
python -m pytest tests/tools/test_bot_live_owner_delivery.py tests/tui_gateway/test_bot_live_owner_delivery.py tests/tools/test_bot_mode_dm.py::test_delivery_runner_hands_off_to_live_owner tests/tools/test_bot_mode_dm.py::test_delivery_runner_surfaces_live_owner_refusal tests/tui_gateway/test_bot_relay_methods.py::test_deliver_lands_in_live_bot_chat_instead_of_subprocess -q
```

12 passed, exit 0.

Fixes #101060