### PR TITLE
fix(cli): validate model switches against plugin provider catalogs

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -7405,6 +7405,83 @@ def validate_requested_model(
             ),
         }
 
+    # ── Profile-based validation for plugin providers ─────────────────────
+    # A ``kind: model-provider`` plugin can override ``fetch_models()`` (or
+    # set ``models_url``) to return its real catalog from a provider-specific
+    # endpoint, and the picker already surfaces that catalog via
+    # ``provider_model_ids()``. For those profiles the generic
+    # ``GET {base}/v1/models`` probe below can contradict the picker: hosts
+    # that front a shared gateway (e.g. a subscription plugin on
+    # api.cline.bot) answer /v1/models with HTTP 200 and the gateway's full
+    # aggregator dump — a *different product catalog* — so the probe
+    # hard-rejects every model the picker itself offered (#101705).
+    # When the profile owns a dedicated catalog endpoint, that catalog is
+    # authoritative for validation too (same chain, SWR cache, and curated
+    # merge as the picker). OpenRouter is exempt: its profile catalog and
+    # the live listing are the same source, and the probe path below carries
+    # the routing-variant (``:nitro`` et al.) handling.
+    try:
+        from providers import get_provider_profile
+        from providers.base import ProviderProfile as _ProfileBase
+
+        _profile = get_provider_profile(normalized)
+        _owns_catalog = _profile is not None and (
+            type(_profile).fetch_models is not _ProfileBase.fetch_models
+            or bool(_profile.models_url)
+        )
+        if (
+            _profile
+            and _owns_catalog
+            and _profile.auth_type == "api_key"
+            and _profile.base_url
+            and normalized != "openrouter"
+        ):
+            catalog_models = provider_model_ids(normalized)
+            if catalog_models:
+                catalog_lower = {m.lower(): m for m in catalog_models}
+                if requested_for_lookup.lower() in catalog_lower:
+                    return {
+                        "accepted": True,
+                        "persist": True,
+                        "recognized": True,
+                        "message": None,
+                    }
+                # Auto-correct only inside the profile catalog — never against
+                # the shared-gateway dump, which would silently swap a
+                # subscription SKU for another vendor's model.
+                auto = get_close_matches(
+                    requested_for_lookup.lower(), list(catalog_lower), n=1, cutoff=0.9
+                )
+                if auto:
+                    corrected = catalog_lower[auto[0]]
+                    return {
+                        "accepted": True,
+                        "persist": True,
+                        "recognized": True,
+                        "corrected_model": corrected,
+                        "message": f"Auto-corrected `{requested}` → `{corrected}`",
+                    }
+                suggestions = get_close_matches(
+                    requested_for_lookup.lower(), list(catalog_lower), n=3, cutoff=0.5
+                )
+                suggestion_text = ""
+                if suggestions:
+                    suggestion_text = "\n  Similar models: " + ", ".join(
+                        f"`{catalog_lower[s]}`" for s in suggestions
+                    )
+                return {
+                    "accepted": False,
+                    "persist": False,
+                    "recognized": False,
+                    "message": (
+                        f"Model `{requested}` was not found in the "
+                        f"{_profile.display_name or normalized} catalog."
+                        f"{suggestion_text}"
+                    ),
+                }
+    except Exception:
+        pass  # No/failed profile resolution — keep the generic probe below.
+
     # Probe the live API to check if the model actually exists
     api_models = fetch_api_models(api_key, base_url)
 

--- a/tests/test_plugin_provider_model_validation.py
+++ b/tests/test_plugin_provider_model_validation.py
@@ -1,0 +1,210 @@
+"""Tests for profile-based model validation of plugin providers (#101705).
+
+A ``kind: model-provider`` plugin can override ``fetch_models()`` to return
+its real catalog from a provider-specific endpoint, and the ``/model`` picker
+surfaces that catalog via ``provider_model_ids()``. ``validate_requested_model()``
+must validate against the same profile catalog instead of the generic
+``GET {base}/v1/models`` probe: on hosts that front a shared gateway the probe
+returns HTTP 200 with a *different* product catalog (the gateway's aggregator
+dump), which used to hard-reject every model the picker itself offered.
+"""
+
+import dataclasses
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.models import validate_requested_model
+from providers.base import ProviderProfile
+
+# Simulates the shared-gateway dump: HTTP 200 with hundreds of foreign-vendor
+# models and none of the plugin's subscription SKUs.
+GATEWAY_DUMP = [
+    "moonshotai/kimi-k3",
+    "z-ai/glm-5.2",
+    "z-ai/glm-5.3",
+    "anthropic/claude-sonnet-4.6",
+    "openai/gpt-5.6",
+]
+
+# The plugin's own catalog (what fetch_models() returns today via
+# provider_model_ids(), including curated fallbacks).
+PLUGIN_CATALOG = [
+    "cline-pass/kimi-k3",
+    "cline-pass/glm-5.3",
+    "cline-pass/claude-sonnet-4.6",
+]
+
+
+def _fake_profile():
+    # ClinePass-shaped: overrides fetch_models() to read a provider-specific
+    # subscription-models endpoint, exactly like the community plugin.
+    @dataclasses.dataclass
+    class _ClinePassProfile(ProviderProfile):
+        name: str = "clinepass"
+        display_name: str = "ClinePass"
+        auth_type: str = "api_key"
+        base_url: str = "https://api.cline.bot/api/v1"
+        fallback_models: tuple = ("cline-pass/kimi-k3",)
+
+        def fetch_models(self, **kw):
+            return list(PLUGIN_CATALOG)
+
+    return _ClinePassProfile()
+
+
+class TestPluginProviderModelValidation:
+    """validate_requested_model() honors the plugin profile catalog."""
+
+    @pytest.fixture(autouse=True)
+    def _plugin_env(self):
+        with patch(
+            "providers.get_provider_profile", return_value=_fake_profile()
+        ), patch(
+            "hermes_cli.models.provider_model_ids",
+            side_effect=lambda provider, **kw: list(PLUGIN_CATALOG),
+        ) as _mock_catalog, patch(
+            "hermes_cli.models.fetch_api_models",
+            return_value=list(GATEWAY_DUMP),
+        ) as _mock_fetch:
+            yield _mock_catalog, _mock_fetch
+
+    def test_plugin_catalog_model_accepted(self, _plugin_env):
+        # The subscription SKU is absent from the gateway dump — before the
+        # fix the generic probe hard-rejected it with foreign suggestions.
+        result = validate_requested_model(
+            "cline-pass/kimi-k3", "clinepass", api_key="sk-test"
+        )
+        assert result["accepted"] is True
+        assert result["persist"] is True
+        assert result["recognized"] is True
+        assert result["message"] is None
+
+    def test_plugin_catalog_case_insensitive(self, _plugin_env):
+        result = validate_requested_model(
+            "CLINE-PASS/KIMI-K3", "clinepass", api_key="sk-test"
+        )
+        assert result["accepted"] is True
+        assert result["recognized"] is True
+
+    def test_plugin_catalog_rejects_gateway_dump_model(self, _plugin_env):
+        # A usage-billing ID from the shared gateway is NOT one of the
+        # plugin's subscription SKUs — it must be rejected against the
+        # profile catalog, without suggesting the gateway's foreign models.
+        result = validate_requested_model(
+            "anthropic/claude-sonnet-4.6", "clinepass", api_key="sk-test"
+        )
+        assert result["accepted"] is False
+        assert result["persist"] is False
+        assert result["recognized"] is False
+        assert "ClinePass" in result["message"]
+        # Suggestions (if any) must come from the profile catalog, never the
+        # gateway dump.
+        if "Similar models" in result["message"]:
+            assert "moonshotai/" not in result["message"]
+            assert "cline-pass/" in result["message"]
+
+    def test_plugin_catalog_typo_auto_corrects_within_catalog(self, _plugin_env):
+        # "cline-pass/kimi-k" is a 0.97 ratio match for the catalog entry but
+        # only ~0.4 against every gateway model, so the correction must come
+        # from the profile catalog.
+        result = validate_requested_model(
+            "cline-pass/kimi-k", "clinepass", api_key="sk-test"
+        )
+        assert result["accepted"] is True
+        assert result["recognized"] is True
+        assert result["corrected_model"] == "cline-pass/kimi-k3"
+
+    def test_plugin_catalog_suggestions_from_catalog(self, _plugin_env):
+        # "cline-pass/glm" is a ~0.87 ratio match for cline-pass/glm-5.3:
+        # above the 0.5 suggestion cutoff, below the 0.9 auto-correct cutoff —
+        # suggests catalog entries only.
+        result = validate_requested_model(
+            "cline-pass/glm", "clinepass", api_key="sk-test"
+        )
+        assert result["accepted"] is False
+        assert "cline-pass/glm-5.3" in result["message"]
+        assert "moonshotai/" not in result["message"]
+
+
+class TestPluginProfileFallbackPaths:
+    """Fail-open: without a usable profile catalog the generic probe stays."""
+
+    def _run(self, requested="cline-pass/kimi-k3"):
+        return validate_requested_model(requested, "clinepass", api_key="sk-test")
+
+    def test_no_profile_uses_generic_probe(self):
+        # No registered profile — the old generic /v1/models path applies.
+        with patch("providers.get_provider_profile", return_value=None), patch(
+            "hermes_cli.models.fetch_api_models", return_value=list(GATEWAY_DUMP)
+        ):
+            result = self._run()
+        assert result["accepted"] is False
+        assert result["recognized"] is False
+
+    def test_profile_error_uses_generic_probe(self):
+        # Profile resolution blowing up must not brick model switching.
+        with patch(
+            "providers.get_provider_profile", side_effect=RuntimeError("boom")
+        ), patch(
+            "hermes_cli.models.fetch_api_models", return_value=list(GATEWAY_DUMP)
+        ):
+            result = self._run()
+        assert result["accepted"] is False
+
+    def test_empty_catalog_uses_generic_probe(self):
+        # provider_model_ids() with no live fetch and no fallbacks returns
+        # [] — nothing authoritative to validate against, keep the probe.
+        with patch(
+            "providers.get_provider_profile", return_value=_fake_profile()
+        ), patch(
+            "hermes_cli.models.provider_model_ids", return_value=[]
+        ), patch(
+            "hermes_cli.models.fetch_api_models", return_value=list(GATEWAY_DUMP)
+        ):
+            result = self._run()
+        assert result["accepted"] is False
+
+    def test_default_catalog_profile_uses_generic_probe(self):
+        # A profile that neither overrides fetch_models() nor sets models_url
+        # has no dedicated catalog endpoint — its listing comes from the same
+        # source as the generic probe, so the probe path (with its
+        # auto-correct and variant handling) must keep applying.
+        default_profile = ProviderProfile(
+            name="plain",
+            auth_type="api_key",
+            base_url="https://api.plain.test/v1",
+        )
+        with patch(
+            "providers.get_provider_profile", return_value=default_profile
+        ), patch(
+            "hermes_cli.models.fetch_api_models", return_value=["plain/alpha"]
+        ):
+            result = validate_requested_model(
+                "plain/alpha", "plain", api_key="sk-test"
+            )
+        assert result["accepted"] is True
+        assert result["recognized"] is True
+
+    def test_models_url_profile_owns_catalog(self):
+        # models_url decouples the catalog endpoint from the inference base
+        # URL, so the profile catalog is authoritative even without a
+        # fetch_models() override.
+        models_url_profile = ProviderProfile(
+            name="plain",
+            auth_type="api_key",
+            base_url="https://api.plain.test/v1",
+            models_url="https://api.plain.test/v2/catalog",
+        )
+        with patch(
+            "providers.get_provider_profile", return_value=models_url_profile
+        ), patch(
+            "hermes_cli.models.provider_model_ids", return_value=["plain/alpha"]
+        ), patch(
+            "hermes_cli.models.fetch_api_models", return_value=list(GATEWAY_DUMP)
+        ):
+            result = validate_requested_model(
+                "plain/alpha", "plain", api_key="sk-test"
+            )
+        assert result["accepted"] is True
+        assert result["recognized"] is True


### PR DESCRIPTION
## What does this PR do?

`kind: model-provider` plugins can override `fetch_models()` (or set `models_url`) to serve their real model catalog from a provider-specific endpoint, and the `/model` picker already surfaces that catalog via `provider_model_ids()`. But `validate_requested_model()` ignored the profile for these providers and probed the generic `GET {base}/v1/models` endpoint instead.

On hosts that front a shared gateway this probe succeeds with the **wrong catalog**: for the ClinePass subscription plugin (`api.cline.bot`), `/v1/models` returns HTTP 200 with the gateway's full OpenRouter aggregator dump — no `cline-pass/*` SKUs — so model-switch validation hard-rejected every model the picker itself offered, suggesting other vendors' models as alternatives.

This PR makes validation use the same `provider_model_ids()` chain the picker uses (inheriting its SWR cache and curated merge) whenever the profile owns a dedicated catalog endpoint. Auto-correct and suggestions are confined to that catalog, so a subscription SKU can no longer be silently swapped for another vendor's model. Profiles whose listing comes from the default `{base}/models` endpoint keep the generic probe path, as does OpenRouter (its live listing is authoritative and the probe path carries the `:nitro`/`:floor` routing-variant handling). Any profile-resolution failure falls back to the generic probe.

## Related Issue

Fixes #101705

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/models.py`: in `validate_requested_model()`, add a profile-based validation block before the generic `/v1/models` probe — for api-key profiles that override `fetch_models()` or set `models_url`, validate requested models against `provider_model_ids()` (direct hit → accepted; ≥0.9 close match → auto-correct within the catalog; otherwise reject with catalog-scoped suggestions). OpenRouter is exempt, and empty catalogs / profile errors fall through to the existing generic probe.
- `tests/test_plugin_provider_model_validation.py`: new regression tests covering the ClinePass shape (subscription SKU accepted despite a 200-but-foreign `/v1/models`; gateway-dump model rejected without foreign suggestions; typo auto-corrected within the catalog; case-insensitive lookup) plus fail-open boundaries (no profile, profile error, empty catalog, default-catalog profile, `models_url` profile).

## How to Test

1. `python -m pytest tests/test_plugin_provider_model_validation.py -q` — Observed result: 10 passed.
2. `python -m pytest tests/test_minimax_model_validation.py tests/hermes_cli/test_model_validation.py tests/hermes_cli/test_user_providers_model_switch.py tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_openai_codex_model_validation_fallback.py tests/hermes_cli/test_openai_listing_authority.py tests/hermes_cli/test_model_switch_opencode_anthropic.py tests/hermes_cli/test_model_switch_copilot_api_mode.py tests/hermes_cli/test_model_switch_configured_provider_routing.py tests/hermes_cli/test_ollama_cloud_auth.py tests/hermes_cli/test_router_provider.py tests/hermes_cli/test_kimi_cn_provider_listing.py tests/hermes_cli/test_api_key_providers.py tests/hermes_cli/test_list_picker_providers.py tests/hermes_cli/test_model_search_alias_dedup.py -q` — Observed result: 169 passed (includes the OpenRouter routing-variant suite, which initially regressed with a broader takeover condition and motivated the fetch_models-override/models_url guard).
3. `python -m ruff check hermes_cli/models.py tests/test_plugin_provider_model_validation.py` — Observed result: All checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (behavior comment added inline where the validation block lives)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure-Python validation logic, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A