### PR TITLE
fix(agent): tear down the backend probe's throwaway sandbox (salvage #95964)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1296,26 +1296,17 @@ def _probe_remote_backend(env_type: str) -> str | None:
         _BACKEND_PROBE_CACHE[cache_key] = ""
         return None
     finally:
-        # The probe only needs a one-shot `uname`. Without this teardown the
+        # The probe only needs a one-shot `uname`; without teardown the
         # backend leaves a second idle sandbox (task_id="prompt-backend-probe")
-        # running for the whole process lifetime, alongside the agent's own
-        # "default" sandbox. force_remove overrides persist mode for this
-        # throwaway env; backends whose cleanup() takes no kwargs get the
-        # bare call (same signature check as tools.terminal_tool.cleanup_vm).
-        #
-        # SSH is the exception: SSHEnvironment has no task-scoped sandbox —
-        # its cleanup() runs sync_back() and `ssh -O exit` on a ControlMaster
-        # socket keyed only by user@host:port, i.e. shared with the agent's
-        # real environment. Nothing leaks there (ControlPersist expires the
-        # master), so leave it alone.
+        # running for the whole process lifetime next to the agent's own one.
+        # ssh is left alone: it has no task-scoped sandbox and its cleanup()
+        # closes a ControlMaster socket (keyed by user@host:port) shared with
+        # the agent's real environment; ControlPersist expires it anyway.
         if env is not None and env_type != "ssh":
             try:
-                import inspect
+                from tools.terminal_tool import _cleanup_env
 
-                if "force_remove" in inspect.signature(env.cleanup).parameters:
-                    env.cleanup(force_remove=True)
-                else:
-                    env.cleanup()
+                _cleanup_env(env, force_remove=True)
             except Exception:
                 logger.debug("Backend probe cleanup failed", exc_info=True)
 

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1214,6 +1214,7 @@ def _probe_remote_backend(env_type: str) -> str | None:
         _BACKEND_PROBE_CACHE[cache_key] = ""
         return None
 
+    env = None
     try:
         config = _get_env_config()
         # Build the environment the same way tools/terminal_tool.py does for a
@@ -1294,6 +1295,20 @@ def _probe_remote_backend(env_type: str) -> str | None:
         logger.debug("Backend probe failed: %s", e)
         _BACKEND_PROBE_CACHE[cache_key] = ""
         return None
+    finally:
+        # The probe only needs a one-shot `uname`. Without this teardown the
+        # backend leaves a second idle sandbox (task_id="prompt-backend-probe")
+        # running for the whole process lifetime, alongside the agent's own
+        # "default" sandbox. force_remove overrides persist mode for this
+        # throwaway env; backends whose cleanup() takes no kwargs fall back.
+        if env is not None:
+            try:
+                try:
+                    env.cleanup(force_remove=True)
+                except TypeError:
+                    env.cleanup()
+            except Exception:
+                logger.debug("Backend probe cleanup failed", exc_info=True)
 
     # Parse key=value lines back into a tidy summary.
     parsed: dict[str, str] = {}

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1300,12 +1300,21 @@ def _probe_remote_backend(env_type: str) -> str | None:
         # backend leaves a second idle sandbox (task_id="prompt-backend-probe")
         # running for the whole process lifetime, alongside the agent's own
         # "default" sandbox. force_remove overrides persist mode for this
-        # throwaway env; backends whose cleanup() takes no kwargs fall back.
-        if env is not None:
+        # throwaway env; backends whose cleanup() takes no kwargs get the
+        # bare call (same signature check as tools.terminal_tool.cleanup_vm).
+        #
+        # SSH is the exception: SSHEnvironment has no task-scoped sandbox —
+        # its cleanup() runs sync_back() and `ssh -O exit` on a ControlMaster
+        # socket keyed only by user@host:port, i.e. shared with the agent's
+        # real environment. Nothing leaks there (ControlPersist expires the
+        # master), so leave it alone.
+        if env is not None and env_type != "ssh":
             try:
-                try:
+                import inspect
+
+                if "force_remove" in inspect.signature(env.cleanup).parameters:
                     env.cleanup(force_remove=True)
-                except TypeError:
+                else:
                     env.cleanup()
             except Exception:
                 logger.debug("Backend probe cleanup failed", exc_info=True)

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -883,10 +883,10 @@ class TestEnvironmentHints:
 
     def test_probe_remote_backend_tolerates_kwargless_cleanup(self, monkeypatch):
         """Backends that inherit the base ``cleanup(self)`` take no kwargs; the
-        probe must fall back to the bare call instead of dying on TypeError."""
+        probe must use the bare call instead of dying on TypeError."""
         import agent.prompt_builder as _pb
 
-        monkeypatch.setenv("TERMINAL_ENV", "ssh")
+        monkeypatch.setenv("TERMINAL_ENV", "singularity")
         _pb._clear_backend_probe_cache()
 
         calls = []
@@ -907,8 +907,38 @@ class TestEnvironmentHints:
         import tools.terminal_tool as _tt
         monkeypatch.setattr(_tt, "_create_environment", lambda **kw: _LegacyEnv())
 
-        assert _pb._probe_remote_backend("ssh") is not None
+        assert _pb._probe_remote_backend("singularity") is not None
         assert calls == ["bare"]
+
+    def test_probe_remote_backend_does_not_tear_down_ssh(self, monkeypatch):
+        """SSH has no task-scoped sandbox: its cleanup() closes a ControlMaster
+        socket shared with the agent's real environment, so the probe must
+        leave it alone (nothing leaks — ControlPersist expires the master)."""
+        import agent.prompt_builder as _pb
+
+        monkeypatch.setenv("TERMINAL_ENV", "ssh")
+        _pb._clear_backend_probe_cache()
+
+        calls = []
+
+        class _SharedSshEnv:
+            def execute(self, cmd, timeout=None):
+                return {
+                    "returncode": 0,
+                    "output": (
+                        "os=Linux\nkernel=6.8.0\nhome=/home/u\n"
+                        "cwd=/home/u\nuser=u\n"
+                    ),
+                }
+
+            def cleanup(self):
+                calls.append("cleanup")
+
+        import tools.terminal_tool as _tt
+        monkeypatch.setattr(_tt, "_create_environment", lambda **kw: _SharedSshEnv())
+
+        assert _pb._probe_remote_backend("ssh") is not None
+        assert calls == []
 
 
     def test_environment_hint_from_env_var_is_appended(self, monkeypatch):

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -820,6 +820,96 @@ class TestEnvironmentHints:
         assert "Linux 6.8.0" in line
         assert "root" in line
 
+    def test_probe_remote_backend_tears_down_its_sandbox(self, monkeypatch):
+        """THE BUG: the probe leaked a second, permanently idle sandbox.
+
+        ``_probe_remote_backend`` spins up an environment with
+        ``task_id="prompt-backend-probe"`` purely to run one ``uname``. Container
+        backends default to ``container_persistent`` /
+        ``docker_persist_across_processes``, so that throwaway sandbox stayed up
+        for the whole process lifetime *next to* the agent's own ``default``
+        sandbox — one wasted idle container per profile, forever. The probe owns
+        that environment, so it must tear it down.
+        """
+        import agent.prompt_builder as _pb
+
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        _pb._clear_backend_probe_cache()
+
+        cleaned = {}
+
+        class _FakeEnv:
+            def execute(self, cmd, timeout=None):
+                return {
+                    "returncode": 0,
+                    "output": (
+                        "os=Linux\nkernel=6.8.0\nhome=/root\n"
+                        "cwd=/workspace\nuser=root\n"
+                    ),
+                }
+
+            def cleanup(self, *, force_remove=False):
+                cleaned["force_remove"] = force_remove
+
+        import tools.terminal_tool as _tt
+        monkeypatch.setattr(_tt, "_create_environment", lambda **kw: _FakeEnv())
+
+        assert _pb._probe_remote_backend("docker") is not None
+        # force_remove=True: persist mode would otherwise leave it running.
+        assert cleaned == {"force_remove": True}
+
+    def test_probe_remote_backend_tears_down_sandbox_on_failure(self, monkeypatch):
+        """Teardown must also run when the probe command blows up — a flaky
+        backend would otherwise leak the container the probe just created."""
+        import agent.prompt_builder as _pb
+
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        _pb._clear_backend_probe_cache()
+
+        cleaned = []
+
+        class _ExplodingEnv:
+            def execute(self, cmd, timeout=None):
+                raise RuntimeError("backend went away")
+
+            def cleanup(self, *, force_remove=False):
+                cleaned.append(force_remove)
+
+        import tools.terminal_tool as _tt
+        monkeypatch.setattr(_tt, "_create_environment", lambda **kw: _ExplodingEnv())
+
+        assert _pb._probe_remote_backend("docker") is None
+        assert cleaned == [True]
+
+    def test_probe_remote_backend_tolerates_kwargless_cleanup(self, monkeypatch):
+        """Backends that inherit the base ``cleanup(self)`` take no kwargs; the
+        probe must fall back to the bare call instead of dying on TypeError."""
+        import agent.prompt_builder as _pb
+
+        monkeypatch.setenv("TERMINAL_ENV", "ssh")
+        _pb._clear_backend_probe_cache()
+
+        calls = []
+
+        class _LegacyEnv:
+            def execute(self, cmd, timeout=None):
+                return {
+                    "returncode": 0,
+                    "output": (
+                        "os=Linux\nkernel=6.8.0\nhome=/home/u\n"
+                        "cwd=/home/u\nuser=u\n"
+                    ),
+                }
+
+            def cleanup(self):
+                calls.append("bare")
+
+        import tools.terminal_tool as _tt
+        monkeypatch.setattr(_tt, "_create_environment", lambda **kw: _LegacyEnv())
+
+        assert _pb._probe_remote_backend("ssh") is not None
+        assert calls == ["bare"]
+
 
     def test_environment_hint_from_env_var_is_appended(self, monkeypatch):
         """HERMES_ENVIRONMENT_HINT lets an embedder describe the runtime env."""

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2431,6 +2431,26 @@ def cleanup_all_environments():
     return cleaned
 
 
+def _cleanup_env(env, *, force_remove: bool = False) -> None:
+    """Tear down one environment, passing ``force_remove`` only when accepted.
+
+    ``DockerEnvironment.cleanup(force_remove=...)`` (issue #20561) diverges
+    from the base ``cleanup(self)``; other backends expose ``stop`` /
+    ``terminate`` instead. Shared by ``cleanup_vm`` and the prompt-time
+    backend probe so the signature check lives in one place.
+    """
+    if hasattr(env, 'cleanup'):
+        import inspect
+        if "force_remove" in inspect.signature(env.cleanup).parameters:
+            env.cleanup(force_remove=force_remove)
+        else:
+            env.cleanup()
+    elif hasattr(env, 'stop'):
+        env.stop()
+    elif hasattr(env, 'terminate'):
+        env.terminate()
+
+
 def cleanup_vm(task_id: str, *, force_remove: bool = False):
     """Manually clean up a specific environment by task_id.
 
@@ -2475,19 +2495,7 @@ def cleanup_vm(task_id: str, *, force_remove: bool = False):
         return
 
     try:
-        if hasattr(env, 'cleanup'):
-            # Pass force_remove only if the env's cleanup() accepts it
-            # (DockerEnvironment after issue #20561; other backends don't).
-            import inspect
-            sig = inspect.signature(env.cleanup)
-            if "force_remove" in sig.parameters:
-                env.cleanup(force_remove=force_remove)
-            else:
-                env.cleanup()
-        elif hasattr(env, 'stop'):
-            env.stop()
-        elif hasattr(env, 'terminate'):
-            env.terminate()
+        _cleanup_env(env, force_remove=force_remove)
 
         logger.info("Manually cleaned up environment for task: %s", task_id)
 


### PR DESCRIPTION
## Summary
When Hermes runs with a container backend (`TERMINAL_ENV=docker`, modal, daytona, singularity, vercel), every process that builds a system prompt now tears down the throwaway sandbox it spun up to run one `uname` — instead of leaving a second idle container running for the process lifetime.

Salvaged from #95964 by @Fatmylin (cherry-picked, authorship preserved) plus one follow-up commit.

## Who / when / why
Anyone on a Docker (or other container) terminal backend. Each `hermes` process — TUI session, gateway, cron job, `hermes chat -q` — probes the backend once at prompt-build time via `_probe_remote_backend()`, which creates an environment with `task_id="prompt-backend-probe"`. Container backends default to persist-mode, where `cleanup()` is a no-op, and the probe never called cleanup anyway. Result on `main`: one extra running container per process, forever, next to the agent's real `default` sandbox.

**Before** (`main` 1cb3ab6173, real Docker, `debian:stable-slim`):
```
probe result=ok (0.9s); hermes containers before=0 after=1; NEW left running: 1
    hermes-7ffcd4a8|hermes-agent=1,hermes-egress=off,hermes-profile=default,hermes-task-id=prompt-backend-probe
```
**After** (this branch):
```
probe result=ok (0.8s); hermes containers before=0 after=0; NEW left running: 0
```

## Changes
- `agent/prompt_builder.py` — `finally:` block tears down the probe env on success and failure (contributor commit). Follow-up: pick `cleanup(force_remove=True)` vs bare `cleanup()` by `inspect.signature` (the idiom `tools/terminal_tool.py::cleanup_vm` already uses) instead of catching `TypeError`, which would misread a `TypeError` raised *inside* `cleanup()` as a signature mismatch and call it twice; skip teardown for `ssh`, whose `cleanup()` runs `sync_back()` + `ssh -O exit` on a ControlMaster socket keyed by `user@host:port` — shared with the agent's real environment, and nothing leaks there (`ControlPersist` expires it).
- `tools/terminal_tool.py` — the signature-checking teardown dispatch `cleanup_vm` already had is extracted into `_cleanup_env(env, *, force_remove)` and shared with the probe (simplify pass: reuse reviewer flagged the duplicate).
- `tests/agent/test_prompt_builder.py` — teardown on success, teardown on failure, kwargless-cleanup fallback (now on `singularity`), and a new ssh-is-left-alone guard.

## Benchmark
Machine: macOS arm64 laptop, Python 3.12 venv, OrbStack Docker 29.4. Same input, main vs this branch, 5 runs each (deterministic).

| | main | this branch |
|---|---|---|
| running `hermes-*` containers left after `_probe_remote_backend("docker")` | 1 per process | 0 |
| probe result | ok | ok |

```python
# ~/triage-perf-p2/bench/95964.py (excerpt)
before = hermes_containers()                      # docker ps, hermes labels
pb._clear_backend_probe_cache(); r = pb._probe_remote_backend("docker")
time.sleep(3)                                     # daemon cleanup thread
print(len([c for c in hermes_containers() if c not in before]))
```
**What actually improved:** the leaked `prompt-backend-probe` container is gone within ~1 s of the probe finishing; the agent's own sandbox is untouched and the probe's output is byte-identical.

## Validation
| | result |
|---|---|
| `tests/agent/test_prompt_builder.py -k "probe_remote_backend or EnvironmentHints"` | 10 passed |
| mutation check (revert `agent/prompt_builder.py` to main) | 3 teardown tests fail, ssh-skip test passes (skip == pre-fix behaviour) |
| real-Docker E2E on the final stack | 0 containers left, 2/2 runs |
| `ruff check` on touched files | clean |
| `tests/` files referencing `cleanup_vm` (`-k cleanup`, 26 tests) | 24 passed, 1 skipped, 1 failure identical on plain main (pre-existing) |
| simplify-code pass (reuse / quality / efficiency reviewers on final diff) | reuse HIGH folded (shared `_cleanup_env`); quality: comment trimmed; efficiency: no material findings (docker cleanup is daemon-threaded, probe env not in `_active_environments` so atexit never waits on it) |

## Related
- #77933 (@Zhou-Ruichen) gives the SSH probe its own socket / `probe_only` path — complementary to this branch's ssh skip; #72594 (@Christoffer91) passes non-persistent container settings to the probe env — complementary belt-and-braces. Neither conflicts with this change.
- Attribution mapping for @Fatmylin: #101581 (must land first for `check-attribution`).

Closes #95964.
