### PR TITLE
fix(update): prevent Windows shim handoff from self-locking updates

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9569,9 +9569,13 @@ def _windows_running_hermes_launcher_locked() -> bool:
 
 # Set on the re-exec'd child so it can never spawn another one.
 _UPDATE_REEXEC_ENV = "HERMES_UPDATE_REEXEC"
+# The child waits for this process before touching the shim, then adopts the
+# exact fleet pause token instead of rediscovering an already-stopped fleet.
+_UPDATE_REEXEC_PARENT_PID_ENV = "HERMES_UPDATE_REEXEC_PARENT_PID"
+_UPDATE_REEXEC_GATEWAY_RESUME_ENV = "HERMES_UPDATE_REEXEC_GATEWAY_RESUME"
 
 
-def _reexec_dependency_sync_off_windows_shim() -> bool:
+def _reexec_dependency_sync_off_windows_shim(gateway_resume=None) -> bool:
     """Hand the dependency sync to the venv interpreter, off the console shim.
 
     Returns True when a child was spawned and the caller must exit at once,
@@ -9593,12 +9597,13 @@ def _reexec_dependency_sync_off_windows_shim() -> bool:
     the whole command, so the quarantine rename is refused and uv fails to
     replace it with os error 32 (#88838, #89599).
 
-    A child is required, and waiting on it cannot work: this process holds the
-    handle the child needs released, so a parent that waits deadlocks against
-    the work it is waiting for. Windows has no exec to escape with either.
-    The shell therefore returns while the install runs on; the child keeps the
-    console and prints its own result, and ``--gateway`` writes the true exit
-    code to ``.update_exit_code`` for the gateway watcher.
+    A child is required, and the parent cannot wait on it: this process holds
+    the handle the child needs released. Instead the child waits for this
+    parent to exit before starting update work. When gateways were paused, the
+    pause token travels in the child environment and ownership is removed from
+    the parent's atexit callback only after ``Popen`` succeeds. The child then
+    resumes exactly that fleet; it must not rediscover an already-stopped fleet
+    or restart gateways while this shim is still alive.
 
     The child re-runs ``hermes update``, so the whole remaining flow — the
     dependency sync and the node/web/lazy-refresh tail behind it — still
@@ -9625,11 +9630,24 @@ def _reexec_dependency_sync_off_windows_shim() -> bool:
     cmd = [str(python_exe), "-m", "hermes_cli.main", *sys.argv[1:]]
     if python_exe.is_file():
         try:
+            child_env = {
+                **os.environ,
+                _UPDATE_REEXEC_ENV: "1",
+                _UPDATE_REEXEC_PARENT_PID_ENV: str(os.getpid()),
+            }
+            if gateway_resume is not None:
+                child_env[_UPDATE_REEXEC_GATEWAY_RESUME_ENV] = json.dumps(
+                    gateway_resume, separators=(",", ":")
+                )
             subprocess.Popen(
                 cmd,
-                env={**os.environ, _UPDATE_REEXEC_ENV: "1"},
+                env=child_env,
                 stdin=subprocess.DEVNULL,
             )
+            if gateway_resume is not None:
+                # The atexit callback closes over this same dict. Disarm it
+                # only after the child inherited an intact, resume-needed copy.
+                gateway_resume["resume_needed"] = False
             print(
                 f"→ Windows: {shim.name} cannot replace itself while it runs; "
                 "finishing the dependency install under the venv Python."
@@ -9639,7 +9657,7 @@ def _reexec_dependency_sync_off_windows_shim() -> bool:
                 "below and this shell returns right away."
             )
             return True
-        except OSError as exc:
+        except (OSError, TypeError, ValueError) as exc:
             logger.debug("Dependency-sync hand-off via %s failed: %s", python_exe, exc)
         print(f"  ⚠ Could not hand the dependency install off {shim.name}.")
         print("    Continuing in-process; if it cannot replace the shim, run:")

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -5578,10 +5578,62 @@ def _abort_dependency_sync_if_self_locked(gateway_resume=None) -> None:
             _m()._resume_windows_gateways_after_update(gateway_resume)
         sys.exit(2)
 
-    if _m()._reexec_dependency_sync_off_windows_shim():
-        if gateway_resume is not None:
-            _m()._resume_windows_gateways_after_update(gateway_resume)
+    if _m()._reexec_dependency_sync_off_windows_shim(gateway_resume):
         sys.exit(0)
+
+
+def _take_windows_gateway_resume_handoff() -> dict | None:
+    """Wait for the shim parent and consume its serialized gateway pause token."""
+    parent_raw = os.environ.pop(_m()._UPDATE_REEXEC_PARENT_PID_ENV, "").strip()
+    token_raw = os.environ.pop(_m()._UPDATE_REEXEC_GATEWAY_RESUME_ENV, "").strip()
+    if not parent_raw and not token_raw:
+        return None
+    if not parent_raw:
+        raise RuntimeError("Windows update handoff is missing its parent PID")
+    try:
+        parent_pid = int(parent_raw)
+    except ValueError as exc:
+        raise RuntimeError("Windows update handoff has an invalid parent PID") from exc
+    if parent_pid <= 0:
+        raise RuntimeError("Windows update handoff has an invalid parent PID")
+
+    try:
+        import psutil
+
+        psutil.Process(parent_pid).wait(timeout=30.0)
+    except psutil.NoSuchProcess:
+        pass
+    except psutil.TimeoutExpired as exc:
+        raise RuntimeError(
+            "Windows update shim did not exit before the dependency handoff"
+        ) from exc
+    except Exception as exc:
+        raise RuntimeError(
+            f"Could not verify Windows update shim exit: {exc}"
+        ) from exc
+
+    if not token_raw:
+        return None
+    try:
+        token = json.loads(token_raw)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError("Windows update handoff has an invalid gateway token") from exc
+    if not isinstance(token, dict) or not token.get("resume_needed"):
+        raise RuntimeError("Windows update handoff has an invalid gateway token")
+    # The fleet is already stopped. Register recovery immediately, before the
+    # child does any probes/backups that could raise, so ownership cannot fall
+    # into a gap between deserialization and the normal pause point below.
+    import atexit
+
+    atexit.register(_m()._resume_windows_gateways_after_update, token)
+    return token
+
+
+def _prepare_windows_gateway_resume(handed_off: dict | None) -> dict | None:
+    """Adopt a handed-off pause token, or pause the currently running fleet."""
+    if handed_off is not None:
+        return handed_off
+    return _m()._pause_windows_gateways_for_update()
 
 
 def _defer_update_for_self_lock(loaded: list[str]) -> None:
@@ -8184,6 +8236,11 @@ def _drain_or_signal_gateway_for_update(
 def _cmd_update_impl(args, gateway_mode: bool):
     """Body of ``cmd_update`` — kept separate so the wrapper can always
     restore stdio even on ``sys.exit``."""
+    # The re-exec'd Windows child shares the update lock with its ancestor.
+    # Wait until that shim exits before any dependency probe or fleet action,
+    # and retain the exact pause token whose atexit ownership it relinquished.
+    _windows_gateway_handoff = _take_windows_gateway_resume_handoff()
+
     # A managed-runtime refresh can replace site-packages before the normal
     # ``.[all]`` install runs. Snapshot while the old environment can still
     # prove which optional backends the user had activated.
@@ -8318,8 +8375,13 @@ def _cmd_update_impl(args, gateway_mode: bool):
     except Exception:
         pass
 
-    _windows_gateway_resume = _m()._pause_windows_gateways_for_update()
-    if _windows_gateway_resume:
+    _windows_gateway_resume = _prepare_windows_gateway_resume(
+        _windows_gateway_handoff
+    )
+    if (
+        _windows_gateway_resume
+        and _windows_gateway_resume is not _windows_gateway_handoff
+    ):
         import atexit as _atexit
 
         _atexit.register(

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -5605,7 +5605,8 @@ def _take_windows_gateway_resume_handoff() -> dict | None:
         pass
     except psutil.TimeoutExpired as exc:
         raise RuntimeError(
-            "Windows update shim did not exit before the dependency handoff"
+            f"Windows update shim PID {parent_pid} did not exit before the "
+            "dependency handoff"
         ) from exc
     except Exception as exc:
         raise RuntimeError(

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2183,7 +2183,12 @@ def _verify_and_restore_state_dbs_post_update() -> None:
         logger.debug("Sibling-profile state.db guard sweep failed: %s", exc)
 
 
-def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> bool:
+def _update_via_zip(
+    args,
+    *,
+    had_desktop_app_before_update: bool = False,
+    gateway_resume: dict | None = None,
+) -> bool:
     """Update Hermes Agent by downloading a ZIP archive.
 
     Used on Windows when git file I/O is broken (antivirus, NTFS filter
@@ -2401,7 +2406,7 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> boo
     # Self-lock deferral (relocated preflight — #86735): the ZIP code swap
     # above is already committed; defer only the dependency sync when this
     # process holds a native extension the sync must rewrite.
-    _m()._abort_dependency_sync_if_self_locked()
+    _m()._abort_dependency_sync_if_self_locked(gateway_resume)
     print("→ Updating Python dependencies...")
 
     from hermes_cli.managed_uv import ensure_uv, update_managed_uv
@@ -8645,6 +8650,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             desktop_build_ok = _update_via_zip(
                 args,
                 had_desktop_app_before_update=had_desktop_app_before_update,
+                gateway_resume=_windows_gateway_resume,
             )
         finally:
             _m()._resume_windows_gateways_after_update(_windows_gateway_resume)
@@ -11097,6 +11103,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             desktop_build_ok = _update_via_zip(
                 args,
                 had_desktop_app_before_update=had_desktop_app_before_update,
+                gateway_resume=_windows_gateway_resume,
             )
             if gateway_mode:
                 _write_gateway_update_exit_code(desktop_build_ok)

--- a/tests/hermes_cli/test_update_shim_self_lock.py
+++ b/tests/hermes_cli/test_update_shim_self_lock.py
@@ -16,6 +16,9 @@ off at all.
 
 from __future__ import annotations
 
+import atexit
+import json
+import os
 import sys
 import types
 from pathlib import Path
@@ -152,6 +155,28 @@ def test_reexec_child_runs_unattended(venv, monkeypatch):
     assert calls[0][2]["stdin"] is cli_main.subprocess.DEVNULL
 
 
+def test_reexec_transfers_gateway_resume_ownership_to_child(venv, monkeypatch):
+    """The child owns the paused fleet; the exiting parent must not resume it."""
+    monkeypatch.setattr(sys, "argv", [str(venv / "hermes.exe"), "update"])
+    monkeypatch.setattr(os, "getpid", lambda: 4321)
+    calls = _capture_popen(monkeypatch)
+    resume = {
+        "resume_needed": True,
+        "profiles": {"default": 98},
+        "unmapped": [{"pid": 99, "argv": ["python.exe", "gateway", "run"]}],
+    }
+
+    assert cli_main._reexec_dependency_sync_off_windows_shim(resume) is True
+
+    child_env = calls[0][1]
+    assert child_env[cli_main._UPDATE_REEXEC_PARENT_PID_ENV] == "4321"
+    assert json.loads(child_env[cli_main._UPDATE_REEXEC_GATEWAY_RESUME_ENV]) == {
+        **resume,
+        "resume_needed": True,
+    }
+    assert resume["resume_needed"] is False
+
+
 def test_reexec_does_not_recurse(venv, monkeypatch):
     monkeypatch.setattr(sys, "argv", [str(venv / "hermes.exe"), "update"])
     monkeypatch.setenv(cli_main._UPDATE_REEXEC_ENV, "1")
@@ -220,6 +245,87 @@ def test_sync_guard_hands_off_when_only_the_shim_is_held(venv, monkeypatch):
 
     assert excinfo.value.code == 0
     assert calls, "expected the dependency sync to be handed to the venv python"
+
+
+def test_sync_guard_does_not_resume_gateways_in_shim_parent(venv, monkeypatch):
+    """Successful handoff exits immediately; only the child resumes the fleet."""
+    from hermes_cli import update_cmd
+
+    sentinel = {"resume_needed": True}
+    handed_off = []
+    resumed = []
+    monkeypatch.setattr(cli_main, "_detect_self_loaded_native_modules", lambda: [])
+    monkeypatch.setattr(
+        cli_main,
+        "_reexec_dependency_sync_off_windows_shim",
+        lambda token=None: handed_off.append(token) or True,
+    )
+    monkeypatch.setattr(
+        cli_main,
+        "_resume_windows_gateways_after_update",
+        lambda token: resumed.append(token),
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        update_cmd._abort_dependency_sync_if_self_locked(sentinel)
+
+    assert excinfo.value.code == 0
+    assert handed_off == [sentinel]
+    assert resumed == []
+
+
+def test_handoff_child_waits_for_parent_and_adopts_gateway_resume(monkeypatch):
+    """The child cannot touch the shim or restart fleet until its parent exits."""
+    from hermes_cli import update_cmd
+
+    events = []
+    token = {"resume_needed": True, "profiles": {"default": 98}, "unmapped": []}
+    monkeypatch.setenv(cli_main._UPDATE_REEXEC_PARENT_PID_ENV, "4321")
+    monkeypatch.setenv(
+        cli_main._UPDATE_REEXEC_GATEWAY_RESUME_ENV,
+        json.dumps(token),
+    )
+
+    class _Parent:
+        def wait(self, timeout):
+            events.append(("wait", timeout))
+
+    monkeypatch.setitem(
+        sys.modules,
+        "psutil",
+        types.SimpleNamespace(Process=lambda pid: _Parent(), TimeoutExpired=TimeoutError),
+    )
+    monkeypatch.setattr(
+        atexit,
+        "register",
+        lambda fn, value: events.append(("register", fn, value)),
+    )
+
+    adopted = update_cmd._take_windows_gateway_resume_handoff()
+
+    assert events == [
+        ("wait", 30.0),
+        ("register", cli_main._resume_windows_gateways_after_update, token),
+    ]
+    assert adopted == token
+    assert cli_main._UPDATE_REEXEC_PARENT_PID_ENV not in os.environ
+    assert cli_main._UPDATE_REEXEC_GATEWAY_RESUME_ENV not in os.environ
+
+
+def test_handoff_resume_token_skips_second_gateway_pause(monkeypatch):
+    """Transferred state is authoritative; rediscovery would lose stopped profiles."""
+    from hermes_cli import update_cmd
+
+    token = {"resume_needed": True, "profiles": {"work": 77}}
+    pauses = []
+    monkeypatch.setattr(
+        cli_main,
+        "_pause_windows_gateways_for_update",
+        lambda: pauses.append("pause") or {"cold_start_if_installed": True},
+    )
+
+    assert update_cmd._prepare_windows_gateway_resume(token) is token
+    assert pauses == []
 
 
 def test_sync_guard_defers_native_lock_before_considering_the_shim(venv, monkeypatch):

--- a/tests/hermes_cli/test_update_shim_self_lock.py
+++ b/tests/hermes_cli/test_update_shim_self_lock.py
@@ -312,6 +312,30 @@ def test_handoff_child_waits_for_parent_and_adopts_gateway_resume(monkeypatch):
     assert cli_main._UPDATE_REEXEC_GATEWAY_RESUME_ENV not in os.environ
 
 
+def test_handoff_parent_timeout_names_the_blocking_pid(monkeypatch):
+    """A stuck shim identifies the process the user must investigate."""
+    from hermes_cli import update_cmd
+
+    monkeypatch.setenv(cli_main._UPDATE_REEXEC_PARENT_PID_ENV, "4321")
+
+    class _Parent:
+        def wait(self, timeout):
+            raise TimeoutError
+
+    monkeypatch.setitem(
+        sys.modules,
+        "psutil",
+        types.SimpleNamespace(
+            Process=lambda pid: _Parent(),
+            NoSuchProcess=ProcessLookupError,
+            TimeoutExpired=TimeoutError,
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match=r"shim PID 4321 did not exit"):
+        update_cmd._take_windows_gateway_resume_handoff()
+
+
 def test_handoff_resume_token_skips_second_gateway_pause(monkeypatch):
     """Transferred state is authoritative; rediscovery would lose stopped profiles."""
     from hermes_cli import update_cmd

--- a/tests/hermes_cli/test_update_zip_symlink_reject.py
+++ b/tests/hermes_cli/test_update_zip_symlink_reject.py
@@ -109,6 +109,13 @@ def test_update_via_zip_accepts_normal_member(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(hermes_main, "PROJECT_ROOT", fake_root)
 
     args = type("Args", (), {})()
+    gateway_resume = {"resume_needed": True, "profiles": {"default": 4321}}
+    guarded_tokens = []
+    monkeypatch.setattr(
+        hermes_main,
+        "_abort_dependency_sync_if_self_locked",
+        lambda token=None: guarded_tokens.append(token),
+    )
 
     def fake_urlretrieve(url, dest):
         with open(zip_path, "rb") as src, open(dest, "wb") as dst:
@@ -124,7 +131,7 @@ def test_update_via_zip_accepts_normal_member(tmp_path, monkeypatch, capsys):
          patch("subprocess.check_call"):
         fake_run.return_value = type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
         try:
-            hermes_main._update_via_zip(args)
+            hermes_main._update_via_zip(args, gateway_resume=gateway_resume)
         except SystemExit:
             pass
 
@@ -135,3 +142,4 @@ def test_update_via_zip_accepts_normal_member(tmp_path, monkeypatch, capsys):
     # confirming the extraction + copy phases ran past the validation gate.
     assert (fake_root / "README.md").exists()
     assert (fake_root / "README.md").read_text() == "ok\n"
+    assert guarded_tokens == [gateway_resume]

--- a/tests/hermes_cli/test_update_zip_symlink_reject.py
+++ b/tests/hermes_cli/test_update_zip_symlink_reject.py
@@ -141,5 +141,5 @@ def test_update_via_zip_accepts_normal_member(tmp_path, monkeypatch, capsys):
     # The fake README from the ZIP should have landed in our sandbox root,
     # confirming the extraction + copy phases ran past the validation gate.
     assert (fake_root / "README.md").exists()
-    assert (fake_root / "README.md").read_text() == "ok\n"
+    assert (fake_root / "README.md").read_text(encoding="utf-8") == "ok\n"
     assert guarded_tokens == [gateway_resume]


### PR DESCRIPTION
## What does this PR do?

This fixes Windows `hermes update` runs that pull successfully but then fail dependency synchronization because the shim parent is still alive while the re-exec child tries to quarantine `venv\Scripts\hermes.exe`. The handoff now transfers the paused gateway fleet to the child, makes the child wait for the shim parent to exit, and leaves gateway restart ownership with the child.

### Symptom

An update started through `hermes.exe` can report that it cannot quarantine the live launcher, defer dependency installation, and then fail with `Windows gateway relaunch after update was not verified alive` even though the checkout advanced.

### Impact

Affected Windows users are left with a failed update receipt and pending dependency/fleet restart work. Running the update directly through the venv Python avoids the failure, but the normal `hermes update` path remains unreliable without this fix.

### Bug Cause

**Trigger:** `hermes_cli/update_cmd.py:_abort_dependency_sync_if_self_locked` after the code pull, when a Windows gateway was paused and the dependency sync is handed from `hermes.exe` to the venv Python.

**Causal chain:**
1. The parent updater pauses the Windows gateway fleet and spawns a re-exec child for dependency synchronization.
2. The parent synchronously resumes and verifies gateways before exiting, while its `hermes.exe` remains open; the child starts concurrently and attempts strict shim quarantine.
3. The child can fail quarantine on the parent's live shim, while gateway recovery is also split across both processes.

**Why it is wrong:** The spawn was treated as a completed ownership handoff, but no process-exit barrier or gateway resume-state transfer existed. The parent continued performing restart work that prolonged the exact shim lifetime the child needed to end.

**Working sibling / contrast:** Invoking `venv\Scripts\python.exe -m hermes_cli.main update` has no live console shim parent and completes the same dependency and gateway path successfully.

**Ruled out:** The dependency set, checkout, and gateway configuration are not the cause; the reported same-machine venv-Python control completed successfully and cleared the pending markers.

### Fix

- Serialize the existing Windows gateway resume token into the handoff child's environment.
- Include the shim parent PID and make the child wait for that process to exit before any dependency probe or fleet action.
- Disarm the parent's atexit resume only after the child is successfully spawned, then register child-side recovery immediately after adopting the token.
- Reuse the transferred token instead of pausing or cold-starting an already-stopped fleet a second time.

## Related Issue

Closes #101600

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py` - serialize parent identity and gateway resume state during the shim-to-Python handoff.
- `hermes_cli/update_cmd.py` - wait for the parent, adopt restart ownership, and avoid duplicate gateway pause/resume work.
- `tests/hermes_cli/test_update_shim_self_lock.py` - cover parent/child ordering, ownership transfer, and pause suppression.

## How to Test

1. On Windows, start the default gateway and run `hermes update` through the normal `hermes.exe` launcher.
2. Verify dependency synchronization begins only after the shim parent exits and no shim quarantine warning occurs.
3. Verify the previously running gateway returns on the updated checkout and the update completes without a pending restart marker.
4. Run the focused automated suites:

```bash
scripts/run_tests.sh tests/hermes_cli/test_update_shim_self_lock.py tests/hermes_cli/test_update_self_lock.py tests/hermes_cli/test_update_handoff_exit.py tests/hermes_cli/test_windows_update_restart_reconciliation.py tests/hermes_cli/test_update_concurrent_quarantine.py tests/hermes_cli/test_update_fleet_probe_resume_token.py -q
```

Result: 96 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test wrapper on the relevant updater suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested the focused suite on Windows 11

### Documentation & Housekeeping

- [x] Documentation changes are N/A; code comments and docstrings describe the handoff contract
- [x] Config example changes are N/A; no config keys changed
- [x] Contributor guide changes are N/A; no contributor workflow changed
- [x] I've considered cross-platform impact; the new handoff state is only emitted by the Windows shim path
- [x] Tool description/schema changes are N/A

## Screenshots / Logs

N/A; the regression is covered by process-ordering and ownership tests.
