### PR TITLE
feat(routing): scope policy to the active main provider

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -554,12 +554,12 @@ def init_agent(
     ephemeral_system_prompt: str = None,
     log_prefix_chars: int = 100,
     log_prefix: str = "",
-    providers_allowed: List[str] = None,
-    providers_ignored: List[str] = None,
-    providers_order: List[str] = None,
-    provider_sort: str = None,
+    providers_allowed: Optional[List[str]] = None,
+    providers_ignored: Optional[List[str]] = None,
+    providers_order: Optional[List[str]] = None,
+    provider_sort: Optional[str] = None,
     provider_require_parameters: bool = False,
-    provider_data_collection: str = None,
+    provider_data_collection: Optional[str] = None,
     openrouter_min_coding_score: Optional[float] = None,
     session_id: str = None,
     tool_progress_callback: callable = None,
@@ -584,7 +584,7 @@ def init_agent(
     event_callback: Optional[Callable[[str, dict], None]] = None,
     reaction_callback: Optional[Callable[[str], None]] = None,
     max_tokens: int = None,
-    reasoning_config: Dict[str, Any] = None,
+    reasoning_config: Optional[Dict[str, Any]] = None,
     service_tier: str = None,
     request_overrides: Dict[str, Any] = None,
     prefill_messages: List[Dict[str, Any]] = None,
@@ -605,7 +605,7 @@ def init_agent(
     parent_session_id: str = None,
     iteration_budget: "IterationBudget" = None,
     run_budget_seconds: Optional[float] = None,
-    fallback_model: Dict[str, Any] = None,
+    fallback_model: Optional[Dict[str, Any] | List[Dict[str, Any]]] = None,
     credential_pool=None,
     checkpoints_enabled: bool = False,
     checkpoint_max_snapshots: int = 20,
@@ -717,6 +717,31 @@ def init_agent(
         key: value for key, value in (capabilities or {}).items()
         if isinstance(key, str) and isinstance(value, bool)
     }
+
+    # Canonicalize URL-only direct construction before any provider-scoped
+    # config is selected. Exact-host helpers reject spoofed/suffix hosts.
+    if provider_name is None:
+        if (
+            agent._base_url_hostname == "chatgpt.com"
+            and "/backend-api/codex" in agent._base_url_lower
+        ):
+            agent.provider = "openai-codex"
+        elif agent._base_url_hostname == "api.x.ai":
+            agent.provider = "xai"
+        elif agent._base_url_hostname == "api.anthropic.com":
+            agent.provider = "anthropic"
+        elif agent._is_openrouter_url():
+            agent.provider = "openrouter"
+        elif base_url_host_matches(agent._base_url_lower, "api.openai.com"):
+            agent.provider = "openai-api"
+        elif agent._base_url_hostname == "api.meta.ai":
+            agent.provider = "meta"
+        elif (
+            agent._base_url_hostname.startswith("bedrock-runtime.")
+            and base_url_host_matches(agent._base_url_lower, "amazonaws.com")
+        ):
+            agent.provider = "bedrock"
+
     agent._credential_pool = credential_pool
     agent.acp_command = acp_command or command
     agent.acp_args = list(acp_args or args or [])
@@ -814,6 +839,89 @@ def init_agent(
             agent.model = normalize_model_for_provider(agent.model, agent.provider)
     except Exception:
         pass
+
+    # Main-provider-scoped policy. The raw config remains unchanged; this
+    # projection exists only for agents whose canonical PRIMARY provider matches
+    # a ``main_provider_policies.<provider>`` entry. Main-agent reasoning is
+    # intentionally outside this policy contract; caller/session reasoning and
+    # the base profile's reasoning settings remain authoritative.
+    _effective_main_provider_cfg = None
+    _main_provider_policy_active = False
+    _main_provider_policy_has_model_override = False
+    try:
+        from hermes_cli.config import (
+            load_config_readonly as _load_policy_config,
+            resolve_main_provider_policy,
+        )
+        from hermes_cli.fallback_config import get_fallback_chain
+
+        _base_policy_cfg = _load_policy_config()
+        _candidate_effective_cfg = resolve_main_provider_policy(
+            _base_policy_cfg, agent.provider, agent.model
+        )
+        _candidate_policy_active = _candidate_effective_cfg is not _base_policy_cfg
+        if _candidate_policy_active:
+            _raw_provider_policy = (
+                (_base_policy_cfg.get("main_provider_policies") or {}).get(
+                    agent.provider
+                )
+            )
+            _raw_model_overrides = (
+                _raw_provider_policy.get("model_overrides")
+                if isinstance(_raw_provider_policy, dict)
+                else None
+            )
+            _candidate_has_model_override = bool(
+                isinstance(_raw_model_overrides, dict)
+                and isinstance(_raw_model_overrides.get(agent.model), dict)
+                and "context_length" in _raw_model_overrides[agent.model]
+            )
+            _policy_routing = _candidate_effective_cfg.get("provider_routing") or {}
+            if not isinstance(_policy_routing, dict):
+                raise TypeError("projected provider_routing must be a mapping")
+            _policy_only = _policy_routing.get("only")
+            _policy_ignore = _policy_routing.get("ignore")
+            _policy_order = _policy_routing.get("order")
+            _policy_sort = _policy_routing.get("sort")
+            _policy_data_collection = _policy_routing.get("data_collection")
+            _candidate_runtime_values = (
+                _policy_only if isinstance(_policy_only, list) else None,
+                _policy_ignore if isinstance(_policy_ignore, list) else None,
+                _policy_order if isinstance(_policy_order, list) else None,
+                _policy_sort if isinstance(_policy_sort, str) else None,
+                bool(_policy_routing.get("require_parameters", False)),
+                (
+                    _policy_data_collection
+                    if isinstance(_policy_data_collection, str)
+                    else None
+                ),
+                get_fallback_chain(_candidate_effective_cfg),
+            )
+
+            # Publish only after routing, fallback, and model/context projection
+            # have all validated successfully.
+            (
+                providers_allowed,
+                providers_ignored,
+                providers_order,
+                provider_sort,
+                provider_require_parameters,
+                provider_data_collection,
+                fallback_model,
+            ) = _candidate_runtime_values
+            _main_provider_policy_has_model_override = (
+                _candidate_has_model_override
+            )
+        _effective_main_provider_cfg = _candidate_effective_cfg
+        _main_provider_policy_active = _candidate_policy_active
+    except Exception:
+        # Policy resolution is an optional config projection; malformed policy
+        # data must degrade to the caller-provided/base runtime, never block an
+        # otherwise valid agent.
+        _effective_main_provider_cfg = None
+        _main_provider_policy_active = False
+
+    agent._main_provider_policy_active = _main_provider_policy_active
 
     # GPT-5.x models usually require the Responses API path, but some
     # providers have exceptions (for example Copilot's gpt-5-mini still
@@ -1811,10 +1919,15 @@ def init_agent(
     from tools.todo_tool import TodoStore
     agent._todo_store = TodoStore()
     
-    # Load config once for memory, skills, and compression sections
+    # Load config once for memory, skills, and compression sections. Reuse the
+    # provider-scoped projection built above so model/context/compression reads
+    # agree with provider routing and fallback resolution for this agent.
     try:
-        from hermes_cli.config import load_config_readonly as _load_agent_config
-        _agent_cfg = _load_agent_config()
+        if _effective_main_provider_cfg is not None:
+            _agent_cfg = _effective_main_provider_cfg
+        else:
+            from hermes_cli.config import load_config_readonly as _load_agent_config
+            _agent_cfg = _load_agent_config()
     except Exception:
         _agent_cfg = {}
 
@@ -2638,7 +2751,9 @@ def init_agent(
             _configured_default_runtime_model
             and _configured_default_runtime_model != _active_runtime_model
         )
-        if _model_mismatch or _route_mismatch:
+        if (
+            _model_mismatch or _route_mismatch
+        ) and not _main_provider_policy_has_model_override:
             _ra().logger.debug(
                 "Ignoring model.context_length=%s for startup runtime %s at %s "
                 "(configured default is %s at %s)",

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3006,6 +3006,123 @@ def switch_model(
     old_model = agent.model
     old_provider = agent.provider
 
+    # Resolve the destination's provider-scoped projection before mutating any
+    # live state.  A switch must either install one coherent routing/context/
+    # fallback view or leave the old runtime untouched.
+    _sm_base_cfg: Dict[str, Any] = {}
+    _sm_effective_cfg: Dict[str, Any] = {}
+    _sm_destination_policy_active = False
+    _sm_policy_refresh = False
+    _sm_policy_context_intent: Optional[int] = None
+    _sm_policy_has_context_override = False
+    _sm_policy_routing: Dict[str, Any] = {}
+    _sm_policy_fallback_chain: List[Dict[str, Any]] = []
+    try:
+        from hermes_cli.config import (
+            load_config_readonly as _sm_load_policy_config,
+            resolve_main_provider_policy,
+        )
+        from hermes_cli.fallback_config import get_fallback_chain
+
+        _sm_base_cfg = _sm_load_policy_config() or {}
+        _sm_policies = _sm_base_cfg.get("main_provider_policies")
+        _sm_effective_cfg = resolve_main_provider_policy(
+            _sm_base_cfg, new_provider, new_model
+        )
+        _sm_destination_policy_active = _sm_effective_cfg is not _sm_base_cfg
+        _sm_policy_refresh = _sm_destination_policy_active or bool(
+            getattr(agent, "_main_provider_policy_active", False)
+        )
+        if _sm_policy_refresh:
+            _sm_policy_routing_value = _sm_effective_cfg.get("provider_routing")
+            if isinstance(_sm_policy_routing_value, dict):
+                _sm_policy_routing = _sm_policy_routing_value
+            _sm_policy_fallback_chain = get_fallback_chain(_sm_effective_cfg)
+
+            _sm_effective_model_cfg = _sm_effective_cfg.get("model")
+            if isinstance(_sm_effective_model_cfg, dict):
+                _sm_raw_context = _sm_effective_model_cfg.get("context_length")
+                if (
+                    isinstance(_sm_raw_context, int)
+                    and not isinstance(_sm_raw_context, bool)
+                    and _sm_raw_context > 0
+                ):
+                    _sm_policy_context_intent = _sm_raw_context
+
+            _sm_provider_key = str(new_provider or "").strip().lower()
+            _sm_policy = (
+                _sm_policies.get(_sm_provider_key)
+                if isinstance(_sm_policies, dict)
+                else None
+            )
+            _sm_model_overrides = (
+                _sm_policy.get("model_overrides")
+                if isinstance(_sm_policy, dict)
+                else None
+            )
+            _sm_exact_model_override = (
+                _sm_model_overrides.get(str(new_model or "").strip())
+                if isinstance(_sm_model_overrides, dict)
+                else None
+            )
+            _sm_policy_has_context_override = bool(
+                _sm_destination_policy_active
+                and isinstance(_sm_exact_model_override, dict)
+                and "context_length" in _sm_exact_model_override
+            )
+
+            # A base model.context_length belongs to its configured route.  A
+            # matching exact model override is the sole policy exception.
+            if (
+                _sm_policy_context_intent is not None
+                and not _sm_policy_has_context_override
+            ):
+                from agent.agent_init import _context_route_mismatch
+                from hermes_cli.config import split_model_config_default
+                from hermes_cli.model_normalize import normalize_model_for_provider
+
+                _sm_base_model_cfg = _sm_base_cfg.get("model")
+                if not isinstance(_sm_base_model_cfg, dict):
+                    _sm_policy_context_intent = None
+                else:
+                    _sm_configured_model = _sm_base_model_cfg.get("default")
+                    if isinstance(_sm_configured_model, dict):
+                        _sm_configured_model, _ = split_model_config_default(
+                            _sm_configured_model
+                        )
+                    _sm_configured_model = normalize_model_for_provider(
+                        str(_sm_configured_model or ""), new_provider
+                    )
+                    _sm_destination_model = normalize_model_for_provider(
+                        str(new_model or ""), new_provider
+                    )
+                    if (
+                        _sm_configured_model
+                        and _sm_configured_model != _sm_destination_model
+                    ) or _context_route_mismatch(
+                        _sm_base_model_cfg.get("base_url"),
+                        base_url,
+                        _sm_base_model_cfg.get("provider"),
+                        new_provider,
+                    ):
+                        _sm_policy_context_intent = None
+    except Exception as _policy_error:
+        logger.debug(
+            "switch_model: main-provider policy projection skipped",
+            exc_info=True,
+        )
+        # Once the source runtime is policy-scoped, continuing without a
+        # readable projection would pair the destination client/model with the
+        # source provider's routing and fallback state. Abort before any live
+        # mutation instead; the caller can retry after the transient read heals.
+        if getattr(agent, "_main_provider_policy_active", False):
+            raise RuntimeError(
+                "switch_model: main-provider policy projection could not be read"
+            ) from _policy_error
+        _sm_destination_policy_active = False
+        _sm_policy_refresh = False
+        _sm_effective_cfg = {}
+
     # ── Determine api_mode if not provided ──
     # Pass model so dual-wire providers (Nous Portal anthropic/* → Messages)
     # resolve correctly; without it determine_api_mode falls back to the
@@ -3083,8 +3200,15 @@ def switch_model(
             "_config_context_length",
             "_reasoning_echo_flag",
             "runtime_capabilities",
+            "_main_provider_policy_active",
         )
     }
+    _compressor = getattr(agent, "context_compressor", None)
+    _compressor_snapshot = (
+        dict(getattr(_compressor, "__dict__", {}))
+        if _compressor is not None
+        else None
+    )
     # _client_kwargs is a dict — snapshot a shallow copy so mutating the
     # live dict doesn't poison the rollback target.
     _snapshot["_client_kwargs"] = dict(getattr(agent, "_client_kwargs", {}) or {})
@@ -3103,6 +3227,12 @@ def switch_model(
                 continue
             try:
                 setattr(agent, _name, _value)
+            except Exception:  # noqa: BLE001
+                pass
+        if _compressor is not None and _compressor_snapshot is not None:
+            try:
+                _compressor.__dict__.clear()
+                _compressor.__dict__.update(_compressor_snapshot)
             except Exception:  # noqa: BLE001
                 pass
 
@@ -3291,10 +3421,15 @@ def switch_model(
 
         _sm_cfg = load_config()
         _sm_custom_providers = get_compatible_custom_providers(_sm_cfg)
-        _destination_context_intent = get_custom_provider_context_length(
+        _custom_context_intent = get_custom_provider_context_length(
             model=agent.model,
             base_url=agent.base_url,
             custom_providers=_sm_custom_providers,
+        )
+        _destination_context_intent = (
+            _sm_policy_context_intent
+            if _sm_policy_refresh and _sm_policy_context_intent is not None
+            else _custom_context_intent
         )
     except Exception:
         _destination_context_intent = None
@@ -3397,6 +3532,31 @@ def switch_model(
     except Exception as _reasoning_err:
         logger.debug("switch_model: could not re-resolve reasoning_config: %s", _reasoning_err)
 
+    # Publish provider-policy routing and fallback state only after client and
+    # context setup have succeeded.  The projection includes the base config
+    # for non-matching providers, so switching away restores it exactly.
+    if _sm_policy_refresh:
+        _only = _sm_policy_routing.get("only")
+        _ignore = _sm_policy_routing.get("ignore")
+        _order = _sm_policy_routing.get("order")
+        _sort = _sm_policy_routing.get("sort")
+        _data_collection = _sm_policy_routing.get("data_collection")
+        agent.providers_allowed = list(_only) if isinstance(_only, list) else None
+        agent.providers_ignored = list(_ignore) if isinstance(_ignore, list) else None
+        agent.providers_order = list(_order) if isinstance(_order, list) else None
+        agent.provider_sort = _sort if isinstance(_sort, str) else None
+        agent.provider_require_parameters = bool(
+            _sm_policy_routing.get("require_parameters", False)
+        )
+        agent.provider_data_collection = (
+            _data_collection if isinstance(_data_collection, str) else None
+        )
+        agent._fallback_chain = [dict(entry) for entry in _sm_policy_fallback_chain]
+        agent._fallback_model = (
+            agent._fallback_chain[0] if agent._fallback_chain else None
+        )
+    agent._main_provider_policy_active = _sm_destination_policy_active
+
     # ── Invalidate cached system prompt so it rebuilds next turn ──
     agent._cached_system_prompt = None
 
@@ -3462,14 +3622,16 @@ def switch_model(
     # ("switched to anthropic, tui keeps trying openrouter").
     old_norm = (old_provider or "").strip().lower()
     new_norm = (new_provider or "").strip().lower()
-    fallback_chain = list(getattr(agent, "_fallback_chain", []) or [])
-    if old_norm and new_norm and old_norm != new_norm:
-        fallback_chain = [
-            entry for entry in fallback_chain
-            if (entry.get("provider") or "").strip().lower() not in {old_norm, new_norm}
-        ]
-    agent._fallback_chain = fallback_chain
-    agent._fallback_model = fallback_chain[0] if fallback_chain else None
+    if not _sm_policy_refresh:
+        fallback_chain = list(getattr(agent, "_fallback_chain", []) or [])
+        if old_norm and new_norm and old_norm != new_norm:
+            fallback_chain = [
+                entry for entry in fallback_chain
+                if (entry.get("provider") or "").strip().lower()
+                not in {old_norm, new_norm}
+            ]
+        agent._fallback_chain = fallback_chain
+        agent._fallback_model = fallback_chain[0] if fallback_chain else None
 
     # Apply the switched-to provider's request_overrides (custom_providers
     # extra_body, e.g. chat_template_kwargs). See helper for rationale.

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3298,9 +3298,15 @@ def _aux_openrouter_settings() -> Tuple[bool, str]:
     config-read failure.
     """
     try:
-        from hermes_cli.config import cfg_get, load_config_readonly
+        from hermes_cli.config import (
+            cfg_get,
+            load_config_readonly,
+            resolve_main_provider_policy,
+        )
 
-        cfg = load_config_readonly()
+        cfg = resolve_main_provider_policy(
+            load_config_readonly(), _read_main_provider(), _read_main_model()
+        )
         free_only = bool(cfg_get(cfg, "auxiliary", "free_only", default=False))
         val = cfg_get(cfg, "auxiliary", "openrouter_model")
         model = val.strip() if isinstance(val, str) and val.strip() else _OPENROUTER_MODEL
@@ -6356,10 +6362,16 @@ def _try_main_fallback_chain(
     participate in the same order as the main agent.
     """
     try:
-        from hermes_cli.config import load_config_readonly
+        from hermes_cli.config import (
+            load_config_readonly,
+            resolve_main_provider_policy,
+        )
         from hermes_cli.fallback_config import get_fallback_chain
 
-        chain = get_fallback_chain(load_config_readonly())
+        config = resolve_main_provider_policy(
+            load_config_readonly(), _read_main_provider(), _read_main_model()
+        )
+        chain = get_fallback_chain(config)
     except Exception as exc:
         logger.debug("Auxiliary %s: could not load main fallback chain: %s", task or "call", exc)
         return None, None, ""
@@ -8881,8 +8893,13 @@ def _get_auxiliary_task_config(task: str) -> Dict[str, Any]:
     if not task:
         return {}
     try:
-        from hermes_cli.config import load_config_readonly
-        config = load_config_readonly()
+        from hermes_cli.config import (
+            load_config_readonly,
+            resolve_main_provider_policy,
+        )
+        config = resolve_main_provider_policy(
+            load_config_readonly(), _read_main_provider(), _read_main_model()
+        )
     except ImportError:
         return {}
     aux = config.get("auxiliary", {}) if isinstance(config, dict) else {}

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6307,7 +6307,11 @@ class TurnRunner:
         # serialization (_running_agents) keeps this safe post-lock.
         if reused_cached_agent and agent is not None:
             self._runner._apply_fallback_chain_to_agent(
-                agent, self._runner._refresh_fallback_model(),
+                agent,
+                self._runner._refresh_fallback_model(
+                    turn_route["runtime"].get("provider", ""),
+                    turn_route["model"],
+                ),
             )
 
         # Lock released — now schedule cleanup of any cross-process-evicted
@@ -6364,7 +6368,10 @@ class TurnRunner:
                 gateway_session_key=ctx.session_key,
                 session_db=getattr(self._runner._session_db, "_db", self._runner._session_db),
                 # Reload from disk — do not reuse the startup snapshot (#60955).
-                fallback_model=self._runner._refresh_fallback_model(),
+                fallback_model=self._runner._refresh_fallback_model(
+                    turn_route["runtime"].get("provider", ""),
+                    turn_route["model"],
+                ),
                 skip_context_files=skip_context_files,
                 # Keep the persona even with minimal context: soul identity is
                 # a single small file, not part of the expensive walk.
@@ -7615,6 +7622,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
         self._provider_routing = self._load_provider_routing()
         self._fallback_model = self._load_fallback_model()
+        # Immutable neutral fallback captured before any provider-scoped
+        # refresh updates the compatibility mirror. It is the only safe
+        # last-known-good for an uncached route on this gateway's own profile.
+        self._startup_fallback_model = [
+            dict(entry) for entry in (self._fallback_model or [])
+        ] or None
 
         # Wire process registry into session store for reset protection.
         # A background process older than the configured threshold (default 24h,
@@ -10914,26 +10927,59 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             pass
         return None
 
-    def _refresh_fallback_model(self) -> list | None:
-        """Re-read fallback_providers from disk for the next agent create/reuse.
+    def _refresh_fallback_model(
+        self, provider: str = "", model: str = ""
+    ) -> list | None:
+        """Re-read the live main route's effective fallback chain from disk.
 
-        Cron already does this per job via ``get_fallback_chain``; the gateway
-        previously froze ``self._fallback_model`` at process start, so a chain
-        configured (or changed) after ``hermes gateway`` was running never
-        reached messaging sessions even though the same process's cron jobs
-        fell back correctly. Fixes #60955.
-
-        A TRANSIENT read/parse failure (user mid-edit of config.yaml with a
-        non-atomic write) keeps the last known-good chain instead of wiping a
-        cached agent's working fallback for that turn.  Only a successful read
-        that genuinely lacks the key clears the chain.
+        Provider policies are resolved for the route that will own the agent.
+        Last-known-good values are keyed by that route so a transient parse
+        failure in one multiplexed session cannot borrow another session's
+        policy chain.
         """
+        config_home = _gateway_config_home()
+        try:
+            home_key = str(config_home.expanduser().resolve(strict=False))
+        except Exception:
+            home_key = str(config_home)
+        try:
+            default_home_key = str(
+                _hermes_home.expanduser().resolve(strict=False)
+            )
+        except Exception:
+            default_home_key = str(_hermes_home)
+        normalized_provider = str(provider or "").strip().lower()
+        normalized_model = str(model or "").strip()
+        route_key = (home_key, normalized_provider, normalized_model)
+        if not hasattr(self, "_startup_fallback_model"):
+            self._startup_fallback_model = [
+                dict(entry)
+                for entry in (getattr(self, "_fallback_model", None) or [])
+            ] or None
+        route_cache = getattr(self, "_fallback_model_by_route", None)
+        if not isinstance(route_cache, dict):
+            route_cache = {}
+            self._fallback_model_by_route = route_cache
+            if home_key == default_home_key and self._startup_fallback_model:
+                route_cache[(default_home_key, "", "")] = [
+                    dict(entry) for entry in self._startup_fallback_model
+                ]
+
+        def startup_chain() -> list | None:
+            if home_key != default_home_key or not self._startup_fallback_model:
+                return None
+            return [dict(entry) for entry in self._startup_fallback_model]
+
+        def remember(chain: list | None) -> list | None:
+            self._fallback_model = chain
+            route_cache[route_key] = chain
+            return chain
+
         try:
             from hermes_cli.config import read_user_config_raw
-            cfg_path = _hermes_home / "config.yaml"
+            cfg_path = config_home / "config.yaml"
             if not cfg_path.exists():
-                self._fallback_model = None
-                return self._fallback_model
+                return remember(None)
             # Raw primitive (raises on parse failure) is required here: the
             # canonical fail-open loader would return {} on a torn mid-edit
             # write and WIPE the last known-good chain. The overlay/expansion
@@ -10952,14 +10998,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 pass
         except Exception:
-            # Transient failure — keep last known-good chain.
+            # Transient failure — keep only this route's last-known-good chain.
             logger.debug(
                 "fallback_providers refresh: config.yaml read failed; "
-                "keeping last known-good chain", exc_info=True,
+                "keeping route-scoped last-known-good chain", exc_info=True,
             )
-            return self._fallback_model
-        self._fallback_model = get_fallback_chain(cfg) or None
-        return self._fallback_model
+            if route_key in route_cache:
+                return route_cache[route_key]
+            return startup_chain()
+
+        try:
+            from hermes_cli.config import resolve_main_provider_policy
+
+            cfg = resolve_main_provider_policy(
+                cfg, normalized_provider, normalized_model
+            )
+        except Exception:
+            logger.debug(
+                "fallback_providers refresh: policy resolution failed; "
+                "keeping route-scoped last-known-good chain",
+                exc_info=True,
+            )
+            if route_key in route_cache:
+                return route_cache[route_key]
+            return startup_chain()
+        return remember(get_fallback_chain(cfg) or None)
 
     @staticmethod
     def _apply_fallback_chain_to_agent(agent: Any, chain: list | None) -> None:
@@ -25585,7 +25648,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     thread_id=source.thread_id,
                     session_db=getattr(self._session_db, "_db", self._session_db),
                     # Reload from disk — do not reuse the startup snapshot (#60955).
-                    fallback_model=self._refresh_fallback_model(),
+                    fallback_model=self._refresh_fallback_model(
+                        turn_route["runtime"].get("provider", ""),
+                        turn_route["model"],
+                    ),
                 )
                 try:
                     return agent.run_conversation(
@@ -29368,6 +29434,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 out[f"{section}.{key}"] = section_val.get(key)
             else:
                 out[f"{section}.{key}"] = None
+        # Provider policies bake routing, auxiliary, fallback, and context
+        # state into AIAgent construction. Include the complete closed policy
+        # map so edits as well as enabled/disabled transitions rebuild it.
+        out["main_provider_policies"] = cfg.get("main_provider_policies")
         try:
             from tools.registry import registry
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2962,6 +2962,212 @@ def _deep_merge(base: dict, override: dict) -> dict:
     return result
 
 
+_MAIN_PROVIDER_POLICY_KEYS = frozenset(
+    {
+        "enabled",
+        "model_overrides",
+        "provider_routing",
+        "auxiliary",
+        "fallback_providers",
+    }
+)
+_MAIN_PROVIDER_ROUTING_LIST_KEYS = frozenset({"only", "ignore", "order"})
+_MAIN_PROVIDER_ROUTING_STRING_KEYS = frozenset({"sort", "data_collection"})
+_MAIN_PROVIDER_ROUTING_BOOL_KEYS = frozenset({"require_parameters"})
+_MAIN_PROVIDER_MODEL_SELECTOR_KEYS = frozenset(
+    {"provider", "default", "model", "base_url", "api_base"}
+)
+
+
+def _is_policy_scalar(value: Any) -> bool:
+    return value is None or isinstance(value, (str, int, float, bool))
+
+
+def _valid_main_provider_policy(policy: dict) -> bool:
+    """Validate the complete supported policy shape before any overlay."""
+    if not set(policy).issubset(_MAIN_PROVIDER_POLICY_KEYS):
+        return False
+
+    if not isinstance(policy.get("enabled", True), bool):
+        return False
+
+    fallback = policy.get("fallback_providers")
+    if fallback is not None:
+        if not isinstance(fallback, list):
+            return False
+        for entry in fallback:
+            if not isinstance(entry, dict):
+                return False
+            provider = entry.get("provider")
+            model = entry.get("model")
+            if not isinstance(provider, str) or not provider.strip():
+                return False
+            if not isinstance(model, str) or not model.strip():
+                return False
+            if any(not _is_policy_scalar(value) for value in entry.values()):
+                return False
+
+    routing = policy.get("provider_routing")
+    if routing is not None:
+        if not isinstance(routing, dict):
+            return False
+        for key, value in routing.items():
+            if not isinstance(key, str) or not key:
+                return False
+            if key in _MAIN_PROVIDER_ROUTING_LIST_KEYS:
+                if not isinstance(value, list) or any(
+                    not isinstance(item, str) for item in value
+                ):
+                    return False
+            elif key in _MAIN_PROVIDER_ROUTING_STRING_KEYS:
+                if not isinstance(value, str):
+                    return False
+            elif key in _MAIN_PROVIDER_ROUTING_BOOL_KEYS:
+                if not isinstance(value, bool):
+                    return False
+            elif not _is_policy_scalar(value):
+                return False
+
+    auxiliary = policy.get("auxiliary")
+    if auxiliary is not None:
+        if not isinstance(auxiliary, dict):
+            return False
+        for task, task_config in auxiliary.items():
+            if task == "free_only":
+                if not isinstance(task_config, bool):
+                    return False
+                continue
+            if task == "openrouter_model":
+                if not isinstance(task_config, str):
+                    return False
+                continue
+            if (
+                not isinstance(task, str)
+                or not task
+                or not isinstance(task_config, dict)
+            ):
+                return False
+            for selector in ("provider", "model"):
+                if selector in task_config and not isinstance(
+                    task_config[selector], str
+                ):
+                    return False
+
+    model_overrides = policy.get("model_overrides")
+    if model_overrides is not None:
+        if not isinstance(model_overrides, dict):
+            return False
+        for model_id, model_config in model_overrides.items():
+            if (
+                not isinstance(model_id, str)
+                or not model_id
+                or not isinstance(model_config, dict)
+            ):
+                return False
+            if set(model_config).intersection(_MAIN_PROVIDER_MODEL_SELECTOR_KEYS):
+                return False
+            context_length = model_config.get("context_length")
+            if context_length is not None and (
+                not isinstance(context_length, int)
+                or isinstance(context_length, bool)
+                or context_length <= 0
+            ):
+                return False
+            if any(not _is_policy_scalar(value) for value in model_config.values()):
+                return False
+
+    return True
+
+
+def resolve_main_provider_policy(
+    config: dict, provider: str, model: str = ""
+) -> dict:
+    """Overlay config scoped to the agent's selected main provider/model.
+
+    ``main_provider_policies.<provider>`` is dormant until an agent is
+    constructed with that provider as its primary route. Optional
+    ``model_overrides.<exact-model-id>`` values are merged into the top-level
+    ``model`` section only for that exact active model, which keeps context
+    pins from leaking to smaller models on the same aggregator.
+
+    The selector itself (``model.provider`` / ``model.default``) remains owned
+    by ``/model`` and ``hermes model``; a policy can tune the selected route but
+    cannot select a different one recursively.
+
+    The input is never mutated. A non-matching, disabled, or malformed policy
+    returns it unchanged so this helper is cheap on the normal path.
+    """
+    if not isinstance(config, dict):
+        return {}
+    provider_key = str(provider or "").strip().lower()
+    if not provider_key:
+        return config
+    policies = config.get("main_provider_policies")
+    if not isinstance(policies, dict):
+        return config
+    policy = policies.get(provider_key)
+    if not isinstance(policy, dict) or not _valid_main_provider_policy(policy):
+        return config
+    if policy.get("enabled", True) is False:
+        return config
+
+    overlay = {
+        key: value
+        for key, value in policy.items()
+        if key not in {"enabled", "model_overrides"}
+    }
+    model_key = str(model or "").strip()
+    model_overrides = policy.get("model_overrides")
+    model_overlay = (
+        model_overrides.get(model_key)
+        if isinstance(model_overrides, dict) and model_key
+        else None
+    )
+    if not overlay and not isinstance(model_overlay, dict):
+        return config
+    resolved = _deep_merge(config, overlay)
+    if isinstance(model_overlay, dict):
+        resolved_model_base = resolved.get("model")
+        if not isinstance(resolved_model_base, dict):
+            resolved_model_base = (
+                {"default": resolved_model_base}
+                if isinstance(resolved_model_base, str)
+                and resolved_model_base.strip()
+                else {}
+            )
+        resolved["model"] = _deep_merge(resolved_model_base, model_overlay)
+
+    # Policies are conditional behavior, not model selectors. Preserve the
+    # configured route even if a malformed policy tries to replace it.
+    base_model = config.get("model")
+    resolved_model = resolved.get("model")
+    if isinstance(base_model, dict) and isinstance(resolved_model, dict):
+        for selector in ("provider", "default", "model"):
+            if selector in base_model:
+                resolved_model[selector] = base_model[selector]
+            else:
+                resolved_model.pop(selector, None)
+    elif (
+        isinstance(base_model, str)
+        and base_model.strip()
+        and isinstance(resolved_model, dict)
+    ):
+        resolved_model["default"] = base_model
+
+    # The config loader already applied managed scope, but the conditional user
+    # policy overlay above runs later. Re-apply through the single managed-scope
+    # owner so no policy leaf can defeat an administrator pin.
+    try:
+        from hermes_cli import managed_scope
+
+        resolved = managed_scope.apply_managed_overlay(resolved)
+    except Exception:
+        # Managed scope itself is fail-open; keep policy resolution equally
+        # non-fatal if its module is unavailable during partial installs.
+        pass
+    return resolved
+
+
 def _strip_dotted_keys(cfg: dict, dotted_keys: set) -> Tuple[dict, set]:
     """Remove the given dotted leaf keys from a nested config dict.
 
@@ -5787,6 +5993,22 @@ def _validate_config_key(key: str) -> tuple[bool, Optional[str]]:
             return False, suggested_full
 
         return False, None
+
+    # main_provider_policies has a dynamic provider-name segment but a closed
+    # policy section immediately below it. Deeper auxiliary task names and
+    # provider-specific settings remain intentionally open.
+    if top == "main_provider_policies":
+        if len(segments) <= 2:
+            return True, None
+        section = segments[2]
+        if section in _MAIN_PROVIDER_POLICY_KEYS:
+            return True, None
+        suggestion = _suggest_closest_key(
+            section, set(_MAIN_PROVIDER_POLICY_KEYS)
+        )
+        if suggestion is None:
+            return False, None
+        return False, ".".join(segments[:2] + [suggestion])
 
     # ── Deeper validation ────────────────────────────────────────────
     # Walk DEFAULT_CONFIG along the user's segments. Stop at:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -7,6 +7,9 @@ verbatim from hermes_cli/config.py. Must not import from hermes_cli.config.
 DEFAULT_CONFIG = {
     "model": "",
     "providers": {},
+    # Provider-scoped runtime overlays. Keys are canonical provider ids; each
+    # policy is dormant unless that provider is the agent's selected main route.
+    "main_provider_policies": {},
     "fallback_providers": [],
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],

--- a/run_agent.py
+++ b/run_agent.py
@@ -560,7 +560,7 @@ class AIAgent:
         parent_session_id: str = None,
         iteration_budget: "IterationBudget" = None,
         run_budget_seconds: Optional[float] = None,
-        fallback_model: Dict[str, Any] = None,
+        fallback_model: Optional[Dict[str, Any] | List[Dict[str, Any]]] = None,
         credential_pool=None,
         checkpoints_enabled: bool = False,
         checkpoint_max_snapshots: int = 20,

--- a/tests/gateway/test_fallback_chain_reload.py
+++ b/tests/gateway/test_fallback_chain_reload.py
@@ -15,6 +15,186 @@ import time
 from types import SimpleNamespace
 
 
+def test_main_provider_policy_changes_bust_agent_cache_signature():
+    from gateway.run import GatewayRunner
+
+    enabled = {
+        "main_provider_policies": {
+            "openrouter": {
+                "enabled": True,
+                "provider_routing": {"data_collection": "deny"},
+            }
+        }
+    }
+    disabled = {
+        "main_provider_policies": {
+            "openrouter": {
+                "enabled": False,
+                "provider_routing": {"data_collection": "deny"},
+            }
+        }
+    }
+    runtime = {"provider": "openrouter", "base_url": "https://openrouter.ai/api/v1"}
+
+    enabled_sig = GatewayRunner._agent_config_signature(
+        "test/model",
+        runtime,
+        [],
+        "",
+        cache_keys=GatewayRunner._extract_cache_busting_config(enabled),
+    )
+    disabled_sig = GatewayRunner._agent_config_signature(
+        "test/model",
+        runtime,
+        [],
+        "",
+        cache_keys=GatewayRunner._extract_cache_busting_config(disabled),
+    )
+
+    assert enabled_sig != disabled_sig
+
+
+def test_refresh_fallback_model_resolves_live_main_policy(tmp_path, monkeypatch):
+    from gateway.run import GatewayRunner
+
+    monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+    (tmp_path / "config.yaml").write_text(
+        "fallback_providers:\n"
+        "  - provider: anthropic\n"
+        "    model: base-model\n"
+        "main_provider_policies:\n"
+        "  openrouter:\n"
+        "    fallback_providers:\n"
+        "      - provider: openai-codex\n"
+        "        model: policy-model\n",
+        encoding="utf-8",
+    )
+    runner = object.__new__(GatewayRunner)
+    runner._fallback_model = None
+    bound = runner._refresh_fallback_model
+
+    chain = bound("openrouter", "main-model")
+
+    assert chain == [{"provider": "openai-codex", "model": "policy-model"}]
+    assert runner._fallback_model == chain
+
+
+def test_fallback_refresh_failure_does_not_leak_another_route(
+    tmp_path, monkeypatch
+):
+    from gateway.run import GatewayRunner
+
+    monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "main_provider_policies:\n"
+        "  openrouter:\n"
+        "    fallback_providers:\n"
+        "      - provider: openai-codex\n"
+        "        model: policy-model\n",
+        encoding="utf-8",
+    )
+    runner = object.__new__(GatewayRunner)
+    runner._fallback_model = None
+    bound = runner._refresh_fallback_model
+    assert bound("openrouter", "main-model") == [
+        {"provider": "openai-codex", "model": "policy-model"}
+    ]
+
+    cfg.write_text("main_provider_policies: [", encoding="utf-8")
+
+    assert bound("anthropic", "claude-model") is None
+
+
+def test_fallback_refresh_isolated_by_profile_home(tmp_path, monkeypatch):
+    from gateway.run import GatewayRunner
+
+    profile_a = tmp_path / "profile-a"
+    profile_b = tmp_path / "profile-b"
+    profile_a.mkdir()
+    profile_b.mkdir()
+    (profile_a / "config.yaml").write_text(
+        "main_provider_policies:\n"
+        "  openrouter:\n"
+        "    fallback_providers:\n"
+        "      - provider: anthropic\n"
+        "        model: profile-a\n",
+        encoding="utf-8",
+    )
+    (profile_b / "config.yaml").write_text(
+        "main_provider_policies:\n"
+        "  openrouter:\n"
+        "    fallback_providers:\n"
+        "      - provider: openai-codex\n"
+        "        model: profile-b\n",
+        encoding="utf-8",
+    )
+    current = {"home": profile_a}
+    monkeypatch.setattr("gateway.run._hermes_home", profile_a)
+    monkeypatch.setattr(
+        "gateway.run._gateway_config_home", lambda: current["home"]
+    )
+    runner = object.__new__(GatewayRunner)
+    runner._fallback_model = None
+
+    assert runner._refresh_fallback_model("openrouter", "main-model") == [
+        {"provider": "anthropic", "model": "profile-a"}
+    ]
+    current["home"] = profile_b
+    assert runner._refresh_fallback_model("openrouter", "main-model") == [
+        {"provider": "openai-codex", "model": "profile-b"}
+    ]
+
+    (profile_a / "config.yaml").write_text("main_provider_policies: [")
+    current["home"] = profile_a
+    assert runner._refresh_fallback_model("openrouter", "main-model") == [
+        {"provider": "anthropic", "model": "profile-a"}
+    ]
+
+
+def test_uncached_default_route_failure_does_not_borrow_named_route(
+    tmp_path, monkeypatch
+):
+    from gateway.run import GatewayRunner
+
+    monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "main_provider_policies:\n"
+        "  openrouter:\n"
+        "    fallback_providers:\n"
+        "      - provider: anthropic\n"
+        "        model: policy-model\n",
+        encoding="utf-8",
+    )
+    base_chain = [{"provider": "openai-codex", "model": "startup-base"}]
+    runner = object.__new__(GatewayRunner)
+    runner._fallback_model = base_chain
+
+    assert runner._refresh_fallback_model("openrouter", "main-model") == [
+        {"provider": "anthropic", "model": "policy-model"}
+    ]
+    cfg.write_text("main_provider_policies: [", encoding="utf-8")
+
+    assert runner._refresh_fallback_model() == base_chain
+
+
+def test_first_read_failure_uses_startup_base_for_default_profile_route(
+    tmp_path, monkeypatch
+):
+    from gateway.run import GatewayRunner
+
+    monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+    (tmp_path / "config.yaml").write_text(
+        "main_provider_policies: [", encoding="utf-8"
+    )
+    base_chain = [{"provider": "openai-codex", "model": "startup-base"}]
+    runner = object.__new__(GatewayRunner)
+    runner._fallback_model = base_chain
+
+    assert runner._refresh_fallback_model("openrouter", "main-model") == base_chain
+
+
 def test_refresh_fallback_model_rereads_config(tmp_path, monkeypatch):
     from gateway.run import GatewayRunner
 
@@ -26,11 +206,9 @@ def test_refresh_fallback_model_rereads_config(tmp_path, monkeypatch):
         "    model: deepseek-v4-flash\n"
     )
 
-    runner = SimpleNamespace(
-        _fallback_model=None,
-    )
-    runner._load_fallback_model = GatewayRunner._load_fallback_model
-    bound = GatewayRunner._refresh_fallback_model.__get__(runner)
+    runner = object.__new__(GatewayRunner)
+    runner._fallback_model = None
+    bound = runner._refresh_fallback_model
     chain = bound()
 
     assert chain == [{"provider": "deepseek", "model": "deepseek-v4-flash"}]
@@ -84,8 +262,8 @@ def test_background_and_main_agent_paths_call_refresh():
     # the old _run_agent_inner closure) references the runner as
     # ``self._runner``; the background-agent site still uses bare ``self``.
     _refresh_calls = (
-        source.count("fallback_model=self._refresh_fallback_model()")
-        + source.count("fallback_model=self._runner._refresh_fallback_model()")
+        source.count("fallback_model=self._refresh_fallback_model(")
+        + source.count("fallback_model=self._runner._refresh_fallback_model(")
     )
     assert _refresh_calls >= 2
     # The cached-agent reuse path (the load-bearing fix for a long-lived
@@ -94,6 +272,14 @@ def test_background_and_main_agent_paths_call_refresh():
         "self._apply_fallback_chain_to_agent(" in source
         or "self._runner._apply_fallback_chain_to_agent(" in source
     )
+    reuse_start = source.index("if reused_cached_agent and agent is not None:")
+    reuse_end = source.index(
+        "# Lock released — now schedule cleanup", reuse_start
+    )
+    reuse_refresh = source[reuse_start:reuse_end]
+    assert 'turn_route["runtime"].get("provider", "")' in reuse_refresh
+    assert 'turn_route["model"]' in reuse_refresh
+    assert 'getattr(agent, "provider", "")' not in reuse_refresh
     # The stale startup-snapshot form must not remain at create sites.
     assert "fallback_model=self._fallback_model," not in source
     assert "fallback_model=self._runner._fallback_model," not in source

--- a/tests/hermes_cli/test_main_provider_policies.py
+++ b/tests/hermes_cli/test_main_provider_policies.py
@@ -1,0 +1,942 @@
+"""Main-provider-scoped config policy tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+
+_BASE_CONFIG: dict[str, Any] = {
+    "model": {"provider": "openai-codex", "default": "gpt-5.6-sol-900k"},
+    "auxiliary": {
+        "compression": {"provider": "anthropic", "model": "claude-opus-5"},
+    },
+    "fallback_providers": [
+        {"provider": "anthropic", "model": "claude-opus-5"},
+    ],
+    "main_provider_policies": {
+        "openrouter": {
+            "model_overrides": {
+                "z-ai/glm-5.3-flash": {"context_length": 1_048_576},
+            },
+            "provider_routing": {
+                "require_parameters": True,
+                "data_collection": "deny",
+            },
+            "auxiliary": {
+                "compression": {
+                    "provider": "openrouter",
+                    "model": "deepseek/deepseek-v4-flash-0731",
+                },
+            },
+            "fallback_providers": [
+                {"provider": "openai-codex", "model": "gpt-5.6-sol-900k"},
+                {"provider": "anthropic", "model": "claude-opus-5"},
+            ],
+        },
+    },
+}
+
+
+def test_matching_main_provider_policy_overlays_without_mutating_base():
+    from hermes_cli.config import resolve_main_provider_policy
+
+    resolved = resolve_main_provider_policy(
+        _BASE_CONFIG, "openrouter", "z-ai/glm-5.3-flash"
+    )
+
+    assert resolved["model"]["default"] == "gpt-5.6-sol-900k"
+    assert resolved["model"]["context_length"] == 1_048_576
+    assert resolved["provider_routing"] == {
+        "require_parameters": True,
+        "data_collection": "deny",
+    }
+    assert resolved["auxiliary"]["compression"] == {
+        "provider": "openrouter",
+        "model": "deepseek/deepseek-v4-flash-0731",
+    }
+    assert resolved["fallback_providers"][0]["provider"] == "openai-codex"
+
+    assert _BASE_CONFIG["auxiliary"]["compression"]["provider"] == "anthropic"
+    assert "context_length" not in _BASE_CONFIG["model"]
+
+
+def test_managed_leaves_win_over_matching_user_policy(tmp_path: Path, monkeypatch):
+    user_home = tmp_path / "user"
+    managed_home = tmp_path / "managed"
+    user_home.mkdir()
+    managed_home.mkdir()
+    user_config = yaml.safe_load(yaml.safe_dump(_BASE_CONFIG))
+    user_config["main_provider_policies"]["openrouter"]["provider_routing"][
+        "data_collection"
+    ] = "allow"
+    user_config["main_provider_policies"]["openrouter"]["auxiliary"][
+        "compression"
+    ]["provider"] = "openrouter"
+    (user_home / "config.yaml").write_text(
+        yaml.safe_dump(user_config, sort_keys=False), encoding="utf-8"
+    )
+    (managed_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "provider_routing": {"data_collection": "deny"},
+                "auxiliary": {"compression": {"provider": "anthropic"}},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(user_home))
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed_home))
+
+    from hermes_cli import managed_scope
+    from hermes_cli.config import (
+        _LOAD_CONFIG_CACHE,
+        load_config_readonly,
+        resolve_main_provider_policy,
+    )
+
+    managed_scope.invalidate_managed_cache()
+    _LOAD_CONFIG_CACHE.clear()
+    loaded = load_config_readonly()
+    resolved = resolve_main_provider_policy(
+        loaded, "openrouter", "z-ai/glm-5.3-flash"
+    )
+
+    assert loaded["provider_routing"]["data_collection"] == "deny"
+    assert resolved["provider_routing"]["data_collection"] == "deny"
+    assert resolved["auxiliary"]["compression"]["provider"] == "anthropic"
+
+
+def test_nonmatching_main_provider_leaves_base_policy_dormant():
+    from hermes_cli.config import resolve_main_provider_policy
+
+    resolved = resolve_main_provider_policy(
+        _BASE_CONFIG, "openai-codex", "gpt-5.6-sol-900k"
+    )
+
+    assert resolved is _BASE_CONFIG
+    assert resolved["auxiliary"]["compression"]["provider"] == "anthropic"
+    assert resolved["fallback_providers"] == [
+        {"provider": "anthropic", "model": "claude-opus-5"}
+    ]
+    assert "provider_routing" not in resolved
+
+
+def test_model_override_does_not_leak_to_another_openrouter_model():
+    from hermes_cli.config import resolve_main_provider_policy
+
+    resolved = resolve_main_provider_policy(
+        _BASE_CONFIG, "openrouter", "qwen/qwen3.8-flash"
+    )
+
+    assert "context_length" not in resolved["model"]
+    assert resolved["provider_routing"]["require_parameters"] is True
+
+
+def test_non_context_model_override_does_not_authorize_base_context(
+    tmp_path: Path, monkeypatch
+):
+    config = yaml.safe_load(yaml.safe_dump(_BASE_CONFIG))
+    config["model"]["default"] = "z-ai/glm-5.3-flash"
+    config["model"]["context_length"] = 222_222
+    config["main_provider_policies"]["openrouter"]["model_overrides"][
+        "z-ai/glm-5.3-flash"
+    ] = {"max_tokens": 1_024}
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(config, sort_keys=False), encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+    from hermes_cli import config as config_module
+    from run_agent import AIAgent
+
+    config_module._LOAD_CONFIG_CACHE.clear()
+    agent = AIAgent(
+        provider="openrouter",
+        requested_provider="openrouter",
+        model="z-ai/glm-5.3-flash",
+        base_url="https://openrouter.ai/api/v1",
+        api_key="test-key",
+        quiet_mode=True,
+        enabled_toolsets=[],
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    assert getattr(agent, "context_compressor").context_length != 222_222
+
+
+def test_model_base_url_override_cannot_authorize_base_context(
+    tmp_path: Path, monkeypatch
+):
+    config = yaml.safe_load(yaml.safe_dump(_BASE_CONFIG))
+    config["model"].update(
+        {
+            "default": "z-ai/glm-5.3-flash",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "context_length": 222_222,
+        }
+    )
+    config["main_provider_policies"]["openrouter"]["model_overrides"][
+        "z-ai/glm-5.3-flash"
+    ] = {"base_url": "https://openrouter.ai/api/v1"}
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(config, sort_keys=False), encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+    from hermes_cli import config as config_module
+    from run_agent import AIAgent
+
+    config_module._LOAD_CONFIG_CACHE.clear()
+    agent = AIAgent(
+        provider="openrouter",
+        requested_provider="openrouter",
+        model="z-ai/glm-5.3-flash",
+        base_url="https://openrouter.ai/api/v1",
+        api_key="test-key",
+        quiet_mode=True,
+        enabled_toolsets=[],
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    assert getattr(agent, "context_compressor").context_length != 222_222
+
+
+def test_disabled_policy_is_dormant():
+    from hermes_cli.config import resolve_main_provider_policy
+
+    config = yaml.safe_load(yaml.safe_dump(_BASE_CONFIG))
+    config["main_provider_policies"]["openrouter"]["enabled"] = False
+
+    assert (
+        resolve_main_provider_policy(config, "openrouter", "z-ai/glm-5.3-flash")
+        is config
+    )
+
+
+@pytest.mark.parametrize(
+    "malformed",
+    [
+        {"enabled": "false"},
+        {"fallback_providers": "anthropic"},
+        {"fallback_providers": [{"provider": "anthropic"}]},
+        {"provider_routing": []},
+        {"provider_routing": {"only": "Anthropic"}},
+        {"auxiliary": []},
+        {"auxiliary": {"review": "anthropic"}},
+        {"model_overrides": []},
+        {"model": "attacker/replacement-model"},
+        {"model_overrides": {"z-ai/glm-5.3-flash": "1048576"}},
+        {
+            "model_overrides": {
+                "z-ai/glm-5.3-flash": {"context_length": "1M"}
+            }
+        },
+        {
+            "model_overrides": {
+                "z-ai/glm-5.3-flash": {"provider": "attacker"}
+            }
+        },
+        {"agent": {"reasoning_effort": "high"}},
+    ],
+)
+def test_malformed_matching_policy_is_wholly_inert(malformed):
+    from hermes_cli.config import resolve_main_provider_policy
+
+    config = yaml.safe_load(yaml.safe_dump(_BASE_CONFIG))
+    policy = {
+        "provider_routing": {"require_parameters": True},
+        "fallback_providers": [
+            {"provider": "openai-codex", "model": "gpt-5.6-sol-900k"}
+        ],
+    }
+    policy.update(malformed)
+    config["main_provider_policies"]["openrouter"] = policy
+
+    resolved = resolve_main_provider_policy(
+        config, "openrouter", "z-ai/glm-5.3-flash"
+    )
+
+    assert resolved is config
+    assert "provider_routing" not in resolved
+    assert resolved["fallback_providers"] == [
+        {"provider": "anthropic", "model": "claude-opus-5"}
+    ]
+
+
+def test_valid_open_dict_policy_extensions_are_preserved():
+    from hermes_cli.config import resolve_main_provider_policy
+
+    config = yaml.safe_load(yaml.safe_dump(_BASE_CONFIG))
+    config["main_provider_policies"]["openrouter"] = {
+        "provider_routing": {
+            "require_parameters": True,
+            "future_provider_scalar": "preferred",
+        },
+        "auxiliary": {
+            "future_task": {
+                "provider": "openrouter",
+                "model": "future/model",
+                "temperature": 0.2,
+                "extra_body": {"vendor_flag": True},
+            }
+        },
+        "model_overrides": {
+            "z-ai/glm-5.3-flash": {
+                "context_length": 1_048_576,
+                "future_model_scalar": 7,
+            }
+        },
+        "fallback_providers": [
+            {
+                "provider": "anthropic",
+                "model": "claude-opus-5",
+                "reasoning_echo": True,
+            }
+        ],
+    }
+
+    resolved = resolve_main_provider_policy(
+        config, "openrouter", "z-ai/glm-5.3-flash"
+    )
+
+    assert resolved["provider_routing"]["future_provider_scalar"] == "preferred"
+    assert resolved["auxiliary"]["future_task"]["extra_body"] == {
+        "vendor_flag": True
+    }
+    assert resolved["model"]["future_model_scalar"] == 7
+    assert resolved["fallback_providers"][0]["reasoning_echo"] is True
+
+
+def test_scalar_model_selector_survives_exact_context_override():
+    from hermes_cli.config import resolve_main_provider_policy
+
+    config = {
+        "model": "base/main-model",
+        "main_provider_policies": {
+            "openrouter": {
+                "model_overrides": {
+                    "base/main-model": {"context_length": 123_456}
+                }
+            }
+        },
+    }
+
+    resolved = resolve_main_provider_policy(
+        config, "openrouter", "base/main-model"
+    )
+
+    assert resolved["model"] == {
+        "default": "base/main-model",
+        "context_length": 123_456,
+    }
+    assert config["model"] == "base/main-model"
+
+
+def test_explicit_reasoning_equal_to_base_is_not_projected_by_policy(
+    tmp_path: Path, monkeypatch
+):
+    config = yaml.safe_load(yaml.safe_dump(_BASE_CONFIG))
+    config["agent"] = {"reasoning_effort": "medium"}
+    config["main_provider_policies"]["openrouter"]["agent"] = {
+        "reasoning_effort": "high"
+    }
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(config, sort_keys=False), encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+    from hermes_cli import config as config_module
+    from run_agent import AIAgent
+
+    config_module._LOAD_CONFIG_CACHE.clear()
+    explicit = {"enabled": True, "effort": "medium"}
+    agent = AIAgent(
+        provider="openrouter",
+        requested_provider="openrouter",
+        model="z-ai/glm-5.3-flash",
+        base_url="https://openrouter.ai/api/v1",
+        api_key="test-key",
+        quiet_mode=True,
+        enabled_toolsets=[],
+        skip_context_files=True,
+        skip_memory=True,
+        reasoning_config=explicit,
+    )
+
+    assert getattr(agent, "reasoning_config") == explicit
+
+
+def test_openrouter_agent_uses_matching_policy_at_runtime(tmp_path: Path, monkeypatch):
+    config = {
+        "model": {"provider": "openai-codex", "default": "gpt-5.6-sol-900k"},
+        "fallback_providers": [
+            {"provider": "anthropic", "model": "claude-opus-5"},
+        ],
+        "main_provider_policies": _BASE_CONFIG["main_provider_policies"],
+    }
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(config, sort_keys=False), encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+    from hermes_cli import config as config_module
+    from run_agent import AIAgent
+
+    config_module._LOAD_CONFIG_CACHE.clear()
+    agent = AIAgent(
+        provider="openrouter",
+        requested_provider="openrouter",
+        model="z-ai/glm-5.3-flash",
+        base_url="https://openrouter.ai/api/v1",
+        api_key="test-key",
+        quiet_mode=True,
+        enabled_toolsets=[],
+        skip_context_files=True,
+        skip_memory=True,
+        fallback_model=config["fallback_providers"],
+    )
+
+    assert getattr(agent, "provider_require_parameters") is True
+    assert getattr(agent, "provider_data_collection") == "deny"
+    assert [entry["provider"] for entry in getattr(agent, "_fallback_chain")] == [
+        "openai-codex",
+        "anthropic",
+    ]
+    assert getattr(agent, "context_compressor").context_length == 1_048_576
+
+
+@pytest.mark.parametrize(
+    ("base_url", "expected_provider"),
+    [
+        ("https://api.anthropic.com", "anthropic"),
+        ("https://openrouter.ai/api/v1", "openrouter"),
+        ("https://api.openai.com/v1", "openai-api"),
+        ("https://api.meta.ai/v1", "meta"),
+        (
+            "https://bedrock-runtime.us-east-1.amazonaws.com",
+            "bedrock",
+        ),
+    ],
+)
+def test_url_canonicalization_precedes_initial_policy_selection(
+    tmp_path: Path, monkeypatch, base_url: str, expected_provider: str
+):
+    config = {
+        "model": {"default": "test/model"},
+        "main_provider_policies": {
+            expected_provider: {
+                "provider_routing": {"only": [f"{expected_provider}-policy"]}
+            }
+        },
+    }
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(config, sort_keys=False), encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from hermes_cli import config as config_module
+    from run_agent import AIAgent
+
+    config_module._LOAD_CONFIG_CACHE.clear()
+    agent = AIAgent(
+        model="test/model",
+        base_url=base_url,
+        api_key="test-key",
+        quiet_mode=True,
+        enabled_toolsets=[],
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    assert getattr(agent, "provider") == expected_provider
+    assert getattr(agent, "providers_allowed") == [f"{expected_provider}-policy"]
+    assert getattr(agent, "_main_provider_policy_active") is True
+
+
+def test_in_place_switch_refreshes_policy_and_restores_base(
+    tmp_path: Path, monkeypatch
+):
+    model = "shared/model-id"
+    config = {
+        "model": {
+            "provider": "openai-codex",
+            "default": model,
+            "context_length": 222_222,
+        },
+        "provider_routing": {
+            "only": ["Base Route"],
+            "require_parameters": False,
+            "data_collection": "allow",
+        },
+        "fallback_providers": [
+            {"provider": "anthropic", "model": "claude-opus-5"},
+        ],
+        "main_provider_policies": {
+            "openrouter": {
+                "model_overrides": {model: {"context_length": 1_048_576}},
+                "provider_routing": {
+                    "only": ["Policy Route"],
+                    "require_parameters": True,
+                    "data_collection": "deny",
+                },
+                "auxiliary": {
+                    "compression": {
+                        "provider": "openrouter",
+                        "model": "deepseek/deepseek-v4-flash-0731",
+                    }
+                },
+                "fallback_providers": [
+                    {"provider": "openai-codex", "model": "gpt-5.6-sol-900k"},
+                    {"provider": "anthropic", "model": "claude-opus-5"},
+                ],
+            }
+        },
+    }
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(config, sort_keys=False), encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+    from hermes_cli import config as config_module
+    from run_agent import AIAgent
+
+    config_module._LOAD_CONFIG_CACHE.clear()
+    agent = AIAgent(
+        provider="openrouter",
+        requested_provider="openrouter",
+        model=model,
+        base_url="https://openrouter.ai/api/v1",
+        api_key="test-key",
+        quiet_mode=True,
+        enabled_toolsets=[],
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    monkeypatch.setattr(agent, "_create_openai_client", lambda *_a, **_k: object())
+
+    assert getattr(agent, "providers_allowed") == ["Policy Route"]
+    assert getattr(agent, "provider_require_parameters") is True
+    assert getattr(agent, "provider_data_collection") == "deny"
+    assert [entry["provider"] for entry in getattr(agent, "_fallback_chain")] == [
+        "openai-codex",
+        "anthropic",
+    ]
+    assert getattr(agent, "context_compressor").context_length == 1_048_576
+
+    agent.switch_model(
+        new_model=model,
+        new_provider="openai-codex",
+        api_key="codex-key",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_mode="codex_responses",
+    )
+
+    assert getattr(agent, "providers_allowed") == ["Base Route"]
+    assert getattr(agent, "provider_require_parameters") is False
+    assert getattr(agent, "provider_data_collection") == "allow"
+    assert getattr(agent, "_fallback_chain") == [
+        {"provider": "anthropic", "model": "claude-opus-5"}
+    ]
+    assert getattr(agent, "context_compressor").context_length == 222_222
+
+    agent.switch_model(
+        new_model=model,
+        new_provider="openrouter",
+        api_key="test-key",
+        base_url="https://openrouter.ai/api/v1",
+        api_mode="chat_completions",
+    )
+
+    assert getattr(agent, "providers_allowed") == ["Policy Route"]
+    assert getattr(agent, "provider_require_parameters") is True
+    assert getattr(agent, "provider_data_collection") == "deny"
+    assert [entry["provider"] for entry in getattr(agent, "_fallback_chain")] == [
+        "openai-codex",
+        "anthropic",
+    ]
+    assert getattr(agent, "context_compressor").context_length == 1_048_576
+
+
+def test_failed_policy_switch_restores_context_and_routing_atomically(
+    tmp_path: Path, monkeypatch
+):
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(_BASE_CONFIG, sort_keys=False), encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+    from hermes_cli import config as config_module
+    from run_agent import AIAgent
+
+    config_module._LOAD_CONFIG_CACHE.clear()
+    agent = AIAgent(
+        provider="openrouter",
+        requested_provider="openrouter",
+        model="z-ai/glm-5.3-flash",
+        base_url="https://openrouter.ai/api/v1",
+        api_key="test-key",
+        quiet_mode=True,
+        enabled_toolsets=[],
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    monkeypatch.setattr(agent, "_create_openai_client", lambda *_a, **_k: object())
+    compressor = getattr(agent, "context_compressor")
+    original_update = compressor.update_model
+
+    def fail_after_context_mutation(**kwargs):
+        original_update(**kwargs)
+        raise RuntimeError("context update failed")
+
+    monkeypatch.setattr(compressor, "update_model", fail_after_context_mutation)
+
+    with pytest.raises(RuntimeError, match="context update failed"):
+        agent.switch_model(
+            new_model="gpt-5.6-sol-900k",
+            new_provider="openai-codex",
+            api_key="codex-key",
+            base_url="https://chatgpt.com/backend-api/codex",
+            api_mode="codex_responses",
+        )
+
+    assert getattr(agent, "provider") == "openrouter"
+    assert getattr(agent, "model") == "z-ai/glm-5.3-flash"
+    assert compressor.provider == "openrouter"
+    assert compressor.model == "z-ai/glm-5.3-flash"
+    assert compressor.context_length == 1_048_576
+    assert getattr(agent, "provider_require_parameters") is True
+    assert [entry["provider"] for entry in getattr(agent, "_fallback_chain")] == [
+        "openai-codex",
+        "anthropic",
+    ]
+
+
+def test_active_policy_switch_aborts_if_projection_cannot_be_read(
+    tmp_path: Path, monkeypatch
+):
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(_BASE_CONFIG, sort_keys=False), encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+    from hermes_cli import config as config_module
+    from run_agent import AIAgent
+
+    config_module._LOAD_CONFIG_CACHE.clear()
+    agent = AIAgent(
+        provider="openrouter",
+        requested_provider="openrouter",
+        model="z-ai/glm-5.3-flash",
+        base_url="https://openrouter.ai/api/v1",
+        api_key="test-key",
+        quiet_mode=True,
+        enabled_toolsets=[],
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    def fail_config_read():
+        raise RuntimeError("injected config read failure")
+
+    monkeypatch.setattr(config_module, "load_config_readonly", fail_config_read)
+
+    with pytest.raises(RuntimeError, match="policy projection"):
+        agent.switch_model(
+            new_model="gpt-5.6-sol-900k",
+            new_provider="openai-codex",
+            api_key="codex-key",
+            base_url="https://chatgpt.com/backend-api/codex",
+            api_mode="codex_responses",
+        )
+
+    assert getattr(agent, "provider") == "openrouter"
+    assert getattr(agent, "model") == "z-ai/glm-5.3-flash"
+    assert getattr(agent, "provider_require_parameters") is True
+    assert getattr(agent, "provider_data_collection") == "deny"
+    assert [entry["provider"] for entry in getattr(agent, "_fallback_chain")] == [
+        "openai-codex",
+        "anthropic",
+    ]
+    assert getattr(agent, "context_compressor").context_length == 1_048_576
+
+
+def test_initial_policy_projection_failure_is_atomic(tmp_path: Path, monkeypatch):
+    model = "z-ai/glm-5.3-flash"
+    config = yaml.safe_load(yaml.safe_dump(_BASE_CONFIG))
+    config["model"] = {
+        "provider": "openrouter",
+        "default": model,
+        "context_length": 222_222,
+    }
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(config, sort_keys=False), encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+    from hermes_cli import config as config_module
+    from hermes_cli import fallback_config
+    from run_agent import AIAgent
+
+    config_module._LOAD_CONFIG_CACHE.clear()
+
+    def fail_chain(_config):
+        raise RuntimeError("injected fallback projection failure")
+
+    monkeypatch.setattr(fallback_config, "get_fallback_chain", fail_chain)
+    caller_fallback = [{"provider": "nous", "model": "caller-fallback"}]
+    agent = AIAgent(
+        provider="openrouter",
+        requested_provider="openrouter",
+        model=model,
+        base_url="https://openrouter.ai/api/v1",
+        api_key="test-key",
+        quiet_mode=True,
+        enabled_toolsets=[],
+        skip_context_files=True,
+        skip_memory=True,
+        providers_allowed=["Caller Only"],
+        providers_ignored=["Caller Ignore"],
+        providers_order=["Caller Order"],
+        provider_sort="latency",
+        provider_require_parameters=False,
+        provider_data_collection="allow",
+        fallback_model=caller_fallback,
+    )
+
+    assert getattr(agent, "providers_allowed") == ["Caller Only"]
+    assert getattr(agent, "providers_ignored") == ["Caller Ignore"]
+    assert getattr(agent, "providers_order") == ["Caller Order"]
+    assert getattr(agent, "provider_sort") == "latency"
+    assert getattr(agent, "provider_require_parameters") is False
+    assert getattr(agent, "provider_data_collection") == "allow"
+    assert getattr(agent, "_fallback_chain") == caller_fallback
+    assert getattr(agent, "context_compressor").context_length == 222_222
+    assert getattr(agent, "_main_provider_policy_active") is False
+
+
+def test_malformed_policy_does_not_refresh_switch_state(
+    tmp_path: Path, monkeypatch
+):
+    config = yaml.safe_load(yaml.safe_dump(_BASE_CONFIG))
+    config["provider_routing"] = {"only": ["Base Route"]}
+    config["main_provider_policies"]["openrouter"]["provider_routing"] = []
+    config["main_provider_policies"]["anthropic"] = {
+        "auxiliary": {"review": {"provider": "anthropic", "model": "review-model"}}
+    }
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(config, sort_keys=False), encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+    from hermes_cli import config as config_module
+    from run_agent import AIAgent
+
+    config_module._LOAD_CONFIG_CACHE.clear()
+    caller_fallback = [{"provider": "nous", "model": "caller-fallback"}]
+    agent = AIAgent(
+        provider="openrouter",
+        requested_provider="openrouter",
+        model="z-ai/glm-5.3-flash",
+        base_url="https://openrouter.ai/api/v1",
+        api_key="test-key",
+        quiet_mode=True,
+        enabled_toolsets=[],
+        skip_context_files=True,
+        skip_memory=True,
+        providers_allowed=["Caller Route"],
+        fallback_model=caller_fallback,
+    )
+    monkeypatch.setattr(agent, "_create_openai_client", lambda *_a, **_k: object())
+
+    agent.switch_model(
+        new_model="z-ai/glm-5.3-flash",
+        new_provider="openrouter",
+        api_key="test-key",
+        base_url="https://openrouter.ai/api/v1",
+        api_mode="chat_completions",
+    )
+
+    assert getattr(agent, "providers_allowed") == ["Caller Route"]
+    assert getattr(agent, "_fallback_chain") == caller_fallback
+
+
+def test_auxiliary_policy_follows_live_main_provider(tmp_path: Path, monkeypatch):
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(_BASE_CONFIG, sort_keys=False), encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from agent.auxiliary_client import (
+        _get_auxiliary_task_config,
+        scoped_runtime_main,
+    )
+    from hermes_cli import config as config_module
+
+    config_module._LOAD_CONFIG_CACHE.clear()
+    with scoped_runtime_main(
+        {"provider": "openrouter", "model": "z-ai/glm-5.3-flash"}
+    ):
+        openrouter_compression = _get_auxiliary_task_config("compression")
+    with scoped_runtime_main(
+        {"provider": "openai-codex", "model": "gpt-5.6-sol-900k"}
+    ):
+        codex_compression = _get_auxiliary_task_config("compression")
+
+    assert openrouter_compression["provider"] == "openrouter"
+    assert openrouter_compression["model"] == "deepseek/deepseek-v4-flash-0731"
+    assert codex_compression["provider"] == "anthropic"
+    assert codex_compression["model"] == "claude-opus-5"
+
+
+def test_aux_openrouter_guards_follow_live_main_policy(tmp_path: Path, monkeypatch):
+    config = yaml.safe_load(yaml.safe_dump(_BASE_CONFIG))
+    config["auxiliary"]["free_only"] = False
+    config["auxiliary"]["openrouter_model"] = "paid/base-model"
+    config["main_provider_policies"]["openrouter"]["auxiliary"].update(
+        {
+            "free_only": True,
+            "openrouter_model": "free/policy-model:free",
+        }
+    )
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(config, sort_keys=False), encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from agent.auxiliary_client import _aux_openrouter_settings, scoped_runtime_main
+    from hermes_cli import config as config_module
+
+    config_module._LOAD_CONFIG_CACHE.clear()
+    with scoped_runtime_main(
+        {"provider": "openrouter", "model": "z-ai/glm-5.3-flash"}
+    ):
+        policy_settings = _aux_openrouter_settings()
+    with scoped_runtime_main(
+        {"provider": "openai-codex", "model": "gpt-5.6-sol-900k"}
+    ):
+        base_settings = _aux_openrouter_settings()
+
+    assert policy_settings == (True, "free/policy-model:free")
+    assert base_settings == (False, "paid/base-model")
+
+
+def test_aux_policy_is_isolated_across_concurrent_profiles(tmp_path: Path):
+    from concurrent.futures import ThreadPoolExecutor
+    from threading import Barrier
+
+    cases = [
+        (
+            tmp_path / "profile-a",
+            "openrouter",
+            {"free_only": False, "openrouter_model": "paid/profile-a-base"},
+            {"free_only": True, "openrouter_model": "free/profile-a:free"},
+            (True, "free/profile-a:free"),
+        ),
+        (
+            tmp_path / "profile-b",
+            "openai-codex",
+            {"free_only": False, "openrouter_model": "paid/profile-b-base"},
+            {"free_only": True, "openrouter_model": "free/profile-b:free"},
+            (False, "paid/profile-b-base"),
+        ),
+    ]
+    for home, _provider, base_aux, policy_aux, _expected in cases:
+        home.mkdir()
+        config = {
+            "model": {"provider": "openrouter", "default": "main/model"},
+            "auxiliary": base_aux,
+            "main_provider_policies": {
+                "openrouter": {"auxiliary": policy_aux}
+            },
+        }
+        (home / "config.yaml").write_text(
+            yaml.safe_dump(config, sort_keys=False), encoding="utf-8"
+        )
+
+    from agent.auxiliary_client import _aux_openrouter_settings, scoped_runtime_main
+    from hermes_cli import config as config_module
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    config_module._LOAD_CONFIG_CACHE.clear()
+    barrier = Barrier(2)
+
+    def read_profile(case) -> tuple[bool, str]:
+        home, provider, _base_aux, _policy_aux, _expected = case
+        home_token = set_hermes_home_override(str(home))
+        try:
+            with scoped_runtime_main(
+                {"provider": provider, "model": "main/model"}
+            ):
+                barrier.wait(timeout=5)
+                return _aux_openrouter_settings()
+        finally:
+            reset_hermes_home_override(home_token)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(read_profile, cases))
+
+    assert results == [case[-1] for case in cases]
+
+
+def test_auto_auxiliary_uses_matching_policy_fallback_chain(
+    tmp_path: Path, monkeypatch
+):
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(_BASE_CONFIG, sort_keys=False), encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from agent import auxiliary_client
+    from hermes_cli import config as config_module
+
+    config_module._LOAD_CONFIG_CACHE.clear()
+    monkeypatch.setattr(
+        auxiliary_client,
+        "_resolve_fallback_entry",
+        lambda entry: (object(), entry["model"]),
+    )
+    with auxiliary_client.scoped_runtime_main(
+        {"provider": "openrouter", "model": "z-ai/glm-5.3-flash"}
+    ):
+        _, model, provider = auxiliary_client._try_main_fallback_chain(
+            "title_generation", failed_provider="openrouter"
+        )
+
+    assert provider == "openai-codex"
+    assert model == "gpt-5.6-sol-900k"
+
+
+def test_main_provider_policy_paths_are_known_config_keys():
+    from hermes_cli.config import _validate_config_key
+
+    assert _validate_config_key(
+        "main_provider_policies.openrouter.auxiliary.compression.model"
+    ) == (True, None)
+    assert _validate_config_key(
+        "main_provider_policies.openrouter.auxiliary.future_task.vendor_flag"
+    ) == (True, None)
+    assert _validate_config_key(
+        "main_provider_policies.openrouter.provider_routing.future_scalar"
+    ) == (True, None)
+    assert _validate_config_key(
+        "main_provider_policies.openrouter.agent.reasoning_effort"
+    )[0] is False

--- a/website/docs/user-guide/features/provider-routing.md
+++ b/website/docs/user-guide/features/provider-routing.md
@@ -33,6 +33,61 @@ provider_routing:
 Provider routing only applies when using OpenRouter or Nous Portal. It has no effect with direct provider connections (e.g., connecting directly to the Anthropic API).
 :::
 
+## Scope settings to the selected main provider
+
+Use `main_provider_policies.<provider>` when auxiliary, fallback, context, or
+provider-routing settings should activate only while that provider is the
+agent's **primary** route. The base profile remains authoritative for every
+other main provider, so switching back restores its original behavior without
+rewriting config.
+
+```yaml
+main_provider_policies:
+  openrouter:
+    enabled: true
+    model_overrides:
+      z-ai/glm-5.3-flash:
+        context_length: 1048576
+    provider_routing:
+      require_parameters: true
+      data_collection: deny
+    auxiliary:
+      compression:
+        provider: openrouter
+        model: deepseek/deepseek-v4-flash-0731
+        reasoning_effort: low
+      review:
+        provider: anthropic
+        model: claude-opus-5
+    fallback_providers:
+      - provider: openai-codex
+        model: gpt-5.6-sol-900k
+      - provider: anthropic
+        model: claude-opus-5
+```
+
+The provider policy is resolved from the live main route when an agent is
+created, including a session `/model` switch, delegated child, gateway session,
+or cron agent. It is **not** activated merely because OpenRouter appears as a
+fallback or auxiliary provider. Within `auxiliary`, the scalar
+`free_only` and `openrouter_model` settings govern OpenRouter auto-fallback for
+that live main route alongside task-specific entries such as `compression` and
+`review`.
+
+Administrator-managed config remains authoritative after policy projection.
+For example, a managed `provider_routing.data_collection: deny` or managed
+auxiliary/compression leaf cannot be relaxed by a user-defined provider policy.
+
+`model_overrides` is keyed by exact model ID. Use it for model-specific values
+such as `context_length`; a pin for one OpenRouter model never leaks to a
+smaller model on the same aggregator. Policies cannot change `model.provider`
+or `model.default` — model selection remains explicit through `hermes model` or
+`/model`.
+
+Set `enabled: false` to keep a policy configured but dormant. `hermes config
+get` continues to show the base profile values; the overlay is a runtime
+projection and is never written over those base values.
+
 ## Options
 
 ### `sort`


### PR DESCRIPTION
## Summary

- add `main_provider_policies.<provider>` as a conditional runtime projection for the selected primary provider/model
- keep model selection and managed configuration authoritative while scoping routing, auxiliary, fallback, and exact-model context settings
- refresh gateway fallback state by profile and primary route, including cached-agent reuse and first-read failure handling
- update in-place model switching atomically and keep main-agent reasoning outside the policy contract
- document the configuration and add focused regression coverage

## Validation

- `323 passed, 1 skipped` across provider-policy, gateway fallback, auxiliary, CLI init, provider inference, and model-switch regression selections
- `49 passed` from a clean clone of the pushed fork SHA
- Ruff: passed
- ty (changed tests): passed
- Docusaurus production build: passed
- three-model review completed before the final rebase; Codex and Grok also revalidated the final rebased bundle. Claude final-byte rerun was quota-blocked, so the commit records its earlier exact feature-bundle review rather than claiming a final-byte Claude verdict.

The repository-wide local runner is not represented as green: this macOS worktree has a known non-green baseline plus long-path and per-file timeout/no-run failures. GitHub CI is the authoritative full-suite gate.

## Scope

- no user `config.yaml` changes
- no installed-runtime changes in this PR
- no OpenRouter Guardrail or other remote account changes
