### PR TITLE
fix(install): repair managed Git PATH entries on Windows

### DIFF
--- a/.github/workflows/installer-tests.yml
+++ b/.github/workflows/installer-tests.yml
@@ -44,3 +44,11 @@ jobs:
       - name: System Node and npm compatibility (Windows PowerShell 5.1)
         shell: powershell
         run: powershell -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-node-compatibility.ps1
+
+      - name: Git PATH repair and checkout preservation (pwsh 7)
+        shell: pwsh
+        run: pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-git-path.ps1
+
+      - name: Git PATH repair and checkout preservation (Windows PowerShell 5.1)
+        shell: powershell
+        run: powershell -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-git-path.ps1

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1422,16 +1422,60 @@ function New-GitBashAslrFailureReason {
     ) -join [Environment]::NewLine
 }
 
+function Get-ManagedGitUserPath {
+    param([AllowEmptyString()][string]$UserPath, [string]$GitDir)
+
+    $entries = @("$GitDir\cmd", "$GitDir\bin", "$GitDir\usr\bin")
+    $legacySuffix = $entries -join ""
+    # Keep this an array even for an empty or single-entry User PATH.
+    # Previously += concatenated strings instead of appending PATH entries.
+    $items = @(
+        if ($UserPath) {
+            foreach ($item in ($UserPath -split ";")) {
+                $prefix = $item
+                $repaired = $false
+                # Repair only the exact concatenation emitted by the old
+                # installer, including repeated retries. Do not split arbitrary
+                # drive letters or rewrite unrelated entries.
+                while ($prefix.EndsWith($legacySuffix, [StringComparison]::OrdinalIgnoreCase)) {
+                    $prefix = $prefix.Substring(0, $prefix.Length - $legacySuffix.Length)
+                    $repaired = $true
+                }
+                if (-not $repaired -or $prefix) { $prefix }
+            }
+        }
+    )
+    foreach ($entry in $entries) {
+        if ($items -notcontains $entry) { $items += $entry }
+    }
+    return ($items -join ";")
+}
+
+function Set-ManagedGitPath {
+    param([string]$GitDir)
+
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    $updated = Get-ManagedGitUserPath -UserPath $userPath -GitDir $GitDir
+    if ($updated -cne $userPath) {
+        [Environment]::SetEnvironmentVariable("Path", $updated, "User")
+    }
+    # Persisted PATH is for later stage processes; this stage needs Git too.
+    if (($env:Path -split ";") -notcontains "$GitDir\cmd") {
+        $env:Path = "$GitDir\cmd;$env:Path"
+    }
+}
+
 function Install-Git {
     <#
     .SYNOPSIS
     Ensure Git (and Git Bash) are installed.  Git for Windows bundles bash.exe
     which Hermes uses to run shell commands.
 
-    Priority order (deliberately simple -- no winget, no registry, no system
+    Discovery order (no winget, registry-based Git discovery, or system
     package manager):
-      1. Existing ``git`` on PATH -- use it as-is (the common fast path).
-      2. Download **PortableGit** from the official git-for-windows GitHub
+      1. Repair PATH visibility for an existing Hermes-managed Git.
+      2. Use ``git`` on the resulting PATH (the common fast path).
+      3. Download **PortableGit** from the official git-for-windows GitHub
          release (self-extracting 7z.exe) and unpack it to
          ``%LOCALAPPDATA%\hermes\git`` -- never touches system Git, never
          requires admin, works even on locked-down machines and machines
@@ -1456,6 +1500,11 @@ function Install-Git {
     #>
     $script:GitInstallFailureReason = $null
     Write-Info "Checking Git..."
+
+    $managedGitDir = Join-Path $HermesHome "git"
+    if (Test-Path -LiteralPath (Join-Path $managedGitDir "cmd\git.exe") -PathType Leaf) {
+        Set-ManagedGitPath -GitDir $managedGitDir
+    }
 
     if (Get-Command git -ErrorAction SilentlyContinue) {
         $version = git --version
@@ -1562,29 +1611,10 @@ function Install-Git {
             throw "Git extraction did not produce git.exe at $gitExe"
         }
 
-        # Add to session PATH so the rest of this install run can use git.
-        $env:Path = "$gitDir\cmd;$env:Path"
-
         # Persist to User PATH so fresh shells see it.  PortableGit needs
         # cmd\ (for git.exe), bin\ (for bash.exe + core tools), and
         # usr\bin\ (for perl, ssh, curl, and other POSIX coreutils).
-        $newPathEntries = @(
-            "$gitDir\cmd",
-            "$gitDir\bin",
-            "$gitDir\usr\bin"
-        )
-        $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
-        $userPathItems = if ($userPath) { $userPath -split ";" } else { @() }
-        $changed = $false
-        foreach ($entry in $newPathEntries) {
-            if ($userPathItems -notcontains $entry) {
-                $userPathItems += $entry
-                $changed = $true
-            }
-        }
-        if ($changed) {
-            [Environment]::SetEnvironmentVariable("Path", ($userPathItems -join ";"), "User")
-        }
+        Set-ManagedGitPath -GitDir $gitDir
 
         $version = & $gitExe --version
         Write-Success "Git $version installed to $gitDir (portable, user-scoped)"
@@ -2133,6 +2163,23 @@ function Install-SystemPackages {
 
 function Install-Repository {
     Write-Info "Installing to $InstallDir..."
+
+    # A missing/unlaunchable Git is not evidence of a broken checkout. Resolve
+    # the managed install again in this fresh stage before any probe or move.
+    $managedGitDir = Join-Path $HermesHome "git"
+    if (Test-Path -LiteralPath (Join-Path $managedGitDir "cmd\git.exe") -PathType Leaf) {
+        Set-ManagedGitPath -GitDir $managedGitDir
+    }
+    if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+        throw "Git is not available on PATH. Rerun the Git installation stage. The existing checkout has not been moved."
+    }
+    try {
+        $global:LASTEXITCODE = 0
+        $null = & git --version
+        if ($LASTEXITCODE -ne 0) { throw "git --version exited $LASTEXITCODE" }
+    } catch {
+        throw "Git could not run: $_. The existing checkout has not been moved."
+    }
 
     $didUpdate = $false
 

--- a/scripts/tests/test-install-ps1-git-path.ps1
+++ b/scripts/tests/test-install-ps1-git-path.ps1
@@ -1,0 +1,141 @@
+# Behavioral regressions for managed Git PATH repair and checkout preservation.
+# Dot-source the real installer without running its entry point. No downloads,
+# registry writes, or existing Hermes files are touched by these tests.
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$testRoot = Join-Path $env:TEMP ("hermes-git-path-test-" + [Guid]::NewGuid().ToString('N'))
+$HermesHome = Join-Path $testRoot 'home'
+$InstallDir = Join-Path $testRoot 'checkout'
+. (Join-Path $repoRoot 'scripts\install.ps1') -HermesHome $HermesHome -InstallDir $InstallDir
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$script:Failures = 0
+function Assert-Equal {
+    param($Expected, $Actual, [string]$Label)
+    if ($Expected -cne $Actual) {
+        Write-Host "FAIL: $Label (expected [$Expected], got [$Actual])"
+        $script:Failures++
+    } else {
+        Write-Host "PASS: $Label"
+    }
+}
+
+$gitDir = 'C:\Example User\hermes\git'
+$entries = @("$gitDir\cmd", "$gitDir\bin", "$gitDir\usr\bin")
+$joined = $entries -join ';'
+$legacy = $entries -join ''
+$cases = @(
+    @{ Name = 'empty PATH'; Before = ''; After = $joined },
+    @{ Name = 'single entry'; Before = 'C:\Other'; After = "C:\Other;$joined" },
+    @{ Name = 'multiple entries'; Before = 'C:\One;C:\Two'; After = "C:\One;C:\Two;$joined" },
+    @{ Name = 'empty segments preserved'; Before = 'C:\Other;;'; After = "C:\Other;;;$joined" },
+    @{ Name = 'existing Git entries'; Before = $joined; After = $joined },
+    @{ Name = 'single existing Git entry'; Before = $entries[0]; After = $joined },
+    @{ Name = 'case insensitive membership'; Before = $joined.ToUpperInvariant(); After = $joined.ToUpperInvariant() },
+    @{ Name = 'legacy empty-PATH corruption'; Before = $legacy; After = $joined },
+    @{ Name = 'legacy single-entry corruption'; Before = "C:\Other$legacy"; After = "C:\Other;$joined" },
+    @{ Name = 'legacy corruption after another stage'; Before = "C:\Example User\hermes\node;$legacy"; After = "C:\Example User\hermes\node;$joined" },
+    @{ Name = 'repeated legacy retry'; Before = "C:\Other$legacy$legacy"; After = "C:\Other;$joined" },
+    @{ Name = 'legacy case variation'; Before = $legacy.ToUpperInvariant(); After = $joined },
+    @{ Name = 'unrelated concatenation untouched'; Before = 'C:\OtherD:\Tools'; After = "C:\OtherD:\Tools;$joined" },
+    @{ Name = 'other Git root untouched'; Before = 'D:\Git\cmdD:\Git\binD:\Git\usr\bin'; After = "D:\Git\cmdD:\Git\binD:\Git\usr\bin;$joined" },
+    @{ Name = 'partial signature untouched'; Before = "$gitDir\cmd$gitDir\bin"; After = "$gitDir\cmd$gitDir\bin;$joined" }
+)
+foreach ($case in $cases) {
+    $actual = Get-ManagedGitUserPath -UserPath $case.Before -GitDir $gitDir
+    Assert-Equal $case.After $actual $case.Name
+    Assert-Equal $actual (Get-ManagedGitUserPath -UserPath $actual -GitDir $gitDir) "$($case.Name): idempotent"
+}
+Assert-Equal $joined (Get-ManagedGitUserPath -UserPath $null -GitDir $gitDir) 'unset PATH'
+
+# Replace the registry-writing setter with an in-memory handoff probe.
+function Set-ManagedGitPath {
+    param([string]$GitDir)
+    $script:FakeUserPath = Get-ManagedGitUserPath -UserPath $script:FakeUserPath -GitDir $GitDir
+    $script:GitAvailable = $true
+    $script:PathRepairs++
+}
+function Write-Info { param([string]$Message) }
+function Write-Warn { param([string]$Message) }
+function Write-Success { param([string]$Message) }
+function Set-GitBashEnvVar { $script:GitBashPath = 'synthetic-bash' }
+function Test-GitBashCompatibility { param([string]$BashPath) $true }
+function Invoke-WebRequest { throw 'unexpected download in Git recovery test' }
+
+$script:GitAvailable = $false
+$script:GitMode = 'ok'
+$script:PathRepairs = 0
+$script:FakeUserPath = ''
+function Get-Command {
+    [CmdletBinding()]
+    param([string]$Name)
+    if ($Name -eq 'git') {
+        if ($script:GitAvailable) {
+            return Microsoft.PowerShell.Core\Get-Command git -CommandType Function
+        }
+        return $null
+    }
+    Microsoft.PowerShell.Core\Get-Command $Name
+}
+function git {
+    if (-not $script:GitAvailable -or $script:GitMode -eq 'throw') {
+        throw [System.Management.Automation.CommandNotFoundException]::new('synthetic Git unavailable')
+    }
+    if ($script:GitMode -eq 'nonzero') { $global:LASTEXITCODE = 1; return }
+    if ($args.Count -eq 1 -and $args[0] -eq '--version') {
+        $global:LASTEXITCODE = 0
+        return 'git version test'
+    }
+    throw 'repository probe reached after successful Git preflight'
+}
+
+New-Item -ItemType Directory -Path $testRoot -Force | Out-Null
+try {
+    # Model a completed Git download with a stale next-stage PATH. The file is
+    # only a discovery fixture; the git function above is the executable seam.
+    $managedCmd = Join-Path $HermesHome 'git\cmd'
+    New-Item -ItemType Directory -Path $managedCmd -Force | Out-Null
+    New-Item -ItemType File -Path (Join-Path $managedCmd 'git.exe') | Out-Null
+    $managedDir = Join-Path $HermesHome 'git'
+    $script:FakeUserPath = "$managedDir\cmd$managedDir\bin$managedDir\usr\bin"
+    Assert-Equal $true (Install-Git) 'existing managed Git recovered without a download'
+    Assert-Equal 1 $script:PathRepairs 'Git stage repairs existing install'
+    Assert-Equal "$managedDir\cmd;$managedDir\bin;$managedDir\usr\bin" $script:FakeUserPath 'Git stage repairs malformed persisted entries'
+
+    # A new repository-stage process must rediscover managed Git too. Abort at
+    # the first post-preflight Git call so this never clones or accesses network.
+    $script:GitAvailable = $false
+    $script:PathRepairs = 0
+    $errorText = ''
+    try { Install-Repository } catch { $errorText = $_.Exception.Message }
+    Assert-Equal 1 $script:PathRepairs 'repository stage repairs managed Git visibility'
+    Assert-Equal $true ($errorText -like '*repository probe reached*') 'repository stage reaches Git only after successful preflight'
+
+    # Missing or unlaunchable Git must leave both .git checkouts and ordinary
+    # existing directories untouched, rather than moving them to .broken-*.
+    Remove-Item -LiteralPath (Join-Path $managedCmd 'git.exe')
+    foreach ($mode in @('missing', 'throw', 'nonzero')) {
+        foreach ($withDotGit in @($false, $true)) {
+            $InstallDir = Join-Path $testRoot ("checkout-$mode-$withDotGit")
+            New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+            $sentinel = Join-Path $InstallDir 'keep.txt'
+            Set-Content -LiteralPath $sentinel -Value 'preserve me'
+            if ($withDotGit) { New-Item -ItemType Directory -Path (Join-Path $InstallDir '.git') | Out-Null }
+            $script:GitAvailable = ($mode -ne 'missing')
+            $script:GitMode = $mode
+            $errorText = ''
+            try { Install-Repository } catch { $errorText = $_.Exception.Message }
+            Assert-Equal $true ($errorText -like '*checkout has not been moved*') "$mode/${withDotGit}: actionable prerequisite error"
+            Assert-Equal $true (Test-Path -LiteralPath $sentinel) "$mode/${withDotGit}: existing files preserved"
+            $backups = @(Get-ChildItem -LiteralPath $testRoot -Directory | Where-Object { $_.Name -like '*.broken-*' })
+            Assert-Equal 0 $backups.Count "$mode/${withDotGit}: no false broken-checkout backup"
+        }
+    }
+} finally {
+    # This is the unique fixture directory created above, never a user home.
+    Remove-Item -LiteralPath $testRoot -Recurse -Force
+}
+
+if ($script:Failures -gt 0) { throw "$script:Failures Git PATH regression assertion(s) failed" }
+Write-Host 'All Git PATH regression tests passed.'


### PR DESCRIPTION
## What does this PR do?

Fixes Windows managed Git PATH persistence for empty and single-entry User PATH values, repairs the exact concatenated entries produced by the old installer, and prevents an unavailable Git executable from being mistaken for a broken checkout.

The conditional assignment to `$userPathItems` unwraps a one-item result into a string (or produces null for no entries). Subsequent `+=` operations concatenate directory names instead of appending array elements. The Git stage can still succeed using its temporary process PATH, but the next stage reloads User PATH and loses access to Git.

`Install-Repository` previously swallowed the missing-command error in its repository probe and could rename an existing checkout to `.broken-*` before discovering that Git was unavailable.

## Changes made

- Keep PATH entries in an explicit array, including the empty and single-entry cases.
- Repair only the exact managed `cmd` + `bin` + `usr\bin` concatenation, including repeated copies. Preserve unrelated entries and leave Machine PATH unchanged.
- Reuse and restore PATH visibility for an existing managed Git installation in both the Git and repository stages.
- Check that Git is discoverable and `git --version` succeeds before any repository validation or backup/move.
- Add native PowerShell behavioral regression tests and wire them into the existing Windows installer workflow for PowerShell 5.1 and 7.

## Verification

Run on Windows with both Windows PowerShell 5.1 and PowerShell 7:

```powershell
powershell -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-git-path.ps1
pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-git-path.ps1
```

Both pass all 54 assertions. Coverage includes empty/single/multiple PATH entries, exact legacy corruption and repeated retries, case-insensitive membership, idempotence, unrelated-path preservation, managed Git recovery across stages, and checkout preservation when Git is missing, throws, or exits nonzero.

The tests execute the installer functions with synthetic filesystem fixtures. Registry writes and external Git/download operations are stubbed, so this is not a claim of a full GUI install or a real registry migration test.

Additional checks:

- Existing Node compatibility, Git Bash compatibility, and stage-protocol suites pass under both test hosts.
- Existing long-path suite passes under Windows PowerShell 5.1.
- The PowerShell 7 long-path suite fails 10 assertions on this host because a startup drive warning contaminates its JSON capture. The identical failure reproduces against unmodified base `6064668c8f`; no long-path code is changed here.
- Windows PowerShell parser and `git diff --check` pass; no non-ASCII text is added to the installer.

## Scope and remaining validation

No changes to installer binaries, dependencies, Machine PATH, or repository recovery policy after Git is confirmed runnable. No customer data, logs, or environment identifiers are included.

Full GUI install/retry validation in a clean Windows environment remains outstanding. Python tests were not run; this change is limited to the PowerShell installer and its native tests.
