### PR TITLE
fix(gemini): key streaming tool call slots on explicit id to prevent argument collisions

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -923,21 +923,25 @@ def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices:
             except (TypeError, ValueError):
                 args_str = "{}"
             thought_signature = part.get("thoughtSignature") if isinstance(part.get("thoughtSignature"), str) else ""
-            call_key = json.dumps(
-                {
-                    "part_index": part_index,
-                    "name": name,
-                    "thought_signature": thought_signature,
-                },
-                sort_keys=True,
-            )
+            call_id = str(fc["id"]).strip() if isinstance(fc.get("id"), str) and fc.get("id") else ""
+            if call_id:
+                call_key = f"id:{call_id}"
+            else:
+                call_key = json.dumps(
+                    {
+                        "part_index": part_index,
+                        "name": name,
+                        "thought_signature": thought_signature,
+                    },
+                    sort_keys=True,
+                )
             slot = tool_call_indices.get(call_key)
             if slot is None:
                 slot = {
                     "index": len(tool_call_indices),
                     "id": (
-                        str(fc["id"])
-                        if isinstance(fc.get("id"), str) and fc.get("id")
+                        call_id
+                        if call_id
                         else f"call_{uuid.uuid4().hex[:12]}"
                     ),
                     "last_arguments": "",

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -568,6 +568,30 @@ class TestGemini3ToolCallIds:
         tool_calls = result.choices[0].message.tool_calls
         assert tool_calls[0].id.startswith("call_")
 
+    def test_translate_stream_event_multiple_calls_same_name(self):
+        from agent.gemini_native_adapter import translate_stream_event
+
+        events = [
+            {"candidates": [{"content": {"parts": [{"functionCall": {"name": "skill_view", "args": {"name": "a"}, "id": "call_1"}, "thoughtSignature": "sig1"}]}}]},
+            {"candidates": [{"content": {"parts": [{"functionCall": {"name": "skill_view", "args": {"name": "b"}, "id": "call_2"}}]}}]},
+            {"candidates": [{"content": {"parts": [{"functionCall": {"name": "skill_view", "args": {"name": "c"}, "id": "call_3"}}]}}]},
+            {"candidates": [{"content": {"parts": [{"text": ""}]}, "finishReason": "STOP"}]},
+        ]
+        tool_call_indices = {}
+        all_chunks = []
+        for ev in events:
+            all_chunks.extend(translate_stream_event(ev, "gemini-3.8-flash", tool_call_indices))
+
+        deltas = [
+            c.choices[0].delta.tool_calls[0]
+            for c in all_chunks
+            if c.choices[0].delta.tool_calls
+        ]
+        assert len(deltas) == 3
+        assert [d.index for d in deltas] == [0, 1, 2]
+        assert [d.id for d in deltas] == ["call_1", "call_2", "call_3"]
+        assert [json.loads(d.function.arguments) for d in deltas] == [{"name": "a"}, {"name": "b"}, {"name": "c"}]
+
 
 # ---------------------------------------------------------------------------
 # Multimodal tool results: image embedding in functionResponse.parts


### PR DESCRIPTION
## Summary
- Fixes an issue in `agent/gemini_native_adapter.py` where parallel streaming tool calls from Gemini 3+ models collide on the same tool slot index.
- Gemini 3+ emits parallel tool calls in separate SSE chunks, each with `part_index=0` and a unique `id` (e.g. `call_1`, `call_2`). Previously, `translate_stream_event` keyed slot indices on `(part_index, name, thought_signature)` and ignored `fc["id"]`. When multiple parallel calls shared the same tool name, they were assigned the same slot index and their JSON argument strings were concatenated, triggering unparseable JSON and repeated max-token retries.
- Key tool call slots on `fc["id"]`, falling back to part index / signature when IDs are absent.

## Test Plan
- Added `test_translate_stream_event_multiple_calls_same_name` in `tests/agent/test_gemini_native_adapter.py` verifying multiple tool calls with the same function name across stream chunks maintain distinct slot indices and uncorrupted JSON payloads.