### PR TITLE
fix(auth): skip the forked-grant heal when a profile auth.json is the root store (salvage #101586)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1260,6 +1260,23 @@ def _same_path(left: Path, right: Path) -> bool:
         return left == right
 
 
+def _is_same_auth_store(left: Path, right: Path) -> bool:
+    """True when two auth paths name ONE store rather than two copies.
+
+    ``_same_path`` already resolves symlinks and ``..`` segments; a hardlinked
+    (or bind-mounted) alias keeps two distinct resolved names for one inode, so
+    fall back to filesystem identity. Used by the forked-grant heal: a shared
+    store has no "other side" to consolidate (#101356).
+    """
+    if _same_path(left, right):
+        return True
+    try:
+        left_stat, right_stat = left.stat(), right.stat()
+    except OSError:
+        return False
+    return (left_stat.st_dev, left_stat.st_ino) == (right_stat.st_dev, right_stat.st_ino)
+
+
 def _auth_lock_holder_for(target_path: Path) -> threading.local:
     """Return a reentrancy tracker keyed to one canonical auth-store path."""
     try:
@@ -2005,6 +2022,17 @@ def _heal_forked_single_use_oauth_grants(provider_id: str) -> Optional[Dict[str,
         if real_home_env and _same_path(root_path, Path(real_home_env) / ".hermes" / "auth.json"):
             return None
     profile_path = _auth_file_path()
+    if _is_same_auth_store(profile_path, root_path):
+        # The profile's auth.json IS the root store (symlink, hardlink, or any
+        # other alias — a deliberate way to share one grant across profiles).
+        # Both "sides" of the consolidation below would read the same file, so
+        # every OAuth row would match itself as its own fork and the strip
+        # would write through the alias and delete the shared credential.
+        # A shared store has nothing to consolidate (#101356).
+        logger.debug(
+            "%s: forked-OAuth heal skipped, %s is the root store", provider_id, profile_path
+        )
+        return None
     profile_home = profile_path.parent
     root_home = root_path.parent
     profile_singleton = profile_home / ".anthropic_oauth.json" if provider_id == "anthropic" else None

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1263,18 +1263,17 @@ def _same_path(left: Path, right: Path) -> bool:
 def _is_same_auth_store(left: Path, right: Path) -> bool:
     """True when two auth paths name ONE store rather than two copies.
 
-    ``_same_path`` already resolves symlinks and ``..`` segments; a hardlinked
-    (or bind-mounted) alias keeps two distinct resolved names for one inode, so
-    fall back to filesystem identity. Used by the forked-grant heal: a shared
-    store has no "other side" to consolidate (#101356).
+    ``_same_path`` resolves symlinks and ``..``; ``samefile`` adds hardlinks
+    and bind-mounts (same inode under two resolved names). Used by the
+    forked-grant heal: a shared store has no "other side" to consolidate
+    (#101356).
     """
     if _same_path(left, right):
         return True
     try:
-        left_stat, right_stat = left.stat(), right.stat()
+        return left.samefile(right)
     except OSError:
         return False
-    return (left_stat.st_dev, left_stat.st_ino) == (right_stat.st_dev, right_stat.st_ino)
 
 
 def _auth_lock_holder_for(target_path: Path) -> threading.local:
@@ -2022,17 +2021,6 @@ def _heal_forked_single_use_oauth_grants(provider_id: str) -> Optional[Dict[str,
         if real_home_env and _same_path(root_path, Path(real_home_env) / ".hermes" / "auth.json"):
             return None
     profile_path = _auth_file_path()
-    if _is_same_auth_store(profile_path, root_path):
-        # The profile's auth.json IS the root store (symlink, hardlink, or any
-        # other alias — a deliberate way to share one grant across profiles).
-        # Both "sides" of the consolidation below would read the same file, so
-        # every OAuth row would match itself as its own fork and the strip
-        # would write through the alias and delete the shared credential.
-        # A shared store has nothing to consolidate (#101356).
-        logger.debug(
-            "%s: forked-OAuth heal skipped, %s is the root store", provider_id, profile_path
-        )
-        return None
     profile_home = profile_path.parent
     root_home = root_path.parent
     profile_singleton = profile_home / ".anthropic_oauth.json" if provider_id == "anthropic" else None
@@ -2051,6 +2039,16 @@ def _heal_forked_single_use_oauth_grants(provider_id: str) -> Optional[Dict[str,
         return None
     if fingerprint[1] is None and fingerprint[2] is None:
         _oauth_heal_clean_marks[provider_id] = fingerprint
+        return None
+    if _is_same_auth_store(profile_path, root_path):
+        # The profile's auth.json IS the root store (symlink/hardlink alias —
+        # a deliberate way to share one grant). Both "sides" below would read
+        # the same file, every OAuth row would match itself, and the strip
+        # would write through the alias and delete the shared credential.
+        # Nothing to consolidate (#101356); the mtime mark keeps this off the
+        # per-call hot path until the shared file changes.
+        _oauth_heal_clean_marks[provider_id] = fingerprint
+        logger.debug("%s: forked-OAuth heal skipped, %s is the root store", provider_id, profile_path)
         return None
 
     summary: Dict[str, Any] = {"adopted": False, "stripped_ids": [], "files": [], "providers_block": False}
@@ -2142,7 +2140,13 @@ def _heal_forked_single_use_oauth_grants(provider_id: str) -> Optional[Dict[str,
                         summary["providers_block"] = True
 
             # ── profile-local .anthropic_oauth.json singleton ───────────
-            if profile_singleton is not None and profile_singleton.exists():
+            if (
+                profile_singleton is not None
+                and profile_singleton.exists()
+                # An aliased singleton pair is one shared grant, not a fork
+                # (#101356): never self-compare or unlink it.
+                and not (root_singleton is not None and _is_same_auth_store(profile_singleton, root_singleton))
+            ):
                 p_single = _singleton_as_row(profile_singleton)
                 root_has_grant = bool(r_oauth) or root_singleton_row is not None
                 if p_single is not None and root_has_grant:

--- a/tests/agent/test_credential_pool_profile_oauth_fork.py
+++ b/tests/agent/test_credential_pool_profile_oauth_fork.py
@@ -450,3 +450,71 @@ def test_heal_is_a_noop_in_classic_mode(fleet):
     before = (fleet["root"] / "auth.json").read_text()
     assert heal_forked_single_use_oauth_grants("anthropic") is None
     assert (fleet["root"] / "auth.json").read_text() == before
+
+
+# ── C. a SHARED root store is not a fork (#101356) ───────────────────────
+
+def _seed_codex_grant(root):
+    """Give the root store an openai-codex pool row AND a providers block."""
+    fresh = int((time.time() + 3600) * 1000)
+    store = json.loads((root / "auth.json").read_text())
+    store["credential_pool"]["openai-codex"] = [{
+        "id": "cdx001", "label": "codex", "auth_type": "oauth", "priority": 0,
+        "source": "manual:device_code", "access_token": "cdx-AT0",
+        "refresh_token": "cdx-RT0", "expires_at_ms": fresh,
+    }]
+    store["providers"]["openai-codex"] = {
+        "tokens": {"access_token": "cdx-AT0", "refresh_token": "cdx-RT0", "expires_at_ms": fresh},
+        "last_refresh": fresh / 1000.0,
+    }
+    (root / "auth.json").write_text(json.dumps(store))
+
+
+def _shared_profile(fleet, name, *, link):
+    """Profile whose auth.json IS the root store (``link`` makes the alias)."""
+    pdir = _profile(fleet, name)
+    pdir.mkdir(parents=True, exist_ok=True)
+    alias = pdir / "auth.json"
+    if alias.is_symlink() or alias.exists():
+        alias.unlink()
+    link(fleet["root"] / "auth.json", alias)
+    return pdir
+
+
+def test_heal_skips_profile_auth_json_symlinked_to_the_root_store(fleet):
+    """#101356: `ln -s ~/.hermes/auth.json <profile>/auth.json` shares ONE store.
+    Both sides of the consolidation read the same file, so every row looks like
+    a fork of itself — healing would strip the shared grant through the link."""
+    from hermes_cli.auth import consume_oauth_heal_notices, heal_forked_single_use_oauth_grants
+
+    root = fleet["root"]
+    _seed_codex_grant(root)
+    before = (root / "auth.json").read_text()
+
+    shared = _shared_profile(fleet, "shared", link=lambda target, alias: alias.symlink_to(target))
+    fleet["use"](shared)
+
+    assert heal_forked_single_use_oauth_grants("openai-codex") is None
+    assert (root / "auth.json").read_text() == before
+    assert (shared / "auth.json").is_symlink()
+    assert consume_oauth_heal_notices() == []
+    store = json.loads((root / "auth.json").read_text())
+    assert [r["id"] for r in store["credential_pool"]["openai-codex"]] == ["cdx001"]
+    assert store["providers"]["openai-codex"]["tokens"]["refresh_token"] == "cdx-RT0"
+
+
+def test_heal_skips_profile_auth_json_hardlinked_to_the_root_store(fleet):
+    """Same class as the symlink: a hardlink resolves to a different name but
+    is the same inode, so it is still one store, not a forked copy."""
+    from hermes_cli.auth import heal_forked_single_use_oauth_grants
+
+    root = fleet["root"]
+    _seed_codex_grant(root)
+    before = (root / "auth.json").read_text()
+
+    shared = _shared_profile(fleet, "twin", link=lambda target, alias: os.link(target, alias))
+    fleet["use"](shared)
+
+    assert heal_forked_single_use_oauth_grants("openai-codex") is None
+    assert (root / "auth.json").read_text() == before
+    assert (shared / "auth.json").samefile(root / "auth.json")

--- a/tests/agent/test_credential_pool_profile_oauth_fork.py
+++ b/tests/agent/test_credential_pool_profile_oauth_fork.py
@@ -518,3 +518,44 @@ def test_heal_skips_profile_auth_json_hardlinked_to_the_root_store(fleet):
     assert heal_forked_single_use_oauth_grants("openai-codex") is None
     assert (root / "auth.json").read_text() == before
     assert (shared / "auth.json").samefile(root / "auth.json")
+
+
+def test_heal_leaves_an_aliased_anthropic_singleton_alone(fleet):
+    """Separate auth.jsons but a profile `.anthropic_oauth.json` symlinked to
+    root's: one shared grant, not a fork. The heal must not self-compare it
+    or unlink the alias (#101356 sibling site)."""
+    from hermes_cli.auth import heal_forked_single_use_oauth_grants
+
+    root = fleet["root"]
+    (root / ".anthropic_oauth.json").write_text(json.dumps({
+        "accessToken": "AT-shared", "refreshToken": "RT-shared",
+        "expiresAt": int((time.time() + 3600) * 1000),
+    }))
+    kid = _profile(fleet, "kid")
+    kid.mkdir(parents=True, exist_ok=True)
+    (kid / "auth.json").write_text(json.dumps({"providers": {}, "credential_pool": {}}))
+    (kid / ".anthropic_oauth.json").symlink_to(root / ".anthropic_oauth.json")
+    before = (root / ".anthropic_oauth.json").read_text()
+
+    fleet["use"](kid)
+    assert heal_forked_single_use_oauth_grants("anthropic") is None
+    assert (kid / ".anthropic_oauth.json").is_symlink()
+    assert (root / ".anthropic_oauth.json").read_text() == before
+
+
+def test_heal_same_store_skip_is_memoized_off_the_hot_path(fleet, monkeypatch):
+    """The shared-store skip must record the clean mark so load_pool()'s
+    per-call heal does not re-stat/resolve both paths every model call."""
+    from hermes_cli import auth as auth_mod
+
+    root = fleet["root"]
+    _seed_codex_grant(root)
+    shared = _shared_profile(fleet, "shared", link=lambda target, alias: alias.symlink_to(target))
+    fleet["use"](shared)
+
+    assert auth_mod.heal_forked_single_use_oauth_grants("openai-codex") is None
+    assert "openai-codex" in auth_mod._oauth_heal_clean_marks
+    calls = []
+    monkeypatch.setattr(auth_mod, "_is_same_auth_store", lambda *a: calls.append(a) or True)
+    assert auth_mod.heal_forked_single_use_oauth_grants("openai-codex") is None
+    assert calls == [], "same-store check ran again despite the clean mark"


### PR DESCRIPTION
## Summary
An OAuth profile whose `auth.json` is a symlink or hardlink to the root store no longer has its shared credential deleted by the forked-grant auto-heal.

Salvage of #101586 by @jwilson411 (cherry-picked, authorship preserved) + one follow-up commit. Also credits #101364 by @liuhao1024, who found the same fix first with a symlink-only check.

Fixes #101356.

## Who hits this
Anyone who shares one login across named profiles with `ln -s ~/.hermes/auth.json ~/.hermes/profiles/<name>/auth.json` (or a hardlink). After #100929, every `hermes auth` device-code login "succeeded" and then vanished: the heal read the one file as both the profile store and the root store, matched every OAuth row against itself as a "fork", and stripped it through the alias. The reporter's log showed the `providers.openai-codex` block being removed right after each login.

## Changes
- `hermes_cli/auth.py`: `_is_same_auth_store()` (resolve-equality, then `Path.samefile`) — the heal returns early when profile and root name one store. The check sits after the mtime fingerprint short-circuit and records the clean mark, so a symlinked profile pays the resolve+stat once per file change, not once per `load_pool()` call. A profile `.anthropic_oauth.json` aliased to root's singleton is treated the same way (no self-compare, no unlink).
- Tests: symlink + hardlink alias (contributor); aliased anthropic singleton; hot-path memoization.

## Validation
| Check | Result |
|---|---|
| `tests/agent/test_credential_pool_profile_oauth_fork.py` | 19 passed |
| E2E (real symlink, real `heal_forked_single_use_oauth_grants`, temp HERMES_HOME): main | pool rows 0, providers block gone |
| E2E: this branch | `None`, pool row + providers block intact, symlink intact |
| Mutation: singleton guard removed | new test fails; restored → passes |
| ruff / ty (auth.py) | clean / 12 → 12 |
