### PR TITLE
fix(tui): mirror glyphs at odd bidi embedding levels

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/bidi-mirroring.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/bidi-mirroring.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { reorderBidi } from './bidi.js'
+import Output from './output.js'
+import { cellAt, CharPool, createScreen, HyperlinkPool, StylePool } from './screen.js'
+
+type BidiCharacter = Parameters<typeof reorderBidi>[0][number]
+
+const charactersFrom = (text: string): BidiCharacter[] =>
+  Array.from(new Intl.Segmenter().segment(text), ({ segment: value }, styleId) => ({
+    value,
+    width: value === '😀' ? 2 : 1,
+    styleId,
+    hyperlink: `https://example.com/${styleId}`
+  }))
+
+const textFrom = (characters: BidiCharacter[]) => characters.map(character => character.value).join('')
+
+beforeEach(() => {
+  // Select an existing software-bidi terminal, without faking the host OS.
+  vi.stubEnv('TERM_PROGRAM', 'vscode')
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('software bidi glyph mirroring', () => {
+  it.each([
+    ['Hebrew parentheses', '(אבג)', '(גבא)'],
+    ['Arabic brackets', 'مرحبا [عالم]', '[ملاع] ابحرم'],
+    ['nested brackets', 'אבג [(דה)]', '[(הד)] גבא'],
+    ['LTR island in RTL prose', 'אבג (React)', '(React) גבא'],
+    ['RTL island in LTR prose', 'English (אבג)', 'English (גבא)'],
+    ['supplementary character before brackets', 'אב 😀 (גד)', '(דג) 😀 בא'],
+    ['combining mark attached to a bracket', '(\u0301אב)', '(בא)\u0301']
+  ])('renders %s', (_name, source, expected) => {
+    const input = charactersFrom(source)
+    const original = input.map(character => ({ ...character }))
+
+    expect(textFrom(reorderBidi(input))).toBe(expected)
+    expect(input).toEqual(original)
+  })
+
+  it.each(['hello (React) [42]', '中文 (日本語)', ''])('preserves LTR/no-text identity: %s', source => {
+    const input = charactersFrom(source)
+
+    expect(reorderBidi(input)).toBe(input)
+  })
+
+  it('preserves cluster metadata and does not mutate mirrored source objects', () => {
+    const input = charactersFrom('(אב)')
+    const original = input.map(character => ({ ...character }))
+    const output = reorderBidi(input)
+
+    expect(output[0]).toEqual({ ...input[3], value: '(' })
+    expect(output[3]).toEqual({ ...input[0], value: ')' })
+    expect(output[0]).not.toBe(input[3])
+    expect(output[3]).not.toBe(input[0])
+    expect(output[1]).toBe(input[2])
+    expect(output[2]).toBe(input[1])
+    expect(input).toEqual(original)
+  })
+
+  it('writes mirrored, styled brackets through the real Output screen path', () => {
+    const stylePool = new StylePool()
+    const screen = createScreen(20, 1, stylePool, new CharPool(), new HyperlinkPool())
+    const output = new Output({ width: 20, height: 1, screen, stylePool })
+    const source = '\x1b[31m(אבג)\x1b[0m'
+
+    output.write(0, 0, source)
+    const rendered = output.get()
+    const cells = Array.from({ length: 5 }, (_, x) => cellAt(rendered, x, 0)!)
+
+    expect(cells.map(cell => cell.char).join('')).toBe('(גבא)')
+    expect(cells.every(cell => cell.styleId === cells[0]!.styleId)).toBe(true)
+    expect(cells[0]!.styleId).not.toBe(stylePool.none)
+
+    // Repainting must not mirror the already-cached visual clusters again.
+    output.write(0, 0, source)
+    const repainted = output.get()
+
+    expect(Array.from({ length: 5 }, (_, x) => cellAt(repainted, x, 0)!.char).join('')).toBe('(גבא)')
+  })
+})

--- a/ui-tui/packages/hermes-ink/src/ink/bidi.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/bidi.ts
@@ -71,18 +71,30 @@ export function reorderBidi(characters: ClusteredChar[]): ClusteredChar[] {
   // Map bidi levels back to ClusteredChar indices.
   // Each ClusteredChar may be multiple code units in the joined string.
   const charLevels: number[] = []
+  const reordered: ClusteredChar[] = []
   let offset = 0
 
-  for (let i = 0; i < characters.length; i++) {
+  for (const character of characters) {
     charLevels.push(levels[offset]!)
-    offset += characters[i]!.value.length
+
+    // UAX #9 L4: mirror glyphs at odd resolved levels. Keep the logical
+    // clusters immutable, including their style, hyperlink and width.
+    let value = ''
+
+    for (const codePoint of character.value) {
+      const mirrored = levels[offset]! & 1 ? bidi.getMirroredCharacter(codePoint) : null
+
+      value += mirrored ?? codePoint
+      offset += codePoint.length
+    }
+
+    reordered.push(value === character.value ? character : { ...character, value })
   }
 
   // Get reorder segments from bidi-js, but we need to work at the
   // ClusteredChar level, not the string level. We'll implement the
   // standard bidi reordering: find the max level, then for each level
   // from max down to 1, reverse all contiguous runs >= that level.
-  const reordered = [...characters]
   const maxLevel = Math.max(...charLevels)
 
   for (let level = maxLevel; level >= 1; level--) {


### PR DESCRIPTION
> *This was generated with AI assistance. The implementation and claims were verified against the cited commands.*

## What does this PR do?

Adds the missing Unicode Bidirectional Algorithm L4 glyph-mirroring step to Hermes's existing software-bidi renderer before visual cluster reordering. Without this step, parentheses and brackets face the wrong way in the software-rendered cells. The existing terminal detection selects this path for Windows Terminal, conhost, WSL/Windows Terminal, and VS Code's integrated terminal; this is not a claim that each terminal was manually tested.

```text
source       before         after
(אבג)        )גבא(          (גבא)
אבג (React)  )React( גבא    (React) גבא
```

The fix uses Hermes's existing `bidi-js` dependency. It changes only visual `ClusteredChar` objects: logical input and message storage are not mutated. A cluster is cloned only when its visible glyph must change, preserving the existing empty and pure-LTR identity fast paths. Terminal selection is a separate limitation described below.

Maintainer disclosure: I maintain [BidiLens](https://github.com/CodeinScrubs/BidiLens), whose renderer/corpus work helped identify this missing UBA step. This PR does not add BidiLens or any other dependency.

## Related Issue

Fixes https://github.com/NousResearch/hermes-agent/issues/101606

This is deliberately separate from #72508: that PR selects a better paragraph base for mixed technical prose, while this patch mirrors paired glyphs after embedding levels are resolved. Either patch can stand alone.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `ui-tui/packages/hermes-ink/src/ink/bidi.ts`
  - apply `bidi-js` glyph mirroring at odd resolved levels
  - account for UTF-16 offsets while walking full code points
  - retain cluster width, style and hyperlink metadata
- `ui-tui/packages/hermes-ink/src/ink/bidi-mirroring.test.ts`
  - cover Hebrew, Arabic, nested punctuation, mixed LTR islands, combining marks and supplementary characters
  - verify logical-input immutability and pure-LTR identity
  - exercise styled output, screen cells, cache and repaint behavior

## How to Test

1. `npm test --workspace ui-tui -- packages/hermes-ink/src/ink/bidi-mirroring.test.ts`
2. `npm test --workspace ui-tui -- packages/hermes-ink/src/ink`
3. `npm run typecheck --workspace ui-tui`
4. `npm run build:ink --workspace ui-tui`
5. `npm exec --workspace ui-tui -- eslint packages/hermes-ink/src/ink/bidi.ts packages/hermes-ink/src/ink/bidi-mirroring.test.ts`
6. `npm exec --workspace ui-tui -- prettier --check packages/hermes-ink/src/ink/bidi.ts packages/hermes-ink/src/ink/bidi-mirroring.test.ts`

Fresh local results on Windows 10 Pro for Workstations, Node 24.19.0:

- mirroring regressions reproduced on unchanged `main` before applying the fix
- patched focused suite: 12/12 tests passed
- wider Ink suite: 235 tests across 29 files passed
- TUI typecheck: passed
- Ink build: passed
- touched-file ESLint: passed
- Prettier and `git diff --check`: passed

The deterministic test selects an existing software-bidi terminal through `TERM_PROGRAM=vscode`; it does not monkeypatch the host OS. A physical Windows Terminal screenshot was not captured. The real `Output` screen path is executed in the regression test, including styled cells and repeated cached rendering.

## Checklist

### Code

- [x] I've read the Contributing Guide and repository `AGENTS.md`
- [x] My commit message follows Conventional Commits
- [x] I searched existing issues and PRs for `bidi mirror` and `bidi bracket`; no match was returned
- [x] My PR contains only the renderer fix and its tests
- [x] I've added behavioral tests for the change
- [x] I've tested on Windows 10 Pro for Workstations
- [ ] Full repository tests were not run; the touched TUI gates listed above were run

### Documentation & Housekeeping

- [x] Documentation update: N/A; this completes an existing renderer's UBA behavior
- [x] Config example: N/A; no setting changed
- [x] Architecture/workflow docs: N/A; no architecture changed
- [x] Cross-platform impact considered: bidi-capable terminals remain on the existing no-op path
- [x] Tool schemas: N/A

## Risk and non-goals

The change affects mapped mirrored characters at odd resolved embedding levels on software-bidi terminals, including mathematical symbols such as `∈` / `∋`, not only paired punctuation. Rollback is the two-file revert. This does not select paragraph direction, shape Arabic, change alignment/cursor behavior, or modify persisted text, and it does not establish full UBA renderer conformance.

**Selection limitation:** Hermes currently copies selected visual screen cells. A direct `Output` + selection probe for logical `(אבג)` therefore returns visual-order `(גבא)`, including the mirrored punctuation. Visual-order selection predates this patch; logical-order selection is not fixed here. An OS clipboard round-trip was not tested.
