### PR TITLE
fix(agent): time out slow context file reads

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -59,11 +59,25 @@ logger = logging.getLogger(__name__)
 from tools.threat_patterns import scan_for_threats as _scan_for_threats
 
 
-# Read deadline for context files (SOUL.md, AGENTS.md, .cursorrules, ...).
+# Default read deadline for context files (SOUL.md, AGENTS.md, .cursorrules,
+# ...); overridable via ``context_file_read_timeout`` in config.yaml.
 # Intentionally short: network-backed filesystems (iCloud Drive, OneDrive,
 # NFS) can fault-in an evicted file and block a cold read indefinitely, which
 # stalls system-prompt assembly before the first turn.
 _CONTEXT_FILE_READ_TIMEOUT_SECS = 5.0
+
+
+def _get_context_file_read_timeout() -> float:
+    """``context_file_read_timeout`` from config.yaml, else the 5s default."""
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        val = load_config_readonly().get("context_file_read_timeout")
+        if isinstance(val, (int, float)) and val > 0:
+            return float(val)
+    except Exception as e:
+        logger.debug("Could not read context_file_read_timeout from config: %s", e)
+    return _CONTEXT_FILE_READ_TIMEOUT_SECS
 
 
 def _read_text_with_timeout(path: Path, timeout: Optional[float] = None) -> Optional[str]:
@@ -75,13 +89,13 @@ def _read_text_with_timeout(path: Path, timeout: Optional[float] = None) -> Opti
     ``try/except`` handling at each site is unchanged.
     """
     if timeout is None:
-        timeout = _CONTEXT_FILE_READ_TIMEOUT_SECS
+        timeout = _get_context_file_read_timeout()
     result: "queue.Queue[tuple[bool, object]]" = queue.Queue(maxsize=1)
 
     def _reader() -> None:
         try:
             result.put((True, path.read_text(encoding="utf-8")))
-        except BaseException as exc:  # re-raised on the caller thread
+        except Exception as exc:  # re-raised on the caller thread
             result.put((False, exc))
 
     threading.Thread(target=_reader, daemon=True, name=f"context-read:{path.name}").start()

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -7,6 +7,7 @@ assemble pieces, then combines them with memory and ephemeral prompts.
 import json
 import logging
 import os
+import queue
 import sys
 import threading
 import contextvars
@@ -56,6 +57,42 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 from tools.threat_patterns import scan_for_threats as _scan_for_threats
+
+
+# Read deadline for context files (SOUL.md, AGENTS.md, .cursorrules, ...).
+# Intentionally short: network-backed filesystems (iCloud Drive, OneDrive,
+# NFS) can fault-in an evicted file and block a cold read indefinitely, which
+# stalls system-prompt assembly before the first turn.
+_CONTEXT_FILE_READ_TIMEOUT_SECS = 5.0
+
+
+def _read_text_with_timeout(path: Path, timeout: Optional[float] = None) -> Optional[str]:
+    """``path.read_text()`` on a daemon thread so a slow file can't stall startup.
+
+    Returns the text, or ``None`` after *timeout* seconds (logged at WARNING;
+    the orphaned reader thread finishes on its own). Read errors propagate to
+    the caller exactly as a direct ``read_text`` would, so existing
+    ``try/except`` handling at each site is unchanged.
+    """
+    if timeout is None:
+        timeout = _CONTEXT_FILE_READ_TIMEOUT_SECS
+    result: "queue.Queue[tuple[bool, object]]" = queue.Queue(maxsize=1)
+
+    def _reader() -> None:
+        try:
+            result.put((True, path.read_text(encoding="utf-8")))
+        except BaseException as exc:  # re-raised on the caller thread
+            result.put((False, exc))
+
+    threading.Thread(target=_reader, daemon=True, name=f"context-read:{path.name}").start()
+    try:
+        ok, value = result.get(timeout=timeout)
+    except queue.Empty:
+        logger.warning("Context file %s read timed out after %.1fs; skipping", path, timeout)
+        return None
+    if ok:
+        return value  # type: ignore[return-value]
+    raise value  # type: ignore[misc]
 
 
 def _scan_context_content(content: str, filename: str) -> str:
@@ -2250,7 +2287,7 @@ def load_soul_md(
     if not soul_path.exists():
         return None
     try:
-        content = soul_path.read_text(encoding="utf-8").strip()
+        content = (_read_text_with_timeout(soul_path) or "").strip()
         if not content:
             return None
         content = _scan_context_content(content, "SOUL.md")
@@ -2270,7 +2307,7 @@ def _load_hermes_md(cwd_path: Path, context_length: Optional[int] = None) -> str
     if not hermes_md_path:
         return ""
     try:
-        content = hermes_md_path.read_text(encoding="utf-8").strip()
+        content = (_read_text_with_timeout(hermes_md_path) or "").strip()
         if not content:
             return ""
         content = _strip_yaml_frontmatter(content)
@@ -2340,7 +2377,7 @@ def _load_agents_md(cwd_path: Path, context_length: Optional[int] = None) -> str
             if not candidate.exists():
                 continue
             try:
-                content = candidate.read_text(encoding="utf-8").strip()
+                content = (_read_text_with_timeout(candidate) or "").strip()
             except Exception as e:
                 logger.debug("Could not read %s: %s", candidate, e)
                 continue
@@ -2381,7 +2418,7 @@ def _load_claude_md(cwd_path: Path, context_length: Optional[int] = None) -> str
         candidate = cwd_path / name
         if candidate.exists():
             try:
-                content = candidate.read_text(encoding="utf-8").strip()
+                content = (_read_text_with_timeout(candidate) or "").strip()
                 if content:
                     content = _scan_context_content(content, name)
                     result = f"## {name}\n\n{content}"
@@ -2400,7 +2437,7 @@ def _load_cursorrules(cwd_path: Path, context_length: Optional[int] = None) -> s
     cursorrules_file = cwd_path / ".cursorrules"
     if cursorrules_file.exists():
         try:
-            content = cursorrules_file.read_text(encoding="utf-8").strip()
+            content = (_read_text_with_timeout(cursorrules_file) or "").strip()
             if content:
                 content = _scan_context_content(content, ".cursorrules")
                 cursorrules_content += f"## .cursorrules\n\n{content}\n\n"
@@ -2412,7 +2449,7 @@ def _load_cursorrules(cwd_path: Path, context_length: Optional[int] = None) -> s
         mdc_files = sorted(cursor_rules_dir.glob("*.mdc"))
         for mdc_file in mdc_files:
             try:
-                content = mdc_file.read_text(encoding="utf-8").strip()
+                content = (_read_text_with_timeout(mdc_file) or "").strip()
                 if content:
                     content = _scan_context_content(content, f".cursor/rules/{mdc_file.name}")
                     cursorrules_content += f"## .cursor/rules/{mdc_file.name}\n\n{content}\n\n"

--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -20,7 +20,7 @@ import shlex
 from pathlib import Path
 from typing import Dict, Any, Optional, Set
 
-from agent.prompt_builder import _scan_context_content
+from agent.prompt_builder import _read_text_with_timeout, _scan_context_content
 
 logger = logging.getLogger(__name__)
 
@@ -105,7 +105,7 @@ class SubdirectoryHintTracker:
             try:
                 if not candidate.is_file():
                     continue
-                content = candidate.read_text(encoding="utf-8").strip()
+                content = (_read_text_with_timeout(candidate) or "").strip()
             except (OSError, UnicodeDecodeError):
                 continue
             if content:
@@ -285,7 +285,7 @@ class SubdirectoryHintTracker:
             except OSError:
                 continue
             try:
-                content = hint_path.read_text(encoding="utf-8").strip()
+                content = (_read_text_with_timeout(hint_path) or "").strip()
                 if not content:
                     continue
                 # Skip content we've already injected. The same AGENTS.md is

--- a/contributors/emails/talmoredder@gmail.com
+++ b/contributors/emails/talmoredder@gmail.com
@@ -1,0 +1,2 @@
+EdderTalmor
+# PR #10110 salvage

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -754,6 +754,11 @@ DEFAULT_CONFIG = {
     # and override the dynamic behavior. Separate from read_file tool limits.
     "context_file_max_chars": None,
 
+    # Seconds to wait for a single context file read before skipping it with a
+    # warning. Guards startup against network-backed filesystems (iCloud Drive,
+    # OneDrive, NFS) that can block a cold read on an evicted file.
+    "context_file_read_timeout": 5.0,
+
     # Maximum characters returned by a single read_file call.  Reads that
     # exceed this are rejected with guidance to use offset+limit.
     # 100K chars ≈ 25–35K tokens across typical tokenisers.

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -5,6 +5,8 @@ import importlib
 import logging
 import os
 import sys
+import time
+from pathlib import Path
 
 import pytest
 
@@ -1140,3 +1142,40 @@ class TestParallelToolCallGuidance:
 # =========================================================================
 
 
+
+
+class TestContextFileReadTimeout:
+    def test_slow_hermes_md_is_skipped_and_agents_md_still_loads(self, tmp_path, monkeypatch, caplog):
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".hermes.md").write_text("Hermes project rules.")
+        (tmp_path / "AGENTS.md").write_text("Agent fallback rules.")
+        # Patch the module object build_context_files_prompt actually closes
+        # over: an earlier test re-imports agent.prompt_builder, so the
+        # sys.modules entry can be a different module object.
+        pb_mod = sys.modules[build_context_files_prompt.__module__]
+        monkeypatch.setattr(pb_mod, "_CONTEXT_FILE_READ_TIMEOUT_SECS", 0.05)
+
+        original_read_text = Path.read_text
+
+        def slow_read_text(self, *args, **kwargs):
+            if self.name == ".hermes.md":
+                time.sleep(0.6)
+            return original_read_text(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", slow_read_text)
+
+        start = time.monotonic()
+        with caplog.at_level(logging.WARNING, logger=pb_mod.__name__):
+            result = build_context_files_prompt(cwd=str(tmp_path))
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 0.4, f"context load blocked for {elapsed:.2f}s"
+        assert "Agent fallback rules" in result
+        assert "Hermes project rules" not in result
+        assert "timed out" in caplog.text.lower()
+
+    def test_read_errors_still_propagate_to_caller(self, tmp_path):
+        from agent.prompt_builder import _read_text_with_timeout
+
+        with pytest.raises(FileNotFoundError):
+            _read_text_with_timeout(tmp_path / "missing.md", timeout=1.0)

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1153,7 +1153,7 @@ class TestContextFileReadTimeout:
         # over: an earlier test re-imports agent.prompt_builder, so the
         # sys.modules entry can be a different module object.
         pb_mod = sys.modules[build_context_files_prompt.__module__]
-        monkeypatch.setattr(pb_mod, "_CONTEXT_FILE_READ_TIMEOUT_SECS", 0.05)
+        monkeypatch.setattr(pb_mod, "_get_context_file_read_timeout", lambda: 0.05)
 
         original_read_text = Path.read_text
 

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -1,5 +1,7 @@
 """Tests for progressive subdirectory hint discovery."""
 
+import time
+
 import pytest
 from pathlib import Path
 from unittest.mock import patch
@@ -114,6 +116,40 @@ class TestSubdirectoryHintTracker:
         assert tracker.check_tool_call("read_file", {}) is None
         assert tracker.check_tool_call("terminal", {"command": ""}) is None
 
+
+
+    def test_timeout_skips_slow_hint_files(self, project, monkeypatch, caplog):
+        """Slow hint reads time out instead of blocking the turn."""
+        backend = project / "backend"
+        (backend / "AGENTS.md").write_text("Backend-specific instructions")
+        import sys
+
+        from agent import subdirectory_hints as sh_mod
+
+        # Patch the module object the hint tracker's helper closes over.
+        pb_mod = sys.modules[sh_mod._read_text_with_timeout.__module__]
+        monkeypatch.setattr(pb_mod, "_CONTEXT_FILE_READ_TIMEOUT_SECS", 0.05)
+
+        original_read_text = Path.read_text
+
+        def slow_read_text(self, *args, **kwargs):
+            if self.name.lower() == "agents.md" and self.parent == backend:
+                time.sleep(0.6)
+            return original_read_text(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", slow_read_text)
+
+        tracker = SubdirectoryHintTracker(working_dir=str(project))
+        start = time.monotonic()
+        with caplog.at_level("WARNING", logger="agent.prompt_builder"):
+            result = tracker.check_tool_call(
+                "read_file", {"path": str(project / "backend" / "src" / "main.py")}
+            )
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 0.4, f"hint load blocked for {elapsed:.2f}s"
+        assert result is None
+        assert "timed out" in caplog.text.lower()
 
 
 class TestPermissionErrorHandling:

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -128,7 +128,7 @@ class TestSubdirectoryHintTracker:
 
         # Patch the module object the hint tracker's helper closes over.
         pb_mod = sys.modules[sh_mod._read_text_with_timeout.__module__]
-        monkeypatch.setattr(pb_mod, "_CONTEXT_FILE_READ_TIMEOUT_SECS", 0.05)
+        monkeypatch.setattr(pb_mod, "_get_context_file_read_timeout", lambda: 0.05)
 
         original_read_text = Path.read_text
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -749,6 +749,12 @@ Set a positive integer to pin a fixed cap instead of the dynamic behavior:
 context_file_max_chars: 25000
 ```
 
+Each context file read is also bounded by `context_file_read_timeout` (seconds, default `5.0`). A file that takes longer to read — typically on a network-backed filesystem such as iCloud Drive, OneDrive or NFS — is skipped with a warning so the rest of the system prompt still loads:
+
+```yaml
+context_file_read_timeout: 5.0
+```
+
 ## File Read Safety
 
 Controls how much content a single `read_file` call can return. Reads that exceed the limit are rejected with an error telling the agent to use `offset` and `limit` for a smaller range. This prevents a single read of a minified JS bundle or large data file from flooding the context window.

--- a/website/docs/user-guide/features/context-files.md
+++ b/website/docs/user-guide/features/context-files.md
@@ -190,6 +190,7 @@ This scanner protects against common injection patterns, but it's not a substitu
 | Limit | Value |
 |-------|-------|
 | Max chars per file | `context_file_max_chars` when set; otherwise dynamic (scales with model context window, floor 20,000, ceiling 500,000) |
+| Read timeout per file | `context_file_read_timeout` (default 5 seconds); a file that takes longer to read — e.g. on iCloud Drive, OneDrive or NFS — is skipped with a warning |
 | Head truncation ratio | 70% |
 | Tail truncation ratio | 20% |
 | Truncation marker | 10% (shows char counts and suggests using file tools) |


### PR DESCRIPTION
## Summary
A context file that hangs on read (SOUL.md, `.hermes.md`, AGENTS.md chain, CLAUDE.md, `.cursorrules`, `.cursor/rules/*.mdc`, subdirectory hint files) no longer stalls system-prompt assembly — it is skipped after a configurable deadline (default 5 s) with a warning, and the remaining context sources still load.

Root cause: network-backed filesystems (iCloud Drive, OneDrive, NFS) can block a cold `read_text()` indefinitely on an evicted file, and every context read ran synchronously on the startup / per-turn path.

Re-cut of #10110 by @EdderTalmor against current main (the original diff predates the `context_length` plumbing and the AGENTS.md directory-chain loader, so cherry-pick was not possible; helper, sites and tests follow the original, commit authored to the contributor).

## Changes
- `agent/prompt_builder.py`: `_read_text_with_timeout()` reads on a daemon thread with a deadline; returns `None` on timeout (logged), re-raises read errors on the caller so each site's existing `try/except` is unchanged. All 6 context read sites use it.
- `agent/subdirectory_hints.py`: both hint read sites use it.
- `hermes_cli/config_defaults.py`: `context_file_read_timeout: 5.0` (top-level, beside `context_file_max_chars`, same resolution shape).
- `website/docs/user-guide/features/context-files.md`: documents the key.
- Tests: slow `.hermes.md` is skipped while AGENTS.md still loads; read errors propagate; slow subdirectory hint is skipped.
- `contributors/emails`: mapping for @EdderTalmor.

## Validation
Bench (`.hermes.md` read forced to block 3 s, timeout set to 0.5 s):

| | main | this PR |
|---|---|---|
| `build_context_files_prompt()` wall time | 3007 ms | 508 ms |
| AGENTS.md fallback still loaded | no | yes |
| New tests against main's `prompt_builder.py` | 3 fail | pass |
| `tests/agent/test_prompt_builder.py` + `test_subdirectory_hints.py` | — | 101 passed |

Prompt-cache note: context files are read once into the cached system prompt per session; a timed-out file is deterministically omitted for that session, so no inter-turn byte drift. Closes #10110.
