### PR TITLE
fix(title): stop titling a session after a code-fence delimiter

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -255,6 +255,17 @@ def is_titleable_user_message(user_message: str) -> bool:
     return bool(_summarize_user_message(user_message).strip())
 
 
+# Markdown code-fence delimiter: ``` or ~~~, optionally followed by an info
+# string (```json, ~~~python). A line that is only a fence carries no intent
+# worth titling — see derive_title.
+_FENCE_LINE_RE = re.compile(r"^\s*(?:`{3,}|~{3,})\s*[\w+.-]*\s*$")
+
+
+def _is_fence_line(line: str) -> bool:
+    """Return whether *line* is nothing but a markdown code-fence delimiter."""
+    return bool(_FENCE_LINE_RE.match(line or ""))
+
+
 def derive_title(user_message: str) -> Optional[str]:
     """Build an instant title from the user's message. No model, never fails.
 
@@ -266,9 +277,18 @@ def derive_title(user_message: str) -> Optional[str]:
     text = _summarize_user_message(user_message)
     if not text:
         return None
-    # First non-empty line: a pasted log or a multi-paragraph brief still gets
-    # named after its opening intent.
-    line = next((ln.strip() for ln in text.splitlines() if ln.strip()), "")
+    # First line carrying real prose. A message that opens with a code fence
+    # (```json, ~~~py) or a bare fence would otherwise be titled after the
+    # delimiter itself — every such session collides on the same name and
+    # accumulates a "#N" suffix from the lineage deduper.
+    line = next(
+        (
+            ln.strip()
+            for ln in text.splitlines()
+            if ln.strip() and not _is_fence_line(ln)
+        ),
+        "",
+    )
     if not line:
         return None
     line = " ".join(line.split())

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -597,3 +597,51 @@ class TestModelSwitchMarkerNotTitleable:
         assert apply_instant_title(db, "sess-1", "南京市秦淮区 小时级天气预报") == (
             "南京市秦淮区 小时级天气预报"
         )
+
+
+class TestDeriveTitleSkipsCodeFences:
+    """A message opening with a code fence must not be titled after the fence.
+
+    Real regression: 12 sessions in production history were named ``` or
+    ```json, colliding repeatedly until the lineage deduper had appended
+    suffixes up to "```json #10". The fence delimiter carries no intent, so
+    derive_title looks past it for the first line of real prose.
+    """
+
+    def test_fence_only_opener_titles_from_body(self):
+        from agent.title_generator import derive_title
+
+        assert derive_title('```json\n{"a": 1}\n```') == '{"a": 1}'
+
+    def test_tilde_fence_is_skipped(self):
+        from agent.title_generator import derive_title
+
+        assert derive_title("~~~python\nprint(1)\n~~~") == "print(1)"
+
+    def test_bare_fence_is_skipped(self):
+        from agent.title_generator import derive_title
+
+        assert derive_title("```\nplain block\n```") == "plain block"
+
+    def test_fence_then_prose_prefers_prose_over_fence(self):
+        from agent.title_generator import derive_title
+
+        assert derive_title("```\n```\nwhy is this failing?") == "why is this failing?"
+
+    def test_prose_first_is_unchanged(self):
+        from agent.title_generator import derive_title
+
+        assert derive_title("Fix the login button\n```js\ncode\n```") == (
+            "Fix the login button"
+        )
+
+    def test_fence_like_prose_is_not_treated_as_a_fence(self):
+        """Only a line that is *nothing but* a delimiter counts as a fence."""
+        from agent.title_generator import derive_title
+
+        assert derive_title("```notafence but prose") == "```notafence but prose"
+
+    def test_message_of_only_fences_yields_no_title(self):
+        from agent.title_generator import derive_title
+
+        assert derive_title("```\n```") is None


### PR DESCRIPTION
## Symptom

A session whose opening message begins with a fenced code block is titled after the fence delimiter itself:

```
```json
```

Because every such session derives the *same* base title, the lineage deduper in `get_next_title_in_lineage` keeps appending a suffix. In one real `state.db` this accumulated 12 sessions:

```
'```'        '``` #2'
'```json'    '```json #2' … '```json #10'
```

`#10` is the tenth collision on a title that carries no information.

## Root cause

`derive_title` (`agent/title_generator.py`) — the instant/derived stage — takes the first non-empty line verbatim:

```python
line = next((ln.strip() for ln in text.splitlines() if ln.strip()), "")
```

A bare ```` ```json ```` line is non-empty, so it wins.

The *model-output* path already handles this: `_extract_title_text` strips fences at `agent/title_generator.py:296`. Only the derived path lacked the guard, so the two stages disagreed about whether a fence is content.

## Fix

`derive_title` now skips lines that are nothing but a fence delimiter and titles from the first line of real prose.

- Handles ``` and `~~~`, with or without an info string (```` ```json ````, `~~~python`)
- A line with trailing content (```` ```notafence but prose ````) is **not** a fence and is still titled verbatim
- A message consisting only of fences returns `None`, matching the existing "nothing usable" contract
- The single-purpose `_is_fence_line` helper keeps the predicate testable and out of the hot loop

Deliberately scoped to the derived path — `_extract_title_text` already covers model output, and widening its regex was not needed.

## Tests

7 regression tests in `TestDeriveTitleSkipsCodeFences` covering fence-only openers, tilde fences, bare fences, fence-then-prose, prose-first (unchanged), fence-like prose, and fences-only.

```
tests/agent/test_title_generator.py .......................................... 43 passed
tests/ -k title ............................................................. 178 passed, 3 skipped
```

Verified against real history: the fix's predicate identifies exactly the 12 polluted titles above and no false positives across 634 titled sessions.