### PR TITLE
perf(tools): persist OSV malware-check verdict cache to disk (salvage #85806)

### DIFF
--- a/tests/tools/test_osv_check.py
+++ b/tests/tools/test_osv_check.py
@@ -66,14 +66,18 @@ class TestParsePackageFromArgs:
 
 class TestCheckPackageForMalware:
     @pytest.fixture(autouse=True)
-    def _fresh_cache(self):
+    def _fresh_cache(self, tmp_path, monkeypatch):
         from tools import osv_check
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         with osv_check._cache_lock:
             osv_check._cache.clear()
+            osv_check._disk_cache_loaded = False
+        (tmp_path / "cache" / "osv_check.json").unlink(missing_ok=True)
         yield
         with osv_check._cache_lock:
             osv_check._cache.clear()
-
+            osv_check._disk_cache_loaded = False
+        (tmp_path / "cache" / "osv_check.json").unlink(missing_ok=True)
     def test_clean_package(self):
         """Clean package returns None (allow)."""
         mock_response = MagicMock()
@@ -188,6 +192,56 @@ class TestCheckPackageForMalware:
                 osv_check._cache[key] = (0.0, result)
             check_package_for_malware("uvx", ["mcp-server-fetch"])
         assert mock_url.call_count == 2
+
+    def test_disk_cache_persists_and_reloads(self, tmp_path, monkeypatch):
+        """A warm disk cache is reused by a fresh in-process cache."""
+        from tools import osv_check
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({"vulns": []}).encode()
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with patch("tools.osv_check.urllib.request.urlopen", return_value=mock_response) as mock_url:
+            check_package_for_malware("uvx", ["mcp-server-persist"])
+
+        cache_file = tmp_path / "cache" / "osv_check.json"
+        assert cache_file.exists(), "disk cache should be written after a warm result"
+
+        with osv_check._cache_lock:
+            osv_check._cache.clear()
+            osv_check._disk_cache_loaded = False
+
+        with patch("tools.osv_check.urllib.request.urlopen", return_value=mock_response) as mock_url2:
+            check_package_for_malware("uvx", ["mcp-server-persist"])
+
+        assert mock_url2.call_count == 0, "disk cache must satisfy the second call"
+
+    def test_disk_cache_format_versioned(self, tmp_path, monkeypatch):
+        """Disk cache JSON has a version field and recoverable entries."""
+        from tools import osv_check
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({"vulns": []}).encode()
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with patch("tools.osv_check.urllib.request.urlopen", return_value=mock_response):
+            check_package_for_malware("uvx", ["mcp-server-format"])
+
+        cache_file = tmp_path / "cache" / "osv_check.json"
+        with open(cache_file, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        assert data["version"] == osv_check._DISK_CACHE_VERSION
+        assert "entries" in data
+        key = "PyPI|mcp-server-format|"
+        assert key in data["entries"]
+        assert "expiry" in data["entries"][key]
+        assert data["entries"][key]["result"] is None
 
 
 class TestLiveOsvQuery:

--- a/tests/tools/test_osv_check.py
+++ b/tests/tools/test_osv_check.py
@@ -1,6 +1,9 @@
 """Tests for OSV malware check on MCP extension packages."""
 
 import json
+import time
+from pathlib import Path
+
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -242,6 +245,44 @@ class TestCheckPackageForMalware:
         assert key in data["entries"]
         assert "expiry" in data["entries"][key]
         assert data["entries"][key]["result"] is None
+
+    def test_disk_cache_retries_after_transient_oserror(self, tmp_path, monkeypatch):
+        """A busy/unreadable cache file must not disable disk loads for the process."""
+        from tools import osv_check
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        cache_file = tmp_path / "cache" / "osv_check.json"
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+        cache_file.write_text(
+            json.dumps({
+                "version": osv_check._DISK_CACHE_VERSION,
+                "entries": {
+                    "PyPI|mcp-server-retry|": {
+                        "expiry": time.time() + 3600,
+                        "result": None,
+                    }
+                },
+            }),
+            encoding="utf-8",
+        )
+
+        real_open = open
+        calls = {"n": 0}
+
+        def flaky_open(path, *args, **kwargs):
+            if Path(path) == cache_file:
+                calls["n"] += 1
+                if calls["n"] == 1:
+                    raise OSError("resource temporarily unavailable")
+            return real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", flaky_open)
+        with osv_check._cache_lock:
+            osv_check._load_disk_cache()
+            assert osv_check._disk_cache_loaded is False
+            osv_check._load_disk_cache()
+            assert osv_check._disk_cache_loaded is True
+            assert ("PyPI", "mcp-server-retry", None) in osv_check._cache
 
 
 class TestLiveOsvQuery:

--- a/tools/osv_check.py
+++ b/tools/osv_check.py
@@ -77,10 +77,11 @@ def _disk_cache_path() -> Optional[Path]:
 def _load_disk_cache() -> None:
     """Load persistent cache entries from disk into the in-process cache.
 
-    Called once under ``_cache_lock`` on first use. Skips expired or
-    malformed entries. Uses absolute wall-clock timestamps. Only adds
-    missing keys so an in-memory overwrite (e.g. a test forcing expiry)
-    is not silently reversed by the disk copy.
+    Invoked under ``_cache_lock`` from every get/put but does real work only
+    once per process (``_disk_cache_loaded`` latch); a transient ``OSError``
+    leaves the latch unset so the next call retries. Skips expired or
+    malformed entries. Only adds missing keys so an in-memory overwrite
+    (e.g. a test forcing expiry) is not silently reversed by the disk copy.
     """
     global _disk_cache_loaded
     if _disk_cache_loaded:
@@ -95,17 +96,13 @@ def _load_disk_cache() -> None:
         with open(path, "r", encoding="utf-8") as f:
             data = json.load(f)
     except FileNotFoundError:
-        _disk_cache_loaded = True
-        return
-    except json.JSONDecodeError:
-        _disk_cache_loaded = True
-        return
+        data = None
     except OSError:
         # Transient I/O (file busy, brief permission flap). Retry next call.
         return
     except Exception:
-        _disk_cache_loaded = True
-        return
+        # Malformed JSON or anything else: unrecoverable, don't spin on it.
+        data = None
 
     _disk_cache_loaded = True
     if not isinstance(data, dict) or data.get("version") != _DISK_CACHE_VERSION:

--- a/tools/osv_check.py
+++ b/tools/osv_check.py
@@ -80,18 +80,29 @@ def _load_disk_cache() -> None:
     global _disk_cache_loaded
     if _disk_cache_loaded:
         return
-    _disk_cache_loaded = True
 
     path = _disk_cache_path()
     if path is None:
+        _disk_cache_loaded = True
         return
 
     try:
         with open(path, "r", encoding="utf-8") as f:
             data = json.load(f)
+    except FileNotFoundError:
+        _disk_cache_loaded = True
+        return
+    except json.JSONDecodeError:
+        _disk_cache_loaded = True
+        return
+    except OSError:
+        # Transient I/O (file busy, brief permission flap). Retry next call.
+        return
     except Exception:
+        _disk_cache_loaded = True
         return
 
+    _disk_cache_loaded = True
     if not isinstance(data, dict) or data.get("version") != _DISK_CACHE_VERSION:
         return
 

--- a/tools/osv_check.py
+++ b/tools/osv_check.py
@@ -13,7 +13,6 @@ import json
 import logging
 import os
 import re
-import tempfile
 import threading
 import time
 import urllib.request
@@ -39,6 +38,12 @@ _TIMEOUT = 10  # seconds
 # `hermes mcp test` processes (and gateway restarts) reuse a warm verdict
 # instead of re-querying OSV. Expiry is stored as absolute wall-clock time so
 # it survives process restarts and monotonic-clock skew.
+#
+# Trade-off: persisting *clean* verdicts means a MAL advisory published right
+# after a clean query is noticed at TTL expiry (<= 1h by default) instead of
+# at the next process start. The window is the same one the in-process cache
+# already accepted; it just now spans restarts. Lower OSV_CHECK_CACHE_TTL to
+# tighten it.
 _CACHE_TTL_S = float(os.getenv("OSV_CHECK_CACHE_TTL", "3600"))
 _CACHE_MAX_ENTRIES = 256
 _cache: dict = {}
@@ -140,12 +145,11 @@ def _save_disk_cache() -> None:
     data = {"version": _DISK_CACHE_VERSION, "entries": entries}
 
     try:
-        tmp_fd, tmp_path = tempfile.mkstemp(
-            dir=path.parent, prefix=path.name + ".tmp-"
-        )
-        with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
-            json.dump(data, f)
-        os.replace(tmp_path, path)
+        # Shared atomic writer (temp file + fsync + rename); mkstemp's 0600
+        # is kept on create, so verdicts never sit in a world-readable file.
+        from utils import atomic_write_text
+
+        atomic_write_text(path, json.dumps(data))
     except Exception as exc:
         logger.debug("Failed to save OSV disk cache to %s: %s", path, exc)
 

--- a/tools/osv_check.py
+++ b/tools/osv_check.py
@@ -9,44 +9,145 @@ Fail-open: network errors allow the package to proceed.
 
 Inspired by Block/goose's extension malware check.
 """
-
 import json
 import logging
 import os
 import re
+import tempfile
 import threading
 import time
 import urllib.request
+from pathlib import Path
 from typing import Optional, Tuple
-
 logger = logging.getLogger(__name__)
 
 _OSV_ENDPOINT = os.getenv("OSV_ENDPOINT", "https://api.osv.dev/v1/query")
 _TIMEOUT = 10  # seconds
 
-# Result cache: (ecosystem, package, version) -> (expiry_monotonic, result).
-# MCP reconnect ladders, stdio recycles, and parked-server self-probes re-run
-# the preflight for the SAME package on every spawn attempt. Without a cache,
-# a flapping server turns into a sustained OSV query/DNS stream — the #75485
-# incident logged 779K api.osv.dev DNS queries in 16h from revival loops.
-# Malware advisories don't appear or vanish on second-to-second timescales,
-# so a successful verdict (clean OR blocked) is reusable. Network failures
-# are NOT cached: fail-open already covers them, and caching a failure could
-# mask a real advisory once connectivity returns.
+# Result cache: (ecosystem, package, version) -> (expiry_timestamp, result).
+# MCP reconnect ladders, stdio recycles, parked-server self-probes, and
+# repeated `hermes mcp test` invocations re-run the preflight for the SAME
+# package on every spawn attempt. Without a cache, a flapping server turns
+# into a sustained OSV query/DNS stream — the #75485 incident logged 779K
+# api.osv.dev DNS queries in 16h from revival loops. Malware advisories don't
+# appear or vanish on second-to-second timescales, so a successful verdict
+# (clean OR blocked) is reusable. Network failures are NOT cached: fail-open
+# already covers them, and caching a failure could mask a real advisory once
+# connectivity returns.
+#
+# The cache is also persisted to disk inside the Hermes home so that separate
+# `hermes mcp test` processes (and gateway restarts) reuse a warm verdict
+# instead of re-querying OSV. Expiry is stored as absolute wall-clock time so
+# it survives process restarts and monotonic-clock skew.
 _CACHE_TTL_S = float(os.getenv("OSV_CHECK_CACHE_TTL", "3600"))
 _CACHE_MAX_ENTRIES = 256
 _cache: dict = {}
 _cache_lock = threading.Lock()
+_disk_cache_loaded = False
+_DISK_CACHE_VERSION = 1
+
+
+def _disk_cache_path() -> Optional[Path]:
+    """Return the path for the persistent OSV verdict cache.
+
+    Uses ``hermes_constants.get_hermes_home()`` so the cache follows the
+    active profile and is isolated across Hermes homes. The cache directory
+    is created on demand. Returns ``None`` when Hermes home cannot be
+    resolved, in which case only the in-process cache is used.
+    """
+    try:
+        from hermes_constants import get_hermes_home
+
+        home = get_hermes_home()
+    except Exception:
+        return None
+    try:
+        cache_dir = home / "cache"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        return cache_dir / "osv_check.json"
+    except Exception:
+        return None
+
+
+def _load_disk_cache() -> None:
+    """Load persistent cache entries from disk into the in-process cache.
+
+    Called once under ``_cache_lock`` on first use. Skips expired or
+    malformed entries. Uses absolute wall-clock timestamps. Only adds
+    missing keys so an in-memory overwrite (e.g. a test forcing expiry)
+    is not silently reversed by the disk copy.
+    """
+    global _disk_cache_loaded
+    if _disk_cache_loaded:
+        return
+    _disk_cache_loaded = True
+
+    path = _disk_cache_path()
+    if path is None:
+        return
+
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception:
+        return
+
+    if not isinstance(data, dict) or data.get("version") != _DISK_CACHE_VERSION:
+        return
+
+    now = time.time()
+    for key_str, entry in data.get("entries", {}).items():
+        if not isinstance(entry, dict):
+            continue
+        expiry = entry.get("expiry")
+        result = entry.get("result")
+        if expiry is None or expiry <= now:
+            continue
+        parts = key_str.split("|", 2)
+        if len(parts) != 3:
+            continue
+        key = (parts[0], parts[1], parts[2] or None)
+        if key not in _cache:
+            _cache[key] = (expiry, result)
+
+
+def _save_disk_cache() -> None:
+    """Persist the in-process cache to disk.
+
+    Caller must hold ``_cache_lock`` for consistency. Writes atomically to
+    a sibling file then renames into place.
+    """
+    path = _disk_cache_path()
+    if path is None:
+        return
+
+    entries: dict = {}
+    for key, (expiry, result) in _cache.items():
+        key_str = "|".join(str(k) if k is not None else "" for k in key)
+        entries[key_str] = {"expiry": expiry, "result": result}
+
+    data = {"version": _DISK_CACHE_VERSION, "entries": entries}
+
+    try:
+        tmp_fd, tmp_path = tempfile.mkstemp(
+            dir=path.parent, prefix=path.name + ".tmp-"
+        )
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+        os.replace(tmp_path, path)
+    except Exception as exc:
+        logger.debug("Failed to save OSV disk cache to %s: %s", path, exc)
 
 
 def _cache_get(key) -> Tuple[bool, Optional[str]]:
     """Return (hit, result) for a fresh cache entry."""
     with _cache_lock:
+        _load_disk_cache()
         entry = _cache.get(key)
         if entry is None:
             return False, None
         expiry, result = entry
-        if time.monotonic() >= expiry:
+        if time.time() >= expiry:
             del _cache[key]
             return False, None
         return True, result
@@ -54,13 +155,15 @@ def _cache_get(key) -> Tuple[bool, Optional[str]]:
 
 def _cache_put(key, result: Optional[str]) -> None:
     with _cache_lock:
+        _load_disk_cache()
         if len(_cache) >= _CACHE_MAX_ENTRIES:
-            now = time.monotonic()
+            now = time.time()
             for k in [k for k, (exp, _) in _cache.items() if exp <= now]:
                 del _cache[k]
             if len(_cache) >= _CACHE_MAX_ENTRIES:
                 _cache.clear()  # tiny working set in practice; safe reset
-        _cache[key] = (time.monotonic() + _CACHE_TTL_S, result)
+        _cache[key] = (time.time() + _CACHE_TTL_S, result)
+        _save_disk_cache()
 
 
 def check_package_for_malware(


### PR DESCRIPTION
## Summary
The OSV malware verdict for an MCP package is now remembered on disk (`$HERMES_HOME/cache/osv_check.json`, mode 0600), so a fresh `hermes` process — `hermes mcp test`, a gateway restart, a cron job — reuses the last hour's verdict instead of re-querying api.osv.dev.

Salvaged from #85806 by @Christopher-Schulze (both commits cherry-picked, authorship preserved) plus one follow-up commit.

## Who / when / why
Anyone running MCP servers via `npx`/`uvx`. The in-process cache added after the #75485 DNS storm (779K api.osv.dev queries in 16 h from revival loops) only helps within one process; every new process still pays a network round-trip per package before the server can start, and a flapping gateway that restarts often re-creates the storm across processes.

**Before** (`main` 1cb3ab6173): 5 fresh processes checking the same package → 5 OSV HTTP queries, no file on disk.
**After** (this branch): 5 fresh processes → 1 OSV HTTP query; `cache/osv_check.json` `-rw-------` 101 B.

## Changes
- `tools/osv_check.py` — versioned JSON disk cache under `get_hermes_home()/cache`, loaded once per process under `_cache_lock`, written on every new verdict; absolute wall-clock expiry so TTL survives restarts; transient `OSError` on load retries next call instead of disabling disk for the process (contributor commits). Follow-up: write through the repo's shared `utils.atomic_write_text` (temp file + fsync + rename — the hand-rolled `mkstemp`/`os.replace` skipped the fsync; 0600 kept on create), drop the `tempfile` import, document the clean-verdict staleness trade-off in the module comment, and collapse `_load_disk_cache`'s five-branch except ladder to one latch assignment with identical retry semantics (simplify pass).
- `tests/tools/test_osv_check.py` — persists-and-reloads, versioned format, transient-OSError retry.

Security checks: path is profile-isolated (`get_hermes_home()`, not cwd) and `<home>/cache` is the established convention; TTL honoured on reload (`expiry <= now` skipped; disk never overwrites a newer in-memory entry); network failures still uncached (fail-open preserved); BLOCKED verdicts cached exactly as before. The one new exposure is that a *clean* verdict now persists across processes for the TTL (≤ 1 h default, `OSV_CHECK_CACHE_TTL`) — previously a new process re-queried immediately. Stated in the module comment.

## Benchmark
Machine: macOS arm64 laptop, Python 3.12 venv. Local `HTTPServer` answering `{"vulns": []}` at `OSV_ENDPOINT`, temp `HERMES_HOME`, 5 subprocesses each calling `check_package_for_malware('uvx', ['mcp-server-fetch'])`.

| | main | this branch |
|---|---|---|
| OSV HTTP queries across 5 fresh processes, same package | 5 | 1 |
| on-disk cache | none | `cache/osv_check.json`, `-rw-------`, 101 B |

```python
# ~/triage-perf-p2/bench/85806.py (excerpt)
for _ in range(5):
    subprocess.run([python, "-c", "from tools.osv_check import check_package_for_malware as c; c('uvx',['mcp-server-fetch'])"], env=env)
print(len(hits))
```
**What actually improved:** four of every five cross-process malware checks no longer touch the network or DNS; the remaining one refreshes the shared verdict at most once per TTL.

## Validation
| | result |
|---|---|
| `tests/tools/test_osv_check.py` | 21 passed (final stack) |
| mutation check (disk write → `pass`) | `test_disk_cache_persists_and_reloads`, `test_disk_cache_format_versioned` fail |
| E2E 5-process bench on final stack | 1 query, 0600 file |
| `ruff check tools/osv_check.py` | clean |
| simplify-code pass (reuse / quality / efficiency reviewers on final diff) | reuse: no generic TTL disk-cache helper exists, `atomic_write_text` is the one shared primitive (used); quality HIGH folded (except ladder); efficiency: 1 `_cache_put` per MCP spawn on miss only, fsync under lock is a few ms — no change |

## Related
Attribution mapping for @Christopher-Schulze: #101581 (must land first for `check-attribution`).

Closes #85806.
