### PR TITLE
feat(a2a): send asserted X-A2A-Identity header on outbound peer requests

### DIFF
--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -144,6 +144,23 @@ def _profile_home(profile: str) -> Optional[str]:
                 return None
         return os.path.expanduser(f"~/.hermes/profiles/{profile}")
 
+def outbound_identity() -> str:
+    """Asserted sender identity for outbound A2A requests (fleet task #322).
+
+    '{profile}-{hostname}' (e.g. 'librarian-kimchi'): profile from
+    _active_profile_name(), machine's short hostname label via socket — the
+    naming pieces the inbound server already uses (_default_agent_name).
+    Sent as the X-A2A-Identity header; advisory display provenance for
+    loopback receivers — asserted, never authentication. No config, no token.
+    """
+    profile = _active_profile_name()
+    try:
+        import socket
+        host = (socket.gethostname() or "localhost").split(".")[0] or "localhost"
+    except Exception:
+        host = "localhost"
+    return f"{profile}-{host}"
+
 def _safe_context_slug(value: str, max_len: int = 96) -> str:
     """Sanitize attacker-provided context ids before using in session titles."""
     slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", str(value or "")).strip("-._")

--- a/plugins/platforms/a2a/tools.py
+++ b/plugins/platforms/a2a/tools.py
@@ -74,6 +74,21 @@ def _auth_header(auth: dict) -> dict:
     return {}
 
 
+def _identity_headers() -> dict:
+    """Asserted identity header for outbound peer requests (fleet task #322).
+
+    X-A2A-Identity: '{profile}-{hostname}' (e.g. 'librarian-kimchi'), reusing
+    the adapter's outbound_identity(). Loopback receivers may surface it as a
+    display identity — asserted provenance, never authentication. Best-effort:
+    a failure here must never block a dispatch.
+    """
+    try:
+        from .adapter import outbound_identity
+        return {"X-A2A-Identity": outbound_identity()}
+    except Exception:
+        return {}
+
+
 # --------------------------------------------------------------------------
 # HTTP
 # --------------------------------------------------------------------------
@@ -153,7 +168,7 @@ def _send_task(agent_label: str, peer: dict, message: str, context_id: str) -> t
     outbound redaction, audit, persistence, and metrics.
     """
     base_url = peer.get("url", "")
-    headers = _auth_header(peer.get("auth", {}) or {})
+    headers = {**_auth_header(peer.get("auth", {}) or {}), **_identity_headers()}
     timeout = int(peer.get("timeout", _DEFAULT_TIMEOUT))
 
     # Best-effort card fetch (to learn the rpc URL); non-fatal on failure.


### PR DESCRIPTION
## Problem
Outbound A2A requests to loopback/tailnet peers carry no asserted sender identity. Receiving pi peers therefore surface dispatches as `ip:127.0.0.1` in their audit log/wrapper instead of a readable peer name like `librarian-kimchi`, which makes cross-host dispatch provenance hard to read and audit.

## Fix
`_send_task` now merges an `X-A2A-Identity: '{profile}-{hostname}'` header (e.g. `librarian-kimchi`) built from the existing naming pieces (`_active_profile_name()` + short socket hostname) that the inbound server already uses. Best-effort: a failure to build the header never blocks a dispatch (returns `{}`). Asserted display provenance for loopback receivers — never authentication; no config, no token.

## Tests
- Local: cherry-picked onto current main; header present in adapter.py + tools.py.
- Live-verified fleet-side (2026-09-01): pi peers record `identity=librarian-kimchi` when hermes dispatches over loopback; cross-host tailnet dispatch recorded `identity=pi-kimchi`. This restores behavior that a local commit (usefulish) carried and that was dropped in a main reset — upstreaming so it survives future upgrades.