### PR TITLE
fix(agent): name reasoning_effort in custom-provider stale timeouts

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -755,6 +755,30 @@ def _record_interrupted_provider_wait(
     return True
 
 
+def _stale_hang_hint(agent, api_kwargs: dict) -> Optional[str]:
+    """Resolve the most actionable stale-hang hint for this request.
+
+    Order: the Codex silent-reject heuristic first (a wrong model on the
+    ChatGPT backend is the sharper diagnosis), then the custom-provider
+    reasoning_effort hint (#100841). Both return None when they don't apply,
+    so this composes without either helper knowing about the other.
+    """
+    for attr in ("_codex_silent_hang_hint", "_custom_reasoning_hang_hint"):
+        fn = getattr(agent, attr, None)
+        if not callable(fn):
+            continue
+        try:
+            if attr == "_codex_silent_hang_hint":
+                hint = fn(model=api_kwargs.get("model"))
+            else:
+                hint = fn(api_kwargs)
+        except Exception:
+            hint = None
+        if isinstance(hint, str) and hint:
+            return hint
+    return None
+
+
 def _report_stale_nonstream_kill(
     agent,
     api_kwargs: dict,
@@ -1320,7 +1344,8 @@ def direct_api_call(agent, api_kwargs: dict):
             return
         elapsed = time.time() - call_start
         _report_stale_nonstream_kill(
-            agent, api_kwargs, elapsed, stale_timeout, inline=True
+            agent, api_kwargs, elapsed, stale_timeout, inline=True,
+            hint=_stale_hang_hint(agent, api_kwargs),
         )
         _touch_stale_kill_activity(agent, elapsed)
 
@@ -1753,13 +1778,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
             and _elapsed > _ttfb_timeout
             and getattr(agent, "_codex_stream_last_event_ts", None) is None
         ):
-            _silent_hint: Optional[str] = None
-            _hint_fn = getattr(agent, "_codex_silent_hang_hint", None)
-            if callable(_hint_fn):
-                try:
-                    _silent_hint = _hint_fn(model=api_kwargs.get("model"))
-                except Exception:
-                    _silent_hint = None
+            _silent_hint = _stale_hang_hint(agent, api_kwargs)
             logger.warning(
                 "Codex stream produced no bytes within TTFB cutoff "
                 "(%.0fs > %.0fs, model=%s). Backend accepted the connection "
@@ -1849,13 +1868,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
         # Stale-call detector: kill the connection if no response
         # arrives within the configured timeout.
         if _elapsed > _stale_timeout:
-            _silent_hint: Optional[str] = None
-            _hint_fn = getattr(agent, "_codex_silent_hang_hint", None)
-            if callable(_hint_fn):
-                try:
-                    _silent_hint = _hint_fn(model=api_kwargs.get("model"))
-                except Exception:
-                    _silent_hint = None
+            _silent_hint = _stale_hang_hint(agent, api_kwargs)
             _report_stale_nonstream_kill(
                 agent, api_kwargs, _elapsed, _stale_timeout, hint=_silent_hint
             )

--- a/contributors/emails/itsflownium@users.noreply.github.com
+++ b/contributors/emails/itsflownium@users.noreply.github.com
@@ -1,0 +1,1 @@
+itsflownium

--- a/run_agent.py
+++ b/run_agent.py
@@ -1678,6 +1678,47 @@ class AIAgent:
             "See hermes-agent#21444 for symptom history."
         )
 
+    def _custom_reasoning_hang_hint(
+        self, api_kwargs: Optional[Dict[str, Any]] = None
+    ) -> Optional[str]:
+        """Return an actionable hint when a stale non-streaming call to a
+        ``provider: custom`` endpoint carried a ``reasoning_effort``.
+
+        vLLM / llama.cpp / SGLang cannot be capability-probed the way
+        Ollama's ``/api/show`` can (#63315), so Hermes forwards the
+        top-level ``reasoning_effort`` field unconditionally on custom
+        endpoints (#90057). When the backend honours it as extended
+        thinking, a request that took seconds without it can stall for
+        minutes — and the only visible symptom is a generic
+        ``Non-streaming API call timed out`` (#100841). This does NOT change
+        the request; it only names the most likely cause in the timeout
+        text so the operator can correlate the stall with
+        ``agent.reasoning_effort`` instead of timing experiments.
+        """
+        if not isinstance(api_kwargs, dict):
+            return None
+        provider = str(getattr(self, "provider", "") or "").strip().lower()
+        if provider not in {"custom", "vllm", "llamacpp", "llama.cpp", "llama-cpp", "local"}:
+            return None
+        effort = api_kwargs.get("reasoning_effort")
+        if effort is None:
+            extra_body = api_kwargs.get("extra_body")
+            if isinstance(extra_body, dict):
+                effort = extra_body.get("reasoning_effort")
+        effort_str = str(effort or "").strip().lower()
+        if not effort_str or effort_str == "none":
+            return None
+        model = api_kwargs.get("model") or getattr(self, "model", "") or "unknown"
+        return (
+            f"This request forwarded reasoning_effort={effort_str!r} to a custom "
+            f"OpenAI-compatible endpoint (model: {model}). vLLM/llama.cpp/SGLang "
+            "backends that honour it as extended thinking can stall for minutes "
+            "with no error instead of rejecting it (unlike Ollama's clean 400). "
+            "If this persists, set `agent.reasoning_effort: ''` (or `none`) in "
+            "config.yaml, or disable thinking server-side. "
+            "See hermes-agent#100841."
+        )
+
     def _is_openrouter_url(self) -> bool:
         """Return True when the base URL targets OpenRouter."""
         return base_url_host_matches(self._base_url_lower, "openrouter.ai")

--- a/tests/run_agent/test_custom_reasoning_hang_hint.py
+++ b/tests/run_agent/test_custom_reasoning_hang_hint.py
@@ -1,0 +1,108 @@
+"""Tests for the custom-provider reasoning_effort stale-hang hint (#100841).
+
+A `provider: custom` endpoint (vLLM / llama.cpp / SGLang) that honours a
+forwarded `reasoning_effort` as extended thinking can stall for minutes with
+no error, surfacing only as a generic "Non-streaming API call timed out".
+The hint in the timeout text must name reasoning_effort as the likely cause
+so operators don't have to rediscover it through timing experiments.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def _make_agent(tmp_path: Path, **overrides):
+    from run_agent import AIAgent
+    kwargs = dict(
+        model="qwen3.8-27b",
+        provider="custom",
+        api_key="sk-dummy",
+        base_url="http://127.0.0.1:8000/v1",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        platform="cli",
+    )
+    kwargs.update(overrides)
+    return AIAgent(**kwargs)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_hermes_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+
+
+def test_hint_fires_for_custom_provider_with_reasoning_effort(tmp_path):
+    agent = _make_agent(tmp_path)
+    hint = agent._custom_reasoning_hang_hint(
+        {"model": "qwen3.8-27b", "reasoning_effort": "medium"}
+    )
+    assert hint is not None
+    assert "reasoning_effort" in hint
+    assert "'medium'" in hint
+    assert "agent.reasoning_effort" in hint
+    assert "100841" in hint
+
+
+def test_hint_silent_when_no_effort_sent(tmp_path):
+    agent = _make_agent(tmp_path)
+    assert agent._custom_reasoning_hang_hint({"model": "qwen3.8-27b"}) is None
+    assert agent._custom_reasoning_hang_hint(
+        {"model": "qwen3.8-27b", "reasoning_effort": "none"}
+    ) is None
+    assert agent._custom_reasoning_hang_hint(
+        {"model": "qwen3.8-27b", "reasoning_effort": ""}
+    ) is None
+    assert agent._custom_reasoning_hang_hint(None) is None
+    assert agent._custom_reasoning_hang_hint("not-a-dict") is None
+
+
+def test_hint_silent_for_non_custom_providers(tmp_path):
+    agent = _make_agent(tmp_path, provider="openrouter",
+                        base_url="https://openrouter.ai/api/v1")
+    assert agent._custom_reasoning_hang_hint(
+        {"model": "qwen3.8-27b", "reasoning_effort": "medium"}
+    ) is None
+
+
+def test_hint_reads_extra_body_effort(tmp_path):
+    """Some transports nest reasoning_effort under extra_body."""
+    agent = _make_agent(tmp_path)
+    hint = agent._custom_reasoning_hang_hint(
+        {"model": "qwen3.8-27b", "extra_body": {"reasoning_effort": "high"}}
+    )
+    assert hint is not None and "'high'" in hint
+
+
+def test_stale_resolver_prefers_codex_hint_when_both_apply(tmp_path):
+    """Codex silent-reject is the sharper diagnosis; it must win the slot."""
+    from agent.chat_completion_helpers import _stale_hang_hint
+    agent = _make_agent(
+        tmp_path, provider="openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex", model="gpt-5.5",
+    )
+    agent.api_mode = "codex_responses"
+    hint = _stale_hang_hint(
+        agent, {"model": "gpt-5.5", "reasoning_effort": "medium"}
+    )
+    assert hint is not None
+    assert "backend-api/codex" in hint
+
+
+def test_stale_resolver_falls_through_to_custom_reasoning(tmp_path):
+    from agent.chat_completion_helpers import _stale_hang_hint
+    agent = _make_agent(tmp_path)
+    hint = _stale_hang_hint(
+        agent, {"model": "qwen3.8-27b", "reasoning_effort": "medium"}
+    )
+    assert hint is not None and "reasoning_effort" in hint
+
+
+def test_stale_resolver_returns_none_without_matching_pattern(tmp_path):
+    from agent.chat_completion_helpers import _stale_hang_hint
+    agent = _make_agent(tmp_path)
+    assert _stale_hang_hint(agent, {"model": "qwen3.8-27b"}) is None


### PR DESCRIPTION
## Root cause (the diagnostic gap, not a code-change to the request)

vLLM / llama.cpp / SGLang endpoints can't be capability-probed like Ollama's `/api/show` (#63315), so Hermes forwards the top-level `reasoning_effort` field to `provider: custom` backends unconditionally (#90057). When the backend honours it as extended thinking, a request that took seconds can stall for minutes — with no error, no log line, and the only visible symptom a generic `Non-streaming API call timed out after 180s`. The reporter lost a fleet of cron jobs to this and had to trace it via manual curl timing experiments.

The issue explicitly does NOT ask to gate the parameter (that would kill the feature for vLLM servers that *do* serve reasoning well) — it asks for the causal link to be visible when the stall happens (their suggestion 1).

## Fix

- `run_agent.py`: new `_custom_reasoning_hang_hint(api_kwargs)` — mirrors the existing `_codex_silent_hang_hint` shape (#21444). Returns an actionable message when a stale non-streaming call went to a `custom`/vLLM-family provider carrying a real `reasoning_effort` (top-level or nested in `extra_body`; `"none"`/empty is ignored), naming the effort value, the likely cause (extended-thinking stall vs Ollama's clean 400), the exact workaround (`agent.reasoning_effort: ''`), and the issue number.
- `agent/chat_completion_helpers.py`: new `_stale_hang_hint(agent, api_kwargs)` resolver (Codex heuristic first — the sharper diagnosis — then the custom-reasoning hint). Wired into **all three** stale-kill paths: the inline `direct_api_call` watchdog and both worker-poll branches (TTFB and generic stale detector), replacing the two duplicated codex-only hint blocks. Behaviour for non-matching requests is byte-identical (hint is `None`).

## Why this works

When the 180s/240s timeout now fires on a vLLM-backed custom provider with `reasoning_effort: medium` set, the `RuntimeError`, the warning log, and the status-line message all say `This request forwarded reasoning_effort='medium' to a custom OpenAI-compatible endpoint … set agent.reasoning_effort: ''` instead of the bare timeout — seconds to diagnose instead of days, and the field forwarding itself is untouched (vLLM reasoning servers keep working).

## Verification

`uv run python -m pytest tests/run_agent/test_custom_reasoning_hang_hint.py tests/run_agent/test_codex_silent_hang_hint.py -o 'addopts=' -q` → **9 passed** (7 new: hint fires with value, silent on none/empty/no-effort, non-custom provider excluded, extra_body nesting, codex precedence, fall-through, no-match → None; plus the 2 pre-existing Codex hint tests to prove no regression in the shared slot).

Also run: `tests/agent/test_cascading_interrupt_6600.py` → 15 passed; `tests/plugins -k custom` → 33 passed, 3 skipped.

Not claimed: I could not reproduce the actual vLLM hang locally (no GPU/vLLM server here) — the tests pin the decision logic and message content, and the reporter's production evidence already documents the stall side.

Closes #100841
