### PR TITLE
fix(desktop): collapse all-profiles scope at exactly one profile

### DIFF
--- a/apps/desktop/src/store/profile-scope.test.ts
+++ b/apps/desktop/src/store/profile-scope.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  $activeGatewayProfile,
+  $profiles,
+  $profileScope,
+  $showAllProfiles,
+  ALL_PROFILES
+} from '@/store/profile'
+import type { ProfileInfo } from '@/types/hermes'
+
+// #101642: a single-profile install could get stuck with showAllProfiles=true
+// (Grouping → Profile, or persisted from a two-profile era) with no rail
+// control showing or clearing it — and every projects.* mutation throwing
+// while the scope read ALL. The scope now ignores the flag at exactly one
+// profile, matching the sidebar's own rendering exemption.
+
+const profile = (name: string, isDefault = false): ProfileInfo => ({
+  has_env: false,
+  is_default: isDefault,
+  model: null,
+  name,
+  path: `/tmp/${name}`,
+  provider: null,
+  skill_count: 0
+})
+
+describe('$profileScope single-profile exemption', () => {
+  beforeEach(() => {
+    window.localStorage.removeItem('hermes.desktop.showAllProfiles')
+    $showAllProfiles.set(false)
+    $activeGatewayProfile.set('default')
+    $profiles.set([])
+  })
+
+  it('honors the all-profiles flag with multiple profiles', () => {
+    $profiles.set([profile('default', true), profile('work')])
+    $showAllProfiles.set(true)
+
+    expect($profileScope.get()).toBe(ALL_PROFILES)
+  })
+
+  it('collapses ALL to the gateway profile at exactly one profile', () => {
+    $profiles.set([profile('default', true)])
+    $showAllProfiles.set(true)
+
+    expect($profileScope.get()).toBe('default')
+  })
+
+  it('keeps honoring the flag before the profile list has loaded', () => {
+    // An empty list means "not loaded yet", not "zero profiles" — collapsing
+    // here would flicker a multi-profile boot profile → all as the list lands.
+    $showAllProfiles.set(true)
+
+    expect($profileScope.get()).toBe(ALL_PROFILES)
+  })
+
+  it('collapses when the profile count drops to one, restores at two', () => {
+    $profiles.set([profile('default', true), profile('work')])
+    $showAllProfiles.set(true)
+    expect($profileScope.get()).toBe(ALL_PROFILES)
+
+    $profiles.set([profile('default', true)])
+    expect($profileScope.get()).toBe('default')
+
+    // The flag stays persisted, so a second profile brings the view back.
+    $profiles.set([profile('default', true), profile('work')])
+    expect($profileScope.get()).toBe(ALL_PROFILES)
+  })
+
+  it('still follows the live gateway profile when the flag is off', () => {
+    $profiles.set([profile('default', true), profile('work')])
+    $activeGatewayProfile.set('work')
+
+    expect($profileScope.get()).toBe('work')
+  })
+})

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -754,8 +754,9 @@ export const messagingTotalsKey = (messagingProfile: string, sourceId: string): 
 
 const SHOW_ALL_PROFILES_STORAGE_KEY = 'hermes.desktop.showAllProfiles'
 
-// Opt-in unified view. When false, scope follows the live gateway profile, so
-// single-profile users (who never see the switcher) are completely unaffected.
+// Opt-in unified view. When false, scope follows the live gateway profile.
+// $profileScope also ignores the flag at exactly one profile (nothing to
+// unite), so single-profile users stay unaffected even if the flag got set.
 export const $showAllProfiles = atom<boolean>(storedBoolean(SHOW_ALL_PROFILES_STORAGE_KEY, false))
 
 $showAllProfiles.subscribe(value => persistBoolean(SHOW_ALL_PROFILES_STORAGE_KEY, value))
@@ -765,8 +766,19 @@ $showAllProfiles.subscribe(value => persistBoolean(SHOW_ALL_PROFILES_STORAGE_KEY
 // gateway so opening/selecting a profile (which swaps the gateway) moves the
 // whole sidebar with it — a real context switch, not a separate filter to keep
 // in sync.
-export const $profileScope = computed([$showAllProfiles, $activeGatewayProfile], (showAll, gateway) =>
-  showAll ? ALL_PROFILES : normalizeProfileKey(gateway)
+//
+// "All profiles" only exists with more than one profile to unite. The flag is
+// reachable at one profile (Grouping → Profile, or persisted from a
+// two-profile era), and honoring it there poisons every profile-scoped writer
+// — projects.* throws (#101642, #94430, #94738) — while the sidebar itself
+// renders flat (index.tsx already exempts single-profile from ALL). So the
+// scope collapses to the gateway profile at exactly one profile, matching the
+// rendering exemption at the single source of truth. The flag stays persisted,
+// so a second profile restores the unified view. An empty list means "not
+// loaded yet": keep honoring the flag so a multi-profile boot doesn't flicker
+// scope profile → all → as the list lands.
+export const $profileScope = computed([$showAllProfiles, $activeGatewayProfile, $profiles], (showAll, gateway, profiles) =>
+  showAll && profiles.length !== 1 ? ALL_PROFILES : normalizeProfileKey(gateway)
 )
 
 // Switch the active context to `name`: leave "All profiles" mode, point new


### PR DESCRIPTION
## Problem

On a single-profile install, `hermes.desktop.showAllProfiles` can be `true` (persisted from a two-profile era, or set via Grouping → Profile) with **no way to see it and no way to unset it** from the profile rail: the default ↔ all toggle is gated behind `multiProfile` (`profiles.length > 1`) and the single-profile pill hardcodes `active`, so it looks identical in either scope. While ALL scope is active, every `projects.*` mutation throws — leaving the Projects context menu permanently broken with nothing on screen explaining why.

## Approach

The sidebar already exempts single-profile installs from *rendering* the ALL view; this PR applies the same exemption at the single source of truth, `$profileScope` in `apps/desktop/src/store/profile.ts`: at exactly one profile the scope collapses to the gateway profile, so profile-scoped writers (projects.\*) work again regardless of the stuck flag.

- The flag stays persisted — a second profile restores the unified view.
- An empty profile list still means "not loaded yet": the flag keeps being honored so a multi-profile boot doesn't flicker scope profile → all as the list lands.
- Deliberately does not touch the pill rendering: with the scope no longer poisoned, there is no broken state left for the rail to explain.

## Tests

New `apps/desktop/src/store/profile-scope.test.ts` (5 tests): flag honored with multiple profiles; collapse at exactly one profile; flag honored while the list is still loading; collapse when the count drops to one and restore at two; gateway-profile following with the flag off.

## Verification (actually run)

- `npm run test:ui` — **715 files / 7141 tests passed**
- `npm run typecheck` — passed (tsc × 3 configs)

## Risk

Low: one computed atom, gated on `profiles.length !== 1`; multi-profile behavior unchanged (covered by the new tests).

Fixes #101642