### PR TITLE
fix(compressor): restate the in-flight cron prompt after the compaction handoff (salvage #101170)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -6802,7 +6802,21 @@ This compaction should PRIORITISE preserving all information related to the focu
                 "handoff so it stays actionable (#100818)"
             )
 
-        if _template_visible_role(compressed[-1]) == "user":
+        # Alternation is judged on template-visible rows only: a tail of
+        # tool_calls/tool pairs is exempt, so a user-pinned summary followed by
+        # such a tail still "ends on user" for the Mistral-style pre-flight
+        # check (#58753). Look through the exempt tail, not just at [-1].
+        last_visible_role = next(
+            (
+                role
+                for role in (
+                    _template_visible_role(msg) for msg in reversed(compressed)
+                )
+                if role is not None
+            ),
+            None,
+        )
+        if last_visible_role == "user":
             carrier["content"] = _append_text_to_content(
                 carrier.get("content"),
                 "\n\n" + _INFLIGHT_TASK_REPLAY_HEADER + "\n" + task_text,

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -386,6 +386,21 @@ def _template_visible_role(message: Any) -> Optional[str]:
     return role
 
 
+def _last_template_visible_role(messages: List[Dict[str, Any]]) -> Optional[str]:
+    """Last role a strict alternation template would count in *messages*.
+
+    ``None`` when every row is template-exempt (tool flow only).
+    """
+    return next(
+        (
+            role
+            for role in (_template_visible_role(m) for m in reversed(messages))
+            if role is not None
+        ),
+        None,
+    )
+
+
 def _strip_persistence_markers(messages: List[Dict[str, Any]]) -> None:
     """Enforce the compaction invariant: no assembled message carries a
     session-store persistence marker.
@@ -6822,20 +6837,7 @@ This compaction should PRIORITISE preserving all information related to the focu
                 "handoff so it stays actionable (#100818)"
             )
 
-        # Alternation is judged on template-visible rows only: a tail of
-        # tool_calls/tool pairs is exempt, so a user-pinned summary followed by
-        # such a tail still "ends on user" for the Mistral-style pre-flight
-        # check (#58753). Look through the exempt tail, not just at [-1].
-        last_visible_role = next(
-            (
-                role
-                for role in (
-                    _template_visible_role(msg) for msg in reversed(compressed)
-                )
-                if role is not None
-            ),
-            None,
-        )
+        last_visible_role = _last_template_visible_role(compressed)
         if inflight.get(_INFLIGHT_REPLAY_MERGED_KEY):
             # Never copy a summary carrier (metadata would mark the replay
             # synthetic): restate as a plain user row.
@@ -8511,20 +8513,10 @@ This compaction should PRIORITISE preserving all information related to the focu
         # Jinja alternation 500, permanently poisoning the session.
         last_head_role: Optional[str] = "user"
         if compressed:
-            last_head_role = next(
-                (
-                    role
-                    for role in (
-                        _template_visible_role(m) for m in reversed(compressed)
-                    )
-                    if role is not None
-                ),
-                # Head holds only template-exempt messages: the summary will
-                # be the first message the template counts, and the sequence
-                # must open with "user" (handled below alongside the forced
-                # cases).
-                None,
-            )
+            # None: head holds only template-exempt messages, so the summary
+            # will be the first message the template counts and the sequence
+            # must open with "user" (handled below alongside the forced cases).
+            last_head_role = _last_template_visible_role(compressed)
         first_tail_role = None
         first_tail_visible_idx: Optional[int] = None
         if tail_messages:

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -521,6 +521,16 @@ _SUMMARY_END_MARKER = (
 _MERGED_PRIOR_CONTEXT_HEADER = "[PRIOR CONTEXT — for reference only; not a new message]"
 _MERGED_SUMMARY_DELIMITER = "[END OF PRIOR CONTEXT — COMPACTION SUMMARY BELOW]"
 
+# Prefixes the copy of a still-running user task that compaction re-states after
+# the handoff boundary (#100818). A cron run's only user turn is the job prompt
+# in the protected head, so compaction leaves it BEFORE the summary — and
+# SUMMARY_PREFIX tells the model to do nothing when no user message follows.
+_INFLIGHT_TASK_REPLAY_HEADER = (
+    "[STILL IN PROGRESS — this is the active request, restated after the "
+    "compaction boundary because it was not finished yet. Continue it; do not "
+    "start over.]"
+)
+
 _SALVAGE_SUMMARY_MAX_CHARS = 8_000
 _SALVAGE_KEEP_RECENT_TOOLS = 2
 
@@ -6688,6 +6698,129 @@ This compaction should PRIORITISE preserving all information related to the focu
             return max(pair_end, head_end + 1)
         return adjusted
 
+    @classmethod
+    def _find_inflight_user_task(
+        cls, messages: List[Dict[str, Any]]
+    ) -> Optional[Dict[str, Any]]:
+        """Return the user turn that is still awaiting completion, or ``None``.
+
+        Scans the WHOLE transcript, not just the compressible region: a cron
+        run's only user turn is the job prompt sitting in the protected head
+        (``protect_first_n`` keeps system + first user), which is exactly the
+        turn ``_find_last_user_message_idx`` cannot see (#100818).
+
+        A turn is in-flight when the transcript does not already end with a
+        completed assistant reply — i.e. a text-bearing assistant message with
+        no pending ``tool_calls``.  A trailing ``tool`` result or an assistant
+        message that still has ``tool_calls`` outstanding means the run was
+        interrupted mid-task and the instruction is still owed an answer.
+
+        Handoff carriers and synthetic scaffolding rows are excluded via the
+        same filter pair as ``_find_last_user_message_idx``, so an idle session
+        whose only user-role row is an inherited summary yields ``None`` and is
+        never re-animated (#80622).
+        """
+        last_user_idx = -1
+        for i in range(len(messages) - 1, -1, -1):
+            msg = messages[i]
+            if cls._is_actionable_user_turn(
+                msg
+            ) and not cls._is_synthetic_compression_user_turn(msg):
+                last_user_idx = i
+                break
+        if last_user_idx < 0:
+            return None
+
+        for msg in reversed(messages[last_user_idx + 1:]):
+            if not isinstance(msg, dict) or msg.get("role") != "assistant":
+                # Trailing tool result (or anything else): still mid-task.
+                break
+            if msg.get("tool_calls"):
+                break
+            if _content_text_for_contains(msg.get("content")).strip():
+                # Final answer already delivered — replaying the ask would
+                # hand the model finished work as a fresh instruction.
+                return None
+            # Empty assistant row (a bare reasoning/stub turn): keep looking.
+        return messages[last_user_idx]
+
+    def _reappend_inflight_user_task(
+        self,
+        compressed: List[Dict[str, Any]],
+        inflight: Optional[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Restate an unfinished user task after the compaction handoff.
+
+        ``SUMMARY_PREFIX`` instructs the model to act only on a user message
+        that appears AFTER the summary, and to do nothing when none does.  When
+        the single in-flight instruction lived in the protected head, the
+        assembled transcript orders it before the handoff and the run ends in a
+        ``[SILENT]`` no-op that the scheduler records as success (#100818).
+
+        Re-append a copy of that turn after the surviving tail so the prefix's
+        "latest user message" pointer resolves to it again.  If the transcript
+        already ends on a template-visible user row, appending a second one
+        would break user/assistant alternation, so the restatement is merged
+        onto the handoff carrier instead — after ``_SUMMARY_END_MARKER``, which
+        is the boundary the prefix's rule is written against.
+        """
+        if inflight is None or not compressed:
+            return compressed
+
+        carrier_idx = -1
+        for idx in range(len(compressed) - 1, -1, -1):
+            if self._is_context_summary_message(compressed[idx]):
+                carrier_idx = idx
+                break
+        if carrier_idx < 0:
+            # No handoff was emitted — nothing reordered the instruction.
+            return compressed
+
+        for msg in compressed[carrier_idx + 1:]:
+            if self._is_actionable_user_turn(
+                msg
+            ) and not self._is_synthetic_compression_user_turn(msg):
+                # A real request already follows the summary.
+                return compressed
+
+        carrier = compressed[carrier_idx]
+        carrier_text = _content_text_for_contains(carrier.get("content"))
+        if _SUMMARY_END_MARKER not in carrier_text:
+            return compressed
+        if carrier_text.split(_SUMMARY_END_MARKER, 1)[1].strip():
+            # The _force_user_leading layout keeps the live request on the
+            # carrier itself, after the marker. Already actionable.
+            return compressed
+
+        task_text = _content_text_for_contains(inflight.get("content")).strip()
+        if not task_text:
+            return compressed
+
+        if not self.quiet_mode:
+            logger.info(
+                "Re-appending the in-flight user task after the compaction "
+                "handoff so it stays actionable (#100818)"
+            )
+
+        if _template_visible_role(compressed[-1]) == "user":
+            carrier["content"] = _append_text_to_content(
+                carrier.get("content"),
+                "\n\n" + _INFLIGHT_TASK_REPLAY_HEADER + "\n" + task_text,
+            )
+            drop_stale_api_content(carrier)
+            return compressed
+
+        replay = _fresh_compaction_message_copy(inflight)
+        replay.pop(_COMPACTION_TAIL_MARKER, None)
+        replay["content"] = _append_text_to_content(
+            replay.get("content"),
+            _INFLIGHT_TASK_REPLAY_HEADER + "\n",
+            prepend=True,
+        )
+        drop_stale_api_content(replay)
+        compressed.append(replay)
+        return compressed
+
     def _ensure_last_n_user_messages_in_tail(
         self,
         messages: List[Dict[str, Any]],
@@ -8523,6 +8656,14 @@ This compaction should PRIORITISE preserving all information related to the focu
                 drop_stale_api_content(msg)
                 _merge_summary_into_tail = False
             compressed.append(msg)
+
+        # The assembled list can order the only live instruction BEFORE the
+        # handoff (single-prompt cron shape: the job prompt is pinned in the
+        # protected head). SUMMARY_PREFIX reads that as "no user message after
+        # the summary → do nothing", so restate it past the boundary (#100818).
+        compressed = self._reappend_inflight_user_task(
+            compressed, self._find_inflight_user_task(messages)
+        )
 
         self.compression_count += 1
 

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -525,6 +525,12 @@ _MERGED_SUMMARY_DELIMITER = "[END OF PRIOR CONTEXT — COMPACTION SUMMARY BELOW]
 # the handoff boundary (#100818). A cron run's only user turn is the job prompt
 # in the protected head, so compaction leaves it BEFORE the summary — and
 # SUMMARY_PREFIX tells the model to do nothing when no user message follows.
+# Set on a compaction carrier when the in-flight task was merged onto it (the
+# carrier ends the list, so a standalone user row would break alternation).
+# conversation_compression._ensure_compressed_has_user_turn treats it as
+# "intent present" so it does not insert a second copy of the same request.
+_INFLIGHT_REPLAY_MERGED_KEY = "_inflight_replay_merged"
+
 _INFLIGHT_TASK_REPLAY_HEADER = (
     "[STILL IN PROGRESS — this is the active request, restated after the "
     "compaction boundary because it was not finished yet. Continue it; do not "
@@ -6720,12 +6726,20 @@ This compaction should PRIORITISE preserving all information related to the focu
         whose only user-role row is an inherited summary yields ``None`` and is
         never re-animated (#80622).
         """
+        from agent.conversation_compression import _is_real_user_message
+
         last_user_idx = -1
         for i in range(len(messages) - 1, -1, -1):
             msg = messages[i]
-            if cls._is_actionable_user_turn(
-                msg
-            ) and not cls._is_synthetic_compression_user_turn(msg):
+            # _is_real_user_message also rejects metadata-flagged scaffolding
+            # (_todo_snapshot_synthetic, recovery nudges, ...) that
+            # _is_actionable_user_turn cannot see.
+            if cls._is_actionable_user_turn(msg) and _is_real_user_message(msg):
+                last_user_idx = i
+                break
+            if isinstance(msg, dict) and msg.get(_INFLIGHT_REPLAY_MERGED_KEY):
+                # A previous cycle merged the live request onto this summary
+                # carrier; it is the only copy left, so it is still the task.
                 last_user_idx = i
                 break
         if last_user_idx < 0:
@@ -6793,6 +6807,12 @@ This compaction should PRIORITISE preserving all information related to the focu
             return compressed
 
         task_text = _content_text_for_contains(inflight.get("content")).strip()
+        if _INFLIGHT_TASK_REPLAY_HEADER in task_text:
+            # Already a restatement from an earlier compaction (standalone row
+            # or merged onto a carrier): take the text after the header so a
+            # task that survives >1 cycle never stacks headers or drags the
+            # old summary along.
+            task_text = task_text.rsplit(_INFLIGHT_TASK_REPLAY_HEADER, 1)[1].strip()
         if not task_text:
             return compressed
 
@@ -6816,22 +6836,42 @@ This compaction should PRIORITISE preserving all information related to the focu
             ),
             None,
         )
+        if inflight.get(_INFLIGHT_REPLAY_MERGED_KEY):
+            # Never copy a summary carrier (metadata would mark the replay
+            # synthetic): restate as a plain user row.
+            replay = {"role": "user", "content": task_text}
+        else:
+            replay = _fresh_compaction_message_copy(inflight)
+        replay.pop(_COMPACTION_TAIL_MARKER, None)
+        if isinstance(replay.get("content"), str):
+            # Plain text: rebuild from the header-stripped task text so a
+            # task surviving several compactions never stacks headers.
+            replay["content"] = _INFLIGHT_TASK_REPLAY_HEADER + "\n" + task_text
+        else:
+            # Multimodal parts: keep them, prepend the header text part.
+            replay["content"] = _append_text_to_content(
+                replay.get("content"),
+                _INFLIGHT_TASK_REPLAY_HEADER + "\n",
+                prepend=True,
+            )
+        drop_stale_api_content(replay)
+
         if last_visible_role == "user":
+            # Alternation is judged on template-visible rows only (tool_calls /
+            # tool rows are exempt), so a user-pinned summary followed by a
+            # tool tail still "ends on user": a standalone user row would break
+            # the Mistral-style pre-flight check (#58753). Merge onto the
+            # carrier instead and flag it — the carrier's own metadata marks it
+            # synthetic, and without the flag _ensure_compressed_has_user_turn
+            # would insert a second copy of the same request.
             carrier["content"] = _append_text_to_content(
                 carrier.get("content"),
                 "\n\n" + _INFLIGHT_TASK_REPLAY_HEADER + "\n" + task_text,
             )
+            carrier[_INFLIGHT_REPLAY_MERGED_KEY] = True
             drop_stale_api_content(carrier)
             return compressed
 
-        replay = _fresh_compaction_message_copy(inflight)
-        replay.pop(_COMPACTION_TAIL_MARKER, None)
-        replay["content"] = _append_text_to_content(
-            replay.get("content"),
-            _INFLIGHT_TASK_REPLAY_HEADER + "\n",
-            prepend=True,
-        )
-        drop_stale_api_content(replay)
         compressed.append(replay)
         return compressed
 
@@ -8675,13 +8715,16 @@ This compaction should PRIORITISE preserving all information related to the focu
         # handoff (single-prompt cron shape: the job prompt is pinned in the
         # protected head). SUMMARY_PREFIX reads that as "no user message after
         # the summary → do nothing", so restate it past the boundary (#100818).
+        # Run BEFORE the in-flight re-append: the sanitizer's trailing-in-flight
+        # exemption (#79278) walks back from the list end, and a replay user row
+        # sitting there would make a genuinely pending assistant(tool_calls) look
+        # orphaned and get its calls stripped.
+        compressed = self._sanitize_tool_pairs(compressed)
         compressed = self._reappend_inflight_user_task(
             compressed, self._find_inflight_user_task(messages)
         )
 
         self.compression_count += 1
-
-        compressed = self._sanitize_tool_pairs(compressed)
 
         # Replace image parts in all compressed messages before the newest
         # image-bearing user turn with a short text placeholder. Without

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -3168,6 +3168,15 @@ def _ensure_compressed_has_user_turn(
         return "already_present"
     if _compressed_has_busy_steer(compressed):
         return "already_present"
+    from agent.context_compressor import _INFLIGHT_REPLAY_MERGED_KEY
+
+    if any(
+        isinstance(message, dict) and message.get(_INFLIGHT_REPLAY_MERGED_KEY)
+        for message in compressed
+    ):
+        # The in-flight request was restated onto the summary carrier
+        # (#100818); inserting an anchor would duplicate it.
+        return "already_present"
     from agent.context_compressor import (
         COMPRESSION_CONTINUATION_USER_CONTENT,
         _fresh_compaction_message_copy,

--- a/tests/agent/test_cron_inflight_prompt_reappend_100818.py
+++ b/tests/agent/test_cron_inflight_prompt_reappend_100818.py
@@ -1,0 +1,214 @@
+"""Regression coverage for #100818: compaction of a single-prompt session
+(the cron shape) must not leave the model with nothing to obey.
+
+A cron run is one user message — the job prompt — followed by nothing but
+assistant/tool turns. When ContextCompressor fires mid-run, that prompt is
+folded into the handoff summary and no user message survives *after* it.
+SUMMARY_PREFIX then reads literally:
+
+    If no user message appears AFTER this summary, do nothing.
+
+so the model correctly does nothing, the scheduler sees the ``[SILENT]``
+sentinel, and records ``last_status: ok`` — a silent failure.
+
+The fix re-appends the in-flight user task after the handoff so the prefix's
+"latest user message" pointer resolves to the job prompt again. The
+#80622 contract is unchanged: an idle session with no in-flight task must
+still be left with nothing to act on.
+"""
+
+from typing import Any, Dict, List
+from unittest.mock import MagicMock, patch
+
+from agent.context_compressor import (
+    _SUMMARY_END_MARKER,
+    SUMMARY_PREFIX,
+    ContextCompressor,
+)
+
+
+JOB_SENTINEL = "CRON_JOB_PROMPT_sentinel_brief_the_inbox_and_write_a_digest"
+
+
+def _make_compressor() -> ContextCompressor:
+    with patch(
+        "agent.context_compressor.get_model_context_length", return_value=100_000
+    ):
+        compressor = ContextCompressor(
+            model="test",
+            quiet_mode=True,
+            protect_first_n=2,
+            protect_last_n=2,
+        )
+    compressor.tail_token_budget = 500
+    return compressor
+
+
+def _tool_pairs(count: int, start: int = 0) -> List[Dict[str, Any]]:
+    """``count`` assistant(tool_calls) + tool result pairs."""
+    turns: List[Dict[str, Any]] = []
+    for i in range(start, start + count):
+        turns.append(
+            {
+                "role": "assistant",
+                "content": f"step {i}",
+                "tool_calls": [
+                    {"id": f"c{i}", "function": {"name": "terminal", "arguments": "{}"}}
+                ],
+            }
+        )
+        turns.append(
+            {
+                "role": "tool",
+                "tool_call_id": f"c{i}",
+                "content": ("tool output " * 200) + f" {i}",
+            }
+        )
+    return turns
+
+
+def _cron_transcript() -> List[Dict[str, Any]]:
+    """system + one user job prompt + many tool turns, NO trailing user."""
+    return [
+        {
+            "role": "system",
+            "content": "You are Hermes. Cron preamble: if nothing to report, "
+            "return [SILENT].",
+        },
+        {"role": "user", "content": JOB_SENTINEL},
+        *_tool_pairs(40),
+    ]
+
+
+def _compress(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.content = (
+        "## Historical Task Snapshot\nUser asked: '" + JOB_SENTINEL + "'\n"
+        "## Summary\nRan a bunch of terminal steps."
+    )
+    compressor = _make_compressor()
+    with patch("agent.context_compressor.call_llm", return_value=response):
+        return compressor.compress(messages, current_tokens=200_000, force=True)
+
+
+def _handoff_idx(compressed: List[Dict[str, Any]]) -> int:
+    """Index of the handoff row (standalone summary or merged carrier)."""
+    for idx in range(len(compressed) - 1, -1, -1):
+        content = compressed[idx].get("content")
+        text = content if isinstance(content, str) else str(content)
+        if SUMMARY_PREFIX[:60] in text or _SUMMARY_END_MARKER in text:
+            return idx
+    return -1
+
+
+def _text(message: Dict[str, Any]) -> str:
+    content = message.get("content")
+    return content if isinstance(content, str) else str(content)
+
+
+def _actionable_user_rows(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    return [
+        m
+        for m in rows
+        if ContextCompressor._is_actionable_user_turn(m)
+        and not ContextCompressor._is_synthetic_compression_user_turn(m)
+    ]
+
+
+def test_cron_job_prompt_survives_after_the_handoff():
+    """The in-flight job prompt must be readable AFTER the summary boundary."""
+    compressed = _compress(_cron_transcript())
+
+    idx = _handoff_idx(compressed)
+    assert idx >= 0, "expected a compaction handoff in the compressed transcript"
+
+    after = compressed[idx + 1:]
+    # The re-append may also land inside the handoff carrier itself, after the
+    # end marker (the alternation-safe merge layout) — accept either shape.
+    carrier_tail = _text(compressed[idx]).split(_SUMMARY_END_MARKER)[-1]
+
+    job_after_summary = any(
+        JOB_SENTINEL in _text(m) for m in _actionable_user_rows(after)
+    ) or (JOB_SENTINEL in carrier_tail)
+    assert job_after_summary, (
+        "the in-flight cron job prompt must appear in a user message AFTER the "
+        "handoff summary — SUMMARY_PREFIX orders the model to do nothing "
+        "otherwise (#100818)"
+    )
+
+
+def test_model_is_not_left_without_a_user_message_after_the_handoff():
+    """The 'no user message after this summary → do nothing' branch of
+    SUMMARY_PREFIX must not be what a mid-run cron compaction produces."""
+    compressed = _compress(_cron_transcript())
+
+    idx = _handoff_idx(compressed)
+    after = compressed[idx + 1:]
+    has_user_after = bool(_actionable_user_rows(after)) or bool(
+        _text(compressed[idx]).split(_SUMMARY_END_MARKER)[-1].strip()
+    )
+    assert has_user_after, (
+        "compaction left no user message after the handoff; the model is "
+        "instructed to do nothing and the cron run fails silently"
+    )
+
+
+def test_role_alternation_and_head_are_preserved():
+    """The re-append must not create two same-role rows in a row, and must
+    not disturb the cached head prefix."""
+    messages = _cron_transcript()
+    compressed = _compress([dict(m) for m in messages])
+
+    assert compressed[0]["role"] == "system"
+    visible = [
+        m.get("role")
+        for m in compressed
+        if not (
+            m.get("role") == "tool"
+            or (m.get("role") == "assistant" and m.get("tool_calls"))
+        )
+    ]
+    for previous, current in zip(visible, visible[1:]):
+        assert not (previous == current == "user"), (
+            f"consecutive user rows in compressed transcript: {visible}"
+        )
+
+
+def test_idle_session_without_inflight_task_is_not_reanimated():
+    """#80622 must hold: a session whose only user-role row is an inherited
+    handoff has no in-flight task, so compaction must not manufacture one."""
+    messages: List[Dict[str, Any]] = [
+        {"role": "system", "content": "You are Hermes."},
+        {
+            "role": "user",
+            "content": (
+                SUMMARY_PREFIX
+                + "\n## Historical Task Snapshot\nUser asked: 'a finished task'\n\n"
+                + _SUMMARY_END_MARKER
+            ),
+        },
+        *_tool_pairs(40),
+    ]
+    compressed = _compress(messages)
+
+    assert not _actionable_user_rows(compressed), (
+        "no real user turn existed before compaction — none may be invented"
+    )
+
+
+def test_completed_exchange_is_not_replayed():
+    """Only an in-flight task is re-appended. A turn that already produced a
+    final assistant reply must not be handed back to the model as a fresh
+    instruction."""
+    messages = [
+        *_cron_transcript(),
+        {"role": "assistant", "content": "Digest written. Nothing else to do."},
+    ]
+    compressed = _compress(messages)
+
+    idx = _handoff_idx(compressed)
+    after = compressed[idx + 1:]
+    assert not any(
+        JOB_SENTINEL in _text(m) for m in _actionable_user_rows(after)
+    ), "a completed exchange must not be re-appended as a new user instruction"

--- a/tests/agent/test_cron_inflight_prompt_reappend_100818.py
+++ b/tests/agent/test_cron_inflight_prompt_reappend_100818.py
@@ -212,3 +212,122 @@ def test_completed_exchange_is_not_replayed():
     assert not any(
         JOB_SENTINEL in _text(m) for m in _actionable_user_rows(after)
     ), "a completed exchange must not be re-appended as a new user instruction"
+
+
+# ---------------------------------------------------------------------------
+# Follow-up coverage (salvage of #101170)
+# ---------------------------------------------------------------------------
+
+
+def _pending_tail_transcript() -> List[Dict[str, Any]]:
+    """Cron shape whose LAST row is an assistant tool_calls turn still awaiting
+    its result — compaction fired inside the tool-execution window."""
+    msgs = _cron_transcript()
+    msgs.append(
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "pending", "function": {"name": "terminal", "arguments": "{}"}}
+            ],
+        }
+    )
+    return msgs
+
+
+def test_pending_trailing_tool_call_survives_the_replay():
+    """The replay row must not make a genuinely in-flight tool_call look
+    orphaned: _sanitize_tool_pairs runs before the re-append, so the trailing
+    assistant(tool_calls) keeps its calls and the late tool result still pairs."""
+    out = _compress(_pending_tail_transcript())
+    pending = [
+        m
+        for m in out
+        if m.get("role") == "assistant"
+        and any(tc.get("id") == "pending" for tc in (m.get("tool_calls") or []))
+    ]
+    assert pending, "trailing in-flight tool_calls were stripped"
+    replay_idx = max(
+        i for i, m in enumerate(out)
+        if m.get("role") == "user" and JOB_SENTINEL in str(m.get("content"))
+    )
+    assert replay_idx > out.index(pending[0])
+
+
+def _compress_with(protect_first_n: int, compression_count: int, messages):
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.content = SUMMARY_PREFIX + "\n## Summary\nran steps."
+    with patch(
+        "agent.context_compressor.get_model_context_length", return_value=100_000
+    ):
+        compressor = ContextCompressor(
+            model="test",
+            quiet_mode=True,
+            protect_first_n=protect_first_n,
+            protect_last_n=2,
+        )
+    compressor.tail_token_budget = 500
+    compressor.compression_count = compression_count
+    with patch.object(
+        compressor, "_generate_summary", return_value=response.choices[0].message.content
+    ):
+        return compressor.compress(messages, current_tokens=90_000)
+
+
+def _job_copies(messages) -> int:
+    return sum(
+        str(m.get("content")).count(JOB_SENTINEL)
+        for m in messages
+        if m.get("role") == "user"
+    )
+
+
+def test_merged_restatement_is_not_anchored_twice():
+    """Later cycle: protect_first_n has decayed, the prompt is summarised away
+    and the summary is pinned to role=user followed by an exempt tool tail, so
+    the restatement is MERGED onto the carrier. The later
+    _ensure_compressed_has_user_turn pass must see intent as present instead
+    of inserting a second copy of the job prompt."""
+    from agent.conversation_compression import _ensure_compressed_has_user_turn
+
+    original = [{"role": "user", "content": JOB_SENTINEL}, *_tool_pairs(40)]
+    out = _compress_with(2, 1, original)
+    assert any(m.get("_inflight_replay_merged") for m in out), "expected merge layout"
+    assert _job_copies(out) == 1
+    assert _ensure_compressed_has_user_turn(original, out) == "already_present"
+    assert _job_copies(out) == 1
+
+
+def test_restatement_survives_repeated_compactions_without_stacking():
+    """A task alive across three compactions is restated exactly once per
+    output — one copy, one header, always after the summary."""
+    from agent.context_compressor import _INFLIGHT_TASK_REPLAY_HEADER
+
+    out = [{"role": "user", "content": JOB_SENTINEL}, *_tool_pairs(40)]
+    for cycle in (1, 2, 3):
+        extra = _tool_pairs(40, start=100 * cycle) if cycle > 1 else []
+        out = _compress_with(2, cycle, out + extra)
+        users = [m for m in out if m.get("role") == "user"]
+        assert _job_copies(out) == 1, cycle
+        assert max(
+            str(m.get("content")).count(_INFLIGHT_TASK_REPLAY_HEADER) for m in users
+        ) == 1, cycle
+        last = str(users[-1].get("content"))
+        assert last.rfind(JOB_SENTINEL) > last.rfind(_SUMMARY_END_MARKER), cycle
+
+
+def test_flagged_scaffolding_row_is_never_the_inflight_task():
+    """A trailing user-role scaffolding row flagged synthetic (todo snapshot)
+    must not be mistaken for the live request and replayed as an instruction."""
+    msgs = _cron_transcript()
+    msgs.append(
+        {
+            "role": "user",
+            "content": "[Your active task list was preserved across context compression]\n- x",
+            "_todo_snapshot_synthetic": True,
+        }
+    )
+    found = ContextCompressor._find_inflight_user_task(msgs)
+    assert found is not None
+    assert JOB_SENTINEL in str(found.get("content"))


### PR DESCRIPTION
## Summary
A cron job whose only user turn sits in the protected head no longer ends in `[SILENT]` after its first compaction: the in-flight task is restated after the handoff so `SUMMARY_PREFIX`'s "latest user message" points at it again.

Salvage of #101170 by @jwilson411 (cherry-picked, authorship preserved) + follow-up commits.

Refs #100818 (closed against v2026.8.31; the reporter's follow-up comment describes exactly the first-compaction / protected-head shape this fixes — `_ensure_compressed_has_user_turn` returns `already_present` because the prompt survives *before* the summary, so nothing is inserted after it). The contributor's test fails on `origin/main` (2 failed) and passes here.

## Who hits this
Any cron job (or single-prompt session) long enough to compact once. `protect_first_n` keeps the job prompt verbatim before the summary, the prefix reads "if no user message appears AFTER this summary, do nothing", the model obeys, the scheduler records `last_status: ok`. Silent failure; retriggers every run.

## Changes
- `agent/context_compressor.py`: `_find_inflight_user_task` (scans the whole transcript for the last real user turn still awaiting a final assistant reply) + `_reappend_inflight_user_task` (restates it after the handoff; merges onto a user-pinned carrier when appending would break alternation).
- Follow-ups (each covered by a test that fails with it reverted):
  - `_sanitize_tool_pairs` now runs *before* the re-append — with the replay row ending the list, a genuinely pending trailing `assistant(tool_calls)` looked orphaned and had its calls stripped.
  - Merge layout flags the carrier (`_inflight_replay_merged`); `_ensure_compressed_has_user_turn` treats it as intent-present instead of inserting a second copy, and the next cycle recognises the carrier as the live task.
  - Header idempotency across cycles (one header, one copy after 3 compactions).
  - The merge-vs-append decision looks through template-exempt tool rows to the last template-visible role (fixes `test_zero_user_guard_still_forces_user`).
  - `_is_real_user_message` used for the scan so flagged scaffolding (todo snapshot, recovery nudges) is never replayed as the task.
  - Shared `_last_template_visible_role` helper (dedupes the summary-role scan).

## Validation
| Check | Result |
|---|---|
| `test_cron_inflight_prompt_reappend_100818.py` (9) + alternation / stale-active-task / summary-prefix / zero-user-provenance / tail-anchor suites | 56 passed |
| Contributor test on `origin/main` | 2 failed (bug reproduced) |
| `tests/agent -k "compress or compaction or summary"` main vs branch | identical failure set (17 pre-existing on this host, order-dependent flakes both sides) |
| 3-cycle probe (protect_first_n decayed) | 1 copy, 1 header, task after summary, anchor `already_present` each cycle |
| ruff / ty | clean / 6→6, 3→3 |
