### PR TITLE
fix(process): keep the sandbox log poller from splitting a UTF-8 character across polls

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -2,6 +2,8 @@
 
 import json
 import os
+import shlex
+import shutil
 import signal
 import subprocess
 import sys
@@ -848,6 +850,33 @@ class TestEnvPollerIncrementalRead:
     def test_read_command_starts_from_zero_on_first_poll(self):
         cmd = ProcessRegistry._log_delta_command("'/tmp/bg.log'", 0)
         assert "O=0" in cmd
+
+    @pytest.mark.skipif(not shutil.which("sh"), reason="needs a POSIX sh")
+    def test_read_command_holds_back_a_split_utf8_sequence(self, tmp_path):
+        """A multibyte character straddling two polls must not be split.
+
+        The backend decodes each execute() result on its own, so returning
+        the first byte of an 'é' in one poll and the rest in the next would
+        yield replacement characters in the transcript (and break watch
+        patterns at the seam). Every prefix of a mixed ASCII/2/3/4-byte
+        string must come back decodable, with at most 3 bytes held back and
+        nothing held back once the trailing character is complete.
+        """
+        full = "hé😀中a\n€bz🚀".encode()
+        log = tmp_path / "bg.log"
+        quoted = shlex.quote(str(log))
+        for n in range(1, len(full) + 1):
+            log.write_bytes(full[:n])
+            out = subprocess.run(
+                ["sh", "-c", ProcessRegistry._log_delta_command(quoted, 0)],
+                capture_output=True, timeout=30,
+            ).stdout
+            header, _, delta = out.partition(b"\n")
+            size, _offset = map(int, header.split())
+            delta.decode("utf-8")  # must not raise
+            assert delta == full[:size]
+            complete = full[:n].decode("utf-8", "ignore").encode() == full[:n]
+            assert (n - size) == 0 if complete else 0 < (n - size) <= 3
 
     def test_first_poll_reads_from_the_start(self, registry):
         session = _make_session(sid="proc_delta")

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1537,12 +1537,31 @@ class ProcessRegistry:
         a file that grows while the command runs never sends a byte twice.
         A file that shrank was rotated or truncated, so the offset drops back
         to 0 and the reader starts over.
+
+        The end of the window is pulled back to a UTF-8 character boundary:
+        the backend decodes each ``execute()`` result on its own, so a
+        multibyte character straddling two polls would otherwise come back
+        as replacement characters (and break watch patterns near the seam).
+        Up to 3 trailing continuation bytes are held for the next poll; the
+        header reports the trimmed size so the offset stays consistent.
         """
         return (
             f"O={offset}; "
             f"S=$({{ wc -c < {quoted_log_path}; }} 2>/dev/null | tr -dc '0-9'); "
             f"S=${{S:-0}}; "
             f'if [ "$S" -lt "$O" ]; then O=0; fi; '
+            # Hold back an INCOMPLETE trailing UTF-8 sequence for the next
+            # poll. Scan back up to 3 continuation bytes (octal 200-277) to
+            # the lead byte; if the lead byte's declared length (3xx=2, 34x-35x
+            # =3, 36x-37x=4) exceeds the bytes present, trim to before it.
+            # Complete sequences and ASCII tails are left untouched.
+            f'N=0; P=$S; while [ "$P" -gt "$O" ] && [ "$N" -lt 3 ]; do '
+            f"B=$(tail -c +$P {quoted_log_path} 2>/dev/null | head -c 1 | od -An -to1 | tr -dc '0-9'); "
+            f'case "$B" in 2[0-7][0-7]) P=$((P-1)); N=$((N+1));; *) break;; esac; done; '
+            f'if [ "$N" -gt 0 ] || [ "$P" -eq "$S" ]; then '
+            f"B=$(tail -c +$P {quoted_log_path} 2>/dev/null | head -c 1 | od -An -to1 | tr -dc '0-9'); "
+            f'case "$B" in 3[0-3][0-7]) L=2;; 3[4-5][0-7]) L=3;; 3[6-7][0-7]) L=4;; *) L=1;; esac; '
+            f'if [ "$L" -gt $((N+1)) ]; then S=$((P-1)); fi; fi; '
             f'echo "$S $O"; '
             f'if [ "$S" -gt "$O" ]; then '
             f"tail -c +$((O+1)) {quoted_log_path} 2>/dev/null | head -c $((S-O)); fi"


### PR DESCRIPTION
## Summary
Background-job log polling on docker/SSH/modal backends no longer splits a multibyte UTF-8 character across two polls — the follow-up to #92164 (@Adolanium, merged as 8b681f70ea) that its review thread asked for.

## Who / when / why
Anyone running background jobs (`terminal(background=true)`) in a sandbox whose output contains non-ASCII text (CJK logs, emoji progress bars, accented paths). #92164 switched the poller from `cat`-the-whole-file to reading only the new bytes since the last poll — a 2 MB → 16 B/poll win — but the byte window it cuts ends wherever the file happened to end when the poll ran. Each `execute()` result is decoded on its own by the backend, so when a poll lands between the bytes of one character, both halves come back as U+FFFD.

**Before** (`main` 8a0843db6f, bash): a 21-byte string `hé😀中a\n€bz🚀` written one byte at a time and polled after every byte → **11 of 21 polls return undecodable deltas** (`h��llo`-style mojibake in the transcript; `_check_watch_patterns` can't match across the seam).
**After**: 0 of 21; incremental reconstruction from the carried offsets yields the exact original string.

## Changes
- `tools/process_registry.py::_log_delta_command` — before printing the header, walk back over up to 3 trailing UTF-8 continuation bytes to the lead byte; if the lead byte's declared length exceeds the bytes present, trim the window to before it and report the trimmed size, so the next poll picks the whole character up. Complete sequences and ASCII tails are untouched. POSIX only (`tail -c`, `head -c`, `od -An -to1`), verified on bash, dash and busybox `sh` (alpine).
- `tests/tools/test_process_registry.py` — exhaustive-prefix regression test: every prefix decodes, ≤ 3 bytes held back, 0 held back when the tail is complete. Fails on `main` (mutation-checked).

## Benchmark
Machine: macOS arm64 laptop, Python 3.12 venv, OrbStack Docker 29.4.

| | main 8a0843db6f | this branch |
|---|---|---|
| undecodable deltas across the 21 byte-prefixes of `hé😀中a\n€bz🚀` (bash) | 11 | 0 |
| same, busybox `sh` (alpine:3.20) | — | 0 |
| same, dash | — | 0 |
| steady-state poll bytes on a 2 MB log (from #92164) | 16 B | 16 B (unchanged) |

```python
# ~/triage-perf-p2/bench/92164_seam.py (excerpt)
for n in range(1, len(full) + 1):
    write(full[:n]); header, delta = poll(O=0)
    delta.decode("utf-8")            # raises on main for 11 of 21 prefixes
```
**What actually improved:** non-ASCII output from sandboxed background jobs now reaches the transcript and watch-pattern matcher intact; the per-poll traffic win from #92164 is kept (the guard reads ≤ 4 single bytes with `tail -c`/`head -c`, no full-file read).

## Validation
| | result |
|---|---|
| `tests/tools/test_process_registry.py -k EnvPoller` | 9 passed |
| mutation check (revert `_log_delta_command` to main) | new seam test fails |
| ruff | clean |

Addresses the UTF-8 seam finding raised on #92164.
