### PR TITLE
fix(desktop): restore missing Bot Chat panes before claiming focus

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -1040,6 +1040,13 @@ export function revealTreePane(paneId: string) {
   // Reveal beats a Close: un-dismiss and let adoption put the pane back.
   if ($dismissedPanes.get().has(paneId)) {
     setDismissed(paneId, false)
+  }
+
+  // A layout replacement can omit a still-registered pane without dismissing
+  // it. Reconcile that saved contribution before claiming to reveal it.
+  const currentTree = $layoutTree.get()
+
+  if (currentTree && !findGroupOfPane(currentTree, paneId)) {
     adoptContributedPanes()
   }
 
@@ -1064,8 +1071,8 @@ export function revealTreePane(paneId: string) {
 
   if (hiddenNow.has(paneId)) {
     setTreePaneHidden(paneId, false)
-
-    return
+    // Reactive unhide preserves a visible sibling. Explicit reveal must also
+    // front this pane and restore its group below.
   }
 
   const tree = $layoutTree.get()

--- a/apps/desktop/src/store/session-pane-focus.test.ts
+++ b/apps/desktop/src/store/session-pane-focus.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+async function setup() {
+  const tree = await import('@/components/pane-shell/tree/store')
+  const model = await import('@/components/pane-shell/tree/model')
+  const { registry } = await import('@/contrib/registry')
+  const session = await import('@/store/session')
+  const states = await import('@/store/session-states')
+  const { paneMirror } = await import('@/app/chat/pane-mirror')
+  const { openSession } = await import('@/app/open-session')
+
+  registry.register({
+    area: 'panes',
+    data: { placement: 'main', uncloseable: true },
+    id: 'workspace',
+    render: () => null,
+    title: 'Chat'
+  })
+  tree.declareDefaultTree(model.group(['workspace'], { active: 'workspace', id: 'main' }))
+  tree.watchContributedPanes()
+  paneMirror({
+    source: states.$sessionTiles,
+    key: tile => tile.storedSessionId,
+    prefix: 'session-tile',
+    dir: () => 'center',
+    minWidth: '20rem',
+    title: id => id,
+    render: () => null,
+    close: states.closeSessionTile
+  })()
+  session.$selectedStoredSessionId.set('previous-chat')
+
+  const scope = {
+    ownerRoute: { connectionId: 'remote-a', mode: 'remote' as const, profile: 'writer' },
+    workspaceMode: 'bots' as const,
+    workspaceOwnerKey: 'remote-a::writer',
+    workspaceTabTitle: 'Bot Chat'
+  }
+
+  states.openSessionTile('canonical-chat', 'center', 'workspace', undefined, scope)
+
+  return { model, openSession, scope, session, states, tree }
+}
+
+describe('focusing a saved Bot Chat requires a visible pane', () => {
+  let ctx: Awaited<ReturnType<typeof setup>>
+  const paneId = 'session-tile:canonical-chat'
+
+  beforeEach(async () => {
+    window.localStorage.clear()
+    vi.resetModules()
+    ctx = await setup()
+  })
+
+  it('re-adopts a saved tab after a profile overlay replaces the layout', async () => {
+    const { applyDesktopOverlay } = await import('@/store/profile-share')
+    const { model, scope, states, tree } = ctx
+    const saved = states.$sessionTiles.get()
+    applyDesktopOverlay('imported-profile', {
+      version: 1,
+      layoutTree: model.group(['workspace'], { active: 'workspace', id: 'imported-main' })
+    })
+    expect(model.findGroupOfPane(tree.$layoutTree.get()!, paneId)).toBeNull()
+
+    expect(states.focusWorkspaceOwnerSessionTile(scope.workspaceOwnerKey, undefined, ['canonical-chat'])).toBe(
+      'canonical-chat'
+    )
+    expect(tree.isPaneVisible(paneId)).toBe(true)
+    expect(tree.$activeTreeGroup.get()).toBe('imported-main')
+    expect(states.$sessionTiles.get()).toEqual(saved)
+    expect(states.sessionTileOwnerRoute('canonical-chat')).toEqual(scope.ownerRoute)
+  })
+
+  it('fronts and un-minimizes a hidden chat instead of leaving its sibling active', () => {
+    const { model, scope, states, tree } = ctx
+    tree.$layoutTree.set(model.group(['workspace', paneId], { active: 'workspace', id: 'main', minimized: true }))
+    tree.setTreePaneHidden(paneId, true)
+
+    expect(states.focusWorkspaceOwnerSessionTile(scope.workspaceOwnerKey, undefined, ['canonical-chat'])).toBe(
+      'canonical-chat'
+    )
+    expect(tree.isPaneVisible(paneId)).toBe(true)
+    expect(model.findGroupOfPane(tree.$layoutTree.get()!, paneId)?.active).toBe(paneId)
+  })
+
+  it('reports a miss through both helpers if the layout cannot place the saved tab', () => {
+    const { scope, session, states, tree } = ctx
+    tree.$layoutTree.set(null)
+
+    expect(states.focusOpenSession('canonical-chat', scope)).toBeNull()
+    expect(states.focusWorkspaceOwnerSessionTile(scope.workspaceOwnerKey, undefined, ['canonical-chat'])).toBeNull()
+    expect(session.$selectedStoredSessionId.get()).toBe('previous-chat')
+    expect(states.$sessionTiles.get().map(tile => tile.storedSessionId)).toEqual(['canonical-chat'])
+  })
+
+  it('keeps an existing tab in place and does not navigate or duplicate it', () => {
+    const { openSession, scope, states, tree } = ctx
+    const navigate = vi.fn()
+    openSession('canonical-chat', navigate, 'in-place', scope)
+
+    expect(tree.isPaneVisible(paneId)).toBe(true)
+    expect(navigate).not.toHaveBeenCalled()
+    expect(states.$sessionTiles.get().map(tile => tile.storedSessionId)).toEqual(['canonical-chat'])
+  })
+})

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -320,6 +320,7 @@ describe('SessionTile workspace scope', () => {
 
     $selectedStoredSessionId.set('bot-chat')
     openSessionTile('bot-chat', 'center', undefined, undefined, scope)
+    $layoutTree.set(group(['workspace', tilePane('bot-chat')], { active: 'workspace', id: 'main' }))
 
     expect($sessionTiles.get()).toEqual([
       expect.objectContaining({
@@ -337,6 +338,7 @@ describe('SessionTile workspace scope', () => {
     // new tip must front that tile, not open the same chat twice.
     setSessions([{ _lineage_ids: ['seg-1', 'seg-2', 'seg-3'], _lineage_root_id: 'seg-1', id: 'seg-3' } as never])
     openSessionTile('seg-2')
+    $layoutTree.set(group(['workspace', tilePane('seg-2')], { active: 'workspace', id: 'main' }))
 
     expect(focusOpenSession('seg-3')).toBe('tile')
     expect($sessionTiles.get().map(t => t.storedSessionId)).toEqual(['seg-2'])
@@ -487,6 +489,7 @@ describe('focusWorkspaceOwnerSessionTile', () => {
     openSessionTile('thread', 'center', 'workspace', undefined, botA)
     rememberActivePane(workspaceScopeKey('bots', 'bot:a'), tilePane('closed-bot-chat'))
     $sessionTiles.set($sessionTiles.get().filter(t => t.storedSessionId !== 'closed-bot-chat'))
+    $layoutTree.set(group(['workspace', tilePane('thread')], { active: 'workspace', id: 'main' }))
 
     expect(focusWorkspaceOwnerSessionTile('bot:a')).toBe('thread')
   })
@@ -533,6 +536,7 @@ describe('focusWorkspaceOwnerSessionTile', () => {
 
     it('a throwing probe keeps the tile — reconciliation must not break the click', () => {
       openSessionTile('bot-chat', 'center', 'workspace', undefined, botA)
+      $layoutTree.set(group(['workspace', tilePane('bot-chat')], { active: 'workspace', id: 'main' }))
 
       expect(
         focusWorkspaceOwnerSessionTile('bot:a', () => {
@@ -542,8 +546,9 @@ describe('focusWorkspaceOwnerSessionTile', () => {
       expect($sessionTiles.get().map(t => t.storedSessionId)).toEqual(['bot-chat'])
     })
 
-    it('no probe keeps the old behavior byte for byte', () => {
+    it('fronts a visible tile without a probe', () => {
       openSessionTile('bot-chat', 'center', 'workspace', undefined, botA)
+      $layoutTree.set(group(['workspace', tilePane('bot-chat')], { active: 'workspace', id: 'main' }))
 
       expect(focusWorkspaceOwnerSessionTile('bot:a')).toBe('bot-chat')
       expect($sessionTiles.get().map(t => t.storedSessionId)).toEqual(['bot-chat'])

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -25,6 +25,7 @@ import {
   $activeTreeGroup,
   $layoutTree,
   focusedSessionTabAnchor,
+  isPaneVisible,
   moveTreePane,
   noteActiveTreeGroup,
   revealTreePane
@@ -1551,9 +1552,11 @@ export function focusOpenSession(
     const tree = $layoutTree.get()
     const group = tree ? findGroupOfPane(tree, paneId) : null
 
-    if (group) {
-      noteActiveTreeGroup(group.id)
+    if (!group || !isPaneVisible(paneId)) {
+      return null
     }
+
+    noteActiveTreeGroup(group.id)
 
     return 'tile'
   }
@@ -1634,9 +1637,9 @@ export function focusWorkspaceOwnerSessionTile(
   const paneId = resolveRememberedActivePane(workspaceScopeKey('bots', workspaceOwnerKey), paneIds) ?? paneIds[0]
   const storedSessionId = paneId.slice(TILE_PANE_PREFIX.length)
 
-  focusOpenSession(storedSessionId, { workspaceMode: 'bots', workspaceOwnerKey })
-
-  return storedSessionId
+  return focusOpenSession(storedSessionId, { workspaceMode: 'bots', workspaceOwnerKey }) === 'tile'
+    ? storedSessionId
+    : null
 }
 
 /** Does a sidebar click still need to navigate after `focusOpenSession`? A miss


### PR DESCRIPTION
## What does this PR do?

Fixes a Desktop focus path that can leave the previous conversation on screen when selecting an already-open Bot Chat.

The saved session tile list and the layout tree are separate stores. A registered tile can survive a layout replacement while its pane disappears. `focusOpenSession()` previously returned `tile` even when reveal did not place the pane, and `focusWorkspaceOwnerSessionTile()` returned the stored ID without checking the result. Bot Mode consequently skipped its authoritative open path despite not displaying the selected chat.

There is a second failure in the same reveal operation: unhiding returned before explicit focus and unminimizing, so another pane could remain active.

This change reconciles missing registered panes through the existing adoption path, completes explicit reveal after unhide, and only reports a tile hit when the pane is visible. It preserves the existing tile, owner route, and canonical Bot Chat identity. No backend, session database, prompt, toolset, or dependency changes.

## Related Issue

Related to the phantom-tile half of #79520. Its closing comment explicitly left that concern for a focused follow-up. This implementation restores a registered pane instead of discarding the saved tile or adding a runtime-opened identity set.

#101431 refreshes the transcript after an existing Bot Chat is focused; it does not repair a missing/hidden pane or reject a false successful focus. These changes address different parts of the open path.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/components/pane-shell/tree/store.ts`: re-adopt a missing registered pane on explicit reveal and finish focus/unminimize after unhide. Passive unhide remains non-stealing.
- `apps/desktop/src/store/session-states.ts`: require a visible pane before returning `tile`; propagate a miss through the Bot Mode owner helper.
- `apps/desktop/src/store/session-pane-focus.test.ts`: exercise real pane registration, tile mirroring, profile overlay application, focus helpers, and in-place session opening with synthetic owner/session IDs.
- `apps/desktop/src/store/session-states.test.ts`: give five positive focus tests actual pane fixtures instead of expecting successful focus with no layout.

## How to Test

From the repository root, with workspace dependencies installed:

```sh
node node_modules/vitest/vitest.mjs run --root apps/desktop --project ui src/store/session-pane-focus.test.ts src/store/session-states.test.ts src/app/open-session.test.ts src/components/pane-shell/tree/tool-pane-toggle.test.ts src/components/pane-shell/tree/reactive-unhide.test.ts src/components/pane-shell/tree/plugin-pane-close.test.ts src/plugins/hermes-bots/bot-row-opens-canonical-chat.test.ts src/plugins/hermes-bots/roster-actions.test.ts --maxWorkers 2
node node_modules/typescript/bin/tsc -p apps/desktop/tsconfig.json --noEmit
```

The new regression file has four cases:

1. Open a Bot-scoped session tile through the real mirror, then apply a profile desktop overlay whose layout omits the tile. Focus must restore the existing pane without changing its owner route or duplicating the tile.
2. Explicitly focus a hidden tile in a minimized group with a different active pane. The requested chat must become visible and active.
3. Remove the layout entirely. Both focus helpers must report a miss, preserving the saved tile and previous main selection.
4. Focus a healthy open tile through `openSession(..., 'in-place')`. It must remain in place without navigation or duplication.

Results on Windows with Node v22.23.2:

- Unmodified base `8cab422ab09332c1867af81ee4e910878ac1172b`: three new regressions fail and the healthy-path control passes.
- Patched: **142 tests passed across 8 focused files**.
- Renderer TypeScript check passed.
- Targeted ESLint and Prettier checks passed.

This verifies the renderer failure class, not an end-to-end reproduction against an affected remote installation. No live customer or operator runtime was modified. Full-suite coverage is left to CI.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows, focused renderer tests and typecheck as detailed above; no packaged-app E2E claim

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - inline comments; no new user procedure
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - renderer-only, no OS branches
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

```text
Unmodified main, new regression file:
Test Files  1 failed (1)
Tests       3 failed | 1 passed (4)

Patched, focused suite:
Test Files  8 passed (8)
Tests       142 passed (142)
```
