### PR TITLE
fix(auxiliary): skip same-provider retry on a vision full-budget timeout (sync + async)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5035,6 +5035,14 @@ def _is_invalid_aux_response_error(exc: Exception) -> bool:
     )
 
 
+# Auxiliary tasks that sit on a user-visible critical path. A same-provider
+# retry after a full-budget timeout costs another whole ``timeout`` window
+# before the fallback chain is reached, so these skip it and fall through
+# immediately. Fast blips (a streaming-close or a 5xx) still retry, since
+# those are cheap. See issue #54465 for the compression case.
+_TIMEOUT_NO_RETRY_TASKS = frozenset({"compression", "vision"})
+
+
 def _evict_cached_clients(provider: str) -> None:
     """Drop cached auxiliary clients for a provider so fresh creds are used."""
     normalized = _normalize_aux_provider(provider)
@@ -10622,14 +10630,17 @@ def _call_llm_impl(
             if not _is_transient_transport_error(transient_err):
                 raise
             # Compression is on the critical preflight path: a user cannot
-            # continue or resume an oversized session until it compacts. A
-            # same-provider retry on a timeout means another full ``timeout``-
-            # long wall-clock block before the except-chain below can fall
-            # back — doubling the user-visible stall (issue #54465). Skip the
-            # same-provider retry for compression on a full-budget timeout and
+            # continue or resume an oversized session until it compacts.
+            # Vision is on the interactive path: the turn holding the image
+            # cannot answer, and because turns are serialised the following
+            # user messages stall behind it. In both cases a same-provider
+            # retry on a timeout means another full ``timeout``-long
+            # wall-clock block before the except-chain below can fall back —
+            # doubling the user-visible stall (issue #54465). Skip the
+            # same-provider retry for those tasks on a full-budget timeout and
             # fall straight through to provider/model fallback; fast blips (a
             # streaming-close or a 5xx) still retry, since those are cheap.
-            if task == "compression" and _is_timeout_error(transient_err):
+            if task in _TIMEOUT_NO_RETRY_TASKS and _is_timeout_error(transient_err):
                 # A fast first-token fail (dead stream detected within the
                 # 60s no-progress window, zero output seen) is cheap — take
                 # the normal same-provider retry chain first; the provider
@@ -10639,9 +10650,9 @@ def _call_llm_impl(
                 # same provider doubles the user-visible stall (#54465).
                 if "no-progress timeout" not in str(transient_err):
                     logger.info(
-                        "Auxiliary compression: timeout on the critical path; "
+                        "Auxiliary %s: timeout on the critical path; "
                         "skipping same-provider retry and falling back: %s",
-                        transient_err,
+                        task, transient_err,
                     )
                     raise
             _max_transient_retries = _transient_retry_count()
@@ -11459,14 +11470,14 @@ async def _async_call_llm_impl(
         except Exception as transient_err:
             if not _is_transient_transport_error(transient_err):
                 raise
-            # See call_llm(): compression is on the critical preflight path,
-            # so skip the same-provider retry on a full-budget timeout and
-            # fall straight through to fallback (issue #54465).
-            if task == "compression" and _is_timeout_error(transient_err):
+            # See call_llm(): compression and vision both sit on a critical
+            # path, so skip the same-provider retry on a full-budget timeout
+            # and fall straight through to fallback (issue #54465).
+            if task in _TIMEOUT_NO_RETRY_TASKS and _is_timeout_error(transient_err):
                 logger.info(
-                    "Auxiliary compression (async): timeout on the critical "
+                    "Auxiliary %s (async): timeout on the critical "
                     "path; skipping same-provider retry and falling back: %s",
-                    transient_err,
+                    task, transient_err,
                 )
                 raise
             logger.info(

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -11472,8 +11472,16 @@ async def _async_call_llm_impl(
                 raise
             # See call_llm(): compression and vision both sit on a critical
             # path, so skip the same-provider retry on a full-budget timeout
-            # and fall straight through to fallback (issue #54465).
-            if task in _TIMEOUT_NO_RETRY_TASKS and _is_timeout_error(transient_err):
+            # and fall straight through to fallback (issue #54465). Same
+            # carve-out as the sync site: a fast first-token fail (no-progress
+            # window, zero output) is cheap and still takes the retry — the
+            # async Codex adapter wraps the sync stream via to_thread, so the
+            # same TimeoutError reaches this handler.
+            if (
+                task in _TIMEOUT_NO_RETRY_TASKS
+                and _is_timeout_error(transient_err)
+                and "no-progress timeout" not in str(transient_err)
+            ):
                 logger.info(
                     "Auxiliary %s (async): timeout on the critical "
                     "path; skipping same-provider retry and falling back: %s",

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5043,6 +5043,30 @@ def _is_invalid_aux_response_error(exc: Exception) -> bool:
 _TIMEOUT_NO_RETRY_TASKS = frozenset({"compression", "vision"})
 
 
+def _should_skip_same_provider_retry(task: Optional[str], exc: Exception) -> bool:
+    """True when a transient error should go straight to fallback.
+
+    Compression is on the critical preflight path: a user cannot continue or
+    resume an oversized session until it compacts. Vision is on the
+    interactive path: the turn holding the image cannot answer, and because
+    turns are serialised the following user messages stall behind it. For
+    those tasks a same-provider retry on a full-budget timeout means another
+    whole ``timeout`` of wall-clock before the fallback chain runs, doubling
+    the user-visible stall (#54465).
+
+    Carve-out: a fast first-token fail (dead stream detected within the 60s
+    no-progress window, zero output seen — see ``_timeout_message``) is cheap,
+    so it keeps the normal same-provider retry; the provider is often fine
+    and only that one stream was stillborn. Mid-stream stalls and hard-ceiling
+    timeouts skip to fallback.
+    """
+    return (
+        task in _TIMEOUT_NO_RETRY_TASKS
+        and _is_timeout_error(exc)
+        and "no-progress timeout" not in str(exc)
+    )
+
+
 def _evict_cached_clients(provider: str) -> None:
     """Drop cached auxiliary clients for a provider so fresh creds are used."""
     normalized = _normalize_aux_provider(provider)
@@ -10629,32 +10653,15 @@ def _call_llm_impl(
         except Exception as transient_err:
             if not _is_transient_transport_error(transient_err):
                 raise
-            # Compression is on the critical preflight path: a user cannot
-            # continue or resume an oversized session until it compacts.
-            # Vision is on the interactive path: the turn holding the image
-            # cannot answer, and because turns are serialised the following
-            # user messages stall behind it. In both cases a same-provider
-            # retry on a timeout means another full ``timeout``-long
-            # wall-clock block before the except-chain below can fall back —
-            # doubling the user-visible stall (issue #54465). Skip the
-            # same-provider retry for those tasks on a full-budget timeout and
-            # fall straight through to provider/model fallback; fast blips (a
-            # streaming-close or a 5xx) still retry, since those are cheap.
-            if task in _TIMEOUT_NO_RETRY_TASKS and _is_timeout_error(transient_err):
-                # A fast first-token fail (dead stream detected within the
-                # 60s no-progress window, zero output seen) is cheap — take
-                # the normal same-provider retry chain first; the provider
-                # is often fine and only that one stream was stillborn. A
-                # mid-stream stall or hard-ceiling timeout skips straight to
-                # fallback, because re-running a multi-minute summary on the
-                # same provider doubles the user-visible stall (#54465).
-                if "no-progress timeout" not in str(transient_err):
-                    logger.info(
-                        "Auxiliary %s: timeout on the critical path; "
-                        "skipping same-provider retry and falling back: %s",
-                        task, transient_err,
-                    )
-                    raise
+            # Critical-path tasks skip the same-provider retry on a
+            # full-budget timeout; see _should_skip_same_provider_retry.
+            if _should_skip_same_provider_retry(task, transient_err):
+                logger.info(
+                    "Auxiliary %s: timeout on the critical path; "
+                    "skipping same-provider retry and falling back: %s",
+                    task, transient_err,
+                )
+                raise
             _max_transient_retries = _transient_retry_count()
             _last_transient = transient_err
             for _attempt in range(1, _max_transient_retries + 1):
@@ -11470,18 +11477,9 @@ async def _async_call_llm_impl(
         except Exception as transient_err:
             if not _is_transient_transport_error(transient_err):
                 raise
-            # See call_llm(): compression and vision both sit on a critical
-            # path, so skip the same-provider retry on a full-budget timeout
-            # and fall straight through to fallback (issue #54465). Same
-            # carve-out as the sync site: a fast first-token fail (no-progress
-            # window, zero output) is cheap and still takes the retry — the
-            # async Codex adapter wraps the sync stream via to_thread, so the
-            # same TimeoutError reaches this handler.
-            if (
-                task in _TIMEOUT_NO_RETRY_TASKS
-                and _is_timeout_error(transient_err)
-                and "no-progress timeout" not in str(transient_err)
-            ):
+            # Same rule as call_llm(); the async Codex adapter wraps the sync
+            # stream via to_thread, so the same TimeoutError reaches here.
+            if _should_skip_same_provider_retry(task, transient_err):
                 logger.info(
                     "Auxiliary %s (async): timeout on the critical "
                     "path; skipping same-provider retry and falling back: %s",

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2118,6 +2118,70 @@ class TestTransientTransportRetry:
         assert primary.chat.completions.create.call_count == 1
         assert fb_client.chat.completions.create.call_count == 1
 
+    def test_vision_skips_same_provider_retry_on_timeout(self):
+        """Vision is on the interactive critical path: the turn holding the
+        image cannot answer, and because turns are serialised the following
+        user messages stall behind it. A full-budget timeout must therefore
+        fall straight through to fallback rather than spending a second
+        ``timeout`` window on the same provider (same reasoning as #54465).
+        """
+        class _Timeout(Exception):
+            pass
+        _Timeout.__name__ = "APITimeoutError"
+
+        primary = MagicMock()
+        primary.base_url = "https://openrouter.ai/api/v1"
+        primary.chat.completions.create.side_effect = _Timeout("Request timed out.")
+
+        fb_client = MagicMock()
+        fb_client.base_url = "https://api.openai.com/v1"
+        fb_client.chat.completions.create.return_value = {"fallback": True}
+
+        p1, p2, p3 = self._patches(primary)
+        with (
+            p1, p2, p3,
+            # Vision resolves its client through resolve_vision_provider_client(),
+            # not _get_cached_client(); the retry block under test is shared.
+            patch(
+                "agent.auxiliary_client.resolve_vision_provider_client",
+                return_value=("openrouter", primary, "some-model"),
+            ),
+            patch(
+                "agent.auxiliary_client._try_configured_fallback_chain",
+                return_value=(None, None, ""),
+            ),
+            patch(
+                "agent.auxiliary_client._try_main_agent_model_fallback",
+                return_value=(fb_client, "fb-model", "openai"),
+            ),
+        ):
+            result = call_llm(task="vision", messages=[{"role": "user", "content": "hi"}])
+        assert result == {"fallback": True}
+        assert primary.chat.completions.create.call_count == 1
+        assert fb_client.chat.completions.create.call_count == 1
+
+    def test_non_critical_task_still_retries_same_provider_on_timeout(self):
+        """The skip is scoped to critical-path tasks. Everything else keeps the
+        existing one-shot same-provider retry, so this is not a blanket change.
+        """
+        class _Timeout(Exception):
+            pass
+        _Timeout.__name__ = "APITimeoutError"
+
+        primary = MagicMock()
+        primary.base_url = "https://openrouter.ai/api/v1"
+        primary.chat.completions.create.side_effect = [
+            _Timeout("Request timed out."),
+            {"retried": True},
+        ]
+
+        p1, p2, p3 = self._patches(primary)
+        with p1, p2, p3:
+            result = call_llm(task="title", messages=[{"role": "user", "content": "hi"}])
+        assert result == {"retried": True}
+        # Same provider was retried once — unchanged behaviour off the critical path.
+        assert primary.chat.completions.create.call_count == 2
+
     def test_timeout_forwards_failed_model_to_configured_chain(self):
         """A timeout is model-specific, so call_llm must forward the failed
         model to the configured chain (failed_model=<model>, not None). This

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2160,6 +2160,75 @@ class TestTransientTransportRetry:
         assert primary.chat.completions.create.call_count == 1
         assert fb_client.chat.completions.create.call_count == 1
 
+    @pytest.mark.asyncio
+    async def test_vision_skips_same_provider_retry_on_timeout_async(self):
+        """Async twin of the sync guard: tools/vision_tools.py drives
+        ``async_call_llm``, so the skip must hold on the async site too."""
+        class _Timeout(Exception):
+            pass
+        _Timeout.__name__ = "APITimeoutError"
+
+        primary = MagicMock()
+        primary.base_url = "https://openrouter.ai/api/v1"
+        primary.chat.completions.create = AsyncMock(
+            side_effect=_Timeout("Request timed out.")
+        )
+        expected = {"fallback": True}
+
+        p1, p2, p3 = self._patches(primary)
+        with (
+            p1, p2, p3,
+            patch(
+                "agent.auxiliary_client.resolve_vision_provider_client",
+                return_value=("openrouter", primary, "some-model"),
+            ),
+            patch(
+                "agent.auxiliary_client._try_configured_fallback_chain",
+                return_value=(MagicMock(), "fb-model", "configured-fallback"),
+            ),
+            patch(
+                "agent.auxiliary_client._to_async_client",
+                return_value=(MagicMock(), "fb-model"),
+            ),
+            patch(
+                "agent.auxiliary_client._call_fallback_candidate_async",
+                new=AsyncMock(return_value=expected),
+            ),
+        ):
+            result = await async_call_llm(
+                task="vision", messages=[{"role": "user", "content": "hi"}]
+            )
+        assert result == expected
+        assert primary.chat.completions.create.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_no_progress_timeout_still_retries_same_provider_async(self):
+        """A stillborn stream (no-progress window, zero output) is cheap: it
+        keeps the same-provider retry on the async site, mirroring sync."""
+        primary = MagicMock()
+        primary.base_url = "https://chatgpt.com/backend-api/codex"
+        primary.chat.completions.create = AsyncMock(side_effect=[
+            TimeoutError(
+                "Codex auxiliary Responses stream produced no output within "
+                "60.0s (no-progress timeout, 60.2s elapsed)"
+            ),
+            {"retried": True},
+        ])
+
+        p1, p2, p3 = self._patches(primary)
+        with (
+            p1, p2, p3,
+            patch(
+                "agent.auxiliary_client.resolve_vision_provider_client",
+                return_value=("openrouter", primary, "some-model"),
+            ),
+        ):
+            result = await async_call_llm(
+                task="vision", messages=[{"role": "user", "content": "hi"}]
+            )
+        assert result == {"retried": True}
+        assert primary.chat.completions.create.call_count == 2
+
     def test_non_critical_task_still_retries_same_provider_on_timeout(self):
         """The skip is scoped to critical-path tasks. Everything else keeps the
         existing one-shot same-provider retry, so this is not a blanket change.


### PR DESCRIPTION
## Summary
A vision call that burns its whole timeout budget now falls straight to the fallback provider instead of spending a second full timeout window on the same provider first — on both the sync and async auxiliary paths.

Who hits this: anyone whose image/PDF-page analysis provider times out. The turn holding the image cannot answer, and because gateway turns are serialised the messages behind it stall too. Before, a 120 s vision timeout cost 240 s before fallback was even attempted. The same reasoning was already applied to compression in #54465; this extends it.

## Changes
- `agent/auxiliary_client.py`: `_TIMEOUT_NO_RETRY_TASKS = frozenset({"compression", "vision"})` replaces the two hardcoded `task == "compression"` checks (sync + async).
- Follow-up: the async site now carries the same "no-progress timeout still retries" carve-out the sync site got in f50b5bb0fa — a stillborn Codex stream that dies inside the 60 s no-progress window with zero output is cheap and still takes the same-provider retry; only stalls and hard-ceiling timeouts skip to fallback. Previously the async path lacked that carve-out entirely.
- Refactor: `_should_skip_same_provider_retry(task, exc)` owns the three-clause rule and its carve-out next to `_TIMEOUT_NO_RETRY_TASKS`; both sites call it instead of re-deriving it (the duplication is how the async site drifted in the first place).
- Tests: vision-skip (sync + async), non-critical task still retries (sync), no-progress still retries (async).

## Before / after
Before (main `1cb3ab6173`, async site):
```
if task == "compression" and _is_timeout_error(transient_err):
    ...
    raise
```
After (both sites):
```
if _should_skip_same_provider_retry(task, transient_err):
    ...
    raise
# where the predicate is:
#   task in _TIMEOUT_NO_RETRY_TASKS and _is_timeout_error(exc)
#   and "no-progress timeout" not in str(exc)
```

## Benchmark
Stubbed network: primary `chat.completions.create` sleeps `TIMEOUT_S=0.5` then raises an `APITimeoutError` look-alike; fallback answers instantly. `task="vision"`, 5 runs, median. macOS / Apple Silicon laptop.

| | sync `call_llm` | async `async_call_llm` | primary attempts |
|---|---|---|---|
| main `1cb3ab6173` | 1015 ms | 1010 ms | 2 |
| this PR | 517 ms | 511 ms | 1 |

Script: `~/triage-perf-p2/bench/97572.py <checkout> [--async]`.

What actually improved: one timeout window instead of two before fallback runs. With the real default vision timeout that is roughly 2 min saved per timed-out image, on the path that blocks the user's next message.

## Tests
`tests/agent/test_auxiliary_client.py -k "TransientTransportRetry"` + `tests/agent/test_codex_aux_no_progress_timeout.py`: 15 passed. Mutation checks: reverting the frozenset change fails the vision-skip test; removing the async no-progress carve-out fails the new async retry test.

## Provenance
Salvaged from #97572 by @xmhuangzhijun-hue (cherry-picked, authorship preserved; conflict against f50b5bb0fa resolved in favour of keeping the sync carve-out). Overlaps #87087 by @mybryan-sketch, which reaches the same outcome via an opt-in `auxiliary.vision.retry_on_timeout` config key on the async path only — see the note on that PR.
