### PR TITLE
fix(cli): skip wrapper-side MCP discovery when chat resolves to the TUI (salvage #81310)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12791,7 +12791,19 @@ _AGENT_SUBCOMMANDS = {
 
 
 def _is_tui_chat_launch(args) -> bool:
-    return bool(getattr(args, "tui", False) or os.environ.get("HERMES_TUI") == "1")
+    if getattr(args, "tui", False) or os.environ.get("HERMES_TUI") == "1":
+        return True
+    # The chat path decides TUI-vs-classic via _resolve_use_tui (--cli/--tui
+    # flags, TTY gate, HERMES_TUI env, display.interface config). Bare
+    # `hermes`/`hermes chat` with a TUI display config was previously missed
+    # here, so the wrapper pre-warmed its own MCP discovery while the TUI
+    # gateway (spawned moments later) ran a second one — an idle stdio MCP
+    # server copy held dead for the whole session. Only chat commands can
+    # launch the TUI; other commands (mcp serve, gateway, acp, cron) keep
+    # their own discovery behavior untouched.
+    if getattr(args, "command", None) not in {None, "chat"}:
+        return False
+    return _resolve_use_tui(args)
 
 
 def _command_has_dedicated_mcp_startup(args) -> bool:

--- a/tests/hermes_cli/test_mcp_startup.py
+++ b/tests/hermes_cli/test_mcp_startup.py
@@ -102,6 +102,96 @@ def test_prepare_agent_startup_backgrounds_blocking_mcp_for_chat(monkeypatch):
         stop.set()
 
 
+def test_prepare_agent_startup_skips_discovery_when_chat_resolves_to_tui(
+    monkeypatch,
+):
+    """Bare ``hermes`` / ``hermes chat`` on a TTY with ``display.interface:
+    tui`` resolves to the TUI via ``_resolve_use_tui``, but does NOT pass
+    ``--tui`` or ``HERMES_TUI``. Discovery must be skipped in the wrapper:
+    the TUI gateway owns it, and the wrapper would otherwise hold a dead
+    MCP server for the entire session (3 copies per TUI instance).
+    """
+    calls = {"background": 0, "inline": 0}
+
+    monkeypatch.setattr(main_mod, "_resolve_use_tui", lambda _args: True)
+    monkeypatch.setattr(
+        mcp_startup,
+        "start_background_mcp_discovery",
+        lambda **_kwargs: calls.__setitem__("background", calls["background"] + 1),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        types.SimpleNamespace(discover_plugins=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        types.SimpleNamespace(
+            read_raw_config=lambda: {"mcp_servers": {"demo": {"transport": "stdio"}}},
+            load_config=lambda: {},
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.shell_hooks",
+        types.SimpleNamespace(register_from_config=lambda *_a, **_k: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool",
+        types.SimpleNamespace(
+            discover_mcp_tools=lambda: calls.__setitem__("inline", calls["inline"] + 1),
+        ),
+    )
+
+    main_mod._prepare_agent_startup(_agent_args(command=None))
+
+    assert calls["background"] == 0
+    assert calls["inline"] == 0
+    assert mcp_startup._mcp_discovery_thread is None
+
+
+def test_prepare_agent_startup_keeps_discovery_for_non_chat_commands(
+    monkeypatch,
+):
+    """Non-chat commands never launch the TUI, so they must keep their own
+    MCP discovery even when the ambient display config resolves to TUI —
+    ``_is_tui_chat_launch`` must not consult ``_resolve_use_tui`` there."""
+    calls = {"inline": 0}
+
+    monkeypatch.setattr(main_mod, "_resolve_use_tui", lambda _args: True)
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        types.SimpleNamespace(discover_plugins=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        types.SimpleNamespace(
+            read_raw_config=lambda: {"mcp_servers": {"demo": {"transport": "stdio"}}},
+            load_config=lambda: {},
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.shell_hooks",
+        types.SimpleNamespace(register_from_config=lambda *_a, **_k: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool",
+        types.SimpleNamespace(
+            discover_mcp_tools=lambda: calls.__setitem__("inline", calls["inline"] + 1),
+        ),
+    )
+
+    main_mod._prepare_agent_startup(_agent_args(command="mcp", mcp_action="serve"))
+
+    assert calls["inline"] == 1
+
+
 def test_background_mcp_discovery_suppresses_interactive_oauth(monkeypatch):
     state = {"active": False, "during_discover": None}
 


### PR DESCRIPTION
## Summary
Bare `hermes` / `hermes chat` with `display.interface: tui` no longer pre-warms the wrapper's own MCP discovery — the TUI gateway spawned moments later is the one that connects, so each stdio MCP server is started once instead of twice.

Salvaged from #81310 by @m1k3s0 (cherry-picked, authorship preserved) onto current `main`.

## Who hits this / when / why it matters
Anyone whose config selects the TUI (the default for interactive terminals) and has stdio MCP servers. `_is_tui_chat_launch` only recognised `--tui` / `HERMES_TUI=1`, not the config/TTY resolution `_resolve_use_tui` performs, so the wrapper process ran a full MCP discovery and then handed off to the TUI gateway which ran another. The wrapper's copy of every stdio server sat idle for the whole session.

## What changed
- `hermes_cli/main.py::_is_tui_chat_launch`: for chat commands (`None` / `chat`), defer to `_resolve_use_tui(args)`; every other command (`mcp serve`, `gateway`, `acp`, `cron`) keeps its own discovery behaviour untouched. +14/−1.
- `tests/hermes_cli/test_mcp_startup.py`: +90 lines covering bare launch with TUI config, `--cli` override, non-TTY, and non-chat commands.

## Verification
| | before (main) | after |
|---|---|---|
| stdio MCP discovery runs on bare `hermes` with TUI config | 2 (wrapper + TUI gateway) | **1** |
| `tests/hermes_cli/test_mcp_startup.py` | — | 14 passed |

Premise reproduced by probe on `main` before salvage (wrapper backgrounded its own discovery with `display.interface: tui`); ruff clean.

## Provenance
Salvaged from #81310 by @m1k3s0 — single commit cherry-picked with authorship preserved. AUTHOR_MAP already contains the contributor.
