### PR TITLE
fix(cli): skip URL-less providers stubs in /model picker

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -3662,6 +3662,14 @@ def list_authenticated_providers(
                 or ep_cfg.get("url", "")
                 or ""
             )
+            # Config-namespace stubs carry runtime settings only (e.g.
+            # ``stale_timeout_seconds``) with no endpoint URL. Emitting a row
+            # for them would claim the slug before section 4 runs and shadow
+            # the real ``custom_providers`` entry of the same name behind a
+            # zero-model phantom row (#101711). Sections 3b and 4 already
+            # require an endpoint URL.
+            if not api_url:
+                continue
             key_env = str(
                 ep_cfg.get("key_env") or ep_cfg.get("api_key_env") or ""
             ).strip()

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -614,3 +614,46 @@ def test_current_custom_model_not_leaked_into_other_provider_rows(monkeypatch):
     for row in providers:
         if row["slug"] != "openrouter" and not row.get("is_current"):
             assert custom not in row.get("models", []), f"leaked into {row['slug']}"
+
+
+def test_url_less_provider_stubs_do_not_shadow_custom_providers(monkeypatch):
+    """``providers:`` stubs without an endpoint URL must not emit picker rows.
+
+    Regression test for #101711: runtime-settings-only keys under
+    ``providers:`` (e.g. ``stale_timeout_seconds`` written under both
+    ``local`` and ``custom:local``) used to collapse into one phantom
+    zero-model row that claimed the ``custom:local`` slug before section 4
+    ran, so the real ``custom_providers`` entry named ``local`` was skipped
+    and its models were unselectable from /model.
+    """
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+    # Keep the picker offline: no live /models probes for either section.
+    monkeypatch.setattr(
+        "hermes_cli.model_switch._fetch_picker_live_models",
+        lambda *_a, **_kw: None,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.cached_fetch_api_models",
+        lambda *_a, **_kw: None,
+    )
+
+    providers = list_authenticated_providers(
+        current_provider="custom:local",
+        user_providers={
+            "custom:local": {"stale_timeout_seconds": 600},
+            "local": {"stale_timeout_seconds": 600},
+        },
+        custom_providers=[
+            {
+                "name": "local",
+                "base_url": "http://localhost:8000/v1",
+                "models": {"unsloth/Qwen3.8-27B-NVFP4": {}},
+            }
+        ],
+        max_models=50,
+    )
+
+    rows = [p for p in providers if p.get("slug") == "custom:local"]
+    assert rows, "the real custom_providers entry must own the custom:local row"
+    assert all("unsloth/Qwen3.8-27B-NVFP4" in p["models"] for p in rows)


### PR DESCRIPTION
## What does this PR do?

A config-namespace stub under `providers:` (an entry with **no** `base_url`/`api`/`url`, only runtime settings like `stale_timeout_seconds`, as written by `hermes config set "providers.custom:local.stale_timeout_seconds" 600`) made the `/model` picker show a phantom zero-model row that shadowed the real `custom_providers` entry of the same name, so the local model became unselectable from the picker.

Root cause: section 3 of `list_authenticated_providers()` emitted a picker row for every key under `providers:` with no endpoint-URL guard. Two URL-less stubs collapse into one empty group (same group key), whose row claims the slug in `seen_slugs` before section 4 runs — the real `custom_providers` group is then skipped by the existing `slug.lower() in seen_slugs` check. Sections 3b and 4 already require an endpoint URL; this adds the same guard to section 3. The fix is intentionally minimal and mirrors the guard already present two sections below.

Runtime settings (`stale_timeout_seconds` etc.) are unaffected: the resolver reads them directly from config and never goes through this picker aggregation.

## Related Issue

Fixes #101711

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/model_switch.py`: in section 3 of `list_authenticated_providers()`, skip `providers:` entries that have no endpoint URL (`base_url`/`api`/`url` all absent), right after `api_url` is computed — same policy as sections 3b/4.
- `tests/hermes_cli/test_user_providers_model_switch.py`: add regression test `test_url_less_provider_stubs_do_not_shadow_custom_providers` reproducing the issue's exact config (stub under both `local` and `custom:local` + a real `custom_providers` entry named `local`) and asserting the `custom:local` row carries the configured model.

## How to Test

1. Config as in the issue:

```yaml
providers:
  custom:local:
    stale_timeout_seconds: 600
  local:
    stale_timeout_seconds: 600

custom_providers:
  - name: local
    base_url: http://localhost:8000/v1
    models:
      unsloth/Qwen3.8-27B-NVFP4: {}
```

2. Before the fix: `python -c "from hermes_cli.inventory import load_picker_context, build_models_payload; rows = build_models_payload(load_picker_context())['providers']; print(next(r for r in rows if r['slug'] == 'custom:local')['models'])"` → `[]` (phantom row, model unreachable from `/model`).
3. After the fix: the same call returns `['unsloth/Qwen3.8-27B-NVFP4']` — the real `custom_providers` entry owns the `custom:local` row, and `get_provider_stale_timeout("custom:local", model)` still resolves the 600 s override.
4. Observed result: `pytest tests/hermes_cli/test_user_providers_model_switch.py -q` → 13 passed (the new test fails on unpatched `main`, passes with the guard); picker-domain suites (`test_model_switch_custom_providers.py`, `test_list_picker_providers.py`, `test_local_picker_identity.py`, `test_local_runtime_picker_row.py`, `test_model_switch_configured_provider_routing.py`, `test_model_picker_excluded_providers.py`, `test_model_switch_parsing.py`, `test_model_switch_once_flags.py`, `test_model_switch_persist_default.py`, `test_model_switch_variant_tags.py`, `test_model_switch_context_display.py`, `test_aux_picker_inventory.py`, `test_picker_prewarm.py`, `test_inventory.py`) → all passed (132 total); `ruff check` on the touched files passes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A