### PR TITLE
fix(sessions): reclaim a backend's own orphaned leases instead of reading them as a sibling owner (salvage #101437)

### DIFF
--- a/hermes_cli/active_sessions.py
+++ b/hermes_cli/active_sessions.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterator, Optional
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_default_hermes_root, get_hermes_home
 
 logger = logging.getLogger(__name__)
 
@@ -757,6 +757,42 @@ def transfer_active_session(
         return updated
 
 
+def _drop_self_orphans(
+    entries: list[dict[str, Any]], own_live_lease_ids: set[str] | None
+) -> list[dict[str, Any]]:
+    """Drop this process's leases only when its caller can vouch for owners."""
+    if own_live_lease_ids is None:
+        return entries
+    pid = os.getpid()
+    return [
+        entry
+        for entry in entries
+        if entry.get("pid") != pid
+        or str(entry.get("lease_id") or "") in own_live_lease_ids
+    ]
+
+
+def _release_orphaned_leases_in_home(
+    registry_home: Path, live_lease_ids: set[str]
+) -> int:
+    state_path = _state_path(registry_home)
+    if not state_path.exists():
+        return 0
+    with _FileLock(_lock_path(registry_home)):
+        try:
+            entries = _prune_dead(_read_entries(state_path, strict=True))
+        except ActiveSessionRegistryError:
+            logger.warning(
+                "Active-session registry is unavailable; skipping orphaned-lease sweep"
+            )
+            return 0
+        kept = _drop_self_orphans(entries, live_lease_ids)
+        dropped = len(entries) - len(kept)
+        if dropped:
+            _write_entries(state_path, kept)
+        return dropped
+
+
 def release_orphaned_leases(live_lease_ids: set[str]) -> int:
     """Drop this process's registry entries that no live session owns.
 
@@ -767,30 +803,26 @@ def release_orphaned_leases(live_lease_ids: set[str]) -> int:
     real, so it drops the rest itself — exact, with no heartbeat write on the
     turn path and no staleness threshold to tune.
     """
-    pid = os.getpid()
-    state_path = _state_path()
-    # No registry file yet means no leases have ever been written under this
-    # home — don't take a lock (or create its file) on the idle-reaper tick.
-    if not state_path.exists():
-        return 0
-    with _FileLock(_lock_path()):
+    root = get_default_hermes_root()
+    homes = [root]
+    profiles_root = root / "profiles"
+    try:
+        homes.extend(
+            profile
+            for profile in profiles_root.iterdir()
+            if profile.is_dir() and not profile.name.startswith(".")
+        )
+    except OSError:
+        pass
+
+    dropped = 0
+    for home in homes:
         try:
-            raw_entries = _read_entries(state_path, strict=True)
-            entries = _prune_dead(raw_entries)
-        except ActiveSessionRegistryError:
-            logger.warning(
-                "Active-session registry is unavailable; skipping orphaned-lease sweep"
+            dropped += _release_orphaned_leases_in_home(home, live_lease_ids)
+        except OSError as exc:
+            logger.debug(
+                "orphaned-lease sweep failed for %s: %s", home, exc
             )
-            return 0
-        kept = [
-            entry
-            for entry in entries
-            if entry.get("pid") != pid
-            or str(entry.get("lease_id") or "") in live_lease_ids
-        ]
-        dropped = len(entries) - len(kept)
-        if dropped:
-            _write_entries(state_path, kept)
     return dropped
 
 
@@ -812,6 +844,7 @@ def active_session_liveness_guard(
     session_id: str,
     *,
     registry_home: str | Path | None = None,
+    own_live_lease_ids: set[str] | None = None,
 ) -> Iterator[bool]:
     """Hold the registry lock while reporting whether ``session_id`` is leased.
 
@@ -823,6 +856,7 @@ def active_session_liveness_guard(
     state_path, lock_path = _lease_paths(registry_home=registry_home)
     with _FileLock(lock_path):
         entries = _prune_dead(_read_entries(state_path, strict=True), strict=True)
+        entries = _drop_self_orphans(entries, own_live_lease_ids)
         _write_entries(state_path, entries)
         yield bool(target) and any(
             str(entry.get("session_id") or "") == target for entry in entries
@@ -833,6 +867,8 @@ def active_session_liveness_guard(
 def release_active_session_liveness_guard(
     lease: ActiveSessionLease,
     session_id: str,
+    *,
+    own_live_lease_ids: set[str] | None = None,
 ) -> Iterator[bool]:
     """Remove ``lease`` and hold its registry lock through a lifecycle write.
 
@@ -842,7 +878,9 @@ def release_active_session_liveness_guard(
     """
     if not lease.enabled or lease.released:
         with active_session_liveness_guard(
-            session_id, registry_home=_registry_home_for_lease(lease)
+            session_id,
+            registry_home=_registry_home_for_lease(lease),
+            own_live_lease_ids=own_live_lease_ids,
         ) as active:
             yield active
         return
@@ -857,6 +895,7 @@ def release_active_session_liveness_guard(
             for entry in entries
             if str(entry.get("lease_id") or "") != lease.lease_id
         ]
+        kept = _drop_self_orphans(kept, own_live_lease_ids)
         if len(kept) != len(entries):
             _write_entries(state_path, kept)
         lease.released = True

--- a/hermes_cli/active_sessions.py
+++ b/hermes_cli/active_sessions.py
@@ -757,6 +757,15 @@ def transfer_active_session(
         return updated
 
 
+# A lease this process wrote in the last few seconds may not be in the
+# caller's ``own_live_lease_ids`` yet: ``try_acquire_active_session`` writes
+# the registry entry under the file lock and the server attaches the lease to
+# its session record only after that returns. A concurrent finalize that
+# snapshotted its live ids in between would otherwise read the brand-new lease
+# as an orphan and drop it. Real orphans are minutes old (#101415).
+_SELF_ORPHAN_GRACE_SECONDS = 30.0
+
+
 def _drop_self_orphans(
     entries: list[dict[str, Any]], own_live_lease_ids: set[str] | None
 ) -> list[dict[str, Any]]:
@@ -764,11 +773,13 @@ def _drop_self_orphans(
     if own_live_lease_ids is None:
         return entries
     pid = os.getpid()
+    cutoff = time.time() - _SELF_ORPHAN_GRACE_SECONDS
     return [
         entry
         for entry in entries
         if entry.get("pid") != pid
         or str(entry.get("lease_id") or "") in own_live_lease_ids
+        or (_optional_float(entry.get("started_at")) or 0.0) > cutoff
     ]
 
 

--- a/tests/hermes_cli/test_active_sessions.py
+++ b/tests/hermes_cli/test_active_sessions.py
@@ -172,6 +172,43 @@ def test_release_orphaned_leases_reclaims_only_unowned_own_pid_entries(tmp_path,
     assert orphan is not None
 
 
+def test_release_orphaned_leases_sweeps_profile_runtime_registries(
+    tmp_path, monkeypatch
+):
+    root = tmp_path / "hermes"
+    profile = root / "profiles" / "worker"
+    profile.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    root_lease, root_error = active_sessions.try_acquire_active_session(
+        session_id="root-orphan", surface="desktop", config={}, registry_home=root
+    )
+    profile_lease, profile_error = active_sessions.try_acquire_active_session(
+        session_id="profile-orphan",
+        surface="desktop",
+        config={},
+        registry_home=profile,
+    )
+    assert root_lease is not None and root_error is None
+    assert profile_lease is not None and profile_error is None
+
+    assert active_sessions.release_orphaned_leases(set()) == 2
+    assert active_sessions.active_session_registry_snapshot(root) == []
+    assert active_sessions.active_session_registry_snapshot(profile) == []
+
+
+def test_drop_self_orphans_spares_foreign_and_vouched_leases():
+    own = os.getpid()
+    entries = [
+        {"lease_id": "orphan", "pid": own},
+        {"lease_id": "live", "pid": own},
+        {"lease_id": "foreign", "pid": own + 1},
+    ]
+
+    assert active_sessions._drop_self_orphans(entries, None) == entries
+    assert active_sessions._drop_self_orphans(entries, {"live"}) == entries[1:]
+
+
 def test_release_under_profile_home_override_targets_acquisition_registry(
     tmp_path, monkeypatch
 ):

--- a/tests/hermes_cli/test_active_sessions.py
+++ b/tests/hermes_cli/test_active_sessions.py
@@ -12,6 +12,17 @@ import pytest
 from hermes_cli import active_sessions
 
 
+
+def _backdate_leases(*homes, age_seconds=600.0):
+    """Age every lease in the given registries past the self-orphan grace."""
+    for home in homes:
+        state_path = active_sessions._state_path(home)
+        entries = active_sessions._read_entries(state_path)
+        for entry in entries:
+            entry["started_at"] = time.time() - age_seconds
+        active_sessions._write_entries(state_path, entries)
+
+
 def test_resolve_max_concurrent_sessions_values(caplog):
     assert active_sessions.resolve_max_concurrent_sessions({}) is None
     assert active_sessions.resolve_max_concurrent_sessions({"max_concurrent_sessions": None}) is None
@@ -164,6 +175,7 @@ def test_release_orphaned_leases_reclaims_only_unowned_own_pid_entries(tmp_path,
         + [{"lease_id": "elsewhere", "session_id": "other", "surface": "cli", "pid": os.getpid() }],
     )
 
+    _backdate_leases(tmp_path / ".hermes")
     assert active_sessions.release_orphaned_leases({kept.lease_id, "elsewhere"}) == 1
     assert sorted(
         entry["session_id"]
@@ -192,6 +204,10 @@ def test_release_orphaned_leases_sweeps_profile_runtime_registries(
     assert root_lease is not None and root_error is None
     assert profile_lease is not None and profile_error is None
 
+    # A lease written seconds ago is never an orphan: a sibling finalize that
+    # snapshotted its live ids before this acquire must not reap it (#101415).
+    assert active_sessions.release_orphaned_leases(set()) == 0
+    _backdate_leases(root, profile)
     assert active_sessions.release_orphaned_leases(set()) == 2
     assert active_sessions.active_session_registry_snapshot(root) == []
     assert active_sessions.active_session_registry_snapshot(profile) == []
@@ -603,3 +619,30 @@ def test_release_wins_against_transfer_waiting_on_same_lease_lock(
     assert lease.released is True
     assert active_sessions.active_session_registry_snapshot() == []
 
+
+
+def test_liveness_guard_keeps_a_just_acquired_own_lease_it_cannot_vouch_for(
+    tmp_path, monkeypatch
+):
+    """Race in #101415's fix: the finalizing session snapshots its live lease
+    ids, then a sibling session acquires a lease before the registry lock is
+    taken. That lease is absent from the snapshot but is not an orphan."""
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    fresh, error = active_sessions.try_acquire_active_session(
+        session_id="fresh", surface="desktop", config={}, registry_home=home
+    )
+    assert fresh is not None and error is None
+
+    with active_sessions.active_session_liveness_guard(
+        "fresh", registry_home=home, own_live_lease_ids=set()
+    ) as active:
+        assert active is True
+    assert [e["lease_id"] for e in active_sessions.active_session_registry_snapshot(home)] == [fresh.lease_id]
+
+    _backdate_leases(home)
+    with active_sessions.active_session_liveness_guard(
+        "fresh", registry_home=home, own_live_lease_ids=set()
+    ) as active:
+        assert active is False
+    assert active_sessions.active_session_registry_snapshot(home) == []

--- a/tests/tui_gateway/test_cross_process_orphan_ownership.py
+++ b/tests/tui_gateway/test_cross_process_orphan_ownership.py
@@ -305,6 +305,11 @@ def test_automatic_cleanup_reclaims_own_orphan_lease_not_treated_as_sibling(
         profile_home=profile_home,
     )
     assert owner_lease is not None and message is None
+    # The owner vanished minutes ago; a lease written seconds ago is still
+    # inside the self-orphan grace window and must be left alone.
+    monkeypatch.setattr(
+        "hermes_cli.active_sessions._SELF_ORPHAN_GRACE_SECONDS", 0.0
+    )
     ended: list[tuple[str, str]] = []
 
     class _FakeDB:

--- a/tests/tui_gateway/test_cross_process_orphan_ownership.py
+++ b/tests/tui_gateway/test_cross_process_orphan_ownership.py
@@ -270,6 +270,79 @@ def test_automatic_cleanup_preserves_corrupt_registry_without_overwrite(
     assert state_path.read_text(encoding="utf-8") == corrupt
 
 
+def test_own_live_lease_ids_reports_live_owners_and_skips_the_excluded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Lease:
+        def __init__(self, lease_id: str) -> None:
+            self.lease_id = lease_id
+
+    first = _Lease("first")
+    second = _Lease("second")
+    monkeypatch.setattr(
+        server,
+        "_sessions",
+        {
+            "one": {"active_session_lease": first},
+            "two": {"active_session_lease": second},
+            "three": {"active_session_lease": None},
+        },
+    )
+
+    assert server._own_live_lease_ids() == {"first", "second"}
+    assert server._own_live_lease_ids(exclude=first) == {"second"}
+
+
+def test_automatic_cleanup_reclaims_own_orphan_lease_not_treated_as_sibling(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    profile_home = tmp_path / "profile-home"
+    session_id = "own-orphan-session"
+    owner_lease, message = server._claim_active_session_slot(
+        session_id,
+        live_session_id="vanished-runtime",
+        surface="desktop",
+        profile_home=profile_home,
+    )
+    assert owner_lease is not None and message is None
+    ended: list[tuple[str, str]] = []
+
+    class _FakeDB:
+        def get_session(self, target: str) -> dict[str, str]:
+            return {"id": target, "source": "desktop"}
+
+        def end_session(self, target: str, reason: str) -> None:
+            ended.append((target, reason))
+
+    @contextlib.contextmanager
+    def _profile_db(_session: dict):
+        yield _FakeDB()
+
+    monkeypatch.setattr(server, "_sessions", {})
+    monkeypatch.setattr(server, "_session_db", _profile_db)
+    monkeypatch.setattr(
+        server, "_notify_session_boundary", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.interrupt_for_session", lambda *args, **kwargs: None
+    )
+    session = {
+        "active_session_lease": None,
+        "agent": None,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "profile_home": str(profile_home),
+        "session_key": session_id,
+        "slash_worker": None,
+        "source": "desktop",
+    }
+
+    server._finalize_session(session, end_reason="ws_orphan_reap")
+
+    assert ended == [(session_id, "ws_orphan_reap")]
+    assert active_session_registry_snapshot(registry_home=profile_home) == []
+
+
 def test_liveness_guard_serializes_cross_process_acquire(tmp_path: Path) -> None:
     home = tmp_path / "guard-home"
     waiting_file = tmp_path / "child-waiting"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -764,6 +764,17 @@ def _release_active_session_slot(session: dict | None) -> bool:
     return False
 
 
+def _own_live_lease_ids(*, exclude=None) -> set[str]:
+    """Snapshot leases still backed by this process's live session records."""
+    with _sessions_lock:
+        return {
+            str(lease.lease_id)
+            for session in _sessions.values()
+            if (lease := session.get("active_session_lease")) is not None
+            and lease is not exclude
+        }
+
+
 @contextlib.contextmanager
 def _other_runtime_lease_guard(session_id: str, session: dict):
     """Release this runtime and lock sibling ownership through the DB write."""
@@ -784,13 +795,20 @@ def _other_runtime_lease_guard(session_id: str, session: dict):
 
     last_error: Exception | None = None
     stack = contextlib.ExitStack()
+    own_live_lease_ids = _own_live_lease_ids(exclude=lease)
     for attempt in range(3):
         try:
             if lease is not None and getattr(lease, "enabled", False):
-                guard = release_active_session_liveness_guard(lease, session_id)
+                guard = release_active_session_liveness_guard(
+                    lease,
+                    session_id,
+                    own_live_lease_ids=own_live_lease_ids,
+                )
             else:
                 guard = active_session_liveness_guard(
-                    session_id, registry_home=session.get("profile_home")
+                    session_id,
+                    registry_home=session.get("profile_home"),
+                    own_live_lease_ids=own_live_lease_ids,
                 )
             active = stack.enter_context(guard)
             break
@@ -1930,12 +1948,7 @@ def _reclaim_orphaned_leases() -> None:
     try:
         from hermes_cli.active_sessions import release_orphaned_leases
 
-        with _sessions_lock:
-            live = {
-                lease.lease_id
-                for session in _sessions.values()
-                if (lease := session.get("active_session_lease")) is not None
-            }
+        live = _own_live_lease_ids()
         if dropped := release_orphaned_leases(live):
             logger.info("Reclaimed %d orphaned active-session lease(s)", dropped)
     except Exception:


### PR DESCRIPTION
## Summary
A desktop backend no longer mistakes its own orphaned session lease for a sibling owner, so reopening a chat stops failing with "already has a live owner" and stranding one more session per reopen.

Salvage of #101437 by @fangliquanflq (issue reporter's own fix; cherry-picked, authorship preserved) + one follow-up commit.

Fixes #101415.

## Who hits this
Desktop users on a long-running `hermes serve --profile X` backend. A session that dies without teardown leaves a registry lease owned by this pid but tracked by no live session record. `_other_runtime_lease_guard` then reads that ghost as "another backend owns an active lease", preserves it, and skips `end_session`; the next open of the same chat is refused (`SESSION_NOT_OWNED`), gets reaped in turn, and leaves its own ghost. Over 40 minutes the reporter's profile registry grew to five entries, four of them ghosts. `_prune_dead` never helps (the owning process is alive), and the every-5-minutes `release_orphaned_leases()` sweep looked only at the ROOT registry while the desktop acquires under `profiles/<name>/runtime/`.

## Changes
- `tui_gateway/server.py`: `_own_live_lease_ids(exclude=)` snapshots the leases this process still has live session records for; threaded into `_other_runtime_lease_guard` and `_reclaim_orphaned_leases`.
- `hermes_cli/active_sessions.py`: `_drop_self_orphans()` removes this pid's entries absent from that set, inside both liveness guards under the registry file lock (atomic with the liveness decision). `None` = caller can't vouch = unchanged behaviour for every other caller. `release_orphaned_leases()` sweeps the root plus every `profiles/*/runtime/` registry.
- Follow-up: `_own_live_lease_ids` is taken before the file lock, and a sibling session attaches its lease to its record only after the registry write — a finalize racing that acquire would have reaped a lease seconds old. Entries this process wrote within a 30 s grace window are never treated as orphans; real orphans are minutes old.
- Tests: 4 contributor tests (own orphan reclaimed and row ended; exclude contract; profile-registry sweep; other pid's leases untouched) + grace-window coverage on the sweep and the guard.

## Validation
| Check | Result |
|---|---|
| `test_active_sessions.py` + `test_cross_process_orphan_ownership.py` + `test_active_session_exclusivity.py` | 38 passed |
| E2E probe (real registry, ghost lease, temp HERMES_HOME): main, process home = profile | guard says another owner → True (ghost preserved) |
| E2E: main, process home = root | sweep dropped 0 (wrong registry) |
| E2E: this branch, both layouts | sweep dropped 1, guard → False, registry empty |
| ruff / ty | clean / server.py 140 → 138, active_sessions.py 0 → 0 |
