### PR TITLE
fix(sessions): map lost_and_found cells by physical column names

### DIFF
--- a/hermes_cli/session_lost_and_found.py
+++ b/hermes_cli/session_lost_and_found.py
@@ -44,12 +44,84 @@ KNOWN_SOURCES = frozenset({
     "tool", "subagent", "cron", "recovered", "imported", "acp",
 })
 
-# Historical physical layouts of the sessions table. Columns are only ever
-# appended (ALTER TABLE ADD COLUMN), so an older record is a strict prefix of
-# the current column order.
+# Field counts observed for historical sessions records. A record's field
+# count is the column count of the table when the row was last written, so
+# these only classify a record — they do NOT imply its cells follow the
+# current *declared* column order. Live stores gain columns through
+# ``_reconcile_columns()`` (ALTER TABLE ADD COLUMN), which appends them in
+# physical add order, while SCHEMA_SQL declares several of them
+# mid-definition; the two orders diverge (#101409). Cells are mapped by
+# name through PHYSICAL_LAYOUTS below, never zipped onto declared order.
 SESSIONS_LAYOUT_NFIELDS = frozenset({55, 54, 52})
 SESSIONS_LEGACY_MINIMAL_NFIELD = 14
 SESSION_MODEL_USAGE_NFIELD = 18
+
+# Physical column order of a store that has been upgraded in place rather
+# than created at the current schema: ``_reconcile_columns()`` APPENDS every
+# newly declared column with ALTER TABLE ADD COLUMN, so the table keeps the
+# order in which columns were added, not the order SCHEMA_SQL declares them.
+# A record with N fields carries the first N names of the matching list
+# (SQLite does not rewrite existing rows when a column is added).
+#
+# The sessions/messages orders below are the ones reported and verified
+# against real salvaged rows in #101409, extended with the columns declared
+# after that report (they are appended in the same way on any store upgraded
+# since). Stores that also carry a column which was declared and then removed
+# again (sessions.handoff_pending, sessions.icon,
+# messages.anthropic_content_blocks — each shipped for days) are shifted from
+# both known orders; such rows fail layout validation below and fall back to
+# the conservative path rather than being mis-mapped.
+PHYSICAL_LAYOUTS: dict[str, tuple[str, ...]] = {
+    "sessions": (
+        "id", "source", "user_id", "model", "model_config",
+        "system_prompt", "parent_session_id", "started_at", "ended_at",
+        "end_reason", "message_count", "tool_call_count", "input_tokens",
+        "output_tokens", "cache_read_tokens", "cache_write_tokens",
+        "reasoning_tokens", "billing_provider", "billing_base_url",
+        "billing_mode", "estimated_cost_usd", "actual_cost_usd",
+        "cost_status", "cost_source", "pricing_version", "title",
+        "api_call_count", "handoff_state", "handoff_platform",
+        "handoff_error", "cwd", "rewind_count", "archived",
+        "session_key", "chat_id", "chat_type", "thread_id", "git_branch",
+        "git_repo_root", "compression_failure_cooldown_until",
+        "compression_failure_error", "display_name", "origin_json",
+        "expiry_finalized", "compression_fallback_streak",
+        "profile_name", "compression_ineffective_count", "pinned",
+        "system_prompt_hash", "last_activity_at",
+        "last_activity_description", "last_activity_provenance",
+        "git_metadata_generation", "title_source", "hidden",
+        "last_read_at", "compression_recovery_deadline", "tool_names",
+    ),
+    "messages": (
+        "id", "session_id", "role", "content", "tool_call_id",
+        "tool_calls", "tool_name", "timestamp", "token_count",
+        "finish_reason", "reasoning", "reasoning_content",
+        "reasoning_details", "codex_reasoning_items",
+        "codex_message_items", "platform_message_id", "observed",
+        "active", "compacted", "effect_disposition", "api_content",
+        "display_kind", "display_metadata", "_compressed_summary",
+    ),
+    # Same class on the usage table: ``task`` is declared sixth but was added
+    # last, and ``billing_mode``/cost columns are declared before the counters
+    # they were added after.
+    "session_model_usage": (
+        "session_id", "model", "billing_provider", "billing_base_url",
+        "api_call_count", "input_tokens", "output_tokens",
+        "cache_read_tokens", "cache_write_tokens", "reasoning_tokens",
+        "estimated_cost_usd", "first_seen", "last_seen", "billing_mode",
+        "actual_cost_usd", "cost_status", "cost_source", "task",
+    ),
+}
+
+# Columns whose salvaged value must look right before a candidate layout is
+# accepted for a record. They are the cells that differ hardest between the
+# declared and the upgraded-physical order, so a wrong layout is rejected
+# instead of silently shifting every field.
+_LAYOUT_SENTINELS: dict[str, tuple[str, ...]] = {
+    "sessions": ("id", "source", "started_at"),
+    "messages": ("session_id", "role", "timestamp"),
+    "session_model_usage": ("session_id", "model"),
+}
 
 # Plausible unix-epoch window for started_at heuristics on legacy layouts.
 _EPOCH_LOW = 1_000_000_000.0   # 2001
@@ -324,6 +396,122 @@ def _insert_prefix_row(
     return cursor.rowcount == 1
 
 
+def _declared_types(conn: sqlite3.Connection, table: str) -> dict[str, str]:
+    return {
+        str(row[1]): str(row[2] or "")
+        for row in conn.execute(f'PRAGMA table_info("{table}")')
+    }
+
+
+def _type_conflicts(value: Any, declared: str) -> bool:
+    """True when a salvaged cell cannot belong to a column of this type."""
+
+    if value is None:
+        return False
+    affinity = declared.upper()
+    if "INT" in affinity or "REAL" in affinity or "FLOA" in affinity or "DOUB" in affinity:
+        return not isinstance(value, (int, float))
+    if "CHAR" in affinity or "CLOB" in affinity or "TEXT" in affinity:
+        return not isinstance(value, str)
+    return False
+
+
+def _sentinel_holds(name: str, value: Any) -> bool:
+    if name == "id":  # sessions.id; messages.id is a rowid alias, never a sentinel
+        return _is_session_id(value)
+    if name == "source":
+        return _looks_like_source(value)
+    if name in ("started_at", "timestamp"):
+        return (
+            isinstance(value, (int, float))
+            and _EPOCH_LOW <= float(value) <= _EPOCH_HIGH
+        )
+    if name == "session_id":
+        return isinstance(value, str) and bool(value)
+    if name == "role":
+        return value in MESSAGE_ROLES
+    if name == "model":
+        return isinstance(value, str) and bool(value)
+    return True
+
+
+def _layout_fits_cells(
+    kind: str,
+    layout: list[str],
+    cells: tuple[Any, ...],
+    dest_types: dict[str, str],
+) -> bool:
+    positions = {name: index for index, name in enumerate(layout)}
+    for name in _LAYOUT_SENTINELS[kind]:
+        if name not in positions or positions[name] >= len(cells):
+            return False
+        if not _sentinel_holds(name, cells[positions[name]]):
+            return False
+    for name, value in zip(layout, cells):
+        declared = dest_types.get(name)
+        if declared is not None and _type_conflicts(value, declared):
+            return False
+    return True
+
+
+def select_physical_layout(
+    kind: str,
+    cells: tuple[Any, ...],
+    dest_columns: list[str],
+    dest_types: dict[str, str],
+) -> Optional[list[str]]:
+    """Return the source column names for ``cells``, or None if unknown.
+
+    A salvaged record carries no schema, so the only way to know which cell
+    is ``started_at`` is to recognise the layout that produced it. Two are
+    known: the destination's own declared order (a store created at the
+    current schema, never ALTERed) and the upgraded-in-place physical order
+    (#101409). Both are checked against the record's sentinel cells and
+    column affinities; an unrecognised layout returns None so the caller can
+    fall back conservatively instead of shifting every field.
+    """
+
+    candidates: list[list[str]] = []
+    for full in (dest_columns, list(PHYSICAL_LAYOUTS.get(kind, ()))):
+        candidate = full[: len(cells)]
+        if candidate and candidate not in candidates:
+            candidates.append(candidate)
+    for candidate in candidates:
+        if _layout_fits_cells(kind, candidate, cells, dest_types):
+            return candidate
+    return None
+
+
+def _insert_named_row(
+    dest: sqlite3.Connection,
+    table: str,
+    layout: list[str],
+    cells: tuple[Any, ...],
+    dest_columns: list[str],
+    notnull_substitutes: dict[str, Any],
+    overrides: Optional[dict[str, Any]] = None,
+) -> bool:
+    """INSERT salvaged cells by source column name, never by position."""
+
+    known = set(dest_columns)
+    mapped: dict[str, Any] = {}
+    for name, value in zip(layout, cells):
+        if name not in known:
+            continue  # column dropped since the source was written
+        if value is None and name in notnull_substitutes:
+            value = notnull_substitutes[name]
+        mapped[name] = value
+    mapped.update(overrides or {})
+    columns = list(mapped)
+    quoted = ", ".join(f'"{column}"' for column in columns)
+    placeholders = ", ".join("?" for _ in columns)
+    cursor = dest.execute(
+        f'INSERT OR IGNORE INTO "{table}" ({quoted}) VALUES ({placeholders})',
+        [mapped[column] for column in columns],
+    )
+    return cursor.rowcount == 1
+
+
 def _copy_direct_tables(
     lf_conn: sqlite3.Connection,
     dest: sqlite3.Connection,
@@ -382,6 +570,8 @@ def map_lost_and_found_rows(
         "direct_table_rows": {},
         "mapped": {"sessions": 0, "messages": 0, "session_model_usage": 0},
         "legacy_minimal_sessions": 0,
+        "mapped_by_layout": 0,
+        "unrecognized_layout_rows": 0,
         "unmapped_rows": 0,
         "insert_conflicts": 0,
         "lost_and_found_tables": [],
@@ -409,6 +599,28 @@ def map_lost_and_found_rows(
             for index in protected:
                 defaults.pop(index, None)
 
+        dest_columns = {
+            "sessions": sessions_columns,
+            "messages": messages_columns,
+            "session_model_usage": usage_columns,
+        }
+        dest_types = {
+            table: _declared_types(dest, table) for table in dest_columns
+        }
+        # The same substitutes, keyed by name for the mapped-by-name path.
+        named_defaults = {
+            table: {
+                dest_columns[table][index]: value
+                for index, value in defaults.items()
+                if index < len(dest_columns[table])
+            }
+            for table, defaults in (
+                ("sessions", sessions_defaults),
+                ("messages", messages_defaults),
+                ("session_model_usage", usage_defaults),
+            )
+        }
+
         lf_tables = [
             str(row[0])
             for row in lf_conn.execute(
@@ -434,8 +646,39 @@ def map_lost_and_found_rows(
                 if kind is None:
                     report["unmapped_rows"] += 1
                     continue
+                layout = select_physical_layout(
+                    kind, cells, dest_columns[kind], dest_types[kind]
+                )
+                if layout is None and not (
+                    kind == "sessions"
+                    and nfield == SESSIONS_LEGACY_MINIMAL_NFIELD
+                ):
+                    # No known layout produced these cells (a store that also
+                    # carries since-removed columns, or a torn sentinel). The
+                    # positional prefix below is a guess, so count it: the
+                    # recovery verifier's plausibility gate is what keeps such
+                    # a salvage from being reported as verified.
+                    report["unrecognized_layout_rows"] += 1
                 try:
-                    if kind == "messages":
+                    if layout is not None:
+                        # The source's own column names are known: map cell to
+                        # column by name (#101409). Zipping onto the fresh
+                        # destination's declared order would shift every field
+                        # of a store upgraded via ALTER TABLE ADD COLUMN.
+                        inserted = _insert_named_row(
+                            dest,
+                            kind,
+                            layout,
+                            cells,
+                            dest_columns[kind],
+                            named_defaults[kind],
+                            # messages.id is a rowid alias: NULL in the record,
+                            # carried by the lost_and_found row id instead.
+                            {"id": lf_rowid} if kind == "messages" else None,
+                        )
+                        if inserted:
+                            report["mapped_by_layout"] += 1
+                    elif kind == "messages":
                         values = [lf_rowid, *cells[1 : min(nfield, len(messages_columns))]]
                         inserted = _insert_prefix_row(
                             dest, "messages", messages_columns, values,

--- a/tests/hermes_cli/test_session_recovery_lost_and_found.py
+++ b/tests/hermes_cli/test_session_recovery_lost_and_found.py
@@ -825,6 +825,208 @@ def test_lost_and_found_lane_refuses_to_verify_a_physically_shifted_source(
         out.close()
 
 
+# The physical column order of the reporter's upgraded store in #101409:
+# every column ALTER TABLE ADD COLUMN appended, in add order, which is NOT
+# the order SCHEMA_SQL declares them in. Written out literally (rather than
+# read back from the production layout table) so the regression pins the
+# reported layout, not whatever the mapper believes today.
+_UPGRADED_SESSIONS_PHYSICAL = (
+    "id", "source", "user_id", "model", "model_config", "system_prompt",
+    "parent_session_id", "started_at", "ended_at", "end_reason",
+    "message_count", "tool_call_count", "input_tokens", "output_tokens",
+    "cache_read_tokens", "cache_write_tokens", "reasoning_tokens",
+    "billing_provider", "billing_base_url", "billing_mode",
+    "estimated_cost_usd", "actual_cost_usd", "cost_status", "cost_source",
+    "pricing_version", "title", "api_call_count", "handoff_state",
+    "handoff_platform", "handoff_error", "cwd", "rewind_count", "archived",
+    "session_key", "chat_id", "chat_type", "thread_id", "git_branch",
+    "git_repo_root", "compression_failure_cooldown_until",
+    "compression_failure_error", "display_name", "origin_json",
+    "expiry_finalized", "compression_fallback_streak", "profile_name",
+    "compression_ineffective_count", "pinned", "system_prompt_hash",
+    "last_activity_at", "last_activity_description",
+    "last_activity_provenance", "git_metadata_generation", "title_source",
+    "hidden", "last_read_at",
+)
+
+_UPGRADED_MESSAGES_PHYSICAL = (
+    "id", "session_id", "role", "content", "tool_call_id", "tool_calls",
+    "tool_name", "timestamp", "token_count", "finish_reason", "reasoning",
+    "reasoning_content", "reasoning_details", "codex_reasoning_items",
+    "codex_message_items", "platform_message_id", "observed", "active",
+    "compacted", "effect_disposition", "api_content", "display_kind",
+    "display_metadata", "_compressed_summary",
+)
+
+_UPGRADED_USAGE_PHYSICAL = (
+    "session_id", "model", "billing_provider", "billing_base_url",
+    "api_call_count", "input_tokens", "output_tokens", "cache_read_tokens",
+    "cache_write_tokens", "reasoning_tokens", "estimated_cost_usd",
+    "first_seen", "last_seen", "billing_mode", "actual_cost_usd",
+    "cost_status", "cost_source", "task",
+)
+
+
+def test_upgraded_physical_layout_maps_cells_by_name(tmp_path: Path) -> None:
+    """#101409: salvaged cells from an ALTER-TABLE-upgraded store must land on
+    the columns they came from, not on the destination's declared order.
+
+    The reporter's store has ``model`` where the template declares
+    ``message_count``, ``started_at`` eight columns earlier than declared, and
+    ``timestamp`` where ``effect_disposition`` is declared. Mapping by
+    position writes the message count into ``model``, 0.0 into ``started_at``
+    and blanks every title.
+    """
+
+    output = tmp_path / "mapped.db"
+    SessionDB(db_path=output).close()
+
+    declared = sqlite3.connect(str(output))
+    try:
+        sessions_declared = [
+            str(row[1]) for row in declared.execute("PRAGMA table_info(sessions)")
+        ]
+        messages_declared = [
+            str(row[1]) for row in declared.execute("PRAGMA table_info(messages)")
+        ]
+    finally:
+        declared.close()
+    # Premise: declared order really does differ from the physical order, so
+    # a positional map cannot be correct.
+    assert sessions_declared[:56] != list(_UPGRADED_SESSIONS_PHYSICAL)
+    assert messages_declared[:24] != list(_UPGRADED_MESSAGES_PHYSICAL)
+
+    session_id = "20260701_101010_abc001"
+    started_at = 1_754_000_000.0
+    message_timestamp = 1_754_000_321.0
+    session_cells = {
+        "id": session_id,
+        "source": "telegram",
+        "model": "gpt-4.1",
+        "started_at": started_at,
+        "message_count": 42,
+        "tool_call_count": 7,
+        "input_tokens": 1_234,
+        "output_tokens": 567,
+        "title": "quarterly planning notes",
+        "title_source": "model",
+        "cwd": "/home/user/project",
+        "git_branch": "main",
+        "last_activity_at": started_at + 900.0,
+        "archived": 0,
+        "pinned": 0,
+    }
+    message_cells = {
+        "id": None,  # rowid alias: NULL in the record
+        "session_id": session_id,
+        "role": "assistant",
+        "content": "salvaged assistant payload",
+        "timestamp": message_timestamp,
+        "token_count": 55,
+        "finish_reason": "stop",
+        "observed": 1,
+        "active": 1,
+    }
+    usage_cells = {
+        "session_id": session_id,
+        "model": "gpt-4.1",
+        "billing_provider": "openai",
+        "billing_base_url": "https://api.openai.com/v1",
+        "api_call_count": 4,
+        "input_tokens": 1_234,
+        "output_tokens": 567,
+        "estimated_cost_usd": 0.25,
+        "billing_mode": "api",
+        "task": "",
+        "first_seen": started_at,
+        "last_seen": started_at + 900.0,
+    }
+
+    lf_path = tmp_path / "lost_and_found.db"
+    lf_conn = sqlite3.connect(str(lf_path), isolation_level=None)
+    try:
+        width = len(_UPGRADED_SESSIONS_PHYSICAL)
+        columns = ", ".join(f"c{index}" for index in range(width))
+        lf_conn.execute(
+            "CREATE TABLE lost_and_found (rootpgno INTEGER, pgno INTEGER, "
+            "nfield INTEGER, id INTEGER, " + columns + ")"
+        )
+
+        def insert(layout: tuple[str, ...], rowid: int, values: dict) -> None:
+            cells = [values.get(name) for name in layout]
+            padded = cells + [None] * (width - len(cells))
+            placeholders = ", ".join("?" for _ in range(4 + width))
+            lf_conn.execute(
+                "INSERT INTO lost_and_found VALUES (" + placeholders + ")",
+                [2, 5, len(layout), rowid, *padded],
+            )
+
+        insert(_UPGRADED_SESSIONS_PHYSICAL, 1, session_cells)
+        insert(_UPGRADED_MESSAGES_PHYSICAL, 100, message_cells)
+        insert(_UPGRADED_USAGE_PHYSICAL, 200, usage_cells)
+    finally:
+        lf_conn.close()
+
+    lf_conn = sqlite3.connect(str(lf_path), isolation_level=None)
+    dest = sqlite3.connect(str(output), isolation_level=None)
+    try:
+        dest.execute("PRAGMA foreign_keys=OFF")
+        report = map_lost_and_found_rows(lf_conn, dest)
+        assert report["mapped"] == {
+            "sessions": 1, "messages": 1, "session_model_usage": 1,
+        }
+        assert report["unrecognized_layout_rows"] == 0
+
+        session = dict(
+            zip(
+                ("started_at", "title", "model", "message_count", "source",
+                 "cwd", "title_source"),
+                dest.execute(
+                    "SELECT started_at, title, model, message_count, source, "
+                    "cwd, title_source FROM sessions WHERE id = ?",
+                    (session_id,),
+                ).fetchone(),
+            )
+        )
+        # Each cell landed on the column it was written from — not shifted.
+        assert session["started_at"] == started_at
+        assert session["title"] == session_cells["title"]
+        assert session["model"] == session_cells["model"]
+        assert session["message_count"] == session_cells["message_count"]
+        assert session["source"] == session_cells["source"]
+        assert session["cwd"] == session_cells["cwd"]
+        assert session["title_source"] == session_cells["title_source"]
+
+        timestamp, role, content, disposition, token_count = dest.execute(
+            "SELECT timestamp, role, content, effect_disposition, token_count "
+            "FROM messages WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()
+        assert timestamp == message_timestamp
+        assert role == message_cells["role"]
+        assert content == message_cells["content"]
+        assert token_count == message_cells["token_count"]
+        # The declared-order collision the issue names: timestamp must not
+        # have been written into effect_disposition.
+        assert disposition is None
+
+        usage_model, task, calls, mode = dest.execute(
+            "SELECT model, task, api_call_count, billing_mode "
+            "FROM session_model_usage WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()
+        assert usage_model == usage_cells["model"]
+        assert task == usage_cells["task"]
+        assert calls == usage_cells["api_call_count"]
+        assert mode == usage_cells["billing_mode"]
+
+        # Correctly mapped salvage has nothing for the gate to flag.
+        assert session_recovery._lost_and_found_plausibility_errors(dest) == []
+    finally:
+        lf_conn.close()
+        dest.close()
+
+
 def test_plausibility_gate_ignores_stub_only_sessions(tmp_path: Path) -> None:
     """Stub rows from ``stub_missing_parent_sessions`` legitimately carry
     ``started_at = 0.0``; a salvage where only stubs survived is depleted,


### PR DESCRIPTION
## Summary
`hermes sessions recover --allow-partial` mapped `lost_and_found` cells onto the **declared** column order of a fresh template (`SCHEMA_SQL`). A `state.db` upgraded in place via `_reconcile_columns()` (`ALTER TABLE ADD COLUMN`) keeps columns in physical add order, which diverges whenever SCHEMA_SQL later inserts a column mid-definition. Recovery still passed integrity/FK/FTS, so every session could land with `started_at = 0`, blank titles, and shifted fields (`model` holding `message_count`, `timestamp` landing in `effect_disposition`).

This maps salvaged cells **by name** using the reporter-verified physical layouts (plus the two sessions columns declared after that report). Layout choice is validated against sentinel cells and column affinities so a store that also carries a since-removed column falls back to the existing conservative path instead of shifting every field. The plausibility gate is unchanged.

## How to test
```
scripts/run_tests.sh tests/hermes_cli/test_session_recovery_lost_and_found.py
```
- `test_upgraded_physical_layout_maps_cells_by_name` builds lost_and_found cells in the upgraded physical order and asserts `started_at`, `title`, `model`, `message_count`, and `messages.timestamp` land on the named columns.
- Sabotage: forcing declared-order prefix mapping fails that test with `started_at == 0.0`; restoring the named insert passes.
- Existing gate test (`test_lost_and_found_lane_refuses_to_verify_a_physically_shifted_source`) still refuses to mark an unrecognized permutation verified.

## Platforms
Linux (this PR). Mapping is SQLite schema logic; no OS-specific path.

Fixes #101409
