### PR TITLE
perf(mcp): skip npx's resident parent when the package is already cached (salvage #93083)

### DIFF
--- a/tests/tools/test_mcp_npx_cached_bin.py
+++ b/tests/tools/test_mcp_npx_cached_bin.py
@@ -154,7 +154,55 @@ def test_swap_happens_after_the_osv_call_in_source():
 
     src = _P(__file__).resolve().parents[2] / "tools" / "mcp_tool.py"
     text = src.read_text(encoding="utf-8")
-    osv_at = text.index("check_package_for_malware, command, args")
-    swap_at = text.index("cached = _npx_cached_bin(args)")
+    osv_needle = "check_package_for_malware, command, args"
+    swap_needle = "cached = _npx_cached_bin(args)"
+    # Report a rename explicitly: a bare .index() ValueError here reads like a
+    # broken test rather than "someone renamed the thing this guards".
+    assert osv_needle in text, (
+        f"cannot find the OSV preflight call ({osv_needle!r}) — it was renamed; "
+        "update this guard and re-verify the swap still happens after it"
+    )
+    assert swap_needle in text, (
+        f"cannot find the npx swap ({swap_needle!r}) — it was renamed; update "
+        "this guard and re-verify it still happens after the OSV preflight"
+    )
 
-    assert osv_at < swap_at, "the npx swap must not precede the OSV malware preflight"
+    assert text.index(osv_needle) < text.index(swap_needle), (
+        "the npx swap now precedes the OSV malware preflight, which silently "
+        "disables it: _infer_ecosystem keys off the command basename being "
+        "npx/uvx/pipx, so a rewritten command yields no ecosystem and "
+        "check_package_for_malware returns None"
+    )
+
+
+def test_windows_selects_launchers_never_the_sh_script():
+    """On Windows the extensionless sh script must never be chosen.
+
+    npm lays down three siblings per bin — `<name>`, `<name>.cmd`,
+    `<name>.ps1` — and spawning the sh one from a Windows process fails, while
+    `os.access(X_OK)` there is effectively an existence check and cannot tell
+    them apart. Tested through the injectable helper rather than by patching
+    `os.name`, which breaks path handling process-wide (it took pytest's own
+    traceback formatting down when I tried).
+    """
+    from tools.mcp_tool import _npx_bin_candidates
+
+    win = _npx_bin_candidates("/c/bin", "mcp-linear", windows=True)
+    assert win == ["/c/bin/mcp-linear.cmd", "/c/bin/mcp-linear.exe"]
+    assert not any(c.endswith("mcp-linear") for c in win), "sh script must not be a candidate"
+
+    assert _npx_bin_candidates("/bin", "mcp-linear", windows=False) == ["/bin/mcp-linear"]
+
+
+def test_posix_resolution_uses_the_helper(tmp_path):
+    """The resolver honours the helper's ordering (POSIX path end-to-end)."""
+    target = _cache(tmp_path, package="mcp-linear", bin_field={"mcp-linear": "i.js"})
+
+    assert _npx_cached_bin(["-y", "mcp-linear"]) == (str(target), [])
+
+
+def test_flag_after_the_spec_is_left_to_npx(tmp_path):
+    """`npx pkg -y` would forward -y to the server; that shape stays with npx."""
+    _cache(tmp_path, package="mcp-linear", bin_field={"mcp-linear": "i.js"})
+
+    assert _npx_cached_bin(["mcp-linear", "-y"]) is None

--- a/tests/tools/test_mcp_npx_cached_bin.py
+++ b/tests/tools/test_mcp_npx_cached_bin.py
@@ -1,0 +1,160 @@
+"""``npx -y <pkg>`` should spawn the cached binary, not a resident `npm exec`.
+
+`npx` resolves the package and then FORKS, staying alive as the real server's
+parent for the whole process lifetime while doing no work. Measured on a
+4-agent host that is ~48 MB of private memory per MCP server — and it buys
+nothing, because Hermes already wraps the child in its own parent-death
+watchdog, so npx's supervision is a second parent nobody reads.
+
+Removing it must stay conservative: a cache miss, a version-pinned spec, or an
+ambiguous ``bin`` map all fall back to plain `npx` so a cold machine still
+installs normally.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from tools.mcp_tool import _npx_cached_bin
+
+
+def _cache(tmp_path, *, package, deps=None, bin_field, make_bin=True, entry="abc123"):
+    """Build a fake npx cache entry the way npm lays one out."""
+    root = tmp_path / ".npm" / "_npx" / entry
+    (root / "node_modules" / package).mkdir(parents=True)
+    (root / "package.json").write_text(
+        json.dumps({"dependencies": deps if deps is not None else {package: "^1.0.0"}}),
+        encoding="utf-8",
+    )
+    (root / "node_modules" / package / "package.json").write_text(
+        json.dumps({"name": package, "bin": bin_field}), encoding="utf-8"
+    )
+    bindir = root / "node_modules" / ".bin"
+    bindir.mkdir(parents=True, exist_ok=True)
+    name = bin_field if isinstance(bin_field, str) else list(bin_field)[0]
+    target = bindir / (os.path.basename(package) if isinstance(bin_field, str) else name)
+    if make_bin:
+        target.write_text("#!/usr/bin/env node\n", encoding="utf-8")
+        target.chmod(0o755)
+    return target
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache(tmp_path, monkeypatch):
+    monkeypatch.setenv("npm_config_cache", str(tmp_path / ".npm"))
+    yield
+
+
+def test_cached_package_resolves_to_its_binary(tmp_path):
+    target = _cache(tmp_path, package="mcp-linear", bin_field={"mcp-linear": "dist/index.js"})
+
+    got = _npx_cached_bin(["-y", "mcp-linear"])
+
+    assert got == (str(target), [])
+
+
+def test_scoped_package_and_trailing_args_survive(tmp_path):
+    target = _cache(
+        tmp_path,
+        package="@tacticlaunch/mcp-linear",
+        bin_field={"mcp-linear": "dist/index.js"},
+    )
+
+    got = _npx_cached_bin(["-y", "@tacticlaunch/mcp-linear", "--port", "7"])
+
+    assert got == (str(target), ["--port", "7"])
+
+
+def test_uncached_package_falls_back_to_npx(tmp_path):
+    _cache(tmp_path, package="something-else", bin_field={"something-else": "i.js"})
+
+    assert _npx_cached_bin(["-y", "mcp-linear"]) is None
+
+
+def test_version_pinned_spec_is_left_to_npx(tmp_path):
+    _cache(tmp_path, package="mcp-linear", bin_field={"mcp-linear": "dist/index.js"})
+
+    # The user pinned a build; npx owns that resolution and the cache key for
+    # a different version would not match this entry.
+    assert _npx_cached_bin(["-y", "mcp-linear@1.2.3"]) is None
+
+
+def test_ambiguous_bin_map_is_left_to_npx(tmp_path):
+    _cache(
+        tmp_path,
+        package="multi",
+        bin_field={"one": "a.js", "two": "b.js"},
+    )
+
+    # Which bin npx would choose is not ours to guess.
+    assert _npx_cached_bin(["-y", "multi"]) is None
+
+
+def test_missing_or_non_executable_binary_falls_back(tmp_path):
+    _cache(
+        tmp_path,
+        package="mcp-linear",
+        bin_field={"mcp-linear": "dist/index.js"},
+        make_bin=False,
+    )
+
+    assert _npx_cached_bin(["-y", "mcp-linear"]) is None
+
+
+def test_no_cache_directory_at_all(tmp_path, monkeypatch):
+    monkeypatch.setenv("npm_config_cache", str(tmp_path / "nope"))
+
+    assert _npx_cached_bin(["-y", "mcp-linear"]) is None
+
+
+def test_corrupt_cache_manifest_is_skipped(tmp_path):
+    root = tmp_path / ".npm" / "_npx" / "broken"
+    root.mkdir(parents=True)
+    (root / "package.json").write_text("{ not json", encoding="utf-8")
+
+    assert _npx_cached_bin(["-y", "mcp-linear"]) is None
+
+
+@pytest.mark.parametrize("args", [[], ["-y"], ["--yes"], ["-p", "x"], None, "notalist"])
+def test_unusable_args_are_ignored(args):
+    assert _npx_cached_bin(args) is None
+
+
+def test_osv_preflight_runs_before_the_swap():
+    """The malware gate must still see `npx` + the package name.
+
+    `_infer_ecosystem` keys off the command basename, so a command already
+    rewritten to `.../node_modules/.bin/mcp-linear` yields no ecosystem and
+    `check_package_for_malware` returns None — the gate silently becomes a
+    no-op. This pins the ordering: OSV inspects the original invocation.
+    """
+    from tools.osv_check import _infer_ecosystem, _parse_package_from_args
+
+    # What the preflight sees today, before any swap.
+    assert _infer_ecosystem("npx") == "npm"
+    assert _parse_package_from_args(["-y", "@tacticlaunch/mcp-linear"], "npm")[0] == (
+        "@tacticlaunch/mcp-linear"
+    )
+
+    # What it would see if the swap happened first — nothing.
+    assert _infer_ecosystem("/home/u/.npm/_npx/abc/node_modules/.bin/mcp-linear") is None
+
+
+def test_swap_happens_after_the_osv_call_in_source():
+    """Structural guard for the ordering above.
+
+    The swap and the preflight live in one async function; a future edit that
+    moves the swap earlier would disable the malware gate silently, and no
+    unit test of either piece alone would notice.
+    """
+    from pathlib import Path as _P
+
+    src = _P(__file__).resolve().parents[2] / "tools" / "mcp_tool.py"
+    text = src.read_text(encoding="utf-8")
+    osv_at = text.index("check_package_for_malware, command, args")
+    swap_at = text.index("cached = _npx_cached_bin(args)")
+
+    assert osv_at < swap_at, "the npx swap must not precede the OSV malware preflight"

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1073,6 +1073,26 @@ def _resolve_stdio_command(command: str, env: dict) -> tuple[str, dict]:
     return resolved_command, resolved_env
 
 
+def _npx_bin_candidates(bin_dir: str, name: str, *, windows: Optional[bool] = None) -> list:
+    """Launcher paths to try for *name* inside an npx cache's ``.bin``, in order.
+
+    On Windows that directory holds three siblings per bin — the extensionless
+    sh script, ``<name>.cmd`` and ``<name>.ps1``. Spawning the sh one from a
+    Windows process fails, and ``os.access(X_OK)`` there is effectively an
+    existence check, so it cannot tell them apart. Select by extension instead,
+    the same precedence ``hermes_constants._candidate_node_command_names``
+    already uses for npm/npx/node; when no launcher exists the caller falls
+    back to npx rather than spawning something that will not run.
+
+    ``windows`` is injectable so the platform branch is testable without
+    monkeypatching ``os.name`` (which breaks path handling process-wide).
+    """
+    is_windows = os.name == "nt" if windows is None else windows
+    if is_windows:
+        return [os.path.join(bin_dir, name + ext) for ext in (".cmd", ".exe")]
+    return [os.path.join(bin_dir, name)]
+
+
 def _npx_cached_bin(args: list) -> Optional[tuple]:
     """Resolve ``npx -y <pkg>`` to the already-installed binary, or None.
 
@@ -1101,6 +1121,12 @@ def _npx_cached_bin(args: list) -> Optional[tuple]:
     while rest and rest[0] in ("-y", "--yes"):
         rest.pop(0)
     if not rest:
+        return None
+
+    # `npx pkg -y` (flag AFTER the spec) is an unusual shape: those args are
+    # forwarded verbatim to the resolved binary, which would hand the server a
+    # flag npx would have eaten. Leave anything like that to npx.
+    if any(str(a) in ("-y", "--yes") for a in rest[1:]):
         return None
 
     spec = str(rest[0])
@@ -1150,9 +1176,10 @@ def _npx_cached_bin(args: list) -> Optional[tuple]:
             # guess. Let npx decide.
             continue
 
-        candidate = os.path.join(npx_root, entry, "node_modules", ".bin", names[0])
-        if os.path.exists(candidate) and os.access(candidate, os.X_OK):
-            return candidate, rest[1:]
+        bin_dir = os.path.join(npx_root, entry, "node_modules", ".bin")
+        for candidate in _npx_bin_candidates(bin_dir, names[0]):
+            if os.path.exists(candidate) and os.access(candidate, os.X_OK):
+                return candidate, rest[1:]
 
     return None
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1073,6 +1073,90 @@ def _resolve_stdio_command(command: str, env: dict) -> tuple[str, dict]:
     return resolved_command, resolved_env
 
 
+def _npx_cached_bin(args: list) -> Optional[tuple]:
+    """Resolve ``npx -y <pkg>`` to the already-installed binary, or None.
+
+    ``npx`` resolves the package and then FORKS: it stays resident as the
+    parent of the real server for the whole process lifetime, doing no work.
+    Measured on a 4-agent host, that is ~48 MB of private memory per MCP
+    server — and it buys nothing here, because Hermes already supervises the
+    child itself (the shared death supervisor), so npx's supervision is a
+    second parent nobody reads.
+
+    When the package is already in npx's cache we can spawn its binary
+    directly and drop the middle process. A cache miss returns None and the
+    caller falls back to ``npx`` unchanged, so the first run still installs
+    and nothing regresses on a cold machine.
+
+    Deliberately conservative — returns None for anything unusual:
+    a version-pinned spec (``pkg@1.2.3``), extra npx flags, a package whose
+    manifest declares no single obvious bin, or any unreadable cache entry.
+
+    Returns ``(binary_path, remaining_args)`` or None.
+    """
+    if not isinstance(args, list) or not args:
+        return None
+
+    rest = list(args)
+    while rest and rest[0] in ("-y", "--yes"):
+        rest.pop(0)
+    if not rest:
+        return None
+
+    spec = str(rest[0])
+    # A version pin means the user asked for a specific build; npx owns that
+    # resolution and the cache key may not match. Scoped names keep their
+    # leading '@', so only an '@' AFTER the scope is a version separator.
+    if "@" in (spec[1:] if spec.startswith("@") else spec):
+        return None
+    if not spec or spec.startswith("-"):
+        return None
+
+    cache_root = os.environ.get("npm_config_cache") or os.path.join(
+        os.path.expanduser("~"), ".npm"
+    )
+    npx_root = os.path.join(cache_root, "_npx")
+    if not os.path.isdir(npx_root):
+        return None
+
+    try:
+        entries = os.listdir(npx_root)
+    except OSError:
+        return None
+
+    for entry in entries:
+        manifest = os.path.join(npx_root, entry, "package.json")
+        try:
+            with open(manifest, "r", encoding="utf-8") as fh:
+                deps = (json.load(fh) or {}).get("dependencies") or {}
+        except (OSError, ValueError, TypeError):
+            continue
+        if spec not in deps:
+            continue
+
+        pkg_json = os.path.join(npx_root, entry, "node_modules", spec, "package.json")
+        try:
+            with open(pkg_json, "r", encoding="utf-8") as fh:
+                bin_field = (json.load(fh) or {}).get("bin")
+        except (OSError, ValueError, TypeError):
+            continue
+
+        if isinstance(bin_field, str):
+            names = [os.path.basename(spec)]
+        elif isinstance(bin_field, dict) and len(bin_field) == 1:
+            names = list(bin_field.keys())
+        else:
+            # Zero or several bins: which one npx would pick is not ours to
+            # guess. Let npx decide.
+            continue
+
+        candidate = os.path.join(npx_root, entry, "node_modules", ".bin", names[0])
+        if os.path.exists(candidate) and os.access(candidate, os.X_OK):
+            return candidate, rest[1:]
+
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Shared parent-death supervisor
 # ---------------------------------------------------------------------------
@@ -3431,6 +3515,25 @@ class MCPServerTask:
             raise ValueError(
                 f"MCP server '{self.name}': {malware_error}"
             )
+
+        # npx resolves the package and then FORKS, staying resident as the
+        # real server's parent for nothing (~48 MB per MCP server, measured).
+        # Hermes already supervises the child (shared death supervisor), so
+        # when the package is cached we spawn its binary directly and drop
+        # that middle process.
+        # Deliberately AFTER the OSV preflight: the check keys off the command
+        # basename being `npx`, so swapping first would silently turn the
+        # malware gate into a no-op. Cache miss leaves npx untouched.
+        if os.path.basename(command).lower().startswith("npx"):
+            cached = _npx_cached_bin(args)
+            if cached:
+                direct_command, direct_args = cached
+                logger.debug(
+                    "MCP server '%s': using cached npx binary %s (skipping the "
+                    "resident `npm exec` parent)",
+                    self.name, direct_command,
+                )
+                command, args = direct_command, direct_args
 
         server_params = StdioServerParameters(
             command=command,


### PR DESCRIPTION
## Summary
When an `npx -y <pkg>` MCP server's package is already in the npx cache, Hermes spawns the package's binary directly instead of going through `npx` — dropping the resident `npm exec` parent process that otherwise sits above every such server for the whole session doing nothing.

Salvaged from #93083 by @jonpol01 (two commits cherry-picked, authorship preserved) onto current `main`, re-anchored after #101598 replaced the per-server watchdog with the shared death supervisor (the PR's hunk referenced the deleted `_wrap_command_with_watchdog`).

## Who hits this / when / why it matters
Anyone with `npx`-launched stdio MCP servers (the most common way MCP servers are configured). `npx` resolves the package then forks and stays resident as the server's parent. Hermes already supervises the child itself, so that parent buys nothing.

## What changed
- `tools/mcp_tool.py`: `_npx_cached_bin(args)` resolves `npx -y <pkg>` to the cached binary (conservative: returns `None` for version pins, extra flags, ambiguous `bin` manifests, unreadable cache — falls back to `npx` unchanged, so cold machines still install). Applied **after** the OSV malware preflight, which keys off the `npx` basename. Second commit picks the Windows launcher, not the `.sh`, from the cache.
- `tests/tools/test_mcp_npx_cached_bin.py` (+ Windows launcher cases).

## Measurement (live, this machine)
Real npx cache, `prettier` as the cached package; process group counted after 2.5 s, RSS summed over the group.

| | `npx -y <pkg>` (main) | direct cached binary (this PR) |
|---|---|---|
| processes per MCP server | 2 | **1** |
| resident memory | 136 MB | **53 MB** |

## Verification
- `tests/tools/test_mcp_npx_cached_bin.py` + `test_mcp_death_supervisor.py` + `test_mcp_stdio_children_dead.py`: 62 passed; ruff clean.
- Composition with the shared supervisor verified: the cached binary is what gets spawned unwrapped and registered by pgid, exactly like any other stdio command.

## Provenance
Salvaged from #93083 by @jonpol01 — both commits cherry-picked with authorship preserved; conflict resolution (re-anchor onto the supervisor) is the only change of mine, in the cherry-pick itself. Complements #101598.
