### PR TITLE
fix(context): resolve commandcode models via live /models

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -3466,6 +3466,15 @@ def get_model_context_length(
         ctx = _resolve_endpoint_context_length(model, base_url, api_key=api_key)
         if ctx is not None:
             return ctx
+    if effective_provider in {"commandcode", "commandcode-anthropic"} and base_url:
+        # commandcode (api.commandcode.ai) exposes authoritative
+        # context_length via /models (e.g. muse-spark 1M) but is a
+        # known provider so step 2's custom-endpoint probe is skipped
+        # and models.dev has no muse-spark entry — without this the
+        # model fell through to the 256K fallback.
+        ctx = _resolve_endpoint_context_length(model, base_url, api_key=api_key)
+        if ctx is not None:
+            return ctx
     # 5e. Ollama native /api/show probe — runs for providers whose base_url
     # is NOT a known non-Ollama provider.  Ollama-compatible servers expose
     # this endpoint regardless of hostname (local Ollama, Ollama Cloud,


### PR DESCRIPTION
## Problem

`commandcode` (`api.commandcode.ai`) exposes authoritative `context_length` via `/v1/models` (e.g. `muse-spark` `1048576` = 1M, matching GOAT docs https://commandcode.ai/docs/plans/goat), but as a known provider it skipped the custom-endpoint probe at step 2 and has no `models.dev` entry. Every `commandcode` model fell through to `DEFAULT_FALLBACK_CONTEXT = 256K`.

Users saw status bar `256K` while provider returned `1M`. Log: `Could not determine context length for model 'meta/muse-spark-1.2-contributor' — falling back to 256,000`.

## Evidence

- `curl https://api.commandcode.ai/provider/v1/models` → `meta/muse-spark-1.2-contributor` `context_length: 1048576` (also `1.1`/`1.2`, 65 models total)
- GOAT RSC `StudioModelTable` same values
- `get_model_context_length('meta/muse-spark-1.2-contributor', base_url='https://api.commandcode.ai/provider/v1', provider='commandcode')` returned `256000` before fix, `1048576` after

## Fix

Add a provider-aware branch mirroring `gmi`/`nous`:

```py
if effective_provider in {"commandcode", "commandcode-anthropic"} and base_url:
    ctx = _resolve_endpoint_context_length(model, base_url, api_key=api_key)
    if ctx is not None:
        return ctx
```

Placed before the Ollama probe, after the `gmi` branch.

Also covers `commandcode-anthropic` (same host `api.commandcode.ai`).

## Verification

```
get_model_context_length('meta/muse-spark-1.2-contributor', ..., provider='commandcode') -> 1048576 PASS
get_model_context_length('meta/muse-spark-1.2', ..., provider='commandcode') -> 1048576 PASS
get_model_context_length('claude-sonnet-5', ..., provider='commandcode') -> 1000000 PASS
```

No `model.context_length` override needed. Disk cache `endpoint_model_metadata.json` already correct; fix makes the resolution path read it.