### PR TITLE
feat(cli): honor -t/--toolsets when spawning MCP servers

### DIFF
--- a/contributors/emails/michel.alexander@gmail.com
+++ b/contributors/emails/michel.alexander@gmail.com
@@ -1,0 +1,2 @@
+SelfParody
+# PR #19000 salvage

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12852,6 +12852,17 @@ def _prepare_agent_startup(args) -> None:
                 "plugin discovery failed at CLI startup",
                 exc_info=True,
             )
+    # -t/--toolsets narrows which configured MCP servers get spawned, on
+    # every discovery path (inline below, background thread, TUI/desktop
+    # deferred start). Built-in toolset names never match a server key, so
+    # `-t terminal` simply spawns nothing; `-t all` keeps the full set.
+    try:
+        from hermes_cli.mcp_startup import set_mcp_server_filter
+
+        set_mcp_server_filter(getattr(args, "toolsets", None))
+    except Exception:
+        logger.debug("MCP server filter setup failed", exc_info=True)
+
     _run_inline_mcp_discovery = True
     if _is_tui_chat_launch(args):
         # The TUI launcher hands off to a dedicated startup path that already
@@ -12880,9 +12891,14 @@ def _prepare_agent_startup(args) -> None:
         try:
             # MCP tool discovery remains synchronous for entrypoints that do
             # not own a later bounded/executor startup path.
+            from hermes_cli.mcp_startup import get_mcp_server_filter
             from tools.mcp_tool import discover_mcp_tools
 
-            discover_mcp_tools()
+            _mcp_filter = get_mcp_server_filter()
+            if _mcp_filter is None:
+                discover_mcp_tools()
+            else:
+                discover_mcp_tools(allowed_mcp_names=_mcp_filter)
         except Exception:
             logger.debug(
                 "MCP tool discovery failed at CLI startup",

--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -10,6 +10,37 @@ _mcp_discovery_lock = threading.Lock()
 _mcp_discovery_started = False
 _mcp_discovery_thread: Optional[threading.Thread] = None
 _mcp_discovery_deferred: Optional[threading.Timer] = None
+# Process-wide MCP server-name allowlist derived from ``-t/--toolsets``.
+# ``None`` = no filter (spawn every configured server). Set once at CLI
+# startup by ``set_mcp_server_filter`` and honored by every discovery path
+# in this module (inline, background, deferred), so a ``-t terminal``
+# oneshot never cold-starts MCP subprocesses it cannot use.
+_mcp_server_filter: Optional[list[str]] = None
+
+
+def set_mcp_server_filter(toolsets: object) -> Optional[list[str]]:
+    """Derive the MCP spawn allowlist from a ``-t/--toolsets`` value.
+
+    Built-in toolset names in the list are harmless (they never match a
+    configured ``mcp_servers`` key). ``all``/``*`` or an empty/absent value
+    clears the filter. Returns the stored list for logging/tests.
+    """
+    global _mcp_server_filter
+    names: list[str] = []
+    if isinstance(toolsets, str):
+        names = [t.strip() for t in toolsets.split(",") if t.strip()]
+    elif isinstance(toolsets, (list, tuple, set)):
+        for item in toolsets:
+            names.extend(t.strip() for t in str(item).split(",") if t.strip())
+    if not names or "all" in names or "*" in names:
+        _mcp_server_filter = None
+    else:
+        _mcp_server_filter = names
+    return _mcp_server_filter
+
+
+def get_mcp_server_filter() -> Optional[list[str]]:
+    return _mcp_server_filter
 
 
 def _has_configured_mcp_servers() -> bool:
@@ -170,7 +201,13 @@ def _discover_mcp_tools_without_interactive_oauth() -> None:
     with suppress_interactive_oauth():
         from tools.mcp_tool import discover_mcp_tools
 
-        discover_mcp_tools()
+        # Only pass the kwarg when a filter is set: many tests (and any
+        # out-of-tree caller) stub discover_mcp_tools with a zero-arg
+        # callable, and the unfiltered call shape is unchanged.
+        if _mcp_server_filter is None:
+            discover_mcp_tools()
+        else:
+            discover_mcp_tools(allowed_mcp_names=_mcp_server_filter)
 
 
 def defer_background_mcp_discovery(*, logger, thread_name: str, delay: float) -> None:

--- a/tests/hermes_cli/test_mcp_startup.py
+++ b/tests/hermes_cli/test_mcp_startup.py
@@ -199,3 +199,99 @@ def _install_retry_stubs(monkeypatch, *, connected: bool, calls: dict):
     )
 
 
+
+
+# --- -t/--toolsets MCP spawn filter (#19000) --------------------------------
+
+
+@pytest.fixture
+def _reset_mcp_server_filter():
+    saved = mcp_startup._mcp_server_filter
+    try:
+        yield
+    finally:
+        mcp_startup._mcp_server_filter = saved
+
+
+@pytest.mark.parametrize(
+    ("toolsets", "expected"),
+    [
+        (None, None),
+        ("", None),
+        ("all", None),
+        (["*"], None),
+        ("terminal,web", ["terminal", "web"]),
+        (["terminal", "code-mcp,web"], ["terminal", "code-mcp", "web"]),
+    ],
+)
+def test_set_mcp_server_filter_normalizes(_reset_mcp_server_filter, toolsets, expected):
+    assert mcp_startup.set_mcp_server_filter(toolsets) == expected
+    assert mcp_startup.get_mcp_server_filter() == expected
+
+
+def test_discover_mcp_tools_spawns_only_allowed_servers(monkeypatch):
+    """The filter must narrow the spawn set before any server is connected;
+    built-in toolset names in the list are ignored."""
+    from tools import mcp_tool
+
+    servers = {
+        "code-mcp": {"command": "true"},
+        "docs-mcp": {"command": "true"},
+    }
+    seen: dict[str, dict] = {}
+
+    monkeypatch.setattr(mcp_tool, "_load_mcp_config", lambda: dict(servers))
+    monkeypatch.setattr(mcp_tool, "_ensure_mcp_sdk", lambda: True)
+    monkeypatch.setattr(mcp_tool, "_try_acquire_mcp_discovery_lock", lambda: mcp_tool._LOCK_UNAVAILABLE)
+    monkeypatch.setattr(mcp_tool, "_release_mcp_discovery_lock", lambda *_a, **_k: None, raising=False)
+
+    def _fake_register(cfgs):
+        seen.update(cfgs)
+        return []
+
+    monkeypatch.setattr(mcp_tool, "register_mcp_servers", _fake_register)
+    monkeypatch.setattr(mcp_tool, "_servers", {})
+    monkeypatch.setattr(mcp_tool, "_server_connecting", set())
+
+    # Everything (no filter) — both would be registered.
+    mcp_tool.discover_mcp_tools()
+    assert set(seen) == {"code-mcp", "docs-mcp"}
+
+    # `-t terminal,code-mcp` — only the matching server; "terminal" is a no-op.
+    seen.clear()
+    mcp_tool.discover_mcp_tools(allowed_mcp_names=["terminal", "code-mcp"])
+    assert set(seen) == {"code-mcp"}
+
+    # `-t terminal` — no MCP server in the filter: skip the whole MCP load.
+    seen.clear()
+    assert mcp_tool.discover_mcp_tools(allowed_mcp_names=["terminal"]) == []
+    assert seen == {}
+
+
+def test_background_discovery_honors_server_filter(monkeypatch, _reset_mcp_server_filter):
+    calls: list = []
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool",
+        types.SimpleNamespace(discover_mcp_tools=lambda allowed_mcp_names=None: calls.append(allowed_mcp_names)),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_oauth",
+        types.SimpleNamespace(suppress_interactive_oauth=nullcontext),
+    )
+    mcp_startup.set_mcp_server_filter("terminal,code-mcp")
+    mcp_startup._discover_mcp_tools_without_interactive_oauth()
+    assert calls == [["terminal", "code-mcp"]]
+
+
+def test_prepare_agent_startup_installs_server_filter(monkeypatch, _reset_mcp_server_filter):
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        types.SimpleNamespace(discover_plugins=lambda: None),
+    )
+    monkeypatch.setattr(main_mod, "_should_background_mcp_startup", lambda args: False)
+    monkeypatch.setattr(main_mod, "_command_has_dedicated_mcp_startup", lambda args: True)
+    main_mod._prepare_agent_startup(_agent_args(toolsets="terminal,code-mcp"))
+    assert mcp_startup.get_mcp_server_filter() == ["terminal", "code-mcp"]

--- a/tests/hermes_cli/test_mcp_startup.py
+++ b/tests/hermes_cli/test_mcp_startup.py
@@ -240,8 +240,14 @@ def test_discover_mcp_tools_spawns_only_allowed_servers(monkeypatch):
     }
     seen: dict[str, dict] = {}
 
+    sdk_probes = {"n": 0}
+
+    def _fake_ensure_sdk():
+        sdk_probes["n"] += 1
+        return True
+
     monkeypatch.setattr(mcp_tool, "_load_mcp_config", lambda: dict(servers))
-    monkeypatch.setattr(mcp_tool, "_ensure_mcp_sdk", lambda: True)
+    monkeypatch.setattr(mcp_tool, "_ensure_mcp_sdk", _fake_ensure_sdk)
     monkeypatch.setattr(mcp_tool, "_try_acquire_mcp_discovery_lock", lambda: mcp_tool._LOCK_UNAVAILABLE)
     monkeypatch.setattr(mcp_tool, "_release_mcp_discovery_lock", lambda *_a, **_k: None, raising=False)
 
@@ -262,10 +268,13 @@ def test_discover_mcp_tools_spawns_only_allowed_servers(monkeypatch):
     mcp_tool.discover_mcp_tools(allowed_mcp_names=["terminal", "code-mcp"])
     assert set(seen) == {"code-mcp"}
 
-    # `-t terminal` — no MCP server in the filter: skip the whole MCP load.
+    # `-t terminal` — no MCP server in the filter: skip the whole MCP load,
+    # including the ~260ms `mcp` SDK import.
     seen.clear()
+    sdk_probes["n"] = 0
     assert mcp_tool.discover_mcp_tools(allowed_mcp_names=["terminal"]) == []
     assert seen == {}
+    assert sdk_probes["n"] == 0
 
 
 def test_background_discovery_honors_server_filter(monkeypatch, _reset_mcp_server_filter):

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -8201,7 +8201,7 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
     return _existing_tool_names()
 
 
-def discover_mcp_tools() -> List[str]:
+def discover_mcp_tools(allowed_mcp_names: Optional[List[str]] = None) -> List[str]:
     """Entry point: load config, connect to MCP servers, register tools.
 
     Called from ``model_tools`` after ``discover_builtin_tools()``. Safe to call even when
@@ -8209,6 +8209,19 @@ def discover_mcp_tools() -> List[str]:
 
     Idempotent for already-connected servers. If some servers failed on a
     previous call, only the missing ones are retried.
+
+    Args:
+        allowed_mcp_names: If provided, only spawn MCP servers whose names
+            appear in this list. Built-in toolset names (e.g. "web", "memory")
+            in the list are ignored — only matching MCP-server names trigger
+            spawning. Pass ``None`` (default) to spawn all configured servers
+            for backwards compatibility.
+
+            This is used by ``hermes -z -t <toolsets>`` to skip cold-starting
+            MCP subprocesses that the caller doesn't need — saving 10-60s of
+            startup wait per non-needed server. The full set of MCP names is
+            still discoverable via the ``-t`` validation path; this filter
+            only affects which servers are actually started.
 
     Returns:
         List of all registered MCP tool names.
@@ -8223,6 +8236,25 @@ def discover_mcp_tools() -> List[str]:
     if not _ensure_mcp_sdk():
         logger.debug("MCP SDK not available -- skipping MCP tool discovery")
         return []
+
+    if allowed_mcp_names is not None:
+        # Filter by MCP-server-name match. Built-in toolset names that aren't
+        # MCP servers will simply not match — that's fine; they don't need
+        # MCP spawning anyway.
+        allowed_set = {str(n) for n in allowed_mcp_names}
+        filtered = {name: cfg for name, cfg in servers.items() if name in allowed_set}
+        skipped_count = len(servers) - len(filtered)
+        if skipped_count:
+            logger.debug(
+                "MCP discovery filter: spawning %d/%d configured server(s) per --toolsets filter "
+                "(skipped: %s)",
+                len(filtered), len(servers),
+                ",".join(sorted(set(servers) - set(filtered))),
+            )
+        servers = filtered
+        if not servers:
+            logger.debug("No MCP servers in --toolsets filter; skipping MCP load entirely")
+            return []
 
     # Cross-process discovery guard (#62771). A lock loser waits for
     # the holder, then performs its own process-local discovery. If locking is

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -8231,12 +8231,6 @@ def discover_mcp_tools(allowed_mcp_names: Optional[List[str]] = None) -> List[st
         logger.debug("No MCP servers configured")
         return []
 
-    # SDK import is deferred to HERE so a config with zero MCP servers (the
-    # default) never pays the ~260ms `mcp` import on CLI startup.
-    if not _ensure_mcp_sdk():
-        logger.debug("MCP SDK not available -- skipping MCP tool discovery")
-        return []
-
     if allowed_mcp_names is not None:
         # Filter by MCP-server-name match. Built-in toolset names that aren't
         # MCP servers will simply not match — that's fine; they don't need
@@ -8255,6 +8249,13 @@ def discover_mcp_tools(allowed_mcp_names: Optional[List[str]] = None) -> List[st
         if not servers:
             logger.debug("No MCP servers in --toolsets filter; skipping MCP load entirely")
             return []
+
+    # SDK import is deferred to HERE so a config with zero MCP servers (the
+    # default) — or a -t/--toolsets filter that keeps none — never pays the
+    # ~260ms `mcp` import on CLI startup.
+    if not _ensure_mcp_sdk():
+        logger.debug("MCP SDK not available -- skipping MCP tool discovery")
+        return []
 
     # Cross-process discovery guard (#62771). A lock loser waits for
     # the holder, then performs its own process-local discovery. If locking is


### PR DESCRIPTION
## Summary
`hermes -t terminal ...` (and any `--toolsets` selection) no longer spawns every configured MCP server — only servers named in the filter are started, and when none are, the `mcp` SDK import is skipped too.

Salvage of #19000 by @SelfParody onto current main. The original PR's second half (orphan MCP subprocess reaping) already landed at `hermes_cli/main.py` startup; this carries the `-t` filter and re-wires it to the startup paths main has grown since (inline, background, deferred).

## Changes
- `tools/mcp_tool.py`: `discover_mcp_tools(allowed_mcp_names=...)` filters configured servers by name; empty result returns before `_ensure_mcp_sdk()`.
- `hermes_cli/mcp_startup.py`: `set_mcp_server_filter()` / `get_mcp_server_filter()` process-global filter (`all`/`*` clears it); `_discover_mcp_tools_without_interactive_oauth` applies it, so background and deferred discovery honor it.
- `hermes_cli/main.py`: `_prepare_agent_startup` installs the filter from `args.toolsets` before any discovery path runs; inline discovery reads it.
- `tests/hermes_cli/test_mcp_startup.py`: filter semantics, background/deferred routing, and the SDK-probe-not-reached assertion.
- `contributors/emails`: mapping for @SelfParody.

## Validation
Bench (`hermes -t terminal` equivalent startup, 3 configured stdio servers, real subprocess spawn):

| | main | this PR |
|---|---|---|
| MCP servers spawned | 3 | 0 |
| Discovery wall time | 2.0 s | 1 ms |
| `mcp` SDK import paid | yes | no |
| `tests/hermes_cli/test_mcp_startup.py` + `tests/tools/test_mcp_tool.py` | — | 111 passed |

Cherry-picked with authorship preserved; follow-ups are separate commits. Closes #19000.
