### PR TITLE
docs(skills): paste-back runbook + dashboard public_url caveat for MCP OAuth on remote gateways

### DIFF
--- a/optional-skills/mcp/mcp-oauth-remote-gateway/SKILL.md
+++ b/optional-skills/mcp/mcp-oauth-remote-gateway/SKILL.md
@@ -75,6 +75,70 @@ Both require an interactive terminal to the Hermes host. The rest of this skill
 is for when there is NO interactive TTY — Hermes running purely as a messaging
 gateway/bot where `/reload-mcp` triggers the flow with nobody at a prompt.
 
+## Paste-Back Runbook: Completing the Built-in Flow From Another Machine
+
+The paste-back fallback above works, but on a remote gateway it is easy to lose
+the round-trip: the flow window is ~300s, the browser is on a different machine,
+and an expired window kills the PKCE verifier with the process. This runbook
+(validated end to end on v0.21.0 — Linux VPS, browser on a separate machine)
+makes the paste-back path reliable:
+
+1. **Pin the callback port** so every retry binds the same, predictable port:
+
+   ```bash
+   hermes config set mcp_servers.<name>.oauth.redirect_port 55675
+   ```
+
+   A pinned port also forces standard RFC 7591 dynamic client registration
+   (CIMD is skipped) — widely accepted. Never set `redirect_uri`/`redirect_host`
+   manually; Hermes derives them.
+2. **Verify the port is free** (snippet below). In use → kill any half-dead
+   login process first.
+3. **Launch the login on an interactive TTY** (SSH, tmux, or agent-managed
+   PTY): `hermes mcp login <name>`. Note the `state=` in the printed URL.
+4. **Hand the authorization URL to the operator on the browser machine.** They
+   authorize; the browser then fails to load
+   `http://127.0.0.1:<port>/callback` (expected — the listener is on the
+   gateway); they copy the full address-bar URL. **The window is ~5 minutes** —
+   the round-trip must happen in one go.
+5. **Paste the callback URL at the prompt.** Sanity-check that the pasted
+   `state=` matches the URL from step 3. The flow completes with
+   `✓ Authenticated — N tool(s) available`.
+6. **Verify externally** — a clean login message is not proof. Run
+   `hermes mcp test <name>` and require `✓ Connected` plus the tool list.
+
+Check the port is free (Python, stdlib):
+
+```python
+import socket
+s = socket.socket(); s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+try:
+    s.bind(("127.0.0.1", 55675)); print("free")
+except OSError as e:
+    print("in use:", e)
+finally:
+    s.close()
+```
+
+Failure modes hit in practice (all in one session on v0.21.0):
+
+- **`invalid_redirect_uri` at client registration (400)** — the provider
+  rejects `http://` redirect URIs on non-loopback hostnames. Some authorization
+  servers accept loopback only (RFC 8252), so a dashboard callback on
+  `http://<internal-host>:<port>` can fail DCR even with a correct
+  `dashboard.public_url`. Probe the registration endpoint directly with a
+  loopback URI before choosing a path (HTTP 201 = the CLI paste-back flow will
+  work).
+- **`OAuth callback port ... already in use ([Errno 98])`** — the flow's
+  internal retry re-binds the pinned port while the first listener still holds
+  it (state-rotation + port self-collision; see #98118 and #87329). Kill the
+  half-dead process, re-check the port, relaunch.
+- **Expired window → the pasted code is dead.** The PKCE verifier died with
+  the process, so the code cannot be recovered. Relaunch and repeat the
+  round-trip — it is a one-command retry. If the operator can SSH, a
+  port-forward (`ssh -N -L <port>:127.0.0.1:<port> <user>@<host>`) before
+  authorizing removes the paste step entirely.
+
 ## Preferred Front Door: the Hermes Dashboard (try this BEFORE manual token surgery)
 
 A remote Hermes gateway often also runs the **dashboard** web UI as a SEPARATE
@@ -91,6 +155,20 @@ MCP server on a remote gateway" is:
 
 1. **Dashboard, in the user's browser** — the intended front door. Add servers, run OAuth, reload, all authenticated as the user. No copy-paste-callback dance, no hand-writing token files.
 2. **Manual token surgery (the rest of this skill)** — the FALLBACK for when there's no browser session to the dashboard (pure-chat/headless context).
+
+**When the dashboard front door does not work:** when `dashboard.public_url` is
+set, the callback `redirect_uri` is built from it and it wins over
+request-reconstruction (`web_server.py`) — but nothing validates that the
+declared origin is actually reachable. A well-formed-but-wrong value (e.g.
+`https://…` missing the non-default port the dashboard actually serves on HTTP)
+silently routes **every** MCP OAuth callback to a dead origin: the operator's
+browser shows `ERR_ADDRESS_UNREACHABLE` and the flow later expires with only a
+generic "OAuth flow expired" 404 server-side (tracked in #101594). Separately,
+some authorization servers reject `http://` redirect URIs on any non-loopback
+hostname at client-registration time (`400 invalid_redirect_uri`), which breaks
+the dashboard callback even when the URL itself is correct. In both cases,
+verify the dashboard origin actually answers (scheme + port + DNS) before
+starting a flow, and fall back to the paste-back runbook above.
 
 **Finding the dashboard's PUBLIC URL.** The dashboard binds internally to
 `0.0.0.0:<port>`, but the user needs the externally-reachable URL. Most deploy
@@ -369,3 +447,6 @@ tools. Refresh happens automatically before `expires_in` elapses.
 
 - `native-mcp` — general guide to configuring MCP in Hermes. Authoritative config reference lives there.
 - `mcporter` — the external CLI bridge, for ad-hoc MCP calls outside of Hermes' config.
+- Issues: #98118 (state rotation while the paste prompt is open), #87329/#80520
+  (callback port self-collision on headless hosts), #101594 (dashboard
+  `public_url` unreachable → silent callback failure).


### PR DESCRIPTION
## What does this PR do?

Documents the **validated, operational path** for completing MCP OAuth on a remote gateway when the browser is on a separate machine: the built-in CLI flow's paste-back fallback, made reliable. Today the skill mentions paste-back in one line and points "no-TTY" users straight to manual token surgery — but for the common case (SSH/gateway host + operator browser elsewhere + an interactive TTY available to the agent/operator), the built-in flow **does** complete, with three small operational precautions. This PR adds a step-by-step runbook for it, plus the failure signatures that sent us to source-reading in the first place.

It also adds a caveat to the "dashboard front door" section: when `dashboard.public_url` is set it wins over request-reconstruction for the callback `redirect_uri`, but nothing validates reachability — a well-formed-but-wrong value (e.g. `https://` missing the non-default HTTP port) silently routes every MCP OAuth callback to a dead origin (`ERR_ADDRESS_UNREACHABLE` browser-side, generic "OAuth flow expired" 404 server-side). Separately, some authorization servers reject `http://` redirect URIs on non-loopback hostnames at DCR time (`400 invalid_redirect_uri`) even when the URL is correct.

Everything documented here was hit and resolved in one real session on v0.21.0 (Linux VPS, browser on a separate machine), then written up generically — no deployment details.

## Related Issue

Complements #98118 (state rotation while the paste prompt is open) and the headless port-collision family (#87329/#80520); documents workarounds for the failure reported in #101594. Not a code change — no behavior is modified.

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- `optional-skills/mcp/mcp-oauth-remote-gateway/SKILL.md`:
  - New section **"Paste-Back Runbook: Completing the Built-in Flow From Another Machine"** — pin `redirect_port`, verify it's free, launch on an interactive TTY, operator round-trip (~5 min window), paste back with `state=` sanity-check, verify with `hermes mcp test`.
  - Failure modes hit in practice: `invalid_redirect_uri` on non-loopback `http://` DCR (with a loopback probe to test an AS before choosing a path), port self-collision (`Errno 98`) from internal retries, expired window killing the PKCE verifier (code unrecoverable, relaunch is one command).
  - New caveat in the dashboard section: unreachable `dashboard.public_url` (e.g. missing port) = silent callback failure; non-loopback `http://` callbacks can fail DCR regardless.
  - `Related` section: links #98118, #87329/#80520, #101594.

## How to Test

Docs-only change; the runbook itself was executed end to end on v0.21.0:

1. Remote HTTP MCP server, `auth: oauth`, pinned `oauth.redirect_port`; `hermes mcp login <name>` on an interactive PTY; authorization completed in a browser on another machine; callback URL pasted back → `✓ Authenticated — N tool(s) available`, and `hermes mcp test <name>` shows `✓ Connected` with the tool list.
2. Failure signatures reproduced on the same host: `400 invalid_redirect_uri` from the AS when the dashboard callback used `http://<internal-host>:<port>` (loopback probe returned 201, confirming AS behavior), and `Errno 98` port self-collision on an internal retry.
3. `dashboard.public_url` without the non-default port → browser `ERR_ADDRESS_UNREACHABLE` on the callback, flow expiry 404 server-side (filed as #101594).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`docs(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] N/A — documentation-only change, no code touched (pytest not applicable)
- [x] N/A — no behavior change, no tests added
- [x] I've tested on my platform: Ubuntu 24.04 (headless VPS), Hermes v0.21.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation — this PR is the documentation update
- [x] N/A — no config keys added/changed
- [x] N/A — no architecture/workflow change
- [x] N/A — cross-platform: documentation only
- [x] N/A — no tool descriptions/schemas changed