### PR TITLE
fix(server): credential-pool handlers off the event loop + bounded Copilot exchange (salvage #91912)

### DIFF
--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -381,6 +381,20 @@ _JWT_DISK_MAX_BYTES = 1_048_576  # 1 MiB cap on the persisted JWT store read
 # Maps raw-token fingerprint -> epoch until which exchange attempts are
 # skipped (raise immediately). Success clears the entry.
 _exchange_failure_cache: dict[str, float] = {}
+# Single-flight guard per token fingerprint: concurrent callers (the dashboard
+# polls /api/credentials/pool every few seconds, each poll off-loop) wait on
+# the ONE in-flight exchange and then hit the positive/negative cache, instead
+# of each spawning their own hung resolver thread during a DNS outage.
+_exchange_locks: dict[str, threading.Lock] = {}
+_exchange_locks_guard = threading.Lock()
+
+
+def _exchange_lock_for(fp: str) -> threading.Lock:
+    with _exchange_locks_guard:
+        lock = _exchange_locks.get(fp)
+        if lock is None:
+            lock = _exchange_locks[fp] = threading.Lock()
+        return lock
 _EXCHANGE_FAILURE_TTL_TRANSIENT_SECONDS = 60.0     # network blips: retry soon
 _EXCHANGE_FAILURE_TTL_PERMANENT_SECONDS = 1800.0   # 401/403/404: won't heal
 # HTTP statuses that indicate the token itself is rejected — retrying with
@@ -539,12 +553,23 @@ def _urlopen_bounded(req, timeout: float):
     import urllib.request
 
     box: dict = {}
+    abandoned = threading.Event()
 
     def _worker() -> None:
         try:
-            box["resp"] = urllib.request.urlopen(req, timeout=timeout)
+            resp = urllib.request.urlopen(req, timeout=timeout)
         except BaseException as exc:  # re-raised on the caller's thread
             box["exc"] = exc
+            return
+        if abandoned.is_set():
+            # The caller already timed out; nobody will read this response,
+            # so release its socket instead of leaking it with the thread.
+            try:
+                resp.close()
+            except Exception:
+                pass
+            return
+        box["resp"] = resp
 
     t = threading.Thread(
         target=_worker, name="copilot-token-exchange", daemon=True
@@ -552,6 +577,7 @@ def _urlopen_bounded(req, timeout: float):
     t.start()
     t.join(timeout + _DNS_GRACE_SECONDS)
     if t.is_alive():
+        abandoned.set()
         raise TimeoutError(
             "copilot token exchange exceeded hard cap of "
             f"{timeout + _DNS_GRACE_SECONDS:.0f}s (DNS/getaddrinfo hang?)"
@@ -579,11 +605,24 @@ def exchange_copilot_token(raw_token: str, *, timeout: float = 10.0) -> tuple[st
     Results are cached in-process and reused until close to expiry.
     Raises ``ValueError`` on failure.
     """
-    import urllib.request
-
     fp = _token_fingerprint(raw_token)
 
-    # Check in-process cache first
+    # Fast path outside the lock: a valid in-process JWT needs no exchange.
+    cached = _jwt_cache.get(fp)
+    if cached and time.time() < cached[1] - _JWT_REFRESH_MARGIN_SECONDS:
+        return cached
+
+    with _exchange_lock_for(fp):
+        return _exchange_copilot_token_locked(raw_token, fp, timeout=timeout)
+
+
+def _exchange_copilot_token_locked(
+    raw_token: str, fp: str, *, timeout: float
+) -> tuple[str, float, Optional[str]]:
+    import urllib.request
+
+    # Re-check the caches under the lock: a concurrent caller may have just
+    # completed (or just failed) the exchange we were queued behind.
     cached = _jwt_cache.get(fp)
     if cached:
         api_token, expires_at, base_url = cached

--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -23,6 +23,7 @@ import logging
 import os
 import shutil
 import subprocess
+import threading
 import time
 from pathlib import Path
 from typing import Optional
@@ -520,6 +521,48 @@ def _save_jwt_to_disk(
         logger.debug("Failed to persist Copilot JWT: %s", exc)
 
 
+# Hard wall-clock cap for the token-exchange HTTP call. urllib's ``timeout``
+# only bounds socket operations AFTER DNS resolution succeeds; getaddrinfo
+# blocks in C and ignores it entirely, so on a networkless Windows host the
+# resolver can hang for many minutes (observed: a 17-minute event-loop stall
+# on 2026-08-22 that took the whole backend down with it).
+_DNS_GRACE_SECONDS = 5.0
+
+
+def _urlopen_bounded(req, timeout: float):
+    """urlopen() with a hard wall-clock cap of timeout + _DNS_GRACE_SECONDS.
+
+    Runs the call on a daemon thread and abandons it if the cap fires, so a
+    DNS/getaddrinfo hang cannot block the caller indefinitely. Raises the
+    worker's exception, or TimeoutError when the cap fires.
+    """
+    import urllib.request
+
+    box: dict = {}
+
+    def _worker() -> None:
+        try:
+            box["resp"] = urllib.request.urlopen(req, timeout=timeout)
+        except BaseException as exc:  # re-raised on the caller's thread
+            box["exc"] = exc
+
+    t = threading.Thread(
+        target=_worker, name="copilot-token-exchange", daemon=True
+    )
+    t.start()
+    t.join(timeout + _DNS_GRACE_SECONDS)
+    if t.is_alive():
+        raise TimeoutError(
+            "copilot token exchange exceeded hard cap of "
+            f"{timeout + _DNS_GRACE_SECONDS:.0f}s (DNS/getaddrinfo hang?)"
+        )
+    if "exc" in box:
+        raise box["exc"]
+    if "resp" not in box:
+        raise TimeoutError("copilot token exchange worker died without result")
+    return box["resp"]
+
+
 def exchange_copilot_token(raw_token: str, *, timeout: float = 10.0) -> tuple[str, float, Optional[str]]:
     """Exchange a raw GitHub token for a short-lived Copilot API token.
 
@@ -593,7 +636,7 @@ def exchange_copilot_token(raw_token: str, *, timeout: float = 10.0) -> tuple[st
     permanent_failure = False
     for attempt in range(_EXCHANGE_MAX_ATTEMPTS):
         try:
-            with urllib.request.urlopen(req, timeout=timeout) as resp:
+            with _urlopen_bounded(req, timeout) as resp:
                 data = json.loads(resp.read().decode())
             break
         except Exception as exc:  # noqa: BLE001 — retry all, re-raise below

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14386,26 +14386,35 @@ async def list_credential_pool():
     from agent.credential_pool import load_pool
     from hermes_cli.auth import read_credential_pool
 
-    providers = []
-    # read_credential_pool(None) lists every provider that has pooled entries;
-    # load_pool() then gives us the rich PooledCredential objects per provider.
-    raw_pool = read_credential_pool()
-    for provider_id in sorted(raw_pool.keys()):
-        try:
-            pool = load_pool(provider_id)
-        except Exception:
-            _log.exception("load_pool(%s) failed", provider_id)
-            continue
-        entries = pool.entries()
-        if not entries:
-            continue
-        providers.append({
-            "provider": provider_id,
-            "entries": [
-                _pool_entry_summary(e, i) for i, e in enumerate(entries, start=1)
-            ],
-        })
-    return {"providers": providers}
+    # load_pool() may hit the network synchronously (Copilot token exchange
+    # over raw urllib). urllib's timeout does NOT bound DNS resolution
+    # (getaddrinfo blocks in C), so on a networkless Windows host this froze
+    # the uvicorn event loop for 17 minutes (2026-08-22 00:03-00:20 stall).
+    # Keep every provider load off the loop - same pattern as
+    # get_memory_status below.
+    def _run():
+        providers = []
+        # read_credential_pool(None) lists every provider that has pooled entries;
+        # load_pool() then gives us the rich PooledCredential objects per provider.
+        raw_pool = read_credential_pool()
+        for provider_id in sorted(raw_pool.keys()):
+            try:
+                pool = load_pool(provider_id)
+            except Exception:
+                _log.exception("load_pool(%s) failed", provider_id)
+                continue
+            entries = pool.entries()
+            if not entries:
+                continue
+            providers.append({
+                "provider": provider_id,
+                "entries": [
+                    _pool_entry_summary(e, i) for i, e in enumerate(entries, start=1)
+                ],
+            })
+        return {"providers": providers}
+
+    return await asyncio.to_thread(_run)
 
 
 @app.post("/api/credentials/pool")
@@ -14424,40 +14433,46 @@ async def add_credential_pool_entry(body: CredentialPoolAdd):
     if not provider or not api_key:
         raise HTTPException(status_code=400, detail="provider and api_key are required")
 
-    try:
-        pool = load_pool(provider)
-        label = (body.label or "").strip() or f"key #{len(pool.entries()) + 1}"
-        entry = PooledCredential(
-            provider=provider,
-            id=_uuid.uuid4().hex[:6],
-            label=label,
-            auth_type=AUTH_TYPE_API_KEY,
-            priority=0,
-            source=SOURCE_MANUAL,
-            access_token=api_key,
-        )
-        pool.add_entry(entry)
-        # Re-adding a credential is an explicit re-engagement signal: lift
-        # every suppression for this provider so a source deleted earlier
-        # (via DELETE below or `hermes auth remove`) can seed again.
-        # Mirrors the `hermes auth add` behaviour in auth_commands.py.
-        if not provider.startswith(CUSTOM_POOL_PREFIX):
-            try:
-                from hermes_cli.auth import (
-                    _load_auth_store,
-                    unsuppress_credential_source,
-                )
-                suppressed = _load_auth_store().get("suppressed_sources", {})
-                for src in list(suppressed.get(provider, []) or []):
-                    unsuppress_credential_source(provider, src)
-            except Exception:
-                _log.exception("unsuppress after pool add failed (non-fatal)")
-    except HTTPException:
-        raise
-    except Exception as exc:
-        _log.exception("POST /api/credentials/pool failed")
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-    return {"ok": True, "provider": provider, "count": len(pool.entries())}
+    # load_pool() may run synchronous OAuth token exchanges (network I/O);
+    # keep it off the event loop - see list_credential_pool (2026-08-22
+    # 17-minute stall fix).
+    def _run():
+        try:
+            pool = load_pool(provider)
+            label = (body.label or "").strip() or f"key #{len(pool.entries()) + 1}"
+            entry = PooledCredential(
+                provider=provider,
+                id=_uuid.uuid4().hex[:6],
+                label=label,
+                auth_type=AUTH_TYPE_API_KEY,
+                priority=0,
+                source=SOURCE_MANUAL,
+                access_token=api_key,
+            )
+            pool.add_entry(entry)
+            # Re-adding a credential is an explicit re-engagement signal: lift
+            # every suppression for this provider so a source deleted earlier
+            # (via DELETE below or `hermes auth add`) can seed again.
+            # Mirrors the `hermes auth add` behaviour in auth_commands.py.
+            if not provider.startswith(CUSTOM_POOL_PREFIX):
+                try:
+                    from hermes_cli.auth import (
+                        _load_auth_store,
+                        unsuppress_credential_source,
+                    )
+                    suppressed = _load_auth_store().get("suppressed_sources", {})
+                    for src in list(suppressed.get(provider, []) or []):
+                        unsuppress_credential_source(provider, src)
+                except Exception:
+                    _log.exception("unsuppress after pool add failed (non-fatal)")
+            return {"ok": True, "provider": provider, "count": len(pool.entries())}
+        except HTTPException:
+            raise
+        except Exception as exc:
+            _log.exception("POST /api/credentials/pool failed")
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return await asyncio.to_thread(_run)
 
 
 @app.delete("/api/credentials/pool/{provider}/{index}")
@@ -14478,44 +14493,50 @@ async def remove_credential_pool_entry(provider: str, index: int):
     from hermes_cli.auth import suppress_credential_source
 
     provider = (provider or "").strip().lower()
-    try:
-        pool = load_pool(provider)
-        removed = pool.remove_index(index)
-    except Exception as exc:
-        _log.exception("DELETE /api/credentials/pool failed")
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-    if removed is None:
-        raise HTTPException(status_code=404, detail="No pool entry at that index")
-
-    cleaned: List[str] = []
-    hints: List[str] = []
-    step = find_removal_step(provider, removed.source or "")
-    if step is not None:
+    # load_pool() may run synchronous token exchanges and the removal steps do
+    # blocking disk writes - keep them off the event loop (see
+    # list_credential_pool; 2026-08-22 17-minute stall fix).
+    def _run():
         try:
-            result = step.remove_fn(provider, removed)
-            cleaned = list(result.cleaned)
-            hints = list(result.hints)
-            if result.suppress:
-                suppress_credential_source(provider, removed.source)
-        except Exception:
-            # Cleanup is best-effort, but suppression is the actual bug fix —
-            # without it the entry resurrects on the next load_pool().  Apply
-            # it even when source-specific cleanup blew up.
-            _log.exception(
-                "credential source cleanup failed for %s/%s; suppressing anyway",
-                provider, removed.source,
-            )
+            pool = load_pool(provider)
+            removed = pool.remove_index(index)
+        except Exception as exc:
+            _log.exception("DELETE /api/credentials/pool failed")
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        if removed is None:
+            raise HTTPException(status_code=404, detail="No pool entry at that index")
+
+        cleaned: List[str] = []
+        hints: List[str] = []
+        step = find_removal_step(provider, removed.source or "")
+        if step is not None:
             try:
-                suppress_credential_source(provider, removed.source)
+                result = step.remove_fn(provider, removed)
+                cleaned = list(result.cleaned)
+                hints = list(result.hints)
+                if result.suppress:
+                    suppress_credential_source(provider, removed.source)
             except Exception:
-                _log.exception("suppress_credential_source failed")
-    return {
-        "ok": True,
-        "provider": provider,
-        "count": len(pool.entries()),
-        "cleaned": cleaned,
-        "hints": hints,
-    }
+                # Cleanup is best-effort, but suppression is the actual bug fix -
+                # without it the entry resurrects on the next load_pool(). Apply
+                # it even when source-specific cleanup blew up.
+                _log.exception(
+                    "credential source cleanup failed for %s/%s; suppressing anyway",
+                    provider, removed.source,
+                )
+                try:
+                    suppress_credential_source(provider, removed.source)
+                except Exception:
+                    _log.exception("suppress_credential_source failed")
+        return {
+            "ok": True,
+            "provider": provider,
+            "count": len(pool.entries()),
+            "cleaned": cleaned,
+            "hints": hints,
+        }
+
+    return await asyncio.to_thread(_run)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_credential_pool_off_loop.py
+++ b/tests/hermes_cli/test_credential_pool_off_loop.py
@@ -1,0 +1,209 @@
+"""Regression tests for the #91912 salvage — credential-pool handlers off-loop
+and the bounded Copilot token exchange.
+
+The 2026-08-22 incident: ``GET /api/credentials/pool`` ran ``load_pool()`` on
+the uvicorn event loop; for the copilot provider that reaches
+``urllib.request.urlopen`` whose ``timeout`` does not bound ``getaddrinfo``,
+so a networkless host froze the whole dashboard backend for 17 minutes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import copilot_auth
+
+
+# ---------------------------------------------------------------------------
+# _urlopen_bounded
+# ---------------------------------------------------------------------------
+
+
+class TestUrlopenBounded:
+    def test_returns_response_when_worker_completes(self):
+        sentinel = object()
+        with patch("urllib.request.urlopen", return_value=sentinel):
+            assert copilot_auth._urlopen_bounded("req", 1.0) is sentinel
+
+    def test_reraises_worker_exception(self):
+        with patch("urllib.request.urlopen", side_effect=OSError("boom")):
+            with pytest.raises(OSError, match="boom"):
+                copilot_auth._urlopen_bounded("req", 1.0)
+
+    def test_hard_cap_fires_on_hung_resolver_and_closes_late_response(self, monkeypatch):
+        """A urlopen that hangs past timeout + grace must raise TimeoutError
+        promptly, and when the abandoned worker later *succeeds* it must close
+        the response instead of leaking the socket."""
+        monkeypatch.setattr(copilot_auth, "_DNS_GRACE_SECONDS", 0.05)
+        release = threading.Event()
+        closed = threading.Event()
+
+        class _LateResponse:
+            def close(self):
+                closed.set()
+
+        def hung_urlopen(req, timeout):
+            release.wait(timeout=5)
+            return _LateResponse()
+
+        with patch("urllib.request.urlopen", side_effect=hung_urlopen):
+            started = time.monotonic()
+            with pytest.raises(TimeoutError, match="hard cap"):
+                copilot_auth._urlopen_bounded("req", 0.05)
+            elapsed = time.monotonic() - started
+            assert elapsed < 2.0
+            release.set()
+            assert closed.wait(timeout=2), "late response was not closed"
+
+
+# ---------------------------------------------------------------------------
+# single-flight exchange
+# ---------------------------------------------------------------------------
+
+
+class TestExchangeSingleFlight:
+    @pytest.fixture(autouse=True)
+    def _clean_caches(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        copilot_auth._jwt_cache.clear()
+        copilot_auth._exchange_failure_cache.clear()
+        copilot_auth._exchange_locks.clear()
+        yield
+        copilot_auth._jwt_cache.clear()
+        copilot_auth._exchange_failure_cache.clear()
+        copilot_auth._exchange_locks.clear()
+
+    def test_concurrent_callers_share_one_exchange(self, monkeypatch):
+        """N concurrent callers for the same token must perform ONE network
+        exchange; the rest wait on the lock and hit the populated cache."""
+        monkeypatch.setattr(copilot_auth, "_load_jwt_from_disk", lambda fp: None)
+        monkeypatch.setattr(copilot_auth, "_save_jwt_to_disk", lambda *a, **k: None)
+        calls = []
+        gate = threading.Event()
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def read(self):
+                return b'{"token": "tid=1;exp=9", "expires_at": 4102444800}'
+
+        def fake_bounded(req, timeout):
+            calls.append(threading.get_ident())
+            gate.wait(timeout=5)  # hold the first exchange open while others queue
+            return _Resp()
+
+        monkeypatch.setattr(copilot_auth, "_urlopen_bounded", fake_bounded)
+
+        results = []
+        threads = [
+            threading.Thread(target=lambda: results.append(copilot_auth.exchange_copilot_token("ghu_" + "x" * 30)))
+            for _ in range(8)
+        ]
+        for t in threads:
+            t.start()
+        time.sleep(0.2)  # let every caller reach the lock
+        assert len(calls) == 1
+        gate.set()
+        for t in threads:
+            t.join(timeout=5)
+
+        assert len(calls) == 1
+        assert len(results) == 8
+        assert {r[0] for r in results} == {"tid=1;exp=9"}
+
+    def test_waiters_observe_negative_cache_after_failed_exchange(self, monkeypatch):
+        """When the single in-flight exchange fails, queued callers must not
+        each start their own exchange — they see the negative cache."""
+        monkeypatch.setattr(copilot_auth, "_load_jwt_from_disk", lambda fp: None)
+        monkeypatch.setattr(copilot_auth, "_EXCHANGE_MAX_ATTEMPTS", 1)
+        calls = []
+        gate = threading.Event()
+
+        def fake_bounded(req, timeout):
+            calls.append(1)
+            gate.wait(timeout=5)
+            raise TimeoutError("hard cap")
+
+        monkeypatch.setattr(copilot_auth, "_urlopen_bounded", fake_bounded)
+        errors = []
+
+        def run():
+            try:
+                copilot_auth.exchange_copilot_token("ghu_" + "y" * 30)
+            except ValueError as exc:
+                errors.append(str(exc))
+
+        threads = [threading.Thread(target=run) for _ in range(5)]
+        for t in threads:
+            t.start()
+        time.sleep(0.2)
+        gate.set()
+        for t in threads:
+            t.join(timeout=5)
+
+        assert len(calls) == 1
+        assert len(errors) == 5
+        assert any("recently failed" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# web_server credential-pool handlers off the loop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_credential_pool_runs_off_event_loop(monkeypatch):
+    import hermes_cli.auth as auth_mod
+    from hermes_cli import web_server
+
+    loop_thread = threading.get_ident()
+    seen = {}
+
+    def fake_read_pool(*args, **kwargs):
+        seen["thread"] = threading.get_ident()
+        return {}
+
+    monkeypatch.setattr(auth_mod, "read_credential_pool", fake_read_pool)
+    result = await web_server.list_credential_pool()
+
+    assert result == {"providers": []}
+    assert seen["thread"] != loop_thread
+
+
+@pytest.mark.asyncio
+async def test_list_credential_pool_keeps_loop_responsive(monkeypatch):
+    """A 200 ms blocking pool read must not freeze a concurrent ticker."""
+    import hermes_cli.auth as auth_mod
+    from hermes_cli import web_server
+
+    def slow_read(*args, **kwargs):
+        time.sleep(0.2)
+        return {}
+
+    monkeypatch.setattr(auth_mod, "read_credential_pool", slow_read)
+
+    gaps = []
+    stop = asyncio.Event()
+
+    async def ticker():
+        last = time.perf_counter()
+        while not stop.is_set():
+            await asyncio.sleep(0.005)
+            now = time.perf_counter()
+            gaps.append(now - last)
+            last = now
+
+    t = asyncio.create_task(ticker())
+    await web_server.list_credential_pool()
+    stop.set()
+    await t
+    assert max(gaps) < 0.1, f"event loop stalled for {max(gaps) * 1000:.0f} ms"


### PR DESCRIPTION
## Summary
The three `/api/credentials/pool` dashboard handlers now run `load_pool()` on a worker thread, and the Copilot token exchange has a hard wall-clock cap — so a networkless host (where `getaddrinfo` hangs for minutes and urllib's `timeout` can't stop it) no longer freezes the whole dashboard backend. Observed incident: a 17-minute event-loop stall.

Salvaged from #91912 by @peetteerr (cherry-picked, authorship preserved) + one follow-up commit addressing the review.

## Who hits this / when
Copilot users with the dashboard/desktop open when the network drops (laptop lid, VPN flap, Wi-Fi handoff). The dashboard polls `/api/credentials/pool` every few seconds; each poll called `load_pool("copilot")` → `exchange_copilot_token` → `urllib.request.urlopen` synchronously on the uvicorn loop. `timeout=` only bounds socket ops after DNS resolves; a hung resolver blocks in C for as long as the OS allows.

Reachability on `origin/main` 1cb3ab6173: `web_server.py:14385 list_credential_pool` → `credential_pool.py:3312 get_copilot_api_token` → `copilot_auth.py:596 urlopen` — none of the three pool handlers were offloaded (main had ~70 `to_thread` sites elsewhere in the file; these were missed).

## Before / after
```python
# before — on the event loop
raw_pool = read_credential_pool()
pool = load_pool(provider_id)          # may block on DNS indefinitely
```
```python
# after
def _run(): ...same body...
return await asyncio.to_thread(_run)
```
`copilot_auth.py`: `urllib.request.urlopen(req, timeout=timeout)` → `_urlopen_bounded(req, timeout)` (worker thread joined with `timeout + 5 s` grace; raises `TimeoutError` on cap).

## Follow-up commit (ours) — addresses the review threads
- **Single-flight per token fingerprint** (andrexibiza / Enough1122 #2): concurrent pool polls now wait on the one in-flight exchange and hit the positive/negative cache instead of each spawning a hung resolver thread. Bounded outstanding workers: 1 per token.
- **Late-response close** (andrexibiza): if the abandoned worker's `urlopen` eventually succeeds, the `HTTPResponse` is closed rather than leaked.
- **Tests** (the PR shipped none): hard cap fires + late close; single-flight success and failure paths (N callers → 1 exchange); pool endpoint runs off-loop and keeps the loop responsive under a 200 ms blocking read. All mutation-checked (fail on the pre-fix code).
- Pool-mutation lost-update (Enough1122 #1) — pre-existing across CLI + dashboard (`hermes auth add` runs in another process anyway); not introduced here, out of scope.

Worst case per exchange is now bounded at 3 × (10 + 5) + 1.5 + 3 = 49.5 s before the 60 s negative cache engages, versus unbounded before.

## Benchmark
Max event-loop gap while `GET /api/credentials/pool` runs with a 200 ms blocking `read_credential_pool` (5 ms asyncio ticker alongside; 5 runs, median; macOS arm64, same worktree):

| | main 1cb3ab6173 | this branch |
|---|---|---|
| max loop gap | 207.2 ms | 6.3 ms |

Script: `~/triage-perf-p2/bench/offloop_stall.py 91912`.

What actually improved: a hung credential-pool load no longer blocks the dashboard loop, and a DNS outage produces one bounded exchange attempt instead of one hung thread per poll.

## Validation
`tests/hermes_cli/test_credential_pool_off_loop.py` (new, 7), `test_copilot_auth.py`, `test_dashboard_admin_endpoints.py`: 65 passed.

Closes #91912
