### PR TITLE
fix(desktop): cleared SSH fields reach main as '' and drift heal aligns route identity

### DIFF
--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -43,6 +43,7 @@ import {
   updateEligibility,
   upsertConnection
 } from './connection-registry'
+import { matchingConnectionId } from './connection-route-identity'
 
 function emptyRegistry(): ConnectionRegistry {
   return normalizeRegistry(null)
@@ -1671,6 +1672,46 @@ test('drift heal leaves a registry that already knows the v1 SSH route untouched
 
   assert.equal(drifted.changed, false)
   assert.equal(drifted.registry, first.registry)
+})
+
+test('drift heal aligns a registered SSH route whose identity fields drifted from the v1 route', () => {
+  // Same host/user as the registered entry, but the v1 route carries a keyPath
+  // the entry never had. matchingConnectionId compares keyPath too, so the live
+  // window would resolve to no connectionId and be treated as the local device.
+  const first = reconcileRegistryDrift(emptyRegistry(), {
+    mode: 'ssh',
+    remote: { host: 'devbox.example.com', user: 'omar' }
+  })
+
+  assert.equal(first.changed, true)
+
+  const drifted = reconcileRegistryDrift(first.registry, {
+    mode: 'ssh',
+    remote: { host: 'devbox.example.com', user: 'omar', keyPath: '~/.ssh/id_rsa' }
+  })
+
+  assert.equal(drifted.changed, true)
+  const sshEntries = drifted.registry.connections.filter(connection => connection.kind === 'ssh')
+  assert.equal(sshEntries.length, 1)
+  assert.equal(sshEntries[0].keyPath, '~/.ssh/id_rsa')
+  assert.equal(drifted.registry.primary, first.registry.primary)
+  assert.equal(
+    matchingConnectionId(
+      drifted.registry,
+      { host: 'devbox.example.com', user: 'omar', keyPath: '~/.ssh/id_rsa', kind: 'ssh' },
+      'primary'
+    ),
+    sshEntries[0].id
+  )
+
+  // Clearing the keyPath again re-aligns the entry.
+  const cleared = reconcileRegistryDrift(drifted.registry, {
+    mode: 'ssh',
+    remote: { host: 'devbox.example.com', user: 'omar' }
+  })
+
+  assert.equal(cleared.changed, true)
+  assert.equal(cleared.registry.connections.find(connection => connection.kind === 'ssh')?.keyPath, undefined)
 })
 
 test('drift heal respects a deliberate primary pick on a registered SSH route', () => {

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -1534,20 +1534,41 @@ export function reconcileRegistryDrift(
 
     const target = normalizedSshTarget(ssh)
 
-    const alreadyRegistered = registry.connections.some(
+    const registered = registry.connections.find(
       connection =>
         connection.kind === 'ssh' &&
         normalizedSshTarget(connection) === target &&
         (connection.port ?? 22) === (ssh.port ?? 22)
     )
 
-    if (alreadyRegistered) {
+    const { mode: _mode, ...sshFields } = ssh
+
+    if (registered) {
       // Route is known; if primary names another source, that is the user's
       // Connections-panel choice, not drift.
-      return unchanged
+      //
+      // Known by target is not enough, though: the router tags the live
+      // window by the FULL route identity (matchingConnectionId also compares
+      // keyPath, remoteHermesPath and remoteProfile). A v1 route carrying a
+      // keyPath the registered entry never had resolves to no connectionId,
+      // the renderer treats the untagged window as the unscoped local backend
+      // ("This device") and the roster force-spawns a phantom local child.
+      // Align the registered entry's identity fields with the route the app
+      // actually dials so both sides compare equal.
+      if (matchingConnectionId(registry, { ...ssh, kind: 'ssh' }, 'unique')) {
+        return unchanged
+      }
+
+      const { host: _host, user: _user, port: _port, ...identityFields } = sshFields
+      const aligned: RegistryConnection = { ...registered }
+      delete aligned.keyPath
+      delete aligned.remoteHermesPath
+      delete aligned.remoteProfile
+      Object.assign(aligned, identityFields)
+
+      return { changed: true, registry: upsertConnection(registry, aligned) }
     }
 
-    const { mode: _mode, ...sshFields } = ssh
 
     let entry: RegistryConnection
 

--- a/apps/desktop/src/app/settings/gateway-settings.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.tsx
@@ -478,9 +478,14 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
     remoteToken: authMode === 'token' ? remoteToken.trim() || undefined : undefined,
     remoteUrl: trimmedUrl,
     sshHost: state.sshHost.trim(),
-    sshUser: state.sshUser.trim() || undefined,
+    // Send an explicit '' for cleared fields. Main merges with `??`, so
+    // `undefined` means "inherit the saved value" and a cleared Identity file
+    // (or User) could never be removed once saved: the form kept refilling
+    // the stale path, and the stale key path made the v1 SSH route's identity
+    // differ from the registered gateway's, leaving the window unscoped.
+    sshUser: state.sshUser.trim(),
     sshPort: state.sshPort,
-    sshKeyPath: state.sshKeyPath.trim() || undefined,
+    sshKeyPath: state.sshKeyPath.trim(),
     sshRemoteHermesPath: state.sshRemoteHermesPath.trim(),
     // Preserve an intentional blank so an existing remote-profile mapping can
     // be cleared instead of being mistaken for an omitted field.


### PR DESCRIPTION
## What does this PR do?

Fixes two bugs that, together, make a Desktop whose **primary** connection is `Connect via SSH` show **"This device"** in the Sessions switcher and spawn a local `hermes serve` the user never asked for, even though the window is in fact connected to the remote.

### How it presents

- Connection mode is SSH, the same host is also in Registered gateways, and the v1 SSH settings carry an Identity file (e.g. `~/.ssh/id_rsa`) that the registered entry does not.
- Boot log: `[ssh] control master established` → `Remote Hermes backend is ready`, then a few seconds later `Starting Hermes backend for profile "default" via Hermes at <local checkout>` — a second, local backend.
- The switcher reads "This device"; sessions created on the remote are recorded in `lastProfileByConnection` under `connectionId: "local"`.
- Clearing the Identity file field and clicking **Save and reconnect** does nothing: the field is refilled with the old path on the next open.

### Bug 1 — a cleared SSH field can never be cleared

`apps/desktop/src/app/settings/gateway-settings.tsx` serialised the form as

```ts
sshUser: state.sshUser.trim() || undefined,
sshKeyPath: state.sshKeyPath.trim() || undefined,
```

while `buildSshBlock` in `electron/main.ts` merges with `??` and documents the contract as: *"an explicit '' (user CLEARED the field) wins over the saved value; only a truly absent (undefined) field inherits."* The renderer turned every cleared field into `undefined`, so the saved value was inherited forever. The form now sends `''` for cleared fields (the way it already does for `sshRemoteHermesPath` and `sshRemoteProfile`); `normalizeSshConfig` drops empty strings, so nothing else changes.

### Bug 2 — drift heal and router disagree on what "the same route" is

`reconcileRegistryDrift` (`electron/connection-registry.ts`) treats a v1 SSH route as already registered when an entry matches on **host / user / port** and returns unchanged. But `matchingConnectionId` (`electron/connection-route-identity.ts`), which is what tags the live window with a registry id, compares the **full** route identity: host, user, port, `keyPath`, `remoteHermesPath`, `remoteProfile`.

So a v1 route carrying a `keyPath` the registered entry never had is "known" to the healer (no repair) yet "unmatched" for the router (no `connectionId`). The renderer treats an untagged window as the legacy unscoped local backend (see the null-is-local handling in `src/plugins/hermes-bots/data.ts` and `primaryRuntimeConnectionId`), labels it "This device", and the roster dials `local`, which force-spawns a local child under `conn:local::<profile>` — exactly the phantom-agent case the comment in `enumerateRegistryAgentSources` warns about.

The heal now checks `matchingConnectionId(registry, route, 'unique')` after the target match. If the route is known by target but not by identity, it aligns the registered entry's identity fields (`keyPath`, `remoteHermesPath`, `remoteProfile`) with the route the app actually dials and returns `changed: true`, so both sides compare equal from then on. Primary selection is untouched, so a deliberate "Make primary" on another source is still respected.

## Related Issue

Fixes #103053

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/settings/gateway-settings.tsx` — send `''` (not `undefined`) for cleared `sshUser` / `sshKeyPath` so main's `??` merge can clear them.
- `apps/desktop/electron/connection-registry.ts` — `reconcileRegistryDrift`: when a v1 SSH route is registered by target but `matchingConnectionId` cannot match it, align the registered entry's identity fields with the route.
- `apps/desktop/electron/connection-registry.test.ts` — regression test: a registered route whose v1 counterpart gains a `keyPath` is aligned (one entry, primary unchanged, `matchingConnectionId(..., 'primary')` now resolves), and clearing the `keyPath` again re-aligns.

## How to Test

1. Connection mode → **Connect via SSH** to a host; also add the same host under Registered gateways without an Identity file. Set an Identity file on the primary form and Save and reconnect.
2. Before: switcher shows "This device", `desktop.log` shows `Starting Hermes backend for profile "default"` right after `Remote Hermes backend is ready`. After: the window is tagged with the registered id, the switcher shows the registered label, and no local backend line appears.
3. Clear the Identity file field and Save and reconnect. Before: the path comes back. After: it stays cleared and `connection.json` no longer has `keyPath`.
4. `cd apps/desktop && npx vitest run --project electron electron/connection-registry.test.ts electron/desktop-remote-route.test.ts` (113 pass), `npx vitest run --project ui src/app/settings/gateway-settings.test.ts src/app/settings/gateway-settings.test.tsx`, `npm run typecheck`, `npx eslint` on the three files.

## Checklist

- [x] Tests added / updated
- [x] Typecheck and lint pass on the changed files
- [x] No behaviour change for desktops whose v1 route already matches the registered entry (the new branch returns `unchanged`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

