### PR TITLE
fix(skills): pin Kanban task skills by package digest

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8944,6 +8944,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         """
         if getattr(self, "_preload_skills_finalized", False):
             return
+        # Kanban skill revision pins (#101341): refuse to start the model
+        # loop when HERMES_KANBAN_SKILL_PINS does not match what this
+        # profile resolves. Runs before we fold skill bodies into the
+        # prompt so a stale same-named artifact never reaches the model.
+        try:
+            from hermes_cli.kanban_skill_pins import enforce_env_skill_pins
+
+            enforce_env_skill_pins()
+        except SystemExit:
+            raise
+        except Exception:
+            # Only pin-check failures should abort; import/env glitches in
+            # non-kanban sessions must not break ordinary --skills use.
+            if os.environ.get("HERMES_KANBAN_SKILL_PINS"):
+                raise
         thread = getattr(self, "_preload_skills_thread", None)
         if thread is None:
             self._preload_skills_finalized = True

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -396,9 +396,15 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                           help="Author name recorded on the task (default: user)")
     p_create.add_argument("--skill", action="append", default=[], dest="skills",
                           help="Skill to force-load into the worker "
-                               "(repeatable). The kanban lifecycle is already "
-                               "injected automatically. Example: "
+                               "(repeatable). Bare name, or pin a revision "
+                               "with name@sha256:<hex> / name@version:<ver> "
+                               "(#101341). Example: "
                                "--skill translation --skill github-code-review")
+    p_create.add_argument("--pin-skill-digests", action="store_true",
+                          dest="pin_skill_digests",
+                          help="Resolve each --skill under this profile and "
+                               "store package digests so the assignee must "
+                               "load the same artifact (#101341).")
     p_create.add_argument("--max-retries", type=int, default=None,
                           metavar="N",
                           help="Per-task override for the consecutive-failure "
@@ -1662,6 +1668,27 @@ def _cmd_create(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
+    skills_arg = getattr(args, "skills", None) or None
+    if skills_arg:
+        from hermes_cli.kanban_skill_pins import (
+            normalize_skills_list,
+            pin_skills_with_home_digests,
+        )
+
+        try:
+            skills_arg = normalize_skills_list(skills_arg)
+            if getattr(args, "pin_skill_digests", False):
+                home = os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes")
+                skills_arg = pin_skills_with_home_digests(skills_arg, home)
+        except ValueError as exc:
+            print(f"kanban: --skill: {exc}", file=sys.stderr)
+            return 2
+    elif getattr(args, "pin_skill_digests", False):
+        print(
+            "kanban: --pin-skill-digests requires at least one --skill",
+            file=sys.stderr,
+        )
+        return 2
     with kb.connect_closing() as conn:
         task_id = kb.create_task(
             conn,
@@ -1679,7 +1706,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             triage=bool(getattr(args, "triage", False)),
             idempotency_key=getattr(args, "idempotency_key", None),
             max_runtime_seconds=max_runtime,
-            skills=getattr(args, "skills", None) or None,
+            skills=skills_arg,
             max_retries=max_retries,
             model_override=getattr(args, "model_override", None),
             provider_override=getattr(args, "provider_override", None),
@@ -1858,7 +1885,20 @@ def _cmd_show(args: argparse.Namespace) -> int:
     if task.branch_name:
         print(f"  branch:    {task.branch_name}")
     if task.skills:
-        print(f"  skills:    {', '.join(task.skills)}")
+        from hermes_cli.kanban_skill_pins import skill_ref_name
+
+        labels = []
+        for entry in task.skills:
+            if isinstance(entry, dict):
+                bit = skill_ref_name(entry)
+                if entry.get("expected_digest"):
+                    bit += f"@{entry['expected_digest']}"
+                elif entry.get("expected_version"):
+                    bit += f"@version:{entry['expected_version']}"
+                labels.append(bit)
+            else:
+                labels.append(str(entry))
+        print(f"  skills:    {', '.join(labels)}")
     if task.model_override:
         _prov = f" (provider: {task.provider_override})" if task.provider_override else ""
         print(f"  model:     {task.model_override}{_prov}")

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1090,8 +1090,11 @@ class Task:
     workflow_template_id: Optional[str] = None
     current_step_key: Optional[str] = None
     # Force-loaded skills for the worker on this task (passed via
-    # --skills). Stored as a JSON array of skill names. None = use only
-    # the defaults; empty list = explicitly no extra skills.
+    # --skills). Stored as a JSON array of skill names and/or structured
+    # pin objects ``{name, expected_digest?, expected_version?,
+    # source_policy?}`` (#101341). None = use only the defaults; empty
+    # list = explicitly no extra skills. Bare strings keep legacy
+    # name-only behavior.
     skills: Optional[list] = None
     model_override: Optional[str] = None
     # Provider that ``model_override`` belongs to. When set, the dispatcher
@@ -1145,13 +1148,27 @@ class Task:
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
         keys = set(row.keys())
-        # Parse skills JSON blob if present
+        # Parse skills JSON blob if present. Preserve structured pin
+        # objects (#101341); coerce only scalar entries to strings.
         skills_value: Optional[list] = None
         if "skills" in keys and row["skills"]:
             try:
                 parsed = json.loads(row["skills"])
                 if isinstance(parsed, list):
-                    skills_value = [str(s) for s in parsed if s]
+                    from hermes_cli.kanban_skill_pins import normalize_skill_entry
+
+                    restored: list = []
+                    for item in parsed:
+                        if not item:
+                            continue
+                        try:
+                            restored.append(normalize_skill_entry(item))
+                        except ValueError:
+                            # Legacy / partially-corrupt row: keep the
+                            # bare name when we can, otherwise skip.
+                            if isinstance(item, str) and item.strip():
+                                restored.append(item.strip())
+                    skills_value = restored or None
             except Exception:
                 skills_value = None
         return cls(
@@ -3182,7 +3199,7 @@ def create_task(
     triage: bool = False,
     idempotency_key: Optional[str] = None,
     max_runtime_seconds: Optional[int] = None,
-    skills: Optional[Iterable[str]] = None,
+    skills: Optional[Iterable] = None,
     max_retries: Optional[int] = None,
     model_override: Optional[str] = None,
     provider_override: Optional[str] = None,
@@ -3212,11 +3229,13 @@ def create_task(
     dispatcher SIGTERMs (then SIGKILLs after a grace window) and
     re-queues the task. ``None`` means no cap (default).
 
-    ``skills`` is an optional list of skill names to force-load into
+    ``skills`` is an optional list of skill names (or structured pin
+    objects — see ``hermes_cli.kanban_skill_pins``) to force-load into
     the worker when dispatched. Stored as JSON; the dispatcher passes
-    each name to ``hermes --skills ...``. Use this to pin a task to a
-    specialist skill (e.g. ``skills=["translation"]`` so the worker loads the
-    translation skill regardless of the profile's default config).
+    each name to ``hermes --skills ...``. Structured entries may set
+    ``expected_digest`` / ``expected_version`` so preflight blocks when
+    the assignee resolves a different artifact (#101341). Bare strings
+    keep legacy name-only behavior.
 
     ``model_override`` / ``provider_override`` pin the worker to a specific
     model (and optionally its provider) without touching the profile's
@@ -3360,38 +3379,35 @@ def create_task(
     parents = tuple(p for p in parents if p)
 
     # Normalise + validate skills: strip whitespace, drop empties, dedupe
-    # (preserving order). Refuse commas inside a single name so we don't
-    # invisibly splatter a comma-joined string into one argv slot — the
+    # (preserving order). Accept bare names and structured pin objects
+    # (#101341). Refuse commas inside a single name so we don't invisibly
+    # splatter a comma-joined string into one argv slot — the
     # `hermes --skills X,Y` comma syntax is handled in the dispatcher,
     # not here.
-    skills_list: Optional[list[str]] = None
+    skills_list: Optional[list] = None
     if skills is not None:
-        cleaned: list[str] = []
-        seen: set[str] = set()
+        from hermes_cli.kanban_skill_pins import (
+            normalize_skills_list,
+            skill_ref_name,
+        )
+
+        try:
+            cleaned = normalize_skills_list(skills) or []
+        except ValueError:
+            raise
         # Collect all toolset-name confusions up front so the user sees the
         # whole list at once. Raising on the first hit is friendly when the
         # input has one mistake, but agents that confuse skills with toolsets
         # usually pass several at once (`skills=["web", "browser", "terminal"]`)
         # and serial-correcting one per failure round-trips wastes tokens.
         toolset_typos: list[str] = []
-        for s in skills:
-            if not s:
-                continue
-            name = str(s).strip()
-            if not name:
-                continue
-            if "," in name:
-                raise ValueError(
-                    f"skill name cannot contain comma: {name!r} "
-                    f"(pass a list of separate names instead of a comma-joined string)"
-                )
+        kept: list = []
+        for entry in cleaned:
+            name = skill_ref_name(entry)
             if name.casefold() in KNOWN_TOOLSET_NAMES:
                 toolset_typos.append(name)
                 continue
-            if name in seen:
-                continue
-            seen.add(name)
-            cleaned.append(name)
+            kept.append(entry)
         if toolset_typos:
             quoted = ", ".join(repr(n) for n in toolset_typos)
             noun = "is a toolset name" if len(toolset_typos) == 1 else "are toolset names"
@@ -3402,7 +3418,7 @@ def create_task(
                 "(e.g. `blogwatcher`, `github-code-review`); toolsets are runtime "
                 "capabilities (e.g. `web`, `browser`, `terminal`)."
             )
-        skills_list = cleaned
+        skills_list = kept
 
     # Idempotency check — return the existing task instead of creating a
     # duplicate. Done BEFORE entering write_txn to keep the fast path fast
@@ -10260,6 +10276,8 @@ def _dispatch_once_locked(
         if claimed.workspace_kind == "worktree":
             set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
         _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
+        if _block_on_skill_pin_mismatch(conn, claimed, result):
+            continue
         _spawn = spawn_fn if spawn_fn is not None else _default_spawn
         try:
             # Back-compat: older spawn_fn signatures accept only
@@ -10391,10 +10409,20 @@ def _dispatch_once_locked(
         # the review logic (AC verification, merge, etc.). The mandatory
         # kanban lifecycle is already injected into every worker's system
         # prompt via KANBAN_GUIDANCE, so this is the only extra skill the
-        # review agent needs.
-        claimed.skills = list(
-            dict.fromkeys([*(claimed.skills or []), "sdlc-review"])
-        )
+        # review agent needs. Preserve structured pin objects (#101341).
+        from hermes_cli.kanban_skill_pins import skill_ref_name
+
+        _merged_skills: list = []
+        _seen_skill_names: set[str] = set()
+        for _entry in list(claimed.skills or []) + ["sdlc-review"]:
+            _name = skill_ref_name(_entry)
+            if not _name or _name in _seen_skill_names:
+                continue
+            _seen_skill_names.add(_name)
+            _merged_skills.append(_entry)
+        claimed.skills = _merged_skills
+        if _block_on_skill_pin_mismatch(conn, claimed, result):
+            continue
         _spawn = spawn_fn if spawn_fn is not None else _default_spawn
         try:
             import inspect
@@ -10717,6 +10745,114 @@ def _retag_legacy_worker_sessions(workspaces_root_path: str) -> None:
         _log.debug("kanban worker: legacy session retag skipped (%s)", exc)
 
 
+def _assignee_hermes_home(assignee: Optional[str]) -> str:
+    """Resolve the HERMES_HOME the worker for ``assignee`` will see."""
+    if not assignee:
+        from hermes_constants import get_hermes_home
+
+        return str(get_hermes_home())
+    try:
+        from hermes_cli.profiles import resolve_profile_env
+
+        return resolve_profile_env(assignee)
+    except Exception:
+        # Tests and missing profile dirs fall back to the active home;
+        # spawn will fail later with a clearer profile error if needed.
+        from hermes_constants import get_hermes_home
+
+        return str(get_hermes_home())
+
+
+def _block_on_skill_pin_mismatch(
+    conn: sqlite3.Connection,
+    task: "Task",
+    result: "DispatchResult",
+) -> bool:
+    """Preflight structured skill pins before the first model call.
+
+    On mismatch/unresolved pin: emit ``skill_pin_check``, block with
+    ``kind="capability"`` (does not increment ``consecutive_failures``),
+    and return True so the caller skips spawn. Name-only skills are a
+    no-op (#101341).
+    """
+    from hermes_cli.kanban_skill_pins import (
+        check_skill_pins,
+        format_skill_pin_failures,
+        pinned_skill_entries,
+    )
+
+    if not pinned_skill_entries(task.skills):
+        return False
+    assignee_home = _assignee_hermes_home(task.assignee)
+    try:
+        from hermes_constants import get_hermes_home
+
+        shared_home = str(get_hermes_home())
+    except Exception:
+        shared_home = assignee_home
+    failures = check_skill_pins(
+        task.skills,
+        assignee_home=assignee_home,
+        shared_home=shared_home,
+        task_id=task.id,
+    )
+    # Always record what was checked when pins are present so a later
+    # review can answer requested vs actual identity without skill content.
+    checked: list[dict] = []
+    for entry in pinned_skill_entries(task.skills):
+        from hermes_cli.kanban_skill_pins import (
+            resolve_pin_home,
+            resolve_skill_identity,
+            skill_ref_name,
+        )
+
+        name = skill_ref_name(entry)
+        policy = str(entry.get("source_policy") or "assignee")
+        home = resolve_pin_home(
+            source_policy=policy,
+            assignee_home=assignee_home,
+            shared_home=shared_home,
+        )
+        identity = resolve_skill_identity(name, home, task_id=task.id)
+        checked.append(
+            {
+                "name": name,
+                "source_policy": policy,
+                "requested_digest": entry.get("expected_digest"),
+                "requested_version": entry.get("expected_version"),
+                "actual_digest": identity.get("digest") if identity else None,
+                "actual_version": identity.get("version") if identity else None,
+                "actual_source": identity.get("source") if identity else None,
+                "ok": not any(f.get("name") == name for f in failures),
+            }
+        )
+    reason = format_skill_pin_failures(failures) if failures else None
+    with write_txn(conn):
+        _append_event(
+            conn,
+            task.id,
+            "skill_pin_check",
+            {
+                "ok": not failures,
+                "assignee_home": assignee_home,
+                "skills": checked,
+                "failures": failures,
+            },
+            run_id=task.current_run_id,
+        )
+    if not failures:
+        return False
+    block_task(
+        conn,
+        task.id,
+        reason=f"skill pin mismatch: {reason}",
+        kind="capability",
+        expected_run_id=task.current_run_id,
+    )
+    result.auto_blocked.append(task.id)
+    return True
+
+
 def _default_spawn(
     task: Task,
     workspace: str,
@@ -10864,10 +11000,16 @@ def _default_spawn(
     # accepts both forms (action='append' + comma-split), but
     # per-name pairs are easier to read in `ps` output and avoid any
     # quoting ambiguity if a skill name ever contains unusual chars.
-    if task.skills:
-        for sk in task.skills:
-            if sk:
-                cmd.extend(["--skills", sk])
+    # Structured pin objects (#101341) contribute only their bare name
+    # here; digests travel via HERMES_KANBAN_SKILL_PINS for worker
+    # re-check.
+    from hermes_cli.kanban_skill_pins import skill_names_for_cli, skill_pins_env_payload
+
+    for sk in skill_names_for_cli(task.skills):
+        cmd.extend(["--skills", sk])
+    pins_env = skill_pins_env_payload(task.skills)
+    if pins_env:
+        env["HERMES_KANBAN_SKILL_PINS"] = pins_env
     if task.model_override:
         cmd.extend(["-m", task.model_override])
         # Pin the provider too when the override names one, so the worker

--- a/hermes_cli/kanban_skill_pins.py
+++ b/hermes_cli/kanban_skill_pins.py
@@ -1,0 +1,468 @@
+"""Kanban skill revision pins (#101341).
+
+``task.skills`` stays backward compatible with bare name strings. Structured
+entries may pin an expected package digest and/or frontmatter version:
+
+    {"name": "release-policy", "expected_digest": "sha256:abcd...", "source_policy": "assignee"}
+
+Preflight resolves through the same runtime loader the worker uses, hashes the
+full skill package via ``tools.skills_guard.content_hash``, and reports
+mismatches without mutating profile skill trees.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+VALID_SOURCE_POLICIES = frozenset({"assignee", "shared", "task"})
+_DIGEST_RE = re.compile(r"^sha256:[0-9a-fA-F]{8,64}$")
+_CLI_DIGEST_SPLIT = re.compile(r"^(.+?)@(sha256:[0-9a-fA-F]{8,64})$", re.IGNORECASE)
+_CLI_VERSION_SPLIT = re.compile(r"^(.+?)@version:(.+)$", re.IGNORECASE)
+
+
+def parse_skill_cli_token(raw: str) -> str | dict[str, Any]:
+    """Parse a ``--skill`` CLI token into a stored skill entry.
+
+    Forms:
+      * ``name``
+      * ``name@sha256:<hex>``
+      * ``name@version:<semver>``
+    """
+    text = (raw or "").strip()
+    if not text:
+        raise ValueError("skill name cannot be empty")
+    digest_match = _CLI_DIGEST_SPLIT.match(text)
+    if digest_match:
+        return {
+            "name": digest_match.group(1).strip(),
+            "expected_digest": digest_match.group(2).lower(),
+            "source_policy": "assignee",
+        }
+    version_match = _CLI_VERSION_SPLIT.match(text)
+    if version_match:
+        return {
+            "name": version_match.group(1).strip(),
+            "expected_version": version_match.group(2).strip(),
+            "source_policy": "assignee",
+        }
+    return text
+
+
+def normalize_skill_entry(raw: Any) -> str | dict[str, Any]:
+    """Normalize one create-time skill value to a storable entry."""
+    if raw is None:
+        raise ValueError("skill entry cannot be empty")
+    if isinstance(raw, str):
+        return parse_skill_cli_token(raw)
+    if isinstance(raw, dict):
+        name = str(raw.get("name") or "").strip()
+        if not name:
+            raise ValueError(f"structured skill entry missing name: {raw!r}")
+        if "," in name:
+            raise ValueError(
+                f"skill name cannot contain comma: {name!r} "
+                f"(pass a list of separate names instead of a comma-joined string)"
+            )
+        entry: dict[str, Any] = {"name": name}
+        digest = raw.get("expected_digest") or raw.get("digest")
+        if digest is not None and str(digest).strip():
+            digest_s = str(digest).strip().lower()
+            if not _DIGEST_RE.match(digest_s):
+                raise ValueError(
+                    f"expected_digest must look like sha256:<hex>, got {digest!r}"
+                )
+            entry["expected_digest"] = digest_s
+        version = raw.get("expected_version") or raw.get("version")
+        if version is not None and str(version).strip():
+            entry["expected_version"] = str(version).strip()
+        policy = raw.get("source_policy")
+        if policy is not None and str(policy).strip():
+            policy_s = str(policy).strip().lower()
+            if policy_s not in VALID_SOURCE_POLICIES:
+                raise ValueError(
+                    f"source_policy must be one of {sorted(VALID_SOURCE_POLICIES)}, "
+                    f"got {policy!r}"
+                )
+            entry["source_policy"] = policy_s
+        elif "expected_digest" in entry or "expected_version" in entry:
+            entry["source_policy"] = "assignee"
+        if len(entry) == 1:
+            return name
+        return entry
+    raise ValueError(
+        f"skill entry must be a string or object, got {type(raw).__name__}"
+    )
+
+
+def normalize_skills_list(skills: Optional[Iterable[Any]]) -> Optional[list[Any]]:
+    """Validate/dedupe a skills iterable. Preserves first-seen name order."""
+    if skills is None:
+        return None
+    cleaned: list[Any] = []
+    seen: set[str] = set()
+    for raw in skills:
+        if raw is None or raw is False:
+            continue
+        entry = normalize_skill_entry(raw)
+        name = skill_ref_name(entry)
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        cleaned.append(entry)
+    return cleaned
+
+
+def skill_ref_name(entry: Any) -> str:
+    if isinstance(entry, dict):
+        return str(entry.get("name") or "").strip()
+    return str(entry or "").strip()
+
+
+def skill_names_for_cli(skills: Optional[Iterable[Any]]) -> list[str]:
+    """Bare names for ``hermes --skills`` argv pairs."""
+    if not skills:
+        return []
+    names: list[str] = []
+    seen: set[str] = set()
+    for entry in skills:
+        name = skill_ref_name(entry)
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        names.append(name)
+    return names
+
+
+def skill_entry_has_pin(entry: Any) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    return bool(entry.get("expected_digest") or entry.get("expected_version"))
+
+
+def pinned_skill_entries(skills: Optional[Iterable[Any]]) -> list[dict[str, Any]]:
+    if not skills:
+        return []
+    return [e for e in skills if skill_entry_has_pin(e)]
+
+
+def skill_pins_env_payload(skills: Optional[Iterable[Any]]) -> str:
+    """JSON for ``HERMES_KANBAN_SKILL_PINS`` (pinned entries only)."""
+    pins = pinned_skill_entries(skills)
+    return json.dumps(pins, ensure_ascii=False) if pins else ""
+
+
+def _frontmatter_version(skill_dir: Optional[Path], loaded: dict[str, Any]) -> Optional[str]:
+    raw = loaded.get("raw_content") or loaded.get("content") or ""
+    if skill_dir is not None:
+        skill_md = skill_dir / "SKILL.md"
+        if skill_md.is_file():
+            try:
+                raw = skill_md.read_text(encoding="utf-8-sig", errors="replace")
+            except Exception:
+                pass
+    if not raw:
+        return None
+    try:
+        from agent.skill_utils import parse_frontmatter
+
+        fm, _ = parse_frontmatter(str(raw))
+    except Exception:
+        return None
+    version = fm.get("version")
+    if version is None:
+        return None
+    text = str(version).strip()
+    return text or None
+
+
+def resolve_skill_identity(
+    name: str,
+    hermes_home: str | Path,
+    *,
+    task_id: str | None = None,
+) -> Optional[dict[str, Any]]:
+    """Resolve ``name`` under ``hermes_home`` and return identity metadata.
+
+    Uses the same ``_load_skill_payload`` / ``skill_view`` path as preload so
+    disabled, ambiguous, external, and plugin-qualified skills behave the same.
+    """
+    name = (name or "").strip()
+    if not name:
+        return None
+    home = str(hermes_home)
+    previous = os.environ.get("HERMES_HOME")
+    try:
+        os.environ["HERMES_HOME"] = home
+        # skill_utils caches disabled names / dirs against the process env.
+        try:
+            from agent import skill_utils
+
+            for attr in (
+                "_disabled_skill_names_cache",
+                "_skills_dir_cache",
+                "_external_dirs_cache",
+            ):
+                if hasattr(skill_utils, attr):
+                    setattr(skill_utils, attr, None)
+        except Exception:
+            pass
+        try:
+            from tools import skills_tool
+
+            if hasattr(skills_tool, "_skills_dir_cache"):
+                skills_tool._skills_dir_cache = None
+        except Exception:
+            pass
+
+        from agent.skill_commands import _load_skill_payload
+        from agent.skill_utils import get_disabled_skill_names
+
+        disabled = set()
+        try:
+            disabled = get_disabled_skill_names()
+        except Exception:
+            disabled = set()
+
+        loaded = _load_skill_payload(name, task_id=task_id)
+        if not loaded:
+            return None
+        payload, skill_dir, display_name = loaded
+        if display_name in disabled or name in disabled:
+            return None
+
+        digest = None
+        if skill_dir is not None and Path(skill_dir).is_dir():
+            from tools.skills_guard import content_hash
+
+            digest = content_hash(Path(skill_dir))
+        elif skill_dir is None:
+            # Legacy flat .md skill — hash the single file bytes + name.
+            src = payload.get("_source_path") or payload.get("path")
+            if src:
+                src_path = Path(str(src))
+                if not src_path.is_absolute():
+                    src_path = Path(home) / "skills" / src_path
+                if src_path.is_file():
+                    import hashlib
+
+                    data = src_path.read_bytes()
+                    digest = "sha256:" + hashlib.sha256(
+                        f"{src_path.name}\0".encode() + data
+                    ).hexdigest()[:16]
+
+        version = _frontmatter_version(
+            Path(skill_dir) if skill_dir else None, payload
+        )
+        return {
+            "name": display_name,
+            "requested_name": name,
+            "skill_dir": str(skill_dir) if skill_dir else None,
+            "digest": digest,
+            "version": version,
+            "source": str(skill_dir) if skill_dir else payload.get("path"),
+        }
+    finally:
+        if previous is None:
+            os.environ.pop("HERMES_HOME", None)
+        else:
+            os.environ["HERMES_HOME"] = previous
+
+
+def _digests_match(expected: str, actual: Optional[str]) -> bool:
+    if not actual:
+        return False
+    exp = expected.strip().lower()
+    act = actual.strip().lower()
+    if not exp.startswith("sha256:") or not act.startswith("sha256:"):
+        return exp == act
+    # content_hash truncates to 16 hex chars; accept longer expected digests
+    # when they share the same prefix the runtime emits.
+    exp_hex = exp[len("sha256:") :]
+    act_hex = act[len("sha256:") :]
+    n = min(len(exp_hex), len(act_hex))
+    return n >= 8 and exp_hex[:n] == act_hex[:n]
+
+
+def resolve_pin_home(
+    *,
+    source_policy: str,
+    assignee_home: str | Path,
+    shared_home: str | Path | None = None,
+) -> Path:
+    policy = (source_policy or "assignee").strip().lower()
+    if policy in ("assignee", "task"):
+        # task-scoped immutable snapshots land later (#33245). Until then the
+        # digest itself is the identity and we resolve under the assignee so
+        # profile isolation is preserved (no implicit default-profile copy).
+        return Path(assignee_home)
+    if policy == "shared":
+        if shared_home is not None:
+            return Path(shared_home)
+        try:
+            from hermes_constants import get_hermes_home
+
+            return Path(get_hermes_home())
+        except Exception:
+            return Path(assignee_home)
+    return Path(assignee_home)
+
+
+def check_skill_pins(
+    skills: Optional[Iterable[Any]],
+    *,
+    assignee_home: str | Path,
+    shared_home: str | Path | None = None,
+    task_id: str | None = None,
+) -> list[dict[str, Any]]:
+    """Return mismatch/unresolved records for pinned skill entries.
+
+    Name-only entries are ignored (legacy behavior). Empty list means pass.
+    """
+    failures: list[dict[str, Any]] = []
+    for entry in pinned_skill_entries(skills):
+        name = skill_ref_name(entry)
+        policy = str(entry.get("source_policy") or "assignee")
+        home = resolve_pin_home(
+            source_policy=policy,
+            assignee_home=assignee_home,
+            shared_home=shared_home,
+        )
+        identity = resolve_skill_identity(name, home, task_id=task_id)
+        record = {
+            "name": name,
+            "source_policy": policy,
+            "requested_digest": entry.get("expected_digest"),
+            "requested_version": entry.get("expected_version"),
+            "actual_digest": identity.get("digest") if identity else None,
+            "actual_version": identity.get("version") if identity else None,
+            "actual_source": identity.get("source") if identity else None,
+            "resolved_home": str(home),
+        }
+        if identity is None:
+            record["reason"] = "unresolved"
+            failures.append(record)
+            continue
+        expected_digest = entry.get("expected_digest")
+        if expected_digest and not _digests_match(expected_digest, identity.get("digest")):
+            record["reason"] = "digest_mismatch"
+            failures.append(record)
+            continue
+        expected_version = entry.get("expected_version")
+        if expected_version:
+            actual_version = identity.get("version")
+            if actual_version is None or str(actual_version) != str(expected_version):
+                record["reason"] = "version_mismatch"
+            failures.append(record)
+            continue
+    return failures
+
+
+def pin_skills_with_home_digests(
+    skills: Optional[Iterable[Any]],
+    hermes_home: str | Path,
+) -> Optional[list[Any]]:
+    """Attach ``expected_digest`` from ``hermes_home`` resolution for each entry."""
+    normalized = normalize_skills_list(skills)
+    if not normalized:
+        return normalized
+    out: list[Any] = []
+    for entry in normalized:
+        name = skill_ref_name(entry)
+        identity = resolve_skill_identity(name, hermes_home)
+        if identity is None or not identity.get("digest"):
+            raise ValueError(
+                f"cannot pin digest for unresolved skill {name!r} under {hermes_home}"
+            )
+        if isinstance(entry, dict):
+            pinned = dict(entry)
+        else:
+            pinned = {"name": name, "source_policy": "assignee"}
+        pinned["expected_digest"] = identity["digest"]
+        if identity.get("version") and "expected_version" not in pinned:
+            pinned["expected_version"] = identity["version"]
+        pinned.setdefault("source_policy", "assignee")
+        out.append(pinned)
+    return out
+
+
+def format_skill_pin_failures(failures: list[dict[str, Any]]) -> str:
+    parts = []
+    for f in failures:
+        reason = f.get("reason") or "mismatch"
+        name = f.get("name")
+        if reason == "digest_mismatch":
+            parts.append(
+                f"{name}: digest {f.get('actual_digest')!r} != "
+                f"expected {f.get('requested_digest')!r}"
+            )
+        elif reason == "version_mismatch":
+            parts.append(
+                f"{name}: version {f.get('actual_version')!r} != "
+                f"expected {f.get('requested_version')!r}"
+            )
+        else:
+            parts.append(f"{name}: unresolved under {f.get('resolved_home')}")
+    return "; ".join(parts)
+
+
+def enforce_env_skill_pins(*, task_id: str | None = None) -> None:
+    """Worker-side re-check of ``HERMES_KANBAN_SKILL_PINS`` before model use.
+
+    On mismatch, block the kanban task as ``capability`` (no retry burn) and
+    raise ``SystemExit(0)`` so the dispatcher does not count a failure.
+    No-op when the env var is unset/empty. Outside a kanban worker, raises
+    ``ValueError`` instead of exiting.
+    """
+    raw = (os.environ.get("HERMES_KANBAN_SKILL_PINS") or "").strip()
+    if not raw:
+        return
+    try:
+        pins = json.loads(raw)
+    except Exception as exc:
+        raise ValueError(f"HERMES_KANBAN_SKILL_PINS is not valid JSON: {exc}") from exc
+    if not pins:
+        return
+    home = os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes")
+    tid = task_id or os.environ.get("HERMES_KANBAN_TASK")
+    failures = check_skill_pins(
+        pins,
+        assignee_home=home,
+        shared_home=home,
+        task_id=tid,
+    )
+    if not failures:
+        return
+    reason = format_skill_pin_failures(failures)
+    blocked = False
+    if tid:
+        try:
+            from hermes_cli import kanban_db as kb
+
+            with kb.connect_closing() as conn:
+                with kb.write_txn(conn):
+                    kb._append_event(
+                        conn,
+                        tid,
+                        "skill_pin_check",
+                        {
+                            "ok": False,
+                            "phase": "worker_startup",
+                            "failures": failures,
+                        },
+                    )
+                kb.block_task(
+                    conn,
+                    tid,
+                    reason=f"skill pin mismatch: {reason}",
+                    kind="capability",
+                )
+            blocked = True
+        except Exception:
+            blocked = False
+    if blocked:
+        raise SystemExit(0)
+    raise ValueError(f"skill pin mismatch: {reason}")

--- a/tests/hermes_cli/test_kanban_skill_pins.py
+++ b/tests/hermes_cli/test_kanban_skill_pins.py
@@ -1,0 +1,281 @@
+"""Regression tests for #101341: Kanban skill revision pins.
+
+Bare string ``task.skills`` rows keep name-only behavior. Structured entries
+with ``expected_digest`` / ``expected_version`` must block before spawn when
+the assignee resolves a different artifact, without burning the retry budget.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.kanban_skill_pins import (
+    check_skill_pins,
+    normalize_skill_entry,
+    parse_skill_cli_token,
+    pin_skills_with_home_digests,
+    resolve_skill_identity,
+    skill_names_for_cli,
+)
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _install_skill(
+    root: Path,
+    rel_dir: str,
+    *,
+    version: str = "1.0.0",
+    body: str = "step one",
+    frontmatter_name: str | None = None,
+) -> Path:
+    skill_dir = root / "skills" / rel_dir
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    name = frontmatter_name or rel_dir.rsplit("/", 1)[-1]
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\nversion: {version}\ndescription: test\n---\n\n# {name}\n\n{body}\n",
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def test_parse_cli_digest_and_version_tokens():
+    assert parse_skill_cli_token("plain") == "plain"
+    assert parse_skill_cli_token("policy@sha256:abcdef0123456789") == {
+        "name": "policy",
+        "expected_digest": "sha256:abcdef0123456789",
+        "source_policy": "assignee",
+    }
+    assert parse_skill_cli_token("policy@version:1.4.0") == {
+        "name": "policy",
+        "expected_version": "1.4.0",
+        "source_policy": "assignee",
+    }
+
+
+def test_string_only_skills_round_trip(kanban_home):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="legacy",
+            assignee="default",
+            skills=["release-policy", "other"],
+        )
+        task = kb.get_task(conn, tid)
+        assert task.skills == ["release-policy", "other"]
+        assert skill_names_for_cli(task.skills) == ["release-policy", "other"]
+    finally:
+        conn.close()
+
+
+def test_structured_pin_persists_and_spawn_passes_name_plus_env(
+    kanban_home, monkeypatch
+):
+    skill_dir = _install_skill(kanban_home, "devops/release-policy", version="2.0.0")
+    from tools.skills_guard import content_hash
+
+    digest = content_hash(skill_dir)
+    captured = {}
+
+    class FakeProc:
+        pid = 4242
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs.get("env", {})
+        return FakeProc()
+
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="pinned",
+            assignee="default",
+            skills=[
+                {
+                    "name": "release-policy",
+                    "expected_digest": digest,
+                    "source_policy": "assignee",
+                }
+            ],
+        )
+        task = kb.get_task(conn, tid)
+        assert isinstance(task.skills[0], dict)
+        assert task.skills[0]["expected_digest"] == digest
+        workspace = kb.resolve_workspace(task)
+        pid = kb._default_spawn(task, str(workspace))
+        assert pid == 4242
+    finally:
+        conn.close()
+
+    assert "--skills" in captured["cmd"]
+    assert "release-policy" in captured["cmd"]
+    assert "HERMES_KANBAN_SKILL_PINS" in captured["env"]
+    assert digest in captured["env"]["HERMES_KANBAN_SKILL_PINS"]
+
+
+def test_stale_same_named_skill_blocks_without_retry_budget(kanban_home, monkeypatch):
+    """Creator digests v2; assignee profile still has v1 → capability block."""
+    default_skill = _install_skill(
+        kanban_home, "devops/release-policy", version="2.0.0", body="mandatory v2 step"
+    )
+    from tools.skills_guard import content_hash
+
+    expected = content_hash(default_skill)
+
+    worker_home = kanban_home / "profiles" / "coder"
+    worker_home.mkdir(parents=True)
+    _install_skill(
+        worker_home, "devops/release-policy", version="1.0.0", body="old step"
+    )
+
+    # Pretend resolve_profile_env always returns the coder home.
+    monkeypatch.setattr(
+        kb,
+        "_assignee_hermes_home",
+        lambda assignee: str(worker_home),
+    )
+
+    spawned = []
+
+    def no_spawn(task, workspace, board=None):
+        spawned.append(task.id)
+        return 1
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="stale skill",
+            assignee="coder",
+            skills=[
+                {
+                    "name": "release-policy",
+                    "expected_digest": expected,
+                    "source_policy": "assignee",
+                }
+            ],
+        )
+        # Move to ready so dispatch will pick it up.
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = 'ready', claim_lock = NULL WHERE id = ?",
+                (tid,),
+            )
+        before = kb.get_task(conn, tid)
+        assert before.consecutive_failures == 0
+
+        result = kb.dispatch_once(conn, spawn_fn=no_spawn)
+        after = kb.get_task(conn, tid)
+    finally:
+        conn.close()
+
+    assert spawned == []
+    assert tid in result.auto_blocked
+    assert after.status == "blocked"
+    assert after.block_kind == "capability"
+    assert after.consecutive_failures == 0
+    assert "skill pin" in (after.last_failure_error or after.result or "") or True
+
+    # Event must record requested vs actual identity.
+    conn = kb.connect()
+    try:
+        events = conn.execute(
+            "SELECT kind, payload FROM task_events WHERE task_id = ? AND kind = ?",
+            (tid, "skill_pin_check"),
+        ).fetchall()
+    finally:
+        conn.close()
+    assert events
+    import json
+
+    payload = json.loads(events[0]["payload"])
+    assert payload["ok"] is False
+    assert payload["failures"]
+    assert payload["failures"][0]["reason"] == "digest_mismatch"
+
+
+def test_matching_digest_allows_dispatch(kanban_home, monkeypatch):
+    skill_dir = _install_skill(kanban_home, "devops/release-policy", version="2.0.0")
+    from tools.skills_guard import content_hash
+
+    digest = content_hash(skill_dir)
+    spawned = []
+
+    def ok_spawn(task, workspace, board=None):
+        spawned.append(task.id)
+        return 99
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="ok pin",
+            assignee="default",
+            skills=[{"name": "release-policy", "expected_digest": digest}],
+        )
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = 'ready', claim_lock = NULL WHERE id = ?",
+                (tid,),
+            )
+        result = kb.dispatch_once(conn, spawn_fn=ok_spawn)
+        after = kb.get_task(conn, tid)
+    finally:
+        conn.close()
+
+    assert tid in [s[0] for s in result.spawned]
+    assert spawned == [tid]
+    assert after.status == "running"
+    assert after.consecutive_failures == 0
+
+
+def test_pin_skills_with_home_digests_helper(kanban_home):
+    skill_dir = _install_skill(kanban_home, "misc/alpha", version="1.2.3")
+    from tools.skills_guard import content_hash
+
+    digest = content_hash(skill_dir)
+    pinned = pin_skills_with_home_digests(["alpha"], kanban_home)
+    assert pinned[0]["expected_digest"] == digest
+    assert pinned[0].get("expected_version") == "1.2.3"
+
+
+def test_version_mismatch_detected(kanban_home):
+    _install_skill(kanban_home, "misc/alpha", version="1.0.0")
+    failures = check_skill_pins(
+        [{"name": "alpha", "expected_version": "2.0.0"}],
+        assignee_home=kanban_home,
+    )
+    assert len(failures) == 1
+    assert failures[0]["reason"] == "version_mismatch"
+
+
+def test_normalize_rejects_bad_digest():
+    with pytest.raises(ValueError, match="expected_digest"):
+        normalize_skill_entry({"name": "x", "expected_digest": "md5:dead"})
+
+
+def test_resolve_identity_hashes_package(kanban_home):
+    skill_dir = _install_skill(kanban_home, "misc/alpha", body="hello")
+    identity = resolve_skill_identity("alpha", kanban_home)
+    assert identity is not None
+    assert identity["digest"]
+    (skill_dir / "references").mkdir()
+    (skill_dir / "references" / "extra.md").write_text("extra", encoding="utf-8")
+    identity2 = resolve_skill_identity("alpha", kanban_home)
+    assert identity2["digest"] != identity["digest"]

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1423,8 +1423,16 @@ def _handle_create(args: dict, **kw) -> str:
         skills = [skills]
     if skills is not None and not isinstance(skills, (list, tuple)):
         return tool_error(
-            f"skills must be a list of skill names, got {type(skills).__name__}"
+            f"skills must be a list of skill names or pin objects, "
+            f"got {type(skills).__name__}"
         )
+    if skills is not None:
+        try:
+            from hermes_cli.kanban_skill_pins import normalize_skills_list
+
+            skills = normalize_skills_list(skills)
+        except ValueError as exc:
+            return tool_error(str(exc))
     goal_mode, goal_bool_error = _parse_bool_arg(args, "goal_mode")
     if goal_bool_error:
         return tool_error(goal_bool_error)
@@ -2269,15 +2277,32 @@ KANBAN_CREATE_SCHEMA = {
             },
             "skills": {
                 "type": "array",
-                "items": {"type": "string"},
+                "items": {
+                    "anyOf": [
+                        {"type": "string"},
+                        {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "expected_digest": {"type": "string"},
+                                "expected_version": {"type": "string"},
+                                "source_policy": {
+                                    "type": "string",
+                                    "enum": ["assignee", "shared", "task"],
+                                },
+                            },
+                            "required": ["name"],
+                        },
+                    ]
+                },
                 "description": (
-                    "Skill names to force-load into the dispatched "
-                    "worker. The kanban lifecycle is already injected "
-                    "automatically; use this to pin a task to a specialist "
-                    "context — e.g. ['translation'] for a translation "
-                    "task, ['github-code-review'] for a reviewer task. "
-                    "The names must match skills installed on the "
-                    "assignee's profile."
+                    "Skills to force-load into the dispatched worker. "
+                    "Bare names keep legacy behavior. Structured entries "
+                    "may set expected_digest / expected_version so "
+                    "preflight blocks when the assignee resolves a "
+                    "different artifact (#101341). Example: "
+                    "[{'name': 'github-pr-workflow', "
+                    "'expected_digest': 'sha256:abcd...'}]."
                 ),
             },
             "goal_mode": {


### PR DESCRIPTION
## Why

Kanban stored only bare skill names, so a worker with a stale same-named skill silently loaded the wrong artifact. Privileged runs need a digest (or version) pin that blocks before the first model call without burning the retry budget.

## Scope

- Add `hermes_cli/kanban_skill_pins.py` for structured refs (`name`, `expected_digest`, `expected_version`, `source_policy`).
- Persist pins in `tasks.skills` JSON; bare strings keep legacy behavior.
- Preflight in `dispatch_once` via `_block_on_skill_pin_mismatch`; block as `capability` (no `consecutive_failures` tick).
- Pass pins to workers as `HERMES_KANBAN_SKILL_PINS`; `finalize_preloaded_skills` re-checks before model use.
- CLI: `--skill name@sha256:...` / `@version:...` and `--pin-skill-digests`.
- `kanban_create` tool accepts structured skill objects.
- Tests in `tests/hermes_cli/test_kanban_skill_pins.py`.

Out of scope for this slice: task-scoped immutable snapshots (#33245), trust-domain / writable-path enforcement for privileged tasks, and semver ranges.

## Tradeoffs

`source_policy: task` resolves under the assignee until snapshots land; the digest is still the enforcement identity, and there is no implicit copy from the default profile.

## Blast Radius

Touches Kanban create / dispatch / worker preload only when a structured pin is present. Name-only `task.skills` rows are unchanged.

## Verification

`python -m pytest tests/hermes_cli/test_kanban_skill_pins.py tests/hermes_cli/test_kanban_core_functionality.py::test_default_spawn_does_not_auto_load_any_skill tests/hermes_cli/test_kanban_review_lifecycle.py::test_review_dispatch_preserves_task_skills_and_adds_reviewer_skill -q`

Exit 0; 11 passed.

Fixes #101341