### PR TITLE
fix(tools): sync Desktop Kanban toggle to profile toolsets

### DIFF
--- a/apps/desktop/src/app/settings/plugins-settings.tsx
+++ b/apps/desktop/src/app/settings/plugins-settings.tsx
@@ -8,7 +8,12 @@ import { Codicon } from '@/components/ui/codicon'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
 import { Tip } from '@/components/ui/tooltip'
-import { $pluginRecords, type PluginRecord, setPluginEnabled } from '@/contrib/plugins-store'
+import {
+  DESKTOP_PLUGIN_PROFILE_TOOLSETS,
+  $pluginRecords,
+  type PluginRecord,
+  setPluginEnabled
+} from '@/contrib/plugins-store'
 import { discoverRuntimePlugins } from '@/contrib/runtime-loader'
 import { getProfiles } from '@/hermes'
 import { useI18n } from '@/i18n'
@@ -313,6 +318,7 @@ function AgentPluginsSection() {
 function PluginRow({ record }: { record: PluginRecord }) {
   const { t } = useI18n()
   const p = t.settings.plugins
+  const { requestGateway } = useGatewayRequest()
 
   return (
     <PluginLine
@@ -330,7 +336,26 @@ function PluginRow({ record }: { record: PluginRecord }) {
             checked={record.status !== 'disabled'}
             onCheckedChange={on => {
               triggerHaptic('selection')
-              void setPluginEnabled(record.id, on)
+              void (async () => {
+                await setPluginEnabled(record.id, on)
+                const toolset = DESKTOP_PLUGIN_PROFILE_TOOLSETS[record.id]
+                if (!toolset) {
+                  return
+                }
+                try {
+                  await requestGateway('tools.configure', {
+                    action: on ? 'enable' : 'disable',
+                    names: [toolset]
+                  })
+                } catch (err) {
+                  notifyError(
+                    err,
+                    on
+                      ? `Could not enable the ${toolset} agent toolset`
+                      : `Could not disable the ${toolset} agent toolset`
+                  )
+                }
+              })()
             }}
           />
         </>

--- a/apps/desktop/src/contrib/plugins-store.ts
+++ b/apps/desktop/src/contrib/plugins-store.ts
@@ -75,6 +75,11 @@ function saveDecisions(next: Record<string, boolean>) {
 
 export const $pluginRecords = atom<Record<string, PluginRecord>>({})
 
+/** Desktop plugin id → profile toolset. Mirrors backend PROFILE_OPT_IN_TOOLSETS. */
+export const DESKTOP_PLUGIN_PROFILE_TOOLSETS: Readonly<Record<string, string>> = {
+  kanban: 'kanban'
+}
+
 /** Loader-owned lifecycle controls for a plugin (activate/deactivate). */
 interface PluginHandle {
   activate: () => Promise<void> | void

--- a/apps/desktop/src/plugins/kanban/plugin.tsx
+++ b/apps/desktop/src/plugins/kanban/plugin.tsx
@@ -80,7 +80,8 @@ function KanbanCount() {
 const plugin: HermesPlugin = {
   id: 'kanban',
   name: 'Kanban',
-  description: 'Multi-agent task board — board page, sidebar entry, and a live in-flight count in the status bar.',
+  description:
+    'Multi-agent task board — board page, sidebar entry, live in-flight count, and the agent kanban toolset.',
   defaultEnabled: false,
   register(ctx) {
     ctx.i18n.register(KANBAN_LOCALES)

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -167,6 +167,10 @@ _DEFAULT_OFF_TOOLSETS = {"homeassistant", "spotify", "discord", "discord_admin",
 # existing tool" flow and the GUI provider matrix instead.
 _CONFIG_ONLY_TOOLSETS = {"stt"}
 
+# Opt-in toolsets on top-level ``toolsets:`` (check_fn / skill gates), not
+# ``platform_toolsets``. Desktop Plugins and ``tools.configure`` write here (#96969).
+PROFILE_OPT_IN_TOOLSETS = frozenset({"kanban"})
+
 
 def _xai_credentials_present() -> bool:
     """Cheap, side-effect-free check for usable xAI credentials.
@@ -6185,6 +6189,29 @@ def _apply_toolset_change(config: dict, platform: str, toolset_names: List[str],
     else:
         updated = enabled | set(toolset_names)
     _save_platform_tools(config, platform, updated)
+
+
+def _apply_profile_toolset_change(
+    config: dict, toolset_names: List[str], action: str
+) -> None:
+    """Add or remove profile opt-in toolsets on the top-level ``toolsets`` list.
+
+    Idempotent: repeated enable/disable converges to the same membership.
+    """
+    raw = config.get("toolsets")
+    current = [str(t) for t in raw] if isinstance(raw, list) else []
+    wanted = {str(name).strip() for name in toolset_names if str(name).strip()}
+    if not wanted:
+        return
+    if action == "disable":
+        updated = [name for name in current if name not in wanted]
+    else:
+        updated = list(current)
+        for name in toolset_names:
+            key = str(name).strip()
+            if key and key not in updated:
+                updated.append(key)
+    config["toolsets"] = updated
 
 
 def _apply_mcp_change(config: dict, targets: List[str], action: str) -> Set[str]:

--- a/tests/hermes_cli/test_profile_opt_in_toolsets.py
+++ b/tests/hermes_cli/test_profile_opt_in_toolsets.py
@@ -1,0 +1,57 @@
+"""Profile opt-in toolsets (e.g. kanban) live in top-level config ``toolsets``.
+
+Desktop feature toggles and ``tools.configure`` must write that list so
+``_profile_has_kanban_toolset`` / skill environment gates agree with the UI.
+Regression for #96969.
+"""
+
+from __future__ import annotations
+
+from hermes_cli.tools_config import (
+    PROFILE_OPT_IN_TOOLSETS,
+    _apply_profile_toolset_change,
+)
+
+
+def test_kanban_is_a_profile_opt_in_toolset():
+    assert "kanban" in PROFILE_OPT_IN_TOOLSETS
+
+
+def test_enable_kanban_appends_top_level_toolsets(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text("toolsets:\n  - hermes-cli\n", encoding="utf-8")
+
+    cfg = {"toolsets": ["hermes-cli"]}
+    _apply_profile_toolset_change(cfg, ["kanban"], "enable")
+    assert cfg["toolsets"] == ["hermes-cli", "kanban"]
+
+    _apply_profile_toolset_change(cfg, ["kanban"], "enable")
+    assert cfg["toolsets"] == ["hermes-cli", "kanban"]
+
+    from tools.kanban_tools import _profile_has_kanban_toolset
+    from hermes_cli.config import save_config
+
+    save_config(cfg)
+    assert _profile_has_kanban_toolset() is True
+
+
+def test_disable_kanban_removes_top_level_toolsets(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    cfg = {"toolsets": ["hermes-cli", "kanban"]}
+    _apply_profile_toolset_change(cfg, ["kanban"], "disable")
+    assert cfg["toolsets"] == ["hermes-cli"]
+
+    _apply_profile_toolset_change(cfg, ["kanban"], "disable")
+    assert cfg["toolsets"] == ["hermes-cli"]
+
+    from tools.kanban_tools import _profile_has_kanban_toolset
+    from hermes_cli.config import save_config
+
+    save_config(cfg)
+    assert _profile_has_kanban_toolset() is False
+
+
+def test_enable_seeds_toolsets_when_missing():
+    cfg: dict = {}
+    _apply_profile_toolset_change(cfg, ["kanban"], "enable")
+    assert cfg["toolsets"] == ["kanban"]

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1642,7 +1642,9 @@ def _(rid, params: dict) -> dict:
         from hermes_cli.config import load_config, save_config
         from hermes_cli.tools_config import (
             CONFIGURABLE_TOOLSETS,
+            PROFILE_OPT_IN_TOOLSETS,
             _apply_mcp_change,
+            _apply_profile_toolset_change,
             _apply_toolset_change,
             _get_platform_tools,
             _get_plugin_toolset_keys,
@@ -1652,18 +1654,34 @@ def _(rid, params: dict) -> dict:
         valid_toolsets = {
             ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS
         } | _get_plugin_toolset_keys()
-        toolset_targets = [name for name in targets if ":" not in name]
+        bare_targets = [name for name in targets if ":" not in name]
         mcp_targets = [name for name in targets if ":" in name]
-        unknown = [name for name in toolset_targets if name not in valid_toolsets]
-        toolset_targets = [name for name in toolset_targets if name in valid_toolsets]
+        profile_targets = [
+            name for name in bare_targets if name in PROFILE_OPT_IN_TOOLSETS
+        ]
+        toolset_targets = [name for name in bare_targets if name in valid_toolsets]
+        unknown = [
+            name
+            for name in bare_targets
+            if name not in valid_toolsets and name not in PROFILE_OPT_IN_TOOLSETS
+        ]
 
         if toolset_targets:
             _apply_toolset_change(cfg, "cli", toolset_targets, action)
+        if profile_targets:
+            _apply_profile_toolset_change(cfg, profile_targets, action)
 
         missing_servers = (
             _apply_mcp_change(cfg, mcp_targets, action) if mcp_targets else set()
         )
         save_config(cfg)
+        if profile_targets:
+            try:
+                from tools.registry import invalidate_check_fn_cache
+
+                invalidate_check_fn_cache()
+            except Exception:
+                pass
 
         session = _sessions.get(params.get("session_id", ""))
         info = (


### PR DESCRIPTION
## Why

Enabling Kanban in Desktop Settings → Plugins only flipped the UI plugin. The agent still lacked `kanban` in top-level `toolsets:`, so check_fn hid tools and skill environment gates hid playbooks (#96969).

## Scope

- `PROFILE_OPT_IN_TOOLSETS` / `_apply_profile_toolset_change` write top-level `toolsets`
- `tools.configure` accepts `kanban` and invalidates check_fn cache
- Desktop Plugins toggle calls `tools.configure` for mapped plugins (`kanban`)
- Focused pytest for enable/disable idempotence and `_profile_has_kanban_toolset`

Out of scope: separate Skills UI for `installed but gated` when the toolset stays off (enabling the plugin now satisfies the gate).

## Tradeoffs

Disable removes `kanban` from top-level `toolsets`, same as agent-plugin toolset sync on disable. Users who want UI off but CLI orchestrator tools on must re-add `kanban` to config.

## Blast Radius

Desktop Kanban enable/disable and `tools.configure` with `kanban`. Other plugins unchanged. Safe default: UI and agent opt-in stay aligned.

## Verification

```
python -m pytest tests/hermes_cli/test_profile_opt_in_toolsets.py tests/tools/test_kanban_tools.py::test_kanban_tools_hidden_without_env_var -q
```

exit 0 — 5 passed

Fixes #96969

Made with [Cursor](https://cursor.com)