### PR TITLE
fix(recovery): never report a mis-mapped lost_and_found salvage as verified (salvage #101423)

### DIFF
--- a/hermes_cli/session_lost_and_found.py
+++ b/hermes_cli/session_lost_and_found.py
@@ -55,6 +55,11 @@ SESSION_MODEL_USAGE_NFIELD = 18
 _EPOCH_LOW = 1_000_000_000.0   # 2001
 _EPOCH_HIGH = 4_000_000_000.0  # 2096
 
+# Title prefix of every session row this lane synthesises (legacy-layout rows
+# and stubbed parents). The recovery verifier keys on it to tell synthesised
+# rows from positionally mapped ones.
+STUB_TITLE_PREFIX = "[best-effort recovered"
+
 SQLITE3_CLI_GUIDANCE = (
     "A last-resort page-level salvage is available when a `.recover`-capable "
     "`sqlite3` command-line shell is installed: its `.recover` command can "
@@ -456,7 +461,7 @@ def map_lost_and_found_rows(
                                     cells[1] if _looks_like_source(cells[1])
                                     else "recovered",
                                     _heuristic_started_at(cells),
-                                    "[best-effort recovered] legacy session "
+                                    f"{STUB_TITLE_PREFIX}] legacy session "
                                     "row (layout unknown)",
                                 ),
                             ).rowcount
@@ -525,7 +530,7 @@ def stub_missing_parent_sessions(dest: sqlite3.Connection) -> dict[str, Any]:
         for session_id, info in sorted(orphan_ids.items()):
             while True:
                 title = (
-                    f"[best-effort recovered {sequence}] session metadata "
+                    f"{STUB_TITLE_PREFIX} {sequence}] session metadata "
                     "was unreadable"
                 )
                 sequence += 1

--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -1448,11 +1448,11 @@ def _lost_and_found_plausibility_errors(
     ``started_at = 0.0`` when no timestamped message survived, so they are
     excluded from the denominator.
     """
-    from hermes_cli.session_lost_and_found import _EPOCH_LOW
+    from hermes_cli.session_lost_and_found import _EPOCH_LOW, STUB_TITLE_PREFIX
 
     errors: list[str] = []
     checks = (
-        ("sessions", "started_at", "WHERE COALESCE(title, '') NOT LIKE '[best-effort recovered%'"),
+        ("sessions", "started_at", f"WHERE COALESCE(title, '') NOT LIKE '{STUB_TITLE_PREFIX}%'"),
         ("messages", "timestamp", ""),
     )
     for table, column, mapped_filter in checks:

--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -1431,11 +1431,6 @@ def _finalize_derived_metadata(destination: sqlite3.Connection) -> dict[str, Any
     return result
 
 
-# Floor for a plausible unix-epoch timestamp (2001-09-09). Salvage rows
-# uniformly below it were mis-mapped, not merely unlucky (#101409).
-_PLAUSIBLE_TIMESTAMP_FLOOR = 1_000_000_000.0
-
-
 def _lost_and_found_plausibility_errors(
     conn: sqlite3.Connection,
 ) -> list[str]:
@@ -1447,47 +1442,35 @@ def _lost_and_found_plausibility_errors(
     from the destination template's declared order, so positional cell
     mapping lands counters/strings where ``started_at``/``timestamp``
     belong — and the NOT NULL substitutes turn gaps into 0.0. When every
-    row violates the epoch floor, the mapping was wrong.
+    mapped row violates the epoch floor, the mapping was wrong.
+
+    Stub rows written by ``stub_missing_parent_sessions`` legitimately carry
+    ``started_at = 0.0`` when no timestamped message survived, so they are
+    excluded from the denominator.
     """
+    from hermes_cli.session_lost_and_found import _EPOCH_LOW
 
     errors: list[str] = []
-
-    (session_total,) = conn.execute(
-        "SELECT COUNT(*) FROM sessions"
-    ).fetchone()
-    if session_total:
+    checks = (
+        ("sessions", "started_at", "WHERE COALESCE(title, '') NOT LIKE '[best-effort recovered%'"),
+        ("messages", "timestamp", ""),
+    )
+    for table, column, mapped_filter in checks:
+        (total,) = conn.execute(f"SELECT COUNT(*) FROM {table} {mapped_filter}").fetchone()
+        if not total:
+            continue
         (implausible,) = conn.execute(
-            "SELECT COUNT(*) FROM sessions "
-            "WHERE started_at IS NULL OR started_at < ?",
-            (_PLAUSIBLE_TIMESTAMP_FLOOR,),
+            f"SELECT COUNT(*) FROM {table} {mapped_filter} "
+            f"{'AND' if mapped_filter else 'WHERE'} ({column} IS NULL OR {column} < ?)",
+            (_EPOCH_LOW,),
         ).fetchone()
-        if implausible == session_total:
+        if implausible == total:
             errors.append(
-                f"sessions.started_at is implausible in all "
-                f"{session_total} salvaged row(s) (NULL or before 2001-09): "
-                "the source's physical column order did not match the "
-                "destination template, so cells were mapped onto the "
-                "wrong columns"
+                f"{table}.{column} is implausible in all {total} salvaged row(s) "
+                "(NULL or before 2001-09): the source's physical column order "
+                "did not match the destination template, so cells were mapped "
+                "onto the wrong columns"
             )
-
-    (message_total,) = conn.execute(
-        "SELECT COUNT(*) FROM messages"
-    ).fetchone()
-    if message_total:
-        (implausible,) = conn.execute(
-            "SELECT COUNT(*) FROM messages "
-            "WHERE timestamp IS NULL OR timestamp < ?",
-            (_PLAUSIBLE_TIMESTAMP_FLOOR,),
-        ).fetchone()
-        if implausible == message_total:
-            errors.append(
-                f"messages.timestamp is implausible in all "
-                f"{message_total} salvaged row(s) (NULL or before 2001-09): "
-                "the source's physical column order did not match the "
-                "destination template, so cells were mapped onto the "
-                "wrong columns"
-            )
-
     return errors
 
 

--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -1431,6 +1431,66 @@ def _finalize_derived_metadata(destination: sqlite3.Connection) -> dict[str, Any
     return result
 
 
+# Floor for a plausible unix-epoch timestamp (2001-09-09). Salvage rows
+# uniformly below it were mis-mapped, not merely unlucky (#101409).
+_PLAUSIBLE_TIMESTAMP_FLOOR = 1_000_000_000.0
+
+
+def _lost_and_found_plausibility_errors(
+    conn: sqlite3.Connection,
+) -> list[str]:
+    """Flag systematic timestamp mis-mapping in a salvaged database.
+
+    Structural checks (integrity, FK, FTS, row counts) pass on mis-mapped
+    salvage because every row still inserts. Only semantics give it away:
+    the physical column order of a source upgraded via ALTER TABLE differs
+    from the destination template's declared order, so positional cell
+    mapping lands counters/strings where ``started_at``/``timestamp``
+    belong — and the NOT NULL substitutes turn gaps into 0.0. When every
+    row violates the epoch floor, the mapping was wrong.
+    """
+
+    errors: list[str] = []
+
+    (session_total,) = conn.execute(
+        "SELECT COUNT(*) FROM sessions"
+    ).fetchone()
+    if session_total:
+        (implausible,) = conn.execute(
+            "SELECT COUNT(*) FROM sessions "
+            "WHERE started_at IS NULL OR started_at < ?",
+            (_PLAUSIBLE_TIMESTAMP_FLOOR,),
+        ).fetchone()
+        if implausible == session_total:
+            errors.append(
+                f"sessions.started_at is implausible in all "
+                f"{session_total} salvaged row(s) (NULL or before 2001-09): "
+                "the source's physical column order did not match the "
+                "destination template, so cells were mapped onto the "
+                "wrong columns"
+            )
+
+    (message_total,) = conn.execute(
+        "SELECT COUNT(*) FROM messages"
+    ).fetchone()
+    if message_total:
+        (implausible,) = conn.execute(
+            "SELECT COUNT(*) FROM messages "
+            "WHERE timestamp IS NULL OR timestamp < ?",
+            (_PLAUSIBLE_TIMESTAMP_FLOOR,),
+        ).fetchone()
+        if implausible == message_total:
+            errors.append(
+                f"messages.timestamp is implausible in all "
+                f"{message_total} salvaged row(s) (NULL or before 2001-09): "
+                "the source's physical column order did not match the "
+                "destination template, so cells were mapped onto the "
+                "wrong columns"
+            )
+
+    return errors
+
+
 def _recover_via_lost_and_found(
     *,
     source: Path,
@@ -1529,6 +1589,21 @@ def _recover_via_lost_and_found(
         "heuristically. Review every count before trusting this output."
     )
     verification["complete"] = False
+
+    # Structural checks cannot see a positional mis-mapping (#101409):
+    # every row still inserts, so integrity/FK/FTS stay green. A
+    # systematic timestamp violation is the semantic tell — surface it
+    # so a mis-mapped salvage is never reported as verified.
+    plausibility_conn = sqlite3.connect(str(output), isolation_level=None)
+    try:
+        plausibility_errors = _lost_and_found_plausibility_errors(
+            plausibility_conn
+        )
+    finally:
+        plausibility_conn.close()
+    if plausibility_errors:
+        verification["errors"].extend(plausibility_errors)
+        verification["healthy"] = False
 
     source_unchanged = (
         _source_fingerprint(source) == inspection["source_fingerprint"]

--- a/tests/hermes_cli/test_session_recovery_lost_and_found.py
+++ b/tests/hermes_cli/test_session_recovery_lost_and_found.py
@@ -17,6 +17,7 @@ import pytest
 from hermes_state import SessionDB
 from hermes_cli import session_recovery
 from hermes_cli.session_lost_and_found import (
+    STUB_TITLE_PREFIX,
     classify_lost_and_found_row,
     map_lost_and_found_rows,
     rebuild_fts_indexes,
@@ -817,7 +818,7 @@ def test_lost_and_found_lane_refuses_to_verify_a_physically_shifted_source(
         # The mis-mapping the gate caught: every mapped (non-stub) session got
         # the NOT NULL substitute where its real start time should be.
         mapped = out.execute(
-            "SELECT started_at FROM sessions WHERE COALESCE(title, '') NOT LIKE '[best-effort recovered%'"
+            f"SELECT started_at FROM sessions WHERE COALESCE(title, '') NOT LIKE '{STUB_TITLE_PREFIX}%'"
         ).fetchall()
         assert mapped and all(row[0] == 0.0 for row in mapped)
     finally:

--- a/tests/hermes_cli/test_session_recovery_lost_and_found.py
+++ b/tests/hermes_cli/test_session_recovery_lost_and_found.py
@@ -736,3 +736,125 @@ def test_plausibility_gate_passes_correctly_mapped_salvage(
         assert session_recovery._lost_and_found_plausibility_errors(conn) == []
     finally:
         conn.close()
+
+
+def _rebuild_with_started_at_appended(conn: sqlite3.Connection) -> None:
+    """Give ``sessions`` the physical layout of an upgraded DB: ``started_at``
+    lands at the END (as ``ALTER TABLE ADD COLUMN`` would place a column that
+    the current template declares mid-definition). Data is preserved."""
+    info = list(conn.execute("PRAGMA table_info(sessions)"))
+    declared = [row[1] for row in info]
+
+    def coldef(row):
+        _, name, ctype, notnull, dflt, pk = row
+        parts = [f'"{name}" {ctype}']
+        if pk:
+            parts.append("PRIMARY KEY")
+        if notnull:
+            parts.append("NOT NULL")
+        if dflt is not None:
+            parts.append(f"DEFAULT {dflt}")
+        return " ".join(parts)
+
+    reordered = [r for r in info if r[1] != "started_at"] + [r for r in info if r[1] == "started_at"]
+    cols = ", ".join(f'"{c}"' for c in declared)
+    conn.executescript("PRAGMA foreign_keys=OFF;")
+    conn.execute("CREATE TABLE sessions_new (" + ", ".join(coldef(r) for r in reordered) + ")")
+    conn.execute(f"INSERT INTO sessions_new({cols}) SELECT {cols} FROM sessions")
+    conn.executescript("DROP TABLE sessions; ALTER TABLE sessions_new RENAME TO sessions;")
+
+
+@pytest.mark.skipif(
+    not HAVE_SQLITE3_CLI,
+    reason="sqlite3 CLI not on PATH; .recover is a shell-only feature",
+)
+def test_lost_and_found_lane_refuses_to_verify_a_physically_shifted_source(
+    tmp_path: Path,
+) -> None:
+    """#101409 end to end: a source whose physical column order differs from
+    the template's declared order maps every cell onto the wrong column. The
+    output still passes integrity/FK/FTS, so only the plausibility gate can
+    stop the report from claiming ``verified``."""
+    source = tmp_path / "upgraded.db"
+    output = tmp_path / "upgraded-recovered.db"
+    db = SessionDB(db_path=source)
+    try:
+        for n in range(3):
+            sid = f"20260812_1400{n:02d}_def{n:03x}"
+            db.create_session(sid, "cli", cwd=f"/tmp/shift-{n}")
+            db.set_session_title(sid, f"shift {n}")
+            for m in range(4):
+                db.append_message(sid, "user" if m % 2 == 0 else "assistant", f"payload {n} {m}")
+    finally:
+        db.close()
+    conn = sqlite3.connect(str(source), isolation_level=None)
+    try:
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        conn.execute("PRAGMA journal_mode=DELETE")
+        _rebuild_with_started_at_appended(conn)
+        conn.execute("VACUUM")
+        physical = [r[1] for r in conn.execute("PRAGMA table_info(sessions)")]
+        assert physical[-1] == "started_at"
+    finally:
+        conn.close()
+    # The reporter's damage: page 1 (header + sqlite_master) overwritten, so
+    # ``.recover`` cannot name any table and every row lands in
+    # lost_and_found, to be mapped positionally onto the template.
+    with open(source, "r+b") as fh:
+        fh.write(b"\0" * _page_size(source.read_bytes()))
+
+    report = recover_session_database(source, output, work_dir=tmp_path, allow_partial=True)
+
+    assert report["mode"] == "lost_and_found_salvage"
+    # Mis-mapped rows that trip a NOT NULL / type constraint are stubbed, not
+    # mapped (the reporter saw 190 of 1,875) — at least one lands positionally.
+    assert report["lost_and_found"]["mapped"]["sessions"] >= 1
+    assert report["verification"]["healthy"] is False
+    assert report["verified"] is False
+    assert any("sessions.started_at is implausible" in e for e in report["verification"]["errors"])
+    out = sqlite3.connect(str(output))
+    try:
+        # The mis-mapping the gate caught: every mapped (non-stub) session got
+        # the NOT NULL substitute where its real start time should be.
+        mapped = out.execute(
+            "SELECT started_at FROM sessions WHERE COALESCE(title, '') NOT LIKE '[best-effort recovered%'"
+        ).fetchall()
+        assert mapped and all(row[0] == 0.0 for row in mapped)
+    finally:
+        out.close()
+
+
+def test_plausibility_gate_ignores_stub_only_sessions(tmp_path: Path) -> None:
+    """Stub rows from ``stub_missing_parent_sessions`` legitimately carry
+    ``started_at = 0.0``; a salvage where only stubs survived is depleted,
+    not mis-mapped, and must not be flagged."""
+    output = tmp_path / "stubs.db"
+    SessionDB(db_path=output).close()
+    conn = sqlite3.connect(str(output))
+    try:
+        now = 1_750_000_000.0
+        conn.execute(
+            "INSERT INTO sessions (id, source, started_at, title) VALUES (?, ?, ?, ?)",
+            ("20260812_140000_aaa000", "recovered", 0.0, "[best-effort recovered 1] session metadata was unreadable"),
+        )
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+            ("20260812_140000_aaa000", "user", "hi", now),
+        )
+        conn.commit()
+        assert session_recovery._lost_and_found_plausibility_errors(conn) == []
+        # One genuinely mapped row with a real timestamp keeps it clean too...
+        conn.execute(
+            "INSERT INTO sessions (id, source, started_at, title) VALUES (?, ?, ?, ?)",
+            ("20260812_140001_aaa001", "cli", now, None),
+        )
+        conn.commit()
+        assert session_recovery._lost_and_found_plausibility_errors(conn) == []
+        # ...and a mapped row at 0.0 with a NULL title (the mis-mapped shape:
+        # blank titles) is still counted as mapped, not as a stub.
+        conn.execute("UPDATE sessions SET started_at = 0.0 WHERE id = '20260812_140001_aaa001'")
+        conn.commit()
+        errors = session_recovery._lost_and_found_plausibility_errors(conn)
+        assert len(errors) == 1 and "sessions.started_at" in errors[0]
+    finally:
+        conn.close()

--- a/tests/hermes_cli/test_session_recovery_lost_and_found.py
+++ b/tests/hermes_cli/test_session_recovery_lost_and_found.py
@@ -569,3 +569,170 @@ def test_fingerprint_error_enumerates_parent_cli_session(
     assert "CLI session" in message
     assert "fresh shell" in message
     assert "snapshot" in message
+
+
+# ── issue #101409: mis-mapped salvage must not be reported verified ─────────
+
+
+def _map_salvage_rows(
+    tmp_path: Path,
+    *,
+    blank_session_started_at: bool,
+    blank_message_timestamp: bool,
+) -> sqlite3.Connection:
+    """Map synthetic lost_and_found cells into a fresh template DB.
+
+    With either ``blank_*`` flag the cells mimic an upgraded source's
+    *physical* column order (#101409): whatever lands on the declared
+    ``started_at``/``timestamp`` position is not an epoch timestamp, so
+    the NOT NULL substitute turns it into 0.0 on every row.
+    """
+
+    schema_ref = tmp_path / "schema-ref.db"
+    SessionDB(db_path=schema_ref).close()
+    schema = sqlite3.connect(str(schema_ref))
+    try:
+        sessions_columns = [
+            str(row[1]) for row in schema.execute("PRAGMA table_info(sessions)")
+        ]
+        messages_columns = [
+            str(row[1]) for row in schema.execute("PRAGMA table_info(messages)")
+        ]
+    finally:
+        schema.close()
+    current_width = len(sessions_columns)
+
+    lf_path = tmp_path / "lost_and_found.db"
+    lf_conn = sqlite3.connect(str(lf_path), isolation_level=None)
+    try:
+        lf_cells = ", ".join(f"c{i}" for i in range(current_width))
+        lf_conn.execute(
+            "CREATE TABLE lost_and_found (rootpgno INTEGER, pgno INTEGER, "
+            "nfield INTEGER, id INTEGER, " + lf_cells + ")"
+        )
+
+        def insert(nfield: int, rowid: int, values: list) -> None:
+            padded = list(values) + [None] * (current_width - len(values))
+            placeholders = ", ".join("?" for _ in range(4 + current_width))
+            lf_conn.execute(
+                "INSERT INTO lost_and_found VALUES (" + placeholders + ")",
+                [2, 5, nfield, rowid, *padded],
+            )
+
+        def session_row(session_id: str) -> list:
+            # title is UNIQUE (idx_sessions_title_unique) — keep it distinct
+            # per row so the probe isolates timestamp mis-mapping.
+            row = {
+                "id": session_id,
+                "source": "telegram",
+                "started_at": None
+                if blank_session_started_at
+                else 1_754_000_000.0,
+                "message_count": 2,
+                "title": f"mis-mapped probe {session_id}",
+            }
+            return [row.get(column) for column in sessions_columns]
+
+        for index in range(3):
+            insert(
+                current_width,
+                index + 1,
+                session_row(f"20260101_01010{index}_aaa00{index}"),
+            )
+
+        for index in range(2):
+            message = {
+                "id": None,
+                "session_id": "20260101_010100_aaa000",
+                "role": "user",
+                "content": "payload",
+                "timestamp": None
+                if blank_message_timestamp
+                else 1_754_000_100.0 + index,
+            }
+            insert(
+                23,
+                100 + index,
+                [message.get(column) for column in messages_columns[:23]],
+            )
+    finally:
+        lf_conn.close()
+
+    output = tmp_path / "mapped.db"
+    SessionDB(db_path=output).close()
+    lf_conn = sqlite3.connect(str(lf_path), isolation_level=None)
+    dest = sqlite3.connect(str(output), isolation_level=None)
+    try:
+        dest.execute("PRAGMA foreign_keys=OFF")
+        map_lost_and_found_rows(lf_conn, dest)
+    finally:
+        lf_conn.close()
+        dest.close()
+    return sqlite3.connect(str(output), isolation_level=None)
+
+
+def test_plausibility_gate_flags_positional_mis_mapping(
+    tmp_path: Path,
+) -> None:
+    """A salvage whose timestamps all landed below the epoch floor was
+    mapped onto the wrong columns and must be flagged, not verified
+    (#101409)."""
+
+    conn = _map_salvage_rows(
+        tmp_path,
+        blank_session_started_at=True,
+        blank_message_timestamp=False,
+    )
+    try:
+        # The mapper happily inserted every row; structural checks pass.
+        assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 3
+        assert conn.execute(
+            "SELECT COUNT(*) FROM sessions WHERE started_at = 0.0"
+        ).fetchone()[0] == 3
+
+        errors = session_recovery._lost_and_found_plausibility_errors(conn)
+        assert len(errors) == 1
+        assert "sessions.started_at" in errors[0]
+    finally:
+        conn.close()
+
+
+def test_plausibility_gate_flags_mis_mapped_message_timestamps(
+    tmp_path: Path,
+) -> None:
+    conn = _map_salvage_rows(
+        tmp_path,
+        blank_session_started_at=False,
+        blank_message_timestamp=True,
+    )
+    try:
+        errors = session_recovery._lost_and_found_plausibility_errors(conn)
+        assert len(errors) == 1
+        assert "messages.timestamp" in errors[0]
+    finally:
+        conn.close()
+
+
+def test_plausibility_gate_passes_correctly_mapped_salvage(
+    tmp_path: Path,
+) -> None:
+    """Well-mapped rows — and partially damaged ones (a torn cell on some
+    rows is expected salvage noise) — must not trip the gate: it fires
+    only on a *systematic* violation."""
+
+    conn = _map_salvage_rows(
+        tmp_path,
+        blank_session_started_at=False,
+        blank_message_timestamp=False,
+    )
+    try:
+        # Damage one of three sessions the way a torn cell would.
+        conn.execute(
+            "UPDATE sessions SET started_at = 0.0 WHERE id = ?",
+            ("20260101_010101_aaa001",),
+        )
+        conn.commit()
+
+        assert session_recovery._lost_and_found_plausibility_errors(conn) == []
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary
`hermes sessions recover --allow-partial` no longer reports a lost_and_found salvage as `verified` when every mapped row's timestamp is implausible — the signature of cells mapped onto the wrong columns.

Salvage of #101423 by @liuhao1024 (cherry-picked, authorship preserved) + one follow-up commit.

Refs #101409 — this is the detection half. The mapping bug itself (positional cells vs. an upgraded DB's physical column order) still needs the layout table the issue proposes; leaving the issue open for that.

## Who hits this
Anyone recovering a `state.db` created before ~July 2026 whose page 1 was destroyed. `_reconcile_columns` appends columns at ALTER time, so the physical order differs from the current `SCHEMA_SQL` wherever a column was inserted mid-declaration. The page-level lane maps salvaged cells positionally onto the declared order: the reporter got 1,875 sessions with `started_at = 0.0`, blank titles, `model` holding `message_count`, `ended_at` holding `reasoning_tokens` — and `verified: true, integrity_check: ok, healthy: true`, because every mis-mapped row still inserts.

## Changes
- `hermes_cli/session_recovery.py::_lost_and_found_plausibility_errors`: after structural verification, if 100 % of mapped `sessions.started_at` or `messages.timestamp` are NULL or before 2001 (`_EPOCH_LOW`, reused from `session_lost_and_found`), append the error and force `healthy`/`verified` to False. "All rows" not "any row": a torn cell on some rows is normal salvage noise. Follow-up: stub rows written by `stub_missing_parent_sessions` legitimately carry `started_at = 0.0` and are excluded from the denominator, so a depleted-but-correct salvage is not flagged.
- Tests: contributor's three unit tests on the gate; end-to-end — a real source rebuilt with `started_at` physically appended, page 1 zeroed, through the real `.recover` lane → `verified: False` (sqlite3-CLI gated); stub-only output not flagged; a mapped row with a NULL title (the mis-mapped shape) still counts as mapped.

## Validation
| Check | Result |
|---|---|
| `test_session_recovery_lost_and_found.py` + `test_session_recovery.py` | 20 passed |
| E2E probe (shifted source, page 1 zeroed, real `recover_session_database`): main | `verified: True`, `started_at = 0.0` |
| E2E: this branch | `verified: False`, error names `sessions.started_at` |
| Mutation: gate wiring disabled | E2E test fails; restored → passes |
| ruff / ty (session_recovery.py) | clean / 0 → 0 |
