### PR TITLE
fix(terminal): expand ${VAR} refs in profile config terminal keys

### DIFF
--- a/tests/tools/test_terminal_scope_multiplex.py
+++ b/tests/tools/test_terminal_scope_multiplex.py
@@ -170,6 +170,43 @@ def test_gateway_runtime_scope_resets_on_error(tmp_path):
     assert get_terminal_scope() is None
 
 
+def test_config_env_refs_expand_against_profile_secret_scope(tmp_path, monkeypatch):
+    """#101659: ${VAR} references in a profile's config.yaml terminal: keys
+    must expand against that profile's secret scope at the per-turn boundary —
+    exactly as the startup config load would — instead of reaching consumers
+    as literals (TERMINAL_CWD="${DEFAULT_CWD}" → runtime_cwd falls back to
+    os.getcwd())."""
+    import gateway.run as gw
+    import tools.terminal_tool as tt
+    from agent import runtime_cwd
+
+    b_cwd = tmp_path / "b-work"
+    b_cwd.mkdir()
+    monkeypatch.setattr(
+        "agent.secret_scope.build_profile_secret_scope",
+        lambda _h: {"DEFAULT_CWD": str(b_cwd)},
+    )
+    home = _profile(tmp_path, "bee", "terminal:\n  cwd: ${DEFAULT_CWD}\n")
+    with gw._profile_runtime_scope(home):
+        cfg = tt._get_env_config()
+        assert cfg["cwd"] == str(b_cwd)
+        assert runtime_cwd.resolve_agent_cwd() == b_cwd
+
+
+def test_unresolved_config_env_ref_stays_verbatim(tmp_path, monkeypatch):
+    """An unresolved ${VAR} keeps its literal form (same contract as the
+    startup _expand_env_vars path) — downstream existence checks warn and
+    fall back; expansion itself never raises."""
+    import gateway.run as gw
+
+    monkeypatch.setattr(
+        "agent.secret_scope.build_profile_secret_scope", lambda _h: {}
+    )
+    home = _profile(tmp_path, "bee", "terminal:\n  cwd: ${NO_SUCH_CWD}\n")
+    with gw._profile_runtime_scope(home):
+        assert terminal_env("TERMINAL_CWD") == "${NO_SUCH_CWD}"
+
+
 def test_tui_and_cron_boundaries_bind_and_reset(tmp_path):
     import tui_gateway.server as server
     from tools.terminal_scope import install_and_reset_profile_terminal_scope

--- a/tools/terminal_scope.py
+++ b/tools/terminal_scope.py
@@ -230,7 +230,15 @@ def build_profile_terminal_scope(hermes_home: "Any") -> Dict[str, str]:
                 ) from exc
             raw_terminal = raw.get("terminal") if isinstance(raw, dict) else None
             if isinstance(raw_terminal, dict):
-                for cfg_key, value in raw_terminal.items():
+                # The profile's file is parsed raw here, so any ${VAR} /
+                # ${env:VAR} reference in terminal: keys is still literal.
+                # Expand with the same resolver the startup config path uses:
+                # _env_ref_lookup honors the active profile's secret scope
+                # (installed before this per-turn scope), so a multiplexed
+                # turn resolves against THIS profile's .env (#101659).
+                from hermes_cli.config import _expand_env_vars
+
+                for cfg_key, value in _expand_env_vars(raw_terminal).items():
                     _apply(cfg_key, value)
     except TerminalPolicyUnavailable:
         raise


### PR DESCRIPTION
## What does this PR do?

Under profile multiplexing, `${VAR}` / `${env:VAR}` references in a profile's `config.yaml` `terminal:` keys were projected into the per-turn terminal scope as literal strings. `build_profile_terminal_scope()` parses the profile's file raw (`fast_safe_load`), so `terminal: cwd: ${DEFAULT_CWD}` installed `TERMINAL_CWD` as the literal placeholder — `agent.runtime_cwd` then warns `TERMINAL_CWD does not exist: ${DEFAULT_CWD}` and silently falls back to `os.getcwd()`. The startup config load expands these refs via `hermes_cli.config._expand_env_vars`; the per-turn scope path (introduced with the multiplex-oriented per-turn terminal scope) bypassed it.

The fix expands the raw `terminal:` mapping with that same `_expand_env_vars` resolver before projecting it into the scope. `_env_ref_lookup` honors the active profile's secret scope (installed before the terminal scope at every profile boundary), so the ref resolves against the routed profile's own `.env` — not another profile's `os.environ` values. Unresolved refs stay verbatim, matching the startup contract; values without refs are untouched.

## Related Issue

Fixes #101659

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/terminal_scope.py` — in `build_profile_terminal_scope()` step 3, expand the raw `terminal:` mapping from the profile's `config.yaml` through `hermes_cli.config._expand_env_vars` before `_apply()` projects it (local import, same idiom as the existing `fast_safe_load` / `TERMINAL_CONFIG_ENV_MAP` imports in this function)
- `tests/tools/test_terminal_scope_multiplex.py` — regression tests: a `${DEFAULT_CWD}` ref in `config.yaml` resolves via the routed profile's secret scope through the real `gateway.run._profile_runtime_scope` boundary (consumers see the expanded path, `runtime_cwd.resolve_agent_cwd()` lands on it); an unresolved `${NO_SUCH_CWD}` ref stays verbatim

## How to Test

1. Create a profile home with `config.yaml` containing `terminal: cwd: ${DEFAULT_CWD}` and a `.env` defining `DEFAULT_CWD=<existing dir>`
2. Enter `gateway.run._profile_runtime_scope(profile_home)` (or run a multiplexed gateway turn routed to that profile)
3. Observed result: before the fix, `terminal_env("TERMINAL_CWD")` returned the literal `${DEFAULT_CWD}` and `tools.terminal_tool._get_env_config()["cwd"]` pointed at a nonexistent path; after the fix, both return the expanded directory and `runtime_cwd.resolve_agent_cwd()` resolves to it
4. `pytest tests/tools/test_terminal_scope_multiplex.py -q` — 10 passed (8 pre-existing + 2 new)
5. Also verified on a clean tree: `tests/tools/test_terminal_config_env_sync.py test_terminal_env_bridge.py test_terminal_task_cwd.py` (26 passed), TERMINAL_CWD consumer chain `tests/cron/test_cron_workdir.py tests/hermes_cli/test_kanban_worker_terminal_cwd.py tests/agent/test_runtime_cwd.py tests/cli/test_cwd_env_respect.py tests/gateway/test_config_cwd_bridge.py` (44 passed), and `tests/test_tui_gateway_server.py` (637 passed)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A