### PR TITLE
fix(tui_gateway): carry the live session handle through in-place agent rebuilds

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -19364,6 +19364,70 @@ def test_reset_session_agent_clears_session_overrides(monkeypatch):
     assert session["agent"] is new_agent
 
 
+def test_reset_session_agent_carries_live_session_db(monkeypatch):
+    """/new (and the toolset/MCP-change rebuild that shares it) must keep
+    writing through the live agent's session handle: _make_agent falls back
+    to the module-level _get_db() singleton, i.e. the LAUNCH profile's shared
+    store, which silently persists a named profile's turns into the launch
+    profile's state.db (#101719)."""
+    captured = {}
+    new_agent = types.SimpleNamespace(model="openai/gpt-5.4", service_tier="")
+    live_db = object()
+    session = _session(agent=types.SimpleNamespace(_session_db=live_db))
+
+    def make_agent(*_args, **kwargs):
+        captured.update(kwargs)
+        return new_agent
+
+    monkeypatch.setattr(server, "_set_session_context", lambda _key: [])
+    monkeypatch.setattr(server, "_clear_session_context", lambda _tokens: None)
+    monkeypatch.setattr(server, "_make_agent", make_agent)
+    monkeypatch.setattr(server, "_config_model_target", lambda: ("", ""))
+    monkeypatch.setattr(server, "_load_show_reasoning", lambda: True)
+    monkeypatch.setattr(server, "_load_tool_progress_mode", lambda: "all")
+    monkeypatch.setattr(server, "_session_info", lambda *_args: {})
+    monkeypatch.setattr(server, "_emit", lambda *_args: None)
+    monkeypatch.setattr(server, "_restart_slash_worker", lambda *_args: None)
+
+    server._reset_session_agent("sid", session)
+
+    assert captured.get("session_db") is live_db
+
+
+def test_sync_bot_capabilities_carries_live_session_db(monkeypatch):
+    """A capability-surface rebuild swaps in a fresh agent for the same Bot
+    Chat; it must hand _make_agent the live agent's session handle so a named
+    profile's bot keeps persisting into its own state.db instead of the
+    launch profile's _get_db() singleton (#101719)."""
+    captured = {}
+    new_agent = types.SimpleNamespace()
+    live_db = object()
+    session = _session(
+        agent=types.SimpleNamespace(_session_title_hint="Bot Chat", _session_db=live_db),
+        profile_home="/profiles/named",
+        bot_caps_seen="old-fp",
+        cwd="/tmp",
+    )
+
+    def make_agent(*_args, **kwargs):
+        captured.update(kwargs)
+        return new_agent
+
+    import tools.bot_mode_probe as bot_mode_probe
+
+    monkeypatch.setattr(bot_mode_probe, "capability_fingerprint", lambda _home: "new-fp")
+    monkeypatch.setattr(server, "_set_session_context", lambda _sid, cwd=None: [])
+    monkeypatch.setattr(server, "_clear_session_context", lambda _tokens: None)
+    monkeypatch.setattr(server, "_make_agent", make_agent)
+    monkeypatch.setattr(server, "_config_model_target", lambda: ("", ""))
+    monkeypatch.setattr(server, "_emit", lambda *_args: None)
+
+    server._sync_bot_capabilities("sid", session)
+
+    assert captured.get("session_db") is live_db
+    assert session["agent"] is new_agent
+
+
 @pytest.mark.parametrize(
     "card,expected",
     [

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6814,6 +6814,10 @@ def _sync_bot_capabilities(sid: str, session: dict) -> None:
     # Capability surface changed — rebuild the agent in place. Same
     # session_id/key, so the DB-backed history and (epoch-refreshed) system
     # prompt carry over; only tool definitions and prompt bytes change.
+    # Keep the live agent's session handle: _make_agent falls back to the
+    # module-level _get_db() (the launch profile's store), which would
+    # silently persist this named profile's Bot Chat turns into the launch
+    # profile's state.db (#101719).
     try:
         tokens = _set_session_context(sid, cwd=_session_cwd(session))
         try:
@@ -6821,6 +6825,7 @@ def _sync_bot_capabilities(sid: str, session: dict) -> None:
                 sid,
                 session["session_key"],
                 session_id=session["session_key"],
+                session_db=getattr(agent, "_session_db", None),
                 platform_override=_session_source(session),
             )
         finally:
@@ -9010,10 +9015,15 @@ def _reset_session_agent(sid: str, session: dict) -> dict:
         session.pop("create_reasoning_override", None)
         session.pop("create_service_tier_override", None)
         session.pop("one_turn_model_restore", None)
+        # Reuse the live agent's session handle so a named profile's /new
+        # (and the toolset/MCP-change rebuild) keeps writing to that
+        # profile's store — _make_agent's _get_db() fallback is the launch
+        # profile's shared handle (#101719).
         new_agent = _make_agent(
             sid,
             session["session_key"],
             session_id=session["session_key"],
+            session_db=getattr(session.get("agent"), "_session_db", None),
             platform_override=_session_source(session),
             context_cwd_is_launch_artifact=(
                 _context_cwd_is_launch_artifact(session)


### PR DESCRIPTION
## What does this PR do?

Fixes a silent cross-profile persistence leak: the two in-place agent rebuild sites — `_sync_bot_capabilities` (Bot Chat capability-refresh) and `_reset_session_agent` (`/new` and the toolset/MCP-change rebuild) — called `_make_agent` without a `session_db`, so `_make_agent` fell back to the module-level `_get_db()` singleton, i.e. the **launch profile's** `state.db`. On a shared-primary topology, a named profile's Bot Chat would then start persisting its turns into the launch profile's store (rows stamped `source='desktop'`, `profile_name='<named profile>'`) after any capability-surface change, toolset/MCP edit, or `/new`, while the owner store received nothing.

The fix passes the live agent's `_session_db` handle through both rebuild sites — the same shape the normal build paths already use (`_start_agent_build` and the `session.resume` path open `_open_profile_session_db(profile_home)` and pass it; only these two in-place rebuild sites skipped it). `getattr(..., "_session_db", None)` also matches the existing access pattern in `_sync_bot_capabilities`'s title lookup, and `agent_init` pins `_owns_session_db = False` for caller-supplied handles, so reusing the live handle adds no close/lifecycle hazard.

## Related Issue

Fixes #101719

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py` — `_sync_bot_capabilities`: pass `session_db=getattr(agent, "_session_db", None)` into the capability-refresh rebuild.
- `tui_gateway/server.py` — `_reset_session_agent`: pass `session_db=getattr(session.get("agent"), "_session_db", None)` into the `/new` rebuild (also covers the `tui_gateway/methods_tools.py` toolset/MCP-change call site, which routes through this function).
- `tests/test_tui_gateway_server.py` — two regression tests asserting both rebuild sites forward the live agent's session handle instead of falling back to `_get_db()`.

## How to Test

1. `pytest tests/test_tui_gateway_server.py -k carries_live_session_db -q` → 2 passed.
2. `pytest tests/test_tui_gateway_server.py -q` → 639 passed (no regressions).
3. Red/green check: with the two `session_db=` lines reverted, both new tests fail (`session_db` absent from the captured `_make_agent` kwargs), proving they pin the regression.
4. Observed result: both rebuild paths now hand `_make_agent` the live agent's session handle, so a named profile's rebuilt Bot Chat keeps writing to that profile's `state.db` instead of the launch profile's `_get_db()` singleton.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A