### PR TITLE
fix(photon): treat a server-answered probe rejection as proof of liveness

### DIFF
--- a/plugins/platforms/photon/sidecar/stream-staleness.mjs
+++ b/plugins/platforms/photon/sidecar/stream-staleness.mjs
@@ -9,12 +9,12 @@
 //
 //   - probe resolves, or rejects with a not-found-shaped error for our
 //     synthetic id            -> ALIVE (the wire round-tripped)
-//   - probe rejects with a server-answered error — gRPC INVALID_ARGUMENT /
-//     FAILED_PRECONDITION, or a message stamped with a spectrum component
-//     source like "[spectrum-imessage] ..." -> ALIVE (a server-side answer
-//     also proves the wire round-tripped; the synthetic probe id is not a
-//     valid Apple message GUID, so the proxy rejects it with a validation
-//     error on every probe — #101618)
+//   - probe rejects with a server-answered error — gRPC INVALID_ARGUMENT,
+//     or a message stamped with a spectrum component source like
+//     "[spectrum-imessage] ..." -> ALIVE (a server-side answer also proves
+//     the wire round-tripped; the synthetic probe id is not a valid Apple
+//     message GUID, so the proxy rejects it with a validation error on
+//     every probe — #101618)
 //   - probe rejects any other way (UNAVAILABLE, DEADLINE_EXCEEDED, network
 //     down, ...)              -> INCONCLUSIVE — never treated as alive, and
 //                                never treated as zombie-proof either
@@ -34,11 +34,13 @@
 const NOT_FOUND_RE = /not[\s_-]?found/i;
 
 // A server-answered rejection also proves a round-trip: gRPC
-// INVALID_ARGUMENT (3) / FAILED_PRECONDITION (9) are generated server-side,
-// as are errors stamped with a spectrum component source — the "[spectrum-*]"
-// prefixes do not exist anywhere in the installed client tree (#101618), so
-// a message carrying one provably came back over the wire.
-const SERVER_ANSWERED_CODES = new Set([3, 9, "invalidArgument", "failedPrecondition"]);
+// INVALID_ARGUMENT (3) is generated server-side, as are errors stamped
+// with a spectrum component source — the "[spectrum-*]" prefixes do not
+// exist anywhere in the installed client tree (#101618), so a message
+// carrying one provably came back over the wire. FAILED_PRECONDITION (9)
+// is deliberately excluded: the proxy can also answer it from a
+// half-ready state that never completed the probe.
+const SERVER_ANSWERED_CODES = new Set([3, "invalidArgument"]);
 const SERVER_ANSWERED_RE = /\[spectrum-[a-z0-9-]+\]/i;
 
 /**

--- a/plugins/platforms/photon/sidecar/stream-staleness.mjs
+++ b/plugins/platforms/photon/sidecar/stream-staleness.mjs
@@ -9,6 +9,12 @@
 //
 //   - probe resolves, or rejects with a not-found-shaped error for our
 //     synthetic id            -> ALIVE (the wire round-tripped)
+//   - probe rejects with a server-answered error — gRPC INVALID_ARGUMENT /
+//     FAILED_PRECONDITION, or a message stamped with a spectrum component
+//     source like "[spectrum-imessage] ..." -> ALIVE (a server-side answer
+//     also proves the wire round-tripped; the synthetic probe id is not a
+//     valid Apple message GUID, so the proxy rejects it with a validation
+//     error on every probe — #101618)
 //   - probe rejects any other way (UNAVAILABLE, DEADLINE_EXCEEDED, network
 //     down, ...)              -> INCONCLUSIVE — never treated as alive, and
 //                                never treated as zombie-proof either
@@ -27,6 +33,14 @@
 // message text. Anything not clearly not-found is inconclusive.
 const NOT_FOUND_RE = /not[\s_-]?found/i;
 
+// A server-answered rejection also proves a round-trip: gRPC
+// INVALID_ARGUMENT (3) / FAILED_PRECONDITION (9) are generated server-side,
+// as are errors stamped with a spectrum component source — the "[spectrum-*]"
+// prefixes do not exist anywhere in the installed client tree (#101618), so
+// a message carrying one provably came back over the wire.
+const SERVER_ANSWERED_CODES = new Set([3, 9, "invalidArgument", "failedPrecondition"]);
+const SERVER_ANSWERED_RE = /\[spectrum-[a-z0-9-]+\]/i;
+
 /**
  * Classify the rejection of the synthetic-id probe read.
  *
@@ -43,6 +57,17 @@ export function classifyProbeRejection(err) {
     // Expected: the synthetic id doesn't exist. The unary call completed a
     // round-trip, so the channel is provably alive.
     return { alive: true, inconclusive: false, reason: "not-found round-trip" };
+  }
+  if (SERVER_ANSWERED_CODES.has(code) || SERVER_ANSWERED_RE.test(message)) {
+    // The server received the request and answered with an application-level
+    // rejection (the synthetic id is not a valid Apple message GUID, so the
+    // proxy rejects it as a validation error instead of not-found). A
+    // server-side answer proves the wire round-tripped just the same.
+    return {
+      alive: true,
+      inconclusive: false,
+      reason: "server-answered round-trip: " + message,
+    };
   }
   // Anything else (UNAVAILABLE, DEADLINE_EXCEEDED, TLS, auth, ...) does NOT
   // prove liveness — and doesn't prove a zombie either.

--- a/tests/plugins/platforms/photon/test_zombie_stream_watchdog.py
+++ b/tests/plugins/platforms/photon/test_zombie_stream_watchdog.py
@@ -64,15 +64,25 @@ def _run_staleness_harness(script: str) -> Dict[str, Any]:
 
 
 def test_probe_rejection_classification_is_strict() -> None:
-    """Only not-found-shaped rejections prove liveness; everything else is
-    inconclusive — a rejected probe is NEVER treated as alive (#45580's
-    original /probe treated any rejection as alive, which was too loose)."""
+    """Only round-trip-proving rejections count as alive: not-found-shaped
+    errors, and server-answered rejections (gRPC INVALID_ARGUMENT /
+    FAILED_PRECONDITION or a "[spectrum-*]" source stamp — the synthetic
+    probe id is not a valid Apple message GUID, so the proxy answers with a
+    validation error on every probe, #101618). Transport-shaped errors stay
+    inconclusive — a rejected probe is NEVER treated as alive on the say-so
+    of the network layer alone (#45580's original /probe treated any
+    rejection as alive, which was too loose)."""
     out = _run_staleness_harness(
         """
         const results = {
           notFoundCode: classifyProbeRejection({ code: 5, message: "5 NOT_FOUND: nope" }),
           notFoundText: classifyProbeRejection(new Error("message not found")),
           sdkNotFound: classifyProbeRejection({ code: "notFound", message: "missing" }),
+          invalidArgCode: classifyProbeRejection({ code: 3, message: "3 INVALID_ARGUMENT: bad guid" }),
+          invalidArgSdk: classifyProbeRejection({ code: "invalidArgument", message: "Expected message resource GUID" }),
+          failedPrecondition: classifyProbeRejection({ code: 9, message: "9 FAILED_PRECONDITION: not ready" }),
+          spectrumStamped: classifyProbeRejection({ code: 3, message: "[spectrum-imessage] Expected message resource GUID" }),
+          spectrumErrorObject: classifyProbeRejection(new Error("[spectrum-imessage] Expected message resource GUID")),
           unavailable: classifyProbeRejection({ code: 14, message: "14 UNAVAILABLE: connect failed" }),
           deadline: classifyProbeRejection({ code: 4, message: "4 DEADLINE_EXCEEDED" }),
           generic: classifyProbeRejection(new Error("socket hang up")),
@@ -81,8 +91,18 @@ def test_probe_rejection_classification_is_strict() -> None:
         process.stdout.write(JSON.stringify(results));
         """
     )
-    # Completed round-trips (server said not-found for our synthetic id).
-    for name in ("notFoundCode", "notFoundText", "sdkNotFound"):
+    # Completed round-trips: the server said not-found for our synthetic id,
+    # or answered with an application-level rejection over the wire.
+    for name in (
+        "notFoundCode",
+        "notFoundText",
+        "sdkNotFound",
+        "invalidArgCode",
+        "invalidArgSdk",
+        "failedPrecondition",
+        "spectrumStamped",
+        "spectrumErrorObject",
+    ):
         assert out[name]["alive"] is True, name
         assert out[name]["inconclusive"] is False, name
     # Everything else: not alive AND explicitly inconclusive.

--- a/tests/plugins/platforms/photon/test_zombie_stream_watchdog.py
+++ b/tests/plugins/platforms/photon/test_zombie_stream_watchdog.py
@@ -65,13 +65,16 @@ def _run_staleness_harness(script: str) -> Dict[str, Any]:
 
 def test_probe_rejection_classification_is_strict() -> None:
     """Only round-trip-proving rejections count as alive: not-found-shaped
-    errors, and server-answered rejections (gRPC INVALID_ARGUMENT /
-    FAILED_PRECONDITION or a "[spectrum-*]" source stamp — the synthetic
-    probe id is not a valid Apple message GUID, so the proxy answers with a
-    validation error on every probe, #101618). Transport-shaped errors stay
-    inconclusive — a rejected probe is NEVER treated as alive on the say-so
-    of the network layer alone (#45580's original /probe treated any
-    rejection as alive, which was too loose)."""
+    errors, and server-answered rejections (gRPC INVALID_ARGUMENT or a
+    "[spectrum-*]" source stamp — the synthetic probe id is not a valid
+    Apple message GUID, so the proxy answers with a validation error on
+    every probe, #101618). Transport-shaped errors stay inconclusive — a
+    rejected probe is NEVER treated as alive on the say-so of the network
+    layer alone (#45580's original /probe treated any rejection as alive,
+    which was too loose). FAILED_PRECONDITION stays inconclusive too: the
+    proxy can answer it from a half-ready state that never completed the
+    probe, and #101618 only ever observed INVALID_ARGUMENT-shaped
+    rejections."""
     out = _run_staleness_harness(
         """
         const results = {
@@ -99,14 +102,21 @@ def test_probe_rejection_classification_is_strict() -> None:
         "sdkNotFound",
         "invalidArgCode",
         "invalidArgSdk",
-        "failedPrecondition",
         "spectrumStamped",
         "spectrumErrorObject",
     ):
         assert out[name]["alive"] is True, name
         assert out[name]["inconclusive"] is False, name
-    # Everything else: not alive AND explicitly inconclusive.
-    for name in ("unavailable", "deadline", "generic", "weird"):
+    # Everything else: not alive AND explicitly inconclusive. That includes
+    # FAILED_PRECONDITION — deliberately excluded from the server-answered
+    # set (a half-ready proxy answer, not a completed probe).
+    for name in (
+        "unavailable",
+        "deadline",
+        "generic",
+        "weird",
+        "failedPrecondition",
+    ):
         assert out[name]["alive"] is False, name
         assert out[name]["inconclusive"] is True, name
 


### PR DESCRIPTION
## What does this PR do?

The Photon sidecar's zombie-stream watchdog was structurally dead: its liveness probe reads a synthetic message id (`hermes-liveness-probe-<ts>-<rand>`) that is not a valid Apple message GUID, so the spectrum proxy answers **every** probe with a validation error (`[spectrum-imessage] Expected message resource GUID`, gRPC `INVALID_ARGUMENT`) instead of the `NOT_FOUND` that `classifyProbeRejection` treats as the only proof of a round-trip. Every probe is therefore classified `inconclusive`, `isZombieSuspect` (which requires `probeOutcome.alive === true`) can never hold, and a half-open inbound gRPC stream keeps `state: "healthy"` on `/healthz` while inbound messages are lost — only a manual gateway restart clears it.

The fix follows the report's central observation: a validation rejection is generated **server-side** (the `[spectrum-*]` prefixes don't exist anywhere in the installed client tree), so the probe did complete a round-trip over the wire — which is exactly the fact the watchdog needed and threw away. `classifyProbeRejection` now classifies a **server-answered** rejection as alive:

- gRPC `INVALID_ARGUMENT` (3), including the SDK string form (`"invalidArgument"`, mirroring the existing `"notFound"` handling), or
- an error message stamped with a spectrum component source (`[spectrum-imessage] ...`).

Transport-shaped rejections (`UNAVAILABLE`, `DEADLINE_EXCEEDED`, TLS, auth, generic network errors) — and `FAILED_PRECONDITION` (9), which the proxy can also answer from a half-ready state that never completed the probe (per review) — remain `inconclusive`, so the existing conservatism is unchanged: never restart on silence alone, never act on an inconclusive probe when the network may simply be down.

## Related Issue

Fixes #101618

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/photon/sidecar/stream-staleness.mjs`: added a `SERVER_ANSWERED_CODES` / `SERVER_ANSWERED_RE` branch to `classifyProbeRejection` that treats `INVALID_ARGUMENT` and `[spectrum-*]`-stamped rejections as a proven round-trip (`reason: "server-answered round-trip: ..."`); updated the module header documenting the three-way classification.
- `tests/plugins/platforms/photon/test_zombie_stream_watchdog.py`: extended `test_probe_rejection_classification_is_strict` with the server-answered shapes (numeric + SDK-string codes, the exact `[spectrum-imessage] Expected message resource GUID` message from the report, with and without a `code` property) and kept `UNAVAILABLE` / `DEADLINE_EXCEEDED` / generic / non-object errors — plus `FAILED_PRECONDITION` (excluded from the server-answered set: no observed shape in #101618, and a half-ready proxy answer is not a completed probe) — asserted inconclusive.

## How to Test

1. `pytest tests/plugins/platforms/photon/ -q` — Observed result: **133 passed** (full photon suite, zero regressions).
2. Red/green check: with only the test change applied on top of `main`, `test_probe_rejection_classification_is_strict` fails (`1 failed, 4 passed`) — Observed result: confirmed the new assertions exercise the fix; with the fix restored, all 5 pass.
3. `ruff check tests/plugins/platforms/photon/test_zombie_stream_watchdog.py` — Observed result: **All checks passed**.
4. Against the report's live shape: a probe rejection of `{ message: "[spectrum-imessage] Expected message resource GUID" }` now yields `alive: true` / `inconclusive: false`, so after the silence threshold `isZombieSuspect` can hold and the existing `markStreamDegraded` → exit-75 restart path becomes reachable. The command below should print `true` for the zombie verdict and `false` for the transport-shaped one:

```bash
node --input-type=module -e "
import { classifyProbeRejection, isZombieSuspect } from './plugins/platforms/photon/sidecar/stream-staleness.mjs';
const probe = classifyProbeRejection(new Error('[spectrum-imessage] Expected message resource GUID'));
console.log(probe.alive, isZombieSuspect(1200000, 600000, probe));
const down = classifyProbeRejection({ code: 14, message: '14 UNAVAILABLE: connect failed' });
console.log(down.inconclusive, isZombieSuspect(1200000, 600000, down));
" 
```

Observed result: `true true` then `true false` (server-answered rejection proves liveness; `UNAVAILABLE` stays inconclusive and never triggers a restart).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — `tests/plugins/platforms/photon/` (133 passed); this is a sidecar `.mjs` decision-module change with its dedicated node-driven test file
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (darwin 25.4.0, arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (module header comment updated in place)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure JS decision logic, no platform surface touched)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

