### PR TITLE
fix(serve): withdraw orphan-reap immunity from a disproved lock claim

### DIFF
--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -954,6 +954,80 @@ def _process_age_seconds(pid: int) -> float:
     return max(0.0, _time.time() - _psutil.Process(pid).create_time())
 
 
+def _lock_claim_is_disproved(
+    pid: int,
+    *,
+    self_home: str | None = None,
+    min_age_seconds: float = _REAP_MIN_AGE_SECONDS,
+) -> bool:
+    """True only when a lock claim is *proven* not to describe a live backend.
+
+    ``backend.lock.json`` records that a Desktop client once claimed this PID.
+    It carries no liveness for the claimant, and only the claimant retires it.
+    A client whose machine stops executing — a laptop asleep in a bag, waking
+    for Power Nap and sleeping again (#101626) — never retires anything, so
+    the claim grants its backend permanent immunity from the reap below. The
+    backend keeps writing the same ``state.db`` this process is about to open,
+    and because immunity is granted per claim while ``HERMES_HOME`` is shared,
+    several claimed backends can hold one database at once.
+
+    Withdrawing immunity needs a proof, not a timeout. Reuse the one the
+    state-repair path already trusts for exactly this shape,
+    ``hermes_state._is_inactive_orphan_desktop_holder``: orphaned under init,
+    older than the startup grace, Desktop ephemeral spawn shape, and no
+    ESTABLISHED socket — a backend whose tunnel still carries a client keeps
+    its immunity. Narrowed further to an exact ``HERMES_HOME`` match, so a
+    backend on a *different* database is never a candidate (#94032).
+
+    Every probe fails closed: anything unreadable or unexpected leaves the
+    claim standing, exactly like the reap's other liveness probes.
+    """
+    if sys.platform == "win32":
+        return False
+
+    try:
+        import time as _time
+
+        import psutil as _psutil
+
+        from hermes_state import _is_inactive_orphan_desktop_holder
+    except Exception:
+        return False
+
+    try:
+        candidate_home = _hermes_home_for_pid(pid)
+    except Exception:
+        return False
+    if not candidate_home:
+        return False
+
+    try:
+        own_home = Path(self_home) if self_home else _hermes_home_dir()
+        if (
+            Path(candidate_home).expanduser().resolve()
+            != own_home.expanduser().resolve()
+        ):
+            return False
+    except (OSError, ValueError, RuntimeError):
+        return False
+
+    try:
+        process = _psutil.Process(pid)
+        return bool(
+            _is_inactive_orphan_desktop_holder(
+                ppid=process.ppid(),
+                age_seconds=max(0.0, _time.time() - process.create_time()),
+                min_age_seconds=min_age_seconds,
+                ephemeral_backend=_is_ephemeral_port_zero_backend(process.cmdline()),
+                connection_statuses=[
+                    conn.status for conn in process.net_connections(kind="inet")
+                ],
+            )
+        )
+    except Exception:
+        return False
+
+
 def _reap_orphaned_desktop_local_serves(
     *,
     reason: str = "orphaned desktop-local hermes serve",
@@ -962,6 +1036,7 @@ def _reap_orphaned_desktop_local_serves(
     sleep_fn=None,
     lock_owned_pids_fn=None,
     process_age_seconds_fn=None,
+    claim_disproved_fn=None,
 ) -> dict[str, list]:
     """Kill leftover Desktop-local ``hermes serve`` backends with no parent.
 
@@ -982,7 +1057,10 @@ def _reap_orphaned_desktop_local_serves(
     - never a PID a valid ``backend.lock.json`` claims as its owner — that is
       a legitimately lock-owned backend, *including SSH remote backends started
       by another client/machine* which legitimately sit at ppid 1 after sshd
-      exits. Killing those is a production incident, not cleanup.
+      exits. Killing those is a production incident, not cleanup. The one
+      exception is a claim this host can positively disprove
+      (``_lock_claim_is_disproved``): an inactive orphan on our own
+      ``HERMES_HOME``, i.e. a second writer on the database we are opening.
     - never fixed-port remote serves (e.g. ``--port 9119``)
     - never a candidate younger than ``_REAP_MIN_AGE_SECONDS`` (or whose age
       cannot be determined). The Desktop client writes ``backend.lock.json``
@@ -1006,6 +1084,8 @@ def _reap_orphaned_desktop_local_serves(
         lock_owned_pids_fn = _lock_owned_serve_pids
     if process_age_seconds_fn is None:
         process_age_seconds_fn = _process_age_seconds
+    if claim_disproved_fn is None:
+        claim_disproved_fn = _lock_claim_is_disproved
 
     if sys.platform == "win32":
         # Windows desktop uses taskkill tree teardown; orphan scan here is POSIX.
@@ -1021,11 +1101,36 @@ def _reap_orphaned_desktop_local_serves(
     # Spare every PID a valid backend.lock.json owns — SSH remote backends
     # started by other clients/machines are legitimate, lock-owned owners even
     # though they are orphaned (ppid 1) on this host. (#78872 regression)
+    #
+    # A claim is not a heartbeat, though: only the claiming client retires it,
+    # and a client that stops executing never does (#101626). Immunity is
+    # withdrawn from the PIDs whose claim this host can positively disprove —
+    # an inactive orphan on our own HERMES_HOME, i.e. a second writer on the
+    # database we are about to open. Everything else stays spared.
+    disowned: set[int] = set()
     try:
-        exclude |= set(lock_owned_pids_fn())
+        lock_owned = set(lock_owned_pids_fn())
     except Exception:
         # Best-effort: never let lock scanning block or widen the reap.
-        pass
+        lock_owned = set()
+    for pid in lock_owned:
+        try:
+            if claim_disproved_fn(pid):
+                disowned.add(pid)
+        except Exception:
+            # An indeterminate probe leaves the claim standing.
+            continue
+    if disowned:
+        # #101626 asks for the missing line: until now an orphan could hold
+        # the database with nothing anywhere saying so.
+        try:
+            print(
+                "⟲ Lock-claimed backend(s) hold this HERMES_HOME with no "
+                f"client and no live owner: {sorted(disowned)} — reaping."
+            )
+        except Exception:
+            pass
+    exclude |= lock_owned - disowned
 
     try:
         scanned = _scan_dashboard_processes(exclude_pids=exclude)
@@ -1036,7 +1141,7 @@ def _reap_orphaned_desktop_local_serves(
     # exclude PIDs, but a lock file may have been written between the scan and
     # now. Defense in depth — never kill a freshly-claimed owner.
     try:
-        owned_now = set(lock_owned_pids_fn())
+        owned_now = set(lock_owned_pids_fn()) - disowned
     except Exception:
         owned_now = set()
 

--- a/tests/hermes_cli/test_orphan_desktop_serve_reap.py
+++ b/tests/hermes_cli/test_orphan_desktop_serve_reap.py
@@ -388,3 +388,214 @@ def test_reap_spare_lock_owned_backend_even_without_exclude_match(tmp_path):
 
     assert terms == []
     assert result["matched"] == []
+
+
+# ── #101626: a lock claim is not a heartbeat ────────────────────────────────
+# `backend.lock.json` records that a Desktop client once claimed a PID. Only
+# that client retires the claim, and a client whose machine stops executing
+# (laptop asleep, waking for Power Nap and sleeping again) never does. The
+# claim then grants its SSH-isolated backend permanent immunity while the
+# backend keeps writing the HERMES_HOME the next backend is about to open.
+
+
+def _reap_with_claims(scanned, lock_owned, claim_disproved, terms):
+    live = {pid for pid, _ in scanned}
+
+    def fake_kill(pid, sig):
+        if sig == 0:
+            if pid in live:
+                return None
+            raise ProcessLookupError()
+        if sig == 15:
+            terms.append(pid)
+            live.discard(pid)
+            return None
+        if sig == 9:
+            live.discard(pid)
+            return None
+        return None
+
+    with (
+        patch(
+            "hermes_cli.dashboard_procs._scan_dashboard_processes",
+            return_value=scanned,
+        ),
+        patch("hermes_cli.dashboard_procs._process_ppid", return_value=1),
+        patch("os.kill", side_effect=fake_kill),
+        patch("sys.platform", "darwin"),
+    ):
+        os.environ.pop("HERMES_DESKTOP_CHILD_PID", None)
+        return _reap_orphaned_desktop_local_serves(
+            sleep_fn=lambda _s: None,
+            signal_term=15,
+            signal_kill=9,
+            lock_owned_pids_fn=lambda: set(lock_owned),
+            process_age_seconds_fn=lambda _pid: 600.0,
+            claim_disproved_fn=claim_disproved,
+        )
+
+
+class _FakeConn:
+    def __init__(self, status):
+        self.status = status
+
+
+class _FakeProcess:
+    """Minimal psutil.Process stand-in for the claim-disproof probes."""
+
+    def __init__(self, *, ppid, age, cmdline, statuses):
+        import time as _time
+
+        self._ppid = ppid
+        self._create_time = _time.time() - age
+        self._cmdline = cmdline
+        self._statuses = statuses
+
+    def ppid(self):
+        return self._ppid
+
+    def create_time(self):
+        return self._create_time
+
+    def cmdline(self):
+        return self._cmdline
+
+    def net_connections(self, kind="inet"):
+        return [_FakeConn(status) for status in self._statuses]
+
+
+SSH_SERVE_CMD = (
+    "hermes serve --isolated --host 127.0.0.1 --port 0 "
+    "--ssh-session-token-file /home/h/.hermes/desktop-ssh/a/b.token "
+    "--ssh-owner-nonce 0123456789abcdef"
+)
+
+
+def test_reap_withdraws_immunity_from_a_disproved_claim():
+    """A sleeping laptop's claim keeps a second writer alive on our database."""
+    terms: list[int] = []
+    result = _reap_with_claims(
+        scanned=[(555, SSH_SERVE_CMD)],
+        lock_owned={555},
+        claim_disproved=lambda pid: pid == 555,
+        terms=terms,
+    )
+
+    assert set(result["matched"]) == {555}
+    assert set(terms) == {555}
+
+
+def test_reap_keeps_immunity_when_the_claim_is_not_disproved():
+    """Indeterminate or live: the claim stands, exactly as before (#78872)."""
+    terms: list[int] = []
+    result = _reap_with_claims(
+        scanned=[(555, SSH_SERVE_CMD)],
+        lock_owned={555},
+        claim_disproved=lambda _pid: False,
+        terms=terms,
+    )
+
+    assert result["matched"] == []
+    assert terms == []
+
+
+def test_reap_never_widens_when_the_claim_probe_raises():
+    """A probe that blows up must not be read as 'claim disproved'."""
+
+    def boom(_pid):
+        raise RuntimeError("psutil exploded")
+
+    terms: list[int] = []
+    result = _reap_with_claims(
+        scanned=[(555, SSH_SERVE_CMD)],
+        lock_owned={555},
+        claim_disproved=boom,
+        terms=terms,
+    )
+
+    assert result["matched"] == []
+    assert terms == []
+
+
+def test_claim_disproved_requires_the_same_hermes_home():
+    """#94032 inverse: a backend on another database is never a candidate."""
+    from hermes_cli.dashboard_procs import _lock_claim_is_disproved
+
+    with (
+        patch("sys.platform", "linux"),
+        patch(
+            "hermes_cli.dashboard_procs._hermes_home_for_pid",
+            return_value="/home/h/.hermes/profiles/other",
+        ),
+    ):
+        assert _lock_claim_is_disproved(555, self_home="/home/h/.hermes") is False
+
+
+def test_claim_disproved_is_false_when_the_home_is_unreadable():
+    from hermes_cli.dashboard_procs import _lock_claim_is_disproved
+
+    with (
+        patch("sys.platform", "linux"),
+        patch("hermes_cli.dashboard_procs._hermes_home_for_pid", return_value=None),
+    ):
+        assert _lock_claim_is_disproved(555, self_home="/home/h/.hermes") is False
+
+
+def test_claim_disproved_spares_a_backend_with_an_established_client(tmp_path):
+    """A tunnel still carrying a client keeps its immunity."""
+    from hermes_cli.dashboard_procs import _lock_claim_is_disproved
+
+    home = str(tmp_path)
+    proc = _FakeProcess(
+        ppid=1,
+        age=6000.0,
+        cmdline=["hermes", "serve", "--isolated", "--host", "127.0.0.1", "--port", "0"],
+        statuses=["LISTEN", "ESTABLISHED"],
+    )
+
+    with (
+        patch("sys.platform", "linux"),
+        patch("hermes_cli.dashboard_procs._hermes_home_for_pid", return_value=home),
+        patch("psutil.Process", return_value=proc),
+    ):
+        assert _lock_claim_is_disproved(555, self_home=home) is False
+
+
+def test_claim_disproved_for_a_clientless_orphan_on_our_home(tmp_path):
+    """The #101626 shape: ppid 1, old, ephemeral, no client, our database."""
+    from hermes_cli.dashboard_procs import _lock_claim_is_disproved
+
+    home = str(tmp_path)
+    proc = _FakeProcess(
+        ppid=1,
+        age=6000.0,
+        cmdline=["hermes", "serve", "--isolated", "--host", "127.0.0.1", "--port", "0"],
+        statuses=["LISTEN"],
+    )
+
+    with (
+        patch("sys.platform", "linux"),
+        patch("hermes_cli.dashboard_procs._hermes_home_for_pid", return_value=home),
+        patch("psutil.Process", return_value=proc),
+    ):
+        assert _lock_claim_is_disproved(555, self_home=home) is True
+
+
+def test_claim_disproved_spares_a_fixed_port_operator_serve(tmp_path):
+    """An operator-managed `--port 9119` serve is not a Desktop ephemeral."""
+    from hermes_cli.dashboard_procs import _lock_claim_is_disproved
+
+    home = str(tmp_path)
+    proc = _FakeProcess(
+        ppid=1,
+        age=6000.0,
+        cmdline=["hermes", "serve", "--host", "127.0.0.1", "--port", "9119"],
+        statuses=["LISTEN"],
+    )
+
+    with (
+        patch("sys.platform", "linux"),
+        patch("hermes_cli.dashboard_procs._hermes_home_for_pid", return_value=home),
+        patch("psutil.Process", return_value=proc),
+    ):
+        assert _lock_claim_is_disproved(555, self_home=home) is False


### PR DESCRIPTION
## What does this PR do?

The backend-start orphan reap (`_reap_orphaned_desktop_local_serves`, run on every `serve` boot under `HERMES_DESKTOP=1` — which the SSH spawn sets) spares **every PID a valid `backend.lock.json` names**. That record is a *claim*, not a heartbeat: only the Desktop client that wrote it ever retires it, and a client whose machine stops executing never retires anything.

So a claimed backend keeps `HERMES_HOME/state.db` open with **permanent immunity**, and because immunity is granted per claim while `HERMES_HOME` is shared, several claimed backends hold one database at once. Nothing on the startup path stops that: `SessionDB.__init__` takes only in-process `threading.Lock`s, the two `PRAGMA locking_mode=EXCLUSIVE` sites (`hermes_state.py:3189`, `:3419`) are reachable only from the repair routine, `gateway.lock` covers `gateway run` and not `serve`, and `_port_bind_conflict` is skipped for `--port 0`. The spare rule is therefore the thing that guarantees the multi-writer state feeding WAL split-brain repair (#97329 / #97330).

This PR withdraws immunity **only where the host can positively disprove the claim**, reusing the proof the state-repair path already trusts for exactly this shape.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A["Dark Wake: SSH Spawns Backend"] --> B["Client Writes backend.lock.json"]
    B --> C{"Laptop Sleeps Again"}
    C -->|"Claim Never Retired"| D["Permanent Immunity"]
    D --> E["Orphan Holds state.db Forever"]
    E --> F["Concurrent Writers - WAL Split-Brain"]

    A --> G["Next Backend Boot: Orphan Reap"]
    G --> H{"Claim Disprovable?"}
    H -->|"Different HERMES_HOME"| I["Claim Stands"]
    H -->|"ESTABLISHED Socket"| I
    H -->|"Probe Indeterminate"| I
    H -->|"Orphan, Old, Ephemeral, No Client, Our Database"| J["Immunity Withdrawn"]
    J --> K["Reaped and Logged"]
```

## Root cause

Two halves of the answer already exist in the tree and never meet:

| Where | Knows | Runs when |
|---|---|---|
| `hermes_cli/dashboard_procs.py::_reap_orphaned_desktop_local_serves` | which backends are orphaned at boot | every `serve` boot — but grants unconditional, permanent immunity to any lock-claimed PID |
| `hermes_state.py::_is_inactive_orphan_desktop_holder` | how to *prove* "orphaned + old + Desktop ephemeral + no client" | only from `hermes_state_schema.py`, i.e. **during a repair — after the corruption** |

At the one moment a second writer appears (`serve` boot), nothing asks who else holds the database. The only thing that asks runs after the damage.

**On the issue's own root-cause claim:** `hermes_cli/main.py` indeed has no watchdog, but the watchdog is in `hermes_cli/web_server.py:19350` (`_start_parent_death_watchdog`, invoked at `:19916`). It exists and is gated on `HERMES_PARENT_PID`, which `buildSpawnCommand` never sets (`remote-lifecycle.ts:1065` exports only `HERMES_DESKTOP=1`). The codebase's own comment says so: *"No-op for standalone `hermes serve` (no HERMES_PARENT_PID env)."* The conclusion in the issue holds; the table pointed one file off.

A `getppid()` watchdog is also not the right instrument here — the remote spawn is `setsid`/`nohup` detached on purpose (#91668), so `PPID=1` is the normal post-detach state, not an orphan signal.

## Changes Made

- `hermes_cli/dashboard_procs.py`
  - `_lock_claim_is_disproved(pid, *, self_home, min_age_seconds)` — new. Returns `True` only when **all** hold: exact `HERMES_HOME` match with this process (so a backend on a different database is never a candidate — the inverse of #94032), `ppid in (0, 1)`, age at or above the existing `_REAP_MIN_AGE_SECONDS`, Desktop ephemeral spawn shape, and **no `ESTABLISHED` socket**. The predicate itself is `hermes_state._is_inactive_orphan_desktop_holder`, imported, not re-implemented. Every probe fails closed: unreadable environ, `AccessDenied` on `net_connections` (macOS without root), missing psutil, Windows — the claim stands.
  - `_reap_orphaned_desktop_local_serves(..., claim_disproved_fn=None)` — the lock-owned spare set is now `lock_owned - disowned`, applied to both the scan exclusion and the defensive `owned_now` re-read.
  - One log line when immunity is withdrawn. The issue asks for exactly this: *"no log line that says an orphan now holds your database."*
- `tests/hermes_cli/test_orphan_desktop_serve_reap.py` — 8 tests.

No timeout, no grace window, no flock, no protocol change, no new module, no client involvement. It runs on the remote host at backend boot, so a sleeping laptop is irrelevant.

## Relationship to #101678

#101678 targets the same issue from inside the backend: a 15-minute client-idle window plus an exclusive per-home flock that makes the **second** `start_server` `raise SystemExit`. Two things about that shape are worth weighing before merging either:

1. **The refusal resolves in the wrong direction.** In the reported scenario the incumbent *is* the orphan and the newcomer *is* the user's live reconnect. The user's backend is the one that exits, and the Desktop has no handler for `BACKEND_SSH_ISOLATED_HOME_LOCKED` — `scrapeReadyPort` just times out. The failure mode becomes "cannot connect for up to 15 minutes" instead of a silent leak.
2. **A 15-minute window against a 16-minute median wake gap** (the issue's own measurement) leaves the orphan holding the database for most of the interval.

This PR takes the opposite resolution — the live backend wins, the provably clientless one yields, immediately, at boot — and touches neither `web_server.py` nor the WebSocket paths. The two are not additive; this is offered as the alternative, and no part of #101678's implementation was carried over.

## Not addressed here (deliberate)

- The reap sits after `server.startup()`, so a brief two-writer window at boot remains. That is pre-existing placement; moving it changes behaviour for local Desktop backends too and belongs in its own change.
- The reap fires at backend boot. A wake where the Desktop successfully **reuses** boots nothing, so a pre-existing orphan waits for the next spawn. Since a second writer can only be created by a boot, this bounds the multi-writer state without a polling sweep.
- Windows returns early from the reap (`_process_ppid` is `None` there) — unchanged.

## Related Issue

fixes #101626

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## How to Test

```
python -m pytest tests/hermes_cli/test_orphan_desktop_serve_reap.py -q
```

Expect 19 passed (11 pre-existing + 8 new). In particular `test_reap_spare_lock_owned_ssh_remote_backend_of_foreign_client` — the #78872 production-incident guard — still passes untouched: its candidate has no readable `HERMES_HOME`, so its claim is indeterminate and stands.

Also run, for neighbours of the changed file:

```
python -m pytest tests/hermes_cli/test_update_stale_dashboard.py tests/hermes_cli/test_serve_runtime_inventory.py tests/hermes_cli/test_stale_pid_guard.py tests/hermes_cli/test_serve_parent_watchdog.py -q
python -m pytest tests/state/test_fts_runtime_rebuild.py -q -k "orphan or holder"
```

Note: `tests/hermes_cli/test_lazy_command_exports.py::test_lazy_reexports_resolve_to_real_objects` fails when run in the same session as `test_update_stale_dashboard.py` / `test_stale_pid_guard.py`. That is pre-existing cross-file import pollution — it reproduces on this branch with the changed test file excluded from the run, and passes when the file runs alone.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the tests above and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, Python 3.12 (the reap path itself is POSIX-only; the new predicate's unit tests patch `sys.platform`)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — the reap's Safety list now states the one exception
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — Windows and non-Linux failure modes fail closed to the current behaviour
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

 
