### PR TITLE
fix(gateway): offload adapter atomic_json_write persists, keep flushes ordered (salvage #84168)

### DIFF
--- a/contributors/emails/298902573+pierrenode@users.noreply.github.com
+++ b/contributors/emails/298902573+pierrenode@users.noreply.github.com
@@ -1,0 +1,2 @@
+pierrenode
+# PR #84168 salvage

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -302,6 +302,10 @@ class ContextTokenStore:
     def __init__(self, hermes_home: str):
         self._root = _account_dir(hermes_home)
         self._cache: Dict[str, str] = {}
+        # Serializes the offloaded flushes so two concurrent set() calls
+        # cannot land their writes out of order (last-writer-wins would drop
+        # the newer token from disk).
+        self._persist_lock = asyncio.Lock()
 
     def _path(self, account_id: str) -> Path:
         return self._root / f"{account_id}.context-tokens.json"
@@ -334,16 +338,22 @@ class ContextTokenStore:
         # atomic_json_write() calls os.fsync(), which blocks until the write
         # reaches stable storage. _process_message runs on the event loop for
         # every inbound message, so offload the flush the same way #83906 did
-        # for the other gateway persist paths.
-        await asyncio.to_thread(self._persist, account_id)
+        # for the other gateway persist paths. The payload is snapshotted here,
+        # on the loop, so the worker never iterates ``_cache`` while another
+        # message task mutates it; the lock keeps flushes in mutation order.
+        async with self._persist_lock:
+            payload = self._payload(account_id)
+            await asyncio.to_thread(self._persist, account_id, payload)
 
-    def _persist(self, account_id: str) -> None:
+    def _payload(self, account_id: str) -> Dict[str, str]:
         prefix = f"{account_id}:"
-        payload = {
+        return {
             key[len(prefix) :]: value
             for key, value in self._cache.items()
             if key.startswith(prefix)
         }
+
+    def _persist(self, account_id: str, payload: Dict[str, str]) -> None:
         try:
             atomic_json_write(self._path(account_id), payload)
         except Exception as exc:

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -329,9 +329,13 @@ class ContextTokenStore:
     def get(self, account_id: str, user_id: str) -> Optional[str]:
         return self._cache.get(self._key(account_id, user_id))
 
-    def set(self, account_id: str, user_id: str, token: str) -> None:
+    async def set(self, account_id: str, user_id: str, token: str) -> None:
         self._cache[self._key(account_id, user_id)] = token
-        self._persist(account_id)
+        # atomic_json_write() calls os.fsync(), which blocks until the write
+        # reaches stable storage. _process_message runs on the event loop for
+        # every inbound message, so offload the flush the same way #83906 did
+        # for the other gateway persist paths.
+        await asyncio.to_thread(self._persist, account_id)
 
     def _persist(self, account_id: str) -> None:
         prefix = f"{account_id}:"
@@ -1501,7 +1505,7 @@ class WeixinAdapter(BasePlatformAdapter):
 
         context_token = str(message.get("context_token") or "").strip()
         if context_token:
-            self._token_store.set(self._account_id, sender_id, context_token)
+            await self._token_store.set(self._account_id, sender_id, context_token)
         asyncio.create_task(self._maybe_fetch_typing_ticket(sender_id, context_token or None))
 
         media_paths: List[str] = []

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -414,7 +414,7 @@ class _DiscordNonConversationalMessageTracker:
         except Exception:
             logger.debug("[%s] Failed to save non-conversational Discord IDs", "Discord", exc_info=True)
 
-    def mark_many(self, message_ids: List[str]) -> None:
+    async def mark_many(self, message_ids: List[str]) -> None:
         changed = False
         for message_id in message_ids:
             key = str(message_id or "").strip()
@@ -422,7 +422,11 @@ class _DiscordNonConversationalMessageTracker:
                 self._ids[key] = None
                 changed = True
         if changed:
-            self._save()
+            # atomic_json_write() calls os.fsync(), which blocks until the
+            # write reaches stable storage. Both callers of mark_many() run
+            # on the event loop, so offload the flush the same way #83906
+            # did for the other gateway persist paths.
+            await asyncio.to_thread(self._save)
 
     def __contains__(self, message_id: str) -> bool:
         return str(message_id or "") in self._ids
@@ -3611,7 +3615,7 @@ class DiscordAdapter(BasePlatformAdapter):
             if message_ids:
                 _target_id = thread_id or chat_id
                 if nonconversational:
-                    self._nonconversational_messages.mark_many(message_ids)
+                    await self._nonconversational_messages.mark_many(message_ids)
                 elif not _looks_like_nonconversational_history_message(content):
                     self._last_self_message_id[_target_id] = message_ids[-1]
 
@@ -7872,7 +7876,7 @@ class DiscordAdapter(BasePlatformAdapter):
             msg = await channel.send(content=content, embed=embed, view=view)
             view._message = msg  # store for on_timeout expiration editing
             if _metadata_marks_nonconversational(metadata):
-                self._nonconversational_messages.mark_many([str(msg.id)])
+                await self._nonconversational_messages.mark_many([str(msg.id)])
             return SendResult(success=True, message_id=str(msg.id))
         except Exception as e:
             return SendResult(success=False, error=str(e))

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -382,6 +382,10 @@ class _DiscordNonConversationalMessageTracker:
     def __init__(self, max_tracked: int = _MAX_TRACKED):
         self._max_tracked = max_tracked
         self._ids: dict[str, None] = dict.fromkeys(self._load())
+        # Serializes the offloaded flushes so two concurrent mark_many() calls
+        # cannot land their writes out of order (last-writer-wins would drop
+        # the newer ids from disk).
+        self._persist_lock = asyncio.Lock()
 
     def _state_path(self) -> _Path:
         from hermes_constants import get_hermes_home
@@ -404,11 +408,15 @@ class _DiscordNonConversationalMessageTracker:
             logger.debug("[%s] Failed to load non-conversational Discord IDs", "Discord")
         return []
 
-    def _save(self) -> None:
+    def _snapshot(self) -> list[str]:
+        """Trim in-memory state and return the ids to persist (loop-side)."""
         ids = list(self._ids)
         if len(ids) > self._max_tracked:
             ids = ids[-self._max_tracked:]
             self._ids = dict.fromkeys(ids)
+        return ids
+
+    def _save(self, ids: list[str]) -> None:
         try:
             atomic_json_write(self._state_path(), ids, indent=None)
         except Exception:
@@ -425,8 +433,13 @@ class _DiscordNonConversationalMessageTracker:
             # atomic_json_write() calls os.fsync(), which blocks until the
             # write reaches stable storage. Both callers of mark_many() run
             # on the event loop, so offload the flush the same way #83906
-            # did for the other gateway persist paths.
-            await asyncio.to_thread(self._save)
+            # did for the other gateway persist paths. The snapshot (and the
+            # trim that reassigns ``_ids``) stays on the loop so the worker
+            # never touches the dict while another task mutates it; the lock
+            # keeps flushes in mutation order.
+            async with self._persist_lock:
+                ids = self._snapshot()
+                await asyncio.to_thread(self._save, ids)
 
     def __contains__(self, message_id: str) -> bool:
         return str(message_id or "") in self._ids

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -4768,9 +4768,17 @@ class FeishuAdapter(BasePlatformAdapter):
         # same way #83906 did for the other gateway persist paths. The lock
         # keeps flushes in mutation order (the snapshot inside the worker is
         # taken under _dedup_lock, but the write itself is not).
-        async with self._dedup_persist_lock:
+        async with self._dedup_persist_lock_or_create():
             await asyncio.to_thread(self._persist_seen_message_ids)
         return False
+
+    def _dedup_persist_lock_or_create(self) -> asyncio.Lock:
+        # Tests build bare adapters via object.__new__ and install dedup state
+        # by hand; create the lock lazily so those fixtures keep working.
+        lock = getattr(self, "_dedup_persist_lock", None)
+        if lock is None:
+            lock = self._dedup_persist_lock = asyncio.Lock()
+        return lock
 
     # =========================================================================
     # Outbound payload construction and send pipeline

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2740,7 +2740,7 @@ class FeishuAdapter(BasePlatformAdapter):
             return
 
         message_id = getattr(message, "message_id", None)
-        if not message_id or self._is_duplicate(message_id):
+        if not message_id or await self._is_duplicate(message_id):
             logger.debug("[Feishu] Dropping duplicate/missing message_id: %s", message_id)
             return
 
@@ -4738,14 +4738,15 @@ class FeishuAdapter(BasePlatformAdapter):
     def _persist_seen_message_ids(self) -> None:
         try:
             self._dedup_state_path.parent.mkdir(parents=True, exist_ok=True)
-            recent = self._seen_message_order[-self._dedup_cache_size:]
-            # Save as {msg_id: timestamp} so TTL filtering works across restarts.
-            payload = {"message_ids": {k: self._seen_message_ids[k] for k in recent if k in self._seen_message_ids}}
+            with self._dedup_lock:
+                recent = self._seen_message_order[-self._dedup_cache_size:]
+                # Save as {msg_id: timestamp} so TTL filtering works across restarts.
+                payload = {"message_ids": {k: self._seen_message_ids[k] for k in recent if k in self._seen_message_ids}}
             atomic_json_write(self._dedup_state_path, payload, indent=None)
         except OSError:
             logger.warning("[Feishu] Failed to persist dedup state to %s", self._dedup_state_path, exc_info=True)
 
-    def _is_duplicate(self, message_id: str) -> bool:
+    async def _is_duplicate(self, message_id: str) -> bool:
         now = time.time()
         ttl = _FEISHU_DEDUP_TTL_SECONDS
         with self._dedup_lock:
@@ -4758,8 +4759,12 @@ class FeishuAdapter(BasePlatformAdapter):
             while len(self._seen_message_order) > self._dedup_cache_size:
                 stale = self._seen_message_order.pop(0)
                 self._seen_message_ids.pop(stale, None)
-            self._persist_seen_message_ids()
-            return False
+        # atomic_json_write() calls os.fsync(), which blocks until the write
+        # reaches stable storage. _handle_message_event_data runs on the
+        # event loop for every inbound message, so offload the flush the
+        # same way #83906 did for the other gateway persist paths.
+        await asyncio.to_thread(self._persist_seen_message_ids)
+        return False
 
     # =========================================================================
     # Outbound payload construction and send pipeline

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1614,6 +1614,9 @@ class FeishuAdapter(BasePlatformAdapter):
         self._seen_message_order: List[str] = []
         self._dedup_state_path = get_hermes_home() / "feishu_seen_message_ids.json"
         self._dedup_lock = threading.Lock()
+        # Serializes the offloaded dedup-state flushes so two concurrent
+        # inbound messages cannot land their writes out of order.
+        self._dedup_persist_lock = asyncio.Lock()
         self._sender_name_cache: Dict[str, tuple[str, float]] = {}  # sender_id → (name, expire_at)
         self._webhook_rate_counts: Dict[str, tuple[int, float]] = {}  # rate_key → (count, window_start)
         self._webhook_anomaly_counts: Dict[str, tuple[int, str, float]] = {}  # ip → (count, last_status, first_seen)
@@ -4762,8 +4765,11 @@ class FeishuAdapter(BasePlatformAdapter):
         # atomic_json_write() calls os.fsync(), which blocks until the write
         # reaches stable storage. _handle_message_event_data runs on the
         # event loop for every inbound message, so offload the flush the
-        # same way #83906 did for the other gateway persist paths.
-        await asyncio.to_thread(self._persist_seen_message_ids)
+        # same way #83906 did for the other gateway persist paths. The lock
+        # keeps flushes in mutation order (the snapshot inside the worker is
+        # taken under _dedup_lock, but the write itself is not).
+        async with self._dedup_persist_lock:
+            await asyncio.to_thread(self._persist_seen_message_ids)
         return False
 
     # =========================================================================

--- a/plugins/platforms/feishu/feishu_meeting_invite.py
+++ b/plugins/platforms/feishu/feishu_meeting_invite.py
@@ -173,7 +173,7 @@ async def handle_meeting_invited_event(adapter: Any, data: Any) -> None:
 
     dedup_key = _dedup_key(payload)
     is_duplicate = getattr(adapter, "_is_duplicate", None)
-    if callable(is_duplicate) and is_duplicate(dedup_key):
+    if callable(is_duplicate) and await is_duplicate(dedup_key):
         logger.debug("[Feishu-MeetingInvite] Dropping duplicate event: %s", dedup_key)
         return
 

--- a/tests/gateway/feishu_helpers.py
+++ b/tests/gateway/feishu_helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import threading
 from types import SimpleNamespace
 from typing import Any, Optional
@@ -59,6 +60,7 @@ def install_dedup_state(adapter: Any, seen: Optional[dict] = None) -> None:
     adapter._seen_message_order = list((seen or {}).keys())
     adapter._dedup_cache_size = 100
     adapter._dedup_lock = threading.Lock()
+    adapter._dedup_persist_lock = asyncio.Lock()
     adapter._dedup_state_path = None
     adapter._persist_seen_message_ids = lambda: None
 

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -854,4 +854,31 @@ class TestNonConversationalTrackerOffload:
         assert write_threads
         assert all(tid != loop_thread for tid in write_threads)
 
+    @pytest.mark.asyncio
+    async def test_concurrent_mark_many_persists_land_in_order(self):
+        """Two in-flight mark_many() calls (send() racing a history fetch) must
+        not let an older snapshot overwrite a newer one on disk."""
+        import asyncio as _asyncio
+        import time
+
+        tracker = discord_platform._DiscordNonConversationalMessageTracker()
+        tracker._ids = {}
+        writes = []
+        calls = [0]
+
+        def slow_first_write(path, data, *args, **kwargs):
+            idx = calls[0]
+            calls[0] += 1
+            if idx == 0:
+                time.sleep(0.05)
+            writes.append(list(data))
+
+        with patch.object(discord_platform, "atomic_json_write", side_effect=slow_first_write):
+            first = _asyncio.create_task(tracker.mark_many(["1"]))
+            await _asyncio.sleep(0.005)
+            second = _asyncio.create_task(tracker.mark_many(["2"]))
+            await _asyncio.gather(first, second)
+
+        assert sorted(writes[-1]) == ["1", "2"]
+
 

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timezone
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 import sys
 
 import pytest
@@ -378,7 +378,7 @@ async def test_fetch_channel_context_skips_self_improvement_boundary_message(ada
         ],
         channel_id=123,
     )
-    adapter._nonconversational_messages.mark_many(["9"])
+    await adapter._nonconversational_messages.mark_many(["9"])
 
     result = await adapter._fetch_channel_context(channel, before=make_message(channel=channel, content="trigger"))
 
@@ -825,5 +825,33 @@ async def test_discord_reply_in_free_channel_triggers_backfill(adapter, monkeypa
     assert event.channel_context == (
         "[Context around the replied-to message]\n[Hermes [bot]] earlier answer"
     )
+
+
+class TestNonConversationalTrackerOffload:
+    """atomic_json_write() calls os.fsync(), which blocks until the write
+    reaches stable storage. mark_many() runs on the event loop from both
+    DiscordAdapter.send() and send_update_prompt(), so the persist step
+    must be offloaded to a thread — mirrors
+    test_directory_write_runs_off_event_loop_thread in
+    test_channel_directory.py for the same #83906 bug class.
+    """
+
+    @pytest.mark.asyncio
+    async def test_mark_many_persist_runs_off_event_loop_thread(self):
+        import threading
+
+        tracker = discord_platform._DiscordNonConversationalMessageTracker()
+        loop_thread = threading.get_ident()
+        write_threads = []
+
+        def fake_write(path, data, *args, **kwargs):
+            write_threads.append(threading.get_ident())
+
+        with patch.object(discord_platform, "atomic_json_write", side_effect=fake_write):
+            await tracker.mark_many(["999"])
+
+        assert "999" in tracker
+        assert write_threads
+        assert all(tid != loop_thread for tid in write_threads)
 
 

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1682,6 +1682,35 @@ class TestDedupTTL(unittest.TestCase):
         self.assertTrue(write_threads)
         self.assertTrue(all(tid != loop_thread for tid in write_threads))
 
+    @patch.dict(os.environ, {}, clear=True)
+    def test_concurrent_dedup_persists_land_in_order(self):
+        """Two in-flight _is_duplicate() calls (two chats) must not let an
+        older seen-ids snapshot overwrite a newer one on disk."""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        writes = []
+        calls = [0]
+
+        def slow_first_write(path, data, *args, **kwargs):
+            idx = calls[0]
+            calls[0] += 1
+            if idx == 0:
+                time.sleep(0.05)
+            writes.append(sorted(data["message_ids"]))
+
+        async def run():
+            first = asyncio.create_task(adapter._is_duplicate("om_a"))
+            await asyncio.sleep(0.005)
+            second = asyncio.create_task(adapter._is_duplicate("om_b"))
+            await asyncio.gather(first, second)
+
+        with patch("plugins.platforms.feishu.adapter.atomic_json_write", side_effect=slow_first_write):
+            asyncio.run(run())
+
+        self.assertEqual(writes[-1], ["om_a", "om_b"])
+
 
 class TestGroupMentionAtAll(unittest.TestCase):
     """Tests for @_all (Feishu @everyone) group mention routing."""

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1186,9 +1186,9 @@ class TestAdapterBehavior(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_home:
             with patch.dict(os.environ, {"HERMES_HOME": temp_home}, clear=False):
                 first = FeishuAdapter(PlatformConfig())
-                self.assertFalse(first._is_duplicate("om_same"))
+                self.assertFalse(asyncio.run(first._is_duplicate("om_same")))
                 second = FeishuAdapter(PlatformConfig())
-                self.assertTrue(second._is_duplicate("om_same"))
+                self.assertTrue(asyncio.run(second._is_duplicate("om_same")))
 
 
     @patch.dict(os.environ, {}, clear=True)
@@ -1622,7 +1622,7 @@ class TestDedupTTL(unittest.TestCase):
         with patch.object(adapter, "_persist_seen_message_ids"):
             adapter._seen_message_ids = {"om_dup": time.time()}
             adapter._seen_message_order = ["om_dup"]
-            self.assertTrue(adapter._is_duplicate("om_dup"))
+            self.assertTrue(asyncio.run(adapter._is_duplicate("om_dup")))
 
 
     @patch.dict(os.environ, {}, clear=True)
@@ -1655,6 +1655,32 @@ class TestDedupTTL(unittest.TestCase):
                 assert "om_good" in adapter._seen_message_ids
                 assert "om_bad_str" not in adapter._seen_message_ids
                 assert "om_bad_null" not in adapter._seen_message_ids
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_persist_on_new_message_runs_off_event_loop_thread(self):
+        """atomic_json_write() calls os.fsync(), which blocks until the write
+        reaches stable storage. _is_duplicate() runs on the event loop for
+        every inbound message (_handle_message_event_data), so the persist
+        step must be offloaded to a thread — mirrors
+        test_directory_write_runs_off_event_loop_thread in
+        test_channel_directory.py for the same #83906 bug class."""
+        import threading
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        loop_thread = threading.get_ident()
+        write_threads = []
+
+        def fake_write(path, data, *args, **kwargs):
+            write_threads.append(threading.get_ident())
+
+        with patch("plugins.platforms.feishu.adapter.atomic_json_write", side_effect=fake_write):
+            is_dup = asyncio.run(adapter._is_duplicate("om_new"))
+
+        self.assertFalse(is_dup)
+        self.assertTrue(write_threads)
+        self.assertTrue(all(tid != loop_thread for tid in write_threads))
 
 
 class TestGroupMentionAtAll(unittest.TestCase):

--- a/tests/gateway/test_feishu_meeting_invite.py
+++ b/tests/gateway/test_feishu_meeting_invite.py
@@ -76,7 +76,7 @@ class _Adapter:
         self.dedup_keys = []
         self.profile_requests = []
 
-    def _is_duplicate(self, key):
+    async def _is_duplicate(self, key):
         self.dedup_keys.append(key)
         return self.duplicate
 
@@ -165,6 +165,19 @@ class TestMeetingInviteHandler(unittest.TestCase):
         self.assertIsNone(event.message_id)
         self.assertIn("You have been invited to join a meeting: 赵磊的视频会议", event.text)
         self.assertNotIn("{'open_id'", event.text)
+
+    def test_duplicate_event_is_dropped_without_routing(self):
+        """_is_duplicate() is async on the real FeishuAdapter (dedup persist
+        is offloaded off the event loop); the dedup check here must await
+        it — a missing await would leave an un-awaited coroutine, which is
+        always truthy, and drop every event as a false duplicate."""
+        adapter = _Adapter(duplicate=True)
+
+        self._run(handle_meeting_invited_event(adapter, _make_payload()))
+
+        self.assertEqual(adapter.dedup_keys, ["vc_invite:evt_1"])
+        self.assertEqual(adapter.events, [])
+        self.assertEqual(adapter.profile_requests, [])
 
 
 class TestMeetingInviteSendRouting(unittest.TestCase):

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -167,6 +167,30 @@ class TestWeixinStatePersistence:
 
         assert json.loads(account_path.read_text(encoding="utf-8")) == original
 
+    @pytest.mark.asyncio
+    async def test_context_token_persist_runs_off_event_loop_thread(self, tmp_path):
+        """atomic_json_write() calls os.fsync(), which blocks until the write
+        reaches stable storage. ContextTokenStore.set() runs on the event
+        loop for every inbound message carrying a context_token
+        (_process_message), so the persist step must be offloaded to a
+        thread — mirrors test_directory_write_runs_off_event_loop_thread in
+        test_channel_directory.py for the same #83906 bug class."""
+        import threading
+
+        store = ContextTokenStore(str(tmp_path))
+        loop_thread = threading.get_ident()
+        write_threads = []
+
+        def fake_write(path, data, *args, **kwargs):
+            write_threads.append(threading.get_ident())
+
+        with patch("gateway.platforms.weixin.atomic_json_write", side_effect=fake_write):
+            await store.set("acct-1", "user-1", "ctx-token-abc")
+
+        assert store.get("acct-1", "user-1") == "ctx-token-abc"
+        assert write_threads
+        assert all(tid != loop_thread for tid in write_threads)
+
 
 class TestWeixinQrLogin:
     @pytest.mark.asyncio

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -191,6 +191,33 @@ class TestWeixinStatePersistence:
         assert write_threads
         assert all(tid != loop_thread for tid in write_threads)
 
+    @pytest.mark.asyncio
+    async def test_concurrent_context_token_persists_land_in_order(self, tmp_path):
+        """Two in-flight set() calls (two concurrent inbound messages) must not
+        let an older snapshot overwrite a newer one on disk. Without
+        serialization the first (slow) flush lands last and drops user-2."""
+        import asyncio as _asyncio
+        import time
+
+        store = ContextTokenStore(str(tmp_path))
+        writes = []
+        calls = [0]
+
+        def slow_first_write(path, data, *args, **kwargs):
+            idx = calls[0]
+            calls[0] += 1
+            if idx == 0:
+                time.sleep(0.05)
+            writes.append(dict(data))
+
+        with patch("gateway.platforms.weixin.atomic_json_write", side_effect=slow_first_write):
+            first = _asyncio.create_task(store.set("acct-1", "user-1", "t1"))
+            await _asyncio.sleep(0.005)
+            second = _asyncio.create_task(store.set("acct-1", "user-2", "t2"))
+            await _asyncio.gather(first, second)
+
+        assert writes[-1] == {"user-1": "t1", "user-2": "t2"}
+
 
 class TestWeixinQrLogin:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Three gateway adapters (WeChat, Discord, Feishu) still called `atomic_json_write` — temp file + `fsync` + replace — directly on the event loop for every inbound message; those persists now run on a worker thread, completing the bug class from #83906.

Salvaged from #84168 by @pierrenode (cherry-picked, authorship preserved) + one follow-up commit fixing an ordering race the offload introduced.

## Who hits this / when
- WeChat: every inbound message carrying a `context_token` persists the token store (`ContextTokenStore.set`).
- Feishu: every inbound message persists the dedup seen-ids file (`_is_duplicate`).
- Discord: every non-conversational send persists the tracked message ids (`mark_many`).
An `fsync` on a slow disk (or a busy laptop SSD under Time Machine) stalls the whole gateway loop — every platform, every chat — for its duration, once per message.

## Before / after
```python
# before (weixin)
def set(self, account_id, user_id, token):
    self._cache[...] = token
    self._persist(account_id)                 # fsync on the loop
```
```python
# after
async def set(self, account_id, user_id, token):
    self._cache[...] = token
    async with self._persist_lock:
        payload = self._payload(account_id)   # snapshot on the loop
        await asyncio.to_thread(self._persist, account_id, payload)
```
Same shape for Discord (`mark_many`); Feishu's `_is_duplicate` became async and its persist is offloaded (callers in `adapter.py` and `feishu_meeting_invite.py` both awaited).

## Follow-up commit (ours)
Offloading lets two inbound messages have two persists in flight. Without ordering, a slow first flush lands after the second and the disk file loses the newer entry (in-memory stays correct; the loss surfaces after a restart). The loop-side dict could also be mutated while the worker iterated it (`RuntimeError`, swallowed → dropped flush). Reproduced on the PR head: two concurrent `set()` → in-memory `[u1, u2]`, disk `[u1]`.

Fix: snapshot the payload on the loop and serialize flushes with a per-store `asyncio.Lock` (weixin, discord); Feishu already snapshots under `_dedup_lock`, so it only gains the ordering lock. Three regression tests (concurrent persists with a slow first write must leave the union on disk) — all fail on the contributor commit alone, pass with the fix.

## Benchmark
Max event-loop gap during `ContextTokenStore.set` with a 200 ms blocking `atomic_json_write` (5 ms asyncio ticker alongside; 5 runs, median; macOS arm64, same worktree):

| | main 1cb3ab6173 | this branch |
|---|---|---|
| max loop gap | 206.6 ms | 5.7 ms |

Script: `~/triage-perf-p2/bench/offloop_stall.py 84168`.

What actually improved: a slow fsync in one adapter's bookkeeping no longer stalls every other chat on the gateway.

## Validation
- `tests/gateway/test_weixin.py`, `test_discord_free_response.py`, `test_feishu.py`, `test_feishu_meeting_invite.py`: 138 passed.
- All `_is_duplicate` / `mark_many` / `token_store.set` callers grepped — none left un-awaited (the meeting-invite path flagged in triage is awaited in this PR).
- Composes with #93967's media-cache offload (`git merge-tree` clean; disjoint functions in the shared files).
- Commit 1 adds pierrenode to `contributors/emails/`.

Closes #84168
