### PR TITLE
fix(update): keep the in-flight update receipt across the stale-module purge

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -92,13 +92,20 @@ _STALE_PURGE_PREFIXES = (
 #: Modules that must survive the purge: they are (or are referenced by) the
 #: code currently EXECUTING the update, so evicting them buys nothing — the
 #: running frames keep their module objects alive regardless — and reloading
-#: them mid-flight is the one genuinely unsafe move.
+#: them mid-flight is the one genuinely unsafe move. Same for a module that
+#: carries this run's process state: ``update_receipt`` holds the in-flight
+#: receipt as a module-level singleton, begun before the checkout changed.
+#: Evict it and every later ``from hermes_cli.update_receipt import
+#: finalize_update_receipt`` (success path, command-boundary safety net)
+#: binds a fresh module with no open receipt, so a successful update
+#: finishes without writing one.
 _STALE_PURGE_PROTECTED = frozenset(
     {
         "hermes_cli",
         "hermes_cli.main",
         "hermes_cli.update_cmd",
         "hermes_cli.hermes_logging",
+        "hermes_cli.update_receipt",
     }
 )
 

--- a/tests/hermes_cli/test_update_stale_module_purge.py
+++ b/tests/hermes_cli/test_update_stale_module_purge.py
@@ -16,6 +16,8 @@ module graph from the updated checkout.
 
 from __future__ import annotations
 
+import importlib
+import json
 import sys
 import types
 
@@ -40,6 +42,18 @@ def _restore_sys_modules():
     for name in list(sys.modules):
         if name not in snapshot:
             del sys.modules[name]
+    # A post-purge import also rebinds the submodule attribute on its parent
+    # package (``hermes_cli.config`` -> fresh module object). Put those back
+    # too: pytest's monkeypatch resolves dotted targets through package
+    # attributes, so a stale binding would make a later test patch a module
+    # object that no ``from hermes_cli.config import ...`` ever sees.
+    for name, mod in snapshot.items():
+        parent, _, child = name.rpartition(".")
+        if not parent or parent not in snapshot:
+            continue
+        bound = getattr(snapshot[parent], child, None)
+        if isinstance(bound, types.ModuleType) and bound is not mod:
+            setattr(snapshot[parent], child, mod)
 
 
 def _fake_module(name: str) -> types.ModuleType:
@@ -134,3 +148,40 @@ def test_stale_symbol_scenario_end_to_end():
         sys.modules.pop(name, None)
         if real is not None:
             sys.modules[name] = real
+
+
+def test_purge_keeps_in_flight_update_receipt(tmp_path, monkeypatch):
+    """The receipt begun before the checkout changed must be the one the
+    success path finalizes after the purge.
+
+    ``hermes_cli.update_receipt`` keeps the open receipt as a module-level
+    singleton. If the purge evicted it, the lazy
+    ``from hermes_cli.update_receipt import finalize_update_receipt`` that
+    follows the gateway-restart phase would bind a fresh module with no open
+    receipt and return None — so every successful update would finish
+    without a receipt on disk (the Desktop's managed SSH update then reports
+    the run as failed for want of a durable receipt).
+    """
+    import hermes_cli.update_receipt as ur
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    # Env, not attribute patching: the purge re-imports hermes_cli.config,
+    # and a fresh module would not carry a monkeypatched attribute.
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    ur._current = None
+    ur.begin_update_receipt()
+    assert ur._current is not None
+    try:
+        cli_main._purge_stale_hermes_modules()
+
+        reimported = importlib.import_module("hermes_cli.update_receipt")
+        assert reimported is ur, "update_receipt was evicted by the purge"
+        assert reimported._current is not None
+
+        path = reimported.finalize_update_receipt("success")
+        assert path is not None and path.exists()
+        assert path.is_relative_to(home)
+        assert json.loads(path.read_text(encoding="utf-8"))["outcome"] == "success"
+    finally:
+        ur._current = None


### PR DESCRIPTION
## Summary

Successful `hermes update` runs write no update receipt. `_purge_stale_hermes_modules()` runs right before the gateway-restart phase and evicts `hermes_cli.update_receipt` from `sys.modules`, but that module holds the in-flight receipt as a module-level singleton (`_current`). Every later lazy `from hermes_cli.update_receipt import finalize_update_receipt` (the success path and the command-boundary safety net in `main.py`) binds a fresh module with no open receipt, so `finalize_update_receipt()` returns `None` and nothing reaches `logs/update_receipts/`.

Runs that fail *before* the purge (dependency install, fetch, preflight) still write receipts, which is why the gap went unnoticed.

Fixes #101690. Related: #101516 (the Desktop's managed SSH update needs a receipt that carries its `correlation_id`; with this bug the receipt does not exist at all, so that fix alone cannot make the Desktop report success).

## Change

- `hermes_cli/update_cmd.py`: add `hermes_cli.update_receipt` to `_STALE_PURGE_PROTECTED`, with the rationale in the comment above the set. It carries this run's process state, the same category as the executing modules already protected; the running frames keep the module object alive regardless, so evicting it buys nothing.
- `tests/hermes_cli/test_update_stale_module_purge.py`:
  - `test_purge_keeps_in_flight_update_receipt`: begin a receipt, run the purge, re-import `hermes_cli.update_receipt` (same object, `_current` intact), finalize → receipt file written under `HERMES_HOME`.
  - The autouse `_restore_sys_modules` fixture now also restores parent-package submodule attributes. A post-purge import rebinds e.g. `hermes_cli.config` on the `hermes_cli` package to the fresh module object; pytest's `monkeypatch.setattr("hermes_cli.config.get_hermes_home", …)` in later tests resolves through that attribute and would otherwise patch a module object no import statement uses (`test_update_receipt.py` failed this way when run after the new test).

## Verification

- `pytest tests/hermes_cli/test_update_stale_module_purge.py tests/hermes_cli/test_update_receipt.py` → 31 passed.
- `pytest tests/hermes_cli/test_update*.py` → 18 failed / 670 passed with this change vs 19 failed / 670 passed on the pristine tree in the same environment (macOS; order-dependent launchd, lock and wedged-gateway tests). No failure is introduced by this change.
- Field evidence (Linux remote, v0.21.0): a run that ended with `✓ Update complete!`, gateway handed back to its supervisor, fleet check up to date, exit code 0, left no receipt and `latest.json` still pointing at an earlier failed run. The in-process reproduction from the issue returns `None` on `main`; with this change the re-import is the same module object and the receipt is written.
