### PR TITLE
feat(gateway): route Sasha Discord toolsets by channel

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -23941,26 +23941,42 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         user_config: dict,
         source: "SessionSource",
         platform_key: str,
+        message: str | None = None,
     ) -> list:
         """Resolve enabled toolsets for an agent run, honoring per-source overrides.
 
-        Asks the receiving adapter for a ``toolsets_for_source()`` override
-        (e.g. per-route webhook toolsets). When present, the override list is
-        validated through the SAME ``_get_platform_tools`` path as normal
-        platform config — by substituting it as the platform's toolset list —
-        so unknown names and platform-restricted toolsets are dropped rather
-        than trusted. When absent, falls back to standard
-        ``platform_toolsets.<platform>`` resolution.
+        Sasha's Discord channel posture is resolved before agent construction
+        so Home stays lean, ``#proj-*`` channels get coding tools, and explicit
+        heavy requests can use a heavy toolset without mutating an existing
+        AIAgent's frozen prompt/tool schema. Adapter overrides (e.g. webhook
+        routes) still use the same validation path as platform config.
         """
         from hermes_cli.tools_config import _get_platform_tools
 
         override = None
         try:
-            adapter = self._adapter_for_source(source)
-            if adapter is not None:
-                override = adapter.toolsets_for_source(source)
+            from gateway.toolset_routing import route_toolsets_for_source_with_reason
+
+            routed = route_toolsets_for_source_with_reason(source, message=message)
+            if routed is not None:
+                override = routed.toolsets
+                logger.info(
+                    "Discord toolset route: reason=%s chat_id=%s parent_chat_id=%s chat_name=%s",
+                    routed.reason,
+                    getattr(source, "chat_id", None),
+                    getattr(source, "parent_chat_id", None),
+                    str(getattr(source, "chat_name", "") or "")[:80],
+                )
         except Exception:
             override = None
+
+        if override is None:
+            try:
+                adapter = self._adapter_for_source(source)
+                if adapter is not None:
+                    override = adapter.toolsets_for_source(source)
+            except Exception:
+                override = None
 
         if override and isinstance(override, list):
             cfg = dict(user_config)
@@ -24010,7 +24026,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             platform_key = _platform_config_key(source.platform)
 
             enabled_toolsets = self._resolve_enabled_toolsets_for_source(
-                user_config, source, platform_key
+                user_config, source, platform_key, message=prompt
             )
             agent_cfg = user_config.get("agent") or {}
             from agent.skill_utils import parse_config_string_list
@@ -29694,8 +29710,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         user_config = _load_gateway_config()
         platform_key = _platform_config_key(source.platform)
 
+        # Heavy routing changes the tool schema. Allow it only on the first
+        # turn of a session; later explicit heavy requests stay on the existing
+        # channel posture so prompt-cache invariants are preserved and the agent
+        # can ask for a new heavy-mode/session boundary instead.
+        _routing_message = message if not history else None
         enabled_toolsets = self._resolve_enabled_toolsets_for_source(
-            user_config, source, platform_key
+            user_config, source, platform_key, message=_routing_message
         )
         agent_cfg_local = user_config.get("agent") or {}
         from agent.skill_utils import parse_config_string_list

--- a/gateway/toolset_routing.py
+++ b/gateway/toolset_routing.py
@@ -1,0 +1,132 @@
+"""Channel-aware gateway toolset routing.
+
+Routes must be selected before agent construction so an AIAgent's system prompt
+and tool schemas stay stable for the life of its cached session.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from gateway.config import Platform
+
+SASHA_HOME_CHANNEL_IDS = {"1513198617198858434"}
+
+# Keep these as concrete built-in toolset names. ``platform_toolsets`` currently
+# does not expand custom_toolsets aliases in the prompt-size/tool resolution
+# path, so returning aliases here would silently produce an agent with no tools.
+SASHA_DISCORD_LEAN_TOOLSETS = [
+    "clarify",
+    "homeassistant",
+    "memory",
+    "session_search",
+    "skills",
+    "todo",
+    "vision",
+    "web",
+]
+SASHA_DISCORD_CODING_TOOLSETS = [
+    "clarify",
+    "code_execution",
+    "delegation",
+    "file",
+    "memory",
+    "session_search",
+    "skills",
+    "terminal",
+    "todo",
+    "web",
+]
+SASHA_DISCORD_HEAVY_TOOLSETS = [
+    "browser",
+    "clarify",
+    "code_execution",
+    "computer_use",
+    "cronjob",
+    "delegation",
+    "file",
+    "homeassistant",
+    "memory",
+    "session_search",
+    "skills",
+    "terminal",
+    "todo",
+    "vision",
+    "web",
+]
+
+_PROJECT_CHANNEL_RE = re.compile(r"(?:^|[/#\s])#?proj-[\w-]+", re.IGNORECASE)
+_HEAVY_INTENT_PATTERNS = (
+    re.compile(r"\b(use|open|drive)\s+(?:the\s+)?browser\b", re.IGNORECASE),
+    re.compile(
+        r"\b(logged[- ]in browser|computer[- ]use|drive my desktop|click|screenshot)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(r"\b(schedule|cron|remind me)\b", re.IGNORECASE),
+    re.compile(r"\b(generate|make|create)\s+(?:an?\s+)?(?:image|audio|video)\b", re.IGNORECASE),
+)
+
+
+@dataclass(frozen=True)
+class ToolsetRoute:
+    toolsets: list[str]
+    reason: str
+
+
+def _platform_value(platform: Any) -> str:
+    value = getattr(platform, "value", platform)
+    return str(value or "").lower()
+
+
+def _source_chat_ids(source: Any) -> set[str]:
+    ids: set[str] = set()
+    for attr in ("chat_id", "parent_chat_id"):
+        value = getattr(source, attr, None)
+        if value is not None:
+            text = str(value).strip()
+            if text:
+                ids.add(text)
+    return ids
+
+
+def _source_channel_name(source: Any) -> str:
+    values = []
+    for attr in ("chat_name", "channel_name", "display_name", "chat_topic"):
+        value = getattr(source, attr, None)
+        if value:
+            values.append(str(value))
+    return " / ".join(values)
+
+
+def _has_heavy_intent(message: str | None) -> bool:
+    text = str(message or "")
+    return any(pattern.search(text) for pattern in _HEAVY_INTENT_PATTERNS)
+
+
+def route_toolsets_for_source(source: Any, *, message: str | None = None) -> list[str] | None:
+    """Return a Sasha Discord toolset override for ``source``, or None.
+
+    Home is forced lean even if the message asks for code/heavy capability.
+    That keeps Ben's Home channel non-coding and avoids changing an existing
+    Home session's prompt/tool schema. Heavy tools route only on explicit
+    requests outside Home; callers should apply this before creating an agent.
+    """
+    route = route_toolsets_for_source_with_reason(source, message=message)
+    return None if route is None else route.toolsets
+
+
+def route_toolsets_for_source_with_reason(
+    source: Any, *, message: str | None = None
+) -> ToolsetRoute | None:
+    """Return routed toolsets plus a compact log-safe reason."""
+    if _platform_value(getattr(source, "platform", None)) != Platform.DISCORD.value:
+        return None
+    if _source_chat_ids(source) & SASHA_HOME_CHANNEL_IDS:
+        return ToolsetRoute(list(SASHA_DISCORD_LEAN_TOOLSETS), "home_channel")
+    if _has_heavy_intent(message):
+        return ToolsetRoute(list(SASHA_DISCORD_HEAVY_TOOLSETS), "heavy_intent")
+    if _PROJECT_CHANNEL_RE.search(_source_channel_name(source)):
+        return ToolsetRoute(list(SASHA_DISCORD_CODING_TOOLSETS), "proj_channel")
+    return ToolsetRoute(list(SASHA_DISCORD_LEAN_TOOLSETS), "default")

--- a/tests/gateway/test_toolset_routing.py
+++ b/tests/gateway/test_toolset_routing.py
@@ -1,0 +1,101 @@
+from dataclasses import dataclass
+
+from gateway.toolset_routing import (
+    SASHA_DISCORD_CODING_TOOLSETS,
+    SASHA_DISCORD_HEAVY_TOOLSETS,
+    SASHA_DISCORD_LEAN_TOOLSETS,
+    route_toolsets_for_source,
+)
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+
+
+@dataclass
+class FakeSource:
+    platform: Platform = Platform.DISCORD
+    chat_id: str = "999"
+    chat_name: str = "general"
+    parent_chat_id: str | None = None
+
+
+def test_home_channel_is_always_lean_even_for_coding_text():
+    source = FakeSource(chat_id="1513198617198858434", chat_name="Home")
+
+    assert route_toolsets_for_source(source, message="edit files and run tests") == SASHA_DISCORD_LEAN_TOOLSETS
+
+
+def test_home_thread_is_always_lean_even_for_coding_text():
+    source = FakeSource(
+        chat_id="thread-1",
+        parent_chat_id="1513198617198858434",
+        chat_name="Home thread",
+    )
+
+    assert route_toolsets_for_source(source, message="use browser and terminal") == SASHA_DISCORD_LEAN_TOOLSETS
+
+
+def test_proj_channel_is_coding_by_default():
+    source = FakeSource(chat_id="999", chat_name="proj-hermes-sashabot")
+
+    assert route_toolsets_for_source(source, message="what next?") == SASHA_DISCORD_CODING_TOOLSETS
+
+
+def test_proj_thread_uses_parent_project_channel_name_from_chat_name_path():
+    source = FakeSource(chat_id="thread-1", chat_name="Coding Agents / #proj-hermes-sashabot / task")
+
+    assert route_toolsets_for_source(source, message="inspect the repo") == SASHA_DISCORD_CODING_TOOLSETS
+
+
+def test_non_project_discord_channel_defaults_lean():
+    source = FakeSource(chat_id="999", chat_name="general")
+
+    assert route_toolsets_for_source(source, message="hello") == SASHA_DISCORD_LEAN_TOOLSETS
+
+
+def test_explicit_heavy_intent_routes_heavy_outside_home():
+    source = FakeSource(chat_id="999", chat_name="proj-hermes-sashabot")
+
+    assert route_toolsets_for_source(source, message="use browser to QA this") == SASHA_DISCORD_HEAVY_TOOLSETS
+
+
+def test_non_discord_keeps_existing_platform_resolution():
+    source = FakeSource(platform=Platform.TELEGRAM, chat_id="999", chat_name="proj-hermes")
+
+    assert route_toolsets_for_source(source, message="use browser") is None
+
+
+def test_gateway_resolver_applies_discord_route_before_agent_creation():
+    runner = object.__new__(GatewayRunner)
+    runner._adapter_for_source = lambda source: None
+    source = FakeSource(chat_id="999", chat_name="proj-hermes-sashabot")
+
+    enabled = GatewayRunner._resolve_enabled_toolsets_for_source(
+        runner,
+        {"platform_toolsets": {"discord": ["clarify"]}},
+        source,
+        "discord",
+        message="inspect repo",
+    )
+
+    assert "terminal" in enabled
+    assert "file" in enabled
+    assert "computer_use" not in enabled
+    assert "cronjob" not in enabled
+
+
+def test_gateway_resolver_forces_home_lean_before_agent_creation():
+    runner = object.__new__(GatewayRunner)
+    runner._adapter_for_source = lambda source: None
+    source = FakeSource(chat_id="1513198617198858434", chat_name="Home")
+
+    enabled = GatewayRunner._resolve_enabled_toolsets_for_source(
+        runner,
+        {"platform_toolsets": {"discord": ["terminal", "file"]}},
+        source,
+        "discord",
+        message="run tests",
+    )
+
+    assert "homeassistant" in enabled
+    assert "terminal" not in enabled
+    assert "file" not in enabled


### PR DESCRIPTION
## Summary
- Adds a pure Discord channel-aware toolset router for Sasha posture: Home stays lean, #proj-* routes coding, explicit first-turn heavy intents route heavy.
- Wires routing before AIAgent construction while preserving existing adapter override fallback.
- Adds regression coverage for Home/proj/default/heavy routing and gateway resolver behavior.

## Test Plan
- uv run --extra dev python -m pytest -q tests/gateway/test_toolset_routing.py tests/gateway/test_webhook_route_toolsets.py
- uv run --extra dev python -m pytest -q tests/gateway/test_toolset_routing.py tests/gateway/test_webhook_route_toolsets.py tests/gateway/test_discord_allowed_channels.py tests/gateway/test_discord_channel_controls.py tests/gateway/test_discord_sync_limit.py tests/gateway/test_stt_config.py tests/gateway/test_discord_attachment_download.py
- python -m py_compile gateway/toolset_routing.py gateway/run.py plugins/platforms/discord/adapter.py