### PR TITLE
fix(cli): make HERMES_HOME authoritative for non-profile roots

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -646,20 +646,37 @@ def _apply_profile_override() -> None:
             consume = 0
             profile_index = None
 
-    # 1.5 If HERMES_HOME is already set and no explicit flag was given, trust it
-    # only when it already points to a specific profile directory.  The
-    # distinguishing heuristic: a profile path has "profiles" as its immediate
-    # parent directory name (e.g. ~/.hermes/profiles/coder or
-    # /opt/data/profiles/coder).  If HERMES_HOME points to the hermes root
-    # instead (e.g. systemd hardcodes HERMES_HOME=/root/.hermes), we must
-    # still read active_profile — the user may have switched profiles via
-    # `hermes profile use` and the gateway should honour that choice.
-    # See issue #22502.
+    # 1.5 If HERMES_HOME is already set, treat it as authoritative.
+    #
+    # A set HERMES_HOME is an explicit launch choice, so we must not silently
+    # override it by reading an unrelated sticky active_profile. Two spellings
+    # are possible:
+    #
+    #   * Parent dir named "profiles" (e.g. ~/.hermes/profiles/coder or
+    #     /opt/data/profiles/coder): HERMES_HOME already points at a profile.
+    #     Return immediately — re-reading active_profile would fight the
+    #     child-process inheritance contract (issue #22502).
+    #
+    #   * Anything else (a custom root like systemd's /root/.hermes, or a
+    #     throwaway /tmp scratch home): HERMES_HOME names the launch root.
+    #     If that root carries its OWN active_profile, honor it (the user or
+    #     the unit deliberately pinned the profile here). If it does NOT, keep
+    #     HERMES_HOME exactly as given and DO NOT fall through to step 2, which
+    #     would otherwise read the *production* active_profile and redirect into
+    #     the live profile tree. A bare /tmp scratch home with no sticky file
+    #     must stay isolated at its scratch home, not hit PRODUCTION — this is
+    #     the isolation break behind the Sep 2 junk-card sprays.
     hermes_home_env = os.environ.get("HERMES_HOME", "")
     if profile_name is None and hermes_home_env:
-        if Path(hermes_home_env).parent.name == "profiles":
+        hermes_home_path = Path(hermes_home_env)
+        if hermes_home_path.parent.name == "profiles":
+            return  # already a profile dir; trust it (issue #22502)
+        # Custom root: only its own active_profile may redirect; otherwise
+        # keep HERMES_HOME as-is and never touch the production sticky file.
+        active_path = hermes_home_path / "active_profile"
+        if not active_path.exists():
             return
-
+        # else fall through to step 2, which reads this root's active_profile
     # 2. If no flag, check active_profile in the hermes root.
     #
     # EXCEPTION: a supervisor-launched gateway child must NOT follow the

--- a/tests/hermes_cli/test_apply_profile_override.py
+++ b/tests/hermes_cli/test_apply_profile_override.py
@@ -286,3 +286,135 @@ class TestGeneralizedSupervisorMarkers:
 
         plist = generate_launchd_plist()
         assert "<key>HERMES_SUPERVISED_CHILD</key>" in plist
+
+
+class TestScratchHomeIsolation:
+    """Regression guard for the HERMES_HOME isolation break (Sep 2 junk-card
+    sprays).
+
+    A custom root HERMES_HOME whose parent dir is NOT ``profiles`` (e.g. a
+    throwaway ``/tmp`` scratch home, or systemd hardcoding ``HERMES_HOME`` to
+    the hermes root) is an explicit launch choice. It must be authoritative:
+
+      * If it carries its OWN ``active_profile``, that file wins (the unit or
+        the user deliberately pinned the profile here) — but the lookup is
+        scoped to *this* root, never the production sticky file.
+      * If it has no ``active_profile`` of its own, HERMES_HOME must be kept
+        exactly as given. It must NOT fall through to step 2 and read the
+        *production* ``active_profile``, which would redirect a bare /tmp
+        scratch home into the live profile tree — the isolation break behind
+        the Sep 2 payment-webhook junk-card sprays.
+    """
+
+    def test_scratch_home_without_active_profile_stays_isolated(
+        self, tmp_path, monkeypatch
+    ):
+        """A /tmp-style scratch HERMES_HOME with no active_profile must not
+        be redirected into the production profile tree.
+
+        Simulate: production root (~/.hermes) has active_profile=coder and a
+        live coder profile. The scratch home (its own tree under tmp) has no
+        active_profile of its own. Before the fix, step 2 read the production
+        sticky file and redirected HERMES_HOME into the live profile.
+        """
+        prod = tmp_path / "prod" / ".hermes"
+        prod.mkdir(parents=True)
+        (prod / "active_profile").write_text("coder")
+        (prod / "profiles" / "coder").mkdir(parents=True)
+
+        scratch = tmp_path / "scratch" / ".hermes"
+        scratch.mkdir(parents=True)
+        (scratch / "profiles" / "coder").mkdir(parents=True)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "prod")
+        monkeypatch.setenv("HERMES_HOME", str(scratch))
+        monkeypatch.setattr(sys, "argv", ["hermes", "chat"])
+
+        for var in (
+            "HERMES_SUPERVISED_CHILD",
+            "HERMES_S6_SUPERVISED_CHILD",
+            "INVOCATION_ID",
+            "HERMES_GATEWAY_EXTERNAL_SUPERVISOR",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+        from hermes_cli.main import _apply_profile_override
+
+        _apply_profile_override()
+
+        result = os.environ.get("HERMES_HOME")
+        assert result is not None
+        # Must remain the scratch home — NOT the production profile dir.
+        assert result == str(scratch), (
+            f"scratch home redirected to {result!r} — isolation break!"
+        )
+        assert "prod" not in result, (
+            f"scratch home leaked into production tree: {result!r}"
+        )
+
+    def test_scratch_home_with_own_active_profile_is_honored(
+        self, tmp_path, monkeypatch
+    ):
+        """A custom root that carries its own active_profile honors that file,
+        but only its own — never a sibling/production one."""
+        prod = tmp_path / "prod" / ".hermes"
+        prod.mkdir(parents=True)
+        (prod / "active_profile").write_text("coder")
+        (prod / "profiles" / "coder").mkdir(parents=True)
+
+        scratch = tmp_path / "scratch" / ".hermes"
+        scratch.mkdir(parents=True)
+        (scratch / "active_profile").write_text("briefer")
+        (scratch / "profiles" / "briefer").mkdir(parents=True)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "prod")
+        monkeypatch.setenv("HERMES_HOME", str(scratch))
+        monkeypatch.setattr(sys, "argv", ["hermes", "chat"])
+
+        for var in (
+            "HERMES_SUPERVISED_CHILD",
+            "HERMES_S6_SUPERVISED_CHILD",
+            "INVOCATION_ID",
+            "HERMES_GATEWAY_EXTERNAL_SUPERVISOR",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+        from hermes_cli.main import _apply_profile_override
+
+        _apply_profile_override()
+
+        result = os.environ.get("HERMES_HOME")
+        assert result is not None
+        assert result.endswith("briefer"), (
+            f"expected scratch's own profile, got {result!r}"
+        )
+
+    def test_profile_dir_home_is_trusted_as_before(self, tmp_path, monkeypatch):
+        """Regression: HERMES_HOME already pointing at a profile dir is still
+        trusted verbatim (issue #22502 inheritance contract)."""
+        prod = tmp_path / "prod" / ".hermes"
+        prod.mkdir(parents=True)
+        (prod / "active_profile").write_text("coder")
+        (prod / "profiles" / "coder").mkdir(parents=True)
+
+        profile_dir = tmp_path / "scratch" / ".hermes" / "profiles" / "coder"
+        profile_dir.mkdir(parents=True)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "prod")
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(sys, "argv", ["hermes", "chat"])
+
+        for var in (
+            "HERMES_SUPERVISED_CHILD",
+            "HERMES_S6_SUPERVISED_CHILD",
+            "INVOCATION_ID",
+            "HERMES_GATEWAY_EXTERNAL_SUPERVISOR",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+        from hermes_cli.main import _apply_profile_override
+
+        _apply_profile_override()
+
+        result = os.environ.get("HERMES_HOME")
+        assert result == str(profile_dir)


### PR DESCRIPTION
## Problem

`_apply_profile_override()` (hermes_cli/main.py) honored an operator-set ``HERMES_HOME`` **only** when its parent directory was named ``profiles/``. Any ``HERMES_HOME`` whose parent was not called ``profiles`` — e.g. a throwaway e2e scratch home at ``/tmp/hermes-<hash>`` or ``/tmp/.hermes`` — was silently ignored. The CLI then fell through to reading the production root's sticky ``active_profile`` and redirected into the **live** profile tree, defeating the isolation contract entirely.

Consequence: on 2026-09-02 every 'isolated' e2e run that pinned ``HERMES_HOME`` to a scratch dir actually hit PRODUCTION, spraying junk webhook cards onto the live kanban board and wasting dispatcher budget.

## Fix

Treat an explicitly set ``HERMES_HOME`` as authoritative. Return immediately when it names a ``profiles/<name>`` dir (issue #22502 inheritance contract preserved), and when it names any other root, honor only that root's own ``active_profile`` — never fall through to step 2 and read the production sticky file. A bare /tmp scratch home with no ``active_profile`` now stays isolated at its scratch home instead of redirecting into the live profile.

## Tests

Added `TestScratchHomeIsolation` (3 cases) to `tests/hermes_cli/test_apply_profile_override.py`:
- scratch home with no own `active_profile` stays isolated (the regression)
- scratch home with its own `active_profile` honors it, scoped to that root only
- profile-dir home is still trusted verbatim (issue #22502 regression guard)

Verified: all cases pass on this branch; the isolation case fails against the pre-fix code.