### PR TITLE
fix(dashboard-auth): offer password choice in native sign-in

### DIFF
--- a/hermes_cli/dashboard_auth/login_page.py
+++ b/hermes_cli/dashboard_auth/login_page.py
@@ -22,8 +22,11 @@ class name MUST NOT change without updating
 from __future__ import annotations
 
 import html
+from typing import Iterable
+from urllib.parse import urlencode
 
 from hermes_cli.dashboard_auth import list_session_providers
+from hermes_cli.dashboard_auth.base import DashboardAuthProvider
 
 # Inline minimal CSS. The dashboard's full skin lives in the React
 # bundle, which we deliberately do NOT load here — the login page must
@@ -498,6 +501,38 @@ def render_login_html(*, next_path: str = "") -> str:
     return _LOGIN_HTML_TEMPLATE.format(
         provider_buttons="\n".join(buttons),
         password_script=script,
+    )
+
+
+def render_native_provider_choice_html(
+    *,
+    providers: Iterable[DashboardAuthProvider],
+    authorize_path: str,
+    code_challenge: str,
+    code_challenge_method: str,
+    redirect_uri: str,
+    state: str,
+) -> str:
+    """Choose an interactive provider without leaving the native PKCE flow."""
+    buttons = []
+    common_params = {
+        "code_challenge": code_challenge,
+        "code_challenge_method": code_challenge_method,
+        "redirect_uri": redirect_uri,
+        "state": state,
+    }
+    for provider in providers:
+        query = urlencode({**common_params, "provider": provider.name})
+        href = html.escape(f"{authorize_path}?{query}", quote=True)
+        label = html.escape(provider.display_name)
+        buttons.append(f'  <a class="provider-btn" href="{href}">Sign in with {label}</a>')
+
+    if not buttons:
+        return _EMPTY_HTML
+
+    return _LOGIN_HTML_TEMPLATE.format(
+        provider_buttons="\n".join(buttons),
+        password_script="",
     )
 
 

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -47,7 +47,10 @@ from hermes_cli.dashboard_auth.cookies import (
     set_pkce_cookie,
     set_session_cookies,
 )
-from hermes_cli.dashboard_auth.login_page import render_login_html
+from hermes_cli.dashboard_auth.login_page import (
+    render_login_html,
+    render_native_provider_choice_html,
+)
 
 _log = logging.getLogger(__name__)
 
@@ -343,31 +346,28 @@ async def auth_native_authorize(
         raise HTTPException(status_code=400, detail="code_challenge required")
     _validate_loopback_redirect_uri(redirect_uri)
 
-    # Resolve the provider. With exactly one brokerable session provider
-    # registered (the common hosted case) an empty ``provider`` selects it,
-    # mirroring the auto-SSO convenience so the desktop needn't hardcode the
-    # name. Password providers are session providers too, but they can never
-    # be the target of the native OAuth broker flow (rejected below), so they
-    # must not count toward "exactly one candidate": otherwise a normal
-    # SSO-with-password-fallback deployment (one OIDC provider + the bundled
-    # ``basic`` provider) would see two session providers, skip the
-    # auto-select, and fail desktop login with a misleading "Unknown provider".
+    # Both OAuth and password providers support native sign-in. Auto-select
+    # only a single interactive provider; otherwise keep every configured
+    # method reachable without requiring the desktop to know provider names.
     p = get_provider(provider) if provider else None
     if p is None and not provider:
-        native_eligible = [
-            pp
-            for pp in list_session_providers()
-            if not getattr(pp, "supports_password", False)
-        ]
-        if len(native_eligible) == 1:
-            p = native_eligible[0]
-        elif not native_eligible:
-            # No brokerable provider at all. Preserve the old behaviour of
-            # selecting a lone password provider so the explicit 400 below
-            # (rather than a 404) explains why native OAuth is unavailable.
-            sess_providers = list_session_providers()
-            if len(sess_providers) == 1:
-                p = sess_providers[0]
+        candidates = list_session_providers()
+        if len(candidates) == 1:
+            p = candidates[0]
+        elif len(candidates) > 1:
+            # Do not allocate a pending authorization or replace its cookie
+            # until the user chooses. Every link re-enters this validated path.
+            return HTMLResponse(
+                render_native_provider_choice_html(
+                    providers=candidates,
+                    authorize_path=f"{_prefix(request)}/auth/native/authorize",
+                    code_challenge=code_challenge,
+                    code_challenge_method=code_challenge_method,
+                    redirect_uri=redirect_uri,
+                    state=state,
+                ),
+                headers={"Cache-Control": "no-store, no-cache, must-revalidate"},
+            )
     if p is None:
         raise HTTPException(
             status_code=404, detail=f"Unknown provider: {provider!r}"

--- a/tests/hermes_cli/test_dashboard_auth_native_flow.py
+++ b/tests/hermes_cli/test_dashboard_auth_native_flow.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import hashlib
 import base64
 import time
+from html.parser import HTMLParser
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -52,11 +53,7 @@ def _make_pkce() -> tuple[str, str]:
 
 
 class _PasswordOnlyProvider(StubAuthProvider):
-    """Mirrors the bundled ``basic`` provider's flags: a session provider
-    (``supports_session`` defaults True) that authenticates by username +
-    password and can never be the target of the native OAuth broker flow.
-    ``start_login`` raises to prove the route must reject it before ever
-    attempting a redirect."""
+    """Password sign-in must use the form, never an upstream IDP redirect."""
 
     name = "pwonly"
     display_name = "Password Only (test)"
@@ -64,8 +61,7 @@ class _PasswordOnlyProvider(StubAuthProvider):
 
     def start_login(self, *, redirect_uri):
         raise AssertionError(
-            "native authorize must reject a password provider before "
-            "calling start_login"
+            "native authorize must not call start_login for a password provider"
         )
 
 
@@ -75,6 +71,26 @@ class _SecondStubProvider(StubAuthProvider):
 
     name = "stub2"
     display_name = "Stub IdP Two (test only)"
+
+
+class _ProviderLinkParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.links = {}
+
+    def handle_starttag(self, tag, attrs):
+        attrs = dict(attrs)
+        if tag == "a" and "provider-btn" in attrs.get("class", "").split():
+            href = attrs["href"]
+            provider = parse_qs(urlparse(href).query)["provider"][0]
+            self.links[provider] = href
+
+
+def _provider_links(response):
+    assert response.status_code == 200, response.text
+    parser = _ProviderLinkParser()
+    parser.feed(response.text)
+    return parser.links
 
 
 # ---------------------------------------------------------------------------
@@ -209,7 +225,7 @@ def test_native_authorize_rejects_non_loopback_redirect(gated_client):
 
 # ---------------------------------------------------------------------------
 # Empty-provider auto-select (the desktop omits ``provider``; the gateway
-# picks when there is exactly one brokerable candidate) — regression #78906
+# picks only when there is exactly one interactive candidate).
 # ---------------------------------------------------------------------------
 
 
@@ -224,23 +240,23 @@ def _native_authorize_params(challenge, **overrides):
     return params
 
 
-def test_native_authorize_empty_provider_auto_selects_oauth_with_password_also_registered(
+def test_native_authorize_chooser_includes_password_and_oauth(
     gated_client,
 ):
-    """Regression for #78906: a password provider is a session provider but
-    can never be the target of the native OAuth broker flow, so it must not
-    count toward the empty-provider auto-select. With one OAuth provider +
-    one password provider (the normal SSO-with-password-fallback setup) the
-    desktop's empty-provider request must auto-select the OAuth provider
-    (302), not fail with ``Unknown provider: ''`` (404)."""
+    """A configured password must remain reachable when SSO is also enabled."""
     register_provider(_PasswordOnlyProvider())
     _verifier, challenge = _make_pkce()
     r = gated_client.get(
         "/auth/native/authorize",
         params=_native_authorize_params(challenge),
     )
-    assert r.status_code == 302, r.text
-    assert "code=stub_code" in r.headers["location"]
+    links = _provider_links(r)
+    assert set(links) == {"stub", "pwonly"}
+    assert "no-store" in r.headers["cache-control"]
+    assert "set-cookie" not in r.headers
+    selected = gated_client.get(links["stub"])
+    assert selected.status_code == 302, selected.text
+    assert "code=stub_code" in selected.headers["location"]
 
 
 def test_native_authorize_empty_provider_auto_selects_single_oauth(gated_client):
@@ -256,15 +272,96 @@ def test_native_authorize_empty_provider_auto_selects_single_oauth(gated_client)
     assert "code=stub_code" in r.headers["location"]
 
 
-def test_native_authorize_empty_provider_ambiguous_multiple_oauth_404(gated_client):
-    """Two brokerable providers: the empty-provider convenience cannot pick
-    unambiguously, so the request still fails — the desktop must pass
-    ``?provider=`` explicitly."""
+def test_native_authorize_chooser_multiple_oauth(gated_client):
+    """Multiple interactive providers are a choice, not an unknown provider."""
     register_provider(_SecondStubProvider())
     _verifier, challenge = _make_pkce()
     r = gated_client.get(
         "/auth/native/authorize",
         params=_native_authorize_params(challenge),
+    )
+    assert set(_provider_links(r)) == {"stub", "stub2"}
+
+
+def test_native_authorize_chooser_preserves_pkce_and_prefix(gated_client):
+    class EscapedProvider(StubAuthProvider):
+        name = 'odd&provider="<test>'
+        display_name = '<img src=x onerror="alert(1)">'
+
+    register_provider(EscapedProvider())
+    _verifier, challenge = _make_pkce()
+    params = _native_authorize_params(
+        challenge, state='state+with&quotes="<>',
+        redirect_uri="http://[::1]:53999/cb?existing=a%26b",
+    )
+    r = gated_client.get(
+        "/auth/native/authorize", params=params,
+        headers={"X-Forwarded-Prefix": "/hermes"},
+    )
+    links = _provider_links(r)
+    assert set(links) == {"stub", EscapedProvider.name}
+    assert EscapedProvider.display_name not in r.text
+    assert "&lt;img" in r.text
+    for provider, href in links.items():
+        parsed = urlparse(href)
+        assert parsed.path == "/hermes/auth/native/authorize"
+        assert parse_qs(parsed.query) == {
+            **{key: [value] for key, value in params.items()},
+            "provider": [provider],
+        }
+
+
+@pytest.mark.parametrize("overrides", [
+    {"code_challenge": ""},
+    {"code_challenge_method": "plain"},
+    {"redirect_uri": "https://example.test/cb"},
+])
+def test_native_authorize_chooser_validates_before_rendering(gated_client, overrides):
+    register_provider(_PasswordOnlyProvider())
+    _verifier, challenge = _make_pkce()
+    r = gated_client.get(
+        "/auth/native/authorize",
+        params=_native_authorize_params(challenge, **overrides),
+    )
+    assert r.status_code == 400
+    assert "set-cookie" not in r.headers
+
+
+def test_native_authorize_chooser_excludes_token_only_providers(gated_client):
+    class TokenOnlyProvider(StubAuthProvider):
+        name = "token-only"
+        supports_session = False
+
+    register_provider(TokenOnlyProvider())
+    _verifier, challenge = _make_pkce()
+    params = _native_authorize_params(challenge)
+    # A token-only provider must not force a chooser for a single sign-in.
+    assert gated_client.get("/auth/native/authorize", params=params).status_code == 302
+    register_provider(_PasswordOnlyProvider())
+    assert set(_provider_links(gated_client.get(
+        "/auth/native/authorize", params=params,
+    ))) == {"stub", "pwonly"}
+    params["provider"] = "token-only"
+    assert gated_client.get("/auth/native/authorize", params=params).status_code == 400
+
+
+@pytest.mark.parametrize("provider", ["", "missing"])
+def test_native_authorize_no_provider_fails_closed(gated_client, provider):
+    clear_providers()
+    _verifier, challenge = _make_pkce()
+    r = gated_client.get(
+        "/auth/native/authorize",
+        params=_native_authorize_params(challenge, provider=provider),
+    )
+    assert r.status_code == 404
+
+
+def test_native_authorize_explicit_provider_does_not_fall_back(gated_client):
+    register_provider(_PasswordOnlyProvider())
+    _verifier, challenge = _make_pkce()
+    r = gated_client.get(
+        "/auth/native/authorize",
+        params=_native_authorize_params(challenge, provider="missing"),
     )
     assert r.status_code == 404
 
@@ -434,10 +531,25 @@ def _start_native_password_login(client, *, challenge, state="desk-state"):
     return r.cookies
 
 
-def test_native_password_login_full_roundtrip(pw_gated_client):
+@pytest.mark.parametrize("use_chooser", [False, True])
+def test_native_password_login_full_roundtrip(pw_gated_client, use_chooser):
     """authorize → /login → password-login → loopback code → bearer tokens."""
     verifier, challenge = _make_pkce()
-    cookies = _start_native_password_login(pw_gated_client, challenge=challenge)
+    if use_chooser:
+        register_provider(StubAuthProvider())
+        r = pw_gated_client.get(
+            "/auth/native/authorize",
+            params=_native_authorize_params(challenge, state="desk-state"),
+        )
+        links = _provider_links(r)
+        r = pw_gated_client.get(links["testpw"])
+        assert r.status_code == 302, r.text
+        assert r.headers["location"] == "/login"
+        cookies = r.cookies
+        page = pw_gated_client.get(r.headers["location"])
+        assert 'data-provider="testpw"' in page.text
+    else:
+        cookies = _start_native_password_login(pw_gated_client, challenge=challenge)
 
     # The browser form POSTs the credentials; the PKCE cookie rides along.
     r = pw_gated_client.post(


### PR DESCRIPTION
## What does this PR do?

Keeps configured password sign-in reachable from Desktop when the remote dashboard also has an OAuth provider enabled.

Desktop opens `/auth/native/authorize` without choosing a provider. Current main excludes password providers during auto-selection, so a backend with one OAuth provider plus username/password goes straight to OAuth. The password option is never offered, even though the native password flow is already implemented. If OAuth cannot complete, users cannot select their working alternative through this entry point.

This change presents the existing login-page styling with a choice of all interactive providers when more than one is configured. Selecting a provider resumes the same native PKCE flow. A single provider still auto-selects. No Desktop client changes, plugin disabling, port changes, new authentication method, or credential-store changes are required.

This fixes provider selection. It does not repair an OAuth provider's redirect-URI registration or claim to resolve unrelated connection failures.

## Related Issue

Found during support investigation; reproduced with synthetic providers against main at `1a451bfaeb`.

Related overlapping work was inspected:

- #76941 provides the native OAuth chooser design reused here. Credit to Phuong Lambert (phuongvm), retained as co-author. This ports the chooser onto current main and includes password providers, which that PR still filters out.
- #97248, #75045, and #70580 change client-side strategy/provider selection, but still select the sole OAuth provider in a mixed OAuth/password deployment. They do not expose the password choice addressed here.

This is a current-main consolidation and extension of the chooser approach, not a second authentication implementation.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_cli/dashboard_auth/routes.py`: offer a chooser for multiple session providers, including password providers, after validating native PKCE inputs and before allocating broker state. Preserve explicit-provider selection and fail-closed handling.
- `hermes_cli/dashboard_auth/login_page.py`: reuse the login template for provider links, preserving the PKCE challenge, method, loopback callback, client state, and proxy prefix with URL encoding and HTML escaping.
- `tests/hermes_cli/test_dashboard_auth_native_flow.py`: replace obsolete OAuth-preference expectations and add behavioral coverage for the mixed-provider choice, OAuth-only choice, encoded fields, proxy prefix, invalid requests, token-only exclusion, explicit invalid providers, and password choice through token redemption and authenticated API access.

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_native_flow.py tests/hermes_cli/test_dashboard_auth_password_login.py -q -j 4`.
2. Against a test backend with OAuth and username/password both configured, use Desktop's Remote gateway Sign in action. The system browser should offer both providers. Choose username/password, submit valid credentials, and finish connecting in Desktop.
3. Check that selecting OAuth still starts its normal flow, and a single configured provider still skips the chooser.

Verified on native Windows using the canonical runner with isolated Hermes state and no external identity provider:

- Before the production patch: the focused chooser/round-trip selection had **5 failed, 4 passed**. Mixed providers redirected to OAuth and multiple OAuth providers returned 404.
- After the production patch: both complete test files passed, **37 passed, 0 failed**, no retries.
- `scripts/check-windows-footguns.py` on the three changed files: passed.
- `git diff --check`: passed.

The local runner's bytecode precompile was temporarily capped at four workers for workstation safety; that runner-only adjustment is not part of this PR. The real Desktop/system-browser/manual-provider round trip has not been exercised. Full-suite coverage is left to CI.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate; overlap and consolidation are explained above
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows, focused in-process HTTP authentication tests

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A: corrected the native selection comments and helper documentation
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A: no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A: existing auth architecture retained
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility): platform-independent HTTP/HTML selection
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A: no tool changes

## Screenshots / Logs

Synthetic regression results:

```text
Before production patch: 5 failed, 4 passed, 15 deselected
After production patch: 37 tests passed, 0 failed (2 files, 4 workers)
```
