### PR TITLE
feat(setup): offer `hermes auth add` at end of bootstrap

### DIFF
--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -451,6 +451,33 @@ else
     fi
 fi
 
+
+# ============================================================================
+# Quick credential setup — offer `hermes auth add` for common providers
+# ============================================================================
+# The full setup wizard (offered next) handles everything, but a direct
+# "do you want to add provider credentials?" prompt saves a round-trip
+# through the wizard for the most common case: pasting API keys or
+# triggering OAuth login for Anthropic, OpenRouter, or OpenAI Codex.
+# Each provider gets its own yes/no — skip the ones you don't use.
+
+_QUICK_PROVIDERS=("anthropic" "openrouter" "openai-codex")
+echo ""
+read -p "Add provider credentials (Anthropic, OpenRouter, OpenAI Codex) now? [y/N] " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    for _p in "${_QUICK_PROVIDERS[@]}"; do
+        echo ""
+        read -p "  Add $_p now? [y/N] " -n 1 -r
+        echo
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            "$SCRIPT_DIR/venv/bin/hermes" auth add "$_p" || true
+        fi
+    done
+    echo ""
+    echo -e "${GREEN}✓${NC} Credential setup done. Run 'hermes auth list' to see all pooled keys."
+fi
+
 # ============================================================================
 # Done
 # ============================================================================


### PR DESCRIPTION
## What

At the end of `setup-hermes.sh`, after the skills sync and before the final "run setup wizard?" prompt, add a direct yes/no:

```
Add provider credentials (Anthropic, OpenRouter, OpenAI Codex) now? [y/N]
```

If yes, loop over the three providers with per-provider yes/no prompts, shelling out to `hermes auth add <provider>` for each accepted one.

## Why

The full setup wizard (`hermes setup`) handles everything, but the most common post-deploy action is just adding API keys or triggering OAuth login. A direct prompt saves a round-trip through the wizard for that case. The full wizard prompt follows immediately after, so nothing is lost.

## How

- Uses the existing `hermes auth add` infrastructure (credential pool, `masked_secret_prompt`, OAuth device-code flows) — no bespoke script.
- Each provider gets its own yes/no so the user can pick which ones to set up.
- `|| true` prevents a failed add from aborting the script under `set -e`.
- `anthropic` → OAuth or API key paste; `openrouter` → API key paste; `openai-codex` → OAuth device-code login.

## Test

Verified the patch applies cleanly (`git apply --check`). The `hermes auth add` flows are existing, well-tested commands — no new logic introduced.