### PR TITLE
fix(gateway): off-loop review follow-ups (negative-cache fast path, buzz read off-loop)

### DIFF
--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -607,11 +607,21 @@ def exchange_copilot_token(raw_token: str, *, timeout: float = 10.0) -> tuple[st
     """
     fp = _token_fingerprint(raw_token)
 
-    # Fast path outside the lock: a valid in-process JWT needs no exchange.
+    # Fast paths outside the lock: a valid in-process JWT needs no exchange,
+    # and a recent failure means queueing behind the in-flight holder (up to
+    # ~50 s) would only park an executor thread to learn the same answer.
     cached = _jwt_cache.get(fp)
     if cached and time.time() < cached[1] - _JWT_REFRESH_MARGIN_SECONDS:
         return cached
+    _fail_until = _exchange_failure_cache.get(fp, 0.0)
+    if time.time() < _fail_until:
+        raise ValueError(
+            "Copilot token exchange recently failed; skipping re-attempt "
+            f"for another {int(_fail_until - time.time())}s"
+        )
 
+    # Note: a waiter's own ``timeout`` is not honoured across the lock wait —
+    # by design of single-flight, it observes the holder's outcome instead.
     with _exchange_lock_for(fp):
         return _exchange_copilot_token_locked(raw_token, fp, timeout=timeout)
 

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -2894,8 +2894,10 @@ class BuzzAdapter(BasePlatformAdapter):
                         mimetypes.guess_type(download_path.name)[0]
                         or "application/octet-stream"
                     )
+                    # Up to the inbound media cap (128 MiB) — read off the loop too.
+                    data = await asyncio.to_thread(download_path.read_bytes)
                     cached = await cache_media_bytes_async(
-                        download_path.read_bytes(),
+                        data,
                         filename=download_path.name,
                         mime_type=mime_type,
                     )

--- a/tests/hermes_cli/test_credential_pool_off_loop.py
+++ b/tests/hermes_cli/test_credential_pool_off_loop.py
@@ -154,6 +154,22 @@ class TestExchangeSingleFlight:
         assert len(errors) == 5
         assert any("recently failed" in e for e in errors)
 
+    def test_negative_cache_short_circuits_before_taking_the_lock(self, monkeypatch):
+        """While one exchange holds the lock, a caller whose fingerprint is
+        already in the failure cache must raise immediately rather than park
+        an executor thread behind the holder."""
+        fp = copilot_auth._token_fingerprint("ghu_" + "z" * 30)
+        copilot_auth._exchange_failure_cache[fp] = time.time() + 60
+        lock = copilot_auth._exchange_lock_for(fp)
+        lock.acquire()  # simulate an in-flight holder
+        try:
+            started = time.monotonic()
+            with pytest.raises(ValueError, match="recently failed"):
+                copilot_auth.exchange_copilot_token("ghu_" + "z" * 30)
+            assert time.monotonic() - started < 0.5
+        finally:
+            lock.release()
+
 
 # ---------------------------------------------------------------------------
 # web_server credential-pool handlers off the loop
@@ -186,7 +202,7 @@ async def test_list_credential_pool_keeps_loop_responsive(monkeypatch):
     from hermes_cli import web_server
 
     def slow_read(*args, **kwargs):
-        time.sleep(0.2)
+        time.sleep(0.5)
         return {}
 
     monkeypatch.setattr(auth_mod, "read_credential_pool", slow_read)
@@ -206,4 +222,6 @@ async def test_list_credential_pool_keeps_loop_responsive(monkeypatch):
     await web_server.list_credential_pool()
     stop.set()
     await t
-    assert max(gaps) < 0.1, f"event loop stalled for {max(gaps) * 1000:.0f} ms"
+    # 0.25 s threshold vs a 0.5 s blocking read: a regression (read on the
+    # loop) trips it by 2x, while runner-noise descheduling would need >200 ms.
+    assert max(gaps) < 0.25, f"event loop stalled for {max(gaps) * 1000:.0f} ms"


### PR DESCRIPTION
## Summary
Three small follow-ups from the /simplify-code efficiency pass on the two off-loop salvages that merged as #101603 (credential pool / Copilot exchange) and #101605 (media cache writes).

## Changes
- `hermes_cli/copilot_auth.py`: check the negative (recent-failure) cache **before** taking the per-fingerprint single-flight lock. During the 60 s post-failure window a dashboard poll now raises immediately instead of parking an executor thread behind the in-flight holder (up to ~50 s) only to learn the same answer. Documented that a waiter's own `timeout` is intentionally not honoured across the lock wait.
- `plugins/platforms/buzz/adapter.py` `_localize_inbound_media`: `download_path.read_bytes()` was still evaluated on the event loop as the argument to the offloaded cache call — up to the 128 MiB inbound cap. Read it off the loop too.
- `tests/hermes_cli/test_credential_pool_off_loop.py`: the loop-responsiveness test uses a 0.5 s block with a 0.25 s threshold (2× margin) so CI runner descheduling cannot false-fail it while a real regression (read on the loop) still trips it.

## Validation
| | |
|---|---|
| `test_credential_pool_off_loop.py` | 8 passed (new: `test_negative_cache_short_circuits_before_taking_the_lock`) |
| mutation check | new test **hangs** (timeout exit 124) with the pre-lock check removed, passes with it |
| `test_copilot_auth.py` + `test_buzz_adapter.py` | green except `test_live_media_redacts_long_path_before_bounding`, which fails identically on `origin/main` on macOS (path length) |

Surfaced during review of #101603 / #101605.
