### PR TITLE
fix(agent): real-prompt pressure floor + UTF-8-byte rough estimate for non-CJK scripts (salvage #87490)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -609,6 +609,28 @@ def _image_error_max_dimension(error: Exception) -> Optional[int]:
     return None
 
 
+def _pressure_with_real_floor(compressor: Any, rough_tokens: int) -> int:
+    """Floor the rough pre-API pressure estimate at the last REAL prompt size.
+
+    The chars/4 rough estimate under-counts Cyrillic (and other non-ASCII
+    scripts) by up to ~2x, so a session can sit at the provider's real context
+    ceiling while the rough figure stays under the compaction threshold — on
+    silent-clip providers (ollama /v1) that is a truncation death spiral the
+    reactive overflow handler never sees (observed live: real prompts
+    64,842→64,995 against a 55,705 threshold). The provider's own last
+    reported prompt_tokens is authoritative; never let the pressure figure
+    fall below it. Skipped for exactly one turn after a compaction, when
+    last_real_prompt_tokens still holds the stale pre-compression value
+    (#36718's awaiting_real_usage_after_compression window).
+    """
+    last_real = int(getattr(compressor, "last_real_prompt_tokens", 0) or 0)
+    if last_real > rough_tokens and not getattr(
+        compressor, "awaiting_real_usage_after_compression", False
+    ):
+        return last_real
+    return rough_tokens
+
+
 def _ollama_context_limit_error(agent: Any, request_tokens: int) -> Optional[str]:
     """Return a user-facing error when Ollama is loaded with too little context."""
     if not getattr(agent, "tools", None):
@@ -2882,6 +2904,9 @@ def run_conversation(
         )
         if _anchored_pressure is not None:
             request_pressure_tokens = _anchored_pressure
+        request_pressure_tokens = _pressure_with_real_floor(
+            agent.context_compressor, request_pressure_tokens
+        )
         total_chars = approx_tokens * 4
         # Stash this request's rough estimate so update_from_response() can
         # pair it with the provider's real prompt count — the (rough, real)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -610,15 +610,23 @@ def _image_error_max_dimension(error: Exception) -> Optional[int]:
 
 
 def _pressure_with_real_floor(compressor: Any, rough_tokens: int) -> int:
-    """Floor the rough pre-API pressure estimate at the last REAL prompt size.
+    """Floor the ROUGH pre-API pressure estimate at the last REAL prompt size.
 
-    The chars/4 rough estimate under-counts Cyrillic (and other non-ASCII
-    scripts) by up to ~2x, so a session can sit at the provider's real context
-    ceiling while the rough figure stays under the compaction threshold — on
-    silent-clip providers (ollama /v1) that is a truncation death spiral the
-    reactive overflow handler never sees (observed live: real prompts
-    64,842→64,995 against a 55,705 threshold). The provider's own last
-    reported prompt_tokens is authoritative; never let the pressure figure
+    Applied only on the fallback path -- when ``anchored_context_tokens`` has
+    no valid anchor (first request, transcript rewritten under the anchor,
+    provider never reported usage). A valid anchor is provider-exact and is
+    used as-is; in particular on MoA turns the anchor deliberately uses the
+    pre-fold aggregator usage while ``last_real_prompt_tokens`` holds the
+    folded figure, so flooring an anchored value would re-add fan-out tokens
+    the anchor exists to exclude.
+
+    On the rough path, non-ASCII text (Cyrillic, Greek, Polish, ...)
+    under-counts by up to ~2x, so a session can sit at the provider's real
+    context ceiling while the rough figure stays under the compaction
+    threshold -- on silent-clip providers (ollama /v1) that is a truncation
+    death spiral the reactive overflow handler never sees (observed live:
+    real prompts 64,842->64,995 against a 55,705 threshold). The provider's
+    last reported prompt_tokens is authoritative; never let the rough figure
     fall below it. Skipped for exactly one turn after a compaction, when
     last_real_prompt_tokens still holds the stale pre-compression value
     (#36718's awaiting_real_usage_after_compression window).
@@ -2904,9 +2912,10 @@ def run_conversation(
         )
         if _anchored_pressure is not None:
             request_pressure_tokens = _anchored_pressure
-        request_pressure_tokens = _pressure_with_real_floor(
-            agent.context_compressor, request_pressure_tokens
-        )
+        else:
+            request_pressure_tokens = _pressure_with_real_floor(
+                agent.context_compressor, request_pressure_tokens
+            )
         total_chars = approx_tokens * 4
         # Stash this request's rough estimate so update_from_response() can
         # pair it with the provider's real prompt count — the (rough, real)

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -3662,10 +3662,19 @@ def estimate_tokens_rough(text: str) -> int:
         # token) where chars/4 under-counted them ~2x and let sessions ride
         # the provider's context ceiling below the compaction threshold.
         # ASCII spans inside mixed text still count at 1 byte each.
-        return (len(text.encode("utf-8")) + 3) // 4
+        #
+        # Calibrated against cl100k/o200k/Qwen2.5 (estimate / mean real):
+        # Russian 0.67->1.24, Ukrainian 0.55->1.03, Arabic 0.53->0.96,
+        # Hindi 0.34->0.90, Greek 0.37->0.68, Polish 0.63->0.69; accented
+        # Latin barely moves (French 1.02->1.03, German 0.99->1.02,
+        # Spanish 1.04->1.07) because only the accented chars widen.
+        # Pure-ASCII prose already over-counts at ~1.4 on the same rule.
+        # errors="replace": lone surrogates (routine in tool output; see
+        # message_sanitization) must not turn an estimate into a raise.
+        return (len(text.encode("utf-8", "replace")) + 3) // 4
     # Mixed CJK + other: dense chars stay ~1 token each; the sparse
     # remainder is byte-counted for the same corrective.
-    return dense + ((len(stripped.encode("utf-8")) + 3) // 4)
+    return dense + ((len(stripped.encode("utf-8", "replace")) + 3) // 4)
 
 
 def estimate_messages_tokens_rough(

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -3652,13 +3652,20 @@ def estimate_tokens_rough(text: str) -> int:
     if text.isascii():
         # O(1) fast path — ASCII text cannot contain token-dense CJK chars.
         return (len(text) + 3) // 4
-    dense = len(text) - len(_CJK_DENSE_RE.sub("", text))
+    stripped = _CJK_DENSE_RE.sub("", text)
+    dense = len(text) - len(stripped)
     if not dense:
-        # Non-ASCII but no CJK (accents, Cyrillic, emoji, ...): keep the
-        # classic ~4 chars/token rule.
-        return (len(text) + 3) // 4
-    sparse = len(text) - dense
-    return dense + ((sparse + 3) // 4)
+        # Non-ASCII but no CJK (accents, Cyrillic, emoji, ...): count UTF-8
+        # BYTES at ~4/token instead of characters. The byte width is the
+        # corrective: Cyrillic/Greek/Arabic are 2 bytes per char, so they
+        # count as ~chars/2 — matching their real BPE cost (~2-3 chars per
+        # token) where chars/4 under-counted them ~2x and let sessions ride
+        # the provider's context ceiling below the compaction threshold.
+        # ASCII spans inside mixed text still count at 1 byte each.
+        return (len(text.encode("utf-8")) + 3) // 4
+    # Mixed CJK + other: dense chars stay ~1 token each; the sparse
+    # remainder is byte-counted for the same corrective.
+    return dense + ((len(stripped.encode("utf-8")) + 3) // 4)
 
 
 def estimate_messages_tokens_rough(

--- a/tests/agent/test_cjk_token_estimation.py
+++ b/tests/agent/test_cjk_token_estimation.py
@@ -88,3 +88,32 @@ def test_cyrillic_counts_by_utf8_bytes():
     assert estimate_tokens_rough("русский текст") == 7
     # Pure ASCII unchanged.
     assert estimate_tokens_rough("a" * 400) == 100
+
+
+def test_accented_latin_is_not_inflated_by_byte_counting():
+    # Byte-counting must not punish Western-European text: only the accented
+    # chars are 2 bytes, so the estimate moves by a few percent, not 2x.
+    from agent.model_metadata import estimate_tokens_rough
+    fr = "La compression du contexte permet aux longues sessions de rester dans la fenêtre du fournisseur sans perdre le fil de la tâche."
+    ascii_rule = (len(fr) + 3) // 4
+    est = estimate_tokens_rough(fr)
+    assert ascii_rule <= est <= int(ascii_rule * 1.10), (ascii_rule, est)
+
+
+def test_mixed_cyrillic_and_ascii_code_counts_ascii_at_one_byte():
+    from agent.model_metadata import estimate_tokens_rough
+    code = "def compress(ctx):\n    # Сжимаем контекст\n    return summarize(ctx)\n"
+    ascii_part = "def compress(ctx):\n    # \n    return summarize(ctx)\n"
+    cyr = "Сжимаем контекст"
+    expected = (len(ascii_part.encode()) + len(cyr.encode()) + 3) // 4
+    assert estimate_tokens_rough(code) == expected
+    # and strictly more than the old chars/4 rule for the same text
+    assert estimate_tokens_rough(code) > (len(code) + 3) // 4
+
+
+def test_lone_surrogates_do_not_raise():
+    # main's estimator was total (len/regex never raise); byte-counting must
+    # stay total too — tool output routinely carries unpaired surrogates.
+    from agent.model_metadata import estimate_tokens_rough
+    assert estimate_tokens_rough("abc\ud800def") >= 2
+    assert estimate_tokens_rough("漢字\udfff") >= 2

--- a/tests/agent/test_cjk_token_estimation.py
+++ b/tests/agent/test_cjk_token_estimation.py
@@ -49,15 +49,16 @@ def test_cjk_tail_does_not_expand_to_english_char_budget():
 
 
 def _reference_per_char_estimate(text: str) -> int:
-    """The pre-perf-gate per-character reference implementation."""
+    """Per-character reference: CJK ~1 token/char, everything else UTF-8
+    bytes/4 (the byte width corrects Cyrillic/Greek/Arabic under-counting)."""
     dense = 0
-    sparse = 0
+    sparse_bytes = 0
     for ch in text:
         if _is_cjk_token_dense_char(ch):
             dense += 1
         else:
-            sparse += 1
-    return dense + ((sparse + 3) // 4)
+            sparse_bytes += len(ch.encode("utf-8"))
+    return dense + ((sparse_bytes + 3) // 4)
 
 
 def test_perf_gated_estimator_matches_per_char_reference():
@@ -79,3 +80,11 @@ def test_perf_gated_estimator_matches_per_char_reference():
 
 
 
+def test_cyrillic_counts_by_utf8_bytes():
+    # «русский текст» = 12 Cyrillic chars (2 bytes each) + 1 ASCII space:
+    # 25 bytes -> ceil(25/4) = 7 tokens; the old chars/4 rule said 4 —
+    # the ~2x under-count that let real prompts ride the context ceiling.
+    from agent.model_metadata import estimate_tokens_rough
+    assert estimate_tokens_rough("русский текст") == 7
+    # Pure ASCII unchanged.
+    assert estimate_tokens_rough("a" * 400) == 100

--- a/tests/run_agent/test_infinite_compaction_loop.py
+++ b/tests/run_agent/test_infinite_compaction_loop.py
@@ -292,3 +292,22 @@ class TestPressureRealFloor:
         from agent.conversation_loop import _pressure_with_real_floor
         assert _pressure_with_real_floor(self._compressor(0), 10_000) == 10_000
         assert _pressure_with_real_floor(object(), 10_000) == 10_000
+
+    def test_anchored_pressure_is_never_floored(self):
+        """A valid usage anchor is provider-exact and wins as-is.
+
+        On MoA turns the anchor deliberately uses the pre-fold aggregator
+        usage while ``last_real_prompt_tokens`` holds the folded figure;
+        flooring the anchored value would re-add the advisor fan-out tokens
+        the anchor exists to exclude. Pin the wiring shape: the floor is
+        applied only on the ``else`` (rough fallback) branch.
+        """
+        import inspect
+        from agent import conversation_loop
+
+        src = inspect.getsource(conversation_loop.run_conversation)
+        i = src.index("if _anchored_pressure is not None:")
+        window = src[i : i + 400]
+        assert "request_pressure_tokens = _anchored_pressure" in window
+        assert "else:" in window
+        assert window.index("else:") < window.index("_pressure_with_real_floor(")

--- a/tests/run_agent/test_infinite_compaction_loop.py
+++ b/tests/run_agent/test_infinite_compaction_loop.py
@@ -262,3 +262,33 @@ class TestCodexSparkShortSessionBoundary:
             f"This would cause the silent context wipe described in #48621."
         )
         assert comp.has_content_to_compress(messages) is True
+
+
+class TestPressureRealFloor:
+    """Regression: Cyrillic-heavy sessions under-count in the rough estimate,
+    letting real prompts ride the provider window (64,842→64,995 observed)
+    while the pre-API gate saw sub-threshold pressure."""
+
+    def _compressor(self, last_real, awaiting=False):
+        class _C:
+            last_real_prompt_tokens = last_real
+            awaiting_real_usage_after_compression = awaiting
+        return _C()
+
+    def test_real_floor_lifts_undercounted_rough(self):
+        from agent.conversation_loop import _pressure_with_real_floor
+        assert _pressure_with_real_floor(self._compressor(64_842), 45_000) == 64_842
+
+    def test_rough_wins_when_larger(self):
+        from agent.conversation_loop import _pressure_with_real_floor
+        assert _pressure_with_real_floor(self._compressor(30_000), 45_000) == 45_000
+
+    def test_stale_real_ignored_right_after_compaction(self):
+        from agent.conversation_loop import _pressure_with_real_floor
+        compressor = self._compressor(64_842, awaiting=True)
+        assert _pressure_with_real_floor(compressor, 20_000) == 20_000
+
+    def test_zero_and_missing_real_are_safe(self):
+        from agent.conversation_loop import _pressure_with_real_floor
+        assert _pressure_with_real_floor(self._compressor(0), 10_000) == 10_000
+        assert _pressure_with_real_floor(object(), 10_000) == 10_000


### PR DESCRIPTION
## Summary
Two estimator fixes so non-English sessions stop riding a silent-clip provider's context ceiling below the compaction threshold. Salvage of the two remaining commits on #87490 (@Komzpa) — the third (65,536 threshold-floor cap) already landed via #99700. Author commits cherry-picked with authorship preserved; one docs/tests commit on top.

## Who hits this / when
Users writing in Cyrillic, Greek, Arabic, Hindi, Polish… on providers that truncate instead of erroring on overflow (ollama `/v1`). The chars/4 rough estimate under-counts those scripts by up to ~3× (Hindi 0.34, Greek 0.37, Ukrainian 0.55 of real), so the pre-API pressure gate saw "sub-threshold" while real prompts sat at 64,842→64,995 against a 55,705 threshold — an 18-minute turn of window-filling continuation retries.

## Changes
- **@Komzpa** `agent/conversation_loop.py` — `_pressure_with_real_floor`: pre-API pressure never falls below the provider's last reported `prompt_tokens` (skipped for the one post-compaction turn where that value is stale, per #36718). Since d3a1c46510 the pressure path anchors on provider usage when the anchor is valid; the floor now runs only on the rough fallback (first request, transcript rewritten under the anchor).
- **@Komzpa** `agent/model_metadata.py` — `estimate_tokens_rough`: non-CJK non-ASCII text counted by UTF-8 bytes/4 instead of chars/4. ASCII fast path untouched; CJK dense chars still ~1 token each.
- follow-up (review findings on the salvaged commits):
  - the floor is applied **only on the rough fallback branch**. A valid anchor is provider-exact and wins as-is — on MoA turns the anchor deliberately uses pre-fold aggregator usage while `last_real_prompt_tokens` holds the folded figure, so flooring an anchored value would re-add the fan-out tokens the anchor exists to exclude.
  - `estimate_tokens_rough` encodes with `errors="replace"`: main's estimator never raised, but `text.encode()` on a lone surrogate (routine in tool output; see `message_sanitization`) raised `UnicodeEncodeError` and would have aborted a turn.
  - calibration recorded in the estimator comment; tests: accented Latin within +10% of the ASCII rule, mixed Cyrillic/ASCII counts ASCII at one byte, lone surrogates don't raise, anchored pressure is never floored.

## Calibration (estimate / mean real over cl100k_base, o200k_base, Qwen2.5)
| script | main (chars/4) | this PR (bytes/4) |
|---|---|---|
| Russian | 0.67 | 1.24 |
| Ukrainian | 0.55 | 1.03 |
| Arabic | 0.53 | 0.96 |
| Hindi | 0.34 | 0.90 |
| Greek | 0.37 | 0.68 |
| Polish | 0.63 | 0.69 |
| French / German / Spanish | 1.02 / 0.99 / 1.04 | 1.03 / 1.02 / 1.07 |
| ASCII prose / Python | 1.40 / 1.19 | unchanged |

Under-counting is the dangerous direction (silent clip); bytes/4 is closer or equal on every sample and moves accented Latin by ≤3%.

## Validation
`tests/agent/test_cjk_token_estimation.py`, `tests/run_agent/test_infinite_compaction_loop.py`, `tests/agent/test_context_compressor.py`, `tests/agent/test_compression_anti_thrash_recovery.py`, `tests/agent/test_model_metadata.py`, `tests/agent/test_usage_anchor.py`: 308 passed.

Closes #87490.
