### PR TITLE
fix(auxiliary): skip text-only main models during vision fallback

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6041,6 +6041,13 @@ def _try_main_agent_model_fallback(
     if not main_provider or not main_model or main_provider.lower() in {"auto", ""}:
         return None, None, ""
 
+    if task == "vision" and not _main_model_supports_vision(main_provider, main_model):
+        logger.info(
+            "Auxiliary vision: skipping text-only main agent model fallback (%s)",
+            main_provider,
+        )
+        return None, None, ""
+
     # Identity + scope semantics owned by agent.backend_identity (#72468):
     # model-scoped failures skip only the exact deployment that failed;
     # provider-wide failures (no failed_model) skip the credential surface.

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1978,6 +1978,45 @@ class TestTryMainAgentModelFallback:
         assert model == "anthropic/claude-sonnet-4"
         assert label == "main-agent(openrouter)"
 
+    def test_vision_skips_known_text_only_main_model(self):
+        from agent.auxiliary_client import _try_main_agent_model_fallback
+
+        with patch("agent.auxiliary_client._read_main_provider", return_value="zai"), \
+             patch("agent.auxiliary_client._read_main_model", return_value="glm-5.3"), \
+             patch("agent.auxiliary_client.resolve_provider_client") as mock_resolve:
+            client, model, label = _try_main_agent_model_fallback(
+                "zai",
+                task="vision",
+                failed_model="glm-5.3-flash",
+            )
+
+        assert client is None and model is None and label == ""
+        mock_resolve.assert_not_called()
+
+    def test_vision_keeps_vision_capable_main_model_fallback(self):
+        from agent.auxiliary_client import _try_main_agent_model_fallback
+
+        sentinel = MagicMock()
+        with patch("agent.auxiliary_client._read_main_provider", return_value="openrouter"), \
+             patch(
+                 "agent.auxiliary_client._read_main_model",
+                 return_value="anthropic/claude-sonnet-4",
+             ), \
+             patch("agent.auxiliary_client._is_provider_unhealthy", return_value=False), \
+             patch(
+                 "agent.auxiliary_client.resolve_provider_client",
+                 return_value=(sentinel, "anthropic/claude-sonnet-4"),
+             ):
+            client, model, label = _try_main_agent_model_fallback(
+                "zai",
+                task="vision",
+                failed_model="glm-5.3-flash",
+            )
+
+        assert client is sentinel
+        assert model == "anthropic/claude-sonnet-4"
+        assert label == "main-agent(openrouter)"
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

When auxiliary vision fails, Hermes currently relays the image to the main agent model even when capability metadata marks that model as text-only. On Z.AI, `glm-5.3` then replaces the useful upstream failure with `400 content.type invalid`.

This PR checks the existing vision-capability resolver before selecting the main-model fallback. Known text-only models are skipped. Vision-capable and unknown models remain eligible, and non-vision auxiliary tasks are unchanged.

## Related Issue

No issue filed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Gate only the vision main-model fallback with `_main_model_supports_vision()`.
- Add regressions for a known text-only Z.AI model and a vision-capable OpenRouter model.

## How to Test

Run `TestTryMainAgentModelFallback` and confirm both capability branches pass. CI is the full-suite check.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched for existing PRs and found no duplicate for this fallback bug.
- [x] This PR contains only changes related to this fix.
- [ ] Full `pytest tests/ -q` result pending CI.
- [x] I've added tests for the change.
- [x] Tested on macOS.

### Documentation & Housekeeping

- [x] Documentation update: N/A.
- [x] `cli-config.yaml.example`: N/A, no config keys changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A, no architecture or workflow changed.
- [x] Cross-platform impact considered. The change is provider routing logic only.
- [x] Tool descriptions/schemas: N/A.
