### PR TITLE
fix(skills): gate shipped SKILL.md on skill_manage hard limits

### DIFF
--- a/tests/tools/test_skill_linter.py
+++ b/tests/tools/test_skill_linter.py
@@ -47,14 +47,45 @@ def test_clean_skill_has_no_findings():
     assert lint_content(CLEAN) == []
 
 
-def test_description_too_long_is_warning():
+def test_description_too_long_is_error():
     long_desc = "x" * 80
     content = CLEAN.replace(
         "Search arXiv papers by keyword, author, or ID.", long_desc
     )
     findings = lint_content(content)
     assert "description-length" in _rules(findings)
-    assert all(f.severity == WARNING for f in findings)
+    assert has_errors(findings)
+
+
+def test_content_over_size_limit_is_error():
+    from tools.skill_manager_tool import MAX_SKILL_CONTENT_CHARS
+
+    content = CLEAN + ("x" * (MAX_SKILL_CONTENT_CHARS + 1))
+    findings = lint_content(content)
+    assert "content-size" in _rules(findings)
+    assert has_errors(findings)
+
+
+def test_shipped_skills_obey_skill_manage_hard_limits():
+    """Ship-time gate for #87502: seeded skills must meet write-path caps.
+
+    skill_manage enforces MAX_SKILL_CONTENT_CHARS and SKILL_PROMPT_DESC_LIMIT on
+    create/edit; bundled and optional skills are copied in without that path.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    hard_rules = {"content-size", "description-length"}
+    offenders: list[str] = []
+    for root_name in ("skills", "optional-skills"):
+        root = repo_root / root_name
+        if not root.is_dir():
+            continue
+        for skill_md in sorted(root.rglob("SKILL.md")):
+            hard = [f for f in lint_skill(skill_md) if f.rule in hard_rules]
+            if hard:
+                rel = skill_md.relative_to(repo_root).as_posix()
+                detail = "; ".join(f"{f.rule}: {f.message}" for f in hard)
+                offenders.append(f"{rel}: {detail}")
+    assert offenders == []
 
 
 def test_marketing_words_flagged():

--- a/tools/skill_linter.py
+++ b/tools/skill_linter.py
@@ -11,6 +11,10 @@ instead of native tools, a missing author/license/metadata block, a
 marketing words in the description, ``platforms:`` gating vs POSIX-only
 primitives, and forbidden scaffolding files.
 
+Two write-path caps are also ERROR here (``content-size``, ``description-length``)
+so CI / ``python -m tools.skill_linter skills optional-skills`` catches seeded
+skills that never pass through ``skill_manage``.
+
 Design contract (matches the Hermes "no lazy-reading escape hatches / don't
 destroy the feature" posture):
 
@@ -152,6 +156,16 @@ def _check_name_format(frontmatter: Dict[str, Any]) -> List[LintFinding]:
     return []
 
 
+def _check_content_size(content: str) -> List[LintFinding]:
+    # Local import: skill_manager_tool imports this module only inside helpers.
+    from tools.skill_manager_tool import _validate_content_size
+
+    err = _validate_content_size(content)
+    if err is None:
+        return []
+    return [LintFinding(ERROR, "content-size", err)]
+
+
 def _check_description(frontmatter: Dict[str, Any]) -> List[LintFinding]:
     findings: List[LintFinding] = []
     # Raw description as authored — extract_skill_description() applies the
@@ -163,7 +177,7 @@ def _check_description(frontmatter: Dict[str, Any]) -> List[LintFinding]:
     if len(desc) > SKILL_PROMPT_DESC_LIMIT:
         findings.append(
             LintFinding(
-                WARNING,
+                ERROR,
                 "description-length",
                 f"description is {len(desc)} chars; the skill index truncates "
                 f"past {SKILL_PROMPT_DESC_LIMIT} chars + '...', losing routing "
@@ -383,6 +397,7 @@ def lint_content(
     """
     frontmatter, body = parse_frontmatter(content)
     findings: List[LintFinding] = []
+    findings += _check_content_size(content)
     findings += _check_name_format(frontmatter)
     findings += _check_name_matches_dir(frontmatter, skill_dir)
     findings += _check_description(frontmatter)


### PR DESCRIPTION
## Why

Issue #87502 found bundled skills that broke `MAX_SKILL_CONTENT_CHARS` and `SKILL_PROMPT_DESC_LIMIT` even though `skill_manage` enforces those caps on create/edit. Seeded skills never hit that path, so the limits only apply after someone tries to patch a shipped file.

The two named skills are already under budget on current main (`research-paper-writing` lives under `optional-skills/` at ~71k chars; `computer-use` description is 55 chars). The remaining gap is ship-time enforcement.

## Scope

- `tools/skill_linter.py`: ERROR `content-size` via `_validate_content_size`; `description-length` is ERROR (was WARNING).
- `tests/tools/test_skill_linter.py`: unit coverage for both rules plus a scan of `skills/` and `optional-skills/`.

## Tradeoffs

Content trim for the original offenders is out of scope; main already satisfies the caps. This PR only closes the class of defect.

## Blast Radius

CI and `python -m tools.skill_linter` fail on over-limit SKILL.md in shipped trees. `skill_manage` still treats linter output as advisory guidance; write-path hard rejects are unchanged.

## Verification

```
python -m pytest tests/tools/test_skill_linter.py -q
```

exit 0 — 20 passed

Pre-fix measure on worktree main tip: 0 size/description violations across `skills/` + `optional-skills/`; `_validate_frontmatter(..., new_skill=True)` also clean.

Fixes #87502