### PR TITLE
fix(tui): render paired punctuation correctly around RTL text

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/bidi.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/bidi.test.ts
@@ -1,0 +1,94 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { reorderBidi } from './bidi.js'
+import Output from './output.js'
+import { cellAt, CharPool, createScreen, HyperlinkPool, StylePool } from './screen.js'
+
+type ClusteredChar = Parameters<typeof reorderBidi>[0][number]
+
+const cluster = (value: string, overrides: Partial<ClusteredChar> = {}): ClusteredChar => ({
+  value,
+  width: 1,
+  styleId: 0,
+  hyperlink: undefined,
+  ...overrides
+})
+
+function renderLine(text: string): ReturnType<typeof cellAt>[] {
+  const width = 32
+  const stylePool = new StylePool()
+  const screen = createScreen(width, 1, stylePool, new CharPool(), new HyperlinkPool())
+  const output = new Output({ width, height: 1, stylePool, screen })
+
+  output.write(0, 0, text)
+  output.get()
+  const rendered = output.get()
+
+  return Array.from({ length: width }, (_, x) => cellAt(rendered, x, 0))
+}
+
+describe('software bidi glyph mirroring', () => {
+  beforeAll(() => {
+    vi.stubEnv('TERM_PROGRAM', 'vscode')
+  })
+
+  afterAll(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it.each([
+    ['(אבג)', '(גבא)'],
+    ['مرحبا [عالم]', '[ملاع] ابحرم'],
+    ['אבג (React)', '(React) גבא'],
+    ['[אב(ג)]', '[(ג)בא]'],
+    ['∈אבג', 'גבא∋']
+  ])('renders mapped punctuation through Output: %s', (logical, visual) => {
+    const cells = renderLine(logical)
+
+    expect(
+      cells
+        .slice(0, visual.length)
+        .map(cell => cell?.char)
+        .join('')
+    ).toBe(visual)
+  })
+
+  it('preserves style and hyperlink metadata on mirrored clusters', () => {
+    const cells = renderLine('\u001B[31m\u001B]8;;https://example.com\u0007(\u001B]8;;\u0007\u001B[0mאבג)')
+    const first = cells[0]!
+    const last = cells[4]!
+
+    expect(first?.char).toBe('(')
+    expect(first?.hyperlink).toBeUndefined()
+    expect(last?.char).toBe(')')
+    expect(last?.hyperlink).toBe('https://example.com')
+    expect(last?.styleId).not.toBe(first?.styleId)
+  })
+
+  it('accounts for supplementary-plane offsets without mutating logical clusters', () => {
+    const characters = [
+      cluster('('),
+      cluster('א'),
+      cluster('ב'),
+      cluster('😀', { width: 2 }),
+      cluster('ג'),
+      cluster(')')
+    ]
+
+    const snapshot = characters.map(character => ({ ...character }))
+    const reordered = reorderBidi(characters)
+
+    expect(reordered.map(character => character.value).join('')).toBe('(ג😀בא)')
+    expect(characters).toEqual(snapshot)
+    expect(reordered[1]).toBe(characters[4])
+    expect(reordered[2]).toBe(characters[3])
+    expect(reordered[0]).not.toBe(characters[5])
+    expect(reordered[0]).toMatchObject({ ...characters[5], value: '(' })
+  })
+
+  it('keeps the pure-LTR identity fast path', () => {
+    const characters = [cluster('a'), cluster('('), cluster('b'), cluster(')')]
+
+    expect(reorderBidi(characters)).toBe(characters)
+  })
+})

--- a/ui-tui/packages/hermes-ink/src/ink/bidi.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/bidi.ts
@@ -67,22 +67,30 @@ export function reorderBidi(characters: ClusteredChar[]): ClusteredChar[] {
 
   const bidi = getBidi()
   const { levels } = bidi.getEmbeddingLevels(plainText, 'auto')
+  const mirroredCharacters = bidi.getMirroredCharactersMap(plainText, levels) as Map<number, string>
 
   // Map bidi levels back to ClusteredChar indices.
   // Each ClusteredChar may be multiple code units in the joined string.
   const charLevels: number[] = []
+  const reordered: ClusteredChar[] = mirroredCharacters.size === 0 ? [...characters] : []
   let offset = 0
 
   for (let i = 0; i < characters.length; i++) {
+    const character = characters[i]!
+
     charLevels.push(levels[offset]!)
-    offset += characters[i]!.value.length
+
+    if (mirroredCharacters.size > 0) {
+      reordered.push(mirrorCluster(character, offset, mirroredCharacters))
+    }
+
+    offset += character.value.length
   }
 
   // Get reorder segments from bidi-js, but we need to work at the
   // ClusteredChar level, not the string level. We'll implement the
   // standard bidi reordering: find the max level, then for each level
   // from max down to 1, reverse all contiguous runs >= that level.
-  const reordered = [...characters]
   const maxLevel = Math.max(...charLevels)
 
   for (let level = maxLevel; level >= 1; level--) {
@@ -108,6 +116,18 @@ export function reorderBidi(characters: ClusteredChar[]): ClusteredChar[] {
   }
 
   return reordered
+}
+
+function mirrorCluster(character: ClusteredChar, sourceOffset: number, mirrors: Map<number, string>): ClusteredChar {
+  let localOffset = 0
+  let value = ''
+
+  for (const codePoint of character.value) {
+    value += mirrors.get(sourceOffset + localOffset) ?? codePoint
+    localOffset += codePoint.length
+  }
+
+  return value === character.value ? character : { ...character, value }
 }
 
 function reverseRange<T>(arr: T[], start: number, end: number): void {


### PR DESCRIPTION
## What does this PR do?

Software bidi rendering now applies Unicode Bidirectional Algorithm rule L4 before rearranging visual clusters. Parentheses, brackets, and other mapped mirrored characters therefore face the correct direction around RTL text in Windows and VS Code-family terminals, while logical message text remains unchanged.

### Symptom

Rendering `(אבג)` through the software bidi path produced `)גבא(` instead of `(גבא)`. Square brackets, nested punctuation, mixed LTR/RTL text, and mirrored mathematical symbols had the same glyph-direction problem.

### Impact

Users reading Hebrew, Arabic, and other RTL output in terminals without native bidi support saw paired punctuation face the wrong direction, making otherwise correctly reordered text misleading and difficult to read.

### Bug Cause

**Trigger:** `ui-tui/packages/hermes-ink/src/ink/bidi.ts` / `reorderBidi()` when software bidi is active and a mirrored character resolves to an odd embedding level.

**Causal chain:**
1. `reorderBidi()` joined styled grapheme clusters and computed their resolved embedding levels.
2. It reversed cluster ranges into visual order but retained every cluster's original glyph.
3. Mirrored punctuation consequently moved to the opposite side of RTL runs without changing its visual shape.

**Why it is wrong:** Unicode Bidirectional Algorithm rule L4 requires characters with bidi mirror mappings at odd resolved levels to use their mirrored glyphs before visual reordering.

**Working sibling / contrast:** Bidi-capable terminals bypass software reordering, and pure LTR lines retain the existing identity fast path.

**Ruled out:** Paragraph-base selection is not the cause because the failure reproduces with an unambiguously RTL paragraph and resolved odd levels across the paired punctuation.

### Fix

Use `bidi-js`'s resolved-level mirror map at original UTF-16 offsets, clone only grapheme clusters whose visible value changes, and then run the existing cluster-level reordering. Width, style, and hyperlink metadata stay attached to each cluster; supplementary-plane code points retain correct offset accounting.

## Related Issue

Closes #101606

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `ui-tui/packages/hermes-ink/src/ink/bidi.ts` - apply mapped glyph mirroring before cluster reordering.
- `ui-tui/packages/hermes-ink/src/ink/bidi.test.ts` - cover the real `Output` screen path, nested pairs, mathematical symbols, metadata retention, cache reuse, input immutability, and supplementary-plane offsets.

## How to Test

1. Set `TERM_PROGRAM=vscode` or run on Windows so the software bidi path is active.
2. Render `(אבג)`, `مرحبا [عالم]`, `אבג (React)`, and `[אב(ג)]` through the TUI output buffer.
3. Run the focused renderer suite and type checks:

```bash
cd ui-tui
npx vitest run packages/hermes-ink/src/ink
npm run typecheck
npx eslint packages/hermes-ink/src/ink/bidi.ts packages/hermes-ink/src/ink/bidi.test.ts
```

The focused renderer suite passes 231 tests.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant TUI test suite and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; behavior is covered by focused tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A - deterministic screen-buffer assertions cover the rendered cell sequence and metadata.
