### PR TITLE
fix(tools): add CREATE_NO_WINDOW to Windows command-provider TTS/STT

### DIFF
--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -741,7 +741,7 @@ def _run_command_stt(
         "env": delegated_child_subprocess_env(scrubbed),
     }
     if os.name == "nt":
-        popen_kwargs["creationflags"] = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+        popen_kwargs["creationflags"] = windows_hide_flags()
     else:
         popen_kwargs["start_new_session"] = True
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1235,7 +1235,7 @@ def _run_command_tts(
         "env": delegated_child_subprocess_env(scrubbed),
     }
     if os.name == "nt":
-        popen_kwargs["creationflags"] = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+        popen_kwargs["creationflags"] = windows_hide_flags()
     else:
         popen_kwargs["start_new_session"] = True
 


### PR DESCRIPTION
## What

On Windows, command-provider TTS and STT (`_run_command_tts` / `_run_command_stt`) spawn shell commands with only `CREATE_NEW_PROCESS_GROUP` set, leaving a visible `cmd.exe` console window that flashes on every call.

Fix: replace `getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)` with `windows_hide_flags()` in both functions — consistent with the pattern used across the rest of the codebase (scheduler.py, kanban_db.py, gateway_windows.py).

`windows_hide_flags()` returns `CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS | CREATE_NO_WINDOW` on Windows, 0 on other platforms.

## Why

The command-provider TTS/STT paths are used when a user configures a custom shell command in `config.yaml` under `tts.providers.<name>.command` or `stt.providers.<name>.command` (e.g. a local Kokoro / Piper / whisper.cpp wrapper). On Windows, this currently spawns a visible console window on every invocation, which is disruptive.

## How to test

1. Configure a command provider in `config.yaml`, e.g.:
   ```yaml
   tts:
     providers:
       localpiper:
         type: command
         command: "piper --model en_US-lessac-medium.onnx --output_file {output_path}"
   ```
2. Trigger any TTS output (or STT transcription) through that provider on Windows.
3. Observe: no `cmd.exe` window should appear.

## Platforms tested

- ✅ Windows 11 (repro environment from #101585)
- Linux/macOS: unchanged (fallback to `start_new_session` is unaffected)

## Related

Closes #101585
