### PR TITLE
fix(curator): exclude .git (top-level and nested) from skill snapshots

### DIFF
--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -61,7 +61,12 @@ DEFAULT_KEEP = 5
 # Entries under skills/ that should NEVER be rolled up into a snapshot.
 # .hub/ is managed by the skills hub; rolling it back would break lockfile
 # invariants. .curator_backups is the backup dir itself — recursion bomb.
-# .git is repository metadata — rolling it back would break git tracking.
+# .git is repository metadata — rolling it back would break git tracking,
+# and snapshots that include it grow with the full history: once backups
+# are committed back, the history contains prior backups, so each snapshot
+# is bigger than the last (observed: 38MB of skills inflating to 24GB in
+# weeks, #91449). ``_tar_filter`` below applies the same set to nested
+# paths, so a ``.git`` inside an individual skill dir is skipped too.
 _EXCLUDE_TOP_LEVEL = {".curator_backups", ".hub", ".git"}
 
 # Snapshot id regex: UTC ISO with colons replaced by dashes so the filename

--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -557,24 +557,37 @@ def _restore_cron_skill_links(snapshot_dir: Path) -> Dict[str, Any]:
 
 
 def _restore_excluded_subtrees(staged: Path, skills: Path) -> None:
-    """Move excluded subtrees (nested ``.git``/``.hub``/...) from *staged*
-    back under *skills* after a successful extract. Best-effort: a subtree
-    is only moved when its parent skill dir was restored and the target
-    does not already exist."""
-    for dirpath, dirnames, _files in os.walk(staged):
+    """Move excluded entries (nested ``.git``/``.hub``/...) from *staged*
+    back under *skills* after a successful extract.
+
+    Snapshots never contain these, so the extract cannot restore them; the
+    staged copy of the live tree is the only source. ``.git`` may be a dir
+    or a file (submodule / worktree ``gitdir:`` pointer) — both are moved.
+    Best-effort and deliberately conditional: an entry is carried over only
+    when its parent skill dir was restored and nothing sits at the target.
+    If the target snapshot predates the skill, the entry is dropped with the
+    staging dir rather than left as an orphan; note the safety snapshot
+    excludes these paths too, so that case is not undoable.
+    """
+    def _carry(src: Path) -> None:
+        dest = skills / src.relative_to(staged)
+        if dest.parent.is_dir() and not dest.exists():
+            try:
+                shutil.move(str(src), str(dest))
+            except OSError as e:
+                logger.debug("Could not restore excluded entry %s: %s", src, e)
+
+    for dirpath, dirnames, filenames in os.walk(staged):
         keep = []
         for name in dirnames:
-            if name not in _EXCLUDE_TOP_LEVEL:
+            if name in _EXCLUDE_TOP_LEVEL:
+                _carry(Path(dirpath) / name)
+            else:
                 keep.append(name)
-                continue
-            src = Path(dirpath) / name
-            dest = skills / src.relative_to(staged)
-            if dest.parent.is_dir() and not dest.exists():
-                try:
-                    shutil.move(str(src), str(dest))
-                except OSError as e:
-                    logger.debug("Could not restore excluded subtree %s: %s", src, e)
         dirnames[:] = keep
+        for name in filenames:
+            if name in _EXCLUDE_TOP_LEVEL:
+                _carry(Path(dirpath) / name)
 
 
 def _unstage(moved: List[Tuple[Path, Path]]) -> List[str]:
@@ -736,10 +749,9 @@ def rollback(backup_id: Optional[str] = None) -> Tuple[bool, str, Optional[Path]
 
     # Extract succeeded. Snapshots never contain excluded subtrees (nested
     # ``.git``, ``.hub``, ...), so the extract cannot restore them — carry
-    # them over from the staged copy of the live tree instead, the same way
-    # a top-level ``.git`` is preserved by never being staged at all. Then
-    # the staging dir has served its purpose; the user's undo handle is the
-    # safety snapshot tarball we took earlier.
+    # them over from the staged copy of the live tree (top-level ``.git`` is
+    # simpler: it is never staged). Then the staging dir has served its
+    # purpose; the user's undo handle is the safety snapshot tarball.
     _restore_excluded_subtrees(staged, skills)
     try:
         shutil.rmtree(staged, ignore_errors=True)

--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import shutil
 import tarfile
@@ -555,6 +556,27 @@ def _restore_cron_skill_links(snapshot_dir: Path) -> Dict[str, Any]:
 
 
 
+def _restore_excluded_subtrees(staged: Path, skills: Path) -> None:
+    """Move excluded subtrees (nested ``.git``/``.hub``/...) from *staged*
+    back under *skills* after a successful extract. Best-effort: a subtree
+    is only moved when its parent skill dir was restored and the target
+    does not already exist."""
+    for dirpath, dirnames, _files in os.walk(staged):
+        keep = []
+        for name in dirnames:
+            if name not in _EXCLUDE_TOP_LEVEL:
+                keep.append(name)
+                continue
+            src = Path(dirpath) / name
+            dest = skills / src.relative_to(staged)
+            if dest.parent.is_dir() and not dest.exists():
+                try:
+                    shutil.move(str(src), str(dest))
+                except OSError as e:
+                    logger.debug("Could not restore excluded subtree %s: %s", src, e)
+        dirnames[:] = keep
+
+
 def _unstage(moved: List[Tuple[Path, Path]]) -> List[str]:
     """Move staged entries back to their original paths.
 
@@ -712,8 +734,13 @@ def rollback(backup_id: Optional[str] = None) -> Tuple[bool, str, Optional[Path]
             pass
         return (False, f"snapshot extract failed (state restored): {e}", None)
 
-    # Extract succeeded — the staging dir has served its purpose. The
-    # user's undo handle is the safety snapshot tarball we took earlier.
+    # Extract succeeded. Snapshots never contain excluded subtrees (nested
+    # ``.git``, ``.hub``, ...), so the extract cannot restore them — carry
+    # them over from the staged copy of the live tree instead, the same way
+    # a top-level ``.git`` is preserved by never being staged at all. Then
+    # the staging dir has served its purpose; the user's undo handle is the
+    # safety snapshot tarball we took earlier.
+    _restore_excluded_subtrees(staged, skills)
     try:
         shutil.rmtree(staged, ignore_errors=True)
     except OSError:

--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -11,6 +11,7 @@ is undoable, then extracts the chosen snapshot into place.
 The snapshot does NOT include:
   - ``.curator_backups/`` (would recurse)
   - ``.hub/`` (hub-installed skills — managed by the hub, not us)
+  - ``.git/`` (repository metadata — managed by git, not the curator)
 
 It DOES include:
   - all SKILL.md files + their directories (``scripts/``, ``references/``,
@@ -60,7 +61,8 @@ DEFAULT_KEEP = 5
 # Entries under skills/ that should NEVER be rolled up into a snapshot.
 # .hub/ is managed by the skills hub; rolling it back would break lockfile
 # invariants. .curator_backups is the backup dir itself — recursion bomb.
-_EXCLUDE_TOP_LEVEL = {".curator_backups", ".hub"}
+# .git is repository metadata — rolling it back would break git tracking.
+_EXCLUDE_TOP_LEVEL = {".curator_backups", ".hub", ".git"}
 
 # Snapshot id regex: UTC ISO with colons replaced by dashes so the filename
 # is portable (Windows-safe). An optional ``-NN`` suffix handles two
@@ -260,6 +262,12 @@ def snapshot_skills(reason: str = "manual", *, protect_ids: Optional[Set[str]] =
         return None
 
     archive = dest / "skills.tar.gz"
+    def _tar_filter(tarinfo: tarfile.TarInfo) -> Optional[tarfile.TarInfo]:
+        parts = Path(tarinfo.name).parts
+        if any(p in _EXCLUDE_TOP_LEVEL for p in parts):
+            return None
+        return tarinfo
+
     try:
         # Stream into the tarball — no tempdir copy needed.
         with tarfile.open(archive, "w:gz", compresslevel=6) as tf:
@@ -268,7 +276,7 @@ def snapshot_skills(reason: str = "manual", *, protect_ids: Optional[Set[str]] =
                     continue
                 # arcname: store paths relative to skills/ so extraction
                 # drops cleanly back into the skills dir.
-                tf.add(str(entry), arcname=entry.name, recursive=True)
+                tf.add(str(entry), arcname=entry.name, recursive=True, filter=_tar_filter)
         # Capture cron/jobs.json alongside the tarball. Never fails the
         # snapshot — the skills side is the core guarantee; cron is
         # additive. We still record in the manifest whether it was

--- a/tests/agent/test_curator_backup.py
+++ b/tests/agent/test_curator_backup.py
@@ -484,3 +484,67 @@ def test_rollback_recovers_cleanly_from_a_partial_extract(backup_env, monkeypatc
     assert present == ["alpha", "beta"], f"tree not restored: {present}"
     assert "current copy" in (skills / "alpha" / "SKILL.md").read_text(encoding="utf-8")
     assert "current only" in (skills / "beta" / "SKILL.md").read_text(encoding="utf-8")
+
+
+def test_snapshot_excludes_git_and_curator_backups_and_hub(backup_env):
+    """Tar snapshots must exclude .git, .curator_backups, and .hub (top-level and nested)."""
+    cb = backup_env["cb"]
+    skills = backup_env["skills"]
+
+    # Top-level excluded structures
+    (skills / ".git").mkdir()
+    (skills / ".git" / "config").write_text("[core]\nrepositoryformatversion = 0\n", encoding="utf-8")
+    (skills / ".hub").mkdir()
+    (skills / ".hub" / "lock.json").write_text("{}", encoding="utf-8")
+
+    # Regular skill with nested .git
+    _write_skill(skills, "alpha", body="alpha body")
+    nested_git = skills / "alpha" / ".git"
+    nested_git.mkdir()
+    (nested_git / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+
+    snap_dir = cb.snapshot_skills(reason="test-exclude-git")
+    assert snap_dir is not None
+
+    archive = snap_dir / "skills.tar.gz"
+    assert archive.exists()
+
+    with tarfile.open(archive, "r:gz") as tf:
+        members = tf.getnames()
+
+    # Ensure no member contains .git, .curator_backups, or .hub
+    for name in members:
+        parts = Path(name).parts
+        assert ".git" not in parts, f".git found in archive: {name}"
+        assert ".curator_backups" not in parts, f".curator_backups found in archive: {name}"
+        assert ".hub" not in parts, f".hub found in archive: {name}"
+
+    assert "alpha/SKILL.md" in members
+
+
+def test_rollback_preserves_top_level_git(backup_env):
+    """Rollback must preserve repository .git metadata untouched in the skills root."""
+    cb = backup_env["cb"]
+    skills = backup_env["skills"]
+
+    git_dir = skills / ".git"
+    git_dir.mkdir()
+    (git_dir / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+    _write_skill(skills, "alpha", body="v1")
+
+    snap_dir = cb.snapshot_skills(reason="snap-v1")
+    assert snap_dir is not None
+
+    # Mutate skills tree and git metadata
+    _write_skill(skills, "alpha", body="v2")
+    _write_skill(skills, "beta", body="new")
+    (git_dir / "HEAD").write_text("ref: refs/heads/feature\n", encoding="utf-8")
+
+    ok, msg, _ = cb.rollback(backup_id=snap_dir.name)
+    assert ok, f"rollback failed: {msg}"
+
+    assert (skills / "alpha" / "SKILL.md").read_text(encoding="utf-8").find("v1") != -1
+    assert not (skills / "beta").exists()
+    assert (git_dir / "HEAD").exists()
+    assert (git_dir / "HEAD").read_text(encoding="utf-8") == "ref: refs/heads/feature\n"
+

--- a/tests/agent/test_curator_backup.py
+++ b/tests/agent/test_curator_backup.py
@@ -548,3 +548,29 @@ def test_rollback_preserves_top_level_git(backup_env):
     assert (git_dir / "HEAD").exists()
     assert (git_dir / "HEAD").read_text(encoding="utf-8") == "ref: refs/heads/feature\n"
 
+
+
+def test_rollback_preserves_nested_git_inside_skill(backup_env):
+    """A skill that is itself a git checkout keeps its .git across rollback:
+    the snapshot excludes it, so rollback must carry it over from the live tree."""
+    cb = backup_env["cb"]
+    skills = backup_env["skills"]
+
+    _write_skill(skills, "alpha", body="v1")
+    nested_git = skills / "alpha" / ".git"
+    nested_git.mkdir()
+    (nested_git / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+
+    snap_dir = cb.snapshot_skills(reason="snap-v1")
+    assert snap_dir is not None
+
+    _write_skill(skills, "alpha", body="v2")
+    (nested_git / "HEAD").write_text("ref: refs/heads/feature\n", encoding="utf-8")
+
+    ok, msg, _ = cb.rollback(backup_id=snap_dir.name)
+    assert ok, f"rollback failed: {msg}"
+    assert "v1" in (skills / "alpha" / "SKILL.md").read_text(encoding="utf-8")
+    # Live .git state (post-snapshot) is what survives — it was never archived.
+    assert (nested_git / "HEAD").read_text(encoding="utf-8") == "ref: refs/heads/feature\n"
+    staging = list((skills / ".curator_backups").glob(".rollback-staging-*"))
+    assert staging == [], f"staging dir left behind: {staging}"

--- a/tests/agent/test_curator_backup.py
+++ b/tests/agent/test_curator_backup.py
@@ -574,3 +574,26 @@ def test_rollback_preserves_nested_git_inside_skill(backup_env):
     assert (nested_git / "HEAD").read_text(encoding="utf-8") == "ref: refs/heads/feature\n"
     staging = list((skills / ".curator_backups").glob(".rollback-staging-*"))
     assert staging == [], f"staging dir left behind: {staging}"
+
+
+def test_rollback_preserves_nested_git_file_pointer(backup_env):
+    """Submodule / worktree checkouts use a ``.git`` FILE (gitdir: pointer);
+    it must be carried across rollback like the dir form."""
+    cb = backup_env["cb"]
+    skills = backup_env["skills"]
+
+    _write_skill(skills, "alpha", body="v1")
+    git_ptr = skills / "alpha" / ".git"
+    git_ptr.write_text("gitdir: ../../.git/modules/alpha\n", encoding="utf-8")
+
+    snap_dir = cb.snapshot_skills(reason="snap-v1")
+    assert snap_dir is not None
+    with tarfile.open(snap_dir / "skills.tar.gz", "r:gz") as tf:
+        assert "alpha/.git" not in tf.getnames()
+
+    _write_skill(skills, "alpha", body="v2")
+    ok, msg, _ = cb.rollback(backup_id=snap_dir.name)
+    assert ok, f"rollback failed: {msg}"
+    assert "v1" in (skills / "alpha" / "SKILL.md").read_text(encoding="utf-8")
+    assert git_ptr.is_file()
+    assert git_ptr.read_text(encoding="utf-8").startswith("gitdir:")


### PR DESCRIPTION
## Summary
Curator skill snapshots no longer archive `.git` — top-level or nested inside a skill dir — so a git-tracked `~/.hermes/skills/` stops compounding into multi-GB tarballs that hang the CLI at startup.

Root cause: `_EXCLUDE_TOP_LEVEL` lacked `.git`, and `tf.add(..., recursive=True)` had no filter, so every weekly snapshot packed the full repo history (which itself contained the previous snapshots). Issue #91449 reports 38 MB of skills growing to 24 GB in a few weeks, with `snapshot_skills()` pinning a core at 100% before the prompt appears.

Who hits this: anyone who keeps `~/.hermes/skills` under git (or installs a skill that is itself a git checkout) with curator backups enabled (the default). When: every curator run, silently, until disk or startup time gives out.

## Changes
- `agent/curator_backup.py`: add `.git` to `_EXCLUDE_TOP_LEVEL`; add a `_tar_filter` passed to `tf.add` that drops any member whose path contains an excluded component (nested `.git` / `.hub` / `.curator_backups`); module docstring updated.
- Comment on `_EXCLUDE_TOP_LEVEL` carries the growth rationale from #91458 (why exclusion is about compounding size, not just rollback safety).
- Rollback follow-up: because snapshots no longer contain a nested `.git`, rollback would have deleted it along with the staging dir (reproduced: main preserved it, exclusion-only branch did not). After a successful extract, excluded entries are moved back from the staged live tree under their restored skill dir — both dir-form and file-form `.git` (submodule/worktree `gitdir:` pointers). Deliberate limit, stated in the docstring: if the target snapshot predates the skill, the entry is dropped with staging (no orphan `.git`).
- `tests/agent/test_curator_backup.py`: nested-exclusion test, rollback-preserves-top-level-`.git` test, rollback-preserves-nested-`.git` (dir) and `.git`-file-pointer tests.

## Before / after
Before (main `1cb3ab6173`):
```
_EXCLUDE_TOP_LEVEL = {".curator_backups", ".hub"}
...
tf.add(str(entry), arcname=entry.name, recursive=True)
```
After:
```
_EXCLUDE_TOP_LEVEL = {".curator_backups", ".hub", ".git"}
...
tf.add(str(entry), arcname=entry.name, recursive=True, filter=_tar_filter)
```

## Benchmark
Synthetic `HERMES_HOME`: 3 skills (~40 KB of SKILL.md), `skills/.git` with 64 MB of incompressible pack data, `alpha/.git` with 8 MB. `snapshot_skills()` ×5, median. macOS / Apple Silicon laptop.

| | wall time | archive size |
|---|---|---|
| main `1cb3ab6173` | 1224 ms | 75.5 MB |
| #91458 (top-level `.git` only) | 128 ms | 8.4 MB (nested `.git` still packed) |
| this PR | 7 ms | 0.0 MB |

Script: `~/triage-perf-p2/bench/91463.py <checkout>` (builds the tree, times 5 snapshots, prints median + archive size).

What actually improved: the snapshot only contains skill content again. On the synthetic tree that is 1.2 s → 7 ms and 75 MB → ~0 per snapshot; on the reporter's real tree it is the difference between a 24 GB tar loop and a sub-second one, and because the archive no longer feeds back into `.git`, the growth stops compounding.

## Tests
`tests/agent/test_curator_backup.py`: 16 passed. Mutation checks: reverting `agent/curator_backup.py` to main fails the 2 exclusion tests; disabling the rollback carry-over fails the nested-`.git` test; dropping the file branch fails the `.git`-pointer test.

## Provenance
Salvaged from #91463 by @frizikk (cherry-picked, authorship preserved). Growth-rationale comment from #91458 by @liuhao1024 (Co-authored-by trailer on the follow-up commit). Closes #91449. Supersedes #91458.
