### PR TITLE
fix(kanban): make coding-worker closeout durable

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2524,6 +2524,10 @@ def _worktree_lock_is_live(repo_root: str, worktree_path: str, timeout: int = 10
             if current != target:
                 continue
             reason = line[len("locked"):].strip()
+            if reason.startswith("active Hermes Kanban task"):
+                # Task leases survive worker/gateway processes; only the
+                # Kanban terminal cleanup path may release them.
+                return "live"
             m = re.search(r"hermes pid=(\d+)", reason)
             if not m:
                 # Locked by something we don't recognize as a hermes session

--- a/hermes_cli/coding_worker_lifecycle.py
+++ b/hermes_cli/coding_worker_lifecycle.py
@@ -1,0 +1,315 @@
+"""Durable task identity and closeout state for Kanban coding workers."""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+from urllib.parse import urlsplit, urlunsplit
+
+from hermes_cli import kanban_db as kb
+
+
+class LifecycleConflict(RuntimeError):
+    """A retry disagreed with identity already assigned to the task."""
+
+
+_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}(?:[0-9a-fA-F]{24})?$")
+
+
+def canonical_pr_url(value: str) -> str:
+    """Return a credential-free canonical GitHub pull-request URL."""
+    parsed = urlsplit(str(value).strip())
+    if parsed.scheme.lower() != "https" or parsed.hostname != "github.com":
+        raise ValueError("pull request URL must be an https://github.com URL")
+    if parsed.username or parsed.password or parsed.port:
+        raise ValueError("pull request URL must not contain credentials or a port")
+    parts = [part for part in parsed.path.split("/") if part]
+    if len(parts) != 4 or parts[2] != "pull" or not parts[3].isdigit():
+        raise ValueError("pull request URL must identify /owner/repo/pull/<number>")
+    return urlunsplit(("https", "github.com", "/" + "/".join(parts), "", ""))
+
+
+def canonical_head_sha(value: str) -> str:
+    """Require an immutable full Git object id and normalize its case."""
+    head = str(value).strip().lower()
+    if not _SHA_RE.fullmatch(head):
+        raise ValueError("head_sha must be a full 40- or 64-character hex digest")
+    return head
+
+
+@dataclass(frozen=True)
+class CodingWorkerState:
+    task_id: str
+    workspace_path: str
+    lease_token: Optional[str]
+    lease_expires: Optional[int]
+    phase: str
+    pr_url: Optional[str]
+    head_sha: Optional[str]
+    review_submitted_at: Optional[int]
+    wait_kind: Optional[str]
+    operation_key: Optional[str]
+    wait_started_at: Optional[int]
+    wait_deadline: Optional[int]
+    silent_checks: int
+    operation_receipt: Optional[str]
+    last_error: Optional[str]
+    updated_at: int
+
+    @classmethod
+    def from_row(cls, row: sqlite3.Row) -> "CodingWorkerState":
+        return cls(**{name: row[name] for name in cls.__dataclass_fields__})
+
+
+def get_state(conn: sqlite3.Connection, task_id: str) -> Optional[CodingWorkerState]:
+    row = conn.execute(
+        "SELECT * FROM coding_worker_lifecycle WHERE task_id=?", (task_id,)
+    ).fetchone()
+    return CodingWorkerState.from_row(row) if row is not None else None
+
+
+def allocate_workspace(
+    conn: sqlite3.Connection,
+    task_id: str,
+    workspace_path: str | Path,
+    *,
+    lease_token: str,
+    now: int,
+    ttl_seconds: int,
+) -> CodingWorkerState:
+    """Allocate once by task id; retries renew but cannot silently retarget."""
+    lease_token = str(lease_token).strip()
+    if not lease_token:
+        raise ValueError("lease_token is required")
+    resolved = str(Path(workspace_path).expanduser().resolve(strict=False))
+    expires = int(now) + max(1, int(ttl_seconds))
+    with kb.write_txn(conn):
+        existing = get_state(conn, task_id)
+        if existing is None:
+            conn.execute(
+                "INSERT INTO coding_worker_lifecycle "
+                "(task_id, workspace_path, lease_token, lease_expires, updated_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (task_id, resolved, lease_token, expires, int(now)),
+            )
+        else:
+            if existing.workspace_path != resolved:
+                raise LifecycleConflict(
+                    f"task {task_id} is already allocated to {existing.workspace_path}"
+                )
+            if (
+                existing.lease_token not in (None, lease_token)
+                and (existing.lease_expires or 0) > int(now)
+            ):
+                raise LifecycleConflict(f"task {task_id} has a live foreign lease")
+            conn.execute(
+                "UPDATE coding_worker_lifecycle SET lease_token=?, lease_expires=?, "
+                "phase=CASE WHEN wait_kind IS NULL AND phase IN "
+                "('blocked','changes_requested','crashed','failed','gave_up',"
+                "'rate_limited','reclaimed','spawn_failed','stale','timed_out') "
+                "THEN 'allocated' ELSE phase END, "
+                "updated_at=? WHERE task_id=?",
+                (lease_token, expires, int(now), task_id),
+            )
+        state = get_state(conn, task_id)
+    assert state is not None
+    return state
+
+
+def _operation_receipts(state: CodingWorkerState) -> dict:
+    try:
+        value = json.loads(state.operation_receipt or "{}")
+    except (TypeError, json.JSONDecodeError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def begin_pr_handoff(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    lease_token: str,
+    operation_key: str,
+    head_sha: str,
+    now: int,
+) -> tuple[CodingWorkerState, bool]:
+    """Reserve the immutable PR head before asking the provider to create it.
+
+    A retry receiving ``False`` must reconcile the provider by head instead of
+    creating another PR. The eventual URL is bound by ``request_review`` in
+    the same transaction as the native Review transition.
+    """
+    operation_key = str(operation_key).strip()
+    if not operation_key:
+        raise ValueError("operation_key is required")
+    head = canonical_head_sha(head_sha)
+    with kb.write_txn(conn):
+        state = get_state(conn, task_id)
+        if state is None:
+            raise LifecycleConflict(f"task {task_id} has no workspace allocation")
+        if state.lease_token != lease_token:
+            raise LifecycleConflict(f"task {task_id} lease ownership changed")
+        if state.head_sha not in (None, head):
+            raise LifecycleConflict(
+                f"task {task_id} review head is immutable ({state.head_sha})"
+            )
+        if state.wait_kind is not None:
+            if state.wait_kind != "pr" or state.operation_key != operation_key:
+                raise LifecycleConflict("a different remote operation is already durable")
+            return state, False
+        if state.pr_url is not None:
+            # Native Changes Requested clears only the reviewed head. The
+            # canonical PR remains bound to the task, so this revision must
+            # reconcile/update that PR instead of creating another one.
+            if state.phase != "allocated" or state.head_sha is not None:
+                raise LifecycleConflict("canonical PR is not awaiting a new revision")
+            conn.execute(
+                "UPDATE coding_worker_lifecycle SET phase='pr_pending', head_sha=?, "
+                "wait_kind='pr', operation_key=?, wait_started_at=?, "
+                "last_error=NULL, updated_at=? WHERE task_id=?",
+                (head, operation_key, int(now), int(now), task_id),
+            )
+            state = get_state(conn, task_id)
+            assert state is not None
+            return state, False
+        conn.execute(
+            "UPDATE coding_worker_lifecycle SET phase='pr_pending', head_sha=?, "
+            "wait_kind='pr', operation_key=?, wait_started_at=?, "
+            "last_error=NULL, updated_at=? WHERE task_id=?",
+            (head, operation_key, int(now), int(now), task_id),
+        )
+        state = get_state(conn, task_id)
+    assert state is not None
+    return state, True
+
+
+def begin_wait(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    kind: str,
+    operation_key: str,
+    now: int,
+    timeout_seconds: int,
+    active_chat_count: Optional[int] = None,
+) -> tuple[CodingWorkerState, bool]:
+    """Persist a bounded merge/deploy operation before its remote side effect.
+
+    ``started`` is true only for the first caller. Retries resume the durable
+    operation key and original deadline; completed receipts also remain
+    idempotent after the active wait fields have been cleared.
+    """
+    if kind not in {"merge", "deploy"}:
+        raise ValueError("wait kind must be 'merge' or 'deploy'")
+    operation_key = str(operation_key).strip()
+    if not operation_key:
+        raise ValueError("operation_key is required")
+    coordination_error: Optional[str] = None
+    if kind == "deploy" and active_chat_count is None:
+        try:
+            from hermes_cli.active_sessions import active_session_registry_snapshot
+
+            active_chat_count = len(active_session_registry_snapshot())
+        except Exception as exc:
+            active_chat_count = -1
+            coordination_error = f"active chat coordination unavailable: {exc}"
+    with kb.write_txn(conn):
+        state = get_state(conn, task_id)
+        if state is None:
+            raise LifecycleConflict(f"task {task_id} has no workspace allocation")
+        completed = _operation_receipts(state).get(kind)
+        if isinstance(completed, dict):
+            if completed.get("operation_key") != operation_key:
+                raise LifecycleConflict(f"{kind} already completed under another key")
+            return state, False
+        if state.wait_kind is not None:
+            if state.wait_kind != kind or state.operation_key != operation_key:
+                raise LifecycleConflict("a different remote operation is already durable")
+            return state, False
+        if kind == "deploy" and int(active_chat_count or 0) != 0:
+            conn.execute(
+                "UPDATE coding_worker_lifecycle SET last_error=?, updated_at=? "
+                "WHERE task_id=?",
+                (
+                    coordination_error or "deploy blocked by active chat sessions",
+                    int(now), task_id,
+                ),
+            )
+            blocked = get_state(conn, task_id)
+            assert blocked is not None
+            return blocked, False
+        deadline = int(now) + max(1, int(timeout_seconds))
+        conn.execute(
+            "UPDATE coding_worker_lifecycle SET phase=?, wait_kind=?, "
+            "operation_key=?, wait_started_at=?, wait_deadline=?, silent_checks=0, "
+            "last_error=NULL, updated_at=? WHERE task_id=?",
+            (
+                f"{kind}_wait", kind, operation_key, int(now), deadline,
+                int(now), task_id,
+            ),
+        )
+        state = get_state(conn, task_id)
+    assert state is not None
+    return state, True
+
+
+def observe_wait(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    operation_key: str,
+    observation: str,
+    now: int,
+    receipt: Optional[dict] = None,
+    error: Optional[str] = None,
+) -> CodingWorkerState:
+    """Record a provider observation without extending the durable deadline."""
+    if observation not in {"pending", "silent", "connection_error", "complete"}:
+        raise ValueError("invalid wait observation")
+    with kb.write_txn(conn):
+        state = get_state(conn, task_id)
+        if state is None or state.operation_key != operation_key:
+            raise LifecycleConflict("remote operation ownership changed")
+        if state.wait_kind not in {"merge", "deploy"}:
+            raise LifecycleConflict("task has no active merge/deploy wait")
+        silent_checks = state.silent_checks + 1 if observation == "silent" else 0
+        phase = state.phase
+        wait_kind = state.wait_kind
+        active_key: Optional[str] = state.operation_key
+        encoded_receipt = state.operation_receipt
+        last_error = error if observation == "connection_error" else None
+        if observation == "complete":
+            phase = "merged" if wait_kind == "merge" else "complete"
+            receipts = _operation_receipts(state)
+            receipts[str(wait_kind)] = {
+                "operation_key": state.operation_key,
+                "receipt": receipt or {},
+            }
+            encoded_receipt = json.dumps(receipts, sort_keys=True)
+            wait_kind = None
+            active_key = None
+            silent_checks = 0
+        elif (
+            observation == "silent"
+            and silent_checks >= 2
+            and state.wait_deadline is not None
+            and int(now) >= state.wait_deadline
+        ):
+            phase = "timed_out"
+            last_error = f"{state.wait_kind} wait exceeded its durable deadline"
+        conn.execute(
+            "UPDATE coding_worker_lifecycle SET phase=?, wait_kind=?, operation_key=?, "
+            "silent_checks=?, operation_receipt=?, last_error=?, updated_at=? "
+            "WHERE task_id=?",
+            (
+                phase, wait_kind, active_key, silent_checks, encoded_receipt,
+                last_error, int(now), task_id,
+            ),
+        )
+        state = get_state(conn, task_id)
+    assert state is not None
+    return state

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1477,6 +1477,31 @@ CREATE TABLE IF NOT EXISTS task_runs (
     error               TEXT
 );
 
+-- Durable identity and closeout state for external coding workers.  The
+-- board database, rather than a worker process, owns this record so retries
+-- and gateway restarts observe one task workspace and one remote operation.
+CREATE TABLE IF NOT EXISTS coding_worker_lifecycle (
+    task_id             TEXT PRIMARY KEY,
+    workspace_path      TEXT NOT NULL,
+    lease_token         TEXT,
+    lease_expires       INTEGER,
+    phase               TEXT NOT NULL DEFAULT 'allocated',
+    pr_url              TEXT,
+    head_sha            TEXT,
+    review_submitted_at INTEGER,
+    wait_kind           TEXT,
+    operation_key       TEXT,
+    wait_started_at     INTEGER,
+    wait_deadline       INTEGER,
+    silent_checks       INTEGER NOT NULL DEFAULT 0,
+    operation_receipt   TEXT,
+    last_error          TEXT,
+    updated_at          INTEGER NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_coding_worker_pr_url
+    ON coding_worker_lifecycle(pr_url) WHERE pr_url IS NOT NULL;
+
 -- Files attached to a task (PDFs, images, source documents). The blob
 -- lives on disk under ``attachments_root(board)/<task_id>/<stored_name>``;
 -- this row carries metadata + the absolute ``stored_path`` so the
@@ -4355,36 +4380,49 @@ def _end_run(
     row = conn.execute(
         "SELECT current_run_id FROM tasks WHERE id = ?", (task_id,),
     ).fetchone()
-    if not row or not row["current_run_id"]:
-        return None
-    run_id = int(row["current_run_id"])
+    run_id: Optional[int] = None
+    if row and row["current_run_id"]:
+        run_id = int(row["current_run_id"])
+        conn.execute(
+            """
+            UPDATE task_runs
+               SET status        = ?,
+                   outcome       = ?,
+                   summary       = ?,
+                   error         = ?,
+                   metadata      = ?,
+                   ended_at      = ?,
+                   claim_lock    = NULL,
+                   claim_expires = NULL,
+                   worker_pid    = NULL
+             WHERE id = ?
+               AND ended_at IS NULL
+            """,
+            (
+                status or outcome,
+                outcome,
+                summary,
+                error,
+                json.dumps(metadata, ensure_ascii=False) if metadata else None,
+                now,
+                run_id,
+            ),
+        )
+        conn.execute(
+            "UPDATE tasks SET current_run_id = NULL WHERE id = ?", (task_id,),
+        )
+    lifecycle_phase = {
+        "completed": "complete",
+        "review_requested": "review",
+    }.get(outcome, outcome)
+    # The task run and its auxiliary coding-worker lease are one ownership
+    # unit. Keeping this in the same transaction prevents a crash/reclaim
+    # from leaving a live lease that blocks the replacement worker.
     conn.execute(
-        """
-        UPDATE task_runs
-           SET status        = ?,
-               outcome       = ?,
-               summary       = ?,
-               error         = ?,
-               metadata      = ?,
-               ended_at      = ?,
-               claim_lock    = NULL,
-               claim_expires = NULL,
-               worker_pid    = NULL
-         WHERE id = ?
-           AND ended_at IS NULL
-        """,
-        (
-            status or outcome,
-            outcome,
-            summary,
-            error,
-            json.dumps(metadata, ensure_ascii=False) if metadata else None,
-            now,
-            run_id,
-        ),
-    )
-    conn.execute(
-        "UPDATE tasks SET current_run_id = NULL WHERE id = ?", (task_id,),
+        "UPDATE coding_worker_lifecycle SET phase=?, lease_token=NULL, "
+        "lease_expires=NULL, last_error=COALESCE(?, last_error), updated_at=? "
+        "WHERE task_id=?",
+        (lifecycle_phase, error, now, task_id),
     )
     return run_id
 
@@ -5996,33 +6034,9 @@ def _cleanup_worktree_workspace(
                 task_id, wp,
             )
             return
-        # No --force: the dirty/unpushed checks above run before removal, so
-        # git's own dirty guard re-verifies at removal time. If the tree
-        # became dirty between our check and the removal (TOCTOU), removal
-        # fails safe and the worktree is preserved.
-        result = subprocess.run(
-            ["git", "-C", str(repo_root), "worktree", "remove", str(wp)],
-            capture_output=True,
-            text=True, encoding='utf-8', errors='replace',
-            timeout=60,
-            check=False,
+        _remove_task_worktree_under_lifecycle_lock(
+            task_id, wp, repo_root, common, branch_name
         )
-        if result.returncode != 0:
-            _log.warning(
-                "git worktree remove failed for task %s at %s: %s",
-                task_id, wp, (result.stderr or result.stdout or "").strip(),
-            )
-            return
-        _log.debug("Removed worktree workspace: %s", wp)
-        branch = (branch_name or "").strip() or f"wt/{task_id}"
-        if branch.startswith("wt/"):
-            subprocess.run(
-                ["git", "-C", str(repo_root), "branch", "-D", branch],
-                capture_output=True,
-                text=True, encoding='utf-8', errors='replace',
-                timeout=30,
-                check=False,
-            )
     except Exception:
         pass  # best-effort — never block completion
 
@@ -6534,6 +6548,29 @@ def request_review(
 
     summary = redact_review_value(summary)
     metadata = redact_review_value(metadata)
+    review_pr_url: Optional[str] = None
+    review_head_sha: Optional[str] = None
+    if isinstance(metadata, dict) and (
+        metadata.get("pr_url") is not None or metadata.get("head_sha") is not None
+    ):
+        if not metadata.get("pr_url") or not metadata.get("head_sha"):
+            return _ret(
+                False,
+                "PR handoff requires both metadata.pr_url and metadata.head_sha",
+            )
+        try:
+            from hermes_cli.coding_worker_lifecycle import (
+                canonical_head_sha,
+                canonical_pr_url,
+            )
+
+            review_pr_url = canonical_pr_url(str(metadata["pr_url"]))
+            review_head_sha = canonical_head_sha(str(metadata["head_sha"]))
+        except ValueError as exc:
+            return _ret(False, str(exc))
+        metadata = dict(metadata)
+        metadata["pr_url"] = review_pr_url
+        metadata["head_sha"] = review_head_sha
     with write_txn(conn):
         if not _parents_satisfied(conn, task_id):
             return _ret(False, "parent dependencies are not satisfied")
@@ -6543,6 +6580,40 @@ def request_review(
         ).fetchone()
         if trow is None:
             return _ret(False, "task not found")
+        from hermes_cli.coding_worker_lifecycle import get_state
+
+        lifecycle = get_state(conn, task_id)
+        if lifecycle is not None and (
+            review_pr_url is None or review_head_sha is None
+        ):
+            return _ret(
+                False,
+                "coding-worker Review requires both metadata.pr_url and "
+                "metadata.head_sha",
+            )
+        if review_pr_url is not None and review_head_sha is not None:
+            if lifecycle is None:
+                return _ret(False, "PR handoff has no durable workspace allocation")
+            if lifecycle.pr_url not in (None, review_pr_url):
+                return _ret(False, f"task is already bound to {lifecycle.pr_url}")
+            if lifecycle.head_sha not in (None, review_head_sha):
+                return _ret(False, f"review head is immutable ({lifecycle.head_sha})")
+            duplicate = conn.execute(
+                "SELECT task_id FROM coding_worker_lifecycle "
+                "WHERE task_id<>? AND pr_url=? LIMIT 1",
+                (task_id, review_pr_url),
+            ).fetchone()
+            if duplicate is not None:
+                return _ret(False, "pull request is already bound to another task")
+            if (
+                lifecycle.phase == "review"
+                and lifecycle.pr_url == review_pr_url
+                and lifecycle.head_sha == review_head_sha
+                and trow["status"] == "review"
+            ):
+                return _ret(True)
+            if lifecycle.lease_token != trow["claim_lock"]:
+                return _ret(False, "coding-worker lease ownership changed")
         # Refuse to clear a live worker's claim without proof of ownership
         # (expected_run_id) or an explicit human override (force=True).
         if (
@@ -6628,6 +6699,16 @@ def request_review(
                 "task is not in running/ready (or expected_run_id did not "
                 "match the current run)",
             )
+        if review_pr_url is not None and review_head_sha is not None:
+            handoff_now = int(time.time())
+            conn.execute(
+                "UPDATE coding_worker_lifecycle SET pr_url=?, head_sha=?, "
+                "review_submitted_at=COALESCE(review_submitted_at, ?), "
+                "wait_kind=NULL, operation_key=NULL, wait_started_at=NULL, "
+                "wait_deadline=NULL, silent_checks=0, updated_at=? "
+                "WHERE task_id=?",
+                (review_pr_url, review_head_sha, handoff_now, handoff_now, task_id),
+            )
         run_id = _end_run(
             conn,
             task_id,
@@ -6646,15 +6727,20 @@ def request_review(
             )
         lines = (summary or "").strip().splitlines()
         event_summary = lines[0][:400] if lines else ""
+        event_payload = {
+            "summary": event_summary or None,
+            "implementer": implementer,
+            "reviewer": reviewer,
+        }
+        if review_pr_url is not None and review_head_sha is not None:
+            event_payload.update(
+                {"pr_url": review_pr_url, "head_sha": review_head_sha}
+            )
         _append_event(
             conn,
             task_id,
             "review_requested",
-            {
-                "summary": event_summary or None,
-                "implementer": implementer,
-                "reviewer": reviewer,
-            },
+            event_payload,
             run_id=run_id,
         )
     return _ret(True)
@@ -6763,6 +6849,17 @@ def request_changes(
             outcome="changes_requested",
             status=new_status,
             summary=reason,
+        )
+        # The reviewed SHA is immutable until native Review explicitly asks
+        # for changes. At that boundary the canonical PR remains task-bound,
+        # while the next implementation run may reserve a new immutable head
+        # for the next review revision.
+        conn.execute(
+            "UPDATE coding_worker_lifecycle SET head_sha=NULL, "
+            "review_submitted_at=NULL, wait_kind=NULL, operation_key=NULL, "
+            "wait_started_at=NULL, wait_deadline=NULL, silent_checks=0, "
+            "updated_at=? WHERE task_id=?",
+            (int(time.time()), task_id),
         )
         _append_event(
             conn,
@@ -7721,34 +7818,188 @@ def _repo_root_for_worktree_target(path: Path) -> Optional[Path]:
         current = current.parent
 
 
+def _worktree_lock_reason(
+    repo_root: Path, worktree: Path,
+) -> tuple[bool, Optional[str]]:
+    """Return whether Git's worktree lock state was readable and its reason."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "worktree", "list", "--porcelain"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=30,
+            check=False,
+        )
+    except Exception:
+        return False, None
+    if result.returncode != 0:
+        return False, None
+    target = worktree.resolve(strict=False)
+    current: Optional[Path] = None
+    for line in result.stdout.splitlines():
+        if line.startswith("worktree "):
+            current = Path(line[len("worktree "):]).resolve(strict=False)
+        elif current == target and (line == "locked" or line.startswith("locked ")):
+            return True, line[len("locked"):].strip()
+    return True, None
+
+
+def _task_worktree_lock_reason(branch_name: str) -> str:
+    return f"active Hermes Kanban task {branch_name}"
+
+
+def _lock_task_worktree(repo_root: Path, target: Path, branch_name: str) -> None:
+    """Idempotently lease an existing checkout to one active Kanban task."""
+    from .active_sessions import _FileLock
+
+    common = _git_common_dir(repo_root)
+    if common is None:
+        raise RuntimeError(f"cannot resolve git common dir for {repo_root}")
+    expected = _task_worktree_lock_reason(branch_name)
+    with _FileLock(common / "hermes-worktree-lifecycle.lock"):
+        result = subprocess.run(
+            [
+                "git", "-C", str(repo_root), "worktree", "lock", "--reason",
+                expected, str(target),
+            ],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=30,
+            check=False,
+        )
+        if result.returncode == 0:
+            return
+        known, reason = _worktree_lock_reason(repo_root, target)
+        if not known or reason != expected:
+            detail = (result.stderr or result.stdout or "").strip()
+            raise RuntimeError(f"git worktree lock failed for {target}: {detail}")
+
+
+def _remove_task_worktree_under_lifecycle_lock(
+    task_id: str,
+    worktree: Path,
+    repo_root: Path,
+    common_dir: Path,
+    branch_name: Optional[str],
+) -> None:
+    """Release only this task's lock, then remove its provably safe tree."""
+    from .active_sessions import _FileLock
+
+    branch = (branch_name or "").strip() or f"wt/{task_id}"
+    expected = _task_worktree_lock_reason(branch)
+    with _FileLock(common_dir / "hermes-worktree-lifecycle.lock"):
+        known, reason = _worktree_lock_reason(repo_root, worktree)
+        if not known:
+            _log.warning(
+                "Preserving worktree for task %s: unable to verify lock at %s",
+                task_id, worktree,
+            )
+            return
+        if reason and reason != expected:
+            _log.info(
+                "Preserving worktree for task %s: foreign lock at %s (%s)",
+                task_id, worktree, reason,
+            )
+            return
+        if reason:
+            unlock = subprocess.run(
+                ["git", "-C", str(repo_root), "worktree", "unlock", str(worktree)],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=30,
+                check=False,
+            )
+            if unlock.returncode != 0:
+                _log.warning(
+                    "git worktree unlock failed for task %s at %s: %s",
+                    task_id, worktree,
+                    (unlock.stderr or unlock.stdout or "").strip(),
+                )
+                return
+        # No --force: Git rechecks dirtiness and any lock acquired after our
+        # owned unlock, so races always fail toward preserving user work.
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "worktree", "remove", str(worktree)],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=60,
+            check=False,
+        )
+        if result.returncode != 0:
+            _log.warning(
+                "git worktree remove failed for task %s at %s: %s",
+                task_id, worktree,
+                (result.stderr or result.stdout or "").strip(),
+            )
+            return
+        _log.debug("Removed worktree workspace: %s", worktree)
+        if branch.startswith("wt/"):
+            subprocess.run(
+                ["git", "-C", str(repo_root), "branch", "-D", branch],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=30,
+                check=False,
+            )
+
+
 def _ensure_git_worktree(repo_root: Path, target: Path, branch_name: str) -> None:
-    """Materialize ``target`` as a linked git worktree under ``repo_root``."""
+    """Materialize and lifecycle-lock a task worktree under ``repo_root``."""
     target = target.expanduser()
     repo_common = _git_common_dir(repo_root)
     if target.exists() and repo_common is not None:
         target_common = _git_common_dir(target)
         if target_common == repo_common:
+            _lock_task_worktree(repo_root, target, branch_name)
             return
     target.parent.mkdir(parents=True, exist_ok=True)
-    if _git_branch_exists(repo_root, branch_name):
-        cmd = ["git", "-C", str(repo_root), "worktree", "add", str(target), branch_name]
-    else:
-        cmd = [
-            "git", "-C", str(repo_root), "worktree", "add", "-b", branch_name,
-            str(target), "HEAD",
-        ]
-    result = subprocess.run(
-        cmd,
-        capture_output=True,
-        text=True, encoding='utf-8', errors='replace',
-        timeout=60,
-        check=False,
-    )
-    if result.returncode != 0:
-        stderr = (result.stderr or result.stdout or "").strip()
-        raise RuntimeError(
-            f"git worktree add failed for {target} on branch {branch_name}: {stderr}"
+    from .active_sessions import _FileLock
+
+    if repo_common is None:
+        raise RuntimeError(f"cannot resolve git common dir for {repo_root}")
+    reason = _task_worktree_lock_reason(branch_name)
+    with _FileLock(repo_common / "hermes-worktree-lifecycle.lock"):
+        # Recheck inside the cross-process lock: two dispatcher processes may
+        # have observed the path missing before either materialized it.
+        if target.exists() and _git_common_dir(target) == repo_common:
+            known, locked_reason = _worktree_lock_reason(repo_root, target)
+            if known and locked_reason == reason:
+                return
+            raise RuntimeError(f"worktree {target} is owned by another lifecycle")
+        if _git_branch_exists(repo_root, branch_name):
+            cmd = [
+                "git", "-C", str(repo_root), "worktree", "add", "--lock",
+                "--reason", reason, str(target), branch_name,
+            ]
+        else:
+            cmd = [
+                "git", "-C", str(repo_root), "worktree", "add", "--lock",
+                "--reason", reason, "-b", branch_name, str(target), "HEAD",
+            ]
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=60,
+            check=False,
         )
+        if result.returncode != 0:
+            stderr = (result.stderr or result.stdout or "").strip()
+            raise RuntimeError(
+                f"git worktree add failed for {target} on branch {branch_name}: {stderr}"
+            )
 
 
 def _resolve_worktree_workspace(
@@ -7805,6 +8056,9 @@ def _resolve_worktree_workspace(
     if requested.exists() and _is_linked_worktree_checkout(requested):
         actual_branch = _git_current_branch(requested)
         if actual_branch == branch_name:
+            _lock_task_worktree(
+                _git_common_dir(requested).parent, requested, branch_name
+            )
             return requested_resolved, actual_branch
         # The requested path is an existing checkout of a DIFFERENT
         # task's branch. Decompose children inherit the root's
@@ -10259,6 +10513,25 @@ def _dispatch_once_locked(
         set_workspace_path(conn, claimed.id, str(workspace))
         if claimed.workspace_kind == "worktree":
             set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
+        try:
+            from hermes_cli.coding_worker_lifecycle import allocate_workspace
+
+            allocate_workspace(
+                conn,
+                claimed.id,
+                workspace,
+                lease_token=claimed.claim_lock or f"run:{claimed.current_run_id}",
+                now=int(time.time()),
+                ttl_seconds=_resolve_claim_ttl_seconds(ttl_seconds),
+            )
+        except Exception as exc:
+            auto = _record_spawn_failure(
+                conn, claimed.id, f"workspace allocation: {exc}",
+                failure_limit=failure_limit,
+            )
+            if auto:
+                result.auto_blocked.append(claimed.id)
+            continue
         _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
         _spawn = spawn_fn if spawn_fn is not None else _default_spawn
         try:
@@ -10386,6 +10659,25 @@ def _dispatch_once_locked(
         set_workspace_path(conn, claimed.id, str(workspace))
         if claimed.workspace_kind == "worktree":
             set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
+        try:
+            from hermes_cli.coding_worker_lifecycle import allocate_workspace
+
+            allocate_workspace(
+                conn,
+                claimed.id,
+                workspace,
+                lease_token=claimed.claim_lock or f"run:{claimed.current_run_id}",
+                now=int(time.time()),
+                ttl_seconds=_resolve_claim_ttl_seconds(ttl_seconds),
+            )
+        except Exception as exc:
+            auto = _record_spawn_failure(
+                conn, claimed.id, f"workspace allocation: {exc}",
+                failure_limit=failure_limit,
+            )
+            if auto:
+                result.auto_blocked.append(claimed.id)
+            continue
         _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
         # Force-load the sdlc-review skill for review agents — it carries
         # the review logic (AC verification, merge, etc.). The mandatory

--- a/tests/gateway/test_kanban_reconcile_orphans.py
+++ b/tests/gateway/test_kanban_reconcile_orphans.py
@@ -149,6 +149,25 @@ class TestReconcileOrphanedRunning:
         conn.commit()
         assert kb.reconcile_orphaned_running(conn) == []
 
+    def test_reconciliation_closes_durable_worker_lease(self, conn, tmp_path):
+        from hermes_cli.coding_worker_lifecycle import allocate_workspace
+
+        tid = kb.create_task(conn, title="leased orphan", assignee="w")
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        allocate_workspace(
+            conn, tid, tmp_path / "workspace", lease_token=claimed.claim_lock,
+            now=10, ttl_seconds=60,
+        )
+        _orphan_running(conn, tid, claim_lock=None, claim_expires=None)
+
+        assert kb.reconcile_orphaned_running(conn) == [tid]
+        state = conn.execute(
+            "SELECT phase, lease_token, lease_expires "
+            "FROM coding_worker_lifecycle WHERE task_id=?", (tid,),
+        ).fetchone()
+        assert tuple(state) == ("reclaimed", None, None)
+
 
 class TestDispatchOnceReconciles:
     def test_dispatch_once_reconciles_orphans(self, conn):
@@ -176,3 +195,116 @@ class TestDispatchOnceReconciles:
         assert conn.execute(
             "SELECT status FROM tasks WHERE id=?", (tid,)
         ).fetchone()["status"] == "running"
+
+
+def test_provider_connection_failure_and_gateway_restart_resume_one_wait(
+    conn, tmp_path,
+):
+    """A fresh connection retains the operation key and original deadline."""
+    from hermes_cli.coding_worker_lifecycle import (
+        allocate_workspace,
+        begin_wait,
+        observe_wait,
+    )
+
+    tid = kb.create_task(conn, title="merge closeout", assignee="worker")
+    allocate_workspace(
+        conn, tid, tmp_path / "workspace", lease_token="lease-1",
+        now=10, ttl_seconds=60,
+    )
+    initial, started = begin_wait(
+        conn, tid, kind="merge", operation_key="merge:abc",
+        now=20, timeout_seconds=30,
+    )
+    assert started is True
+    assert initial.wait_deadline == 50
+    failed = observe_wait(
+        conn, tid, operation_key="merge:abc", observation="connection_error",
+        now=25, error="connection refused",
+    )
+    assert failed.phase == "merge_wait"
+
+    with kb.connect_closing() as restarted:
+        resumed, started_again = begin_wait(
+            restarted, tid, kind="merge", operation_key="merge:abc",
+            now=40, timeout_seconds=300,
+        )
+        assert started_again is False
+        assert resumed.wait_deadline == 50
+        assert resumed.last_error == "connection refused"
+        observe_wait(
+            restarted, tid, operation_key="merge:abc", observation="complete",
+            now=45, receipt={"merge_sha": "b" * 40},
+        )
+        _done, duplicate = begin_wait(
+            restarted, tid, kind="merge", operation_key="merge:abc",
+            now=46, timeout_seconds=30,
+        )
+        assert duplicate is False
+
+
+def test_deploy_wait_is_fail_closed_while_any_chat_is_active(conn, tmp_path):
+    from hermes_cli.coding_worker_lifecycle import allocate_workspace, begin_wait
+
+    tid = kb.create_task(conn, title="deploy closeout", assignee="worker")
+    allocate_workspace(
+        conn, tid, tmp_path / "workspace", lease_token="lease-1",
+        now=10, ttl_seconds=60,
+    )
+
+    blocked, started = begin_wait(
+        conn, tid, kind="deploy", operation_key="deploy:abc",
+        now=20, timeout_seconds=60, active_chat_count=1,
+    )
+    assert started is False
+    assert blocked.wait_kind is None
+    assert "active chat" in (blocked.last_error or "")
+
+    active, started = begin_wait(
+        conn, tid, kind="deploy", operation_key="deploy:abc",
+        now=30, timeout_seconds=60, active_chat_count=0,
+    )
+    retry, started_again = begin_wait(
+        conn, tid, kind="deploy", operation_key="deploy:abc",
+        now=40, timeout_seconds=600, active_chat_count=0,
+    )
+    assert started is True and started_again is False
+    assert active.wait_deadline == retry.wait_deadline == 90
+
+
+def test_timeout_requires_two_consecutive_silent_watchdog_checks(conn, tmp_path):
+    from hermes_cli.coding_worker_lifecycle import (
+        allocate_workspace,
+        begin_wait,
+        observe_wait,
+    )
+
+    tid = kb.create_task(conn, title="silent deploy", assignee="worker")
+    allocate_workspace(
+        conn, tid, tmp_path / "workspace", lease_token="lease-1",
+        now=10, ttl_seconds=60,
+    )
+    begin_wait(
+        conn, tid, kind="deploy", operation_key="deploy:quiet",
+        now=20, timeout_seconds=10, active_chat_count=0,
+    )
+    first = observe_wait(
+        conn, tid, operation_key="deploy:quiet", observation="silent", now=31,
+    )
+    # Any provider response breaks the silence streak without moving the
+    # original deadline; two new silent observations are then required.
+    pending = observe_wait(
+        conn, tid, operation_key="deploy:quiet", observation="pending", now=32,
+    )
+    second_first = observe_wait(
+        conn, tid, operation_key="deploy:quiet", observation="silent", now=33,
+    )
+    second = observe_wait(
+        conn, tid, operation_key="deploy:quiet", observation="silent", now=34,
+    )
+
+    assert first.phase == "deploy_wait" and first.silent_checks == 1
+    assert pending.silent_checks == 0
+    assert second_first.phase == "deploy_wait" and second_first.silent_checks == 1
+    assert second.phase == "timed_out" and second.silent_checks == 2
+    assert second.wait_deadline == 30

--- a/tests/hermes_cli/test_kanban_review_lifecycle.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle.py
@@ -708,3 +708,232 @@ def test_reviewer_reassigns_for_autonomous_dispatch(kanban_home: Path) -> None:
         ev = _events(conn, tid, kind="review_requested")[0][1]
         assert ev["reviewer"] == "lead-reviewer"
         assert ev["implementer"] == "worker"
+
+
+def test_pr_handoff_binds_canonical_url_and_immutable_head_atomically(
+    kanban_home: Path, tmp_path: Path,
+) -> None:
+    """A response-loss retry reuses one native Review handoff and identity."""
+    from hermes_cli.coding_worker_lifecycle import allocate_workspace
+
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="PR handoff", assignee="worker")
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None and claimed.current_run_id is not None
+        allocate_workspace(
+            conn, tid, tmp_path / "workspace", lease_token=claimed.claim_lock,
+            now=10, ttl_seconds=60,
+        )
+        metadata = {
+            "pr_url": "https://github.com/acme/widgets/pull/12/?from=worker",
+            "head_sha": "D" * 40,
+        }
+
+        first = kb.request_review(
+            conn, tid, summary="ready", metadata=metadata,
+            expected_run_id=claimed.current_run_id, with_reason=True,
+        )
+        retry = kb.request_review(
+            conn, tid, summary="ready", metadata=metadata,
+            expected_run_id=claimed.current_run_id, with_reason=True,
+        )
+
+        assert first == retry == (True, None)
+        lifecycle = conn.execute(
+            "SELECT phase, pr_url, head_sha, lease_token "
+            "FROM coding_worker_lifecycle WHERE task_id=?", (tid,),
+        ).fetchone()
+        assert tuple(lifecycle) == (
+            "review", "https://github.com/acme/widgets/pull/12", "d" * 40, None,
+        )
+        events = _events(conn, tid, kind="review_requested")
+        assert len(events) == 1
+        assert events[0][1]["pr_url"] == "https://github.com/acme/widgets/pull/12"
+        assert events[0][1]["head_sha"] == "d" * 40
+
+        ok, reason = kb.request_review(
+            conn, tid, metadata={
+                "pr_url": "https://github.com/acme/widgets/pull/12",
+                "head_sha": "e" * 40,
+            }, force=True, with_reason=True,
+        )
+        assert ok is False
+        assert "immutable" in (reason or "")
+
+
+def test_lifecycle_managed_review_rejects_missing_pr_identity(
+    kanban_home: Path, tmp_path: Path,
+) -> None:
+    """A coding worker cannot report success through an identity-free Review."""
+    from hermes_cli.coding_worker_lifecycle import allocate_workspace
+
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="missing PR identity", assignee="worker")
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        allocate_workspace(
+            conn, tid, tmp_path / "workspace", lease_token=claimed.claim_lock,
+            now=10, ttl_seconds=60,
+        )
+
+        ok, reason = kb.request_review(
+            conn, tid, summary="implemented",
+            expected_run_id=claimed.current_run_id, with_reason=True,
+        )
+
+        assert ok is False
+        assert "pr_url" in (reason or "") and "head_sha" in (reason or "")
+        assert kb.get_task(conn, tid).status == "running"
+        assert _events(conn, tid, kind="review_requested") == []
+
+
+def test_review_gap_resumes_reserved_pr_head_without_second_creation(
+    kanban_home: Path, tmp_path: Path,
+) -> None:
+    """A crash after PR creation leaves one operation for the retry to reconcile."""
+    from hermes_cli.coding_worker_lifecycle import (
+        allocate_workspace,
+        begin_pr_handoff,
+    )
+
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="review gap", assignee="worker")
+        first_run = kb.claim_task(conn, tid)
+        assert first_run is not None
+        workspace = tmp_path / "workspace"
+        allocate_workspace(
+            conn, tid, workspace, lease_token=first_run.claim_lock,
+            now=10, ttl_seconds=60,
+        )
+        reserved, should_create = begin_pr_handoff(
+            conn, tid, lease_token=first_run.claim_lock,
+            operation_key=f"pr:{tid}", head_sha="c" * 40, now=20,
+        )
+        assert should_create is True
+        assert reserved.head_sha == "c" * 40
+
+        # The provider created the PR, then the worker died before the URL was
+        # committed. Normal crash reconciliation closes only the lease; it
+        # deliberately retains the PR operation/head for provider lookup.
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status='ready', claim_lock=NULL, "
+                "claim_expires=NULL, worker_pid=NULL WHERE id=?", (tid,),
+            )
+            kb._end_run(conn, tid, outcome="crashed", status="crashed")
+
+        retry_run = kb.claim_task(conn, tid)
+        assert retry_run is not None
+        allocate_workspace(
+            conn, tid, workspace, lease_token=retry_run.claim_lock,
+            now=21, ttl_seconds=60,
+        )
+        resumed, should_create_again = begin_pr_handoff(
+            conn, tid, lease_token=retry_run.claim_lock,
+            operation_key=f"pr:{tid}", head_sha="c" * 40, now=22,
+        )
+        assert should_create_again is False
+        assert resumed.workspace_path == str(workspace.resolve())
+
+        assert kb.request_review(
+            conn, tid, summary="reconciled existing PR",
+            metadata={
+                "pr_url": "https://github.com/acme/widgets/pull/19",
+                "head_sha": "c" * 40,
+            }, expected_run_id=retry_run.current_run_id,
+        )
+        final = conn.execute(
+            "SELECT phase, pr_url, head_sha, wait_kind, operation_key "
+            "FROM coding_worker_lifecycle WHERE task_id=?", (tid,),
+        ).fetchone()
+        assert tuple(final) == (
+            "review", "https://github.com/acme/widgets/pull/19", "c" * 40,
+            None, None,
+        )
+
+
+def test_review_closeout_reconciles_lifecycle_without_an_active_run(
+    kanban_home: Path, tmp_path: Path,
+) -> None:
+    from hermes_cli.coding_worker_lifecycle import allocate_workspace
+
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="approve PR", assignee="worker")
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        allocate_workspace(
+            conn, tid, tmp_path / "workspace", lease_token=claimed.claim_lock,
+            now=10, ttl_seconds=60,
+        )
+        assert kb.request_review(
+            conn, tid, summary="ready",
+            metadata={
+                "pr_url": "https://github.com/acme/widgets/pull/21",
+                "head_sha": "f" * 40,
+            }, expected_run_id=claimed.current_run_id,
+        )
+        assert kb.get_task(conn, tid).current_run_id is None
+
+        assert kb.complete_task(conn, tid, summary="approved", result="approved")
+        state = conn.execute(
+            "SELECT phase FROM coding_worker_lifecycle WHERE task_id=?", (tid,),
+        ).fetchone()
+        assert state["phase"] == "complete"
+
+
+def test_changes_requested_allows_new_immutable_head_on_same_pr(
+    kanban_home: Path, tmp_path: Path,
+) -> None:
+    """Native Review unlocks only the head binding, never the canonical PR."""
+    from hermes_cli.coding_worker_lifecycle import (
+        allocate_workspace,
+        begin_pr_handoff,
+    )
+
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="revise PR", assignee="worker")
+        workspace = tmp_path / "workspace"
+        implementation = kb.claim_task(conn, tid)
+        assert implementation is not None
+        allocate_workspace(
+            conn, tid, workspace, lease_token=implementation.claim_lock,
+            now=10, ttl_seconds=60,
+        )
+        pr_url = "https://github.com/acme/widgets/pull/31"
+        assert kb.request_review(
+            conn, tid, summary="first revision",
+            metadata={"pr_url": pr_url, "head_sha": "a" * 40},
+            expected_run_id=implementation.current_run_id,
+        )
+
+        review = kb.claim_review_task(conn, tid, claimer="reviewer")
+        assert review is not None
+        allocate_workspace(
+            conn, tid, workspace, lease_token=review.claim_lock,
+            now=20, ttl_seconds=60,
+        )
+        assert kb.request_changes(
+            conn, tid, reason="please revise",
+            expected_run_id=review.current_run_id,
+        )[0]
+
+        revision = kb.claim_task(conn, tid, claimer="worker-2")
+        assert revision is not None
+        allocate_workspace(
+            conn, tid, workspace, lease_token=revision.claim_lock,
+            now=30, ttl_seconds=60,
+        )
+        reserved, should_create = begin_pr_handoff(
+            conn, tid, lease_token=revision.claim_lock,
+            operation_key=f"pr:{tid}:revision-2", head_sha="b" * 40, now=31,
+        )
+        assert should_create is False
+        assert reserved.pr_url == pr_url
+        assert reserved.head_sha == "b" * 40
+
+        assert kb.request_review(
+            conn, tid, summary="second revision",
+            metadata={"pr_url": pr_url, "head_sha": "b" * 40},
+            expected_run_id=revision.current_run_id,
+        )
+        assert len(_events(conn, tid, kind="review_requested")) == 2

--- a/tests/hermes_cli/test_kanban_worker_lifecycle_hooks.py
+++ b/tests/hermes_cli/test_kanban_worker_lifecycle_hooks.py
@@ -208,3 +208,89 @@ def test_no_subscriber_short_circuits_worker_hooks(
     assert "on_kanban_worker_spawned" not in invoked
     # The shipped claimed hook has no short-circuit and still fires.
     assert "kanban_task_claimed" in invoked
+
+
+def test_coding_worker_workspace_allocation_is_idempotent_across_retry(
+    kanban_home, tmp_path,
+):
+    """A replacement worker renews one task allocation instead of retargeting it."""
+    from hermes_cli.coding_worker_lifecycle import allocate_workspace
+
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="durable worker", assignee="worker")
+        workspace = tmp_path / "workspace"
+        first = allocate_workspace(
+            conn, task_id, workspace, lease_token="lease-1", now=10,
+            ttl_seconds=30,
+        )
+        retry = allocate_workspace(
+            conn, task_id, workspace, lease_token="lease-1", now=20,
+            ttl_seconds=30,
+        )
+
+        assert retry.workspace_path == first.workspace_path == str(workspace.resolve())
+        assert retry.lease_expires == 50
+        count = conn.execute(
+            "SELECT COUNT(*) FROM coding_worker_lifecycle WHERE task_id=?",
+            (task_id,),
+        ).fetchone()[0]
+        assert count == 1
+    finally:
+        conn.close()
+
+
+def test_crash_reclaim_atomically_releases_coding_worker_lease(
+    kanban_home, tmp_path, monkeypatch,
+):
+    """Crash recovery closes the run and its durable workspace lease together."""
+    from hermes_cli.coding_worker_lifecycle import allocate_workspace
+
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="crashing worker", assignee="worker")
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None
+        allocate_workspace(
+            conn, task_id, tmp_path / "workspace",
+            lease_token=claimed.claim_lock, now=10, ttl_seconds=60,
+        )
+        kb._set_worker_pid(conn, task_id, 98765)
+        monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+
+        assert kb.detect_crashed_workers(conn) == [task_id]
+        state = conn.execute(
+            "SELECT phase, lease_token, lease_expires "
+            "FROM coding_worker_lifecycle WHERE task_id=?",
+            (task_id,),
+        ).fetchone()
+        assert tuple(state) == ("crashed", None, None)
+    finally:
+        conn.close()
+
+
+def test_dispatch_persists_workspace_allocation_before_spawn(
+    kanban_home, all_assignees_spawnable,
+):
+    """The real dispatcher path durably allocates before invoking the worker."""
+    observed: list[tuple[str, str]] = []
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="dispatch allocation", assignee="alice")
+
+        def spawn(task, workspace, *_args):
+            row = conn.execute(
+                "SELECT workspace_path, lease_token "
+                "FROM coding_worker_lifecycle WHERE task_id=?", (task.id,),
+            ).fetchone()
+            assert row is not None
+            observed.append((row["workspace_path"], row["lease_token"]))
+            return 4242
+
+        result = kb.dispatch_once(conn, spawn_fn=spawn)
+        assert any(row[0] == tid for row in result.spawned)
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert observed == [(task.workspace_path, task.claim_lock)]
+    finally:
+        conn.close()

--- a/tests/hermes_cli/test_kanban_worktree_teardown.py
+++ b/tests/hermes_cli/test_kanban_worktree_teardown.py
@@ -75,9 +75,56 @@ def _branch_exists(repo: Path, branch: str) -> bool:
     return bool(out.strip())
 
 
+def _worktree_is_locked(repo: Path, worktree: Path) -> bool:
+    listing = _git("-C", str(repo), "worktree", "list", "--porcelain")
+    target = f"worktree {worktree.resolve()}"
+    return any(
+        block.splitlines()[0] == target
+        and any(line.startswith("locked") for line in block.splitlines()[1:])
+        for block in listing.strip().split("\n\n")
+        if block
+    )
+
+
 # ---------------------------------------------------------------------------
 # _cleanup_worktree_workspace unit behavior
 # ---------------------------------------------------------------------------
+
+
+def test_materialized_task_worktree_is_lifecycle_locked(repo: Path) -> None:
+    import cli
+
+    wt = _make_worktree(repo, "t_aabbccdd")
+    assert _worktree_is_locked(repo, wt)
+    assert cli._worktree_lock_is_live(str(repo), str(wt)) == "live"
+    attempted = subprocess.run(
+        ["git", "-C", str(repo), "worktree", "remove", str(wt)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert attempted.returncode != 0
+    assert wt.is_dir()
+
+
+def test_retry_adopts_matching_unlocked_worktree_under_lifecycle_lock(
+    kanban_home: Path, repo: Path,
+) -> None:
+    target = repo / ".worktrees" / "legacy-task"
+    branch = "wt/legacy-task"
+    _git("-C", str(repo), "worktree", "add", "-b", branch, str(target), "HEAD")
+    assert not _worktree_is_locked(repo, target)
+
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(
+            conn, title="adopt legacy workspace", workspace_kind="worktree",
+            workspace_path=str(target), branch_name=branch,
+        )
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert kb.resolve_workspace(task) == target.resolve()
+
+    assert _worktree_is_locked(repo, target)
 
 
 def test_clean_pushed_worktree_removed(repo: Path) -> None:
@@ -96,6 +143,20 @@ def test_dirty_worktree_preserved(repo: Path) -> None:
     kb._cleanup_worktree_workspace("t_bbbb2222", str(wt))
     assert wt.is_dir()
     assert (wt / "wip.txt").exists()
+
+
+def test_foreign_locked_worktree_preserved(repo: Path) -> None:
+    wt = _make_worktree(repo, "t_abcd2222")
+    _git("-C", str(repo), "worktree", "unlock", str(wt))
+    _git(
+        "-C", str(repo), "worktree", "lock", "--reason",
+        "owned by another lifecycle", str(wt),
+    )
+
+    kb._cleanup_worktree_workspace("t_abcd2222", str(wt))
+
+    assert wt.is_dir()
+    assert _branch_exists(repo, "wt/t_abcd2222")
 
 
 def test_unpushed_commits_preserved(repo: Path) -> None:
@@ -174,6 +235,33 @@ def test_complete_task_reaps_clean_worktree(kanban_home: Path, repo: Path) -> No
             conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
         assert kb.claim_task(conn, tid, claimer="worker") is not None
         assert kb.complete_task(conn, tid, summary="done")
+    assert not wt.exists()
+    assert not _branch_exists(repo, f"wt/{tid}")
+
+
+def test_complete_reconciles_lease_before_clean_worktree_removal(
+    kanban_home: Path, repo: Path,
+) -> None:
+    from hermes_cli.coding_worker_lifecycle import allocate_workspace
+
+    with kb.connect_closing() as conn:
+        tid, wt = _worktree_task(conn, repo)
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+        claimed = kb.claim_task(conn, tid, claimer="worker")
+        assert claimed is not None
+        allocate_workspace(
+            conn, tid, wt, lease_token=claimed.claim_lock,
+            now=10, ttl_seconds=60,
+        )
+
+        assert kb.complete_task(conn, tid, summary="done")
+        lifecycle = conn.execute(
+            "SELECT phase, lease_token, lease_expires "
+            "FROM coding_worker_lifecycle WHERE task_id=?", (tid,),
+        ).fetchone()
+        assert tuple(lifecycle) == ("complete", None, None)
+
     assert not wt.exists()
     assert not _branch_exists(repo, f"wt/{tid}")
 

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1958,7 +1958,9 @@ KANBAN_REQUEST_REVIEW_SCHEMA = {
                 "type": "object",
                 "description": (
                     "Optional structured handoff facts for the reviewer, such "
-                    "as changed_files, tests_run, commit, or decisions."
+                    "as changed_files, tests_run, commit, or decisions. "
+                    "Lifecycle-managed coding workers must include canonical "
+                    "pr_url and the full immutable head_sha."
                 ),
                 "additionalProperties": True,
             },


### PR DESCRIPTION
Kanban task: t_16452b50 (Mission Control: https://mc.solobot.cloud)

## Summary
- Persist coding-worker workspace, lease, PR, review, and bounded waiter identity in Kanban state.
- Make worktree locking/teardown fail closed and preserve dirty or unpublished work.
- Require canonical PR URL/head evidence for lifecycle-managed Review handoff.
- Add focused lifecycle, reconciliation, teardown, and hook regression coverage.

## Verification
- `HERMES_PYTHON=/home/solo/.hermes/hermes-agent/venv/bin/python3 bash scripts/run_tests.sh tests/hermes_cli/test_kanban_review_lifecycle.py tests/hermes_cli/test_kanban_worktree_teardown.py tests/gateway/test_kanban_reconcile_orphans.py tests/hermes_cli/test_kanban_worker_lifecycle_hooks.py -q`
- 60 passed, 0 failed
- `git diff --check` passed

No merge or deployment performed; review and deployment verification remain with Orion.