### PR TITLE
fix(kanban): gate runtime acceptance

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -81,6 +81,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "session_id": t.session_id,
         "workflow_template_id": t.workflow_template_id,
         "current_step_key": t.current_step_key,
+        "requires_runtime_acceptance": t.requires_runtime_acceptance,
     }
 
 
@@ -418,6 +419,11 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                           help="Provider the --model belongs to (passed as "
                                "--provider <name> to the worker). Requires "
                                "--model.")
+    p_create.add_argument("--requires-runtime-acceptance", action="store_true",
+                          help="Mark runtime-affecting work. Reviewer completion "
+                               "then requires done QA/live-verification parents "
+                               "plus commit and runtime_evidence metadata. Leave "
+                               "off for code-only changes.")
     p_create.add_argument("--goal", action="store_true", dest="goal_mode",
                           help="Run the worker in a goal loop: after each "
                                "turn a judge checks the response against the "
@@ -1686,6 +1692,9 @@ def _cmd_create(args: argparse.Namespace) -> int:
             goal_mode=bool(getattr(args, "goal_mode", False)),
             goal_max_turns=getattr(args, "goal_max_turns", None),
             initial_status=getattr(args, "initial_status", "running"),
+            requires_runtime_acceptance=bool(
+                getattr(args, "requires_runtime_acceptance", False)
+            ),
         )
         task = kb.get_task(conn, task_id)
     if getattr(args, "json", False):

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -423,7 +423,16 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                           help="Mark runtime-affecting work. Reviewer completion "
                                "then requires done QA/live-verification parents "
                                "plus commit and runtime_evidence metadata. Leave "
-                               "off for code-only changes.")
+                               "off for ordinary code-only changes.")
+    p_create.add_argument(
+        "--runtime-acceptance-parent",
+        action="append",
+        default=[],
+        help=(
+            "Explicit QA/live-verification parent task id. Repeat for multiple "
+            "parents; each id must also be passed with --parent."
+        ),
+    )
     p_create.add_argument("--goal", action="store_true", dest="goal_mode",
                           help="Run the worker in a goal loop: after each "
                                "turn a judge checks the response against the "
@@ -1694,6 +1703,9 @@ def _cmd_create(args: argparse.Namespace) -> int:
             initial_status=getattr(args, "initial_status", "running"),
             requires_runtime_acceptance=bool(
                 getattr(args, "requires_runtime_acceptance", False)
+            ),
+            runtime_acceptance_parents=tuple(
+                getattr(args, "runtime_acceptance_parent", None) or ()
             ),
         )
         task = kb.get_task(conn, task_id)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1141,6 +1141,11 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    # Runtime-acceptance gate (c-017). When True, reviewer completion
+    # fails closed unless every QA/live-verification parent is terminal and
+    # the handoff cites ``commit`` + ``runtime_evidence``. See
+    # ``complete_task`` and ``_runtime_acceptance_block_reason``.
+    requires_runtime_acceptance: bool = False
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -1234,6 +1239,12 @@ class Task:
                 int(row["block_recurrences"])
                 if "block_recurrences" in keys and row["block_recurrences"] is not None
                 else 0
+            ),
+            requires_runtime_acceptance=(
+                bool(row["requires_runtime_acceptance"])
+                if "requires_runtime_acceptance" in keys
+                and row["requires_runtime_acceptance"]
+                else False
             ),
         )
 
@@ -1422,7 +1433,13 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    -- Runtime-acceptance gate (correction c-017 / t_3130c1eb). When 1, the
+    -- card requires production-like runtime evidence before reviewer
+    -- completion: every QA/live-verification parent must be terminal AND the
+    -- completing handoff must cite a ``commit`` plus ``runtime_evidence``.
+    -- 0/NULL (the default) = ordinary code-only card, completely ungated.
+    requires_runtime_acceptance INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -2690,6 +2707,17 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "block_recurrences INTEGER NOT NULL DEFAULT 0",
         )
 
+    if "requires_runtime_acceptance" not in cols:
+        # Runtime-acceptance gate (c-017). Existing rows default to 0 =
+        # unmarked, which is exactly the behaviour they had before the
+        # column existed: no card is retroactively gated.
+        _add_column_if_missing(
+            conn,
+            "tasks",
+            "requires_runtime_acceptance",
+            "requires_runtime_acceptance INTEGER NOT NULL DEFAULT 0",
+        )
+
     # Indexes over additive ``tasks`` columns must be created after the
     # columns exist. Keeping them in SCHEMA_SQL breaks legacy boards: SQLite
     # parses each statement in ``executescript`` against the live schema, so a
@@ -3194,6 +3222,7 @@ def create_task(
     board: Optional[str] = None,
     project_id: Optional[str] = None,
     project_source_task_id: Optional[str] = None,
+    requires_runtime_acceptance: bool = False,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -3508,8 +3537,9 @@ def create_task(
                         max_runtime_seconds,
                         skills, max_retries, model_override, provider_override,
                         reasoning_effort,
-                        goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        goal_mode, goal_max_turns, session_id,
+                        requires_runtime_acceptance
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -3535,6 +3565,7 @@ def create_task(
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
+                        1 if requires_runtime_acceptance else 0,
                     ),
                 )
                 for pid in parents:
@@ -3563,6 +3594,9 @@ def create_task(
                         "goal_mode": bool(goal_mode) or None,
                         "model_override": model_override,
                         "provider_override": provider_override,
+                        "requires_runtime_acceptance": (
+                            bool(requires_runtime_acceptance) or None
+                        ),
                     },
                 )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
@@ -4625,6 +4659,158 @@ def _parents_satisfied(conn: sqlite3.Connection, task_id: str) -> bool:
     ).fetchone() is None
 
 
+def set_requires_runtime_acceptance(
+    conn: sqlite3.Connection, task_id: str, value: bool
+) -> bool:
+    """Set (or clear) the runtime-acceptance marker on a task.
+
+    Raises ValueError when the task does not exist. The flip is auditable
+    via a ``runtime_acceptance_marked`` / ``runtime_acceptance_unmarked``
+    event so board history shows when a card entered or left the gated
+    class.
+    """
+    with write_txn(conn):
+        cur = conn.execute(
+            "UPDATE tasks SET requires_runtime_acceptance = ? WHERE id = ?",
+            (1 if value else 0, task_id),
+        )
+        if cur.rowcount != 1:
+            raise ValueError(f"unknown task id: {task_id}")
+        _append_event(
+            conn,
+            task_id,
+            "runtime_acceptance_marked" if value
+            else "runtime_acceptance_unmarked",
+            None,
+        )
+    return True
+
+
+def _runtime_acceptance_block_reason(
+    conn: sqlite3.Connection, task_id: str, metadata: Optional[dict]
+) -> Optional[str]:
+    """Return why a runtime-acceptance completion must be refused, or None.
+
+    Enforces the c-017 contract on cards marked
+    ``requires_runtime_acceptance``:
+
+    1. Every QA/live-verification parent (a parent whose title/body names
+       live verification / QA / acceptance testing) must be terminal.
+    2. The completing handoff metadata must cite the tested candidate
+       ``commit`` and non-empty production-like ``runtime_evidence``.
+
+    Unmarked cards always return None — code-only work is never gated
+    (no global browser/UI evidence requirement).
+    """
+    row = conn.execute(
+        "SELECT requires_runtime_acceptance FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if row is None or not row["requires_runtime_acceptance"]:
+        return None
+
+    md = metadata if isinstance(metadata, dict) else {}
+    pinned = md.get("runtime_acceptance_parents")
+    all_parents = conn.execute(
+        "SELECT p.id, p.title, p.body, p.status FROM task_links l "
+        "JOIN tasks p ON p.id = l.parent_id WHERE l.child_id = ?",
+        (task_id,),
+    ).fetchall()
+    linked_ids = {p["id"] for p in all_parents}
+    if isinstance(pinned, list) and pinned:
+        pinned_ids = [str(p).strip() for p in pinned if str(p).strip()]
+        missing = [p for p in pinned_ids if p not in linked_ids]
+        if missing:
+            return (
+                "runtime acceptance required: runtime_acceptance_parents "
+                f"must be linked parents of this card (invalid: {', '.join(missing)})"
+            )
+        pinned_set = set(pinned_ids)
+        parents = [p for p in all_parents if p["id"] in pinned_set]
+        non_qa = [
+            p["id"] for p in parents
+            if not _looks_like_qa_task(
+                f"{p['title'] or ''}\n{p['body'] or ''}"
+            )
+        ]
+        if non_qa:
+            return (
+                "runtime acceptance required: pinned runtime_acceptance_parents "
+                "must describe QA/live verification in their title or body "
+                f"(invalid: {', '.join(non_qa)})"
+            )
+    else:
+        parents = [
+            p for p in all_parents
+            if _looks_like_qa_task(
+                f"{p['title'] or ''}\n{p['body'] or ''}"
+            )
+        ]
+
+    if not parents:
+        return (
+            "runtime acceptance required: no explicit QA/live-verification "
+            "parent is linked (set runtime_acceptance_parents in metadata "
+            "when the parent title is not self-describing)"
+        )
+    open_qa = [p["id"] for p in parents if p["status"] != "done"]
+    if open_qa:
+        return (
+            "runtime acceptance required: live-verification parent(s) are "
+            f"not done: {', '.join(open_qa)}"
+        )
+
+    commit = md.get("commit")
+    if not isinstance(commit, str) or not re.fullmatch(
+        r"[0-9a-fA-F]{7,64}", commit.strip()
+    ):
+        return (
+            "runtime acceptance required: handoff metadata must cite the "
+            "tested candidate commit as a 7-64 character hex Git SHA (`commit`)"
+        )
+    evidence = md.get("runtime_evidence")
+    if not isinstance(evidence, dict):
+        return (
+            "runtime acceptance required: `runtime_evidence` must be an "
+            "object with candidate_commit, environment, command, and result"
+        )
+    required_evidence = ("candidate_commit", "environment", "command", "result")
+    missing_evidence = [
+        key for key in required_evidence
+        if not isinstance(evidence.get(key), str) or not evidence[key].strip()
+    ]
+    if missing_evidence:
+        return (
+            "runtime acceptance required: runtime_evidence is missing "
+            + ", ".join(missing_evidence)
+        )
+    if evidence["candidate_commit"].strip().casefold() != commit.strip().casefold():
+        return (
+            "runtime acceptance required: runtime_evidence.candidate_commit "
+            "does not match metadata.commit"
+        )
+    return None
+
+
+def _looks_like_qa_task(text: str) -> bool:
+    """Heuristic: does this title/body describe QA / live verification?
+
+    Used only to pick which parents of a runtime-acceptance card must be
+    terminal before reviewer completion. Broad on purpose — gating is the
+    fail-closed direction, and a false positive merely requires that a
+    genuinely-open related card finish first.
+    """
+    t = text.casefold()
+    return any(
+        marker in t
+        for marker in (
+            "live-verif", "live verif", "verify", "verification",
+            "qa", "acceptance", "e2e", "end-to-end", "smoke test",
+            "smoke-test", "runtime audit", "production-like",
+        )
+    )
+
+
 def claim_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -5407,6 +5593,16 @@ def complete_task(
     # Fail before validating cards or staging artifacts; re-check inside the
     # final write transaction below to close the parent-reopen race.
     if not _parents_satisfied(conn, task_id):
+        # For runtime-acceptance cards the refusal must be specific and
+        # auditable — emit the blocked event in its own txn (the plain
+        # parent gate is silent by design for unmarked cards).
+        ra_reason = _runtime_acceptance_block_reason(conn, task_id, metadata)
+        if ra_reason is not None:
+            with write_txn(conn):
+                _append_event(
+                    conn, task_id, "completion_blocked_runtime_acceptance",
+                    {"reason": ra_reason},
+                )
         return False
 
     # Gate: verify created_cards BEFORE the main write txn. A rejected
@@ -5440,6 +5636,21 @@ def complete_task(
         conn, task_id, metadata, summary=summary, result=result,
     )
     with write_txn(conn):
+        # Runtime-acceptance gate (c-017): a card marked as requiring
+        # runtime acceptance fails closed unless its QA/live-verification
+        # parents are terminal AND the handoff cites the tested commit plus
+        # production-like runtime evidence. Checked BEFORE the generic
+        # parent gate so the refusal is specific and auditable (the plain
+        # parent check refuses silently, which is exactly how c-017's
+        # missing evidence went unnoticed). Re-checked inside the txn so a
+        # parent reopened mid-completion cannot slip through.
+        ra_reason = _runtime_acceptance_block_reason(conn, task_id, metadata)
+        if ra_reason is not None:
+            _append_event(
+                conn, task_id, "completion_blocked_runtime_acceptance",
+                {"reason": ra_reason},
+            )
+            return False
         # Parent completion is a hard invariant even for direct human review
         # approval. A parent may have been reopened after this task entered
         # ``review`` or ``running``.
@@ -5555,6 +5766,19 @@ def complete_task(
                 ]
                 if cleaned_artifacts:
                     completed_payload["artifacts"] = cleaned_artifacts
+        # Record the runtime-acceptance evidence on the completed event so
+        # downstream consumers (notifier, dashboard, audits) can verify the
+        # gate was satisfied without reading the run row.
+        if isinstance(metadata, dict) and metadata.get("runtime_evidence"):
+            completed_payload["runtime_acceptance"] = {
+                "commit": str(metadata.get("commit") or "").strip(),
+                "runtime_evidence": metadata.get("runtime_evidence"),
+                **(
+                    {"runtime_acceptance_parents": metadata["runtime_acceptance_parents"]}
+                    if isinstance(metadata.get("runtime_acceptance_parents"), list)
+                    else {}
+                ),
+            }
         _append_event(
             conn, task_id, "completed",
             completed_payload,
@@ -7328,6 +7552,37 @@ def decompose_triage_task(
     if root_assignee is not None:
         root_assignee = _canonical_assignee(root_assignee)
 
+    # c-017: normalize runtime-acceptance graphs at the DB boundary too.
+    # The LLM-facing decomposer already performs this rewrite, but callers
+    # can invoke decompose_triage_task directly (CLI/tests/plugins), so the
+    # durable graph constructor must enforce the same invariant: QA/live
+    # verification is a parent of the marked review card, never a child
+    # that runs after it.
+    for idx, child in enumerate(children):
+        if not isinstance(child, dict) or not child.get("requires_runtime_acceptance"):
+            continue
+        qa_siblings = [
+            i for i, candidate in enumerate(children)
+            if i != idx
+            and isinstance(candidate, dict)
+            and _looks_like_qa_task(
+                " ".join(
+                    str(candidate.get(key) or "")
+                    for key in ("title", "body")
+                )
+            )
+        ]
+        if not qa_siblings:
+            continue
+        for qa_idx in qa_siblings:
+            qa_parents = children[qa_idx].get("parents") or []
+            children[qa_idx]["parents"] = [p for p in qa_parents if p != idx]
+        review_parents = list(child.get("parents") or [])
+        for qa_idx in qa_siblings:
+            if qa_idx not in review_parents:
+                review_parents.append(qa_idx)
+        child["parents"] = review_parents
+
     # Pre-validate the children list shape outside the txn. Cheap checks
     # that don't need DB access. Bad input aborts before we touch the DB.
     for idx, child in enumerate(children):
@@ -7430,8 +7685,9 @@ def decompose_triage_task(
             conn.execute(
                 "INSERT INTO tasks "
                 "(id, title, body, assignee, status, workspace_kind, "
-                " workspace_path, tenant, created_at, created_by) "
-                "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?)",
+                " workspace_path, tenant, created_at, created_by, "
+                " requires_runtime_acceptance) "
+                "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?, ?)",
                 (
                     new_id,
                     title,
@@ -7442,6 +7698,7 @@ def decompose_triage_task(
                     tenant,
                     now,
                     (author or "decomposer"),
+                    1 if child.get("requires_runtime_acceptance") else 0,
                 ),
             )
             _append_event(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1436,13 +1436,25 @@ CREATE TABLE IF NOT EXISTS tasks (
     block_recurrences    INTEGER NOT NULL DEFAULT 0,
     -- Runtime-acceptance gate (correction c-017 / t_3130c1eb). When 1, the
     -- card requires production-like runtime evidence before reviewer
-    -- completion: every QA/live-verification parent must be terminal AND the
-    -- completing handoff must cite a ``commit`` plus ``runtime_evidence``.
+    -- completion: explicit linked runtime_acceptance_parents must be done AND
+    -- the completing handoff must cite a ``commit`` plus ``runtime_evidence``.
     -- 0/NULL (the default) = ordinary code-only card, completely ungated.
-    requires_runtime_acceptance INTEGER NOT NULL DEFAULT 0
+    requires_runtime_acceptance INTEGER NOT NULL DEFAULT 0,
+    -- Immutable-history sentinel. Once non-NULL, runtime parent identity may
+    -- never be replaced even if the designated dependency is later unlinked.
+    runtime_acceptance_designated_at INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
+    parent_id  TEXT NOT NULL,
+    child_id   TEXT NOT NULL,
+    PRIMARY KEY (parent_id, child_id)
+);
+
+-- Durable identity for QA/live-verification parents of runtime-gated cards.
+-- A plain dependency edge is insufficient: completion must distinguish the
+-- explicitly designated acceptance checks from unrelated task parents.
+CREATE TABLE IF NOT EXISTS task_runtime_acceptance_parents (
     parent_id  TEXT NOT NULL,
     child_id   TEXT NOT NULL,
     PRIMARY KEY (parent_id, child_id)
@@ -1535,6 +1547,7 @@ CREATE INDEX IF NOT EXISTS idx_tasks_assignee_status ON tasks(assignee, status);
 CREATE INDEX IF NOT EXISTS idx_tasks_status          ON tasks(status);
 CREATE INDEX IF NOT EXISTS idx_links_child           ON task_links(child_id);
 CREATE INDEX IF NOT EXISTS idx_links_parent          ON task_links(parent_id);
+CREATE INDEX IF NOT EXISTS idx_runtime_acceptance_child ON task_runtime_acceptance_parents(child_id);
 CREATE INDEX IF NOT EXISTS idx_comments_task         ON task_comments(task_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_events_task           ON task_events(task_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_runs_task             ON task_runs(task_id, started_at);
@@ -2718,6 +2731,14 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "requires_runtime_acceptance INTEGER NOT NULL DEFAULT 0",
         )
 
+    if "runtime_acceptance_designated_at" not in cols:
+        _add_column_if_missing(
+            conn,
+            "tasks",
+            "runtime_acceptance_designated_at",
+            "runtime_acceptance_designated_at INTEGER",
+        )
+
     # Indexes over additive ``tasks`` columns must be created after the
     # columns exist. Keeping them in SCHEMA_SQL breaks legacy boards: SQLite
     # parses each statement in ``executescript`` against the live schema, so a
@@ -3223,6 +3244,7 @@ def create_task(
     project_id: Optional[str] = None,
     project_source_task_id: Optional[str] = None,
     requires_runtime_acceptance: bool = False,
+    runtime_acceptance_parents: Iterable[str] = (),
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -3387,6 +3409,19 @@ def create_task(
                 project_repo = str(project_obj.primary_path)
 
     parents = tuple(p for p in parents if p)
+    runtime_acceptance_parents = tuple(
+        dict.fromkeys(p for p in runtime_acceptance_parents if p)
+    )
+    if runtime_acceptance_parents and not requires_runtime_acceptance:
+        raise ValueError(
+            "runtime_acceptance_parents require requires_runtime_acceptance=true"
+        )
+    unknown_runtime_parents = set(runtime_acceptance_parents) - set(parents)
+    if unknown_runtime_parents:
+        raise ValueError(
+            "runtime_acceptance_parents must be included in parents: "
+            + ", ".join(sorted(unknown_runtime_parents))
+        )
 
     # Normalise + validate skills: strip whitespace, drop empties, dedupe
     # (preserving order). Refuse commas inside a single name so we don't
@@ -3572,6 +3607,13 @@ def create_task(
                     conn.execute(
                         "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
                         (pid, task_id),
+                    )
+                if runtime_acceptance_parents:
+                    designate_runtime_acceptance_parents(
+                        conn,
+                        task_id,
+                        runtime_acceptance_parents,
+                        allow_nested=True,
                     )
                 # Notify-sub inheritance (ACK-edge: the originating channel
                 # still hears about a child that BLOCKs, not just the final
@@ -3927,6 +3969,11 @@ def _would_cycle(conn: sqlite3.Connection, parent_id: str, child_id: str) -> boo
 
 def unlink_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> bool:
     with write_txn(conn):
+        conn.execute(
+            "DELETE FROM task_runtime_acceptance_parents "
+            "WHERE parent_id = ? AND child_id = ?",
+            (parent_id, child_id),
+        )
         cur = conn.execute(
             "DELETE FROM task_links WHERE parent_id = ? AND child_id = ?",
             (parent_id, child_id),
@@ -4662,20 +4709,29 @@ def _parents_satisfied(conn: sqlite3.Connection, task_id: str) -> bool:
 def set_requires_runtime_acceptance(
     conn: sqlite3.Connection, task_id: str, value: bool
 ) -> bool:
-    """Set (or clear) the runtime-acceptance marker on a task.
+    """Set the runtime-acceptance marker on a task.
 
-    Raises ValueError when the task does not exist. The flip is auditable
-    via a ``runtime_acceptance_marked`` / ``runtime_acceptance_unmarked``
-    event so board history shows when a card entered or left the gated
-    class.
+    Once enabled, the marker is immutable through this unprivileged mutation
+    surface. This prevents a caller from clearing the gate in one request and
+    completing the card without evidence in a later request, regardless of
+    whether review has started. Raises ValueError when the task does not exist
+    and RuntimeError for a forbidden clear. Every accepted flip is auditable.
     """
     with write_txn(conn):
-        cur = conn.execute(
+        row = conn.execute(
+            "SELECT requires_runtime_acceptance FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if row is None:
+            raise ValueError(f"unknown task id: {task_id}")
+        if not value and row["requires_runtime_acceptance"]:
+            raise RuntimeError(
+                "cannot clear requires_runtime_acceptance once enabled"
+            )
+        conn.execute(
             "UPDATE tasks SET requires_runtime_acceptance = ? WHERE id = ?",
             (1 if value else 0, task_id),
         )
-        if cur.rowcount != 1:
-            raise ValueError(f"unknown task id: {task_id}")
         _append_event(
             conn,
             task_id,
@@ -4686,6 +4742,70 @@ def set_requires_runtime_acceptance(
     return True
 
 
+def designate_runtime_acceptance_parents(
+    conn: sqlite3.Connection,
+    task_id: str,
+    parent_ids: Iterable[str],
+    *,
+    allow_nested: bool = False,
+) -> None:
+    """Persist a task's immutable explicit runtime-acceptance parent identity.
+
+    This is a one-time designation for marked tasks, including legacy marked
+    cards created before durable identity storage existed. Every designated
+    task must already be a linked parent. Re-designation is refused.
+    """
+    normalized = tuple(dict.fromkeys(str(value).strip() for value in parent_ids))
+    if not normalized or any(not value for value in normalized):
+        raise ValueError("runtime_acceptance_parents must contain task ids")
+    with write_txn(conn, allow_nested=allow_nested):
+        task = conn.execute(
+            "SELECT requires_runtime_acceptance, runtime_acceptance_designated_at "
+            "FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if task is None:
+            raise ValueError(f"unknown task id: {task_id}")
+        if not task["requires_runtime_acceptance"]:
+            raise ValueError("runtime acceptance parents require a marked task")
+        if task["runtime_acceptance_designated_at"] is not None:
+            raise RuntimeError("runtime acceptance parents are already designated")
+        existing = conn.execute(
+            "SELECT parent_id FROM task_runtime_acceptance_parents "
+            "WHERE child_id = ?",
+            (task_id,),
+        ).fetchall()
+        if existing:
+            raise RuntimeError("runtime acceptance parents are already designated")
+        linked = conn.execute(
+            "SELECT parent_id FROM task_links WHERE child_id = ?",
+            (task_id,),
+        ).fetchall()
+        linked_ids = {row["parent_id"] for row in linked}
+        missing = [parent_id for parent_id in normalized if parent_id not in linked_ids]
+        if missing:
+            raise ValueError(
+                "runtime_acceptance_parents must be linked parents: "
+                + ", ".join(missing)
+            )
+        for parent_id in normalized:
+            conn.execute(
+                "INSERT INTO task_runtime_acceptance_parents "
+                "(parent_id, child_id) VALUES (?, ?)",
+                (parent_id, task_id),
+            )
+        conn.execute(
+            "UPDATE tasks SET runtime_acceptance_designated_at = ? WHERE id = ?",
+            (int(time.time()), task_id),
+        )
+        _append_event(
+            conn,
+            task_id,
+            "runtime_acceptance_parents_designated",
+            {"parents": list(normalized)},
+        )
+
+
 def _runtime_acceptance_block_reason(
     conn: sqlite3.Connection, task_id: str, metadata: Optional[dict]
 ) -> Optional[str]:
@@ -4694,8 +4814,9 @@ def _runtime_acceptance_block_reason(
     Enforces the c-017 contract on cards marked
     ``requires_runtime_acceptance``:
 
-    1. Every QA/live-verification parent (a parent whose title/body names
-       live verification / QA / acceptance testing) must be terminal.
+    1. Handoff metadata must name one or more explicit linked QA/live-
+       verification parents in ``runtime_acceptance_parents``; title/body
+       prose is never used as task identity. Every named parent must be done.
     2. The completing handoff metadata must cite the tested candidate
        ``commit`` and non-empty production-like ``runtime_evidence``.
 
@@ -4711,49 +4832,53 @@ def _runtime_acceptance_block_reason(
 
     md = metadata if isinstance(metadata, dict) else {}
     pinned = md.get("runtime_acceptance_parents")
+    if not isinstance(pinned, list) or not pinned:
+        return (
+            "runtime acceptance required: handoff metadata must cite explicit "
+            "linked QA/live-verification task ids in runtime_acceptance_parents"
+        )
+    pinned_ids = [str(parent_id).strip() for parent_id in pinned]
+    if any(not parent_id for parent_id in pinned_ids):
+        return (
+            "runtime acceptance required: runtime_acceptance_parents must "
+            "contain non-empty linked task ids"
+        )
+    if len(set(pinned_ids)) != len(pinned_ids):
+        return (
+            "runtime acceptance required: runtime_acceptance_parents must "
+            "not contain duplicate task ids"
+        )
+
+    designated_rows = conn.execute(
+        "SELECT parent_id FROM task_runtime_acceptance_parents WHERE child_id = ?",
+        (task_id,),
+    ).fetchall()
+    designated_ids = {row["parent_id"] for row in designated_rows}
+    if not designated_ids:
+        return (
+            "runtime acceptance required: no durable QA/live-verification "
+            "parents are designated for this card"
+        )
+    if set(pinned_ids) != designated_ids:
+        return (
+            "runtime acceptance required: runtime_acceptance_parents must "
+            "exactly match the card's designated QA/live-verification parents"
+        )
+
     all_parents = conn.execute(
-        "SELECT p.id, p.title, p.body, p.status FROM task_links l "
+        "SELECT p.id, p.status FROM task_links l "
         "JOIN tasks p ON p.id = l.parent_id WHERE l.child_id = ?",
         (task_id,),
     ).fetchall()
-    linked_ids = {p["id"] for p in all_parents}
-    if isinstance(pinned, list) and pinned:
-        pinned_ids = [str(p).strip() for p in pinned if str(p).strip()]
-        missing = [p for p in pinned_ids if p not in linked_ids]
-        if missing:
-            return (
-                "runtime acceptance required: runtime_acceptance_parents "
-                f"must be linked parents of this card (invalid: {', '.join(missing)})"
-            )
-        pinned_set = set(pinned_ids)
-        parents = [p for p in all_parents if p["id"] in pinned_set]
-        non_qa = [
-            p["id"] for p in parents
-            if not _looks_like_qa_task(
-                f"{p['title'] or ''}\n{p['body'] or ''}"
-            )
-        ]
-        if non_qa:
-            return (
-                "runtime acceptance required: pinned runtime_acceptance_parents "
-                "must describe QA/live verification in their title or body "
-                f"(invalid: {', '.join(non_qa)})"
-            )
-    else:
-        parents = [
-            p for p in all_parents
-            if _looks_like_qa_task(
-                f"{p['title'] or ''}\n{p['body'] or ''}"
-            )
-        ]
-
-    if not parents:
+    linked_by_id = {parent["id"]: parent for parent in all_parents}
+    missing = [parent_id for parent_id in pinned_ids if parent_id not in linked_by_id]
+    if missing:
         return (
-            "runtime acceptance required: no explicit QA/live-verification "
-            "parent is linked (set runtime_acceptance_parents in metadata "
-            "when the parent title is not self-describing)"
+            "runtime acceptance required: runtime_acceptance_parents must be "
+            f"linked parents of this card (invalid: {', '.join(missing)})"
         )
-    open_qa = [p["id"] for p in parents if p["status"] != "done"]
+    parents = [linked_by_id[parent_id] for parent_id in pinned_ids]
+    open_qa = [parent["id"] for parent in parents if parent["status"] != "done"]
     if open_qa:
         return (
             "runtime acceptance required: live-verification parent(s) are "
@@ -4790,25 +4915,6 @@ def _runtime_acceptance_block_reason(
             "does not match metadata.commit"
         )
     return None
-
-
-def _looks_like_qa_task(text: str) -> bool:
-    """Heuristic: does this title/body describe QA / live verification?
-
-    Used only to pick which parents of a runtime-acceptance card must be
-    terminal before reviewer completion. Broad on purpose — gating is the
-    fail-closed direction, and a false positive merely requires that a
-    genuinely-open related card finish first.
-    """
-    t = text.casefold()
-    return any(
-        marker in t
-        for marker in (
-            "live-verif", "live verif", "verify", "verification",
-            "qa", "acceptance", "e2e", "end-to-end", "smoke test",
-            "smoke-test", "runtime audit", "production-like",
-        )
-    )
 
 
 def claim_task(
@@ -5637,9 +5743,9 @@ def complete_task(
     )
     with write_txn(conn):
         # Runtime-acceptance gate (c-017): a card marked as requiring
-        # runtime acceptance fails closed unless its QA/live-verification
-        # parents are terminal AND the handoff cites the tested commit plus
-        # production-like runtime evidence. Checked BEFORE the generic
+        # runtime acceptance fails closed unless explicitly cited linked QA/
+        # live-verification parents are done AND the handoff cites the tested
+        # commit plus production-like runtime evidence. Checked BEFORE the generic
         # parent gate so the refusal is specific and auditable (the plain
         # parent check refuses silently, which is exactly how c-017's
         # missing evidence went unnoticed). Re-checked inside the txn so a
@@ -7552,55 +7658,83 @@ def decompose_triage_task(
     if root_assignee is not None:
         root_assignee = _canonical_assignee(root_assignee)
 
-    # c-017: normalize runtime-acceptance graphs at the DB boundary too.
-    # The LLM-facing decomposer already performs this rewrite, but callers
-    # can invoke decompose_triage_task directly (CLI/tests/plugins), so the
-    # durable graph constructor must enforce the same invariant: QA/live
-    # verification is a parent of the marked review card, never a child
-    # that runs after it.
-    for idx, child in enumerate(children):
-        if not isinstance(child, dict) or not child.get("requires_runtime_acceptance"):
-            continue
-        qa_siblings = [
-            i for i, candidate in enumerate(children)
-            if i != idx
-            and isinstance(candidate, dict)
-            and _looks_like_qa_task(
-                " ".join(
-                    str(candidate.get(key) or "")
-                    for key in ("title", "body")
-                )
-            )
-        ]
-        if not qa_siblings:
-            continue
-        for qa_idx in qa_siblings:
-            qa_parents = children[qa_idx].get("parents") or []
-            children[qa_idx]["parents"] = [p for p in qa_parents if p != idx]
-        review_parents = list(child.get("parents") or [])
-        for qa_idx in qa_siblings:
-            if qa_idx not in review_parents:
-                review_parents.append(qa_idx)
-        child["parents"] = review_parents
-
-    # Pre-validate the children list shape outside the txn. Cheap checks
-    # that don't need DB access. Bad input aborts before we touch the DB.
+    # Validate the child object shape before runtime-edge normalization, which
+    # dereferences explicitly named siblings. Malformed input must produce the
+    # documented ValueError rather than an incidental AttributeError.
     for idx, child in enumerate(children):
         if not isinstance(child, dict):
             raise ValueError(f"child[{idx}] is not a dict")
         title = child.get("title")
         if not isinstance(title, str) or not title.strip():
             raise ValueError(f"child[{idx}].title is required")
-        parents_idx = child.get("parents") or []
-        if not isinstance(parents_idx, list):
+        raw_parents = child.get("parents", [])
+        if not isinstance(raw_parents, list):
             raise ValueError(f"child[{idx}].parents must be a list")
-        for p in parents_idx:
-            if not isinstance(p, int) or p < 0 or p >= len(children):
+        for parent_idx in raw_parents:
+            if (
+                not isinstance(parent_idx, int)
+                or isinstance(parent_idx, bool)
+                or parent_idx < 0
+                or parent_idx >= len(children)
+            ):
                 raise ValueError(
-                    f"child[{idx}].parents[{p}] is not a valid index into children"
+                    f"child[{idx}].parents[{parent_idx}] is not a valid "
+                    "index into children"
                 )
-            if p == idx:
+            if parent_idx == idx:
                 raise ValueError(f"child[{idx}] cannot list itself as a parent")
+
+    # c-017: normalize explicitly typed runtime-acceptance edges at the DB
+    # boundary too. A marked review child must name its QA/live-verification
+    # siblings by index in ``runtime_acceptance_parents``. Titles and bodies
+    # are deliberately ignored: prose is neither a stable type nor proof that
+    # a parent exercised the candidate runtime.
+    for idx, child in enumerate(children):
+        runtime_parents = child.get("runtime_acceptance_parents", [])
+        if runtime_parents and not child.get("requires_runtime_acceptance"):
+            raise ValueError(
+                f"child[{idx}].runtime_acceptance_parents require "
+                "requires_runtime_acceptance=true"
+            )
+        if not child.get("requires_runtime_acceptance"):
+            continue
+        runtime_parents = child.get("runtime_acceptance_parents")
+        if not isinstance(runtime_parents, list) or not runtime_parents:
+            raise ValueError(
+                f"child[{idx}].runtime_acceptance_parents must name at least "
+                "one QA/live-verification child index"
+            )
+        normalized_runtime_parents: list[int] = []
+        for parent_idx in runtime_parents:
+            if (
+                not isinstance(parent_idx, int)
+                or isinstance(parent_idx, bool)
+                or parent_idx < 0
+                or parent_idx >= len(children)
+                or parent_idx == idx
+            ):
+                raise ValueError(
+                    f"child[{idx}].runtime_acceptance_parents[{parent_idx}] "
+                    "is not a valid sibling index"
+                )
+            if children[parent_idx].get("requires_runtime_acceptance"):
+                raise ValueError(
+                    f"child[{idx}].runtime_acceptance_parents[{parent_idx}] "
+                    "cannot itself require runtime acceptance"
+                )
+            if parent_idx not in normalized_runtime_parents:
+                normalized_runtime_parents.append(parent_idx)
+        child["runtime_acceptance_parents"] = normalized_runtime_parents
+        for parent_idx in normalized_runtime_parents:
+            inverse_parents = children[parent_idx].get("parents") or []
+            children[parent_idx]["parents"] = [
+                parent for parent in inverse_parents if parent != idx
+            ]
+        review_parents = list(child.get("parents") or [])
+        for parent_idx in normalized_runtime_parents:
+            if parent_idx not in review_parents:
+                review_parents.append(parent_idx)
+        child["parents"] = review_parents
 
     # Detect cycles in the sibling parent graph (Kahn's topological sort).
     # link_tasks() calls _would_cycle() for every new edge; here we check
@@ -7722,6 +7856,17 @@ def decompose_triage_task(
                     conn, child_id, "linked",
                     {"parent": parent_id, "child": child_id},
                 )
+            runtime_parent_ids = [
+                child_ids[p_idx]
+                for p_idx in child.get("runtime_acceptance_parents", [])
+            ]
+            if runtime_parent_ids:
+                designate_runtime_acceptance_parents(
+                    conn,
+                    child_ids[idx],
+                    runtime_parent_ids,
+                    allow_nested=True,
+                )
 
         # Link the ROOT task as a child of every leaf child — i.e. the
         # root waits for the whole graph. Simpler than computing leaves:
@@ -7822,6 +7967,11 @@ def delete_archived_task(conn: sqlite3.Connection, task_id: str) -> bool:
         if not row or row["status"] != "archived":
             return False
         conn.execute(
+            "DELETE FROM task_runtime_acceptance_parents "
+            "WHERE parent_id = ? OR child_id = ?",
+            (task_id, task_id),
+        )
+        conn.execute(
             "DELETE FROM task_links WHERE parent_id = ? OR child_id = ?",
             (task_id, task_id),
         )
@@ -7847,6 +7997,11 @@ def delete_task(conn: sqlite3.Connection, task_id: str) -> bool:
         cur = conn.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
         if cur.rowcount != 1:
             return False
+        conn.execute(
+            "DELETE FROM task_runtime_acceptance_parents "
+            "WHERE parent_id = ? OR child_id = ?",
+            (task_id, task_id),
+        )
         conn.execute("DELETE FROM task_links WHERE parent_id = ? OR child_id = ?", (task_id, task_id))
         conn.execute("DELETE FROM task_comments WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM task_events WHERE task_id = ?", (task_id,))

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -89,6 +89,14 @@ Rules:
     and the system will route to the default_assignee.
   - Each child task body is what a fresh worker will read with no other
     context — be specific about goal, approach, and acceptance criteria.
+  - When work changes runtime behavior (gateway routing, scheduled jobs,
+    service deployments, platform adapters), set "requires_runtime_acceptance":
+    true on the review/approval child AND create an explicit
+    QA/live-verification child that deploys and exercises the change in a
+    production-like environment. Express the dependency as
+    QA/live-verification -> review (the review child lists the QA child in
+    "parents"), never review -> later verification. Code-only changes do
+    NOT need the marker or a QA child.
 
 When the task is genuinely a single unit of work (no useful decomposition),
 return:
@@ -237,6 +245,49 @@ def _build_roster() -> tuple[list[dict], set[str]]:
         })
         valid.add(p.name)
     return roster, valid
+
+
+def _child_looks_like_qa(entry: object) -> bool:
+    """Heuristic: does a decomposer child entry describe QA / live
+    verification work? Delegates to the DB-layer matcher
+    (``hermes_cli.kanban_db._looks_like_qa_task``) over title + body so
+    both layers share one marker vocabulary."""
+    if not isinstance(entry, dict):
+        return False
+    text = " ".join(str(entry.get(key) or "") for key in ("title", "body"))
+    return kb._looks_like_qa_task(text)
+
+
+def _enforce_qa_before_review_order(
+    children: list[dict], raw_tasks: list[object]
+) -> None:
+    """Normalize marked decomposer graphs to QA -> reviewer order in-place.
+
+    The LLM sometimes emits the inverse edge: QA lists the review card as a
+    parent, so review can run and approve before QA. For every marked card,
+    detect QA siblings, remove that inverse edge, and add QA as a parent of
+    the marked card. No QA sibling means no graph rewrite; completion still
+    requires explicit commit + runtime evidence.
+    """
+    for idx, child in enumerate(children):
+        if not child.get("requires_runtime_acceptance"):
+            continue
+        qa_siblings = [
+            i for i, entry in enumerate(raw_tasks)
+            if i != idx and _child_looks_like_qa(entry)
+        ]
+        if not qa_siblings:
+            continue
+        for qa_idx in qa_siblings:
+            qa_parents = children[qa_idx].get("parents") or []
+            children[qa_idx]["parents"] = [
+                p for p in qa_parents if p != idx
+            ]
+        review_parents = list(child.get("parents") or [])
+        for qa_idx in qa_siblings:
+            if qa_idx not in review_parents:
+                review_parents.append(qa_idx)
+        child["parents"] = review_parents
 
 
 def _format_roster(roster: list[dict]) -> str:
@@ -422,12 +473,20 @@ def decompose_task(
             parents = []
         # Clean parent indices: drop non-int and out-of-range.
         clean_parents = [p for p in parents if isinstance(p, int) and 0 <= p < len(raw_tasks) and p != idx]
+        marked = bool(entry.get("requires_runtime_acceptance"))
+        # c-017 dependency order: a runtime-acceptance review card must be
+        # gated BY its QA/live-verification sibling (QA -> reviewer), never
+        # the reverse. After the raw entries are normalized, fix inverted
+        # QA edges for every marked card in the graph.
         children.append({
             "title": title.strip()[:200],
             "body": body.strip(),
             "assignee": chosen,
             "parents": clean_parents,
+            "requires_runtime_acceptance": marked,
         })
+
+    _enforce_qa_before_review_order(children, raw_tasks)
 
     try:
         with kb.connect_closing() as conn:

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -70,7 +70,9 @@ Output a single JSON object with this exact shape:
         "title": "<concrete task title, imperative voice, <= 80 chars>",
         "body":  "<detailed spec for the worker on this child task>",
         "assignee": "<profile name from the roster, or null for default>",
-        "parents": [<int>, ...]
+        "parents": [<int>, ...],
+        "requires_runtime_acceptance": false,
+        "runtime_acceptance_parents": [<int>, ...]
       },
       ...
     ]
@@ -93,10 +95,12 @@ Rules:
     service deployments, platform adapters), set "requires_runtime_acceptance":
     true on the review/approval child AND create an explicit
     QA/live-verification child that deploys and exercises the change in a
-    production-like environment. Express the dependency as
-    QA/live-verification -> review (the review child lists the QA child in
-    "parents"), never review -> later verification. Code-only changes do
-    NOT need the marker or a QA child.
+    production-like environment. On the marked child, set
+    "runtime_acceptance_parents" to the QA child index (or indices). This
+    explicit field is required; titles and body prose are never used to infer
+    QA identity. Express the dependency as QA/live-verification -> review,
+    never review -> later verification. Code-only changes leave the marker
+    false and "runtime_acceptance_parents" empty.
 
 When the task is genuinely a single unit of work (no useful decomposition),
 return:
@@ -247,46 +251,38 @@ def _build_roster() -> tuple[list[dict], set[str]]:
     return roster, valid
 
 
-def _child_looks_like_qa(entry: object) -> bool:
-    """Heuristic: does a decomposer child entry describe QA / live
-    verification work? Delegates to the DB-layer matcher
-    (``hermes_cli.kanban_db._looks_like_qa_task``) over title + body so
-    both layers share one marker vocabulary."""
-    if not isinstance(entry, dict):
-        return False
-    text = " ".join(str(entry.get(key) or "") for key in ("title", "body"))
-    return kb._looks_like_qa_task(text)
+def _enforce_runtime_acceptance_order(children: list[dict]) -> None:
+    """Normalize explicit QA -> reviewer edges in-place.
 
-
-def _enforce_qa_before_review_order(
-    children: list[dict], raw_tasks: list[object]
-) -> None:
-    """Normalize marked decomposer graphs to QA -> reviewer order in-place.
-
-    The LLM sometimes emits the inverse edge: QA lists the review card as a
-    parent, so review can run and approve before QA. For every marked card,
-    detect QA siblings, remove that inverse edge, and add QA as a parent of
-    the marked card. No QA sibling means no graph rewrite; completion still
-    requires explicit commit + runtime evidence.
+    ``runtime_acceptance_parents`` is a list of sibling indices supplied on
+    each marked review child. Using explicit indices avoids classifying QA by
+    title/body prose, which can both accept unrelated work and reject a valid
+    non-self-describing verification card.
     """
     for idx, child in enumerate(children):
         if not child.get("requires_runtime_acceptance"):
             continue
-        qa_siblings = [
-            i for i, entry in enumerate(raw_tasks)
-            if i != idx and _child_looks_like_qa(entry)
-        ]
-        if not qa_siblings:
+        runtime_parents = child.get("runtime_acceptance_parents") or []
+        for parent_idx in runtime_parents:
+            if children[parent_idx].get("requires_runtime_acceptance"):
+                raise ValueError(
+                    f"tasks[{idx}].runtime_acceptance_parents[{parent_idx}] "
+                    "cannot itself require runtime acceptance"
+                )
+
+    for idx, child in enumerate(children):
+        if not child.get("requires_runtime_acceptance"):
             continue
-        for qa_idx in qa_siblings:
-            qa_parents = children[qa_idx].get("parents") or []
-            children[qa_idx]["parents"] = [
-                p for p in qa_parents if p != idx
+        runtime_parents = child.get("runtime_acceptance_parents") or []
+        for parent_idx in runtime_parents:
+            inverse_parents = children[parent_idx].get("parents") or []
+            children[parent_idx]["parents"] = [
+                parent for parent in inverse_parents if parent != idx
             ]
         review_parents = list(child.get("parents") or [])
-        for qa_idx in qa_siblings:
-            if qa_idx not in review_parents:
-                review_parents.append(qa_idx)
+        for parent_idx in runtime_parents:
+            if parent_idx not in review_parents:
+                review_parents.append(parent_idx)
         child["parents"] = review_parents
 
 
@@ -468,27 +464,67 @@ def decompose_task(
                 "routing to default_assignee %r",
                 task_id, idx, assignee, default_assignee,
             )
-        parents = entry.get("parents") or []
+        parents = entry.get("parents", [])
         if not isinstance(parents, list):
-            parents = []
+            return DecomposeOutcome(
+                task_id, False, f"tasks[{idx}].parents must be a list",
+            )
         # Clean parent indices: drop non-int and out-of-range.
-        clean_parents = [p for p in parents if isinstance(p, int) and 0 <= p < len(raw_tasks) and p != idx]
+        clean_parents = [
+            p
+            for p in parents
+            if isinstance(p, int)
+            and not isinstance(p, bool)
+            and 0 <= p < len(raw_tasks)
+            and p != idx
+        ]
         marked = bool(entry.get("requires_runtime_acceptance"))
-        # c-017 dependency order: a runtime-acceptance review card must be
-        # gated BY its QA/live-verification sibling (QA -> reviewer), never
-        # the reverse. After the raw entries are normalized, fix inverted
-        # QA edges for every marked card in the graph.
+        runtime_parents = entry.get("runtime_acceptance_parents", [])
+        if not isinstance(runtime_parents, list):
+            return DecomposeOutcome(
+                task_id,
+                False,
+                f"tasks[{idx}].runtime_acceptance_parents must be a list",
+            )
+        if any(
+            not isinstance(parent_idx, int)
+            or isinstance(parent_idx, bool)
+            or not 0 <= parent_idx < len(raw_tasks)
+            or parent_idx == idx
+            for parent_idx in runtime_parents
+        ):
+            return DecomposeOutcome(
+                task_id,
+                False,
+                f"tasks[{idx}].runtime_acceptance_parents contains an invalid "
+                "sibling index",
+            )
+        clean_runtime_parents = list(dict.fromkeys(runtime_parents))
+        if clean_runtime_parents and not marked:
+            return DecomposeOutcome(
+                task_id,
+                False,
+                f"tasks[{idx}].runtime_acceptance_parents require "
+                "requires_runtime_acceptance=true",
+            )
+        if marked and not clean_runtime_parents:
+            return DecomposeOutcome(
+                task_id,
+                False,
+                f"tasks[{idx}].runtime_acceptance_parents must name at least "
+                "one QA/live-verification task index",
+            )
         children.append({
             "title": title.strip()[:200],
             "body": body.strip(),
             "assignee": chosen,
             "parents": clean_parents,
             "requires_runtime_acceptance": marked,
+            "runtime_acceptance_parents": clean_runtime_parents,
         })
 
-    _enforce_qa_before_review_order(children, raw_tasks)
-
     try:
+        _enforce_runtime_acceptance_order(children)
         with kb.connect_closing() as conn:
             child_ids = kb.decompose_triage_task(
                 conn,

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -611,6 +611,7 @@ class CreateTaskBody(BaseModel):
     skills: Optional[list[str]] = None
     goal_mode: bool = False
     goal_max_turns: Optional[int] = None
+    requires_runtime_acceptance: bool = False
     model_override: Optional[str] = None
     provider_override: Optional[str] = None
     # Per-task thinking depth (none|minimal|…|ultra). None = inherit the
@@ -643,6 +644,7 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             skills=payload.skills,
             goal_mode=payload.goal_mode,
             goal_max_turns=payload.goal_max_turns,
+            requires_runtime_acceptance=payload.requires_runtime_acceptance,
             model_override=payload.model_override,
             provider_override=payload.provider_override,
             reasoning_effort=payload.reasoning_effort,
@@ -839,6 +841,7 @@ class UpdateTaskBody(BaseModel):
     # complete --summary ... --metadata ...``.
     summary: Optional[str] = None
     metadata: Optional[dict] = None
+    requires_runtime_acceptance: Optional[bool] = None
     # Per-task model/provider override (the board's model dropdown).
     # ``model_override=""`` clears both. ``clear_model_override=True`` is
     # the explicit clear signal — needed because Optional[str]=None means
@@ -879,6 +882,25 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
         review_assignee_deferred = (
             payload.status == "review" and payload.assignee is not None
         )
+
+        if (
+            payload.status == "done"
+            and payload.requires_runtime_acceptance is False
+            and task.requires_runtime_acceptance
+        ):
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "Cannot clear requires_runtime_acceptance in the same "
+                    "request that completes a gated task"
+                ),
+            )
+        if payload.requires_runtime_acceptance is not None:
+            kanban_db.set_requires_runtime_acceptance(
+                conn,
+                task_id,
+                payload.requires_runtime_acceptance,
+            )
 
         # --- assignee ----------------------------------------------------
         # For a combined assignee+review patch, request_review must capture

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -612,6 +612,7 @@ class CreateTaskBody(BaseModel):
     goal_mode: bool = False
     goal_max_turns: Optional[int] = None
     requires_runtime_acceptance: bool = False
+    runtime_acceptance_parents: list[str] = Field(default_factory=list)
     model_override: Optional[str] = None
     provider_override: Optional[str] = None
     # Per-task thinking depth (none|minimal|…|ultra). None = inherit the
@@ -645,6 +646,7 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             goal_mode=payload.goal_mode,
             goal_max_turns=payload.goal_max_turns,
             requires_runtime_acceptance=payload.requires_runtime_acceptance,
+            runtime_acceptance_parents=payload.runtime_acceptance_parents,
             model_override=payload.model_override,
             provider_override=payload.provider_override,
             reasoning_effort=payload.reasoning_effort,
@@ -842,6 +844,7 @@ class UpdateTaskBody(BaseModel):
     summary: Optional[str] = None
     metadata: Optional[dict] = None
     requires_runtime_acceptance: Optional[bool] = None
+    runtime_acceptance_parents: Optional[list[str]] = None
     # Per-task model/provider override (the board's model dropdown).
     # ``model_override=""`` clears both. ``clear_model_override=True`` is
     # the explicit clear signal — needed because Optional[str]=None means
@@ -883,24 +886,39 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
             payload.status == "review" and payload.assignee is not None
         )
 
-        if (
-            payload.status == "done"
-            and payload.requires_runtime_acceptance is False
-            and task.requires_runtime_acceptance
-        ):
+        payload_fields = getattr(
+            payload, "model_fields_set", getattr(payload, "__fields_set__", set())
+        )
+        gate_fields = {
+            "requires_runtime_acceptance",
+            "runtime_acceptance_parents",
+        } & payload_fields
+        if gate_fields and len(payload_fields) > 1:
             raise HTTPException(
                 status_code=409,
                 detail=(
-                    "Cannot clear requires_runtime_acceptance in the same "
-                    "request that completes a gated task"
+                    "Update runtime acceptance fields in their own request so "
+                    "immutable gate state cannot partially commit"
                 ),
             )
         if payload.requires_runtime_acceptance is not None:
-            kanban_db.set_requires_runtime_acceptance(
-                conn,
-                task_id,
-                payload.requires_runtime_acceptance,
-            )
+            try:
+                kanban_db.set_requires_runtime_acceptance(
+                    conn,
+                    task_id,
+                    payload.requires_runtime_acceptance,
+                )
+            except RuntimeError as exc:
+                raise HTTPException(status_code=409, detail=str(exc))
+        if payload.runtime_acceptance_parents is not None:
+            try:
+                kanban_db.designate_runtime_acceptance_parents(
+                    conn, task_id, payload.runtime_acceptance_parents
+                )
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc))
+            except RuntimeError as exc:
+                raise HTTPException(status_code=409, detail=str(exc))
 
         # --- assignee ----------------------------------------------------
         # For a combined assignee+review patch, request_review must capture

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -113,6 +113,126 @@ def test_decompose_with_fanout_creates_children(kanban_home):
     assert c1.assignee == "engineer"
 
 
+def test_decompose_runtime_acceptance_uses_explicit_parent_indices(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="ship runtime change", triage=True)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "runtime acceptance",
+        "tasks": [
+            {
+                "title": "review candidate",
+                "body": "Approve the candidate.",
+                "assignee": "reviewer",
+                "parents": [],
+                "requires_runtime_acceptance": True,
+                "runtime_acceptance_parents": [1],
+            },
+            {
+                "title": "candidate receipt",
+                "body": "Exercise the production-like runtime.",
+                "assignee": "qa",
+                "parents": [0],
+            },
+        ],
+    })
+
+    patches = _patch_list_profiles(["orchestrator", "reviewer", "qa"])
+    for item in patches:
+        item.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body():
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for item in patches:
+            item.stop()
+
+    assert outcome.ok, outcome.reason
+    assert outcome.child_ids and len(outcome.child_ids) == 2
+    review_id, qa_id = outcome.child_ids
+    with kb.connect() as conn:
+        review = kb.get_task(conn, review_id)
+        links = conn.execute(
+            "SELECT parent_id, child_id FROM task_links "
+            "WHERE parent_id IN (?, ?) AND child_id IN (?, ?)",
+            (review_id, qa_id, review_id, qa_id),
+        ).fetchall()
+        designated = conn.execute(
+            "SELECT parent_id FROM task_runtime_acceptance_parents "
+            "WHERE child_id = ?",
+            (review_id,),
+        ).fetchall()
+    assert review is not None
+    assert review.requires_runtime_acceptance is True
+    assert {row["parent_id"] for row in designated} == {qa_id}
+    assert {(row["parent_id"], row["child_id"]) for row in links} == {
+        (qa_id, review_id),
+    }
+
+
+def test_decompose_rejects_mixed_runtime_parent_indices(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="ship runtime change", triage=True)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "runtime acceptance",
+        "tasks": [
+            {
+                "title": "review candidate",
+                "assignee": "reviewer",
+                "requires_runtime_acceptance": True,
+                "runtime_acceptance_parents": [1, "1"],
+            },
+            {"title": "candidate receipt", "assignee": "qa"},
+        ],
+    })
+
+    patches = _patch_list_profiles(["orchestrator", "reviewer", "qa"])
+    for item in patches:
+        item.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body():
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for item in patches:
+            item.stop()
+
+    assert outcome.ok is False
+    assert "runtime_acceptance_parents" in outcome.reason
+    with kb.connect() as conn:
+        root = kb.get_task(conn, tid)
+    assert root is not None
+    assert root.status == "triage"
+
+
+
+@pytest.mark.parametrize("parents", [0, False, ""])
+def test_decompose_rejects_scalar_parents_from_llm(kanban_home, parents):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="ship runtime change", triage=True)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "bad graph",
+        "tasks": [{"title": "review candidate", "parents": parents}],
+    })
+    patches = _patch_list_profiles(["orchestrator"])
+    for item in patches:
+        item.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body():
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for item in patches:
+            item.stop()
+
+    assert outcome.ok is False
+    assert "parents must be a list" in outcome.reason
+
+
+
 def test_decompose_fanout_false_invalid_llm_assignee_uses_default(kanban_home):
     with kb.connect() as conn:
         tid = kb.create_task(conn, title="route me safely", triage=True)

--- a/tests/hermes_cli/test_kanban_runtime_acceptance_gate.py
+++ b/tests/hermes_cli/test_kanban_runtime_acceptance_gate.py
@@ -1,0 +1,504 @@
+"""Runtime-acceptance gate: deterministic enforcement that runtime-affecting
+work cannot be approved as done without production-like runtime evidence.
+
+Correction c-017 contract (task t_3130c1eb): reviewer session
+20260903_002313_1d4b70 approved a runtime-affecting candidate without
+exercising its scheduled end-to-end runtime path. Prose policy was
+insufficient. A review card explicitly marked ``requires_runtime_acceptance``
+must be parent-gated on its explicit QA/live-verification card(s), and
+reviewer completion must fail closed unless:
+
+* every QA/live-verification parent is terminal (``done``/``archived``), and
+* the review handoff metadata cites the tested candidate ``commit`` plus
+  ``runtime_evidence`` (a non-empty description of the production-like
+  runtime run).
+
+Code-only changes (the default: marker absent/NULL/0) are completely
+unaffected — no global browser/UI evidence requirement.
+
+The marker survives decomposition: decompose children marked
+``requires_runtime_acceptance`` propagate it, and the DB layer enforces the
+QA/live-verification -> reviewer edge order (never reviewer -> later
+verification) on marked cards.
+
+Existing graphs migrate safely: legacy boards get the additive column with
+a NULL/0 default, which leaves every existing card unmarked and ungated.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def conn(tmp_path: Path) -> sqlite3.Connection:
+    db = kb.connect(tmp_path / "kanban.db")
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+EVIDENCE = {
+    "commit": "6a49d075dd",
+    "runtime_evidence": {
+        "candidate_commit": "6a49d075dd",
+        "environment": "managed gateway serving all 13 configured profiles",
+        "command": "exercise one live routed request and inspect delivery receipt run/912",
+        "result": "exactly-once routed delivery and creator-session wake observed",
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Canonical field plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_marker_defaults_off_and_create_task_persists_it(conn) -> None:
+    tid = kb.create_task(conn, title="plain card", assignee="coder")
+    assert kb.get_task(conn, tid).requires_runtime_acceptance is False
+
+    tid2 = kb.create_task(
+        conn,
+        title="runtime card",
+        assignee="coder",
+        requires_runtime_acceptance=True,
+    )
+    assert kb.get_task(conn, tid2).requires_runtime_acceptance is True
+
+
+def test_set_runtime_acceptance_flag_roundtrip(conn) -> None:
+    tid = kb.create_task(conn, title="later marked", assignee="coder")
+    assert kb.set_requires_runtime_acceptance(conn, tid, True) is True
+    assert kb.get_task(conn, tid).requires_runtime_acceptance is True
+    assert kb.set_requires_runtime_acceptance(conn, tid, False) is True
+    assert kb.get_task(conn, tid).requires_runtime_acceptance is False
+    with pytest.raises(ValueError):
+        kb.set_requires_runtime_acceptance(conn, "t_missing000", True)
+
+
+# ---------------------------------------------------------------------------
+# The gate: reviewer completion fail-closed
+# ---------------------------------------------------------------------------
+
+
+def _runtime_review_card(conn, *, marked=True):
+    """Marked card -> review, ready for approval, no parents attached.
+
+    The c-017 failure was not a graph-parent violation (plain parent gating
+    already covers that) but an approval without runtime evidence — so the
+    baseline card under review has no QA parent at all, which is exactly
+    what a decomposer or worker produces when the QA linkage was never
+    constructed. Tests then attach/pin QA state to exercise the gate.
+    """
+    impl = kb.create_task(
+        conn,
+        title="implement the fix",
+        assignee="coder",
+        requires_runtime_acceptance=marked,
+    )
+    impl_run = kb.claim_task(conn, impl, claimer="coder:1")
+    assert impl_run is not None
+    assert kb.request_review(
+        conn,
+        impl,
+        summary="Implementation ready.",
+        reviewer="reviewer",
+        expected_run_id=impl_run.current_run_id,
+    )
+    review = kb.claim_review_task(conn, impl, claimer="reviewer:1")
+    assert review is not None
+    return impl, review
+
+
+def test_premature_approval_blocked_when_qa_parent_not_done(conn) -> None:
+    impl, review = _runtime_review_card(conn)
+    # Legacy/misconstructed graph: an open live-verification parent is
+    # linked after the card entered review (link_tasks does not demote a
+    # review-lane child), exactly the state the gate must catch.
+    qa = kb.create_task(
+        conn,
+        title="live-verify on the managed gateway",
+        assignee="qa",
+    )
+    kb.link_tasks(conn, qa, impl)
+    assert kb.get_task(conn, qa).status == "ready"  # QA still open
+
+    assert not kb.complete_task(
+        conn,
+        impl,
+        summary="Approved.",
+        metadata=dict(EVIDENCE),
+        expected_run_id=review.current_run_id,
+    )
+    assert kb.get_task(conn, impl).status in ("review", "running")
+    # The rejected attempt is auditable.
+    events = kb.list_events(conn, impl)
+    assert any(
+        e.kind == "completion_blocked_runtime_acceptance" for e in events
+    )
+
+
+def test_pinned_non_qa_parent_cannot_satisfy_gate(conn) -> None:
+    impl, review = _runtime_review_card(conn)
+    ordinary = kb.create_task(conn, title="write release notes", assignee="writer")
+    kb.link_tasks(conn, ordinary, impl)
+    assert kb.complete_task(conn, ordinary, summary="Notes published.")
+
+    metadata = dict(EVIDENCE)
+    metadata["runtime_acceptance_parents"] = [ordinary]
+    assert not kb.complete_task(
+        conn,
+        impl,
+        summary="Approved.",
+        metadata=metadata,
+        expected_run_id=review.current_run_id,
+    )
+    events = kb.list_events(conn, impl)
+    blocked = [e for e in events if e.kind == "completion_blocked_runtime_acceptance"]
+    assert blocked and blocked[-1].payload is not None
+    assert "must describe QA/live verification" in blocked[-1].payload["reason"]
+
+
+def test_qa_parent_can_be_identified_from_body(conn) -> None:
+    impl, review = _runtime_review_card(conn)
+    qa = kb.create_task(
+        conn,
+        title="release receipt",
+        body="Production-like live verification of the candidate runtime.",
+        assignee="qa",
+    )
+    kb.link_tasks(conn, qa, impl)
+
+    assert not kb.complete_task(
+        conn,
+        impl,
+        summary="Approved.",
+        metadata=dict(EVIDENCE),
+        expected_run_id=review.current_run_id,
+    )
+    events = kb.list_events(conn, impl)
+    blocked = [e for e in events if e.kind == "completion_blocked_runtime_acceptance"]
+    assert blocked and blocked[-1].payload is not None
+    assert "not done" in blocked[-1].payload["reason"]
+
+
+def test_evidence_backed_completion_succeeds_after_qa_done(conn) -> None:
+    impl, review = _runtime_review_card(conn)
+    qa = kb.create_task(
+        conn,
+        title="live-verify on the managed gateway",
+        assignee="qa",
+    )
+    kb.link_tasks(conn, qa, impl)
+    assert kb.complete_task(conn, qa, summary="Live verification passed.")
+
+    assert kb.complete_task(
+        conn,
+        impl,
+        summary="Approved with runtime evidence.",
+        metadata=dict(EVIDENCE),
+        expected_run_id=review.current_run_id,
+    )
+    assert kb.get_task(conn, impl).status == "done"
+    # Evidence rides the completed event for downstream consumers.
+    completed = [
+        e.payload for e in kb.list_events(conn, impl)
+        if e.kind == "completed"
+    ][-1]
+    assert completed["runtime_acceptance"]["commit"] == EVIDENCE["commit"]
+
+
+def test_missing_commit_or_evidence_fails_closed(conn) -> None:
+    impl, review = _runtime_review_card(conn)
+    qa = kb.create_task(
+        conn,
+        title="live-verify on the managed gateway",
+        assignee="qa",
+    )
+    kb.link_tasks(conn, qa, impl)
+    assert kb.complete_task(conn, qa, summary="Live verification passed.")
+
+    # No metadata at all.
+    assert not kb.complete_task(
+        conn,
+        impl,
+        summary="Approved.",
+        expected_run_id=review.current_run_id,
+    )
+    # Commit without runtime evidence.
+    assert not kb.complete_task(
+        conn,
+        impl,
+        summary="Approved.",
+        metadata={"commit": "abc123"},
+        expected_run_id=review.current_run_id,
+    )
+    # Runtime evidence without a commit.
+    assert not kb.complete_task(
+        conn,
+        impl,
+        summary="Approved.",
+        metadata={"runtime_evidence": EVIDENCE["runtime_evidence"]},
+        expected_run_id=review.current_run_id,
+    )
+    # A non-hash label is not a candidate commit.
+    assert not kb.complete_task(
+        conn,
+        impl,
+        summary="Approved.",
+        metadata={
+            "commit": "latest",
+            "runtime_evidence": EVIDENCE["runtime_evidence"],
+        },
+        expected_run_id=review.current_run_id,
+    )
+    # Evidence for a different candidate commit must not approve this one.
+    mismatched = dict(EVIDENCE["runtime_evidence"])
+    mismatched["candidate_commit"] = "deadbeef"
+    assert not kb.complete_task(
+        conn,
+        impl,
+        summary="Approved.",
+        metadata={"commit": "6a49d075dd", "runtime_evidence": mismatched},
+        expected_run_id=review.current_run_id,
+    )
+    # Blank strings don't count.
+    assert not kb.complete_task(
+        conn,
+        impl,
+        summary="Approved.",
+        metadata={"commit": "  ", "runtime_evidence": "  "},
+        expected_run_id=review.current_run_id,
+    )
+    assert kb.get_task(conn, impl).status in ("review", "running")
+
+
+def test_code_only_cards_are_ungated(conn) -> None:
+    """The default path: no marker, no evidence requirement. A reviewer
+    approves a plain code-only card exactly as before."""
+    impl = kb.create_task(conn, title="code-only refactor", assignee="coder")
+    impl_run = kb.claim_task(conn, impl, claimer="coder:1")
+    assert impl_run is not None
+    assert kb.request_review(
+        conn,
+        impl,
+        summary="Refactor ready.",
+        reviewer="reviewer",
+        expected_run_id=impl_run.current_run_id,
+    )
+    review = kb.claim_review_task(conn, impl, claimer="reviewer:1")
+    assert review is not None
+    assert kb.complete_task(
+        conn,
+        impl,
+        summary="Approved.",
+        expected_run_id=review.current_run_id,
+    )
+    assert kb.get_task(conn, impl).status == "done"
+
+
+def test_unmarked_parent_does_not_gate_marked_child_contract(
+    conn,
+) -> None:
+    """Only QA/live-verification PARENTS gate the marked card. A plain
+    parent that finishes does not substitute; the check is parent-status
+    based so this test pins that an unmarked non-QA parent completing does
+    not by itself allow approval without evidence."""
+    impl = kb.create_task(
+        conn,
+        title="runtime card",
+        assignee="coder",
+        requires_runtime_acceptance=True,
+    )
+    docs = kb.create_task(
+        conn, title="write docs", assignee="coder", parents=[impl]
+    )
+    impl_run = kb.claim_task(conn, impl, claimer="coder:1")
+    assert impl_run is not None
+    assert kb.request_review(
+        conn,
+        impl,
+        summary="Ready.",
+        reviewer="reviewer",
+        expected_run_id=impl_run.current_run_id,
+    )
+    review = kb.claim_review_task(conn, impl, claimer="reviewer:1")
+    assert review is not None
+    kb.complete_task(conn, docs, summary="docs done")
+    # QA-style parent (live-verification) absent: even with parents done,
+    # missing evidence still fails closed.
+    assert not kb.complete_task(
+        conn,
+        impl,
+        summary="Approved.",
+        metadata={"commit": "abc"},
+        expected_run_id=review.current_run_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Decomposition preserves the marker and enforces QA -> reviewer order
+# ---------------------------------------------------------------------------
+
+
+def test_decompose_preserves_marker_and_rejects_reviewer_before_qa(
+    kanban_home,
+) -> None:
+    with kb.connect_closing() as conn:
+        root = kb.create_task(conn, title="triage me", triage=True)
+        children = [
+            {
+                "title": "implement",
+                "assignee": "coder",
+                "requires_runtime_acceptance": True,
+            },
+            {"title": "live-verify", "assignee": "qa", "parents": [0]},
+        ]
+        child_ids = kb.decompose_triage_task(
+            conn, root, root_assignee="orchestrator", children=children
+        )
+        assert child_ids is not None
+        impl, qa = (kb.get_task(conn, cid) for cid in child_ids)
+        assert impl.requires_runtime_acceptance is True
+        assert qa.requires_runtime_acceptance is False
+        # The decomposer flipped the inverted edge: the QA card must be a
+        # PARENT of the marked review card (QA -> reviewer), never the
+        # review card a parent of QA (reviewer -> later verification).
+        links = conn.execute(
+            "SELECT parent_id, child_id FROM task_links "
+            "WHERE parent_id IN (?, ?) AND child_id IN (?, ?)",
+            (child_ids[0], child_ids[1], child_ids[0], child_ids[1]),
+        ).fetchall()
+        pairs = {(r["parent_id"], r["child_id"]) for r in links}
+        assert (child_ids[1], child_ids[0]) in pairs
+        assert (child_ids[0], child_ids[1]) not in pairs
+
+
+def test_decompose_links_marked_review_child_under_qa_child(
+    kanban_home,
+) -> None:
+    """A decomposed child marked requires_runtime_acceptance whose parent
+    list points at a non-QA sibling gets a live-verification edge inserted:
+    the QA sibling (or, absent one, every leaf work producer) must become a
+    parent of the marked card so QA -> reviewer is structural."""
+    with kb.connect_closing() as conn:
+        root = kb.create_task(conn, title="triage me", triage=True)
+        children = [
+            {"title": "implement", "assignee": "coder"},
+            {
+                "title": "review PR",
+                "assignee": "reviewer",
+                "requires_runtime_acceptance": True,
+                "parents": [0],
+            },
+        ]
+        child_ids = kb.decompose_triage_task(
+            conn, root, root_assignee="orchestrator", children=children
+        )
+        assert child_ids is not None
+        links = conn.execute(
+            "SELECT parent_id, child_id FROM task_links WHERE child_id = ?",
+            (child_ids[1],),
+        ).fetchall()
+        parents = {r["parent_id"] for r in links}
+        # The marked review card still waits on the root (decompose links
+        # every leaf under the root via the reverse edge) AND cannot have
+        # shed the QA ordering: its parents include the work producer.
+        assert child_ids[0] in parents
+
+
+# ---------------------------------------------------------------------------
+# Existing graph migration
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_board_migration_adds_nullable_marker(tmp_path: Path) -> None:
+    """Opening a legacy board DB (pre-marker schema) is safe: the additive
+    column lands as 0/NULL and nothing is gated."""
+    db_path = tmp_path / "legacy.db"
+    with kb.connect_closing(db_path) as conn:
+        qa = kb.create_task(conn, title="legacy QA", assignee="qa")
+        tid = kb.create_task(
+            conn,
+            title="legacy-style review card",
+            assignee="reviewer",
+            parents=[qa],
+        )
+        conn.execute("ALTER TABLE tasks DROP COLUMN requires_runtime_acceptance")
+        conn.commit()
+    # Simulate another process opening this pre-marker file: clear this
+    # process's init cache so connect() runs additive migrations again.
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    with kb.connect_closing(db_path) as conn:
+        cols = {
+            r["name"] for r in conn.execute("PRAGMA table_info(tasks)")
+        }
+        assert "requires_runtime_acceptance" in cols
+        assert kb.get_task(conn, tid).requires_runtime_acceptance is False
+        assert kb.get_task(conn, tid).status == "todo"
+        link = conn.execute(
+            "SELECT 1 FROM task_links WHERE parent_id = ? AND child_id = ?",
+            (qa, tid),
+        ).fetchone()
+        assert link is not None
+
+
+def test_manual_done_on_marked_review_card_also_gated(kanban_home) -> None:
+    """The gate is at complete_task, not the run-CAS path only: a dashboard
+    drag / manual CLI completion of a marked card sitting in ``review``
+    without evidence fails closed too."""
+    with kb.connect_closing() as conn:
+        impl = kb.create_task(
+            conn,
+            title="runtime card",
+            assignee="coder",
+            requires_runtime_acceptance=True,
+        )
+        kb.claim_task(conn, impl)
+        assert kb.request_review(
+            conn,
+            impl,
+            summary="Ready.",
+            reviewer="reviewer",
+            force=True,
+        )
+        # Review lane, no active run, manual approval attempt.
+        assert kb.get_task(conn, impl).status == "review"
+        assert not kb.complete_task(
+            conn, impl, summary="Manual approve, no evidence."
+        )
+        assert kb.get_task(conn, impl).status == "review"
+        # Backfill a QA parent as done + evidence → now it completes.
+        qa = kb.create_task(conn, title="live verify", assignee="qa")
+        kb.link_tasks(conn, qa, impl)
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = 'done', completed_at = ? "
+                "WHERE id = ?",
+                (int(__import__("time").time()), qa),
+            )
+        assert kb.complete_task(
+            conn,
+            impl,
+            summary="Manual approve with evidence.",
+            metadata=dict(EVIDENCE),
+        )
+        assert kb.get_task(conn, impl).status == "done"

--- a/tests/hermes_cli/test_kanban_runtime_acceptance_gate.py
+++ b/tests/hermes_cli/test_kanban_runtime_acceptance_gate.py
@@ -8,7 +8,7 @@ insufficient. A review card explicitly marked ``requires_runtime_acceptance``
 must be parent-gated on its explicit QA/live-verification card(s), and
 reviewer completion must fail closed unless:
 
-* every QA/live-verification parent is terminal (``done``/``archived``), and
+* every explicitly cited QA/live-verification parent is ``done``, and
 * the review handoff metadata cites the tested candidate ``commit`` plus
   ``runtime_evidence`` (a non-empty description of the production-like
   runtime run).
@@ -88,10 +88,24 @@ def test_set_runtime_acceptance_flag_roundtrip(conn) -> None:
     tid = kb.create_task(conn, title="later marked", assignee="coder")
     assert kb.set_requires_runtime_acceptance(conn, tid, True) is True
     assert kb.get_task(conn, tid).requires_runtime_acceptance is True
-    assert kb.set_requires_runtime_acceptance(conn, tid, False) is True
-    assert kb.get_task(conn, tid).requires_runtime_acceptance is False
+    with pytest.raises(RuntimeError, match="cannot clear requires_runtime_acceptance"):
+        kb.set_requires_runtime_acceptance(conn, tid, False)
+    current = kb.get_task(conn, tid)
+    assert current is not None
+    assert current.requires_runtime_acceptance is True
     with pytest.raises(ValueError):
         kb.set_requires_runtime_acceptance(conn, "t_missing000", True)
+
+
+def test_runtime_acceptance_marker_cannot_be_cleared_after_review_requested(
+    conn,
+) -> None:
+    impl, _review = _runtime_review_card(conn)
+
+    with pytest.raises(RuntimeError, match="cannot clear requires_runtime_acceptance"):
+        kb.set_requires_runtime_acceptance(conn, impl, False)
+
+    assert kb.get_task(conn, impl).requires_runtime_acceptance is True
 
 
 # ---------------------------------------------------------------------------
@@ -139,13 +153,16 @@ def test_premature_approval_blocked_when_qa_parent_not_done(conn) -> None:
         assignee="qa",
     )
     kb.link_tasks(conn, qa, impl)
+    kb.designate_runtime_acceptance_parents(conn, impl, [qa])
     assert kb.get_task(conn, qa).status == "ready"  # QA still open
 
+    metadata = dict(EVIDENCE)
+    metadata["runtime_acceptance_parents"] = [qa]
     assert not kb.complete_task(
         conn,
         impl,
         summary="Approved.",
-        metadata=dict(EVIDENCE),
+        metadata=metadata,
         expected_run_id=review.current_run_id,
     )
     assert kb.get_task(conn, impl).status in ("review", "running")
@@ -156,36 +173,73 @@ def test_premature_approval_blocked_when_qa_parent_not_done(conn) -> None:
     )
 
 
-def test_pinned_non_qa_parent_cannot_satisfy_gate(conn) -> None:
+def test_non_self_describing_explicit_parent_can_satisfy_gate(conn) -> None:
     impl, review = _runtime_review_card(conn)
-    ordinary = kb.create_task(conn, title="write release notes", assignee="writer")
-    kb.link_tasks(conn, ordinary, impl)
-    assert kb.complete_task(conn, ordinary, summary="Notes published.")
+    qa = kb.create_task(conn, title="candidate receipt", assignee="qa")
+    kb.link_tasks(conn, qa, impl)
+    kb.designate_runtime_acceptance_parents(conn, impl, [qa])
+    assert kb.complete_task(conn, qa, summary="Production-like runtime passed.")
 
     metadata = dict(EVIDENCE)
-    metadata["runtime_acceptance_parents"] = [ordinary]
-    assert not kb.complete_task(
+    metadata["runtime_acceptance_parents"] = [qa]
+    assert kb.complete_task(
         conn,
         impl,
         summary="Approved.",
         metadata=metadata,
         expected_run_id=review.current_run_id,
     )
-    events = kb.list_events(conn, impl)
-    blocked = [e for e in events if e.kind == "completion_blocked_runtime_acceptance"]
-    assert blocked and blocked[-1].payload is not None
-    assert "must describe QA/live verification" in blocked[-1].payload["reason"]
+    assert kb.get_task(conn, impl).status == "done"
 
 
-def test_qa_parent_can_be_identified_from_body(conn) -> None:
+def test_unrelated_done_parent_cannot_replace_designated_runtime_parent(conn) -> None:
     impl, review = _runtime_review_card(conn)
-    qa = kb.create_task(
-        conn,
-        title="release receipt",
-        body="Production-like live verification of the candidate runtime.",
-        assignee="qa",
-    )
+    qa = kb.create_task(conn, title="candidate receipt", assignee="qa")
+    unrelated = kb.create_task(conn, title="docs check", assignee="writer")
     kb.link_tasks(conn, qa, impl)
+    kb.link_tasks(conn, unrelated, impl)
+    kb.designate_runtime_acceptance_parents(conn, impl, [qa])
+    assert kb.complete_task(conn, qa, summary="Runtime passed.")
+    assert kb.complete_task(conn, unrelated, summary="Docs passed.")
+
+    metadata = dict(EVIDENCE)
+    metadata["runtime_acceptance_parents"] = [unrelated]
+    assert not kb.complete_task(
+        conn,
+        impl,
+        summary="Approved against wrong parent.",
+        metadata=metadata,
+        expected_run_id=review.current_run_id,
+    )
+
+
+
+def test_runtime_parent_designation_cannot_be_replaced_after_unlink(conn) -> None:
+    qa = kb.create_task(conn, title="candidate receipt")
+    replacement = kb.create_task(conn, title="unrelated done parent")
+    impl = kb.create_task(
+        conn,
+        title="runtime card",
+        parents=[qa, replacement],
+        requires_runtime_acceptance=True,
+        runtime_acceptance_parents=[qa],
+    )
+
+    assert kb.unlink_tasks(conn, qa, impl)
+    with pytest.raises(RuntimeError, match="already designated"):
+        kb.designate_runtime_acceptance_parents(conn, impl, [replacement])
+
+
+
+def test_prose_only_parent_cannot_satisfy_gate(conn) -> None:
+    impl, review = _runtime_review_card(conn)
+    prose_match = kb.create_task(
+        conn,
+        title="Verify changelog formatting",
+        assignee="writer",
+    )
+    kb.link_tasks(conn, prose_match, impl)
+    assert kb.complete_task(conn, prose_match, summary="Formatting checked.")
 
     assert not kb.complete_task(
         conn,
@@ -197,7 +251,7 @@ def test_qa_parent_can_be_identified_from_body(conn) -> None:
     events = kb.list_events(conn, impl)
     blocked = [e for e in events if e.kind == "completion_blocked_runtime_acceptance"]
     assert blocked and blocked[-1].payload is not None
-    assert "not done" in blocked[-1].payload["reason"]
+    assert "runtime_acceptance_parents" in blocked[-1].payload["reason"]
 
 
 def test_evidence_backed_completion_succeeds_after_qa_done(conn) -> None:
@@ -208,13 +262,16 @@ def test_evidence_backed_completion_succeeds_after_qa_done(conn) -> None:
         assignee="qa",
     )
     kb.link_tasks(conn, qa, impl)
+    kb.designate_runtime_acceptance_parents(conn, impl, [qa])
     assert kb.complete_task(conn, qa, summary="Live verification passed.")
 
+    metadata = dict(EVIDENCE)
+    metadata["runtime_acceptance_parents"] = [qa]
     assert kb.complete_task(
         conn,
         impl,
         summary="Approved with runtime evidence.",
-        metadata=dict(EVIDENCE),
+        metadata=metadata,
         expected_run_id=review.current_run_id,
     )
     assert kb.get_task(conn, impl).status == "done"
@@ -234,6 +291,7 @@ def test_missing_commit_or_evidence_fails_closed(conn) -> None:
         assignee="qa",
     )
     kb.link_tasks(conn, qa, impl)
+    kb.designate_runtime_acceptance_parents(conn, impl, [qa])
     assert kb.complete_task(conn, qa, summary="Live verification passed.")
 
     # No metadata at all.
@@ -248,7 +306,7 @@ def test_missing_commit_or_evidence_fails_closed(conn) -> None:
         conn,
         impl,
         summary="Approved.",
-        metadata={"commit": "abc123"},
+        metadata={"commit": "abc123", "runtime_acceptance_parents": [qa]},
         expected_run_id=review.current_run_id,
     )
     # Runtime evidence without a commit.
@@ -256,7 +314,10 @@ def test_missing_commit_or_evidence_fails_closed(conn) -> None:
         conn,
         impl,
         summary="Approved.",
-        metadata={"runtime_evidence": EVIDENCE["runtime_evidence"]},
+        metadata={
+            "runtime_evidence": EVIDENCE["runtime_evidence"],
+            "runtime_acceptance_parents": [qa],
+        },
         expected_run_id=review.current_run_id,
     )
     # A non-hash label is not a candidate commit.
@@ -267,6 +328,7 @@ def test_missing_commit_or_evidence_fails_closed(conn) -> None:
         metadata={
             "commit": "latest",
             "runtime_evidence": EVIDENCE["runtime_evidence"],
+            "runtime_acceptance_parents": [qa],
         },
         expected_run_id=review.current_run_id,
     )
@@ -277,7 +339,11 @@ def test_missing_commit_or_evidence_fails_closed(conn) -> None:
         conn,
         impl,
         summary="Approved.",
-        metadata={"commit": "6a49d075dd", "runtime_evidence": mismatched},
+        metadata={
+            "commit": "6a49d075dd",
+            "runtime_evidence": mismatched,
+            "runtime_acceptance_parents": [qa],
+        },
         expected_run_id=review.current_run_id,
     )
     # Blank strings don't count.
@@ -285,7 +351,11 @@ def test_missing_commit_or_evidence_fails_closed(conn) -> None:
         conn,
         impl,
         summary="Approved.",
-        metadata={"commit": "  ", "runtime_evidence": "  "},
+        metadata={
+            "commit": "  ",
+            "runtime_evidence": "  ",
+            "runtime_acceptance_parents": [qa],
+        },
         expected_run_id=review.current_run_id,
     )
     assert kb.get_task(conn, impl).status in ("review", "running")
@@ -359,6 +429,99 @@ def test_unmarked_parent_does_not_gate_marked_child_contract(
 # ---------------------------------------------------------------------------
 
 
+def test_decompose_rejects_marked_runtime_parent_cycle(kanban_home) -> None:
+    with kb.connect_closing() as conn:
+        root = kb.create_task(conn, title="triage me", triage=True)
+        children = [
+            {
+                "title": "review A",
+                "requires_runtime_acceptance": True,
+                "runtime_acceptance_parents": [1],
+            },
+            {
+                "title": "review B",
+                "requires_runtime_acceptance": True,
+                "runtime_acceptance_parents": [0],
+            },
+        ]
+        with pytest.raises(ValueError, match="cannot itself require runtime acceptance"):
+            kb.decompose_triage_task(
+                conn, root, root_assignee="orchestrator", children=children
+            )
+        root_task = kb.get_task(conn, root)
+        assert root_task is not None
+        assert root_task.status == "triage"
+
+
+@pytest.mark.parametrize("scalar_parent_owner", ["review", "runtime_parent"])
+@pytest.mark.parametrize("scalar_parent_value", [1, 0, False, ""])
+def test_decompose_rejects_scalar_parents_before_runtime_edge_normalization(
+    kanban_home,
+    scalar_parent_owner,
+    scalar_parent_value,
+) -> None:
+    review_parents = scalar_parent_value if scalar_parent_owner == "review" else []
+    qa_parents = scalar_parent_value if scalar_parent_owner == "runtime_parent" else []
+    with kb.connect_closing() as conn:
+        root = kb.create_task(conn, title="triage me", triage=True)
+        children = [
+            {
+                "title": "review",
+                "assignee": "reviewer",
+                "parents": review_parents,
+                "requires_runtime_acceptance": True,
+                "runtime_acceptance_parents": [1],
+            },
+            {
+                "title": "candidate receipt",
+                "assignee": "qa",
+                "parents": qa_parents,
+            },
+        ]
+        with pytest.raises(ValueError, match="parents must be a list"):
+            kb.decompose_triage_task(
+                conn, root, root_assignee="orchestrator", children=children
+            )
+
+
+def test_decompose_rejects_boolean_runtime_parent_index(kanban_home) -> None:
+    with kb.connect_closing() as conn:
+        root = kb.create_task(conn, title="triage me", triage=True)
+        children = [
+            {
+                "title": "review",
+                "assignee": "reviewer",
+                "requires_runtime_acceptance": True,
+                "runtime_acceptance_parents": [True],
+            },
+            {"title": "candidate receipt", "assignee": "qa"},
+        ]
+        with pytest.raises(ValueError, match="not a valid sibling index"):
+            kb.decompose_triage_task(
+                conn, root, root_assignee="orchestrator", children=children
+            )
+
+
+def test_decompose_validates_referenced_child_before_normalizing_runtime_edges(
+    kanban_home,
+) -> None:
+    with kb.connect_closing() as conn:
+        root = kb.create_task(conn, title="triage me", triage=True)
+        children = [
+            {
+                "title": "review",
+                "assignee": "reviewer",
+                "requires_runtime_acceptance": True,
+                "runtime_acceptance_parents": [1],
+            },
+            "not a child object",
+        ]
+        with pytest.raises(ValueError, match=r"child\[1\] is not a dict"):
+            kb.decompose_triage_task(
+                conn, root, root_assignee="orchestrator", children=children
+            )
+
+
 def test_decompose_preserves_marker_and_rejects_reviewer_before_qa(
     kanban_home,
 ) -> None:
@@ -369,8 +532,9 @@ def test_decompose_preserves_marker_and_rejects_reviewer_before_qa(
                 "title": "implement",
                 "assignee": "coder",
                 "requires_runtime_acceptance": True,
+                "runtime_acceptance_parents": [1],
             },
-            {"title": "live-verify", "assignee": "qa", "parents": [0]},
+            {"title": "candidate receipt", "assignee": "qa", "parents": [0]},
         ]
         child_ids = kb.decompose_triage_task(
             conn, root, root_assignee="orchestrator", children=children
@@ -407,6 +571,7 @@ def test_decompose_links_marked_review_child_under_qa_child(
                 "title": "review PR",
                 "assignee": "reviewer",
                 "requires_runtime_acceptance": True,
+                "runtime_acceptance_parents": [0],
                 "parents": [0],
             },
         ]
@@ -489,16 +654,19 @@ def test_manual_done_on_marked_review_card_also_gated(kanban_home) -> None:
         # Backfill a QA parent as done + evidence → now it completes.
         qa = kb.create_task(conn, title="live verify", assignee="qa")
         kb.link_tasks(conn, qa, impl)
+        kb.designate_runtime_acceptance_parents(conn, impl, [qa])
         with kb.write_txn(conn):
             conn.execute(
                 "UPDATE tasks SET status = 'done', completed_at = ? "
                 "WHERE id = ?",
                 (int(__import__("time").time()), qa),
             )
+        metadata = dict(EVIDENCE)
+        metadata["runtime_acceptance_parents"] = [qa]
         assert kb.complete_task(
             conn,
             impl,
             summary="Manual approve with evidence.",
-            metadata=dict(EVIDENCE),
+            metadata=metadata,
         )
         assert kb.get_task(conn, impl).status == "done"

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -785,6 +785,38 @@ def test_dashboard_cancel_keeps_task_in_old_status(client):
     assert r.json()["task"]["status"] == "ready"
 
 
+def test_runtime_acceptance_marker_round_trips_and_cannot_clear_on_complete(
+    client, kanban_home
+):
+    created = client.post(
+        "/api/plugins/kanban/tasks",
+        json={
+            "title": "runtime-gated",
+            "assignee": "reviewer",
+            "requires_runtime_acceptance": True,
+        },
+    )
+    assert created.status_code == 200, created.text
+    task = created.json()["task"]
+    assert task["requires_runtime_acceptance"] is True
+
+    bypass = client.patch(
+        f"/api/plugins/kanban/tasks/{task['id']}",
+        json={
+            "status": "done",
+            "requires_runtime_acceptance": False,
+            "summary": "approve without evidence",
+        },
+    )
+    assert bypass.status_code == 409
+
+    current = client.get(
+        f"/api/plugins/kanban/tasks/{task['id']}"
+    ).json()["task"]
+    assert current["requires_runtime_acceptance"] is True
+    assert current["status"] != "done"
+
+
 def test_dashboard_confirm_dispatches_expected_patch_body(client):
     """Behavioral: the PATCH body shape the bundle produces on confirm
     (status + result + summary) must be accepted by the backend without

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -817,6 +817,132 @@ def test_runtime_acceptance_marker_round_trips_and_cannot_clear_on_complete(
     assert current["status"] != "done"
 
 
+def test_runtime_acceptance_marker_cannot_be_cleared_while_entering_review(
+    client, kanban_home
+):
+    created = client.post(
+        "/api/plugins/kanban/tasks",
+        json={
+            "title": "runtime-gated combined review",
+            "assignee": "coder",
+            "requires_runtime_acceptance": True,
+        },
+    )
+    task_id = created.json()["task"]["id"]
+    with kb.connect_closing() as conn:
+        assert kb.claim_task(conn, task_id, claimer="coder:1") is not None
+
+    bypass = client.patch(
+        f"/api/plugins/kanban/tasks/{task_id}",
+        json={
+            "status": "review",
+            "assignee": "reviewer",
+            "requires_runtime_acceptance": False,
+            "summary": "Ready.",
+        },
+    )
+    assert bypass.status_code == 409
+    current = client.get(
+        f"/api/plugins/kanban/tasks/{task_id}"
+    ).json()["task"]
+    assert current["requires_runtime_acceptance"] is True
+    assert current["status"] == "running"
+
+
+def test_runtime_acceptance_marker_cannot_be_cleared_before_review_lifecycle(
+    client, kanban_home
+):
+    created = client.post(
+        "/api/plugins/kanban/tasks",
+        json={
+            "title": "runtime-gated before review",
+            "assignee": "reviewer",
+            "requires_runtime_acceptance": True,
+        },
+    )
+    task_id = created.json()["task"]["id"]
+
+    clear = client.patch(
+        f"/api/plugins/kanban/tasks/{task_id}",
+        json={"requires_runtime_acceptance": False},
+    )
+    assert clear.status_code == 409
+
+    complete = client.patch(
+        f"/api/plugins/kanban/tasks/{task_id}",
+        json={"status": "done", "summary": "approve without evidence"},
+    )
+    assert complete.status_code == 409
+    current = client.get(
+        f"/api/plugins/kanban/tasks/{task_id}"
+    ).json()["task"]
+    assert current["requires_runtime_acceptance"] is True
+    assert current["status"] != "done"
+
+
+
+def test_combined_marker_and_status_patch_is_rejected_without_partial_update(
+    client, kanban_home
+):
+    task = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "plain card", "assignee": "coder"},
+    ).json()["task"]
+
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{task['id']}",
+        json={"requires_runtime_acceptance": True, "status": "review"},
+    )
+    assert response.status_code == 409
+    current = client.get(
+        f"/api/plugins/kanban/tasks/{task['id']}"
+    ).json()["task"]
+    assert current["requires_runtime_acceptance"] is False
+    assert current["status"] == "ready"
+
+
+
+def test_runtime_acceptance_marker_cannot_be_cleared_before_later_completion(
+    client, kanban_home
+):
+    created = client.post(
+        "/api/plugins/kanban/tasks",
+        json={
+            "title": "runtime-gated review",
+            "assignee": "coder",
+            "requires_runtime_acceptance": True,
+        },
+    )
+    task_id = created.json()["task"]["id"]
+    with kb.connect_closing() as conn:
+        claimed = kb.claim_task(conn, task_id, claimer="coder:1")
+        assert claimed is not None
+        assert kb.request_review(
+            conn,
+            task_id,
+            summary="Ready.",
+            reviewer="reviewer",
+            expected_run_id=claimed.current_run_id,
+        )
+
+    clear = client.patch(
+        f"/api/plugins/kanban/tasks/{task_id}",
+        json={"requires_runtime_acceptance": False},
+    )
+    assert clear.status_code == 409
+
+    complete = client.patch(
+        f"/api/plugins/kanban/tasks/{task_id}",
+        json={"status": "done", "summary": "approve without evidence"},
+    )
+    assert complete.status_code == 409
+    current = client.get(
+        f"/api/plugins/kanban/tasks/{task_id}"
+    ).json()["task"]
+    assert current["requires_runtime_acceptance"] is True
+    assert current["status"] != "done"
+
+
 def test_dashboard_confirm_dispatches_expected_patch_body(client):
     """Behavioral: the PATCH body shape the bundle produces on confirm
     (status + result + summary) must be accepted by the backend without

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -80,6 +80,30 @@ def test_show_defaults_to_env_task_id(worker_env):
     assert "runs" in d
 
 
+def test_show_and_list_expose_runtime_acceptance_marker(monkeypatch, worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="runtime-gated",
+            assignee="reviewer",
+            requires_runtime_acceptance=True,
+        )
+    finally:
+        conn.close()
+
+    shown = json.loads(kt._handle_show({"task_id": tid}))
+    assert shown["task"]["requires_runtime_acceptance"] is True
+
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    listed = json.loads(kt._handle_list({"assignee": "reviewer", "limit": 10}))
+    row = next(task for task in listed["tasks"] if task["id"] == tid)
+    assert row["requires_runtime_acceptance"] is True
+
+
 def test_list_filters_tasks(monkeypatch, worker_env):
     """kanban_list gives orchestrators filtered board discovery."""
     monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -503,6 +503,7 @@ def _task_summary_dict(kb, conn, task) -> dict[str, Any]:
         "current_run_id": task.current_run_id,
         "model_override": task.model_override,
         "provider_override": task.provider_override,
+        "requires_runtime_acceptance": task.requires_runtime_acceptance,
         "parents": parents,
         "children": children,
         "parent_count": len(parents),
@@ -549,6 +550,7 @@ def _handle_show(args: dict, **kw) -> str:
                     "current_run_id": t.current_run_id,
                     "model_override": t.model_override,
                     "provider_override": t.provider_override,
+                    "requires_runtime_acceptance": t.requires_runtime_acceptance,
                 }
 
             def _run_dict(r):
@@ -1394,6 +1396,11 @@ def _handle_create(args: dict, **kw) -> str:
     triage, bool_error = _parse_bool_arg(args, "triage")
     if bool_error:
         return tool_error(bool_error)
+    requires_runtime_acceptance, runtime_bool_error = _parse_bool_arg(
+        args, "requires_runtime_acceptance"
+    )
+    if runtime_bool_error:
+        return tool_error(runtime_bool_error)
     idempotency_key = args.get("idempotency_key")
     max_runtime_seconds = args.get("max_runtime_seconds")
     initial_status = args.get("initial_status") or "running"
@@ -1461,6 +1468,7 @@ def _handle_create(args: dict, **kw) -> str:
                 initial_status=str(initial_status),
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
                 session_id=session_id,
+                requires_runtime_acceptance=requires_runtime_acceptance,
             )
             new_task = kb.get_task(conn, new_tid)
             subscribed = _maybe_auto_subscribe(conn, new_tid)
@@ -1801,7 +1809,12 @@ KANBAN_COMPLETE_SCHEMA = {
                     "Free-form dict of structured facts about this "
                     "attempt — {\"changed_files\": [...], \"tests_run\": 12, "
                     "\"findings\": [...]}. Surfaced to downstream "
-                    "workers alongside ``summary``."
+                    "workers alongside ``summary``. For a card marked "
+                    "requires_runtime_acceptance, include `commit` (7-64 "
+                    "hex Git SHA), `runtime_acceptance_parents` (linked QA "
+                    "task ids), and `runtime_evidence` with non-empty "
+                    "candidate_commit (matching commit), environment, "
+                    "command, and result strings."
                 ),
             },
             "result": {
@@ -2258,6 +2271,17 @@ KANBAN_CREATE_SCHEMA = {
                     "task, ['github-code-review'] for a reviewer task. "
                     "The names must match skills installed on the "
                     "assignee's profile."
+                ),
+            },
+            "requires_runtime_acceptance": {
+                "type": "boolean",
+                "description": (
+                    "Mark this card as runtime-affecting. Reviewer completion "
+                    "then fails closed unless explicit QA/live-verification "
+                    "parents are done and completion metadata cites the tested "
+                    "candidate commit plus production-like runtime_evidence. "
+                    "Leave false for code-only changes; browser/UI evidence is "
+                    "not globally required."
                 ),
             },
             "goal_mode": {

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1401,6 +1401,11 @@ def _handle_create(args: dict, **kw) -> str:
     )
     if runtime_bool_error:
         return tool_error(runtime_bool_error)
+    runtime_acceptance_parents = args.get("runtime_acceptance_parents") or []
+    if isinstance(runtime_acceptance_parents, str):
+        runtime_acceptance_parents = [runtime_acceptance_parents]
+    if not isinstance(runtime_acceptance_parents, (list, tuple)):
+        return tool_error("runtime_acceptance_parents must be a list of task ids")
     idempotency_key = args.get("idempotency_key")
     max_runtime_seconds = args.get("max_runtime_seconds")
     initial_status = args.get("initial_status") or "running"
@@ -1469,6 +1474,7 @@ def _handle_create(args: dict, **kw) -> str:
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
                 session_id=session_id,
                 requires_runtime_acceptance=requires_runtime_acceptance,
+                runtime_acceptance_parents=tuple(runtime_acceptance_parents),
             )
             new_task = kb.get_task(conn, new_tid)
             subscribed = _maybe_auto_subscribe(conn, new_tid)
@@ -2282,6 +2288,14 @@ KANBAN_CREATE_SCHEMA = {
                     "candidate commit plus production-like runtime_evidence. "
                     "Leave false for code-only changes; browser/UI evidence is "
                     "not globally required."
+                ),
+            },
+            "runtime_acceptance_parents": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Explicit QA/live-verification parent task ids for a "
+                    "runtime-gated card. Every id must also appear in parents."
                 ),
             },
             "goal_mode": {


### PR DESCRIPTION
Summary
- persist and expose a requires_runtime_acceptance marker across DB, CLI, model tools, dashboard API, and decomposition
- fail closed at complete_task until linked QA/live-verification parents are done and structured evidence cites the tested candidate SHA
- normalize decomposed runtime-review graphs to QA -> reviewer ordering and preserve legacy graph migrations
- prevent dashboard clear-and-complete bypasses and audit blocked completion attempts

Verification
- scripts/run_tests.sh: 133 targeted tests passed
- Ruff: all checks passed
- git diff --check: passed
- independent staged-diff review: passed with no security or logic findings

Kanban: t_3130c1eb