### PR TITLE
fix(search): bounded, fail-closed search_files fallbacks with shared engine/ordering policy (salvage #97770)

### DIFF
--- a/agent/search_policy.py
+++ b/agent/search_policy.py
@@ -1,0 +1,30 @@
+"""Shared directory pruning policy for broad recursive scans.
+
+These names identify version-control internals, dependency trees, generated
+artifacts, caches, and backup copies that are not useful results for broad
+agent-facing discovery. Ordinary search callers may still target an explicit
+path; broad diagnostic probes should apply this policy to recursive walks.
+"""
+
+from __future__ import annotations
+
+
+# Keep this policy conservative and name-based so it works for local and remote
+# shell backends alike. The same set is used by context discovery and search
+# probes; adding a directory here protects every broad recursive consumer.
+SEARCH_PRUNE_DIR_NAMES = frozenset({
+    # Version-control internals.
+    ".git", ".hg", ".svn",
+    # Dependency and vendored trees.
+    "node_modules", "venv", ".venv", "site-packages", "dist-packages",
+    "vendor", "third_party",
+    # Generated/build output.
+    "build", "dist", "target", "out", "coverage",
+    ".next", ".turbo", ".parcel-cache", ".nuxt", ".svelte-kit",
+    # Python and package-manager caches.
+    "__pycache__", ".cache", ".Trash", ".tox", ".nox", ".mypy_cache",
+    ".pytest_cache", ".ruff_cache", ".npm", ".yarn", ".pnpm-store",
+    ".gradle", ".m2", ".nuget",
+    # Backup copies.
+    "backups", "backup", ".backups",
+})

--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Dict, Any, Optional, Set
 
 from agent.prompt_builder import _read_text_with_timeout, _scan_context_content
+from agent.search_policy import SEARCH_PRUNE_DIR_NAMES
 
 logger = logging.getLogger(__name__)
 
@@ -47,17 +48,9 @@ _COMMAND_TOOLS = {"terminal"}
 # Prevents scanning all the way to / for deeply nested paths.
 _MAX_ANCESTOR_WALK = 5
 
-# Directory names that never contain authoritative project context.
-# Backups, vendored deps, VCS internals, and caches routinely hold *copies* of
-# AGENTS.md; loading those duplicates real context and inflates the prompt.
-_EXCLUDED_DIR_NAMES = frozenset({
-    "node_modules", "venv", ".venv", "__pycache__",
-    ".git", ".hg", ".svn",
-    ".Trash", ".cache", ".tox", ".mypy_cache", ".pytest_cache",
-    "site-packages", "dist-packages",
-    "backups", "backup", ".backups",
-    "vendor", "third_party",
-})
+# Shared with broad recursive search probes so context discovery and search do
+# not drift into different dependency/cache/build trees.
+_EXCLUDED_DIR_NAMES = SEARCH_PRUNE_DIR_NAMES
 
 
 def _is_ancestor_or_same(a: Path, b: Path) -> bool:

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -6,6 +6,7 @@ import pytest
 from pathlib import Path
 from unittest.mock import patch
 
+from agent.search_policy import SEARCH_PRUNE_DIR_NAMES
 from agent.subdirectory_hints import SubdirectoryHintTracker
 
 
@@ -281,7 +282,7 @@ class TestExcludedDirectories:
 
     @pytest.mark.parametrize(
         "excluded",
-        ["backups", "node_modules", ".git", "venv", "site-packages", ".Trash", "vendor"],
+        sorted(SEARCH_PRUNE_DIR_NAMES),
     )
     def test_excluded_directory_skipped(self, tmp_path, excluded):
         target = tmp_path / excluded / "snapshot"

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -475,10 +475,11 @@ class TestStubSchemaDrift(unittest.TestCase):
         compile(src, "hermes_tools.py", "exec")
 
         # Verify specific parameter signatures are in the source
-        # search_files must accept context, offset, output_mode
+        # search_files must accept its pagination, output, and ordering controls
         self.assertIn("context", src)
         self.assertIn("offset", src)
         self.assertIn("output_mode", src)
+        self.assertIn("order", src)
 
         # patch must accept mode and patch params
         self.assertIn("mode", src)

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -156,10 +156,16 @@ class TestSearchResult:
         assert d["matches"][0]["path"] == "a.py"
 
 
-    def test_truncated_flag(self):
+    def test_truncated_flag_marks_total_as_lower_bound(self):
         r = SearchResult(total_count=100, truncated=True)
         d = r.to_dict()
         assert d["truncated"] is True
+        assert d["total_count_is_lower_bound"] is True
+
+    def test_untruncated_total_omits_lower_bound_flag(self):
+        r = SearchResult(total_count=100)
+        d = r.to_dict()
+        assert "total_count_is_lower_bound" not in d
 
 
 class TestSearchResultDensify:

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -1,14 +1,13 @@
 """Tests for tools/file_operations.py — deny list, result dataclasses, helpers."""
 
 import os
-import re
 import pytest
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock
 
 from tests.tools.file_ops_fakes import READ_SENTINEL_RE, compound_read_output
-from tools.environments.local import _find_bash, _msys_to_windows_path
+from tools.environments.local import _find_bash, _msys_to_windows_path, LocalEnvironment
 from tools.file_operations import (
     _is_write_denied,
     ReadResult,
@@ -257,7 +256,6 @@ def make_real_subprocess_env(cwd: str, include_stderr: bool = False) -> MagicMoc
     env.cwd = cwd
 
     def execute(command, **kwargs):
-        shell_command = command
         stdin_data = kwargs.get("stdin_data")
         is_windows = os.name == "nt"
         if is_windows:
@@ -276,20 +274,6 @@ def make_real_subprocess_env(cwd: str, include_stderr: bool = False) -> MagicMoc
             completed.stdout.decode("utf-8", "replace")
             if is_windows else completed.stdout
         )
-        if is_windows and shell_command.startswith("find "):
-            # GNU find echoes its MSYS-form root. Convert only find records so
-            # pathlib applies hidden-descendant filtering on the native drive.
-            normalized_lines = []
-            for line in output.splitlines(keepends=True):
-                body = line.rstrip("\r\n")
-                ending = line[len(body):]
-                prefix, separator, path = body.partition(" ")
-                if not (separator and prefix.replace(".", "").isdigit()):
-                    prefix, separator, path = "", "", body
-                if re.match(r"^/[A-Za-z]/", path):
-                    path = _msys_to_windows_path(path)
-                normalized_lines.append(f"{prefix}{separator}{path}{ending}")
-            output = "".join(normalized_lines)
         if include_stderr:
             output += (
                 completed.stderr.decode("utf-8", "replace")
@@ -469,7 +453,7 @@ class TestSearchPathValidation:
 
 class TestSearchFilesFallbackHiddenPaths:
     def _make_env(self):
-        return make_real_subprocess_env("/")
+        return LocalEnvironment("/")
 
     def test_hidden_root_with_hidden_ancestor_includes_files(self, tmp_path, monkeypatch):
         """Fallback find should include visible files when path is inside hidden root."""

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 from tests.tools.file_ops_fakes import READ_SENTINEL_RE, compound_read_output
+from tools.environments.local import _find_bash, _msys_to_windows_path
 from tools.file_operations import (
     _is_write_denied,
     ReadResult,
@@ -256,16 +257,44 @@ def make_real_subprocess_env(cwd: str, include_stderr: bool = False) -> MagicMoc
     env.cwd = cwd
 
     def execute(command, **kwargs):
+        shell_command = command
+        stdin_data = kwargs.get("stdin_data")
+        is_windows = os.name == "nt"
+        if is_windows:
+            # Match LocalEnvironment: commands are POSIX scripts executed by
+            # Git Bash, and stdin bytes must bypass Windows newline rewriting.
+            command = [_find_bash(), "-c", command]
         completed = subprocess.run(
             command,
-            shell=True,
-            text=True,
+            shell=not is_windows,
+            text=not is_windows,
             capture_output=True,
-            input=kwargs.get("stdin_data"),
+            input=(stdin_data.encode("utf-8", "surrogateescape")
+                   if is_windows and stdin_data is not None else stdin_data),
         )
-        output = completed.stdout
+        output = (
+            completed.stdout.decode("utf-8", "replace")
+            if is_windows else completed.stdout
+        )
+        if is_windows and shell_command.startswith("find "):
+            # GNU find echoes its MSYS-form root. Convert only find records so
+            # pathlib applies hidden-descendant filtering on the native drive.
+            normalized_lines = []
+            for line in output.splitlines(keepends=True):
+                body = line.rstrip("\r\n")
+                ending = line[len(body):]
+                prefix, separator, path = body.partition(" ")
+                if not (separator and prefix.replace(".", "").isdigit()):
+                    prefix, separator, path = "", "", body
+                if re.match(r"^/[A-Za-z]/", path):
+                    path = _msys_to_windows_path(path)
+                normalized_lines.append(f"{prefix}{separator}{path}{ending}")
+            output = "".join(normalized_lines)
         if include_stderr:
-            output += completed.stderr
+            output += (
+                completed.stderr.decode("utf-8", "replace")
+                if is_windows else completed.stderr
+            )
         return {
             "output": output,
             "returncode": completed.returncode,

--- a/tests/tools/test_file_operations_edge_cases.py
+++ b/tests/tools/test_file_operations_edge_cases.py
@@ -236,7 +236,7 @@ class TestPaginationBounds:
             commands.append(command)
             if command.startswith("test -e"):
                 return MagicMock(exit_code=0, stdout="exists")
-            if command.startswith("rg --files"):
+            if "--files" in command:
                 return MagicMock(exit_code=0, stdout="a.py\n")
             return MagicMock(exit_code=0, stdout="")
 
@@ -245,9 +245,9 @@ class TestPaginationBounds:
             result = ops.search("*.py", target="files", path=".", offset=-4, limit=-2)
 
         assert result.files == ["a.py"]
-        rg_commands = [cmd for cmd in commands if cmd.startswith("rg --files")]
+        rg_commands = [cmd for cmd in commands if "--files" in cmd]
         assert rg_commands
-        assert "| head -n 1" in rg_commands[0]
+        assert "| head -n 2" in rg_commands[0]
 
 
 # =========================================================================

--- a/tests/tools/test_interrupt.py
+++ b/tests/tools/test_interrupt.py
@@ -76,38 +76,60 @@ class TestInterruptModule:
 
     @pytest.mark.parametrize("callback_should_fail", [False, True])
     def test_run_if_not_interrupted_orders_callback_before_concurrent_interrupt(
-        self, callback_should_fail
+        self, callback_should_fail, monkeypatch
     ):
-        from tools.interrupt import (
-            _interrupted_threads,
-            _lock,
-            run_if_not_interrupted,
-            set_interrupt,
-        )
+        import tools.interrupt as interrupt
 
         class CallbackFailure(Exception):
             pass
 
-        setter_started = threading.Event()
+        original_lock = interrupt._lock
+        attempting_interrupt_lock = threading.Event()
         interrupt_published = threading.Event()
+        publisher_lock_contention = []
         callback_observations = []
         setters = []
         setter_tids = []
 
+        class ObservedLock:
+            def __enter__(self):
+                if (
+                    threading.current_thread() in setters
+                    and not attempting_interrupt_lock.is_set()
+                ):
+                    acquired = original_lock.acquire(blocking=False)
+                    publisher_lock_contention.append(not acquired)
+                    attempting_interrupt_lock.set()
+                    if acquired:
+                        return self
+                original_lock.acquire()
+                return self
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                original_lock.release()
+
+        interrupt.set_interrupt(False)
+        with original_lock:
+            baseline = (
+                set(interrupt._interrupted_threads),
+                dict(interrupt._interrupt_reasons),
+            )
+        monkeypatch.setattr(interrupt, "_lock", ObservedLock())
+
         def publish_interrupt():
             setter_tids.append(threading.get_ident())
-            setter_started.set()
             try:
-                set_interrupt(True)
+                interrupt.set_interrupt(True)
                 interrupt_published.set()
             finally:
-                set_interrupt(False)
+                interrupt.set_interrupt(False)
 
         def callback():
             setter = threading.Thread(target=publish_interrupt)
             setters.append(setter)
             setter.start()
-            assert setter_started.wait(5)
+            assert attempting_interrupt_lock.wait(5)
+            assert publisher_lock_contention == [True]
             callback_observations.append(interrupt_published.is_set())
             if callback_should_fail:
                 raise CallbackFailure
@@ -115,24 +137,29 @@ class TestInterruptModule:
         try:
             if callback_should_fail:
                 with pytest.raises(CallbackFailure):
-                    run_if_not_interrupted(callback)
+                    interrupt.run_if_not_interrupted(callback)
             else:
-                assert run_if_not_interrupted(callback) is True
+                assert interrupt.run_if_not_interrupted(callback) is True
+            assert interrupt_published.wait(5)
         finally:
             for setter in setters:
                 if setter.ident is not None:
-                    setter.join()
-            for setter_tid in setter_tids:
-                set_interrupt(False, setter_tid)
-            set_interrupt(False)
+                    setter.join(timeout=5)
+            interrupt.set_interrupt(False)
 
         assert setters
         assert all(not setter.is_alive() for setter in setters)
         assert setter_tids
         assert callback_observations == [False]
         assert interrupt_published.is_set()
-        with _lock:
-            assert not _interrupted_threads
+        with original_lock:
+            final_state = (
+                set(interrupt._interrupted_threads),
+                dict(interrupt._interrupt_reasons),
+            )
+        assert final_state == baseline
+        assert all(setter_tid not in final_state[0] for setter_tid in setter_tids)
+        assert all(setter_tid not in final_state[1] for setter_tid in setter_tids)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_interrupt.py
+++ b/tests/tools/test_interrupt.py
@@ -75,14 +75,21 @@ class TestInterruptModule:
         assert callbacks == []
 
     def test_run_if_not_interrupted_orders_callback_before_concurrent_interrupt(self):
-        from tools.interrupt import run_if_not_interrupted, set_interrupt
+        from tools.interrupt import (
+            _interrupted_threads,
+            _lock,
+            run_if_not_interrupted,
+            set_interrupt,
+        )
 
         setter_started = threading.Event()
         interrupt_published = threading.Event()
         callback_observations = []
         setters = []
+        setter_tids = []
 
         def publish_interrupt():
+            setter_tids.append(threading.get_ident())
             setter_started.set()
             set_interrupt(True)
             interrupt_published.set()
@@ -96,13 +103,19 @@ class TestInterruptModule:
 
         assert run_if_not_interrupted(callback) is True
         setter = setters[0]
-        setter.join(5)
         try:
+            setter.join(5)
             assert not setter.is_alive()
             assert callback_observations == [False]
             assert interrupt_published.is_set()
         finally:
+            for setter_tid in setter_tids:
+                set_interrupt(False, setter_tid)
             set_interrupt(False)
+
+        assert setter_tids
+        with _lock:
+            assert setter_tids[0] not in _interrupted_threads
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_interrupt.py
+++ b/tests/tools/test_interrupt.py
@@ -74,13 +74,19 @@ class TestInterruptModule:
 
         assert callbacks == []
 
-    def test_run_if_not_interrupted_orders_callback_before_concurrent_interrupt(self):
+    @pytest.mark.parametrize("callback_should_fail", [False, True])
+    def test_run_if_not_interrupted_orders_callback_before_concurrent_interrupt(
+        self, callback_should_fail
+    ):
         from tools.interrupt import (
             _interrupted_threads,
             _lock,
             run_if_not_interrupted,
             set_interrupt,
         )
+
+        class CallbackFailure(Exception):
+            pass
 
         setter_started = threading.Event()
         interrupt_published = threading.Event()
@@ -91,8 +97,11 @@ class TestInterruptModule:
         def publish_interrupt():
             setter_tids.append(threading.get_ident())
             setter_started.set()
-            set_interrupt(True)
-            interrupt_published.set()
+            try:
+                set_interrupt(True)
+                interrupt_published.set()
+            finally:
+                set_interrupt(False)
 
         def callback():
             setter = threading.Thread(target=publish_interrupt)
@@ -100,22 +109,30 @@ class TestInterruptModule:
             setter.start()
             assert setter_started.wait(5)
             callback_observations.append(interrupt_published.is_set())
+            if callback_should_fail:
+                raise CallbackFailure
 
-        assert run_if_not_interrupted(callback) is True
-        setter = setters[0]
         try:
-            setter.join(5)
-            assert not setter.is_alive()
-            assert callback_observations == [False]
-            assert interrupt_published.is_set()
+            if callback_should_fail:
+                with pytest.raises(CallbackFailure):
+                    run_if_not_interrupted(callback)
+            else:
+                assert run_if_not_interrupted(callback) is True
         finally:
+            for setter in setters:
+                if setter.ident is not None:
+                    setter.join()
             for setter_tid in setter_tids:
                 set_interrupt(False, setter_tid)
             set_interrupt(False)
 
+        assert setters
+        assert all(not setter.is_alive() for setter in setters)
         assert setter_tids
+        assert callback_observations == [False]
+        assert interrupt_published.is_set()
         with _lock:
-            assert setter_tids[0] not in _interrupted_threads
+            assert not _interrupted_threads
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_interrupt.py
+++ b/tests/tools/test_interrupt.py
@@ -62,6 +62,48 @@ class TestInterruptModule:
             assert other_tid in _interrupted_threads  # other thread untouched
             _interrupted_threads.discard(other_tid)
 
+    def test_run_if_not_interrupted_skips_callback_when_already_interrupted(self):
+        from tools.interrupt import run_if_not_interrupted, set_interrupt
+
+        callbacks = []
+        set_interrupt(True)
+        try:
+            assert run_if_not_interrupted(lambda: callbacks.append("claimed")) is False
+        finally:
+            set_interrupt(False)
+
+        assert callbacks == []
+
+    def test_run_if_not_interrupted_orders_callback_before_concurrent_interrupt(self):
+        from tools.interrupt import run_if_not_interrupted, set_interrupt
+
+        setter_started = threading.Event()
+        interrupt_published = threading.Event()
+        callback_observations = []
+        setters = []
+
+        def publish_interrupt():
+            setter_started.set()
+            set_interrupt(True)
+            interrupt_published.set()
+
+        def callback():
+            setter = threading.Thread(target=publish_interrupt)
+            setters.append(setter)
+            setter.start()
+            assert setter_started.wait(5)
+            callback_observations.append(interrupt_published.is_set())
+
+        assert run_if_not_interrupted(callback) is True
+        setter = setters[0]
+        setter.join(5)
+        try:
+            assert not setter.is_alive()
+            assert callback_observations == [False]
+            assert interrupt_published.is_set()
+        finally:
+            set_interrupt(False)
+
 
 # ---------------------------------------------------------------------------
 # Unit tests: pre-tool interrupt check

--- a/tests/tools/test_macos_protected_search.py
+++ b/tests/tools/test_macos_protected_search.py
@@ -1,5 +1,6 @@
 """macOS TCC-safe behavior for broad file searches."""
 
+import re
 from pathlib import Path
 
 import tools.file_operations as file_operations
@@ -201,6 +202,67 @@ def test_find_fallback_prunes_protected_directories(tmp_path, monkeypatch):
     for command in find_commands:
         assert ops._escape_shell_arg(str(home / "Downloads")) in command
         assert "-prune" in command
+
+
+def _multi_root_protected_search(tmp_path, monkeypatch, engine):
+    home = tmp_path / "Users" / "alice"
+    downloads = home / "Downloads"
+    downloads.mkdir(parents=True)
+    env = RecordingEnvironment(home)
+    ops = ShellFileOperations(env)
+    monkeypatch.setattr(file_operations, "_HOME", str(home))
+    monkeypatch.setattr(file_operations.sys, "platform", "darwin")
+    monkeypatch.setattr(ops, "_has_command", lambda command: command == engine)
+    path_checks = 0
+
+    def execute(command, cwd=None, **kwargs):
+        nonlocal path_checks
+        env.commands.append(command)
+        if command.startswith("test -e"):
+            path_checks += 1
+            output = "not_found\n" if path_checks == 1 else "exists\n"
+            return {"output": output, "returncode": 0}
+        if "--files" in command or command.startswith("set -o pipefail; find "):
+            return {"output": "", "returncode": 0}
+        return {"output": "yes\n", "returncode": 0}
+
+    env.execute = execute
+    result = ops.search("*.txt", path=f"{home} {downloads}", target="files")
+    return ops, env, result, downloads
+
+
+def test_rg_multi_root_keeps_explicit_protected_root_and_reports_actual_skips(
+    tmp_path, monkeypatch
+):
+    ops, env, result, downloads = _multi_root_protected_search(
+        tmp_path, monkeypatch, "rg"
+    )
+
+    command = _rg_files_commands(env.commands)[0]
+    assert downloads.as_posix() in command
+    assert "!Downloads/**" not in command
+    assert "path contained 2 entries" in (result.warning or "")
+    assert "macOS protected folders" in (result.warning or "")
+    protected_warning = result.warning.split("macOS protected folders", 1)[1]
+    assert "Desktop" in protected_warning
+    assert "Downloads" not in protected_warning
+
+
+def test_find_multi_root_keeps_explicit_protected_root_and_reports_actual_skips(
+    tmp_path, monkeypatch
+):
+    ops, env, result, downloads = _multi_root_protected_search(
+        tmp_path, monkeypatch, "find"
+    )
+
+    command = _find_commands(env.commands)[0]
+    assert "Downloads" in command
+    assert re.search(r"(?<!! )-path '[^']*/Downloads'", command) is None
+    assert "path contained 2 entries" in (result.warning or "")
+    assert "macOS protected folders" in (result.warning or "")
+    protected_warning = result.warning.split("macOS protected folders", 1)[1]
+    assert "Desktop" in protected_warning
+    assert "Downloads" not in protected_warning
 
 
 def test_real_ripgrep_does_not_descend_into_protected_folder(tmp_path, monkeypatch):

--- a/tests/tools/test_macos_protected_search.py
+++ b/tests/tools/test_macos_protected_search.py
@@ -333,6 +333,32 @@ def test_rg_scoped_multi_root_handles_dot_spaces_and_overlapping_roots(monkeypat
     assert result.files == ["/Users/alice/work space/local.txt"]
 
 
+def test_rg_scoped_multi_root_terminates_options_before_dash_prefixed_root(monkeypatch):
+    env = RecordingEnvironment("/Users/alice")
+    ops = ShellFileOperations(env)
+    monkeypatch.setattr(file_operations, "_HOME", "/Users/alice")
+    monkeypatch.setattr(file_operations.sys, "platform", "darwin")
+
+    def execute(command, cwd=None, **kwargs):
+        env.commands.append(command)
+        if command.startswith("test -e"):
+            output = "not_found\n" if "'., --version'" in command else "exists\n"
+            return {"output": output, "returncode": 0}
+        if command.startswith("command -v rg"):
+            return {"output": "/usr/bin/rg\n", "returncode": 0}
+        if "--files" in command:
+            return {"output": "", "returncode": 0}
+        raise AssertionError(command)
+
+    env.execute = execute
+    result = ops.search("*.txt", path="., --version", target="files")
+
+    command = _rg_files_commands(env.commands)[0]
+    assert "cd '/Users/alice' &&" in command
+    assert " -- '.' '--version' 2>/dev/null" in command
+    assert result.error is None
+
+
 def test_real_ripgrep_does_not_descend_into_protected_folder(tmp_path, monkeypatch):
     home = tmp_path / "Users" / "alice"
     safe = home / "safe"

--- a/tests/tools/test_macos_protected_search.py
+++ b/tests/tools/test_macos_protected_search.py
@@ -239,7 +239,12 @@ def test_rg_multi_root_keeps_explicit_protected_root_and_reports_actual_skips(
     )
 
     command = _rg_files_commands(env.commands)[0]
-    assert downloads.as_posix() in command
+    absolute_operand = downloads.as_posix() in command
+    anchored_operand = (
+        f"cd {ops._escape_shell_arg(downloads.parent.as_posix())} &&" in command
+        and " -- '.' 'Downloads' 2>/dev/null" in command
+    )
+    assert absolute_operand or anchored_operand
     assert "!Downloads/**" not in command
     assert "path contained 2 entries" in (result.warning or "")
     assert "macOS protected folders" in (result.warning or "")

--- a/tests/tools/test_macos_protected_search.py
+++ b/tests/tools/test_macos_protected_search.py
@@ -32,6 +32,17 @@ PROTECTED_NAMES = {
 }
 
 
+def _rg_files_commands(commands):
+    return [command for command in commands if "--files" in command]
+
+
+def _find_commands(commands):
+    return [
+        command for command in commands
+        if command.startswith("find ") or "; find " in command
+    ]
+
+
 def test_broad_home_search_excludes_macos_protected_folders(tmp_path):
     home = tmp_path / "Users" / "alice"
 
@@ -72,7 +83,7 @@ def test_broad_file_search_passes_protected_globs_to_ripgrep(tmp_path, monkeypat
 
     result = ops.search("*.txt", path=str(home), target="files")
 
-    rg_command = next(command for command in env.commands if command.startswith("rg --files"))
+    rg_command = _rg_files_commands(env.commands)[0]
     for dirname in PROTECTED_NAMES:
         assert f"!{dirname}/**" in rg_command
     assert result.warning is not None
@@ -94,7 +105,7 @@ def test_broad_content_search_passes_protected_globs_to_ripgrep(tmp_path, monkey
         assert f"!{dirname}/**" in rg_command
 
 
-def test_legacy_ripgrep_file_fallback_keeps_protected_globs(tmp_path, monkeypatch):
+def test_empty_ripgrep_file_search_is_one_scan_with_protected_globs(tmp_path, monkeypatch):
     home = tmp_path / "Users" / "alice"
     home.mkdir(parents=True)
     env = RecordingEnvironment(home)
@@ -104,8 +115,8 @@ def test_legacy_ripgrep_file_fallback_keeps_protected_globs(tmp_path, monkeypatc
 
     ops.search("*.txt", path=str(home), target="files")
 
-    rg_commands = [command for command in env.commands if command.startswith("rg --files")]
-    assert len(rg_commands) == 2
+    rg_commands = _rg_files_commands(env.commands)
+    assert len(rg_commands) == 1
     for command in rg_commands:
         assert "!Downloads/**" in command
 
@@ -128,7 +139,7 @@ def test_grep_fallback_prunes_by_path_not_basename(tmp_path, monkeypatch):
     for dirname in PROTECTED_NAMES:
         # Path-scoped pruning: full protected path present, no basename-wide
         # --exclude-dir for protected names.
-        assert str(home / dirname) in pruned_command
+        assert ops._escape_shell_arg(str(home / dirname)) in pruned_command
         assert f"--exclude-dir={dirname}" not in pruned_command
         assert f"--exclude-dir='{dirname}'" not in pruned_command
 
@@ -169,7 +180,7 @@ def test_remote_backend_never_prunes(tmp_path, monkeypatch):
 
     result = ops.search("*.txt", path=str(home), target="files")
 
-    rg_command = next(command for command in env.commands if command.startswith("rg --files"))
+    rg_command = _rg_files_commands(env.commands)[0]
     assert "!Downloads/**" not in rg_command
     assert result.warning is None
 
@@ -185,10 +196,10 @@ def test_find_fallback_prunes_protected_directories(tmp_path, monkeypatch):
 
     ops.search("*.txt", path=str(home), target="files")
 
-    find_commands = [command for command in env.commands if command.startswith("find ")]
+    find_commands = _find_commands(env.commands)
     assert find_commands
     for command in find_commands:
-        assert str(home / "Downloads") in command
+        assert ops._escape_shell_arg(str(home / "Downloads")) in command
         assert "-prune" in command
 
 

--- a/tests/tools/test_macos_protected_search.py
+++ b/tests/tools/test_macos_protected_search.py
@@ -265,6 +265,74 @@ def test_find_multi_root_keeps_explicit_protected_root_and_reports_actual_skips(
     assert "Downloads" not in protected_warning
 
 
+def test_rg_multi_root_scopes_protected_globs_and_restores_absolute_paths(monkeypatch):
+    env = RecordingEnvironment("/")
+    ops = ShellFileOperations(env)
+    monkeypatch.setattr(file_operations, "_HOME", "/Users/alice")
+    monkeypatch.setattr(file_operations.sys, "platform", "darwin")
+
+    def execute(command, cwd=None, **kwargs):
+        env.commands.append(command)
+        if command.startswith("test -e"):
+            output = "not_found\n" if "'/Users/alice /repo'" in command else "exists\n"
+            return {"output": output, "returncode": 0}
+        if command.startswith("command -v rg"):
+            return {"output": "/usr/bin/rg\n", "returncode": 0}
+        if "--version" in command:
+            return {"output": "ripgrep 14.1.1\n", "returncode": 0}
+        if "--files" in command:
+            return {
+                "output": "repo/Downloads/visible.txt\nUsers/alice/safe.txt\n",
+                "returncode": 0,
+            }
+        raise AssertionError(command)
+
+    env.execute = execute
+    result = ops.search(
+        "*.txt", path="/Users/alice /repo", target="files", order="modified"
+    )
+
+    commands = _rg_files_commands(env.commands)
+    assert len(commands) == 1
+    command = commands[0]
+    assert command.startswith("set -o pipefail; cd '/' && ")
+    assert "--sortr=modified" in command
+    assert "'!Users/alice/Downloads/**'" in command
+    assert "'!repo/Downloads/**'" not in command
+    assert "'Users/alice' 'repo'" in command
+    assert result.files == [
+        "/repo/Downloads/visible.txt",
+        "/Users/alice/safe.txt",
+    ]
+
+
+def test_rg_scoped_multi_root_handles_dot_spaces_and_overlapping_roots(monkeypatch):
+    env = RecordingEnvironment("/Users/alice/work space")
+    ops = ShellFileOperations(env)
+    monkeypatch.setattr(file_operations, "_HOME", "/Users/alice")
+    monkeypatch.setattr(file_operations.sys, "platform", "darwin")
+
+    def execute(command, cwd=None, **kwargs):
+        env.commands.append(command)
+        if command.startswith("test -e"):
+            output = "not_found\n" if "'., /Users/alice'" in command else "exists\n"
+            return {"output": output, "returncode": 0}
+        if command.startswith("command -v rg"):
+            return {"output": "/usr/bin/rg\n", "returncode": 0}
+        if "--files" in command:
+            return {"output": "work space/local.txt\n", "returncode": 0}
+        raise AssertionError(command)
+
+    env.execute = execute
+    result = ops.search("*.txt", path="., /Users/alice", target="files")
+
+    command = _rg_files_commands(env.commands)[0]
+    assert "cd '/Users/alice' &&" in command
+    assert "'work space' '.'" in command
+    assert "'!Downloads/**'" in command
+    assert result.files == ["/Users/alice/work space/local.txt"]
+
+
 def test_real_ripgrep_does_not_descend_into_protected_folder(tmp_path, monkeypatch):
     home = tmp_path / "Users" / "alice"
     safe = home / "safe"

--- a/tests/tools/test_search_budget_truncation.py
+++ b/tests/tools/test_search_budget_truncation.py
@@ -1,3 +1,4 @@
+import shlex
 from unittest.mock import MagicMock
 
 import pytest
@@ -171,6 +172,40 @@ def test_no_rg_multi_root_modified_is_one_globally_sorted_scan():
     assert "! -path '/one/.hidden'" in command
     assert "! -path '/two/.cache'" in command
     assert kwargs["timeout"] <= 60
+
+
+def test_find_dash_prefixed_relative_root_is_an_explicit_operand(
+    tmp_path, monkeypatch
+):
+    dash_root = tmp_path / "--version"
+    ordinary_root = tmp_path / "ordinary"
+    dash_root.mkdir()
+    ordinary_root.mkdir()
+    (dash_root / "dash.py").write_text("", encoding="utf-8")
+    (ordinary_root / "plain.py").write_text("", encoding="utf-8")
+
+    ops = ShellFileOperations(LocalEnvironment(str(tmp_path)))
+    monkeypatch.setattr(ops, "_has_command", lambda command: command == "find")
+    executed = []
+    real_exec = ops._exec
+
+    def recording_exec(command, **kwargs):
+        if command.startswith("set -o pipefail; find "):
+            executed.append(command)
+        return real_exec(command, **kwargs)
+
+    monkeypatch.setattr(ops, "_exec", recording_exec)
+    result = ops._search_files(
+        "*.py", ["--version", "ordinary"], limit=10, offset=0
+    )
+
+    assert result.error is None
+    assert sorted(result.files) == ["./--version/dash.py", "ordinary/plain.py"]
+    assert len(executed) == 1
+    command_tokens = shlex.split(executed[0].removeprefix("set -o pipefail; "))
+    assert "./--version" in command_tokens
+    assert "--version" not in command_tokens
+    assert all("find (GNU findutils)" not in path for path in result.files)
 
 
 def test_find_modified_capability_failure_is_actionable_without_retry():

--- a/tests/tools/test_search_budget_truncation.py
+++ b/tests/tools/test_search_budget_truncation.py
@@ -102,6 +102,21 @@ class FindRecordingEnvironment:
         ]
 
 
+class MultiRootFindEnvironment(FindRecordingEnvironment):
+    def execute(self, command, **kwargs):
+        self.commands.append((command, kwargs))
+        if command.startswith("test -e "):
+            output = "not_found\n" if "'/one/.hidden /two/.cache'" in command else "exists\n"
+            return {"output": output, "returncode": 0}
+        if command.startswith("command -v find"):
+            return {"output": "yes\n", "returncode": 0}
+        if command.startswith("command -v rg"):
+            return {"output": "", "returncode": 1}
+        if "find " in command:
+            return {"output": self.output, "returncode": self.code}
+        return {"output": "", "returncode": 1}
+
+
 def test_find_discovery_is_one_unsorted_pruned_bounded_scan():
     env = FindRecordingEnvironment("/narrow/a.py\n/narrow/b.py\n/narrow/c.py\n/narrow/d.py\n")
     result = ShellFileOperations(env)._search_files(
@@ -130,6 +145,32 @@ def test_find_modified_is_one_exact_scan_without_bsd_retry():
     assert "-printf '%T@ %p\\n'" in command
     assert "sort -rn" in command
     assert "head -n 3" in command
+
+
+def test_no_rg_multi_root_modified_is_one_globally_sorted_scan():
+    env = MultiRootFindEnvironment(
+        "30 /two/.cache/new.py\n10 /one/.hidden/old.py\n"
+    )
+
+    result = ShellFileOperations(env).search(
+        "*.py",
+        path="/one/.hidden /two/.cache",
+        target="files",
+        order="modified",
+        limit=1,
+    )
+
+    assert result.error is None
+    assert result.files == ["/two/.cache/new.py"]
+    assert result.truncated is True
+    assert len(env.find_commands) == 1
+    command, kwargs = env.find_commands[0]
+    assert "find '/one/.hidden' '/two/.cache'" in command
+    assert "sort -rn" in command
+    assert "head -n 2" in command
+    assert "! -path '/one/.hidden'" in command
+    assert "! -path '/two/.cache'" in command
+    assert kwargs["timeout"] <= 60
 
 
 def test_find_modified_capability_failure_is_actionable_without_retry():

--- a/tests/tools/test_search_budget_truncation.py
+++ b/tests/tools/test_search_budget_truncation.py
@@ -183,6 +183,48 @@ def test_find_modified_capability_failure_is_actionable_without_retry():
 
 
 @pytest.mark.parametrize(
+    ("order", "output"),
+    [
+        (
+            "discovery",
+            "/narrow/a.py\n/narrow/b.py\n/narrow/c.py\n/narrow/d.py\n",
+        ),
+        (
+            "modified",
+            "40 /narrow/a.py\n30 /narrow/b.py\n20 /narrow/c.py\n10 /narrow/d.py\n",
+        ),
+    ],
+)
+def test_find_sigpipe_is_benign_only_after_fetch_limit_rows(order, output):
+    result = ShellFileOperations(FindRecordingEnvironment(output, code=141))._search_files(
+        "*.py", "/narrow", limit=2, offset=1, order=order
+    )
+
+    assert result.error is None
+    assert result.files == ["/narrow/b.py", "/narrow/c.py"]
+    assert result.truncated is True
+
+
+@pytest.mark.parametrize(
+    ("order", "output", "error_fragment"),
+    [
+        ("discovery", "/narrow/partial.py\n", "bounded find traversal"),
+        ("modified", "10 /narrow/partial.py\n", "modification-time"),
+    ],
+)
+def test_find_sigpipe_with_fewer_than_fetch_limit_rows_fails_closed(
+    order, output, error_fragment
+):
+    result = ShellFileOperations(FindRecordingEnvironment(output, code=141))._search_files(
+        "*.py", "/narrow", limit=2, offset=1, order=order
+    )
+
+    assert error_fragment in (result.error or "")
+    assert result.files == []
+    assert result.total_count == 0
+
+
+@pytest.mark.parametrize(
     ("order", "output", "error_fragment"),
     [
         ("discovery", "/narrow/partial.py\n", "bounded find traversal"),

--- a/tests/tools/test_search_budget_truncation.py
+++ b/tests/tools/test_search_budget_truncation.py
@@ -182,6 +182,45 @@ def test_find_modified_capability_failure_is_actionable_without_retry():
     assert len(env.find_commands) == 1
 
 
+@pytest.mark.parametrize(
+    ("order", "output", "error_fragment"),
+    [
+        ("discovery", "/narrow/partial.py\n", "bounded find traversal"),
+        ("modified", "/narrow/not-a-timestamp.py\n", "modification-time"),
+    ],
+)
+def test_find_hard_error_discards_partial_output(order, output, error_fragment):
+    env = FindRecordingEnvironment(output, code=2)
+
+    result = ShellFileOperations(env)._search_files(
+        "*.py", "/narrow", limit=2, offset=0, order=order
+    )
+
+    assert error_fragment in (result.error or "")
+    assert result.files == []
+    assert result.total_count == 0
+
+
+def test_find_timeout_preserves_partial_results_and_limit_reason():
+    env = FindRecordingEnvironment(timeout_output("/narrow/partial.py"), code=124)
+
+    result = ShellFileOperations(env)._search_files(
+        "*.py", "/narrow", limit=2, offset=0, order="discovery"
+    )
+
+    assert result.files == ["/narrow/partial.py"]
+    assert_timed_out(result)
+
+
+def test_find_zero_match_exit_zero_is_success():
+    result = ShellFileOperations(FindRecordingEnvironment("", code=0))._search_files(
+        "*.missing", "/narrow", limit=2, offset=0, order="discovery"
+    )
+
+    assert result.error is None
+    assert result.files == []
+
+
 def test_local_broad_no_rg_refuses_before_find(monkeypatch, tmp_path):
     home = tmp_path / "home"
     home.mkdir()

--- a/tests/tools/test_search_budget_truncation.py
+++ b/tests/tools/test_search_budget_truncation.py
@@ -2,6 +2,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+import tools.file_operations as file_operations
+from tools.environments.local import LocalEnvironment
 from tools.file_operations import ExecuteResult, ShellFileOperations, _search_stdout_and_limit
 
 
@@ -71,3 +73,91 @@ def test_real_rg_error_still_hard_fails(ops, monkeypatch):
 
     assert result.error == "Search failed: rg: regex parse error:"
     assert result.limit_reason is None
+
+
+class FindRecordingEnvironment:
+    is_local = False
+    cwd = "/narrow"
+
+    def __init__(self, output="", code=0):
+        self.output = output
+        self.code = code
+        self.commands = []
+
+    def execute(self, command, **kwargs):
+        self.commands.append((command, kwargs))
+        if command.startswith("command -v find"):
+            return {"output": "yes\n", "returncode": 0}
+        if command.startswith("command -v rg"):
+            return {"output": "", "returncode": 1}
+        if "find " in command:
+            return {"output": self.output, "returncode": self.code}
+        return {"output": "", "returncode": 1}
+
+    @property
+    def find_commands(self):
+        return [
+            item for item in self.commands
+            if item[0].startswith("find ") or "; find " in item[0]
+        ]
+
+
+def test_find_discovery_is_one_unsorted_pruned_bounded_scan():
+    env = FindRecordingEnvironment("/narrow/a.py\n/narrow/b.py\n/narrow/c.py\n/narrow/d.py\n")
+    result = ShellFileOperations(env)._search_files(
+        "*.py", "/narrow", limit=2, offset=1, order="discovery"
+    )
+    assert result.files == ["/narrow/b.py", "/narrow/c.py"]
+    assert result.truncated is True
+    assert len(env.find_commands) == 1
+    command, kwargs = env.find_commands[0]
+    assert "-printf" not in command
+    assert "sort " not in command
+    assert "-prune" in command
+    assert "head -n 4" in command
+    assert kwargs["timeout"] <= 60
+
+
+def test_find_modified_is_one_exact_scan_without_bsd_retry():
+    env = FindRecordingEnvironment("30 /narrow/new.py\n20 /narrow/mid.py\n10 /narrow/old.py\n")
+    result = ShellFileOperations(env)._search_files(
+        "*.py", "/narrow", limit=1, offset=1, order="modified"
+    )
+    assert result.files == ["/narrow/mid.py"]
+    assert result.truncated is True
+    assert len(env.find_commands) == 1
+    command, _ = env.find_commands[0]
+    assert "-printf '%T@ %p\\n'" in command
+    assert "sort -rn" in command
+    assert "head -n 3" in command
+
+
+def test_find_modified_capability_failure_is_actionable_without_retry():
+    env = FindRecordingEnvironment("", code=1)
+    result = ShellFileOperations(env)._search_files(
+        "*.py", "/narrow", limit=2, offset=0, order="modified"
+    )
+    assert "modification-time" in (result.error or "")
+    assert len(env.find_commands) == 1
+
+
+def test_local_broad_no_rg_refuses_before_find(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    ops = ShellFileOperations(LocalEnvironment(str(home)))
+    monkeypatch.setattr(file_operations, "_HOME", str(home))
+    monkeypatch.setattr(file_operations.os.path, "isfile", lambda path: False)
+    commands = []
+
+    def fake_exec(command, **kwargs):
+        commands.append((command, kwargs))
+        if command.startswith("command -v rg"):
+            return ExecuteResult("", 1)
+        if command.startswith("command -v find"):
+            return ExecuteResult("yes\n", 0)
+        raise AssertionError(f"broad fallback must not execute: {command}")
+
+    monkeypatch.setattr(ops, "_exec", fake_exec)
+    result = ops._search_files("*.py", str(home), 10, 0, "discovery")
+    assert "ripgrep" in (result.error or "").lower()
+    assert not any(command.startswith("find ") for command, _ in commands)

--- a/tests/tools/test_search_files_cpu_windows.py
+++ b/tests/tools/test_search_files_cpu_windows.py
@@ -1,0 +1,238 @@
+"""Concurrency admission tests for expensive filename walks."""
+
+from concurrent.futures import ThreadPoolExecutor
+import threading
+import types
+
+import pytest
+
+from tools.environments.local import LocalEnvironment
+from tools.file_operations import (
+    _ACTIVE_FILENAME_SEARCH_ROOTS,
+    _FILENAME_SEARCH_ADMISSION,
+    _normalized_filename_search_root,
+    SearchResult,
+    ShellFileOperations,
+)
+from tools.interrupt import set_interrupt
+
+
+class RemoteEnvironment:
+    is_local = False
+    cwd = "/workspace"
+
+    def execute(self, command, **kwargs):
+        raise AssertionError(f"unexpected backend command: {command}")
+
+
+def _operations(env, scan):
+    operations = ShellFileOperations(env)
+    operations._resolve_command = lambda command: "/usr/bin/rg" if command == "rg" else None
+    operations._search_files_rg = types.MethodType(scan, operations)
+    return operations
+
+
+def test_same_backend_class_and_root_serialize_five_filename_walks():
+    entered = threading.Event()
+    release = threading.Event()
+    counter_lock = threading.Lock()
+    active = 0
+    maximum_active = 0
+    completed = 0
+
+    def scan(self, pattern, path, limit, offset, order, rg_executable=None):
+        nonlocal active, maximum_active, completed
+        with counter_lock:
+            active += 1
+            maximum_active = max(maximum_active, active)
+            entered.set()
+        assert release.wait(5)
+        with counter_lock:
+            active -= 1
+            completed += 1
+        return SearchResult(files=[str(path)], total_count=1)
+
+    operations = [_operations(RemoteEnvironment(), scan) for _ in range(5)]
+    with ThreadPoolExecutor(max_workers=5) as pool:
+        futures = [
+            pool.submit(operation._search_files, "*.py", "/repo", 50, 0)
+            for operation in operations
+        ]
+        assert entered.wait(5)
+        release.set()
+        results = [future.result(timeout=5) for future in futures]
+
+    assert all(result.error is None for result in results)
+    assert completed == 5
+    assert maximum_active == 1
+
+
+def test_different_roots_can_enter_filename_walks_together():
+    both_entered = threading.Barrier(2)
+
+    def scan(self, pattern, path, limit, offset, order, rg_executable=None):
+        both_entered.wait(5)
+        return SearchResult(files=[str(path)], total_count=1)
+
+    first = _operations(RemoteEnvironment(), scan)
+    second = _operations(RemoteEnvironment(), scan)
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [
+            pool.submit(first._search_files, "*.py", "/one", 50, 0),
+            pool.submit(second._search_files, "*.py", "/two", 50, 0),
+        ]
+        assert [future.result(timeout=5).error for future in futures] == [None, None]
+
+
+def test_different_backend_classes_can_walk_the_same_root_together():
+    class OtherRemoteEnvironment(RemoteEnvironment):
+        pass
+
+    both_entered = threading.Barrier(2)
+
+    def scan(self, pattern, path, limit, offset, order, rg_executable=None):
+        both_entered.wait(5)
+        return SearchResult(files=[str(path)], total_count=1)
+
+    first = _operations(RemoteEnvironment(), scan)
+    second = _operations(OtherRemoteEnvironment(), scan)
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [
+            pool.submit(first._search_files, "*.py", "/same", 50, 0),
+            pool.submit(second._search_files, "*.py", "/same", 50, 0),
+        ]
+        assert [future.result(timeout=5).error for future in futures] == [None, None]
+
+
+def test_overlapping_multi_root_sets_are_claimed_atomically(monkeypatch):
+    first_entered = threading.Event()
+    release_first = threading.Event()
+    second_waiting = threading.Event()
+    lock = threading.Lock()
+    active = 0
+    maximum_active = 0
+
+    def scan(self, pattern, path, limit, offset, order, rg_executable=None):
+        nonlocal active, maximum_active
+        with lock:
+            active += 1
+            maximum_active = max(maximum_active, active)
+            if path == ["/a", "/b"]:
+                first_entered.set()
+        if path == ["/a", "/b"]:
+            assert release_first.wait(5)
+        with lock:
+            active -= 1
+        return SearchResult(files=[str(path)], total_count=1)
+
+    first = _operations(RemoteEnvironment(), scan)
+    second = _operations(RemoteEnvironment(), scan)
+    original_wait = _FILENAME_SEARCH_ADMISSION.wait
+
+    def observed_wait(timeout=None):
+        second_waiting.set()
+        return original_wait(timeout)
+
+    monkeypatch.setattr(_FILENAME_SEARCH_ADMISSION, "wait", observed_wait)
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first_future = pool.submit(first._search_files, "*.py", ["/a", "/b"], 50, 0)
+        assert first_entered.wait(5)
+        second_future = pool.submit(second._search_files, "*.py", ["/b", "/c"], 50, 0)
+        assert second_waiting.wait(5)
+        release_first.set()
+        assert first_future.result(timeout=5).error is None
+        assert second_future.result(timeout=5).error is None
+
+    assert maximum_active == 1
+
+
+def test_interrupted_waiter_returns_without_dispatch_or_late_dispatch(monkeypatch):
+    holder_entered = threading.Event()
+    release_holder = threading.Event()
+    waiter_waiting = threading.Event()
+    waiter_tid = []
+    dispatches = []
+
+    def scan(self, pattern, path, limit, offset, order, rg_executable=None):
+        dispatches.append(threading.get_ident())
+        holder_entered.set()
+        assert release_holder.wait(5)
+        return SearchResult(files=[str(path)], total_count=1)
+
+    holder = _operations(RemoteEnvironment(), scan)
+    waiter = _operations(RemoteEnvironment(), scan)
+
+    original_wait = _FILENAME_SEARCH_ADMISSION.wait
+
+    def observed_wait(timeout=None):
+        waiter_waiting.set()
+        return original_wait(timeout)
+
+    monkeypatch.setattr(_FILENAME_SEARCH_ADMISSION, "wait", observed_wait)
+
+    def run_waiter():
+        waiter_tid.append(threading.get_ident())
+        return waiter._search_files("*.py", "/repo", 50, 0)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        holder_future = pool.submit(holder._search_files, "*.py", "/repo", 50, 0)
+        assert holder_entered.wait(5)
+        waiter_future = pool.submit(run_waiter)
+        assert waiter_waiting.wait(5)
+        set_interrupt(True, waiter_tid[0])
+        try:
+            interrupted = waiter_future.result(timeout=5)
+            assert "interrupted" in (interrupted.error or "").lower()
+            assert len(dispatches) == 1
+            release_holder.set()
+            assert holder_future.result(timeout=5).error is None
+            assert len(dispatches) == 1
+        finally:
+            set_interrupt(False, waiter_tid[0])
+            release_holder.set()
+
+
+@pytest.mark.parametrize("raised", [Exception, KeyboardInterrupt, SystemExit, BaseException])
+def test_admission_releases_after_every_base_exception_path(raised):
+    attempts = 0
+
+    def scan(self, pattern, path, limit, offset, order, rg_executable=None):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise raised("engine failed")
+        return SearchResult(files=[str(path)], total_count=1)
+
+    operations = _operations(RemoteEnvironment(), scan)
+    with pytest.raises(raised, match="engine failed"):
+        operations._search_files("*.py", "/repo", 50, 0)
+
+    result = operations._search_files("*.py", "/repo", 50, 0)
+    assert result.error is None
+    assert attempts == 2
+    assert _ACTIVE_FILENAME_SEARCH_ROOTS == set()
+
+
+def test_remote_roots_are_normalized_lexically_against_backend_cwd(monkeypatch):
+    env = RemoteEnvironment()
+    monkeypatch.setattr(
+        "tools.file_operations.os.path.abspath",
+        lambda path: (_ for _ in ()).throw(AssertionError("controller resolution used")),
+    )
+
+    relative = _normalized_filename_search_root(env, "repo/../repo", "/controller")
+    absolute = _normalized_filename_search_root(env, "/workspace/repo", "/controller")
+
+    assert relative == "/workspace/repo"
+    assert absolute == relative
+
+
+@pytest.mark.windows_only
+def test_windows_local_root_spellings_share_one_normalized_key():
+    env = LocalEnvironment.__new__(LocalEnvironment)
+    env.cwd = "C:/Repo"
+
+    native = _normalized_filename_search_root(env, r"C:\Repo\src\..", "C:/ignored")
+    msys = _normalized_filename_search_root(env, "/c/Repo", "C:/ignored")
+
+    assert native == msys

--- a/tests/tools/test_search_files_cpu_windows.py
+++ b/tests/tools/test_search_files_cpu_windows.py
@@ -192,6 +192,68 @@ def test_interrupted_waiter_returns_without_dispatch_or_late_dispatch(monkeypatc
             release_holder.set()
 
 
+def test_interrupt_published_after_final_sample_prevents_filename_dispatch(monkeypatch):
+    sampled_clear = threading.Event()
+    resume_acquire = threading.Event()
+    worker_tid = []
+    dispatches = []
+
+    def scan(self, pattern, path, limit, offset, order, rg_executable=None):
+        dispatches.append(threading.get_ident())
+        return SearchResult(files=[str(path)], total_count=1)
+
+    operations = _operations(RemoteEnvironment(), scan)
+    original_is_interrupted = __import__(
+        "tools.interrupt", fromlist=["is_interrupted"]
+    ).is_interrupted
+
+    def pause_after_clear_sample():
+        interrupted = original_is_interrupted()
+        if not interrupted and threading.get_ident() == worker_tid[0]:
+            sampled_clear.set()
+            assert resume_acquire.wait(5)
+        return interrupted
+
+    monkeypatch.setattr(
+        "tools.file_operations.tool_interrupt.is_interrupted",
+        pause_after_clear_sample,
+    )
+
+    def run_search():
+        worker_tid.append(threading.get_ident())
+        return operations._search_files("*.py", "/repo", 50, 0)
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(run_search)
+        assert sampled_clear.wait(5)
+        set_interrupt(True, worker_tid[0])
+        resume_acquire.set()
+        try:
+            result = future.result(timeout=5)
+        finally:
+            set_interrupt(False, worker_tid[0])
+            resume_acquire.set()
+
+    assert "interrupted" in (result.error or "").lower()
+    assert dispatches == []
+    assert _ACTIVE_FILENAME_SEARCH_ROOTS == set()
+
+
+def test_empty_filename_roots_are_rejected_before_engine_resolution():
+    def scan(self, pattern, path, limit, offset, order, rg_executable=None):
+        raise AssertionError("filename engine dispatched")
+
+    operations = _operations(RemoteEnvironment(), scan)
+    operations._resolve_command = lambda command: (_ for _ in ()).throw(
+        AssertionError(f"engine resolution attempted: {command}")
+    )
+
+    result = operations._search_files("*.py", [], 50, 0)
+
+    assert "at least one search root" in (result.error or "").lower()
+    assert _ACTIVE_FILENAME_SEARCH_ROOTS == set()
+
+
 @pytest.mark.parametrize("raised", [Exception, KeyboardInterrupt, SystemExit, BaseException])
 def test_admission_releases_after_every_base_exception_path(raised):
     attempts = 0

--- a/tests/tools/test_search_files_engine_selection.py
+++ b/tests/tools/test_search_files_engine_selection.py
@@ -58,6 +58,42 @@ def test_default_file_search_runs_one_bounded_unsorted_rg_command():
     assert "head -n 3" in env.rg_commands[0]
 
 
+@pytest.mark.parametrize("engine", ["rg", "find"])
+def test_bounded_filename_total_is_serialized_as_a_lower_bound(engine, monkeypatch):
+    conceptual_files = [f"/repo/file-{index:03}.py" for index in range(200)]
+    env = RecordingEnvironment()
+
+    def execute(command, **kwargs):
+        env.commands.append(command)
+        if command.startswith("test -e "):
+            return {"output": "exists\n", "returncode": 0}
+        if command.startswith("command -v rg"):
+            return {
+                "output": "/usr/bin/rg\n" if engine == "rg" else "",
+                "returncode": 0 if engine == "rg" else 1,
+            }
+        if "--files" in command or command.startswith("set -o pipefail; find "):
+            fetch_limit = int(re.search(r"head -n (\d+)", command).group(1))
+            return {
+                "output": "\n".join(conceptual_files[:fetch_limit]) + "\n",
+                "returncode": 0,
+            }
+        return {"output": "", "returncode": 1}
+
+    env.execute = execute
+    ops = ShellFileOperations(env)
+    if engine == "find":
+        monkeypatch.setattr(ops, "_has_command", lambda command: command == "find")
+
+    result = ops.search("*.py", path="/repo", target="files", limit=50)
+    serialized = result.to_dict()
+
+    assert result.total_count == 51
+    assert len(result.files) == 50
+    assert serialized["truncated"] is True
+    assert serialized["total_count_is_lower_bound"] is True
+
+
 def test_modified_file_search_runs_one_exact_order_rg_command():
     env = RecordingEnvironment()
     ops = ShellFileOperations(env)

--- a/tests/tools/test_search_files_engine_selection.py
+++ b/tests/tools/test_search_files_engine_selection.py
@@ -81,7 +81,21 @@ def test_modified_zero_match_exit_one_is_valid_without_capability_error():
 
 @pytest.mark.parametrize(
     "version",
-    ["ripgrep 13.0.0\n", "ripgrep unknown\n", "ripgrep 14 garbage\n"],
+    [
+        "ripgrep 13.0.0\n",
+        "ripgrep unknown\n",
+        "ripgrep 14 garbage\n",
+        "ripgrep 14\n",
+        "ripgrep 14.1\n",
+        "ripgrep 14.1.1-\n",
+        "ripgrep 14.1.1+\n",
+        "ripgrep 14.1.1-alpha..1\n",
+        "ripgrep 14.1.1+build..2\n",
+        "ripgrep 14.1.1-01\n",
+        "ripgrep 014.1.1\n",
+        "ripgrep 14.01.1\n",
+        "ripgrep 14.1.01\n",
+    ],
 )
 def test_modified_requires_parseable_ripgrep_14_before_search(version):
     env = RecordingEnvironment()
@@ -114,6 +128,28 @@ def test_modified_accepts_complete_ripgrep_semver_with_revision_text():
         if "--version" in command:
             env.commands.append(command)
             return {"output": "ripgrep 14.1.1 (rev abc123)\n", "returncode": 0}
+        return original_execute(command, **kwargs)
+
+    env.execute = execute
+    result = ShellFileOperations(env).search(
+        "*.py", path="/repo", target="files", order="modified"
+    )
+
+    assert result.error is None
+    assert len(env.rg_commands) == 1
+
+
+def test_modified_accepts_ripgrep_semver_with_prerelease_and_build_metadata():
+    env = RecordingEnvironment()
+    original_execute = env.execute
+
+    def execute(command, **kwargs):
+        if "--version" in command:
+            env.commands.append(command)
+            return {
+                "output": "ripgrep 14.1.1-alpha.1+build.2\n",
+                "returncode": 0,
+            }
         return original_execute(command, **kwargs)
 
     env.execute = execute
@@ -160,6 +196,33 @@ def test_rg_partial_output_with_error_exit_fails_closed(order):
     assert result.error is not None
     assert result.files == []
     assert len(env.rg_commands) == 1
+
+
+@pytest.mark.parametrize("order", ["discovery", "modified"])
+def test_rg_sigpipe_is_benign_only_after_fetch_limit_paths(order):
+    output = "".join(f"/repo/{name}.py\n" for name in ("a", "b", "c", "d"))
+    env = RecordingEnvironment(rg_output=output, rg_code=141)
+
+    result = ShellFileOperations(env).search(
+        "*.py", path="/repo", target="files", limit=2, offset=1, order=order
+    )
+
+    assert result.error is None
+    assert result.files == ["/repo/b.py", "/repo/c.py"]
+    assert result.truncated is True
+
+
+@pytest.mark.parametrize("order", ["discovery", "modified"])
+def test_rg_sigpipe_with_fewer_than_fetch_limit_paths_fails_closed(order):
+    env = RecordingEnvironment(rg_output="/repo/partial.py\n", rg_code=141)
+
+    result = ShellFileOperations(env).search(
+        "*.py", path="/repo", target="files", limit=2, offset=1, order=order
+    )
+
+    assert result.error is not None
+    assert result.files == []
+    assert result.total_count == 0
 
 
 def test_invalid_direct_file_order_returns_structured_error():

--- a/tests/tools/test_search_files_engine_selection.py
+++ b/tests/tools/test_search_files_engine_selection.py
@@ -1,0 +1,288 @@
+"""Behavior tests for file-search ordering and ripgrep selection."""
+
+import json
+import re
+
+import pytest
+
+from tools.environments.local import LocalEnvironment
+from tools.file_operations import SearchResult, ShellFileOperations
+from tools.file_tools import SEARCH_FILES_SCHEMA, _handle_search_files, search_tool
+
+
+class RecordingEnvironment:
+    is_local = False
+    cwd = "/repo"
+
+    def __init__(self, *, rg_output="/repo/one.py\n/repo/two.py\n", rg_code=0):
+        self.commands = []
+        self.rg_output = rg_output
+        self.rg_code = rg_code
+
+    def execute(self, command, **kwargs):
+        self.commands.append(command)
+        if command.startswith("test -e "):
+            return {"output": "exists\n", "returncode": 0}
+        if command.startswith("command -v rg"):
+            return {"output": "/opt/Rip Grep/rg\n", "returncode": 0}
+        if "--files" in command:
+            return {"output": self.rg_output, "returncode": self.rg_code}
+        return {"output": "", "returncode": 1}
+
+    @property
+    def rg_commands(self):
+        return [command for command in self.commands if "--files" in command]
+
+
+def test_schema_exposes_fast_discovery_default_and_exact_modified_opt_in():
+    order = SEARCH_FILES_SCHEMA["parameters"]["properties"]["order"]
+
+    assert order["enum"] == ["discovery", "modified"]
+    assert order["default"] == "discovery"
+    assert "fast bounded traversal order" in order["description"]
+    assert "exact global newest-first" in order["description"]
+    assert "ignored for content" in order["description"]
+
+
+def test_default_file_search_runs_one_bounded_unsorted_rg_command():
+    env = RecordingEnvironment()
+    ops = ShellFileOperations(env)
+
+    result = ops.search("*.py", path="/repo", target="files", limit=1, offset=1)
+
+    assert result.files == ["/repo/two.py"]
+    assert len(env.rg_commands) == 1
+    assert "--sortr" not in env.rg_commands[0]
+    assert "head -n 2" in env.rg_commands[0]
+
+
+def test_modified_file_search_runs_one_exact_order_rg_command():
+    env = RecordingEnvironment()
+    ops = ShellFileOperations(env)
+
+    result = ops.search("*.py", path="/repo", target="files", order="modified")
+
+    assert result.error is None
+    assert len(env.rg_commands) == 1
+    assert "--sortr=modified" in env.rg_commands[0]
+
+
+def test_empty_discovery_output_is_zero_matches_without_retry():
+    env = RecordingEnvironment(rg_output="", rg_code=0)
+    ops = ShellFileOperations(env)
+
+    result = ops.search("*.missing", path="/repo", target="files")
+
+    assert result.error is None
+    assert result.files == []
+    assert result.total_count == 0
+    assert len(env.rg_commands) == 1
+
+
+def test_modified_capability_failure_is_actionable_and_not_downgraded():
+    env = RecordingEnvironment(rg_output="", rg_code=2)
+    ops = ShellFileOperations(env)
+
+    result = ops.search("*.py", path="/repo", target="files", order="modified")
+
+    assert len(env.rg_commands) == 1
+    assert result.error is not None
+    assert "exact modification-time order" in result.error.lower()
+    assert "ripgrep" in result.error
+
+
+def test_invalid_direct_file_order_returns_structured_error():
+    env = RecordingEnvironment()
+    ops = ShellFileOperations(env)
+
+    result = ops.search("*.py", path="/repo", target="files", order="random")
+
+    assert isinstance(result, SearchResult)
+    assert result.error == "Invalid file search order 'random'; expected 'discovery' or 'modified'."
+    assert env.rg_commands == []
+
+
+def test_handler_forwards_modified_order(monkeypatch):
+    captured = {}
+
+    def fake_search_tool(**kwargs):
+        captured.update(kwargs)
+        return "{}"
+
+    monkeypatch.setattr("tools.file_tools.search_tool", fake_search_tool)
+
+    _handle_search_files({"pattern": "*.py", "target": "files", "order": "modified"})
+
+    assert captured["order"] == "modified"
+
+
+def test_repeated_search_key_distinguishes_order(monkeypatch):
+    class StubOperations:
+        def search(self, **kwargs):
+            return SearchResult()
+
+    monkeypatch.setattr("tools.file_tools._get_file_ops", lambda task_id: StubOperations())
+    task_id = "engine-order-key"
+    for _ in range(3):
+        assert "BLOCKED" not in json.loads(
+            search_tool("*.py", target="files", order="discovery", task_id=task_id)
+        ).get("error", "")
+
+    changed = json.loads(
+        search_tool("*.py", target="files", order="modified", task_id=task_id)
+    )
+
+    assert "BLOCKED" not in changed.get("error", "")
+
+
+class RipgrepInvocationEnvironment(RecordingEnvironment):
+    def execute(self, command, **kwargs):
+        self.commands.append(command)
+        if command.startswith("test -e "):
+            return {"output": "exists\n", "returncode": 0}
+        if command.startswith("command -v rg"):
+            return {"output": "/opt/Rip Grep/rg\n", "returncode": 0}
+        if "--files" in command:
+            return {"output": "/repo/a.py\n", "returncode": 0}
+        if "--line-number" in command:
+            return {"output": "/repo/a.py:1:needle\n", "returncode": 0}
+        if "--count-matches" in command:
+            return {"output": "", "returncode": 1}
+        return {"output": "", "returncode": 1}
+
+
+def test_resolved_executable_with_spaces_is_used_by_every_rg_invocation():
+    env = RipgrepInvocationEnvironment()
+    ops = ShellFileOperations(env)
+
+    assert ops.search("*.py", path="/repo", target="files").files
+    assert ops.search("needle", path="/repo", target="content").matches
+    assert ops._zero_match_probe("absent", "/repo", None) is None
+
+    invocations = [
+        command for command in env.commands
+        if any(flag in command for flag in ("--files", "--line-number", "--count-matches"))
+    ]
+    assert invocations
+    assert all("'/opt/Rip Grep/rg'" in command for command in invocations)
+    assert all(not re.search(r"(?:^|[; ])rg\s", command) for command in invocations)
+    assert len([c for c in env.commands if c.startswith("command -v rg")]) == 1
+
+
+@pytest.mark.windows_only
+def test_off_path_windows_rg_miss_is_reprobed_then_success_is_cached(
+    tmp_path, monkeypatch
+):
+    local_app_data = tmp_path / "Local Data"
+    candidate = local_app_data / "Microsoft" / "WinGet" / "Links" / "rg.exe"
+    monkeypatch.setenv("LOCALAPPDATA", str(local_app_data))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path / "User Profile"))
+    monkeypatch.delenv("SCOOP", raising=False)
+    ops = ShellFileOperations(LocalEnvironment(str(tmp_path)))
+    probes = []
+
+    def command_v_miss(command, **kwargs):
+        probes.append(command)
+        from tools.file_operations import ExecuteResult
+        return ExecuteResult(stdout="", exit_code=1)
+
+    monkeypatch.setattr(ops, "_exec", command_v_miss)
+
+    assert ops._resolve_command("rg") is None
+    candidate.parent.mkdir(parents=True)
+    candidate.write_text("")
+    expected = str(candidate).replace("\\", "/")
+    assert ops._resolve_command("rg") == expected
+    assert ops._resolve_command("rg") == expected
+    assert probes == ["command -v rg 2>/dev/null", "command -v rg 2>/dev/null"]
+
+
+def test_remote_resolution_never_probes_controller_host_paths(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "controller-local"))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path / "controller-user"))
+    env = RecordingEnvironment()
+
+    def miss(command, **kwargs):
+        env.commands.append(command)
+        return {"output": "", "returncode": 1}
+
+    env.execute = miss
+    ops = ShellFileOperations(env)
+
+    assert ops._resolve_command("rg") is None
+    assert env.commands == ["command -v rg 2>/dev/null"]
+    assert str(tmp_path) not in env.commands[0]
+
+
+@pytest.mark.windows_only
+def test_remote_msys_shaped_executable_is_not_rewritten_as_controller_path():
+    env = RecordingEnvironment()
+
+    def execute(command, **kwargs):
+        env.commands.append(command)
+        if command.startswith("test -e "):
+            return {"output": "exists\n", "returncode": 0}
+        if command.startswith("command -v rg"):
+            return {"output": "/c/remote-tools/rg\n", "returncode": 0}
+        if "--files" in command:
+            return {"output": "/repo/a.py\n", "returncode": 0}
+        return {"output": "", "returncode": 1}
+
+    env.execute = execute
+
+    result = ShellFileOperations(env).search("*.py", path="/repo", target="files")
+
+    assert result.files
+    assert "'/c/remote-tools/rg' --files" in env.rg_commands[0]
+    assert "C:/remote-tools/rg" not in env.rg_commands[0]
+
+
+def test_modified_multi_path_search_preserves_exact_order_request():
+    env = RecordingEnvironment()
+
+    def execute(command, **kwargs):
+        env.commands.append(command)
+        if command.startswith("test -e "):
+            if "'/one /two'" in command:
+                return {"output": "not_found\n", "returncode": 0}
+            return {"output": "exists\n", "returncode": 0}
+        if command.startswith("command -v rg"):
+            return {"output": "/usr/bin/rg\n", "returncode": 0}
+        if "--files" in command:
+            return {"output": "found.py\n", "returncode": 0}
+        return {"output": "", "returncode": 1}
+
+    env.execute = execute
+    result = ShellFileOperations(env).search(
+        "*.py", path="/one /two", target="files", order="modified"
+    )
+
+    assert result.error is None
+    assert len(env.rg_commands) == 2
+    assert all("--sortr=modified" in command for command in env.rg_commands)
+
+
+def test_modified_timeout_preserves_partial_results_and_limit_reason():
+    env = RecordingEnvironment(
+        rg_output="/repo/partial.py\n[Command timed out after 60s]\n",
+        rg_code=124,
+    )
+
+    result = ShellFileOperations(env).search(
+        "*.py", path="/repo", target="files", order="modified"
+    )
+
+    assert result.files == ["/repo/partial.py"]
+    assert result.truncated is True
+    assert result.limit_reason == "search_timeout"
+
+
+def test_order_is_ignored_for_content_search():
+    env = RipgrepInvocationEnvironment()
+
+    result = ShellFileOperations(env).search(
+        "needle", path="/repo", target="content", order="not-a-file-order"
+    )
+
+    assert result.error is None
+    assert result.matches

--- a/tests/tools/test_search_files_engine_selection.py
+++ b/tests/tools/test_search_files_engine_selection.py
@@ -79,7 +79,10 @@ def test_modified_zero_match_exit_one_is_valid_without_capability_error():
     assert len(env.rg_commands) == 1
 
 
-@pytest.mark.parametrize("version", ["ripgrep 13.0.0\n", "ripgrep unknown\n"])
+@pytest.mark.parametrize(
+    "version",
+    ["ripgrep 13.0.0\n", "ripgrep unknown\n", "ripgrep 14 garbage\n"],
+)
 def test_modified_requires_parseable_ripgrep_14_before_search(version):
     env = RecordingEnvironment()
 
@@ -101,6 +104,25 @@ def test_modified_requires_parseable_ripgrep_14_before_search(version):
     assert second.error == first.error
     assert env.rg_commands == []
     assert len([c for c in env.commands if "--version" in c]) == 1
+
+
+def test_modified_accepts_complete_ripgrep_semver_with_revision_text():
+    env = RecordingEnvironment()
+    original_execute = env.execute
+
+    def execute(command, **kwargs):
+        if "--version" in command:
+            env.commands.append(command)
+            return {"output": "ripgrep 14.1.1 (rev abc123)\n", "returncode": 0}
+        return original_execute(command, **kwargs)
+
+    env.execute = execute
+    result = ShellFileOperations(env).search(
+        "*.py", path="/repo", target="files", order="modified"
+    )
+
+    assert result.error is None
+    assert len(env.rg_commands) == 1
 
 
 def test_empty_discovery_output_is_zero_matches_without_retry():
@@ -337,6 +359,37 @@ def test_modified_multi_path_search_preserves_exact_order_request():
     assert "--sortr=modified" in env.rg_commands[0]
     assert "'/one'" in env.rg_commands[0]
     assert "'/two'" in env.rg_commands[0]
+
+
+def test_comma_delimited_file_roots_preserve_internal_spaces_in_one_search():
+    env = RecordingEnvironment(rg_output="C:/root one/a.py\nC:/root two/b.py\n")
+    combined = "C:/root one, C:/root two"
+
+    path_checks = 0
+
+    def execute(command, **kwargs):
+        nonlocal path_checks
+        env.commands.append(command)
+        if command.startswith("test -e "):
+            path_checks += 1
+            output = "not_found\n" if path_checks == 1 else "exists\n"
+            return {"output": output, "returncode": 0}
+        if command.startswith("command -v rg"):
+            return {"output": "/usr/bin/rg\n", "returncode": 0}
+        if "--files" in command:
+            return {"output": env.rg_output, "returncode": 0}
+        return {"output": "", "returncode": 1}
+
+    env.execute = execute
+    result = ShellFileOperations(env).search(
+        "*.py", path=combined, target="files"
+    )
+
+    assert result.error is None
+    assert result.files == ["C:/root one/a.py", "C:/root two/b.py"]
+    assert len(env.rg_commands) == 1
+    assert "'C:/root one' 'C:/root two'" in env.rg_commands[0]
+    assert "path contained 2 entries" in (result.warning or "")
 
 
 def test_multi_path_modified_capability_error_propagates():

--- a/tests/tools/test_search_files_engine_selection.py
+++ b/tests/tools/test_search_files_engine_selection.py
@@ -127,6 +127,19 @@ def test_modified_capability_failure_is_actionable_and_not_downgraded():
     assert "ripgrep" in result.error
 
 
+@pytest.mark.parametrize("order", ["discovery", "modified"])
+def test_rg_partial_output_with_error_exit_fails_closed(order):
+    env = RecordingEnvironment(rg_output="/repo/partial.py\n", rg_code=2)
+
+    result = ShellFileOperations(env).search(
+        "*.py", path="/repo", target="files", order=order
+    )
+
+    assert result.error is not None
+    assert result.files == []
+    assert len(env.rg_commands) == 1
+
+
 def test_invalid_direct_file_order_returns_structured_error():
     env = RecordingEnvironment()
     ops = ShellFileOperations(env)

--- a/tests/tools/test_search_files_engine_selection.py
+++ b/tests/tools/test_search_files_engine_selection.py
@@ -297,6 +297,19 @@ def test_remote_msys_shaped_executable_is_not_rewritten_as_controller_path():
     assert "C:/remote-tools/rg" not in env.rg_commands[0]
 
 
+@pytest.mark.windows_only
+def test_every_windows_drive_root_is_broad_even_when_home_is_on_another_drive(
+    tmp_path, monkeypatch
+):
+    import tools.file_operations as file_operations
+
+    monkeypatch.setattr(file_operations, "_HOME", "C:/Users/alice")
+    ops = ShellFileOperations(LocalEnvironment(str(tmp_path)))
+
+    assert ops._is_broad_local_search_root("D:/") is True
+    assert ops._is_broad_local_search_root("D:/repo") is False
+
+
 def test_modified_multi_path_search_preserves_exact_order_request():
     env = RecordingEnvironment()
 

--- a/tests/tools/test_search_files_engine_selection.py
+++ b/tests/tools/test_search_files_engine_selection.py
@@ -25,6 +25,8 @@ class RecordingEnvironment:
             return {"output": "exists\n", "returncode": 0}
         if command.startswith("command -v rg"):
             return {"output": "/opt/Rip Grep/rg\n", "returncode": 0}
+        if "--version" in command:
+            return {"output": "ripgrep 14.1.1\n", "returncode": 0}
         if "--files" in command:
             return {"output": self.rg_output, "returncode": self.rg_code}
         return {"output": "", "returncode": 1}
@@ -53,7 +55,7 @@ def test_default_file_search_runs_one_bounded_unsorted_rg_command():
     assert result.files == ["/repo/two.py"]
     assert len(env.rg_commands) == 1
     assert "--sortr" not in env.rg_commands[0]
-    assert "head -n 2" in env.rg_commands[0]
+    assert "head -n 3" in env.rg_commands[0]
 
 
 def test_modified_file_search_runs_one_exact_order_rg_command():
@@ -65,6 +67,40 @@ def test_modified_file_search_runs_one_exact_order_rg_command():
     assert result.error is None
     assert len(env.rg_commands) == 1
     assert "--sortr=modified" in env.rg_commands[0]
+
+
+def test_modified_zero_match_exit_one_is_valid_without_capability_error():
+    env = RecordingEnvironment(rg_output="", rg_code=1)
+    result = ShellFileOperations(env).search(
+        "*.missing", path="/repo", target="files", order="modified"
+    )
+    assert result.error is None
+    assert result.files == []
+    assert len(env.rg_commands) == 1
+
+
+@pytest.mark.parametrize("version", ["ripgrep 13.0.0\n", "ripgrep unknown\n"])
+def test_modified_requires_parseable_ripgrep_14_before_search(version):
+    env = RecordingEnvironment()
+
+    def execute(command, **kwargs):
+        env.commands.append(command)
+        if command.startswith("test -e "):
+            return {"output": "exists\n", "returncode": 0}
+        if command.startswith("command -v rg"):
+            return {"output": "/opt/Rip Grep/rg\n", "returncode": 0}
+        if "--version" in command:
+            return {"output": version, "returncode": 0}
+        raise AssertionError(f"search must not run: {command}")
+
+    env.execute = execute
+    ops = ShellFileOperations(env)
+    first = ops.search("*.py", path="/repo", target="files", order="modified")
+    second = ops.search("*.py", path="/repo", target="files", order="modified")
+    assert "ripgrep 14" in (first.error or "").lower()
+    assert second.error == first.error
+    assert env.rg_commands == []
+    assert len([c for c in env.commands if "--version" in c]) == 1
 
 
 def test_empty_discovery_output_is_zero_matches_without_retry():
@@ -142,6 +178,8 @@ class RipgrepInvocationEnvironment(RecordingEnvironment):
             return {"output": "exists\n", "returncode": 0}
         if command.startswith("command -v rg"):
             return {"output": "/opt/Rip Grep/rg\n", "returncode": 0}
+        if "--version" in command:
+            return {"output": "ripgrep 14.1.1\n", "returncode": 0}
         if "--files" in command:
             return {"output": "/repo/a.py\n", "returncode": 0}
         if "--line-number" in command:
@@ -167,6 +205,15 @@ def test_resolved_executable_with_spaces_is_used_by_every_rg_invocation():
     assert all("'/opt/Rip Grep/rg'" in command for command in invocations)
     assert all(not re.search(r"(?:^|[; ])rg\s", command) for command in invocations)
     assert len([c for c in env.commands if c.startswith("command -v rg")]) == 1
+
+
+def test_non_rg_command_cache_keeps_cached_misses_and_bool_values():
+    env = RecordingEnvironment()
+    ops = ShellFileOperations(env)
+    assert ops._has_command("find") is False
+    assert ops._has_command("find") is False
+    assert ops._command_cache == {"find": False}
+    assert len([c for c in env.commands if c.startswith("command -v find")]) == 1
 
 
 @pytest.mark.windows_only
@@ -248,8 +295,10 @@ def test_modified_multi_path_search_preserves_exact_order_request():
             return {"output": "exists\n", "returncode": 0}
         if command.startswith("command -v rg"):
             return {"output": "/usr/bin/rg\n", "returncode": 0}
+        if "--version" in command:
+            return {"output": "ripgrep 14.1.1\n", "returncode": 0}
         if "--files" in command:
-            return {"output": "found.py\n", "returncode": 0}
+            return {"output": "/two/new.py\n/one/old.py\n", "returncode": 0}
         return {"output": "", "returncode": 1}
 
     env.execute = execute
@@ -257,9 +306,33 @@ def test_modified_multi_path_search_preserves_exact_order_request():
         "*.py", path="/one /two", target="files", order="modified"
     )
 
-    assert result.error is None
-    assert len(env.rg_commands) == 2
-    assert all("--sortr=modified" in command for command in env.rg_commands)
+    assert result.files == ["/two/new.py", "/one/old.py"]
+    assert len(env.rg_commands) == 1
+    assert "--sortr=modified" in env.rg_commands[0]
+    assert "'/one'" in env.rg_commands[0]
+    assert "'/two'" in env.rg_commands[0]
+
+
+def test_multi_path_modified_capability_error_propagates():
+    env = RecordingEnvironment()
+
+    def execute(command, **kwargs):
+        env.commands.append(command)
+        if command.startswith("test -e "):
+            output = "not_found\n" if "'/one /two'" in command else "exists\n"
+            return {"output": output, "returncode": 0}
+        if command.startswith("command -v rg"):
+            return {"output": "/usr/bin/rg\n", "returncode": 0}
+        if "--version" in command:
+            return {"output": "ripgrep 13.0.0\n", "returncode": 0}
+        raise AssertionError(command)
+
+    env.execute = execute
+    result = ShellFileOperations(env).search(
+        "*.py", path="/one /two", target="files", order="modified"
+    )
+    assert "ripgrep 14" in (result.error or "").lower()
+    assert env.rg_commands == []
 
 
 def test_modified_timeout_preserves_partial_results_and_limit_reason():

--- a/tests/tools/test_search_zero_match_and_multipath.py
+++ b/tests/tools/test_search_zero_match_and_multipath.py
@@ -60,7 +60,7 @@ class TestZeroMatchProbe:
 
     def test_hidden_probe_prunes_dependency_trees_and_keeps_local_ignored(self, proj, monkeypatch):
         d = proj / "proj"
-        dependency = d / "node_modules" / "package"
+        dependency = d / "node_modules" / "package" / ".hidden"
         dependency.mkdir(parents=True)
         dependency_file = dependency / "dependency.js"
         dependency_file.write_text("BOUNDED_HIDDEN_TOKEN = true\n")

--- a/tests/tools/test_search_zero_match_and_multipath.py
+++ b/tests/tools/test_search_zero_match_and_multipath.py
@@ -58,6 +58,86 @@ class TestZeroMatchProbe:
         # Same class as the casing probe: the path must be in the hint.
         assert "conf.cfg" in r.get("warning", "")
 
+    def test_hidden_probe_prunes_dependency_trees_and_keeps_local_ignored(self, proj, monkeypatch):
+        d = proj / "proj"
+        dependency = d / "node_modules" / "package"
+        dependency.mkdir(parents=True)
+        dependency_file = dependency / "dependency.js"
+        dependency_file.write_text("BOUNDED_HIDDEN_TOKEN = true\n")
+        local = d / ".project-local"
+        local.mkdir()
+        local_file = local / "settings.cfg"
+        local_file.write_text("BOUNDED_HIDDEN_TOKEN = true\n")
+        (d / ".gitignore").write_text("node_modules/\n.project-local/\n")
+
+        # Drive the public search seam while recording the commands that the
+        # zero-match probe actually executes. The real rg calls still run.
+        from tools.file_tools import _get_file_ops
+
+        task_id = "t-zm-pruned-hidden"
+        ops = _get_file_ops(task_id=task_id)
+        commands = []
+        real_exec = ops._exec
+
+        def recording_exec(command, *args, **kwargs):
+            commands.append(command)
+            return real_exec(command, *args, **kwargs)
+
+        monkeypatch.setattr(ops, "_exec", recording_exec)
+        r = json.loads(search_tool("BOUNDED_HIDDEN_TOKEN", path=str(d), task_id=task_id))
+        warning = r.get("warning", "")
+
+        assert r["total_count"] == 0
+        assert "hidden or gitignored" in warning
+        assert local_file.name in warning
+        assert dependency_file.name not in warning
+
+        hidden_probe_commands = [
+            command for command in commands
+            if "--hidden" in command and "--no-ignore" in command
+        ]
+        assert len(hidden_probe_commands) == 1
+        hidden_probe = hidden_probe_commands[0]
+        assert "--glob" in hidden_probe
+        assert "'!node_modules/**'" in hidden_probe
+        assert "'!**/node_modules/**'" in hidden_probe
+
+    def test_hidden_probe_prunes_explicit_dependency_root(self, proj, monkeypatch):
+        d = proj / "proj"
+        dependency = d / "node_modules" / "package" / ".hidden"
+        dependency.mkdir(parents=True)
+        (dependency / "dependency.js").write_text("EXPLICIT_ROOT_TOKEN = true\n")
+        (d / ".gitignore").write_text("node_modules/\n")
+
+        from tools.file_tools import _get_file_ops
+
+        task_id = "t-zm-explicit-pruned-root"
+        ops = _get_file_ops(task_id=task_id)
+        commands = []
+        real_exec = ops._exec
+
+        def recording_exec(command, *args, **kwargs):
+            commands.append(command)
+            return real_exec(command, *args, **kwargs)
+
+        monkeypatch.setattr(ops, "_exec", recording_exec)
+        r = json.loads(search_tool(
+            "EXPLICIT_ROOT_TOKEN",
+            path=str(d / "node_modules"),
+            task_id=task_id,
+        ))
+
+        assert r["total_count"] == 0
+        assert "warning" not in r
+        hidden_probe_commands = [
+            command for command in commands
+            if "--hidden" in command and "--no-ignore" in command
+        ]
+        assert len(hidden_probe_commands) == 1
+        hidden_probe = hidden_probe_commands[0]
+        assert "'!node_modules/**'" in hidden_probe
+        assert "'!**/node_modules/**'" in hidden_probe
+
     def test_probe_path_list_is_capped(self, proj):
         d = proj / "proj"
         for i in range(8):

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -408,9 +408,9 @@ _TOOL_STUBS = {
     ),
     "search_files": (
         "search_files",
-        'pattern: str, target: str = "content", path: str = ".", file_glob: str = None, limit: int = 50, offset: int = 0, output_mode: str = "content", context: int = 0',
+        'pattern: str, target: str = "content", path: str = ".", file_glob: str = None, limit: int = 50, offset: int = 0, output_mode: str = "content", context: int = 0, order: str = "discovery"',
         '"""Search file contents (target="content") or find files by name (target="files"). Returns dict with "matches"."""',
-        '{"pattern": pattern, "target": target, "path": path, "file_glob": file_glob, "limit": limit, "offset": offset, "output_mode": output_mode, "context": context}',
+        '{"pattern": pattern, "target": target, "path": path, "file_glob": file_glob, "limit": limit, "offset": offset, "output_mode": output_mode, "context": context, "order": order}',
     ),
     "patch": (
         "patch",
@@ -2331,7 +2331,7 @@ _TOOL_DOC_LINES = [
      "  write_file(path: str, content: str) -> dict\n"
      "    Always overwrites the entire file."),
     ("search_files",
-     "  search_files(pattern: str, target=\"content\", path=\".\", file_glob=None, limit=50) -> dict\n"
+     "  search_files(pattern: str, target=\"content\", path=\".\", file_glob=None, limit=50, order=\"discovery\") -> dict\n"
      "    target: \"content\" (search inside files) or \"files\" (find files by name). Returns {\"matches\": [...]}"),
     ("patch",
      "  patch(path: str, old_string: str, new_string: str, replace_all: bool = False) -> dict\n"

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -123,8 +123,9 @@ def _acquire_filename_search_roots(
                 return False
         if tool_interrupt.is_interrupted():
             return False
-        _ACTIVE_FILENAME_SEARCH_ROOTS.update(keys)
-        return True
+        return tool_interrupt.run_if_not_interrupted(
+            lambda: _ACTIVE_FILENAME_SEARCH_ROOTS.update(keys)
+        )
 
 
 def _release_filename_search_roots(
@@ -3770,6 +3771,10 @@ class ShellFileOperations(FileOperations):
             search_pattern = pattern.split('/')[-1]
 
         roots = [path] if isinstance(path, str) else path
+        if not roots:
+            return SearchResult(
+                error="File search requires at least one search root in 'path'."
+            )
 
         # Prefer ripgrep: bounded parallel traversal with ignore semantics.
         # Resolve the engine and exact-order capability before admission so a

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -3572,6 +3572,12 @@ class ShellFileOperations(FileOperations):
             else:
                 files.append(line)
 
+        # Git Bash find echoes native drive roots as /c/... paths. Convert only
+        # local Windows output; remote and container paths must remain untouched.
+        from tools.environments.local import LocalEnvironment, _IS_WINDOWS, _msys_to_windows_path
+        if _IS_WINDOWS and isinstance(self.env, LocalEnvironment):
+            files = [_msys_to_windows_path(file_path) for file_path in files]
+
         # For explicit hidden roots, find's path-based filtering excludes every
         # file under the hidden path. Apply descendant filtering after command
         # execution so only the explicit root ancestry is bypassed.

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -3736,7 +3736,11 @@ class ShellFileOperations(FileOperations):
         # Prune hidden descendant directories while still allowing an
         # explicitly selected hidden root. Hidden files are excluded too,
         # matching rg's default semantics.
-        q_roots = [self._escape_shell_arg(root) for root in roots]
+        find_roots = [
+            f"./{root}" if root.startswith("-") else root
+            for root in roots
+        ]
+        q_roots = [self._escape_shell_arg(root) for root in find_roots]
         root_exemptions = "".join(f" ! -path {root}" for root in q_roots)
         hidden_prune = (
             f" \\( -type d -name '.*'{root_exemptions} \\) -prune -o"

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -3460,6 +3460,35 @@ class ShellFileOperations(FileOperations):
         return _macos_protected_search_exclusions(
             path, cwd=cwd, home=_HOME, platform=sys.platform
         )
+
+    def _effective_macos_search_exclusions(
+        self, roots: List[str]
+    ) -> List[tuple[str, str, str]]:
+        """Return unique exclusions without pruning an explicitly chosen root."""
+        explicit_roots = {
+            os.path.normcase(os.path.abspath(os.path.normpath(root)))
+            for root in roots
+        }
+        seen = set()
+        effective = []
+        for root in roots:
+            for relative in self._macos_search_exclusions(root):
+                absolute = os.path.normpath(os.path.join(root, relative))
+                key = os.path.normcase(os.path.abspath(absolute))
+                if key in explicit_roots or key in seen:
+                    continue
+                seen.add(key)
+                effective.append((root, relative, absolute))
+        return effective
+
+    @staticmethod
+    def _macos_protected_search_warning(paths: List[str]) -> str:
+        skipped = ", ".join(os.path.basename(item) for item in paths)
+        return (
+            "Skipped macOS protected folders during broad search to avoid "
+            f"an unattended privacy prompt: {skipped}. Search a protected "
+            "folder directly when access is intentional."
+        )
     
     def _try_multi_path_search(self, pattern: str, path: str, target: str,
                                file_glob: Optional[str], limit: int, offset: int,
@@ -3518,7 +3547,18 @@ class ShellFileOperations(FileOperations):
             note += "; skipped missing: " + ", ".join(missing[:3])
             if len(missing) > 3:
                 note += f" (+{len(missing) - 3} more)"
-        merged.warning = note
+        warning_parts = [note]
+        if not merged.error:
+            protected_paths = [
+                absolute
+                for _root, _relative, absolute
+                in self._effective_macos_search_exclusions(existing)
+            ]
+            if protected_paths:
+                warning_parts.append(
+                    self._macos_protected_search_warning(protected_paths)
+                )
+        merged.warning = " ".join(warning_parts)
         return merged
 
     def _zero_match_probe(self, pattern: str, path: str,
@@ -3618,12 +3658,15 @@ class ShellFileOperations(FileOperations):
 
         root = normalized(path)
         home = normalized(_HOME)
+        drive = os.path.splitdrive(root)[0]
+        anchor = drive + os.sep if drive else os.path.abspath(os.sep)
+        if root == os.path.normcase(anchor):
+            return True
         try:
             common = os.path.commonpath([root, home])
         except ValueError:
             return False
-        anchor = os.path.splitdrive(root)[0] + os.sep if os.path.splitdrive(root)[0] else os.path.abspath(os.sep)
-        return root == home or common == root or root == os.path.normcase(anchor)
+        return root == home or common == root
 
     def _search_files(self, pattern: str, path: str | List[str], limit: int, offset: int,
                       order: str = "discovery") -> SearchResult:
@@ -3668,9 +3711,9 @@ class ShellFileOperations(FileOperations):
             f" \\( -type d -name '.*'{root_exemptions} \\) -prune -o"
         )
         protected_paths = [
-            os.path.normpath(os.path.join(root, item))
-            for root in roots
-            for item in self._macos_search_exclusions(root)
+            absolute
+            for _root, _relative, absolute
+            in self._effective_macos_search_exclusions(roots)
         ]
         protected_prune = ""
         if protected_paths:
@@ -3697,12 +3740,12 @@ class ShellFileOperations(FileOperations):
 
         result = self._exec(cmd, timeout=60)
         stdout, limit_reason = _search_stdout_and_limit(result)
-        if order == "modified" and result.exit_code not in {0, 124} and not stdout.strip():
+        if order == "modified" and result.exit_code not in {0, 124}:
             return SearchResult(error=(
                 "Exact modification-time order requires GNU find with "
                 "-printf support; install ripgrep 14+ or use order='discovery'."
             ))
-        if order == "discovery" and result.exit_code not in {0, 1, 124} and not stdout.strip():
+        if order == "discovery" and result.exit_code not in {0, 124}:
             return SearchResult(error="File search failed while running bounded find traversal.")
 
         raw_files: List[str] = []
@@ -3746,12 +3789,11 @@ class ShellFileOperations(FileOperations):
 
         roots = [path] if isinstance(path, str) else path
         fetch_limit = limit + offset + 1
-        exclusion_terms: List[str] = []
-        for root in roots:
-            exclusion_terms.extend(
-                f"--glob {self._escape_shell_arg(f'!{item}/**')}"
-                for item in self._macos_search_exclusions(root)
-            )
+        exclusion_terms = [
+            f"--glob {self._escape_shell_arg(f'!{relative}/**')}"
+            for _root, relative, _absolute
+            in self._effective_macos_search_exclusions(roots)
+        ]
         exclusion_globs = " ".join(dict.fromkeys(exclusion_terms))
         exclusion_args = f" {exclusion_globs}" if exclusion_globs else ""
         rg_executable = rg_executable or self._resolve_command("rg")

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -3871,7 +3871,7 @@ class ShellFileOperations(FileOperations):
         )
         cmd = (
             f"set -o pipefail; {cd_prefix}{rg} --files{sort_arg} -g {self._escape_shell_arg(glob_pattern)}"
-            f"{exclusion_args} {root_args} 2>/dev/null | head -n {fetch_limit}"
+            f"{exclusion_args} -- {root_args} 2>/dev/null | head -n {fetch_limit}"
         )
         result = self._exec(cmd, timeout=60)
         stdout, limit_reason = _search_stdout_and_limit(result)

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1106,7 +1106,11 @@ class ShellFileOperations(FileOperations):
             return self._rg_modified_capability[executable]
         quoted = self._quote_executable(executable)
         result = self._exec(f"{quoted} --version", timeout=10)
-        match = re.search(r"(?im)^ripgrep\s+(\d+)(?:\.|\s|$)", result.stdout or "")
+        match = re.search(
+            r"(?im)^ripgrep\s+(\d+)\.\d+\.\d+"
+            r"(?:[-+][0-9A-Za-z.-]+)?(?:\s|$)",
+            result.stdout or "",
+        )
         if result.exit_code == 0 and match and int(match.group(1)) >= 14:
             error = None
         else:
@@ -3497,12 +3501,17 @@ class ShellFileOperations(FileOperations):
         """Recover a not-found ``path`` that is really several paths in one string.
 
         Production trajectories show models passing "dir1 dir2 dir3" (or
-        comma-separated lists) as ``path``. Split on whitespace/commas; when
-        at least one candidate exists and at least two candidates were given,
-        search every existing path, merge results, and note skipped parts.
-        Returns None when this doesn't look like a multi-path string.
+        comma-separated lists) as ``path``. Commas explicitly delimit paths and
+        therefore preserve internal spaces; without commas, retain the legacy
+        whitespace-separated recovery. When at least one candidate exists and
+        at least two candidates were given, search every existing path, merge
+        results, and note skipped parts. Returns None when this doesn't look
+        like a multi-path string.
         """
-        parts = [p for chunk in path.split(",") for p in chunk.split() if p.strip()]
+        if "," in path:
+            parts = [part.strip() for part in path.split(",") if part.strip()]
+        else:
+            parts = path.split()
         if len(parts) < 2:
             return None
         existing, missing = [], []
@@ -3740,14 +3749,11 @@ class ShellFileOperations(FileOperations):
 
         result = self._exec(cmd, timeout=60)
         stdout, limit_reason = _search_stdout_and_limit(result)
-        if order == "modified" and result.exit_code not in {0, 124}:
-            return SearchResult(error=(
-                "Exact modification-time order requires GNU find with "
-                "-printf support; install ripgrep 14+ or use order='discovery'."
-            ))
-        if order == "discovery" and result.exit_code not in {0, 124}:
-            return SearchResult(error="File search failed while running bounded find traversal.")
 
+        # Parse before classifying exit 141: with pipefail, a bounded producer
+        # can receive SIGPIPE when head intentionally closes after fetch_limit
+        # rows. It is benign only when the parsed payload proves that bound was
+        # reached; a shorter payload remains a hard failure.
         raw_files: List[str] = []
         for line in stdout.splitlines():
             if order == "modified":
@@ -3757,6 +3763,15 @@ class ShellFileOperations(FileOperations):
                 raw_files.append(parts[1])
             elif line:
                 raw_files.append(line)
+        bounded_sigpipe = result.exit_code == 141 and len(raw_files) >= fetch_limit
+
+        if order == "modified" and result.exit_code not in {0, 124} and not bounded_sigpipe:
+            return SearchResult(error=(
+                "Exact modification-time order requires GNU find with "
+                "-printf support; install ripgrep 14+ or use order='discovery'."
+            ))
+        if order == "discovery" and result.exit_code not in {0, 124} and not bounded_sigpipe:
+            return SearchResult(error="File search failed while running bounded find traversal.")
 
         from tools.environments.local import LocalEnvironment, _IS_WINDOWS, _msys_to_windows_path
         if _IS_WINDOWS and isinstance(self.env, LocalEnvironment):

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -627,7 +627,8 @@ class FileOperations(ABC):
     @abstractmethod
     def search(self, pattern: str, path: str = ".", target: str = "content",
                file_glob: Optional[str] = None, limit: int = 50, offset: int = 0,
-               output_mode: str = "content", context: int = 0) -> SearchResult:
+               output_mode: str = "content", context: int = 0,
+               order: str = "discovery") -> SearchResult:
         """Search for content or files."""
         ...
 
@@ -997,8 +998,9 @@ class ShellFileOperations(FileOperations):
         self.cwd = cwd or getattr(terminal_env, 'cwd', None) or \
                    getattr(getattr(terminal_env, 'config', None), 'cwd', None) or "/"
 
-        # Cache for command availability checks
-        self._command_cache: Dict[str, bool] = {}
+        # Cache successful command resolutions. Misses are deliberately not
+        # cached so a tool installed while this instance is alive is visible.
+        self._command_cache: Dict[str, str] = {}
     
     def _exec(self, command: str, cwd: str = None, timeout: int = None,
               stdin_data: str = None) -> ExecuteResult:
@@ -1039,12 +1041,62 @@ class ShellFileOperations(FileOperations):
             exit_code=exit_code
         )
     
+    def _resolve_command(self, cmd: str) -> Optional[str]:
+        """Resolve an executable in the command host's namespace.
+
+        Only successful resolutions are cached. Native Windows local searches
+        additionally recognize common off-PATH ripgrep install locations;
+        remote backends must resolve exclusively in their own namespace.
+        """
+        cached = self._command_cache.get(cmd)
+        if cached:
+            return cached
+
+        result = self._exec(f"command -v {cmd} 2>/dev/null")
+        if result.exit_code == 0 and result.stdout.strip():
+            resolved = result.stdout.strip().splitlines()[0]
+            # Compatibility with test/fake environments that historically
+            # answered the old boolean probe with the literal "yes".
+            if resolved == "yes":
+                resolved = cmd
+            self._command_cache[cmd] = resolved
+            return resolved
+
+        if cmd == "rg":
+            from tools.environments.local import LocalEnvironment, _IS_WINDOWS
+
+            if _IS_WINDOWS and isinstance(self.env, LocalEnvironment):
+                user_profile = os.environ.get("USERPROFILE") or str(Path.home())
+                local_app_data = os.environ.get("LOCALAPPDATA")
+                scoop = os.environ.get("SCOOP") or os.path.join(user_profile, "scoop")
+                candidates = [
+                    os.path.join(user_profile, ".cargo", "bin", "rg.exe"),
+                    os.path.join(scoop, "shims", "rg.exe"),
+                ]
+                if local_app_data:
+                    candidates.append(
+                        os.path.join(local_app_data, "Microsoft", "WinGet", "Links", "rg.exe")
+                    )
+                for candidate in candidates:
+                    if os.path.isfile(candidate):
+                        resolved = candidate.replace("\\", "/")
+                        self._command_cache[cmd] = resolved
+                        return resolved
+        return None
+
     def _has_command(self, cmd: str) -> bool:
-        """Check if a command exists in the environment (cached)."""
-        if cmd not in self._command_cache:
-            result = self._exec(f"command -v {cmd} >/dev/null 2>&1 && echo 'yes'")
-            self._command_cache[cmd] = result.stdout.strip() == 'yes'
-        return self._command_cache[cmd]
+        """Return whether a command resolves in the execution environment."""
+        return self._resolve_command(cmd) is not None
+
+    def _quote_executable(self, executable: str) -> str:
+        """Quote an executable without leaking controller path semantics."""
+        if re.fullmatch(r"[A-Za-z0-9_.-]+", executable):
+            return executable
+        from tools.environments.local import LocalEnvironment
+
+        if isinstance(self.env, LocalEnvironment):
+            return self._escape_native_tool_arg(executable)
+        return "'" + executable.replace("'", "'\"'\"'") + "'"
     
     def _sample_file_bytes(self, path: str, length: int = 1000):
         """Fetch the first ``length`` raw bytes of a file through the terminal.
@@ -3271,7 +3323,8 @@ class ShellFileOperations(FileOperations):
     
     def search(self, pattern: str, path: str = ".", target: str = "content",
                file_glob: Optional[str] = None, limit: int = 50, offset: int = 0,
-               output_mode: str = "content", context: int = 0) -> SearchResult:
+               output_mode: str = "content", context: int = 0,
+               order: str = "discovery") -> SearchResult:
         """
         Search for content or files.
         
@@ -3284,11 +3337,18 @@ class ShellFileOperations(FileOperations):
             offset: Skip first N results
             output_mode: "content", "files_only", or "count"
             context: Lines of context around matches
+            order: File-search ordering: fast discovery or exact modified time
         
         Returns:
             SearchResult with matches or file list
         """
         offset, limit = normalize_search_pagination(offset, limit)
+
+        if target == "files" and order not in {"discovery", "modified"}:
+            return SearchResult(
+                error=(f"Invalid file search order {order!r}; expected "
+                       "'discovery' or 'modified'.")
+            )
 
         # Expand ~ and other shell paths
         path = self._expand_path(path)
@@ -3301,7 +3361,8 @@ class ShellFileOperations(FileOperations):
             # failing the whole call, split, search every path that exists,
             # merge the results, and report the skipped parts.
             multi = self._try_multi_path_search(
-                pattern, path, target, file_glob, limit, offset, output_mode, context
+                pattern, path, target, file_glob, limit, offset, output_mode, context,
+                order,
             )
             if multi is not None:
                 return multi
@@ -3336,7 +3397,7 @@ class ShellFileOperations(FileOperations):
             )
         
         if target == "files":
-            result = self._search_files(pattern, path, limit, offset)
+            result = self._search_files(pattern, path, limit, offset, order)
         else:
             result = self._search_content(pattern, path, file_glob, limit, offset,
                                           output_mode, context)
@@ -3373,7 +3434,8 @@ class ShellFileOperations(FileOperations):
     
     def _try_multi_path_search(self, pattern: str, path: str, target: str,
                                file_glob: Optional[str], limit: int, offset: int,
-                               output_mode: str, context: int) -> Optional[SearchResult]:
+                               output_mode: str, context: int,
+                               order: str = "discovery") -> Optional[SearchResult]:
         """Recover a not-found ``path`` that is really several paths in one string.
 
         Production trajectories show models passing "dir1 dir2 dir3" (or
@@ -3398,7 +3460,7 @@ class ShellFileOperations(FileOperations):
         merged = SearchResult()
         for p in existing:
             if target == "files":
-                sub = self._search_files(pattern, p, limit, offset)
+                sub = self._search_files(pattern, p, limit, offset, order)
             else:
                 sub = self._search_content(pattern, p, file_glob, limit, offset,
                                            output_mode, context)
@@ -3430,8 +3492,10 @@ class ShellFileOperations(FileOperations):
         metacharacters, also probe it as a fixed string. Bounded: two rg
         invocations max, count-only output.
         """
-        if not self._has_command('rg'):
+        rg_executable = self._resolve_command('rg')
+        if not rg_executable:
             return None
+        rg = self._quote_executable(rg_executable)
 
         def _tally(stdout: str):
             """Parse ``path:count`` lines from rg --count-matches."""
@@ -3451,7 +3515,7 @@ class ShellFileOperations(FileOperations):
 
         glob_expr = f" --glob {self._escape_shell_arg(file_glob)}" if file_glob else ""
         probe = self._exec(
-            f"rg -i --count-matches{glob_expr} "
+            f"{rg} -i --count-matches{glob_expr} "
             f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
@@ -3468,7 +3532,7 @@ class ShellFileOperations(FileOperations):
         # returning a bare zero (bench case: match in .hidden/ silently
         # missing from results).
         hidden = self._exec(
-            f"rg --hidden --no-ignore --count-matches{glob_expr} "
+            f"{rg} --hidden --no-ignore --count-matches{glob_expr} "
             f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
@@ -3482,7 +3546,7 @@ class ShellFileOperations(FileOperations):
             )
         if re.search(r"[.\[\](){}?*+^$\\|]", pattern):
             fixed = self._exec(
-                f"rg -F --count-matches{glob_expr} "
+                f"{rg} -F --count-matches{glob_expr} "
                 f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
                 f"2>/dev/null | head -50",
                 timeout=30,
@@ -3497,7 +3561,8 @@ class ShellFileOperations(FileOperations):
                 )
         return None
 
-    def _search_files(self, pattern: str, path: str, limit: int, offset: int) -> SearchResult:
+    def _search_files(self, pattern: str, path: str, limit: int, offset: int,
+                      order: str = "discovery") -> SearchResult:
         """Search for files by name pattern (glob-like)."""
         # Auto-prepend **/ for recursive search if not already present
         if not pattern.startswith('**/') and '/' not in pattern:
@@ -3515,7 +3580,10 @@ class ShellFileOperations(FileOperations):
         # default, and has parallel directory traversal (~200x faster than
         # find on wide trees).  Mirrors _search_content which already uses rg.
         if self._has_command('rg'):
-            return self._search_files_rg(search_pattern, path, limit, offset)
+            return self._search_files_rg(
+                search_pattern, path, limit, offset, order,
+                rg_executable=self._resolve_command("rg") or "rg",
+            )
 
         # Fallback: find (slower, no .gitignore awareness)
         if not self._has_command('find'):
@@ -3602,13 +3670,15 @@ class ShellFileOperations(FileOperations):
             limit_reason=limit_reason,
         )
 
-    def _search_files_rg(self, pattern: str, path: str, limit: int, offset: int) -> SearchResult:
+    def _search_files_rg(self, pattern: str, path: str, limit: int, offset: int,
+                         order: str = "discovery",
+                         rg_executable: Optional[str] = None) -> SearchResult:
         """Search for files by name using ripgrep's --files mode.
 
         rg --files respects .gitignore and excludes hidden directories by
         default, and uses parallel directory traversal for ~200x speedup
-        over find on wide trees.  Results are sorted by modification time
-        (most recently edited first) when rg >= 13.0 supports --sortr.
+        over find on wide trees. Discovery order stays bounded and fast;
+        exact modification-time ordering is explicit because it scans globally.
         """
         # rg --files -g uses glob patterns; wrap bare names so they match
         # at any depth (equivalent to find -name).
@@ -3623,28 +3693,29 @@ class ShellFileOperations(FileOperations):
             for item in self._macos_search_exclusions(path)
         )
         exclusion_args = f" {exclusion_globs}" if exclusion_globs else ""
-        # Try mtime-sorted first (rg 13+); fall back to unsorted if not supported.
-        cmd_sorted = (
-            f"rg --files --sortr=modified -g {self._escape_shell_arg(glob_pattern)}"
+        rg_executable = rg_executable or self._resolve_command("rg")
+        if not rg_executable:
+            return SearchResult(error="File search requires ripgrep (rg).")
+        rg = self._quote_executable(rg_executable)
+        sort_arg = " --sortr=modified" if order == "modified" else ""
+        cmd = (
+            f"set -o pipefail; {rg} --files{sort_arg} -g {self._escape_shell_arg(glob_pattern)}"
             f"{exclusion_args} "
             f"{self._escape_native_tool_arg(path)} 2>/dev/null "
             f"| head -n {fetch_limit}"
         )
-        result = self._exec(cmd_sorted, timeout=60)
+        result = self._exec(cmd, timeout=60)
         stdout, limit_reason = _search_stdout_and_limit(result)
         all_files = [f for f in stdout.strip().split('\n') if f]
 
-        if not all_files and not limit_reason:
-            # --sortr may have failed on older rg; retry without it.
-            cmd_plain = (
-                f"rg --files -g {self._escape_shell_arg(glob_pattern)}"
-                f"{exclusion_args} "
-                f"{self._escape_native_tool_arg(path)} 2>/dev/null "
-                f"| head -n {fetch_limit}"
+        if order == "modified" and result.exit_code not in {0, 124}:
+            return SearchResult(
+                error=(
+                    "Exact modification-time order requires ripgrep with "
+                    "--sortr=modified support; upgrade ripgrep or use "
+                    "order='discovery'."
+                )
             )
-            result = self._exec(cmd_plain, timeout=60)
-            stdout, limit_reason = _search_stdout_and_limit(result)
-            all_files = [f for f in stdout.strip().split('\n') if f]
 
         page = all_files[offset:offset + limit]
 
@@ -3663,7 +3734,8 @@ class ShellFileOperations(FileOperations):
         if self._has_command('rg'):
             used_rg = True
             result = self._search_with_rg(pattern, path, file_glob, limit, offset,
-                                          output_mode, context)
+                                          output_mode, context,
+                                          rg_executable=self._resolve_command("rg") or "rg")
         elif self._has_command('grep'):
             result = self._search_with_grep(pattern, path, file_glob, limit, offset,
                                             output_mode, context)
@@ -3694,9 +3766,13 @@ class ShellFileOperations(FileOperations):
         return _maybe_warn_line_oriented_newline_pattern(result, pattern)
     
     def _search_with_rg(self, pattern: str, path: str, file_glob: Optional[str],
-                        limit: int, offset: int, output_mode: str, context: int) -> SearchResult:
+                        limit: int, offset: int, output_mode: str, context: int,
+                        rg_executable: Optional[str] = None) -> SearchResult:
         """Search using ripgrep."""
-        cmd_parts = ["rg", "--line-number", "--no-heading", "--with-filename"]
+        rg_executable = rg_executable or self._resolve_command("rg")
+        if not rg_executable:
+            return SearchResult(error="Content search requires ripgrep (rg).")
+        cmd_parts = [self._quote_executable(rg_executable), "--line-number", "--no-heading", "--with-filename"]
 
         # Giant-single-line containment (ported from cline/cline#13525): a
         # match inside a serialized dump (multi-MB single-line JSON/minified

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1107,8 +1107,13 @@ class ShellFileOperations(FileOperations):
         quoted = self._quote_executable(executable)
         result = self._exec(f"{quoted} --version", timeout=10)
         match = re.search(
-            r"(?im)^ripgrep\s+(\d+)\.\d+\.\d+"
-            r"(?:[-+][0-9A-Za-z.-]+)?(?:\s|$)",
+            r"(?m)^ripgrep\s+((?:0|[1-9]\d*))\."
+            r"(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)"
+            r"(?:-(?:(?:0|[1-9]\d*)|(?:[0-9A-Za-z-]*[A-Za-z-]"
+            r"[0-9A-Za-z-]*))(?:\.(?:(?:0|[1-9]\d*)|"
+            r"(?:[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)))*)?"
+            r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+            r"(?:\s+\(rev [^)]+\))?\s*$",
             result.stdout or "",
         )
         if result.exit_code == 0 and match and int(match.group(1)) >= 14:
@@ -3828,8 +3833,9 @@ class ShellFileOperations(FileOperations):
         result = self._exec(cmd, timeout=60)
         stdout, limit_reason = _search_stdout_and_limit(result)
         all_files = [f for f in stdout.splitlines() if f]
+        bounded_sigpipe = result.exit_code == 141 and len(all_files) >= fetch_limit
 
-        if result.exit_code not in {0, 1, 124}:
+        if result.exit_code not in {0, 1, 124} and not bounded_sigpipe:
             if order == "modified":
                 return SearchResult(error=(
                     "Exact modification-time order failed; ripgrep 14+ is "

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -998,9 +998,13 @@ class ShellFileOperations(FileOperations):
         self.cwd = cwd or getattr(terminal_env, 'cwd', None) or \
                    getattr(getattr(terminal_env, 'config', None), 'cwd', None) or "/"
 
-        # Cache successful command resolutions. Misses are deliberately not
-        # cached so a tool installed while this instance is alive is visible.
-        self._command_cache: Dict[str, str] = {}
+        # Preserve the historical bool cache for ordinary executables: both
+        # hits and misses stay cached. Ripgrep is special because it has an
+        # off-PATH resolver and may be installed while this object is alive;
+        # only successful rg resolutions are cached.
+        self._command_cache: Dict[str, bool] = {}
+        self._rg_resolution_cache: Dict[str, str] = {}
+        self._rg_modified_capability: Dict[str, Optional[str]] = {}
     
     def _exec(self, command: str, cwd: str = None, timeout: int = None,
               stdin_data: str = None) -> ExecuteResult:
@@ -1044,49 +1048,74 @@ class ShellFileOperations(FileOperations):
     def _resolve_command(self, cmd: str) -> Optional[str]:
         """Resolve an executable in the command host's namespace.
 
-        Only successful resolutions are cached. Native Windows local searches
-        additionally recognize common off-PATH ripgrep install locations;
-        remote backends must resolve exclusively in their own namespace.
+        Ordinary commands retain the original bool hit/miss cache. Ripgrep
+        alone caches successful resolved paths and re-probes misses so a
+        mid-session install becomes visible.
         """
-        cached = self._command_cache.get(cmd)
+        if cmd != "rg":
+            return cmd if self._has_command(cmd) else None
+
+        cached = self._rg_resolution_cache.get(cmd)
         if cached:
             return cached
 
-        result = self._exec(f"command -v {cmd} 2>/dev/null")
+        result = self._exec("command -v rg 2>/dev/null")
         if result.exit_code == 0 and result.stdout.strip():
             resolved = result.stdout.strip().splitlines()[0]
-            # Compatibility with test/fake environments that historically
-            # answered the old boolean probe with the literal "yes".
+            # Compatibility with old boolean-probe fakes.
             if resolved == "yes":
-                resolved = cmd
-            self._command_cache[cmd] = resolved
+                resolved = "rg"
+            self._rg_resolution_cache[cmd] = resolved
             return resolved
 
-        if cmd == "rg":
-            from tools.environments.local import LocalEnvironment, _IS_WINDOWS
+        from tools.environments.local import LocalEnvironment, _IS_WINDOWS
 
-            if _IS_WINDOWS and isinstance(self.env, LocalEnvironment):
-                user_profile = os.environ.get("USERPROFILE") or str(Path.home())
-                local_app_data = os.environ.get("LOCALAPPDATA")
-                scoop = os.environ.get("SCOOP") or os.path.join(user_profile, "scoop")
-                candidates = [
-                    os.path.join(user_profile, ".cargo", "bin", "rg.exe"),
-                    os.path.join(scoop, "shims", "rg.exe"),
-                ]
-                if local_app_data:
-                    candidates.append(
-                        os.path.join(local_app_data, "Microsoft", "WinGet", "Links", "rg.exe")
-                    )
-                for candidate in candidates:
-                    if os.path.isfile(candidate):
-                        resolved = candidate.replace("\\", "/")
-                        self._command_cache[cmd] = resolved
-                        return resolved
+        if _IS_WINDOWS and isinstance(self.env, LocalEnvironment):
+            user_profile = os.environ.get("USERPROFILE") or str(Path.home())
+            local_app_data = os.environ.get("LOCALAPPDATA")
+            scoop = os.environ.get("SCOOP") or os.path.join(user_profile, "scoop")
+            candidates = [
+                os.path.join(user_profile, ".cargo", "bin", "rg.exe"),
+                os.path.join(scoop, "shims", "rg.exe"),
+            ]
+            if local_app_data:
+                candidates.append(
+                    os.path.join(local_app_data, "Microsoft", "WinGet", "Links", "rg.exe")
+                )
+            for candidate in candidates:
+                if os.path.isfile(candidate):
+                    resolved = candidate.replace("\\", "/")
+                    self._rg_resolution_cache[cmd] = resolved
+                    return resolved
         return None
 
     def _has_command(self, cmd: str) -> bool:
-        """Return whether a command resolves in the execution environment."""
-        return self._resolve_command(cmd) is not None
+        """Check command availability with rg-specific resolution semantics."""
+        if cmd == "rg":
+            return self._resolve_command(cmd) is not None
+        if cmd not in self._command_cache:
+            result = self._exec(
+                f"command -v {cmd} >/dev/null 2>&1 && echo 'yes'"
+            )
+            self._command_cache[cmd] = result.stdout.strip() == "yes"
+        return self._command_cache[cmd]
+
+    def _modified_rg_capability_error(self, executable: str) -> Optional[str]:
+        """Return a cached actionable error unless rg can sort exactly."""
+        if executable in self._rg_modified_capability:
+            return self._rg_modified_capability[executable]
+        quoted = self._quote_executable(executable)
+        result = self._exec(f"{quoted} --version", timeout=10)
+        match = re.search(r"(?im)^ripgrep\s+(\d+)(?:\.|\s|$)", result.stdout or "")
+        if result.exit_code == 0 and match and int(match.group(1)) >= 14:
+            error = None
+        else:
+            error = (
+                "Exact modification-time order requires ripgrep 14 or newer; "
+                "upgrade ripgrep or use order='discovery'."
+            )
+        self._rg_modified_capability[executable] = error
+        return error
 
     def _quote_executable(self, executable: str) -> str:
         """Quote an executable without leaking controller path semantics."""
@@ -3457,23 +3486,49 @@ class ShellFileOperations(FileOperations):
         if not existing:
             return None
 
-        merged = SearchResult()
-        for p in existing:
-            if target == "files":
-                sub = self._search_files(pattern, p, limit, offset, order)
+        if target == "files":
+            # A file search across several roots is one global rg traversal so
+            # modified ordering and pagination are exact across the whole set.
+            if self._has_command("rg"):
+                resolved = self._resolve_command("rg") or "rg"
+                merged = self._search_files_rg(
+                    pattern.split("/")[-1], existing, limit, offset, order,
+                    rg_executable=resolved,
+                )
             else:
-                sub = self._search_content(pattern, p, file_glob, limit, offset,
-                                           output_mode, context)
-            if sub.error:
-                continue
-            merged.matches.extend(sub.matches)
-            merged.files.extend(sub.files)
-            merged.counts.update(sub.counts)
-            merged.total_count += sub.total_count
-            merged.truncated = merged.truncated or sub.truncated
-        # Respect the caller's limit across the merged set.
-        merged.matches = merged.matches[:limit]
-        merged.files = merged.files[:limit]
+                # find cannot accept the same cross-platform guarantees as rg;
+                # preserve per-root fallback scans, but never swallow an error
+                # and apply the caller's page once to the combined result.
+                collected: List[str] = []
+                any_truncated = False
+                fetch = offset + limit + 1
+                for root in existing:
+                    sub = self._search_files(pattern, root, fetch, 0, order)
+                    if sub.error:
+                        return sub
+                    collected.extend(sub.files)
+                    any_truncated = any_truncated or sub.truncated
+                merged = SearchResult(
+                    files=collected[offset:offset + limit],
+                    total_count=len(collected),
+                    truncated=any_truncated or len(collected) > offset + limit,
+                )
+        else:
+            merged = SearchResult()
+            for root in existing:
+                sub = self._search_content(
+                    pattern, root, file_glob, limit, offset, output_mode, context
+                )
+                if sub.error:
+                    return sub
+                merged.matches.extend(sub.matches)
+                merged.files.extend(sub.files)
+                merged.counts.update(sub.counts)
+                merged.total_count += sub.total_count
+                merged.truncated = merged.truncated or sub.truncated
+            merged.matches = merged.matches[:limit]
+            merged.files = merged.files[:limit]
+
         note = f"path contained {len(parts)} entries; searched {len(existing)} that exist"
         if missing:
             note += "; skipped missing: " + ", ".join(missing[:3])
@@ -3561,6 +3616,31 @@ class ShellFileOperations(FileOperations):
                 )
         return None
 
+    def _is_broad_local_search_root(self, path: str) -> bool:
+        """Whether a no-rg local root is unsafe for recursive find."""
+        from tools.environments.local import (
+            LocalEnvironment, _IS_WINDOWS, _msys_to_windows_path,
+        )
+
+        if not isinstance(self.env, LocalEnvironment):
+            return False
+
+        def normalized(value: str) -> str:
+            if _IS_WINDOWS:
+                value = _msys_to_windows_path(value).replace("\\", "/")
+            if not os.path.isabs(value):
+                value = os.path.join(getattr(self.env, "cwd", None) or self.cwd, value)
+            return os.path.normcase(os.path.abspath(value))
+
+        root = normalized(path)
+        home = normalized(_HOME)
+        try:
+            common = os.path.commonpath([root, home])
+        except ValueError:
+            return False
+        anchor = os.path.splitdrive(root)[0] + os.sep if os.path.splitdrive(root)[0] else os.path.abspath(os.sep)
+        return root == home or common == root or root == os.path.normcase(anchor)
+
     def _search_files(self, pattern: str, path: str, limit: int, offset: int,
                       order: str = "discovery") -> SearchResult:
         """Search for files by name pattern (glob-like)."""
@@ -3570,107 +3650,97 @@ class ShellFileOperations(FileOperations):
         else:
             search_pattern = pattern.split('/')[-1]
 
-        search_root = Path(path)
-        has_hidden_path_ancestor = any(
-            part not in {".", ".."} and part.startswith(".")
-            for part in search_root.parts
-        )
-
-        # Prefer ripgrep: respects .gitignore, excludes hidden dirs by
-        # default, and has parallel directory traversal (~200x faster than
-        # find on wide trees).  Mirrors _search_content which already uses rg.
-        if self._has_command('rg'):
+        # Prefer ripgrep: bounded parallel traversal with ignore semantics.
+        if self._has_command("rg"):
             return self._search_files_rg(
                 search_pattern, path, limit, offset, order,
                 rg_executable=self._resolve_command("rg") or "rg",
             )
 
-        # Fallback: find (slower, no .gitignore awareness)
-        if not self._has_command('find'):
+        # A local find traversal rooted at/above the user's home or at a
+        # filesystem root can consume minutes and prompt on protected paths.
+        # Refuse before invoking find. Controller paths never classify remotes.
+        if self._is_broad_local_search_root(path):
+            return SearchResult(error=(
+                "Broad local file search without ripgrep is disabled because "
+                "find cannot keep this traversal safely bounded. Install "
+                "ripgrep or search a narrower directory."
+            ))
+
+        if not self._has_command("find"):
             return SearchResult(
                 error="File search requires 'rg' (ripgrep) or 'find'. "
                       "Install ripgrep for best results: "
                       "https://github.com/BurntSushi/ripgrep#installation"
             )
 
-        # Exclude hidden directories (matching ripgrep's default behavior).
-        hidden_exclude = "-not -path '*/.*'" if not has_hidden_path_ancestor else ""
-        hidden_filter_expr = f" {hidden_exclude}" if hidden_exclude else ""
-
-        # Use shell pagination for standard roots. For hidden roots, gather full
-        # output so we can re-apply hidden-descendant filtering while allowing
-        # explicit hidden-root searches.
-        pagination_expr = ""
-        if not has_hidden_path_ancestor:
-            pagination_expr = f" | tail -n +{offset + 1} | head -n {limit}"
-
-        # Prune protected directories before traversal so macOS never receives
-        # an access attempt (filtering matched paths after descent is too late).
+        # Prune hidden descendant directories while still allowing an
+        # explicitly selected hidden root. Hidden files are excluded too,
+        # matching rg's default semantics.
+        q_path = self._escape_shell_arg(path)
+        hidden_prune = (
+            f" \\( -type d -name '.*' ! -path {q_path} \\) -prune -o"
+        )
         protected_paths = [
             os.path.normpath(os.path.join(path, item))
             for item in self._macos_search_exclusions(path)
         ]
-        prune_expr = ""
+        protected_prune = ""
         if protected_paths:
-            prune_terms = " -o ".join(
+            terms = " -o ".join(
                 f"-path {self._escape_shell_arg(item)}" for item in protected_paths
             )
-            prune_expr = f" \\( {prune_terms} \\) -prune -o"
+            protected_prune = f" \\( {terms} \\) -prune -o"
 
-        cmd = f"find {self._escape_shell_arg(path)}{prune_expr}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
-              f"-printf '%T@ %p\\n' 2>/dev/null | sort -rn{pagination_expr}"
+        fetch_limit = offset + limit + 1
+        base = (
+            f"find {q_path}{protected_prune}{hidden_prune} -type f "
+            f"! -name '.*' -name {self._escape_shell_arg(search_pattern)}"
+        )
+        if order == "modified":
+            cmd = (
+                "set -o pipefail; " + base
+                + f" -printf '%T@ %p\\n' 2>/dev/null | sort -rn | head -n {fetch_limit}"
+            )
+        else:
+            cmd = (
+                "set -o pipefail; " + base
+                + f" -print 2>/dev/null | head -n {fetch_limit}"
+            )
 
         result = self._exec(cmd, timeout=60)
         stdout, limit_reason = _search_stdout_and_limit(result)
+        if order == "modified" and result.exit_code not in {0, 124} and not stdout.strip():
+            return SearchResult(error=(
+                "Exact modification-time order requires GNU find with "
+                "-printf support; install ripgrep 14+ or use order='discovery'."
+            ))
+        if order == "discovery" and result.exit_code not in {0, 1, 124} and not stdout.strip():
+            return SearchResult(error="File search failed while running bounded find traversal.")
 
-        if not stdout.strip() and not limit_reason:
-            # Try without -printf (BSD find compatibility -- macOS)
-            cmd_simple = f"find {self._escape_shell_arg(path)}{prune_expr}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
-                        f"2>/dev/null | sort -rn{pagination_expr}"
-            result = self._exec(cmd_simple, timeout=60)
-            stdout, limit_reason = _search_stdout_and_limit(result)
+        raw_files: List[str] = []
+        for line in stdout.splitlines():
+            if order == "modified":
+                parts = line.split(" ", 1)
+                if len(parts) != 2 or not parts[0].replace(".", "", 1).isdigit():
+                    continue
+                raw_files.append(parts[1])
+            elif line:
+                raw_files.append(line)
 
-        files = []
-        for line in stdout.strip().split('\n'):
-            if not line:
-                continue
-            parts = line.split(' ', 1)
-            if len(parts) == 2 and parts[0].replace('.', '').isdigit():
-                files.append(parts[1])
-            else:
-                files.append(line)
-
-        # Git Bash find echoes native drive roots as /c/... paths. Convert only
-        # local Windows output; remote and container paths must remain untouched.
         from tools.environments.local import LocalEnvironment, _IS_WINDOWS, _msys_to_windows_path
         if _IS_WINDOWS and isinstance(self.env, LocalEnvironment):
-            files = [_msys_to_windows_path(file_path) for file_path in files]
+            raw_files = [_msys_to_windows_path(file_path) for file_path in raw_files]
 
-        # For explicit hidden roots, find's path-based filtering excludes every
-        # file under the hidden path. Apply descendant filtering after command
-        # execution so only the explicit root ancestry is bypassed.
-        if has_hidden_path_ancestor:
-            normalized_root = search_root.resolve()
-            filtered_files = []
-            for file_path in files:
-                try:
-                    rel_parts = Path(file_path).resolve().relative_to(normalized_root).parts
-                except ValueError:
-                    rel_parts = Path(file_path).parts
-                if any(part not in {".", ".."} and part.startswith(".") for part in rel_parts):
-                    continue
-                filtered_files.append(file_path)
-            files = filtered_files[offset:offset + limit]
-        # pagination for standard roots is already applied in shell
-
+        page = raw_files[offset:offset + limit]
         return SearchResult(
-            files=files,
-            total_count=len(files),
-            truncated=bool(limit_reason),
+            files=page,
+            total_count=len(raw_files),
+            truncated=len(raw_files) > offset + limit or bool(limit_reason),
             limit_reason=limit_reason,
         )
 
-    def _search_files_rg(self, pattern: str, path: str, limit: int, offset: int,
+    def _search_files_rg(self, pattern: str, path: str | List[str], limit: int, offset: int,
                          order: str = "discovery",
                          rg_executable: Optional[str] = None) -> SearchResult:
         """Search for files by name using ripgrep's --files mode.
@@ -3687,42 +3757,47 @@ class ShellFileOperations(FileOperations):
         else:
             glob_pattern = pattern
 
-        fetch_limit = limit + offset
-        exclusion_globs = " ".join(
-            f"--glob {self._escape_shell_arg(f'!{item}/**')}"
-            for item in self._macos_search_exclusions(path)
-        )
+        roots = [path] if isinstance(path, str) else path
+        fetch_limit = limit + offset + 1
+        exclusion_terms: List[str] = []
+        for root in roots:
+            exclusion_terms.extend(
+                f"--glob {self._escape_shell_arg(f'!{item}/**')}"
+                for item in self._macos_search_exclusions(root)
+            )
+        exclusion_globs = " ".join(dict.fromkeys(exclusion_terms))
         exclusion_args = f" {exclusion_globs}" if exclusion_globs else ""
         rg_executable = rg_executable or self._resolve_command("rg")
         if not rg_executable:
             return SearchResult(error="File search requires ripgrep (rg).")
+        if order == "modified":
+            capability_error = self._modified_rg_capability_error(rg_executable)
+            if capability_error:
+                return SearchResult(error=capability_error)
         rg = self._quote_executable(rg_executable)
         sort_arg = " --sortr=modified" if order == "modified" else ""
+        root_args = " ".join(self._escape_native_tool_arg(root) for root in roots)
         cmd = (
             f"set -o pipefail; {rg} --files{sort_arg} -g {self._escape_shell_arg(glob_pattern)}"
-            f"{exclusion_args} "
-            f"{self._escape_native_tool_arg(path)} 2>/dev/null "
-            f"| head -n {fetch_limit}"
+            f"{exclusion_args} {root_args} 2>/dev/null | head -n {fetch_limit}"
         )
         result = self._exec(cmd, timeout=60)
         stdout, limit_reason = _search_stdout_and_limit(result)
-        all_files = [f for f in stdout.strip().split('\n') if f]
+        all_files = [f for f in stdout.splitlines() if f]
 
-        if order == "modified" and result.exit_code not in {0, 124}:
-            return SearchResult(
-                error=(
-                    "Exact modification-time order requires ripgrep with "
-                    "--sortr=modified support; upgrade ripgrep or use "
-                    "order='discovery'."
-                )
-            )
+        if result.exit_code not in {0, 1, 124} and not all_files:
+            if order == "modified":
+                return SearchResult(error=(
+                    "Exact modification-time order failed; ripgrep 14+ is "
+                    "required. Upgrade ripgrep or use order='discovery'."
+                ))
+            return SearchResult(error="File search failed while running ripgrep.")
 
         page = all_files[offset:offset + limit]
-
         return SearchResult(
             files=page,
             total_count=len(all_files),
-            truncated=len(all_files) >= fetch_limit or bool(limit_reason),
+            truncated=len(all_files) > offset + limit or bool(limit_reason),
             limit_reason=limit_reason,
         )
     

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -28,6 +28,7 @@ Usage:
 import base64
 import binascii
 import os
+import posixpath
 import re
 import secrets
 import sys
@@ -372,6 +373,7 @@ class SearchResult:
             result["counts"] = self.counts
         if self.truncated:
             result["truncated"] = True
+            result["total_count_is_lower_bound"] = True
         if self.limit_reason:
             result["limit_reason"] = self.limit_reason
         if self.warning:
@@ -3474,16 +3476,31 @@ class ShellFileOperations(FileOperations):
         self, roots: List[str]
     ) -> List[tuple[str, str, str]]:
         """Return unique exclusions without pruning an explicitly chosen root."""
-        explicit_roots = {
-            os.path.normcase(os.path.abspath(os.path.normpath(root)))
+        cwd = getattr(self.env, "cwd", None) or self.cwd
+        use_posix_paths = sys.platform == "darwin" and all(
+            not re.match(r"^[A-Za-z]:[\\/]", root) and "\\" not in root
             for root in roots
-        }
+        )
+
+        def normalized(root: str) -> str:
+            if use_posix_paths:
+                if not posixpath.isabs(root):
+                    root = posixpath.join(cwd, root)
+                return posixpath.normpath(root)
+            return os.path.normcase(os.path.abspath(os.path.normpath(root)))
+
+        normalized_roots = [normalized(root) for root in roots]
+        explicit_roots = set(normalized_roots)
         seen = set()
         effective = []
-        for root in roots:
+        for root, normalized_root in zip(roots, normalized_roots):
             for relative in self._macos_search_exclusions(root):
-                absolute = os.path.normpath(os.path.join(root, relative))
-                key = os.path.normcase(os.path.abspath(absolute))
+                if use_posix_paths:
+                    absolute = posixpath.normpath(posixpath.join(normalized_root, relative))
+                    key = absolute
+                else:
+                    absolute = os.path.normpath(os.path.join(root, relative))
+                    key = os.path.normcase(os.path.abspath(absolute))
                 if key in explicit_roots or key in seen:
                     continue
                 seen.add(key)
@@ -3809,11 +3826,34 @@ class ShellFileOperations(FileOperations):
 
         roots = [path] if isinstance(path, str) else path
         fetch_limit = limit + offset + 1
-        exclusion_terms = [
-            f"--glob {self._escape_shell_arg(f'!{relative}/**')}"
-            for _root, relative, _absolute
-            in self._effective_macos_search_exclusions(roots)
-        ]
+        effective_exclusions = self._effective_macos_search_exclusions(roots)
+        scoped_common = None
+        command_roots = roots
+        use_posix_paths = sys.platform == "darwin" and all(
+            not re.match(r"^[A-Za-z]:[\\/]", root) and "\\" not in root
+            for root in roots
+        )
+        if len(roots) > 1 and effective_exclusions and use_posix_paths:
+            cwd = getattr(self.env, "cwd", None) or self.cwd
+            absolute_roots = [
+                posixpath.normpath(
+                    root if posixpath.isabs(root) else posixpath.join(cwd, root)
+                )
+                for root in roots
+            ]
+            scoped_common = posixpath.commonpath(absolute_roots)
+            command_roots = [
+                posixpath.relpath(root, scoped_common) for root in absolute_roots
+            ]
+            exclusion_terms = [
+                f"--glob {self._escape_shell_arg(f'!{posixpath.relpath(absolute, scoped_common)}/**')}"
+                for _root, _relative, absolute in effective_exclusions
+            ]
+        else:
+            exclusion_terms = [
+                f"--glob {self._escape_shell_arg(f'!{relative}/**')}"
+                for _root, relative, _absolute in effective_exclusions
+            ]
         exclusion_globs = " ".join(dict.fromkeys(exclusion_terms))
         exclusion_args = f" {exclusion_globs}" if exclusion_globs else ""
         rg_executable = rg_executable or self._resolve_command("rg")
@@ -3825,14 +3865,23 @@ class ShellFileOperations(FileOperations):
                 return SearchResult(error=capability_error)
         rg = self._quote_executable(rg_executable)
         sort_arg = " --sortr=modified" if order == "modified" else ""
-        root_args = " ".join(self._escape_native_tool_arg(root) for root in roots)
+        root_args = " ".join(self._escape_native_tool_arg(root) for root in command_roots)
+        cd_prefix = (
+            f"cd {self._escape_shell_arg(scoped_common)} && " if scoped_common else ""
+        )
         cmd = (
-            f"set -o pipefail; {rg} --files{sort_arg} -g {self._escape_shell_arg(glob_pattern)}"
+            f"set -o pipefail; {cd_prefix}{rg} --files{sort_arg} -g {self._escape_shell_arg(glob_pattern)}"
             f"{exclusion_args} {root_args} 2>/dev/null | head -n {fetch_limit}"
         )
         result = self._exec(cmd, timeout=60)
         stdout, limit_reason = _search_stdout_and_limit(result)
         all_files = [f for f in stdout.splitlines() if f]
+        if scoped_common:
+            all_files = [
+                file_path if posixpath.isabs(file_path)
+                else posixpath.normpath(posixpath.join(scoped_common, file_path))
+                for file_path in all_files
+            ]
         bounded_sigpipe = result.exit_code == 141 and len(all_files) >= fetch_limit
 
         if result.exit_code not in {0, 1, 124} and not bounded_sigpipe:

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -3496,23 +3496,7 @@ class ShellFileOperations(FileOperations):
                     rg_executable=resolved,
                 )
             else:
-                # find cannot accept the same cross-platform guarantees as rg;
-                # preserve per-root fallback scans, but never swallow an error
-                # and apply the caller's page once to the combined result.
-                collected: List[str] = []
-                any_truncated = False
-                fetch = offset + limit + 1
-                for root in existing:
-                    sub = self._search_files(pattern, root, fetch, 0, order)
-                    if sub.error:
-                        return sub
-                    collected.extend(sub.files)
-                    any_truncated = any_truncated or sub.truncated
-                merged = SearchResult(
-                    files=collected[offset:offset + limit],
-                    total_count=len(collected),
-                    truncated=any_truncated or len(collected) > offset + limit,
-                )
+                merged = self._search_files(pattern, existing, limit, offset, order)
         else:
             merged = SearchResult()
             for root in existing:
@@ -3641,7 +3625,7 @@ class ShellFileOperations(FileOperations):
         anchor = os.path.splitdrive(root)[0] + os.sep if os.path.splitdrive(root)[0] else os.path.abspath(os.sep)
         return root == home or common == root or root == os.path.normcase(anchor)
 
-    def _search_files(self, pattern: str, path: str, limit: int, offset: int,
+    def _search_files(self, pattern: str, path: str | List[str], limit: int, offset: int,
                       order: str = "discovery") -> SearchResult:
         """Search for files by name pattern (glob-like)."""
         # Auto-prepend **/ for recursive search if not already present
@@ -3660,7 +3644,8 @@ class ShellFileOperations(FileOperations):
         # A local find traversal rooted at/above the user's home or at a
         # filesystem root can consume minutes and prompt on protected paths.
         # Refuse before invoking find. Controller paths never classify remotes.
-        if self._is_broad_local_search_root(path):
+        roots = [path] if isinstance(path, str) else path
+        if any(self._is_broad_local_search_root(root) for root in roots):
             return SearchResult(error=(
                 "Broad local file search without ripgrep is disabled because "
                 "find cannot keep this traversal safely bounded. Install "
@@ -3677,13 +3662,15 @@ class ShellFileOperations(FileOperations):
         # Prune hidden descendant directories while still allowing an
         # explicitly selected hidden root. Hidden files are excluded too,
         # matching rg's default semantics.
-        q_path = self._escape_shell_arg(path)
+        q_roots = [self._escape_shell_arg(root) for root in roots]
+        root_exemptions = "".join(f" ! -path {root}" for root in q_roots)
         hidden_prune = (
-            f" \\( -type d -name '.*' ! -path {q_path} \\) -prune -o"
+            f" \\( -type d -name '.*'{root_exemptions} \\) -prune -o"
         )
         protected_paths = [
-            os.path.normpath(os.path.join(path, item))
-            for item in self._macos_search_exclusions(path)
+            os.path.normpath(os.path.join(root, item))
+            for root in roots
+            for item in self._macos_search_exclusions(root)
         ]
         protected_prune = ""
         if protected_paths:
@@ -3694,7 +3681,7 @@ class ShellFileOperations(FileOperations):
 
         fetch_limit = offset + limit + 1
         base = (
-            f"find {q_path}{protected_prune}{hidden_prune} -type f "
+            f"find {' '.join(q_roots)}{protected_prune}{hidden_prune} -type f "
             f"! -name '.*' -name {self._escape_shell_arg(search_pattern)}"
         )
         if order == "modified":
@@ -3785,7 +3772,7 @@ class ShellFileOperations(FileOperations):
         stdout, limit_reason = _search_stdout_and_limit(result)
         all_files = [f for f in stdout.splitlines() if f]
 
-        if result.exit_code not in {0, 1, 124} and not all_files:
+        if result.exit_code not in {0, 1, 124}:
             if order == "modified":
                 return SearchResult(error=(
                     "Exact modification-time order failed; ripgrep 14+ is "

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -50,6 +50,7 @@ from agent.file_safety import (
     get_write_denied_error,
     is_write_denied as _shared_is_write_denied,
 )
+from agent.search_policy import SEARCH_PRUNE_DIR_NAMES
 from tools import interrupt as tool_interrupt
 
 logger = logging.getLogger(__name__)
@@ -3654,15 +3655,31 @@ class ShellFileOperations(FileOperations):
         merged.warning = " ".join(warning_parts)
         return merged
 
+    def _search_prune_glob_args(self) -> str:
+        """Return rg globs that prune known heavyweight recursive subtrees.
+
+        The two forms cover both a root whose basename is a protected name and
+        protected descendants. Globs are relative to each rg search root, so a
+        single ``**/name/**`` pattern does not cover an explicitly selected
+        ``name/`` root. The directory names come from the shared scan policy;
+        this method deliberately does not maintain a second search-only list.
+        """
+        globs = []
+        for dirname in sorted(SEARCH_PRUNE_DIR_NAMES):
+            for prefix in ("", "**/"):
+                pattern = f"!{prefix}{dirname}/**"
+                globs.extend(("--glob", self._escape_shell_arg(pattern)))
+        return " ".join(globs)
+
     def _zero_match_probe(self, pattern: str, path: str,
                           file_glob: Optional[str]) -> Optional[str]:
         """Return a hint for a 0-match content search, or None.
 
         13.9% of production content searches return zero matches and give
-        the model nothing to steer by. Run ONE cheap case-insensitive count
-        probe; if it hits, say so. If the pattern contains regex
-        metacharacters, also probe it as a fixed string. Bounded: two rg
-        invocations max, count-only output.
+        the model nothing to steer by. Run cheap count-only probes for near
+        misses (wrong casing, hidden-only matches, unescaped regex
+        metacharacters). The hidden/ignored probe is bounded with the shared
+        dependency, cache, VCS, vendor, and build-tree pruning policy.
         """
         rg_executable = self._resolve_command('rg')
         if not rg_executable:
@@ -3702,9 +3719,12 @@ class ShellFileOperations(FileOperations):
         # Hidden/ignored probe: rg skips dotdirs and .gitignore'd files by
         # default. When the pattern exists only there, say so instead of
         # returning a bare zero (bench case: match in .hidden/ silently
-        # missing from results).
+        # missing from results). Keep --no-ignore so project-local ignored
+        # files remain diagnosable, but prune heavyweight trees before rg can
+        # recurse into them.
         hidden = self._exec(
-            f"{rg} --hidden --no-ignore --count-matches{glob_expr} "
+            f"{rg} --hidden --no-ignore --count-matches{glob_expr}"
+            f" {self._search_prune_glob_args()} "
             f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
             f"2>/dev/null | head -50",
             timeout=30,

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -36,6 +36,7 @@ import difflib
 import hashlib
 import json
 import logging
+import threading
 import unicodedata
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -49,6 +50,7 @@ from agent.file_safety import (
     get_write_denied_error,
     is_write_denied as _shared_is_write_denied,
 )
+from tools import interrupt as tool_interrupt
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +70,70 @@ _MACOS_TCC_PROTECTED_HOME_DIRS = (
     "Music",
     "Pictures",
 )
+
+
+_FILENAME_SEARCH_ADMISSION = threading.Condition()
+_ACTIVE_FILENAME_SEARCH_ROOTS: set[tuple[str, str, str]] = set()
+_FILENAME_SEARCH_WAIT_SECONDS = 0.05
+
+
+def _normalized_filename_search_root(env: Any, root: str, fallback_cwd: str) -> str:
+    """Normalize a filename-walk root without resolving remote paths locally."""
+    from tools.environments.local import LocalEnvironment, _IS_WINDOWS, _msys_to_windows_path
+
+    cwd = getattr(env, "cwd", None) or fallback_cwd
+    if isinstance(env, LocalEnvironment):
+        if _IS_WINDOWS:
+            root = _msys_to_windows_path(root)
+            cwd = _msys_to_windows_path(cwd)
+        if not os.path.isabs(root):
+            root = os.path.join(cwd, root)
+        return os.path.normcase(os.path.abspath(os.path.normpath(root)))
+
+    if not posixpath.isabs(root):
+        root = posixpath.join(cwd, root)
+    return posixpath.normpath(root)
+
+
+def _filename_search_root_keys(
+    env: Any, roots: List[str], fallback_cwd: str
+) -> tuple[tuple[str, str, str], ...]:
+    """Return unique backend/root admission keys in deterministic order."""
+    env_type = type(env)
+    return tuple(sorted({
+        (
+            env_type.__module__,
+            env_type.__qualname__,
+            _normalized_filename_search_root(env, root, fallback_cwd),
+        )
+        for root in roots
+    }))
+
+
+def _acquire_filename_search_roots(
+    keys: tuple[tuple[str, str, str], ...],
+) -> bool:
+    """Atomically claim every key, polling for thread-scoped interruption."""
+    with _FILENAME_SEARCH_ADMISSION:
+        while any(key in _ACTIVE_FILENAME_SEARCH_ROOTS for key in keys):
+            if tool_interrupt.is_interrupted():
+                return False
+            _FILENAME_SEARCH_ADMISSION.wait(_FILENAME_SEARCH_WAIT_SECONDS)
+            if tool_interrupt.is_interrupted():
+                return False
+        if tool_interrupt.is_interrupted():
+            return False
+        _ACTIVE_FILENAME_SEARCH_ROOTS.update(keys)
+        return True
+
+
+def _release_filename_search_roots(
+    keys: tuple[tuple[str, str, str], ...],
+) -> None:
+    """Release a completed walk and leave no idle per-root state behind."""
+    with _FILENAME_SEARCH_ADMISSION:
+        _ACTIVE_FILENAME_SEARCH_ROOTS.difference_update(keys)
+        _FILENAME_SEARCH_ADMISSION.notify_all()
 
 
 def _macos_protected_search_exclusions(
@@ -3547,16 +3613,11 @@ class ShellFileOperations(FileOperations):
             return None
 
         if target == "files":
-            # A file search across several roots is one global rg traversal so
+            # A file search across several roots is one global traversal so
             # modified ordering and pagination are exact across the whole set.
-            if self._has_command("rg"):
-                resolved = self._resolve_command("rg") or "rg"
-                merged = self._search_files_rg(
-                    pattern.split("/")[-1], existing, limit, offset, order,
-                    rg_executable=resolved,
-                )
-            else:
-                merged = self._search_files(pattern, existing, limit, offset, order)
+            # Route every engine through _search_files so root admission wraps
+            # the actual rg/find invocation for this multi-root request.
+            merged = self._search_files(pattern, existing, limit, offset, order)
         else:
             merged = SearchResult()
             for root in existing:
@@ -3708,17 +3769,34 @@ class ShellFileOperations(FileOperations):
         else:
             search_pattern = pattern.split('/')[-1]
 
+        roots = [path] if isinstance(path, str) else path
+
         # Prefer ripgrep: bounded parallel traversal with ignore semantics.
+        # Resolve the engine and exact-order capability before admission so a
+        # queued request does not occupy a root while doing command discovery.
         if self._has_command("rg"):
-            return self._search_files_rg(
-                search_pattern, path, limit, offset, order,
-                rg_executable=self._resolve_command("rg") or "rg",
-            )
+            rg_executable = self._resolve_command("rg") or "rg"
+            if order == "modified":
+                capability_error = self._modified_rg_capability_error(rg_executable)
+                if capability_error:
+                    return SearchResult(error=capability_error)
+            keys = _filename_search_root_keys(self.env, roots, self.cwd)
+            if not _acquire_filename_search_roots(keys):
+                return SearchResult(error=(
+                    "File search was interrupted while waiting for another filename "
+                    "search on the same root. Retry when ready."
+                ))
+            try:
+                return self._search_files_rg(
+                    search_pattern, path, limit, offset, order,
+                    rg_executable=rg_executable,
+                )
+            finally:
+                _release_filename_search_roots(keys)
 
         # A local find traversal rooted at/above the user's home or at a
         # filesystem root can consume minutes and prompt on protected paths.
         # Refuse before invoking find. Controller paths never classify remotes.
-        roots = [path] if isinstance(path, str) else path
         if any(self._is_broad_local_search_root(root) for root in roots):
             return SearchResult(error=(
                 "Broad local file search without ripgrep is disabled because "
@@ -3773,7 +3851,16 @@ class ShellFileOperations(FileOperations):
                 + f" -print 2>/dev/null | head -n {fetch_limit}"
             )
 
-        result = self._exec(cmd, timeout=60)
+        keys = _filename_search_root_keys(self.env, roots, self.cwd)
+        if not _acquire_filename_search_roots(keys):
+            return SearchResult(error=(
+                "File search was interrupted while waiting for another filename "
+                "search on the same root. Retry when ready."
+            ))
+        try:
+            result = self._exec(cmd, timeout=60)
+        finally:
+            _release_filename_search_roots(keys)
         stdout, limit_reason = _search_stdout_and_limit(result)
 
         # Parse before classifying exit 141: with pipefail, a bounded producer

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2587,6 +2587,7 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
 def search_tool(pattern: str, target: str = "content", path: str = ".",
                 file_glob: str = None, limit: int = 50, offset: int = 0,
                 output_mode: str = "content", context: int = 0,
+                order: str = "discovery",
                 task_id: str = "default") -> str:
     """Search for content or files."""
     try:
@@ -2603,6 +2604,7 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
             file_glob or "",
             limit,
             offset,
+            order,
         )
         with _read_tracker_lock:
             task_data = _read_tracker.setdefault(task_id, {
@@ -2648,7 +2650,8 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
         file_ops = _get_file_ops(task_id)
         result = file_ops.search(
             pattern=pattern, path=path, target=target, file_glob=file_glob,
-            limit=limit, offset=offset, output_mode=output_mode, context=context
+            limit=limit, offset=offset, output_mode=output_mode, context=context,
+            order=order,
         )
         omitted = _filter_read_blocked_search_results(result, task_id)
         if hasattr(result, 'matches'):
@@ -2840,7 +2843,7 @@ def _is_openai_family_main() -> bool:
 
 SEARCH_FILES_SCHEMA = {
     "name": "search_files",
-    "description": "Search file contents or find files by name. Use this instead of grep/rg/find/ls in terminal. Ripgrep-backed, faster than shell equivalents. On macOS, broad searches above the user home automatically skip TCC-protected folders (Desktop, Documents, Downloads, Library, Movies, Music, Pictures); target one directly when access is intentional.\n\nContent search (target='content'): Regex search inside files. Output modes: full matches with line numbers, file paths only, or match counts.\n\nFile search (target='files'): Find files by glob pattern (e.g., '*.py', '*config*'). Also use this instead of ls — results sorted by modification time.",
+    "description": "Search file contents or find files by name. Use this instead of grep/rg/find/ls in terminal. Ripgrep-backed, faster than shell equivalents. On macOS, broad searches above the user home automatically skip TCC-protected folders (Desktop, Documents, Downloads, Library, Movies, Music, Pictures); target one directly when access is intentional.\n\nContent search (target='content'): Regex search inside files. Output modes: full matches with line numbers, file paths only, or match counts.\n\nFile search (target='files'): Find files by glob pattern (e.g., '*.py', '*config*'). Also use this instead of ls. Discovery order is the fast bounded default; exact global newest-first order is an explicit opt-in and may scan the full tree.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -2850,6 +2853,7 @@ SEARCH_FILES_SCHEMA = {
             "file_glob": {"type": "string", "description": "Filter files by pattern in grep mode (e.g., '*.py' to only search Python files)"},
             "limit": {"type": "integer", "description": "Maximum number of results to return (default: 50)", "default": 50},
             "offset": {"type": "integer", "description": "Skip first N results for pagination (default: 0)", "default": 0},
+            "order": {"type": "string", "enum": ["discovery", "modified"], "description": "File-search order: 'discovery' is fast bounded traversal order; 'modified' is exact global newest-first and may scan the full tree; ignored for content", "default": "discovery"},
             "output_mode": {"type": "string", "enum": ["content", "files_only", "count"], "description": "Output format for grep mode: 'content' shows matching lines with line numbers, 'files_only' lists file paths, 'count' shows match counts per file", "default": "content"},
             "context": {"type": "integer", "description": "Number of context lines before and after each match (grep mode only)", "default": 0}
         },
@@ -2909,7 +2913,8 @@ def _handle_search_files(args, **kw):
     return search_tool(
         pattern=args.get("pattern", ""), target=target, path=args.get("path", "."),
         file_glob=args.get("file_glob"), limit=args.get("limit", 50), offset=args.get("offset", 0),
-        output_mode=args.get("output_mode", "content"), context=args.get("context", 0), task_id=tid)
+        output_mode=args.get("output_mode", "content"), context=args.get("context", 0),
+        order=args.get("order", "discovery"), task_id=tid)
 
 
 def _read_file_schema_overrides():

--- a/tools/interrupt.py
+++ b/tools/interrupt.py
@@ -17,6 +17,7 @@ Usage in tools:
 import logging
 import os
 import threading
+from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
 
@@ -93,6 +94,21 @@ def is_thread_interrupted(thread_id: int | None) -> bool:
         return False
     with _lock:
         return thread_id in _interrupted_threads
+
+
+def run_if_not_interrupted(callback: Callable[[], None]) -> bool:
+    """Run a state transition atomically with current-thread interruption.
+
+    Returns ``False`` without calling ``callback`` when the current thread is
+    already interrupted. The callback runs under the interrupt lock and must
+    not block or re-enter any interrupt API.
+    """
+    tid = threading.current_thread().ident
+    with _lock:
+        if tid in _interrupted_threads:
+            return False
+        callback()
+        return True
 
 
 def get_interrupt_reason() -> str | None:


### PR DESCRIPTION
## Summary
`search_files` gets a bounded, fail-closed fallback path when `rg` is unavailable or a probe finds nothing: a shared `agent/search_policy.py` decides engine + ordering, filename walks are serialised per root, heavy trees are pruned from the zero-match probe, and the Windows/`find` fallback normalises its paths — so no-`rg` hosts stop burning CPU on concurrent unbounded walks.

Salvaged from #97770 by @royalaid (all 19 commits cherry-picked, authorship preserved) onto current `main`; every conflict was import-line merging against #95160/#95940 which landed first.

## Who hits this / when / why it matters
Installs without `rg` (Windows without Git-for-Windows extras, minimal containers) and any host where a filename search walks a large tree: the previous fallbacks ran unbounded `find` walks concurrently per call and could return partial results silently on error.

## What changed (19 commits, on-topic per-commit — search ordering / fallback / interrupt)
- `agent/search_policy.py` (new): engine selection + "fast discovery" file ordering, shared by the tool and the code sandbox.
- `tools/file_operations.py`: fallback scans unified and fail-closed (partial errors rejected, explicit roots preserved), bounded `rg` SIGPIPE accepted, root options terminated, dash-prefixed and macOS-glob roots handled, filename walks serialised by root, admission-cancellation race closed.
- `agent/subdirectory_hints.py`: heavy trees pruned from the zero-match probe.
- Tests: `test_search_files_engine_selection.py`, `test_search_files_cpu_windows.py` (new) + interrupt-publisher hardening.

## Verification
- Touched tests + the file-ops suites (`test_file_ops_single_roundtrip`, `edge_cases`, `read_unicode_filename_retry`): **370 passed, 8 skipped**; ruff clean.
- Composition with #95160 (already on `main`): `read_file` bench unchanged (2 MB page 1 → 1 exec / 84 ms), native≡shell parity harness 20/20 identical.
- Composition with #95940 (already on `main`): its `--max-columns` hunks are outside this PR's ranges; both apply.
- Claimed CPU regression (Windows Defender + concurrent `find` fallbacks) was not reproducible on macOS in the triage window; the fail-closed/bounded behaviour is verified by the new tests.

## Provenance
Salvaged from #97770 by @royalaid — 19 commits cherry-picked with authorship preserved (noreply email). My only changes are the import-line conflict resolutions inside the cherry-picks.
