### PR TITLE
fix(state): drop tool_calls from the trigram index and advertise the v1 storage rebuild (salvage #88217)

### DIFF
--- a/contributors/emails/andrewwikel@gmail.com
+++ b/contributors/emails/andrewwikel@gmail.com
@@ -1,0 +1,2 @@
+slash1andy
+# PR #88217 salvage

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -35,6 +35,7 @@ from hermes_cli.colors import Colors, color
 from hermes_cli.models import _HERMES_USER_AGENT
 from hermes_cli.vercel_auth import describe_vercel_auth
 from hermes_constants import OPENROUTER_MODELS_URL
+from hermes_state_common import FTS_STORAGE_VERSION
 from utils import base_url_host_matches
 
 
@@ -496,21 +497,20 @@ def _render_state_db_stats(stats: dict, holders=None) -> list:
             "optimize-storage' with the gateway stopped)",
         ))
 
-    # Advisory: oversized database. Suggest auto_prune, and — when the v23
-    # FTS rebuild is pending OR the DB still carries the legacy inline
-    # trigram layout (fts_storage_version marker absent) — the offline
+    # Advisory: oversized database. Suggest auto_prune, and — when the FTS
+    # rebuild is pending OR the DB predates the current trigram layout — the offline
     # optimize-storage pass that migrates/compacts the FTS indexes.
     if logical is not None and logical > STATE_DB_SIZE_WARN_BYTES:
         detail = (
             "consider enabling sessions.auto_prune in config.yaml "
             "to bound growth"
         )
-        legacy_trigram = (
+        stale_trigram = (
             fts is not None
             and fts.get("messages_fts_trigram")
-            and stats.get("fts_storage_version") is None
+            and (stats.get("fts_storage_version") or 0) < FTS_STORAGE_VERSION
         )
-        if stats.get("fts_rebuild_pending") or legacy_trigram:
+        if stats.get("fts_rebuild_pending") or stale_trigram:
             detail += (
                 "; run 'hermes sessions optimize-storage' offline "
                 "(with the gateway stopped) to compact FTS storage"

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1050,9 +1050,9 @@ def _print_curator_first_run_notice() -> None:
 def _print_fts_optimize_available_notice() -> None:
     """Advertise the opt-in v23 search-index optimization after `hermes update`.
 
-    Only fires when the current profile's state.db is still on the legacy
-    (pre-v23) inline FTS layout. Leads with the reclaimable-space figure and
-    points at the exact command. Honors ``sessions.fts_optimize_notice``:
+    Only fires when the current profile's state.db still needs an FTS storage
+    rebuild. Leads with the reclaimable-space figure and points at the exact
+    command. Honors ``sessions.fts_optimize_notice``:
     ``advise`` (default) prints an advisory notice, ``require`` prints a
     firmer required-upgrade notice, ``off`` suppresses it. Silent for
     fresh/already-optimized installs.
@@ -1088,13 +1088,17 @@ def _print_fts_optimize_available_notice() -> None:
         return
     db = None
     interrupted = False
+    needs_upgrade = False
     try:
         db = SessionDB(db_path=db_path, read_only=True)
-        # read_only opens skip schema init, so probe the layout directly.
+        # read_only opens skip schema init, so probe the stored layout directly.
         row = db._conn.execute(
             "SELECT sql FROM sqlite_master "
             "WHERE type = 'table' AND name = 'messages_fts'"
         ).fetchone()
+        needs_upgrade = bool(row) and getattr(
+            db, "_db_needs_fts_storage_upgrade"
+        )(db._conn)
         # An interrupted `optimize-storage` run: the table is already the
         # v23 shape, but backfill markers / demoted trash tables remain.
         # Offer the command again — re-running resumes and finishes it.
@@ -1120,9 +1124,8 @@ def _print_fts_optimize_available_notice() -> None:
                 db.close()
             except Exception:
                 pass
-    sql = (row[0] if row else "") or ""
-    if not sql or ("tool_name" in sql and not interrupted):
-        # v23 layout already present (fresh/optimized) — nothing to offer.
+    if not needs_upgrade and not interrupted:
+        # Current layout already present (fresh/optimized) — nothing to offer.
         return
 
     if interrupted:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6016,6 +6016,28 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # means a legacy shape that doesn't index tool metadata → optimize.
         return "tool_name" not in sql
 
+    @staticmethod
+    def _db_has_trigram_tool_calls_projection(cursor: sqlite3.Cursor) -> bool:
+        """True when the trigram vtable still includes tool_calls payload."""
+        row = cursor.execute(
+            "SELECT sql FROM sqlite_master "
+            "WHERE type = 'table' AND name = 'messages_fts_trigram'"
+        ).fetchone()
+        if row is None:
+            return False
+        sql = (row[0] if not isinstance(row, sqlite3.Row) else row["sql"]) or ""
+        return "tool_calls" in sql.lower()
+
+    @classmethod
+    def _db_needs_fts_storage_upgrade(
+        cls, cursor: sqlite3.Cursor
+    ) -> bool:
+        """True when the current FTS storage layout should be treated as stale."""
+        return (
+            cls._db_has_legacy_inline_fts(cursor)
+            or cls._db_has_trigram_tool_calls_projection(cursor)
+        )
+
     def _warn_trigram_unavailable(self, exc: sqlite3.OperationalError) -> None:
         """Log once that the trigram tokenizer is missing; base FTS5 stays enabled."""
         if getattr(self, "_trigram_unavailable_warned", False):

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -363,9 +363,9 @@ SCHEMA_VERSION = 29
 # reaches the current version when a DB is either born fresh or explicitly
 # optimized via ``hermes sessions optimize-storage``. A legacy DB sits at
 # layout 0 (marker absent) with a working inline index until the user opts in.
-#   1 = v23 external-content layout (content/tool_name/tool_calls,
-#       tool-row-excluded trigram)
-FTS_STORAGE_VERSION = 1
+#   1 = v23 external-content layout with a tool-row-excluded trigram
+#   2 = trigram also excludes structured tool_calls JSON
+FTS_STORAGE_VERSION = 2
 
 # Tool results are often multi-megabyte machine payloads. Index a useful
 # prefix for new tool rows instead of tokenizing the entire body while the
@@ -772,15 +772,19 @@ END;
 # matching.  The trigram tokenizer creates overlapping 3-byte sequences so
 # substring queries work natively for any script (CJK, Thai, etc.).
 #
-# The trigram index is the most expensive index in state.db, and tool output
-# plus cron transcripts are overwhelmingly machine-generated text. The index
-# therefore reads through ``messages_fts_trigram_src``, a view that excludes
-# both classes. They stay fully stored in ``messages`` and searchable via the
-# standard ``messages_fts`` index; they just don't get trigram treatment.
-# ``search_messages`` routes explicit tool/cron CJK searches to LIKE.
+# The trigram index is the most expensive index in state.db (~2.6x the size
+# of the text it covers). Tool output (~90% of message bytes, machine noise)
+# and cron transcripts are excluded: the index reads through
+# ``messages_fts_trigram_src``, a view that skips both classes. They stay
+# fully stored in ``messages`` and searchable via the standard
+# ``messages_fts`` index; they just don't get trigram (CJK substring)
+# treatment. ``search_messages`` routes explicit tool/cron CJK searches to
+# LIKE for the same reason. Structured ``tool_calls`` JSON likewise stays
+# searchable through ``messages_fts``; excluding it here avoids indexing
+# repetitive JSON syntax as trigrams (FTS_STORAGE_VERSION 2).
 FTS_TRIGRAM_SQL = """
 CREATE VIEW IF NOT EXISTS messages_fts_trigram_src AS
-    SELECT m.id, m.role, m.content, m.tool_name, m.tool_calls
+    SELECT m.id, m.role, m.content, m.tool_name
     FROM messages AS m
     JOIN sessions AS s ON s.id = m.session_id
     WHERE m.role <> 'tool' AND s.source <> 'cron';
@@ -788,7 +792,6 @@ CREATE VIEW IF NOT EXISTS messages_fts_trigram_src AS
 CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts_trigram USING fts5(
     content,
     tool_name,
-    tool_calls,
     content='messages_fts_trigram_src',
     content_rowid='id',
     tokenize='trigram'
@@ -803,8 +806,8 @@ WHEN new.role <> 'tool'
      OR new.id <= COALESCE((SELECT CAST(value AS INTEGER) FROM state_meta
                             WHERE key = 'fts_rebuild_progress'), -1))
 BEGIN
-    INSERT INTO messages_fts_trigram(rowid, content, tool_name, tool_calls)
-    VALUES (new.id, new.content, new.tool_name, new.tool_calls);
+    INSERT INTO messages_fts_trigram(rowid, content, tool_name)
+    VALUES (new.id, new.content, new.tool_name);
 END;
 
 CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_delete AFTER DELETE ON messages
@@ -816,28 +819,27 @@ WHEN old.role <> 'tool'
      OR old.id <= COALESCE((SELECT CAST(value AS INTEGER) FROM state_meta
                             WHERE key = 'fts_rebuild_progress'), -1))
 BEGIN
-    INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content, tool_name, tool_calls)
-    VALUES ('delete', old.id, old.content, old.tool_name, old.tool_calls);
+    INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content, tool_name)
+    VALUES ('delete', old.id, old.content, old.tool_name);
 END;
 
 CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_update
-AFTER UPDATE OF content, tool_name, tool_calls, role ON messages
+AFTER UPDATE OF content, tool_name, role ON messages
 WHEN (old.content IS NOT new.content
     OR old.tool_name IS NOT new.tool_name
-    OR old.tool_calls IS NOT new.tool_calls
     OR old.role IS NOT new.role)
    AND (old.id > COALESCE((SELECT CAST(value AS INTEGER) FROM state_meta
                            WHERE key = 'fts_rebuild_high_water'), -1)
      OR old.id <= COALESCE((SELECT CAST(value AS INTEGER) FROM state_meta
                             WHERE key = 'fts_rebuild_progress'), -1))
 BEGIN
-    INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content, tool_name, tool_calls)
-    SELECT 'delete', old.id, old.content, old.tool_name, old.tool_calls
+    INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content, tool_name)
+    SELECT 'delete', old.id, old.content, old.tool_name
     WHERE old.role <> 'tool'
       AND EXISTS (SELECT 1 FROM sessions
                   WHERE id = old.session_id AND source <> 'cron');
-    INSERT INTO messages_fts_trigram(rowid, content, tool_name, tool_calls)
-    SELECT new.id, new.content, new.tool_name, new.tool_calls
+    INSERT INTO messages_fts_trigram(rowid, content, tool_name)
+    SELECT new.id, new.content, new.tool_name
     WHERE new.role <> 'tool'
       AND EXISTS (SELECT 1 FROM sessions
                   WHERE id = new.session_id AND source <> 'cron');

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -1528,7 +1528,10 @@ class SessionSchemaMixin:
                 # advances to SCHEMA_VERSION here like every other migration —
                 # future v24+ migrations land automatically for legacy-FTS
                 # users too. Only the FTS *layout* waits for opt-in.
-                if fts5_available and self._db_has_legacy_inline_fts(cursor):
+                if (
+                    fts5_available
+                    and self._db_needs_fts_storage_upgrade(cursor)
+                ):
                     self.set_meta("fts_optimize_available", "1", cursor=cursor)
 
             if current_version < 25:
@@ -1561,7 +1564,7 @@ class SessionSchemaMixin:
             # transition actually completes.
             if (
                 fts5_available
-                and not self._db_has_legacy_inline_fts(cursor)
+                and not self._db_needs_fts_storage_upgrade(cursor)
                 and cursor.execute(
                     "SELECT 1 FROM state_meta "
                     "WHERE key = 'fts_rebuild_high_water' LIMIT 1"

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -426,6 +426,15 @@ class SessionSchemaMixin:
         """
         if self._db_has_legacy_inline_fts(cursor):
             return True
+        if self._db_has_trigram_tool_calls_projection(cursor):
+            # The existing vtable still declares the FTS_STORAGE_VERSION 1
+            # ``tool_calls`` column. Replacing the view underneath it would
+            # make the 'rebuild' read ``T.tool_calls`` from a view that no
+            # longer has it. Changing vtable columns is the opt-in
+            # ``hermes sessions optimize-storage`` path (it recreates the
+            # vtable from FTS_TRIGRAM_SQL, cron-filtered view included), so
+            # leave this install to that path instead of half-migrating it.
+            return True
         trigram_exists = self._fts_table_probe(cursor, "messages_fts_trigram")
         if trigram_exists is not True:
             # Let the normal ensure path create/backfill a missing optional

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -348,7 +348,9 @@ class SessionSearchMixin:
             return True  # transient (lock contention) — caller retries
         if more is False:
             status = self.fts_rebuild_status()
-            if status is not None and status["indexed"] >= status["total"]:
+            if high_water <= 0 or (
+                status is not None and status["indexed"] >= status["total"]
+            ):
                 self._fts_rebuild_finish()
             return False
         return bool(more)

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -165,8 +165,8 @@ class SessionSearchMixin:
                 )
                 if include_trigram:
                     conn.execute(
-                        "INSERT INTO messages_fts_trigram(rowid, content, tool_name, tool_calls) "
-                        "SELECT m.id, m.content, m.tool_name, m.tool_calls "
+                        "INSERT INTO messages_fts_trigram(rowid, content, tool_name) "
+                        "SELECT m.id, m.content, m.tool_name "
                         "FROM messages m JOIN sessions s ON s.id = m.session_id "
                         "WHERE m.id > ? AND m.id <= ? AND m.role <> 'tool' "
                         "AND s.source <> 'cron' "
@@ -325,8 +325,8 @@ class SessionSearchMixin:
             if include_trigram:
                 conn.execute(
                     "INSERT INTO messages_fts_trigram"
-                    "(rowid, content, tool_name, tool_calls) "
-                    "SELECT m.id, m.content, m.tool_name, m.tool_calls "
+                    "(rowid, content, tool_name) "
+                    "SELECT m.id, m.content, m.tool_name "
                     "FROM messages m JOIN sessions s ON s.id = m.session_id "
                     "WHERE m.id > ? AND m.id <= ? AND m.role <> 'tool' "
                     "AND s.source <> 'cron'",
@@ -657,16 +657,19 @@ class SessionSearchMixin:
         is a legacy inline-FTS install that can be optimized to the v23
         external-content schema, or a previous optimize run was interrupted
         (legacy vtables already demoted, but backfill markers and/or trash
-        tables remain) and re-running would resume it, or the CJK-bigram
-        index needs a backfill/rebuild on this tokenizer-capable host, or
-        a prior demote left an empty external-content index without markers
-        (healable on re-run).
+        tables remain) and re-running would resume it, or this DB is v23 with the
+        old tool-calls-inclusive trigram projection (repairable via this same
+        migration flow), or the CJK-bigram index needs a backfill/rebuild on this
+        tokenizer-capable host, or a prior demote left an empty external-content
+        index without markers (healable on re-run).
         False for fresh and fully-optimized installs (and when FTS5 is
         unavailable)."""
         if not self._fts_enabled or self.read_only:
             return False
         with self._read_ctx() as conn:
             if self._db_has_legacy_inline_fts(conn):
+                return True
+            if self._db_has_trigram_tool_calls_projection(self._conn):
                 return True
             # Interrupted optimize: demotion already removed the legacy
             # vtables (so the check above is False), but the transition is
@@ -694,7 +697,7 @@ class SessionSearchMixin:
             return self._fts_external_index_empty_with_messages(conn)
 
     def _demote_legacy_fts_to_trash(self) -> int:
-        """Demote the legacy inline FTS vtables and stage their shadow tables
+        """Demote upgrade-eligible FTS vtables and stage their shadow tables
         for chunked teardown. Returns MAX(messages.id) as the rebuild high
         water. O(1) schema surgery — the heavy delete is deferred to the
         chunked teardown, exactly as the validated auto path did.
@@ -767,9 +770,16 @@ class SessionSearchMixin:
         progress_cb: Optional[Callable[[Dict[str, Any]], None]] = None,
         vacuum: bool = True,
     ) -> Dict[str, Any]:
-        """Migrate a legacy v22 inline-FTS DB to the v23 external-content
-        schema, foreground and to completion. Safe to re-run: if a previous
-        attempt was interrupted it resumes from the progress marker.
+        """Repair an older FTS layout into the current v23-compatible shape,
+        foreground and to completion.
+
+        Supports two paths:
+        - legacy-v22 inline -> demote to v23 external-content
+        - v23 installs where ``messages_fts_trigram`` still stores
+          ``tool_calls`` payloads
+
+        Safe to re-run: if a previous attempt was interrupted it resumes from
+        the progress marker.
 
         ``progress_cb`` receives {"phase", "percent", "indexed", "total"}
         dicts for a CLI progress bar. Returns a summary dict.
@@ -793,11 +803,13 @@ class SessionSearchMixin:
         # finishing the backfill + teardown — this is what makes re-running
         # after an interruption safe.
         with self._lock:
-            legacy = self._db_has_legacy_inline_fts(self._conn)
+            needs_storage_upgrade = self._db_needs_fts_storage_upgrade(
+                self._conn
+            )
         pending = self.get_meta("fts_rebuild_high_water") is not None
-        if legacy and not pending:
+        if needs_storage_upgrade and not pending:
             self._demote_legacy_fts_to_trash()
-        elif pending and not legacy:
+        elif pending and not needs_storage_upgrade:
             # Resume mid-demote: markers exist, empty v23 tables may still be
             # missing if the process died between the staged demote commit and
             # schema ensure. Re-ensure is IF NOT EXISTS and cheap.

--- a/tests/hermes_cli/test_fts_optimize_notice.py
+++ b/tests/hermes_cli/test_fts_optimize_notice.py
@@ -1,0 +1,42 @@
+"""Regression coverage for FTS storage upgrade discoverability."""
+
+import sqlite3
+from types import SimpleNamespace
+
+
+def test_update_notice_offers_v1_trigram_tool_calls_rebuild(tmp_path, monkeypatch, capsys):
+    """A deployed v1 trigram projection still receives the opt-in notice."""
+    from hermes_cli import update_cmd
+    import hermes_constants
+    import hermes_state
+
+    db_path = tmp_path / "state.db"
+    db_path.touch()
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE state_meta (key TEXT PRIMARY KEY, value TEXT);
+        CREATE TABLE messages_fts (content TEXT, tool_name TEXT, tool_calls TEXT);
+        CREATE TABLE messages_fts_trigram (content TEXT, tool_name TEXT, tool_calls TEXT);
+        """
+    )
+
+    class FakeSessionDB:
+        def __init__(self, **_kwargs):
+            self._conn = conn
+
+        def close(self):
+            pass
+
+        _db_needs_fts_storage_upgrade = staticmethod(
+            hermes_state.SessionDB._db_needs_fts_storage_upgrade
+        )
+
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(hermes_state, "SessionDB", FakeSessionDB)
+    monkeypatch.setattr(update_cmd.Path, "stat", lambda _path: SimpleNamespace(st_size=512 * 1024 ** 2))
+
+    update_cmd._print_fts_optimize_available_notice()
+
+    assert "hermes sessions optimize-storage" in capsys.readouterr().out
+    conn.close()

--- a/tests/hermes_cli/test_fts_optimize_notice.py
+++ b/tests/hermes_cli/test_fts_optimize_notice.py
@@ -34,7 +34,17 @@ def test_update_notice_offers_v1_trigram_tool_calls_rebuild(tmp_path, monkeypatc
 
     monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
     monkeypatch.setattr(hermes_state, "SessionDB", FakeSessionDB)
-    monkeypatch.setattr(update_cmd.Path, "stat", lambda _path: SimpleNamespace(st_size=512 * 1024 ** 2))
+    # Report a large state.db without patching Path.stat globally: a
+    # 1-arg lambda on the class breaks pathlib.exists(follow_symlinks=...)
+    # for every caller in the process (pytest's own teardown included).
+    real_stat = update_cmd.Path.stat
+
+    def _stat(path, *args, **kwargs):
+        if path.name == "state.db":
+            return SimpleNamespace(st_size=512 * 1024 ** 2)
+        return real_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(update_cmd.Path, "stat", _stat)
 
     update_cmd._print_fts_optimize_available_notice()
 

--- a/tests/state/test_fts_trigram_cron_exclusion.py
+++ b/tests/state/test_fts_trigram_cron_exclusion.py
@@ -28,22 +28,37 @@ def _trigram_rowids(db: SessionDB) -> set[int]:
     }
 
 
-def _install_pre_v27_trigram(db: SessionDB) -> None:
+def _install_pre_v27_trigram(db: SessionDB, *, with_tool_calls: bool = False) -> None:
+    """Recreate the pre-cron-exclusion external-content trigram boundary.
+
+    ``with_tool_calls=True`` reproduces the FTS_STORAGE_VERSION 1 vtable
+    (``tool_calls`` projected) that installs upgraded before #88217 carry;
+    the default is the v2 column set with only the view/trigger predicates
+    behind, which is what the in-place v29 migration handles.
+    """
+    cols = "content, tool_name" + (", tool_calls" if with_tool_calls else "")
+    vals = "new.content, new.tool_name" + (", new.tool_calls" if with_tool_calls else "")
     db._conn.executescript(
-        """
+        f"""
         DROP TRIGGER messages_fts_trigram_insert;
         DROP TRIGGER messages_fts_trigram_delete;
         DROP TRIGGER messages_fts_trigram_update;
+        DROP TABLE messages_fts_trigram;
         DROP VIEW messages_fts_trigram_src;
         CREATE VIEW messages_fts_trigram_src AS
             SELECT id, role, content, tool_name, tool_calls
             FROM messages WHERE role <> 'tool';
+        CREATE VIRTUAL TABLE messages_fts_trigram USING fts5(
+            {cols},
+            content='messages_fts_trigram_src',
+            content_rowid='id',
+            tokenize='trigram'
+        );
         CREATE TRIGGER messages_fts_trigram_insert AFTER INSERT ON messages
         WHEN new.role <> 'tool'
         BEGIN
-            INSERT INTO messages_fts_trigram(
-                rowid, content, tool_name, tool_calls
-            ) VALUES (new.id, new.content, new.tool_name, new.tool_calls);
+            INSERT INTO messages_fts_trigram(rowid, {cols})
+            VALUES (new.id, {vals});
         END;
         """
     )
@@ -157,6 +172,42 @@ def test_install_already_at_v28_still_gets_the_cron_exclusion_migration(tmp_path
         assert _trigram_rowids(migrated) == {cli_id}, (
             "a v28 database kept cron rows in the trigram index: the migration gate did not fire"
         )
+    finally:
+        migrated.close()
+
+
+def test_v1_tool_calls_layout_is_left_for_optimize_storage(tmp_path):
+    """A FTS_STORAGE_VERSION 1 trigram vtable (``tool_calls`` projected) must
+    survive the v29 startup migration untouched and be finished by the opt-in
+    ``optimize_fts_storage`` path — not half-migrated into a view/vtable
+    column mismatch (which used to fail the rebuild with
+    ``no such column: T.tool_calls``)."""
+    db_path = tmp_path / "state.db"
+    old = SessionDB(db_path=db_path)
+    if not old._trigram_available:
+        old.close()
+        pytest.skip("trigram tokenizer unavailable in this SQLite build")
+    _install_pre_v27_trigram(old, with_tool_calls=True)
+    old.create_session("cli", source="cli")
+    old.create_session("cron", source="cron")
+    cli_id = old.append_message("cli", role="user", content="交互迁移内容")
+    cron_id = old.append_message("cron", role="user", content="定时迁移内容")
+    assert _trigram_rowids(old) == {cli_id, cron_id}
+    old._conn.execute("UPDATE schema_version SET version = 28")
+    old._conn.commit()
+    old.close()
+
+    migrated = SessionDB(db_path=db_path)  # must not raise
+    try:
+        # Startup left the v1 layout alone (cron row still there) …
+        assert _trigram_rowids(migrated) == {cli_id, cron_id}
+        assert migrated.fts_optimize_available() is True
+        # … and the opt-in path completes the transition: v2 columns,
+        # cron-filtered view, cron row purged.
+        migrated.optimize_fts_storage()
+        cols = [r[1] for r in migrated._conn.execute("PRAGMA table_info(messages_fts_trigram)")]
+        assert "tool_calls" not in cols
+        assert _trigram_rowids(migrated) == {cli_id}
     finally:
         migrated.close()
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -11,7 +11,13 @@ import pytest
 
 import hermes_state
 from agent.session_activity import ActivityProvenance
-from hermes_state import SCHEMA_SQL, SCHEMA_VERSION, SessionDB
+from hermes_state import (
+    FTS_SQL,
+    FTS_STORAGE_VERSION,
+    SCHEMA_SQL,
+    SCHEMA_VERSION,
+    SessionDB,
+)
 
 
 class _NoFtsCursor(sqlite3.Cursor):
@@ -3631,6 +3637,145 @@ class TestFTSExternalContentMigration:
             # A new write is indexed live by the legacy triggers.
             db.append_message("s1", role="user", content="AFTEROPEN token")
             assert len(db.search_messages("AFTEROPEN")) == 1
+        finally:
+            db.close()
+
+    def test_v23_rebuild_from_trigram_tool_calls_projection(self, tmp_path):
+        """v23 installs built with historical trigram projection should be
+        repaired via optimize-storage: trigram must drop tool_calls while
+        standard messages_fts keeps indexing them."""
+        db_path = tmp_path / "v23-toolcalls.db"
+
+        # Build an external-content DB that is already at schema version 23,
+        # but with the old tool_calls-inclusive trigram projection.
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript(SCHEMA_SQL)
+        conn.executescript(FTS_SQL)
+        conn.executescript(
+            """
+            DROP TRIGGER IF EXISTS messages_fts_trigram_insert;
+            DROP TRIGGER IF EXISTS messages_fts_trigram_delete;
+            DROP TRIGGER IF EXISTS messages_fts_trigram_update;
+            DROP TABLE IF EXISTS messages_fts_trigram;
+            DROP VIEW IF EXISTS messages_fts_trigram_src;
+
+            CREATE VIEW IF NOT EXISTS messages_fts_trigram_src AS
+                SELECT id, role, content, tool_name, tool_calls
+                FROM messages
+                WHERE role <> 'tool';
+
+            CREATE VIRTUAL TABLE messages_fts_trigram USING fts5(
+                content,
+                tool_name,
+                tool_calls,
+                content='messages_fts_trigram_src',
+                content_rowid='id',
+                tokenize='trigram'
+            );
+
+            CREATE TRIGGER messages_fts_trigram_insert AFTER INSERT ON messages
+            WHEN new.role <> 'tool'
+            BEGIN
+                INSERT INTO messages_fts_trigram(rowid, content, tool_name, tool_calls)
+                VALUES (new.id, new.content, new.tool_name, new.tool_calls);
+            END;
+
+            CREATE TRIGGER messages_fts_trigram_delete AFTER DELETE ON messages
+            WHEN old.role <> 'tool'
+            BEGIN
+                INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content, tool_name, tool_calls)
+                VALUES ('delete', old.id, old.content, old.tool_name, old.tool_calls);
+            END;
+
+            CREATE TRIGGER messages_fts_trigram_update
+            AFTER UPDATE OF content, tool_name, tool_calls, role ON messages
+            WHEN (old.content IS NOT new.content
+                OR old.tool_name IS NOT new.tool_name
+                OR old.tool_calls IS NOT new.tool_calls
+                OR old.role IS NOT new.role)
+            BEGIN
+                INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content, tool_name, tool_calls)
+                SELECT 'delete', old.id, old.content, old.tool_name, old.tool_calls
+                WHERE old.role <> 'tool';
+                INSERT INTO messages_fts_trigram(rowid, content, tool_name, tool_calls)
+                SELECT new.id, new.content, new.tool_name, new.tool_calls
+                WHERE new.role <> 'tool';
+            END;
+            """
+        )
+        # Simulate the historical v23 projection shipped before this fix.
+        conn.execute(
+            "INSERT OR REPLACE INTO state_meta (key, value) VALUES ('fts_storage_version', '1')"
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO state_meta (key, value) VALUES ('fts_optimize_available', '1')"
+        )
+        conn.commit()
+        conn.close()
+
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
+            ("s1", "cli", time.time()),
+        )
+        conn.execute(
+            "INSERT INTO messages (session_id, timestamp, role, content, tool_name, tool_calls) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                "s1",
+                time.time(),
+                "assistant",
+                "部署完成 assistant content",
+                "legacyTool",
+                '{"name": "legacy", "arguments": "UNIQUE_TOOLCALL_TOKEN_43701"}',
+            ),
+        )
+        conn.commit()
+        assert conn.execute(
+            "SELECT rowid FROM messages_fts_trigram WHERE messages_fts_trigram MATCH 'UNIQUE_TOOLCALL_TOKEN_43701'"
+        ).fetchall()
+        conn.close()
+
+        db = SessionDB(db_path=db_path)
+        try:
+            assert db._conn is not None
+            assert db.fts_optimize_available() is True
+            assert db.get_meta("fts_storage_version") == "1"
+
+            original_ensure = db._ensure_fts_schema
+
+            def interrupt_after_demote(cursor, table_name, ddl):
+                if table_name == "messages_fts_trigram":
+                    raise RuntimeError("injected trigram rebuild interruption")
+                return original_ensure(cursor, table_name, ddl)
+
+            db._ensure_fts_schema = interrupt_after_demote
+            with pytest.raises(RuntimeError, match="injected trigram"):
+                db.optimize_fts_storage(vacuum=False)
+            assert db.get_meta("fts_rebuild_high_water") is not None
+            assert db.fts_optimize_available() is True
+            assert db.get_meta("fts_storage_version") == "1"
+
+            db._ensure_fts_schema = original_ensure
+            result = db.optimize_fts_storage(vacuum=False)
+            assert result["ok"] is True
+
+            # messages_fts stays in the tool-calls search path.
+            assert len(db.search_messages("UNIQUE_TOOLCALL_TOKEN_43701")) == 1
+            # New trigram schema excludes tool_calls from trigram projection.
+            assert not db._conn.execute(
+                "SELECT 1 FROM messages_fts_trigram WHERE messages_fts_trigram MATCH 'UNIQUE_TOOLCALL_TOKEN_43701' LIMIT 1"
+            ).fetchone()
+            assert db._conn.execute(
+                "SELECT 1 FROM messages_fts_trigram "
+                "WHERE messages_fts_trigram MATCH '部署完成' LIMIT 1"
+            ).fetchone()
+            trigger_sql = db._conn.execute(
+                "SELECT sql FROM sqlite_master "
+                "WHERE type = 'trigger' AND name = 'messages_fts_trigram_update'"
+            ).fetchone()[0]
+            assert "tool_calls" not in trigger_sql
+            assert db.get_meta("fts_storage_version") == str(FTS_STORAGE_VERSION)
         finally:
             db.close()
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3640,7 +3640,10 @@ class TestFTSExternalContentMigration:
         finally:
             db.close()
 
-    def test_v23_rebuild_from_trigram_tool_calls_projection(self, tmp_path):
+    @pytest.mark.parametrize("with_message", [False, True])
+    def test_v23_rebuild_from_trigram_tool_calls_projection(
+        self, tmp_path, with_message
+    ):
         """v23 installs built with historical trigram projection should be
         repaired via optimize-storage: trigram must drop tool_calls while
         standard messages_fts keeps indexing them."""
@@ -3713,28 +3716,29 @@ class TestFTSExternalContentMigration:
         conn.commit()
         conn.close()
 
-        conn = sqlite3.connect(str(db_path))
-        conn.execute(
-            "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
-            ("s1", "cli", time.time()),
-        )
-        conn.execute(
-            "INSERT INTO messages (session_id, timestamp, role, content, tool_name, tool_calls) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
-            (
-                "s1",
-                time.time(),
-                "assistant",
-                "部署完成 assistant content",
-                "legacyTool",
-                '{"name": "legacy", "arguments": "UNIQUE_TOOLCALL_TOKEN_43701"}',
-            ),
-        )
-        conn.commit()
-        assert conn.execute(
-            "SELECT rowid FROM messages_fts_trigram WHERE messages_fts_trigram MATCH 'UNIQUE_TOOLCALL_TOKEN_43701'"
-        ).fetchall()
-        conn.close()
+        if with_message:
+            conn = sqlite3.connect(str(db_path))
+            conn.execute(
+                "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
+                ("s1", "cli", time.time()),
+            )
+            conn.execute(
+                "INSERT INTO messages (session_id, timestamp, role, content, tool_name, tool_calls) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    "s1",
+                    time.time(),
+                    "assistant",
+                    "部署完成 assistant content",
+                    "legacyTool",
+                    '{"name": "legacy", "arguments": "UNIQUE_TOOLCALL_TOKEN_43701"}',
+                ),
+            )
+            conn.commit()
+            assert conn.execute(
+                "SELECT rowid FROM messages_fts_trigram WHERE messages_fts_trigram MATCH 'UNIQUE_TOOLCALL_TOKEN_43701'"
+            ).fetchall()
+            conn.close()
 
         db = SessionDB(db_path=db_path)
         try:
@@ -3752,24 +3756,35 @@ class TestFTSExternalContentMigration:
             db._ensure_fts_schema = interrupt_after_demote
             with pytest.raises(RuntimeError, match="injected trigram"):
                 db.optimize_fts_storage(vacuum=False)
-            assert db.get_meta("fts_rebuild_high_water") is not None
+
+            db.close()
+            db = SessionDB(db_path=db_path)
+            assert db._conn is not None
+            assert db.get_meta("fts_rebuild_high_water") is None
+            assert db.get_meta("fts_rebuild_progress") is None
+            assert db._has_fts_trash(db._conn) is True
             assert db.fts_optimize_available() is True
             assert db.get_meta("fts_storage_version") == "1"
+            if with_message:
+                assert db._conn.execute(
+                    "SELECT 1 FROM messages_fts_trigram "
+                    "WHERE messages_fts_trigram MATCH '部署完成' LIMIT 1"
+                ).fetchone()
 
-            db._ensure_fts_schema = original_ensure
             result = db.optimize_fts_storage(vacuum=False)
             assert result["ok"] is True
 
-            # messages_fts stays in the tool-calls search path.
-            assert len(db.search_messages("UNIQUE_TOOLCALL_TOKEN_43701")) == 1
-            # New trigram schema excludes tool_calls from trigram projection.
-            assert not db._conn.execute(
-                "SELECT 1 FROM messages_fts_trigram WHERE messages_fts_trigram MATCH 'UNIQUE_TOOLCALL_TOKEN_43701' LIMIT 1"
-            ).fetchone()
-            assert db._conn.execute(
-                "SELECT 1 FROM messages_fts_trigram "
-                "WHERE messages_fts_trigram MATCH '部署完成' LIMIT 1"
-            ).fetchone()
+            if with_message:
+                # messages_fts stays in the tool-calls search path.
+                assert len(db.search_messages("UNIQUE_TOOLCALL_TOKEN_43701")) == 1
+                # New trigram schema excludes tool_calls from trigram projection.
+                assert not db._conn.execute(
+                    "SELECT 1 FROM messages_fts_trigram WHERE messages_fts_trigram MATCH 'UNIQUE_TOOLCALL_TOKEN_43701' LIMIT 1"
+                ).fetchone()
+                assert db._conn.execute(
+                    "SELECT 1 FROM messages_fts_trigram "
+                    "WHERE messages_fts_trigram MATCH '部署完成' LIMIT 1"
+                ).fetchone()
             trigger_sql = db._conn.execute(
                 "SELECT sql FROM sqlite_master "
                 "WHERE type = 'trigger' AND name = 'messages_fts_trigram_update'"

--- a/tests/test_state_db_stats.py
+++ b/tests/test_state_db_stats.py
@@ -236,6 +236,20 @@ def test_render_large_db_legacy_trigram_suggests_optimize():
     assert "optimize-storage" in blob
 
 
+def test_render_large_db_v1_trigram_suggests_optimize():
+    from hermes_cli.doctor import STATE_DB_SIZE_WARN_BYTES, _render_state_db_stats
+
+    lines = _render_state_db_stats(
+        _base_stats(
+            logical_size_bytes=STATE_DB_SIZE_WARN_BYTES + 1,
+            fts_storage_version=1,
+        ),
+        holders=None,
+    )
+    blob = " ".join(" ".join(str(p) for p in line) for line in lines)
+    assert "optimize-storage" in blob
+
+
 def test_render_does_not_duplicate_legacy_wal_warning():
     """A large WAL must NOT warn here: doctor's pre-existing WAL check
     (50 MB threshold, with a --fix checkpoint) already covers it, and a


### PR DESCRIPTION
## Summary
The trigram index stops indexing structured `tool_calls` JSON (FTS_STORAGE_VERSION 2), `hermes update`/`doctor` advertise the opt-in `hermes sessions optimize-storage` rebuild to installs still on the v1 layout, and empty rebuild markers are finalised — trigram 1.13 MB → 0.54 MB on the bench. Third of the FTS trio, on top of #93834 + #101266.

Salvaged from #88217 by @slash1andy (three commits cherry-picked, authorship preserved). Two follow-up commits of mine: a composition fix with #101266 that I reproduced against a real `main`-built store, and a test hygiene fix.

## Who hits this / when / why it matters
Everyone: every assistant turn with tool calls indexed its JSON argument blob as trigrams. It stays searchable via `messages_fts`; the trigram index only needs prose.

## What changed
- `hermes_state_common.py`: trigram vtable/view/triggers drop `tool_calls`; `FTS_STORAGE_VERSION` 1 → 2 (opt-in layout change via `optimize-storage`, per main's existing scheme).
- `hermes_cli/update_cmd.py`, `hermes_cli/doctor.py`: the notice/advisory fires for v1 trigram layouts too.
- `hermes_state_search.py`: empty rebuild markers are finalised instead of lingering.
- **Composition fix (mine):** #101266's in-place v29 startup migration swapped the trigram view under an install still carrying the v1 vtable (with `tool_calls`), and the FTS5 `rebuild` then failed with `no such column: T.tool_calls` — `SessionDB.__init__` raised. Reproduced by opening a real `main`-built DB on the stacked branch. The in-place migration now leaves v1-layout installs to `optimize-storage` (which recreates the vtable from `FTS_TRIGRAM_SQL`, cron filter included); they are already offered it. New test builds a real v1 external-content vtable and asserts: startup doesn't raise, `fts_optimize_available()` is true, `optimize_fts_storage()` yields v2 columns + purges the cron row. Mutation-checked (removing the guard reproduces the `T.tool_calls` failure).
- **Test hygiene (mine):** `test_fts_optimize_notice.py` patched `Path.stat` with a 1-arg lambda, crashing pytest's own teardown (`TypeError: follow_symlinks`); it now delegates to the real `stat` for every other path.

## Benchmark (`bench/s2_fts_size.py`)
| | before | after (trio) |
|---|---|---|
| trigram index | 1.13 MB | **0.54 MB** |

## Verification
- E2E on a `main`-built store: opens (schema 29, v1 layout untouched, integrity ok) → `optimize_fts_storage()` → columns `content, tool_name`, trigram rowids = non-cron non-tool rows only, storage marker stamped.
- `tests/state/test_fts_trigram_cron_exclusion.py` (8), `tests/hermes_cli/test_fts_optimize_notice.py`, `tests/test_fts_tool_write_bounds.py`, `tests/test_state_db_stats.py`: 28 passed; `tests/test_hermes_state.py`: 257 passed, the 2 failures are identical on `main` (macOS disk-space / read-only-open artifacts). ruff clean.

## Provenance
Salvaged from #88217 by @slash1andy — three commits cherry-picked with authorship preserved (email mapped via AUTHOR_MAP). Follow-ups are mine.
