### PR TITLE
fix(gateway): run loop-wakeup SessionDB calls off the event loop

### DIFF
--- a/contributors/emails/agent@dynamicagency.com
+++ b/contributors/emails/agent@dynamicagency.com
@@ -1,0 +1,2 @@
+agentdynamic
+# PR #92413 salvage

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -24715,8 +24715,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # init on the loop thread before the first read.
                 await self._warm_goals_session_db("loop wakeup")
 
+                # Run list_active_loops() in an executor to avoid blocking the event loop.
+                # list_active_loops() calls list_meta_prefix() which acquires self._lock,
+                # and that lock is also held by writers doing BEGIN IMMEDIATE and periodic
+                # FTS5-merge/WAL-checkpoint work. A slow write holding the lock while the
+                # watcher blocks the entire event loop on the same lock froze it for 90+
+                # seconds until the liveness watchdog force-exited. Moving this off the
+                # loop thread prevents the freeze.
+                loop = asyncio.get_event_loop()
+                active_loops = await loop.run_in_executor(None, list_active_loops)
+
                 now = time.time()
-                for sid, state in list_active_loops():
+                for sid, state in active_loops:
                     if state.awaiting_response or now < state.next_due_at:
                         continue
                     route = state.route or {}

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -24715,15 +24715,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # init on the loop thread before the first read.
                 await self._warm_goals_session_db("loop wakeup")
 
-                # Run list_active_loops() in an executor to avoid blocking the event loop.
-                # list_active_loops() calls list_meta_prefix() which acquires self._lock,
-                # and that lock is also held by writers doing BEGIN IMMEDIATE and periodic
-                # FTS5-merge/WAL-checkpoint work. A slow write holding the lock while the
-                # watcher blocks the entire event loop on the same lock froze it for 90+
-                # seconds until the liveness watchdog force-exited. Moving this off the
-                # loop thread prevents the freeze.
-                loop = asyncio.get_running_loop()
-                active_loops = await loop.run_in_executor(None, list_active_loops)
+                # Every SessionDB call in this scan runs off the loop thread.
+                # fire_tick()/complete_tick() are writes (BEGIN IMMEDIATE) that
+                # take the writer lock; a slow writer elsewhere (FTS merge, WAL
+                # checkpoint, a long flush) holding it while the watcher blocked
+                # the loop on the same lock froze the gateway for 90+ s until
+                # the liveness watchdog force-exited. list_active_loops() reads
+                # via _read_ctx (lock-free under WAL) but still convoys on the
+                # writer lock when WAL is unavailable, so it goes off-loop too.
+                # _run_in_executor_with_context keeps the profile HERMES_HOME
+                # override alive under multiplex, like the warm-up above.
+                active_loops = await self._run_in_executor_with_context(list_active_loops)
 
                 now = time.time()
                 for sid, state in active_loops:
@@ -24774,10 +24776,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     mgr = LoopManager(session_id=sid)
                     if not mgr.is_due(now):
                         continue
-                    # fire_tick() is a write (BEGIN IMMEDIATE) that acquires self._lock,
-                    # same contention source as list_meta_prefix(). Run it in an executor
-                    # to avoid blocking the event loop.
-                    wakeup = await loop.run_in_executor(None, mgr.fire_tick)
+                    wakeup = await self._run_in_executor_with_context(mgr.fire_tick)
                     if not wakeup:
                         continue
                     try:
@@ -24797,10 +24796,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         # path and never hit the post-turn completion hook —
                         # complete the tick immediately (caps + scheduling).
                         if wakeup.lstrip().startswith("/"):
-                            # complete_tick() is a write (BEGIN IMMEDIATE) that acquires
-                            # self._lock, same contention source as list_meta_prefix().
-                            # Run it in an executor to avoid blocking the event loop.
-                            await loop.run_in_executor(None, mgr.complete_tick, "")
+                            await self._run_in_executor_with_context(mgr.complete_tick, "")
                     except Exception as exc:
                         logger.warning("loop wakeup injection failed for %s: %s", sid, exc)
                         try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -24722,7 +24722,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # watcher blocks the entire event loop on the same lock froze it for 90+
                 # seconds until the liveness watchdog force-exited. Moving this off the
                 # loop thread prevents the freeze.
-                loop = asyncio.get_event_loop()
+                loop = asyncio.get_running_loop()
                 active_loops = await loop.run_in_executor(None, list_active_loops)
 
                 now = time.time()
@@ -24774,7 +24774,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     mgr = LoopManager(session_id=sid)
                     if not mgr.is_due(now):
                         continue
-                    wakeup = mgr.fire_tick()
+                    # fire_tick() is a write (BEGIN IMMEDIATE) that acquires self._lock,
+                    # same contention source as list_meta_prefix(). Run it in an executor
+                    # to avoid blocking the event loop.
+                    wakeup = await loop.run_in_executor(None, mgr.fire_tick)
                     if not wakeup:
                         continue
                     try:
@@ -24794,7 +24797,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         # path and never hit the post-turn completion hook —
                         # complete the tick immediately (caps + scheduling).
                         if wakeup.lstrip().startswith("/"):
-                            mgr.complete_tick("")
+                            # complete_tick() is a write (BEGIN IMMEDIATE) that acquires
+                            # self._lock, same contention source as list_meta_prefix().
+                            # Run it in an executor to avoid blocking the event loop.
+                            await loop.run_in_executor(None, mgr.complete_tick, "")
                     except Exception as exc:
                         logger.warning("loop wakeup injection failed for %s: %s", sid, exc)
                         try:

--- a/tests/gateway/test_loop_command.py
+++ b/tests/gateway/test_loop_command.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import threading
 import time
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -323,3 +324,76 @@ async def test_loop_wakeup_watcher_keeps_event_loop_responsive_under_writer_lock
     assert released.is_set()
     # If the DB call ran on the loop thread, one heartbeat gap would be ~hold_s.
     assert max(gaps) < hold_s / 2, f"event loop stalled for {max(gaps):.3f}s"
+
+
+@pytest.mark.asyncio
+async def test_loop_wakeup_watcher_runs_every_sessiondb_call_off_loop_thread(loop_env):
+    """Full wakeup path (slash-command loop, adapter present): list_active_loops,
+    fire_tick and complete_tick must each execute on an executor thread, never
+    on the event-loop thread (#92413)."""
+    runner = _make_runner()
+    runner._running = True
+    runner._running_agents = {}
+
+    class _Adapter:
+        handled = []
+
+        async def handle_message(self, event):
+            self.handled.append(event.text)
+
+    runner.adapters = {Platform.DISCORD: _Adapter()}
+    runner._build_process_event_source = lambda evt: SimpleNamespace(
+        platform=Platform.DISCORD, chat_id=evt["chat_id"], chat_type=evt["chat_type"],
+        thread_id=evt["thread_id"] or None, user_id=evt["user_id"], user_name=evt["user_name"],
+    )
+    runner._session_key_for_source = lambda source: "agent:main:discord:channel:chat-loop"
+
+    # A slash-command loop that is due now.
+    await GatewayRunner._handle_loop_command(runner, _make_event("/loop 5m /status"))
+    state = loops.load_loop("sid-gateway-loop")
+    state.next_due_at = time.time() - 1
+    loops.save_loop("sid-gateway-loop", state)
+
+    loop_thread = threading.current_thread()
+    on_loop_calls = []
+
+    def _record(name):
+        if threading.current_thread() is loop_thread:
+            on_loop_calls.append(name)
+
+    real_list = loops.list_active_loops
+    real_fire = loops.LoopManager.fire_tick
+    real_complete = loops.LoopManager.complete_tick
+
+    def _list_active_loops(*a, **k):
+        _record("list_active_loops")
+        return real_list(*a, **k)
+
+    def _fire_tick(self):
+        _record("fire_tick")
+        return real_fire(self)
+
+    def _complete_tick(self, last_response):
+        _record("complete_tick")
+        return real_complete(self, last_response)
+
+    orig_sleep = asyncio.sleep
+    calls = {"n": 0}
+
+    async def _one_pass_sleep(delay):
+        calls["n"] += 1
+        if calls["n"] >= 2:
+            runner._running = False
+        return await orig_sleep(0)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(loops, "list_active_loops", _list_active_loops)
+        mp.setattr(loops.LoopManager, "fire_tick", _fire_tick)
+        mp.setattr(loops.LoopManager, "complete_tick", _complete_tick)
+        mp.setattr(asyncio, "sleep", _one_pass_sleep)
+        await GatewayRunner._loop_wakeup_watcher(runner, interval=0)
+
+    assert _Adapter.handled == ["/status"], _Adapter.handled
+    assert on_loop_calls == [], f"SessionDB calls ran on the event-loop thread: {on_loop_calls}"
+    # complete_tick ran (slash-command loops complete immediately).
+    assert loops.load_loop("sid-gateway-loop").ticks_fired == 1

--- a/tests/gateway/test_loop_command.py
+++ b/tests/gateway/test_loop_command.py
@@ -1,6 +1,8 @@
 """Gateway /loop command tests — dispatch, routing capture, mid-run guard."""
 
+import asyncio
 import logging
+import threading
 import time
 from unittest.mock import AsyncMock, Mock
 
@@ -255,3 +257,69 @@ async def test_post_turn_session_resolution_failure_is_logged(loop_env, caplog):
         )
 
     assert "post-turn session resolution failed: store unavailable" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_loop_wakeup_watcher_keeps_event_loop_responsive_under_writer_lock(loop_env):
+    """The wakeup scan's SessionDB calls (list_active_loops / fire_tick /
+    complete_tick) must run off the loop thread. A slow writer holding the
+    SessionDB writer lock used to block the whole gateway event loop for the
+    duration of the hold (#92413)."""
+    runner = _make_runner()
+    runner._running = True
+    runner._running_agents = {}
+    runner.adapters = {}
+
+    # Persist an active loop that is due now, routed to a platform with no
+    # adapter (so the scan exits after list_active_loops(), before fire_tick).
+    await GatewayRunner._handle_loop_command(runner, _make_event("/loop 5m poll CI"))
+    state = loops.load_loop("sid-gateway-loop")
+    state.next_due_at = time.time() - 1
+    loops.save_loop("sid-gateway-loop", state)
+
+    db = loops._get_session_db()
+    hold_s = 0.6
+    released = threading.Event()
+
+    def _hold_writer_lock():
+        with db._lock:
+            time.sleep(hold_s)
+        released.set()
+
+    # Force the read path onto the writer lock (non-WAL degradation) so the
+    # test binds the offload regardless of the host SQLite's WAL support.
+    db._wal_active = False
+
+    # One scan only: patch asyncio.sleep inside the watcher to stop the loop
+    # after the first iteration.
+    orig_sleep = asyncio.sleep
+    calls = {"n": 0}
+
+    async def _one_pass_sleep(delay):
+        calls["n"] += 1
+        if calls["n"] >= 2:  # first call is the 5s connect grace, second ends the scan
+            runner._running = False
+        return await orig_sleep(0)
+
+    holder = threading.Thread(target=_hold_writer_lock)
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(asyncio, "sleep", _one_pass_sleep)
+        holder.start()
+        time.sleep(0.05)  # ensure the lock is held before the scan starts
+        watcher = asyncio.ensure_future(GatewayRunner._loop_wakeup_watcher(runner, interval=0))
+
+        # Heartbeat coroutine: measures the longest gap between loop turns
+        # while the watcher is (supposedly) blocked in the executor.
+        gaps = []
+        last = time.monotonic()
+        while not watcher.done():
+            await orig_sleep(0.01)
+            now = time.monotonic()
+            gaps.append(now - last)
+            last = now
+        await watcher
+    holder.join()
+
+    assert released.is_set()
+    # If the DB call ran on the loop thread, one heartbeat gap would be ~hold_s.
+    assert max(gaps) < hold_s / 2, f"event loop stalled for {max(gaps):.3f}s"

--- a/tests/gateway/test_loop_command.py
+++ b/tests/gateway/test_loop_command.py
@@ -356,8 +356,12 @@ async def test_loop_wakeup_watcher_runs_every_sessiondb_call_off_loop_thread(loo
 
     loop_thread = threading.current_thread()
     on_loop_calls = []
+    seen_calls = []
 
     def _record(name):
+        # Positive count guards against a future import hoist in run.py that
+        # would bypass these wrappers and leave the off-loop assertion vacuous.
+        seen_calls.append(name)
         if threading.current_thread() is loop_thread:
             on_loop_calls.append(name)
 
@@ -394,6 +398,7 @@ async def test_loop_wakeup_watcher_runs_every_sessiondb_call_off_loop_thread(loo
         await GatewayRunner._loop_wakeup_watcher(runner, interval=0)
 
     assert _Adapter.handled == ["/status"], _Adapter.handled
+    assert seen_calls == ["list_active_loops", "fire_tick", "complete_tick"], seen_calls
     assert on_loop_calls == [], f"SessionDB calls ran on the event-loop thread: {on_loop_calls}"
     # complete_tick ran (slash-command loops complete immediately).
     assert loops.load_loop("sid-gateway-loop").ticks_fired == 1


### PR DESCRIPTION
## Summary
The gateway event loop no longer freezes while the `/loop` wakeup watcher waits on the SessionDB writer lock.

Root cause: the 15s wakeup scan called `list_active_loops()`, `fire_tick()` and `complete_tick()` directly on the event-loop thread. Any slow writer holding `SessionDB._lock` elsewhere (FTS merge, WAL checkpoint, a long flush) blocked the whole gateway for the duration of the hold — reported as 90+ s freezes ending in a liveness-watchdog force-exit.

Salvage of #92413 by @agentdynamic onto current main. The `hermes_state.py` half of the original PR (`list_meta_prefix` under `self._lock`) already landed independently; this carries the remaining `gateway/run.py` half.

## Changes
- `gateway/run.py`: the three SessionDB calls in `_loop_wakeup_watcher` go through `_run_in_executor_with_context` (the established off-loop hop; preserves the multiplex `HERMES_HOME` override, unlike bare `run_in_executor`).
- `tests/gateway/test_loop_command.py`: two regression tests — (1) a writer holds `db._lock` for 0.6 s during a scan; the longest event-loop heartbeat gap must stay < 0.3 s; (2) full wakeup path (adapter present, slash-command loop) asserts each of the three calls runs off the loop thread.
- `contributors/emails`: mapping for @agentdynamic.

## Validation
| | main | this PR |
|---|---|---|
| Event-loop stall while a writer holds the lock 0.6 s | **0.53 s** | 0 (< 0.01 s) |
| New tests with main's `run.py` | fail (`['list_active_loops', 'fire_tick', 'complete_tick']` on loop thread) | pass |
| `tests/gateway/test_loop_command.py` | — | 12/12 |

Contributor commits cherry-picked with authorship preserved; follow-ups are separate commits. Closes #92413.
