### PR TITLE
fix(gateway): preserve runtime Node path under source overlays

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3945,16 +3945,28 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
             return False
 
     candidates = []
+    active_venv = Path(sys.prefix) if sys.prefix != sys.base_prefix else None
 
     venv_bin = project_root / "venv" / "bin"
     if _is_dir(venv_bin):
         candidates.append(str(venv_bin))
-    elif sys.prefix != sys.base_prefix:
-        candidates.append(str(Path(sys.prefix) / "bin"))
+    elif active_venv is not None:
+        candidates.append(str(active_venv / "bin"))
 
-    node_bin = project_root / "node_modules" / ".bin"
-    if _is_dir(node_bin):
-        candidates.append(str(node_bin))
+    # A service can deliberately import Python from a PYTHONPATH overlay while
+    # still executing from another checkout's virtualenv. Keep that runtime
+    # checkout's Node shims available too; otherwise the exact service-env
+    # stale check drops them and falsely reports the installed unit as old.
+    node_roots = [project_root]
+    if active_venv is not None and active_venv.name in {".venv", "venv"}:
+        runtime_project_root = active_venv.parent
+        if runtime_project_root != project_root:
+            node_roots.append(runtime_project_root)
+
+    for node_root in node_roots:
+        node_bin = node_root / "node_modules" / ".bin"
+        if _is_dir(node_bin):
+            candidates.append(str(node_bin))
 
     hermes_home = get_hermes_home()
     hermes_node = hermes_home / "node" / "bin"

--- a/tests/hermes_cli/test_gateway_service_paths.py
+++ b/tests/hermes_cli/test_gateway_service_paths.py
@@ -1,9 +1,16 @@
+from pathlib import Path
 from unittest.mock import patch
+
+
+def _mkdir(path: Path) -> Path:
+    path.mkdir(parents=True)
+    return path
 
 
 def test_service_path_skips_nonexistent_node_modules(tmp_path):
     """Service PATH should not include node_modules/.bin if it doesn't exist."""
     from hermes_cli.gateway import _build_service_path_dirs
+
     with patch("hermes_cli.gateway.get_hermes_home", return_value=tmp_path / ".hermes"):
         dirs = _build_service_path_dirs(project_root=tmp_path)
     node_modules_bin = str(tmp_path / "node_modules" / ".bin")
@@ -15,8 +22,114 @@ def test_service_path_includes_node_modules_when_present(tmp_path):
     nm_bin = tmp_path / "node_modules" / ".bin"
     nm_bin.mkdir(parents=True)
     from hermes_cli.gateway import _build_service_path_dirs
+
     with patch("hermes_cli.gateway.get_hermes_home", return_value=tmp_path / ".hermes"):
         dirs = _build_service_path_dirs(project_root=tmp_path)
     assert str(nm_bin) in dirs
 
 
+def test_service_path_includes_runtime_checkout_node_bin_for_python_overlay(
+    tmp_path, monkeypatch
+):
+    from hermes_cli import gateway as gateway_cli
+
+    overlay = _mkdir(tmp_path / "overlay")
+    runtime = _mkdir(tmp_path / "runtime")
+    active_venv = _mkdir(runtime / ".venv")
+    _mkdir(active_venv / "bin")
+    runtime_node_bin = _mkdir(runtime / "node_modules" / ".bin")
+    hermes_home = _mkdir(tmp_path / "hermes-home")
+
+    monkeypatch.setattr(gateway_cli.sys, "prefix", str(active_venv))
+    monkeypatch.setattr(gateway_cli.sys, "base_prefix", str(tmp_path / "base-python"))
+    monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: hermes_home)
+
+    result = gateway_cli._build_service_path_dirs(project_root=overlay)
+
+    assert result == [str(active_venv / "bin"), str(runtime_node_bin)]
+
+
+def test_service_path_does_not_infer_project_root_from_custom_named_venv(
+    tmp_path, monkeypatch
+):
+    from hermes_cli import gateway as gateway_cli
+
+    overlay = _mkdir(tmp_path / "overlay")
+    venv_parent = _mkdir(tmp_path / "venvs")
+    active_venv = _mkdir(venv_parent / "hermes-runtime")
+    _mkdir(active_venv / "bin")
+    unrelated_node_bin = _mkdir(venv_parent / "node_modules" / ".bin")
+    hermes_home = _mkdir(tmp_path / "hermes-home")
+
+    monkeypatch.setattr(gateway_cli.sys, "prefix", str(active_venv))
+    monkeypatch.setattr(gateway_cli.sys, "base_prefix", str(tmp_path / "base-python"))
+    monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: hermes_home)
+
+    result = gateway_cli._build_service_path_dirs(project_root=overlay)
+
+    assert result == [str(active_venv / "bin")]
+    assert str(unrelated_node_bin) not in result
+
+
+def test_service_path_does_not_duplicate_node_bin_without_overlay(
+    tmp_path, monkeypatch
+):
+    from hermes_cli import gateway as gateway_cli
+
+    runtime = _mkdir(tmp_path / "runtime")
+    active_venv = _mkdir(runtime / "venv")
+    venv_bin = _mkdir(active_venv / "bin")
+    node_bin = _mkdir(runtime / "node_modules" / ".bin")
+    hermes_home = _mkdir(tmp_path / "hermes-home")
+
+    monkeypatch.setattr(gateway_cli.sys, "prefix", str(active_venv))
+    monkeypatch.setattr(gateway_cli.sys, "base_prefix", str(tmp_path / "base-python"))
+    monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: hermes_home)
+
+    result = gateway_cli._build_service_path_dirs(project_root=runtime)
+
+    assert result == [str(venv_bin), str(node_bin)]
+
+
+def test_generated_unit_remains_current_under_python_source_overlay(
+    tmp_path, monkeypatch
+):
+    from hermes_cli import gateway as gateway_cli
+
+    runtime = _mkdir(tmp_path / "runtime")
+    overlay = _mkdir(tmp_path / "overlay")
+    active_venv = _mkdir(runtime / ".venv")
+    _mkdir(active_venv / "bin")
+    runtime_node_bin = _mkdir(runtime / "node_modules" / ".bin")
+    hermes_home = _mkdir(tmp_path / "hermes-home")
+    unit_path = tmp_path / "hermes-gateway.service"
+
+    monkeypatch.setattr(gateway_cli.sys, "prefix", str(active_venv))
+    monkeypatch.setattr(gateway_cli.sys, "base_prefix", str(tmp_path / "base-python"))
+    monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: hermes_home)
+    monkeypatch.setattr(
+        gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path
+    )
+    monkeypatch.setattr(
+        gateway_cli,
+        "_sync_hermes_home_from_systemd_unit",
+        lambda system=False: None,
+    )
+    monkeypatch.setattr(
+        gateway_cli, "_append_node_dir_for_service", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        gateway_cli, "_build_user_local_paths", lambda *args, **kwargs: []
+    )
+    monkeypatch.setattr(
+        gateway_cli, "_build_wsl_interop_paths", lambda *args, **kwargs: []
+    )
+
+    monkeypatch.setattr(gateway_cli, "PROJECT_ROOT", runtime)
+    installed = gateway_cli.generate_systemd_unit(system=False)
+    assert str(runtime_node_bin) in installed
+    unit_path.write_text(installed, encoding="utf-8")
+
+    monkeypatch.setattr(gateway_cli, "PROJECT_ROOT", overlay)
+
+    assert gateway_cli.systemd_unit_is_current(system=False) is True


### PR DESCRIPTION
## What does this PR do?

Keeps a gateway service definition stable when Hermes imports Python from a `PYTHONPATH` source overlay but executes from another checkout's conventional `.venv` or `venv`.

Before this change, `_build_service_path_dirs()` used the imported overlay as `PROJECT_ROOT`. It preserved the active virtualenv's `bin` directory, but only looked for `node_modules/.bin` under the overlay. If the installed unit had been generated from the interpreter/runtime checkout, the exact service-environment comparison dropped that checkout's Node shims and incorrectly reported the unit as outdated.

The fix derives the runtime checkout from `sys.prefix` only for conventional `.venv`/`venv` layouts and includes its existing `node_modules/.bin` after the overlay's own entry. Custom virtualenv layouts are not treated as project roots.

## Related Issue

No existing issue or pull request found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `hermes_cli/gateway.py` to preserve the runtime checkout's existing Node shims under a Python source overlay.
- Extend `tests/hermes_cli/test_gateway_service_paths.py` with overlay, custom-venv, deduplication, and generated-unit/current-unit regression coverage.

## How to Test

1. Run `pytest -q tests/hermes_cli/test_gateway_service_paths.py tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_systemd_watchdog_unit.py tests/hermes_cli/test_systemd_optional_directives.py tests/hermes_cli/test_gateway_windows.py tests/hermes_cli/test_gateway_wsl.py`.
2. Confirm the new end-to-end test fails on the unmodified base because `systemd_unit_is_current()` returns `False` after switching `PROJECT_ROOT` from the runtime checkout to the overlay.
3. Confirm it passes with this change and the generated unit remains byte-current.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run the complete `pytest tests/ -q` suite
- [x] I've added tests for my changes
- [x] I've tested on Linux

### Documentation & Housekeeping

- [x] Documentation update: N/A — internal service-generation correction with regression coverage
- [x] `cli-config.yaml.example`: N/A — no config changes
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A — no architecture or workflow change
- [x] Cross-platform impact considered; conventional-path derivation uses `pathlib`, and Windows/WSL gateway tests are included
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

Canonical affected-file runner: `6 passed, 0 failed`.

Broader gateway/systemd coverage: `128 passed, 5 skipped`.

GitHub Actions completed cleanly: all required checks passed, including Python tests, e2e, macOS-only tests, Windows-only tests, Ruff/ty, Windows footguns, amd64/arm64 builds, Nix, and supply-chain checks.

Ruff, `py_compile`, and `git diff --check` pass. The new end-to-end test was also run against the unmodified pinned base and failed at the intended `systemd_unit_is_current() is True` assertion, establishing that it detects the regression.
