### PR TITLE
fix(desktop): keep Space editable in the portaled Rename dialog

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
@@ -2,6 +2,8 @@ import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-li
 import { atom } from 'nanostores'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { ActionsContextMenu } from '@/components/ui/actions-menu'
+
 import { SessionActionsMenu, SessionContextMenu } from './session-actions-menu'
 
 afterEach(cleanup)
@@ -122,6 +124,14 @@ function renderMenu() {
   )
 }
 
+function openActionsMenu() {
+  const trigger = screen.getByRole('button', { name: 'Session actions' })
+
+  fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' })
+  fireEvent.pointerUp(trigger, { button: 0, pointerType: 'mouse' })
+  fireEvent.click(trigger)
+}
+
 describe('SessionActionsMenu', () => {
   it('opens the dropdown on click without a tooltip on the kebab', async () => {
     renderMenu()
@@ -133,13 +143,48 @@ describe('SessionActionsMenu', () => {
     // Radix's dropdown trigger opens on pointerdown (not on the synthetic
     // 'click' fireEvent alone would dispatch), so fire the full mouse
     // sequence a real click produces.
-    fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' })
-    fireEvent.pointerUp(trigger, { button: 0, pointerType: 'mouse' })
-    fireEvent.click(trigger)
+    openActionsMenu()
 
     expect(await screen.findByRole('menu')).toBeTruthy()
     expect(screen.getByRole('menuitem', { name: /rename/i })).toBeTruthy()
     expect(screen.getByRole('menuitem', { name: /archive/i })).toBeTruthy()
+  })
+
+  // A portaled dialog still bubbles React events through its LOGICAL owner —
+  // here the row wrapped by ActionsContextMenu. Without the modal's own
+  // boundary, Space reaches that owner, is treated as row/menu activation, and
+  // is cancelled before the input can insert it: the Rename field silently
+  // refuses spaces. The stand-in ancestor below cancels Space the way the real
+  // context-menu trigger does.
+  it('keeps Space editable in the portaled Rename dialog inside a context-menu row', async () => {
+    render(
+      <ActionsContextMenu ariaLabel="Row actions" items={() => null}>
+        <div
+          onKeyDown={event => {
+            if (event.key === ' ') {
+              event.preventDefault()
+            }
+          }}
+        >
+          <SessionActionsMenu align="end" sessionId="s1" sideOffset={6} title="My session">
+            <button aria-label="Session actions" type="button">
+              ⋮
+            </button>
+          </SessionActionsMenu>
+        </div>
+      </ActionsContextMenu>
+    )
+
+    openActionsMenu()
+    fireEvent.click(await screen.findByRole('menuitem', { name: /rename/i }))
+
+    const input = await screen.findByDisplayValue('My session')
+
+    const accepted = input.dispatchEvent(
+      new KeyboardEvent('keydown', { bubbles: true, cancelable: true, code: 'Space', key: ' ' })
+    )
+
+    expect(accepted).toBe(true)
   })
 
   it('opens the rename dialog focused on its input, not the row trigger', async () => {

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -686,7 +686,7 @@ function RenameSessionDialog({ open, onOpenChange, sessionId, currentTitle, prof
 
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
-      <DialogContent className="max-w-md">
+      <DialogContent className="max-w-md" onKeyDown={event => event.stopPropagation()}>
         <DialogHeader>
           <DialogTitle>{r.renameTitle}</DialogTitle>
         </DialogHeader>


### PR DESCRIPTION
## What does this PR do?

Fixes the session **Rename** dialog silently swallowing the space bar. Typing `My session two` stores `Mysessiontwo`. Enter-to-submit and Escape-to-close work normally — only Space is lost, which makes it read like a broken keyboard rather than an app bug.

**Root cause.** `RenameSessionDialog` portals into `<body>`, but React events still bubble through the dialog's **logical** owner tree. `SessionContextMenu` wraps the session row in a Radix `ContextMenuTrigger`, and Space arriving there is treated as row/menu activation and cancelled. Chromium then emits no `beforeinput`, so the input's value never changes.

This is why the bug resists inspection: the offending ancestor is **absent from the portaled DOM chain**. Walking DOM ancestry from the input finds nothing that cancels Space. A CDP keyboard trace against a packaged build confirmed the sequence — Space reaches the input uncancelled at capture and target phase, then becomes `defaultPrevented` during the React bubble.

**Why this approach.** The boundary belongs on the modal, not on the input and not on the context menu. Putting it on `DialogContent` stops stray keydown from leaking into whatever logical owner the dialog happens to hang off, without the dialog needing to know who that owner is. It runs *after* the input's own target handler, so Enter and Escape are untouched, and Radix still handles Escape-to-close internally.

## Related Issue

No existing issue — happy to file one if you'd prefer that first.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx` — add `onKeyDown={event => event.stopPropagation()}` to the `RenameSessionDialog` `DialogContent` (1 line).
- `apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx` — regression test plus a small `openActionsMenu()` helper extracted from the existing test.

The test renders the portaled Rename dialog beneath an ancestor that cancels Space, reproducing the *logical* owner relationship rather than the DOM one, and asserts the input's keydown is not cancelled.

## How to Test

1. Open the sidebar, click the kebab on any session, choose **Rename**.
2. Type a title containing spaces, e.g. `My session two`.
3. **Before:** spaces are dropped — the field shows `Mysessiontwo`. **After:** spaces insert normally, and Enter still saves while Escape still cancels.

Automated:

```bash
cd apps/desktop
npx vitest run --project ui src/app/chat/sidebar/session-actions-menu.test.tsx
```

Verified on this branch against current `main`:

- With the fix: **7/7 pass**.
- With the one-line boundary reverted: `keeps Space editable in the portaled Rename dialog inside a context-menu row` fails with `AssertionError: expected false to be true`, 6/7 pass. So the test genuinely pins this behavior.
- `npx tsc -p . --noEmit` — clean.
- `npx eslint` on both touched files — clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, this is a desktop renderer change with no Python surface; the relevant `vitest` suite is run above
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.6 (Apple Silicon), packaged Electron build

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture change
- [x] I've considered cross-platform impact — the fix is platform-independent React event handling; no platform-specific code paths

---

Authored by Claude (Opus 5) working in this repo; submitted by the account opening the PR. Happy to re-author under a human contributor email if the project prefers — say the word and I'll amend.
