### PR TITLE
fix(cli): finish the dashboard profiles router off-loop sweep (salvage #84376)

### DIFF
--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -913,15 +913,23 @@ async def get_active_profile_endpoint():
     the running dashboard/gateway is scoped to (derived from HERMES_HOME).
     """
     from hermes_cli import profiles as profiles_mod
-    try:
-        active = profiles_mod.get_active_profile() or "default"
-    except Exception:
-        active = "default"
-    try:
-        current = profiles_mod.get_active_profile_name() or "default"
-    except Exception:
-        current = "default"
-    return {"active": active, "current": current}
+
+    def _run():
+        # Both reads touch the filesystem: get_active_profile() reads the
+        # active_profile state file and get_active_profile_name() resolves
+        # HERMES_HOME against the profiles root. Batched into one hop so the
+        # sidebar's polling costs a single executor round-trip, not two.
+        try:
+            active = profiles_mod.get_active_profile() or "default"
+        except Exception:
+            active = "default"
+        try:
+            current = profiles_mod.get_active_profile_name() or "default"
+        except Exception:
+            current = "default"
+        return {"active": active, "current": current}
+
+    return await asyncio.get_running_loop().run_in_executor(None, _run)
 
 
 @router.post("/api/profiles/active")
@@ -932,8 +940,14 @@ async def set_active_profile_endpoint(body: ProfileActiveUpdate):
     it changes which profile subsequent CLI commands and gateways use.
     """
     from hermes_cli import profiles as profiles_mod
+
+    def _run():
+        return profiles_mod.set_active_profile(body.name)
+
     try:
-        profiles_mod.set_active_profile(body.name)
+        # set_active_profile() stats the target profile, creates the state
+        # directory and writes active_profile through a temp file + replace.
+        await asyncio.get_running_loop().run_in_executor(None, _run)
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except ValueError as e:
@@ -1006,8 +1020,16 @@ async def open_profile_terminal_endpoint(name: str):
 @router.patch("/api/profiles/{name}")
 async def rename_profile_endpoint(name: str, body: ProfileRename):
     from hermes_cli import profiles as profiles_mod
+
+    def _run():
+        return profiles_mod.rename_profile(name, body.new_name)
+
     try:
-        path = profiles_mod.rename_profile(name, body.new_name)
+        # rename_profile() stops a running gateway through the same 10-second
+        # _stop_gateway_process() poll that delete does, then renames the
+        # profile directory, rewrites the Honcho host blocks and regenerates
+        # the wrapper script.
+        path = await asyncio.get_running_loop().run_in_executor(None, _run)
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except (ValueError, FileExistsError) as e:

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -84,6 +84,12 @@ _strip_session_list_rows = late("_strip_session_list_rows")
 _write_profile_mcp_servers = late("_write_profile_mcp_servers")
 _write_profile_model = late("_write_profile_model")
 
+# Returned by the offloaded file readers below to mean "the file is not there",
+# which a plain ``None`` cannot express: ``desktop.json`` may legitimately hold
+# the document ``null``, and that is an existing-but-empty overlay rather than
+# an absent one.
+_MISSING = object()
+
 
 # Bounded cache lifetime for the expensive sidebar scan. Short enough that the
 # UI never shows meaningfully stale data, long enough to coalesce the desktop's
@@ -1089,18 +1095,28 @@ async def delete_profile_endpoint(name: str):
 @router.get("/api/profiles/{name}/soul")
 async def get_profile_soul(name: str):
     soul_path = _resolve_profile_dir(name) / "SOUL.md"
-    if soul_path.exists():
-        try:
-            return {"content": soul_path.read_text(encoding="utf-8"), "exists": True}
-        except OSError as e:
-            raise HTTPException(status_code=500, detail=f"Could not read SOUL.md: {e}")
-    return {"content": "", "exists": False}
+
+    def _run():
+        # Probe and read in the same hop: two round-trips would also widen the
+        # window between the existence check and the read.
+        if not soul_path.exists():
+            return _MISSING
+        return soul_path.read_text(encoding="utf-8")
+
+    try:
+        content = await asyncio.get_running_loop().run_in_executor(None, _run)
+    except OSError as e:
+        raise HTTPException(status_code=500, detail=f"Could not read SOUL.md: {e}")
+    if content is _MISSING:
+        return {"content": "", "exists": False}
+    return {"content": content, "exists": True}
 
 
 @router.put("/api/profiles/{name}/soul")
 async def update_profile_soul(name: str, body: ProfileSoulUpdate):
     soul_path = _resolve_profile_dir(name) / "SOUL.md"
-    try:
+
+    def _run():
         from utils import atomic_write_text
 
         # PUT replaces the whole persona document from the dashboard editor.
@@ -1120,6 +1136,12 @@ async def update_profile_soul(name: str, body: ProfileSoulUpdate):
         atomic_write_text(
             soul_path, body.content, preserve_mode=True, create_mode=0o644
         )
+
+    try:
+        # atomic_write_text() writes a temp file, fsyncs it and replaces the
+        # original — three syscalls that block for as long as the filesystem
+        # takes to durably commit the persona document.
+        await asyncio.get_running_loop().run_in_executor(None, _run)
     except OSError as e:
         _log.exception("PUT /api/profiles/%s/soul failed", name)
         raise HTTPException(status_code=500, detail=f"Could not write SOUL.md: {e}")
@@ -1137,12 +1159,18 @@ async def update_profile_description_endpoint(name: str, body: ProfileDescriptio
     from hermes_cli import profiles as profiles_mod
     profile_dir = _resolve_profile_dir(name)
     text = (body.description or "").strip()
-    try:
+
+    def _run():
         profiles_mod.write_profile_meta(
             profile_dir,
             description=text,
             description_auto=False,
         )
+
+    try:
+        # write_profile_meta() reads profile.yaml, merges the new keys and
+        # writes the document back out.
+        await asyncio.get_running_loop().run_in_executor(None, _run)
     except Exception as e:
         _log.exception("PUT /api/profiles/%s/description failed", name)
         raise HTTPException(status_code=500, detail=str(e))
@@ -1299,10 +1327,19 @@ async def get_profile_desktop_overlay(name: str):
     """The desktop appearance/interface overlay bundled with an imported
     profile (``desktop.json`` at the profile root), or ``exists: false``."""
     overlay_path = _resolve_profile_dir(name) / "desktop.json"
-    if not overlay_path.is_file():
-        return {"exists": False, "desktop": None}
-    try:
+
+    def _run():
+        if not overlay_path.is_file():
+            return _MISSING
         import json as _json
-        return {"exists": True, "desktop": _json.loads(overlay_path.read_text(encoding="utf-8"))}
+        return _json.loads(overlay_path.read_text(encoding="utf-8"))
+
+    try:
+        overlay = await asyncio.get_running_loop().run_in_executor(None, _run)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Could not read desktop.json: {e}")
+    # _MISSING rather than None: an overlay file holding the document ``null``
+    # exists, and must not be reported as absent.
+    if overlay is _MISSING:
+        return {"exists": False, "desktop": None}
+    return {"exists": True, "desktop": overlay}

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -12,7 +12,6 @@ late-binding seam in :mod:`hermes_cli.web_deps` so tests that
 ``monkeypatch.setattr(web_server, "_helper", ...)`` keep working.
 """
 
-import asyncio  # noqa: F401 — used by handlers
 import copy
 import functools
 import inspect
@@ -935,7 +934,7 @@ async def get_active_profile_endpoint():
             current = "default"
         return {"active": active, "current": current}
 
-    return await asyncio.get_running_loop().run_in_executor(None, _run)
+    return await run_in_threadpool(_run)
 
 
 @router.post("/api/profiles/active")
@@ -953,7 +952,7 @@ async def set_active_profile_endpoint(body: ProfileActiveUpdate):
     try:
         # set_active_profile() stats the target profile, creates the state
         # directory and writes active_profile through a temp file + replace.
-        await asyncio.get_running_loop().run_in_executor(None, _run)
+        await run_in_threadpool(_run)
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except ValueError as e:
@@ -1035,7 +1034,7 @@ async def rename_profile_endpoint(name: str, body: ProfileRename):
         # _stop_gateway_process() poll that delete does, then renames the
         # profile directory, rewrites the Honcho host blocks and regenerates
         # the wrapper script.
-        path = await asyncio.get_running_loop().run_in_executor(None, _run)
+        path = await run_in_threadpool(_run)
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except (ValueError, FileExistsError) as e:
@@ -1081,7 +1080,7 @@ async def delete_profile_endpoint(name: str):
         # gateway is up — which this path announces as "⚠ Gateway is running
         # — it will be stopped" — therefore parks the loop for a full ten
         # seconds, and the desktop's WebSocket ready-probe gives up at ten.
-        path = await asyncio.get_running_loop().run_in_executor(None, _run)
+        path = await run_in_threadpool(_run)
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except ValueError as e:
@@ -1104,7 +1103,7 @@ async def get_profile_soul(name: str):
         return soul_path.read_text(encoding="utf-8")
 
     try:
-        content = await asyncio.get_running_loop().run_in_executor(None, _run)
+        content = await run_in_threadpool(_run)
     except OSError as e:
         raise HTTPException(status_code=500, detail=f"Could not read SOUL.md: {e}")
     if content is _MISSING:
@@ -1141,7 +1140,7 @@ async def update_profile_soul(name: str, body: ProfileSoulUpdate):
         # atomic_write_text() writes a temp file, fsyncs it and replaces the
         # original — three syscalls that block for as long as the filesystem
         # takes to durably commit the persona document.
-        await asyncio.get_running_loop().run_in_executor(None, _run)
+        await run_in_threadpool(_run)
     except OSError as e:
         _log.exception("PUT /api/profiles/%s/soul failed", name)
         raise HTTPException(status_code=500, detail=f"Could not write SOUL.md: {e}")
@@ -1170,7 +1169,7 @@ async def update_profile_description_endpoint(name: str, body: ProfileDescriptio
     try:
         # write_profile_meta() reads profile.yaml, merges the new keys and
         # writes the document back out.
-        await asyncio.get_running_loop().run_in_executor(None, _run)
+        await run_in_threadpool(_run)
     except Exception as e:
         _log.exception("PUT /api/profiles/%s/description failed", name)
         raise HTTPException(status_code=500, detail=str(e))
@@ -1190,7 +1189,8 @@ async def update_profile_model_endpoint(name: str, body: ProfileModelUpdate):
     if not provider or not model:
         raise HTTPException(status_code=400, detail="provider and model are required")
     try:
-        _write_profile_model(profile_dir, provider, model)
+        # _write_profile_model() reads and rewrites the profile's config.yaml.
+        await run_in_threadpool(_write_profile_model, profile_dir, provider, model)
     except Exception as e:
         _log.exception("PUT /api/profiles/%s/model failed", name)
         raise HTTPException(status_code=500, detail=str(e))
@@ -1221,7 +1221,7 @@ async def describe_profile_auto_endpoint(name: str, body: ProfileDescribeAuto):
         # call_llm() — a synchronous provider round-trip with a 60 s ceiling,
         # six times the desktop's WebSocket disconnect threshold. Held on the
         # loop it stalls every other dashboard request for that whole window.
-        outcome = await asyncio.get_running_loop().run_in_executor(None, _run)
+        outcome = await run_in_threadpool(_run)
     except Exception as e:
         _log.exception("POST /api/profiles/%s/describe-auto failed", name)
         raise HTTPException(status_code=500, detail=str(e))
@@ -1256,11 +1256,9 @@ async def export_profile_endpoint(name: str, body: ProfileExport):
         except OSError as exc:
             raise HTTPException(status_code=500, detail=f"Could not create export directory: {exc}")
 
-    loop = asyncio.get_running_loop()
     try:
-        result = await loop.run_in_executor(
-            None,
-            lambda: profiles_mod.export_profile(name, output, extra_files=body.extra_files or None),
+        result = await run_in_threadpool(
+            profiles_mod.export_profile, name, output, extra_files=body.extra_files or None
         )
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
@@ -1280,11 +1278,9 @@ async def import_profile_endpoint(body: ProfileImport):
     if not archive:
         raise HTTPException(status_code=400, detail="archive path is required")
 
-    loop = asyncio.get_running_loop()
     try:
-        profile_dir = await loop.run_in_executor(
-            None,
-            lambda: profiles_mod.import_profile(archive, name=(body.name or "").strip() or None),
+        profile_dir = await run_in_threadpool(
+            profiles_mod.import_profile, archive, name=(body.name or "").strip() or None
         )
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
@@ -1335,7 +1331,7 @@ async def get_profile_desktop_overlay(name: str):
         return _json.loads(overlay_path.read_text(encoding="utf-8"))
 
     try:
-        overlay = await asyncio.get_running_loop().run_in_executor(None, _run)
+        overlay = await run_in_threadpool(_run)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Could not read desktop.json: {e}")
     # _MISSING rather than None: an overlay file holding the document ``null``

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -1157,10 +1157,21 @@ async def describe_profile_auto_endpoint(name: str, body: ProfileDescribeAuto):
     ``ok: false`` with a reason rather than an HTTP error so the UI can
     surface it inline and let the operator fix config and retry.
     """
+    # Resolution stays on the loop: it is a name check plus one stat, and it
+    # owns the 400/404 mapping that the ``except Exception`` below would
+    # otherwise flatten into a 500.
     _resolve_profile_dir(name)
-    try:
+
+    def _run():
         from hermes_cli import profile_describer
-        outcome = profile_describer.describe_profile(name, overwrite=bool(body.overwrite))
+        return profile_describer.describe_profile(name, overwrite=bool(body.overwrite))
+
+    try:
+        # describe_profile() is a plain def that reaches auxiliary_client's
+        # call_llm() — a synchronous provider round-trip with a 60 s ceiling,
+        # six times the desktop's WebSocket disconnect threshold. Held on the
+        # loop it stalls every other dashboard request for that whole window.
+        outcome = await asyncio.get_running_loop().run_in_executor(None, _run)
     except Exception as e:
         _log.exception("POST /api/profiles/%s/describe-auto failed", name)
         raise HTTPException(status_code=500, detail=str(e))

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -1042,8 +1042,18 @@ async def delete_profile_endpoint(name: str):
     its own dialog before this request, so we always pass ``yes=True`` to
     skip the CLI's interactive prompt."""
     from hermes_cli import profiles as profiles_mod
+
+    def _run():
+        return profiles_mod.delete_profile(name, yes=True)
+
     try:
-        path = profiles_mod.delete_profile(name, yes=True)
+        # delete_profile() stops a running gateway by polling its PID once
+        # every 500 ms for up to 10 s (profiles._stop_gateway_process) and
+        # then rmtree()s the profile directory. Deleting a profile whose
+        # gateway is up — which this path announces as "⚠ Gateway is running
+        # — it will be stopped" — therefore parks the loop for a full ten
+        # seconds, and the desktop's WebSocket ready-probe gives up at ten.
+        path = await asyncio.get_running_loop().run_in_executor(None, _run)
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except ValueError as e:

--- a/tests/hermes_cli/test_web_profile_soul_writes.py
+++ b/tests/hermes_cli/test_web_profile_soul_writes.py
@@ -12,6 +12,7 @@ small and focused on this one endpoint pair.
 
 from __future__ import annotations
 
+import asyncio
 import os
 import stat
 import sys
@@ -33,7 +34,11 @@ def client(tmp_path, monkeypatch):
     from hermes_cli import web_server
 
     with TestClient(web_server.app, raise_server_exceptions=False) as c:
-        c.headers["Authorization"] = "Bearer soul-test-token"
+        # web_server resolves _SESSION_TOKEN once, at import. Read it back from
+        # the module instead of assuming the env var above won the race — any
+        # test file that imports web_server earlier in the session fixes the
+        # token before this fixture runs.
+        c.headers["Authorization"] = f"Bearer {web_server._SESSION_TOKEN}"
         yield c
 
 
@@ -129,3 +134,81 @@ class TestSoulWriteDurability:
         assert r.status_code == 200, r.text
         mode = stat.S_IMODE(soul.stat().st_mode)
         assert mode == 0o644, f"first save created SOUL.md as {oct(mode)}"
+
+
+class TestSoulIoIsOffTheEventLoop:
+    """Neither half of the persona editor may run its I/O on the ASGI loop.
+
+    The durability the tests above buy comes from ``atomic_write_text``, which
+    fsyncs before replacing — so the save blocks for as long as the filesystem
+    takes to commit. These handlers sit in the same router as the profile
+    delete and describe-auto paths; the rest of that sweep is covered by
+    ``tests/hermes_cli/test_web_profiles_off_loop.py``.
+    """
+
+    @staticmethod
+    def _probe(seen, tag):
+        """Record whether the caller's thread is running an event loop."""
+        try:
+            asyncio.get_running_loop()
+            seen.append((tag, True))
+        except RuntimeError:
+            seen.append((tag, False))
+
+    def test_get_soul_reads_off_loop(self, client, profile_dir: Path, monkeypatch):
+        (profile_dir / "SOUL.md").write_text(SOUL, encoding="utf-8")
+        seen: list[tuple[str, bool]] = []
+        real_read_text = Path.read_text
+
+        def probing_read_text(self, *args, **kwargs):
+            if self.name == "SOUL.md":
+                TestSoulIoIsOffTheEventLoop._probe(seen, "read")
+            return real_read_text(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", probing_read_text)
+
+        r = client.get("/api/profiles/demo/soul")
+
+        assert r.status_code == 200, r.text
+        assert r.json()["content"] == SOUL
+        assert ("read", False) in seen, (
+            f"SOUL.md must be read off the event loop; proof: {seen}"
+        )
+
+    def test_put_soul_writes_off_loop(self, client, profile_dir: Path, monkeypatch):
+        seen: list[tuple[str, bool]] = []
+        import utils
+
+        real_write = utils.atomic_write_text
+
+        def probing_write(*args, **kwargs):
+            TestSoulIoIsOffTheEventLoop._probe(seen, "write")
+            return real_write(*args, **kwargs)
+
+        monkeypatch.setattr(utils, "atomic_write_text", probing_write)
+
+        r = client.put("/api/profiles/demo/soul", json={"content": SOUL})
+
+        assert r.status_code == 200, r.text
+        assert (profile_dir / "SOUL.md").read_text(encoding="utf-8") == SOUL
+        assert ("write", False) in seen, (
+            f"SOUL.md must be written off the event loop; proof: {seen}"
+        )
+
+    def test_missing_soul_is_still_reported_absent(self, client, profile_dir: Path):
+        """The offloaded reader must keep distinguishing "no file" from
+        "empty file" — the whole point of the durability tests above."""
+        assert not (profile_dir / "SOUL.md").exists()
+
+        r = client.get("/api/profiles/demo/soul")
+
+        assert r.status_code == 200, r.text
+        assert r.json() == {"content": "", "exists": False}
+
+    def test_empty_soul_is_still_reported_present(self, client, profile_dir: Path):
+        (profile_dir / "SOUL.md").write_text("", encoding="utf-8")
+
+        r = client.get("/api/profiles/demo/soul")
+
+        assert r.status_code == 200, r.text
+        assert r.json() == {"content": "", "exists": True}

--- a/tests/hermes_cli/test_web_profiles_off_loop.py
+++ b/tests/hermes_cli/test_web_profiles_off_loop.py
@@ -400,3 +400,23 @@ def test_describe_auto_unknown_profile_is_still_404(client):
     assert (
         client.post("/api/profiles/nope/describe-auto", json={}).status_code == 404
     )
+
+
+# ── PUT /api/profiles/{name}/model — config.yaml read-modify-write ───────────
+
+
+def test_update_profile_model_runs_off_loop(client, monkeypatch, loop_probe):
+    seen, probe = loop_probe
+    from hermes_cli.web_routers import profiles as router_mod
+
+    def fake_write_model(profile_dir, provider, model):
+        probe("write_profile_model")
+
+    monkeypatch.setattr(router_mod, "_write_profile_model", fake_write_model)
+
+    resp = client.put(
+        "/api/profiles/demo/model", json={"provider": "openrouter", "model": "x/y"}
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert_off_loop(seen, "write_profile_model")

--- a/tests/hermes_cli/test_web_profiles_off_loop.py
+++ b/tests/hermes_cli/test_web_profiles_off_loop.py
@@ -1,0 +1,402 @@
+"""Regression tests: ``/api/profiles`` handlers must not block the event loop.
+
+``hermes_cli/web_routers/profiles.py`` holds handler bodies that were extracted
+verbatim from ``web_server.py``, so the blocking library calls they inherited
+run inline on the ASGI event loop. The worst of them are unbounded from the
+dashboard's point of view: deleting a profile whose gateway is up sleeps up to
+10 s in ``profiles._stop_gateway_process``, and ``describe-auto`` makes a
+provider round-trip with a 60 s ceiling. While the loop is parked, the process
+serves nothing else — including the ``/api/ws`` probes the desktop app and the
+dashboard's own Chat tab depend on.
+
+Two complementary assertions per site:
+
+* a **loop probe** — the stubbed callee records whether an event loop is
+  running in its own thread, mirroring
+  ``tests/hermes_cli/test_cron_dashboard_off_loop.py``; and
+* a **concurrency proof** — the stubbed callee blocks on a ``threading.Event``
+  while an unrelated request is timed, which fails if the loop is parked.
+
+The block is bounded by a timeout so a regression costs the suite a few
+seconds rather than hanging it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient  # noqa: E402
+
+# How long a stubbed blocking call holds its thread when nobody releases it.
+BLOCK_SECONDS = 5.0
+# A concurrently-served request has to land well inside that window. The gap is
+# large (a served request takes milliseconds) so the bound is not timing-fragile.
+CONCURRENT_BUDGET = BLOCK_SECONDS / 2
+
+
+@pytest.fixture()
+def profile_dir(tmp_path, monkeypatch) -> Path:
+    """A real profile directory under a throwaway HERMES_HOME."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from hermes_cli import profiles as profiles_mod
+
+    d = profiles_mod.get_profile_dir("demo")
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+@pytest.fixture()
+def client(profile_dir):
+    """One ``TestClient`` context == one portal == one event loop.
+
+    This matters: entering the context manager pins a single blocking portal
+    for every request, so a handler that parks the loop really does starve the
+    concurrent request below. A bare ``TestClient(app)`` spins up a fresh loop
+    per request and would pass these tests even unfixed.
+    """
+    from hermes_cli import web_server
+
+    with TestClient(web_server.app, raise_server_exceptions=False) as c:
+        # web_server resolves _SESSION_TOKEN once, at import, so read it back
+        # from the module rather than pinning a value from this file.
+        c.headers["Authorization"] = f"Bearer {web_server._SESSION_TOKEN}"
+        yield c
+
+
+@pytest.fixture()
+def loop_probe():
+    """Collect ``(tag, on_loop)`` proof from stubbed blocking callees."""
+    seen: list[tuple[str, bool]] = []
+
+    def probe(tag: str) -> None:
+        try:
+            asyncio.get_running_loop()
+            seen.append((tag, True))
+        except RuntimeError:
+            seen.append((tag, False))
+
+    return seen, probe
+
+
+def assert_off_loop(seen, tag: str) -> None:
+    assert (tag, False) in seen, (
+        f"{tag} must run off the event loop; proof: {seen}"
+    )
+
+
+class _Blocker:
+    """A stand-in for a slow library call, released by the test."""
+
+    def __init__(self, result=None):
+        self.entered = threading.Event()
+        self.release = threading.Event()
+        self._result = result
+
+    def __call__(self, *args, **kwargs):
+        self.entered.set()
+        # Bounded on purpose: a regression must not hang the suite.
+        self.release.wait(timeout=BLOCK_SECONDS)
+        return self._result
+
+
+def assert_serves_concurrently(client, blocker: _Blocker, fire) -> None:
+    """Fire a request that blocks inside its handler, then time another one.
+
+    ``fire`` issues the blocking request from a worker thread. Once the stub
+    has been entered, an unrelated cheap route is timed on this thread: it can
+    only answer quickly if the blocking work left the event loop.
+    """
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        blocked = pool.submit(fire)
+        try:
+            assert blocker.entered.wait(timeout=BLOCK_SECONDS), (
+                "the blocking stub was never reached"
+            )
+            start = time.monotonic()
+            probe = client.get("/api/profiles/demo/setup-command")
+            elapsed = time.monotonic() - start
+        finally:
+            blocker.release.set()
+        blocked.result(timeout=BLOCK_SECONDS * 2)
+
+    assert probe.status_code == 200, probe.text
+    assert elapsed < CONCURRENT_BUDGET, (
+        f"a concurrent request waited {elapsed:.2f}s while the handler was "
+        f"busy — the event loop was parked by the blocking call"
+    )
+
+
+# ── DELETE /api/profiles/{name} — the 10 s gateway-stop sleep ────────────────
+
+
+def test_delete_profile_runs_off_loop(client, monkeypatch, loop_probe, tmp_path):
+    seen, probe = loop_probe
+    from hermes_cli import profiles as profiles_mod
+
+    def fake_delete(name, yes=False):
+        probe("delete_profile")
+        return tmp_path / "profiles" / name
+
+    monkeypatch.setattr(profiles_mod, "delete_profile", fake_delete)
+
+    resp = client.delete("/api/profiles/demo")
+
+    assert resp.status_code == 200, resp.text
+    assert_off_loop(seen, "delete_profile")
+
+
+def test_delete_profile_does_not_block_the_dashboard(client, monkeypatch, tmp_path):
+    """``delete_profile`` stops a running gateway by polling for up to 10 s.
+
+    That is longer than the desktop's WebSocket ready-probe tolerates, so it
+    must not hold the loop.
+    """
+    from hermes_cli import profiles as profiles_mod
+
+    blocker = _Blocker(result=tmp_path / "profiles" / "demo")
+    monkeypatch.setattr(profiles_mod, "delete_profile", blocker)
+
+    assert_serves_concurrently(
+        client, blocker, lambda: client.delete("/api/profiles/demo")
+    )
+
+
+# ── POST /api/profiles/{name}/describe-auto — the 60 s LLM round-trip ────────
+
+
+def _outcome(ok=True, reason="described", description="a demo profile"):
+    from hermes_cli.profile_describer import DescribeOutcome
+
+    return DescribeOutcome("demo", ok, reason, description=description)
+
+
+def test_describe_auto_runs_off_loop(client, monkeypatch, loop_probe):
+    seen, probe = loop_probe
+    from hermes_cli import profile_describer
+
+    def fake_describe(name, overwrite=False, timeout=None):
+        probe("describe_profile")
+        return _outcome()
+
+    monkeypatch.setattr(profile_describer, "describe_profile", fake_describe)
+
+    resp = client.post("/api/profiles/demo/describe-auto", json={"overwrite": True})
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["ok"] is True
+    assert_off_loop(seen, "describe_profile")
+
+
+def test_describe_auto_does_not_block_the_dashboard(client, monkeypatch):
+    """The auxiliary provider call has a 60 s ceiling — six times the
+    desktop's disconnect threshold."""
+    from hermes_cli import profile_describer
+
+    blocker = _Blocker(result=_outcome())
+    monkeypatch.setattr(profile_describer, "describe_profile", blocker)
+
+    assert_serves_concurrently(
+        client,
+        blocker,
+        lambda: client.post(
+            "/api/profiles/demo/describe-auto", json={"overwrite": True}
+        ),
+    )
+
+
+# ── PATCH /api/profiles/{name} — rename walks and rewrites the profile tree ──
+
+
+def test_rename_profile_runs_off_loop(client, monkeypatch, loop_probe, tmp_path):
+    seen, probe = loop_probe
+    from hermes_cli import profiles as profiles_mod
+
+    def fake_rename(old, new):
+        probe("rename_profile")
+        return tmp_path / "profiles" / new
+
+    monkeypatch.setattr(profiles_mod, "rename_profile", fake_rename)
+
+    resp = client.patch("/api/profiles/demo", json={"new_name": "renamed"})
+
+    assert resp.status_code == 200, resp.text
+    assert_off_loop(seen, "rename_profile")
+
+
+def test_rename_profile_does_not_block_the_dashboard(client, monkeypatch, tmp_path):
+    from hermes_cli import profiles as profiles_mod
+
+    blocker = _Blocker(result=tmp_path / "profiles" / "renamed")
+    monkeypatch.setattr(profiles_mod, "rename_profile", blocker)
+
+    assert_serves_concurrently(
+        client,
+        blocker,
+        lambda: client.patch("/api/profiles/demo", json={"new_name": "renamed"}),
+    )
+
+
+# ── /api/profiles/active — sticky active-profile state file ──────────────────
+
+
+def test_get_active_profile_runs_off_loop(client, monkeypatch, loop_probe):
+    seen, probe = loop_probe
+    from hermes_cli import profiles as profiles_mod
+
+    def fake_get_active():
+        probe("get_active_profile")
+        return "demo"
+
+    def fake_get_current():
+        probe("get_active_profile_name")
+        return "default"
+
+    monkeypatch.setattr(profiles_mod, "get_active_profile", fake_get_active)
+    monkeypatch.setattr(profiles_mod, "get_active_profile_name", fake_get_current)
+
+    resp = client.get("/api/profiles/active")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"active": "demo", "current": "default"}
+    assert_off_loop(seen, "get_active_profile")
+    assert_off_loop(seen, "get_active_profile_name")
+
+
+def test_set_active_profile_runs_off_loop(client, monkeypatch, loop_probe):
+    seen, probe = loop_probe
+    from hermes_cli import profiles as profiles_mod
+
+    def fake_set_active(name):
+        probe("set_active_profile")
+
+    monkeypatch.setattr(profiles_mod, "set_active_profile", fake_set_active)
+
+    resp = client.post("/api/profiles/active", json={"name": "demo"})
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["active"] == "demo"
+    assert_off_loop(seen, "set_active_profile")
+
+
+# ── PUT /api/profiles/{name}/description — profile.yaml read/modify/write ────
+
+
+def test_update_description_runs_off_loop(client, monkeypatch, loop_probe):
+    seen, probe = loop_probe
+    from hermes_cli import profiles as profiles_mod
+
+    def fake_write_meta(profile_dir, **kwargs):
+        probe("write_profile_meta")
+
+    monkeypatch.setattr(profiles_mod, "write_profile_meta", fake_write_meta)
+
+    resp = client.put(
+        "/api/profiles/demo/description", json={"description": "a demo profile"}
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["description_auto"] is False
+    assert_off_loop(seen, "write_profile_meta")
+
+
+# ── GET /api/profiles/{name}/desktop-overlay — reads desktop.json ────────────
+
+
+def test_desktop_overlay_read_runs_off_loop(client, monkeypatch, loop_probe, profile_dir):
+    seen, probe = loop_probe
+    (profile_dir / "desktop.json").write_text('{"theme": "dark"}', encoding="utf-8")
+
+    real_read_text = Path.read_text
+
+    def probing_read_text(self, *args, **kwargs):
+        if self.name == "desktop.json":
+            probe("desktop.json read")
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", probing_read_text)
+
+    resp = client.get("/api/profiles/demo/desktop-overlay")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"exists": True, "desktop": {"theme": "dark"}}
+    assert_off_loop(seen, "desktop.json read")
+
+
+def test_desktop_overlay_absent_still_reports_missing(client):
+    """The offloaded read must keep distinguishing "no file" from "no data"."""
+    resp = client.get("/api/profiles/demo/desktop-overlay")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"exists": False, "desktop": None}
+
+
+def test_desktop_overlay_null_document_still_reports_present(client, profile_dir):
+    """A ``desktop.json`` holding literal ``null`` exists, it is just empty —
+    it must not be reported the same as a missing file."""
+    (profile_dir / "desktop.json").write_text("null", encoding="utf-8")
+
+    resp = client.get("/api/profiles/demo/desktop-overlay")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"exists": True, "desktop": None}
+
+
+def test_desktop_overlay_unreadable_document_is_a_500(client, profile_dir):
+    """A malformed overlay still surfaces as a 500, not a silent success."""
+    (profile_dir / "desktop.json").write_text("{not json", encoding="utf-8")
+
+    resp = client.get("/api/profiles/demo/desktop-overlay")
+
+    assert resp.status_code == 500, resp.text
+
+
+# ── Status-code mapping must survive the move into a worker thread ───────────
+
+
+def test_delete_missing_profile_is_still_404(client, monkeypatch):
+    from hermes_cli import profiles as profiles_mod
+
+    def fake_delete(name, yes=False):
+        raise FileNotFoundError(f"Profile '{name}' does not exist.")
+
+    monkeypatch.setattr(profiles_mod, "delete_profile", fake_delete)
+
+    assert client.delete("/api/profiles/demo").status_code == 404
+
+
+def test_rename_to_existing_profile_is_still_400(client, monkeypatch):
+    from hermes_cli import profiles as profiles_mod
+
+    def fake_rename(old, new):
+        raise FileExistsError(f"Profile '{new}' already exists.")
+
+    monkeypatch.setattr(profiles_mod, "rename_profile", fake_rename)
+
+    resp = client.patch("/api/profiles/demo", json={"new_name": "taken"})
+    assert resp.status_code == 400, resp.text
+
+
+def test_set_active_missing_profile_is_still_404(client, monkeypatch):
+    from hermes_cli import profiles as profiles_mod
+
+    def fake_set_active(name):
+        raise FileNotFoundError(f"Profile '{name}' does not exist.")
+
+    monkeypatch.setattr(profiles_mod, "set_active_profile", fake_set_active)
+
+    assert client.post("/api/profiles/active", json={"name": "demo"}).status_code == 404
+
+
+def test_describe_auto_unknown_profile_is_still_404(client):
+    """``_resolve_profile_dir`` still runs before the worker hop, so an
+    unknown profile is a 404 rather than a 500 from the wrapped call."""
+    assert (
+        client.post("/api/profiles/nope/describe-auto", json={}).status_code == 404
+    )


### PR DESCRIPTION
## Summary
The five profile endpoints in the dashboard's Profiles router that still did disk I/O or a 60 s LLM call on the event loop now run that work on a worker thread, so deleting/renaming a profile (which polls a gateway shutdown for up to 10 s) no longer freezes every other dashboard request.

Salvaged from #84376 by @briandevans (5 commits cherry-picked, authorship preserved) + one follow-up commit.

## Who hits this / when
Anyone using the desktop app or `hermes dashboard`. Deleting or renaming a profile whose gateway is running parks the FastAPI loop for the full 10 s gateway-stop poll; `describe-auto` parks it for the LLM round-trip (60 s ceiling). During that window the desktop's WebSocket ready-probe (10 s) gives up and the sidebar goes dead.

## Before / after
Before (`origin/main` 1cb3ab6173), `hermes_cli/web_routers/profiles.py`:
```python
path = profiles_mod.delete_profile(name, yes=True)      # blocks loop ≤10 s
active = profiles_mod.get_active_profile() or "default" # sync file read
return {"content": soul_path.read_text(encoding="utf-8"), "exists": True}
```
After:
```python
path = await run_in_threadpool(_run)   # _run wraps the same call
```
Endpoints covered: active-profile GET/POST, rename, delete, soul GET/PUT, description PUT, describe-auto, desktop overlay GET, and (follow-up) model PUT.

## Follow-up commit (ours)
- The PR used `asyncio.get_running_loop().run_in_executor(None, _run)`; the module already binds `run_in_threadpool` (used at `list_profiles_endpoint`) and every sibling router uses it — switched the 9 new sites to the same idiom. Behaviour-identical.
- `update_profile_model_endpoint` was the one remaining sync writer (`_write_profile_model` rewrites config.yaml) — offloaded + test.

## Benchmark
Max event-loop gap while `GET /api/profiles/active` runs with a 200 ms blocking read (5 ms asyncio ticker alongside; 5 runs, median; macOS arm64, same worktree):

| | main 1cb3ab6173 | this branch |
|---|---|---|
| max loop gap | 207.6 ms | 6.4 ms |

Script: `~/triage-perf-p2/bench/offloop_stall.py 84376` (patches `get_active_profile` to `time.sleep(0.2)`, measures ticker gaps).

What actually improved: the event loop is no longer frozen for the duration of profile disk/LLM work; concurrent dashboard requests keep being served.

## Validation
- `tests/hermes_cli/test_web_profiles_off_loop.py` + `test_web_profile_soul_writes.py`: 27 passed (new off-loop test for model PUT included).
- No hunk overlap with #78420 (touches `get_profiles_sessions` only).
- Review notes addressed: run_in_threadpool convention (Enough1122 #1 — per-profile mutation lock declined: the CLI already allows concurrent `hermes profile` commands, and the desktop serializes profile ops in its UI; noted, not changed).

Closes #84376
