### PR TITLE
fix(credits): stop desktop reap/resume from re-announcing the same us…

### DIFF
--- a/agent/credits_tracker.py
+++ b/agent/credits_tracker.py
@@ -777,6 +777,29 @@ def _credits_state_from_account(info) -> Optional[CreditsState]:
         return None
 
 
+# Process-lifetime memory of the usage band last SHOWN for a given
+# agent.session_id, so a desktop reap/resume rebuild doesn't re-announce a
+# band the user already saw. Desktop creates a brand-new AIAgent (and thus a
+# brand-new, empty _credits_latch — see agent_init.new_credits_latch()) on
+# every idle-reap/resume cycle, but agent.session_id is stable across those
+# rebuilds. Deliberately NOT persisted anywhere durable: a genuinely new
+# process (app restart, gateway restart) is a genuinely fresh "session open"
+# observation, and the cold-start seed SHOULD warn immediately in that case.
+# Bounded so a long-running gateway juggling many distinct sessions can't
+# grow this without limit.
+_seen_usage_bands: dict = {}
+_SEEN_USAGE_BANDS_MAX = 500
+
+
+def _remember_shown_band(session_id: str, band) -> None:
+    if not session_id:
+        return
+    _seen_usage_bands.pop(session_id, None)  # refresh insertion order (MRU-last)
+    _seen_usage_bands[session_id] = band
+    if len(_seen_usage_bands) > _SEEN_USAGE_BANDS_MAX:
+        _seen_usage_bands.pop(next(iter(_seen_usage_bands)))
+
+
 def _hydrate_seed_state(agent, state) -> None:
     """Install a seed CreditsState on the agent and fire the notice policy once.
 
@@ -784,16 +807,28 @@ def _hydrate_seed_state(agent, state) -> None:
     gate (the cold-start snapshot IS the first observation, so a session that opens
     already in a band warns immediately — the live header path keeps true crossing
     semantics), then emits. Safe to call from a worker thread: emit already runs
-    off-thread in the TUI build path."""
+    off-thread in the TUI build path.
+
+    Also restores the usage band already shown for agent.session_id (if any) from
+    a prior incarnation of this same logical session, before evaluating — without
+    this, every desktop reap/resume rebuild starts from a blank latch and
+    re-announces the CURRENT band as if it had just been crossed, even though the
+    user saw that exact notice moments ago (#101578)."""
     agent._credits_state = state
     if getattr(agent, "_credits_session_start_micros", None) is None:
         agent._credits_session_start_micros = state.remaining_micros
     _latch = getattr(agent, "_credits_latch", None)
+    _sid = getattr(agent, "session_id", None)
     if isinstance(_latch, dict) and state.used_fraction is not None:
         # Prime ONLY seen_below_90 (open-high band warnings are wanted at open).
         # Never prime seen_grant_unspent here: a seed observing grant-spent is a
         # steady state, and priming it would revive the every-session nag.
         _latch["seen_below_90"] = True
+        if _sid and _sid in _seen_usage_bands:
+            _prior_band = _seen_usage_bands[_sid]
+            _latch["usage_band"] = _prior_band
+            if _prior_band is not None:
+                _latch["active"].add(CREDITS_USAGE_KEY)
     emit = getattr(agent, "_emit_credits_notices", None)
     if callable(emit):
         emit()

--- a/run_agent.py
+++ b/run_agent.py
@@ -4779,6 +4779,14 @@ class AIAgent:
                 self._emit_notice_clear(key)
             for notice in to_show:      # … then shows (depleted lands last in a latest-wins slot)
                 self._emit_notice(notice)
+            # Remember the band just shown for this session, so a desktop
+            # reap/resume rebuild (a fresh AIAgent + a fresh, empty
+            # _credits_latch — see agent_init.new_credits_latch()) restores it
+            # instead of re-announcing the current band as a brand-new
+            # crossing (#101578). Covers both this warm path and the
+            # cold-start seed, which also routes through this method.
+            from agent.credits_tracker import _remember_shown_band
+            _remember_shown_band(getattr(self, "session_id", None), latch.get("usage_band"))
         except Exception:
             logger.warning("credits notice evaluation/emit failed", exc_info=True)
 

--- a/tests/agent/test_credits_cold_start.py
+++ b/tests/agent/test_credits_cold_start.py
@@ -76,13 +76,14 @@ def test_dev_fixtures_drive_cold_start():
 class _FakeAgent:
     """Minimal agent surface for the seed helper: state slots + an emit that runs
     the real policy against the latch (mirroring run_agent._emit_credits_notices,
-    including the free-model suppression flag)."""
+    including the free-model suppression flag and the cross-rebuild band memory)."""
 
-    def __init__(self, provider="nous", model=""):
+    def __init__(self, provider="nous", model="", session_id="session-1"):
         from agent.credits_tracker import evaluate_credits_notices, is_free_tier_model
 
         self.provider = provider
         self.model = model
+        self.session_id = session_id
         self._credits_state = None
         self._credits_session_start_micros = None
         self._credits_latch = {"active": set(), "seen_below_90": False, "usage_band": None}
@@ -99,6 +100,9 @@ class _FakeAgent:
             model_is_free=self._is_free(self.model),
         )
         self.emitted.append(([n.key for n in show], clear))
+        from agent.credits_tracker import _remember_shown_band
+
+        _remember_shown_band(self.session_id, self._credits_latch.get("usage_band"))
 
 
 def _seed(agent, fixture):
@@ -157,3 +161,96 @@ def test_seed_skips_non_nous():
     a = _FakeAgent(provider="openrouter")
     assert seed_credits_at_session_start(a) is False
     assert a._credits_state is None
+
+
+# ── desktop reap/resume rebuilds must not re-announce the same band (#101578) ─
+#
+# Desktop rebuilds the AIAgent (and its _credits_latch) on idle-reap/resume,
+# but agent.session_id is stable across rebuilds. A fresh latch that blindly
+# re-primes seen_below_90 re-announces the CURRENT band on every rebuild even
+# though the user already saw it moments ago on the previous incarnation.
+
+
+def _band_50_state() -> CreditsState:
+    return _state(
+        remaining_micros=10_000_000, subscription_micros=10_000_000,
+        subscription_limit_micros=20_000_000, subscription_limit_usd="20.00",
+        denominator_kind="subscription_cap", paid_access=True,
+    )
+
+
+def _band_75_state() -> CreditsState:
+    return _state(
+        remaining_micros=5_000_000, subscription_micros=5_000_000,
+        subscription_limit_micros=20_000_000, subscription_limit_usd="20.00",
+        denominator_kind="subscription_cap", paid_access=True,
+    )
+
+
+def test_rebuild_with_same_band_does_not_refire(monkeypatch):
+    import agent.credits_tracker as ct
+
+    monkeypatch.setattr(ct, "_seen_usage_bands", {})
+    # First incarnation: session opens already at 50% — fires once.
+    a1 = _FakeAgent(session_id="desktop-session-1")
+    a1._credits_state = _band_50_state()
+    a1._credits_latch["seen_below_90"] = True
+    a1._emit_credits_notices()
+    assert a1.emitted == [(["credits.usage"], [])]
+
+    # Desktop idle-reap/resume: a BRAND NEW agent object, fresh empty latch,
+    # SAME session_id, usage unchanged. Must not re-announce band 50.
+    a2 = _FakeAgent(session_id="desktop-session-1")
+    from agent.credits_tracker import _hydrate_seed_state
+
+    _hydrate_seed_state(a2, _band_50_state())
+    assert a2.emitted == [([], [])]
+
+
+def test_rebuild_still_fires_on_genuine_band_change(monkeypatch):
+    import agent.credits_tracker as ct
+
+    monkeypatch.setattr(ct, "_seen_usage_bands", {})
+    a1 = _FakeAgent(session_id="desktop-session-2")
+    a1._credits_state = _band_50_state()
+    a1._credits_latch["seen_below_90"] = True
+    a1._emit_credits_notices()
+    assert a1.emitted == [(["credits.usage"], [])]
+
+    # Usage genuinely climbed to 75% before the next rebuild — must still warn.
+    a2 = _FakeAgent(session_id="desktop-session-2")
+    from agent.credits_tracker import _hydrate_seed_state
+
+    _hydrate_seed_state(a2, _band_75_state())
+    assert a2.emitted == [(["credits.usage"], ["credits.usage"])]
+
+
+def test_unrelated_session_id_not_suppressed(monkeypatch):
+    import agent.credits_tracker as ct
+
+    monkeypatch.setattr(ct, "_seen_usage_bands", {})
+    a1 = _FakeAgent(session_id="desktop-session-a")
+    a1._credits_state = _band_50_state()
+    a1._credits_latch["seen_below_90"] = True
+    a1._emit_credits_notices()
+    assert a1.emitted == [(["credits.usage"], [])]
+
+    # A different session at the same band has never been shown anything.
+    a2 = _FakeAgent(session_id="desktop-session-b")
+    from agent.credits_tracker import _hydrate_seed_state
+
+    _hydrate_seed_state(a2, _band_50_state())
+    assert a2.emitted == [(["credits.usage"], [])]
+
+
+def test_agent_without_session_id_falls_back_to_prior_behavior(monkeypatch):
+    """CLI/plain agents may have no session_id at all -- must degrade to the
+    pre-fix behavior (always re-primes), never raise."""
+    import agent.credits_tracker as ct
+
+    monkeypatch.setattr(ct, "_seen_usage_bands", {})
+    a = _FakeAgent(session_id=None)
+    from agent.credits_tracker import _hydrate_seed_state
+
+    _hydrate_seed_state(a, _band_50_state())
+    assert a.emitted == [(["credits.usage"], [])]


### PR DESCRIPTION
…age band

Desktop rebuilds the AIAgent per turn (idle reap -> next message re-mint), and agent_init.py gives every rebuilt agent a brand-new, empty _credits_latch via new_credits_latch(). seed_credits_at_session_start() -> _hydrate_seed_state() then unconditionally primes latch["seen_below_90"] = True on that fresh latch and evaluates once -- correct for a genuinely new session opening mid-band, but on a reap/resume rebuild it makes evaluate_credits_notices() see shown_band=None vs. current_band=<the same band as before>, so it re-fires "You've used $X of your $Y cap" on every message even though nothing changed and the user already saw that exact notice moments ago on the previous incarnation of the same session.

agent.session_id is stable across these rebuilds even though the agent object and its latch are not, so add a small process-lifetime cache (_seen_usage_bands, bounded to 500 entries) keyed by session_id that remembers the last usage_band actually shown. _hydrate_seed_state() restores it into the fresh latch before evaluating, so a rebuild with unchanged usage sees shown_band == current_band and stays quiet, while a rebuild after a genuine crossing (recorded via the same warm-path write in run_agent._emit_credits_notices, the single chokepoint both the seed and live-header paths already share) still fires normally. Deliberately not persisted anywhere durable -- a real process restart is a real "session open" and should still warn immediately, matching the existing cold-start seed behavior for a session that opens already in a band. An agent with no session_id (plain CLI, never rebuilt) falls back to the pre-fix behavior unchanged.

Added tests/agent/test_credits_cold_start.py coverage: a rebuild with the same session_id and unchanged usage does not re-fire, a rebuild after a genuine band change still fires (and clears the old key), a different session_id is never suppressed by another session's history, and an agent without a session_id degrades to the old always-prime behavior without raising.

Fixes #101578

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

