### PR TITLE
feat(hooks): include parsed rate-limit state in post_api_request payload

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -434,6 +434,43 @@ def _moa_reference_metrics_for_hook(agent: Any) -> Any:
         return None
 
 
+def _rate_limit_state_for_hook(agent: Any) -> Any:
+    """Dict snapshot of the parsed x-ratelimit-* state for post_api_request, or None.
+
+    ``agent/rate_limit_tracker.py`` already parses the full 12-header
+    ``x-ratelimit-*`` schema into ``agent._rate_limit_state`` on every
+    streamed response (it feeds the ``/usage`` slash command), but the state
+    was unreachable from plugins: the ``post_api_request`` payload carried a
+    token-usage summary only, so approaching-limit observers had to
+    approximate provider state from configured caps. Pure passthrough of
+    state the loop already computes — no new parsing, no new headers read.
+    Buckets serialize with their derived ``usage_pct`` so a consumer does not
+    re-implement the tracker's own arithmetic.
+    """
+    getter = getattr(agent, "get_rate_limit_state", None)
+    if not callable(getter):
+        return None
+    try:
+        state = getter()
+    except Exception:
+        return None
+    if state is None:
+        return None
+    try:
+        from dataclasses import asdict, is_dataclass
+
+        if not is_dataclass(state):
+            return None
+        payload = asdict(state)
+        for bucket_name in ("requests_min", "requests_hour", "tokens_min", "tokens_hour"):
+            bucket = getattr(state, bucket_name, None)
+            if bucket is not None and isinstance(payload.get(bucket_name), dict):
+                payload[bucket_name]["usage_pct"] = bucket.usage_pct
+        return payload
+    except Exception:
+        return None
+
+
 def _apply_active_turn_redirect(agent: Any, messages: List[Dict[str, Any]], text: str) -> None:
     """Append a provider-safe checkpoint and correction to the live turn.
 
@@ -7419,6 +7456,10 @@ def run_conversation(
                             finish_reason=finish_reason,
                         ),
                         usage=agent._usage_summary_for_api_request_hook(response),
+                        # Parsed x-ratelimit-* snapshot (dict form of
+                        # RateLimitState, buckets carrying usage_pct), or None
+                        # when the provider sent no rate-limit headers.
+                        rate_limit=_rate_limit_state_for_hook(agent),
                         assistant_message=assistant_message,
                         assistant_content_chars=len(_assistant_text),
                         assistant_tool_call_count=len(_assistant_tool_calls),

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -462,10 +462,17 @@ def _rate_limit_state_for_hook(agent: Any) -> Any:
         if not is_dataclass(state):
             return None
         payload = asdict(state)
-        for bucket_name in ("requests_min", "requests_hour", "tokens_min", "tokens_hour"):
-            bucket = getattr(state, bucket_name, None)
-            if bucket is not None and isinstance(payload.get(bucket_name), dict):
-                payload[bucket_name]["usage_pct"] = bucket.usage_pct
+        # Attach each bucket's derived usage_pct by shape rather than by a
+        # hardcoded name list, so a future fifth bucket field serializes with
+        # its percentage instead of silently missing it (review nit, #101688).
+        for field_name, serialized in payload.items():
+            if not (isinstance(serialized, dict)
+                    and "limit" in serialized and "remaining" in serialized):
+                continue
+            bucket = getattr(state, field_name, None)
+            usage_pct = getattr(bucket, "usage_pct", None)
+            if usage_pct is not None:
+                serialized["usage_pct"] = usage_pct
         return payload
     except Exception:
         return None

--- a/tests/agent/test_rate_limit_hook_payload.py
+++ b/tests/agent/test_rate_limit_hook_payload.py
@@ -1,0 +1,70 @@
+"""Behavior contract for ``rate_limit`` in the post_api_request hook payload.
+
+``agent/rate_limit_tracker.py`` parses the full ``x-ratelimit-*`` schema into
+``agent._rate_limit_state`` on every streamed response, but the state was
+unreachable from plugins: the ``post_api_request`` payload carried a
+token-usage summary only. ``_rate_limit_state_for_hook`` is a pure
+passthrough of that already-computed state.
+
+Contract under test:
+
+- With a captured ``RateLimitState``, the payload value is its dict form,
+  each bucket carrying the tracker's own derived ``usage_pct``.
+- No captured state (``None``), an agent without the getter, a getter that
+  raises, and a non-dataclass return all yield ``None`` — the hook payload
+  never breaks the loop and never fabricates state.
+"""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+from agent.conversation_loop import _rate_limit_state_for_hook
+from agent.rate_limit_tracker import RateLimitBucket, RateLimitState
+
+
+def _agent_with_state(state):
+    return SimpleNamespace(get_rate_limit_state=lambda: state)
+
+
+def test_captured_state_serializes_with_bucket_usage_pct():
+    state = RateLimitState(
+        requests_min=RateLimitBucket(limit=100, remaining=40, reset_seconds=30.0),
+        tokens_hour=RateLimitBucket(limit=200_000, remaining=50_000, reset_seconds=900.0),
+        captured_at=time.time(),
+        provider="openai",
+    )
+    payload = _rate_limit_state_for_hook(_agent_with_state(state))
+
+    assert isinstance(payload, dict)
+    assert payload["provider"] == "openai"
+    assert payload["captured_at"] == state.captured_at
+    # Raw bucket fields survive asdict...
+    assert payload["requests_min"]["limit"] == 100
+    assert payload["requests_min"]["remaining"] == 40
+    # ...and each bucket carries the tracker's own derived percentage, so a
+    # consumer does not re-implement the arithmetic.
+    assert payload["requests_min"]["usage_pct"] == state.requests_min.usage_pct
+    assert payload["tokens_hour"]["usage_pct"] == state.tokens_hour.usage_pct
+    # Untouched buckets serialize too (defaults), rather than being dropped.
+    assert "tokens_min" in payload and "requests_hour" in payload
+
+
+def test_no_captured_state_is_none():
+    assert _rate_limit_state_for_hook(_agent_with_state(None)) is None
+
+
+def test_agent_without_getter_is_none():
+    assert _rate_limit_state_for_hook(SimpleNamespace()) is None
+
+
+def test_raising_getter_is_none():
+    def boom():
+        raise RuntimeError("tracker unavailable")
+
+    assert _rate_limit_state_for_hook(SimpleNamespace(get_rate_limit_state=boom)) is None
+
+
+def test_non_dataclass_state_is_none():
+    assert _rate_limit_state_for_hook(_agent_with_state({"limit": 1})) is None


### PR DESCRIPTION
## What does this PR do?

`agent/rate_limit_tracker.py` already parses the full 12-header `x-ratelimit-*` schema into `agent._rate_limit_state` on every streamed response (it feeds `/usage`), but that state is unreachable from plugins: the `post_api_request` payload carries a token-usage summary only, so an approaching-limit observability plugin must approximate provider state from per-tenant configured caps. This adds `rate_limit=` to the hook payload — a pure dict passthrough of state the loop already computes (`asdict` of `RateLimitState`, each bucket carrying its own derived `usage_pct`), `None` when no headers were captured. No new parsing, no new headers read; fail-open exactly like the neighboring `moa_references` helper.

**Not speculative — real shipped consumer:** the sopheva-overlay limit-watch plugin (external plugin repo, per your prescribed distribution model for third-party product plugins) ships today on configured-caps approximation and upgrades to true header state in place when this lands.

## Related Issue

Requested as ask 3 of #100592.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/conversation_loop.py`: new `_rate_limit_state_for_hook(agent)` helper (beside `_moa_reference_metrics_for_hook`) + one `rate_limit=` kwarg in the post_api_request payload.
- `tests/agent/test_rate_limit_hook_payload.py`: 5 behavior-contract cases (serialization with bucket `usage_pct`; no-state, no-getter, raising-getter, non-dataclass all yield `None`).

## How to Test

1. `pytest tests/agent/test_rate_limit_hook_payload.py -q` → 5 passed.
2. `pytest tests/run_agent/test_first_chunk_at_hook.py tests/agent/test_moa_observability_bridge.py tests/hermes_cli/test_plugins.py -q` → unchanged (105 passed combined with the new file).
3. In a plugin: `def on_post_api_request(rate_limit=None, **kw)` — after any streamed response whose provider sent `x-ratelimit-*`, `rate_limit["tokens_min"]["usage_pct"]` is populated.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs — no duplicate (searched "rate limit post_api_request", "rate_limit hook payload")
- [x] My PR contains only changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass — **partial, disclosed**: targeted suites 105/105 (files above + audio-guard); two relay test files error at collection in my env (missing `pytest_asyncio` dev dep, pre-existing on clean main); full-suite runs on this machine were repeatedly terminated by a local process supervisor at ~39% with no pytest summary (not test failures). Deferring the authoritative full run to CI.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.2)

### Documentation & Housekeeping

- [x] Docstrings updated (helper + payload comment) — README/docs N/A (hook payload documented in-code like neighboring fields)
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] Cross-platform impact considered: pure in-process dict passthrough, no OS surface
- [x] Tool descriptions/schemas — N/A