### PR TITLE
fix(desktop): show cross-profile worker sessions

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -16041,25 +16041,44 @@ async function mergeRemoteProfileSessions(searchParams, remoteProfiles) {
   const remoteSet = new Set(remoteProfiles)
   const merged = rowsOf(base).filter(s => !remoteSet.has(s?.profile))
   const profileTotals = { ...(base.profile_totals || {}) }
+  const errors = Array.isArray(base.errors) ? [...base.errors] : []
   let total = (Number(base.total) || 0) - remoteProfiles.reduce((n, p) => n + (profileTotals[p] || 0), 0)
 
   // Swap each remote profile's stale local rows/total for the remote's real ones.
-  await Promise.all(
+  // Promise.all preserves input order, so errors and row insertion stay
+  // deterministic even when remote responses finish out of order.
+  const remoteResults = await Promise.all(
     remoteProfiles.map(async name => {
-      const list = await remoteSessionList(name, remoteParams).catch(() => null)
-
-      if (!list) {
-        delete profileTotals[name] // dead remote → drop its stale local total too
-
-        return
+      try {
+        return { list: await remoteSessionList(name, remoteParams), name }
+      } catch (error) {
+        return { error, list: null, name }
       }
-
-      const rows = rowsOf(list)
-      merged.push(...rows)
-      profileTotals[name] = Number(list.total) || rows.length
-      total += profileTotals[name]
     })
   )
+
+  for (const { error, list, name } of remoteResults) {
+    if (error) {
+      errors.push({
+        error: error instanceof Error ? error.message : String(error),
+        profile: name
+      })
+      delete profileTotals[name] // dead remote → drop its stale local total too
+
+      continue
+    }
+
+    if (!list) {
+      delete profileTotals[name] // dead remote → drop its stale local total too
+
+      continue
+    }
+
+    const rows = rowsOf(list)
+    merged.push(...rows)
+    profileTotals[name] = Number(list.total) || rows.length
+    total += profileTotals[name]
+  }
 
   // Registry gateways (v2 connections): splice every CONNECTED gateway's rows
   // into the unified list. Only already-pooled backends are read — a sidebar
@@ -16069,8 +16088,11 @@ async function mergeRemoteProfileSessions(searchParams, remoteProfiles) {
   const registrySources = await pooledRegistrySessionSources()
 
   if (registrySources.length) {
-    const registryRows = await fetchRegistrySessionRows(registrySources, remoteParams, (descriptor, path) =>
-      getJsonForBackend(descriptor, path, { timeoutMs: 10_000 })
+    const registryRows = await fetchRegistrySessionRows(
+      registrySources,
+      remoteParams,
+      (descriptor, path) => getJsonForBackend(descriptor, path, { timeoutMs: 10_000 }),
+      error => errors.push(error)
     )
 
     const { added } = spliceRegistrySessionRows(merged, registryRows, profileTotals)
@@ -16084,7 +16106,8 @@ async function mergeRemoteProfileSessions(searchParams, remoteProfiles) {
     ...(base as any),
     sessions: mergeProfileSessionWindow(merged, offset, limit),
     total,
-    profile_totals: profileTotals
+    profile_totals: profileTotals,
+    errors
   }
 }
 

--- a/apps/desktop/electron/managed-ssh-update.test.ts
+++ b/apps/desktop/electron/managed-ssh-update.test.ts
@@ -288,7 +288,7 @@ test('POSIX managed launcher executes the updater command and atomically publish
       {
         ssh: { exec: async () => '' },
         platform: 'Linux',
-        hermesPath: '/bin/true',
+        hermesPath: '/usr/bin/true',
         hermesHome: home
       },
       CORRELATION

--- a/apps/desktop/electron/profile-session-routing.test.ts
+++ b/apps/desktop/electron/profile-session-routing.test.ts
@@ -206,6 +206,17 @@ test('merged profile windows retain pinned rows outside the recency window', () 
   assert.deepEqual(mergeProfileSessionWindow(rows, 0, 3), [rows[0], rows[1], rows[2], rows[3], rows[4]])
 })
 
+test('merged profile windows dedupe only the same durable connection/profile/lineage identity', () => {
+  const rows = [
+    { id: 'tip-new', _lineage_root_id: 'root', profile: 'work', connection_id: 'gw-1', last_active: 30 },
+    { id: 'tip-old', _lineage_root_id: 'root', profile: 'work', connection_id: 'gw-1', last_active: 20 },
+    { id: 'tip-old', _lineage_root_id: 'root', profile: 'work', connection_id: 'gw-2', last_active: 10 },
+    { id: 'tip-old', _lineage_root_id: 'root', profile: 'other', connection_id: 'gw-1', last_active: 5 }
+  ]
+
+  assert.deepEqual(mergeProfileSessionWindow(rows, 0, 10), [rows[0], rows[2], rows[3]])
+})
+
 test('remote session reads keep small requests on one call', async () => {
   const calls: Array<{ profile: string | null; path: string }> = []
   const expected = { sessions: [{ id: 'session-1' }], total: 1, limit: 20, offset: 0 }
@@ -368,6 +379,8 @@ test('registry sources: an older shared host without the aggregator falls back t
 })
 
 test('registry sources: a dead gateway contributes nothing instead of breaking the list', async () => {
+  const errors: Array<{ connection_id: string; error: string; profile: string }> = []
+
   const rows = await fetchRegistrySessionRows(
     [
       { connectionId: 'gw-dead', kind: 'ssh', backends: [{ descriptor: 'dead', profileLabel: 'x' }] },
@@ -380,16 +393,18 @@ test('registry sources: a dead gateway contributes nothing instead of breaking t
       }
 
       return { sessions: [{ id: 'ok-1' }], total: 1 }
-    }
+    },
+    error => errors.push(error)
   )
 
   assert.deepEqual(
     rows.map(row => (row as any).id),
     ['ok-1']
   )
+  assert.deepEqual(errors, [{ connection_id: 'gw-dead', error: 'ECONNREFUSED', profile: 'x' }])
 })
 
-test('splice: registry rows dedupe by id and extend per-profile totals', () => {
+test('splice: registry rows dedupe by durable owner identity and extend per-profile totals', () => {
   const merged: unknown[] = [
     { id: 'local-1', profile: 'default', last_active: 100 },
     { id: 'dupe', profile: 'work', last_active: 90 }
@@ -401,20 +416,21 @@ test('splice: registry rows dedupe by id and extend per-profile totals', () => {
     merged,
     [
       { id: 'dupe', profile: 'work', connection_id: 'gw-1', last_active: 95 },
+      { id: 'dupe', profile: 'work', connection_id: 'gw-1', last_active: 94 },
       { id: 'remote-1', profile: 'hermes-claude', connection_id: 'gw-1', last_active: 120 },
       { id: 'remote-2', connection_id: 'gw-1', last_active: 110 }
     ],
     totals
   )
 
-  assert.equal(added, 2)
+  assert.equal(added, 3)
   assert.deepEqual(
     merged.map(row => (row as any).id),
-    ['local-1', 'dupe', 'remote-1', 'remote-2']
+    ['local-1', 'dupe', 'dupe', 'remote-1', 'remote-2']
   )
   assert.equal(totals['hermes-claude'], 1)
   assert.equal(totals.default, 2) // untagged registry row counts under default
-  assert.equal(totals.work, 1) // deduped row does not double-count
+  assert.equal(totals.work, 2) // local and gw-1 are distinct owners; gw-1 duplicate collapsed
 })
 
 test('finds the remote owner profile for a hint-less session read (#85834)', async () => {

--- a/apps/desktop/electron/profile-session-routing.ts
+++ b/apps/desktop/electron/profile-session-routing.ts
@@ -82,30 +82,54 @@ function isPinned(row: unknown): boolean {
   return Boolean(row && typeof row === 'object' && 'pinned' in row && row.pinned)
 }
 
-function profileSessionId(row: unknown): string | null {
+function durableSessionIdentity(row: unknown): string | null {
   const id = sessionId(row)
 
   if (!id) {
     return null
   }
 
-  const profile =
-    row && typeof row === 'object' && 'profile' in row && typeof row.profile === 'string' ? row.profile : ''
+  const session = row as Record<string, unknown>
+  const profile = typeof session.profile === 'string' && session.profile.trim() ? session.profile.trim() : 'default'
 
-  return `${profile}\0${id}`
+  const connection =
+    typeof session.connection_id === 'string' && session.connection_id.trim() ? session.connection_id.trim() : 'local'
+
+  const lineage =
+    typeof session._lineage_root_id === 'string' && session._lineage_root_id.trim()
+      ? session._lineage_root_id.trim()
+      : id
+
+  return `${connection}\0${profile}\0${lineage}`
 }
 
 export function mergeProfileSessionWindow(rows: unknown[], offset: number, limit: number): unknown[] {
-  const window = rows.slice(offset, offset + limit)
-  const seenRows = new Set(window)
-  const seenIds = new Set(window.map(profileSessionId).filter((id): id is string => id !== null))
+  const seenIdentities = new Set<string>()
 
-  for (const row of rows.slice(offset + limit)) {
+  const deduped = rows.filter(row => {
+    const identity = durableSessionIdentity(row)
+
+    if (identity && seenIdentities.has(identity)) {
+      return false
+    }
+
+    if (identity) {
+      seenIdentities.add(identity)
+    }
+
+    return true
+  })
+
+  const window = deduped.slice(offset, offset + limit)
+  const seenRows = new Set(window)
+  const seenIds = new Set(window.map(durableSessionIdentity).filter((id): id is string => id !== null))
+
+  for (const row of deduped.slice(offset + limit)) {
     if (!isPinned(row)) {
       continue
     }
 
-    const id = profileSessionId(row)
+    const id = durableSessionIdentity(row)
 
     if ((id && seenIds.has(id)) || (!id && seenRows.has(row))) {
       continue
@@ -191,6 +215,12 @@ export interface RegistrySessionSource {
 
 type GetJsonForDescriptor = (descriptor: unknown, path: string) => Promise<unknown>
 
+export interface RegistrySessionError {
+  connection_id: string
+  error: string
+  profile: string
+}
+
 /**
  * Every connected registry gateway's session rows for the unified Sessions
  * list (#88880), tagged with the owning `connection_id` + remote `profile` so
@@ -208,11 +238,12 @@ type GetJsonForDescriptor = (descriptor: unknown, path: string) => Promise<unkno
 export async function fetchRegistrySessionRows(
   sources: RegistrySessionSource[],
   searchParams: URLSearchParams,
-  getJson: GetJsonForDescriptor
+  getJson: GetJsonForDescriptor,
+  onError?: (error: RegistrySessionError) => void
 ): Promise<unknown[]> {
-  const rows: unknown[] = []
+  const tag = (data: unknown, connectionId: string, profileLabel: null | string): unknown[] => {
+    const tagged: unknown[] = []
 
-  const tag = (data: unknown, connectionId: string, profileLabel: null | string) => {
     for (const row of rowsOf(data)) {
       if (!row || typeof row !== 'object') {
         continue
@@ -228,28 +259,39 @@ export async function fetchRegistrySessionRows(
 
       session.is_default_profile = false
       session.connection_id = connectionId
-      rows.push(session)
+      tagged.push(session)
     }
+
+    return tagged
   }
 
-  await Promise.all(
+  const results = await Promise.all(
     sources.map(async source => {
       if (source.kind === 'ssh') {
         // Each ssh-scoped backend serves its own state.db natively.
-        await Promise.all(
+        return Promise.all(
           source.backends.map(async ({ descriptor, profileLabel }) => {
             const params = new URLSearchParams(searchParams)
             params.delete('profile')
 
-            const data = await getJson(descriptor, `/api/sessions?${params}`).catch(() => null)
+            try {
+              const data = await getJson(descriptor, `/api/sessions?${params}`)
 
-            if (data) {
-              tag(data, source.connectionId, profileLabel || 'default')
+              return { errors: [], rows: tag(data, source.connectionId, profileLabel || 'default') }
+            } catch (error) {
+              return {
+                errors: [
+                  {
+                    connection_id: source.connectionId,
+                    error: error instanceof Error ? error.message : String(error),
+                    profile: profileLabel || 'default'
+                  }
+                ],
+                rows: []
+              }
             }
           })
         )
-
-        return
       }
 
       // Shared remote/cloud host: one cross-profile read returns every
@@ -257,26 +299,51 @@ export async function fetchRegistrySessionRows(
       const shared = source.backends[0]
 
       if (!shared) {
-        return
+        return []
       }
 
       const params = new URLSearchParams(searchParams)
       params.set('profile', 'all')
 
-      let data = await getJson(shared.descriptor, `/api/profiles/sessions?${params}`).catch(() => null)
+      try {
+        const data = await getJson(shared.descriptor, `/api/profiles/sessions?${params}`)
 
-      if (!data) {
+        return [{ errors: [], rows: tag(data, source.connectionId, null) }]
+      } catch {
         // Older remote without the aggregator: its own default-profile list.
         const flat = new URLSearchParams(searchParams)
         flat.delete('profile')
-        data = await getJson(shared.descriptor, `/api/sessions?${flat}`).catch(() => null)
-      }
 
-      if (data) {
-        tag(data, source.connectionId, null)
+        try {
+          const data = await getJson(shared.descriptor, `/api/sessions?${flat}`)
+
+          return [{ errors: [], rows: tag(data, source.connectionId, null) }]
+        } catch (error) {
+          return [
+            {
+              errors: [
+                {
+                  connection_id: source.connectionId,
+                  error: error instanceof Error ? error.message : String(error),
+                  profile: 'all'
+                }
+              ],
+              rows: []
+            }
+          ]
+        }
       }
     })
   )
+
+  const rows: unknown[] = []
+
+  for (const sourceResults of results) {
+    for (const result of sourceResults) {
+      rows.push(...result.rows)
+      result.errors.forEach(error => onError?.(error))
+    }
+  }
 
   return rows
 }
@@ -291,11 +358,11 @@ export function spliceRegistrySessionRows(
   registryRows: unknown[],
   profileTotals: Record<string, number>
 ): { added: number } {
-  const seen = new Set(merged.map(sessionId).filter((id): id is string => id !== null))
+  const seen = new Set(merged.map(durableSessionIdentity).filter((id): id is string => id !== null))
   let added = 0
 
   for (const row of registryRows) {
-    const id = sessionId(row)
+    const id = durableSessionIdentity(row)
 
     if (id && seen.has(id)) {
       continue

--- a/apps/desktop/src/app/command-center/delete-confirm.test.tsx
+++ b/apps/desktop/src/app/command-center/delete-confirm.test.tsx
@@ -42,7 +42,7 @@ const SESSION: SessionInfo = {
   title: 'Precious conversation'
 } as SessionInfo
 
-function renderCommandCenter(onDeleteSession: (id: string) => Promise<void>) {
+function renderCommandCenter(onDeleteSession: (session: SessionInfo) => Promise<void>) {
   return render(
     <MemoryRouter>
       <CommandCenterView
@@ -78,7 +78,7 @@ describe('Command Center session delete confirmation (#99410)', () => {
     const dialog = await screen.findByRole('dialog')
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
 
-    await waitFor(() => expect(onDeleteSession).toHaveBeenCalledWith('sess-1'))
+    await waitFor(() => expect(onDeleteSession).toHaveBeenCalledWith(SESSION))
     expect(dialog).toBeTruthy()
   })
 

--- a/apps/desktop/src/app/command-center/index.tsx
+++ b/apps/desktop/src/app/command-center/index.tsx
@@ -30,7 +30,7 @@ import { useStoreSelector } from '@/lib/use-session-slice'
 import { cn } from '@/lib/utils'
 import { upsertDesktopActionTask } from '@/store/activity'
 import { $pinnedSessionIds, pinSession, unpinSession } from '@/store/layout'
-import { $sessions, sessionPinId } from '@/store/session'
+import { sessionPinId } from '@/store/session'
 
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
 import { useRouteEnumParam } from '../hooks/use-route-enum-param'
@@ -38,6 +38,7 @@ import { OverlayMain, OverlayNav, OverlaySplitLayout } from '../overlays/overlay
 import { OverlayView } from '../overlays/overlay-view'
 
 import { MaintenancePanel } from './maintenance'
+import { useCommandCenterSessions } from './sessions'
 
 export type CommandCenterSection = 'maintenance' | 'sessions' | 'system' | 'usage'
 
@@ -58,10 +59,10 @@ const EMPTY_PINNED: readonly string[] = []
 interface CommandCenterViewProps {
   initialSection?: CommandCenterSection
   onClose: () => void
-  onDeleteSession: (sessionId: string) => Promise<void>
+  onDeleteSession: (session: SessionInfo) => Promise<void>
   // Accepted for call-site parity; navigation lives in the global Cmd+K palette.
   onNavigateRoute?: (path: string) => void
-  onOpenSession: (sessionId: string) => void
+  onOpenSession: (session: SessionInfo) => void
 }
 
 function formatTimestamp(value?: number | null): string {
@@ -136,14 +137,19 @@ function EmptyPanel({ action, description, title }: { action?: ReactNode; descri
 export function CommandCenterView({ initialSection, onClose, onDeleteSession, onOpenSession }: CommandCenterViewProps) {
   const { t } = useI18n()
   const cc = t.commandCenter
-  // $sessions ticks on every streaming token (title updates, new sessions),
-  // but we only need the data on the Sessions tab. Subscribe conditionally so
-  // the System/Usage/Maintenance tabs don't re-render on every stream delta.
   const [section, setSection] = useRouteEnumParam('section', SECTIONS, initialSection ?? 'sessions')
-  const sessions = useStoreSelector($sessions, s => (section === 'sessions' ? s : EMPTY_SESSIONS))
+
+  const {
+    errors: sessionErrors,
+    loading: sessionsLoading,
+    refresh: refreshSessions,
+    sessions
+  } = useCommandCenterSessions(section === 'sessions')
+
   const pinnedSessionIds = useStoreSelector($pinnedSessionIds, s => (section === 'sessions' ? s : EMPTY_PINNED))
 
   const [query, setQuery] = useState('')
+  const [profileFilter, setProfileFilter] = useState('all')
   const [pendingDelete, setPendingDelete] = useState<SessionInfo | null>(null)
   const [status, setStatus] = useState<StatusResponse | null>(null)
   const [logs, setLogs] = useState<string[]>([])
@@ -162,7 +168,12 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
   const debouncedQuery = useDebouncedValue(query.trim(), 180)
 
   const filteredSessions = useMemo(() => {
-    const sorted = [...sessions].sort((a, b) => {
+    const scoped =
+      profileFilter === 'all'
+        ? sessions
+        : sessions.filter(session => (session.profile?.trim() || 'default') === profileFilter)
+
+    const sorted = [...scoped].sort((a, b) => {
       const left = a.last_active || a.started_at || 0
       const right = b.last_active || b.started_at || 0
 
@@ -176,11 +187,18 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
     }
 
     return sorted.filter(session => {
-      const haystack = `${sessionTitle(session)} ${session.id}`.toLowerCase()
+      const haystack =
+        `${sessionTitle(session)} ${session.id} ${session.profile ?? 'default'} ${session.kanban_task_id ?? ''} ${session.kanban_task_title ?? ''} ${session.kanban_run_status ?? ''}`.toLowerCase()
 
       return haystack.includes(needle)
     })
-  }, [debouncedQuery, sessions])
+  }, [debouncedQuery, profileFilter, sessions])
+
+  const sessionProfiles = useMemo(
+    () =>
+      [...new Set(sessions.map(session => session.profile?.trim() || 'default'))].sort((a, b) => a.localeCompare(b)),
+    [sessions]
+  )
 
   const refreshSystem = useCallback(async () => {
     setSystemLoading(true)
@@ -243,7 +261,9 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
   }, [refreshUsage, section, usagePeriod])
 
   useRefreshHotkey(() => {
-    if (section === 'system') {
+    if (section === 'sessions') {
+      void refreshSessions()
+    } else if (section === 'system') {
       void refreshSystem()
     } else if (section === 'usage') {
       void refreshUsage(usagePeriod)
@@ -341,12 +361,27 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
             </div>
             <div className="flex shrink-0 items-center gap-2">
               {section === 'sessions' && (
-                <SearchField
-                  containerClassName="max-w-[40vw]"
-                  onChange={next => setQuery(next)}
-                  placeholder={cc.searchPlaceholder}
-                  value={query}
-                />
+                <>
+                  <select
+                    aria-label={t.profiles.allProfiles}
+                    className="h-7 max-w-44 rounded-md border border-(--ui-stroke-secondary) bg-(--ui-bg-secondary) px-2 text-xs text-foreground"
+                    onChange={event => setProfileFilter(event.target.value)}
+                    value={profileFilter}
+                  >
+                    <option value="all">{t.profiles.allProfiles}</option>
+                    {sessionProfiles.map(profile => (
+                      <option key={profile} value={profile}>
+                        {profile}
+                      </option>
+                    ))}
+                  </select>
+                  <SearchField
+                    containerClassName="max-w-[40vw]"
+                    onChange={next => setQuery(next)}
+                    placeholder={cc.searchPlaceholder}
+                    value={query}
+                  />
+                </>
               )}
               {section === 'usage' && (
                 <SegmentedControl
@@ -361,7 +396,11 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
           {section === 'sessions' ? (
             <div className="min-h-0 flex-1 overflow-y-auto">
               {!sessionListHasResults ? (
-                <EmptyPanel description={debouncedQuery ? cc.noResults : cc.noSessions} />
+                sessionsLoading ? (
+                  <PageLoader className="min-h-48" label={cc.refreshing} />
+                ) : (
+                  <EmptyPanel description={debouncedQuery || profileFilter !== 'all' ? cc.noResults : cc.noSessions} />
+                )
               ) : (
                 <ul>
                   {filteredSessions.map(session => {
@@ -369,44 +408,61 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
                     const pinned = pinnedSessionIds.includes(pinId)
 
                     return (
-                      <li className="group flex items-center gap-2 py-2" key={session.id}>
+                      <li
+                        className="group flex items-center gap-2 py-2"
+                        key={`${session.connection_id ?? 'local'}:${session.profile ?? 'default'}:${pinId}`}
+                      >
                         <button
                           className="min-w-0 flex-1 text-left"
-                          onClick={() => onOpenSession(session.id)}
+                          onClick={() => onOpenSession(session)}
                           type="button"
                         >
                           <div className="truncate text-[length:var(--conversation-text-font-size)] font-medium text-foreground">
-                            {sessionTitle(session)}
+                            {session.kanban_task_title || sessionTitle(session)}
                           </div>
-                          <div className="truncate text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
-                            {formatTimestamp(session.last_active || session.started_at)}
+                          <div className="flex min-w-0 items-center gap-1.5 truncate text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
+                            <span>{session.profile?.trim() || 'default'}</span>
+                            {session.kanban_task_id && <span>{session.kanban_task_id}</span>}
+                            {session.source === 'kanban' && (
+                              <span>
+                                {session.kanban_run_status || (session.is_active ? cc.actionRunning : cc.actionDone)}
+                              </span>
+                            )}
+                            <span>{formatTimestamp(session.last_active || session.started_at)}</span>
                           </div>
                         </button>
-                        <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
-                          <RowIconButton
-                            onClick={() => (pinned ? unpinSession(pinId) : pinSession(pinId))}
-                            title={pinned ? cc.unpinSession : cc.pinSession}
-                          >
-                            {pinned ? <BookmarkFilled className="size-3.5" /> : <Bookmark className="size-3.5" />}
-                          </RowIconButton>
-                          <RowIconButton
-                            onClick={() => void exportSession(session.id, { session, title: sessionTitle(session) })}
-                            title={cc.exportSession}
-                          >
-                            <Download className="size-3.5" />
-                          </RowIconButton>
-                          <RowIconButton
-                            className="hover:text-destructive"
-                            onClick={() => setPendingDelete(session)}
-                            title={cc.deleteSession}
-                          >
-                            <Trash2 className="size-3.5" />
-                          </RowIconButton>
-                        </div>
+                        {session.source !== 'kanban' && (
+                          <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
+                            <RowIconButton
+                              onClick={() => (pinned ? unpinSession(pinId) : pinSession(pinId))}
+                              title={pinned ? cc.unpinSession : cc.pinSession}
+                            >
+                              {pinned ? <BookmarkFilled className="size-3.5" /> : <Bookmark className="size-3.5" />}
+                            </RowIconButton>
+                            <RowIconButton
+                              onClick={() => void exportSession(session.id, { session, title: sessionTitle(session) })}
+                              title={cc.exportSession}
+                            >
+                              <Download className="size-3.5" />
+                            </RowIconButton>
+                            <RowIconButton
+                              className="hover:text-destructive"
+                              onClick={() => setPendingDelete(session)}
+                              title={cc.deleteSession}
+                            >
+                              <Trash2 className="size-3.5" />
+                            </RowIconButton>
+                          </div>
+                        )}
                       </li>
                     )
                   })}
                 </ul>
+              )}
+              {sessionErrors.length > 0 && (
+                <div className="py-2 text-[length:var(--conversation-caption-font-size)] text-amber-600">
+                  {sessionErrors.map(error => error.profile).join(', ')}
+                </div>
               )}
             </div>
           ) : section === 'usage' ? (
@@ -519,7 +575,7 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
           destructive
           doneLabel={t.sidebar.row.deleted}
           onClose={() => setPendingDelete(null)}
-          onConfirm={() => void onDeleteSession(pendingDelete.id)}
+          onConfirm={() => void onDeleteSession(pendingDelete)}
           open
           title={t.sidebar.row.deleteTitle}
         />

--- a/apps/desktop/src/app/command-center/sessions-pane.test.tsx
+++ b/apps/desktop/src/app/command-center/sessions-pane.test.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SessionInfo } from '@/hermes'
+
+import { CommandCenterView } from '.'
+
+const listAllProfileSessions = vi.hoisted(() => vi.fn())
+
+vi.mock('@/hermes', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  listAllProfileSessions: (...args: unknown[]) => listAllProfileSessions(...args)
+}))
+
+const worker = (id: string, profile: string, taskId: string, active: boolean): SessionInfo =>
+  ({
+    ended_at: active ? null : 120,
+    id,
+    input_tokens: 0,
+    is_active: active,
+    kanban_board: 'xscale-control-room',
+    kanban_run_status: active ? 'running' : 'done',
+    kanban_task_id: taskId,
+    kanban_task_status: active ? 'running' : 'done',
+    kanban_task_title: active ? 'Client Ops delivery' : 'Agent Ops delivery',
+    last_active: active ? 200 : 150,
+    message_count: 4,
+    model: 'gpt-5.6',
+    output_tokens: 0,
+    preview: `work kanban task ${taskId}`,
+    profile,
+    source: 'kanban',
+    started_at: 100,
+    title: `Work kanban task ${taskId}`,
+    tool_call_count: 0
+  }) as SessionInfo
+
+describe('Command Center cross-profile worker sessions', () => {
+  beforeEach(() => {
+    listAllProfileSessions.mockReset()
+  })
+
+  it('renders worker task/profile/status, filters profiles, and opens the selected owner row', async () => {
+    const client = worker('20260902_164119_254ae5', 'clientops', 't_5faae42d', true)
+    const agent = worker('20260902_164323_4b026f', 'agentops', 't_3b5c5c01', false)
+
+    const foreground = {
+      ...worker('foreground', 'default', 'ignored', false),
+      source: 'desktop',
+      title: 'foreground',
+      kanban_task_title: undefined
+    }
+
+    delete foreground.kanban_task_id
+    listAllProfileSessions.mockResolvedValue({ errors: [], sessions: [client, agent, foreground], total: 3 })
+    const onOpenSession = vi.fn()
+
+    render(
+      <MemoryRouter>
+        <CommandCenterView
+          initialSection="sessions"
+          onClose={() => {}}
+          onDeleteSession={() => Promise.resolve()}
+          onOpenSession={onOpenSession}
+        />
+      </MemoryRouter>
+    )
+
+    expect(await screen.findByText('t_5faae42d')).toBeTruthy()
+    expect(screen.getAllByText('clientops').length).toBeGreaterThan(0)
+    expect(screen.getByText('running')).toBeTruthy()
+    expect(screen.getByText('t_3b5c5c01')).toBeTruthy()
+    expect(screen.getAllByText('agentops').length).toBeGreaterThan(0)
+    expect(screen.getByText('done')).toBeTruthy()
+    expect(screen.getByText('foreground')).toBeTruthy()
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'All profiles' }), { target: { value: 'clientops' } })
+    expect(screen.queryByText('t_3b5c5c01')).toBeNull()
+    expect(screen.getByText('t_5faae42d')).toBeTruthy()
+
+    fireEvent.click(screen.getByText('Client Ops delivery'))
+    await waitFor(() => expect(onOpenSession).toHaveBeenCalledWith(client))
+  })
+})

--- a/apps/desktop/src/app/command-center/sessions.test.tsx
+++ b/apps/desktop/src/app/command-center/sessions.test.tsx
@@ -1,0 +1,184 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SessionInfo } from '@/hermes'
+
+import {
+  commandCenterSessionOwnerRoute,
+  mergeCommandCenterSessions,
+  openCommandCenterSession,
+  useCommandCenterSessions
+} from './sessions'
+
+const listAllProfileSessions = vi.hoisted(() => vi.fn())
+const openSession = vi.hoisted(() => vi.fn())
+const requestSessionResume = vi.hoisted(() => vi.fn())
+const setSessionOwnerHint = vi.hoisted(() => vi.fn())
+
+vi.mock('@/hermes', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  listAllProfileSessions: (...args: unknown[]) => listAllProfileSessions(...args)
+}))
+
+vi.mock('../open-session', () => ({ openSession: (...args: unknown[]) => openSession(...args) }))
+
+vi.mock('@/store/session', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  requestSessionResume: (...args: unknown[]) => requestSessionResume(...args),
+  setSessionOwnerHint: (...args: unknown[]) => setSessionOwnerHint(...args)
+}))
+
+const row = (id: string, profile: string, over: Partial<SessionInfo> = {}): SessionInfo =>
+  ({
+    ended_at: null,
+    id,
+    input_tokens: 0,
+    is_active: false,
+    last_active: 100,
+    message_count: 1,
+    model: null,
+    output_tokens: 0,
+    preview: null,
+    profile,
+    source: 'desktop',
+    started_at: 90,
+    title: id,
+    tool_call_count: 0,
+    ...over
+  }) as SessionInfo
+
+describe('command center session aggregation', () => {
+  beforeEach(() => {
+    listAllProfileSessions.mockReset()
+    openSession.mockReset()
+    requestSessionResume.mockReset()
+    setSessionOwnerHint.mockReset()
+  })
+
+  it('keeps profiles distinct and dedupes the same durable session identity deterministically', () => {
+    const sessions = mergeCommandCenterSessions(
+      [],
+      [
+        row('shared', 'clientops', { last_active: 100, title: 'stale' }),
+        row('shared', 'agentops', { last_active: 150, title: 'other profile' }),
+        row('shared', 'clientops', { last_active: 200, title: 'fresh' }),
+        row('shared', 'clientops', { connection_id: 'remote-a', last_active: 175, title: 'remote twin' })
+      ]
+    )
+
+    expect(
+      sessions.map(session => [session.connection_id ?? 'local', session.profile, session.id, session.title])
+    ).toEqual([
+      ['local', 'clientops', 'shared', 'fresh'],
+      ['remote-a', 'clientops', 'shared', 'remote twin'],
+      ['local', 'agentops', 'shared', 'other profile']
+    ])
+  })
+
+  it('carries the last known rows for a profile whose database read failed', () => {
+    const sessions = mergeCommandCenterSessions(
+      [row('worker', 'clientops', { last_active: 200 }), row('old-default', 'default')],
+      [row('new-default', 'default', { last_active: 300 })],
+      [{ error: 'unable to open database file', profile: 'clientops' }]
+    )
+
+    expect(sessions.map(session => `${session.profile}:${session.id}`)).toEqual([
+      'default:new-default',
+      'clientops:worker'
+    ])
+  })
+
+  it('carries failed rows for only the exact connection and profile owner', () => {
+    const sessions = mergeCommandCenterSessions(
+      [
+        row('failed-worker', 'clientops', { connection_id: 'remote-a', last_active: 200 }),
+        row('healthy-stale', 'clientops', { connection_id: 'remote-b', last_active: 190 })
+      ],
+      [row('healthy-fresh', 'clientops', { connection_id: 'remote-b', last_active: 300 })],
+      [{ connection_id: 'remote-a', error: 'gateway unavailable', profile: 'clientops' }]
+    )
+
+    expect(sessions.map(session => `${session.connection_id}:${session.id}`)).toEqual([
+      'remote-b:healthy-fresh',
+      'remote-a:failed-worker'
+    ])
+  })
+
+  it('carries every prior profile when a shared gateway aggregate fails', () => {
+    const sessions = mergeCommandCenterSessions(
+      [
+        row('client-worker', 'clientops', { connection_id: 'remote-a' }),
+        row('agent-worker', 'agentops', { connection_id: 'remote-a' }),
+        row('stale-other', 'clientops', { connection_id: 'remote-b' })
+      ],
+      [row('fresh-other', 'clientops', { connection_id: 'remote-b', last_active: 300 })],
+      [{ connection_id: 'remote-a', error: 'gateway unavailable', profile: 'all' }]
+    )
+
+    expect(sessions.map(session => `${session.connection_id}:${session.id}`).sort()).toEqual([
+      'remote-a:agent-worker',
+      'remote-a:client-worker',
+      'remote-b:fresh-other'
+    ])
+  })
+
+  it('ignores a stale cross-profile response that lands after a newer refresh', async () => {
+    let resolveOld!: (value: unknown) => void
+    let resolveNew!: (value: unknown) => void
+
+    const oldResponse = new Promise(resolve => {
+      resolveOld = resolve
+    })
+
+    const newResponse = new Promise(resolve => {
+      resolveNew = resolve
+    })
+
+    listAllProfileSessions.mockReturnValueOnce(oldResponse).mockReturnValueOnce(newResponse)
+
+    const { result } = renderHook(() => useCommandCenterSessions(true))
+
+    await vi.waitFor(() => expect(listAllProfileSessions).toHaveBeenCalledTimes(1))
+    let refresh!: Promise<void>
+    act(() => {
+      refresh = result.current.refresh()
+    })
+
+    await act(async () => {
+      resolveNew({ errors: [], sessions: [row('new', 'clientops')], total: 1 })
+      await refresh
+    })
+    expect(result.current.sessions.map(session => session.id)).toEqual(['new'])
+
+    await act(async () => {
+      resolveOld({ errors: [], sessions: [row('stale', 'agentops')], total: 1 })
+      await oldResponse
+    })
+    expect(result.current.sessions.map(session => session.id)).toEqual(['new'])
+    expect(listAllProfileSessions).toHaveBeenLastCalledWith(500, 0, 'include', 'recent', 'all')
+  })
+
+  it('routes a selected row through its exact profile socket', () => {
+    expect(commandCenterSessionOwnerRoute(row('local-worker', 'clientops'))).toEqual({
+      connectionId: 'local',
+      profile: 'clientops'
+    })
+    expect(commandCenterSessionOwnerRoute(row('remote-worker', 'agentops', { connection_id: 'remote-a' }))).toEqual({
+      connectionId: 'remote-a',
+      profile: 'agentops'
+    })
+  })
+
+  it('forces an exact-owner main resume instead of focusing a same-id tile from another owner', () => {
+    const navigate = vi.fn()
+    const session = row('shared', 'agentops', { connection_id: 'remote-a' })
+
+    openCommandCenterSession(session, navigate)
+
+    const owner = { connectionId: 'remote-a', profile: 'agentops' }
+
+    expect(setSessionOwnerHint).toHaveBeenCalledWith('shared', owner)
+    expect(openSession).toHaveBeenCalledWith('shared', navigate, 'main')
+    expect(requestSessionResume).toHaveBeenCalledWith('shared', owner)
+  })
+})

--- a/apps/desktop/src/app/command-center/sessions.ts
+++ b/apps/desktop/src/app/command-center/sessions.ts
@@ -1,0 +1,131 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { getApiRequestConnection } from '@/api/client'
+import { listAllProfileSessions, type SessionInfo } from '@/hermes'
+import { requestSessionResume, setSessionOwnerHint, $sessions as sidebarSessions } from '@/store/session'
+import type { SessionOwnerRoute } from '@/store/session-request-router'
+
+import { openSession, type OpenSessionNavigate } from '../open-session'
+
+const profileKey = (session: Pick<SessionInfo, 'profile'>): string => session.profile?.trim() || 'default'
+const connectionKey = (session: Pick<SessionInfo, 'connection_id'>): string => session.connection_id?.trim() || 'local'
+
+const ownerKey = (owner: { connection_id?: string; profile?: string }): string =>
+  JSON.stringify([owner.connection_id?.trim() || 'local', owner.profile?.trim() || 'default'])
+
+const durableId = (session: Pick<SessionInfo, '_lineage_root_id' | 'connection_id' | 'id' | 'profile'>): string =>
+  JSON.stringify([connectionKey(session), profileKey(session), session._lineage_root_id || session.id])
+
+const recency = (session: SessionInfo): number => Math.max(session.last_active || 0, session.started_at || 0)
+
+export function commandCenterSessionOwnerRoute(session: SessionInfo): SessionOwnerRoute {
+  return {
+    connectionId: connectionKey(session),
+    profile: profileKey(session)
+  }
+}
+
+/**
+ * Open an aggregate row through the owner captured on that exact row.
+ *
+ * Force the main surface rather than focusing a same-id tile: stored ids can be
+ * duplicated by copied profile stores, while tile identity is historically
+ * id-only. The explicit resume event carries the owner route even when the URL
+ * is already `/session/:id`, so a same-id selection cannot reuse another
+ * profile's runtime or rely on an ambient socket.
+ */
+export function openCommandCenterSession(session: SessionInfo, navigate: OpenSessionNavigate): void {
+  const owner = commandCenterSessionOwnerRoute(session)
+
+  setSessionOwnerHint(session.id, owner)
+  openSession(session.id, navigate, 'main')
+  requestSessionResume(session.id, owner)
+}
+
+/**
+ * Deterministic command-center view over cross-profile session rows.
+ *
+ * A stored id is only durable inside its owning connection + profile. Copied
+ * profile databases and separate registered gateways may legitimately carry the
+ * same id; those rows remain distinct. Duplicate observations of the same exact
+ * owner/lineage collapse to the freshest row.
+ */
+export function mergeCommandCenterSessions(
+  previous: SessionInfo[],
+  incoming: SessionInfo[],
+  errors: Array<{ connection_id?: string; error?: string; profile?: string }> = []
+): SessionInfo[] {
+  const failedConnections = new Set(
+    errors.filter(error => error.profile?.trim() === 'all').map(error => error.connection_id?.trim() || 'local')
+  )
+
+  const failedOwners = new Set(errors.filter(error => error.profile?.trim() !== 'all').map(ownerKey))
+  const byIdentity = new Map<string, SessionInfo>()
+
+  const retained = previous.filter(
+    row => failedConnections.has(connectionKey(row)) || failedOwners.has(ownerKey(row))
+  )
+
+  for (const session of [...retained, ...incoming]) {
+    const key = durableId(session)
+    const current = byIdentity.get(key)
+
+    if (!current || recency(session) >= recency(current)) {
+      byIdentity.set(key, session)
+    }
+  }
+
+  return [...byIdentity.entries()]
+    .sort(([leftKey, left], [rightKey, right]) => recency(right) - recency(left) || leftKey.localeCompare(rightKey))
+    .map(([, session]) => session)
+}
+
+export function useCommandCenterSessions(enabled: boolean) {
+  // Paint the already-known foreground/default rows immediately. The aggregate
+  // replaces this seed when it lands; a missing/older backend leaves the
+  // existing Desktop history usable instead of flashing an empty pane.
+  const [sessions, setSessions] = useState<SessionInfo[]>(() => sidebarSessions.get())
+  const [errors, setErrors] = useState<Array<{ error: string; profile: string }>>([])
+  const [loading, setLoading] = useState(false)
+  const requestRef = useRef(0)
+
+  const refresh = useCallback(async () => {
+    const requestId = requestRef.current + 1
+    requestRef.current = requestId
+    setLoading(true)
+
+    try {
+      const result = await listAllProfileSessions(500, 0, 'include', 'recent', 'all')
+
+      if (requestRef.current !== requestId) {
+        return
+      }
+
+      const requestConnection = getApiRequestConnection() ?? 'local'
+
+      const nextErrors = (result.errors ?? []).map(error => ({
+        ...error,
+        connection_id: error.connection_id || requestConnection
+      }))
+
+      setSessions(previous => mergeCommandCenterSessions(previous, result.sessions ?? [], nextErrors))
+      setErrors(nextErrors)
+    } catch (error) {
+      if (requestRef.current === requestId) {
+        setErrors([{ error: error instanceof Error ? error.message : String(error), profile: 'all' }])
+      }
+    } finally {
+      if (requestRef.current === requestId) {
+        setLoading(false)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    if (enabled) {
+      void refresh()
+    }
+  }, [enabled, refresh])
+
+  return { errors, loading, refresh, sessions }
+}

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -89,6 +89,7 @@ import { useSkinCommand } from '@/themes/use-skin-command'
 import { closeWorkspaceTab } from '../chat/close-tab'
 import { requestComposerInsert } from '../chat/composer/focus'
 import { useComposerActions } from '../chat/hooks/use-composer-actions'
+import { openCommandCenterSession } from '../command-center/sessions'
 import { CommandPalette } from '../command-palette'
 import { triggerAndRefreshCronJobs } from '../cron/cron-actions'
 import { useGatewayBoot } from '../gateway/hooks/use-gateway-boot'
@@ -1218,9 +1219,9 @@ export function ContribWiring({ children }: { children: ReactNode }) {
           <CommandCenterView
             initialSection={commandCenterInitialSection}
             onClose={closeOverlayToPreviousRoute}
-            onDeleteSession={removeSession}
+            onDeleteSession={session => removeSession(session.id, session)}
             onNavigateRoute={path => navigateToWorkspacePage(navigate, path)}
-            onOpenSession={sessionId => openSession(sessionId, navigate)}
+            onOpenSession={session => openCommandCenterSession(session, navigate)}
           />
         </Suspense>
       )}

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -360,6 +360,36 @@ describe('connection-qualified session deletion', () => {
     expect(requestGateway).not.toHaveBeenCalledWith('session.close', expect.anything())
   })
 
+  it('prefers the explicitly selected aggregate row over an ambiguous same-id listed row', async () => {
+    let actions: HarnessHandle | null = null
+
+    setSessions([storedSession({ connection_id: 'source-a', id: 'shared-session', profile: 'worker' })])
+    vi.mocked(deleteSession).mockResolvedValue({ ok: true })
+
+    render(
+      <Harness
+        activeSessionId={null}
+        onReady={value => {
+          actions = value
+        }}
+        requestGateway={vi.fn().mockResolvedValue({})}
+        selectedStoredSessionId={null}
+      />
+    )
+    await waitFor(() => expect(actions).not.toBeNull())
+
+    const selected = storedSession({ connection_id: 'source-b', id: 'shared-session', profile: 'worker' })
+
+    await act(async () => {
+      await actions?.removeSession('shared-session', selected)
+    })
+
+    expect(deleteSession).toHaveBeenCalledWith('shared-session', {
+      connectionId: 'source-b',
+      profile: 'worker'
+    })
+  })
+
   it('tears down the selected session from synchronous refs when render state is stale', async () => {
     const navigate = vi.fn()
     const requestGateway = vi.fn().mockResolvedValue({})

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -11,6 +11,7 @@ import {
   fetchStoredTranscriptAcrossBackends,
   getAllSessionMessages,
   getLatestSessionMessages,
+  type SessionInfo,
   setSessionArchived
 } from '@/hermes'
 import { useI18n } from '@/i18n'
@@ -2375,7 +2376,7 @@ export function useSessionActions({
   )
 
   const removeSession = useCallback(
-    async (storedSessionId: string) => {
+    async (storedSessionId: string, selectedSession?: SessionInfo) => {
       clearNotifications()
 
       // The row may live in the main list, the messaging/cron sidebar slices,
@@ -2386,7 +2387,9 @@ export function useSessionActions({
       const listed = findListedSession(storedSessionId)
 
       const removed =
-        listed?.session ?? $archivedSessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
+        selectedSession ??
+        listed?.session ??
+        $archivedSessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
 
       // Messaging/cron rows frequently arrive without an inline profile; fall
       // back to the stored-session ownership lookup so their DELETE routes to

--- a/apps/desktop/src/lib/session-export.test.ts
+++ b/apps/desktop/src/lib/session-export.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+
+import { sessionExportScope } from './session-export'
+
+describe('session export routing', () => {
+  it('keeps the selected aggregate row on its exact connection and profile', () => {
+    expect(sessionExportScope({ connection_id: 'remote-a', profile: 'agentops' })).toEqual({
+      connectionId: 'remote-a',
+      profile: 'agentops'
+    })
+    expect(sessionExportScope({ profile: 'clientops' })).toBe('clientops')
+  })
+})

--- a/apps/desktop/src/lib/session-export.ts
+++ b/apps/desktop/src/lib/session-export.ts
@@ -10,6 +10,18 @@ interface ExportSessionParams {
   session?: SessionInfo
 }
 
+export function sessionExportScope(
+  session?: Pick<SessionInfo, 'connection_id' | 'profile'>,
+  profile?: string | null
+): string | { connectionId: string; profile: string } | undefined {
+  const ownerProfile = profile ?? session?.profile
+  const connectionId = session?.connection_id?.trim()
+
+  return connectionId
+    ? { connectionId, profile: ownerProfile?.trim() || 'default' }
+    : ownerProfile?.trim() || undefined
+}
+
 function sanitizeFilenamePart(value: string) {
   return value
     .trim()
@@ -32,8 +44,8 @@ export async function exportSession(sessionId: string, params: Omit<ExportSessio
   }
 
   try {
-    const profile = params.profile ?? params.session?.profile
-    const { messages } = await getAllSessionMessages(sessionId, profile)
+    const scope = sessionExportScope(params.session, params.profile)
+    const { messages } = await getAllSessionMessages(sessionId, scope)
 
     const payload = {
       exported_at: new Date().toISOString(),

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -468,7 +468,7 @@ export interface PaginatedSessions {
   profile_totals?: Record<string, number>
   /** Per-profile read failures from the cross-profile aggregator (e.g. a locked
    *  or corrupt state.db). Present only on `/api/profiles/sessions`. */
-  errors?: Array<{ profile: string; error: string }>
+  errors?: Array<{ profile: string; error: string; connection_id?: string }>
 }
 
 export interface RpcEvent<T = unknown> {
@@ -562,6 +562,14 @@ export interface SessionInfo {
    *  rows served by the primary/local backend. Opens must route through the
    *  connection-scoped gateway (`ensureGatewayAgent`) when present. */
   connection_id?: string
+  /** Canonical Kanban identity/lifecycle joined read-only from the board run
+   * that owns a `source: "kanban"` worker session. Absent for ordinary sessions
+   * and older backends. */
+  kanban_board?: string
+  kanban_run_status?: string
+  kanban_task_id?: string
+  kanban_task_status?: string
+  kanban_task_title?: string
 }
 
 export type TimelineDisplayMetadata =

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1257,6 +1257,7 @@ class Run:
     claim_lock: Optional[str]
     claim_expires: Optional[int]
     worker_pid: Optional[int]
+    session_id: Optional[str]
     max_runtime_seconds: Optional[int]
     last_heartbeat_at: Optional[int]
     started_at: int
@@ -1281,6 +1282,7 @@ class Run:
             claim_lock=row["claim_lock"],
             claim_expires=row["claim_expires"],
             worker_pid=row["worker_pid"],
+            session_id=(row["session_id"] if "session_id" in row.keys() else None),
             max_runtime_seconds=row["max_runtime_seconds"],
             last_heartbeat_at=row["last_heartbeat_at"],
             started_at=int(row["started_at"]),
@@ -1465,6 +1467,7 @@ CREATE TABLE IF NOT EXISTS task_runs (
     claim_lock          TEXT,
     claim_expires       INTEGER,
     worker_pid          INTEGER,
+    session_id          TEXT,
     max_runtime_seconds INTEGER,
     last_heartbeat_at   INTEGER,
     started_at          INTEGER NOT NULL,
@@ -2704,6 +2707,22 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id)"
     )
+
+    run_table_exists = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='task_runs'"
+    ).fetchone() is not None
+    if run_table_exists:
+        run_cols = {
+            row["name"] for row in conn.execute("PRAGMA table_info(task_runs)")
+        }
+        if "session_id" not in run_cols:
+            _add_column_if_missing(
+                conn, "task_runs", "session_id", "session_id TEXT"
+            )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_task_runs_session_id "
+            "ON task_runs(session_id)"
+        )
 
     # task_events gained a run_id column; back-fill it as NULL for
     # historical events (they predate runs and can't be attributed).
@@ -12042,6 +12061,38 @@ def known_assignees(conn: sqlite3.Connection) -> list[dict]:
 # ---------------------------------------------------------------------------
 # Runs (attempt history on a task)
 # ---------------------------------------------------------------------------
+
+
+def bind_worker_session(
+    conn: sqlite3.Connection,
+    task_id: str,
+    run_id: int,
+    session_id: str,
+) -> bool:
+    """Bind one canonical worker session to the exact active attempt."""
+    clean_session_id = str(session_id or "").strip()
+    if not clean_session_id or len(clean_session_id) > 255:
+        return False
+    with write_txn(conn):
+        cur = conn.execute(
+            """
+            UPDATE task_runs
+               SET session_id = ?
+             WHERE id = ?
+               AND task_id = ?
+               AND status = 'running'
+               AND (session_id IS NULL OR session_id = ?)
+               AND EXISTS (
+                    SELECT 1 FROM tasks
+                     WHERE tasks.id = task_runs.task_id
+                       AND tasks.status = 'running'
+                       AND tasks.current_run_id = task_runs.id
+               )
+            """,
+            (clean_session_id, int(run_id), task_id, clean_session_id),
+        )
+        return cur.rowcount == 1
+
 
 def list_runs(
     conn: sqlite3.Connection,

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -18,6 +18,7 @@ import inspect
 import json
 import logging
 import re
+import sqlite3
 import subprocess  # noqa: F401
 import sys  # noqa: F401
 import threading
@@ -52,6 +53,131 @@ _log = logging.getLogger("hermes_cli.web_server")
 # (profile, message) per process so a persistent failure is loud in
 # errors.log without turning every sidebar poll into log spam.
 _profile_read_warned: set = set()
+
+
+def _kanban_board_db_paths() -> List[Tuple[str, Path]]:
+    """Return every canonical board DB without opening or creating one."""
+    try:
+        from hermes_cli import kanban_db
+
+        boards = kanban_db.list_boards(include_archived=True)
+    except Exception:
+        _log.exception("profile session aggregation: kanban board discovery failed")
+        return []
+
+    paths: List[Tuple[str, Path]] = []
+    seen: set = set()
+    for board in boards:
+        slug = str(board.get("slug") or "default")
+        raw_path = board.get("db_path")
+        if not raw_path:
+            continue
+        path = Path(raw_path).expanduser()
+        key = str(path.resolve())
+        if key in seen:
+            continue
+        seen.add(key)
+        paths.append((slug, path))
+    return paths
+
+
+def _enrich_kanban_session_rows(
+    sessions: List[Dict[str, Any]],
+    board_paths: Optional[List[Tuple[str, Path]]] = None,
+) -> None:
+    """Attach canonical task/run identity and lifecycle to Kanban rows.
+
+    SessionDB owns the transcript, while the Kanban run owns whether a worker is
+    still running and when it ended. Read board databases in strict read-only
+    mode; a missing/old/corrupt board is non-fatal and leaves the session row's
+    existing heuristic untouched.
+    """
+    worker_keys = {
+        ((str(session.get("profile") or "").strip() or "default"), str(session.get("id") or ""))
+        for session in sessions
+        if session.get("source") == "kanban" and session.get("id")
+    }
+    if not worker_keys:
+        return
+
+    by_key: Dict[Tuple[str, str], Dict[str, Any]] = {}
+    paths = _kanban_board_db_paths() if board_paths is None else board_paths
+    for board, path in paths:
+        if not path.is_file():
+            continue
+        conn = None
+        try:
+            conn = sqlite3.connect(f"{path.resolve().as_uri()}?mode=ro", uri=True, timeout=1.0)
+            conn.row_factory = sqlite3.Row
+            run_columns = {
+                str(column["name"])
+                for column in conn.execute("PRAGMA table_info(task_runs)").fetchall()
+            }
+            metadata_session = (
+                "CASE WHEN json_valid(r.metadata) "
+                "THEN json_extract(r.metadata, '$.worker_session_id') END"
+            )
+            worker_session = (
+                f"COALESCE(NULLIF(r.session_id, ''), {metadata_session})"
+                if "session_id" in run_columns
+                else metadata_session
+            )
+            session_ids = sorted({session_id for _, session_id in worker_keys})
+            placeholders = ",".join("?" for _ in session_ids)
+            rows = conn.execute(
+                f"""SELECT r.id AS run_id, {worker_session} AS worker_session_id,
+                           r.task_id, r.profile,
+                           r.status AS run_status, r.started_at, r.ended_at,
+                           t.title AS task_title, t.status AS task_status
+                    FROM task_runs AS r
+                    JOIN tasks AS t ON t.id = r.task_id
+                    WHERE {worker_session} IN ({placeholders})
+                    ORDER BY r.started_at DESC, r.id DESC""",
+                session_ids,
+            ).fetchall()
+        except Exception as exc:
+            _warn_profile_read_error(f"kanban:{board}", exc)
+            continue
+        finally:
+            if conn is not None:
+                conn.close()
+
+        for row in rows:
+            key = (
+                (str(row["profile"] or "").strip() or "default"),
+                str(row["worker_session_id"] or ""),
+            )
+            if key not in worker_keys:
+                continue
+            candidate = {**dict(row), "board": board}
+            existing = by_key.get(key)
+            candidate_rank = (candidate["started_at"] or 0, candidate["run_id"] or 0, candidate["board"])
+            existing_rank = (
+                (existing["started_at"] or 0, existing["run_id"] or 0, existing["board"])
+                if existing is not None
+                else None
+            )
+            if existing_rank is None or candidate_rank > existing_rank:
+                by_key[key] = candidate
+
+    for session in sessions:
+        key = ((str(session.get("profile") or "").strip() or "default"), str(session.get("id") or ""))
+        run = by_key.get(key)
+        if session.get("source") != "kanban" or run is None:
+            continue
+        running = run["run_status"] == "running"
+        session.update(
+            {
+                "is_active": running,
+                "kanban_board": run["board"],
+                "kanban_run_status": run["run_status"],
+                "kanban_task_id": run["task_id"],
+                "kanban_task_status": run["task_status"],
+                "kanban_task_title": run["task_title"],
+            }
+        )
+        if not running and run["ended_at"] is not None:
+            session["ended_at"] = run["ended_at"]
 
 
 def _warn_profile_read_error(profile: str, exc: Exception) -> None:
@@ -366,6 +492,10 @@ def get_profiles_sessions(
     if len(merged) > offset + limit:
         seen = {id(s) for s in window}
         window.extend(s for s in merged[offset + limit:] if s.get("pinned") and id(s) not in seen)
+    # SessionDB owns transcript/activity, but the board run owns Kanban worker
+    # lifecycle and task identity. Enrich only the bounded response window so a
+    # broad aggregate does not turn into an unbounded board query.
+    _enrich_kanban_session_rows(window)
     if not full:
         _strip_session_list_rows(window)
     return {

--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -190,6 +190,13 @@ def get_sessions(
                 # SQLite stores the flag as 0/1; expose a real JSON boolean.
                 s["archived"] = bool(s.get("archived"))
                 s["pinned"] = bool(s.get("pinned"))
+            # SSH/legacy remote Desktop sources list the serving profile through
+            # this flat endpoint rather than /api/profiles/sessions. Apply the
+            # same read-only Kanban task/run join so worker identity and terminal
+            # truth do not depend on which transport served the row.
+            from hermes_cli.web_routers.profiles import _enrich_kanban_session_rows
+
+            _enrich_kanban_session_rows(sessions)
             if not full:
                 _strip_session_list_rows(sessions)
             return {"sessions": sessions, "total": total, "limit": limit, "offset": offset}

--- a/tests/hermes_cli/test_kanban_worker_session_binding.py
+++ b/tests/hermes_cli/test_kanban_worker_session_binding.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    return home
+
+
+def _running_task(conn, *, assignee: str = "dev") -> tuple[str, int]:
+    task_id = kb.create_task(conn, title="bind worker session", assignee=assignee)
+    now = int(time.time())
+    conn.execute(
+        "UPDATE tasks SET status='running', claim_lock='host:claim', "
+        "claim_expires=?, worker_pid=1234, started_at=? WHERE id=?",
+        (now + 300, now, task_id),
+    )
+    conn.execute(
+        "INSERT INTO task_runs (task_id, profile, status, claim_lock, "
+        "claim_expires, worker_pid, started_at) "
+        "VALUES (?, ?, 'running', 'host:claim', ?, 1234, ?)",
+        (task_id, assignee, now + 300, now),
+    )
+    run_id = int(conn.execute("SELECT last_insert_rowid()").fetchone()[0])
+    conn.execute("UPDATE tasks SET current_run_id=? WHERE id=?", (run_id, task_id))
+    conn.commit()
+    return task_id, run_id
+
+
+def test_task_runs_session_id_schema_and_row_parser(kanban_home):
+    conn = kb.connect()
+    try:
+        columns = {row["name"] for row in conn.execute("PRAGMA table_info(task_runs)")}
+        assert "session_id" in columns
+        task_id, run_id = _running_task(conn)
+        assert kb.bind_worker_session(conn, task_id, run_id, "session-a") is True
+        run = kb.list_runs(conn, task_id)[0]
+        assert run.session_id == "session-a"
+    finally:
+        conn.close()
+
+
+def test_bind_worker_session_rejects_stale_or_ended_attempt(kanban_home):
+    conn = kb.connect()
+    try:
+        task_id, run_id = _running_task(conn)
+        assert kb.bind_worker_session(conn, task_id, run_id, "session-a") is True
+        assert kb.bind_worker_session(conn, task_id, run_id + 1, "session-stale") is False
+        row = conn.execute("SELECT session_id FROM task_runs WHERE id=?", (run_id,)).fetchone()
+        assert row["session_id"] == "session-a"
+
+        conn.execute("UPDATE task_runs SET status='done' WHERE id=?", (run_id,))
+        conn.execute("UPDATE tasks SET status='done', current_run_id=NULL WHERE id=?", (task_id,))
+        conn.commit()
+        assert kb.bind_worker_session(conn, task_id, run_id, "session-late") is False
+        row = conn.execute("SELECT session_id FROM task_runs WHERE id=?", (run_id,)).fetchone()
+        assert row["session_id"] == "session-a"
+    finally:
+        conn.close()

--- a/tests/hermes_cli/test_profile_worker_sessions.py
+++ b/tests/hermes_cli/test_profile_worker_sessions.py
@@ -1,0 +1,169 @@
+import json
+import sqlite3
+
+from hermes_cli import kanban_db
+from hermes_cli.web_routers import profiles
+
+
+def _board(path, rows):
+    conn = sqlite3.connect(path)
+    conn.executescript(kanban_db.SCHEMA_SQL)
+    for row in rows:
+        conn.execute(
+            """INSERT INTO tasks (id, title, status, created_at)
+               VALUES (?, ?, ?, ?)""",
+            (row["task_id"], row["task_title"], row["task_status"], row["started_at"]),
+        )
+        conn.execute(
+            """INSERT INTO task_runs
+               (task_id, profile, status, started_at, ended_at, metadata)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (
+                row["task_id"],
+                row["profile"],
+                row["run_status"],
+                row["started_at"],
+                row.get("ended_at"),
+                json.dumps({"worker_session_id": row["session_id"]}),
+            ),
+        )
+    conn.commit()
+    conn.close()
+
+
+def test_enrich_kanban_sessions_uses_task_run_lifecycle_truth(tmp_path):
+    board = tmp_path / "board.db"
+    _board(
+        board,
+        [
+            {
+                "task_id": "t_live",
+                "task_title": "Live task",
+                "task_status": "running",
+                "profile": "clientops",
+                "run_status": "running",
+                "session_id": "live-session",
+                "started_at": 100,
+            },
+            {
+                "task_id": "t_done",
+                "task_title": "Done task",
+                "task_status": "done",
+                "profile": "agentops",
+                "run_status": "done",
+                "session_id": "done-session",
+                "started_at": 90,
+                "ended_at": 120,
+            },
+        ],
+    )
+    sessions = [
+        {
+            "id": "live-session",
+            "source": "kanban",
+            "profile": "clientops",
+            "ended_at": None,
+            "is_active": False,
+        },
+        {
+            "id": "done-session",
+            "source": "kanban",
+            "profile": "agentops",
+            "ended_at": None,
+            "is_active": True,
+        },
+        {
+            "id": "ordinary",
+            "source": "desktop",
+            "profile": "default",
+            "ended_at": None,
+            "is_active": True,
+        },
+    ]
+
+    profiles._enrich_kanban_session_rows(sessions, [("control-room", board)])
+
+    assert sessions[0] == {
+        "id": "live-session",
+        "source": "kanban",
+        "profile": "clientops",
+        "ended_at": None,
+        "is_active": True,
+        "kanban_board": "control-room",
+        "kanban_run_status": "running",
+        "kanban_task_id": "t_live",
+        "kanban_task_status": "running",
+        "kanban_task_title": "Live task",
+    }
+    assert sessions[1] == {
+        "id": "done-session",
+        "source": "kanban",
+        "profile": "agentops",
+        "ended_at": 120,
+        "is_active": False,
+        "kanban_board": "control-room",
+        "kanban_run_status": "done",
+        "kanban_task_id": "t_done",
+        "kanban_task_status": "done",
+        "kanban_task_title": "Done task",
+    }
+    assert sessions[2]["is_active"] is True
+    assert "kanban_task_id" not in sessions[2]
+
+
+def test_enrich_kanban_sessions_dedupes_by_profile_and_session_using_newest_run(tmp_path):
+    older = tmp_path / "older.db"
+    newer = tmp_path / "newer.db"
+    common = {
+        "profile": "clientops",
+        "run_status": "done",
+        "session_id": "same-session",
+        "task_status": "done",
+    }
+    _board(
+        older,
+        [
+            {
+                **common,
+                "task_id": "t_old",
+                "task_title": "Old duplicate",
+                "started_at": 100,
+                "ended_at": 110,
+            }
+        ],
+    )
+    _board(
+        newer,
+        [
+            {
+                **common,
+                "task_id": "t_new",
+                "task_title": "Newest duplicate",
+                "started_at": 200,
+                "ended_at": 220,
+            }
+        ],
+    )
+    sessions = [
+        {"id": "same-session", "source": "kanban", "profile": "clientops", "ended_at": None, "is_active": True},
+        {"id": "same-session", "source": "kanban", "profile": "agentops", "ended_at": None, "is_active": True},
+    ]
+
+    profiles._enrich_kanban_session_rows(sessions, [("older", older), ("newer", newer)])
+
+    assert sessions[0]["kanban_task_id"] == "t_new"
+    assert sessions[0]["kanban_board"] == "newer"
+    assert sessions[0]["ended_at"] == 220
+    assert "kanban_task_id" not in sessions[1]
+
+
+def test_enrich_kanban_sessions_ignores_missing_profile_board_db(tmp_path):
+    sessions = [
+        {"id": "worker", "source": "kanban", "profile": "clientops", "ended_at": None, "is_active": True}
+    ]
+
+    profiles._enrich_kanban_session_rows(sessions, [("missing", tmp_path / "missing.db")])
+
+    assert sessions == [
+        {"id": "worker", "source": "kanban", "profile": "clientops", "ended_at": None, "is_active": True}
+    ]

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -80,6 +80,31 @@ def test_show_defaults_to_env_task_id(worker_env):
     assert "runs" in d
 
 
+def test_show_binds_exact_worker_session_to_current_run(worker_env, monkeypatch):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, worker_env)
+        assert task is not None and task.current_run_id is not None
+        run_id = int(task.current_run_id)
+    finally:
+        conn.close()
+
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+    monkeypatch.setenv("HERMES_SESSION_ID", "worker-session-a")
+    result = json.loads(kt._handle_show({}))
+    assert result["session_binding"] is True
+
+    conn = kb.connect()
+    try:
+        run = kb.list_runs(conn, worker_env)[0]
+        assert run.session_id == "worker-session-a"
+    finally:
+        conn.close()
+
+
 def test_list_filters_tasks(monkeypatch, worker_env):
     """kanban_list gives orchestrators filtered board discovery."""
     monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -535,6 +535,28 @@ def _handle_show(args: dict, **kw) -> str:
             task = kb.get_task(conn, tid)
             if task is None:
                 return tool_error(f"task {tid} not found")
+
+            session_binding = None
+            owned_task_id = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
+            if owned_task_id and tid == owned_task_id:
+                run_raw = (os.environ.get("HERMES_KANBAN_RUN_ID") or "").strip()
+                session_id = (os.environ.get("HERMES_SESSION_ID") or "").strip()
+                if run_raw and session_id:
+                    try:
+                        session_binding = kb.bind_worker_session(
+                            conn, tid, int(run_raw), session_id
+                        )
+                    except (TypeError, ValueError):
+                        session_binding = False
+                    except Exception:
+                        logger.debug(
+                            "kanban_show worker-session bind failed",
+                            exc_info=True,
+                        )
+                        session_binding = False
+                else:
+                    session_binding = False
+
             comments = kb.list_comments(conn, tid)
             events = kb.list_events(conn, tid)
             runs = kb.list_runs(conn, tid)
@@ -561,12 +583,14 @@ def _handle_show(args: dict, **kw) -> str:
                 return {
                     "id": r.id, "profile": r.profile,
                     "status": r.status, "outcome": r.outcome,
+                    "session_id": r.session_id,
                     "summary": r.summary, "error": r.error,
                     "metadata": r.metadata,
                     "started_at": r.started_at, "ended_at": r.ended_at,
                 }
 
             return json.dumps({
+                "session_binding": session_binding,
                 "task": _task_dict(task),
                 "parents": parents,
                 "children": children,


### PR DESCRIPTION
## Summary
- aggregate Desktop Sessions across profiles and registered gateways while preserving foreground rows
- enrich Kanban worker rows with canonical task/run lifecycle data and bind active workers to exact run/session identity
- deduplicate and route open/delete/export by connection + profile + session identity, with profile filtering and owner-scoped stale-result retention
- preserve prior rows for transient per-profile or per-connection failures and make registry fetch ordering deterministic

## Verification
- `npm run check` (full Desktop lint, typecheck, UI tests, platform tests, desktop tests, build/package)
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_worker_session_binding.py tests/tools/test_kanban_tools.py tests/hermes_cli/test_profile_worker_sessions.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_web_server.py -q` (255 passed, 1 Windows-only skipped on macOS)
- read-only canonical-store check resolved `clientops/20260902_164119_254ae5` to `t_5faae42d` and `agentops/20260902_164323_4b026f` to `t_3b5c5c01`
- final independent review: passed, no blocking correctness or security findings

## Safety
- no session activation, transcript copy, profile-state rewrite, deployment, or task/workstream mutation was used for inspection
- no credentials or secrets included

## Rollback
Revert commit `389b7333027afbb2968c3b51035e5b6e39f0d082`. Preserve installed source and signed app until an independently approved release.
