### PR TITLE
fix(tests): audio-playback guard covers the tts_tool/voice_mode route

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1697,6 +1697,35 @@ def _audio_playback_guard(request, monkeypatch):
     if hasattr(_voice, "play_audio_file"):
         monkeypatch.setattr(_voice, "play_audio_file", _blocked_play_audio_file)
 
+    # Second escape route (receipted 2026-09-02: a plain ``pytest tests/ -q``
+    # spoke "Hello world" through a developer's real speakers — caught live as
+    # ``afplay /var/folders/.../tmpcsxohl4y.mp3`` under the keyless ``edge``
+    # provider, so no API key stood between the suite and the speakers):
+    # ``tools/tts_tool.py`` never goes near ``hermes_cli.voice``. It plays
+    # through ``tools.voice_mode.play_audio_file`` — imported at CALL time
+    # inside ``speak()`` / ``_play_via_tempfile``, so patching the
+    # ``tools.voice_mode`` module attribute is what intercepts it — and,
+    # off-macOS, directly through a sounddevice ``OutputStream`` opened via
+    # ``tools.tts_tool._import_sounddevice``. Block both; the stream block
+    # routes synthesis to the tempfile path, whose playback is the stub.
+    try:
+        import tools.voice_mode as _voice_mode
+        if hasattr(_voice_mode, "play_audio_file"):
+            monkeypatch.setattr(_voice_mode, "play_audio_file", _blocked_play_audio_file)
+    except Exception:
+        pass
+    try:
+        import tools.tts_tool as _tts_tool
+
+        def _blocked_import_sounddevice():
+            raise ImportError("sounddevice blocked by the audio-playback guard")
+
+        if hasattr(_tts_tool, "_import_sounddevice"):
+            monkeypatch.setattr(
+                _tts_tool, "_import_sounddevice", _blocked_import_sounddevice)
+    except Exception:
+        pass
+
     yield
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1708,12 +1708,25 @@ def _audio_playback_guard(request, monkeypatch):
     # off-macOS, directly through a sounddevice ``OutputStream`` opened via
     # ``tools.tts_tool._import_sounddevice``. Block both; the stream block
     # routes synthesis to the tempfile path, whose playback is the stub.
+    # Guard-rot must be LOUD (review note, #101689): if either module path
+    # renames, a silent `except: pass` would quietly reopen the speakers and
+    # nobody would know until the next audible incident. Warn on failure so
+    # coverage loss shows up in the test run's warning summary.
+    import warnings as _warnings
     try:
         import tools.voice_mode as _voice_mode
         if hasattr(_voice_mode, "play_audio_file"):
             monkeypatch.setattr(_voice_mode, "play_audio_file", _blocked_play_audio_file)
-    except Exception:
-        pass
+        else:
+            _warnings.warn(
+                "audio-playback guard: tools.voice_mode.play_audio_file is gone — "
+                "the tts_tool playback route is UNGUARDED; update _audio_playback_guard",
+                RuntimeWarning, stacklevel=1)
+    except Exception as exc:
+        _warnings.warn(
+            f"audio-playback guard: could not patch tools.voice_mode ({exc!r}) — "
+            "the tts_tool playback route is UNGUARDED; update _audio_playback_guard",
+            RuntimeWarning, stacklevel=1)
     try:
         import tools.tts_tool as _tts_tool
 
@@ -1723,8 +1736,16 @@ def _audio_playback_guard(request, monkeypatch):
         if hasattr(_tts_tool, "_import_sounddevice"):
             monkeypatch.setattr(
                 _tts_tool, "_import_sounddevice", _blocked_import_sounddevice)
-    except Exception:
-        pass
+        else:
+            _warnings.warn(
+                "audio-playback guard: tools.tts_tool._import_sounddevice is gone — "
+                "the direct speaker stream is UNGUARDED; update _audio_playback_guard",
+                RuntimeWarning, stacklevel=1)
+    except Exception as exc:
+        _warnings.warn(
+            f"audio-playback guard: could not patch tools.tts_tool ({exc!r}) — "
+            "the direct speaker stream is UNGUARDED; update _audio_playback_guard",
+            RuntimeWarning, stacklevel=1)
 
     yield
 

--- a/tests/test_audio_playback_guard.py
+++ b/tests/test_audio_playback_guard.py
@@ -124,3 +124,41 @@ def test_bypass_marker_restores_the_real_speak_text():
     import hermes_cli.voice as voice
 
     assert voice.speak_text.__name__ == "speak_text"
+
+
+def test_tts_tool_playback_route_is_stubbed():
+    """The tts_tool/afplay route is guarded, not just ``hermes_cli.voice``.
+
+    Receipted 2026-09-02: a plain ``pytest tests/ -q`` spoke "Hello world"
+    through real speakers via ``tools/tts_tool.py::text_to_speech_tool`` —
+    the tool plays through ``tools.voice_mode.play_audio_file`` (imported at
+    call time, so the module attribute is the interception point) and the
+    keyless ``edge`` provider meant no API key stood between the suite and
+    the speakers. The original guard only patched ``hermes_cli.voice``.
+    """
+    import tools.voice_mode as voice_mode
+
+    assert voice_mode.play_audio_file.__name__ == "_blocked_play_audio_file"
+
+
+def test_tts_tool_sounddevice_stream_is_blocked():
+    """The direct speaker path (sounddevice OutputStream) cannot open.
+
+    Off-macOS the streamer bypasses tempfile playback entirely and writes
+    PCM straight to the output device; blocking the import routes synthesis
+    to the tempfile path, whose playback is the stub above.
+    """
+    import tools.tts_tool as tts_tool
+
+    with pytest.raises(ImportError):
+        tts_tool._import_sounddevice()
+
+
+@pytest.mark.real_audio_playback
+def test_bypass_marker_restores_the_real_tts_tool_route():
+    """The opt-out hands back the real bindings on this route too."""
+    import tools.tts_tool as tts_tool
+    import tools.voice_mode as voice_mode
+
+    assert voice_mode.play_audio_file.__name__ == "play_audio_file"
+    assert tts_tool._import_sounddevice.__name__ == "_import_sounddevice"


### PR DESCRIPTION
## What does this PR do?

Closes a real coverage hole in the test-suite audio-playback guard, caught live on 2026-09-02: a plain `pytest tests/ -q` spoke "Hello world" through a developer's REAL speakers (`afplay` of an edge-TTS tempfile, confirmed with an audio-out device assertion while the suite ran). `tests/conftest.py::_audio_playback_guard` stubs `hermes_cli.voice.speak_text`/`play_audio_file` — the route from the original "partial answer complete" incident — but `tools/tts_tool.py` never goes near `hermes_cli.voice`: it plays through `tools.voice_mode.play_audio_file` (imported at CALL time inside `speak()` / `_play_via_tempfile`, so the module attribute is the interception point) and, off-macOS, straight through a sounddevice `OutputStream` via `_import_sounddevice`. The keyless `edge` provider means no API key stands between a test run and the speakers — the same property the original incident writeup names.

The fix patches both in the same autouse fixture: `tools.voice_mode.play_audio_file` gets the existing blocked stub, and `_import_sounddevice` raises `ImportError` (routing synthesis to the tempfile path, whose playback is the stub). The `real_audio_playback` opt-out marker restores both, same as before.

## Related Issue

None filed — incident receipt is in the PR body; happy to file one if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tests/conftest.py`: `_audio_playback_guard` additionally patches `tools.voice_mode.play_audio_file` and blocks `tools.tts_tool._import_sounddevice`.
- `tests/test_audio_playback_guard.py`: 3 new cases (route stubbed, stream blocked, bypass marker restores the real bindings).

## How to Test

1. Repro on main: in any test, call `tools.tts_tool.text_to_speech_tool(text="Hello world")` with the `edge` provider available → audible playback through host speakers.
2. On this branch: `pytest tests/test_audio_playback_guard.py -q` → 7 passed; the same call stays silent (playback binding is `_blocked_play_audio_file`, stream import raises).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs — no duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — **partial, disclosed** (same environment note as #101688: targeted suites green incl. the guard suite 7/7; two relay files collection-error on missing `pytest_asyncio` dev dep pre-existing on clean main; full local runs terminated externally mid-suite — CI is the authoritative run).
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: macOS 15 (Darwin 25.2)

### Documentation & Housekeeping

- [x] Docs — N/A beyond the fixture's own comment block (extended with the receipt)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] Cross-platform impact considered: guard-only change; the sounddevice block applies on all hosts, macOS already routed to tempfile playback
- [x] Tool descriptions/schemas — N/A