### PR TITLE
fix(desktop): open local directory transcript links natively

### DIFF
--- a/apps/desktop/src/components/chat/preview-attachment.tsx
+++ b/apps/desktop/src/components/chat/preview-attachment.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useSessionView } from '@/app/chat/session-view'
 import { useI18n } from '@/i18n'
 import { Download, MonitorPlay } from '@/lib/icons'
+import { existingLocalDirectoryPath } from '@/lib/local-directory'
 import { normalizeOrLocalPreviewTarget } from '@/lib/local-preview'
 import { downloadGatewayMediaFile } from '@/lib/media'
 import { previewName } from '@/lib/preview-targets'
@@ -19,6 +20,7 @@ export function PreviewAttachment({ source = 'manual', target }: { source?: Prev
   const [opening, setOpening] = useState(false)
   const [downloading, setDownloading] = useState(false)
   const [downloaded, setDownloaded] = useState(false)
+  const [directoryPath, setDirectoryPath] = useState<string | null>(null)
   const cwdRef = useRef(cwd)
   const mountedRef = useRef(false)
   const requestTokenRef = useRef(0)
@@ -39,6 +41,23 @@ export function PreviewAttachment({ source = 'manual', target }: { source?: Prev
     }
   }, [])
 
+  // Probe only the Electron-local filesystem. Existing directories get a native
+  // folder action instead of being misclassified as extensionless text files.
+  useEffect(() => {
+    let current = true
+    setDirectoryPath(null)
+
+    void existingLocalDirectoryPath(target, cwd || undefined).then(path => {
+      if (current) {
+        setDirectoryPath(path)
+      }
+    })
+
+    return () => {
+      current = false
+    }
+  }, [cwd, target])
+
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
     requestTokenRef.current += 1
@@ -47,6 +66,28 @@ export function PreviewAttachment({ source = 'manual', target }: { source?: Prev
 
   async function togglePreview() {
     if (opening) {
+      return
+    }
+
+    if (directoryPath) {
+      setOpening(true)
+
+      try {
+        const result = await window.hermesDesktop?.openDir?.(directoryPath)
+
+        if (!result?.ok) {
+          throw new Error(result?.error || `Could not open directory: ${directoryPath}`)
+        }
+      } catch (error) {
+        if (mountedRef.current) {
+          notifyError(error, t.preview.unavailable)
+        }
+      } finally {
+        if (mountedRef.current) {
+          setOpening(false)
+        }
+      }
+
       return
     }
 
@@ -133,24 +174,34 @@ export function PreviewAttachment({ source = 'manual', target }: { source?: Prev
       <span className="min-w-0 flex-1 truncate text-[0.78rem] font-medium text-foreground/90" title={target}>
         {name}
       </span>
-      <button
-        aria-label={t.fileMenu.download}
-        className="flex shrink-0 items-center gap-1 rounded-md border border-(--ui-stroke-tertiary) bg-background/40 px-2 py-1 text-[0.7rem] font-medium text-muted-foreground transition-colors hover:bg-accent/55 hover:text-foreground disabled:opacity-50"
-        disabled={downloading}
-        onClick={() => void downloadFile()}
-        title={t.fileMenu.download}
-        type="button"
-      >
-        <Download className="size-3" />
-        {downloaded ? t.fileMenu.downloadSaved : t.fileMenu.download}
-      </button>
+      {!directoryPath && (
+        <button
+          aria-label={t.fileMenu.download}
+          className="flex shrink-0 items-center gap-1 rounded-md border border-(--ui-stroke-tertiary) bg-background/40 px-2 py-1 text-[0.7rem] font-medium text-muted-foreground transition-colors hover:bg-accent/55 hover:text-foreground disabled:opacity-50"
+          disabled={downloading}
+          onClick={() => void downloadFile()}
+          title={t.fileMenu.download}
+          type="button"
+        >
+          <Download className="size-3" />
+          {downloaded ? t.fileMenu.downloadSaved : t.fileMenu.download}
+        </button>
+      )}
       <button
         className="shrink-0 rounded-md border border-(--ui-stroke-tertiary) bg-background/40 px-2 py-1 text-[0.7rem] font-medium text-muted-foreground transition-colors hover:bg-accent/55 hover:text-foreground disabled:opacity-50"
         disabled={opening}
         onClick={() => void togglePreview()}
         type="button"
       >
-        {opening ? t.preview.opening : isActive ? t.preview.hide : t.preview.openPreview}
+        {directoryPath
+          ? opening
+            ? t.preview.opening
+            : t.fileMenu.revealFileManager
+          : opening
+            ? t.preview.opening
+            : isActive
+              ? t.preview.hide
+              : t.preview.openPreview}
       </button>
     </div>
   )

--- a/apps/desktop/src/lib/local-directory.test.ts
+++ b/apps/desktop/src/lib/local-directory.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { isDesktopFsRemoteMode, readDesktopDir } = vi.hoisted(() => ({
+  isDesktopFsRemoteMode: vi.fn(() => false),
+  readDesktopDir: vi.fn()
+}))
+
+vi.mock('@/lib/desktop-fs', () => ({
+  isDesktopFsRemoteMode,
+  readDesktopDir,
+  readDesktopFileDataUrl: vi.fn(),
+  readDesktopFileText: vi.fn()
+}))
+
+import { existingLocalDirectoryPath } from './local-directory'
+
+describe('existingLocalDirectoryPath', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    isDesktopFsRemoteMode.mockReturnValue(false)
+  })
+
+  it('returns an existing local directory resolved against the session cwd', async () => {
+    readDesktopDir.mockResolvedValue({ entries: [] })
+
+    await expect(existingLocalDirectoryPath('historical', '/work/reports')).resolves.toBe('/work/reports/historical')
+    expect(readDesktopDir).toHaveBeenCalledWith('/work/reports/historical')
+  })
+
+  it('normalizes a Windows file URL before probing the directory', async () => {
+    readDesktopDir.mockResolvedValue({ entries: [] })
+
+    await expect(existingLocalDirectoryPath('file:///C:/Users/E/reports/historical')).resolves.toBe(
+      'C:/Users/E/reports/historical'
+    )
+    expect(readDesktopDir).toHaveBeenCalledWith('C:/Users/E/reports/historical')
+  })
+
+  it('returns null when the target is not a directory', async () => {
+    readDesktopDir.mockRejectedValue(new Error('not a directory'))
+
+    await expect(existingLocalDirectoryPath('/work/report.md')).resolves.toBeNull()
+  })
+
+  it('does not probe remote-backend paths on the Electron host', async () => {
+    isDesktopFsRemoteMode.mockReturnValue(true)
+
+    await expect(existingLocalDirectoryPath('/srv/reports')).resolves.toBeNull()
+    expect(readDesktopDir).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/lib/local-directory.ts
+++ b/apps/desktop/src/lib/local-directory.ts
@@ -1,0 +1,31 @@
+import { isDesktopFsRemoteMode, readDesktopDir } from '@/lib/desktop-fs'
+import { localPreviewTarget } from '@/lib/local-preview'
+
+/**
+ * Resolve a transcript link to an existing directory on the Desktop machine.
+ * Remote-backend paths deliberately stay out of this path: their filesystem is
+ * not the Electron host filesystem and must keep using gateway-backed actions.
+ */
+export async function existingLocalDirectoryPath(rawTarget: string, cwd?: string | null): Promise<string | null> {
+  if (isDesktopFsRemoteMode()) {
+    return null
+  }
+
+  const target = localPreviewTarget(rawTarget, cwd)
+
+  if (!target || target.kind !== 'file' || !target.path) {
+    return null
+  }
+
+  // URL.pathname yields /C:/... for Windows file URLs. Electron filesystem
+  // IPC expects the native drive path instead.
+  const path = /^\/[a-z]:\//i.test(target.path) ? target.path.slice(1) : target.path
+
+  try {
+    await readDesktopDir(path)
+
+    return path
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the local-directory half of #101683 without duplicating #100869's local-file system-app action.

Existing transcript links to directories can fall through `normalizePreviewTarget()` as `null`, then be renderer-classified as extensionless text files. That produces a broken text preview and offers Download for a path that already exists locally.

This change:
- probes transcript targets with the existing Desktop filesystem directory reader before sending them through the file-preview pipeline;
- keeps remote-backend paths out of Electron-local filesystem probing;
- normalizes Windows `file:///C:/...` directory paths before the probe;
- hides Download for confirmed local directories and opens them through the existing Electron `openDir` bridge instead of creating a preview tab;
- adds focused regression coverage for cwd-relative directories, Windows file URLs, non-directories, and remote-backend isolation.

## Duplicate check

#100869 adds **Open in system app** for delivered local files. It does not preserve/classify directories or prevent them from entering the text-preview/Download path, so this PR is intentionally limited to that remaining directory-specific gap.

## Validation

Refreshed onto upstream `main` (`db23c79bbeb945397e5ca5aca00bb2a834e51b31`) after confirming none of the three touched files changed in the intervening commits. The branch remains one focused commit ahead with the same three-file diff.

Hosted checks on head `5091d19e265650f113e98e95236c6d5222e2309a` all passed:
- CI ✅
- Docker Build, Test, and Publish ✅
- Nix flake check ✅

Fixes #101683