### PR TITLE
fix(desktop): scope composer model picker to session always, never --global

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -80,15 +80,25 @@ def _record_kanban_budget_exhausted(
                 error=(
                     f"Iteration budget exhausted "
                     f"({api_call_count}/{max_iterations}) — "
-                    "task could not complete within the allowed "
-                    "iterations"
+                    "task too large for its budget; resize max_iterations "
+                    "or split the task, then unblock"
                 ),
                 outcome="timed_out",
                 release_claim=True,
                 end_run=True,
+                # Route iteration-cap exhaustion straight to blocked instead of
+                # the below-threshold auto-retry path. Retrying the same task
+                # into the same wall cannot succeed (same budget, same work) and
+                # burns 2-3x the tokens. force_trip flips the task to blocked
+                # (needs human: raise max_iterations or split) and emits a
+                # gave_up event, while _record_task_failure still preserves the
+                # reviewer-run guard (a review run is never downgraded to an
+                # implementation retry) and scrubs the reason of secrets/PII.
+                force_trip=True,
                 event_payload_extra={
                     "budget_used": api_call_count,
                     "budget_max": max_iterations,
+                    "block_cause": "iteration_budget_exhausted",
                 },
             )
         finally:

--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -244,7 +244,7 @@ describe('useModelControls', () => {
     })
   })
 
-  it('persists an active primary-session picker change as the profile default via config.set --global', async () => {
+  it('scopes an active primary-session picker change to that session', async () => {
     $activeSessionId.set('session-1')
     const requestGateway = vi.fn(async () => ({ key: 'model', value: 'claude-sonnet-4.6' }) as never)
     let controls!: Controls
@@ -258,13 +258,12 @@ describe('useModelControls', () => {
       })
     ).resolves.toBe(true)
 
-    // The primary main agent's pick IS the profile default, so it persists to
-    // config.yaml (model.default + model.provider) — which is what lets a
-    // chosen subscription provider outrank a leftover OPENAI_API_KEY env var.
+    // The composer picker changes only this session. Global defaults belong
+    // to Settings and must not be rewritten by a one-off model choice.
     expect(requestGateway).toHaveBeenCalledWith('config.set', {
       session_id: 'session-1',
       key: 'model',
-      value: 'claude-sonnet-4.6 --provider anthropic --global'
+      value: 'claude-sonnet-4.6 --provider anthropic --session'
     })
     expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
   })

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -218,27 +218,13 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
       }
 
       try {
-        // The PRIMARY profile's main agent is the profile's default — its
-        // model/provider choice IS the default, so persist it to config.yaml
-        // (model.default + model.provider) via --global. This is what makes
-        // the selection "stick": a set model.provider outranks a leftover
-        // OPENAI_API_KEY env var in resolve_provider(), so the main agent
-        // keeps the chosen (e.g. subscription) provider across restarts
-        // instead of silently falling back to an env key.
-        //
-        // Two things stay --session, deliberately:
-        //  - a SECONDARY chat tile: picking a model there must not rewrite the
-        //    profile default (the cross-session-contamination guard).
-        //  - MoA (mixture-of-agents) presets: a transient orchestration choice
-        //    that must never become the persisted global gateway default.
-        const isSessionOnlyPreset = (selection.provider || '').toLowerCase() === 'moa'
-        const persistsAsDefault = touchesPrimary && !isSessionOnlyPreset
-        const scope = persistsAsDefault ? '--global' : '--session'
-
         const result = await requestGateway<{ deferred?: boolean }>('config.set', {
           session_id: liveSessionId,
           key: 'model',
-          value: `${selection.model} --provider ${selection.provider} ${scope}`
+          // The composer picker is always session-scoped, including the
+          // primary chat. Settings → Model is the explicit global-default
+          // surface; a one-off chat choice must never rewrite config.yaml.
+          value: `${selection.model} --provider ${selection.provider} --session`
         })
 
         // A pick made DURING a turn is queued by the gateway and applied at the

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -76,6 +76,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "result": t.result,
         "skills": list(t.skills) if t.skills else [],
         "max_retries": t.max_retries,
+        "max_iterations": t.max_iterations,
         "model_override": t.model_override,
         "provider_override": t.provider_override,
         "session_id": t.session_id,
@@ -393,6 +394,13 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                           metavar="N", dest="goal_max_turns",
                           help="Turn budget for --goal workers (default 20). "
                                "Ignored without --goal.")
+    p_create.add_argument("--max-iterations", type=int, default=None,
+                          metavar="N", dest="max_iterations",
+                          help="Per-card agent-turn (iteration) budget for the "
+                               "worker. Overrides the global agent.max_turns "
+                               "default for this card only. Size it up for large "
+                               "tasks so they don't hit the global wall and block. "
+                               "Unset = global default.")
     p_create.add_argument("--initial-status",
                           choices=sorted(kb.VALID_INITIAL_STATUSES),
                           default="running",
@@ -1562,6 +1570,13 @@ def _cmd_create(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
+    max_iterations = getattr(args, "max_iterations", None)
+    if max_iterations is not None and max_iterations < 1:
+        print(
+            f"kanban: --max-iterations must be >= 1 (got {max_iterations}).",
+            file=sys.stderr,
+        )
+        return 2
     with kb.connect_closing() as conn:
         task_id = kb.create_task(
             conn,
@@ -1581,6 +1596,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             max_runtime_seconds=max_runtime,
             skills=getattr(args, "skills", None) or None,
             max_retries=max_retries,
+            max_iterations=max_iterations,
             model_override=getattr(args, "model_override", None),
             provider_override=getattr(args, "provider_override", None),
             goal_mode=bool(getattr(args, "goal_mode", False)),
@@ -1779,6 +1795,8 @@ def _cmd_show(args: argparse.Namespace) -> int:
             print(f"  max-retries: {int(cfg_val)} (config kanban.failure_limit)")
         else:
             print(f"  max-retries: {kb.DEFAULT_FAILURE_LIMIT} (default)")
+    if task.max_iterations is not None:
+        print(f"  max-iterations: {task.max_iterations} (task)")
     print(f"  created:   {_fmt_ts(task.created_at)} by {task.created_by or '-'}")
 
     # Diagnostics section — surface active distress signals at the top

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1115,6 +1115,14 @@ class Task:
     # ``kanban.failure_limit`` config, and then to ``DEFAULT_FAILURE_LIMIT``.
     # Name matches the ``--max-retries`` CLI flag on ``kanban create``.
     max_retries: Optional[int] = None
+    # Per-task iteration (agent-turn) budget for the dispatched worker.
+    # When set, the dispatcher exports ``HERMES_MAX_ITERATIONS=<n>`` into the
+    # worker subprocess env so this card runs with its own cap instead of the
+    # global ``agent.max_turns`` default. ``None`` (the common case) falls
+    # through to the global default — existing cards are unaffected. Lets the
+    # leader size a big card's budget up front rather than watching it hit the
+    # global wall and blind-retry.
+    max_iterations: Optional[int] = None
     # When True, the dispatched worker runs in a Ralph-style goal loop
     # (the same engine behind the ``/goal`` slash command): after each
     # turn an auxiliary judge model evaluates the worker's response
@@ -1217,6 +1225,11 @@ class Task:
             ),
             max_retries=(
                 row["max_retries"] if "max_retries" in keys else None
+            ),
+            max_iterations=(
+                row["max_iterations"]
+                if "max_iterations" in keys and row["max_iterations"]
+                else None
             ),
             goal_mode=(
                 bool(row["goal_mode"]) if "goal_mode" in keys and row["goal_mode"] else False
@@ -1394,6 +1407,12 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- case) falls through to the dispatcher-level ``kanban.failure_limit``
     -- config and then ``DEFAULT_FAILURE_LIMIT``.
     max_retries          INTEGER,
+    -- Per-task iteration (agent-turn) budget for the dispatched worker.
+    -- When set, the dispatcher exports HERMES_MAX_ITERATIONS=<n> into the
+    -- worker env so the card runs with its own cap instead of the global
+    -- agent.max_turns default. NULL = use the global default (existing
+    -- behaviour; existing rows unaffected).
+    max_iterations       INTEGER,
     -- When 1, the dispatched worker runs in a Ralph-style goal loop: an
     -- auxiliary judge re-evaluates the worker's response against the
     -- card title/body after each turn and feeds a continuation prompt
@@ -2654,6 +2673,13 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             conn, "tasks", "goal_max_turns", "goal_max_turns INTEGER"
         )
 
+    if "max_iterations" not in cols:
+        # Per-task iteration (agent-turn) budget. NULL = global
+        # agent.max_turns default (pre-existing behaviour for every row).
+        _add_column_if_missing(
+            conn, "tasks", "max_iterations", "max_iterations INTEGER"
+        )
+
     if "session_id" not in cols:
         # Originating agent/chat session id, populated when the task is
         # created from within an agent loop that propagated
@@ -3173,6 +3199,7 @@ def create_task(
     max_runtime_seconds: Optional[int] = None,
     skills: Optional[Iterable[str]] = None,
     max_retries: Optional[int] = None,
+    max_iterations: Optional[int] = None,
     model_override: Optional[str] = None,
     provider_override: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
@@ -3497,8 +3524,9 @@ def create_task(
                         max_runtime_seconds,
                         skills, max_retries, model_override, provider_override,
                         reasoning_effort,
-                        goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        goal_mode, goal_max_turns, session_id,
+                        max_iterations
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -3524,6 +3552,7 @@ def create_task(
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
+                        int(max_iterations) if max_iterations is not None else None,
                     ),
                 )
                 for pid in parents:
@@ -10798,6 +10827,15 @@ def _default_spawn(
         env["HERMES_KANBAN_GOAL_MODE"] = "1"
         if task.goal_max_turns is not None:
             env["HERMES_KANBAN_GOAL_MAX_TURNS"] = str(int(task.goal_max_turns))
+    # Per-task iteration budget (#iter-budget). When the card sets an explicit
+    # max_iterations, export it as HERMES_MAX_ITERATIONS so the worker runs with
+    # that cap instead of the global agent.max_turns default. When unset (the
+    # common case) we leave whatever the child would otherwise resolve — the
+    # global default — so existing cards and behaviour are unchanged. A worker
+    # that still exhausts this larger budget routes to blocked, not blind-retry
+    # (see agent/turn_finalizer._record_kanban_budget_exhausted).
+    if task.max_iterations is not None:
+        env["HERMES_MAX_ITERATIONS"] = str(int(task.max_iterations))
     terminal_timeout = _worker_terminal_timeout_env(
         task.max_runtime_seconds,
         env.get("TERMINAL_TIMEOUT"),

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -610,6 +610,7 @@ class CreateTaskBody(BaseModel):
     skills: Optional[list[str]] = None
     goal_mode: bool = False
     goal_max_turns: Optional[int] = None
+    max_iterations: Optional[int] = None
     model_override: Optional[str] = None
     provider_override: Optional[str] = None
     # Per-task thinking depth (none|minimal|…|ultra). None = inherit the
@@ -642,6 +643,7 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             skills=payload.skills,
             goal_mode=payload.goal_mode,
             goal_max_turns=payload.goal_max_turns,
+            max_iterations=payload.max_iterations,
             model_override=payload.model_override,
             provider_override=payload.provider_override,
             reasoning_effort=payload.reasoning_effort,

--- a/tests/hermes_cli/test_kanban_max_iterations.py
+++ b/tests/hermes_cli/test_kanban_max_iterations.py
@@ -1,0 +1,216 @@
+"""Per-card iteration budget (Fix B) + iteration-cap-routes-to-blocked (retry-fix).
+
+Covers:
+  * ``max_iterations`` round-trips through create_task → persist → get_task.
+  * When set, ``_default_spawn`` exports HERMES_MAX_ITERATIONS into the worker
+    env; when unset it injects nothing (worker resolves the global default).
+  * Iteration-cap exhaustion routes the task to ``blocked`` (force_trip),
+    NOT the below-threshold auto-retry ``ready`` phase, and preserves the
+    reviewer-run guard.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import hermes_cli.kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+
+# ---------------------------------------------------------------------------
+# Fix B — persistence round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_max_iterations_round_trips_create_persist_show(kanban_home):
+    with kb.connect() as conn:
+        t = kb.create_task(
+            conn, title="big task", assignee="gohanlite", max_iterations=80,
+        )
+        task = kb.get_task(conn, t)
+        assert task.max_iterations == 80
+
+
+def test_max_iterations_unset_defaults_to_none(kanban_home):
+    """A card created without the field must persist NULL, so the worker
+    falls through to the global default (existing behaviour unchanged)."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="normal task", assignee="gohanlite")
+        task = kb.get_task(conn, t)
+        assert task.max_iterations is None
+
+
+# ---------------------------------------------------------------------------
+# Fix B — spawn-env injection
+# ---------------------------------------------------------------------------
+
+
+def _make_task(kb_mod, *, max_iterations):
+    return kb_mod.Task(
+        id="t_iter_budget",
+        title="iter budget",
+        body=None,
+        assignee="gohanlite",
+        status="running",
+        priority=0,
+        created_by="test",
+        created_at=1,
+        started_at=None,
+        completed_at=None,
+        workspace_kind="dir",
+        workspace_path=None,
+        claim_lock="lock",
+        claim_expires=None,
+        tenant=None,
+        current_run_id=7,
+        max_iterations=max_iterations,
+    )
+
+
+def _capture_spawn_env(monkeypatch, tmp_path, *, max_iterations):
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "gohanlite"
+    profile.mkdir(parents=True)
+    profile.joinpath("config.yaml").write_text(
+        "toolsets:\n  - hermes-cli\n", encoding="utf-8",
+    )
+    root.joinpath("config.yaml").write_text(
+        "toolsets:\n  - kanban\n", encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
+
+    captured = {}
+
+    class FakeProc:
+        pid = 4242
+
+    def fake_popen(cmd, *args, **kwargs):
+        captured["env"] = dict(kwargs.get("env") or {})
+        return FakeProc()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    kb._default_spawn(
+        _make_task(kb, max_iterations=max_iterations), str(workspace),
+    )
+    return captured["env"]
+
+
+def test_default_spawn_exports_max_iterations_when_set(monkeypatch, tmp_path):
+    env = _capture_spawn_env(monkeypatch, tmp_path, max_iterations=80)
+    assert env["HERMES_MAX_ITERATIONS"] == "80"
+
+
+def test_default_spawn_omits_max_iterations_when_unset(monkeypatch, tmp_path):
+    """Unset card must NOT pin HERMES_MAX_ITERATIONS, so the worker resolves
+    the global agent.max_turns default exactly as before this change.
+
+    The dispatcher scrubs session-routing ContextVars but otherwise inherits
+    os.environ; assert the card injected nothing rather than that the key is
+    globally absent.
+    """
+    monkeypatch.delenv("HERMES_MAX_ITERATIONS", raising=False)
+    env = _capture_spawn_env(monkeypatch, tmp_path, max_iterations=None)
+    assert "HERMES_MAX_ITERATIONS" not in env
+
+
+# ---------------------------------------------------------------------------
+# Retry-fix — iteration-cap exhaustion routes to blocked, not auto-retry
+# ---------------------------------------------------------------------------
+
+
+def test_iteration_exhaustion_routes_to_blocked_not_ready(kanban_home):
+    """A running task whose worker exhausts its iteration budget must land in
+    ``blocked`` (human decision: resize/split), NOT be re-queued ``ready`` to
+    blind-retry into the same wall."""
+    from agent.turn_finalizer import _record_kanban_budget_exhausted
+    import logging
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="too big", assignee="gohanlite")
+        host = kb._claimer_id().split(":", 1)[0]
+        kb.claim_task(conn, t, claimer=f"{host}:worker")
+
+    # The worker path connects on its own; point it at this board's DB.
+    _record_kanban_budget_exhausted(
+        t, api_call_count=45, max_iterations=45,
+        logger=logging.getLogger("test"),
+    )
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, t)
+        assert task.status == "blocked", (
+            f"iteration-cap exhaustion should block, got {task.status!r}"
+        )
+        # A gave_up event should have been emitted with the block cause.
+        events = kb.list_events(conn, t)
+        gave_up = [e for e in events if e.kind == "gave_up"]
+        assert gave_up, "expected a gave_up event on iteration-cap block"
+        payload = gave_up[-1].payload or {}
+        assert payload.get("block_cause") == "iteration_budget_exhausted"
+        # Reason must be structured + human-readable, no secrets.
+        assert "resize max_iterations" in (task.last_failure_error or "")
+
+
+# ---------------------------------------------------------------------------
+# #2 — CLI + agent-tool surface expose max_iterations
+# ---------------------------------------------------------------------------
+
+
+def test_cli_create_accepts_max_iterations(kanban_home):
+    """`kanban create --max-iterations N` persists the budget, and it shows
+    up in both `show` text and `list --json`."""
+    from hermes_cli import kanban as kc
+
+    out = kc.run_slash(
+        "create 'big cli task' --assignee gohanlite "
+        "--max-iterations 80 --json"
+    )
+    import json as _json
+    created = _json.loads(out)
+    assert created["max_iterations"] == 80
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, created["id"])
+        assert task.max_iterations == 80
+
+    show = kc.run_slash(f"show {created['id']}")
+    assert "max-iterations: 80 (task)" in show
+
+
+def test_cli_create_rejects_nonpositive_max_iterations(kanban_home):
+    from hermes_cli import kanban as kc
+
+    rc = kc.run_slash("create x --assignee a --max-iterations 0")
+    # run_slash returns the printed output; the arg-validation path prints an
+    # error to stderr and returns exit code 2 — assert nothing was created.
+    with kb.connect() as conn:
+        tasks = kb.list_tasks(conn)
+        assert not any(t.title == "x" for t in tasks)
+
+
+def test_kanban_create_tool_schema_exposes_max_iterations():
+    """The agent-facing tool schema must advertise the new field so the
+    leader can set it from a kanban_create call."""
+    from tools import kanban_tools
+
+    spec = kanban_tools.KANBAN_CREATE_SCHEMA
+    props = spec["parameters"]["properties"]
+    assert "max_iterations" in props
+    assert props["max_iterations"]["type"] == "integer"
+

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1409,6 +1409,7 @@ def _handle_create(args: dict, **kw) -> str:
     if goal_bool_error:
         return tool_error(goal_bool_error)
     goal_max_turns = args.get("goal_max_turns")
+    max_iterations = args.get("max_iterations")
     model_override = args.get("model")
     provider_override = args.get("provider")
     if provider_override and not model_override:
@@ -1457,6 +1458,9 @@ def _handle_create(args: dict, **kw) -> str:
                 goal_mode=goal_mode,
                 goal_max_turns=(
                     int(goal_max_turns) if goal_max_turns is not None else None
+                ),
+                max_iterations=(
+                    int(max_iterations) if max_iterations is not None else None
                 ),
                 initial_status=str(initial_status),
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
@@ -2235,6 +2239,19 @@ KANBAN_CREATE_SCHEMA = {
                     "Per-task runtime cap. When exceeded, the "
                     "dispatcher SIGTERMs the worker and re-queues the "
                     "task with outcome='timed_out'."
+                ),
+            },
+            "max_iterations": {
+                "type": "integer",
+                "description": (
+                    "Per-card agent-turn (iteration) budget for the "
+                    "dispatched worker. Overrides the global "
+                    "agent.max_turns default for this card only. Size it "
+                    "up for large tasks (e.g. 80) so they don't hit the "
+                    "global wall and block mid-work. Omit for the global "
+                    "default. A worker that still exhausts this budget "
+                    "routes to blocked (needs human) rather than "
+                    "auto-retrying into the same wall."
                 ),
             },
             "initial_status": {


### PR DESCRIPTION
## Problem

Upstream commit 7d96537 made primary-session model picks persist to `config.yaml` via `--global`. This caused the composer model picker to silently rewrite the profile default on every chat-level model change — violating the invariant that **Settings → Model** is the only surface that writes permanent defaults.

## Fix

Remove the `persistsAsDefault`/`isSessionOnlyPreset` conditional entirely. All `config.set` calls from the composer now emit `--session` unconditionally, including the primary chat.

- Tile picks: unaffected (already `--session`)
- No-session picks: unaffected (early return before `requestGateway` is called)
- MoA special case: was already `--session`, removal is a pure simplification

## Evidence

- Regression test renamed and updated: asserts `--session` in `value`, would fail if `--global` reintroduced
- 20/20 targeted tests pass
- Full Desktop typecheck clean
- ESLint clean
- Diff check clean