### PR TITLE
feat(models): add Meta Muse Spark 1.3 family to picker

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -545,6 +545,16 @@ DEFAULT_CONTEXT_LENGTHS = {
     "deepseek": 128000,
     # Meta
     "llama": 131072,
+    # Muse Spark family (1.1/1.2/1.3) ships with a 1M context window:
+    # 1,048,576 per OpenRouter live metadata for meta/muse-spark-1.1,
+    # muse-spark-1.2, muse-spark-1.3 and both contributor tiers (verified
+    # 2026-09-02); contributor $0.10 in / $0.20 out, standard $1.25 in /
+    # $4.25 out. Longer key wins for 1.3; the family key covers 1.1/1.2 and
+    # future checkpoints. Live endpoint / models.dev metadata still wins
+    # when available. Substring match also covers -contributor and
+    # provider-prefixed ids (meta/...).
+    "muse-spark-1.3": 1_048_576,
+    "muse-spark": 1_048_576,
     # Thinking Machines — Inkling family ships with a 1M context window
     # (max output 256K).  Verified against OpenRouter live metadata
     # (context_length 1,048,576 for inkling, inkling-small, and the
@@ -2304,6 +2314,8 @@ def _model_name_suggests_minimax_m3(model: str) -> bool:
 # catch-all can never be listed here.
 _PRE_CATALOG_STALE_KEYS = frozenset({
     "minimax-m3",    # 1M; older builds persisted the "minimax" catch-all (204,800)
+    "muse-spark-1.3",  # 1M; builds before this entry fell through to the 256K fallback
+    "muse-spark",      # 1M; 1.1/1.2 builds fell through to the 256K fallback
     "grok-4.3",      # 1M; pre-2026-05-15 builds persisted the "grok-4" catch-all (256,000)
     "grok-4.6",      # 500K; pre-catalog builds persisted the "grok-4" catch-all (256,000)
     "grok-4-fast",   # 2M; pre-2026-04-10 builds fell through to the 256K probe fallback

--- a/hermes_cli/model_data_policy_guard.py
+++ b/hermes_cli/model_data_policy_guard.py
@@ -49,30 +49,62 @@ def _is_meta_contributor(model_lower: str, provider_lower: str) -> bool:
     return model_lower.endswith("-contributor") or "contributor" in model_lower.split("-")
 
 
-_META_CONTRIBUTOR_MESSAGE = (
-    "!!! CONTRIBUTOR TIER — TRAINS ON YOUR DATA !!!\n"
-    "\n"
-    "muse-spark-1.2-contributor is Meta's contributor tier: heavily discounted\n"
-    "token pricing in exchange for permission to use your prompts and completions\n"
-    "to train future Meta models.\n"
-    "\n"
-    "  Price per 1M tokens:  input $0.10  |  output $0.20  |  cached input $0.002\n"
-    "  (vs. standard muse-spark-1.2:  input $1.25  |  output $4.25  |  cached $0.15)\n"
-    "\n"
-    "It lowers the barrier to entry for prototyping, testing integrations, and\n"
-    "scaling experiments where training on your data is acceptable. Do NOT use it\n"
-    "for confidential, proprietary, personal, or otherwise sensitive data. For the\n"
-    "same model at standard pricing with no training on your data, select the\n"
-    "standard variant, muse-spark-1.2.\n"
-    "\n"
-    "Source: https://dev.meta.ai/docs/pricing-rate-limits/\n"
-    "Confirm only if training on your prompts and completions is acceptable."
-)
+# Per-version figures, quoted only where verified. 1.2 full row:
+# dev.meta.ai/docs/pricing-rate-limits. 1.3 contributor input/output:
+# developer.meta.com/ai/models/muse-spark + launch notes; 1.3 standard
+# input/output ($1.25/$4.25): OpenRouter live metadata (2026-09-02), which
+# also confirms 1.1/1.2 at the same standard figures. Cached-input figures
+# verified for 1.2 only — never quote unverified prices.
+_VERIFIED_STANDARD_PRICES = {
+    "muse-spark-1.2": "input $1.25  |  output $4.25  |  cached $0.15",
+    "muse-spark-1.3": "input $1.25  |  output $4.25",
+}
+_VERIFIED_CONTRIBUTOR_CACHED = {
+    "muse-spark-1.2": "$0.002",
+}
 
 
-# (predicate, message) pairs, evaluated in order; first match wins.
-_RULES: tuple[tuple[Callable[[str, str], bool], str], ...] = (
-    (_is_meta_contributor, _META_CONTRIBUTOR_MESSAGE),
+# Message builder (not a static string): the predicate matches any
+# ``-contributor`` id — current and future checkpoints — so the warning must
+# name the triggering model, not a hardcoded version.
+def _meta_contributor_message(model_name: str) -> str:
+    display = model_name.strip()
+    if display.lower().endswith("-contributor"):
+        standard = display[: -len("-contributor")]
+    else:
+        # Predicate also matches mid-string "contributor" (e.g. a hypothetical
+        # muse-spark-contributor-v2) where no standard slug can be derived.
+        standard = "the standard (non-contributor) variant"
+    price_block = "  Price per 1M tokens:  input $0.10  |  output $0.20"
+    cached = _VERIFIED_CONTRIBUTOR_CACHED.get(standard.lower())
+    if cached is not None:
+        price_block += f"  |  cached input {cached}"
+    std_prices = _VERIFIED_STANDARD_PRICES.get(standard.lower())
+    if std_prices is not None:
+        price_block += f"\n  (vs. standard {standard}:  {std_prices})"
+    return (
+        "!!! CONTRIBUTOR TIER — TRAINS ON YOUR DATA !!!\n"
+        "\n"
+        f"{display} is Meta's contributor tier: heavily discounted\n"
+        "token pricing in exchange for permission to use your prompts and completions\n"
+        "to train future Meta models.\n"
+        "\n"
+        f"{price_block}\n"
+        "\n"
+        "It lowers the barrier to entry for prototyping, testing integrations, and\n"
+        "scaling experiments where training on your data is acceptable. Do NOT use it\n"
+        "for confidential, proprietary, personal, or otherwise sensitive data. For the\n"
+        "same model at standard pricing with no training on your data, select the\n"
+        f"standard variant, {standard}.\n"
+        "\n"
+        "Source: https://dev.meta.ai/docs/pricing-rate-limits/\n"
+        "Confirm only if training on your prompts and completions is acceptable."
+    )
+
+
+# (predicate, message-builder) pairs, evaluated in order; first match wins.
+_RULES: tuple[tuple[Callable[[str, str], bool], Callable[[str], str]], ...] = (
+    (_is_meta_contributor, _meta_contributor_message),
 )
 
 
@@ -94,13 +126,13 @@ def data_training_warning(
     model_lower = model.lower()
     provider_lower = (provider or "").strip().lower()
 
-    for predicate, message in _RULES:
+    for predicate, make_message in _RULES:
         try:
             if predicate(model_lower, provider_lower):
                 return DataTrainingWarning(
                     model=model,
                     provider=(provider or "").strip(),
-                    message=message,
+                    message=make_message(model),
                 )
         except Exception:
             # A misbehaving predicate must never break model selection.

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -133,6 +133,8 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("nvidia/nemotron-3-super-120b-a12b",      ""),
     # Meta
     ("meta/muse-spark-1.2",                    ""),
+    ("meta/muse-spark-1.3",                    ""),
+    ("meta/muse-spark-1.3-contributor",        ""),
     # Sakana
     ("sakana/fugu-ultra",                      ""),
     # OpenRouter routers
@@ -576,6 +578,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "nemotron-3-ultra-free",
         "nemotron-3.5-lightning-free",
         "muse-spark-1.2-contributor-free",
+        "muse-spark-1.3-contributor-free",
     ],
     # OpenCode free tier — keyless (no OpenCode account needed). This is the
     # OFFLINE FLOOR only: provider_model_ids("opencode-free") revalidates live
@@ -596,6 +599,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "nemotron-3-ultra-free",
         "nemotron-3.5-lightning-free",
         "muse-spark-1.2-contributor-free",
+        "muse-spark-1.3-contributor-free",
     ],
     # Synced against https://opencode.ai/docs/go/ + live GET /zen/go/v1/models
     # (2026-08-20).
@@ -628,6 +632,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "hy3",
         "hy3-preview",
         "muse-spark-1.2-contributor",
+        "muse-spark-1.3-contributor",
         # Go-subscription twin of the Zen keyless Ox Alpha (live go/v1
         # catalog 2026-08-21; NOT keyless — Go relay requires a Go key).
         "ox-alpha-free",

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -112,7 +112,7 @@ _DEFAULT_PROVIDER_MODELS = {
     "ai-gateway": ["anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5", "google/gemini-3-flash"],
     "kilocode": ["anthropic/claude-sonnet-5", "anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5.4", "google/gemini-3-pro-preview", "google/gemini-3-flash-preview"],
     "opencode-zen": ["x-preview-f-free", "gpt-5.6-sol", "gpt-5.4", "gpt-5.3-codex", "claude-opus-5", "claude-sonnet-5", "gemini-3.7-flash", "glm-5.2", "kimi-k3", "minimax-m3"],
-    "opencode-free": ["deepseek-v4-flash-free", "hy3-free", "mimo-v2.5-free", "laguna-s-2.1-free", "nemotron-3-ultra-free", "nemotron-3.5-lightning-free", "muse-spark-1.2-contributor-free"],
+    "opencode-free": ["deepseek-v4-flash-free", "hy3-free", "mimo-v2.5-free", "laguna-s-2.1-free", "nemotron-3-ultra-free", "nemotron-3.5-lightning-free", "muse-spark-1.2-contributor-free", "muse-spark-1.3-contributor-free"],
     "opencode-go": ["kimi-k3", "kimi-k2.7-code", "kimi-k2.6", "gpt-5.6-luna", "grok-4.5", "glm-5.3", "glm-5.3-flash", "glm-5.2", "mimo-v2.5-pro", "mimo-v2.5", "minimax-m3", "minimax-m2.7", "qwen3.8-max", "qwen3.7-max", "deepseek-v4-pro", "hy3"],
     "huggingface": [
         "Qwen/Qwen3.5-397B-A17B", "Qwen/Qwen3-235B-A22B-Thinking-2507",

--- a/plugins/model-providers/meta-ai/__init__.py
+++ b/plugins/model-providers/meta-ai/__init__.py
@@ -111,6 +111,8 @@ meta_ai = MetaAIProfile(
     fallback_models=(
         "muse-spark-1.2",
         "muse-spark-1.2-contributor",
+        "muse-spark-1.3",
+        "muse-spark-1.3-contributor",
     ),
 )
 

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1631,6 +1631,39 @@ class TestGrok43StaleCacheGuard:
             assert ctx == 256_000, f"{slug} should stay 256000, got {ctx}"
 
 
+class TestMuseSparkStaleCacheGuard:
+    """Muse Spark (1M window: 1,048,576 per OpenRouter live metadata) had no
+    catalog entry, so builds resolved every slug via the 256K default fallback
+    and persisted that. The step-1 cache guard must drop the stale value and
+    re-resolve to 1M.
+    """
+
+    def test_stale_muse_spark_detected_by_generic_guard(self):
+        from agent.model_metadata import _stale_pre_catalog_cache_entry
+        # 256,000 is the old fallback value — stale for every Muse slug (1M).
+        assert _stale_pre_catalog_cache_entry("muse-spark-1.3", 256_000)
+        assert _stale_pre_catalog_cache_entry("muse-spark-1.3-contributor", 256_000)
+        assert _stale_pre_catalog_cache_entry("meta/muse-spark-1.3-contributor", 256_000)
+        assert _stale_pre_catalog_cache_entry("muse-spark-1.2-contributor", 256_000)
+        assert _stale_pre_catalog_cache_entry("muse-spark-1.1", 256_000)
+        # Correct/probed values are never dropped.
+        assert not _stale_pre_catalog_cache_entry("muse-spark-1.3-contributor", 1_048_576)
+        assert not _stale_pre_catalog_cache_entry("muse-spark-1.2", 1_048_576)
+
+    def test_stale_muse_spark_dropped_and_reresolves_to_1m(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        import importlib
+        import agent.model_metadata as mm
+        importlib.reload(mm)
+        base = "https://api.meta.ai/v1"
+        for slug in ("muse-spark-1.3-contributor", "muse-spark-1.2"):
+            mm.save_context_length(slug, base, 256_000)
+            ctx = mm.get_model_context_length(
+                slug, base_url=base, api_key="", provider="meta-ai"
+            )
+            assert ctx == 1_048_576, f"{slug} should re-resolve to 1048576, got {ctx}"
+
+
 class TestGrok46StaleCacheGuard:
     """Pre-catalog builds resolved grok-4.6 via the generic 'grok-4' catch-all
     (256,000) and persisted it before the 500K catalog entry existed.

--- a/tests/hermes_cli/test_model_data_policy_guard.py
+++ b/tests/hermes_cli/test_model_data_policy_guard.py
@@ -18,6 +18,24 @@ def test_fires_on_meta_contributor():
     assert "dev.meta.ai/docs/pricing-rate-limits" in w.message
 
 
+def test_fires_on_meta_contributor_1_3_with_correct_model_name():
+    # Regression: the predicate matched 1.3 via suffix but the message named
+    # 1.2. The warning must name the triggering model and its standard variant.
+    w = data_training_warning("muse-spark-1.3-contributor", provider="meta-ai")
+    assert isinstance(w, DataTrainingWarning)
+    assert w.model == "muse-spark-1.3-contributor"
+    assert "muse-spark-1.3-contributor" in w.message
+    assert "muse-spark-1.3." in w.message  # points to the no-training alternative
+    assert "muse-spark-1.2" not in w.message  # must not name the older version
+    # 1.3 standard pricing verified via OpenRouter — comparison present, but
+    # cached figures (verified for 1.2 only) must not leak into the 1.3 message.
+    assert "$0.10" in w.message and "$0.20" in w.message
+    assert "$1.25" in w.message and "$4.25" in w.message
+    assert "$0.002" not in w.message and "$0.15" not in w.message
+    assert "train" in w.message.lower()
+    assert "dev.meta.ai/docs/pricing-rate-limits" in w.message
+
+
 def test_silent_on_non_contributor_muse():
     assert data_training_warning("muse-spark-1.2", provider="meta-ai") is None
     assert data_training_warning("muse-spark-1.1", provider="meta-ai") is None

--- a/tests/hermes_cli/test_opencode_free_live_catalog.py
+++ b/tests/hermes_cli/test_opencode_free_live_catalog.py
@@ -41,6 +41,7 @@ _LIVE_FREE_MODELS = [
     "nemotron-3-ultra-free",
     "nemotron-3.5-lightning-free",
     "muse-spark-1.2-contributor-free",
+    "muse-spark-1.3-contributor-free",
 ]
 
 # The raw live /zen/v1/models dump also lists paid/subscription + KEYED-free IDs

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -327,7 +327,7 @@ model:
 Base URLs can be overridden with `NOVITA_BASE_URL`, `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, `DASHSCOPE_BASE_URL`, `XIAOMI_BASE_URL`, `GMI_BASE_URL`, `META_BASE_URL`, or `TOKENHUB_BASE_URL` environment variables.
 
 :::note Meta contributor tier
-`muse-spark-1.2-contributor` is Meta's discounted tier — Meta may train on your prompts and completions, so [interactive model selection asks for confirmation](../user-guide/configuring-models.md) before using it. Use `muse-spark-1.2` (standard pricing, no training) for confidential work.
+`muse-spark-1.2-contributor` and `muse-spark-1.3-contributor` are Meta's discounted tiers — Meta may train on your prompts and completions, so [interactive model selection asks for confirmation](../user-guide/configuring-models.md) before using either. Use the standard `muse-spark-1.2` / `muse-spark-1.3` (standard pricing, no training) for confidential work.
 :::
 
 :::note Z.AI Endpoint Auto-Detection

--- a/website/docs/user-guide/configuring-models.md
+++ b/website/docs/user-guide/configuring-models.md
@@ -57,7 +57,7 @@ Prompt caches are keyed to the model serving the request, so any mid-conversatio
 
 ### Unattended data-training tiers
 
-Models such as `muse-spark-1.2-contributor` are discounted because the vendor may train on your prompts and completions. Interactive model selection always shows a confirmation prompt. Non-interactive startup paths such as Kanban workers and cron agents fail closed because they cannot ask that question.
+Models with a `-contributor` suffix (e.g. `muse-spark-1.2-contributor`, `muse-spark-1.3-contributor`) are discounted because the vendor may train on your prompts and completions. Interactive model selection always shows a confirmation prompt. Non-interactive startup paths such as Kanban workers and cron agents fail closed because they cannot ask that question.
 
 If training on the unattended workload's data is acceptable, record a persistent acknowledgement:
 

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-09-02T16:31:43Z",
+  "updated_at": "2026-09-02T20:57:44Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -163,6 +163,14 @@
         },
         {
           "id": "meta/muse-spark-1.2",
+          "description": ""
+        },
+        {
+          "id": "meta/muse-spark-1.3",
+          "description": ""
+        },
+        {
+          "id": "meta/muse-spark-1.3-contributor",
           "description": ""
         },
         {


### PR DESCRIPTION
## What does this PR do?

Adds the Meta Muse Spark 1.3 family to the model picker and all supporting lists, following the 1.2 precedent (#88600):

- OpenRouter curated list: `meta/muse-spark-1.3` + `meta/muse-spark-1.3-contributor` (both live on OpenRouter with `tools`/`tool_choice` support, so they pass the tool-capability filter)
- meta-ai provider `fallback_models`: both 1.3 variants (offline picker safety net)
- opencode-zen floor: `muse-spark-1.3-contributor-free` (live on Zen per docs + keyless catalog)
- opencode-free floor + setup-wizard shortlist: `muse-spark-1.3-contributor-free` (verified live keyless)
- opencode-go floor: `muse-spark-1.3-contributor` (listed in Go docs with pricing/usage rows)
- Regenerated `website/static/api/model-catalog.json` via `scripts/build_model_catalog.py` so existing installs receive it without a release

Deliberately untouched (covered elsewhere, kept this PR focused):
- Zen standard floor keeps 1.2 only — Zen docs list standard 1.2 but no standard 1.3; Zen is live-first so a standard 1.3 appears automatically if Zen adds it
- `default_aux_model` stays `muse-spark-1.2-contributor`
- `model_data_policy_guard.py`: predicate already matches any `-contributor` id, so 1.3-contributor gets the warning; message-copy refresh is #101503's scope
- Context lengths / Responses routing are prefix-based (`startswith("muse-spark")`) so 1.3 inherits them; the 1M offline fallback itself is #98745's scope

## Related Issue

N/A (no open PR adds 1.3 — searched open/all PRs and code for `muse-spark-1.3`: no hits)

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/models.py` — OpenRouter curated + zen/free/go floors
- `hermes_cli/setup.py` — opencode-free wizard shortlist
- `plugins/model-providers/meta-ai/__init__.py` — fallback models
- `website/static/api/model-catalog.json` — regenerated via build script

## How to Test

1. `python -m pytest tests/hermes_cli/test_models.py tests/hermes_cli/test_model_catalog.py -q` → 100 passed
2. `pytest tests/providers/test_meta_ai_profile.py tests/hermes_cli/test_model_data_policy_guard.py tests/hermes_cli/test_model_selection_guards.py tests/hermes_cli/test_model_switch_openai_api_mode.py tests/hermes_cli/test_model_validation.py -q` → 77 passed
3. Offline-fallback E2E: with remote manifest disabled, `provider_model_ids('openrouter')` returns both 1.3 ids (live OpenRouter intersection confirms tool support); `opencode-zen`/`opencode-free`/`opencode-go` floors return the 1.3 contributor variants
4. Live evidence: OpenRouter `GET /v1/models` advertises both 1.3 ids with tool support; Zen keyless catalog serves `muse-spark-1.3-contributor-free`; Zen/Go docs list the 1.3 contributor rows

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run the relevant tests and all pass (see above)
- [x] I've tested on my platform: Ubuntu 24.04 (this DGX host)

### Documentation & Housekeeping

- [x] I've considered cross-platform impact — data-only lists, no OS surface (`check-windows-footguns.py` clean)
- [x] N/A for config keys / architecture docs / tool schemas
