### PR TITLE
fix(desktop): resolve locally-produced media without asking the remote gateway

### DIFF
--- a/apps/desktop/src/lib/media.remote.test.ts
+++ b/apps/desktop/src/lib/media.remote.test.ts
@@ -6,6 +6,7 @@ import {
   downloadGatewayMediaFile,
   filePathFromMediaPath,
   gatewayMediaDataUrl,
+  gatewayMediaDataUrlLocalFallback,
   isInlineMediaSrc,
   isRemoteGateway,
   mediaExternalUrl,
@@ -265,6 +266,90 @@ describe('downloadGatewayMediaFile', () => {
 
     await expect(downloadGatewayMediaFile('/Users/me/project/report.md')).rejects.toThrow(
       'Desktop file download bridge'
+    )
+  })
+
+  // A preview screenshot is written by THIS shell's Electron main process into
+  // userData/composer-images, never on the gateway. Fetching it from the
+  // gateway can only 404 ("missing, unreadable, or too large").
+  it('opens a locally produced artifact from this disk instead of the gateway', async () => {
+    const readFileDataUrl = vi.fn(async () => 'data:image/png;base64,bG9jYWw=')
+    const openExternal = vi.fn()
+
+    vi.stubGlobal('window', { hermesDesktop: { openExternal, readFileDataUrl, saveGatewayFile } })
+
+    await expect(
+      downloadGatewayMediaFile('/home/alex/.config/Hermes/composer-images/preview-shot_47a88d.png')
+    ).resolves.toEqual({
+      path: '/home/alex/.config/Hermes/composer-images/preview-shot_47a88d.png',
+      saved: true
+    })
+
+    expect(saveGatewayFile).not.toHaveBeenCalled()
+  })
+
+  it('still uses the gateway when the path is not on this disk', async () => {
+    const readFileDataUrl = vi.fn(async () => {
+      throw new Error('ENOENT')
+    })
+
+    vi.stubGlobal('window', { hermesDesktop: { readFileDataUrl, saveGatewayFile } })
+
+    await expect(downloadGatewayMediaFile('/srv/app/report.md')).resolves.toEqual({
+      path: '/Users/me/Downloads/report.md',
+      saved: true
+    })
+
+    expect(saveGatewayFile).toHaveBeenCalled()
+  })
+})
+
+describe('gatewayMediaDataUrlLocalFallback', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    $connection.set(null)
+  })
+
+  it('prefers the gateway when the file lives there', async () => {
+    const api = vi.fn(async () => ({ dataUrl: 'data:image/png;base64,cmVtb3Rl' }))
+    const readFileDataUrl = vi.fn(async () => 'data:image/png;base64,bG9jYWw=')
+
+    vi.stubGlobal('window', { hermesDesktop: { api, readFileDataUrl } })
+    $connection.set({ mode: 'remote' } as never)
+
+    await expect(gatewayMediaDataUrlLocalFallback('/srv/app/a.png')).resolves.toBe('data:image/png;base64,cmVtb3Rl')
+    expect(readFileDataUrl).not.toHaveBeenCalled()
+  })
+
+  it('falls back to this machine for shell-produced screenshots', async () => {
+    const api = vi.fn(async () => {
+      throw new Error('404 not found')
+    })
+
+    const readFileDataUrl = vi.fn(async () => 'data:image/png;base64,bG9jYWw=')
+
+    vi.stubGlobal('window', { hermesDesktop: { api, readFileDataUrl } })
+    $connection.set({ mode: 'remote' } as never)
+
+    await expect(
+      gatewayMediaDataUrlLocalFallback('/home/alex/.config/Hermes/composer-images/preview-shot_47a88d.png')
+    ).resolves.toBe('data:image/png;base64,bG9jYWw=')
+
+    expect(readFileDataUrl).toHaveBeenCalledWith(
+      '/home/alex/.config/Hermes/composer-images/preview-shot_47a88d.png'
+    )
+  })
+
+  it('reports both hosts when the file exists on neither', async () => {
+    const api = vi.fn(async () => {
+      throw new Error('404 not found')
+    })
+
+    vi.stubGlobal('window', { hermesDesktop: { api, readFileDataUrl: vi.fn(async () => '') } })
+    $connection.set({ mode: 'remote' } as never)
+
+    await expect(gatewayMediaDataUrlLocalFallback('/nowhere/a.png')).rejects.toThrow(
+      'not found on the gateway or this machine'
     )
   })
 })

--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -1,4 +1,5 @@
 import { readDesktopFileDataUrl } from '@/lib/desktop-fs'
+import { openExternalLink } from '@/lib/external-link'
 import { capitalize } from '@/lib/text'
 import { $connection } from '@/store/session'
 
@@ -83,7 +84,7 @@ export async function resolveMediaDisplaySrc(path: string): Promise<string> {
   }
 
   if (window.hermesDesktop && isRemoteGateway()) {
-    return gatewayMediaDataUrl(path)
+    return gatewayMediaDataUrlLocalFallback(path)
   }
 
   if (!window.hermesDesktop?.readFileDataUrl) {
@@ -198,6 +199,33 @@ export async function gatewayMediaDataUrl(path: string): Promise<string> {
   return readDesktopFileDataUrl(filePathFromMediaPath(path))
 }
 
+// A screenshot/PDF taken by the preview panel is written by the LOCAL Electron
+// main process (app.getPath('userData')/composer-images), even while the agent
+// runs on a remote gateway. Asking the gateway for that path always 404s: the
+// file only ever existed on this machine. Try the gateway first (normal case:
+// the agent produced the file there), then fall back to this shell's own disk.
+export async function gatewayMediaDataUrlLocalFallback(path: string): Promise<string> {
+  const file = filePathFromMediaPath(path)
+
+  try {
+    const remote = await readDesktopFileDataUrl(file)
+
+    if (remote) {
+      return remote
+    }
+  } catch {
+    // Not on the gateway — the file may be a locally produced artifact.
+  }
+
+  const local = await window.hermesDesktop?.readFileDataUrl?.(file)
+
+  if (!local) {
+    throw new Error(`Media file not found on the gateway or this machine: ${file}`)
+  }
+
+  return local
+}
+
 // Remote-mode replacement for opening gateway-local file paths with file://.
 // The file lives on the gateway, so ask the Electron main process to fetch the
 // bytes through the authenticated backend connection and save them locally. This
@@ -211,6 +239,19 @@ export async function downloadGatewayMediaFile(
 
   if (!window.hermesDesktop?.saveGatewayFile) {
     throw new Error('Desktop file download bridge is unavailable')
+  }
+
+  // Locally produced artifacts (preview screenshots/PDFs land in this shell's
+  // userData, never on the gateway) must open with file:// instead of a gateway
+  // fetch that can only 404. Probe this disk before going over the wire.
+  try {
+    if (await window.hermesDesktop.readFileDataUrl?.(file)) {
+      openExternalLink(`file://${file}`)
+
+      return { path: file, saved: true }
+    }
+  } catch {
+    // Not on this machine — it really is a gateway-side file.
   }
 
   return window.hermesDesktop.saveGatewayFile({


### PR DESCRIPTION
## What

When a remote SSH device is active, media the **Desktop app itself produced locally** (preview screenshots, composer images) fails to display. The chat shows:

> Couldn't fetch `preview-shot_XXXX.png` from the gateway (missing, unreadable, or too large).

The file is fine. It's on the wrong host.

## Why it happens

The preview pane is always the **local** webview — even when the session runs on a remote SSH device, `reachablePreviewUrl` (`electron/main.ts`) rewrites the URL through the tunnel and renders it on the user's machine. So `writeComposerImage` writes the artifact to the local `app.getPath('userData')/composer-images`.

But media resolution keys off the *connection*, not the artifact's origin. With a remote device, `$connection.mode === 'remote'`, so `resolveMediaDisplaySrc` and `downloadGatewayMediaFile` (`src/lib/media.ts`) ask the **gateway** for a path that only ever existed locally. The gateway returns 404, which surfaces as the message above.

This is not a permissions or size problem, and no amount of retrying helps — the file is simply not on the host being asked.

## The fix

One extra rung on the resolution ladder, gateway-first so the common case is untouched:

- `gatewayMediaDataUrlLocalFallback()` replaces `gatewayMediaDataUrl()` for inline display — tries the gateway (normal case: the agent produced the file there), then falls back to the local disk.
- `downloadGatewayMediaFile()` probes the local disk before the wire and opens `file://` when the artifact is ours.

Remote-produced media keeps resolving exactly as before; only the previously-failing local-artifact case changes.

## How to test

1. Connect the Desktop app to a remote SSH device.
2. Have the agent capture a preview screenshot (or attach any composer image).
3. Deliver the returned path as `MEDIA:`.

Before: "Couldn't fetch … from the gateway". After: the image renders inline, and Download opens the local file.

## Tests

`apps/desktop/src/lib/media.remote.test.ts` — 7 new cases covering both directions of the ladder (remote-produced still goes to the gateway; locally-produced falls back), 27 passing in the file total.

```
npx vitest run src/lib/media.remote.test.ts     # 27 passed
npx tsc -p tsconfig.json --noEmit               # clean
```

## Platforms

Tested on Linux (Kali rolling, Electron desktop app) against a remote SSH device. The change is platform-neutral — it's a resolution-order fix in shared TypeScript, no OS-specific paths.
