### PR TITLE
fix(tui): bridge the boot cache over skinless re-resolves (startup palette flash)

### DIFF
--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -7,6 +7,8 @@ import { getTurnState, resetTurnState } from '../app/turnStore.js'
 import { getUiState, patchUiState, resetUiState } from '../app/uiStore.js'
 import { ZERO } from '../domain/usage.js'
 import { estimateTokensRough } from '../lib/text.js'
+import type { BootTheme } from '../lib/themeBoot.js'
+import { DEFAULT_THEME } from '../theme.js'
 import type { Msg } from '../types.js'
 
 // Mock the external-URL opener so the billing.step_up.verification test can
@@ -884,6 +886,162 @@ describe('createGatewayEventHandler', () => {
     expect(polarityBackgroundFromForeground('#ffffff')).toBeUndefined()
     expect(polarityBackgroundFromForeground('#808080')).toBeUndefined()
     expect(polarityBackgroundFromForeground('not-a-color')).toBeUndefined()
+  })
+
+  // ── Boot-cache bridge: skin.changed races the OSC-11 probe ──────────
+  //
+  // While no gateway skin has arrived, reapplyTheme() (driven by the
+  // OSC-11/10 answers, which can beat gateway.ready) must not repaint
+  // through the skinless default palette — a skinned session flashes gold
+  // until skin.changed lands. The bridge serves the boot cache instead
+  // while it still describes THIS terminal; every fall-through below
+  // asserts the OLD default-theme behavior survives for skinless users.
+
+  const cachedPrimary = '#e6edf3' // mono-skin sentinel, distinct from the dark default's gold
+
+  const cacheFixture = (over: Partial<BootTheme> = {}): BootTheme => ({
+    background: '#141414',
+    theme: { ...DEFAULT_THEME, color: { ...DEFAULT_THEME.color, primary: cachedPrimary } },
+    ...over
+  })
+
+  // Fresh module graph per scenario: bootThemeSnapshot is read once at
+  // import, so the themeBoot mock must be installed before the handler (and
+  // its uiStore) load. Assertions go through the SAME fresh uiStore the
+  // fresh handler writes to (resetModules re-instances both together).
+  const freshHandlerWithCache = async (snapshot: BootTheme | null) => {
+    vi.resetModules()
+    vi.doMock('../lib/themeBoot.js', () => ({
+      bootSeededPin: false,
+      bootTheme: snapshot?.theme ?? null,
+      bootThemeSnapshot: snapshot,
+      invalidateBootBackground: () => false,
+      writeBootTheme: () => undefined
+    }))
+
+    const handler = await import('../app/createGatewayEventHandler.js')
+    const ui = await import('../app/uiStore.js')
+
+    return { handler, ui }
+  }
+
+  // Neutralize inherited host signals so the fall-through default is the
+  // deterministic dark palette (#FFD700 primary) in every scenario.
+  const stubNeutralHost = () => {
+    vi.stubEnv('TERM_PROGRAM', '')
+    vi.stubEnv('COLORFGBG', '')
+    vi.stubEnv('HERMES_TUI_BACKGROUND', '')
+  }
+
+  it('bridges the boot cache when the live OSC answer matches the cached background', async () => {
+    stubNeutralHost()
+    vi.stubEnv('HERMES_TUI_BACKGROUND', '#141414')
+
+    const { handler, ui } = await freshHandlerWithCache(cacheFixture())
+    handler.reapplyTheme()
+
+    expect(ui.getUiState().theme.color.primary).toBe(cachedPrimary)
+    vi.unstubAllEnvs()
+  })
+
+  it('bridges the boot cache before any live OSC answer exists', async () => {
+    stubNeutralHost()
+
+    const { handler, ui } = await freshHandlerWithCache(cacheFixture())
+    handler.reapplyTheme()
+
+    expect(ui.getUiState().theme.color.primary).toBe(cachedPrimary)
+    vi.unstubAllEnvs()
+  })
+
+  it('falls through to the skinless default when the terminal changed', async () => {
+    stubNeutralHost()
+    vi.stubEnv('HERMES_TUI_BACKGROUND', '#282828') // different terminal than the cache
+
+    const { handler, ui } = await freshHandlerWithCache(cacheFixture())
+    handler.reapplyTheme()
+
+    expect(ui.getUiState().theme.color.primary).toBe('#FFD700')
+    vi.unstubAllEnvs()
+  })
+
+  it('keeps the bridge only for an equal config pin, not a contradicting one', async () => {
+    stubNeutralHost()
+
+    // Contradicting pin: the cache was pinned dark, config now says light.
+    vi.stubEnv('HERMES_TUI_THEME', 'light')
+    const contradicting = await freshHandlerWithCache(cacheFixture({ mode: 'dark' }))
+    contradicting.handler.reapplyTheme()
+    expect(contradicting.ui.getUiState().theme.color.primary).toBe('#867000')
+    vi.unstubAllEnvs()
+
+    // Equal pin (the boot cache replayed it): the bridge holds.
+    stubNeutralHost()
+    vi.stubEnv('HERMES_TUI_THEME', 'dark')
+    const agreeing = await freshHandlerWithCache(cacheFixture({ mode: 'dark' }))
+    agreeing.handler.reapplyTheme()
+    expect(agreeing.ui.getUiState().theme.color.primary).toBe(cachedPrimary)
+    vi.unstubAllEnvs()
+  })
+
+  it('never bridges a pure-black cache against a contradicting light answer', async () => {
+    // The pure-black fingerprint is "unset default", not a measurement — it
+    // must not pin polarity. A dark cache on a dark terminal still bridges
+    // (nothing contradicts it), but a light answer must win.
+    stubNeutralHost()
+    vi.stubEnv('HERMES_TUI_BACKGROUND', '#000000')
+
+    const { handler, ui } = await freshHandlerWithCache(cacheFixture({ background: '#000000' }))
+
+    // Unknown-polarity phase (probe distrusted, nothing resolved): dark.
+    handler.reapplyTheme()
+    expect(ui.getUiState().theme.color.primary).toBe('#FFD700')
+
+    // A light-terminal answer arrives: the untrustworthy black cache must
+    // not hold the bridge against it.
+    vi.stubEnv('HERMES_TUI_BACKGROUND', '#ffffff')
+    handler.reapplyTheme()
+    expect(ui.getUiState().theme.color.primary).toBe('#867000')
+
+    vi.unstubAllEnvs()
+  })
+
+  it('behaves exactly as before on first launch (no cache), still tracking polarity', async () => {
+    stubNeutralHost()
+
+    const { handler, ui } = await freshHandlerWithCache(null)
+    handler.reapplyTheme()
+    expect(ui.getUiState().theme.color.primary).toBe('#FFD700')
+
+    // #20379 regression guard: a later light-terminal answer still re-derives.
+    vi.stubEnv('HERMES_TUI_BACKGROUND', '#ffffff')
+    handler.reapplyTheme()
+    expect(ui.getUiState().theme.color.primary).toBe('#867000')
+    vi.unstubAllEnvs()
+  })
+
+  it('clears the bridge once the first skin arrives — the skin wins for good', async () => {
+    stubNeutralHost()
+    vi.stubEnv('HERMES_TUI_BACKGROUND', '#141414')
+
+    const { handler, ui } = await freshHandlerWithCache(cacheFixture())
+
+    const appended: Msg[] = []
+    const onEvent = handler.createGatewayEventHandler(buildCtx(appended))
+
+    // A late probe answer before the skin: still the cached mono theme.
+    handler.reapplyTheme()
+    expect(ui.getUiState().theme.color.primary).toBe(cachedPrimary)
+
+    // The skin lands: it takes over and the bridge is spent.
+    onEvent({ payload: { colors: { ui_primary: '#00FF88' } }, type: 'skin.changed' } as any)
+    expect(ui.getUiState().theme.color.primary).toBe('#00FF88')
+
+    // Another probe-driven re-resolve keeps the skin (never regresses to
+    // the cache or the default mid-session).
+    handler.reapplyTheme()
+    expect(ui.getUiState().theme.color.primary).toBe('#00FF88')
+    vi.unstubAllEnvs()
   })
 
   it('claims wake-word ownership when the gateway becomes ready', () => {

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -21,7 +21,13 @@ import { rpcErrorMessage } from '../lib/rpc.js'
 import { topLevelSubagents } from '../lib/subagentTree.js'
 import { isPaintableHex, setTerminalBackground, setTerminalForeground } from '../lib/terminalModes.js'
 import { formatAbandonedClarify, formatAbandonedClarifyBatch, formatToolCall, stripAnsi } from '../lib/text.js'
-import { bootSeededPin, invalidateBootBackground, writeBootTheme } from '../lib/themeBoot.js'
+import {
+  bootSeededPin,
+  type BootTheme,
+  bootThemeSnapshot,
+  invalidateBootBackground,
+  writeBootTheme
+} from '../lib/themeBoot.js'
 import { defaultThemeForCurrentBackground, fromSkin, skinIsLight, type Theme, themeToneHex } from '../theme.js'
 import type { Msg, SubagentProgress, SubagentStatus, Usage } from '../types.js'
 
@@ -171,6 +177,10 @@ const paintTerminalDefaults = (theme: Theme) => {
 }
 
 const applySkin = (s: GatewaySkin) => {
+  if (!lastSkin) {
+    bootThemeBeforeSkin = null
+  }
+
   lastSkin = s
   const theme = themeForSkin(s)
 
@@ -178,10 +188,62 @@ const applySkin = (s: GatewaySkin) => {
   paintTerminalDefaults(theme)
 }
 
+// ── Boot-cache bridge (skin.changed races the OSC-11 probe) ────────────
+//
+// Theme resolution is async at startup: the gateway skin event and the
+// terminal's OSC-11 background probe answer in either order. While no skin
+// has arrived, a probe-driven re-resolve must NOT repaint through the
+// skinless default palette — for a skinned session that flashes the default
+// identity colors (gold-on-navy) for a frame or several until skin.changed
+// lands, even though the boot cache already holds the correct theme
+// (lib/themeBoot.ts replays it for frame one; this bridges it past frame
+// one). Capture the seeded theme once at module load and treat it as the
+// "no-skin" answer while it still describes this terminal:
+//
+//   - the seeded/cached background matches the live OSC-11 answer (same
+//     terminal), or detection has nothing live to offer (no answer yet);
+//   - no explicit user override (HERMES_TUI_LIGHT / HERMES_TUI_THEME)
+//     contradicts the cached mode pin;
+//   - the cached background is not the distrusted pure-black fingerprint;
+//   - no skin has arrived (applySkin clears the capture).
+//
+// Any other case falls through to the skinless default exactly as before,
+// so #20379's polarity machinery keeps working for skinless sessions.
+let bootThemeBeforeSkin: null | BootTheme = bootThemeSnapshot
+
+export function themeBeforeSkin(): Theme {
+  const cached = bootThemeBeforeSkin
+
+  if (!cached) {
+    return defaultThemeForCurrentBackground()
+  }
+
+  const liveBackground = process.env.HERMES_TUI_BACKGROUND
+
+  const seedableBackground =
+    cached.background && cached.background.toLowerCase() !== '#000000' ? cached.background : undefined
+
+  const hasLiveAnswer = Boolean(liveBackground)
+
+  const backgroundCompatible =
+    !hasLiveAnswer ||
+    (seedableBackground !== undefined && liveBackground!.toLowerCase() === seedableBackground.toLowerCase())
+
+  const explicitOverride =
+    process.env.HERMES_TUI_LIGHT !== undefined ||
+    (process.env.HERMES_TUI_THEME !== undefined && process.env.HERMES_TUI_THEME !== cached.mode)
+
+  if (backgroundCompatible && !explicitOverride) {
+    return cached.theme
+  }
+
+  return defaultThemeForCurrentBackground()
+}
+
 /** Re-derive the theme from current detection signals (env overrides, cached
  *  OSC-11 answer) — used by /theme, config sync, and the OSC listener. */
 export function reapplyTheme(): void {
-  const theme = lastSkin ? themeForSkin(lastSkin) : defaultThemeForCurrentBackground()
+  const theme = lastSkin ? themeForSkin(lastSkin) : themeBeforeSkin()
 
   commitTheme(theme)
   // Polarity flips swap paired palettes, so the default fg must track the

--- a/ui-tui/src/lib/themeBoot.ts
+++ b/ui-tui/src/lib/themeBoot.ts
@@ -207,3 +207,13 @@ export const bootSeededPin: boolean = seedBootEnvironment(boot, process.env).see
 
 /** The cached theme for the first frame, or null on first launch. */
 export const bootTheme: Theme | null = boot?.theme ?? null
+
+/**
+ * The full boot-cache snapshot (theme + cached background + config pin) for
+ * the boot-cache bridge in createGatewayEventHandler: while no gateway skin
+ * has arrived, probe-driven theme re-resolves prefer this over the skinless
+ * default so a skinned session never repaints through the default identity
+ * palette mid-boot. Null on first launch (nothing cached — the default is
+ * the only theme that has ever described this terminal).
+ */
+export const bootThemeSnapshot: BootTheme | null = boot


### PR DESCRIPTION
## Problem

With a non-default skin configured, the TUI flashes the skinless default palette (gold-on-navy) for a frame or several at startup before repainting in the skin's colors.

Theme resolution at startup races two async signals:

1. the gateway's skin event (`gateway.ready` / `skin.changed`)
2. the terminal's OSC-11 background probe reply

When the probe wins, `reapplyTheme()` runs while `lastSkin` is still `null` and commits `defaultThemeForCurrentBackground()` — the skinless default (dark seeds: `primary #FFD700`, `accent #FFBF00`, navy surfaces). When the skin event lands, `applySkin` repaints everything in the skin's palette. Users on `mono` see a yellow flash on launches where the race goes the wrong way (slow gateway warmup, cold python imports, MCP init).

The boot cache (`lib/themeBoot.ts`, the "flash-free theme boot") already persists the last resolved theme and replays it for **frame one** — but nothing consulted the cache past that frame, so the very next re-resolve repainted through the default anyway.

## Fix

While no gateway skin has arrived, a probe-driven `reapplyTheme()` now serves the cached theme instead of the skinless default — and only while the cache still describes *this* terminal:

- the cached background matches the live OSC-11 answer (or detection has no live answer yet),
- no explicit override (`HERMES_TUI_LIGHT` / `HERMES_TUI_THEME`) contradicts the cached mode pin,
- the cached background is not the distrusted pure-black fingerprint,
- no skin has arrived (`applySkin` clears the bridge).

Everything else falls through to the skinless default exactly as before, preserving #20379's polarity adaptation for skinless sessions and the seed/invalidate contract covered by `themeBoot.test.ts`.

## Testing

- 7 new unit tests in `createGatewayEventHandler.test.ts` covering: bridge-holds (matching + no live answer), fall-through (terminal changed, contradicting pin, pure-black cache vs light answer), first-launch no-cache behavior (incl. #20379 polarity tracking), and bridge-spent-once-skin-arrives.
- `themeBoot.test.ts` (12 seed/invalidate tests) unchanged and passing.
- Full ui-tui suite: 1714 passing; the 28 failures (billingStepUp, subscriptionOverlay, textInputFastEcho, appChromeBlockedTimers, ink-backpressure) reproduce on a clean `origin/main` checkout on this machine (stale `@hermes/ink` mock at import time) and are unrelated.
- `tsc --noEmit`, `eslint`, `prettier --check` clean on touched files.

## Notes

Manually exercised the race with a pty harness that plays terminal emulator (answers OSC-11/10/DA1 and SIGSTOPs the gateway so the probe is the only live signal); with the fix the frozen-gateway startup paints the cached skin palette and never the default.