### PR TITLE
fix(desktop): reap leftover dashboard pid on model-picker code-skew 503

### DIFF
--- a/apps/desktop/electron/backend-recycle.test.ts
+++ b/apps/desktop/electron/backend-recycle.test.ts
@@ -1,6 +1,47 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { recycleOwnedBackend, recycleOwnedBackendTarget } from './backend-recycle'
+import {
+  canReapSkewServingPid,
+  listenPidsFromLsofT,
+  localLoopbackListenPort,
+  recycleOwnedBackend,
+  recycleOwnedBackendTarget
+} from './backend-recycle'
+
+describe('canReapSkewServingPid', () => {
+  it('reaps only a local hermes dashboard/serve pid, fail-closed otherwise', () => {
+    expect(
+      canReapSkewServingPid(4242, { command: 'hermes serve --port 9119', selfPid: 1 })
+    ).toBe(true)
+    expect(
+      canReapSkewServingPid(4242, { command: 'python -m hermes_cli.main dashboard', selfPid: 1 })
+    ).toBe(true)
+    expect(canReapSkewServingPid(4242, { command: 'ssh', selfPid: 1 })).toBe(false)
+    expect(canReapSkewServingPid(4242, { command: null, selfPid: 1 })).toBe(false)
+    expect(
+      canReapSkewServingPid(1, { command: 'hermes serve --port 9119', selfPid: 99 })
+    ).toBe(false)
+    expect(
+      canReapSkewServingPid(99, { command: 'hermes serve --port 9119', selfPid: 99 })
+    ).toBe(false)
+  })
+})
+
+describe('localLoopbackListenPort', () => {
+  it('returns the port only for loopback picker URLs', () => {
+    expect(localLoopbackListenPort('http://127.0.0.1:9119')).toBe(9119)
+    expect(localLoopbackListenPort('http://localhost:43210')).toBe(43210)
+    expect(localLoopbackListenPort('http://example.com:9119')).toBeNull()
+    expect(localLoopbackListenPort('')).toBeNull()
+  })
+})
+
+describe('listenPidsFromLsofT', () => {
+  it('parses unique positive pids from lsof -t output', () => {
+    expect(listenPidsFromLsofT('4242\n4242\n99\n')).toEqual([4242, 99])
+    expect(listenPidsFromLsofT('')).toEqual([])
+  })
+})
 
 describe('recycleOwnedBackendTarget', () => {
   it('treats an empty or matching profile as the primary backend', () => {
@@ -88,5 +129,84 @@ describe('recycleOwnedBackend', () => {
     await run
 
     expect(events).toEqual(['ssh-start', 'ssh-done', 'primary', 'applied'])
+  })
+
+  it('reaps the leftover 503-serving pid, not only the Electron-owned child (#101561)', async () => {
+    const events: string[] = []
+    const teardownServingPid = vi.fn(async (pid: number) => {
+      events.push(`serving:${pid}`)
+    })
+
+    const target = await recycleOwnedBackend({
+      notifyApplied: () => events.push('applied'),
+      primaryProfile: 'default',
+      servingPid: 4242,
+      teardownPool: async () => {
+        events.push('pool')
+      },
+      teardownPrimary: async () => {
+        events.push('primary')
+      },
+      teardownServingPid,
+      teardownSsh: async profile => {
+        events.push(`ssh:${profile}`)
+      }
+    })
+
+    expect(target).toBe('primary')
+    expect(teardownServingPid).toHaveBeenCalledWith(4242)
+    expect(events).toEqual(['ssh:', 'serving:4242', 'primary', 'applied'])
+  })
+
+  it('still recycles the owned child if leftover teardown throws', async () => {
+    const events: string[] = []
+
+    const target = await recycleOwnedBackend({
+      notifyApplied: () => events.push('applied'),
+      primaryProfile: 'default',
+      servingPid: 4242,
+      teardownPool: vi.fn(),
+      teardownPrimary: async () => {
+        events.push('primary')
+      },
+      teardownServingPid: async () => {
+        events.push('serving-throw')
+        throw new Error('leftover refused')
+      },
+      teardownSsh: async () => {
+        events.push('ssh')
+      }
+    })
+
+    expect(target).toBe('primary')
+    expect(events).toEqual(['ssh', 'serving-throw', 'primary', 'applied'])
+  })
+
+  it('reaps the loopback listener when the leftover 503 has no pid (#101561)', async () => {
+    const events: string[] = []
+    const teardownListenPort = vi.fn(async (port: number) => {
+      events.push(`listen:${port}`)
+    })
+    const teardownServingPid = vi.fn()
+
+    const target = await recycleOwnedBackend({
+      listenPort: 9119,
+      notifyApplied: () => events.push('applied'),
+      primaryProfile: 'default',
+      teardownListenPort,
+      teardownPool: vi.fn(),
+      teardownPrimary: async () => {
+        events.push('primary')
+      },
+      teardownServingPid,
+      teardownSsh: async () => {
+        events.push('ssh')
+      }
+    })
+
+    expect(target).toBe('primary')
+    expect(teardownServingPid).not.toHaveBeenCalled()
+    expect(teardownListenPort).toHaveBeenCalledWith(9119)
+    expect(events).toEqual(['ssh', 'listen:9119', 'primary', 'applied'])
   })
 })

--- a/apps/desktop/electron/backend-recycle.ts
+++ b/apps/desktop/electron/backend-recycle.ts
@@ -6,7 +6,61 @@
  * stale process via the lockfile. Kill the owned remote serve first (while
  * the SSH channel can still exec), then tear down the local child — the
  * same order as connection apply (#97046, #91668).
+ *
+ * #101561: also reap a leftover local dashboard/serve that served the 503
+ * when it is not the Electron-owned child. Never treat a remote pid number
+ * as a local kill target without a hermes serve/dashboard cmdline match.
  */
+
+import { backendCommandMatches } from './backend-ownership'
+
+export function canReapSkewServingPid(
+  pid: unknown,
+  opts: { command: null | string; selfPid: number }
+): boolean {
+  if (!Number.isInteger(pid) || (pid as number) <= 1 || pid === opts.selfPid) {
+    return false
+  }
+
+  return Boolean(opts.command) && backendCommandMatches(opts.command)
+}
+
+/** Loopback TCP port the picker is talking to, or null for remote URLs. */
+export function localLoopbackListenPort(baseUrl: unknown): number | null {
+  if (typeof baseUrl !== 'string' || !baseUrl.trim()) {
+    return null
+  }
+
+  try {
+    const url = new URL(baseUrl)
+    const host = url.hostname.toLowerCase()
+
+    if (host !== '127.0.0.1' && host !== 'localhost' && host !== '::1') {
+      return null
+    }
+
+    const port = Number(url.port || (url.protocol === 'https:' ? 443 : 80))
+
+    return Number.isInteger(port) && port > 0 ? port : null
+  } catch {
+    return null
+  }
+}
+
+/** PIDs from `lsof -t` listen output. */
+export function listenPidsFromLsofT(stdout: unknown): number[] {
+  const seen = new Set<number>()
+
+  for (const part of String(stdout ?? '').split(/[\s,]+/)) {
+    const pid = Number(part)
+
+    if (Number.isInteger(pid) && pid > 1 && !seen.has(pid)) {
+      seen.add(pid)
+    }
+  }
+
+  return [...seen]
+}
 
 export type RecycleOwnedBackendTarget = 'pool' | 'primary'
 
@@ -14,8 +68,14 @@ export interface RecycleOwnedBackendDeps {
   notifyApplied: () => void
   primaryProfile: string
   profile?: null | string
+  /** Local leftover dashboard/serve that actually served the 503 (#101561). */
+  servingPid?: null | number
+  /** Loopback port the picker talks to — used when the leftover predates pid= in 503. */
+  listenPort?: null | number
   teardownPool: (profile: string) => Promise<void>
   teardownPrimary: () => Promise<void>
+  teardownServingPid?: (pid: number) => Promise<void>
+  teardownListenPort?: (port: number) => Promise<void>
   teardownSsh: (profile: string) => Promise<void>
 }
 
@@ -31,9 +91,26 @@ export function recycleOwnedBackendTarget(
 export async function recycleOwnedBackend(deps: RecycleOwnedBackendDeps): Promise<RecycleOwnedBackendTarget> {
   const target = recycleOwnedBackendTarget(deps.profile, deps.primaryProfile)
   const profile = String(deps.profile ?? '').trim()
+  const servingPid = Number(deps.servingPid)
+  const listenPort = Number(deps.listenPort)
+  const reapLeftover = async () => {
+    try {
+      if (Number.isInteger(servingPid) && servingPid > 1) {
+        await deps.teardownServingPid?.(servingPid)
+        return
+      }
+
+      if (Number.isInteger(listenPort) && listenPort > 0) {
+        await deps.teardownListenPort?.(listenPort)
+      }
+    } catch {
+      // Leftover reap must not skip owned-child recycle (#101561).
+    }
+  }
 
   if (target === 'primary') {
     await deps.teardownSsh('')
+    await reapLeftover()
     await deps.teardownPrimary()
     deps.notifyApplied()
 
@@ -41,6 +118,7 @@ export async function recycleOwnedBackend(deps: RecycleOwnedBackendDeps): Promis
   }
 
   await deps.teardownSsh(profile)
+  await reapLeftover()
   await deps.teardownPool(profile)
 
   return target

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -63,7 +63,13 @@ import {
   verifyHermesCli
 } from './backend-probes'
 import { waitForDashboardPortAnnouncement } from './backend-ready'
-import { recycleOwnedBackend } from './backend-recycle'
+import {
+  canReapSkewServingPid,
+  listenPidsFromLsofT,
+  localLoopbackListenPort,
+  recycleOwnedBackend,
+  recycleOwnedBackendTarget
+} from './backend-recycle'
 import { isPidAliveWindows, waitForBackendRelease } from './backend-release-gate'
 import {
   isHostKeyChangedBootFailure,
@@ -14749,16 +14755,94 @@ const hudIpc = registerHudIpc({
   }
 })
 
-ipcMain.handle('hermes:backend:recycle', async (_event, profile) => {
+async function listenPidsOnTcpPort(port) {
+  try {
+    const stdout = await execText('lsof', ['-nP', `-iTCP:${port}`, '-sTCP:LISTEN', '-t'])
+
+    return listenPidsFromLsofT(stdout)
+  } catch {
+    return []
+  }
+}
+
+async function currentLocalListenPort(profile) {
+  const target = recycleOwnedBackendTarget(profile, primaryProfileKey())
+
+  if (target === 'pool') {
+    const key = String(profile || '').trim()
+    const entry = backendPool.get(key)
+
+    if (Number.isInteger(entry?.port) && entry.port > 0) {
+      return entry.port
+    }
+
+    return localLoopbackListenPort(entry?.remoteBaseUrl)
+  }
+
+  const pending = backendConnectionState.getPromise()
+
+  if (!pending) {
+    return null
+  }
+
+  try {
+    const connection = await pending
+
+    return localLoopbackListenPort(connection?.baseUrl)
+  } catch {
+    return null
+  }
+}
+
+async function teardownSkewListenPort(port) {
+  if (!Number.isInteger(port) || port <= 0) {
+    return
+  }
+
+  for (const pid of await listenPidsOnTcpPort(port)) {
+    await teardownSkewServingPid(pid)
+  }
+}
+
+async function teardownSkewServingPid(pid) {
+  // Fail closed: only reap a live local hermes dashboard/serve. A remote SSH
+  // 503 pid must not be interpreted as a local kill target (#101561).
+  const command = Number.isInteger(pid) ? await backendCommandForPid(pid) : null
+
+  if (!canReapSkewServingPid(pid, { command, selfPid: process.pid })) {
+    return
+  }
+
+  try {
+    await stopOwnedBackend({
+      nonce: 'code-skew-serving',
+      pid,
+      profile: 'skew-recovery',
+      startMarker: pidOnlyStartMarker(pid)
+    })
+  } catch {
+    // Leftover refused to exit must not block owned-child recycle (#101561).
+  }
+}
+
+ipcMain.handle('hermes:backend:recycle', async (_event, profile, servingPid) => {
   // Models-page recovery after a code-skew 503 (#97046): kill the owned
   // SSH serve (if any) before the local child so reconnect cannot reuse a
   // stale lockfile. Soft primary teardown keeps the renderer shell mounted.
+  // #101561: also reap the leftover local dashboard/serve that actually
+  // served the 503 when it is not the Electron-owned child.
+  const recycleProfile = typeof profile === 'string' ? profile : ''
+
   await recycleOwnedBackend({
     notifyApplied: sendConnectionApplied,
     primaryProfile: primaryProfileKey(),
-    profile: typeof profile === 'string' ? profile : '',
+    profile: recycleProfile,
+    servingPid: Number.isInteger(servingPid) ? servingPid : undefined,
+    listenPort: Number.isInteger(servingPid) ? undefined : await currentLocalListenPort(recycleProfile),
     teardownPool: teardownPoolBackendAndWait,
     teardownPrimary: () => teardownPrimaryBackendAndWait({ soft: true }),
+    teardownServingPid: teardownSkewServingPid,
+    teardownListenPort: teardownSkewListenPort,
     teardownSsh: value => teardownSshConnection(value || null)
   })
 

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -480,7 +480,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   // reload mid-bootstrap.
   getBootstrapState: () => ipcRenderer.invoke('hermes:bootstrap:get'),
   continueBootstrapLocal: () => ipcRenderer.invoke('hermes:bootstrap:continue-local'),
-  recycleBackend: profile => ipcRenderer.invoke('hermes:backend:recycle', profile),
+  recycleBackend: (profile, servingPid) => ipcRenderer.invoke('hermes:backend:recycle', profile, servingPid),
   resetBootstrap: () => ipcRenderer.invoke('hermes:bootstrap:reset'),
   repairBootstrap: () => ipcRenderer.invoke('hermes:bootstrap:repair'),
   cancelBootstrap: () => ipcRenderer.invoke('hermes:bootstrap:cancel'),

--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -596,7 +596,7 @@ describe('ModelSettings MoA preset editor', () => {
 
 describe('ModelSettings code-skew 503', () => {
   const skewError = new Error(
-    'Error invoking remote method \'hermes:api\': Error: 503: {"detail":"Restart required: This process is running code from 08b4875f4a but the checkout on disk is now 48d2528066. The model picker would risk a stale-module crash — restart the Desktop-owned backend to load the new code (use Restart backend in Hermes Desktop, or quit and reopen the app)"}'
+    'Error invoking remote method \'hermes:api\': Error: 503: {"detail":"Restart required: This process is running code from 08b4875f4a but the checkout on disk is now 48d2528066 (pid=4242). The model picker would risk a stale-module crash — restart the Desktop-owned backend to load the new code (use Restart backend in Hermes Desktop, or quit and reopen the app)"}'
   )
 
   afterEach(() => {
@@ -630,7 +630,7 @@ describe('ModelSettings code-skew 503', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Restart backend' }))
 
-    await waitFor(() => expect(recycleBackend).toHaveBeenCalledWith(undefined))
+    await waitFor(() => expect(recycleBackend).toHaveBeenCalledWith(undefined, 4242))
     await waitFor(() => expect(getGlobalModelOptions.mock.calls.length).toBeGreaterThan(1))
   })
 })

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -24,7 +24,7 @@ import type {
   StaleAuxAssignment
 } from '@/hermes'
 import { useI18n } from '@/i18n'
-import { isCodeSkewRestartRequired } from '@/lib/code-skew-error'
+import { isCodeSkewRestartRequired, servingPidFromCodeSkewError } from '@/lib/code-skew-error'
 import { AlertTriangle, Cpu, Loader2 } from '@/lib/icons'
 import { DEFAULT_REASONING_EFFORT, REASONING_EFFORT_VALUES } from '@/lib/reasoning-effort'
 import { cn } from '@/lib/utils'
@@ -231,10 +231,12 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
   // so a request in flight when the user switches profiles can't paint profile
   // A's models/providers into profile B (or fire onMainModelChanged for A).
   const profileEpoch = useRef(0)
+  const lastSkewServingPid = useRef<number | null>(null)
 
   const setCaughtError = useCallback(
     (err: unknown, fallback: string) => {
       const skew = isCodeSkewRestartRequired(err)
+      lastSkewServingPid.current = skew ? servingPidFromCodeSkewError(err) : null
       setSkewRestart(skew)
       setError(skew ? m.restartRequired : readableError(err, fallback).message)
     },
@@ -810,7 +812,13 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
     setSkewRestart(false)
 
     try {
-      await window.hermesDesktop?.recycleBackend?.(scopeProfile)
+      const servingPid = lastSkewServingPid.current
+      if (servingPid != null) {
+        await window.hermesDesktop?.recycleBackend?.(scopeProfile, servingPid)
+      } else {
+        await window.hermesDesktop?.recycleBackend?.(scopeProfile)
+      }
+      lastSkewServingPid.current = null
       await refresh({ replaceSelection: true })
     } catch (err) {
       setCaughtError(err, m.restartFailed)

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -499,7 +499,7 @@ declare global {
       onBootProgress: (callback: (payload: DesktopBootProgress) => void) => () => void
       getBootstrapState: () => Promise<DesktopBootstrapState>
       continueBootstrapLocal: () => Promise<{ ok: boolean }>
-      recycleBackend?: (profile?: null | string) => Promise<{ ok: boolean }>
+      recycleBackend?: (profile?: null | string, servingPid?: number) => Promise<{ ok: boolean }>
       resetBootstrap: () => Promise<{ ok: boolean }>
       repairBootstrap: () => Promise<{ ok: boolean }>
       cancelBootstrap: () => Promise<{ ok: boolean; cancelled: boolean }>

--- a/apps/desktop/src/lib/code-skew-error.test.ts
+++ b/apps/desktop/src/lib/code-skew-error.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { isCodeSkewRestartRequired } from './code-skew-error'
+import { isCodeSkewRestartRequired, servingPidFromCodeSkewError } from './code-skew-error'
 
 const SKEW_IPC =
   'Error invoking remote method \'hermes:api\': Error: 503: {"detail":"Restart required: This process is running code from 08b4875f4a but the checkout on disk is now 48d2528066. The model picker would risk a stale-module crash — restart the Desktop-owned backend to load the new code (use Restart backend in Hermes Desktop, or quit and reopen the app)"}'
@@ -8,6 +8,15 @@ const SKEW_IPC =
 describe('isCodeSkewRestartRequired', () => {
   it('detects the Models-page IPC 503 from a stale Desktop-owned backend', () => {
     expect(isCodeSkewRestartRequired(new Error(SKEW_IPC))).toBe(true)
+  })
+
+  it('extracts the serving pid from a code-skew 503 so recycle can reap leftovers (#101561)', () => {
+    const withPid =
+      'Error invoking remote method \'hermes:api\': Error: 503: {"detail":"Restart required: This process is running code from 08b4875f4a but the checkout on disk is now 48d2528066 (pid=4242). The model picker would risk a stale-module crash"}'
+
+    expect(servingPidFromCodeSkewError(new Error(withPid))).toBe(4242)
+    expect(servingPidFromCodeSkewError(new Error(SKEW_IPC))).toBeNull()
+    expect(servingPidFromCodeSkewError(null)).toBeNull()
   })
 
   it('detects a bare FastAPI detail string', () => {

--- a/apps/desktop/src/lib/code-skew-error.ts
+++ b/apps/desktop/src/lib/code-skew-error.ts
@@ -3,6 +3,19 @@ export function isCodeSkewRestartRequired(error: unknown): boolean {
   return /Restart required:/i.test(errorText(error))
 }
 
+/** OS pid of the process that served a code-skew 503, if the backend named it (#101561). */
+export function servingPidFromCodeSkewError(error: unknown): number | null {
+  const match = /\(pid=(\d+)\)/.exec(errorText(error))
+
+  if (!match) {
+    return null
+  }
+
+  const pid = Number(match[1])
+
+  return Number.isInteger(pid) && pid > 1 ? pid : null
+}
+
 function errorText(error: unknown): string {
   if (error instanceof Error) {
     return error.message

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8911,7 +8911,10 @@ def _restart_managed_dashboard_service(
     SIGTERM of the service's main PID as a clean stop, so ``Restart=on-failure``
     will not bring the dashboard back.
     """
-    if sys.platform == "win32":
+    # systemd-only. macOS/Windows/BSD have no hermes-dashboard unit; probing
+    # ``systemctl`` is FileNotFoundError (or a Homebrew binary that is not
+    # the host manager). Fail through to PID cleanup immediately (#101561).
+    if sys.platform != "linux" or not shutil.which("systemctl"):
         return False
 
     def _systemctl(*args: str, timeout: int = 10) -> subprocess.CompletedProcess:

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1295,6 +1295,10 @@ def _finish_dashboard_update_cleanup(
         print()
         print("  ℹ Leaving running dashboard process(es) untouched because the")
         print("    Node.js dependency refresh did not complete.")
+        print(
+            "    If the model picker reports code skew (503), stop stale "
+            "processes via: hermes dashboard --stop"
+        )
         return
 
     # The scan path lazy-imports symbols from _subprocess_compat; make sure

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7533,8 +7533,8 @@ def _dashboard_code_skew_guard() -> Optional[str]:
     boot_rev, disk_rev = skew
     return (
         f"This process is running code from {boot_rev} but the checkout on "
-        f"disk is now {disk_rev}. The model picker would risk a stale-module "
-        f"crash — {_dashboard_skew_restart_hint()}"
+        f"disk is now {disk_rev} (pid={os.getpid()}). The model picker would "
+        f"risk a stale-module crash — {_dashboard_skew_restart_hint()}"
     )
 
 
@@ -7544,16 +7544,19 @@ def _dashboard_skew_restart_hint() -> str:
     The same FastAPI app backs the browser dashboard *and* Desktop-owned
     ``hermes serve --isolated`` (local or SSH). Hardcoding a systemd unit
     misleads macOS/launchd hosts and Desktop SSH backends, which have no
-    ``hermes-dashboard`` unit (#97046).
+    ``hermes-dashboard`` unit (#97046). Do not suggest ``hermes dashboard
+    --port`` while a leftover still holds the socket — that is EADDRINUSE
+    (#101561). Point at ``hermes dashboard --stop`` / ``hermes serve --stop``.
     """
     if os.environ.get("HERMES_SERVE_HEADLESS") == "1":
         return (
             "restart the Desktop-owned backend to load the new code "
-            "(use Restart backend in Hermes Desktop, or quit and reopen the app)"
+            "(use Restart backend in Hermes Desktop, quit and reopen the app, "
+            "or stop stale backends via: hermes serve --stop)"
         )
     return (
         "restart this Hermes process to load the new code "
-        "(hermes dashboard --port <port>, or the equivalent service restart for this install)"
+        "(stop stale backends with: hermes dashboard --stop, then start: hermes dashboard)"
     )
 
 

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -310,6 +310,18 @@ class TestKillStaleDashboardWindows:
         assert "✓ stopped PID 12346" in out
 
 
+class TestRestartManagedDashboardSystemctl:
+    """Managed restart is systemd-only; missing systemctl must not be probed."""
+
+    def test_missing_systemctl_skips_probe(self, monkeypatch):
+        from hermes_cli import main
+
+        monkeypatch.setattr(main.shutil, "which", lambda _name: None)
+        with patch("subprocess.run") as mock_run:
+            assert main._restart_managed_dashboard_service("test") is False
+            mock_run.assert_not_called()
+
+
 class TestBackCompatAlias:
     """``_warn_stale_dashboard_processes`` is kept as an alias for the
     new kill function so old imports don't break."""
@@ -888,7 +900,7 @@ class TestPostUpdateStaleModuleReload:
 
         assert order == ["reload", "kill"]
 
-    def test_node_failures_skip_reload_and_kill(self):
+    def test_node_failures_skip_reload_and_kill(self, capsys):
         """A failed Node refresh leaves the running dashboard untouched —
         no reload, no kill (existing safety rule preserved)."""
         from hermes_cli import update_cmd
@@ -899,6 +911,7 @@ class TestPostUpdateStaleModuleReload:
 
         mock_reload.assert_not_called()
         mock_kill.assert_not_called()
+        assert "hermes dashboard --stop" in capsys.readouterr().out
 
     def test_reload_restores_missing_symbol(self):
         """Simulate the stale-module state: strip ``bounded_probe_run`` off

--- a/tests/test_code_skew.py
+++ b/tests/test_code_skew.py
@@ -10,6 +10,7 @@ stale-module ImportError after ``hermes update``.
 
 import asyncio
 import contextlib
+import os
 
 import pytest
 
@@ -90,6 +91,9 @@ class TestDashboardCodeSkewGuard:
         assert "restart" in msg.lower()
         # Browser-dashboard path: never hardcode a Linux-only unit (#97046).
         assert "systemctl" not in msg
+        # Do not tell the user to bind --port while a leftover still holds it.
+        assert "hermes dashboard --stop" in msg
+        assert "--port" not in msg
 
     def test_serve_guard_message_points_at_desktop_backend(self, monkeypatch):
         from hermes_cli import web_server
@@ -101,6 +105,23 @@ class TestDashboardCodeSkewGuard:
         assert "Desktop-owned backend" in msg
         assert "systemctl" not in msg
         assert "hermes-dashboard" not in msg
+        assert "hermes serve --stop" in msg
+
+    def test_dashboard_guard_message_names_serving_pid(self, monkeypatch):
+        """#101561: recovery must address the process that served the 503.
+
+        Restarting gateway / only the Electron-owned child leaves an unmanaged
+        ``hermes dashboard`` answering the picker. The message has to name
+        *this* PID so recycle/stop can reap it.
+        """
+        import os
+
+        from hermes_cli import web_server
+
+        monkeypatch.setattr(code_skew, "detect_code_skew", lambda: ("abc1234567", "def4567890"))
+        msg = web_server._dashboard_code_skew_guard()
+        assert msg is not None
+        assert f"pid={os.getpid()}" in msg
 
 
 class TestModelOptionsSkewGuard:
@@ -130,6 +151,7 @@ class TestModelOptionsSkewGuard:
 
         assert excinfo.value.status_code == 503
         assert "restart" in str(excinfo.value.detail).lower()
+        assert f"pid={os.getpid()}" in str(excinfo.value.detail)
         # The stale-import crash site (the payload build) is never reached.
         assert payload_calls == []
 


### PR DESCRIPTION
## What does this PR do?

The model picker 503 from the dashboard/`hermes serve` code-skew guard is intentional (stale-module crash protection). Recovery was bound to the Electron-owned child (and, for users, often to the gateway service) even when a leftover `hermes dashboard` process was the one answering `/api/model/options`. Telling the user to start `hermes dashboard --port <port>` while that leftover still held the socket produced EADDRINUSE instead of a cleanup path.

This change:

- Names the serving OS pid on the 503 and has Desktop **Restart backend** reap that pid when it is a local hermes dashboard/serve (cmdline match), in addition to the existing SSH + owned-child recycle (#97046).
- If the leftover predates `pid=` in the 503, Restart backend reaps the loopback listener on the picker URL (cmdline-gated).
- Points the 503 hint at `hermes dashboard --stop` / `hermes serve --stop` instead of binding `--port` on a taken socket.
- Skips the systemd `systemctl` probe unless the host is Linux and `systemctl` is on PATH, so macOS falls through to PID cleanup immediately.
- When `hermes update` skips dashboard restart because Node refresh failed, prints how to clear a 503 leftover (`hermes dashboard --stop`).

Gateway restart is left alone so it cannot SIGTERM live Desktop backends.

Residual: named settings-profile recycle may skip the listen-port path; Windows without `lsof` relies on the `pid=` path; Cmd+Q of an unmanaged dashboard is unchanged.

## Related Issue

Fixes #101561

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/web_server.py` — `_dashboard_code_skew_guard` includes `(pid=<os.getpid()>)`; restart hint uses `--stop` rather than `--port`.
- `apps/desktop/src/lib/code-skew-error.ts` — parse that pid from picker errors.
- `apps/desktop/electron/backend-recycle.ts` — after SSH teardown, reap `servingPid` (cmdline-gated); if the leftover predates `pid=`, reap the loopback listener on the picker URL. Leftover teardown errors do not skip owned-child recycle.
- `apps/desktop/electron/main.ts` / `preload.ts` / `model-settings.tsx` — pass the pid on `hermes:backend:recycle`.
- `hermes_cli/main.py` — `_restart_managed_dashboard_service` is Linux + `systemctl`-on-PATH only.
- `hermes_cli/update_cmd.py` — after a skipped Node-failure cleanup, mention `hermes dashboard --stop`.
- Tests: `tests/test_code_skew.py`, `tests/hermes_cli/test_update_stale_dashboard.py`, `backend-recycle.test.ts`, `code-skew-error.test.ts`, `model-settings.test.tsx`.

## How to Test

1. Python: `scripts/run_tests.sh tests/test_code_skew.py tests/hermes_cli/test_update_stale_dashboard.py -q --tb=line` — 56 passed, 3 skipped (OS-marked).
2. Desktop (CI / local with desktop deps): from `apps/desktop`, `npx vitest run src/lib/code-skew-error.test.ts electron/backend-recycle.test.ts src/app/settings/model-settings.test.tsx`.
3. Manual: boot a long-lived `hermes dashboard` or Desktop-owned `hermes serve`, diverge the checkout, open the model picker (503). Click Restart backend — the process named in `(pid=…)` should exit if it is a local hermes dashboard/serve. Without Desktop, `hermes dashboard --stop` should be the hint (not `--port` on the same socket).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (class repro + unit tests); reporter was macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
