### PR TITLE
fix(computer-use): preserve driver element targeting

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -58,6 +58,25 @@ class TestSchema:
         from tools.computer_use.schema import COMPUTER_USE_SCHEMA
         assert "max_elements" not in COMPUTER_USE_SCHEMA["parameters"]["properties"]
 
+    def test_element_schema_requires_exact_zero_based_capture_index(self):
+        """The model must pass through cua-driver's displayed index unchanged."""
+        from tools.computer_use.schema import COMPUTER_USE_SCHEMA
+
+        description = COMPUTER_USE_SCHEMA["parameters"]["properties"]["element"]["description"]
+        assert "0-based" in description
+        assert "exactly as returned" in description
+        assert "1-based" not in description
+
+    def test_coordinate_schema_uses_native_desktop_space(self):
+        """Screenshot pixels can be downscaled; raw clicks use native coordinates."""
+        from tools.computer_use.schema import COMPUTER_USE_SCHEMA
+
+        description = COMPUTER_USE_SCHEMA["parameters"]["properties"]["coordinate"]["description"]
+        normalized = description.lower()
+        assert "native desktop coordinates" in normalized
+        assert "element bounds" in normalized
+        assert "relative to the captured window screenshot" not in normalized
+
 
 class TestRegistration:
     def test_tool_registers_with_registry(self):
@@ -2196,6 +2215,10 @@ class TestElementTokenAttachment:
                 return cap in capabilities.get(tool, set())
             return any(cap in caps for caps in capabilities.values())
         backend._session.supports_capability = _supports
+        backend._session.supports_input_property = lambda tool, prop: (
+            prop in backend._session._tool_schemas.get(tool, {}).get("properties", {})
+        )
+        backend._session._tool_schemas = {}
         backend._active_pid = 111
         backend._active_window_id = 222
         return backend
@@ -2210,6 +2233,20 @@ class TestElementTokenAttachment:
         assert name == "click"
         assert args["element_index"] == 5
         # The matching token rode along — cua-driver will prefer it.
+        assert args["element_token"] == "s0001:5"
+
+    def test_token_attached_when_schema_accepts_it_without_capability_claim(self):
+        """Current cua-driver exposes element_token in schema but no capability list."""
+        backend = self._backend_with_session({"click": set()})
+        backend._session._tool_schemas = {
+            "click": {"properties": {"element_token": {"type": "string"}}},
+        }
+        backend._snapshot_tokens = {5: "s0001:5"}
+
+        backend.click(element=5, button="left")
+
+        call_tool = cast(Any, backend._session.call_tool)
+        _, args = call_tool.call_args.args
         assert args["element_token"] == "s0001:5"
 
 
@@ -2472,8 +2509,11 @@ class TestCapturePayloadBudget:
         cap = CaptureResult(mode="som", width=1024, height=768,
                             png_b64="iVBORw0KGgo=", elements=elements,
                             app="X", window_title="t", png_bytes_len=10)
-        with patch("model_tools._run_async",
-                   return_value=json.dumps({"analysis": "a screen"})):
+        with patch("tools.vision_tools.vision_analyze_tool",
+                   new=lambda *_args, **_kwargs: object()), patch(
+                       "model_tools._run_async",
+                       return_value=json.dumps({"analysis": "a screen"}),
+                   ):
             out = cu_tool._route_capture_through_aux_vision(
                 cap, "summary",
                 visible_elements=elements[:5], truncated_elements=45,

--- a/tools/computer_use/backend.py
+++ b/tools/computer_use/backend.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, List, Optional, Tuple
 class UIElement:
     """One interactable element on the current screen."""
 
-    index: int                       # 1-based SOM index
+    index: int                       # 0-based driver index; pass through unchanged
     role: str                        # AX role (AXButton, AXTextField, ...)
     label: str = ""                  # AXTitle / AXDescription / AXValue snippet
     bounds: Tuple[int, int, int, int] = (0, 0, 0, 0)  # x, y, w, h (logical px)
@@ -213,7 +213,7 @@ class ComputerUseBackend(ABC):
     def set_value(self, value: str, element: Optional[int] = None) -> ActionResult:
         """Set a native value on an element (e.g. AXPopUpButton selection).
 
-        `element` is the 1-based SOM index returned by a prior capture call.
+        `element` is the 0-based index returned by a prior capture call.
         """
 
     # ── Timing ──────────────────────────────────────────────────────

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -4079,9 +4079,11 @@ class CuaDriverBackend(ComputerUseBackend):
            supplied. Returns an explicit 'stale' error if the snapshot
            has been superseded."
 
-        Gated on the per-tool capability claim so we don't send the
-        field to drivers that predate the surface (which would reject
-        the schema with `additionalProperties: false`).
+        Compatible drivers expose `element_token` either through the
+        capability list or directly in the live tool schema. The schema is
+        authoritative when capability metadata is absent; older drivers that
+        accept neither remain untouched because they commonly reject unknown
+        fields with `additionalProperties: false`.
         """
         idx = args.get("element_index")
         if not isinstance(idx, int):
@@ -4089,9 +4091,10 @@ class CuaDriverBackend(ComputerUseBackend):
         token = self._snapshot_tokens.get(idx)
         if not token:
             return
-        if not self._session.supports_capability(
+        supports_tokens = self._session.supports_capability(
             "accessibility.element_tokens", tool=tool
-        ):
+        ) or self._session.supports_input_property(tool, "element_token")
+        if not supports_tokens:
             return
         args["element_token"] = token
 

--- a/tools/computer_use/schema.py
+++ b/tools/computer_use/schema.py
@@ -110,9 +110,8 @@ COMPUTER_USE_SCHEMA: Dict[str, Any] = {
             "element": {
                 "type": "integer",
                 "description": (
-                    "The 1-based SOM index returned by the last "
-                    "`capture(mode='som')` call. Strongly preferred over "
-                    "raw coordinates."
+                    "The 0-based element index from the last capture, passed "
+                    "exactly as returned. Strongly preferred over raw coordinates."
                 ),
             },
             "coordinate": {
@@ -121,9 +120,10 @@ COMPUTER_USE_SCHEMA: Dict[str, Any] = {
                 "minItems": 2,
                 "maxItems": 2,
                 "description": (
-                    "Pixel coordinates [x, y] relative to the captured window "
-                    "screenshot (top-left origin). Only use this if no element "
-                    "index is available."
+                    "Native desktop coordinates [x, y], preferably derived "
+                    "from returned element bounds. They are not necessarily "
+                    "screenshot pixels on scaled displays. Only use this if "
+                    "no element index is available."
                 ),
             },
             "button": {
@@ -151,13 +151,13 @@ COMPUTER_USE_SCHEMA: Dict[str, Any] = {
                 "type": "array",
                 "items": {"type": "integer"},
                 "minItems": 2, "maxItems": 2,
-                "description": "Source [x,y] (drag; use when no element available).",
+                "description": "Source native desktop [x,y] (use when no element is available).",
             },
             "to_coordinate": {
                 "type": "array",
                 "items": {"type": "integer"},
                 "minItems": 2, "maxItems": 2,
-                "description": "Target [x,y] (drag; use when no element available).",
+                "description": "Target native desktop [x,y] (use when no element is available).",
             },
             # ── scroll ─────────────────────────────────────────────
             "direction": {


### PR DESCRIPTION
> **Historical status:** Closed unmerged in favor of #92694, the earlier open implementation of the same `cua-driver` element-targeting fix. The original pre-submission search missed that overlap.

## What does this PR do?

Fixes structured Computer Use element targeting with `cua-driver 0.23.2`.

Hermes cached the `element_token` values returned by capture, but only attached a token when the driver advertised `accessibility.element_tokens` through capability metadata. `cua-driver 0.23.2` exposed `element_token` in the live click schema without that capability claim, so Hermes sent a bare `element_index` and the driver rejected an otherwise valid click:

```text
bare element_index is not accepted; pass element_token, or snapshot_id together with element_index
```

The change treats the live input schema as authoritative when capability metadata is absent while retaining compatibility with older drivers that accept neither surface. It also aligns the model-facing contract with zero-based element indices and native-desktop click/drag coordinates on scaled displays.

## Related Issue

Duplicate of #92694. This PR was closed in favor of that earlier implementation after triage identified the same schema-advertised `element_token` fallback.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/computer_use/cua_backend.py`
  - attach a cached snapshot token when either the per-tool capability claim or live tool schema supports `element_token`;
  - leave calls unchanged for older drivers supporting neither surface.
- `tools/computer_use/schema.py`
  - document exact zero-based element-index pass-through and the native-desktop coordinate contract for click/drag fallbacks.
- `tools/computer_use/backend.py`
  - align internal element-index documentation with the driver contract.
- `tests/tools/test_computer_use.py`
  - add regressions for schema-only token support, zero-based indices, and native-coordinate descriptions;
  - avoid constructing an unused coroutine in an auxiliary-vision payload-budget test.

## How to Test

1. Capture a native macOS window in AX mode using `cua-driver 0.23.2`.
2. Click a returned element index when the click schema exposes `element_token` but capability metadata does not.
3. Confirm Hermes attaches the matching snapshot token and the driver reports the effect as confirmed.
4. Run `scripts/run_tests.sh tests/tools/test_computer_use*.py -q`, Ruff, and `git diff --check`.

Verified locally on the historical head:

- 16 focused test files: 244 passed and 2 Linux-only tests skipped on macOS.
- Ruff passed.
- `git diff --check` passed.
- Live macOS 26.6.2 smoke test with `cua-driver 0.23.2`: Appearance and General-restore clicks both returned `ok=True, effect=confirmed`.

The complete repository suite was started but exceeded the local execution limit, so it is not claimed green.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I found no duplicate — #92694 was missed initially and this PR was closed when triage identified the overlap
- [x] My PR contains **only** changes related to this fix, its model-facing contract, and regression tests
- [ ] I've run `pytest tests/ -q` and all tests pass — the full repository run did not complete locally
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.6.2, `cua-driver 0.23.2`

### Documentation & Housekeeping

- [x] I've updated relevant documentation — model-facing schema and docstrings were corrected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — schema/capability detection is platform-neutral; Linux-specific tests remain in CI
- [x] I've updated tool descriptions/schemas to match the corrected behavior

## Screenshots / Logs

N/A — the exact structured-driver error and confirmed live-click outcomes are recorded above.
