### PR TITLE
ci: exact-SHA witness for #100763 856e71ba

### DIFF
--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -89,10 +89,10 @@ $script:Ui = $null
 $script:UiStage = "Hermes will open once done."   # until the first gate; matches ui.html
 $script:UiStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 
-function Write-HandoffLog([string]$Message) {
+function Write-HandoffLog([string]$Message, [bool]$EchoToHost = $true) {
     $line = "{0:yyyy-MM-ddTHH:mm:ssK} {1}" -f (Get-Date), $Message
     try { Add-Content -LiteralPath $LogPath -Value $line -Encoding UTF8 } catch {}
-    Write-Host $line
+    if ($EchoToHost) { Write-Host $line }
 }
 
 # ── The shim: repo-owned HTML in a chromeless default-browser app window ───
@@ -971,13 +971,15 @@ function Step-PipeDrain($Reader, [ref]$Task, $Buffer, $Sink, [ref]$Moved) {
     return $false
 }
 
-function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
-    # The window does not stream child output, so no line-pump: both pipes
-    # drain asynchronously (no deadlock however chatty the child) while a small
-    # DoEvents loop keeps the marquee animating through long silent
-    # stretches (pip installs) -- the old EndOfStream pump blocked on quiet
-    # children and froze it. Full output still lands in the hand-off log
-    # afterwards, where `hermes debug share` picks it up.
+function Invoke-HermesStep(
+    [string]$Exe,
+    [string[]]$HermesArgs,
+    [string]$Tag,
+    [bool]$EchoCapturedOutput = $true
+) {
+    # Captured output always lands in desktop-update-handoff.log and in the
+    # returned Output string. EchoCapturedOutput controls only replay to this
+    # process's host console; production callers retain the default ($true).
     #
     # The drain is bounded once the step exits (#90455). Waiting for pipe EOF
     # is waiting on the step's whole surviving descendant tree, and this
@@ -1107,10 +1109,14 @@ function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
     $outText = $outSink.ToString()
     $errText = $errSink.ToString()
     foreach ($ln in ($outText -split "`r?`n")) {
-        if ($ln.Trim()) { Write-HandoffLog ("{0}| {1}" -f $Tag, $ln) }
+        if ($ln.Trim()) {
+            Write-HandoffLog ("{0}| {1}" -f $Tag, $ln) $EchoCapturedOutput
+        }
     }
     foreach ($ln in ($errText -split "`r?`n")) {
-        if ($ln.Trim()) { Write-HandoffLog ("{0}!| {1}" -f $Tag, $ln) }
+        if ($ln.Trim()) {
+            Write-HandoffLog ("{0}!| {1}" -f $Tag, $ln) $EchoCapturedOutput
+        }
     }
     $all = $outText
     if ($errText) { $all += "`n" + $errText }
@@ -1273,10 +1279,11 @@ exit 3
     }
 
     $floodSw = [System.Diagnostics.Stopwatch]::StartNew()
-    $flood = Invoke-HermesStep $powershell @(
+    Write-HandoffLog ("PIPE-DRAIN SELF-TEST: running flood arm ({0}KB; raw payload retained in hand-off log)" -f $floodKb)
+    $flood = Invoke-HermesStep -Exe $powershell -HermesArgs @(
         "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $floodPs1,
         "-Kb", [string]$floodKb
-    ) "pipeflood"
+    ) -Tag "pipeflood" -EchoCapturedOutput $false
     $floodSw.Stop()
     $floodElapsed = [Math]::Round($floodSw.Elapsed.TotalSeconds, 2)
     $floodBytes = $flood.Output.Length

--- a/tests/test_desktop_update_windows_pipe_drain.py
+++ b/tests/test_desktop_update_windows_pipe_drain.py
@@ -168,6 +168,7 @@ def test_update_step_survives_pipe_leak_flood_and_live_child_stall(
     if not powershell.is_file():
         pytest.skip(f"Windows PowerShell not found at {powershell}")
 
+    flood_kb = 8192
     env = {
         **os.environ,
         # The fixture writes its child scripts, pid file and hand-off log under
@@ -180,6 +181,7 @@ def test_update_step_survives_pipe_leak_flood_and_live_child_stall(
         "HERMES_UPDATE_PIPE_DRAIN_SECONDS": "3",
         "HERMES_UPDATE_STEP_IDLE_SECONDS": "3",
         "HERMES_SELFTEST_HOLD_SECONDS": "45",
+        "HERMES_SELFTEST_FLOOD_KB": str(flood_kb),
     }
 
     result = subprocess.run(
@@ -204,7 +206,7 @@ def test_update_step_survives_pipe_leak_flood_and_live_child_stall(
 
     assert "PIPE-DRAIN SELF-TEST: PASS" in result.stdout, (
         "The Windows update hand-off's step drain regressed: it either waited "
-        "on a descendant holding the pipe open (the Desktop parks on 'Updating "
+        "on a descendant holding the pipe open (the Desktop parks on 'Updating "  # windows-footgun: ok -- prose, not open()
         "Hermes' forever) or metered a chatty step (backpressure on the running "
         f"update). Fixture diagnosis follows.\n--- stdout ---\n{result.stdout}\n"
         f"--- stderr ---\n{result.stderr}"
@@ -213,3 +215,17 @@ def test_update_step_survives_pipe_leak_flood_and_live_child_stall(
         f"-SelfTestPipeDrain exited {result.returncode}.\n"
         f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
     )
+    handoff_log = tmp_path / "logs" / "desktop-update-handoff.log"
+    emitted_stdout_bytes = len(result.stdout.encode("utf-8"))
+    assert emitted_stdout_bytes < 64 * 1024, (
+        "GitHub Actions throttling risk: self-test emitted "
+        f"{emitted_stdout_bytes} stdout bytes"
+    )
+    if "pipeflood| " in result.stdout:
+        pytest.fail("GitHub Actions throttling risk: flood output was replayed")
+    assert "pipedrain| pipe-drain step output" in result.stdout
+    assert "stepstall| step entered silent finalization" in result.stdout
+    assert handoff_log.is_file()
+    assert handoff_log.stat().st_size >= flood_kb * 1024
+    with handoff_log.open(encoding="utf-8-sig") as log_handle:
+        assert any("pipeflood| " in line for line in log_handle)


### PR DESCRIPTION
Temporary exact-SHA workflow witness for current #100763 head `856e71ba184588b98fab057f723f541e4e826f9f`.

The original CI object on this immutable head failed at workflow parsing during the repository-wide CI YAML defect; Docker and Nix succeeded. Main has since repaired that workflow class. This carrier introduces no product change and exists only to obtain a fresh exact-SHA CI/Docker/Nix matrix under the repaired workflow.

Do not review or merge. Close after terminal receipts are read back; #100763 remains the product owner.