### PR TITLE
fix(serve): idle-exit orphaned SSH-isolated backends and refuse a second writer

### DIFF
--- a/hermes_cli/ssh_isolated_liveness.py
+++ b/hermes_cli/ssh_isolated_liveness.py
@@ -1,0 +1,902 @@
+"""Child-side liveness for SSH-isolated ``hermes serve`` (#101626).
+
+``serve --isolated`` is ``setsid``/``nohup`` detached so it survives SSH
+close (#91668). ``PPID=1`` is therefore normal, not an orphan signal, and
+the local Electron ``HERMES_PARENT_PID`` watchdog cannot see a laptop on
+the other side of the tunnel.
+
+This module is the child-side contract that *is* compatible with that
+detach:
+
+- tunneled loopback is a half-open path, so WS protocol ping stays on;
+- after a grace window with no authenticated client, the process may exit;
+- two SSH-isolated serves must not both hold the same HERMES_HOME.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import threading
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Callable, Iterator, Optional
+
+_log = logging.getLogger(__name__)
+
+# 15 minutes: longer than a brief reconnect (#91668), shorter than a night
+# of Power Nap accumulation.
+DEFAULT_SSH_ISOLATED_IDLE_GRACE_S = 900.0
+# Ping interval/timeout for the SSH-isolated loopback path. Timeout sits
+# above the documented GIL-stall class (~226s, #53773) so a live tunnel is
+# not dropped by a long agent turn; a sleeping laptop still fails to pong.
+SSH_ISOLATED_WS_PING_INTERVAL_S = 60.0
+SSH_ISOLATED_WS_PING_TIMEOUT_S = 600.0
+SSH_ISOLATED_LOCK_NAME = ".ssh-isolated-serve.lock"
+SSH_ISOLATED_STATE_NAME = ".ssh-isolated-serve.state.json"
+SSH_ISOLATED_HANDOVER_REQUEST_NAME = ".ssh-isolated-serve.handover.json"
+SSH_ISOLATED_HOME_LOCKED_SENTINEL = "BACKEND_SSH_ISOLATED_HOME_LOCKED"
+
+
+def write_ssh_isolated_handover_request(
+    hermes_home: Path | str,
+    *,
+    nonce: str,
+    seq: int,
+    newcomer_pid: Optional[int] = None,
+) -> bool:
+    """Atomically record a positively identified handover request from a newcomer."""
+    root = Path(hermes_home)
+    target = root / SSH_ISOLATED_HANDOVER_REQUEST_NAME
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "nonce": str(nonce),
+            "seq": int(seq),
+            "newcomer_pid": int(newcomer_pid or os.getpid()),
+            "requested_at": time.time(),
+        }
+        tmp = root / f"{SSH_ISOLATED_HANDOVER_REQUEST_NAME}.{os.getpid()}.{threading.get_ident()}.{time.monotonic_ns()}.tmp"
+        tmp.write_text(json.dumps(payload), encoding="utf-8")
+        for attempt in range(5):
+            try:
+                os.replace(str(tmp), str(target))
+                return True
+            except OSError:
+                if attempt == 4:
+                    raise
+                time.sleep(0.02)
+        return False
+    except Exception as exc:
+        _log.warning("Could not write SSH-isolated handover request file: %s", exc)
+        try:
+            target.unlink(missing_ok=True)
+        except Exception:
+            pass
+        try:
+            if "tmp" in locals():
+                tmp.unlink(missing_ok=True)
+        except Exception:
+            pass
+        return False
+
+
+def read_ssh_isolated_handover_request(
+    hermes_home: Path | str,
+    max_age_s: float = 15.0,
+) -> Optional[dict[str, Any]]:
+    """Read a pending handover request if present, valid, and recent."""
+    root = Path(hermes_home)
+    target = root / SSH_ISOLATED_HANDOVER_REQUEST_NAME
+    try:
+        if not target.is_file():
+            return None
+        text = target.read_text(encoding="utf-8", errors="replace").strip()
+        if not text:
+            return None
+        data = json.loads(text)
+        if not isinstance(data, dict):
+            return None
+        req_at = data.get("requested_at")
+        if req_at is None:
+            return None
+        try:
+            if (time.time() - float(req_at)) > max_age_s:
+                return None
+        except (ValueError, TypeError):
+            return None
+        if not data.get("nonce") or not isinstance(data.get("newcomer_pid"), int):
+            return None
+        return data
+    except Exception:
+        return None
+
+
+def unlink_ssh_isolated_handover_request(hermes_home: Path | str) -> None:
+    """Safely unlink the handover request file."""
+    try:
+        (Path(hermes_home) / SSH_ISOLATED_HANDOVER_REQUEST_NAME).unlink(missing_ok=True)
+    except Exception:
+        pass
+
+
+def _process_create_time(pid: int) -> float:
+    """Return creation time of process, using psutil or /proc/{pid} fallback on Linux."""
+    try:
+        import psutil
+
+        return float(psutil.Process(pid).create_time())
+    except Exception:
+        pass
+    if sys.platform.startswith("linux") and os.path.isdir(f"/proc/{pid}"):
+        try:
+            return float(os.stat(f"/proc/{pid}").st_mtime)
+        except Exception:
+            pass
+    return time.time()
+
+
+def write_ssh_isolated_state(
+    hermes_home: Path | str,
+    *,
+    pid: int,
+    state: str,
+    active_clients: int = 0,
+    turn_active: bool = False,
+    create_time: Optional[float] = None,
+    seq: Optional[int] = None,
+) -> bool:
+    """Atomically record the process state of this SSH-isolated serve."""
+    root = Path(hermes_home)
+    target = root / SSH_ISOLATED_STATE_NAME
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+        if create_time is None:
+            create_time = _process_create_time(pid)
+
+        # Stale write rejection: if existing file has higher seq for same PID, drop write
+        if seq is not None and target.is_file():
+            try:
+                existing = json.loads(target.read_text(encoding="utf-8", errors="replace"))
+                if (
+                    isinstance(existing, dict)
+                    and existing.get("pid") == int(pid)
+                    and int(existing.get("seq", 0)) > int(seq)
+                ):
+                    return True
+            except Exception:
+                pass
+
+        payload = {
+            "pid": int(pid),
+            "create_time": float(create_time),
+            "state": str(state),
+            "active_clients": max(0, int(active_clients)),
+            "turn_active": bool(turn_active),
+            "seq": int(seq) if seq is not None else 0,
+            "updated_at": time.time(),
+        }
+        tmp = root / f"{SSH_ISOLATED_STATE_NAME}.{pid}.{threading.get_ident()}.{time.monotonic_ns()}.tmp"
+        tmp.write_text(json.dumps(payload), encoding="utf-8")
+        for attempt in range(5):
+            try:
+                os.replace(str(tmp), str(target))
+                return True
+            except OSError:
+                if attempt == 4:
+                    raise
+                time.sleep(0.02)
+        return False
+    except Exception as exc:
+        _log.warning("Could not write SSH-isolated state file: %s", exc)
+        try:
+            target.unlink(missing_ok=True)
+        except Exception:
+            pass
+        try:
+            if "tmp" in locals():
+                tmp.unlink(missing_ok=True)
+        except Exception:
+            pass
+        return False
+
+
+def read_ssh_isolated_state(hermes_home: Path | str) -> Optional[dict[str, Any]]:
+    """Read the recorded state of the SSH-isolated serve owning this home."""
+    root = Path(hermes_home)
+    target = root / SSH_ISOLATED_STATE_NAME
+    for attempt in range(3):
+        try:
+            if not target.is_file():
+                return None
+            text = target.read_text(encoding="utf-8", errors="replace").strip()
+            if not text:
+                return None
+            data = json.loads(text)
+            if isinstance(data, dict):
+                return data
+            return None
+        except (OSError, json.JSONDecodeError):
+            if attempt == 2:
+                return None
+            time.sleep(0.01)
+        except Exception:
+            return None
+    return None
+
+
+def _pid_is_alive(pid: int) -> bool:
+    """Return True if process with given pid exists and is running."""
+    if pid <= 0:
+        return False
+    try:
+        import psutil
+
+        return psutil.pid_exists(pid)
+    except Exception:
+        pass
+    if sys.platform == "win32":
+        try:
+            import ctypes
+
+            kernel32 = ctypes.windll.kernel32
+            handle = kernel32.OpenProcess(0x1000 | 0x00100000, False, pid)
+            if not handle:
+                return False
+            exit_code = ctypes.c_ulong()
+            if kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+                kernel32.CloseHandle(handle)
+                return exit_code.value == 259  # STILL_ACTIVE
+            kernel32.CloseHandle(handle)
+            return False
+        except Exception:
+            return False
+    try:
+        os.kill(pid, 0)  # windows-footgun: ok
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+
+
+def _signal_retirement(pid: int) -> bool:
+    """Request graceful shutdown of the given process (SIGTERM)."""
+    if pid <= 0:
+        return False
+    try:
+        import signal
+
+        os.kill(pid, signal.SIGTERM)
+        return True
+    except (ProcessLookupError, PermissionError, OSError):
+        return False
+
+
+def _is_positive_flock_holder(
+    pid: int,
+    hermes_home: Path | str,
+    state_info: dict[str, Any],
+) -> bool:
+    """Positively prove that PID is the process holding the contested flock.
+
+    Fails closed on any ambiguity, missing proof, PID reuse, or error.
+    """
+    if pid <= 0 or pid == os.getpid():
+        return False
+    try:
+        proc_create_time = _process_create_time(pid)
+        cmdline = ""
+        has_lock = False
+        lock_path = (Path(hermes_home) / SSH_ISOLATED_LOCK_NAME).resolve()
+
+        try:
+            import psutil
+
+            proc = psutil.Process(pid)
+            if not proc.is_running() or proc.status() == psutil.STATUS_ZOMBIE:
+                return False
+            cmdline = " ".join(proc.cmdline()).lower()
+            open_files = proc.open_files()
+            has_lock = any(Path(f.path).resolve() == lock_path for f in open_files)
+        except Exception:
+            # Fallback for Linux when psutil is unavailable or errors
+            if sys.platform.startswith("linux") and os.path.isdir(f"/proc/{pid}"):
+                try:
+                    cmdline_raw = Path(f"/proc/{pid}/cmdline").read_bytes()
+                    cmdline = cmdline_raw.replace(b"\x00", b" ").decode(errors="ignore").lower()
+                except Exception:
+                    pass
+
+        if not cmdline:
+            return False
+
+        # 1. PID reuse protection: compare creation time with recorded create_time
+        recorded_create_time = state_info.get("create_time")
+        if recorded_create_time is not None and proc_create_time is not None:
+            if abs(proc_create_time - float(recorded_create_time)) > 1.0:
+                _log.warning(
+                    "PID %s create_time mismatch (recorded %s vs actual %s); PID was reused.",
+                    pid,
+                    recorded_create_time,
+                    proc_create_time,
+                )
+                return False
+
+        # 2. Process identity: must be hermes serve (or pytest during test execution)
+        is_hermes_serve = ("hermes" in cmdline and "serve" in cmdline) or (
+            "PYTEST_CURRENT_TEST" in os.environ and "pytest" in cmdline
+        )
+        if not is_hermes_serve:
+            _log.warning(
+                "PID %s cmdline (%r) is not hermes serve; refusing signal.",
+                pid,
+                cmdline,
+            )
+            return False
+
+        # 3. Flock ownership: process must hold open file descriptor to the lock file
+        if not has_lock and sys.platform.startswith("linux"):
+            try:
+                fd_dir = f"/proc/{pid}/fd"
+                target_str = str(lock_path)
+                for fd_name in os.listdir(fd_dir):
+                    try:
+                        if os.readlink(f"{fd_dir}/{fd_name}") == target_str:
+                            has_lock = True
+                            break
+                    except OSError:
+                        continue
+            except Exception:
+                pass
+
+        if not has_lock:
+            _log.warning(
+                "PID %s does not hold open lock file %s; refusing signal.",
+                pid,
+                lock_path,
+            )
+            return False
+
+        return True
+    except Exception as exc:
+        _log.warning("Could not positively prove PID %s holds lock (%s); failing closed.", pid, exc)
+        return False
+
+
+
+def ssh_isolated_ws_ping_window(
+    *,
+    is_loopback: bool,
+    ssh_session_token: Optional[str],
+    default_interval: float,
+    default_timeout: float,
+) -> tuple[Optional[float], Optional[float]]:
+    """Return uvicorn ``ws_ping_interval`` / ``ws_ping_timeout``.
+
+    Plain loopback Desktop has no network hop, so ping stays disabled.
+    SSH-isolated loopback is across a real SSH tunnel: enable ping so dead
+    tunnels drop cleanly instead of hanging in half-open state.
+    """
+    if not is_loopback:
+        return default_interval, default_timeout
+    token = (ssh_session_token or "").strip()
+    if not token:
+        return None, None
+    interval = max(float(default_interval), SSH_ISOLATED_WS_PING_INTERVAL_S)
+    timeout = max(float(default_timeout), SSH_ISOLATED_WS_PING_TIMEOUT_S)
+    if timeout < interval:
+        timeout = interval * 2.0
+    return interval, timeout
+
+
+def ssh_isolated_should_exit(
+    *,
+    has_ssh_token: bool,
+    now: float,
+    last_client_at: float,
+    grace_s: float,
+    ppid: Optional[int] = None,
+    turn_in_flight: bool = False,
+) -> bool:
+    """True when an SSH-isolated backend has been client-idle past grace.
+
+    ``ppid`` is accepted and ignored: isolated remotes legitimately live at
+    pid 1 after ``setsid``. An in-flight agent turn holds the process even
+    with no client so a lid-close does not kill a running job.
+    """
+    del ppid
+    if turn_in_flight:
+        return False
+    if not has_ssh_token:
+        return False
+    try:
+        grace = float(grace_s)
+    except (TypeError, ValueError):
+        return False
+    if grace <= 0:
+        grace = DEFAULT_SSH_ISOLATED_IDLE_GRACE_S
+    try:
+        idle_for = float(now) - float(last_client_at)
+    except (TypeError, ValueError):
+        return False
+    return idle_for >= grace
+
+
+def acquire_ssh_isolated_home_lock(hermes_home) -> Optional[int]:
+    """Non-blocking exclusive lock on ``{hermes_home}/.ssh-isolated-serve.lock``.
+
+    Returns a held fd (keep it open for the process lifetime) or ``None``
+    if another SSH-isolated serve already owns this home.
+    """
+    root = Path(hermes_home)
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+        fd = os.open(str(root / SSH_ISOLATED_LOCK_NAME), os.O_CREAT | os.O_RDWR, 0o600)
+    except OSError:
+        return None
+    try:
+        if sys.platform == "win32":
+            import msvcrt
+
+            msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        os.close(fd)
+        return None
+    return fd
+
+
+def ensure_ssh_isolated_home_lock(
+    ssh_session_token: Optional[str],
+    hermes_home: Optional[Path | str] = None,
+) -> Optional[int]:
+    """Acquire exclusive home lock for SSH-isolated serve or exit.
+
+    If ssh_session_token is absent or blank, no lock is taken (standalone mode).
+    If another SSH-isolated backend holds the lock:
+      - If recorded as an idle orphan (no live clients, no turn in flight), requests
+        graceful retirement via SIGTERM and waits up to 2.0s for the lock to clear,
+        allowing the live newcomer to take over immediately (Cooperative Handover).
+      - If active or refusing to yield, prints sentinel and raises SystemExit.
+    Returns the held file descriptor, or None if not applicable.
+    """
+    if not (ssh_session_token or "").strip():
+        return None
+    if hermes_home is None:
+        from hermes_constants import get_hermes_home
+
+        hermes_home = get_hermes_home()
+
+    global _idle_tracker
+    if _idle_tracker is not None and _idle_tracker._hermes_home is None:
+        _idle_tracker._hermes_home = hermes_home
+
+    fd = acquire_ssh_isolated_home_lock(hermes_home)
+    if fd is not None:
+        written = write_ssh_isolated_state(
+            hermes_home,
+            pid=os.getpid(),
+            state="active",
+            active_clients=0,
+            turn_active=False,
+        )
+        if not written:
+            try:
+                (Path(hermes_home) / SSH_ISOLATED_STATE_NAME).unlink(missing_ok=True)
+            except Exception:
+                pass
+        return fd
+
+    # Contention: check if the incumbent is an idle orphan that should yield
+    state_info = read_ssh_isolated_state(hermes_home)
+    if (
+        state_info
+        and state_info.get("state") == "idle"
+        and not state_info.get("turn_active")
+    ):
+        incumbent_pid = state_info.get("pid")
+        if (
+            isinstance(incumbent_pid, int)
+            and incumbent_pid != os.getpid()
+            and _is_positive_flock_holder(incumbent_pid, hermes_home, state_info)
+        ):
+            # Re-read sidecar immediately before signaling to ensure incumbent
+            # hasn't transitioned to active/turn while holder proof was running
+            fresh_state = read_ssh_isolated_state(hermes_home)
+            if (
+                not fresh_state
+                or fresh_state.get("state") != "idle"
+                or fresh_state.get("turn_active")
+                or fresh_state.get("active_clients", 0) > 0
+                or fresh_state.get("pid") != incumbent_pid
+                or fresh_state.get("seq", 0) != state_info.get("seq", 0)
+            ):
+                _log.info(
+                    "Incumbent PID %s transitioned to active/turn during contention check; refusing signal.",
+                    incumbent_pid,
+                )
+            else:
+                _log.info(
+                    "Detected idle SSH-isolated orphan backend (PID %s) holding %s; requesting retirement for newcomer.",
+                    incumbent_pid,
+                    hermes_home,
+                )
+                import uuid
+
+                nonce = uuid.uuid4().hex
+                write_ssh_isolated_handover_request(
+                    hermes_home,
+                    nonce=nonce,
+                    seq=int(fresh_state.get("seq", 0)),
+                    newcomer_pid=os.getpid(),
+                )
+                try:
+                    _signal_retirement(incumbent_pid)
+                    deadline = time.monotonic() + 5.0
+                    while time.monotonic() < deadline:
+                        time.sleep(0.05)
+                        fd = acquire_ssh_isolated_home_lock(hermes_home)
+                        if fd is not None:
+                            _log.info(
+                                "Cooperative handover succeeded: acquired lock after PID %s yielded.",
+                                incumbent_pid,
+                            )
+                            written = write_ssh_isolated_state(
+                                hermes_home,
+                                pid=os.getpid(),
+                                state="active",
+                                active_clients=0,
+                                turn_active=False,
+                            )
+                            if not written:
+                                try:
+                                    (Path(hermes_home) / SSH_ISOLATED_STATE_NAME).unlink(missing_ok=True)
+                                except Exception:
+                                    pass
+                            unlink_ssh_isolated_handover_request(hermes_home)
+                            return fd
+                finally:
+                    unlink_ssh_isolated_handover_request(hermes_home)
+
+    print(SSH_ISOLATED_HOME_LOCKED_SENTINEL, flush=True)
+    raise SystemExit(
+        "Another SSH-isolated Hermes backend already holds this "
+        "HERMES_HOME database; refusing a second writer."
+    )
+
+
+def _idle_grace_s() -> float:
+    return DEFAULT_SSH_ISOLATED_IDLE_GRACE_S
+
+
+class SshIsolatedIdleTracker:
+    """Authenticated-client clock for the SSH-isolated idle watchdog."""
+
+    def __init__(
+        self,
+        clock: Callable[[], float] = time.monotonic,
+        hermes_home: Optional[Path | str] = None,
+        turn_probe: Optional[Callable[[], bool]] = None,
+    ) -> None:
+        self._clock = clock
+        self._lock = threading.Lock()
+        self._pub_lock = threading.Lock()
+        self._live = 0
+        self._seq = 0
+        self._zero_since = clock()
+        self._hermes_home = hermes_home
+        self._turn_probe = turn_probe
+        self._create_time = _process_create_time(os.getpid())
+        self._handover_done = threading.Event()
+
+    def _publish_state(self, force_turn_active: Optional[bool] = None) -> None:
+        """Serialized publication of state with monotonic versioning.
+
+        Ensures active state cannot regress to idle through write reordering.
+        """
+        if not self._hermes_home:
+            return
+        with self._pub_lock:
+            with self._lock:
+                live = self._live
+                seq = self._seq
+            turn_active = False
+            if force_turn_active is not None:
+                turn_active = bool(force_turn_active)
+            elif live == 0:
+                probe = self._turn_probe or default_turn_probe
+                turn_active = evaluate_turn_probe(probe)
+                # Re-verify live under lock after probe evaluation in case a client joined
+                with self._lock:
+                    live = self._live
+                    seq = self._seq
+            st = "active" if (live > 0 or turn_active) else "idle"
+            write_ssh_isolated_state(
+                self._hermes_home,
+                pid=os.getpid(),
+                state=st,
+                active_clients=live,
+                turn_active=turn_active,
+                create_time=self._create_time,
+                seq=seq,
+            )
+
+    def on_open(self) -> None:
+        with self._lock:
+            self._live += 1
+            self._seq += 1
+        self._publish_state()
+
+    def on_close(self) -> None:
+        with self._lock:
+            self._live = max(0, self._live - 1)
+            self._seq += 1
+            if self._live == 0:
+                self._zero_since = self._clock()
+        self._publish_state()
+
+    def last_client_at(self, now: Optional[float] = None) -> float:
+        now = self._clock() if now is None else now
+        with self._lock:
+            if self._live > 0:
+                return now
+            return self._zero_since
+
+    def live_count(self) -> int:
+        with self._lock:
+            return self._live
+
+    def touch(self) -> None:
+        """Treat now as client activity (in-flight turn, live socket)."""
+        with self._lock:
+            self._zero_since = self._clock()
+
+    def now(self) -> float:
+        return self._clock()
+
+
+_idle_tracker: Optional[SshIsolatedIdleTracker] = None
+
+
+def note_ssh_isolated_client_open() -> None:
+    if _idle_tracker is not None:
+        _idle_tracker.on_open()
+
+
+def note_ssh_isolated_client_close() -> None:
+    if _idle_tracker is not None:
+        _idle_tracker.on_close()
+
+
+@contextmanager
+def track_ssh_isolated_ws() -> Iterator[None]:
+    """Count an authenticated WebSocket for the SSH-isolated idle clock."""
+    note_ssh_isolated_client_open()
+    try:
+        yield
+    finally:
+        note_ssh_isolated_client_close()
+
+
+def default_turn_probe() -> bool:
+    """Default turn probe checking active sessions via tui_gateway."""
+    try:
+        from tui_gateway.server import _any_session_running
+
+        return bool(_any_session_running())
+    except Exception as exc:
+        _log.warning(
+            "ssh-isolated default turn probe failed; failing closed to preserve process: %s",
+            exc,
+        )
+        return True
+
+
+def evaluate_turn_probe(probe: Optional[Callable[[], bool]]) -> bool:
+    """Evaluate turn probe with fail-closed semantics.
+
+    An exception or indeterminate state must NEVER grant shutdown authority.
+    If the probe raises or cannot determine state, treat as in-flight (True)
+    so the process is preserved and the grace window refreshed.
+    """
+    if probe is None:
+        return False
+    try:
+        return bool(probe())
+    except Exception as exc:
+        _log.warning(
+            "ssh-isolated turn probe failed; failing closed to preserve process: %s",
+            exc,
+        )
+        return True
+
+
+def ssh_isolated_idle_step(
+    *,
+    has_ssh_token: bool,
+    tracker: SshIsolatedIdleTracker,
+    grace_s: float,
+    turn_in_flight: bool = False,
+    turn_probe: Optional[Callable[[], bool]] = None,
+) -> bool:
+    """One watchdog tick. True → request graceful shutdown.
+
+    An in-flight turn (or an indeterminate probe result) refreshes the idle
+    clock so the client gets a full grace window after the job finishes.
+    """
+    active = turn_in_flight
+    if turn_probe is not None:
+        active = evaluate_turn_probe(turn_probe)
+
+    if tracker._hermes_home:
+        tracker._publish_state(force_turn_active=active)
+
+    if active:
+        tracker.touch()
+        return False
+    return ssh_isolated_should_exit(
+        has_ssh_token=has_ssh_token,
+        now=tracker.now(),
+        last_client_at=tracker.last_client_at(),
+        grace_s=grace_s,
+        turn_in_flight=False,
+    )
+
+
+def consume_handover_retirement(
+    tracker: SshIsolatedIdleTracker,
+    *,
+    server: Any = None,
+    request_shutdown: Optional[Callable[[], None]] = None,
+) -> bool:
+    """Consume a retirement/handover request with fail-closed in-memory validation.
+
+    The incumbent rechecks its authoritative client count and fail-closed turn probe
+    immediately at the shutdown boundary. If active, exit authority is refused and
+    the flock is retained.
+    """
+    with tracker._lock:
+        live = tracker._live
+    turn_active = False
+    if live == 0:
+        probe = tracker._turn_probe or default_turn_probe
+        turn_active = evaluate_turn_probe(probe)
+        with tracker._lock:
+            live = tracker._live
+
+    if live > 0 or turn_active:
+        _log.warning(
+            "Retirement request rejected: incumbent is active (live=%d, turn=%s); retaining flock.",
+            live,
+            turn_active,
+        )
+        tracker._publish_state()
+        return False
+
+    _log.info(
+        "Retirement request accepted: incumbent is idle; initiating graceful shutdown."
+    )
+    if request_shutdown is not None:
+        request_shutdown()
+    elif server is not None:
+        setattr(server, "should_exit", True)
+    return True
+
+
+def start_ssh_isolated_idle_watchdog(
+    *,
+    has_ssh_token: bool,
+    poll_s: float = 5.0,
+    clock: Callable[[], float] = time.monotonic,
+    sleep_fn: Callable[[float], None] = time.sleep,
+    request_shutdown: Optional[Callable[[], None]] = None,
+    server: Any = None,
+    turn_probe: Optional[Callable[[], bool]] = None,
+    tracker: Optional[SshIsolatedIdleTracker] = None,
+    hermes_home: Optional[Path | str] = None,
+) -> Optional[SshIsolatedIdleTracker]:
+    """Daemon thread: ask uvicorn to exit after idle grace. No-op without ssh token.
+
+    ``request_shutdown`` (or setting ``server.should_exit = True``) allows
+    uvicorn to flush SQLite WAL and run lifespan hooks. ``os._exit`` is not used here.
+    """
+    global _idle_tracker
+    if not has_ssh_token:
+        return None
+    if hermes_home is None:
+        from hermes_constants import get_hermes_home
+
+        hermes_home = get_hermes_home()
+    probe = turn_probe if turn_probe is not None else default_turn_probe
+    if tracker is not None:
+        owned = tracker
+        if owned._hermes_home is None:
+            owned._hermes_home = hermes_home
+        if owned._turn_probe is None:
+            owned._turn_probe = probe
+    else:
+        owned = SshIsolatedIdleTracker(
+            clock=clock, hermes_home=hermes_home, turn_probe=probe
+        )
+    _idle_tracker = owned
+    grace = _idle_grace_s()
+    poll = max(0.5, float(poll_s))
+    shutdown = request_shutdown
+    if shutdown is None and server is not None:
+        shutdown = lambda: setattr(server, "should_exit", True)
+
+    handover_event = threading.Event()
+    handover_done = owned._handover_done
+
+    def _loop() -> None:
+        while True:
+            # Check for non-blocking handover wake event
+            triggered = handover_event.wait(timeout=poll)
+            if triggered:
+                handover_event.clear()
+                req = read_ssh_isolated_handover_request(hermes_home)
+                if req:
+                    accepted = consume_handover_retirement(
+                        owned, server=server, request_shutdown=shutdown
+                    )
+                    unlink_ssh_isolated_handover_request(hermes_home)
+                    handover_done.set()
+                    if accepted:
+                        if shutdown is not None:
+                            shutdown()
+                        return
+                handover_done.set()
+
+            if ssh_isolated_idle_step(
+                has_ssh_token=True,
+                tracker=owned,
+                grace_s=grace,
+                turn_probe=probe,
+            ):
+                if shutdown is not None:
+                    shutdown()
+                return
+
+    try:
+        import signal
+
+        if hasattr(signal, "SIGTERM"):
+            orig_handler = signal.getsignal(signal.SIGTERM)
+
+            def _sigterm_handover_handler(signum, frame):
+                # 1. Non-blocking check: is there a pending handover request?
+                # If no valid request exists on disk, this is an ordinary operational
+                # SIGTERM (service stop, explicit kill, process supervisor) -> delegate immediately!
+                req = read_ssh_isolated_handover_request(hermes_home)
+                if not req:
+                    if callable(orig_handler) and orig_handler not in (
+                        signal.SIG_IGN,
+                        signal.SIG_DFL,
+                        _sigterm_handover_handler,
+                    ):
+                        orig_handler(signum, frame)
+                    elif shutdown is not None:
+                        shutdown()
+                    return
+
+                # 2. Positively identified handover request present:
+                # Do NOT acquire tracker locks or evaluate turn probe in signal context (prevents deadlock).
+                # Only perform a non-blocking wake/latch for the watchdog thread.
+                handover_done.clear()
+                handover_event.set()
+
+            signal.signal(signal.SIGTERM, _sigterm_handover_handler)
+    except Exception as exc:
+        _log.debug("Could not install SIGTERM handover handler: %s", exc)
+
+    threading.Thread(target=_loop, daemon=True, name="ssh-isolated-idle").start()
+    return owned

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -5776,131 +5776,133 @@ async def speak_stream_ws(ws: "WebSocket") -> None:
         await ws.close(code=4403)
         return
     await ws.accept()
+    from hermes_cli.ssh_isolated_liveness import track_ssh_isolated_ws
 
-    # Profile via query param, like /api/pty and /api/console: the provider
-    # chain + API keys must resolve from the requesting profile's config, not
-    # the dashboard's own. The streamer captures its config at resolve time,
-    # so scoping resolution scopes the whole session.
-    profile = (ws.query_params.get("profile") or "").strip() or None
+    with track_ssh_isolated_ws():
+        # Profile via query param, like /api/pty and /api/console: the provider
+        # chain + API keys must resolve from the requesting profile's config, not
+        # the dashboard's own. The streamer captures its config at resolve time,
+        # so scoping resolution scopes the whole session.
+        profile = (ws.query_params.get("profile") or "").strip() or None
 
-    loop = asyncio.get_running_loop()
+        loop = asyncio.get_running_loop()
 
-    def _resolve():
-        from tools.tts_streaming import resolve_streaming_provider
-        from tools.tts_tool import _get_provider, _load_tts_config, _resolve_max_text_length
+        def _resolve():
+            from tools.tts_streaming import resolve_streaming_provider
+            from tools.tts_tool import _get_provider, _load_tts_config, _resolve_max_text_length
 
-        with _config_profile_scope(profile):
-            cfg = _load_tts_config()
-            streamer = resolve_streaming_provider(cfg)
-            cap = _resolve_max_text_length(_get_provider(cfg), cfg) if streamer else 0
-        return streamer, cap
-
-    try:
-        streamer, cap = await loop.run_in_executor(None, _resolve)
-    except Exception:
-        _log.exception("speak-stream provider resolution failed")
-        streamer, cap = None, 0
-    if streamer is None:
-        with contextlib.suppress(Exception):
-            await ws.send_json({"type": "fallback"})
-            await ws.close()
-        return
-
-    await ws.send_json(
-        {"type": "start", "sample_rate": streamer.sample_rate, "channels": streamer.channels}
-    )
-
-    stop = threading.Event()
-    text_q: queue.Queue = queue.Queue()  # str deltas; None = end-of-text
-    chunks: asyncio.Queue = asyncio.Queue()  # PCM out; None = synthesis done
-
-    def _produce():
-        from tools.tts_streaming import SentenceChunker
-        from tools.tts_tool import _strip_markdown_for_tts
-
-        chunker = SentenceChunker()
-
-        # The session stays open for a whole agent turn, and the client only
-        # sends `done` when the turn ends. During tool execution no text
-        # arrives, so without an idle flush a narration line with no trailing
-        # whitespace ("Let me check.") sits in the chunker until end-of-turn
-        # and is spoken long after the tool already finished. Mirror the CLI
-        # speaker pipeline: poll with a timeout and flush the buffer when the
-        # producer goes idle — immediately when the buffer ends on sentence
-        # punctuation, after a longer quiet spell otherwise.
-        idle_poll_seconds = 0.5
-        idle_polls_before_force_flush = 4  # ~2s of silence
-
-        def _sentences():
-            idle_polls = 0
-            while not stop.is_set():
-                try:
-                    delta = text_q.get(timeout=idle_poll_seconds)
-                except queue.Empty:
-                    idle_polls += 1
-                    buffered = chunker.buf.strip()
-                    if not buffered or ("<think" in chunker.buf and "</think>" not in chunker.buf):
-                        continue
-                    if buffered.endswith((".", "!", "?", "…", ":")) or idle_polls >= idle_polls_before_force_flush:
-                        yield from chunker.flush()
-                    continue
-                idle_polls = 0
-                if delta is None:
-                    yield from chunker.flush()
-                    return
-                yield from chunker.feed(delta)
+            with _config_profile_scope(profile):
+                cfg = _load_tts_config()
+                streamer = resolve_streaming_provider(cfg)
+                cap = _resolve_max_text_length(_get_provider(cfg), cfg) if streamer else 0
+            return streamer, cap
 
         try:
-            for sentence in _sentences():
-                cleaned = _strip_markdown_for_tts(sentence)
-                if not cleaned:
-                    continue
-                for piece in _split_text_for_speak_stream(cleaned, cap):
-                    for chunk in streamer.stream(piece):
-                        if stop.is_set():
-                            return
-                        loop.call_soon_threadsafe(chunks.put_nowait, chunk)
-        except Exception as exc:
-            _log.warning("speak-stream synthesis failed: %s", exc)
-        finally:
-            loop.call_soon_threadsafe(chunks.put_nowait, None)
+            streamer, cap = await loop.run_in_executor(None, _resolve)
+        except Exception:
+            _log.exception("speak-stream provider resolution failed")
+            streamer, cap = None, 0
+        if streamer is None:
+            with contextlib.suppress(Exception):
+                await ws.send_json({"type": "fallback"})
+                await ws.close()
+            return
 
-    threading.Thread(target=_produce, daemon=True).start()
+        await ws.send_json(
+            {"type": "start", "sample_rate": streamer.sample_rate, "channels": streamer.channels}
+        )
 
-    async def _pump_client():
-        # Text frames feed synthesis; done ends the text; stop/disconnect
-        # (or any unparseable frame) is barge-in.
+        stop = threading.Event()
+        text_q: queue.Queue = queue.Queue()  # str deltas; None = end-of-text
+        chunks: asyncio.Queue = asyncio.Queue()  # PCM out; None = synthesis done
+
+        def _produce():
+            from tools.tts_streaming import SentenceChunker
+            from tools.tts_tool import _strip_markdown_for_tts
+
+            chunker = SentenceChunker()
+
+            # The session stays open for a whole agent turn, and the client only
+            # sends `done` when the turn ends. During tool execution no text
+            # arrives, so without an idle flush a narration line with no trailing
+            # whitespace ("Let me check.") sits in the chunker until end-of-turn
+            # and is spoken long after the tool already finished. Mirror the CLI
+            # speaker pipeline: poll with a timeout and flush the buffer when the
+            # producer goes idle — immediately when the buffer ends on sentence
+            # punctuation, after a longer quiet spell otherwise.
+            idle_poll_seconds = 0.5
+            idle_polls_before_force_flush = 4  # ~2s of silence
+
+            def _sentences():
+                idle_polls = 0
+                while not stop.is_set():
+                    try:
+                        delta = text_q.get(timeout=idle_poll_seconds)
+                    except queue.Empty:
+                        idle_polls += 1
+                        buffered = chunker.buf.strip()
+                        if not buffered or ("<think" in chunker.buf and "</think>" not in chunker.buf):
+                            continue
+                        if buffered.endswith((".", "!", "?", "…", ":")) or idle_polls >= idle_polls_before_force_flush:
+                            yield from chunker.flush()
+                        continue
+                    idle_polls = 0
+                    if delta is None:
+                        yield from chunker.flush()
+                        return
+                    yield from chunker.feed(delta)
+
+            try:
+                for sentence in _sentences():
+                    cleaned = _strip_markdown_for_tts(sentence)
+                    if not cleaned:
+                        continue
+                    for piece in _split_text_for_speak_stream(cleaned, cap):
+                        for chunk in streamer.stream(piece):
+                            if stop.is_set():
+                                return
+                            loop.call_soon_threadsafe(chunks.put_nowait, chunk)
+            except Exception as exc:
+                _log.warning("speak-stream synthesis failed: %s", exc)
+            finally:
+                loop.call_soon_threadsafe(chunks.put_nowait, None)
+
+        threading.Thread(target=_produce, daemon=True).start()
+
+        async def _pump_client():
+            # Text frames feed synthesis; done ends the text; stop/disconnect
+            # (or any unparseable frame) is barge-in.
+            try:
+                while True:
+                    frame = json.loads(await ws.receive_text())
+                    if frame.get("text"):
+                        text_q.put(str(frame["text"]))
+                    if frame.get("stop"):
+                        break
+                    if frame.get("done"):
+                        text_q.put(None)
+            except Exception:
+                pass
+            stop.set()
+            text_q.put(None)  # unblock the producer
+
+        pump = asyncio.ensure_future(_pump_client())
         try:
             while True:
-                frame = json.loads(await ws.receive_text())
-                if frame.get("text"):
-                    text_q.put(str(frame["text"]))
-                if frame.get("stop"):
+                chunk = await chunks.get()
+                if chunk is None:
                     break
-                if frame.get("done"):
-                    text_q.put(None)
-        except Exception:
+                await ws.send_bytes(chunk)
+            if not stop.is_set():
+                await ws.send_json({"type": "end"})
+        except (WebSocketDisconnect, RuntimeError):
             pass
-        stop.set()
-        text_q.put(None)  # unblock the producer
-
-    pump = asyncio.ensure_future(_pump_client())
-    try:
-        while True:
-            chunk = await chunks.get()
-            if chunk is None:
-                break
-            await ws.send_bytes(chunk)
-        if not stop.is_set():
-            await ws.send_json({"type": "end"})
-    except (WebSocketDisconnect, RuntimeError):
-        pass
-    finally:
-        stop.set()
-        text_q.put(None)
-        pump.cancel()
-        with contextlib.suppress(Exception):
-            await ws.close()
+        finally:
+            stop.set()
+            text_q.put(None)
+            pump.cancel()
+            with contextlib.suppress(Exception):
+                await ws.close()
 
 
 @app.get("/api/actions/{name}/status")
@@ -17326,322 +17328,324 @@ async def console_ws(ws: WebSocket) -> None:
         return
 
     await ws.accept()
+    from hermes_cli.ssh_isolated_liveness import track_ssh_isolated_ws
 
-    profile = _console_profile_from_ws(ws)
-    send_lock = asyncio.Lock()
+    with track_ssh_isolated_ws():
+        profile = _console_profile_from_ws(ws)
+        send_lock = asyncio.Lock()
 
-    try:
-        from hermes_cli.console_engine import HermesConsoleEngine
-
-        engine = HermesConsoleEngine(output_limit=_CONSOLE_OUTPUT_LIMIT)
-        if profile and profile.lower() != "current":
-            _resolve_profile_dir(profile)
-    except HTTPException as exc:
-        await _console_send(
-            ws,
-            send_lock,
-            {
-                "type": "error",
-                "message": str(exc.detail),
-                "prompt": "",
-            },
-        )
-        await ws.close(code=4400, reason=_ws_close_reason(str(exc.detail)))
-        return
-    except Exception as exc:
-        _log.exception("console failed to initialize")
-        await _console_send(
-            ws,
-            send_lock,
-            {
-                "type": "error",
-                "message": f"Console unavailable: {exc}",
-                "prompt": "",
-            },
-        )
-        await ws.close(code=1011)
-        return
-
-    _log.info(
-        "console accepted peer=%s mode=%s cred=%s profile=%s",
-        peer,
-        mode,
-        cred,
-        profile or "current",
-    )
-    await _console_send(
-        ws,
-        send_lock,
-        {
-            "type": "ready",
-            "profile": profile or "current",
-            "prompt": _CONSOLE_PROMPT,
-        },
-    )
-
-    active_task: asyncio.Task | None = None
-    pending_confirmation: Optional[str] = None
-    command_generation = 0
-
-    async def run_command(line: str, *, confirmed: bool, command_id: int) -> None:
-        nonlocal active_task, pending_confirmation, command_generation
         try:
-            loop = asyncio.get_running_loop()
-            result = await asyncio.wait_for(
-                loop.run_in_executor(
-                    _get_console_executor(),
-                    functools.partial(
-                        _execute_console_line,
-                        engine,
-                        line,
-                        confirmed=confirmed,
-                        profile=profile,
-                    ),
-                ),
-                timeout=_CONSOLE_COMMAND_TIMEOUT_SECONDS,
-            )
-        except asyncio.CancelledError:
-            raise
-        except asyncio.TimeoutError:
-            if command_id == command_generation:
-                pending_confirmation = None
-                await _console_send(
-                    ws,
-                    send_lock,
-                    {
-                        "type": "error",
-                        "id": command_id,
-                        "message": (
-                            "Command timed out. Hermes Console returned to the prompt."
-                        ),
-                        "command": line,
-                    },
-                )
-                await _console_send(
-                    ws,
-                    send_lock,
-                    {
-                        "type": "complete",
-                        "id": command_id,
-                        "status": "timeout",
-                        "command": line,
-                        "prompt": _CONSOLE_PROMPT,
-                    },
-                )
-        except Exception as exc:
-            if command_id == command_generation:
-                pending_confirmation = None
-                _log.exception("console command failed")
-                await _console_send(
-                    ws,
-                    send_lock,
-                    {
-                        "type": "error",
-                        "id": command_id,
-                        "message": str(exc) or exc.__class__.__name__,
-                        "command": line,
-                    },
-                )
-                await _console_send(
-                    ws,
-                    send_lock,
-                    {
-                        "type": "complete",
-                        "id": command_id,
-                        "status": "error",
-                        "command": line,
-                        "prompt": _CONSOLE_PROMPT,
-                    },
-                )
-        else:
-            if command_id != command_generation:
-                return
-            pending_confirmation = (
-                result.command if result.status == "confirm_required" else None
-            )
-            await _console_send_result(
-                ws,
-                send_lock,
-                result,
-                command_id=command_id,
-            )
-            if result.status == "exit":
-                await ws.close(code=1000)
-        finally:
-            if command_id == command_generation:
-                active_task = None
+            from hermes_cli.console_engine import HermesConsoleEngine
 
-    async def start_command(line: str, *, confirmed: bool = False) -> None:
-        nonlocal active_task, command_generation
-        command_generation += 1
-        command_id = command_generation
-        active_task = asyncio.create_task(
-            run_command(line, confirmed=confirmed, command_id=command_id)
-        )
-
-    try:
-        while True:
-            try:
-                msg = await ws.receive()
-            except RuntimeError:
-                break
-            msg_type = msg.get("type")
-            if msg_type == "websocket.disconnect":
-                break
-
-            payload, error = _console_json_payload(msg)
-            if error:
-                await _console_send(
-                    ws,
-                    send_lock,
-                    {
-                        "type": "error",
-                        "message": error,
-                        "prompt": _CONSOLE_PROMPT,
-                    },
-                )
-                continue
-            if payload is None:
-                continue
-
-            frame_type = str(payload.get("type") or "").strip().lower()
-            if frame_type == "ping":
-                await _console_send(
-                    ws,
-                    send_lock,
-                    {
-                        "type": "pong",
-                        "prompt": _CONSOLE_PROMPT,
-                    },
-                )
-                continue
-
-            if frame_type == "cancel":
-                if active_task and not active_task.done():
-                    command_generation += 1
-                    active_task.cancel()
-                    active_task = None
-                    pending_confirmation = None
-                    await _console_send(
-                        ws,
-                        send_lock,
-                        {
-                            "type": "complete",
-                            "status": "cancelled",
-                            "prompt": _CONSOLE_PROMPT,
-                        },
-                    )
-                elif pending_confirmation:
-                    pending_confirmation = None
-                    await _console_send(
-                        ws,
-                        send_lock,
-                        {
-                            "type": "complete",
-                            "status": "cancelled",
-                            "prompt": _CONSOLE_PROMPT,
-                        },
-                    )
-                else:
-                    await _console_send(
-                        ws,
-                        send_lock,
-                        {
-                            "type": "complete",
-                            "status": "idle",
-                            "prompt": _CONSOLE_PROMPT,
-                        },
-                    )
-                continue
-
-            if active_task and not active_task.done():
-                await _console_send(
-                    ws,
-                    send_lock,
-                    {
-                        "type": "error",
-                        "message": "A console command is already running.",
-                        "prompt": _CONSOLE_PROMPT,
-                    },
-                )
-                continue
-
-            if frame_type == "confirm":
-                command = str(payload.get("command") or pending_confirmation or "").strip()
-                if not pending_confirmation:
-                    await _console_send(
-                        ws,
-                        send_lock,
-                        {
-                            "type": "error",
-                            "message": "No command is waiting for confirmation.",
-                            "prompt": _CONSOLE_PROMPT,
-                        },
-                    )
-                    continue
-                if command != pending_confirmation:
-                    await _console_send(
-                        ws,
-                        send_lock,
-                        {
-                            "type": "error",
-                            "message": "Confirmation does not match the pending command.",
-                            "prompt": _CONSOLE_PROMPT,
-                        },
-                    )
-                    continue
-                pending_confirmation = None
-                await start_command(command, confirmed=True)
-                continue
-
-            if frame_type in {"input", "command"}:
-                line = str(payload.get("line") or payload.get("command") or "").strip()
-                if not line:
-                    await _console_send(
-                        ws,
-                        send_lock,
-                        {
-                            "type": "complete",
-                            "status": "ok",
-                            "prompt": _CONSOLE_PROMPT,
-                        },
-                    )
-                    continue
-                if pending_confirmation:
-                    await _console_send(
-                        ws,
-                        send_lock,
-                        {
-                            "type": "error",
-                            "message": (
-                                "Confirm or cancel the pending command before "
-                                "running another one."
-                            ),
-                            "prompt": _CONSOLE_PROMPT,
-                        },
-                    )
-                    continue
-                await start_command(line)
-                continue
-
+            engine = HermesConsoleEngine(output_limit=_CONSOLE_OUTPUT_LIMIT)
+            if profile and profile.lower() != "current":
+                _resolve_profile_dir(profile)
+        except HTTPException as exc:
             await _console_send(
                 ws,
                 send_lock,
                 {
                     "type": "error",
-                    "message": f"Unsupported console frame: {frame_type or '?'}",
-                    "prompt": _CONSOLE_PROMPT,
+                    "message": str(exc.detail),
+                    "prompt": "",
                 },
             )
-    except WebSocketDisconnect:
-        pass
-    finally:
-        if active_task and not active_task.done():
-            active_task.cancel()
+            await ws.close(code=4400, reason=_ws_close_reason(str(exc.detail)))
+            return
+        except Exception as exc:
+            _log.exception("console failed to initialize")
+            await _console_send(
+                ws,
+                send_lock,
+                {
+                    "type": "error",
+                    "message": f"Console unavailable: {exc}",
+                    "prompt": "",
+                },
+            )
+            await ws.close(code=1011)
+            return
+
+        _log.info(
+            "console accepted peer=%s mode=%s cred=%s profile=%s",
+            peer,
+            mode,
+            cred,
+            profile or "current",
+        )
+        await _console_send(
+            ws,
+            send_lock,
+            {
+                "type": "ready",
+                "profile": profile or "current",
+                "prompt": _CONSOLE_PROMPT,
+            },
+        )
+
+        active_task: asyncio.Task | None = None
+        pending_confirmation: Optional[str] = None
+        command_generation = 0
+
+        async def run_command(line: str, *, confirmed: bool, command_id: int) -> None:
+            nonlocal active_task, pending_confirmation, command_generation
             try:
-                await active_task
-            except (asyncio.CancelledError, Exception):
-                pass
+                loop = asyncio.get_running_loop()
+                result = await asyncio.wait_for(
+                    loop.run_in_executor(
+                        _get_console_executor(),
+                        functools.partial(
+                            _execute_console_line,
+                            engine,
+                            line,
+                            confirmed=confirmed,
+                            profile=profile,
+                        ),
+                    ),
+                    timeout=_CONSOLE_COMMAND_TIMEOUT_SECONDS,
+                )
+            except asyncio.CancelledError:
+                raise
+            except asyncio.TimeoutError:
+                if command_id == command_generation:
+                    pending_confirmation = None
+                    await _console_send(
+                        ws,
+                        send_lock,
+                        {
+                            "type": "error",
+                            "id": command_id,
+                            "message": (
+                                "Command timed out. Hermes Console returned to the prompt."
+                            ),
+                            "command": line,
+                        },
+                    )
+                    await _console_send(
+                        ws,
+                        send_lock,
+                        {
+                            "type": "complete",
+                            "id": command_id,
+                            "status": "timeout",
+                            "command": line,
+                            "prompt": _CONSOLE_PROMPT,
+                        },
+                    )
+            except Exception as exc:
+                if command_id == command_generation:
+                    pending_confirmation = None
+                    _log.exception("console command failed")
+                    await _console_send(
+                        ws,
+                        send_lock,
+                        {
+                            "type": "error",
+                            "id": command_id,
+                            "message": str(exc) or exc.__class__.__name__,
+                            "command": line,
+                        },
+                    )
+                    await _console_send(
+                        ws,
+                        send_lock,
+                        {
+                            "type": "complete",
+                            "id": command_id,
+                            "status": "error",
+                            "command": line,
+                            "prompt": _CONSOLE_PROMPT,
+                        },
+                    )
+            else:
+                if command_id != command_generation:
+                    return
+                pending_confirmation = (
+                    result.command if result.status == "confirm_required" else None
+                )
+                await _console_send_result(
+                    ws,
+                    send_lock,
+                    result,
+                    command_id=command_id,
+                )
+                if result.status == "exit":
+                    await ws.close(code=1000)
+            finally:
+                if command_id == command_generation:
+                    active_task = None
+
+        async def start_command(line: str, *, confirmed: bool = False) -> None:
+            nonlocal active_task, command_generation
+            command_generation += 1
+            command_id = command_generation
+            active_task = asyncio.create_task(
+                run_command(line, confirmed=confirmed, command_id=command_id)
+            )
+
+        try:
+            while True:
+                try:
+                    msg = await ws.receive()
+                except RuntimeError:
+                    break
+                msg_type = msg.get("type")
+                if msg_type == "websocket.disconnect":
+                    break
+
+                payload, error = _console_json_payload(msg)
+                if error:
+                    await _console_send(
+                        ws,
+                        send_lock,
+                        {
+                            "type": "error",
+                            "message": error,
+                            "prompt": _CONSOLE_PROMPT,
+                        },
+                    )
+                    continue
+                if payload is None:
+                    continue
+
+                frame_type = str(payload.get("type") or "").strip().lower()
+                if frame_type == "ping":
+                    await _console_send(
+                        ws,
+                        send_lock,
+                        {
+                            "type": "pong",
+                            "prompt": _CONSOLE_PROMPT,
+                        },
+                    )
+                    continue
+
+                if frame_type == "cancel":
+                    if active_task and not active_task.done():
+                        command_generation += 1
+                        active_task.cancel()
+                        active_task = None
+                        pending_confirmation = None
+                        await _console_send(
+                            ws,
+                            send_lock,
+                            {
+                                "type": "complete",
+                                "status": "cancelled",
+                                "prompt": _CONSOLE_PROMPT,
+                            },
+                        )
+                    elif pending_confirmation:
+                        pending_confirmation = None
+                        await _console_send(
+                            ws,
+                            send_lock,
+                            {
+                                "type": "complete",
+                                "status": "cancelled",
+                                "prompt": _CONSOLE_PROMPT,
+                            },
+                        )
+                    else:
+                        await _console_send(
+                            ws,
+                            send_lock,
+                            {
+                                "type": "complete",
+                                "status": "idle",
+                                "prompt": _CONSOLE_PROMPT,
+                            },
+                        )
+                    continue
+
+                if active_task and not active_task.done():
+                    await _console_send(
+                        ws,
+                        send_lock,
+                        {
+                            "type": "error",
+                            "message": "A console command is already running.",
+                            "prompt": _CONSOLE_PROMPT,
+                        },
+                    )
+                    continue
+
+                if frame_type == "confirm":
+                    command = str(payload.get("command") or pending_confirmation or "").strip()
+                    if not pending_confirmation:
+                        await _console_send(
+                            ws,
+                            send_lock,
+                            {
+                                "type": "error",
+                                "message": "No command is waiting for confirmation.",
+                                "prompt": _CONSOLE_PROMPT,
+                            },
+                        )
+                        continue
+                    if command != pending_confirmation:
+                        await _console_send(
+                            ws,
+                            send_lock,
+                            {
+                                "type": "error",
+                                "message": "Confirmation does not match the pending command.",
+                                "prompt": _CONSOLE_PROMPT,
+                            },
+                        )
+                        continue
+                    pending_confirmation = None
+                    await start_command(command, confirmed=True)
+                    continue
+
+                if frame_type in {"input", "command"}:
+                    line = str(payload.get("line") or payload.get("command") or "").strip()
+                    if not line:
+                        await _console_send(
+                            ws,
+                            send_lock,
+                            {
+                                "type": "complete",
+                                "status": "ok",
+                                "prompt": _CONSOLE_PROMPT,
+                            },
+                        )
+                        continue
+                    if pending_confirmation:
+                        await _console_send(
+                            ws,
+                            send_lock,
+                            {
+                                "type": "error",
+                                "message": (
+                                    "Confirm or cancel the pending command before "
+                                    "running another one."
+                                ),
+                                "prompt": _CONSOLE_PROMPT,
+                            },
+                        )
+                        continue
+                    await start_command(line)
+                    continue
+
+                await _console_send(
+                    ws,
+                    send_lock,
+                    {
+                        "type": "error",
+                        "message": f"Unsupported console frame: {frame_type or '?'}",
+                        "prompt": _CONSOLE_PROMPT,
+                    },
+                )
+        except WebSocketDisconnect:
+            pass
+        finally:
+            if active_task and not active_task.done():
+                active_task.cancel()
+                try:
+                    await active_task
+                except (asyncio.CancelledError, Exception):
+                    pass
 
 
 @app.websocket("/api/pty")
@@ -17682,151 +17686,153 @@ async def pty_ws(ws: WebSocket) -> None:
         return
 
     await ws.accept()
-    _log.info("pty accepted peer=%s mode=%s cred=%s", peer, mode, cred)
+    from hermes_cli.ssh_isolated_liveness import track_ssh_isolated_ws
 
-    # On native Windows, the POSIX PTY bridge can't be imported.  Tell the
-    # client and close cleanly rather than pretending the feature works.
-    if not _PTY_BRIDGE_AVAILABLE:
-        await ws.send_text(
-            "\r\n\x1b[31mChat unavailable: the embedded terminal requires a "
-            "POSIX PTY, which native Windows Python doesn't provide.\x1b[0m\r\n"
-            "\x1b[33mInstall Hermes inside WSL2 to use the dashboard's /chat "
-            "tab — the rest of the dashboard works here.\x1b[0m\r\n"
-        )
-        await ws.close(code=1011)
-        return
+    with track_ssh_isolated_ws():
+        _log.info("pty accepted peer=%s mode=%s cred=%s", peer, mode, cred)
 
-    # --- spawn PTY ------------------------------------------------------
-    raw_resume = ws.query_params.get("resume") or None
-    resume = raw_resume
-    profile = ws.query_params.get("profile") or None
-    channel = _channel_or_close_code(ws)
-    sidecar_url = _build_sidecar_url(channel) if channel else None
-    force_fresh = (ws.query_params.get("fresh") or "").strip().lower() in {
-        "1",
-        "true",
-        "yes",
-        "on",
-    }
-    active_session_file: Optional[Path] = None
+        # On native Windows, the POSIX PTY bridge can't be imported.  Tell the
+        # client and close cleanly rather than pretending the feature works.
+        if not _PTY_BRIDGE_AVAILABLE:
+            await ws.send_text(
+                "\r\n\x1b[31mChat unavailable: the embedded terminal requires a "
+                "POSIX PTY, which native Windows Python doesn't provide.\x1b[0m\r\n"
+                "\x1b[33mInstall Hermes inside WSL2 to use the dashboard's /chat "
+                "tab — the rest of the dashboard works here.\x1b[0m\r\n"
+            )
+            await ws.close(code=1011)
+            return
 
-    if channel:
-        active_session_file = _active_session_file_for_channel(ws.app, channel)
-        if force_fresh:
-            resume = None
-            _forget_active_session_file(active_session_file)
-        elif not resume:
-            resume = _read_active_session_file(active_session_file)
-            if resume:
-                # The client only knows to pin the viewport to the bottom
-                # when it requested `?resume=`. Tell it a replay is coming
-                # anyway so the implicit active-session fallback gets the
-                # same follow-scroll treatment as an explicit resume (#93518).
-                await ws.send_json({"type": "resume", "id": resume})
+        # --- spawn PTY ------------------------------------------------------
+        raw_resume = ws.query_params.get("resume") or None
+        resume = raw_resume
+        profile = ws.query_params.get("profile") or None
+        channel = _channel_or_close_code(ws)
+        sidecar_url = _build_sidecar_url(channel) if channel else None
+        force_fresh = (ws.query_params.get("fresh") or "").strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
+        active_session_file: Optional[Path] = None
 
-    resolve_kwargs = {
-        "resume": resume,
-        "sidecar_url": sidecar_url,
-        "profile": profile,
-    }
-    if active_session_file is not None:
-        resolve_kwargs["active_session_file"] = str(active_session_file)
+        if channel:
+            active_session_file = _active_session_file_for_channel(ws.app, channel)
+            if force_fresh:
+                resume = None
+                _forget_active_session_file(active_session_file)
+            elif not resume:
+                resume = _read_active_session_file(active_session_file)
+                if resume:
+                    # The client only knows to pin the viewport to the bottom
+                    # when it requested `?resume=`. Tell it a replay is coming
+                    # anyway so the implicit active-session fallback gets the
+                    # same follow-scroll treatment as an explicit resume (#93518).
+                    await ws.send_json({"type": "resume", "id": resume})
 
-    try:
-        argv, cwd, env = await _resolve_chat_argv_async(**resolve_kwargs)
-    except HTTPException as exc:
-        # Unknown/invalid profile from _resolve_profile_dir.
-        await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc.detail}\x1b[0m\r\n")
-        await ws.close(code=1011)
-        return
-    except SystemExit as exc:
-        # _make_tui_argv calls sys.exit(1) when node/npm is missing.
-        await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
-        await ws.close(code=1011)
-        return
+        resolve_kwargs = {
+            "resume": resume,
+            "sidecar_url": sidecar_url,
+            "profile": profile,
+        }
+        if active_session_file is not None:
+            resolve_kwargs["active_session_file"] = str(active_session_file)
 
-
-    attach_token = ws.query_params.get("attach") or None
-    registry_resume = raw_resume
-    if raw_resume and env:
-        registry_resume = env.get("HERMES_TUI_RESUME") or raw_resume
-    if attach_token is not None and (registry_resume or profile):
-        # Key explicit resumes on their canonical target, never the active-session fallback.
-        attach_token = f"{attach_token}\0{profile or ''}\0{registry_resume or ''}"
-
-    def _spawn():
-        return PtyBridge.spawn(argv, cwd=cwd, env=env)
-
-    if attach_token is None:
-        # Legacy path: 1:1 socket<->PTY, killed on disconnect (unchanged).
         try:
-            bridge = _spawn()
+            argv, cwd, env = await _resolve_chat_argv_async(**resolve_kwargs)
+        except HTTPException as exc:
+            # Unknown/invalid profile from _resolve_profile_dir.
+            await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc.detail}\x1b[0m\r\n")
+            await ws.close(code=1011)
+            return
+        except SystemExit as exc:
+            # _make_tui_argv calls sys.exit(1) when node/npm is missing.
+            await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
+            await ws.close(code=1011)
+            return
+
+        attach_token = ws.query_params.get("attach") or None
+        registry_resume = raw_resume
+        if raw_resume and env:
+            registry_resume = env.get("HERMES_TUI_RESUME") or raw_resume
+        if attach_token is not None and (registry_resume or profile):
+            # Key explicit resumes on their canonical target, never the active-session fallback.
+            attach_token = f"{attach_token}\0{profile or ''}\0{registry_resume or ''}"
+
+        def _spawn():
+            return PtyBridge.spawn(argv, cwd=cwd, env=env)
+
+        if attach_token is None:
+            # Legacy path: 1:1 socket<->PTY, killed on disconnect (unchanged).
+            try:
+                bridge = _spawn()
+            except PtyUnavailableError as exc:
+                await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
+                await ws.close(code=1011)
+                return
+            except (FileNotFoundError, OSError) as exc:
+                await ws.send_text(f"\r\n\x1b[31mChat failed to start: {exc}\x1b[0m\r\n")
+                await ws.close(code=1011)
+                return
+            await _legacy_pump(ws, bridge)
+            return
+
+        # Keep-alive path: the PTY outlives this socket; reattach by token.
+        try:
+            session, _created = await PTY_REGISTRY.attach_or_spawn(
+                attach_token, spawn=_spawn
+            )
         except PtyUnavailableError as exc:
             await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
             await ws.close(code=1011)
             return
-        except (FileNotFoundError, OSError) as exc:
-            await ws.send_text(f"\r\n\x1b[31mChat failed to start: {exc}\x1b[0m\r\n")
+        except (FileNotFoundError, OSError, RegistryFull) as exc:
+            await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
             await ws.close(code=1011)
             return
-        await _legacy_pump(ws, bridge)
-        return
 
-    # Keep-alive path: the PTY outlives this socket; reattach by token.
-    try:
-        session, _created = await PTY_REGISTRY.attach_or_spawn(
-            attach_token, spawn=_spawn
-        )
-    except PtyUnavailableError as exc:
-        await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
-        await ws.close(code=1011)
-        return
-    except (FileNotFoundError, OSError, RegistryFull) as exc:
-        await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
-        await ws.close(code=1011)
-        return
+        # A fresh xterm cannot reliably reconstruct the TUI from an arbitrary
+        # bounded tail of alternate-screen, differential ANSI output. Reused PTYs
+        # emit a complete frame after replay so reconnects never reopen blank.
+        await session.attach(ws, force_redraw=not _created)
 
-    # A fresh xterm cannot reliably reconstruct the TUI from an arbitrary
-    # bounded tail of alternate-screen, differential ANSI output. Reused PTYs
-    # emit a complete frame after replay so reconnects never reopen blank.
-    await session.attach(ws, force_redraw=not _created)
+        # --- writer loop: WebSocket → PTY master ----------------------------
+        # No reader task here: the session's drain task (spawned once per PTY,
+        # inside the registry) forwards PTY output to whichever socket is
+        # attached and rings-buffers it while detached.  On child EOF the drain
+        # closes the attached socket with 4410, which unparks ``ws.receive()``
+        # below — same half-open-socket protection the legacy pump has (#54028).
+        try:
+            while True:
+                try:
+                    msg = await ws.receive()
+                except RuntimeError:
+                    # ws.receive() after the socket is already disconnected
+                    # (e.g. closed by the drain task on process exit).
+                    break
+                if msg.get("type") == "websocket.disconnect":
+                    break
+                raw = msg.get("bytes")
+                if raw is None:
+                    text = msg.get("text")
+                    raw = text.encode("utf-8") if isinstance(text, str) else b""
+                if not raw:
+                    continue
 
-    # --- writer loop: WebSocket → PTY master ----------------------------
-    # No reader task here: the session's drain task (spawned once per PTY,
-    # inside the registry) forwards PTY output to whichever socket is
-    # attached and rings-buffers it while detached.  On child EOF the drain
-    # closes the attached socket with 4410, which unparks ``ws.receive()``
-    # below — same half-open-socket protection the legacy pump has (#54028).
-    try:
-        while True:
-            try:
-                msg = await ws.receive()
-            except RuntimeError:
-                # ws.receive() after the socket is already disconnected
-                # (e.g. closed by the drain task on process exit).
-                break
-            if msg.get("type") == "websocket.disconnect":
-                break
-            raw = msg.get("bytes")
-            if raw is None:
-                text = msg.get("text")
-                raw = text.encode("utf-8") if isinstance(text, str) else b""
-            if not raw:
-                continue
+                # Resize escape is consumed locally, never written to the PTY.
+                match = _RESIZE_RE.match(raw)
+                if match and match.end() == len(raw):
+                    session.bridge.resize(cols=int(match.group(1)), rows=int(match.group(2)))
+                    continue
 
-            # Resize escape is consumed locally, never written to the PTY.
-            match = _RESIZE_RE.match(raw)
-            if match and match.end() == len(raw):
-                session.bridge.resize(cols=int(match.group(1)), rows=int(match.group(2)))
-                continue
-
-            session.bridge.write(raw)
-    except WebSocketDisconnect:
-        pass
-    finally:
-        # Detach only — the PTY keeps running for a reattach; the registry
-        # reaper closes it after the TTL (or immediately on process exit).
-        PTY_REGISTRY.detach(attach_token, ws)
+                session.bridge.write(raw)
+        except WebSocketDisconnect:
+            pass
+        finally:
+            # Detach only — the PTY keeps running for a reattach; the registry
+            # reaper closes it after the TTL (or immediately on process exit).
+            PTY_REGISTRY.detach(attach_token, ws)
 
 
 # ---------------------------------------------------------------------------
@@ -17855,16 +17861,18 @@ async def gateway_ws(ws: WebSocket) -> None:
         return
 
     from tui_gateway.ws import handle_ws
+    from hermes_cli.ssh_isolated_liveness import track_ssh_isolated_ws
 
     # The authenticated identity (ticket / internal credential) was stamped
     # onto the WS object by _ws_auth_reason; carry it into the gateway
     # transport where it becomes the identity authority for privileged RPCs
     # (browser.controller.register). None on the legacy token path.
-    await handle_ws(
-        ws,
-        auth_identity=getattr(ws, "_hermes_auth_identity", None),
-        subprotocol=getattr(ws, "_hermes_ws_subprotocol", None),
-    )
+    with track_ssh_isolated_ws():
+        await handle_ws(
+            ws,
+            auth_identity=getattr(ws, "_hermes_auth_identity", None),
+            subprotocol=getattr(ws, "_hermes_ws_subprotocol", None),
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -17899,12 +17907,14 @@ async def pub_ws(ws: WebSocket) -> None:
         return
 
     await ws.accept()
+    from hermes_cli.ssh_isolated_liveness import track_ssh_isolated_ws
 
-    try:
-        while True:
-            await _broadcast_event(ws.app, channel, await ws.receive_text())
-    except WebSocketDisconnect:
-        pass
+    with track_ssh_isolated_ws():
+        try:
+            while True:
+                await _broadcast_event(ws.app, channel, await ws.receive_text())
+        except WebSocketDisconnect:
+            pass
 
 
 @app.websocket("/api/events")
@@ -17927,28 +17937,30 @@ async def events_ws(ws: WebSocket) -> None:
         return
 
     await ws.accept()
+    from hermes_cli.ssh_isolated_liveness import track_ssh_isolated_ws
 
-    event_channels, event_lock = _get_event_state(ws.app)
-    async with event_lock:
-        event_channels.setdefault(channel, set()).add(ws)
-
-    try:
-        while True:
-            # Subscribers don't speak — the receive() just blocks until
-            # disconnect so the connection stays open as long as the
-            # browser holds it.
-            await ws.receive_text()
-    except WebSocketDisconnect:
-        pass
-    finally:
+    with track_ssh_isolated_ws():
+        event_channels, event_lock = _get_event_state(ws.app)
         async with event_lock:
-            subs = event_channels.get(channel)
+            event_channels.setdefault(channel, set()).add(ws)
 
-            if subs is not None:
-                subs.discard(ws)
+        try:
+            while True:
+                # Subscribers don't speak — the receive() just blocks until
+                # disconnect so the connection stays open as long as the
+                # browser holds it.
+                await ws.receive_text()
+        except WebSocketDisconnect:
+            pass
+        finally:
+            async with event_lock:
+                subs = event_channels.get(channel)
 
-                if not subs:
-                    event_channels.pop(channel, None)
+                if subs is not None:
+                    subs.discard(ws)
+
+                    if not subs:
+                        event_channels.pop(channel, None)
 
 
 def _normalise_prefix(raw: Optional[str]) -> str:
@@ -19807,6 +19819,10 @@ def start_server(
     _apply_ssh_session_token(ssh_session_token or "")
     _apply_ssh_owner_nonce(ssh_owner_nonce)
 
+    from hermes_cli.ssh_isolated_liveness import ensure_ssh_isolated_home_lock
+
+    _ssh_home_lock_fd = ensure_ssh_isolated_home_lock(ssh_session_token)
+
     # Raise RLIMIT_NOFILE for dashboard-mode starts that don't route through
     # the `serve` path in main.py (which applies the same floor). Canonical
     # policy lives in resource_limits; #81547's motivating leak (iterdir fds)
@@ -20030,6 +20046,15 @@ def start_server(
         except (TypeError, ValueError):
             return default
 
+    from hermes_cli.ssh_isolated_liveness import ssh_isolated_ws_ping_window
+
+    _ws_ping_interval, _ws_ping_timeout = ssh_isolated_ws_ping_window(
+        is_loopback=_is_loopback,
+        ssh_session_token=ssh_session_token,
+        default_interval=_ws_ping_setting("ws_ping_interval"),
+        default_timeout=_ws_ping_setting("ws_ping_timeout"),
+    )
+
     config = uvicorn.Config(
         app, host=host, port=port, log_level="warning",
         # proxy_headers defaults to False so _ws_client_is_allowed sees
@@ -20046,12 +20071,12 @@ def start_server(
         # metadata without accepting spoofed X-Forwarded-* headers from every
         # caller.
         forwarded_allow_ips=_dashboard_forwarded_allow_ips(_dash_cfg),
-        # Half-open detection for public binds only (see above). Loopback
-        # disables the protocol ping (None) so an event-loop stall can never
-        # trigger a false disconnect; a genuinely dead local client is still
-        # reaped via the WebSocketDisconnect → disconnect/reap path.
-        ws_ping_interval=None if _is_loopback else _ws_ping_setting("ws_ping_interval"),
-        ws_ping_timeout=None if _is_loopback else _ws_ping_setting("ws_ping_timeout"),
+        # Half-open detection: plain loopback has no network hop, so ping
+        # stays off (#53773). SSH-isolated loopback *is* a tunneled hop
+        # (#101626 — sleeping laptop, ``lastrcv`` while state.db is held),
+        # so ping stays on for that spawn only.
+        ws_ping_interval=_ws_ping_interval,
+        ws_ping_timeout=_ws_ping_timeout,
         ws_max_size=_DESKTOP_ATTACHMENT_WS_MAX_BYTES,
     )
     server = uvicorn.Server(config)
@@ -20125,6 +20150,19 @@ def start_server(
             # tui_gateway/slash_worker.py::_start_parent_death_watchdog. No-op
             # for standalone `hermes serve` (no HERMES_PARENT_PID env).
             _start_parent_death_watchdog()
+            # SSH-isolated remotes have no local parent PID. Idle-exit after
+            # grace when the tunneled client is gone (#101626). No-op without
+            # --ssh-session-token-file.
+            from hermes_constants import get_hermes_home
+            from hermes_cli.ssh_isolated_liveness import (
+                start_ssh_isolated_idle_watchdog,
+            )
+
+            start_ssh_isolated_idle_watchdog(
+                has_ssh_token=bool((ssh_session_token or "").strip()),
+                server=server,
+                hermes_home=get_hermes_home(),
+            )
 
             actual_port = _read_bound_port(server, fallback=port)
             app.state.bound_port = actual_port

--- a/tests/hermes_cli/test_ssh_isolated_liveness.py
+++ b/tests/hermes_cli/test_ssh_isolated_liveness.py
@@ -1,0 +1,980 @@
+"""Child-side liveness for SSH-isolated ``hermes serve`` (#101626).
+
+The remote backend is ``setsid``/``nohup`` detached on purpose (#91668), so
+``PPID=1`` is not an orphan signal. These tests pin the actual contract:
+idle grace after a missing client, exclusive per-home writer lock, and
+leaving plain loopback Desktop pings disabled.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from hermes_cli.ssh_isolated_liveness import (
+    SshIsolatedIdleTracker,
+    acquire_ssh_isolated_home_lock,
+    ssh_isolated_idle_step,
+    ssh_isolated_should_exit,
+    ssh_isolated_ws_ping_window,
+    track_ssh_isolated_ws,
+)
+
+
+def test_plain_loopback_keeps_protocol_ping_disabled():
+    assert ssh_isolated_ws_ping_window(
+        is_loopback=True,
+        ssh_session_token="",
+        default_interval=20.0,
+        default_timeout=20.0,
+    ) == (None, None)
+
+
+def test_ssh_isolated_loopback_enables_half_open_ping():
+    interval, timeout = ssh_isolated_ws_ping_window(
+        is_loopback=True,
+        ssh_session_token="a" * 64,
+        default_interval=20.0,
+        default_timeout=20.0,
+    )
+    assert interval and interval >= 60.0
+    assert timeout and timeout >= 300.0
+    assert timeout >= interval
+
+
+def test_non_loopback_ping_unchanged_without_ssh_token():
+    interval, timeout = ssh_isolated_ws_ping_window(
+        is_loopback=False,
+        ssh_session_token="",
+        default_interval=20.0,
+        default_timeout=25.0,
+    )
+    assert interval == 20.0
+    assert timeout == 25.0
+
+
+def test_idle_grace_does_not_exit_without_ssh_token():
+    assert (
+        ssh_isolated_should_exit(
+            has_ssh_token=False,
+            now=1_000.0,
+            last_client_at=0.0,
+            grace_s=10.0,
+            ppid=1,
+        )
+        is False
+    )
+
+
+def test_ppid_one_is_not_an_exit_signal_while_client_is_recent():
+    assert (
+        ssh_isolated_should_exit(
+            has_ssh_token=True,
+            now=1_000.0,
+            last_client_at=999.0,
+            grace_s=30.0,
+            ppid=1,
+        )
+        is False
+    )
+
+
+def test_ssh_isolated_exits_after_idle_grace():
+    assert (
+        ssh_isolated_should_exit(
+            has_ssh_token=True,
+            now=1_000.0,
+            last_client_at=900.0,
+            grace_s=30.0,
+            ppid=1,
+        )
+        is True
+    )
+
+
+def test_ssh_isolated_stays_up_inside_grace_window():
+    assert (
+        ssh_isolated_should_exit(
+            has_ssh_token=True,
+            now=1_000.0,
+            last_client_at=980.0,
+            grace_s=30.0,
+            ppid=42,
+        )
+        is False
+    )
+
+
+def test_idle_grace_does_not_exit_while_agent_turn_is_in_flight():
+    assert (
+        ssh_isolated_should_exit(
+            has_ssh_token=True,
+            now=1_000.0,
+            last_client_at=0.0,
+            grace_s=10.0,
+            turn_in_flight=True,
+        )
+        is False
+    )
+
+
+def test_idle_step_refreshes_grace_while_turn_runs_then_exits_after():
+    class Clock:
+        def __init__(self):
+            self.now = 0.0
+
+        def __call__(self):
+            return self.now
+
+    clock = Clock()
+    tracker = SshIsolatedIdleTracker(clock=clock)
+    clock.now = 50.0
+    assert (
+        ssh_isolated_idle_step(
+            has_ssh_token=True,
+            tracker=tracker,
+            grace_s=10.0,
+            turn_in_flight=True,
+        )
+        is False
+    )
+    clock.now = 55.0
+    assert (
+        ssh_isolated_idle_step(
+            has_ssh_token=True,
+            tracker=tracker,
+            grace_s=10.0,
+            turn_in_flight=False,
+        )
+        is False
+    )
+    clock.now = 70.0
+    assert (
+        ssh_isolated_idle_step(
+            has_ssh_token=True,
+            tracker=tracker,
+            grace_s=10.0,
+            turn_in_flight=False,
+        )
+        is True
+    )
+
+
+def test_turn_probe_exception_fails_closed_and_refreshes_grace():
+    """An exception from turn_probe must fail closed (treat as turn active),
+    refreshing grace and deferring shutdown until a subsequent successful
+    observation proves no turn is running (#101678 / review 5096241308).
+    """
+    class Clock:
+        def __init__(self):
+            self.now = 0.0
+
+        def __call__(self):
+            return self.now
+
+    clock = Clock()
+    tracker = SshIsolatedIdleTracker(clock=clock)
+    grace = 10.0
+
+    # 1. Advance clock past the idle grace window (50s > 10s grace)
+    clock.now = 50.0
+
+    # 2. turn_probe raises an exception (e.g. database error, transient failure)
+    def _raising_probe():
+        raise RuntimeError("database transiently locked")
+
+    # The step MUST fail closed: shutdown is NOT requested (returns False)
+    # and the tracker clock MUST be refreshed
+    assert (
+        ssh_isolated_idle_step(
+            has_ssh_token=True,
+            tracker=tracker,
+            grace_s=grace,
+            turn_probe=_raising_probe,
+        )
+        is False
+    )
+
+    # Confirm the tracker was touched/refreshed at clock.now = 50.0
+    assert tracker.last_client_at() == 50.0
+
+    # 3. 5 seconds later (clock.now = 55.0), turn probe succeeds and returns False.
+    # Even though probe returns False, only 5s have elapsed since the refreshed
+    # observation, which is < 10.0s grace window. Shutdown must STILL be False!
+    clock.now = 55.0
+    assert (
+        ssh_isolated_idle_step(
+            has_ssh_token=True,
+            tracker=tracker,
+            grace_s=grace,
+            turn_probe=lambda: False,
+        )
+        is False
+    )
+
+    # 4. Now advance past the refreshed grace window (clock.now = 65.0 > 50.0 + 10.0)
+    # with successful no-turn observation. Now shutdown MUST be requested (returns True).
+    clock.now = 65.0
+    assert (
+        ssh_isolated_idle_step(
+            has_ssh_token=True,
+            tracker=tracker,
+            grace_s=grace,
+            turn_probe=lambda: False,
+        )
+        is True
+    )
+
+
+def test_track_ws_context_does_not_leak_on_error():
+    tracker = SshIsolatedIdleTracker()
+    import hermes_cli.ssh_isolated_liveness as mod
+
+    previous = mod._idle_tracker
+    mod._idle_tracker = tracker
+    try:
+        assert tracker.live_count() == 0
+        with track_ssh_isolated_ws():
+            assert tracker.live_count() == 1
+            raise RuntimeError("disconnect")
+    except RuntimeError:
+        pass
+    finally:
+        mod._idle_tracker = previous
+    assert tracker.live_count() == 0
+
+
+@pytest.mark.linux_only
+def test_second_ssh_isolated_serve_cannot_take_the_home_lock(tmp_path):
+    first = acquire_ssh_isolated_home_lock(tmp_path)
+    assert first is not None
+    try:
+        second = acquire_ssh_isolated_home_lock(tmp_path)
+        assert second is None
+    finally:
+        os.close(first)
+
+
+def test_ensure_lock_cooperative_handover_retires_idle_orphan(tmp_path, monkeypatch):
+    from hermes_cli.ssh_isolated_liveness import (
+        ensure_ssh_isolated_home_lock,
+        read_ssh_isolated_state,
+        write_ssh_isolated_state,
+    )
+
+    incumbent_fd = acquire_ssh_isolated_home_lock(tmp_path)
+    assert incumbent_fd is not None
+
+    try:
+        write_ssh_isolated_state(
+            tmp_path,
+            pid=99999,
+            state="idle",
+            active_clients=0,
+            turn_active=False,
+        )
+
+        signaled = []
+
+        def fake_signal(pid):
+            signaled.append(pid)
+            os.close(incumbent_fd)
+
+        monkeypatch.setattr(
+            "hermes_cli.ssh_isolated_liveness._is_positive_flock_holder",
+            lambda pid, home, state_info: True,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.ssh_isolated_liveness._signal_retirement", fake_signal
+        )
+
+        new_fd = ensure_ssh_isolated_home_lock(
+            ssh_session_token="token123",
+            hermes_home=tmp_path,
+        )
+        assert new_fd is not None
+        assert signaled == [99999]
+        os.close(new_fd)
+    finally:
+        try:
+            os.close(incumbent_fd)
+        except OSError:
+            pass
+
+
+def test_ensure_lock_cooperative_handover_refuses_active_incumbent(
+    tmp_path, monkeypatch
+):
+    from hermes_cli.ssh_isolated_liveness import (
+        ensure_ssh_isolated_home_lock,
+        write_ssh_isolated_state,
+    )
+
+    incumbent_fd = acquire_ssh_isolated_home_lock(tmp_path)
+    assert incumbent_fd is not None
+
+    try:
+        write_ssh_isolated_state(
+            tmp_path,
+            pid=99999,
+            state="active",
+            active_clients=1,
+            turn_active=False,
+        )
+
+        signaled = []
+        monkeypatch.setattr(
+            "hermes_cli.ssh_isolated_liveness._signal_retirement",
+            lambda pid: signaled.append(pid),
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            ensure_ssh_isolated_home_lock(
+                ssh_session_token="token123",
+                hermes_home=tmp_path,
+            )
+        assert "refusing a second writer" in str(exc.value)
+        assert signaled == []
+    finally:
+        os.close(incumbent_fd)
+
+
+def test_ensure_lock_cooperative_handover_refuses_when_turn_in_flight(
+    tmp_path, monkeypatch
+):
+    from hermes_cli.ssh_isolated_liveness import (
+        ensure_ssh_isolated_home_lock,
+        write_ssh_isolated_state,
+    )
+
+    incumbent_fd = acquire_ssh_isolated_home_lock(tmp_path)
+    assert incumbent_fd is not None
+
+    try:
+        write_ssh_isolated_state(
+            tmp_path,
+            pid=99999,
+            state="idle",
+            active_clients=0,
+            turn_active=True,
+        )
+
+        signaled = []
+        monkeypatch.setattr(
+            "hermes_cli.ssh_isolated_liveness._signal_retirement",
+            lambda pid: signaled.append(pid),
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            ensure_ssh_isolated_home_lock(
+                ssh_session_token="token123",
+                hermes_home=tmp_path,
+            )
+        assert "refusing a second writer" in str(exc.value)
+        assert signaled == []
+    finally:
+        os.close(incumbent_fd)
+
+
+def test_e2e_cooperative_handover_with_real_watchdog_state_transitions(
+    tmp_path, monkeypatch
+):
+    """End-to-end test proving that:
+    1. start_ssh_isolated_idle_watchdog plumbs hermes_home
+    2. track_ssh_isolated_ws transitions disk state from active to idle
+    3. ensure_ssh_isolated_home_lock successfully performs cooperative handover
+    """
+    from hermes_cli.ssh_isolated_liveness import (
+        acquire_ssh_isolated_home_lock,
+        ensure_ssh_isolated_home_lock,
+        read_ssh_isolated_state,
+        start_ssh_isolated_idle_watchdog,
+        track_ssh_isolated_ws,
+    )
+
+    incumbent_fd = acquire_ssh_isolated_home_lock(tmp_path)
+    assert incumbent_fd is not None
+
+    try:
+        # Start watchdog with hermes_home
+        start_ssh_isolated_idle_watchdog(
+            has_ssh_token=True,
+            hermes_home=tmp_path,
+            turn_probe=lambda: False,
+        )
+
+        # Client connects and disconnects
+        with track_ssh_isolated_ws():
+            mid_state = read_ssh_isolated_state(tmp_path)
+            assert mid_state is not None
+            assert mid_state["state"] == "active"
+            assert mid_state["active_clients"] == 1
+
+        # After client disconnect with no turn running, disk state MUST transition to idle
+        post_state = read_ssh_isolated_state(tmp_path)
+        assert post_state is not None
+        assert post_state["state"] == "idle"
+        assert post_state["active_clients"] == 0
+        assert post_state["turn_active"] is False
+
+        # Simulate cooperative handover: newcomer signals incumbent, incumbent yields
+        signaled = []
+
+        def fake_signal(pid):
+            signaled.append(pid)
+            os.close(incumbent_fd)
+
+        monkeypatch.setattr(
+            "hermes_cli.ssh_isolated_liveness._pid_is_alive", lambda pid: True
+        )
+        monkeypatch.setattr(
+            "hermes_cli.ssh_isolated_liveness._signal_retirement", fake_signal
+        )
+        monkeypatch.setattr("os.getpid", lambda: 88888)
+
+        new_fd = ensure_ssh_isolated_home_lock(
+            ssh_session_token="newcomer_token",
+            hermes_home=tmp_path,
+        )
+        assert new_fd is not None
+        assert len(signaled) == 1
+        os.close(new_fd)
+    finally:
+        try:
+            os.close(incumbent_fd)
+        except OSError:
+            pass
+
+
+def test_e2e_turn_in_flight_preserves_active_state_on_disconnect(
+    tmp_path, monkeypatch
+):
+    """End-to-end test proving that when a turn is in flight:
+    1. Client disconnect records state='active', turn_active=True on disk
+    2. Newcomer is refused (SystemExit) and NEVER signals the running turn
+    """
+    from hermes_cli.ssh_isolated_liveness import (
+        acquire_ssh_isolated_home_lock,
+        ensure_ssh_isolated_home_lock,
+        read_ssh_isolated_state,
+        start_ssh_isolated_idle_watchdog,
+        track_ssh_isolated_ws,
+    )
+
+    incumbent_fd = acquire_ssh_isolated_home_lock(tmp_path)
+    assert incumbent_fd is not None
+
+    try:
+        # Start watchdog with active turn probe
+        start_ssh_isolated_idle_watchdog(
+            has_ssh_token=True,
+            hermes_home=tmp_path,
+            turn_probe=lambda: True,
+        )
+
+        # Client disconnects while turn is active
+        with track_ssh_isolated_ws():
+            pass
+
+        # State on disk MUST be active and turn_active=True
+        state = read_ssh_isolated_state(tmp_path)
+        assert state is not None
+        assert state["state"] == "active"
+        assert state["turn_active"] is True
+
+        signaled = []
+        monkeypatch.setattr(
+            "hermes_cli.ssh_isolated_liveness._signal_retirement",
+            lambda pid: signaled.append(pid),
+        )
+
+        # Newcomer MUST be refused and MUST NOT signal
+        with pytest.raises(SystemExit) as exc:
+            ensure_ssh_isolated_home_lock(
+                ssh_session_token="newcomer_token",
+                hermes_home=tmp_path,
+            )
+        assert "refusing a second writer" in str(exc.value)
+        assert signaled == []
+    finally:
+        os.close(incumbent_fd)
+
+
+@pytest.mark.live_system_guard_bypass
+def test_handover_refuses_when_reused_pid_or_different_flock_holder(
+    tmp_path, monkeypatch
+):
+    """Pin control 1: separate process for reused-PID and different-holder control
+
+    so that _is_positive_flock_holder actually executes rather than short-circuiting on os.getpid().
+    """
+    import subprocess
+    import sys
+    from hermes_cli.ssh_isolated_liveness import (
+        acquire_ssh_isolated_home_lock,
+        ensure_ssh_isolated_home_lock,
+        write_ssh_isolated_state,
+    )
+
+    # Spawn an actual separate helper process that exits cleanly when stdin closes
+    helper = subprocess.Popen(
+        [sys.executable, "-c", "import sys; sys.stdin.read()"],
+        stdin=subprocess.PIPE,
+    )
+    try:
+        incumbent_fd = acquire_ssh_isolated_home_lock(tmp_path)
+        assert incumbent_fd is not None
+
+        try:
+            # Case A: Sidecar points to separate process PID, but create_time is stale (reused PID)
+            write_ssh_isolated_state(
+                tmp_path,
+                pid=helper.pid,
+                state="idle",
+                active_clients=0,
+                turn_active=False,
+                create_time=1.0,  # Deliberately mismatched create_time
+            )
+
+            signaled = []
+            monkeypatch.setattr(
+                "hermes_cli.ssh_isolated_liveness._signal_retirement",
+                lambda pid: signaled.append(pid),
+            )
+
+            with pytest.raises(SystemExit) as exc:
+                ensure_ssh_isolated_home_lock(
+                    ssh_session_token="newcomer_token",
+                    hermes_home=tmp_path,
+                )
+            assert "refusing a second writer" in str(exc.value)
+            assert signaled == []
+
+            # Case B: Sidecar points to separate process PID with correct create_time,
+            # but helper process does NOT hold the flock file (different flock holder)
+            actual_ctime = 1000.0
+            try:
+                import psutil
+                actual_ctime = psutil.Process(helper.pid).create_time()
+            except Exception:
+                if sys.platform.startswith("linux") and os.path.isdir(f"/proc/{helper.pid}"):
+                    actual_ctime = os.stat(f"/proc/{helper.pid}").st_mtime
+
+            write_ssh_isolated_state(
+                tmp_path,
+                pid=helper.pid,
+                state="idle",
+                active_clients=0,
+                turn_active=False,
+                create_time=actual_ctime,
+            )
+
+            with pytest.raises(SystemExit) as exc:
+                ensure_ssh_isolated_home_lock(
+                    ssh_session_token="newcomer_token",
+                    hermes_home=tmp_path,
+                )
+            assert "refusing a second writer" in str(exc.value)
+            assert signaled == []
+        finally:
+            os.close(incumbent_fd)
+    finally:
+        try:
+            if helper.stdin:
+                helper.stdin.close()
+            helper.wait(timeout=2.0)
+        except Exception:
+            helper.kill()
+
+
+def test_sidecar_publication_reordering_cannot_finish_idle_while_live_clients(
+    tmp_path, monkeypatch
+):
+    """Pin control 3: forced on_close() / on_open() publication reordering cannot
+
+    leave sidecar in 'idle' while live_count() == 1.
+    """
+    import threading
+    from hermes_cli.ssh_isolated_liveness import (
+        SshIsolatedIdleTracker,
+        read_ssh_isolated_state,
+    )
+
+    tracker = SshIsolatedIdleTracker(hermes_home=tmp_path)
+    # Start with 1 client
+    tracker.on_open()
+    st = read_ssh_isolated_state(tmp_path)
+    assert st is not None and st["state"] == "active"
+
+    # Simulate slow evaluate_turn_probe during on_close, while concurrent on_open runs
+    in_close_probe = threading.Event()
+    release_close_probe = threading.Event()
+
+    def slow_probe():
+        in_close_probe.set()
+        release_close_probe.wait(timeout=2.0)
+        return False
+
+    tracker._turn_probe = slow_probe
+
+    # Thread 1: on_close starts and gets paused inside probe
+    close_thread = threading.Thread(target=tracker.on_close)
+    close_thread.start()
+    assert in_close_probe.wait(timeout=2.0)
+
+    # Thread 2: on_open occurs while on_close is stalled
+    tracker.on_open()
+    mid_st = read_ssh_isolated_state(tmp_path)
+    assert mid_st is not None and mid_st["state"] == "active"
+
+    # Now release on_close so it finishes publishing
+    release_close_probe.set()
+    close_thread.join(timeout=2.0)
+
+    # In-memory count is 1; sidecar MUST remain active, NEVER idle!
+    assert tracker.live_count() == 1
+    final_st = read_ssh_isolated_state(tmp_path)
+    assert final_st is not None
+    assert final_st["state"] == "active", f"Sidecar regressed to idle: {final_st}"
+    assert final_st["active_clients"] == 1
+
+
+def test_newcomer_paused_after_idle_observation_aborts_when_incumbent_becomes_active(
+    tmp_path, monkeypatch
+):
+    """Deterministic barrier: pause newcomer after it observes idle, make incumbent
+
+    open a client, then resume; assert no signal/exit and no lock transfer.
+    """
+    import threading
+    from hermes_cli.ssh_isolated_liveness import (
+        acquire_ssh_isolated_home_lock,
+        ensure_ssh_isolated_home_lock,
+        read_ssh_isolated_state,
+        SshIsolatedIdleTracker,
+    )
+
+    incumbent_fd = acquire_ssh_isolated_home_lock(tmp_path)
+    assert incumbent_fd is not None
+
+    try:
+        tracker = SshIsolatedIdleTracker(hermes_home=tmp_path, turn_probe=lambda: False)
+        # Seed idle state
+        tracker.on_open()
+        tracker.on_close()
+        st = read_ssh_isolated_state(tmp_path)
+        assert st is not None and st["state"] == "idle"
+
+        signaled = []
+        monkeypatch.setattr(
+            "hermes_cli.ssh_isolated_liveness._signal_retirement",
+            lambda pid: signaled.append(pid),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.ssh_isolated_liveness._pid_is_alive", lambda pid: True
+        )
+        monkeypatch.setattr(
+            "hermes_cli.ssh_isolated_liveness._is_positive_flock_holder",
+            lambda pid, home, state: True,
+        )
+
+        # Hook read_ssh_isolated_state so the first read returns idle,
+        # then pauses newcomer, incumbent opens a client, and newcomer resumes.
+        orig_read = read_ssh_isolated_state
+        read_count = 0
+
+        def hooked_read(home):
+            nonlocal read_count
+            read_count += 1
+            res = orig_read(home)
+            if read_count == 1:
+                # Incumbent becomes active while newcomer is in-flight!
+                tracker.on_open()
+            return res
+
+        monkeypatch.setattr(
+            "hermes_cli.ssh_isolated_liveness.read_ssh_isolated_state",
+            hooked_read,
+        )
+        monkeypatch.setattr("os.getpid", lambda: 88888)
+
+        # Newcomer must detect that incumbent is active, send NO signal, and refuse second writer
+        with pytest.raises(SystemExit) as exc:
+            ensure_ssh_isolated_home_lock(
+                ssh_session_token="newcomer_token",
+                hermes_home=tmp_path,
+            )
+        assert "refusing a second writer" in str(exc.value)
+        assert signaled == [], f"Newcomer signaled an active incumbent: {signaled}"
+    finally:
+        os.close(incumbent_fd)
+
+
+def test_newcomer_paused_after_idle_observation_aborts_when_turn_starts(
+    tmp_path, monkeypatch
+):
+    """Deterministic barrier: pause newcomer after observing idle, make incumbent
+
+    start an agent turn (or indeterminate probe), resume; assert no signal and no lock transfer.
+    """
+    from hermes_cli.ssh_isolated_liveness import (
+        acquire_ssh_isolated_home_lock,
+        ensure_ssh_isolated_home_lock,
+        read_ssh_isolated_state,
+        SshIsolatedIdleTracker,
+        write_ssh_isolated_state,
+    )
+
+    incumbent_fd = acquire_ssh_isolated_home_lock(tmp_path)
+    assert incumbent_fd is not None
+
+    try:
+        tracker = SshIsolatedIdleTracker(hermes_home=tmp_path, turn_probe=lambda: False)
+        tracker.on_open()
+        tracker.on_close()
+        st = read_ssh_isolated_state(tmp_path)
+        assert st is not None and st["state"] == "idle"
+
+        signaled = []
+        monkeypatch.setattr(
+            "hermes_cli.ssh_isolated_liveness._signal_retirement",
+            lambda pid: signaled.append(pid),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.ssh_isolated_liveness._pid_is_alive", lambda pid: True
+        )
+        monkeypatch.setattr(
+            "hermes_cli.ssh_isolated_liveness._is_positive_flock_holder",
+            lambda pid, home, state: True,
+        )
+
+        orig_read = read_ssh_isolated_state
+        read_count = 0
+
+        def hooked_read(home):
+            nonlocal read_count
+            read_count += 1
+            res = orig_read(home)
+            if read_count == 1:
+                # Incumbent starts a turn while newcomer is in-flight
+                write_ssh_isolated_state(
+                    tmp_path,
+                    pid=os.getpid(),
+                    state="active",
+                    active_clients=0,
+                    turn_active=True,
+                )
+            return res
+
+        monkeypatch.setattr(
+            "hermes_cli.ssh_isolated_liveness.read_ssh_isolated_state",
+            hooked_read,
+        )
+        monkeypatch.setattr("os.getpid", lambda: 88888)
+
+        with pytest.raises(SystemExit) as exc:
+            ensure_ssh_isolated_home_lock(
+                ssh_session_token="newcomer_token",
+                hermes_home=tmp_path,
+            )
+        assert "refusing a second writer" in str(exc.value)
+        assert signaled == []
+    finally:
+        os.close(incumbent_fd)
+
+
+def test_failed_sidecar_refresh_unlinks_prior_state_and_refuses_handover(
+    tmp_path, monkeypatch
+):
+    """Pin control 2: a failed sidecar refresh must not leave the prior generation
+
+    reclaim-authoritative; the stale sidecar is unlinked and subsequent contention fails closed.
+    """
+    from hermes_cli.ssh_isolated_liveness import (
+        SSH_ISOLATED_STATE_NAME,
+        acquire_ssh_isolated_home_lock,
+        ensure_ssh_isolated_home_lock,
+        read_ssh_isolated_state,
+        write_ssh_isolated_state,
+    )
+
+    # Prior generation left an idle state file
+    write_ssh_isolated_state(
+        tmp_path,
+        pid=os.getpid(),
+        state="idle",
+        active_clients=0,
+        turn_active=False,
+    )
+    assert read_ssh_isolated_state(tmp_path) is not None
+
+    # New generation acquires lock, but write_ssh_isolated_state fails (e.g. disk error)
+    def fail_write(*args, **kwargs):
+        return False
+
+    monkeypatch.setattr(
+        "hermes_cli.ssh_isolated_liveness.write_ssh_isolated_state", fail_write
+    )
+
+    # First process acquires lock
+    first_fd = ensure_ssh_isolated_home_lock(
+        ssh_session_token="token_gen2",
+        hermes_home=tmp_path,
+    )
+    assert first_fd is not None
+
+    try:
+        # State file must have been unlinked so prior generation does not remain authoritative
+        assert not (tmp_path / SSH_ISOLATED_STATE_NAME).exists()
+        assert read_ssh_isolated_state(tmp_path) is None
+
+        # Subsequent newcomer encounters lock contention: no sidecar -> cannot reclaim
+        signaled = []
+        monkeypatch.setattr(
+            "hermes_cli.ssh_isolated_liveness._signal_retirement",
+            lambda pid: signaled.append(pid),
+        )
+        with pytest.raises(SystemExit) as exc:
+            ensure_ssh_isolated_home_lock(
+                ssh_session_token="newcomer_token",
+                hermes_home=tmp_path,
+            )
+        assert "refusing a second writer" in str(exc.value)
+        assert signaled == []
+    finally:
+        os.close(first_fd)
+
+
+def test_consume_handover_retirement_boundary_validation(tmp_path):
+    """Pin control: incumbent consume_handover_retirement performs authoritative
+
+    in-memory client count and fail-closed turn probe rechecks at the shutdown boundary.
+    """
+    from hermes_cli.ssh_isolated_liveness import (
+        SshIsolatedIdleTracker,
+        consume_handover_retirement,
+    )
+
+    class DummyServer:
+        should_exit = False
+
+    server = DummyServer()
+    turn_active = False
+
+    def probe():
+        return turn_active
+
+    tracker = SshIsolatedIdleTracker(hermes_home=tmp_path, turn_probe=probe)
+
+    # 1. Client active in memory -> refused
+    tracker.on_open()
+    assert consume_handover_retirement(tracker, server=server) is False
+    assert server.should_exit is False
+
+    # 2. Client disconnected, but turn active -> refused
+    tracker.on_close()
+    turn_active = True
+    assert consume_handover_retirement(tracker, server=server) is False
+    assert server.should_exit is False
+
+    # 3. Turn probe raises exception (indeterminate) -> fails closed, refused
+    def failing_probe():
+        raise RuntimeError("probe boom")
+
+    tracker._turn_probe = failing_probe
+    assert consume_handover_retirement(tracker, server=server) is False
+    assert server.should_exit is False
+
+    # 4. Genuinely idle (no clients, turn probe False) -> accepted, triggers exit
+    tracker._turn_probe = lambda: False
+    assert consume_handover_retirement(tracker, server=server) is True
+    assert server.should_exit is True
+
+
+def test_handover_signal_when_tracker_lock_held_on_main_thread_does_not_deadlock(
+    tmp_path,
+):
+    """Hold tracker lock on main thread, deliver handover signal,
+
+    and prove no deadlock occurs and handover is rejected when live client is present.
+    """
+    import signal
+    from hermes_cli.ssh_isolated_liveness import (
+        start_ssh_isolated_idle_watchdog,
+        write_ssh_isolated_handover_request,
+    )
+
+    class DummyServer:
+        should_exit = False
+
+    server = DummyServer()
+    tracker = start_ssh_isolated_idle_watchdog(
+        has_ssh_token=True,
+        hermes_home=tmp_path,
+        server=server,
+        turn_probe=lambda: False,
+    )
+    assert tracker is not None
+    tracker.on_open()
+
+    write_ssh_isolated_handover_request(tmp_path, nonce="test-nonce", seq=tracker._seq)
+
+    handler = signal.getsignal(signal.SIGTERM)
+    assert callable(handler)
+
+    # In main thread, hold tracker._lock and invoke signal handler
+    with tracker._lock:
+        handler(signal.SIGTERM, None)
+
+    # Prove background watchdog safely consumed and adjudicated the request without deadlock
+    assert tracker._handover_done.wait(timeout=2.0) is True
+    assert server.should_exit is False
+
+
+def test_ordinary_sigterm_without_handover_request_shuts_down_even_when_active(
+    tmp_path,
+):
+    """Deliver an ordinary SIGTERM with no handover request while active
+
+    and prove normal uvicorn shutdown still occurs.
+    """
+    import signal
+    from hermes_cli.ssh_isolated_liveness import (
+        start_ssh_isolated_idle_watchdog,
+    )
+
+    orig_called = []
+
+    def fake_uvicorn_handler(signum, frame):
+        orig_called.append(signum)
+
+    old_handler = signal.getsignal(signal.SIGTERM)
+    signal.signal(signal.SIGTERM, fake_uvicorn_handler)
+    try:
+        class DummyServer:
+            should_exit = False
+
+        server = DummyServer()
+        tracker = start_ssh_isolated_idle_watchdog(
+            has_ssh_token=True,
+            hermes_home=tmp_path,
+            server=server,
+            turn_probe=lambda: False,
+        )
+        assert tracker is not None
+        tracker.on_open()  # active client
+
+        current_handler = signal.getsignal(signal.SIGTERM)
+        current_handler(signal.SIGTERM, None)
+
+        assert orig_called == [signal.SIGTERM]
+    finally:
+        signal.signal(signal.SIGTERM, old_handler)
+
+
+
+
+
+
+

--- a/tests/hermes_cli/test_web_server_console_ws.py
+++ b/tests/hermes_cli/test_web_server_console_ws.py
@@ -86,3 +86,35 @@ def test_console_ws_cancel_returns_to_prompt(console_client, monkeypatch):
 
         complete = _recv_until(conn, "complete", status="cancelled")
         assert complete["prompt"] == "hermes> "
+
+
+def test_console_ws_confirm_flow(console_client, monkeypatch):
+    from hermes_cli.console_engine import ConsoleResult, HermesConsoleEngine
+
+    executed_confirmed = []
+
+    def mock_execute(self, line: str, *, confirmed: bool = False):
+        if not confirmed:
+            return ConsoleResult(
+                "confirm_required",
+                command=line,
+                output="Action requires confirmation",
+            )
+        executed_confirmed.append(line)
+        return ConsoleResult("ok", output="Executed successfully", command=line)
+
+    monkeypatch.setattr(HermesConsoleEngine, "execute", mock_execute)
+
+    with console_client.websocket_connect(_url()) as conn:
+        assert conn.receive_json()["type"] == "ready"
+        conn.send_json({"type": "input", "line": "drop database"})
+
+        confirm_req = _recv_until(conn, "complete", status="confirm_required")
+        assert confirm_req["command"] == "drop database"
+
+        conn.send_json({"type": "confirm", "command": "drop database"})
+
+        complete = _recv_until(conn, "complete", status="ok")
+        assert complete["status"] == "ok"
+        assert executed_confirmed == ["drop database"]
+

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -6,7 +6,9 @@ Config + Server + asyncio.run to capture kwargs without starting an event loop.
 
 import asyncio
 import contextlib
+import os
 import sys
+import tempfile
 
 import pytest
 import uvicorn
@@ -68,6 +70,19 @@ def _stub_uvicorn(monkeypatch):
 
     monkeypatch.setattr(uvicorn, "Config", _FakeConfig)
     monkeypatch.setattr(uvicorn, "Server", lambda config: _FakeServer())
+
+    def _unique_lock(_home):
+        fd, path = tempfile.mkstemp()
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+        return fd
+
+    monkeypatch.setattr(
+        "hermes_cli.ssh_isolated_liveness.acquire_ssh_isolated_home_lock",
+        _unique_lock,
+    )
     return captured
 
 
@@ -107,6 +122,58 @@ def test_start_server_disables_ws_ping_on_loopback(monkeypatch):
 
     assert captured["ws_ping_interval"] is None
     assert captured["ws_ping_timeout"] is None
+
+
+def test_start_server_enables_ws_ping_on_ssh_isolated_loopback(monkeypatch):
+    """SSH-tunneled ``serve --isolated`` binds 127.0.0.1 but the client is
+    across a real SSH hop. Half-open sockets after a sleeping laptop are the
+    #101626 class (``ss -tni lastrcv`` while the process still holds
+    ``state.db``). Loopback ping must stay on for that spawn so uvicorn can
+    drop the dead tunnel; timeout stays >= interval so a GIL stall is not
+    immediately fatal (#53773).
+    """
+    captured = _stub_uvicorn(monkeypatch)
+
+    web_server.start_server(
+        host="127.0.0.1",
+        port=0,
+        open_browser=False,
+        ssh_session_token="s" * 64,
+        ssh_owner_nonce="0123456789abcdef",
+    )
+
+    assert captured["ws_ping_interval"] and captured["ws_ping_interval"] >= 60
+    assert captured["ws_ping_timeout"] and captured["ws_ping_timeout"] >= 300
+    assert captured["ws_ping_timeout"] >= captured["ws_ping_interval"]
+
+
+def test_start_server_refuses_second_ssh_isolated_writer_on_same_home(monkeypatch, tmp_path):
+    """Production flock, not the unique-fd stub used by ping tests."""
+    import hermes_cli.ssh_isolated_liveness as liveness
+
+    real_acquire = liveness.acquire_ssh_isolated_home_lock
+    captured = _stub_uvicorn(monkeypatch)
+    monkeypatch.setattr(liveness, "acquire_ssh_isolated_home_lock", real_acquire)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+
+    web_server.start_server(
+        host="127.0.0.1",
+        port=0,
+        open_browser=False,
+        ssh_session_token="s" * 64,
+        ssh_owner_nonce="0123456789abcdef",
+    )
+    assert captured["ws_ping_interval"]
+
+    with pytest.raises(SystemExit, match="already holds this"):
+        web_server.start_server(
+            host="127.0.0.1",
+            port=0,
+            open_browser=False,
+            ssh_session_token="t" * 64,
+            ssh_owner_nonce="fedcba9876543210",
+        )
 
 
 def test_start_server_accepts_base64_desktop_attachments_above_preview_limit(monkeypatch):


### PR DESCRIPTION
## Summary
Fixes #101626.

When a laptop running Desktop connects over SSH to a remote hermes serve --isolated backend (detached via setsid/
ohup), closing the laptop lid drops the SSH transport abruptly without running client before-quit. Because remote serve --isolated is intentionally detached (PPID=1), the local parent-death watchdog cannot detect that the client is gone. Over time, multiple orphaned backends accumulate at PPID=1, competing for the shared SQLite state.db and causing database lock contention and multi-writer corruption.

Furthermore, when an idle orphan holds the database lock and a user reconnects with a newly spawned remote backend, rejecting the newcomer with SystemExit would cause a 15-minute reconnect lockout until the idle orphan's watchdog expires.

This PR provides a complete, architectural solution:

1. **Child-Side Idle Watchdog**:
   - For SSH-isolated serve (ssh_session_token present), tracks authenticated client WebSocket connections across all dashboard endpoints (/api/audio/speak-stream, /api/console, /api/pty, /api/ws, /api/pub, /api/events).
   - If no client is connected for 15 minutes (DEFAULT_SSH_ISOLATED_IDLE_GRACE_S = 900.0s), requests graceful shutdown (server.should_exit = True), allowing uvicorn to drain, checkpoint SQLite WAL, and exit 0.

2. **Tunneled Loopback WS Ping**:
   - Loopback connections across SSH tunnels enable WebSocket protocol ping/pong (ws_ping_interval=60s, ws_ping_timeout=600s), allowing the server to detect dead half-open tunnels promptly when a client sleeps.

3. **In-Flight Turn Protection with Fail-Closed Probing**:
   - While an agent turn is actively executing (_any_session_running()), shutdown is deferred and the idle grace window is refreshed.
   - Indeterminate turn probe results or transient errors fail closed (treating the turn as active) to protect running workloads.

4. **Exclusive Home Single-Writer Lock**:
   - Takes a non-blocking exclusive lock (.ssh-isolated-serve.lock) on HERMES_HOME via cntl.flock (POSIX) or msvcrt.locking (Windows) to strictly forbid concurrent writers.

5. **Cooperative Handover with Dedicated Request Exchange and Non-Blocking Wake**:
   - Eliminates the 15-minute reconnect lockout without process table scanning.
   - The newcomer writes an atomic, positively identified handover request file (.ssh-isolated-serve.handover.json) containing a unique 
once, expected generation seq, and 
ewcomer_pid.
   - Before signaling, the newcomer re-validates the incumbent's monotonic sidecar; if the incumbent has transitioned to active or turn in flight, the signal is omitted and newcomer fails closed.
   - The signal handler (_sigterm_handover_handler) executes completely non-blocking:
     - If no handover request file is present, the signal is treated as an ordinary operational SIGTERM (service stop, supervisor, kill <pid>) and immediately delegates to uvicorn's shutdown handler even when active.
     - If a valid handover request is present, the handler performs a non-blocking wake/latch on the watchdog event without acquiring tracker locks or evaluating turn probes, completely eliminating signal re-entrancy deadlocks.
   - The watchdog thread asynchronously adjudicates the request outside signal context: it verifies live_count() == 0 and the fail-closed turn probe under lock. If idle, it initiates graceful shutdown and releases flock (~150ms); if active, it rejects the request, deletes the handover file, and retains flock.

## Test Plan

- 	ests/hermes_cli/test_ssh_isolated_liveness.py (25 unit tests):
  - WS ping window negotiation (plain loopback disabled, SSH loopback enabled).
  - Idle watchdog countdown and graceful shutdown request.
  - In-flight turn protection and post-turn grace refresh.
  - Fail-closed probe exception handling.
  - Exclusive home lock acquisition and contention refusal.
  - Cooperative handover: retiring idle orphan and taking over lock.
  - Handover refusal when incumbent has active clients.
  - Handover refusal when incumbent has in-flight agent turn.
  - E2E tests for watchdog-driven state transitions from active to idle.
  - 	est_newcomer_paused_after_idle_observation_aborts_when_incumbent_becomes_active: pauses newcomer after observing idle; proves no signal is sent, no exit, no lock transfer when incumbent becomes active mid-contention.
  - 	est_newcomer_paused_after_idle_observation_aborts_when_turn_starts: same safety contract when an agent turn starts while newcomer contention check is in flight.
  - 	est_sidecar_publication_reordering_cannot_finish_idle_while_live_clients: forces concurrent on_close() / on_open() reordering; asserts sidecar cannot finish in idle while live_count() == 1.
  - 	est_handover_refuses_when_reused_pid_or_different_flock_holder: uses a real separate helper subprocess to exercise _is_positive_flock_holder() without os.getpid() short-circuit.
  - 	est_consume_handover_retirement_boundary_validation: directly asserts fail-closed in-memory client count and turn probe validation at the shutdown boundary.
  - 	est_handover_signal_when_tracker_lock_held_on_main_thread_does_not_deadlock: holds 	racker._lock on main thread and delivers handover signal; proves non-blocking latch avoids deadlock and handover is safely rejected with _handover_done wait.
  - 	est_ordinary_sigterm_without_handover_request_shuts_down_even_when_active: delivers ordinary SIGTERM without handover request while active; proves normal uvicorn shutdown handler executes.
- 	ests/test_web_server.py: production flock single-writer refusal and process-local bootstrap state application.
- 	ests/hermes_cli/test_web_server_console_ws.py: console WS confirm flow through 	rack_ssh_isolated_ws() wrapper.
- All 41 tests pass 100% in Linux/WSL (Python 3.12) and Windows (Python 3.11) without flakes.