### PR TITLE
fix(kanban): validate skills against assignee profile

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3404,6 +3404,13 @@ def create_task(
             )
         skills_list = cleaned
 
+    if assignee and skills_list:
+        missing_skills = missing_profile_skills(assignee, skills_list)
+        if missing_skills:
+            raise ValueError(
+                missing_profile_skills_reason(assignee, missing_skills)
+            )
+
     # Idempotency check — return the existing task instead of creating a
     # duplicate. Done BEFORE entering write_txn to keep the fast path fast
     # and to avoid holding a write lock during the lookup. Race is
@@ -8024,6 +8031,73 @@ _RESPAWN_GUARD_PR_URL_RE = re.compile(
 )
 
 
+def missing_profile_skills(
+    assignee: str,
+    skills: Optional[Iterable[str]],
+) -> Optional[list[str]]:
+    """Return forced skills unavailable in the assignee's profile.
+
+    ``None`` means the assignee is not a resolvable Hermes profile. The
+    dispatcher's existing profile gate handles that case separately.
+
+    Project-local skills are deliberately excluded. A task's ``skills`` field
+    crosses a profile boundary and therefore may only name skills available to
+    the target profile itself (including its configured external directories
+    and plugins). This prevents a creator's project or profile skill from being
+    mistaken for a capability of the worker that will receive ``--skills``.
+    """
+    if isinstance(skills, str):
+        skills = [skills]
+    requested = list(dict.fromkeys(
+        name
+        for raw in (skills or [])
+        if (name := str(raw).strip())
+    ))
+    if not requested:
+        return []
+
+    try:
+        from hermes_cli.profiles import resolve_profile_env
+
+        profile_home = resolve_profile_env(assignee)
+    except (FileNotFoundError, ValueError):
+        return None
+
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+    from tools.skills_tool import skill_view
+
+    token = set_hermes_home_override(profile_home)
+    try:
+        missing: list[str] = []
+        for name in requested:
+            try:
+                payload = json.loads(skill_view(
+                    name,
+                    preprocess=False,
+                    include_project_skills=False,
+                ))
+            except Exception:
+                payload = {"success": False}
+            if not payload.get("success"):
+                missing.append(name)
+        return missing
+    finally:
+        reset_hermes_home_override(token)
+
+
+def missing_profile_skills_reason(assignee: str, missing: Iterable[str]) -> str:
+    """Build the operator-facing capability blocker for a task handoff."""
+    names = ", ".join(repr(name) for name in missing)
+    return (
+        f"Assignee profile {assignee!r} cannot load required skill(s): {names}. "
+        "Remove them from task.skills or install the appropriate skill in "
+        f"the {assignee!r} profile."
+    )
+
+
 @dataclass
 class DispatchResult:
     """Outcome of a single ``dispatch`` pass."""
@@ -8063,7 +8137,7 @@ class DispatchResult:
     crashed: list[str] = field(default_factory=list)
     """Task ids reclaimed because their worker PID disappeared."""
     auto_blocked: list[str] = field(default_factory=list)
-    """Task ids auto-blocked by the spawn-failure circuit breaker."""
+    """Task ids auto-blocked by capability preflight or the failure breaker."""
     timed_out: list[str] = field(default_factory=list)
     """Task ids whose workers exceeded ``max_runtime_seconds``."""
     stale: list[str] = field(default_factory=list)
@@ -10241,6 +10315,22 @@ def _dispatch_once_locked(
         claimed = claim_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
             continue
+        missing_skills = missing_profile_skills(
+            claimed.assignee or "", claimed.skills,
+        )
+        if missing_skills:
+            reason = missing_profile_skills_reason(
+                claimed.assignee or "", missing_skills,
+            )
+            if block_task(
+                conn,
+                claimed.id,
+                reason=reason,
+                kind="capability",
+                expected_run_id=claimed.current_run_id,
+            ):
+                result.auto_blocked.append(claimed.id)
+            continue
         try:
             resolved_branch_name = None
             if claimed.workspace_kind == "worktree":
@@ -10368,6 +10458,28 @@ def _dispatch_once_locked(
         claimed = claim_review_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
             continue
+        # Review workers also receive the bundled review workflow as a forced
+        # skill, so include it in the same target-profile preflight as the
+        # task's explicit skills.
+        claimed.skills = list(
+            dict.fromkeys([*(claimed.skills or []), "sdlc-review"])
+        )
+        missing_skills = missing_profile_skills(
+            claimed.assignee or "", claimed.skills,
+        )
+        if missing_skills:
+            reason = missing_profile_skills_reason(
+                claimed.assignee or "", missing_skills,
+            )
+            if block_task(
+                conn,
+                claimed.id,
+                reason=reason,
+                kind="capability",
+                expected_run_id=claimed.current_run_id,
+            ):
+                result.auto_blocked.append(claimed.id)
+            continue
         try:
             resolved_branch_name = None
             if claimed.workspace_kind == "worktree":
@@ -10387,14 +10499,6 @@ def _dispatch_once_locked(
         if claimed.workspace_kind == "worktree":
             set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
         _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
-        # Force-load the sdlc-review skill for review agents — it carries
-        # the review logic (AC verification, merge, etc.). The mandatory
-        # kanban lifecycle is already injected into every worker's system
-        # prompt via KANBAN_GUIDANCE, so this is the only extra skill the
-        # review agent needs.
-        claimed.skills = list(
-            dict.fromkeys([*(claimed.skills or []), "sdlc-review"])
-        )
         _spawn = spawn_fn if spawn_fn is not None else _default_spawn
         try:
             import inspect

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -753,6 +753,90 @@ def test_default_spawn_does_not_auto_load_any_skill(kanban_home, monkeypatch):
 
 
 
+def test_dispatch_blocks_task_when_assignee_profile_lacks_forced_skill(
+    kanban_home,
+):
+    """A stale invalid card is blocked before a worker is spawned."""
+    spawned = []
+
+    with kb.connect() as conn:
+        # Legacy cards and cards whose target profile changed after creation
+        # can pre-date the create-time validation.
+        task_id = kb.create_task(
+            conn,
+            title="Legacy invalid handoff",
+            assignee="cto",
+            skills=["coding-project-orchestrator"],
+        )
+        (kanban_home / "profiles" / "cto" / "skills").mkdir(parents=True)
+        creator_skill = (
+            kanban_home
+            / "profiles"
+            / "ceo"
+            / "skills"
+            / "software-development"
+            / "coding-project-orchestrator"
+        )
+        creator_skill.mkdir(parents=True)
+        (creator_skill / "SKILL.md").write_text(
+            "---\nname: coding-project-orchestrator\ndescription: CEO workflow\n---\n",
+            encoding="utf-8",
+        )
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda task, workspace: spawned.append(task.id),
+        )
+        task = kb.get_task(conn, task_id)
+        run = kb.latest_run(conn, task_id)
+
+    assert spawned == []
+    assert result.auto_blocked == [task_id]
+    assert task is not None
+    assert task.status == "blocked"
+    assert task.block_kind == "capability"
+    assert task.consecutive_failures == 0
+    assert run is not None
+    assert "coding-project-orchestrator" in (run.summary or "")
+    assert "cto" in (run.summary or "")
+
+
+def test_dispatch_spawns_task_when_assignee_profile_has_forced_skill(
+    kanban_home,
+):
+    """A valid target-profile skill remains force-loaded for the worker."""
+    target_skill = (
+        kanban_home
+        / "profiles"
+        / "cto"
+        / "skills"
+        / "planning"
+        / "implementation-planner"
+    )
+    target_skill.mkdir(parents=True)
+    (target_skill / "SKILL.md").write_text(
+        "---\nname: implementation-planner\ndescription: CTO planning\n---\n",
+        encoding="utf-8",
+    )
+    spawned = []
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="Valid handoff",
+            assignee="cto",
+            skills=["implementation-planner"],
+        )
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda task, workspace: spawned.append(
+                list(task.skills or [])
+            ),
+        )
+
+    assert task_id in [item[0] for item in result.spawned]
+    assert spawned == [["implementation-planner"]]
+
+
 def test_legacy_db_without_skills_column_migrates(tmp_path):
     """_migrate_add_optional_columns is idempotent and adds skills
     when absent. Run it twice on a pared-down schema to confirm."""
@@ -1406,5 +1490,3 @@ def test_notify_sub_starts_caught_up_on_active_task(kanban_home):
         assert events == [], "historical events must not replay to a new sub"
     finally:
         conn.close()
-
-

--- a/tests/hermes_cli/test_kanban_review_lifecycle.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle.py
@@ -527,6 +527,43 @@ def test_review_dispatch_preserves_task_skills_and_adds_reviewer_skill(
     assert captured == [["domain-specific-review", "sdlc-review"]]
 
 
+def test_review_dispatch_blocks_when_reviewer_profile_lacks_review_skill(
+    kanban_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The implicit review skill is checked before a reviewer is spawned."""
+    (kanban_home / "profiles" / "cto" / "skills").mkdir(parents=True)
+    monkeypatch.setattr(kb, "review_dispatch_enabled", lambda: True)
+    spawned: list[str] = []
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="review without capability",
+            assignee="cto",
+        )
+        implementation = kb.claim_task(conn, task_id)
+        assert implementation is not None
+        assert kb.request_review(
+            conn,
+            task_id,
+            summary="ready",
+            expected_run_id=implementation.current_run_id,
+        )
+
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda task, workspace: spawned.append(task.id),
+        )
+        task = kb.get_task(conn, task_id)
+
+    assert spawned == []
+    assert result.auto_blocked == [task_id]
+    assert task is not None
+    assert task.status == "blocked"
+    assert task.block_kind == "capability"
+
+
 def test_review_dispatch_honors_global_and_per_profile_caps(
     kanban_home: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -416,6 +416,76 @@ def test_create_happy_path(worker_env):
         conn.close()
 
 
+def test_create_rejects_skill_missing_from_assignee_profile(
+    monkeypatch, worker_env, tmp_path,
+):
+    """A creator-only skill must not be forwarded to a different profile."""
+    from tools import kanban_tools as kt
+
+    creator_skill = (
+        tmp_path
+        / ".hermes"
+        / "profiles"
+        / "ceo"
+        / "skills"
+        / "software-development"
+        / "coding-project-orchestrator"
+    )
+    creator_skill.mkdir(parents=True)
+    (creator_skill / "SKILL.md").write_text(
+        "---\nname: coding-project-orchestrator\ndescription: CEO workflow\n---\n",
+        encoding="utf-8",
+    )
+    (tmp_path / ".hermes" / "profiles" / "cto" / "skills").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_PROFILE", "ceo")
+
+    out = json.loads(kt._handle_create({
+        "title": "Plan implementation",
+        "assignee": "cto",
+        "skills": ["coding-project-orchestrator"],
+    }))
+
+    assert "error" in out
+    assert "coding-project-orchestrator" in out["error"]
+    assert "cto" in out["error"]
+    from hermes_cli import kanban_db as kb
+    with kb.connect() as conn:
+        assert all(
+            task.title != "Plan implementation"
+            for task in kb.list_tasks(conn, limit=100)
+        )
+
+
+def test_create_accepts_skill_installed_in_assignee_profile(
+    worker_env, tmp_path,
+):
+    """The guard preserves valid target-profile skill handoffs."""
+    from tools import kanban_tools as kt
+
+    target_skill = (
+        tmp_path
+        / ".hermes"
+        / "profiles"
+        / "cto"
+        / "skills"
+        / "planning"
+        / "implementation-planner"
+    )
+    target_skill.mkdir(parents=True)
+    (target_skill / "SKILL.md").write_text(
+        "---\nname: implementation-planner\ndescription: CTO planning\n---\n",
+        encoding="utf-8",
+    )
+
+    out = json.loads(kt._handle_create({
+        "title": "Plan implementation",
+        "assignee": "cto",
+        "skills": ["implementation-planner"],
+    }))
+
+    assert out["ok"] is True
+
+
 def test_link_happy_path(worker_env):
     from hermes_cli import kanban_db as kb
     conn = kb.connect()

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -2277,7 +2277,8 @@ KANBAN_CREATE_SCHEMA = {
                     "context — e.g. ['translation'] for a translation "
                     "task, ['github-code-review'] for a reviewer task. "
                     "The names must match skills installed on the "
-                    "assignee's profile."
+                    "assignee's profile; do not attach a creator-only or "
+                    "orchestrator skill merely because it informed the handoff."
                 ),
             },
             "goal_mode": {

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1088,6 +1088,7 @@ def skill_view(
     file_path: str = None,
     task_id: str = None,
     preprocess: bool = True,
+    include_project_skills: bool = True,
 ) -> str:
     """
     View the content of a skill or a specific file within a skill directory.
@@ -1100,6 +1101,9 @@ def skill_view(
         preprocess: Apply configured SKILL.md template and inline shell rendering
             to main skill content. Internal slash/preload callers disable this
             because they render the skill message themselves.
+        include_project_skills: Include trusted skills from the current project.
+            Internal cross-profile validation disables this so a creator's
+            project skill cannot satisfy a target profile's capability check.
 
     Returns:
         JSON string with skill content or error message
@@ -1242,7 +1246,7 @@ def skill_view(
         # Build list of all skill directories to search. Project dirs first —
         # they're the highest-precedence tier and the collision resolver
         # below uses this ordering.
-        project_dirs = get_project_skills_dirs()
+        project_dirs = get_project_skills_dirs() if include_project_skills else []
         all_dirs = list(project_dirs)
         active_skills_dir = _skills_dir()
         if active_skills_dir.exists():

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -461,7 +461,7 @@ hermes kanban create "audit auth flow" \
 
 **From the dashboard**, type the skills comma-separated into the **skills** field of the create-task dialog.
 
-The dispatcher emits one `--skills <name>` flag per skill listed, so the worker spawns with all of them loaded on top of the auto-injected kanban guidance. The skill names must match skills that are actually installed on the assignee's profile (run `hermes skills list` to see what's available); there's no runtime install.
+The dispatcher emits one `--skills <name>` flag per skill listed, so the worker spawns with all of them loaded on top of the auto-injected kanban guidance. The skill names must match skills that are actually installed on the assignee's profile (run `hermes skills list` to see what's available); a skill used only by the creating orchestrator does not belong on the child task. Hermes rejects an invalid profile/skill pair when the task is created. If an older task becomes invalid later because a skill was removed, the dispatcher blocks it as a capability issue before starting a worker. There's no runtime install.
 
 ### Per-task model override
 


### PR DESCRIPTION
## Summary
- validate forced task skills against the assignee profile before persisting a card
- block legacy or configuration-drifted cards as capability issues before spawning a worker
- keep creator/project-only skills from satisfying cross-profile handoffs and document the contract

## Verification
- `scripts/run_tests.sh tests/tools/test_kanban_tools.py tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_review_lifecycle.py tests/tools/test_skills_tool.py tests/tools/test_skills_tool_profile_scope.py tests/cli/test_cli_preloaded_skills.py -q` — 126 passed, 1 skipped
- full Kanban group with the environment-only ACP import case excluded — 448 passed, 2 skipped
- the excluded ACP test also fails unchanged on the base checkout because the local test environment lacks the optional `acp` package
- `ruff check` on all changed Python files — passed
- `git diff --check` — passed