### PR TITLE
feat(tui): append a 'Hermes <state>' segment to the terminal title so agent-aware terminals (Orca) show live status

### DIFF
--- a/ui-tui/src/__tests__/paths.test.ts
+++ b/ui-tui/src/__tests__/paths.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { composeTabTitle, fmtCwdBranch, fmtProjectCwdBranch, shortCwd, shortProject } from '../domain/paths.js'
+import {
+  AGENT_STATE_WORDS,
+  composeTabTitle,
+  fmtCwdBranch,
+  fmtProjectCwdBranch,
+  shortCwd,
+  shortProject
+} from '../domain/paths.js'
 
 describe('shortCwd', () => {
   const origHome = process.env.HOME
@@ -104,8 +111,10 @@ describe('fmtProjectCwdBranch', () => {
 })
 
 describe('composeTabTitle', () => {
-  it('joins marker, name, model, and cwd in order', () => {
-    expect(composeTabTitle('✓', 'auth refactor', 'opus-4', '~/proj')).toBe('✓ auth refactor · opus-4 · ~/proj')
+  it('joins marker, name, model, cwd, and the agent-state tail in order', () => {
+    expect(composeTabTitle('✓', 'auth refactor', 'opus-4', '~/proj')).toBe(
+      '✓ auth refactor · opus-4 · ~/proj · Hermes ready'
+    )
   })
 
   it('glues the marker to the first segment with a space, not a separator', () => {
@@ -113,19 +122,23 @@ describe('composeTabTitle', () => {
   })
 
   it('omits the session name when empty (matches the pre-name format)', () => {
-    expect(composeTabTitle('✓', '', 'opus-4', '~/proj')).toBe('✓ opus-4 · ~/proj')
+    expect(composeTabTitle('✓', '', 'opus-4', '~/proj')).toBe('✓ opus-4 · ~/proj · Hermes ready')
   })
 
   it('treats a whitespace-only name as absent', () => {
-    expect(composeTabTitle('✓', '   ', 'opus-4', '~/proj')).toBe('✓ opus-4 · ~/proj')
+    expect(composeTabTitle('✓', '   ', 'opus-4', '~/proj')).toBe('✓ opus-4 · ~/proj · Hermes ready')
   })
 
   it('omits the cwd when empty', () => {
-    expect(composeTabTitle('✓', 'my session', 'opus-4', '')).toBe('✓ my session · opus-4')
+    expect(composeTabTitle('✓', 'my session', 'opus-4', '')).toBe('✓ my session · opus-4 · Hermes ready')
   })
 
-  it('falls back to just the marker when only the marker is present', () => {
-    expect(composeTabTitle('✓', '', '', '')).toBe('✓')
+  it('still carries the agent-state tail when every human segment is absent', () => {
+    expect(composeTabTitle('✓', '', '', '')).toBe('✓ Hermes ready')
+  })
+
+  it('falls back to just the marker for an unknown marker with no segments', () => {
+    expect(composeTabTitle('?', '', '', '')).toBe('?')
   })
 
   it('truncates an over-long session name with an ellipsis', () => {
@@ -139,6 +152,30 @@ describe('composeTabTitle', () => {
   it('keeps a name at the boundary length intact', () => {
     const name = 'b'.repeat(28)
     const out = composeTabTitle('✓', name, 'opus-4', '', 28)
-    expect(out).toBe(`✓ ${name} · opus-4`)
+    expect(out).toBe(`✓ ${name} · opus-4 · Hermes ready`)
+  })
+
+  describe('agent-aware terminal contract (Orca and friends read words, not glyphs)', () => {
+    it.each([
+      ['⏳', 'working'],
+      ['⚠', 'waiting'],
+      ['✓', 'ready']
+    ])('maps %s to a trailing "Hermes %s" segment', (marker, word) => {
+      const out = composeTabTitle(marker, 'sess', 'm', '~/x')
+      expect(out.endsWith(` · Hermes ${word}`)).toBe(true)
+      expect(AGENT_STATE_WORDS[marker]).toBe(word)
+    })
+
+    it('puts the tail LAST so narrow tab bars clip it before the session name', () => {
+      const out = composeTabTitle('⏳', 'sess', 'm', '~/x')
+      expect(out.indexOf('sess')).toBeLessThan(out.indexOf('Hermes working'))
+    })
+
+    it('emits the agent name as a standalone word (token match, never a path fragment)', () => {
+      // Orca's HERMES_AGENT_NAME_RE refuses `hermes` glued to [\w./\\-]; the
+      // ` · ` separator on the left and a space on the right keep it a clean token.
+      const out = composeTabTitle('⏳', 'sess', 'm', '~/hermes-work')
+      expect(out).toMatch(/(?<![\w./\\-])Hermes(?![\w./\\-])/)
+    })
   })
 })

--- a/ui-tui/src/domain/paths.ts
+++ b/ui-tui/src/domain/paths.ts
@@ -45,13 +45,29 @@ export const fmtProjectCwdBranch = (cwd: string, branch: null | string, projectN
 
 /**
  * Compose the terminal titlebar string:
- *   `<marker> <session name> · <model> · <cwd>`
+ *   `<marker> <session name> · <model> · <cwd> · Hermes <state>`
  *
  * The session name and cwd are each omitted when empty, and a long session
  * name is truncated. The marker is always glued to the first present segment
  * with a plain space (not a ` · ` separator). When no model is known yet the
  * caller should fall back to a plain brand string instead of calling this.
+ *
+ * The trailing `Hermes <state>` segment is for agent-aware terminals (Orca,
+ * and any host that classifies agent panes by OSC title). Those hosts key on
+ * the word `hermes` to recognise the pane and on plain English state words
+ * (`working` / `waiting` / `ready`) to pick a status glyph — they do not
+ * read our `⏳ ⚠ ✓` markers. Human-first segments stay in front so a narrow
+ * tab bar still shows marker + session name; the machine-readable tail is
+ * what gets clipped first.
  */
+
+/** Human marker → the status word agent-aware terminals understand. */
+export const AGENT_STATE_WORDS: Readonly<Record<string, string>> = {
+  '⏳': 'working',
+  '⚠': 'waiting',
+  '✓': 'ready'
+}
+
 export const composeTabTitle = (
   marker: string,
   sessionName: string,
@@ -61,8 +77,10 @@ export const composeTabTitle = (
 ): string => {
   const name = sessionName.trim()
   const shortName = name.length > maxName ? `${name.slice(0, maxName - 1)}…` : name
+  const stateWord = AGENT_STATE_WORDS[marker]
+  const agentTail = stateWord ? `Hermes ${stateWord}` : ''
 
-  const segments = [shortName, model, cwd].filter(Boolean)
+  const segments = [shortName, model, cwd, agentTail].filter(Boolean)
 
   return segments.length ? `${marker} ${segments.join(' · ')}` : marker
 }


### PR DESCRIPTION
## What does this PR do?

Makes the Ink TUI's terminal title legible to **agent-aware terminal hosts** — Orca (onorca.dev) today, and any host that classifies agent panes from the OSC title — so a Hermes pane shows live *working / needs-you / idle* status instead of "plain shell, no agent".

**Problem.** The TUI already writes a rich title via `useTerminalTitle` (`⏳ <session> · <model> · <cwd>`, `⚠` when waiting on approval/clarify, `✓` idle). Orca's detector (`src/shared/agent-title-status.ts` on their `main`) works differently:

1. It first asks *"is this an agent I know?"* by **token-matching the agent name** — it has a `HERMES_AGENT_NAME_RE`, but the word `hermes` only appears in our title before the first model loads (the bare `'Hermes'` fallback). After that the pane is classified as not-an-agent and ignored.
2. Even for a recognized pane it derives state from **English keywords** (`working/thinking/running`, `ready/idle/done`, `waiting/permission`) plus a few agents' own glyphs it was taught (Claude `✳`, Gemini `✦ ◇ ✋`). Our `⏳ ⚠ ✓` mean nothing to it.

Net effect: on Orca (local or over SSH) a Hermes tab never gets a status glyph, never lands in the "Needs You" column, never fires a done notification. Orca tracks this as stablyai/orca#15110 ("no status integration exists at all" for Hermes).

**Fix.** `composeTabTitle` appends one trailing segment, `· Hermes <state>`, with `⏳→working`, `⚠→waiting`, `✓→ready`:

```
before:  ⏳ pdf ingest diagnosis · claude-sonnet-4 · ~/proj
after:   ⏳ pdf ingest diagnosis · claude-sonnet-4 · ~/proj · Hermes working
```

Design choices:
- **Human-first ordering preserved.** Marker + session name stay at the front, so a narrow tab bar still shows what people read today; the machine-readable tail is what gets clipped first. Nothing that existed in the title moved.
- **Words Orca already understands, no new protocol.** `ready` rather than `idle`/`done` because Orca treats `done` as turn-completion (fires a notification) — an idle prompt is not a completion event. `waiting` maps to their `permission` state → "Needs You" column, which is exactly what `⚠` means for us.
- **Token-safe.** The ` · ` separator on the left and a space on the right keep `Hermes` a standalone word; Orca deliberately refuses `hermes` glued to path characters (`~/hermes/working`), and a test pins that.
- **Unknown marker → no tail**, so the function's fallback behaviour for callers passing other markers is unchanged.

## Related Issue

Upstream (Orca side): stablyai/orca#15110 — this PR is the "Hermes emits something Orca can read" half; a companion Orca-side change teaching their detector our glyphs is being filed separately so either side alone fixes it.
Adjacent, not duplicate: #74654 adds a title lifecycle to the **classic** prompt_toolkit CLI; this PR touches only the Ink TUI's existing composer.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `ui-tui/src/domain/paths.ts` — `composeTabTitle` gains the trailing `Hermes <state>` segment; new exported `AGENT_STATE_WORDS` map (marker → word); doc comment explains the contract and why the tail is last.
- `ui-tui/src/__tests__/paths.test.ts` — existing `composeTabTitle` expectations updated to the new format; new cases pin the three marker→word mappings, the tail-is-last ordering, the standalone-token guarantee, and unknown-marker fallback.

No config keys, no Python changes, no docs pages describe the title format (checked `website/`).

## How to Test

1. `cd ui-tui && npm run build:ink && npx vitest run src/__tests__/paths.test.ts` — 28 tests pass (was 25).
2. `npm run typecheck && npx eslint src/domain/paths.ts src/__tests__/paths.test.ts && npx prettier --check src/domain/paths.ts src/__tests__/paths.test.ts` — clean.
3. Live: `npm run build`, launch `hermes` (TUI) under a pty and capture OSC sequences. Observed from this branch on macOS:
   ```
   OSC 0: 'Hermes'                                                         (pre-model fallback, unchanged)
   OSC 1: '✓ Hermes ready'                                                 (tab title)
   OSC 2: '✓ claude-sonnet-4 · …gentSpace/ai-native-org · Hermes ready'    (window title)
   ```
4. Cross-checked against Orca's detector by running their `agent-title-status.ts` (fetched from `main`) over the emitted titles:
   ```
   '⏳ … · Hermes working'   → agent: true, status: working
   '⚠ … · Hermes waiting'   → agent: true, status: permission   (→ "Needs You")
   '✓ … · Hermes ready'     → agent: true, status: idle
   '⏳ pdf ingest · claude-sonnet-4 · ~/proj'   (today's format) → agent: false, status: null
   ```
5. Full `ui-tui` vitest suite: 3 pre-existing failing files on untouched `main` (`subscriptionOverlay`, `appChromeBlockedTimers`, `ink-backpressure`), identical count before/after this change; `paths.test.ts` is the only file touched.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant test suite — TUI change, so `ui-tui` vitest (Python `pytest tests/` untouched by this diff)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5 (Mac mini), Hermes launched both locally and as an Orca SSH agent tab

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — doc comment on `composeTabTitle`; no docs page describes the title format
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure string composition; the Windows branch of `useTerminalTitle` (`process.title`) receives the same string
