### PR TITLE
fix(tools): isolate lazy installs from ambient UV_* interpreter steering (#83264)

### DIFF
--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -13,6 +13,9 @@ call is mocked — we never actually shell out during unit tests.
 from __future__ import annotations
 
 
+import sys
+from pathlib import Path
+
 import pytest
 
 import tools.lazy_deps as ld
@@ -600,3 +603,85 @@ class TestInstallWarmsBytecode:
         cmd = uv_cmds[0]
         assert "--compile-bytecode" in cmd
         assert cmd.index("--compile-bytecode") < cmd.index("zzzfake==1.0")
+
+
+class TestInstallEnvIsolation:
+    """#83264: ambient UV_*/CONDA_*/PYTHON* steering vars must not choose the
+    uv pip install target. UV_PYTHON takes precedence over VIRTUAL_ENV, so an
+    ambient value made every lazy-backend and memory-provider refresh fail
+    with "No virtual environment found" even though VIRTUAL_ENV was correct —
+    while the core update install (managed_python_env isolation, #83914)
+    succeeded. The installer must apply the same isolation."""
+
+    @staticmethod
+    def _run_install(monkeypatch, target=None):
+        captured = {}
+
+        class _Completed:
+            returncode = 0
+            stdout = "out"
+            stderr = "err"
+
+        def fake_run(cmd, *a, **kw):
+            captured["cmd"] = list(cmd)
+            captured["env"] = dict(kw.get("env") or {})
+            return _Completed()
+
+        if target is None:
+            monkeypatch.setattr(ld, "_lazy_install_target", lambda: None)
+        else:
+            monkeypatch.setattr(ld, "_lazy_install_target", lambda: target)
+        monkeypatch.setattr(
+            ld.shutil, "which", lambda name: "uv" if name == "uv" else None
+        )
+        monkeypatch.setattr(
+            "hermes_cli.managed_uv.resolve_uv",
+            lambda *a, **kw: "uv",
+            raising=False,
+        )
+        monkeypatch.setattr(ld.subprocess, "run", fake_run)
+        monkeypatch.setattr(ld, "_warm_installed_bytecode", lambda specs, target: None)
+
+        monkeypatch.setenv("UV_PYTHON", "/opt/other-software/python3.12")
+        monkeypatch.setenv("UV_SYSTEM_PYTHON", "1")
+        monkeypatch.setenv("UV_PYTHON_INSTALL_DIR", "/opt/other-software/store")
+        monkeypatch.setenv("CONDA_PREFIX", "/opt/conda")
+        monkeypatch.setenv("PYTHONHOME", "/opt/foreign-python")
+
+        result = ld._venv_pip_install(("zzzfake==1.0",))
+        return result, captured
+
+    def test_ambient_uv_python_cannot_steer_the_install_target(self, monkeypatch):
+        result, captured = self._run_install(monkeypatch)
+        assert result.success is True
+
+        env = captured["env"]
+        for stolen in (
+            "UV_PYTHON",
+            "UV_SYSTEM_PYTHON",
+            "UV_PYTHON_INSTALL_DIR",
+            "CONDA_PREFIX",
+            "PYTHONHOME",
+            "PYTHONPATH",
+        ):
+            assert stolen not in env, stolen
+        assert env["VIRTUAL_ENV"] == str(Path(sys.executable).parent.parent)
+        assert env["UV_NO_CONFIG"] == "1"
+
+        cmd = captured["cmd"]
+        assert "--python" in cmd
+        assert cmd[cmd.index("--python") + 1] == sys.executable
+
+    def test_durable_target_mode_strips_steering_but_pins_no_python(
+        self, monkeypatch, tmp_path
+    ):
+        result, captured = self._run_install(monkeypatch, target=tmp_path / "lt")
+        assert result.success is True
+
+        env = captured["env"]
+        assert "UV_PYTHON" not in env
+        assert env["VIRTUAL_ENV"] == str(Path(sys.executable).parent.parent)
+
+        cmd = captured["cmd"]
+        assert "--target" in cmd
+        assert "--python" not in cmd

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -506,13 +506,44 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
     try:
         from tools.environments.local import hermes_subprocess_env
         uv_env = hermes_subprocess_env(inherit_credentials=False)
+        # Third-party UV_*/CONDA_* steering vars must not choose the install
+        # target here (#83264): UV_PYTHON in particular takes precedence over
+        # VIRTUAL_ENV, so an ambient value (set by unrelated software in the
+        # user's shell) makes uv resolve a non-venv interpreter and fail with
+        # "No virtual environment found" even though VIRTUAL_ENV is correct —
+        # while the core update install, which applies the same isolation via
+        # managed_python_env() (#83914), succeeds. PYTHONHOME/PYTHONPATH are
+        # stripped for the same reason: neither uv nor the venv's pip should
+        # inherit a foreign interpreter environment.
+        for key in (
+            "CONDA_DEFAULT_ENV",
+            "CONDA_PREFIX",
+            "UV_PROJECT_ENVIRONMENT",
+            "UV_NO_MANAGED_PYTHON",
+            "UV_PYTHON",
+            "UV_PYTHON_DOWNLOADS",
+            "UV_PYTHON_INSTALL_DIR",
+            "UV_SYSTEM_PYTHON",
+            "PYTHONHOME",
+            "PYTHONPATH",
+        ):
+            uv_env.pop(key, None)
+        # A user-level uv.toml (project or user scope) could steer resolution
+        # the same way; the core update install already disables it.
+        uv_env["UV_NO_CONFIG"] = "1"
         uv_env["VIRTUAL_ENV"] = str(Path(sys.executable).parent.parent)
         # Tier 1: uv. --compile-bytecode because uv writes no __pycache__ by default, so the first
         # import would recompile the backend AND its transitives (_warm_installed_bytecode is the
-        # belt-and-braces pass for the spec's own roots on any tier).
+        # belt-and-braces pass for the spec's own roots on any tier). --python pins the target
+        # explicitly (venv-scoped installs only; --target mode already pins its destination) so
+        # the install lands in the running venv even if an unknown ambient variable survived the
+        # strip above (#83264).
         if uv_bin := _uv_binary():
             try:
-                r = _run_installer([uv_bin, "pip", "install", "--compile-bytecode", *extra_args, *specs], timeout=timeout, env=uv_env)
+                python_args: list[str] = (
+                    [] if target is not None else ["--python", str(sys.executable)]
+                )
+                r = _run_installer([uv_bin, "pip", "install", "--compile-bytecode", *python_args, *extra_args, *specs], timeout=timeout, env=uv_env)
                 if r.returncode != 0:
                     logger.debug("uv pip install failed: %s", r.stderr)
                 # A uv resolver failure is authoritative: falling through to pip would discard uv


### PR DESCRIPTION
## What does this PR do?

Fixes the #83264 failure class: during \`hermes update\`, every active lazy backend and the active memory provider's dependencies "fail to refresh" with \`pip install failed: error: No virtual environment found\` — while the packages are actually installed and working (the reporter: "My Hindsight is just working, so this is wrong").

**Root cause (verified):** \`tools/lazy_deps.py::_venv_pip_install()\` — the shared installer for lazy backends AND memory-provider bridge deps (\`memory_setup._install_dependencies\` → \`install_specs\`) — runs uv with \`hermes_subprocess_env()\` plus \`VIRTUAL_ENV\`, but preserves ambient \`UV_*\` variables from the user's shell. \`uv pip\` gives **\`UV_PYTHON\` precedence over \`VIRTUAL_ENV\`**, so an ambient value pointing at a non-venv interpreter makes uv abort with "No virtual environment found" even though \`VIRTUAL_ENV\` is correct. The core update install is already immune — it applies the \`managed_python_env()\` isolation for exactly this reason (#83914); the lazy/memory refresh paths were missed.

Reproduced live on current \`main\`:

\`\`\`
$ UV_PYTHON=/nonexistent/python <venv python> -c "_venv_pip_install(('six==1.17.0',))"
success: False
stderr: error: No virtual environment or system Python installation found for path
        \`/nonexistent/python\`; run \`uv venv\` to create an environment   # <- the reported error
\`\`\`
With the fix, the same invocation installs into the running venv correctly (\`Using Python 3.12.9 environment at: <venv>\`).

## Changes Made

- \`tools/lazy_deps.py\` — \`_venv_pip_install()\` now strips the same ambient steering keys the core install strips (#83914): \`UV_PYTHON\`, \`UV_PYTHON_DOWNLOADS\`, \`UV_PYTHON_INSTALL_DIR\`, \`UV_SYSTEM_PYTHON\`, \`UV_NO_MANAGED_PYTHON\`, \`UV_PROJECT_ENVIRONMENT\`, \`CONDA_PREFIX\`, \`CONDA_DEFAULT_ENV\`, \`PYTHONHOME\`, \`PYTHONPATH\`; sets \`UV_NO_CONFIG=1\` (user \`uv.toml\` can steer resolution the same way); and passes \`--python <sys.executable>\` for venv-scoped installs so the target is unambiguous. Durable-target mode is unchanged (\`--target\` already pins its destination).
- \`tests/tools/test_lazy_deps.py\` — \`TestInstallEnvIsolation\`: with polluted ambient env, the spawned uv command's env must be clean, \`VIRTUAL_ENV\` must be the running venv, and venv-scoped mode must pin \`--python\` (durable-target mode must not).

## How to Test

1. \`UV_PYTHON=/nonexistent/python scripts/run_tests.sh tests/tools/test_lazy_deps.py -q\` — new tests fail on \`main\`, pass here.
2. Full adjacent suites: \`scripts/run_tests.sh tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_cmd_update_apt.py tests/hermes_cli/test_cmd_update_docker.py tests/hermes_cli/test_local_runtime_updates.py tests/hermes_cli/test_memory_setup_env_denylist.py tests/hermes_cli/test_memory_setup_provider_arg.py tests/tools/test_lazy_deps.py tests/tools/test_lazy_deps_durable_target.py tests/tools/test_lazy_deps_managed.py tests/plugins/memory/test_memory_lazy_install.py -q\` → 186 passed, 0 failed.
3. Real-installer E2E (not mocked): pre-fix fails with the reported uv error; post-fix succeeds into the correct venv (transcript above).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] Conventional Commits
- [x] Only changes related to this fix
- [x] Tests added
- [x] Tested on Linux (Python 3.12) — real uv E2E + CI-parity runner

## Related Issue

Fixes #83264