### PR TITLE
fix(terminal): keep a statement after a backgrounded compound valid — remote kernel spawn (salvage #42278)

### DIFF
--- a/tests/tools/test_terminal_compound_background.py
+++ b/tests/tools/test_terminal_compound_background.py
@@ -12,6 +12,10 @@ The rewriter fixes this by wrapping the tail in a brace group —
 the current shell. No subshell fork, no wait.
 """
 
+import shutil
+import subprocess
+
+import pytest
 
 from tools.terminal_tool import _rewrite_compound_background as rewrite
 
@@ -100,3 +104,88 @@ class TestEdgeCases:
 
     def test_tabs_between_tokens(self):
         assert rewrite("A\t&&\tB\t&") == "A\t&&\t{ B\t& }"
+
+
+class TestTrailingStatementSeparator:
+    """A statement after the backgrounded compound on the SAME line.
+
+    In ``A && B & C`` the trailing ``&`` is both the background operator and
+    the separator between the compound and ``C``. The rewrite consumes that
+    ``&`` into the brace group; without restoring a separator the result is
+    ``A && { B & } C`` — a bash syntax error (a brace group must be terminated
+    by ``;``, ``&``, ``|``, a newline, or ``)``/``}`` before the next command).
+    That mangles a valid command into one that fails entirely.
+    """
+
+    def test_trailing_command_gets_separator(self):
+        assert rewrite("echo hi && sleep 5 & echo done") == (
+            "echo hi && { sleep 5 & } ; echo done"
+        )
+
+    def test_trailing_chain_gets_separator(self):
+        assert rewrite("a && b & c && d") == "a && { b & } ; c && d"
+
+    def test_redirect_then_trailing_command(self):
+        assert rewrite("echo hi && sleep 5 &>/dev/null & echo done") == (
+            "echo hi && { sleep 5 &>/dev/null & } ; echo done"
+        )
+
+    def test_existing_semicolon_separator_untouched(self):
+        # An explicit `;` already separates the group; don't add a second one.
+        assert rewrite("a && b &; c") == "a && { b & }; c"
+
+    def test_newline_separator_untouched(self):
+        # A newline already terminates the brace group — no `;` needed.
+        assert rewrite("a && b &\necho next") == "a && { b & }\necho next"
+
+    def test_pipe_after_group_untouched(self):
+        # `{ ...; } | cmd` is valid; the pipe is its own terminator.
+        assert rewrite("a && b & | cat") == "a && { b & } | cat"
+
+    def test_second_background_then_trailing(self):
+        assert rewrite("echo a && sleep 5 & echo b & echo c") == (
+            "echo a && { sleep 5 & } ; echo b & echo c"
+        )
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+class TestRewriteIsValidBash:
+    """The rewrite must always produce syntactically valid bash.
+
+    This is the crux of the trailing-statement bug: a mangled command fails
+    with a confusing syntax error and neither half runs. ``bash -n`` parses
+    without executing, so it catches the corruption directly.
+    """
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "echo hi && sleep 5 & echo done",
+            "a && b & c && d",
+            "echo hi && sleep 5 &>/dev/null & echo done",
+            "echo a && sleep 5 & echo b & echo c",
+            "A && B &",
+            "A && B &; C",
+            "A && B &\nC",
+            "cd /tmp && python3 -m http.server 0 &>/dev/null & curl localhost",
+        ],
+    )
+    def test_rewrite_parses(self, command):
+        rewritten = rewrite(command)
+        result = subprocess.run(
+            ["bash", "-n", "-c", rewritten],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            f"rewrite produced invalid bash: {rewritten!r}\n{result.stderr}"
+        )
+
+    def test_trailing_statement_actually_runs(self):
+        # End-to-end: the command after the backgrounded compound must run.
+        rewritten = rewrite("echo first && true & echo SECOND_RAN")
+        result = subprocess.run(
+            ["bash", "-c", rewritten], capture_output=True, text=True
+        )
+        assert result.returncode == 0
+        assert "SECOND_RAN" in result.stdout

--- a/tests/tools/test_terminal_compound_background.py
+++ b/tests/tools/test_terminal_compound_background.py
@@ -142,6 +142,20 @@ class TestTrailingStatementSeparator:
         # `{ ...; } | cmd` is valid; the pipe is its own terminator.
         assert rewrite("a && b & | cat") == "a && { b & } | cat"
 
+    def test_redirect_prefix_on_trailing_command_gets_separator(self):
+        # `&>` after the group is a redirect for the NEXT command, not a
+        # terminator: `{ b & } &>/dev/null c` is a syntax error.
+        assert rewrite("a && b & &>/dev/null c") == "a && { b & } ; &>/dev/null c"
+
+    def test_case_arm_terminator_untouched(self):
+        # `;;` already terminates the arm; adding `;` would leave an empty
+        # command between `;` and `;;`, which bash rejects.
+        assert rewrite("case $x in p) b && c & ;; esac") == "case $x in p) b && { c & } ;; esac"
+
+    def test_separator_is_idempotent(self):
+        once = rewrite("echo hi && sleep 5 & echo done")
+        assert rewrite(once) == once
+
     def test_second_background_then_trailing(self):
         assert rewrite("echo a && sleep 5 & echo b & echo c") == (
             "echo a && { sleep 5 & } ; echo b & echo c"
@@ -168,6 +182,9 @@ class TestRewriteIsValidBash:
             "A && B &; C",
             "A && B &\nC",
             "cd /tmp && python3 -m http.server 0 &>/dev/null & curl localhost",
+            "a && b & &>/dev/null c",
+            "case $x in p) b && c & ;; esac",
+            "A && B & echo x\nC && D & echo y && E & echo z",
         ],
     )
     def test_rewrite_parses(self, command):

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1018,17 +1018,17 @@ def _rewrite_compound_background(command: str) -> str:
         # `{` needs a trailing space in bash; the closing `}` needs to be
         # preceded by `;` or `&` — we're providing `&` from the backgrounding.
         #
-        # The source `&` we consumed into the group also served as the
-        # statement separator when another command followed on the SAME line
-        # (`A && B & C`). A brace group must be terminated by `;`, `&`, `|`,
-        # a newline, or `)`/`}` before the next command, so `{ B & } C` is a
-        # bash syntax error that fails the entire command. Restore a `;`
-        # separator after `}` whenever the suffix resumes with command text.
-        # Strip only spaces/tabs (not newlines) — a newline already terminates
-        # the group, and an existing separator (`;`/`&`/`|`/`)`/`}`) needs no
-        # help.
+        # The consumed `&` also separated the compound from any statement
+        # that followed on the same line (`A && B & C`); `{ B & } C` is a
+        # syntax error, so restore a `;` when the suffix resumes with command
+        # text. No separator when the suffix already starts with a
+        # terminator (`;` `&` `|` newline `)` `}`) — except `&>`, which is a
+        # redirect prefix for the NEXT command, not a terminator.
         tail = suffix.lstrip(" \t")
-        separator = " ;" if tail and tail[0] not in ";\n&|)}" else ""
+        needs_separator = bool(tail) and (
+            tail[0] not in ";\n&|)}" or tail.startswith("&>")
+        )
+        separator = " ;" if needs_separator else ""
         result = prefix + "{ " + middle + "& }" + separator + suffix
 
     return result

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1017,7 +1017,19 @@ def _rewrite_compound_background(command: str) -> str:
         suffix = result[amp_pos + 1 :]
         # `{` needs a trailing space in bash; the closing `}` needs to be
         # preceded by `;` or `&` — we're providing `&` from the backgrounding.
-        result = prefix + "{ " + middle + "& }" + suffix
+        #
+        # The source `&` we consumed into the group also served as the
+        # statement separator when another command followed on the SAME line
+        # (`A && B & C`). A brace group must be terminated by `;`, `&`, `|`,
+        # a newline, or `)`/`}` before the next command, so `{ B & } C` is a
+        # bash syntax error that fails the entire command. Restore a `;`
+        # separator after `}` whenever the suffix resumes with command text.
+        # Strip only spaces/tabs (not newlines) — a newline already terminates
+        # the group, and an existing separator (`;`/`&`/`|`/`)`/`}`) needs no
+        # help.
+        tail = suffix.lstrip(" \t")
+        separator = " ;" if tail and tail[0] not in ";\n&|)}" else ""
+        result = prefix + "{ " + middle + "& }" + separator + suffix
 
     return result
 


### PR DESCRIPTION
## Summary
`A && B & C` no longer rewrites to a bash syntax error, so the persistent `execute_code` kernel actually spawns on Docker/SSH/Modal backends.

Salvage of #42278 by @entropy-0x (cherry-picked, authorship preserved; open since June, most complete of the four competing fixes) + one follow-up commit. Related: #41368 (@oryn-oryn), #98230 (@lEWFkRAD), #100932 (@kyssta-exe) fix the same line with narrower separator sets.

Fixes #98222.

## Who hits this
Every sandboxed profile. `code_kernel_remote.py` spawns the kernel with `cd DIR && nohup env ... python3 kernel_runner.py > log 2>&1 & echo PID:$!`; `Environment.execute()` rewrites the `A && B &` tail into `{ B & }` to avoid the subshell-wait leak, producing `... & } echo PID:$!` — `syntax error near unexpected token 'echo'`. No PID comes back, so every `execute_code` call silently falls back to a one-shot interpreter: no variables or imports persist between calls, and the agent looks incompetent rather than broken. One reporter counted 57/57 spawn failures over a day. The same rewrite applies to any user command of that shape on those backends.

## Changes
- `tools/terminal_tool.py::_rewrite_compound_background`: insert ` ;` after the brace group when the suffix resumes with command text (`{ B & } ; C`). No separator when the suffix already starts with a terminator (`;` `&` `|` newline `)` `}`) — except `&>`, which is a redirect prefix for the next command (follow-up: `a && b & &>/dev/null c` was still rewritten to a syntax error).
- Tests: `bash -n` parse matrix over the rewritten output (incl. the `&>` shape, `;;` case arm which must NOT gain a separator, multi-line mixed), end-to-end "trailing statement actually runs", separator idempotence.

## Validation
| Check | Result |
|---|---|
| `tests/tools/test_terminal_compound_background.py` | 37 passed |
| kernel spawn template through `bash -c` on main | rc=2 `syntax error near unexpected token 'echo'` |
| kernel spawn template through `bash -c` on this branch | rc=0, `PID:62178` (real backgrounded job) |
| 30-case input-vs-output `bash -n` matrix | no valid input parses to invalid output |
| ruff / ty (terminal_tool.py) | clean / 22 → 22 |
