### PR TITLE
fix(tui-gateway): keep the Desktop WebSocket open on a lone-surrogate frame (salvage #97622)

### DIFF
--- a/tests/tui_gateway/test_ws_surrogate_send.py
+++ b/tests/tui_gateway/test_ws_surrogate_send.py
@@ -1,0 +1,63 @@
+"""Lone UTF-16 surrogates must not tear down the Desktop WebSocket (#97288)."""
+
+from __future__ import annotations
+
+import asyncio
+
+from tui_gateway.ws import WSTransport, _sanitize_ws_text
+
+
+LONE_SURROGATE = "\ud83d"
+
+
+def test_sanitize_ws_text_makes_utf8_encodable() -> None:
+    dirty = f"gateway.ready {LONE_SURROGATE} payload"
+    out = _sanitize_ws_text(dirty)
+    out.encode("utf-8")
+    assert LONE_SURROGATE not in out
+
+
+def test_sanitize_ws_text_leaves_valid_text_unchanged() -> None:
+    clean = '{"type":"gateway.ready","ok":true}'
+    assert _sanitize_ws_text(clean) is clean or _sanitize_ws_text(clean) == clean
+
+
+class _FakeWS:
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+        self.raise_on: str | None = None
+
+    async def send_text(self, line: str) -> None:
+        line.encode("utf-8")
+        if self.raise_on is not None and self.raise_on in line:
+            raise UnicodeEncodeError("utf-8", line, 0, 1, "surrogates not allowed")
+        self.sent.append(line)
+
+
+def test_safe_send_sanitizes_surrogate_and_keeps_connection() -> None:
+    async def _run() -> None:
+        loop = asyncio.get_running_loop()
+        ws = _FakeWS()
+        transport = WSTransport(ws, loop, peer="127.0.0.1:1")
+        dirty = f'{{"type":"gateway.ready","x":"{LONE_SURROGATE}"}}'
+        await transport._safe_send_many(["first", dirty, "third"])
+        assert transport.closed is False
+        assert ws.sent[0] == "first"
+        assert ws.sent[-1] == "third"
+        assert LONE_SURROGATE not in "".join(ws.sent)
+        assert len(ws.sent) == 3
+
+    asyncio.run(_run())
+
+
+def test_unicode_encode_error_does_not_close_socket() -> None:
+    async def _run() -> None:
+        loop = asyncio.get_running_loop()
+        ws = _FakeWS()
+        ws.raise_on = "BOOM"
+        transport = WSTransport(ws, loop, peer="127.0.0.1:1")
+        await transport._safe_send_many(["ok-a", "BOOM-frame", "ok-b"])
+        assert transport.closed is False
+        assert ws.sent == ["ok-a", "ok-b"]
+
+    asyncio.run(_run())

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -61,6 +61,24 @@ def _note_dashboard_client_activity(*, force: bool = False) -> None:
     except Exception:  # noqa: BLE001 - liveness garnish must never break the WS
         _log.debug("dashboard client heartbeat touch failed", exc_info=True)
 
+
+def _sanitize_ws_text(text: str) -> str:
+    """Return *text* that can be UTF-8 encoded for a WebSocket frame.
+
+    Python ``str`` may contain lone UTF-16 surrogates (``\\ud800``-``\\udfff``)
+    that ``json.dumps(..., ensure_ascii=False)`` will happily emit. Starlette
+    then encodes the frame as UTF-8 and raises ``UnicodeEncodeError``, which
+    used to latch the whole connection closed (#97288). Replace those
+    code points rather than dropping the connection.
+    """
+    if not text:
+        return text
+    try:
+        text.encode("utf-8")
+    except UnicodeEncodeError:
+        return text.encode("utf-8", "replace").decode("utf-8")
+    return text
+
 # Max seconds a pool-dispatched handler will block waiting for the event loop
 # to flush a WS frame before we mark the transport dead. Protects handler
 # threads from a wedged socket.
@@ -277,20 +295,30 @@ class WSTransport:
         async with self._send_lock:
             if self._closed:
                 return
-            try:
-                for line in lines:
-                    if self._closed:
-                        return
-                    await self._ws.send_text(line)
-            except Exception as exc:
-                # Latch while still holding the writer lock so queued batches
-                # observe the failure before they get a chance to touch the
-                # socket.
-                self._closed = True
-                _log.warning(
-                    "ws send failed peer=%s error_type=%s error=%s",
-                    self._peer, type(exc).__name__, exc,
-                )
+            for line in lines:
+                if self._closed:
+                    return
+                payload = _sanitize_ws_text(line)
+                try:
+                    await self._ws.send_text(payload)
+                except UnicodeEncodeError as exc:
+                    # A single illegal UTF-8 frame (lone surrogate in a
+                    # status/ready payload) must not tear down the socket.
+                    # Fresh Desktop installs looped on this (#97288).
+                    _log.warning(
+                        "ws send skipped invalid utf-8 frame peer=%s error=%s",
+                        self._peer, exc,
+                    )
+                    continue
+                except Exception as exc:
+                    # Latch while still holding the writer lock so queued
+                    # batches observe the failure before they touch the socket.
+                    self._closed = True
+                    _log.warning(
+                        "ws send failed peer=%s error_type=%s error=%s",
+                        self._peer, type(exc).__name__, exc,
+                    )
+                    return
 
     def close(self) -> None:
         self._closed = True

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -33,6 +33,7 @@ import time
 from typing import Any
 
 from tui_gateway import server
+from agent.message_sanitization import _sanitize_surrogates
 from tui_gateway.event_replay import replay_epoch
 
 _log = logging.getLogger(__name__)
@@ -65,19 +66,13 @@ def _note_dashboard_client_activity(*, force: bool = False) -> None:
 def _sanitize_ws_text(text: str) -> str:
     """Return *text* that can be UTF-8 encoded for a WebSocket frame.
 
-    Python ``str`` may contain lone UTF-16 surrogates (``\\ud800``-``\\udfff``)
-    that ``json.dumps(..., ensure_ascii=False)`` will happily emit. Starlette
-    then encodes the frame as UTF-8 and raises ``UnicodeEncodeError``, which
-    used to latch the whole connection closed (#97288). Replace those
-    code points rather than dropping the connection.
+    ``json.dumps(..., ensure_ascii=False)`` happily emits lone UTF-16
+    surrogates; Starlette's ``send_text`` then raises ``UnicodeEncodeError``,
+    which used to latch the whole connection closed (#97288). Same U+FFFD
+    replacement every other Hermes transport applies.
     """
-    if not text:
-        return text
-    try:
-        text.encode("utf-8")
-    except UnicodeEncodeError:
-        return text.encode("utf-8", "replace").decode("utf-8")
-    return text
+    return _sanitize_surrogates(text) if text else text
+
 
 # Max seconds a pool-dispatched handler will block waiting for the event loop
 # to flush a WS frame before we mark the transport dead. Protects handler


### PR DESCRIPTION
## Summary
A single WebSocket frame containing a lone UTF-16 surrogate no longer tears down the Desktop ↔ backend connection; the surrogate is replaced with U+FFFD and the frame is sent.

Salvage of #97622 by @686f6c61 (cherry-picked, authorship preserved) + one follow-up commit.

Fixes #97288. Also the actual mechanism behind #101195 (the `18789` theory there was retracted by the reporter; `errors.log` showed `ws send failed ... 'utf-8' codec can't encode character '\ud83d' ... surrogates not allowed`).

## Who hits this
Desktop users whose transcript or status payload contains a lone surrogate (an emoji split across a paste, a half-escaped `\ud83d` round-tripped through storage). `tui_gateway/ws.py` serialised frames with `json.dumps(..., ensure_ascii=False)`, `send_text` raised `UnicodeEncodeError`, `_safe_send_many` latched `_closed = True`, and the poisoned content was replayed on every reconnect — a permanent "Waiting for gateway connection" banner instead of a flap. `gateway/run.py`, `hermes_cli/oneshot.py` and the chat helpers already sanitise surrogates; the WS transport was the only major transport that didn't.

## Changes
- `tui_gateway/ws.py`: `_sanitize_ws_text()` applied per frame; a `UnicodeEncodeError` from `send_text` skips that frame with a warning instead of closing the socket; other send failures still latch closed. Follow-up: the helper delegates to `agent.message_sanitization._sanitize_surrogates` (the same U+FFFD replacement every other transport uses) instead of a second encode/decode round-trip.
- Tests: sanitizer makes text encodable / leaves clean text alone; a surrogate frame is skipped and the socket stays open; a non-encoding failure still latches closed.

## Validation
| Check | Result |
|---|---|
| `tests/tui_gateway/test_ws_surrogate_send.py` + `test_ws_keepalive.py` | 6 passed |
| Probe (`json.dumps` of a payload with `\ud83d`, real module): main | `UnicodeEncodeError` on encode, no sanitizer |
| Probe: this branch | frame encodes, `"ok \ufffd tail"` |
| ruff / ty (ws.py) | clean / 0 → 0 |
