### PR TITLE
perf(file-ops): collapse read_file/write_file shell probes into one round-trip (salvage #95160)

### DIFF
--- a/contributors/emails/yj2761@nyu.edu
+++ b/contributors/emails/yj2761@nyu.edu
@@ -1,0 +1,2 @@
+yaojiejia
+# PR #95160 salvage

--- a/tests/tools/file_ops_fakes.py
+++ b/tests/tools/file_ops_fakes.py
@@ -1,0 +1,61 @@
+"""Fakes for ``ShellFileOperations``' compound shell probes.
+
+``read_file`` and ``write_file`` ask the shell everything in ONE command
+whose stdout is split on a per-call random sentinel line. Test doubles that
+script ``env.execute`` / ``_exec`` need to answer that command with exactly
+the stream the shell would produce; these helpers build it. Match the
+sentinel out of the command first (it is random), then compose:
+
+    m = READ_SENTINEL_RE.search(command)
+    if m:
+        return {"output": compound_read_output(m.group(0), size=5, sample=b"hello",
+                                               content="hello\\n", total_lines=1),
+                "returncode": 0}
+"""
+
+import base64
+import re
+from typing import Optional
+
+READ_SENTINEL_RE = re.compile(r"__HERMES_RF_[0-9a-f]{32}__")
+WRITE_SENTINEL_RE = re.compile(r"__HERMES_WF_[0-9a-f]{32}__")
+
+
+def compound_read_output(
+    sentinel: str,
+    *,
+    size: int,
+    sample: Optional[bytes],
+    content: str,
+    total_lines: int,
+    trailing_newline: bool = True,
+    sample_rc: int = 0,
+    read_rc: int = 0,
+) -> str:
+    """Stdout of ``_read_probe_cmd`` for a regular file.
+
+    ``content`` is the ``sed | cut`` page exactly as the shell prints it:
+    every line newline-terminated (``cut`` always adds one), or ``""`` for a
+    page past EOF. ``sample`` is the raw first-1000-bytes slice (``None``
+    emits an empty base64 segment, e.g. a shell without ``base64``).
+    """
+    sample_seg = base64.b64encode(sample).decode() + "\n" if sample else ""
+    return (
+        f"{size}\n{sentinel}\n"
+        f"{sample_seg}{sentinel}\n"
+        f"{content}{sentinel}\n"
+        f"{total_lines}\n{sentinel}\n"
+        f"{1 if trailing_newline else 0}\n{sentinel}\n"
+        f"{sample_rc} {read_rc}\n"
+    )
+
+
+def compound_write_probe_output(sentinel: str, *, head3: bytes, body: str) -> str:
+    """Stdout of ``_write_probe_cmd`` for an existing file.
+
+    ``head3`` is the first three bytes on disk (BOM detection); ``body`` is
+    the second segment: the whole file when pre-content was wanted, else
+    the 4 KB line-ending sample.
+    """
+    head_seg = base64.b64encode(head3).decode() + "\n" if head3 else ""
+    return f"{head_seg}{sentinel}\n{body}"

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -7,6 +7,7 @@ import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock
 
+from tests.tools.file_ops_fakes import READ_SENTINEL_RE, compound_read_output
 from tools.file_operations import (
     _is_write_denied,
     ReadResult,
@@ -303,19 +304,14 @@ class TestShellFileOpsHelpers:
 
         def side_effect(command, **kwargs):
             commands.append(command)
-            # The size probe gates `wc -c` behind `[ -f ]` so a FIFO or device
-            # cannot block the read; it still reports a plain byte count.
-            if command.startswith("if [ -f ") or command.startswith("wc -c"):
-                return {"output": "5\n", "returncode": 0}
-            if command.startswith("head -c") and "| base64" in command:
-                import base64 as b64
-                return {"output": b64.b64encode(b"hello").decode(), "returncode": 0}
-            if command.startswith("head -c"):
-                return {"output": "hello", "returncode": 0}
-            if command.startswith("sed -n"):
-                return {"output": "hello\n", "returncode": 0}
-            if command.startswith("wc -l"):
-                return {"output": "1\n", "returncode": 0}
+            m = READ_SENTINEL_RE.search(command)
+            if m:
+                return {
+                    "output": compound_read_output(
+                        m.group(0), size=5, sample=b"hello", content="hello\n", total_lines=1
+                    ),
+                    "returncode": 0,
+                }
             return {"output": "", "returncode": 0}
 
         mock_env.execute.side_effect = side_effect
@@ -323,16 +319,22 @@ class TestShellFileOpsHelpers:
         result = ops.read_file(r"C:\Users\alice\notes.txt")
 
         assert result.error is None
-        assert commands[0] == (
+        # One compound probe carries every stage; each embeds the MSYS path.
+        # The size probe gates `wc -c` behind `[ -f ]` so a FIFO or device
+        # cannot block the read; it still reports a plain byte count.
+        assert len(commands) == 1
+        probe = commands[0]
+        assert probe.startswith(
             "if [ -f '/c/Users/alice/notes.txt' ]; "
             "then wc -c < '/c/Users/alice/notes.txt' 2>/dev/null; "
+        )
+        assert "head -c 1000 '/c/Users/alice/notes.txt' 2>/dev/null | base64" in probe
+        assert "sed -n '1,2000p' '/c/Users/alice/notes.txt' 2>/dev/null | cut -b1-8001" in probe
+        assert "wc -l < '/c/Users/alice/notes.txt'" in probe
+        assert (
             "elif [ -e '/c/Users/alice/notes.txt' ]; "
             "then echo __hermes_not_regular__; "
-            "else exit 1; fi"
-        )
-        assert commands[1] == "head -c 1000 '/c/Users/alice/notes.txt' 2>/dev/null | base64"
-        assert commands[2] == "sed -n '1,2000p' '/c/Users/alice/notes.txt' | cut -b1-8001"
-        assert commands[3] == "wc -l < '/c/Users/alice/notes.txt'"
+        ) in probe
 
     def test_is_likely_binary_by_extension(self, file_ops):
         assert file_ops._is_likely_binary("photo.png") is True
@@ -355,14 +357,15 @@ class TestShellFileOpsHelpers:
         )
 
         def side_effect(command, **kwargs):
-            if command.startswith("if [ -f ") or command.startswith("wc -c"):
-                return {"output": "12\n", "returncode": 0}
-            if command.startswith("head -c"):
-                return {"output": "print('ok')\n", "returncode": 0}
-            if command.startswith("sed -n"):
-                return {"output": leaked, "returncode": 0}
-            if command.startswith("wc -l"):
-                return {"output": "1\n", "returncode": 0}
+            m = READ_SENTINEL_RE.search(command)
+            if m:
+                return {
+                    "output": compound_read_output(
+                        m.group(0), size=12, sample=b"print('ok')\n",
+                        content=leaked, total_lines=1,
+                    ),
+                    "returncode": 0,
+                }
             return {"output": "", "returncode": 0}
 
         mock_env.execute.side_effect = side_effect
@@ -773,17 +776,19 @@ class TestByteLayerBinaryDetection:
     # --- integration: read_file over the mocked terminal ------------------
 
     def _dispatch(self, cjk_bytes):
-        import base64 as b64
-
         def side_effect(command, **kwargs):
-            if command.startswith("if [ -f ") or command.startswith("wc -c"):
-                return {"output": f"{len(cjk_bytes)}\n", "returncode": 0}
-            if command.startswith("head -c") and "| base64" in command:
-                return {"output": b64.b64encode(cjk_bytes[:1000]).decode(), "returncode": 0}
-            if command.startswith("sed -n"):
-                return {"output": cjk_bytes.decode("utf-8", errors="replace"), "returncode": 0}
-            if command.startswith("wc -l"):
-                return {"output": "1\n", "returncode": 0}
+            m = READ_SENTINEL_RE.search(command)
+            if m:
+                return {
+                    "output": compound_read_output(
+                        m.group(0),
+                        size=len(cjk_bytes),
+                        sample=cjk_bytes[:1000],
+                        content=cjk_bytes.decode("utf-8", errors="replace"),
+                        total_lines=1,
+                    ),
+                    "returncode": 0,
+                }
             return {"output": "", "returncode": 0}
 
         return side_effect

--- a/tests/tools/test_file_operations_edge_cases.py
+++ b/tests/tools/test_file_operations_edge_cases.py
@@ -8,6 +8,7 @@ Covers:
 import pytest
 from unittest.mock import MagicMock, patch
 
+from tests.tools.file_ops_fakes import READ_SENTINEL_RE, compound_read_output
 from tools.file_operations import ShellFileOperations, _parse_search_context_line
 
 
@@ -205,14 +206,15 @@ class TestPaginationBounds:
 
         def fake_exec(command, *args, **kwargs):
             commands.append(command)
-            if command.startswith("if [ -f ") or command.startswith("wc -c"):
-                return MagicMock(exit_code=0, stdout="12")
-            if command.startswith("head -c"):
-                return MagicMock(exit_code=0, stdout="line1\nline2\n")
-            if command.startswith("sed -n"):
-                return MagicMock(exit_code=0, stdout="line1\n")
-            if command.startswith("wc -l"):
-                return MagicMock(exit_code=0, stdout="2")
+            m = READ_SENTINEL_RE.search(command)
+            if m:
+                return MagicMock(
+                    exit_code=0,
+                    stdout=compound_read_output(
+                        m.group(0), size=12, sample=b"line1\nline2\n",
+                        content="line1\n", total_lines=2,
+                    ),
+                )
             return MagicMock(exit_code=0, stdout="")
 
         with patch.object(ops, "_exec", side_effect=fake_exec):
@@ -220,8 +222,9 @@ class TestPaginationBounds:
 
         assert result.error is None
         assert "1|line1" in result.content
-        sed_commands = [cmd for cmd in commands if cmd.startswith("sed -n")]
-        assert sed_commands == ["sed -n '1,1p' 'notes.txt' | cut -b1-8001"]
+        # The clamped range rides the single compound probe.
+        assert len(commands) == 1
+        assert "sed -n '1,1p' 'notes.txt' 2>/dev/null | cut -b1-8001" in commands[0]
 
     def test_search_clamps_offset_and_limit_before_building_head_pipeline(self):
         env = MagicMock()

--- a/tests/tools/test_file_ops_single_roundtrip.py
+++ b/tests/tools/test_file_ops_single_roundtrip.py
@@ -23,21 +23,43 @@ pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="POSIX shell pro
 READ_PROBE_MARK = "__HERMES_RF_"
 
 
+@pytest.fixture(scope="module")
+def _local_env(tmp_path_factory):
+    """One real LocalEnvironment per module; constructing one costs ~0.8 s."""
+    return LocalEnvironment(cwd=str(tmp_path_factory.mktemp("file-ops")))
+
+
 @pytest.fixture
-def shell(tmp_path, monkeypatch):
-    """(ops, calls): file ops over a real local shell, every execute recorded."""
-    # Pin the shell path even where a native fast path exists.
-    monkeypatch.setenv("HERMES_NATIVE_FILE_READ", "0")
-    env = LocalEnvironment(cwd=str(tmp_path))
+def _ops(_local_env, tmp_path):
+    """(ops, calls): file ops over the real local shell, every execute recorded."""
+    env = _local_env
+    env.cwd = str(tmp_path)
     calls = []
-    real_execute = env.execute
+    real_execute = type(env).execute.__get__(env, type(env))
 
     def spy(command, *args, **kwargs):
         calls.append(command)
         return real_execute(command, *args, **kwargs)
 
     env.execute = spy
-    return ShellFileOperations(env, cwd=str(tmp_path)), calls
+    try:
+        yield ShellFileOperations(env, cwd=str(tmp_path)), calls
+    finally:
+        env.__dict__.pop("execute", None)
+
+
+@pytest.fixture
+def shell(_ops, monkeypatch):
+    """Pin the shell path even where a native fast path exists."""
+    monkeypatch.setenv("HERMES_NATIVE_FILE_READ", "0")
+    return _ops
+
+
+@pytest.fixture
+def native(_ops, monkeypatch):
+    """Same wiring with the native fast path on."""
+    monkeypatch.delenv("HERMES_NATIVE_FILE_READ", raising=False)
+    return _ops
 
 
 def _write(tmp_path, name, data: bytes):
@@ -256,6 +278,130 @@ class TestWriteFileRoundTrips:
             r = ops.write_file(str(p), "x\ny\n")
         assert r.error is None
         assert p.read_bytes() == b"x\r\ny\r\n"
+
+
+class TestNativeRead:
+    def test_native_read_makes_no_shell_call(self, native, tmp_path):
+        ops, calls = native
+        r = ops.read_file(_write(tmp_path, "a.txt", b"one\ntwo\n"))
+        assert calls == []
+        assert r.error is None and r.content == "1|one\n2|two\n3|"
+        assert (r.total_lines, r.file_size) == (2, 8)
+
+    def test_kill_switch_routes_to_the_shell(self, native, tmp_path, monkeypatch):
+        ops, calls = native
+        p = _write(tmp_path, "a.txt", b"one\n")
+        monkeypatch.setenv("HERMES_NATIVE_FILE_READ", "0")
+        ops.read_file(p)
+        assert len(calls) == 1 and READ_PROBE_MARK in calls[0]
+
+    def test_non_local_environment_keeps_the_shell_path(self):
+        from unittest.mock import MagicMock
+
+        env = MagicMock()
+        env.cwd = "/tmp"
+        assert ShellFileOperations(env)._native_read_enabled() is False
+
+    def test_tilde_still_expands_through_the_shell(self, native):
+        ops, calls = native
+        r = ops.read_file("~/hermes-no-such-file-7f3a.txt")
+        assert calls[0] == "echo $HOME"
+        assert r.error and "File not found" in r.error
+
+    def test_injection_lookalike_path_is_never_expanded(self, native, tmp_path):
+        ops, calls = native
+        marker = tmp_path / "pwned"
+        r = ops.read_file(f"~; echo PWNED > {marker}")
+        assert r.error and not marker.exists()
+        # The text reaches the shell only single-quoted, inside the missing-
+        # file recovery's directory listing; the tilde probe is a fixed
+        # ``echo $HOME`` that never embeds the path. Nothing else runs.
+        for c in calls:
+            assert c == "echo $HOME" or c.startswith("ls -1 '~; echo PWNED"), c
+
+    @pytest.mark.linux_only
+    def test_fifo_refused_without_a_shell_and_without_blocking(self, native, tmp_path):
+        if not hasattr(os, "mkfifo"):
+            pytest.skip("no mkfifo")
+        ops, calls = native
+        fifo = tmp_path / "pipe"
+        os.mkfifo(fifo)
+        box = {}
+
+        def run():
+            box["r"] = ops.read_file(str(fifo))
+
+        t = threading.Thread(target=run, daemon=True)
+        t.start()
+        t.join(20)
+        assert not t.is_alive(), "native read_file blocked on a writer-less FIFO"
+        assert "not a regular file" in box["r"].error
+        assert calls == []
+
+
+PARITY_CASES = [
+    ("plain", b"one\ntwo\nthree\n", {}),
+    ("no_trailing_newline", b"a\nb", {}),
+    ("blank_tail", b"a\n\n", {}),
+    ("crlf", b"x\r\ny\r\n", {}),
+    ("lone_cr", b"a\rb\n", {}),
+    ("bom", "﻿hello\n".encode("utf-8"), {}),
+    ("empty", b"", {}),
+    ("single_no_newline", b"solo", {}),
+    ("only_newline", b"\n", {}),
+    ("unicode", "héllo wörld\n汉字\n".encode("utf-8"), {}),
+    ("long_line", b"a" * 9000 + b"\nshort\n", {}),
+    ("multibyte_long_line", ("汉" * 4000 + "\nx\n").encode("utf-8"), {}),
+    ("multi_chunk_line", b"b" * 3_000_000 + b"\nz\n", {}),
+    ("window", b"".join(b"l%d\n" % i for i in range(1, 11)), {"offset": 3, "limit": 2}),
+    ("window_reaches_eof", b"".join(b"l%d\n" % i for i in range(1, 11)), {"offset": 9, "limit": 5}),
+    ("past_eof", b"".join(b"l%d\n" % i for i in range(1, 6)), {"offset": 50}),
+    ("nul_binary", b"\x00\x01\x02" * 20, {}),
+    ("latin1_tail", b"caf\xe9\n", {}),
+    ("sentinel_lookalike", b"x\n__HERMES_RF_" + b"ab" * 16 + b"__\ny\n", {}),
+]
+
+
+class TestNativeReadParity:
+    """The native path must be indistinguishable from the shell path."""
+
+    @pytest.mark.parametrize("name,data,kwargs", PARITY_CASES, ids=[c[0] for c in PARITY_CASES])
+    def test_shell_and_native_agree(self, native, tmp_path, monkeypatch, name, data, kwargs):
+        ops, calls = native
+        p = _write(tmp_path, f"{name}.txt", data)
+        monkeypatch.setenv("HERMES_NATIVE_FILE_READ", "0")
+        via_shell = ops.read_file(p, **kwargs).to_dict()
+        assert calls and READ_PROBE_MARK in calls[0]
+        calls.clear()
+        monkeypatch.delenv("HERMES_NATIVE_FILE_READ")
+        via_native = ops.read_file(p, **kwargs).to_dict()
+        assert via_native == via_shell
+        # The native path touches the shell only for the UTF-16 rescue of binaries.
+        assert not any(READ_PROBE_MARK in c for c in calls)
+
+    def test_special_paths_agree(self, native, tmp_path, monkeypatch):
+        ops, calls = native
+        _write(tmp_path, "real.txt", b"target\n")
+        os.symlink(tmp_path / "real.txt", tmp_path / "link.txt")
+        os.symlink(tmp_path / "gone", tmp_path / "dangling.txt")
+        (tmp_path / "sub").mkdir()
+        _write(tmp_path, "pic.png", b"\x89PNG\r\n")
+        _write(tmp_path, "notes.txt", b"n\n")
+        for p in (
+            str(tmp_path / "link.txt"),
+            str(tmp_path / "dangling.txt"),
+            str(tmp_path / "sub"),
+            str(tmp_path / "pic.png"),
+            str(tmp_path / "note.txt"),   # missing → similar-file suggestions
+            "real.txt",                   # relative to env.cwd
+        ):
+            monkeypatch.setenv("HERMES_NATIVE_FILE_READ", "0")
+            via_shell = ops.read_file(p).to_dict()
+            monkeypatch.delenv("HERMES_NATIVE_FILE_READ")
+            calls.clear()
+            via_native = ops.read_file(p).to_dict()
+            assert via_native == via_shell, p
+            assert not any(READ_PROBE_MARK in c for c in calls), p
 
 
 class TestCompoundFallback:

--- a/tests/tools/test_file_ops_single_roundtrip.py
+++ b/tests/tools/test_file_ops_single_roundtrip.py
@@ -11,7 +11,6 @@ import logging
 import os
 import sys
 import threading
-import unicodedata
 from unittest.mock import patch
 
 import pytest
@@ -160,13 +159,17 @@ class TestReadFileNonTextPaths:
 
     def test_unicode_variant_retry_still_works(self, shell, tmp_path):
         ops, calls = shell
-        nfc = unicodedata.normalize("NFC", "café.txt")
-        nfd = unicodedata.normalize("NFD", "café.txt")
-        assert nfc != nfd
-        _write(tmp_path, nfc, b"accent\n")
-        r = ops.read_file(str(tmp_path / nfd))
+        # A curly apostrophe vs the ASCII one: visually identical in a
+        # terminal, and — unlike NFC/NFD — never aliased by the filesystem
+        # (APFS resolves NFD lookups to NFC files directly, which would skip
+        # the retry path this test exists to exercise).
+        on_disk = "it\u2019s.txt"
+        typed = "it's.txt"
+        assert on_disk != typed
+        _write(tmp_path, on_disk, b"accent\n")
+        r = ops.read_file(str(tmp_path / typed))
         assert r.error is None and r.content == "1|accent\n2|"
-        assert "unicode-equivalent" in r.hint
+        assert r.hint is not None and "unicode-equivalent" in r.hint
 
     def test_directory_is_not_regular(self, shell, tmp_path):
         ops, calls = shell

--- a/tests/tools/test_file_ops_single_roundtrip.py
+++ b/tests/tools/test_file_ops_single_roundtrip.py
@@ -7,6 +7,7 @@ line count, trailing newline), so each proves the compound reply carries
 that answer.
 """
 
+import logging
 import os
 import sys
 import threading
@@ -448,3 +449,23 @@ class TestCompoundFallback:
         assert r.error is None and r.content == "1|one\n2|two\n3|"
         assert r.total_lines == 2
 
+    def test_fallback_is_logged_at_debug(self, shell, tmp_path, caplog):
+        """A backend that keeps falling back shows up in debug logs."""
+        ops, calls = shell
+        p = _write(tmp_path, "a.txt", b"one\n")
+        real_exec = ops._exec
+
+        def garbled(command, *args, **kwargs):
+            if READ_PROBE_MARK in command:
+                return ExecuteResult(stdout="garbage\n", exit_code=0)
+            return real_exec(command, *args, **kwargs)
+
+        with caplog.at_level(logging.DEBUG, logger="tools.file_operations"), \
+             patch.object(ops, "_exec", side_effect=garbled):
+            r = ops.read_file(p)
+        assert r.error is None and r.content == "1|one\n2|"
+        assert any(
+            "falling back to sequential probes" in rec.getMessage()
+            and str(p) in rec.getMessage()
+            for rec in caplog.records
+        )

--- a/tests/tools/test_file_ops_single_roundtrip.py
+++ b/tests/tools/test_file_ops_single_roundtrip.py
@@ -339,6 +339,13 @@ class TestNativeRead:
         assert calls == []
 
 
+# The native reader scans 1 MiB chunks and clamps each page line to
+# ``4 * get_max_line_length() + 1`` bytes (8001 by default), exactly as
+# ``sed | cut -b1-N`` does. These shapes put a newline, a line, the clamp
+# point, a CRLF pair and EOF precisely on those chunk boundaries.
+_CHUNK = 1 << 20
+_CLAMP = 8001
+
 PARITY_CASES = [
     ("plain", b"one\ntwo\nthree\n", {}),
     ("no_trailing_newline", b"a\nb", {}),
@@ -353,6 +360,27 @@ PARITY_CASES = [
     ("long_line", b"a" * 9000 + b"\nshort\n", {}),
     ("multibyte_long_line", ("汉" * 4000 + "\nx\n").encode("utf-8"), {}),
     ("multi_chunk_line", b"b" * 3_000_000 + b"\nz\n", {}),
+    ("newline_last_byte_of_chunk", b"a" * (_CHUNK - 1) + b"\nsecond\n", {}),
+    ("newline_first_byte_of_next_chunk", b"a" * _CHUNK + b"\nsecond\n", {}),
+    ("line_spans_three_boundaries", b"p\n" + b"b" * (3 * _CHUNK + 5) + b"\nz\n", {}),
+    (
+        "clamp_fills_on_boundary",
+        b"x" * (_CHUNK - _CLAMP - 1) + b"\n" + b"c" * 20000 + b"\ntail\n",
+        {"offset": 2, "limit": 3},
+    ),
+    (
+        "clamp_fills_after_boundary",
+        b"x" * (_CHUNK - _CLAMP) + b"\n" + b"c" * 20000 + b"\ntail\n",
+        {"offset": 2, "limit": 3},
+    ),
+    ("eof_midline_on_boundary", b"l1\n" + b"d" * (2 * _CHUNK - 3), {}),
+    ("blank_lines_on_boundary", b"e" * (_CHUNK - 2) + b"\n\n\n" + b"f\n", {}),
+    ("crlf_split_on_boundary", b"r" * (_CHUNK - 1) + b"\r\n" + b"s\r\n", {}),
+    (
+        "page_starts_in_second_chunk",
+        b"q\n" * (_CHUNK // 2 + 3) + b"target1\ntarget2\n",
+        {"offset": _CHUNK // 2 + 3, "limit": 4},
+    ),
     ("window", b"".join(b"l%d\n" % i for i in range(1, 11)), {"offset": 3, "limit": 2}),
     ("window_reaches_eof", b"".join(b"l%d\n" % i for i in range(1, 11)), {"offset": 9, "limit": 5}),
     ("past_eof", b"".join(b"l%d\n" % i for i in range(1, 6)), {"offset": 50}),
@@ -419,3 +447,4 @@ class TestCompoundFallback:
             r = ops.read_file(p)
         assert r.error is None and r.content == "1|one\n2|two\n3|"
         assert r.total_lines == 2
+

--- a/tests/tools/test_file_ops_single_roundtrip.py
+++ b/tests/tools/test_file_ops_single_roundtrip.py
@@ -1,0 +1,203 @@
+"""``read_file`` / ``write_file`` cost one shell round-trip, not four.
+
+Real ``LocalEnvironment`` against ``tmp_path`` (no mocks), with a spy on
+``env.execute`` counting round-trips. The cases below are exactly the ones
+that used to need their own probe (existence, size, binary sample, page,
+line count, trailing newline), so each proves the compound reply carries
+that answer.
+"""
+
+import os
+import sys
+import threading
+import unicodedata
+from unittest.mock import patch
+
+import pytest
+
+from tools.environments.local import LocalEnvironment
+from tools.file_operations import ExecuteResult, ShellFileOperations
+
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="POSIX shell probes")
+
+READ_PROBE_MARK = "__HERMES_RF_"
+
+
+@pytest.fixture
+def shell(tmp_path, monkeypatch):
+    """(ops, calls): file ops over a real local shell, every execute recorded."""
+    # Pin the shell path even where a native fast path exists.
+    monkeypatch.setenv("HERMES_NATIVE_FILE_READ", "0")
+    env = LocalEnvironment(cwd=str(tmp_path))
+    calls = []
+    real_execute = env.execute
+
+    def spy(command, *args, **kwargs):
+        calls.append(command)
+        return real_execute(command, *args, **kwargs)
+
+    env.execute = spy
+    return ShellFileOperations(env, cwd=str(tmp_path)), calls
+
+
+def _write(tmp_path, name, data: bytes):
+    p = tmp_path / name
+    p.write_bytes(data)
+    return str(p)
+
+
+class TestReadFileOneRoundTrip:
+    def test_text_read_is_one_round_trip(self, shell, tmp_path):
+        ops, calls = shell
+        p = _write(tmp_path, "a.txt", b"one\ntwo\nthree\n")
+        r = ops.read_file(p)
+        assert len(calls) == 1 and READ_PROBE_MARK in calls[0]
+        assert r.error is None
+        # ``_add_line_numbers`` numbers the empty tail after the final
+        # newline: long-standing behaviour, preserved byte for byte.
+        assert r.content == "1|one\n2|two\n3|three\n4|"
+        assert (r.total_lines, r.file_size, r.truncated) == (3, 14, False)
+
+    def test_no_trailing_newline_needs_no_extra_probe(self, shell, tmp_path):
+        ops, calls = shell
+        p = _write(tmp_path, "b.txt", b"a\nb")
+        r = ops.read_file(p)
+        assert len(calls) == 1
+        # ``cut`` newline-terminates the last line; the artifact is stripped
+        # from the same reply that used to need a fifth ``tail -c 1`` call.
+        assert r.content == "1|a\n2|b"
+        assert r.total_lines == 1  # wc -l semantics, unchanged
+
+    def test_pagination_window_and_hint(self, shell, tmp_path):
+        ops, calls = shell
+        p = _write(tmp_path, "c.txt", b"".join(b"l%d\n" % i for i in range(1, 11)))
+        r = ops.read_file(p, offset=3, limit=2)
+        assert len(calls) == 1
+        assert r.content == "3|l3\n4|l4\n5|"
+        assert r.truncated is True and r.total_lines == 10
+        assert "offset=5" in r.hint
+
+    def test_offset_past_eof_note(self, shell, tmp_path):
+        ops, calls = shell
+        p = _write(tmp_path, "c.txt", b"".join(b"l%d\n" % i for i in range(1, 6)))
+        r = ops.read_file(p, offset=50)
+        assert len(calls) == 1
+        assert r.content == "" and r.error is None
+        assert "beyond the end" in r.hint and "5" in r.hint
+
+    def test_empty_file(self, shell, tmp_path):
+        ops, calls = shell
+        r = ops.read_file(_write(tmp_path, "e.txt", b""))
+        assert len(calls) == 1
+        assert r.error is None and r.content == "" and r.total_lines == 0
+        assert "empty" in r.hint
+
+    def test_bom_stripped_on_first_page(self, shell, tmp_path):
+        ops, calls = shell
+        r = ops.read_file(_write(tmp_path, "f.txt", "﻿hello\n".encode("utf-8")))
+        assert len(calls) == 1
+        assert r.content == "1|hello\n2|"
+
+    def test_crlf_bytes_survive(self, shell, tmp_path):
+        ops, calls = shell
+        r = ops.read_file(_write(tmp_path, "g.txt", b"x\r\ny\r\n"))
+        assert r.content == "1|x\r\n2|y\r\n3|"
+
+    def test_long_line_clamped_and_marked(self, shell, tmp_path):
+        ops, calls = shell
+        r = ops.read_file(_write(tmp_path, "L.txt", b"a" * 9000 + b"\nshort\n"))
+        assert len(calls) == 1
+        first, second, tail = r.content.split("\n")
+        assert first.endswith("... [truncated]") and len(first) < 9000
+        assert second == "2|short" and tail == "3|"
+
+    def test_relative_path_resolves_against_env_cwd(self, shell, tmp_path):
+        ops, calls = shell
+        _write(tmp_path, "rel.txt", b"here\n")
+        r = ops.read_file("rel.txt")
+        assert r.error is None and r.content == "1|here\n2|"
+
+    def test_sentinel_lookalike_in_content_reads_intact(self, shell, tmp_path):
+        ops, calls = shell
+        lookalike = "__HERMES_RF_" + "ab" * 16 + "__"
+        p = _write(tmp_path, "s.txt", f"x\n{lookalike}\ny\n".encode("utf-8"))
+        r = ops.read_file(p)
+        assert r.error is None and r.total_lines == 3
+        assert r.content == f"1|x\n2|{lookalike}\n3|y\n4|"
+
+
+class TestReadFileNonTextPaths:
+    def test_missing_file_probes_once_then_suggests(self, shell, tmp_path):
+        ops, calls = shell
+        _write(tmp_path, "notes.txt", b"x\n")
+        r = ops.read_file(str(tmp_path / "note.txt"))
+        assert READ_PROBE_MARK in calls[0]
+        assert r.error and "File not found" in r.error
+        assert any(s.endswith("notes.txt") for s in r.similar_files)
+
+    def test_unicode_variant_retry_still_works(self, shell, tmp_path):
+        ops, calls = shell
+        nfc = unicodedata.normalize("NFC", "café.txt")
+        nfd = unicodedata.normalize("NFD", "café.txt")
+        assert nfc != nfd
+        _write(tmp_path, nfc, b"accent\n")
+        r = ops.read_file(str(tmp_path / nfd))
+        assert r.error is None and r.content == "1|accent\n2|"
+        assert "unicode-equivalent" in r.hint
+
+    def test_directory_is_not_regular(self, shell, tmp_path):
+        ops, calls = shell
+        r = ops.read_file(str(tmp_path))
+        assert len(calls) == 1
+        assert r.error and "not a regular file" in r.error
+
+    def test_binary_sample_detected_in_same_reply(self, shell, tmp_path):
+        ops, calls = shell
+        p = _write(tmp_path, "blob", b"\x00\x01\x02" + b"\x00" * 50)
+        r = ops.read_file(p)
+        assert READ_PROBE_MARK in calls[0]
+        assert r.is_binary is True and r.error
+        # Only the UTF-16 rescue may add round-trips, never a second sample.
+        assert not any("head -c 1000" in c for c in calls[1:])
+
+    def test_image_extension_stops_at_size_probe(self, shell, tmp_path):
+        ops, calls = shell
+        r = ops.read_file(_write(tmp_path, "p.png", b"\x89PNG\r\n"))
+        assert len(calls) == 1 and READ_PROBE_MARK not in calls[0]
+        assert r.is_image is True and r.file_size == 6
+
+    @pytest.mark.linux_only
+    def test_fifo_returns_not_regular_without_blocking(self, shell, tmp_path):
+        if not hasattr(os, "mkfifo"):
+            pytest.skip("no mkfifo")
+        ops, calls = shell
+        fifo = tmp_path / "pipe"
+        os.mkfifo(fifo)
+        box = {}
+
+        def run():
+            box["r"] = ops.read_file(str(fifo))
+
+        t = threading.Thread(target=run, daemon=True)
+        t.start()
+        t.join(20)
+        assert not t.is_alive(), "read_file blocked on a writer-less FIFO"
+        assert "not a regular file" in box["r"].error
+        assert len(calls) == 1
+
+
+class TestCompoundFallback:
+    def test_unparseable_reply_falls_back_to_sequential_probes(self, shell, tmp_path):
+        ops, calls = shell
+        p = _write(tmp_path, "a.txt", b"one\ntwo\n")
+        real_exec = ops._exec
+
+        def garbled(command, *args, **kwargs):
+            if READ_PROBE_MARK in command:
+                return ExecuteResult(stdout="[Command timed out after 1s]\n", exit_code=124)
+            return real_exec(command, *args, **kwargs)
+
+        with patch.object(ops, "_exec", side_effect=garbled):
+            r = ops.read_file(p)
+        assert r.error is None and r.content == "1|one\n2|two\n3|"
+        assert r.total_lines == 2

--- a/tests/tools/test_file_ops_single_roundtrip.py
+++ b/tests/tools/test_file_ops_single_roundtrip.py
@@ -186,6 +186,78 @@ class TestReadFileNonTextPaths:
         assert len(calls) == 1
 
 
+class TestWriteFileRoundTrips:
+    """write_file: one probe, one atomic write, one hash check (three calls)."""
+
+    @staticmethod
+    def _execs(calls):
+        return [c for c in calls]
+
+    def test_new_text_file_is_three_round_trips(self, shell, tmp_path):
+        ops, calls = shell
+        p = str(tmp_path / "new.txt")
+        r = ops.write_file(p, "line one\nline two\n")
+        assert r.error is None and r.verified is True
+        assert len(calls) == 3
+        assert "__HERMES_WF_" in calls[0]          # probe
+        assert "mv -f" in calls[1]                  # atomic write
+        assert calls[2].startswith("sha256sum ")   # verify
+        assert (tmp_path / "new.txt").read_bytes() == b"line one\nline two\n"
+
+    def test_crlf_file_keeps_crlf_from_the_probe(self, shell, tmp_path):
+        ops, calls = shell
+        p = tmp_path / "crlf.txt"
+        p.write_bytes(b"a\r\nb\r\n")
+        r = ops.write_file(str(p), "x\ny\n")
+        assert r.error is None and len(calls) == 3
+        assert p.read_bytes() == b"x\r\ny\r\n"
+
+    def test_bom_is_read_from_disk_and_preserved(self, shell, tmp_path):
+        ops, calls = shell
+        p = tmp_path / "bom.txt"
+        p.write_bytes("﻿old\n".encode("utf-8"))
+        r = ops.write_file(str(p), "new\n")
+        assert r.error is None and len(calls) == 3
+        assert p.read_bytes() == "﻿new\n".encode("utf-8")
+
+    def test_pre_content_read_rides_the_same_probe(self, shell, tmp_path):
+        """A lintable extension wants the old text (lint delta); it comes
+        back in the probe reply instead of a separate ``cat``."""
+        ops, calls = shell
+        p = tmp_path / "code.py"
+        p.write_bytes(b"x = 1\r\ny = 2\r\n")
+        r = ops.write_file(str(p), "x = 1\ny = 3\n")
+        assert r.error is None
+        probes = [c for c in calls if "__HERMES_WF_" in c]
+        assert len(probes) == 1 and "cat " in probes[0]
+        assert not any(c.startswith("cat ") for c in calls)
+        assert p.read_bytes() == b"x = 1\r\ny = 3\r\n"
+
+    def test_missing_file_probe_does_not_block_the_write(self, shell, tmp_path):
+        ops, calls = shell
+        p = tmp_path / "deep" / "er" / "new.md"
+        r = ops.write_file(str(p), "hi\n")
+        assert r.error is None and r.dirs_created is True
+        assert len(calls) == 3
+        assert p.read_bytes() == b"hi\n"
+
+    def test_unparseable_probe_reply_falls_back_to_separate_probes(self, shell, tmp_path):
+        ops, calls = shell
+        p = tmp_path / "crlf.txt"
+        p.write_bytes(b"a\r\nb\r\n")
+        real_exec = ops._exec
+
+        def garbled(command, *args, **kwargs):
+            if "__HERMES_WF_" in command:
+                return ExecuteResult(stdout="[Command timed out after 1s]\n", exit_code=124)
+            return real_exec(command, *args, **kwargs)
+
+        with patch.object(ops, "_exec", side_effect=garbled):
+            r = ops.write_file(str(p), "x\ny\n")
+        assert r.error is None
+        assert p.read_bytes() == b"x\r\ny\r\n"
+
+
 class TestCompoundFallback:
     def test_unparseable_reply_falls_back_to_sequential_probes(self, shell, tmp_path):
         ops, calls = shell

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1562,12 +1562,17 @@ class ShellFileOperations(FileOperations):
         existence, size, binary sample, the page, line count, trailing
         newline (see ``_read_probe_cmd``). A reply that cannot be parsed
         falls back to ``_read_file_sequential``, the one-probe-per-call
-        form, so an exotic shell can never do worse than before.
+        form, so an exotic shell can never do worse than before. On a local
+        POSIX environment the read never touches the shell at all; see
+        ``_read_file_native``.
         """
         # Expand ~ and other shell paths
         path = self._expand_path(path)
 
         offset, limit = normalize_read_pagination(offset, limit)
+
+        if self._native_read_enabled():
+            return self._read_file_native(path, offset, limit)
 
         # Images and known-binary extensions never inline content; the
         # sequential path stops at the probes for them, so nothing is gained
@@ -1644,6 +1649,137 @@ class ShellFileOperations(FileOperations):
             total_lines=total_lines,
             file_size=file_size,
             file_ends_with_newline=file_ends_with_newline,
+        )
+
+    def _native_read_enabled(self) -> bool:
+        """Whether ``read_file`` may bypass the shell and read from this host.
+
+        Only on POSIX with a ``LocalEnvironment``: the file is on this
+        machine and the path is already in native form. Windows keeps the
+        shell path, since file_operations holds Git-Bash-style paths there.
+        ``HERMES_NATIVE_FILE_READ=0`` turns the fast path off.
+        """
+        flag = os.environ.get("HERMES_NATIVE_FILE_READ", "1").strip().lower()
+        if flag in ("0", "false", "no", "off"):
+            return False
+        cached = getattr(self, "_native_read_ok", None)
+        if cached is not None:
+            return cached
+        ok = False
+        if sys.platform != "win32":
+            env = getattr(self, "env", None)
+            if env is not None:
+                try:
+                    from tools.environments.local import LocalEnvironment
+                    ok = isinstance(env, LocalEnvironment)
+                except Exception:  # noqa: BLE001 - never let an import problem break a read
+                    ok = False
+        self._native_read_ok = ok
+        return ok
+
+    def _read_file_native(self, path: str, offset: int, limit: int) -> ReadResult:
+        """``read_file`` without a shell: the file lives on this host.
+
+        Same contract as the shell path, byte for byte. ``os.stat`` is the
+        ``[ -f ]`` guard (a stat, never an open, so FIFOs and devices are
+        refused before anything touches their contents); the first 1000
+        bytes drive the byte-layer binary check; the page is produced
+        exactly as ``sed -n 'a,bp' | cut -b1-N`` prints it (every line
+        clamped to N bytes and newline-terminated), then decoded with
+        errors="replace" like the terminal transport. One chunked pass
+        counts lines and collects the page, so neither the file nor a
+        single pathological line is ever held in memory whole.
+
+        ``path`` is already expanded and ``offset``/``limit`` normalized.
+        Anything unexpected from the OS hands over to the shell path.
+        """
+        import stat as _stat
+
+        full = path if os.path.isabs(path) else os.path.join(
+            getattr(self.env, "cwd", None) or self.cwd, path
+        )
+        try:
+            st = os.stat(full)
+        except (FileNotFoundError, NotADirectoryError):
+            return self._read_file_missing(path, offset, limit)
+        except OSError:
+            return self._read_file_sequential(path, offset, limit)
+        if not _stat.S_ISREG(st.st_mode):
+            return self._not_regular_error(path)
+        file_size = st.st_size
+
+        # Images are never inlined: redirect to the vision tool
+        if self._is_image(path):
+            return self._image_redirect_result(file_size)
+
+        from tools.tool_output_limits import get_max_line_length
+        clamp = 4 * get_max_line_length() + 1
+        end_line = offset + limit - 1
+
+        page: List[bytes] = []
+        total_lines = 0
+        lineno = 1              # the line currently being scanned
+        kept = bytearray()      # first ``clamp`` bytes of that line
+        have_partial = False    # that line has bytes but no newline yet
+        last_byte = b""
+        try:
+            with open(full, "rb") as fh:
+                sample = fh.read(1000)
+                ext_binary = os.path.splitext(path)[1].lower() in BINARY_EXTENSIONS
+                if ext_binary or self._is_likely_binary_bytes(sample):
+                    return self._read_binary_file(path, offset, limit, file_size, sample)
+                fh.seek(0)
+                while True:
+                    chunk = fh.read(1 << 20)
+                    if not chunk:
+                        break
+                    last_byte = chunk[-1:]
+                    pos, n = 0, len(chunk)
+                    while pos < n:
+                        nl = chunk.find(b"\n", pos)
+                        in_page = offset <= lineno <= end_line
+                        if nl < 0:
+                            if in_page and len(kept) < clamp:
+                                kept += chunk[pos:pos + (clamp - len(kept))]
+                            have_partial = True
+                            break
+                        if in_page:
+                            if len(kept) < clamp:
+                                kept += chunk[pos:min(nl, pos + (clamp - len(kept)))]
+                            page.append(bytes(kept) + b"\n")
+                        kept = bytearray()
+                        have_partial = False
+                        total_lines += 1
+                        lineno += 1
+                        pos = nl + 1
+        except OSError:
+            return self._read_file_sequential(path, offset, limit)
+        if have_partial and offset <= lineno <= end_line:
+            # ``sed`` prints a final line that lacks a newline; ``cut`` adds one.
+            page.append(bytes(kept) + b"\n")
+
+        read_output = _strip_terminal_fence_leaks(
+            b"".join(page).decode("utf-8", errors="replace")
+        )
+        return self._assemble_read_result(
+            read_output,
+            offset=offset,
+            end_line=end_line,
+            total_lines=total_lines,
+            file_size=file_size,
+            file_ends_with_newline=(last_byte == b"\n") if file_size else None,
+        )
+
+    @staticmethod
+    def _image_redirect_result(file_size: int) -> ReadResult:
+        return ReadResult(
+            is_image=True,
+            is_binary=True,
+            file_size=file_size,
+            hint=(
+                "Image file detected. Automatically redirected to vision_analyze tool. "
+                "Use vision_analyze with this file path to inspect the image contents."
+            ),
         )
 
     def _read_probe_cmd(self, path: str, offset: int, end_line: int,
@@ -1749,15 +1885,7 @@ class ShellFileOperations(FileOperations):
 
         # Images are never inlined — redirect to the vision tool
         if self._is_image(path):
-            return ReadResult(
-                is_image=True,
-                is_binary=True,
-                file_size=file_size,
-                hint=(
-                    "Image file detected. Automatically redirected to vision_analyze tool. "
-                    "Use vision_analyze with this file path to inspect the image contents."
-                ),
-            )
+            return self._image_redirect_result(file_size)
 
         # Read a sample to check for binary content — at the byte layer when
         # the transport allows, falling back to the legacy text heuristic.

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2174,6 +2174,100 @@ class ShellFileOperations(FileOperations):
     # WRITE Implementation
     # =========================================================================
 
+    def _write_probe_cmd(self, path: str, sentinel: str, body: Optional[str]) -> str:
+        """One shell command for the on-disk questions ``write_file`` asks.
+
+        Two segments closed by a ``sentinel`` line: base64 of the first three
+        bytes (BOM detection at the byte layer, the same on-disk truth as
+        ``_file_has_bom``), then ``body``: ``"cat"`` for the full text when
+        pre-content is wanted, ``"sample"`` for the 4 KB line-ending sample,
+        or ``None`` for nothing. Gated on ``[ -f ]`` so a FIFO or device never
+        reaches ``head``/``cat``; a missing path echoes ``MISSING_SENTINEL``.
+        """
+        arg = self._escape_shell_arg(path)
+        if body == "cat":
+            body_cmd = f"cat {arg} 2>/dev/null"
+        elif body == "sample":
+            body_cmd = f"head -c 4096 {arg} 2>/dev/null"
+        else:
+            body_cmd = ":"
+        return (
+            f"if [ -f {arg} ]; then "
+            f"head -c 3 {arg} 2>/dev/null | base64 2>/dev/null; echo {sentinel}; "
+            f"{body_cmd}; "
+            f"else echo {MISSING_SENTINEL}; fi"
+        )
+
+    def _probe_write_target(
+        self, path: str, pre_content: Optional[str], want_pre: bool,
+    ) -> tuple[bool, Optional[str], Optional[str]]:
+        """Return ``(has_bom, pre_content, original_line_ending)`` for ``path``.
+
+        Replaces three probes (``cat`` when pre-content is wanted, a
+        ``head -c 4096`` line-ending sample, a ``head -c 3`` BOM check) with
+        one round-trip. Semantics are unchanged: pre-content is only read
+        when wanted and not supplied; the line ending comes from pre-content
+        when there is any, else from the sample; the BOM always comes from
+        the bytes on disk. A reply that cannot be parsed falls back to the
+        separate probes.
+        """
+        if want_pre and pre_content is None:
+            body_mode: Optional[str] = "cat"
+        elif not pre_content:
+            body_mode = "sample"
+        else:
+            body_mode = None
+
+        sentinel = _new_sentinel(_WRITE_SENTINEL_PREFIX)
+        probe = self._exec(self._write_probe_cmd(path, sentinel, body_mode))
+        output = probe.stdout or ""
+
+        if sentinel not in output:
+            if _strip_terminal_fence_leaks(output).strip() == MISSING_SENTINEL:
+                ending = _detect_line_ending(pre_content) if pre_content else None
+                return False, pre_content, ending
+            return self._probe_write_target_sequential(path, pre_content, want_pre)
+
+        segments = _split_segments(output, sentinel)
+        if probe.exit_code != 0 or len(segments) != 2:
+            return self._probe_write_target_sequential(path, pre_content, want_pre)
+        head_seg, body = segments
+
+        head_bytes = self._decode_base64_sample(head_seg)
+        if head_bytes is None:
+            # No clean base64 on this shell; ask the way we used to.
+            has_bom = self._file_has_bom(path, pre_content)
+        else:
+            has_bom = head_bytes.startswith(_UTF8_BOM.encode("utf-8"))
+
+        if body_mode == "cat" and body:
+            pre_content = body
+
+        if pre_content:
+            ending = _detect_line_ending(pre_content)
+        elif body_mode == "sample" and body:
+            ending = _detect_line_ending(body)
+        else:
+            ending = None
+        return has_bom, pre_content, ending
+
+    def _probe_write_target_sequential(
+        self, path: str, pre_content: Optional[str], want_pre: bool,
+    ) -> tuple[bool, Optional[str], Optional[str]]:
+        """The pre-compound form of ``_probe_write_target``: one exec per question."""
+        if want_pre and pre_content is None:
+            # Best-effort read; failure (file missing, permission) leaves
+            # pre_content as None which makes both downstream consumers
+            # degrade gracefully (lint reports all errors; LSP skips the
+            # shift map).
+            read_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"
+            read_result = self._exec(read_cmd)
+            if read_result.exit_code == 0 and read_result.stdout:
+                pre_content = read_result.stdout
+        ending = self._detect_file_line_ending(path, pre_content)
+        has_bom = self._file_has_bom(path, pre_content)
+        return has_bom, pre_content, ending
+
     def write_file(self, path: str, content: str,
                    pre_content: Optional[str] = None) -> WriteResult:
         """
@@ -2293,29 +2387,20 @@ class ShellFileOperations(FileOperations):
         # extensions outside both sets (binaries, opaque formats),
         # skipping the read keeps the hot path fast.
         want_pre = ext in LINTERS_INPROC or self._lsp_handles_extension(ext)
-        if want_pre:
-            if pre_content is not None:
-                # Caller already has file content (e.g. patch_replace read it
-                # for fuzzy matching) — reuse directly, skip redundant cat.
-                pass
-            else:
-                # Best-effort read; failure (file missing, permission) leaves
-                # pre_content as None which makes both downstream consumers
-                # degrade gracefully (lint reports all errors; LSP skips the
-                # shift map).
-                read_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"
-                read_result = self._exec(read_cmd)
-                if read_result.exit_code == 0 and read_result.stdout:
-                    pre_content = read_result.stdout
+        # One shell round-trip answers every on-disk question the write
+        # needs (pre-content when wanted, line endings, BOM); see
+        # _probe_write_target. A caller that already has the file content
+        # (e.g. patch_replace read it for fuzzy matching) skips the read;
+        # the BOM is still taken from disk, never from pre_content.
+        has_bom, pre_content, original_ending = self._probe_write_target(
+            path, pre_content, want_pre
+        )
 
         # ── Line-ending preservation (Roo Code pattern) ──────────────
         # If the file existed with CRLF endings and the agent's content
         # has bare LFs, convert to CRLF before writing.  Otherwise the
         # write silently normalizes a Windows-line-ending file (and patch
         # produces mixed endings when only a substituted region changes).
-        # Detect from a small head sample to avoid reading the full file
-        # for line-ending purposes alone.
-        original_ending = self._detect_file_line_ending(path, pre_content)
         if original_ending == "\r\n":
             content = _normalize_line_endings(content, "\r\n")
 
@@ -2328,7 +2413,7 @@ class ShellFileOperations(FileOperations):
         # toolchains key on it). Only prepend when the original had a BOM
         # and the new content doesn't already carry one (guards against
         # double-BOM if a caller passed raw bytes).
-        if self._file_has_bom(path, pre_content) and not _has_bom(content):
+        if has_bom and not _has_bom(content):
             content = _UTF8_BOM + content
 
         # Snapshot LSP diagnostics for this file (best-effort) so the

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -29,6 +29,7 @@ import base64
 import binascii
 import os
 import re
+import secrets
 import sys
 import difflib
 import hashlib
@@ -848,6 +849,36 @@ DEFAULT_SEARCH_LIMIT = 50
 # `wc -c` prints only digits, so this can never collide with a real size.
 NOT_REGULAR_SENTINEL = "__hermes_not_regular__"
 
+# Echoed by the compound read/write probes when the path does not exist.
+# A compound command only reports its *last* exit status, so the missing-file
+# signal that ``_size_probe_cmd`` carries in ``exit 1`` has to travel in-band.
+MISSING_SENTINEL = "__hermes_missing__"
+
+_READ_SENTINEL_PREFIX = "__HERMES_RF_"
+_WRITE_SENTINEL_PREFIX = "__HERMES_WF_"
+
+
+def _new_sentinel(prefix: str) -> str:
+    """Per-call separator line for a compound shell probe.
+
+    128 random bits make a collision with file content negligible, and the
+    underscores keep the token outside the base64 alphabet, so a sentinel
+    that ever leaked into a sample segment fails base64 validation instead
+    of decoding into bytes.
+    """
+    return f"{prefix}{secrets.token_hex(16)}__"
+
+
+def _split_segments(output: str, sentinel: str) -> List[str]:
+    """Split compound-probe stdout on its sentinel lines.
+
+    Every producer (``wc``, ``base64``, ``cut``) newline-terminates its
+    output or prints nothing, so the separator is always ``sentinel + "\\n"``
+    on a line of its own. The text after the final sentinel is the status
+    segment.
+    """
+    return output.split(sentinel + "\n")
+
 
 def _coerce_int(value: Any, default: int) -> int:
     """Best-effort integer coercion for tool pagination inputs."""
@@ -1032,7 +1063,18 @@ class ShellFileOperations(FileOperations):
         )
         if result.exit_code != 0:
             return None
-        encoded = _strip_terminal_fence_leaks(result.stdout)
+        return self._decode_base64_sample(result.stdout)
+
+    @staticmethod
+    def _decode_base64_sample(text: str) -> Optional[bytes]:
+        """Decode one base64 sample as emitted by ``head -c N | base64``.
+
+        Whitespace-joins the whole text first (``base64`` wraps at 76
+        columns), so callers must hand over exactly one segment; anything
+        else in the text fails validation and yields ``None``, which sends
+        the caller to the legacy text-sample heuristic.
+        """
+        encoded = _strip_terminal_fence_leaks(text)
         encoded = "".join(encoded.split())
         if not encoded:
             return b""
@@ -1507,42 +1549,190 @@ class ShellFileOperations(FileOperations):
     def read_file(self, path: str, offset: int = 1, limit: int = 2000) -> ReadResult:
         """
         Read a file with pagination, binary detection, and line numbers.
-        
+
         Args:
             path: File path (absolute or relative to cwd)
             offset: Line number to start from (1-indexed, default 1)
             limit: Maximum lines to return (default 500, max 2000)
-        
+
         Returns:
             ReadResult with content, metadata, or error info
+
+        One shell round-trip answers every question the read needs:
+        existence, size, binary sample, the page, line count, trailing
+        newline (see ``_read_probe_cmd``). A reply that cannot be parsed
+        falls back to ``_read_file_sequential``, the one-probe-per-call
+        form, so an exotic shell can never do worse than before.
         """
         # Expand ~ and other shell paths
         path = self._expand_path(path)
-        
+
         offset, limit = normalize_read_pagination(offset, limit)
-        
+
+        # Images and known-binary extensions never inline content; the
+        # sequential path stops at the probes for them, so nothing is gained
+        # by streaming their bytes through the page pipeline.
+        if self._is_image(path) or os.path.splitext(path)[1].lower() in BINARY_EXTENSIONS:
+            return self._read_file_sequential(path, offset, limit)
+
+        from tools.tool_output_limits import get_max_line_length
+        line_clamp_bytes = 4 * get_max_line_length() + 1
+        end_line = offset + limit - 1
+        sentinel = _new_sentinel(_READ_SENTINEL_PREFIX)
+        probe = self._exec(
+            self._read_probe_cmd(path, offset, end_line, line_clamp_bytes, sentinel)
+        )
+        output = probe.stdout or ""
+
+        if sentinel not in output:
+            # Single-line replies: the path is missing or not a regular file.
+            marker = _strip_terminal_fence_leaks(output).strip()
+            if marker == MISSING_SENTINEL:
+                return self._read_file_missing(path, offset, limit)
+            if marker == NOT_REGULAR_SENTINEL:
+                return self._not_regular_error(path)
+            return self._read_file_sequential(path, offset, limit)
+
+        segments = _split_segments(output, sentinel)
+        if probe.exit_code != 0 or len(segments) != 6:
+            return self._read_file_sequential(path, offset, limit)
+        size_seg, sample_seg, page_seg, wc_seg, tail_seg, status_seg = segments
+
+        status = _strip_terminal_fence_leaks(status_seg).split()
+        try:
+            sample_rc, read_rc = int(status[0]), int(status[1])
+        except (IndexError, ValueError):
+            return self._read_file_sequential(path, offset, limit)
+
+        try:
+            file_size = int(_strip_terminal_fence_leaks(size_seg).strip())
+        except ValueError:
+            file_size = 0
+
+        # Byte-layer binary detection when base64 was available, else the
+        # legacy text heuristic over a plain sample: one extra round-trip,
+        # paid only on shells without base64.
+        sample_bytes = self._decode_base64_sample(sample_seg) if sample_rc == 0 else None
+        if sample_bytes is not None:
+            is_binary = self._is_likely_binary_bytes(sample_bytes)
+        else:
+            sample_cmd = f"head -c 1000 {self._escape_shell_arg(path)} 2>/dev/null"
+            sample_result = self._exec(sample_cmd)
+            sample_output = _strip_terminal_fence_leaks(sample_result.stdout)
+            is_binary = self._is_likely_binary(path, sample_output)
+
+        if is_binary:
+            return self._read_binary_file(path, offset, limit, file_size, sample_bytes)
+
+        if read_rc != 0:
+            return ReadResult(
+                error=f"Failed to read file: {_strip_terminal_fence_leaks(page_seg)}"
+            )
+
+        read_output = _strip_terminal_fence_leaks(page_seg)
+        try:
+            total_lines = int(_strip_terminal_fence_leaks(wc_seg).strip())
+        except ValueError:
+            total_lines = 0
+        tail_flag = _strip_terminal_fence_leaks(tail_seg).strip()
+        file_ends_with_newline = tail_flag == "1" if tail_flag in ("0", "1") else None
+
+        return self._assemble_read_result(
+            read_output,
+            offset=offset,
+            end_line=end_line,
+            total_lines=total_lines,
+            file_size=file_size,
+            file_ends_with_newline=file_ends_with_newline,
+        )
+
+    def _read_probe_cmd(self, path: str, offset: int, end_line: int,
+                        line_clamp_bytes: int, sentinel: str) -> str:
+        """One shell command answering every question ``read_file`` asks.
+
+        Six segments, each closed by a ``sentinel`` line: byte size, base64
+        of the first 1000 bytes, the ``sed | cut`` page, ``wc -l``, whether
+        the last byte is a newline, then the base64 and page pipeline
+        statuses. The probes run only inside ``[ -f ]``, the same
+        stat-not-open guard as ``_size_probe_cmd``, so a FIFO or device
+        never reaches ``head``/``sed``. A missing path echoes
+        ``MISSING_SENTINEL`` instead of exiting non-zero, because a compound
+        command only reports its last status. Every stage silences stderr:
+        the local backend merges stderr into stdout and a stray diagnostic
+        would otherwise land inside a segment.
+
+        The page clamp is byte-based on purpose; see ``_read_file_sequential``
+        for why it is ``4 * max_line_length + 1``.
+        """
+        arg = self._escape_shell_arg(path)
+        mark = f"echo {sentinel}"
+        return (
+            f"if [ -f {arg} ]; then "
+            f"wc -c < {arg} 2>/dev/null; {mark}; "
+            f"head -c 1000 {arg} 2>/dev/null | base64 2>/dev/null; __hs=$?; {mark}; "
+            f"sed -n '{offset},{end_line}p' {arg} 2>/dev/null"
+            f" | cut -b1-{line_clamp_bytes} 2>/dev/null; __hr=$?; {mark}; "
+            f"wc -l < {arg} 2>/dev/null; {mark}; "
+            f"tail -c 1 {arg} 2>/dev/null | wc -l; {mark}; "
+            f'echo "$__hs $__hr"; '
+            f"elif [ -e {arg} ]; then echo {NOT_REGULAR_SENTINEL}; "
+            f"else echo {MISSING_SENTINEL}; fi"
+        )
+
+    def _read_file_missing(self, path: str, offset: int, limit: int) -> ReadResult:
+        """Not-found recovery shared by every read path.
+
+        Before failing, try unicode-equivalent spellings: NFC/NFD, narrow
+        no-break space, curly quotes render identically in a terminal, so
+        the model retyping a visually-correct path can never discover the
+        byte mismatch on its own (retrying is the tool's job, not the
+        model's). No equivalent spelling → suggest similar files.
+        """
+        variant = self._unicode_variant_match(path)
+        if variant is not None:
+            result = self.read_file(variant, offset=offset, limit=limit)
+            note = (
+                f"Note: '{path}' not found byte-for-byte; resolved to "
+                f"the unicode-equivalent file '{variant}' (invisible "
+                "encoding difference: NFC/NFD or special space/quote "
+                "characters)."
+            )
+            result.hint = f"{note} {result.hint}" if result.hint else note
+            return result
+        return self._suggest_similar_files(path)
+
+    def _read_binary_file(self, path: str, offset: int, limit: int,
+                          file_size: int, sample_bytes: Optional[bytes]) -> ReadResult:
+        """Binary branch shared by every read path.
+
+        UTF-16 rescue (ported from MoonshotAI/kimi-code#2647): the terminal
+        env decodes stdout as UTF-8 with errors="replace", so a UTF-16 text
+        file (Windows Notepad .txt, PowerShell `>` redirects) arrives
+        mangled with U+FFFD and trips the binary guard. Probe the raw bytes
+        via the backend's Python and transcode to UTF-8 when a BOM or the
+        zero-byte parity heuristic identifies UTF-16.
+        """
+        utf16_result = self._try_read_utf16(path, offset, limit, file_size)
+        if utf16_result is not None:
+            return utf16_result
+        return ReadResult(
+            is_binary=True,
+            file_size=file_size,
+            error=describe_binary_file(sample_bytes, file_size),
+        )
+
+    def _read_file_sequential(self, path: str, offset: int, limit: int) -> ReadResult:
+        """One-probe-per-call read: the pre-compound form, kept as fallback.
+
+        ``read_file`` lands here for image / known-binary extensions (only
+        the probes matter) and whenever the compound reply cannot be parsed.
+        ``path`` is already expanded and ``offset``/``limit`` normalized.
+        """
         # Check if file exists and get size (POSIX, works on Linux + macOS)
         stat_result = self._exec(self._size_probe_cmd(path))
 
         if stat_result.exit_code != 0:
-            # File not found. Before failing, try unicode-equivalent
-            # spellings — NFC/NFD, narrow no-break space, curly quotes
-            # render identically in a terminal, so the model retyping a
-            # visually-correct path can never discover the byte mismatch
-            # on its own (retrying is the tool's job, not the model's).
-            variant = self._unicode_variant_match(path)
-            if variant is not None:
-                result = self.read_file(variant, offset=offset, limit=limit)
-                note = (
-                    f"Note: '{path}' not found byte-for-byte; resolved to "
-                    f"the unicode-equivalent file '{variant}' (invisible "
-                    "encoding difference: NFC/NFD or special space/quote "
-                    "characters)."
-                )
-                result.hint = f"{note} {result.hint}" if result.hint else note
-                return result
-            # No equivalent spelling — suggest similar files
-            return self._suggest_similar_files(path)
+            return self._read_file_missing(path, offset, limit)
 
         stat_output = _strip_terminal_fence_leaks(stat_result.stdout)
         if stat_output.strip() == NOT_REGULAR_SENTINEL:
@@ -1551,12 +1741,12 @@ class ShellFileOperations(FileOperations):
             file_size = int(stat_output.strip())
         except ValueError:
             file_size = 0
-        
+
         # Check if file is too large
         if file_size > MAX_FILE_SIZE:
             # Still try to read, but warn
             pass
-        
+
         # Images are never inlined — redirect to the vision tool
         if self._is_image(path):
             return ReadResult(
@@ -1568,7 +1758,7 @@ class ShellFileOperations(FileOperations):
                     "Use vision_analyze with this file path to inspect the image contents."
                 ),
             )
-        
+
         # Read a sample to check for binary content — at the byte layer when
         # the transport allows, falling back to the legacy text heuristic.
         sample_bytes = self._sample_file_bytes(path)
@@ -1582,22 +1772,8 @@ class ShellFileOperations(FileOperations):
             is_binary = self._is_likely_binary(path, sample_output)
 
         if is_binary:
-            # UTF-16 rescue (ported from MoonshotAI/kimi-code#2647): the
-            # terminal env decodes stdout as UTF-8 with errors="replace", so
-            # a UTF-16 text file (Windows Notepad .txt, PowerShell `>`
-            # redirects) arrives mangled with U+FFFD and trips the binary
-            # guard. Probe the raw bytes via the backend's Python and
-            # transcode to UTF-8 when a BOM or the zero-byte parity
-            # heuristic identifies UTF-16.
-            utf16_result = self._try_read_utf16(path, offset, limit, file_size)
-            if utf16_result is not None:
-                return utf16_result
-            return ReadResult(
-                is_binary=True,
-                file_size=file_size,
-                error=describe_binary_file(sample_bytes, file_size),
-            )
-        
+            return self._read_binary_file(path, offset, limit, file_size, sample_bytes)
+
         # Read with pagination using sed, clamping each line to a byte
         # budget IN THE SHELL so a pathological single-line file (e.g. one
         # 400MB minified line) never crosses the exec transport. The Python
@@ -1630,16 +1806,11 @@ class ShellFileOperations(FileOperations):
             f" | cut -b1-{line_clamp_bytes}"
         )
         read_result = self._exec(read_cmd)
-        
+
         if read_result.exit_code != 0:
             return ReadResult(error=f"Failed to read file: {read_result.stdout}")
         read_output = _strip_terminal_fence_leaks(read_result.stdout)
-        # Strip a leading UTF-8 BOM so the model never sees a phantom U+FEFF
-        # before the first real character. Only meaningful on the first
-        # chunk (the marker lives at byte 0); later pages can't carry it.
-        if offset == 1:
-            read_output, _ = _strip_bom(read_output)
-        
+
         # Get total line count
         wc_cmd = f"wc -l < {self._escape_shell_arg(path)}"
         wc_result = self._exec(wc_cmd)
@@ -1648,7 +1819,50 @@ class ShellFileOperations(FileOperations):
             total_lines = int(wc_output.strip())
         except ValueError:
             total_lines = 0
-        
+
+        # Only the page that reaches the file's final line can carry the
+        # ``cut`` newline artifact (see _assemble_read_result); probe the
+        # last byte just for that case, exactly as before.
+        file_ends_with_newline: Optional[bool] = None
+        if not total_lines > end_line and read_output.endswith('\n'):
+            tail_cmd = f"tail -c 1 {self._escape_shell_arg(path)} | wc -l"
+            tail_result = self._exec(tail_cmd)
+            tail_output = _strip_terminal_fence_leaks(tail_result.stdout)
+            if tail_result.exit_code == 0:
+                file_ends_with_newline = tail_output.strip() != "0"
+
+        return self._assemble_read_result(
+            read_output,
+            offset=offset,
+            end_line=end_line,
+            total_lines=total_lines,
+            file_size=file_size,
+            file_ends_with_newline=file_ends_with_newline,
+        )
+
+    def _assemble_read_result(
+        self,
+        read_output: str,
+        *,
+        offset: int,
+        end_line: int,
+        total_lines: int,
+        file_size: int,
+        file_ends_with_newline: Optional[bool],
+    ) -> ReadResult:
+        """Turn a raw ``sed | cut`` page into the final ``ReadResult``.
+
+        Shared by every read path so the BOM strip, pagination hint, the
+        ``cut`` newline artifact fix and the ambiguous-silence guards can
+        never drift apart. ``file_ends_with_newline`` is ``None`` when the
+        caller could not tell (the artifact is then left alone, as before).
+        """
+        # Strip a leading UTF-8 BOM so the model never sees a phantom U+FEFF
+        # before the first real character. Only meaningful on the first
+        # chunk (the marker lives at byte 0); later pages can't carry it.
+        if offset == 1:
+            read_output, _ = _strip_bom(read_output)
+
         # Check if truncated
         truncated = total_lines > end_line
         hint = None
@@ -1658,13 +1872,13 @@ class ShellFileOperations(FileOperations):
         # ``cut`` (unlike sed -n p) always newline-terminates its output,
         # so a file whose final line has no trailing newline would grow a
         # phantom empty last line. Only possible when this page reaches the
-        # file's final line; probe the last byte and strip the artifact.
-        if not truncated and read_output.endswith('\n'):
-            tail_cmd = f"tail -c 1 {self._escape_shell_arg(path)} | wc -l"
-            tail_result = self._exec(tail_cmd)
-            tail_output = _strip_terminal_fence_leaks(tail_result.stdout)
-            if tail_result.exit_code == 0 and tail_output.strip() == "0":
-                read_output = read_output[:-1]
+        # file's final line; strip the artifact when the last byte says so.
+        if (
+            not truncated
+            and read_output.endswith('\n')
+            and file_ends_with_newline is False
+        ):
+            read_output = read_output[:-1]
 
         # Ambiguous-silence guards: an empty content string is
         # indistinguishable, from inside the model, from a broken tool —

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1685,20 +1685,10 @@ class ShellFileOperations(FileOperations):
         flag = os.environ.get("HERMES_NATIVE_FILE_READ", "1").strip().lower()
         if flag in ("0", "false", "no", "off"):
             return False
-        cached = getattr(self, "_native_read_ok", None)
-        if cached is not None:
-            return cached
-        ok = False
-        if sys.platform != "win32":
-            env = getattr(self, "env", None)
-            if env is not None:
-                try:
-                    from tools.environments.local import LocalEnvironment
-                    ok = isinstance(env, LocalEnvironment)
-                except Exception:  # noqa: BLE001 - never let an import problem break a read
-                    ok = False
-        self._native_read_ok = ok
-        return ok
+        # Same "is this env the local host" test the LSP path already uses;
+        # ``self.env`` is bound once in __init__ and never rebound, and the
+        # isinstance check is microseconds, so there is nothing to memoize.
+        return sys.platform != "win32" and self._lsp_local_only()
 
     def _read_file_native(self, path: str, offset: int, limit: int) -> ReadResult:
         """``read_file`` without a shell: the file lives on this host.
@@ -1757,6 +1747,13 @@ class ShellFileOperations(FileOperations):
                     if not chunk:
                         break
                     last_byte = chunk[-1:]
+                    if lineno > end_line:
+                        # Past the requested window: only the line count and
+                        # trailing byte are still needed, so let memchr do the
+                        # rest instead of the per-line bookkeeping below.
+                        total_lines += chunk.count(b"\n")
+                        have_partial = chunk[-1:] != b"\n"
+                        continue
                     pos, n = 0, len(chunk)
                     while pos < n:
                         nl = chunk.find(b"\n", pos)

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -34,6 +34,7 @@ import sys
 import difflib
 import hashlib
 import json
+import logging
 import unicodedata
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -47,6 +48,8 @@ from agent.file_safety import (
     get_write_denied_error,
     is_write_denied as _shared_is_write_denied,
 )
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -1596,10 +1599,20 @@ class ShellFileOperations(FileOperations):
                 return self._read_file_missing(path, offset, limit)
             if marker == NOT_REGULAR_SENTINEL:
                 return self._not_regular_error(path)
+            logger.debug(
+                "read_file: compound probe reply for %s has no sentinel "
+                "(exit %s, %d chars); falling back to sequential probes",
+                path, probe.exit_code, len(output),
+            )
             return self._read_file_sequential(path, offset, limit)
 
         segments = _split_segments(output, sentinel)
         if probe.exit_code != 0 or len(segments) != 6:
+            logger.debug(
+                "read_file: compound probe for %s returned exit %s with %d "
+                "segments (want 6); falling back to sequential probes",
+                path, probe.exit_code, len(segments),
+            )
             return self._read_file_sequential(path, offset, limit)
         size_seg, sample_seg, page_seg, wc_seg, tail_seg, status_seg = segments
 
@@ -1607,6 +1620,11 @@ class ShellFileOperations(FileOperations):
         try:
             sample_rc, read_rc = int(status[0]), int(status[1])
         except (IndexError, ValueError):
+            logger.debug(
+                "read_file: compound probe for %s has unparseable status %r; "
+                "falling back to sequential probes",
+                path, status_seg[-40:],
+            )
             return self._read_file_sequential(path, offset, limit)
 
         try:
@@ -1621,6 +1639,11 @@ class ShellFileOperations(FileOperations):
         if sample_bytes is not None:
             is_binary = self._is_likely_binary_bytes(sample_bytes)
         else:
+            logger.debug(
+                "read_file: no usable base64 sample for %s (base64 exit %s); "
+                "paying one extra round-trip for the text heuristic",
+                path, sample_rc,
+            )
             sample_cmd = f"head -c 1000 {self._escape_shell_arg(path)} 2>/dev/null"
             sample_result = self._exec(sample_cmd)
             sample_output = _strip_terminal_fence_leaks(sample_result.stdout)
@@ -2354,16 +2377,31 @@ class ShellFileOperations(FileOperations):
             if _strip_terminal_fence_leaks(output).strip() == MISSING_SENTINEL:
                 ending = _detect_line_ending(pre_content) if pre_content else None
                 return False, pre_content, ending
+            logger.debug(
+                "write_file: pre-write probe reply for %s has no sentinel "
+                "(exit %s, %d chars); falling back to sequential probes",
+                path, probe.exit_code, len(output),
+            )
             return self._probe_write_target_sequential(path, pre_content, want_pre)
 
         segments = _split_segments(output, sentinel)
         if probe.exit_code != 0 or len(segments) != 2:
+            logger.debug(
+                "write_file: pre-write probe for %s returned exit %s with %d "
+                "segments (want 2); falling back to sequential probes",
+                path, probe.exit_code, len(segments),
+            )
             return self._probe_write_target_sequential(path, pre_content, want_pre)
         head_seg, body = segments
 
         head_bytes = self._decode_base64_sample(head_seg)
         if head_bytes is None:
             # No clean base64 on this shell; ask the way we used to.
+            logger.debug(
+                "write_file: no usable base64 head for %s; paying one extra "
+                "round-trip for the BOM probe",
+                path,
+            )
             has_bom = self._file_has_bom(path, pre_content)
         else:
             has_bom = head_bytes.startswith(_UTF8_BOM.encode("utf-8"))


### PR DESCRIPTION
## Summary
`read_file` now costs one shell round-trip instead of four or five, and `write_file` three instead of four, with identical results — including on files whose content contains the probe's own marker strings.

Salvaged from #95160 by @yaojiejia (five commits cherry-picked, authorship preserved) onto current `main`, plus an AUTHOR_MAP chore and one test fix from review.

## Who hits this / when / why it matters
Every `read_file`/`write_file` call the agent makes goes through `ShellFileOperations`, which used to issue a separate shell command per probe (size, byte sample, page, line count, tail). Each exec is a subprocess spawn locally and a network round-trip on Docker/SSH/Modal backends, so a single page read was 4–5 round-trips and the agent's most frequent tool paid it every time.

## What changed (`tools/file_operations.py`)
- Read path: size + sample + page + `wc -l` + tail probes become one compound command whose segments are separated by a per-call random 128-bit sentinel line; missing / not-regular are reported in-band. Underscores keep the sentinel outside the base64 alphabet, and any parse failure falls back to the old per-probe sequence.
- Write path: line-ending probe, BOM probe, atomic write and sha256 verify collapse into one round-trip; the pre-existing CRLF/BOM-preserving guarantees are kept.
- Native fast path (`HERMES_NATIVE_FILE_READ`, local POSIX `LocalEnvironment` only): no shell at all, with a 27-shape parity suite pinning native ≡ shell output including 1 MiB chunk boundaries.
- Follow-up (mine, /simplify-code): once the native read is past the requested window it counts the remaining lines with `bytes.count` instead of per-line Python bookkeeping (page 1 of a 3 M-line / 123 MB file: 448 ms → 49 ms; native ≡ shell across a 20-shape parity harness); `_native_read_enabled` reuses the class's existing `_lsp_local_only()` gate instead of a second `LocalEnvironment` check memoised on `self`.
- Follow-up (mine): `test_unicode_variant_retry_still_works` relied on NFC/NFD spellings being distinct files, which APFS aliases — the retry path never ran on macOS and the test crashed on `None`. It now uses a curly-vs-ASCII apostrophe, which no filesystem aliases.

## Benchmark
Real `LocalEnvironment` shell (`HERMES_NATIVE_FILE_READ=0`), execs counted with a spy on `execute`; macOS arm64 (Apple M3), medians of 7. Script: `bench/s3_fileops.py` in my triage workspace.

| operation | before (main) | after |
|---|---|---|
| `read_file` 2 MB, page 1 | 4 execs / 128 ms | **1 exec / 82 ms** |
| `read_file` 2 MB, mid-file page | 4 execs / 166 ms | **1 exec / 79 ms** |
| `read_file` small file | 5 execs / 210 ms | **1 exec / 52 ms** |
| `write_file` 6 KB overwrite | 4 execs / 209 ms | **3 execs / 175 ms** |

What actually improved: the probe round-trips are gone — a read is one exec — so the saving grows with per-exec cost (remote backends), while output is byte-identical.

## Verification
- E2E matrix against a real shell, content compared with `main`: missing file, directory, `/dev/null`, empty, CRLF, BOM, binary, no trailing newline, 2 MB, **and a file whose content contains the literal sentinel strings** — identical in every case.
- `tests/tools/test_file_operations*.py`, `test_file_ops_single_roundtrip.py`, `test_read_unicode_filename_retry.py`: 195 passed, 6 skipped (macOS; the 2 `test_file_tools.py` failures are pre-existing on `main`, `/tmp` vs `/private/tmp`); ruff clean.
- Deep review (parse fallback, write atomicity + hash, CRLF/BOM, native-path gate, chunk-boundary scan): no further findings.

## Provenance
Salvaged from #95160 by @yaojiejia — cherry-picked with authorship preserved; `chore: map contributor email` and the test fix are mine. #90043 (@DenisCDev, read path to 2 execs) was closed with credit as a strict subset.

## Review responses (from #95160)
- **@Enough1122 (AI review: sentinel collision, base64 alphabet, fallback):** the sentinel is 128-bit random per call with an underscore prefix that cannot occur in base64 output; a reply with the wrong segment count falls back to the old per-probe path (`test_unparseable_reply_falls_back`); a file whose *content* contains the literal sentinel strings reads identically to `main` (E2E above). @yaojiejia's reply on the original already covered the rest and matches what I verified.
- **`HERMES_NATIVE_FILE_READ`:** a kill-switch for a transparent fast path (default on), not user-facing behavioural config — kept as an env var per the precedent for debug/kill-switch flags; not documented as a setting. Happy to move it to `config.yaml` if the maintainers prefer.
- **Known trade-off (not changed):** on the *shell* path an extension-less content-binary now pays one full `sed` + `wc -l` pass before the sample flags it binary (the native path returns early after the sample). Parity holds; flagged for the maintainer rather than adding a second round-trip.
