### PR TITLE
feat(plugins): add local RustPush iMessage plugin to index

### DIFF
--- a/hermes_cli/data/plugin_index.json
+++ b/hermes_cli/data/plugin_index.json
@@ -63,6 +63,18 @@
       "capabilities": ["tools"],
       "api_version": 1,
       "added_at": "2026-08-12"
+    },
+    {
+      "name": "hermes-rustpush-imessage",
+      "description": "Local-only iMessage platform plugin for Hermes using pinned OpenBubbles RustPush over a same-user Unix socket; no Messages.app automation or third-party relay.",
+      "author": "boobutler",
+      "tags": ["imessage", "messaging", "macos", "local-first", "rustpush"],
+      "repo": "boobutler/hermes-rustpush-imessage",
+      "ref": "695f74755cbcdbcd742baa51021fdb96a78ac10e",
+      "homepage": "https://github.com/boobutler/hermes-rustpush-imessage",
+      "capabilities": ["platform"],
+      "api_version": 1,
+      "added_at": "2026-09-02"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Adds a SHA-pinned community plugin-index entry for [boobutler/hermes-rustpush-imessage](https://github.com/boobutler/hermes-rustpush-imessage), a local-only iMessage platform plugin backed by OpenBubbles RustPush.

Following the third-party integration placement rule in `CONTRIBUTING.md`, the implementation lives in a standalone plugin repository. This PR changes only the bundled index; it does not add a platform implementation or change core runtime behavior.

The standalone plugin uses persistent APNs/IDS connections through pinned RustPush code and a same-user Unix socket. It does not disable SIP, control Messages.app, use Accessibility automation, or use a third-party relay. Its README explicitly documents the private-protocol risk, Apple ID/2FA setup, the current Contact Key Verification limitation, and the source licenses.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `hermes-rustpush-imessage` to `hermes_cli/data/plugin_index.json`.
- Pinned the entry to public commit `695f74755cbcdbcd742baa51021fdb96a78ac10e`.
- Declared the plugin's `platform` capability and discovery tags.
- Left `generated_at` unchanged, consistent with community index-entry PRs.

## How to Test

1. Run `python -m pytest tests/hermes_cli/test_plugin_index_search.py -q`.
2. Confirm the bundled index parses and the entry has a 40-character commit pin.
3. Clone the pinned plugin commit and run `hermes plugins doctor . --ci`.
4. Optionally install the standalone plugin disabled with `hermes plugins install boobutler/hermes-rustpush-imessage --ref 695f74755cbcdbcd742baa51021fdb96a78ac10e --no-enable` and follow its interactive macOS setup guide.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched existing PRs; there is no open RustPush plugin/index PR, and the existing iMessage PRs use different transports
- [x] My PR contains only the related plugin-index entry
- [ ] I've run `pytest tests/ -q` and all tests pass — the full suite was started but is not practical to complete locally; focused tests pass and CI is requested
- [x] Existing plugin-index parsing/search/install tests cover this metadata-only change; the standalone plugin also contains 17 adapter/runtime tests
- [x] I've tested on macOS 15.7.7 with SIP enabled

### Documentation & Housekeeping

- [x] Relevant documentation is in the standalone plugin README; no core docs change is needed
- [x] `cli-config.yaml.example` — N/A; this PR adds no core config key
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A; this PR does not change architecture or workflows
- [x] Cross-platform impact considered: the index entry is portable; the plugin is explicitly macOS-only
- [x] Tool descriptions/schemas — N/A; this PR changes no tool behavior

## Verification

- Core focused tests: `38 passed`
- Standalone plugin tests: `17 passed`
- Plugin Doctor against a fresh clone of the public pinned commit: passed
- Clean pinned RustPush/Corten source build and local code-sign verification: passed
- Independent unauthenticated APNs preflight before IDS sign-in: passed
- Authorized two-client local pilot: send/receive, typing, delivery/read receipts, reactions, replies, edits, undo-send events, and attachment materialization verified; group operations are contract-tested but were not live-tested with additional participants
- Observed inbound transport latency in the pilot: 44.5–120 ms, 107 ms median

The standalone repository is source-only: no built dylib, Apple credentials, device identity, encrypted runtime state, pairing data, or logs are committed.
