### PR TITLE
chore: map contributor emails for Fatmylin and Christopher-Schulze

### DIFF
--- a/contributors/emails/16833782+Fatmylin@users.noreply.github.com
+++ b/contributors/emails/16833782+Fatmylin@users.noreply.github.com
@@ -1,0 +1,2 @@
+Fatmylin
+# PR #95964 salvage

--- a/contributors/emails/210261288+Christopher-Schulze@users.noreply.github.com
+++ b/contributors/emails/210261288+Christopher-Schulze@users.noreply.github.com
@@ -1,0 +1,2 @@
+Christopher-Schulze
+# PR #85806 salvage


### PR DESCRIPTION
## Summary
Adds the two `contributors/emails/` mapping files the `check-attribution` gate needs before the wave-3 perf salvages of #95964 (@Fatmylin) and #85806 (@Christopher-Schulze) can land with their authorship preserved.

## Changes
- `contributors/emails/16833782+Fatmylin@users.noreply.github.com` → `Fatmylin`
- `contributors/emails/210261288+Christopher-Schulze@users.noreply.github.com` → `Christopher-Schulze`

Written with `scripts/add_contributor.py`; no code changes.
