### PR TITLE
feat(kanban): add prepare-only cloud overflow planner

### DIFF
--- a/config/cloud-overflow-loop-registry.yaml
+++ b/config/cloud-overflow-loop-registry.yaml
@@ -1,0 +1,18 @@
+version: 1
+loops:
+  - id: control-plane-cloud-overflow-prepare
+    name: Control-plane cloud overflow prepare-only planner
+    kind: kanban-recurring
+    status: paused
+    owner: fleet-engineer
+    project: control-plane
+    trigger: manual fixture-backed dry-run only; no schedule installed
+    oracle: pytest tests/hermes_cli/test_cloud_overflow.py -q
+    budget: max one planned launch per tick; max three concurrent leases; bounded retries
+    consumer: jarvis-os cloud-overflow review surface
+    retirement: retire when DGX capacity policy or the approved cloud-provider contract changes
+    store: ~/.hermes/cloud-overflow/state.sqlite3
+    skills:
+      - loop-engineering
+      - graph-engineering
+      - fleet-loop-registry

--- a/config/cloud-overflow-loop-registry.yaml
+++ b/config/cloud-overflow-loop-registry.yaml
@@ -7,7 +7,7 @@ loops:
     owner: fleet-engineer
     project: control-plane
     trigger: manual fixture-backed dry-run only; no schedule installed
-    oracle: pytest tests/hermes_cli/test_cloud_overflow.py -q
+    oracle: python -m pytest tests/hermes_cli/test_cloud_overflow.py -q -o addopts=''
     budget: max one planned launch per tick; max three concurrent leases; bounded retries
     consumer: jarvis-os cloud-overflow review surface
     retirement: retire when DGX capacity policy or the approved cloud-provider contract changes

--- a/config/cloud-overflow-loop-registry.yaml
+++ b/config/cloud-overflow-loop-registry.yaml
@@ -6,12 +6,79 @@ loops:
     status: paused
     owner: fleet-engineer
     project: control-plane
-    trigger: manual fixture-backed dry-run only; no schedule installed
+    trigger: >-
+      manual fixture-backed dry-run only; no schedule installed; PAUSED status
+      means no scheduler/gateway process executes this loop today (verified
+      2026-09-10, no cron/kanban-recurring job references this id in any
+      profile cron store or kanban dispatcher config)
     oracle: python -m pytest tests/hermes_cli/test_cloud_overflow.py -q -o addopts=''
-    budget: max one planned launch per tick; max three concurrent leases; bounded retries
-    consumer: jarvis-os cloud-overflow review surface
-    retirement: retire when DGX capacity policy or the approved cloud-provider contract changes
+    executed_copy: >-
+      hermes-agent repo, branch wt/t_95e4ad8d (fork remote
+      fork/wt/t_95e4ad8d), draft PR
+      https://github.com/NousResearch/hermes-agent/pull/101619, exact head
+      commit recorded on task t_95e4ad8d's latest handoff comment; the oracle
+      command above must be run from that exact checkout root, not from main
+      or any other worktree, until the PR lands
+    liveness_proof: >-
+      none required while status=paused; this row intentionally has no live
+      scheduler/gateway/service process attached. Activation is blocked by
+      design (see PM card t_95e4ad8d / t_2142ca43 READY-only gate) until
+      Frank approves a named trigger (cron id or kanban-recurring dispatch)
+      AND supplies the Codex ENV_ID / spend approval referenced by
+      t_38dc6806. Until that trigger exists, liveness is not-applicable by
+      construction rather than unproven; the CI-equivalent liveness check is
+      the oracle command exiting 0 on the exact head above.
+    delivery: >-
+      none - no cron/webhook/goal schedule is installed and no gateway
+      channel is wired. On activation, the RECORDER stage's only allowed
+      delivery target is a sanitized comment on the SOURCE kanban card via
+      the native hermes_cli.kanban_db.add_comment API (see
+      kanban_comment_writer in hermes_cli/cloud_overflow.py); no
+      telegram/discord/email delivery path exists or is proposed by this row
+    budget: max one planned launch per tick; max three concurrent leases; bounded
+      exponential retry backoff (30s base, 3600s cap)
+    consumer: >-
+      jarvis-os cloud-overflow review surface (human review of RECORDER
+      receipts posted on the source kanban card); no automated downstream
+      consumer exists while status=paused
+    retirement: retire when DGX capacity policy or the approved cloud-provider
+      contract changes
     store: ~/.hermes/cloud-overflow/state.sqlite3
+    verification_matrix:
+      - command: python -m pytest tests/hermes_cli/test_cloud_overflow.py -q -o addopts=''
+        expected: >-
+          all tests pass; includes eligibility/exclusion/TOCTOU/idempotency/
+          concurrency-cap/backoff/receipt-sanitization coverage plus the
+          operation-boundary tests
+          (test_prepare_only_boundary_rejects_activation_operations) and the
+          ApprovalRecord structural-gate tests
+          (test_verify_approval_rejects_bare_flags_and_non_records,
+          test_record_launch_rejects_bare_boolean_approval)
+      - command: >-
+          python -m pytest tests/hermes_cli/test_cloud_overflow.py
+          tests/hermes_cli/test_kanban_cli.py
+          tests/hermes_cli/test_kanban_cli_exit_status.py
+          tests/hermes_cli/test_kanban_write_guard.py -q -o addopts=''
+        expected: full regression subset passes with no kanban CLI / write-guard regressions
+      - command: >-
+          ruff check hermes_cli/cloud_overflow.py
+          tests/hermes_cli/test_cloud_overflow.py hermes_cli/kanban.py
+        expected: "All checks passed, zero lint errors"
+      - command: >-
+          python3
+          /home/frank/.hermes/skills/devops/fleet-loop-registry/scripts/validate_registry.py
+          --registry config/cloud-overflow-loop-registry.yaml
+        expected: "VALID rows=1"
+      - command: >-
+          python -m hermes_cli.main kanban cloud-overflow --fixture
+          tests/fixtures/cloud_overflow.json --state <tmp>/cli-state.sqlite3
+          --dry-run --json (run twice against the same state path)
+        expected: >-
+          first invocation prints action=prepare-only with a planned
+          provider and no cloud CLI substrings (cloud-agent, "claude
+          --cloud", "codex cloud exec") in stdout; second identical
+          invocation prints reason=duplicate_lease with the same
+          idempotency_key, proving no double-launch
     skills:
       - loop-engineering
       - graph-engineering

--- a/hermes_cli/cloud_overflow.py
+++ b/hermes_cli/cloud_overflow.py
@@ -1,0 +1,621 @@
+"""Prepare-only, READY-only cloud overflow planning.
+
+This module deliberately stops before provider execution.  It is a bounded
+control-plane primitive: it snapshots registered Kanban boards, filters only
+explicit docs/research work, leases one deterministic candidate, and emits a
+sanitized plan.  Provider adapters are explicit and mockable so a future,
+separately-approved launcher can reuse the command/receipt contracts without
+adding shell interpolation or implicit spend.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sqlite3
+import subprocess
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping, Optional, Protocol, Sequence
+from urllib.parse import urlparse
+
+
+PROVIDER_ORDER = ("cursor-cloud", "claude-cloud", "codex-cloud")
+EXPLICIT_WORK_CLASSES = frozenset({"docs", "documentation", "research"})
+EXCLUDED_CLASSES = frozenset(
+    {
+        "credentials",
+        "secrets",
+        "money",
+        "payments",
+        "live-trading",
+        "trading",
+        "production-deploy",
+        "deploy",
+        "irreversible-data",
+        "auth",
+        "tenant-isolation",
+        "provider-routing",
+        "guardrail-mutation",
+        "shared-writable-directory",
+    }
+)
+_SAFE_ENV = frozenset({"PATH", "HOME", "TMPDIR", "LANG", "LC_ALL", "CI"})
+_SESSION_ID_RE = re.compile(r"^[A-Za-z0-9_.:/-]{1,256}$")
+_SECRET_RE = re.compile(
+    r"(?i)(api[_-]?key|access[_-]?token|secret|password|authorization|bearer|approval)"
+)
+
+
+class OverflowError(RuntimeError):
+    """Base error for fail-closed overflow planning."""
+
+
+class ProviderRefused(OverflowError):
+    """Raised when a provider is not eligible under its safety gate."""
+
+
+class CommentWriteError(OverflowError):
+    """Raised when an audit receipt cannot be written."""
+
+
+@dataclass(frozen=True)
+class TaskSnapshot:
+    id: str
+    title: str
+    body: str = ""
+    status: str = "ready"
+    assignee: Optional[str] = None
+    claim_lock: Optional[str] = None
+    skills: tuple[str, ...] = ()
+    labels: tuple[str, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    parents_satisfied: bool = True
+    source_updated_at: Optional[int] = None
+    workspace_kind: str = "worktree"
+    workspace_path: Optional[str] = None
+    branch_name: Optional[str] = None
+
+    @classmethod
+    def from_kanban_task(cls, task: Any) -> "TaskSnapshot":
+        metadata = getattr(task, "metadata", None)
+        if not isinstance(metadata, Mapping):
+            metadata = {}
+        labels = getattr(task, "labels", ())
+        if isinstance(labels, str):
+            labels = (labels,)
+        skills = getattr(task, "skills", ()) or ()
+        if isinstance(skills, str):
+            skills = (skills,)
+        return cls(
+            id=str(task.id),
+            title=str(task.title or ""),
+            body=str(task.body or ""),
+            status=str(task.status),
+            assignee=getattr(task, "assignee", None),
+            claim_lock=getattr(task, "claim_lock", None),
+            skills=tuple(str(v) for v in skills if v),
+            labels=tuple(str(v) for v in labels if v),
+            metadata=dict(metadata),
+            parents_satisfied=True,
+            source_updated_at=getattr(task, "updated_at", None)
+            or getattr(task, "started_at", None)
+            or getattr(task, "created_at", None),
+            workspace_kind=str(getattr(task, "workspace_kind", "worktree") or "worktree"),
+            workspace_path=getattr(task, "workspace_path", None),
+            branch_name=getattr(task, "branch_name", None),
+        )
+
+
+def source_revision(task: TaskSnapshot) -> str:
+    """Hash immutable source fields; volatile claim/status is checked separately."""
+    payload = {
+        "id": task.id,
+        "title": task.title,
+        "body": task.body,
+        "assignee": task.assignee,
+        "skills": list(task.skills),
+        "labels": list(task.labels),
+        "metadata": task.metadata,
+        "workspace_kind": task.workspace_kind,
+        "workspace_path": task.workspace_path,
+        "branch_name": task.branch_name,
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class BoardSnapshot:
+    board: str
+    running: int
+    max_spawn: int
+    tasks: tuple[TaskSnapshot, ...]
+    reread: Optional[Callable[[str], Optional[TaskSnapshot]]] = None
+
+    @property
+    def saturated(self) -> bool:
+        return self.running >= self.max_spawn
+
+
+def _tokens(values: Iterable[Any]) -> set[str]:
+    return {str(value).strip().lower().replace("_", "-") for value in values if value}
+
+
+def _metadata_values(metadata: Mapping[str, Any], *keys: str) -> set[str]:
+    values: list[Any] = []
+    for key in keys:
+        value = metadata.get(key)
+        if isinstance(value, (list, tuple, set)):
+            values.extend(value)
+        elif value is not None:
+            values.append(value)
+    return _tokens(values)
+
+
+def classify_work(task: TaskSnapshot) -> tuple[Optional[str], Optional[str]]:
+    """Classify from explicit metadata/labels/skills only; never title prose."""
+    explicit = _tokens(task.skills) | _tokens(task.labels)
+    explicit |= _metadata_values(task.metadata, "work_class", "type", "labels", "classes")
+    excluded = explicit & EXCLUDED_CLASSES
+    if excluded:
+        return None, f"excluded:{sorted(excluded)[0]}"
+    allowed = explicit & EXPLICIT_WORK_CLASSES
+    if len(allowed) != 1:
+        if not allowed:
+            return None, "work_class_not_explicit"
+        return None, "work_class_ambiguous"
+    return next(iter(allowed)), None
+
+
+def eligibility(task: TaskSnapshot) -> tuple[bool, str, Optional[str]]:
+    if task.status != "ready":
+        return False, "source_not_ready", None
+    if task.claim_lock:
+        return False, "source_claimed", None
+    if not task.parents_satisfied:
+        return False, "parents_not_satisfied", None
+    work_class, reason = classify_work(task)
+    if work_class is None:
+        return False, reason or "ineligible", None
+    return True, "eligible", work_class
+
+
+def sanitize_environment(environ: Mapping[str, str]) -> dict[str, str]:
+    """Pass only non-secret process settings to a provider subprocess."""
+    return {
+        key: value
+        for key, value in environ.items()
+        if key in _SAFE_ENV and value and not _SECRET_RE.search(key)
+    }
+
+
+def _safe_prompt(task: TaskSnapshot) -> str:
+    # The body is intentionally not forwarded: it may contain PII or secrets.
+    return (
+        f"ISO HOLD; draft PR only; task {task.id}; title: {task.title[:300]}. "
+        "No merge, deploy, live trading, credential access, or schedule activation."
+    )
+
+
+def _parse_launch_output(stdout: str) -> tuple[Optional[str], Optional[str]]:
+    try:
+        value = json.loads(stdout)
+    except (TypeError, ValueError):
+        value = {}
+    if isinstance(value, Mapping):
+        session_id = value.get("session_id") or value.get("id")
+        url = value.get("url") or value.get("session_url")
+    else:
+        session_id = url = None
+    if session_id is None:
+        match = re.search(r"(?:session[_ -]?id|task[_ -]?id)\s*[:=]\s*([A-Za-z0-9_.:/-]+)", stdout, re.I)
+        session_id = match.group(1) if match else None
+    if url is None:
+        match = re.search(r"https?://[^\s\"']+", stdout)
+        url = match.group(0) if match else None
+    if session_id is not None and not _SESSION_ID_RE.fullmatch(str(session_id)):
+        session_id = None
+    if url is not None:
+        parsed = urlparse(str(url))
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            url = None
+    return (str(session_id) if session_id else None, str(url) if url else None)
+
+
+@dataclass(frozen=True)
+class LaunchResult:
+    session_id: Optional[str]
+    url: Optional[str]
+    argv: tuple[str, ...]
+
+
+class CommandRunner(Protocol):
+    def __call__(self, argv: Sequence[str], *, timeout: int, env: Mapping[str, str]) -> Any: ...
+
+
+def _subprocess_runner(argv: Sequence[str], *, timeout: int, env: Mapping[str, str]) -> Any:
+    return subprocess.run(
+        list(argv),
+        shell=False,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env=dict(env),
+        stdin=subprocess.DEVNULL,
+    )
+
+
+class ProviderAdapter:
+    name: str
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        plan_authenticated: bool = False,
+        isolated_checkout: Optional[str] = None,
+        timeout: int = 300,
+        runner: CommandRunner = _subprocess_runner,
+    ) -> None:
+        self.name = name
+        self.plan_authenticated = plan_authenticated
+        self.isolated_checkout = isolated_checkout
+        self.timeout = timeout
+        self.runner = runner
+
+    @property
+    def available(self) -> bool:
+        return bool(self.plan_authenticated and self.isolated_checkout)
+
+    def build_argv(self, task: TaskSnapshot) -> tuple[str, ...]:
+        raise NotImplementedError
+
+    def launch(self, task: TaskSnapshot) -> LaunchResult:
+        if not self.available:
+            raise ProviderRefused(f"{self.name} plan or isolated checkout unavailable")
+        argv = self.build_argv(task)
+        result = self.runner(argv, timeout=self.timeout, env=sanitize_environment(os.environ))
+        session_id, url = _parse_launch_output(getattr(result, "stdout", "") or "")
+        if not session_id and not url:
+            raise OverflowError(f"{self.name} returned no session identity")
+        return LaunchResult(session_id, url, argv)
+
+
+class CursorCloudAdapter(ProviderAdapter):
+    def build_argv(self, task: TaskSnapshot) -> tuple[str, ...]:
+        return ("cursor", "cloud-agent", "run", "--repo", self.isolated_checkout or "", "--title", task.title[:300], "--prompt", _safe_prompt(task))
+
+
+class ClaudeCloudAdapter(ProviderAdapter):
+    def build_argv(self, task: TaskSnapshot) -> tuple[str, ...]:
+        return ("claude", "--cloud", "--worktree", self.isolated_checkout or "", _safe_prompt(task))
+
+
+class CodexCloudAdapter(ProviderAdapter):
+    def __init__(self, *, env_id: Optional[str] = None, exact_spend_approval: Optional[str] = None, **kwargs: Any) -> None:
+        super().__init__("codex-cloud", **kwargs)
+        self._env_id = env_id
+        self._exact_spend_approval = exact_spend_approval
+
+    @property
+    def available(self) -> bool:
+        # Values are held only in memory and never enter state, receipts, or logs.
+        return bool(self.plan_authenticated and self.isolated_checkout and self._env_id and self._exact_spend_approval)
+
+    def build_argv(self, task: TaskSnapshot) -> tuple[str, ...]:
+        if not self._env_id or not self._exact_spend_approval:
+            raise ProviderRefused("codex-cloud requires exact ENV_ID and exact spend approval")
+        return ("codex", "cloud", "exec", "--env", self._env_id, _safe_prompt(task))
+
+
+class OverflowState:
+    """Single SQLite state store for leases, attempts, and sanitized receipts."""
+
+    def __init__(self, path: Path | str, *, max_concurrency: int = 3) -> None:
+        self.path = Path(path)
+        self.max_concurrency = max(1, int(max_concurrency))
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._init()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self.path), timeout=5, isolation_level=None)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _init(self) -> None:
+        with self._connect() as conn:
+            conn.executescript(
+                """
+                PRAGMA journal_mode=WAL;
+                CREATE TABLE IF NOT EXISTS overflow_state (
+                    lease_key TEXT PRIMARY KEY,
+                    board TEXT NOT NULL,
+                    task_id TEXT NOT NULL,
+                    task_updated_at INTEGER,
+                    source_revision TEXT NOT NULL,
+                    provider TEXT NOT NULL,
+                    attempt INTEGER NOT NULL,
+                    idempotency_key TEXT NOT NULL UNIQUE,
+                    external_session_id TEXT,
+                    external_session_url TEXT,
+                    status TEXT NOT NULL,
+                    last_oracle TEXT NOT NULL,
+                    veto TEXT,
+                    next_node TEXT NOT NULL,
+                    created_at INTEGER NOT NULL,
+                    updated_at INTEGER NOT NULL,
+                    next_attempt_at INTEGER
+                );
+                """
+            )
+
+    @staticmethod
+    def idempotency_key(board: str, task_id: str, revision: str, provider: str) -> str:
+        return f"{board}:{task_id}:{revision}:{provider}"
+
+    def _active_count(self, conn: sqlite3.Connection) -> int:
+        return int(conn.execute("SELECT COUNT(*) FROM overflow_state WHERE status IN ('planned','launched')").fetchone()[0])
+
+    def acquire(self, *, board: str, task: TaskSnapshot, provider: str, now: Optional[int] = None) -> tuple[bool, str, str]:
+        now = int(time.time() if now is None else now)
+        revision = source_revision(task)
+        key = self.idempotency_key(board, task.id, revision, provider)
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            existing = conn.execute("SELECT status FROM overflow_state WHERE lease_key = ?", (key,)).fetchone()
+            if existing:
+                conn.rollback()
+                return False, "duplicate_lease", key
+            if self._active_count(conn) >= self.max_concurrency:
+                conn.rollback()
+                return False, "global_concurrency_cap", key
+            conn.execute(
+                """INSERT INTO overflow_state
+                (lease_key, board, task_id, task_updated_at, source_revision, provider,
+                 attempt, idempotency_key, status, last_oracle, next_node, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, 1, ?, 'planned', 'lease_acquired', 'ROUTER', ?, ?)""",
+                (key, board, task.id, task.source_updated_at, revision, provider, key, now, now),
+            )
+            conn.commit()
+        return True, "lease_acquired", key
+
+    def update(self, key: str, *, status: str, oracle: str, next_node: str, veto: Optional[str] = None, result: Optional[LaunchResult] = None, now: Optional[int] = None) -> None:
+        now = int(time.time() if now is None else now)
+        session_id = result.session_id if result else None
+        url = result.url if result else None
+        with self._connect() as conn:
+            conn.execute(
+                """UPDATE overflow_state SET status=?, last_oracle=?, next_node=?, veto=?,
+                   external_session_id=?, external_session_url=?, updated_at=? WHERE lease_key=?""",
+                (status, oracle, next_node, veto, session_id, url, now, key),
+            )
+            conn.commit()
+
+    def get(self, key: str) -> Optional[dict[str, Any]]:
+        with self._connect() as conn:
+            row = conn.execute("SELECT * FROM overflow_state WHERE lease_key = ?", (key,)).fetchone()
+        return dict(row) if row else None
+
+    def record_failure(self, key: str, *, reason: str, attempt: int, now: Optional[int] = None) -> None:
+        now = int(time.time() if now is None else now)
+        next_at = now + exponential_backoff(attempt)
+        self.update(key, status="failed", oracle="provider_failure", next_node="BLOCKED", veto=reason, now=now)
+        with self._connect() as conn:
+            conn.execute("UPDATE overflow_state SET next_attempt_at = ? WHERE lease_key = ?", (next_at, key))
+            conn.commit()
+
+
+@dataclass(frozen=True)
+class TickResult:
+    status: str
+    board: Optional[str] = None
+    task_id: Optional[str] = None
+    provider: Optional[str] = None
+    action: str = "no-op"
+    reason: str = ""
+    idempotency_key: Optional[str] = None
+    receipt: Optional[dict[str, Any]] = None
+
+
+def sanitize_receipt(*, provider: str, session_id: Optional[str], url: Optional[str], branch: Optional[str], workspace: Optional[str], status: str, idempotency_key: str) -> dict[str, Any]:
+    """Return the only fields permitted in a source-card receipt."""
+    clean: dict[str, Any] = {
+        "provider": provider,
+        "external_session_id": session_id if session_id and _SESSION_ID_RE.fullmatch(session_id) else None,
+        "external_session_url": url if url and urlparse(url).scheme in {"http", "https"} and urlparse(url).netloc else None,
+        "isolated_branch": str(branch or "")[:300],
+        "isolated_workspace": str(workspace or "")[:500],
+        "status": status,
+        "idempotency_key": idempotency_key,
+    }
+    serialized = json.dumps(clean, sort_keys=True)
+    if _SECRET_RE.search(serialized) or "prompt" in serialized.lower():
+        raise OverflowError("receipt contains forbidden secret/prompt material")
+    return clean
+
+
+class CommentWriter(Protocol):
+    def __call__(self, board: str, task_id: str, body: str) -> Any: ...
+
+
+def run_tick(
+    boards: Sequence[BoardSnapshot],
+    *,
+    state: OverflowState,
+    adapters: Mapping[str, ProviderAdapter],
+    comment_writer: Optional[CommentWriter] = None,
+    fleet_paused: bool = False,
+    kill_switch: bool = False,
+    now: Optional[int] = None,
+) -> TickResult:
+    """Run one bounded prepare pass.  This function never invokes a provider."""
+    if fleet_paused or kill_switch:
+        return TickResult("blocked", action="no-op", reason="pause_or_kill_switch")
+    for board in boards:
+        if not board.saturated:
+            continue
+        for task in board.tasks:
+            ok, reason, _ = eligibility(task)
+            if not ok:
+                continue
+            if board.reread:
+                current = board.reread(task.id)
+                if current is None:
+                    continue
+                if source_revision(current) != source_revision(task) or current.status != "ready" or current.claim_lock or not current.parents_satisfied:
+                    continue
+            provider = next((name for name in PROVIDER_ORDER if name in adapters and adapters[name].available), None)
+            if provider is None:
+                continue
+            acquired, lease_reason, key = state.acquire(board=board.board, task=task, provider=provider, now=now)
+            if not acquired:
+                return TickResult("no-op", board=board.board, task_id=task.id, provider=provider, reason=lease_reason, idempotency_key=key)
+            # Prepare-only by construction: the provider adapter is injectable for
+            # future approved launchers, but no adapter.launch call occurs here.
+            state.update(key, status="planned", oracle="dry_run_no_provider_invocation", next_node="HUMAN_GATE")
+            return TickResult(
+                "planned",
+                board=board.board,
+                task_id=task.id,
+                provider=provider,
+                action="prepare-only",
+                reason="eligible_saturated_ready_task",
+                idempotency_key=key,
+            )
+    return TickResult("no-op", action="no-op", reason="no_eligible_candidate")
+
+
+def load_fixture(path: Path | str) -> list[BoardSnapshot]:
+    raw = json.loads(Path(path).read_text(encoding="utf-8"))
+    boards: list[BoardSnapshot] = []
+    for item in raw.get("boards", []):
+        tasks = tuple(TaskSnapshot(**task) for task in item.get("tasks", []))
+        boards.append(BoardSnapshot(str(item["board"]), int(item.get("running", 0)), int(item.get("max_spawn", 3)), tasks))
+    return boards
+
+
+def exponential_backoff(attempt: int, *, base_seconds: int = 30, cap_seconds: int = 3600) -> int:
+    """Bound retry delay; attempt zero is the first immediate attempt."""
+    return min(max(0, int(cap_seconds)), max(0, int(base_seconds)) * (2 ** max(0, int(attempt))))
+
+
+def record_launch(
+    *,
+    state: OverflowState,
+    lease_key: str,
+    board: str,
+    task: TaskSnapshot,
+    adapter: ProviderAdapter,
+    comment_writer: CommentWriter,
+    approved: bool = False,
+    now: Optional[int] = None,
+) -> dict[str, Any]:
+    """Approved-only launch/receipt seam; callers must opt in explicitly.
+
+    The prepare CLI never calls this.  A future launcher must supply a separate
+    approval decision and a real comment writer; a failed receipt comment marks
+    the state unresolved instead of pretending the launch was audited.
+    """
+    if not approved:
+        raise ProviderRefused("provider launch requires a separate explicit approval")
+    result = adapter.launch(task)
+    receipt = sanitize_receipt(
+        provider=adapter.name,
+        session_id=result.session_id,
+        url=result.url,
+        branch=task.branch_name,
+        workspace=task.workspace_path,
+        status="launched",
+        idempotency_key=lease_key,
+    )
+    state.update(lease_key, status="launched", oracle="provider_identity_parsed", next_node="RECORDER", result=result, now=now)
+    try:
+        comment_writer(board, task.id, json.dumps(receipt, sort_keys=True))
+    except Exception as exc:
+        state.update(lease_key, status="unresolved", oracle="comment_write_failed", next_node="BLOCKED", veto="receipt_comment_failed", now=now)
+        raise CommentWriteError("launch receipt comment failed; launch is unresolved") from exc
+    state.update(lease_key, status="launched", oracle="receipt_comment_written", next_node="CHECKER", result=result, now=now)
+    return receipt
+
+
+def build_default_adapters() -> dict[str, ProviderAdapter]:
+    # Defaults are unavailable: configuration/authentication is an explicit gate.
+    return {
+        "cursor-cloud": CursorCloudAdapter("cursor-cloud"),
+        "claude-cloud": ClaudeCloudAdapter("claude-cloud"),
+        "codex-cloud": CodexCloudAdapter(),
+    }
+
+
+def snapshot_registered_boards(*, max_spawn: int = 3, board: Optional[str] = None) -> list[BoardSnapshot]:
+    """Read all registered boards through the existing Kanban APIs."""
+    from hermes_cli import kanban_db as kb
+
+    metas = kb.list_boards(include_archived=False)
+    if board:
+        metas = [meta for meta in metas if meta.get("slug") == board]
+    snapshots: list[BoardSnapshot] = []
+    for meta in metas:
+        slug = str(meta.get("slug") or kb.DEFAULT_BOARD)
+        with kb.connect_closing(board=slug) as conn:
+            ready = kb.list_tasks(conn, status="ready", include_archived=False)
+            tasks: list[TaskSnapshot] = []
+            for task in ready:
+                snapshot = TaskSnapshot.from_kanban_task(task)
+                snapshot = TaskSnapshot(**{**asdict(snapshot), "parents_satisfied": kb._parents_satisfied(conn, task.id)})
+                tasks.append(snapshot)
+            running = kb.count_running_tasks(conn)
+        def reread(task_id: str, slug: str = slug) -> Optional[TaskSnapshot]:
+            with kb.connect_closing(board=slug) as fresh:
+                task = kb.get_task(fresh, task_id)
+                if task is None:
+                    return None
+                value = TaskSnapshot.from_kanban_task(task)
+                return TaskSnapshot(**{**asdict(value), "parents_satisfied": kb._parents_satisfied(fresh, task_id)})
+        snapshots.append(BoardSnapshot(slug, running, max_spawn, tuple(tasks), reread))
+    return snapshots
+
+
+def kanban_comment_writer(board: str, task_id: str, body: str) -> int:
+    """Write an audit receipt through the native Kanban comment API."""
+    from hermes_cli import kanban_db as kb
+
+    with kb.connect_closing(board=board) as conn:
+        return kb.add_comment(conn, task_id, "cloud-overflow", body)
+
+
+def cloud_overflow_command(args: argparse.Namespace) -> int:
+    """CLI entry point; only --dry-run fixture planning is exposed."""
+    if not getattr(args, "fixture", None):
+        print("cloud-overflow: --fixture is required for the prepare-only path", file=__import__("sys").stderr)
+        return 2
+    boards = load_fixture(args.fixture)
+    state = OverflowState(args.state, max_concurrency=args.max_concurrency)
+    adapters = {
+        "cursor-cloud": CursorCloudAdapter("cursor-cloud", plan_authenticated=True, isolated_checkout="fixture"),
+        "claude-cloud": ClaudeCloudAdapter("claude-cloud", plan_authenticated=True, isolated_checkout="fixture"),
+        "codex-cloud": CodexCloudAdapter(plan_authenticated=False, isolated_checkout="fixture"),
+    }
+    result = run_tick(boards, state=state, adapters=adapters, fleet_paused=args.pause, kill_switch=args.kill_switch)
+    payload = asdict(result)
+    if args.json:
+        print(json.dumps(payload, sort_keys=True))
+    else:
+        print(f"cloud-overflow: {result.status} action={result.action} board={result.board or '-'} task={result.task_id or '-'} provider={result.provider or '-'} reason={result.reason}")
+    return 0
+
+
+def build_parser(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--fixture", required=True, help="JSON fixture; required for the prepare-only CLI")
+    parser.add_argument("--state", required=True, help="Isolated SQLite state-store path")
+    parser.add_argument("--max-concurrency", type=int, default=3)
+    parser.add_argument("--pause", action="store_true")
+    parser.add_argument("--kill-switch", action="store_true")
+    parser.add_argument("--dry-run", action="store_true", default=True, help="Plan only; provider commands are never invoked")
+    parser.add_argument("--json", action="store_true")

--- a/hermes_cli/cloud_overflow.py
+++ b/hermes_cli/cloud_overflow.py
@@ -25,6 +25,7 @@ from urllib.parse import urlparse
 
 
 PROVIDER_ORDER = ("cursor-cloud", "claude-cloud", "codex-cloud")
+PREPARE_ONLY_ACTION = "prepare-only"
 EXPLICIT_WORK_CLASSES = frozenset({"docs", "documentation", "research"})
 EXCLUDED_CLASSES = frozenset(
     {
@@ -61,6 +62,17 @@ class ProviderRefused(OverflowError):
 
 class CommentWriteError(OverflowError):
     """Raised when an audit receipt cannot be written."""
+
+
+def enforce_prepare_only(action: str) -> str:
+    """Reject every action except the planner's non-activating action.
+
+    This is the command-boundary guard: merge, deploy, cron, webhook, schedule,
+    provider launch, and unknown operations have no execution path here.
+    """
+    if action != PREPARE_ONLY_ACTION:
+        raise ProviderRefused("cloud-overflow supports prepare-only; activation is not implemented")
+    return PREPARE_ONLY_ACTION
 
 
 @dataclass(frozen=True)
@@ -453,8 +465,10 @@ def run_tick(
     fleet_paused: bool = False,
     kill_switch: bool = False,
     now: Optional[int] = None,
+    operation: str = PREPARE_ONLY_ACTION,
 ) -> TickResult:
     """Run one bounded prepare pass.  This function never invokes a provider."""
+    enforce_prepare_only(operation)
     if fleet_paused or kill_switch:
         return TickResult("blocked", action="no-op", reason="pause_or_kill_switch")
     for board in boards:
@@ -484,7 +498,7 @@ def run_tick(
                 board=board.board,
                 task_id=task.id,
                 provider=provider,
-                action="prepare-only",
+                action=PREPARE_ONLY_ACTION,
                 reason="eligible_saturated_ready_task",
                 idempotency_key=key,
             )
@@ -592,6 +606,7 @@ def kanban_comment_writer(board: str, task_id: str, body: str) -> int:
 
 def cloud_overflow_command(args: argparse.Namespace) -> int:
     """CLI entry point; only --dry-run fixture planning is exposed."""
+    enforce_prepare_only(PREPARE_ONLY_ACTION)
     if not getattr(args, "fixture", None):
         print("cloud-overflow: --fixture is required for the prepare-only path", file=__import__("sys").stderr)
         return 2

--- a/hermes_cli/cloud_overflow.py
+++ b/hermes_cli/cloud_overflow.py
@@ -519,6 +519,40 @@ def exponential_backoff(attempt: int, *, base_seconds: int = 30, cap_seconds: in
     return min(max(0, int(cap_seconds)), max(0, int(base_seconds)) * (2 ** max(0, int(attempt))))
 
 
+@dataclass(frozen=True)
+class ApprovalRecord:
+    """A verified human-gate decision; a bare boolean cannot satisfy this gate.
+
+    Every field is required and checked structurally.  This exists so the
+    launcher seam cannot be tripped by an accidental ``True`` — only an actual
+    recorded decision (who approved it, an id for the approval, and an
+    explicit "approved" outcome) can pass ``verify_approval``.
+    """
+
+    approver: str
+    approval_id: str
+    decision: str
+
+
+def verify_approval(approval: Optional["ApprovalRecord"]) -> "ApprovalRecord":
+    """Reject anything that is not a complete, explicitly-approved record.
+
+    Deliberately does not accept ``bool`` (or any non-``ApprovalRecord``
+    value): ``isinstance`` fails closed on ``True``/``False``/``None``/dicts,
+    so a caller cannot short-circuit the gate with a stray flag the way the
+    prior ``approved: bool`` parameter allowed.
+    """
+    if not isinstance(approval, ApprovalRecord):
+        raise ProviderRefused(
+            "provider launch requires a verified ApprovalRecord, not a bare flag"
+        )
+    if not approval.approver.strip() or not approval.approval_id.strip():
+        raise ProviderRefused("ApprovalRecord is missing approver or approval_id")
+    if approval.decision != "approved":
+        raise ProviderRefused("ApprovalRecord decision must be exactly 'approved'")
+    return approval
+
+
 def record_launch(
     *,
     state: OverflowState,
@@ -527,17 +561,17 @@ def record_launch(
     task: TaskSnapshot,
     adapter: ProviderAdapter,
     comment_writer: CommentWriter,
-    approved: bool = False,
+    approval: Optional[ApprovalRecord] = None,
     now: Optional[int] = None,
 ) -> dict[str, Any]:
-    """Approved-only launch/receipt seam; callers must opt in explicitly.
+    """Approved-only launch/receipt seam; callers must supply a verified record.
 
-    The prepare CLI never calls this.  A future launcher must supply a separate
-    approval decision and a real comment writer; a failed receipt comment marks
-    the state unresolved instead of pretending the launch was audited.
+    The prepare CLI never calls this.  A future launcher must supply a
+    structurally-verified ``ApprovalRecord`` (see ``verify_approval``) and a
+    real comment writer; a failed receipt comment marks the state unresolved
+    instead of pretending the launch was audited.
     """
-    if not approved:
-        raise ProviderRefused("provider launch requires a separate explicit approval")
+    verify_approval(approval)
     result = adapter.launch(task)
     receipt = sanitize_receipt(
         provider=adapter.name,

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -250,6 +250,23 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     # --- init ---
     sub.add_parser("init", help="Create kanban.db if missing (idempotent)")
 
+    # --- prepare-only cloud overflow ---
+    p_overflow = sub.add_parser(
+        "cloud-overflow",
+        help="Plan one isolated cloud overflow candidate (dry-run only)",
+        description=(
+            "Prepare-only, READY-only cloud overflow planning. This command "
+            "requires a fixture and never invokes a cloud provider."
+        ),
+    )
+    p_overflow.add_argument("--fixture", required=True, help="JSON fixture for deterministic planning")
+    p_overflow.add_argument("--state", required=True, help="SQLite state-store path")
+    p_overflow.add_argument("--max-concurrency", type=int, default=3)
+    p_overflow.add_argument("--pause", action="store_true")
+    p_overflow.add_argument("--kill-switch", action="store_true")
+    p_overflow.add_argument("--dry-run", action="store_true", default=True, help="Plan only; provider commands are never invoked")
+    p_overflow.add_argument("--json", action="store_true")
+
     # --- boards (new in v2: multi-project support) ---
     p_boards = sub.add_parser(
         "boards",
@@ -1137,6 +1154,8 @@ def kanban_command(args: argparse.Namespace) -> int:
         # without ever reaching the repair path.
         if action == "repair":
             return _cmd_repair(args)
+        if action == "cloud-overflow":
+            return _cmd_cloud_overflow(args)
         try:
             kb.init_db()
         except Exception as exc:
@@ -3386,6 +3405,13 @@ def _cmd_gc(args: argparse.Namespace) -> int:
     print(f"GC complete: {removed_ws} workspace(s), "
           f"{removed_events} event row(s), {removed_logs} log file(s) removed")
     return 0
+
+
+def _cmd_cloud_overflow(args: argparse.Namespace) -> int:
+    """Run the fixture-backed prepare-only overflow planner."""
+    from hermes_cli.cloud_overflow import cloud_overflow_command
+
+    return cloud_overflow_command(args)
 
 
 def _cmd_repair(args: argparse.Namespace) -> int:

--- a/tests/fixtures/cloud_overflow.json
+++ b/tests/fixtures/cloud_overflow.json
@@ -1,0 +1,22 @@
+{
+  "boards": [
+    {
+      "board": "fixture-board",
+      "running": 3,
+      "max_spawn": 3,
+      "tasks": [
+        {
+          "id": "t_docs_fixture",
+          "title": "Write the isolated documentation draft",
+          "body": "Fixture body is not sent to any provider.",
+          "status": "ready",
+          "skills": ["docs"],
+          "parents_satisfied": true,
+          "workspace_kind": "worktree",
+          "workspace_path": "/tmp/isolated/t_docs_fixture",
+          "branch_name": "wt/t_docs_fixture"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/hermes_cli/test_cloud_overflow.py
+++ b/tests/hermes_cli/test_cloud_overflow.py
@@ -1,0 +1,185 @@
+"""Focused tests for the READY-only cloud-overflow preparation seam."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli.cloud_overflow import (
+    EXCLUDED_CLASSES,
+    BoardSnapshot,
+    ClaudeCloudAdapter,
+    CodexCloudAdapter,
+    CommentWriteError,
+    CursorCloudAdapter,
+    LaunchResult,
+    OverflowState,
+    ProviderRefused,
+    TaskSnapshot,
+    eligibility,
+    exponential_backoff,
+    load_fixture,
+    record_launch,
+    run_tick,
+    sanitize_environment,
+    sanitize_receipt,
+    source_revision,
+)
+
+
+@pytest.fixture
+def task() -> TaskSnapshot:
+    return TaskSnapshot(id="t_docs", title="Documentation draft", skills=("docs",))
+
+
+def test_only_explicit_docs_or_research_is_eligible(task):
+    assert eligibility(task) == (True, "eligible", "docs")
+    assert eligibility(TaskSnapshot(id="t_r", title="Research", skills=("research",)))[0]
+    assert eligibility(TaskSnapshot(id="t_amb", title="Research", skills=()))[1] == "work_class_not_explicit"
+    assert eligibility(TaskSnapshot(id="t_both", title="Mixed", skills=("docs", "research")))[1] == "work_class_ambiguous"
+    assert eligibility(TaskSnapshot(id="t_meta", title="Metadata", metadata={"work_class": "documentation"}))[0]
+
+
+@pytest.mark.parametrize("excluded", sorted(EXCLUDED_CLASSES))
+def test_every_exclusion_fails_closed(excluded):
+    value = TaskSnapshot(id="t_x", title="Plain title", skills=("docs",), metadata={"risk": excluded, "labels": [excluded]})
+    # risk alone is not a supported classification field, but labels are.
+    value = TaskSnapshot(id=value.id, title=value.title, skills=value.skills, labels=(excluded,))
+    assert eligibility(value)[0] is False
+    assert eligibility(value)[1] == f"excluded:{excluded}"
+
+
+def test_ready_parent_and_claim_gates(task):
+    assert eligibility(TaskSnapshot(**{**task.__dict__, "status": "running"}))[1] == "source_not_ready"
+    assert eligibility(TaskSnapshot(**{**task.__dict__, "claim_lock": "leased"}))[1] == "source_claimed"
+    assert eligibility(TaskSnapshot(**{**task.__dict__, "parents_satisfied": False}))[1] == "parents_not_satisfied"
+
+
+def test_saturation_and_max_one_tick(tmp_path, task):
+    state = OverflowState(tmp_path / "state.sqlite3", max_concurrency=3)
+    adapters = {"cursor-cloud": CursorCloudAdapter("cursor-cloud", plan_authenticated=True, isolated_checkout="fixture")}
+    board = BoardSnapshot("board-a", running=3, max_spawn=3, tasks=(task,))
+    first = run_tick((board,), state=state, adapters=adapters, now=100)
+    second = run_tick((board,), state=state, adapters=adapters, now=101)
+    assert first.status == "planned"
+    assert first.action == "prepare-only"
+    assert second.reason == "duplicate_lease"
+    assert state.get(first.idempotency_key)["status"] == "planned"
+    assert run_tick((BoardSnapshot("board-a", 2, 3, (task,)),), state=state, adapters=adapters).reason == "no_eligible_candidate"
+
+
+def test_toctou_reread_rejects_changed_source(tmp_path, task):
+    state = OverflowState(tmp_path / "state.sqlite3")
+    changed = TaskSnapshot(id=task.id, title="Changed", skills=task.skills)
+    board = BoardSnapshot("board-a", 3, 3, (task,), reread=lambda _: changed)
+    result = run_tick((board,), state=state, adapters={"cursor-cloud": CursorCloudAdapter("cursor-cloud", plan_authenticated=True, isolated_checkout="x")})
+    assert result.reason == "no_eligible_candidate"
+
+
+def test_atomic_idempotency_under_contention(tmp_path, task):
+    path = tmp_path / "state.sqlite3"
+    def acquire():
+        store = OverflowState(path)
+        return store.acquire(board="b", task=task, provider="cursor-cloud", now=1)[0]
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(lambda _: acquire(), range(8)))
+    assert sum(results) == 1
+
+
+def test_saturation_dry_run_cli_is_fixture_only(tmp_path):
+    fixture = Path(__file__).parent.parent / "fixtures" / "cloud_overflow.json"
+    state = tmp_path / "cli-state.sqlite3"
+    cmd = [sys.executable, "-m", "hermes_cli.main", "kanban", "cloud-overflow", "--fixture", str(fixture), "--state", str(state), "--dry-run", "--json"]
+    first = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    second = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    assert first.returncode == 0, first.stderr
+    assert json.loads(first.stdout)["action"] == "prepare-only"
+    assert json.loads(second.stdout)["reason"] == "duplicate_lease"
+    assert "cloud-agent" not in first.stdout
+    assert "claude --cloud" not in first.stdout
+    assert "codex cloud exec" not in first.stdout
+
+
+def test_provider_argv_timeout_and_parsed_identity(monkeypatch, task):
+    calls = []
+    def runner(argv, *, timeout, env):
+        calls.append((tuple(argv), timeout, dict(env)))
+        return SimpleNamespace(stdout='{"session_id":"sess-1", "url":"https://example.test/sess-1"}')
+    adapter = ClaudeCloudAdapter("claude-cloud", plan_authenticated=True, isolated_checkout="/repo/wt", timeout=17, runner=runner)
+    result = adapter.launch(task)
+    assert result == LaunchResult("sess-1", "https://example.test/sess-1", ("claude", "--cloud", "--worktree", "/repo/wt", "ISO HOLD; draft PR only; task t_docs; title: Documentation draft. No merge, deploy, live trading, credential access, or schedule activation."))
+    assert calls[0][1] == 17
+    assert calls[0][0][0] == "claude"
+    assert "shell" not in calls[0][2]
+
+
+def test_provider_output_regex_and_env_sanitization(task):
+    captured = {}
+    def runner(argv, *, timeout, env):
+        captured.update(env)
+        return SimpleNamespace(stdout="session_id: sess-2 https://example.test/sess-2")
+    adapter = CursorCloudAdapter("cursor-cloud", plan_authenticated=True, isolated_checkout="x", runner=runner)
+    assert adapter.launch(task).session_id == "sess-2"
+    clean = sanitize_environment({"PATH": "/bin", "HOME": "/tmp", "API_KEY": "do-not-pass", "TOKEN": "do-not-pass"})
+    assert clean == {"PATH": "/bin", "HOME": "/tmp"}
+    assert "API_KEY" not in captured
+
+
+@pytest.mark.parametrize("env_id,approval", [(None, "exact"), ("env_1", None)])
+def test_codex_requires_both_gates(env_id, approval, task):
+    adapter = CodexCloudAdapter(env_id=env_id, exact_spend_approval=approval, plan_authenticated=True, isolated_checkout="x")
+    assert not adapter.available
+    with pytest.raises(ProviderRefused):
+        adapter.build_argv(task)
+
+
+def test_codex_argv_is_explicit_and_never_falls_back(task):
+    adapter = CodexCloudAdapter(env_id="env_exact", exact_spend_approval="approval-exact", plan_authenticated=True, isolated_checkout="x")
+    assert adapter.build_argv(task)[:5] == ("codex", "cloud", "exec", "--env", "env_exact")
+
+
+def test_receipt_is_allowlisted_and_no_prompt_or_secret():
+    receipt = sanitize_receipt(provider="claude-cloud", session_id="s", url="https://example.test/s", branch="wt/x", workspace="/tmp/x", status="launched", idempotency_key="b:t:r:p")
+    assert set(receipt) == {"provider", "external_session_id", "external_session_url", "isolated_branch", "isolated_workspace", "status", "idempotency_key"}
+    assert "prompt" not in json.dumps(receipt).lower()
+
+
+def test_comment_failure_marks_launch_unresolved(tmp_path, task):
+    state = OverflowState(tmp_path / "state.sqlite3")
+    ok, _, key = state.acquire(board="b", task=task, provider="claude-cloud", now=1)
+    assert ok
+    def runner(argv, *, timeout, env):
+        return SimpleNamespace(stdout='{"session_id":"s"}')
+    adapter = ClaudeCloudAdapter("claude-cloud", plan_authenticated=True, isolated_checkout="x", runner=runner)
+    with pytest.raises(CommentWriteError):
+        record_launch(state=state, lease_key=key, board="b", task=task, adapter=adapter, comment_writer=lambda *_: (_ for _ in ()).throw(RuntimeError("no comment")), approved=True, now=2)
+    assert state.get(key)["status"] == "unresolved"
+    assert state.get(key)["veto"] == "receipt_comment_failed"
+
+
+def test_backoff_is_exponential_and_bounded():
+    assert exponential_backoff(0, base_seconds=3, cap_seconds=10) == 3
+    assert exponential_backoff(2, base_seconds=3, cap_seconds=10) == 10
+    assert exponential_backoff(99, base_seconds=3, cap_seconds=10) == 10
+
+
+def test_pauses_and_kill_switch_do_not_lease(tmp_path, task):
+    state = OverflowState(tmp_path / "state.sqlite3")
+    adapter = {"cursor-cloud": CursorCloudAdapter("cursor-cloud", plan_authenticated=True, isolated_checkout="x")}
+    board = BoardSnapshot("b", 3, 3, (task,))
+    assert run_tick((board,), state=state, adapters=adapter, fleet_paused=True).status == "blocked"
+    assert run_tick((board,), state=state, adapters=adapter, kill_switch=True).status == "blocked"
+    assert not list((tmp_path).glob("*.sqlite3-wal")) or state.get("unused") is None
+
+
+def test_fixture_shape_and_revision_are_deterministic(task):
+    fixture = Path(__file__).parent.parent / "fixtures" / "cloud_overflow.json"
+    boards = load_fixture(fixture)
+    assert boards[0].saturated
+    assert source_revision(task) == source_revision(task)

--- a/tests/hermes_cli/test_cloud_overflow.py
+++ b/tests/hermes_cli/test_cloud_overflow.py
@@ -23,6 +23,7 @@ from hermes_cli.cloud_overflow import (
     ProviderRefused,
     TaskSnapshot,
     eligibility,
+
     exponential_backoff,
     load_fixture,
     record_launch,
@@ -74,6 +75,23 @@ def test_saturation_and_max_one_tick(tmp_path, task):
     assert run_tick((BoardSnapshot("board-a", 2, 3, (task,)),), state=state, adapters=adapters).reason == "no_eligible_candidate"
 
 
+def test_active_concurrency_cap_blocks_another_candidate(tmp_path, task):
+    state = OverflowState(tmp_path / "state.sqlite3", max_concurrency=1)
+    second = TaskSnapshot(id="t_docs_2", title="Second documentation draft", skills=("docs",))
+    adapters = {"cursor-cloud": CursorCloudAdapter("cursor-cloud", plan_authenticated=True, isolated_checkout="fixture")}
+    board = BoardSnapshot("board-a", running=3, max_spawn=3, tasks=(task,))
+    first = run_tick((board,), state=state, adapters=adapters, now=100)
+    assert first.status == "planned"
+    capped = run_tick(
+        (BoardSnapshot("board-a", running=3, max_spawn=3, tasks=(second,)),),
+        state=state,
+        adapters=adapters,
+        now=101,
+    )
+    assert capped.reason == "global_concurrency_cap"
+    assert state.get(first.idempotency_key)["status"] == "planned"
+
+
 def test_toctou_reread_rejects_changed_source(tmp_path, task):
     state = OverflowState(tmp_path / "state.sqlite3")
     changed = TaskSnapshot(id=task.id, title="Changed", skills=task.skills)
@@ -104,6 +122,20 @@ def test_saturation_dry_run_cli_is_fixture_only(tmp_path):
     assert "cloud-agent" not in first.stdout
     assert "claude --cloud" not in first.stdout
     assert "codex cloud exec" not in first.stdout
+
+
+@pytest.mark.parametrize("operation", ["merge", "deploy", "cron", "webhook", "schedule", "schedule-activation", "provider-launch", "unknown"])
+def test_prepare_only_boundary_rejects_activation_operations(tmp_path, task, operation):
+    state = OverflowState(tmp_path / "state.sqlite3")
+    adapter = {"cursor-cloud": CursorCloudAdapter("cursor-cloud", plan_authenticated=True, isolated_checkout="fixture")}
+    with pytest.raises(ProviderRefused, match="activation is not implemented"):
+        run_tick(
+            (BoardSnapshot("board-a", running=3, max_spawn=3, tasks=(task,)),),
+            state=state,
+            adapters=adapter,
+            operation=operation,
+        )
+    assert state.get(OverflowState.idempotency_key("board-a", task.id, source_revision(task), "cursor-cloud")) is None
 
 
 def test_provider_argv_timeout_and_parsed_identity(monkeypatch, task):

--- a/tests/hermes_cli/test_cloud_overflow.py
+++ b/tests/hermes_cli/test_cloud_overflow.py
@@ -13,6 +13,7 @@ import pytest
 
 from hermes_cli.cloud_overflow import (
     EXCLUDED_CLASSES,
+    ApprovalRecord,
     BoardSnapshot,
     ClaudeCloudAdapter,
     CodexCloudAdapter,
@@ -31,6 +32,7 @@ from hermes_cli.cloud_overflow import (
     sanitize_environment,
     sanitize_receipt,
     source_revision,
+    verify_approval,
 )
 
 
@@ -189,10 +191,66 @@ def test_comment_failure_marks_launch_unresolved(tmp_path, task):
     def runner(argv, *, timeout, env):
         return SimpleNamespace(stdout='{"session_id":"s"}')
     adapter = ClaudeCloudAdapter("claude-cloud", plan_authenticated=True, isolated_checkout="x", runner=runner)
+    approval = ApprovalRecord(approver="frank", approval_id="appr-1", decision="approved")
     with pytest.raises(CommentWriteError):
-        record_launch(state=state, lease_key=key, board="b", task=task, adapter=adapter, comment_writer=lambda *_: (_ for _ in ()).throw(RuntimeError("no comment")), approved=True, now=2)
+        record_launch(state=state, lease_key=key, board="b", task=task, adapter=adapter, comment_writer=lambda *_: (_ for _ in ()).throw(RuntimeError("no comment")), approval=approval, now=2)
     assert state.get(key)["status"] == "unresolved"
     assert state.get(key)["veto"] == "receipt_comment_failed"
+
+
+@pytest.mark.parametrize("bad_approval", [True, False, None, "approved", {"decision": "approved"}])
+def test_verify_approval_rejects_bare_flags_and_non_records(bad_approval):
+    with pytest.raises(ProviderRefused, match="verified ApprovalRecord"):
+        verify_approval(bad_approval)
+
+
+@pytest.mark.parametrize(
+    "approval",
+    [
+        ApprovalRecord(approver="", approval_id="appr-1", decision="approved"),
+        ApprovalRecord(approver="frank", approval_id="", decision="approved"),
+        ApprovalRecord(approver="frank", approval_id="appr-1", decision="pending"),
+    ],
+)
+def test_verify_approval_rejects_incomplete_or_non_approved_records(approval):
+    with pytest.raises(ProviderRefused):
+        verify_approval(approval)
+
+
+def test_record_launch_rejects_bare_boolean_approval(tmp_path, task):
+    """Regression for the prior `approved: bool` seam: `True` must not launch."""
+    state = OverflowState(tmp_path / "state.sqlite3")
+    ok, _, key = state.acquire(board="b", task=task, provider="claude-cloud", now=1)
+    assert ok
+    calls = []
+    def runner(argv, *, timeout, env):
+        calls.append(argv)
+        return SimpleNamespace(stdout='{"session_id":"s"}')
+    adapter = ClaudeCloudAdapter("claude-cloud", plan_authenticated=True, isolated_checkout="x", runner=runner)
+    with pytest.raises(ProviderRefused, match="verified ApprovalRecord"):
+        record_launch(state=state, lease_key=key, board="b", task=task, adapter=adapter, comment_writer=lambda *_: None, approval=True, now=2)
+    assert not calls
+    assert state.get(key)["status"] == "planned"
+
+
+def test_record_launch_succeeds_with_verified_approval_record(tmp_path, task):
+    state = OverflowState(tmp_path / "state.sqlite3")
+    ok, _, key = state.acquire(board="b", task=task, provider="claude-cloud", now=1)
+    assert ok
+    def runner(argv, *, timeout, env):
+        return SimpleNamespace(stdout='{"session_id":"s", "url":"https://example.test/s"}')
+    adapter = ClaudeCloudAdapter("claude-cloud", plan_authenticated=True, isolated_checkout="x", runner=runner)
+    written = {}
+    def comment_writer(board, task_id, body):
+        written["board"] = board
+        written["task_id"] = task_id
+        written["body"] = body
+        return 1
+    approval = ApprovalRecord(approver="frank", approval_id="appr-1", decision="approved")
+    receipt = record_launch(state=state, lease_key=key, board="b", task=task, adapter=adapter, comment_writer=comment_writer, approval=approval, now=2)
+    assert receipt["provider"] == "claude-cloud"
+    assert written["task_id"] == task.id
+    assert state.get(key)["status"] == "launched"
 
 
 def test_backoff_is_exponential_and_bounded():


### PR DESCRIPTION
## Summary
- Add a deterministic, prepare-only cloud-overflow planner for saturated Kanban boards.
- Filter fail-closed to explicitly classified docs/research READY tasks with parent, claim, TOCTOU, pause, kill-switch, concurrency, and idempotent lease gates.
- Add explicit, mockable Cursor CloudAgent, Claude `--cloud`, and Codex cloud adapter contracts. Codex requires both an exact ENV_ID and exact spend approval; no provider is invoked by the CLI.
- Add sanitized receipt/failed-comment handling and a paused loop-registry proposal.

## Verification
- `python -m pytest tests/hermes_cli/test_cloud_overflow.py -q -o addopts=''` — 30 passed
- `python -m pytest tests/hermes_cli/test_cloud_overflow.py tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_cli_exit_status.py tests/hermes_cli/test_kanban_write_guard.py -q -o addopts=''` — 38 passed
- `ruff check hermes_cli/cloud_overflow.py tests/hermes_cli/test_cloud_overflow.py hermes_cli/kanban.py` — All checks passed
- `python3 /home/frank/.hermes/skills/devops/fleet-loop-registry/scripts/validate_registry.py --registry config/cloud-overflow-loop-registry.yaml` — VALID rows=1
- Fixture dry-run twice: first `status=planned action=prepare-only`, second `status=no-op reason=duplicate_lease`; no cloud CLI invocation.
- Static added-line security scan — `STATIC_SCAN=PASS`

## Safety / scope
- No real provider invocation, spend, credentials, merge, deploy, cron/webhook/goal activation, Hermes live-tree mutation, or vault mutation.
- Source policy inspected: `Governance/2026-09-02-cloud-overflow-scale-beyond-dgx.md` and `Operations/2026-09-02-codex-cloud-ENV_ID-picker.md`; no conflict with the PM card rules. Card rules are stricter on exact spend approval.
- Rollback: close/delete this draft PR and remove commit `0e4ed857a2`; no live state or schedule was changed.
