### PR TITLE
fix(model-picker): respect excluded_providers for virtual MoA rows

### DIFF
--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -206,9 +206,18 @@ def build_models_payload(
         excluded_providers=ctx.excluded_providers or [],
     )
 
-    moa_row = _moa_provider_row(ctx.current_provider)
-    if moa_row is not None:
-        rows = [moa_row] + [r for r in rows if str(r.get("slug", "")).lower() != "moa"]
+    _excluded_slugs = {
+        str(p).strip().lower() for p in (ctx.excluded_providers or []) if p
+    }
+    if "moa" in _excluded_slugs:
+        # MoA is a virtual overlay provider but still honours
+        # ``model_catalog.excluded_providers``: drop the row entirely rather
+        # than reinserting it at the front.
+        rows = [r for r in rows if str(r.get("slug", "")).lower() != "moa"]
+    else:
+        moa_row = _moa_provider_row(ctx.current_provider)
+        if moa_row is not None:
+            rows = [moa_row] + [r for r in rows if str(r.get("slug", "")).lower() != "moa"]
 
     if explicit_only:
         rows = _filter_explicit_provider_rows(rows, ctx)

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -4147,7 +4147,11 @@ def list_authenticated_providers(
     return results
 
 
-def _prepend_moa_picker_provider(providers: List[dict], current_provider: str = "") -> List[dict]:
+def _prepend_moa_picker_provider(
+    providers: List[dict],
+    current_provider: str = "",
+    excluded_providers: list | None = None,
+) -> List[dict]:
     """Add the virtual MoA provider row used by interactive model pickers.
 
     ``list_authenticated_providers()`` only returns real/auth-backed providers.
@@ -4155,7 +4159,15 @@ def _prepend_moa_picker_provider(providers: List[dict], current_provider: str = 
     normal providers; gateway pickers call ``list_picker_providers()`` directly,
     so they need the same virtual row here. Reuse the inventory's single row
     builder so the row shape stays defined in one place.
+
+    MoA is a virtual overlay provider but still honours
+    ``model_catalog.excluded_providers``: when ``"moa"`` is in the exclusion
+    set the row is suppressed, matching the treatment of credential-backed
+    providers.
     """
+    excluded = {str(p).strip().lower() for p in (excluded_providers or []) if p}
+    if "moa" in excluded:
+        return [p for p in providers if str(p.get("slug", "")).lower() != "moa"]
     try:
         from hermes_cli.inventory import _moa_provider_row
 
@@ -4209,7 +4221,11 @@ def list_picker_providers(
         excluded_providers=excluded_providers,
     )
     if include_moa:
-        providers = _prepend_moa_picker_provider(providers, current_provider=current_provider)
+        providers = _prepend_moa_picker_provider(
+            providers,
+            current_provider=current_provider,
+            excluded_providers=excluded_providers,
+        )
 
     filtered: List[dict] = []
     for p in providers:

--- a/tests/hermes_cli/test_model_picker_excluded_providers.py
+++ b/tests/hermes_cli/test_model_picker_excluded_providers.py
@@ -117,3 +117,118 @@ def test_cli_picker_hides_excluded_provider_by_alias(config_home):
     )
 
 
+# ---------------------------------------------------------------------------
+# Virtual MoA overlay row honours excluded_providers (#1)
+# ---------------------------------------------------------------------------
+#
+# ``moa`` is an ``auth_type="virtual"`` overlay provider that the gateway
+# picker (``list_picker_providers``) and CLI inventory (``build_models_payload``)
+# reinsert at the front of the provider list. It must respect the same
+# ``model_catalog.excluded_providers`` policy as credential-backed providers.
+
+_FAKE_MOA_ROW = {
+    "slug": "moa",
+    "name": "Mixture of Agents",
+    "is_current": False,
+    "is_user_defined": False,
+    "models": ["balanced"],
+    "total_models": 1,
+    "source": "virtual",
+    "authenticated": True,
+    "auth_type": "virtual",
+}
+
+
+def test_gateway_picker_does_not_reinsert_excluded_moa(monkeypatch):
+    """``list_picker_providers(include_moa=True, excluded_providers=["moa"])``
+    must not surface the virtual MoA row, even when a stale ``moa`` row is
+    already present in the base list."""
+    from hermes_cli import model_switch
+
+    monkeypatch.setattr(
+        model_switch, "list_authenticated_providers",
+        lambda **kw: [dict(_FAKE_MOA_ROW), _make_row("openai")],
+    )
+    monkeypatch.setattr("hermes_cli.inventory._moa_provider_row",
+                        lambda *_a, **_kw: dict(_FAKE_MOA_ROW))
+    monkeypatch.setattr("hermes_cli.models.fetch_openrouter_models",
+                        lambda *a, **kw: [])
+
+    rows = model_switch.list_picker_providers(
+        include_moa=True, excluded_providers=["moa"],
+    )
+    assert "moa" not in {str(r.get("slug", "")).lower() for r in rows}
+
+
+def test_inventory_omits_moa_when_excluded(monkeypatch):
+    """``build_models_payload`` must drop the virtual MoA row when ``moa`` is
+    in ``ctx.excluded_providers``."""
+    from hermes_cli import inventory
+    from hermes_cli.inventory import ConfigContext, build_models_payload
+
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.list_authenticated_providers",
+        lambda **kw: [_make_row("openai")],
+    )
+    monkeypatch.setattr(inventory, "_moa_provider_row",
+                        lambda *_a, **_kw: dict(_FAKE_MOA_ROW))
+
+    ctx = ConfigContext(
+        current_provider="openai",
+        current_model="gpt-5",
+        current_base_url="",
+        user_providers={},
+        custom_providers=[],
+        excluded_providers=["moa"],
+    )
+    payload = build_models_payload(ctx)
+    slugs = {str(r.get("slug", "")).lower() for r in payload["providers"]}
+    assert "moa" not in slugs
+
+
+def test_moa_remains_visible_when_not_excluded(monkeypatch):
+    """Sanity: with no exclusion the virtual MoA row is still prepended by both
+    the gateway picker and the CLI inventory."""
+    from hermes_cli import inventory, model_switch
+    from hermes_cli.inventory import ConfigContext, build_models_payload
+
+    monkeypatch.setattr(
+        model_switch, "list_authenticated_providers",
+        lambda **kw: [_make_row("openai")],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.list_authenticated_providers",
+        lambda **kw: [_make_row("openai")],
+    )
+    monkeypatch.setattr(inventory, "_moa_provider_row",
+                        lambda *_a, **_kw: dict(_FAKE_MOA_ROW))
+    monkeypatch.setattr("hermes_cli.models.fetch_openrouter_models",
+                        lambda *a, **kw: [])
+
+    rows = model_switch.list_picker_providers(include_moa=True, excluded_providers=[])
+    assert rows[0]["slug"] == "moa"
+
+    ctx = ConfigContext(
+        current_provider="openai",
+        current_model="gpt-5",
+        current_base_url="",
+        user_providers={},
+        custom_providers=[],
+        excluded_providers=[],
+    )
+    payload = build_models_payload(ctx)
+    assert payload["providers"][0]["slug"] == "moa"
+
+
+def _make_row(slug, models=("m1",)):
+    return {
+        "slug": slug,
+        "name": slug.title(),
+        "is_current": False,
+        "is_user_defined": False,
+        "models": list(models),
+        "total_models": len(models),
+        "source": "built-in",
+    }
+
+


### PR DESCRIPTION
## Problem

The MoA provider is a virtual overlay (`auth_type='virtual'`) that gets reinserted into picker lists after normal provider filtering. This caused it to appear even when explicitly excluded via `model_catalog.excluded_providers`.

## Solution

- `_prepend_moa_picker_provider` now accepts `excluded_providers` parameter and suppresses MoA when `'moa'` is in the exclusion set
- `build_models_payload` applies the same guard to inventory path
- Added 3 regression tests verifying MoA respects exclusion policy

## Testing

- All 5 tests in `test_model_picker_excluded_providers.py` pass
- 58/58 tests pass in picker/inventory regression sweep
- Focused diff: 3 files, 145 insertions, 5 deletions

Fixes: model picker showing MoA despite exclusion config