### PR TITLE
fix(skills): stop syncing bookkeeping dirs to sandboxes and prune them from the walk

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -31,6 +31,7 @@ EXCLUDED_SKILL_DIRS = frozenset(
         ".github",
         ".hub",
         ".archive",
+        ".curator_backups",
         ".venv",
         "venv",
         "node_modules",

--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -147,6 +147,46 @@ class TestIterSkillsFiles:
         # Symlink should be excluded
         assert not any("evil" in f["container_path"] for f in files)
 
+    def test_skips_excluded_bookkeeping_dirs(self, tmp_path):
+        """Bookkeeping and dependency dirs must not be uploaded to a sandbox.
+
+        The sync path used a bare rglob("*"), so the .hub download cache,
+        .archive, curator backups and any node_modules/.git under a skills
+        tree were packed up on every sync even though the sandbox never
+        reads them. Sync now honours EXCLUDED_SKILL_DIRS like discovery.
+        """
+        hermes_home = tmp_path / ".hermes"
+        skills_dir = hermes_home / "skills"
+        (skills_dir / "cat" / "myskill").mkdir(parents=True)
+        (skills_dir / "cat" / "myskill" / "SKILL.md").write_text("# skill")
+        # Progressive-disclosure support files must still be synced.
+        (skills_dir / "cat" / "myskill" / "references").mkdir()
+        (skills_dir / "cat" / "myskill" / "references" / "api.md").write_text("ref")
+
+        for excluded in (".hub", ".archive", ".curator_backups", "node_modules"):
+            junk = skills_dir / excluded / "vendored"
+            junk.mkdir(parents=True)
+            (junk / "SKILL.md").write_text("# stale copy")
+        # Also nested inside an otherwise-valid skill package.
+        cache = skills_dir / "cat" / "myskill" / "__pycache__"
+        cache.mkdir()
+        (cache / "helper.cpython-311.pyc").write_text("bytecode")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            files = iter_skills_files()
+
+        paths = {f["container_path"] for f in files}
+        assert "/root/.hermes/skills/cat/myskill/SKILL.md" in paths
+        assert "/root/.hermes/skills/cat/myskill/references/api.md" in paths
+        for excluded in (
+            ".hub",
+            ".archive",
+            ".curator_backups",
+            "node_modules",
+            "__pycache__",
+        ):
+            assert not any(excluded in path for path in paths), excluded
+
     def test_empty_when_no_skills_dir(self, tmp_path):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -112,6 +112,34 @@ class TestSkillsDirectoryMount:
         # Symlink should NOT be present
         assert not (safe_path / "evil_link").exists()
 
+    def test_sanitized_copy_skips_bookkeeping_dirs(self, tmp_path):
+        """The symlink-safe copy is what gets mounted, so it must apply the
+        same EXCLUDED_SKILL_DIRS rule as the per-file sync path."""
+        hermes_home = tmp_path / ".hermes"
+        skills_dir = hermes_home / "skills"
+        (skills_dir / "cat" / "myskill" / "references").mkdir(parents=True)
+        (skills_dir / "cat" / "myskill" / "SKILL.md").write_text("# skill")
+        (skills_dir / "cat" / "myskill" / "references" / "api.md").write_text("ref")
+        for excluded in (".hub", ".curator_backups", "node_modules"):
+            junk = skills_dir / excluded / "vendored"
+            junk.mkdir(parents=True)
+            (junk / "blob.bin").write_bytes(b"\0" * 64)
+        # Force the sanitizing copy path.
+        secret = tmp_path / "secret.txt"
+        secret.write_text("TOP SECRET")
+        (skills_dir / "evil_link").symlink_to(secret)
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            mounts = get_skills_directory_mount()
+
+        safe_path = Path(mounts[0]["host_path"])
+        assert safe_path != skills_dir
+        assert (safe_path / "cat" / "myskill" / "SKILL.md").exists()
+        assert (safe_path / "cat" / "myskill" / "references" / "api.md").exists()
+        assert not (safe_path / "evil_link").exists()
+        for excluded in (".hub", ".curator_backups", "node_modules"):
+            assert not (safe_path / excluded).exists(), excluded
+
     def test_no_symlinks_returns_original_dir(self, tmp_path):
         """When no symlinks exist, the original dir is returned (no copy)."""
         hermes_home = tmp_path / ".hermes"

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -346,21 +346,29 @@ def _safe_skills_path(skills_dir: Path) -> str:
     return str(safe_dir)
 
 
-def _is_excluded_skills_dir(rel: Path) -> bool:
-    """True if *rel* sits under a directory excluded from skill scanning.
+def _iter_syncable_files(root: Path):
+    """Yield ``(path, rel)`` for every regular, non-symlink file under *root*
+    that a sandbox should receive.
 
-    Reuses ``agent.skill_utils.EXCLUDED_SKILL_DIRS`` so the sync path agrees
-    with discovery. These are local bookkeeping and dependency directories
-    (``.hub`` download cache, ``.archive``, ``.curator_backups``,
-    ``node_modules``, ``__pycache__``, ``.git``, ...) that the remote agent
-    never reads.
+    Prunes ``agent.skill_utils.EXCLUDED_SKILL_DIRS`` *before* descending, so
+    the walk never enters local bookkeeping and dependency trees (``.hub``
+    download cache, ``.archive``, ``.curator_backups``, ``node_modules``,
+    ``__pycache__``, ``.git``, ...) that the remote agent never reads — the
+    sync path agrees with discovery on what counts as skill content.
 
     This deliberately does not use ``is_excluded_skill_path()``, which also
     prunes ``references/``, ``templates/``, ``assets/`` and ``scripts/``.
     Those hold progressive-disclosure support files and bundled scripts the
     sandbox does execute, so they must keep syncing.
     """
-    return any(part in EXCLUDED_SKILL_DIRS for part in rel.parts[:-1])
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = sorted(d for d in dirnames if d not in EXCLUDED_SKILL_DIRS)
+        base = Path(dirpath)
+        for name in filenames:
+            item = base / name
+            if item.is_symlink() or not item.is_file():
+                continue
+            yield item, item.relative_to(root)
 
 
 def iter_skills_files(
@@ -379,12 +387,7 @@ def iter_skills_files(
     skills_dir = hermes_home / "skills"
     if skills_dir.is_dir():
         container_root = f"{container_base.rstrip('/')}/skills"
-        for item in skills_dir.rglob("*"):
-            if item.is_symlink() or not item.is_file():
-                continue
-            rel = item.relative_to(skills_dir)
-            if _is_excluded_skills_dir(rel):
-                continue
+        for item, rel in _iter_syncable_files(skills_dir):
             result.append({
                 "host_path": str(item),
                 "container_path": f"{container_root}/{rel}",
@@ -397,12 +400,7 @@ def iter_skills_files(
             if not ext_dir.is_dir():
                 continue
             container_root = f"{container_base.rstrip('/')}/external_skills/{idx}"
-            for item in ext_dir.rglob("*"):
-                if item.is_symlink() or not item.is_file():
-                    continue
-                rel = item.relative_to(ext_dir)
-                if _is_excluded_skills_dir(rel):
-                    continue
+            for item, rel in _iter_syncable_files(ext_dir):
                 result.append({
                     "host_path": str(item),
                     "container_path": f"{container_root}/{rel}",
@@ -411,12 +409,7 @@ def iter_skills_files(
             if not proj_dir.is_dir():
                 continue
             container_root = f"{container_base.rstrip('/')}/project_skills/{idx}"
-            for item in proj_dir.rglob("*"):
-                if item.is_symlink() or not item.is_file():
-                    continue
-                rel = item.relative_to(proj_dir)
-                if _is_excluded_skills_dir(rel):
-                    continue
+            for item, rel in _iter_syncable_files(proj_dir):
                 result.append({
                     "host_path": str(item),
                     "container_path": f"{container_root}/{rel}",

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -28,6 +28,8 @@ from pathlib import Path
 from typing import Dict, List, Optional
 from hermes_cli.config import cfg_get
 
+from agent.skill_utils import EXCLUDED_SKILL_DIRS
+
 try:  # pragma: no cover - exercised via the fail-closed test below
     from agent.file_safety import get_read_block_error
 except ImportError:  # noqa: F401 - sentinel consumed in register_credential_file
@@ -344,15 +346,32 @@ def _safe_skills_path(skills_dir: Path) -> str:
     return str(safe_dir)
 
 
+def _is_excluded_skills_dir(rel: Path) -> bool:
+    """True if *rel* sits under a directory excluded from skill scanning.
+
+    Reuses ``agent.skill_utils.EXCLUDED_SKILL_DIRS`` so the sync path agrees
+    with discovery. These are local bookkeeping and dependency directories
+    (``.hub`` download cache, ``.archive``, ``.curator_backups``,
+    ``node_modules``, ``__pycache__``, ``.git``, ...) that the remote agent
+    never reads.
+
+    This deliberately does not use ``is_excluded_skill_path()``, which also
+    prunes ``references/``, ``templates/``, ``assets/`` and ``scripts/``.
+    Those hold progressive-disclosure support files and bundled scripts the
+    sandbox does execute, so they must keep syncing.
+    """
+    return any(part in EXCLUDED_SKILL_DIRS for part in rel.parts[:-1])
+
+
 def iter_skills_files(
     container_base: str = "/root/.hermes",
 ) -> List[Dict[str, str]]:
     """Yield individual (host_path, container_path) entries for skills files.
 
     Includes both the local skills dir and any external dirs configured via
-    skills.external_dirs.  Skips symlinks entirely.  Preferred for backends
-    that upload files individually (Daytona, Modal) rather than mounting a
-    directory.
+    skills.external_dirs.  Skips symlinks and anything under
+    EXCLUDED_SKILL_DIRS entirely.  Preferred for backends that upload files
+    individually (Daytona, Modal) rather than mounting a directory.
     """
     result: List[Dict[str, str]] = []
 
@@ -364,6 +383,8 @@ def iter_skills_files(
             if item.is_symlink() or not item.is_file():
                 continue
             rel = item.relative_to(skills_dir)
+            if _is_excluded_skills_dir(rel):
+                continue
             result.append({
                 "host_path": str(item),
                 "container_path": f"{container_root}/{rel}",
@@ -380,6 +401,8 @@ def iter_skills_files(
                 if item.is_symlink() or not item.is_file():
                     continue
                 rel = item.relative_to(ext_dir)
+                if _is_excluded_skills_dir(rel):
+                    continue
                 result.append({
                     "host_path": str(item),
                     "container_path": f"{container_root}/{rel}",
@@ -392,6 +415,8 @@ def iter_skills_files(
                 if item.is_symlink() or not item.is_file():
                     continue
                 rel = item.relative_to(proj_dir)
+                if _is_excluded_skills_dir(rel):
+                    continue
                 result.append({
                     "host_path": str(item),
                     "container_path": f"{container_root}/{rel}",

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -326,16 +326,19 @@ def _safe_skills_path(skills_dir: Path) -> str:
     safe_dir = Path(tempfile.mkdtemp(prefix="hermes-skills-safe-"))
     _safe_skills_tempdir = safe_dir
 
-    for item in skills_dir.rglob("*"):
-        if item.is_symlink():
-            continue
-        rel = item.relative_to(skills_dir)
-        target = safe_dir / rel
-        if item.is_dir():
-            target.mkdir(parents=True, exist_ok=True)
-        elif item.is_file():
-            target.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(str(item), str(target))
+    # Same exclusion rule as the per-file sync path (_iter_syncable_files):
+    # the sanitized copy is what gets mounted, so it must not carry the
+    # bookkeeping trees either. Prune before descending so a multi-GB
+    # .curator_backups is never even walked.
+    for dirpath, dirnames, filenames in os.walk(skills_dir):
+        dirnames[:] = sorted(d for d in dirnames if d not in EXCLUDED_SKILL_DIRS)
+        base = Path(dirpath)
+        (safe_dir / base.relative_to(skills_dir)).mkdir(parents=True, exist_ok=True)
+        for name in filenames:
+            item = base / name
+            if item.is_symlink() or not item.is_file():
+                continue
+            shutil.copy2(str(item), str(safe_dir / item.relative_to(skills_dir)))
 
     def _cleanup():
         if safe_dir.is_dir():


### PR DESCRIPTION
## Summary
Skills sync to remote sandboxes (Modal, Daytona, SSH `FileSyncManager`) no longer uploads local bookkeeping trees — `.hub` download cache, `.archive`, `.curator_backups`, `node_modules`, `__pycache__`, nested `.git` — and no longer walks into them on every sync tick.

Who hits this: anyone running the terminal on a remote backend with a lived-in `~/.hermes/skills/`. `iter_skills_files()` used a bare `rglob("*")`, so every 5 s sync tick re-enumerated (and on first sync uploaded) files the sandbox never reads. The SSH backend has a 120 s upload deadline; the contributor measured 67 MB → 8 MB on their install. Once curator snapshots live under `skills/.curator_backups/` (they do), this is also every past skills tarball being shipped to the sandbox.

## Changes
- `agent/skill_utils.py`: `.curator_backups` added to `EXCLUDED_SKILL_DIRS`.
- `tools/credential_files.py`: `iter_skills_files()` uses a single `_iter_syncable_files(root)` generator (os.walk, excluded dir names pruned from `dirnames` before descent) for the local, external, and project skills dirs. Reuses `EXCLUDED_SKILL_DIRS` so sync agrees with discovery; deliberately does not use `is_excluded_skill_path()` because that also prunes `references/`, `scripts/`, `templates/`, `assets/`, which the sandbox does read/execute.
- `_safe_skills_path()` (the symlink-forced sanitized copy used by mount backends) applies the same prune, so Docker/Singularity mounts don't carry the bookkeeping trees either.
- Tests: bookkeeping dirs excluded from the file list; `references/api.md` still synced; sanitized mount copy excludes them too.

## Before / after
Before (main `1cb3ab6173`, ×3 copies):
```
for item in skills_dir.rglob("*"):
    if item.is_symlink() or not item.is_file():
        continue
    rel = item.relative_to(skills_dir)
```
After:
```
for item, rel in _iter_syncable_files(skills_dir):
```

## Benchmark
Synthetic `HERMES_HOME`: 20 skills (SKILL.md + references/), `skills/.hub` with 400 cached files, `skills/.curator_backups` with 5×8 MB tarballs, `skills/.archive` with 50 files, `__pycache__` in two skills. `iter_skills_files()` ×7, median. macOS / Apple Silicon laptop.

| | wall time | files returned | bytes that would upload |
|---|---|---|---|
| main `1cb3ab6173` | 30.5 ms | 497 | 42.5 MB |
| #96474 as submitted (post-walk filter) | 35.4 ms | 40 | 0.0 MB |
| this PR (pruned walk) | 2.4 ms | 40 | 0.0 MB |

Script: `~/triage-perf-p2/bench/96474.py <checkout>`.

What actually improved: the sandbox receives only skill content (497 → 40 files, 42 MB → 0 on the synthetic tree), and because the walk stops at the excluded directory instead of stat-ing everything underneath it, each 5 s sync tick costs ~2 ms instead of ~30 ms on this tree.

Symlink behaviour is unchanged: `rglob` and `os.walk` both skip symlinked directories on 3.11–3.13; verified with a symlinked dir fixture on both main and this branch (identical output).

## Tests
`tests/tools/test_credential_files.py` + `tests/tools/test_file_sync*.py`: 79 passed, 2 skipped. Mutation checks: removing the `dirnames` prune in the sync walk fails `test_skips_excluded_bookkeeping_dirs`; removing it in `_safe_skills_path` fails `test_sanitized_copy_skips_bookkeeping_dirs`.

## Provenance
Salvaged from #96474 by @Carry00 (cherry-picked, authorship preserved); walk-pruning and `_safe_skills_path` sibling-site commits are ours. Complementary to the curator `.git` exclusion (#91463 salvage) — different boundary, same disease.
