### PR TITLE
fix(recovery): quarantine malformed session model config

### DIFF
--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -914,6 +914,7 @@ def _verify_row_counts(
 def _verify_recovered_database(
     output: Path, *, expected_counts: dict[str, Optional[int]], copy_report: dict[str, dict[str, Any]],
     allow_partial: bool = False, orphan_cleanup: Optional[dict[str, Any]] = None,
+    semantic_cleanup: Optional[dict[str, Any]] = None,
 ) -> dict[str, Any]:
     verification: dict[str, Any] = {"errors": [], "warnings": [], "loss_detected": False}
     open_error = _db_opens_cleanly(output)
@@ -1098,7 +1099,7 @@ def _recover_via_lost_and_found(
         source, output, inspection, disk_space, verification, on_source_change="healthy",
         allow_partial=True, mode="lost_and_found_salvage", best_effort=True, unreadable_schemas=missing_required,
         sqlite3_cli=cli_report, lost_and_found=mapping, session_stubs=stubbing, fts_rebuild=fts, copy=copy_report,
-        orphan_cleanup=orphan_cleanup, derived_metadata=derived_metadata,
+        orphan_cleanup=orphan_cleanup, semantic_cleanup=semantic_cleanup, derived_metadata=derived_metadata,
     )
 
 
@@ -1164,6 +1165,10 @@ def recover_session_database(
                 output, topic_tables=any(inspection["tables"][table].get("available") for table in _TOPIC_TABLES),
             )
             copy_report: dict[str, dict[str, Any]] = {}
+            semantic_cleanup: dict[str, Any] = {
+                "malformed_json_values_quarantined": 0,
+                "columns": {},
+            }
             for table in (*_CANONICAL_TABLES, "state_meta", *_TOPIC_TABLES, *_AUXILIARY_TABLES):
                 if table not in _CANONICAL_TABLES and not inspection["tables"][table].get("available"):
                     copy_report[table] = {"status": "missing", "copied_rows": 0}
@@ -1174,7 +1179,11 @@ def recover_session_database(
                     source_conn, destination_conn, table, salvage=allow_partial, chunk_size=chunk_size,
                     progress_cb=progress_cb, source_rows=inspection["tables"][table].get("rows"),
                 )
-            semantic_cleanup = _quarantine_malformed_json(destination_conn)
+                # Message FTS triggers inspect the owning session's model_config.
+                # Quarantine immediately after copying sessions so malformed JSON
+                # cannot make the subsequent message copy fail.
+                if table == "sessions":
+                    semantic_cleanup = _quarantine_malformed_json(destination_conn)
             orphan_cleanup = _cleanup_partial_orphans(destination_conn) if allow_partial else None
             derived_metadata = _finalize_derived_metadata(destination_conn)
         finally:
@@ -1194,7 +1203,7 @@ def recover_session_database(
         return _recovery_report(
             source, output, inspection, disk_space, verification, on_source_change="complete",
             allow_partial=allow_partial, copy=copy_report, orphan_cleanup=orphan_cleanup,
-            derived_metadata=derived_metadata,
+            semantic_cleanup=semantic_cleanup, derived_metadata=derived_metadata,
         )
     finally:
         temp_dir.cleanup()

--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -55,6 +55,13 @@ _MAX_SALVAGE_RANGE_QUERIES = 10_000
 _MIN_SQLITE_ROWID = -(2**63)
 _MAX_SQLITE_ROWID = 2**63 - 1
 
+# ``sessions.model_config`` is queried with SQLite's JSON functions by session
+# list/count/lineage paths. A malformed value can survive a physically sound
+# recovery and make those whole surfaces raise ``malformed JSON``. Keep this
+# declaration narrow and explicit; raw values are deliberately not reported
+# because model configuration can contain credentials.
+_RECOVERY_JSON_COLUMNS = (("sessions", "model_config", "{}"),)
+
 
 class SessionRecoveryError(RuntimeError):
     """Base error for offline session recovery."""
@@ -399,7 +406,54 @@ def _append_skipped_range(ranges: list[dict[str, Any]], low: int, high: int, err
     ranges.append({"low": low, "high": high, "error": error})
 
 
-def _salvage_rowid_bounds(source: sqlite3.Connection, table: str) -> dict[str, Any]:
+def _quarantine_malformed_json(
+    destination: sqlite3.Connection,
+) -> dict[str, Any]:
+    """Replace malformed runtime JSON with safe empty values and count it.
+
+    SQLite's physical integrity checks do not validate JSON stored in TEXT
+    columns. Recovery therefore enforces this semantic invariant before
+    declaring an output usable. The original source/snapshot stays untouched;
+    the report records only table/column counts, never raw values.
+    """
+
+    result: dict[str, Any] = {
+        "malformed_json_values_quarantined": 0,
+        "columns": {},
+    }
+    destination.execute("BEGIN IMMEDIATE")
+    try:
+        for table, column, replacement in _RECOVERY_JSON_COLUMNS:
+            if column not in _table_columns(destination, table):
+                continue
+            invalid = int(
+                destination.execute(
+                    f'SELECT COUNT(*) FROM "{table}" '
+                    f'WHERE "{column}" IS NOT NULL '
+                    f'AND NOT json_valid("{column}")'
+                ).fetchone()[0]
+            )
+            if not invalid:
+                continue
+            destination.execute(
+                f'UPDATE "{table}" SET "{column}" = ? '
+                f'WHERE "{column}" IS NOT NULL '
+                f'AND NOT json_valid("{column}")',
+                (replacement,),
+            )
+            result["columns"][f"{table}.{column}"] = invalid
+            result["malformed_json_values_quarantined"] += invalid
+        destination.execute("COMMIT")
+    except BaseException:
+        destination.execute("ROLLBACK")
+        raise
+    return result
+
+
+def _salvage_rowid_bounds(
+    source: sqlite3.Connection,
+    table: str,
+) -> dict[str, Any]:
     """Find the readable rowid edges without scanning the complete table."""
     result: dict[str, Any] = {"errors": [], "fallback_edges": []}
     rows: dict[str, Optional[int]] = {"low": None, "high": None}
@@ -874,6 +928,16 @@ def _verify_recovered_database(
             orphan_cleanup=orphan_cleanup,
         )
         _verify_fts_indexes(conn, verification)
+
+        quarantined_json = int(
+            (semantic_cleanup or {}).get("malformed_json_values_quarantined") or 0
+        )
+        if quarantined_json:
+            verification["warnings"].append(
+                f"quarantined {quarantined_json} malformed JSON value(s) "
+                "from runtime metadata; original values remain in the source database"
+            )
+            verification["loss_detected"] = True
     except sqlite3.DatabaseError as exc:
         verification["errors"].append(f"verification query failed: {exc}")
     finally:
@@ -990,6 +1054,7 @@ def _recover_via_lost_and_found(
     try:
         mapping = map_lost_and_found_rows(lf_conn, destination_conn)
         stubbing = stub_missing_parent_sessions(destination_conn)
+        semantic_cleanup = _quarantine_malformed_json(destination_conn)
         fts = rebuild_fts_indexes(destination_conn)
         derived_metadata = _finalize_derived_metadata(destination_conn)
     finally:
@@ -1011,6 +1076,7 @@ def _recover_via_lost_and_found(
     verification = _verify_recovered_database(
         output, expected_counts={"sessions": None, "messages": None}, copy_report=copy_report, allow_partial=True,
         orphan_cleanup=orphan_cleanup,
+        semantic_cleanup=semantic_cleanup,
     )
     verification["warnings"].append(
         "BEST-EFFORT page-level salvage: the source table schemas were unreadable, so rows were rebuilt from raw "
@@ -1108,6 +1174,7 @@ def recover_session_database(
                     source_conn, destination_conn, table, salvage=allow_partial, chunk_size=chunk_size,
                     progress_cb=progress_cb, source_rows=inspection["tables"][table].get("rows"),
                 )
+            semantic_cleanup = _quarantine_malformed_json(destination_conn)
             orphan_cleanup = _cleanup_partial_orphans(destination_conn) if allow_partial else None
             derived_metadata = _finalize_derived_metadata(destination_conn)
         finally:
@@ -1122,6 +1189,7 @@ def recover_session_database(
         verification = _verify_recovered_database(
             output, expected_counts=expected_counts, copy_report=copy_report, allow_partial=allow_partial,
             orphan_cleanup=orphan_cleanup,
+            semantic_cleanup=semantic_cleanup,
         )
         return _recovery_report(
             source, output, inspection, disk_space, verification, on_source_change="complete",

--- a/tests/hermes_cli/test_session_recovery.py
+++ b/tests/hermes_cli/test_session_recovery.py
@@ -834,3 +834,54 @@ def test_lost_and_found_direct_copy_creates_lazy_delivery_ledger(tmp_path: Path)
         lf_conn.close()
         dest.close()
     assert rows == [("ob-1", "pending", None), ("ob-2", "failed", "boom")]
+
+
+def test_recovery_quarantines_malformed_session_model_config(tmp_path: Path) -> None:
+    """A physically sound output must also survive real session-list JSON reads."""
+
+    source = tmp_path / "state.db"
+    output = tmp_path / "recovered.db"
+    _make_source(source)
+
+    conn = sqlite3.connect(str(source))
+    try:
+        conn.execute(
+            "UPDATE sessions SET model_config = ? WHERE id = ?",
+            ('{"broken"', "recovery-session-1"),
+        )
+        conn.commit()
+        assert conn.execute("PRAGMA integrity_check").fetchall() == [("ok",)]
+    finally:
+        conn.close()
+    source_hash = _sha256(source)
+
+    report = recover_session_database(source, output, work_dir=tmp_path)
+
+    assert _sha256(source) == source_hash
+    assert '{"broken"' not in json.dumps(report)
+    assert report["verified"] is True
+    assert report["complete"] is False
+    assert report["partial"] is True
+    assert report["semantic_cleanup"] == {
+        "malformed_json_values_quarantined": 1,
+        "columns": {"sessions.model_config": 1},
+    }
+    assert any(
+        "quarantined 1 malformed JSON value" in warning
+        for warning in report["verification"]["warnings"]
+    )
+
+    recovered = SessionDB(db_path=output)
+    try:
+        rows = recovered.list_sessions_rich(limit=10)
+        row = recovered.get_session("recovery-session-1")
+    finally:
+        recovered.close()
+
+    assert {item["id"] for item in rows} == {
+        "recovery-session-0",
+        "recovery-session-1",
+        "recovery-session-2",
+    }
+    assert row is not None
+    assert row["model_config"] == "{}"

--- a/tests/hermes_cli/test_session_recovery.py
+++ b/tests/hermes_cli/test_session_recovery.py
@@ -885,3 +885,38 @@ def test_recovery_quarantines_malformed_session_model_config(tmp_path: Path) -> 
     }
     assert row is not None
     assert row["model_config"] == "{}"
+
+
+def test_quarantine_malformed_json_is_not_called_inside_an_open_transaction(
+    tmp_path: Path,
+) -> None:
+    """Regression guard for the reviewer-flagged nested-BEGIN concern.
+
+    ``_quarantine_malformed_json`` issues its own ``BEGIN IMMEDIATE`` /
+    ``COMMIT`` / ``ROLLBACK``. Both recovery call sites hand it a fresh
+    autocommit (``isolation_level=None``) connection, so SQLite is not inside
+    a transaction when the quarantine runs. If a future caller ever invokes
+    it while a transaction is already open, the nested ``BEGIN`` raises
+    ``sqlite3.OperationalError: cannot start a transaction within a
+    transaction`` — this test pins the current safe contract by asserting the
+    connection is transaction-free at entry on both call paths.
+    """
+
+    source = tmp_path / "state.db"
+    output = tmp_path / "recovered.db"
+    _make_source(source)
+
+    in_transaction_at_entry: list[bool] = []
+    real_quarantine = session_recovery._quarantine_malformed_json
+
+    def spy_quarantine(destination: sqlite3.Connection) -> dict:
+        in_transaction_at_entry.append(destination.in_transaction)
+        return real_quarantine(destination)
+
+    session_recovery._quarantine_malformed_json = spy_quarantine
+    try:
+        recover_session_database(source, output, work_dir=tmp_path)
+    finally:
+        session_recovery._quarantine_malformed_json = real_quarantine
+
+    assert in_transaction_at_entry == [False]


### PR DESCRIPTION
## What does this PR do?

Makes offline session recovery enforce the runtime JSON invariant for `sessions.model_config` before declaring a recovered database usable.

A field recovery produced a database that passed `PRAGMA integrity_check`, foreign-key checks, and FTS checks, yet `hermes sessions list` immediately failed with:

```text
sqlite3.OperationalError: malformed JSON
```

Two recovered `sessions.model_config` cells contained malformed JSON. Session list/count/lineage queries call SQLite `json_extract(...)` on that column, so one malformed historical value can take down the whole surface even though the database is physically sound.

This PR quarantines malformed `sessions.model_config` values to `{}` in both recovery lanes:

- normal SQL copy / rowid salvage;
- page-level `.recover` / lost-and-found fallback.

The recovery report records only table/column counts, never the raw value, because model configuration can contain credentials. Any quarantine is reported as loss: the output remains `verified=true` when physical and relational checks pass, but becomes `complete=false` / `partial=true` with an explicit warning.

The source database remains untouched and retains the original value for forensic recovery.

## Relationship to #101726

Paired with #101726, which adds the complementary read-time guard for existing/live databases. This PR owns recovery-time normalization and loss reporting; #101726 keeps session list/count/lineage/routing/resume reads non-throwing without mutating stored metadata.

## Related work

Related to the recurring corruption field reports in #100896 and #100313.

This complements rather than duplicates:

- #101168, which reconciles short range reads and ghost b-tree cells during row discovery;
- #63956, which validates new session imports but explicitly does not repair unsafe values already present in a database.

A duplicate sweep for `malformed JSON model_config`, `semantic session recovery`, and `json_valid recovery` found no open PR covering this recovery invariant.

## Root cause

SQLite physical integrity checks validate database structure, not application-level JSON stored in `TEXT`. Recovery copied readable cell bytes verbatim, then `_verify_recovered_database()` checked structure, counts, FKs, and FTS only. It could therefore return `complete=true` for an output that failed its first real session-list query.

## Changes

- Add a narrow recovery semantic-cleanup pass for `sessions.model_config`.
- Replace malformed values with the safe empty object `{}` in the destination only.
- Report aggregate quarantine counts without row contents or values.
- Mark quarantines as a partial/lossy recovery while preserving a healthy/verified output.
- Run the cleanup in both SQL salvage and lost-and-found recovery paths.
- Add an end-to-end synthetic regression test through `recover_session_database()` and `SessionDB.list_sessions_rich()`.

## Test evidence

Current upstream `main` at `6441d3a916d74d781860e996cb70bc2d60094ab9`, with only the new regression test applied:

```text
FAILED test_recovery_quarantines_malformed_session_model_config
assert report["complete"] is False
E assert True is False
```

Feature branch on the same base:

```text
scripts/run_tests.sh \
  tests/hermes_cli/test_session_recovery.py \
  tests/hermes_cli/test_session_recovery_lost_and_found.py -q

19 passed, 2 skipped
```

Additional gates:

```text
ruff check .
All checks passed!

python scripts/check-windows-footguns.py --all
No Windows footguns found (1085 files scanned).

git diff --check
clean
```

The full 96-core suite is left to required CI; no full-suite-green claim is made from the local 8-worker host.

## Risk and compatibility

- No schema migration, dependency, config key, or model-tool change.
- Valid and NULL `model_config` values are unchanged.
- Row counts and session/message content are unchanged.
- Only malformed runtime metadata is replaced in the newly generated output.
- New report key: `semantic_cleanup`; existing keys keep their meaning.
- Raw malformed values are never included in the report.

## Checklist

- [x] Read `CONTRIBUTING.md` and `AGENTS.md`
- [x] Searched open and merged issues/PRs for duplicates
- [x] Added a regression test that fails on current `main`
- [x] Proved the test fails when the fix is removed and passes when restored
- [x] Ran affected recovery tests
- [x] Ran blocking Ruff and Windows-footgun gates
- [x] No dependency or lockfile changes
- [x] No user-facing configuration or documentation changes required
- [ ] Full required CI suite — pending on the PR
