### PR TITLE
fix(state): restore journal mode inside the repair guard, never reopen after release (salvage #101085)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3726,11 +3726,13 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
                 # database.journal_mode setting is the restore target.
                 before_mode = _probe_journal_mode_for_repair(db_path)
                 result = _repair_state_db_schema_locked(
-                    db_path, backup=backup, report=report
+                    db_path,
+                    backup=backup,
+                    report=report,
+                    journal_mode_before=before_mode,
                 )
                 if result.get("repaired"):
                     result["journal_mode_before"] = before_mode
-                    _restore_journal_mode_after_repair(db_path, before_mode)
             # Environmental aborts happen before a strategy gets to mutate the
             # isolated snapshot. They are retriable operating conditions, not
             # proof that the damaged database exhausted a repair strategy.
@@ -3766,7 +3768,9 @@ def _probe_journal_mode_for_repair(db_path: Path) -> Optional[str]:
         return None
 
 
-def _restore_journal_mode_after_repair(db_path: Path, before_mode: Optional[str]) -> None:
+def _restore_journal_mode_after_repair(
+    db_path: Path, before_mode: Optional[str], *, conn=None
+) -> None:
     """Re-apply the journal mode after schema surgery (#89674).
 
     A repaired/rebuilt SQLite file comes back in the default journal mode
@@ -3791,12 +3795,15 @@ def _restore_journal_mode_after_repair(db_path: Path, before_mode: Optional[str]
     Best-effort by design: the repair itself already succeeded, so failures
     to re-apply are logged at WARNING, never raised.
     """
+    owned_conn = conn is None
     try:
-        conn = _connect_repair_durable(db_path)
+        if owned_conn:
+            conn = _connect_repair_durable(db_path)
         try:
             after = apply_wal_with_fallback(conn, db_label=db_path.name)
         finally:
-            conn.close()
+            if owned_conn:
+                conn.close()
         if before_mode and after != before_mode:
             logger.warning(
                 "state.db repair changed journal_mode %r -> %r "
@@ -3814,7 +3821,11 @@ def _restore_journal_mode_after_repair(db_path: Path, before_mode: Optional[str]
 
 
 def _repair_state_db_schema_locked(
-    db_path: Path, *, backup: bool, report: Dict[str, Any]
+    db_path: Path,
+    *,
+    backup: bool,
+    report: Dict[str, Any],
+    journal_mode_before: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Repair strategies for :func:`repair_state_db_schema`.
 
@@ -3955,6 +3966,11 @@ def _repair_state_db_schema_locked(
                         "state.db repaired via '%s' and promoted transactionally: %s",
                         report.get("strategy"),
                         db_path,
+                    )
+                    _restore_journal_mode_after_repair(
+                        db_path,
+                        journal_mode_before,
+                        conn=live_guard,
                     )
             if not report.get("repaired"):
                 # Logged HERE, not inside the strategies: they run against the

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3780,6 +3780,14 @@ def _restore_journal_mode_after_repair(
     inside the repair path, not at open (the open-time flip #89393 warns
     about is a different door).
 
+    ``conn`` must be the exclusive repair guard connection when called from
+    the repair path (#101064): opening a fresh connection AFTER the guard
+    released let a writer still holding the unlinked old ``-wal`` inode
+    coexist with a brand-new ``state.db-wal`` this connection created — two
+    generations of one store. The transactional promotion already leaves the
+    destination in its pre-repair mode, so on that path this is mostly the
+    WAL-companion re-assertion; the reopen is the hazard, not the mode.
+
     The restore runs through :func:`apply_wal_with_fallback` — the canonical
     journal-mode path — rather than issuing a switch pragma directly, so it
     inherits the vulnerable-SQLite WAL-reset gate (a rebuilt file IS a new

--- a/tests/state/test_state_db_wal_unlink_race.py
+++ b/tests/state/test_state_db_wal_unlink_race.py
@@ -1,0 +1,29 @@
+"""Regression coverage for WAL restoration during state.db repair."""
+
+import sqlite3
+
+import pytest
+
+import hermes_state
+
+
+def test_wal_restoration_reuses_exclusive_repair_connection(tmp_path, monkeypatch):
+    """WAL must be restored before the repair guard releases the live DB."""
+    db_path = tmp_path / "state.db"
+    conn = sqlite3.connect(db_path, isolation_level=None)
+    conn.execute("CREATE TABLE marker (value TEXT)")
+    conn.execute("PRAGMA journal_mode=DELETE")
+
+    def fail_if_reopened(_path):
+        pytest.fail("WAL restoration reopened state.db outside the repair guard")
+
+    monkeypatch.setattr(hermes_state, "_connect_repair_durable", fail_if_reopened)
+
+    hermes_state._restore_journal_mode_after_repair(
+        db_path,
+        "delete",
+        conn=conn,
+    )
+
+    assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+    conn.close()

--- a/tests/state/test_state_db_wal_unlink_race.py
+++ b/tests/state/test_state_db_wal_unlink_race.py
@@ -1,36 +1,84 @@
-"""Regression coverage for WAL restoration during state.db repair."""
+"""Regression coverage for WAL restoration during state.db repair (#101064).
+
+Journal-mode restoration used to open a NEW connection after the exclusive
+repair guard had released the live database. In WAL mode a writer could still
+hold the unlinked old WAL inode while that second connection created a fresh
+``state.db-wal`` path — two generations of one store. The restore must run
+through the guard connection, before the guard releases.
+"""
 
 import sqlite3
 
 import pytest
 
 import hermes_state
+from hermes_state import repair_state_db_schema
 
 
-@pytest.mark.requires_wal
+def _make_db(path):
+    conn = sqlite3.connect(str(path), isolation_level=None)
+    conn.execute("CREATE TABLE sessions (name TEXT)")
+    conn.execute("INSERT INTO sessions VALUES ('seed')")
+    conn.close()
+
+
 def test_wal_restoration_reuses_exclusive_repair_connection(tmp_path, monkeypatch):
-    """WAL must be restored before the repair guard releases the live DB.
-
-    Gated on ``requires_wal``: where the linked SQLite carries the WAL-reset
-    bug (or the filesystem cannot host WAL) ``apply_wal_with_fallback`` keeps
-    the store in DELETE by design, so the final ``== "wal"`` assertion would
-    fail for a reason unrelated to the connection-reuse contract.
-    """
+    """Unit contract: given the guard connection, no reopen happens."""
     db_path = tmp_path / "state.db"
     conn = sqlite3.connect(db_path, isolation_level=None)
     conn.execute("CREATE TABLE marker (value TEXT)")
-    conn.execute("PRAGMA journal_mode=DELETE")
 
     def fail_if_reopened(_path):
         pytest.fail("WAL restoration reopened state.db outside the repair guard")
 
     monkeypatch.setattr(hermes_state, "_connect_repair_durable", fail_if_reopened)
 
-    hermes_state._restore_journal_mode_after_repair(
-        db_path,
-        "delete",
-        conn=conn,
-    )
-
-    assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+    hermes_state._restore_journal_mode_after_repair(db_path, None, conn=conn)
+    # The mode itself is whatever apply_wal_with_fallback resolves on this
+    # runtime (WAL, or DELETE on WAL-reset-vulnerable SQLite builds); the
+    # contract under test is the connection reuse, asserted above.
+    assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() in ("wal", "delete")
     conn.close()
+
+
+def test_repair_never_reopens_after_the_guard_releases(tmp_path, monkeypatch):
+    """End to end through repair_state_db_schema: every connection the repair
+    opens is opened while the exclusive guard is still held, and none after."""
+    db = tmp_path / "state.db"
+    _make_db(db)
+    monkeypatch.setattr(hermes_state, "_db_opens_cleanly", lambda path: "forced-unhealthy")
+    # The scratch-space pre-flight wants ~10GB headroom; irrelevant here.
+    monkeypatch.setattr(hermes_state, "_repair_scratch_space_error", lambda path: None)
+
+    def fake_strategies(scratch_path, report):
+        report["repaired"] = True
+        report["strategy"] = "test_strategy"
+        return report
+
+    monkeypatch.setattr(hermes_state, "_run_repair_strategies", fake_strategies)
+
+    events: list[str] = []
+    real_guard = hermes_state._exclusive_repair_db_guard
+    real_connect = hermes_state._connect_repair_durable
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def tracing_guard(path):
+        events.append("guard-enter")
+        with real_guard(path) as pair:
+            yield pair
+        events.append("guard-exit")
+
+    def tracing_connect(path, *a, **kw):
+        events.append("connect")
+        return real_connect(path, *a, **kw)
+
+    monkeypatch.setattr(hermes_state, "_exclusive_repair_db_guard", tracing_guard)
+    monkeypatch.setattr(hermes_state, "_connect_repair_durable", tracing_connect)
+
+    report = repair_state_db_schema(db, backup=False)
+    assert report["repaired"] is True
+    assert "guard-exit" in events
+    after_release = events[events.index("guard-exit") + 1 :]
+    assert "connect" not in after_release, events

--- a/tests/state/test_state_db_wal_unlink_race.py
+++ b/tests/state/test_state_db_wal_unlink_race.py
@@ -7,8 +7,15 @@ import pytest
 import hermes_state
 
 
+@pytest.mark.requires_wal
 def test_wal_restoration_reuses_exclusive_repair_connection(tmp_path, monkeypatch):
-    """WAL must be restored before the repair guard releases the live DB."""
+    """WAL must be restored before the repair guard releases the live DB.
+
+    Gated on ``requires_wal``: where the linked SQLite carries the WAL-reset
+    bug (or the filesystem cannot host WAL) ``apply_wal_with_fallback`` keeps
+    the store in DELETE by design, so the final ``== "wal"`` assertion would
+    fail for a reason unrelated to the connection-reuse contract.
+    """
     db_path = tmp_path / "state.db"
     conn = sqlite3.connect(db_path, isolation_level=None)
     conn.execute("CREATE TABLE marker (value TEXT)")


### PR DESCRIPTION
## Summary
`repair_state_db_schema` no longer reopens `state.db` after the exclusive repair guard has released: the journal-mode restore runs through the guard connection, so a writer still holding the unlinked old `-wal` inode can no longer coexist with a fresh `state.db-wal` a post-guard connection creates.

Salvage of #101085 by @JoaoMarcos44 (WAL commit cherry-picked, authorship preserved; the bundled Telegram preview commit was dropped — #98552 is closed via #100533) + two follow-up commits.

Refs #101064 (closed via #101221 / #101118, which cover the open-time and thread-pool sides; the post-guard reopen in the repair path was still on `origin/main`).

## Changes
- `hermes_state.py`: `_restore_journal_mode_after_repair(..., conn=live_guard)` is called inside `_repair_state_db_schema_locked` after promotion; the post-guard call in `repair_state_db_schema` is gone. Docstring names the actual hazard (the reopen), not just the legacy "rebuild resets to delete" framing.
- `tests/state/test_state_db_wal_unlink_race.py`: the contributor's unit check (connection reuse) plus an end-to-end test through `repair_state_db_schema` that traces every `_connect_repair_durable` against the guard's enter/exit and fails on main's shape. Runs on every platform — the first iteration's `== "wal"` assertion could only run on non-WAL-reset-vulnerable SQLite builds.

## Validation
| Check | Result |
|---|---|
| `test_state_db_wal_unlink_race.py` (2), `test_state_db_repair_live_writer_guard.py` | passed (Linux-only witnesses skip on macOS) |
| E2E test with the restore moved back after the guard (main's shape) | fails: `connect` recorded after `guard-exit` |
| `tests/test_state_db_repair_non_destructive.py` — 10 failures | pre-existing on `origin/main` on this host (repair pre-flight wants ~10 GB free), identical set |
| Empirical: `backup()` into an EXCLUSIVE-locking-mode guard preserves the destination's journal mode | WAL→WAL, DELETE→DELETE |
| ruff / ty | clean / 89→87 |
