### PR TITLE
fix(desktop): New Group Chat gate counts all non-ghost bots, not just local source

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/roster-pane.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/roster-pane.tsx
@@ -637,7 +637,7 @@ export function BotsPane() {
                 <Codicon className="mr-1.5" name="hubot" />
                 {b.bot.newTitle}
               </DropdownMenuItem>
-              <DropdownMenuItem disabled={activeSourceRoster.length < 2} onSelect={() => setGroupCreateOpen(true)}>
+              <DropdownMenuItem disabled={roster.filter((bot: RosterRow) => !bot?.ghost).length < 2} onSelect={() => setGroupCreateOpen(true)}>
                 <Codicon className="mr-1.5" name="organization" />
                 {b.group.newTitle}
               </DropdownMenuItem>


### PR DESCRIPTION
## What

Fix the **New Group Chat** menu gate in the Bot Mode roster pane to count **all non-ghost bots** across the full multi-source roster, not just local-source bots.

## Why

The menu gate used `activeSourceRoster` (which intentionally filters out `remoteSource` rows) to decide whether **New Group Chat** is enabled:

`disabled={activeSourceRoster.length < 2}`

With 1 local bot + 1 remote bot, this gate is always `< 2` → menu stays disabled. But the creation dialog itself correctly receives the **full roster** and can seat remote bots (their turns route to their own machines). Two different rosters: the door counts local-only, the room behind it counts everyone.

## Change

```diff
-              <DropdownMenuItem disabled={activeSourceRoster.length < 2} onSelect={() => setGroupCreateOpen(true)}>
+              <DropdownMenuItem disabled={roster.filter((bot: RosterRow) => !bot?.ghost).length < 2} onSelect={() => setGroupCreateOpen(true)}>
```

This matches the dialog's own `selectableRoster = roster.filter(bot => !bot?.ghost)` + `canCreate = selected.length >= 2` contract.

## Related

- Issue #101543 (user-facing reproduction/specification)
- Issue #92843 (blank roster bug, unrelated)