### PR TITLE
desktop: scope the config-record cache to the active gateway

### DIFF
--- a/apps/desktop/src/app/hooks/use-config-record.test.tsx
+++ b/apps/desktop/src/app/hooks/use-config-record.test.tsx
@@ -1,0 +1,116 @@
+import { QueryClientProvider } from '@tanstack/react-query'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import type { WritableAtom } from 'nanostores'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/store/connections', async () => {
+  const { atom } = await import('nanostores')
+
+  return { $activeConnectionId: atom<null | string>(null) }
+})
+vi.mock('@/store/gateway', async () => {
+  const { atom } = await import('nanostores')
+
+  return { $activeGatewayRoute: atom('default') }
+})
+
+const apiMocks = vi.hoisted(() => ({ getHermesConfigRecord: vi.fn() }))
+
+vi.mock('@/hermes', () => ({ getHermesConfigRecord: apiMocks.getHermesConfigRecord }))
+
+import { queryClient } from '@/lib/query-client'
+import { $activeConnectionId as $mockedConnectionId } from '@/store/connections'
+import { $activeGatewayRoute } from '@/store/gateway'
+
+import { HERMES_CONFIG_KEY, hermesConfigCacheWriter, hermesConfigKey, setHermesConfigCache, useHermesConfigRecord } from './use-config-record'
+
+// The real store exports a computed (read-only) atom; the mock is a plain writable one.
+const $activeConnectionId = $mockedConnectionId as WritableAtom<null | string>
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}
+
+const record = (marker: string) => ({ marker }) as unknown as Record<string, unknown>
+
+beforeEach(() => {
+  $activeConnectionId.set(null)
+  $activeGatewayRoute.set('default')
+  queryClient.clear()
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('hermesConfigKey', () => {
+  it('scopes the ambient record to the active gateway connection and profile', () => {
+    expect(hermesConfigKey()).toEqual([...HERMES_CONFIG_KEY, 'primary::default'])
+
+    $activeConnectionId.set('devbox')
+    expect(hermesConfigKey()).toEqual([...HERMES_CONFIG_KEY, 'devbox::default'])
+
+    $activeGatewayRoute.set('work')
+    expect(hermesConfigKey()).toEqual([...HERMES_CONFIG_KEY, 'devbox::work'])
+  })
+
+  it('lands an explicit pin on the active source on the ambient row', () => {
+    $activeConnectionId.set('devbox')
+
+    expect(hermesConfigKey({ connectionId: 'devbox', profile: 'default' })).toEqual(hermesConfigKey())
+    expect(hermesConfigKey({ connectionId: 'local', profile: 'default' })).not.toEqual(hermesConfigKey())
+  })
+})
+
+describe('setHermesConfigCache', () => {
+  it('writes the row of the gateway active at write time, even through a memoized writer', () => {
+    $activeConnectionId.set('local')
+    const writer = hermesConfigCacheWriter()
+    setHermesConfigCache(record('laptop'))
+
+    $activeConnectionId.set('devbox')
+    expect(queryClient.getQueryData(hermesConfigKey())).toBeUndefined()
+    writer(record('remote'))
+    expect(queryClient.getQueryData(hermesConfigKey())).toEqual(record('remote'))
+
+    $activeConnectionId.set('local')
+    expect(queryClient.getQueryData(hermesConfigKey())).toEqual(record('laptop'))
+  })
+})
+
+describe('useHermesConfigRecord', () => {
+  it('never serves the previous gateway record after a switch', async () => {
+    apiMocks.getHermesConfigRecord.mockImplementation(async () => record($activeConnectionId.get() ?? 'primary'))
+    $activeConnectionId.set('local')
+    const paints: Array<[null | string, unknown]> = []
+
+    const { result } = renderHook(
+      () => {
+        const query = useHermesConfigRecord()
+        paints.push([$activeConnectionId.get(), query.data])
+
+        return query
+      },
+      { wrapper }
+    )
+
+    await waitFor(() => expect(result.current.data).toEqual(record('local')))
+
+    // Switch the active gateway: the ambient key moves with the connection in
+    // the same render.
+    await act(async () => {
+      $activeConnectionId.set('devbox')
+    })
+
+    await waitFor(() => expect(result.current.data).toEqual(record('devbox')))
+    // The laptop record was never painted while the remote was active — that
+    // stale paint is what a settings save then PUT onto the other machine.
+    const remotePaints = paints.filter(([connectionId]) => connectionId === 'devbox').map(([, data]) => data)
+    expect(remotePaints.length).toBeGreaterThan(0)
+    expect(remotePaints).not.toContainEqual(record('local'))
+    // Each source keeps its own row.
+    expect(queryClient.getQueryData([...HERMES_CONFIG_KEY, 'devbox::default'])).toEqual(record('devbox'))
+    expect(queryClient.getQueryData([...HERMES_CONFIG_KEY, 'local::default'])).toEqual(record('local'))
+  })
+})

--- a/apps/desktop/src/app/hooks/use-config-record.ts
+++ b/apps/desktop/src/app/hooks/use-config-record.ts
@@ -1,7 +1,14 @@
+import { useStore } from '@nanostores/react'
 import { useQuery } from '@tanstack/react-query'
 
-import { getHermesConfigRecord, type ProfileScope, profileScopeKey } from '@/hermes'
+// profileScopeKey comes from its home module, not the '@/hermes' barrel: the
+// ambient key calls it on every render, and settings tests that mock the
+// barrel would otherwise have to re-export it.
+import { profileScopeKey } from '@/api/client'
+import { getHermesConfigRecord, type ProfileScope } from '@/hermes'
 import { queryClient, writeCache } from '@/lib/query-client'
+import { $activeConnectionId } from '@/store/connections'
+import { $activeGatewayRoute } from '@/store/gateway'
 import type { HermesConfigRecord } from '@/types/hermes'
 
 // One shared cache for the whole profile config record (`GET /api/config`).
@@ -13,36 +20,72 @@ import type { HermesConfigRecord } from '@/types/hermes'
 // it pushes personality/cwd/voice/… into the session stores for live chat.
 export const HERMES_CONFIG_KEY = ['hermes-config-record'] as const
 
-// Per-scope cache key. The base key (no suffix) is the app-wide active
-// profile, unchanged for every caller that passes nothing. An explicit scope —
-// the Capabilities scope selector configuring ANOTHER profile, possibly on
-// another registered gateway — gets its own suffixed key so switching the
-// selector refetches and never paints stale cross-profile config (the
-// AGENTS.md scope-in-key rule). profileScopeKey folds a remote pin's
-// connection id into the suffix, so two gateways' same-named profiles never
-// share a cache row.
-export const hermesConfigKey = (profile?: ProfileScope) =>
-  profile == null ? HERMES_CONFIG_KEY : ([...HERMES_CONFIG_KEY, profileScopeKey(profile)] as const)
+/** Source of the AMBIENT record: the active registry connection (null → the
+ *  legacy primary route) and the bare profile the active gateway serves. */
+export interface AmbientConfigScope {
+  connectionId: null | string
+  profileKey: string
+}
+
+export const ambientConfigScope = (): AmbientConfigScope => ({
+  connectionId: $activeConnectionId.get(),
+  profileKey: $activeGatewayRoute.get()
+})
+
+// Scope suffix of the ambient record. The key must carry the source (AGENTS.md
+// scope-in-key rule): with a bare root key, switching gateways served the
+// previous machine's record from cache, and the next settings save PUT that
+// whole record — deep-merged on the remote — onto the other machine's
+// config.yaml. Same `connectionId::profile` shape as an explicit pin, so a pin
+// on the active source shares its row.
+export const ambientConfigScopeKey = (ambient: AmbientConfigScope = ambientConfigScope()): string =>
+  profileScopeKey({ connectionId: ambient.connectionId ?? 'primary', profile: ambient.profileKey })
+
+// Per-scope cache key. No profile → the ambient record of the active gateway
+// and profile (resolved on every call, never cached). An explicit scope — the
+// Capabilities scope selector configuring ANOTHER profile, possibly on another
+// registered gateway — gets its own suffix so switching the selector refetches
+// and never paints stale cross-profile config. profileScopeKey folds a remote
+// pin's connection id into the suffix, so two gateways' same-named profiles
+// never share a cache row.
+export const hermesConfigKey = (profile?: ProfileScope, ambient?: AmbientConfigScope) =>
+  [...HERMES_CONFIG_KEY, profile == null ? ambientConfigScopeKey(ambient) : profileScopeKey(profile)] as const
 
 // staleTime 0 → serve cache instantly, background-revalidate on every mount.
-// `profile` scopes both the query key and the fetch; omitting it preserves the
-// exact app-wide behavior (base key, `profileScoped(undefined)` fallback).
-export const useHermesConfigRecord = (profile?: ProfileScope) =>
-  useQuery({
-    queryKey: hermesConfigKey(profile),
+// `profile` scopes both the query key and the fetch; omitting it targets the
+// app-wide active profile (`profileScoped(undefined)` fallback) on the active
+// gateway.
+export const useHermesConfigRecord = (profile?: ProfileScope) => {
+  // Reactive reads, not store getters: under the React Compiler a value with
+  // no reactive inputs is computed once per component instance, so a
+  // getter-based key would freeze on the first gateway and keep serving its
+  // record after a switch.
+  const connectionId = useStore($activeConnectionId)
+  const profileKey = useStore($activeGatewayRoute)
+
+  return useQuery({
+    queryKey: hermesConfigKey(profile, { connectionId, profileKey }),
     // null/undefined both mean "no override" → fetch with undefined so
     // capabilityScoped falls back to the app-wide active profile (passing null
     // would wrongly target the primary backend).
     queryFn: () => getHermesConfigRecord(profile ?? undefined),
     staleTime: 0
   })
+}
 
-// setHermesConfigCache writes the app-wide (base-key) record. Pass a profile to
-// write the suffixed per-profile cache instead — keeps the selector's optimistic
-// write-through landing on the same key its query reads.
-export const setHermesConfigCache = writeCache<HermesConfigRecord>(HERMES_CONFIG_KEY)
-export const hermesConfigCacheWriter = (profile?: ProfileScope) =>
-  writeCache<HermesConfigRecord>(hermesConfigKey(profile))
+type ConfigCacheUpdate = HermesConfigRecord | undefined | ((prev: HermesConfigRecord | undefined) => HermesConfigRecord | undefined)
+
+// Cache writer for optimistic write-through. The key is resolved at WRITE
+// time, not when the writer is created, so a writer memoized by a long-lived
+// settings panel keeps landing on the row of whichever gateway is active when
+// the save happens — the same row its query reads.
+export const hermesConfigCacheWriter =
+  (profile?: ProfileScope) =>
+  (next: ConfigCacheUpdate): void =>
+    writeCache<HermesConfigRecord>(hermesConfigKey(profile))(next)
+
+// setHermesConfigCache writes the ambient (active gateway + profile) record.
+export const setHermesConfigCache = hermesConfigCacheWriter()
 
 export const invalidateHermesConfig = (profile?: ProfileScope) =>
   queryClient.invalidateQueries({ queryKey: hermesConfigKey(profile) })


### PR DESCRIPTION
Fixes #101640.

## Problem

`useHermesConfigRecord()` with no explicit scope used the bare root key `['hermes-config-record']` for the ambient record, whichever gateway was active. With two registered gateways (say a laptop and a remote dev box):

1. Open Settings on the local gateway. The local config record lands on the root key.
2. Switch to the remote gateway. Settings paints the local record from cache (`staleTime: 0` only revalidates in the background), and the writer for the next save targets the same root row.
3. Save a setting. The PUT carries the whole local record, deep-merged on the remote, onto the remote's `config.yaml`.

## Fix

- The ambient row is keyed `connectionId::profile` (`primary` for the legacy route with no registry connection). That is the same shape `profileScopeKey` produces for an explicit pin, so a pin on the active source shares the ambient row.
- The hook reads `$activeConnectionId` and `$activeGatewayRoute` through `useStore` and passes them into the key builder. This matters under the React Compiler: a key built from store getters has no reactive inputs, is computed once per component instance, and freezes on the first gateway even when a store subscription re-renders the component. (A first draft of this fix failed its own switch test exactly that way.)
- `hermesConfigCacheWriter`, `setHermesConfigCache` and `invalidateHermesConfig` resolve the key at call time, so a writer memoized by a long-lived settings panel lands on the row of the gateway active when the save happens, the same row its query reads.

## Tests

New `use-config-record.test.tsx`:
- the ambient key follows connection and profile; an explicit pin on the active source shares the ambient row
- a memoized writer writes the row of the gateway active at write time
- after a switch, the previous gateway's record is never painted while the new one is active, and each source keeps its own row

Also run: `src/app/settings`, `src/app/skills`, `src/app/contrib` (44 files, 417 tests) plus the sidebar suites that mock the connections store; `eslint`; `tsc -p . --noEmit`.
