### PR TITLE
fix(vision): explain 403 model_access_denied as a base_url entitlement problem

### DIFF
--- a/contributors/emails/itsflownium@users.noreply.github.com
+++ b/contributors/emails/itsflownium@users.noreply.github.com
@@ -1,0 +1,1 @@
+itsflownium

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -702,6 +702,43 @@ class TestErrorClassification:
         assert "rejected the image" in result["analysis"].lower()
         assert "smaller" in result["analysis"].lower()
 
+    @pytest.mark.asyncio
+    async def test_model_access_denied_points_at_base_url_entitlement(self, tmp_path):
+        """#100897: a 403 model_access_denied is a routing/entitlement problem.
+
+        The raw provider error blames the model name; the friendly mapping
+        must steer the reader toward the base_url/key-entitlement pairing
+        instead of letting the request fall through to the generic hint.
+        """
+        img = tmp_path / "test.png"
+        img.write_bytes(VALID_PNG + b"\x00" * 8)
+
+        api_error = Exception(
+            "Error code: 403 - {'error': {'code': 'model_access_denied', "
+            "'message': 'No permission to access model: glm-5.3'}}"
+        )
+
+        with (
+            patch(
+                "tools.vision_tools._image_to_base64_data_url",
+                return_value="data:image/png;base64,abc",
+            ),
+            patch(
+                "tools.vision_tools.async_call_llm",
+                new_callable=AsyncMock,
+                side_effect=api_error,
+            ),
+        ):
+            result = json.loads(await vision_analyze_tool(str(img), "describe", "glm-5.3"))
+
+        assert result["success"] is False
+        analysis = result["analysis"].lower()
+        assert "denied access" in analysis
+        assert "base_url" in analysis
+        assert "not a bad model name" in analysis
+        # It must NOT fall into the generic catch-all.
+        assert "there was a problem with the request" not in analysis
+
 
 class TestVisionRegistration:
     def test_vision_analyze_registered_with_schema(self):

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1703,6 +1703,26 @@ async def vision_analyze_tool(
                 f"{model} does not support vision or our request was not "
                 f"accepted by the server. Error: {e}"
             )
+        elif any(hint in err_str for hint in (
+            "model_access_denied", "permission denied", "permissiondenied",
+            "no permission to access model", "403",
+        )):
+            # A 403 / model_access_denied from an OpenAI-wire surface usually
+            # means the KEY is not entitled to the surface the request landed
+            # on, not that the model name is wrong (#100897: a coding-plan
+            # key configured against an /anthropic base_url was routed to a
+            # general OpenAI-wire endpoint it had no access to, and the raw
+            # error blamed the model for two months). Point at the base_url /
+            # entitlement pairing so the next reader checks routing first.
+            analysis = (
+                f"The vision provider denied access to {model} (403 / "
+                "model_access_denied). This is usually an entitlement or "
+                "routing problem, not a bad model name: check that your "
+                "auxiliary.vision base_url points at the surface your API key "
+                "is entitled to (Anthropic-wire /anthropic endpoints are "
+                "rewritten to the provider's OpenAI-wire sibling for vision), "
+                f"and that the key has access to this model there. Error: {e}"
+            )
         elif "invalid_request" in err_str or "image_url" in err_str:
             analysis = (
                 "The vision API rejected the image. This can happen when the "


### PR DESCRIPTION
## What this PR does

Closes #100897 (the reachable remainder of it — see "Routing already fixed on main" below).

### Root cause (routing) — already fixed on `main`
The reporter's checkout was `b177d4ee4` (2026-06-25). At that commit `_to_openai_base_url()` unconditionally rewrote any `…/anthropic` base_url to `…/v1`, so `https://api.z.ai/api/anthropic` became `https://api.z.ai/api/v1` — a surface a coding-plan key is not entitled to → `403 model_access_denied` on 100% of vision calls.

Current `main` already has the routing fix: `0d24c4f41` (rewrite only for dual-surface hosts), `ddbef9cd7` (ZAI Coding Plan routing → `/api/coding/paas/v4`), and `2d9f11635` (host-anchored matching). `api.z.ai/api/anthropic` now maps to `api.z.ai/api/coding/paas/v4` — exactly the surface the reporter's probe table shows returning 200 — and Anthropic-only gateways keep their path. `tests/agent/test_minimax_auxiliary_url.py::test_zai_anthropic_routes_to_coding_plan_openai_endpoint` pins it.

### What was still broken — the error surface (this PR)
The issue's third item: a `403 model_access_denied` fell through `vision_analyze_tool`'s friendly-error mapping to the generic *"There was a problem with the request"* branch, and the raw provider text blames the **model name**. That sent three separate debugging passes (two LLM auditors and a human) down a "wrong model string" path for ~2 months.

`tools/vision_tools.py` now maps `model_access_denied` / `permission denied` / `no permission to access model` / `403` to a hint that says this is an **entitlement/routing** problem — check that `auxiliary.vision.base_url` points at the surface the key is entitled to (and that `/anthropic` endpoints are rewritten to the provider's OpenAI-wire sibling) — rather than a bad model name. Ordered after the 402/billing and "does not support vision" branches so their existing behavior is unchanged.

### Tests
- `tests/tools/test_vision_tools.py::TestVisionAnalyzeToolErrors::test_model_access_denied_points_at_base_url_entitlement` — drives `vision_analyze_tool` with the exact 403 body from the issue and asserts the entitlement hint (and that it does **not** fall into the generic catch-all).

Ran: `uv run python -m pytest tests/tools/test_vision_tools.py tests/agent/test_minimax_auxiliary_url.py tests/agent/test_auxiliary_explicit_base_anthropic.py -o 'addopts=' -q` → **55 passed**.

### Not done / follow-up
The issue's option 1 (treat a raw `/anthropic` base_url as an explicit opt-in to the Anthropic wire for vision) would be a larger routing-policy change and is already partially covered by `api_mode: anthropic_messages` on custom providers; left out of this PR on purpose to keep it minimal.
