### PR TITLE
fix(auth): skip OAuth heal when profile auth.json is the root store

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1260,6 +1260,23 @@ def _same_path(left: Path, right: Path) -> bool:
         return left == right
 
 
+def _is_same_auth_store(left: Path, right: Path) -> bool:
+    """True when two auth paths name ONE store rather than two copies.
+
+    ``_same_path`` already resolves symlinks and ``..`` segments; a hardlinked
+    (or bind-mounted) alias keeps two distinct resolved names for one inode, so
+    fall back to filesystem identity. Used by the forked-grant heal: a shared
+    store has no "other side" to consolidate (#101356).
+    """
+    if _same_path(left, right):
+        return True
+    try:
+        left_stat, right_stat = left.stat(), right.stat()
+    except OSError:
+        return False
+    return (left_stat.st_dev, left_stat.st_ino) == (right_stat.st_dev, right_stat.st_ino)
+
+
 def _auth_lock_holder_for(target_path: Path) -> threading.local:
     """Return a reentrancy tracker keyed to one canonical auth-store path."""
     try:
@@ -2005,6 +2022,17 @@ def _heal_forked_single_use_oauth_grants(provider_id: str) -> Optional[Dict[str,
         if real_home_env and _same_path(root_path, Path(real_home_env) / ".hermes" / "auth.json"):
             return None
     profile_path = _auth_file_path()
+    if _is_same_auth_store(profile_path, root_path):
+        # The profile's auth.json IS the root store (symlink, hardlink, or any
+        # other alias — a deliberate way to share one grant across profiles).
+        # Both "sides" of the consolidation below would read the same file, so
+        # every OAuth row would match itself as its own fork and the strip
+        # would write through the alias and delete the shared credential.
+        # A shared store has nothing to consolidate (#101356).
+        logger.debug(
+            "%s: forked-OAuth heal skipped, %s is the root store", provider_id, profile_path
+        )
+        return None
     profile_home = profile_path.parent
     root_home = root_path.parent
     profile_singleton = profile_home / ".anthropic_oauth.json" if provider_id == "anthropic" else None

--- a/tests/agent/test_credential_pool_profile_oauth_fork.py
+++ b/tests/agent/test_credential_pool_profile_oauth_fork.py
@@ -450,3 +450,71 @@ def test_heal_is_a_noop_in_classic_mode(fleet):
     before = (fleet["root"] / "auth.json").read_text()
     assert heal_forked_single_use_oauth_grants("anthropic") is None
     assert (fleet["root"] / "auth.json").read_text() == before
+
+
+# ── C. a SHARED root store is not a fork (#101356) ───────────────────────
+
+def _seed_codex_grant(root):
+    """Give the root store an openai-codex pool row AND a providers block."""
+    fresh = int((time.time() + 3600) * 1000)
+    store = json.loads((root / "auth.json").read_text())
+    store["credential_pool"]["openai-codex"] = [{
+        "id": "cdx001", "label": "codex", "auth_type": "oauth", "priority": 0,
+        "source": "manual:device_code", "access_token": "cdx-AT0",
+        "refresh_token": "cdx-RT0", "expires_at_ms": fresh,
+    }]
+    store["providers"]["openai-codex"] = {
+        "tokens": {"access_token": "cdx-AT0", "refresh_token": "cdx-RT0", "expires_at_ms": fresh},
+        "last_refresh": fresh / 1000.0,
+    }
+    (root / "auth.json").write_text(json.dumps(store))
+
+
+def _shared_profile(fleet, name, *, link):
+    """Profile whose auth.json IS the root store (``link`` makes the alias)."""
+    pdir = _profile(fleet, name)
+    pdir.mkdir(parents=True, exist_ok=True)
+    alias = pdir / "auth.json"
+    if alias.is_symlink() or alias.exists():
+        alias.unlink()
+    link(fleet["root"] / "auth.json", alias)
+    return pdir
+
+
+def test_heal_skips_profile_auth_json_symlinked_to_the_root_store(fleet):
+    """#101356: `ln -s ~/.hermes/auth.json <profile>/auth.json` shares ONE store.
+    Both sides of the consolidation read the same file, so every row looks like
+    a fork of itself — healing would strip the shared grant through the link."""
+    from hermes_cli.auth import consume_oauth_heal_notices, heal_forked_single_use_oauth_grants
+
+    root = fleet["root"]
+    _seed_codex_grant(root)
+    before = (root / "auth.json").read_text()
+
+    shared = _shared_profile(fleet, "shared", link=lambda target, alias: alias.symlink_to(target))
+    fleet["use"](shared)
+
+    assert heal_forked_single_use_oauth_grants("openai-codex") is None
+    assert (root / "auth.json").read_text() == before
+    assert (shared / "auth.json").is_symlink()
+    assert consume_oauth_heal_notices() == []
+    store = json.loads((root / "auth.json").read_text())
+    assert [r["id"] for r in store["credential_pool"]["openai-codex"]] == ["cdx001"]
+    assert store["providers"]["openai-codex"]["tokens"]["refresh_token"] == "cdx-RT0"
+
+
+def test_heal_skips_profile_auth_json_hardlinked_to_the_root_store(fleet):
+    """Same class as the symlink: a hardlink resolves to a different name but
+    is the same inode, so it is still one store, not a forked copy."""
+    from hermes_cli.auth import heal_forked_single_use_oauth_grants
+
+    root = fleet["root"]
+    _seed_codex_grant(root)
+    before = (root / "auth.json").read_text()
+
+    shared = _shared_profile(fleet, "twin", link=lambda target, alias: os.link(target, alias))
+    fleet["use"](shared)
+
+    assert heal_forked_single_use_oauth_grants("openai-codex") is None
+    assert (root / "auth.json").read_text() == before
+    assert (shared / "auth.json").samefile(root / "auth.json")


### PR DESCRIPTION
## What

`heal_forked_single_use_oauth_grants` treated a profile `auth.json` that is an alias of the root store (symlink, hardlink, bind-mount) as a forked copy. It loaded the same file as both sides, matched every OAuth row against itself, stripped the profile pool rows / `providers.<id>` block, and `_save_auth_store()` wrote that strip through the alias — deleting the shared credential.

#100339 / PR #100929 fixed *copied* stores. A shared store has no other side to consolidate.

## Why

Reported on `openai-codex` device-code grants: login succeeded, then the next pool load removed `providers.openai-codex` and the pool row. Repeating login did not help.

## Approach

- Add `_is_same_auth_store()` next to `_same_path()`: resolve first (covers symlinks), then `st_dev`/`st_ino` (covers hardlinks).
- `_heal_forked_single_use_oauth_grants()` returns `None` with no write when the profile path is the root store.

## How to test

```
scripts/run_tests.sh tests/agent/test_credential_pool_profile_oauth_fork.py tests/agent/test_credential_pool_oauth_writethrough.py
```

New coverage: openai-codex pool row + providers block behind a symlink and a hardlink. Copied-fork heals from #100339 still pass.

Sabotage: removing the guard fails both new tests (`stripped_ids: ['cdx001']`, `providers_block: True`).

## Platforms

Linux. Path identity uses `Path.resolve` + inode; Windows symlink/hardlink cases share the same guard.

Fixes #101356
