### PR TITLE
fix(state): tolerate malformed session marker JSON

### DIFF
--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -38,6 +38,16 @@ def _sql_literal(text: str) -> str:
     return "'" + text.replace("'", "''") + "'"
 
 
+def _sql_json_extract(expression: str, path: str) -> str:
+    """Build a non-throwing JSON marker lookup for a JSON TEXT column."""
+
+    safe_json = (
+        f"(CASE WHEN json_valid({expression}) "
+        f"THEN {expression} ELSE json_object() END)"
+    )
+    return f"json_extract({safe_json}, {_sql_literal(path)})"
+
+
 def _sql_ltrim_whitespace(expression: str) -> str:
     return f"LTRIM({expression}, {_SQL_WHITESPACE})"
 
@@ -110,7 +120,7 @@ _PREVIEW_RAW_SUBQUERY_SQL = (f"COALESCE((SELECT {_PREVIEW_RAW_SELECT} FROM messa
 # ── Session lineage predicates ({a} = sessions alias) ───────────────────────
 
 # /branch child (kept visible, never cascade-deleted): stable marker OR legacy end_reason heuristic.
-_BRANCH_CHILD_SQL = ("json_extract(COALESCE({a}.model_config, '{{}}'), '$._branched_from') IS NOT NULL"
+_BRANCH_CHILD_SQL = (f"{_sql_json_extract('{a}.model_config', '$._branched_from')} IS NOT NULL"
     " OR EXISTS (SELECT 1 FROM sessions p            WHERE p.id = {a}.parent_session_id"
     "            AND p.end_reason = 'branched'            AND {a}.started_at >= p.ended_at)")
 _COMPRESSION_CHILD_SQL = ("EXISTS (SELECT 1 FROM sessions p        WHERE p.id = {a}.parent_session_id"
@@ -160,7 +170,7 @@ def _legacy_reset_child_sql(alias: str, reasons_sql: str) -> str:
 
 # A reset starts a separate user-visible conversation though rows keep parent_session_id for lineage.
 # Stable marker, or the same-key fallback for pre-marker rows (exact key keeps subagent children out).
-_RESET_CHILD_SQL = ("json_extract(COALESCE({a}.model_config, '{{}}'), '$._reset_from') IS NOT NULL"
+_RESET_CHILD_SQL = (f"{_sql_json_extract('{a}.model_config', '$._reset_from')} IS NOT NULL"
     " OR " + _legacy_reset_child_sql("{a}", _RESET_END_REASONS_SQL))
 
 # Picker-visible rows: roots + branch/reset children (not subagent runs or compression continuations).

--- a/hermes_state_compression.py
+++ b/hermes_state_compression.py
@@ -12,8 +12,8 @@ import time
 from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_state_common import (
-    _COMPRESSION_LOCK_ROW_SQL as _LOCK_ROW_SQL, _ENDED_ROW_SQL, _ended_by_compression, _sql_session_last_active,
-    is_automatic_end_reason)
+    _COMPRESSION_LOCK_ROW_SQL as _LOCK_ROW_SQL, _ENDED_ROW_SQL, _ended_by_compression, _sql_json_extract,
+    _sql_session_last_active, is_automatic_end_reason)
 
 # Log-record parity with the origin module (caplog tests pin "hermes_state").
 logger = logging.getLogger("hermes_state")
@@ -29,8 +29,8 @@ _CHAIN_STEP_SQL = f"""
                     JOIN sessions child ON child.parent_session_id = parent.id
                     WHERE parent.id = ?
                       AND parent.end_reason = 'compression'
-                      AND json_extract(COALESCE(child.model_config, '{{}}'), '$._branched_from') IS NULL
-                      AND json_extract(COALESCE(child.model_config, '{{}}'), '$._delegate_from') IS NULL
+                      AND {_sql_json_extract('child.model_config', '$._branched_from')} IS NULL
+                      AND {_sql_json_extract('child.model_config', '$._delegate_from')} IS NULL
                       AND COALESCE(child.source, '') != 'tool'
                     ORDER BY
                       CASE

--- a/hermes_state_gateway.py
+++ b/hermes_state_gateway.py
@@ -12,14 +12,15 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-from hermes_state_common import _RECOVERABLE_END_REASONS_SQL, _RESET_END_REASONS_SQL, _sql_session_last_active
+from hermes_state_common import (
+    _RECOVERABLE_END_REASONS_SQL, _RESET_END_REASONS_SQL, _sql_json_extract, _sql_session_last_active)
 
 # Log-record parity with the origin module (caplog tests pin "hermes_state").
 logger = logging.getLogger("hermes_state")
 
 # Recursive CTE naming a session plus its compression ancestors (rows a
 # resume must keep on one routing peer); branch/delegate/tool rows stop it.
-_COMPRESSION_LINEAGE_CTE = """
+_COMPRESSION_LINEAGE_CTE = f"""
                     WITH RECURSIVE compression_lineage(id) AS (
                         SELECT ?
                         UNION
@@ -28,14 +29,8 @@ _COMPRESSION_LINEAGE_CTE = """
                         JOIN sessions child ON child.id = lineage.id
                         JOIN sessions parent ON parent.id = child.parent_session_id
                         WHERE parent.end_reason = 'compression'
-                          AND json_extract(
-                              COALESCE(child.model_config, '{}'),
-                              '$._branched_from'
-                          ) IS NULL
-                          AND json_extract(
-                              COALESCE(child.model_config, '{}'),
-                              '$._delegate_from'
-                          ) IS NULL
+                          AND {_sql_json_extract('child.model_config', '$._branched_from')} IS NULL
+                          AND {_sql_json_extract('child.model_config', '$._delegate_from')} IS NULL
                           AND COALESCE(child.source, '') != 'tool'
                     )
                 """
@@ -108,10 +103,8 @@ _ORPHANS_SQL = f"""
                   AND EXISTS (SELECT 1 FROM messages m
                                WHERE m.session_id = o.id)
                   AND COALESCE(o.source, '') != 'tool'
-                  AND json_extract(COALESCE(o.model_config, '{{}}'),
-                                   '$._branched_from') IS NULL
-                  AND json_extract(COALESCE(o.model_config, '{{}}'),
-                                   '$._delegate_from') IS NULL
+                  AND {_sql_json_extract('o.model_config', '$._branched_from')} IS NULL
+                  AND {_sql_json_extract('o.model_config', '$._delegate_from')} IS NULL
                 ORDER BY o.started_at ASC
                 """
 _ORPHAN_LINEAGE_DONOR_SQL = f"""

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -13,7 +13,7 @@ from agent.memory_manager import sanitize_context
 from agent.message_sanitization import _sanitize_surrogates
 from hermes_state_common import (
     _COMPRESSION_LOCK_ROW_SQL, _ENDED_ROW_SQL, _RESET_END_REASONS, _RESET_END_REASONS_SQL, _ended_by_compression,
-    _legacy_reset_child_sql, _placeholders)
+    _legacy_reset_child_sql, _placeholders, _sql_json_extract)
 
 logger = logging.getLogger("hermes_state")  # caplog tests pin the origin module's name
 
@@ -711,9 +711,9 @@ class SessionMessagesMixin:
                         best = current
                     child_row = conn.execute(
                         "SELECT id FROM sessions AS child WHERE child.parent_session_id = ? "
-                        "  AND json_extract(COALESCE(child.model_config, '{}'), '$._branched_from') IS NULL "
-                        "  AND json_extract(COALESCE(child.model_config, '{}'), '$._delegate_from') IS NULL "
-                        "  AND json_extract(COALESCE(child.model_config, '{}'), '$._reset_from') IS NULL "
+                        f"  AND {_sql_json_extract('child.model_config', '$._branched_from')} IS NULL "
+                        f"  AND {_sql_json_extract('child.model_config', '$._delegate_from')} IS NULL "
+                        f"  AND {_sql_json_extract('child.model_config', '$._reset_from')} IS NULL "
                         f"  AND NOT {_legacy_reset_child_sql('child', _RESET_END_REASONS_SQL)} "
                         "  AND COALESCE(child.source, '') != 'tool' "
                         "ORDER BY child.started_at DESC, child.id DESC LIMIT 1", (current,)).fetchone()

--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -16,7 +16,7 @@ from agent.session_activity import (
 from hermes_state_common import (
     _LISTABLE_CHILD_SQL, _PREVIEW_ELIGIBLE_SQL, _PREVIEW_RAW_SELECT, _RECOVERABLE_END_REASONS,
     _RECOVERABLE_END_REASONS_SQL, _RESET_END_REASONS, _legacy_reset_child_sql, _shape_preview,
-    _sql_session_last_active, _sql_session_last_active_by_id, escape_like as _escape_like,
+    _sql_json_extract, _sql_session_last_active, _sql_session_last_active_by_id, escape_like as _escape_like,
     _placeholders as _session_ids_placeholders,
 )
 
@@ -31,7 +31,7 @@ def workspace_key(row: Dict[str, Any]) -> Optional[str]:
 
 
 def _delegate_from_json(col: str = "model_config") -> str:
-    return f"json_extract(COALESCE({col}, '{{}}'), '$._delegate_from')"
+    return _sql_json_extract(col, "$._delegate_from")
 
 
 # _merge_model_config_json's "no such row" result — distinct from the legal None
@@ -420,10 +420,9 @@ class SessionSessionsMixin:
     # are bound to the queried parent id: continuations inherit model_config verbatim, so
     # presence-matching misclassified them as delegates.
     _NON_CONTINUATION_CHILD_FILTER_SQL = (
-        "  AND COALESCE(json_extract(COALESCE({alias}model_config, '{{}}'),"
-        " '$._branched_from'), '') != ?\n"
-        "  AND COALESCE(json_extract(COALESCE({alias}model_config, '{{}}'),"
-        " '$._delegate_from'), '') != ?\n  AND COALESCE({alias}source, '') != 'tool'\n"
+        f"  AND COALESCE({_sql_json_extract('{alias}model_config', '$._branched_from')}, '') != ?\n"
+        f"  AND COALESCE({_sql_json_extract('{alias}model_config', '$._delegate_from')}, '') != ?\n"
+        "  AND COALESCE({alias}source, '') != 'tool'\n"
     )
 
     def end_session(self, session_id: str, end_reason: str) -> None:
@@ -1213,8 +1212,8 @@ class SessionSessionsMixin:
                     JOIN sessions parent ON parent.id = c.cur_id
                     JOIN sessions child ON child.parent_session_id = c.cur_id
                     WHERE parent.end_reason = 'compression'
-                      AND json_extract(COALESCE(child.model_config, '{{}}'), '$._branched_from') IS NULL
-                      AND json_extract(COALESCE(child.model_config, '{{}}'), '$._delegate_from') IS NULL
+                      AND {_sql_json_extract('child.model_config', '$._branched_from')} IS NULL
+                      AND {_sql_json_extract('child.model_config', '$._delegate_from')} IS NULL
                       AND COALESCE(child.source, '') != 'tool'
                 ),
                 chain_max AS (

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2403,6 +2403,33 @@ class TestListSessionsRich:
             for row in db.find_orphaned_gateway_sessions()
         )
 
+    @pytest.mark.parametrize(
+        "unsafe_model_config",
+        ["{not-json", "[]", '"scalar"', "5", "null"],
+    )
+    def test_unsafe_model_config_child_does_not_break_continuation_reads(
+        self, db, unsafe_model_config
+    ):
+        """Malformed child ``model_config`` must fail open on the
+        ``_NON_CONTINUATION_CHILD_FILTER_SQL`` paths (``{alias}``-formatted):
+        the child still counts as the parent's continuation."""
+        db.create_session("parent", "telegram")
+        db.append_message("parent", "user", "parent message")
+        db.end_session("parent", "compression")
+        db.create_session("child", "telegram", parent_session_id="parent")
+        db.append_message("child", "user", "child message")
+        db._conn.execute(
+            "UPDATE sessions SET model_config = ? WHERE id = ?",
+            (unsafe_model_config, "child"),
+        )
+        db._conn.commit()
+
+        child = db.find_live_compression_child("parent")
+        assert child is not None
+        assert child["id"] == "child"
+        assert db.reopen_orphaned_compression_session("parent") is False
+        assert db.get_session("parent")["end_reason"] == "compression"
+
 
 
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2350,6 +2350,59 @@ class TestListSessionsRich:
         assert len(sessions) == 1
         assert "Help me refactor the auth module" in sessions[0]["preview"]
 
+    @pytest.mark.parametrize(
+        "unsafe_model_config",
+        ["{not-json", "[]", '"scalar"', "5", "null"],
+    )
+    def test_unsafe_model_config_does_not_break_session_surfaces(
+        self, db, unsafe_model_config
+    ):
+        db.create_session("root", "telegram")
+        db.append_message("root", "user", "root message")
+        db.create_session("compression-parent", "telegram")
+        db.end_session("compression-parent", "compression")
+        db.create_session(
+            "compression-child",
+            "telegram",
+            parent_session_id="compression-parent",
+        )
+        db.append_message("compression-child", "user", "child message")
+        db.create_session("routing-orphan", "telegram")
+        db.append_message("routing-orphan", "user", "orphan message")
+        db._conn.execute(
+            "UPDATE sessions SET model_config = ? "
+            "WHERE id IN (?, ?, ?)",
+            (unsafe_model_config, "root", "compression-child", "routing-orphan"),
+        )
+        db._conn.commit()
+
+        listed = db.list_sessions_rich(source="telegram")
+        ordered = db.list_sessions_rich(
+            source="telegram", order_by_last_active=True
+        )
+
+        assert "root" in {row["id"] for row in listed}
+        assert "root" in {row["id"] for row in ordered}
+        assert db.session_count(source="telegram", exclude_children=True) == 3
+        assert db.session_count_by_source(exclude_children=True)["telegram"] == 3
+        assert db.get_compression_chain("compression-parent") == [
+            "compression-parent",
+            "compression-child",
+        ]
+        db.record_gateway_session_peer(
+            "compression-child",
+            source="telegram",
+            session_key="agent:main:telegram:dm:recovered",
+            include_compression_ancestors=True,
+        )
+        assert db.get_session("compression-parent")["session_key"] == (
+            "agent:main:telegram:dm:recovered"
+        )
+        assert any(
+            row["orphan_id"] == "routing-orphan"
+            for row in db.find_orphaned_gateway_sessions()
+        )
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Makes the session-list/count/lineage/routing/resume SQL marker reads from `sessions.model_config` non-throwing.

A recovered database can be physically sound (`PRAGMA integrity_check = ok`) while one historical `model_config` TEXT cell is malformed JSON. Current session list/count/lineage queries call `json_extract(COALESCE(model_config, '{}'), ...)` directly, so that one row raises:

```text
sqlite3.OperationalError: malformed JSON
```

and takes down `hermes sessions list` plus other consumers of the same predicates.

This PR adds one shared SQL-expression builder that validates JSON before extraction. Malformed JSON is treated as an empty object for marker lookup — equivalent to “no `_branched_from` / `_delegate_from` / `_reset_from` marker” — instead of aborting the whole query.

## Relationship to #101679

Follow-up to #101679.

- #101679 sanitizes malformed `model_config` values while producing a new recovery output and reports that metadata loss.
- This PR protects existing/live databases and read surfaces before recovery or when malformed historical metadata is encountered.

The layers are intentionally separate: this PR is read-only and never rewrites the malformed value. Recovery policy and reporting remain owned by #101679.

It also complements #101168 (row-discovery/short-read recovery) and #63956 (new import validation); none guard existing runtime marker reads.

## Root cause

`COALESCE(model_config, '{}')` handles NULL but not syntactically invalid JSON. SQLite `json_extract()` raises on malformed TEXT. The marker predicate was duplicated across listing, counting, compression-lineage, routing-ancestor, orphan inspection, and resume-resolution queries.

## Changes

- Add `_sql_json_extract()` in `hermes_state_common.py`:
  - valid JSON is passed to `json_extract` unchanged;
  - malformed JSON is replaced with `json_object()` inside a lazy `CASE`;
  - the JSON path is emitted through the existing SQL-literal escaper.
- Route shared branch/reset/delegate marker predicates through the helper.
- Replace direct marker extraction in:
  - compression chain and ordered-list CTEs;
  - gateway routing ancestor walks;
  - orphaned gateway-session inspection;
  - non-continuation child filters;
  - resume child selection.
- Add synthetic regression coverage for malformed JSON plus valid non-object JSON (`[]`, string, number, `null`).

## Behavioral contract

- Valid object-valued `model_config` and its marker semantics are unchanged.
- NULL, malformed JSON, and valid non-object JSON behave as “no marker.”
- No row or metadata value is mutated.
- No schema, migration, dependency, config, or tool surface changes.
- Write paths that intentionally modify `model_config` are out of scope; recovery-time normalization and loss reporting remain in #101679.

## Test evidence

Regression reproduced on upstream `main` at `cf86c4762483eebf1ab56063fded9b3efbf4bd45`, with only the new test applied; the final branch is rebased onto `57162d0cc1875ef6307aebe6cb599b5a1d052dd2`:

```text
1 failed, 4 passed
sqlite3.OperationalError: malformed JSON
```

Feature branch (targeted regression rerun after the final rebase):

```text
scripts/run_tests.sh tests/test_hermes_state.py -q -k unsafe_model_config
5 passed

scripts/run_tests.sh tests/test_hermes_state.py -q -k TestListSessionsRich
25 passed

# Neighboring routing/compression/lineage callsites (at cf86c47624)
11 files, 223 passed

scripts/run_tests.sh \
  tests/hermes_state/test_resolve_resume_session_id.py \
  tests/hermes_state/test_orphan_gateway_session_repair.py -q
17 passed
```

Additional gates:

```text
ruff check .
All checks passed!

python scripts/check-windows-footguns.py --all
No Windows footguns found (1086 files scanned).

uv lock --check
git diff --check
clean
```

The monolithic full `tests/test_hermes_state.py` run exceeded the local tool's 420-second cap, so no full-suite-green claim is made. The repository's required 96-core CI remains authoritative for the complete suite.

## Risk

Marker predicates perform one `json_valid()` check before `json_extract()`. Valid values preserve the old result; invalid values fail open only as marker absence instead of failing the complete read. Existing branch/reset/delegate marker behavior remains covered by the surrounding state-store tests.

## Checklist

- [x] Read `CONTRIBUTING.md` and `AGENTS.md`
- [x] Searched open and merged issues/PRs for duplicates
- [x] References and complements #101679
- [x] Regression test fails on a pinned upstream `main` baseline
- [x] Valid marker and neighboring lineage/routing tests pass
- [x] Ruff, Windows-footgun, lockfile, and whitespace gates pass
- [x] No dependency or lockfile changes
- [x] No data mutation or schema migration
- [ ] Full required CI — pending on the PR
