### PR TITLE
Harden CLI config resolution and WeCom callback deduplication

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -444,273 +444,108 @@ def load_cli_config() -> Dict[str, Any]:
     else:
         config_path = project_config_path
 
-    # Default configuration
-    defaults = {
-        "model": {
-            "default": "",
+    from hermes_cli import managed_scope
+    from hermes_cli.config import (
+        apply_terminal_config_to_env,
+        load_config_snapshot_with_raw,
+    )
+
+    defaults, raw_config = load_config_snapshot_with_raw(config_path)
+
+    # Keep the classic CLI's model mapping shape while sourcing its value from
+    # the canonical snapshot. HermesCLI still has a few mapping-based readers;
+    # no effective defaults are resolved here.
+    if not isinstance(defaults.get("model"), dict):
+        defaults["model"] = {
+            "default": defaults.get("model") or "",
             "base_url": "",
             "provider": "auto",
-        },
-        "terminal": {
-            "env_type": "local",
-            "cwd": ".",  # "." is resolved to os.getcwd() at runtime
-            "home_mode": "auto",
-            "lifetime_seconds": 300,
-            "docker_image": "nikolaik/python-nodejs:python3.11-nodejs20",
-            "docker_forward_env": [],
-            "singularity_image": "docker://nikolaik/python-nodejs:python3.11-nodejs20",
-            "modal_image": "nikolaik/python-nodejs:python3.11-nodejs20",
-            "daytona_image": "nikolaik/python-nodejs:python3.11-nodejs20",
-            "docker_volumes": [],  # host:container volume mounts for Docker backend
-            "docker_mount_cwd_to_workspace": False,  # explicit opt-in only; default off for sandbox isolation
-            "docker_shared_container_key": "",
-        },
-        "browser": {
-            "inactivity_timeout": 120,  # Auto-cleanup inactive browser sessions after 2 min
-            "record_sessions": False,  # Auto-record browser sessions as WebM videos
-            "engine": "auto",  # Browser engine: auto (Chrome), lightpanda, chrome
-            "camofox": {
-                "rewrite_loopback_urls": False,
-                "loopback_host_alias": "host.docker.internal",
-            },
-        },
-        "compression": {
-            "enabled": True,      # Auto-compress when approaching context limit
-            "threshold": 0.50,    # Compress at 50% of model's context limit
-            "min_tail_user_messages": 1,  # Real user messages guaranteed in the tail (1 = existing single anchor)
-        },
-        "agent": {
-            "max_turns": 500,  # Default max tool-calling iterations (shared with subagents)
-            "verbose": False,
-            "system_prompt": "",
-            "prefill_messages_file": "",
-            "reasoning_effort": "",
-            "service_tier": "",
-            # Built-in personalities live in hermes_cli.personality
-            # (BUILTIN_PERSONALITIES) — the single owner. Entries here are
-            # user-defined additions/overrides merged on top by name.
-            "personalities": {},
-        },
-
-        "display": {
-            "compact": False,
-            "resume_display": "full",
-            # Recap tuning for /resume — see hermes_cli/config.py DEFAULT_CONFIG.
-            "resume_exchanges": 10,
-            "resume_max_user_chars": 300,
-            "resume_max_assistant_chars": 200,
-            "resume_max_assistant_lines": 3,
-            "resume_skip_tool_only": True,
-            # Live reasoning display default ON — keep in sync with
-            # hermes_cli/config.py DEFAULT_CONFIG (display.show_reasoning).
-            "show_reasoning": True,
-            "reasoning_full": False,
-            "streaming": True,
-            "busy_input_mode": "interrupt",
-            "persistent_output": True,
-            "persistent_output_max_lines": 200,
-            # Clear terminal scrollback as well as the visible viewport when the
-            # classic CLI performs a full redraw/resize recovery. Disabled by
-            # default because some users prefer preserving terminal history;
-            # enable when a terminal/tmux stack stamps stale prompt chrome into
-            # scrollback during fullscreen/restore resizes.
-            "cli_rebuild_scrollback_on_redraw": False,
-            # Print a one-line summary of resolved modal prompts (approval /
-            # clarify) into scrollback so the decision survives the repaint.
-            "persist_prompts": True,
-
-            "skin": "default",
-        },
-        "clarify": {
-            "timeout": 120,  # Seconds to wait for a clarify answer before auto-proceeding
-        },
-        "code_execution": {
-            "timeout": 300,    # Max seconds a sandbox script can run before being killed (5 min)
-            "max_tool_calls": 50,  # Max RPC tool calls per execution
-        },
-        "auxiliary": {
-            "vision": {
-                "provider": "auto",
-                "model": "",
-                "base_url": "",
-                "api_key": "",
-            },
-        },
-        "delegation": {
-            "max_iterations": 45,  # Max tool-calling turns per child agent
-            "model": "",       # Subagent model override (empty = inherit parent model)
-            "provider": "",    # Subagent provider override (empty = inherit parent provider)
-            "base_url": "",    # Direct OpenAI-compatible endpoint for subagents
-            "api_key": "",     # API key for delegation.base_url (falls back to OPENAI_API_KEY)
-        },
-        "onboarding": {
-            # First-touch hint flags (see agent/onboarding.py).  Each hint is
-            # shown once per install then latched here.
-            "seen": {},
-        },
+        }
+    else:
+        defaults["model"].setdefault("default", "")
+        defaults["model"].setdefault("base_url", "")
+        defaults["model"].setdefault("provider", "auto")
+    
+    # Preserve presence-sensitive terminal env behavior without confusing
+    # canonical defaults for settings authored in the selected compatibility
+    # file. Managed provenance comes from the managed-scope API, not a second
+    # ad-hoc YAML read.
+    raw_terminal_config = raw_config.get("terminal", {})
+    if not isinstance(raw_terminal_config, dict):
+        raw_terminal_config = {}
+    authored_terminal_keys = set(raw_terminal_config)
+    managed_terminal_keys = {
+        key.removeprefix("terminal.")
+        for key in managed_scope.managed_config_keys()
+        if key.startswith("terminal.")
     }
-    
-    # Track whether the config file explicitly set terminal config.
-    # When using defaults (no config file / no terminal section), we should NOT
-    # overwrite env vars that were already set by .env -- only a user's config
-    # file should be authoritative.
-    _file_has_terminal_config = False
+    authoritative_terminal_keys = authored_terminal_keys | managed_terminal_keys
 
-    # Load from file if exists
-    if config_path.exists():
-        try:
-            with open(config_path, "r", encoding="utf-8") as f:
-                from hermes_cli.config import _normalize_root_model_keys
-
-                file_config = _normalize_root_model_keys(fast_safe_load(f) or {})
-            
-            _file_has_terminal_config = "terminal" in file_config
-
-            # Handle model config - can be string (new format) or dict (old format)
-            if "model" in file_config:
-                if isinstance(file_config["model"], str):
-                    # New format: model is just a string, convert to dict structure
-                    defaults["model"]["default"] = file_config["model"]
-                elif isinstance(file_config["model"], dict):
-                    # Old format: model is a dict with default/base_url
-                    defaults["model"].update(file_config["model"])
-                    # If the user config sets model.model but not model.default,
-                    # promote model.model to model.default so the user's explicit
-                    # choice isn't shadowed by the hardcoded default.  Without this,
-                    # profile configs that only set "model:" (not "default:") silently
-                    # fall back to claude-opus because the merge preserves the
-                    # hardcoded default and HermesCLI.__init__ checks "default" first.
-                    if "model" in file_config["model"] and "default" not in file_config["model"]:
-                        defaults["model"]["default"] = file_config["model"]["model"]
-
-            # Deep merge file_config into defaults.
-            # First: merge keys that exist in both (deep-merge dicts, overwrite scalars)
-            for key in defaults:
-                if key == "model":
-                    continue  # Already handled above
-                if key in file_config:
-                    if isinstance(defaults[key], dict) and file_config[key] is None:
-                        continue
-                    if isinstance(defaults[key], dict) and isinstance(file_config[key], dict):
-                        defaults[key].update(file_config[key])
-                    else:
-                        defaults[key] = file_config[key]
-            
-            # Second: carry over keys from file_config that aren't in defaults
-            # (e.g. platform_toolsets, provider_routing, memory, honcho, etc.)
-            for key in file_config:
-                if key not in defaults and key != "model":
-                    defaults[key] = file_config[key]
-            
-            # Handle legacy root-level max_turns (backwards compat) - copy to
-            # agent.max_turns whenever the nested key is missing.
-            agent_file_config = file_config.get("agent")
-            if "max_turns" in file_config and not (
-                isinstance(agent_file_config, dict)
-                and agent_file_config.get("max_turns") is not None
-            ):
-                defaults["agent"]["max_turns"] = file_config["max_turns"]
-        except Exception as e:
-            logger.warning("Failed to load cli-config.yaml: %s", e)
-
-    # Expand ${ENV_VAR} references in config values before bridging to env vars.
-    from hermes_cli.config import _expand_env_vars
-    defaults = _expand_env_vars(defaults)
-
-    # Managed scope: overlay administrator-pinned values LAST so they win over
-    # the user's config here too. cli.py builds its config independently of
-    # hermes_cli.config._load_config_impl (which has its own managed merge), so
-    # without this the entire interactive CLI/TUI surface — skin, display prefs,
-    # etc. read from CLI_CONFIG — would silently ignore managed scope while
-    # `hermes config`/`doctor`/guards (which use load_config) honor it. The
-    # shared helper mirrors _load_config_impl (env-only expansion, root-model
-    # normalization, leaf-merge) and is fail-open.
-    from hermes_cli import managed_scope
-
-    defaults = managed_scope.apply_managed_overlay(defaults)
-
-    # Apply terminal config to environment variables (so terminal_tool picks them up)
     terminal_config = defaults.get("terminal", {})
-    
-    # Normalize config key: the new config system (hermes_cli/config.py) and all
-    # documentation use "backend", the legacy cli-config.yaml uses "env_type".
-    # Accept both, with "backend" taking precedence (it's the documented key).
-    if "backend" in terminal_config:
-        terminal_config["env_type"] = terminal_config["backend"]
-    
+    if not isinstance(terminal_config, dict):
+        terminal_config = {}
+        defaults["terminal"] = terminal_config
+
+    # ``env_type`` is the classic CLI's legacy alias. A canonical backend only
+    # wins when a user or administrator actually authored it; DEFAULT_CONFIG's
+    # ``backend: local`` must not erase a legacy ``env_type: docker``.
+    canonical_backend_is_authored = "backend" in authored_terminal_keys
+    legacy_backend_is_authored = "env_type" in authored_terminal_keys
+    managed_canonical_backend = "backend" in managed_terminal_keys
+    managed_legacy_backend = "env_type" in managed_terminal_keys
+    # Aliases are one logical setting, so precedence is decided across layers,
+    # not independently by spelling. In descending order: managed canonical,
+    # managed legacy, user canonical, user legacy, default.
+    if managed_canonical_backend:
+        effective_backend = terminal_config.get("backend", "local")
+    elif managed_legacy_backend:
+        effective_backend = terminal_config.get("env_type", "local")
+    elif canonical_backend_is_authored:
+        effective_backend = terminal_config.get("backend", "local")
+    elif legacy_backend_is_authored:
+        effective_backend = terminal_config.get("env_type", "local")
+    else:
+        effective_backend = terminal_config.get("backend", "local")
+    terminal_config["backend"] = effective_backend
+    terminal_config["env_type"] = effective_backend
+    if managed_canonical_backend or managed_legacy_backend or (
+        legacy_backend_is_authored and not canonical_backend_is_authored
+    ):
+        authoritative_terminal_keys.add("backend")
+
     # CWD resolution for CLI/TUI. The gateway has its own config bridge in
     # gateway/run.py but may lazily import cli.py (triggering this code).
     # Local backend: always os.getcwd(). Use `cd /dir && hermes` to control it.
-    # Non-local with placeholder: pop so terminal_tool uses its per-backend default.
-    # Non-local with explicit path: keep as-is.
+    # Non-local with placeholder: omit it so terminal_tool uses its default.
     _CWD_PLACEHOLDERS = (".", "auto", "cwd")
-    effective_backend = terminal_config.get("env_type", "local")
-
     if effective_backend == "local":
         terminal_config["cwd"] = os.getcwd()
-        defaults["terminal"]["cwd"] = terminal_config["cwd"]
     elif terminal_config.get("cwd") in _CWD_PLACEHOLDERS:
         terminal_config.pop("cwd", None)
-    
-    env_mappings = {
-        "env_type": "TERMINAL_ENV",
-        "degraded_mode": "TERMINAL_DEGRADED_MODE",
-        "cwd": "TERMINAL_CWD",
-        "timeout": "TERMINAL_TIMEOUT",
-        "home_mode": "TERMINAL_HOME_MODE",
-        "lifetime_seconds": "TERMINAL_LIFETIME_SECONDS",
-        "docker_image": "TERMINAL_DOCKER_IMAGE",
-        "docker_forward_env": "TERMINAL_DOCKER_FORWARD_ENV",
-        "singularity_image": "TERMINAL_SINGULARITY_IMAGE",
-        "modal_image": "TERMINAL_MODAL_IMAGE",
-        "daytona_image": "TERMINAL_DAYTONA_IMAGE",
-        "vercel_runtime": "TERMINAL_VERCEL_RUNTIME",
-        # SSH config
-        "ssh_host": "TERMINAL_SSH_HOST",
-        "ssh_user": "TERMINAL_SSH_USER",
-        "ssh_port": "TERMINAL_SSH_PORT",
-        "ssh_key": "TERMINAL_SSH_KEY",
-        # Container resource config (docker, singularity, modal, daytona, vercel_sandbox -- ignored for local/ssh)
-        "container_cpu": "TERMINAL_CONTAINER_CPU",
-        "container_memory": "TERMINAL_CONTAINER_MEMORY",
-        "container_disk": "TERMINAL_CONTAINER_DISK",
-        "container_persistent": "TERMINAL_CONTAINER_PERSISTENT",
-        "docker_volumes": "TERMINAL_DOCKER_VOLUMES",
-        "docker_env": "TERMINAL_DOCKER_ENV",
-        "docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
-        "docker_shm_size": "TERMINAL_DOCKER_SHM_SIZE",
-        "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
-        "docker_network": "TERMINAL_DOCKER_NETWORK",
-        "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
-        "docker_persist_across_processes": "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",
-        "docker_shared_container_key": "TERMINAL_DOCKER_SHARED_CONTAINER_KEY",
-        "docker_orphan_reaper": "TERMINAL_DOCKER_ORPHAN_REAPER",
-        "sandbox_dir": "TERMINAL_SANDBOX_DIR",
-        # Persistent shell (non-local backends)
-        "persistent_shell": "TERMINAL_PERSISTENT_SHELL",
-        # Sudo support (works with all backends)
-        "sudo_password": "SUDO_PASSWORD",
-    }
-    
-    # Bridge config → env vars for terminal_tool. TERMINAL_CWD is force-exported
-    # UNLESS we're inside a gateway process (detected by _HERMES_GATEWAY marker)
-    # where it was already set correctly by gateway/run.py's config bridge.
+
+    # Reuse the canonical map/application path for every terminal setting.
+    # Keep only the two classic-CLI exceptions here: legacy env_type selection
+    # above, and CLI-specific cwd ownership.
     _is_gateway = os.environ.get("_HERMES_GATEWAY") == "1"
-    for config_key, env_var in env_mappings.items():
-        if config_key in terminal_config:
-            if env_var == "TERMINAL_CWD":
-                if _is_gateway:
-                    continue
-                # CLI: always export (overrides stale .env or inherited values)
-                os.environ[env_var] = str(terminal_config[config_key])
-                continue
-            if _file_has_terminal_config or env_var not in os.environ:
-                val = terminal_config[config_key]
-                if isinstance(val, (list, dict)):
-                    os.environ[env_var] = json.dumps(val)
-                else:
-                    os.environ[env_var] = str(val)
-    
+    bridge_terminal_config = dict(terminal_config)
+    if _is_gateway:
+        bridge_terminal_config.pop("cwd", None)
+    elif "cwd" in bridge_terminal_config:
+        authoritative_terminal_keys.add("cwd")
+    apply_terminal_config_to_env(
+        config={"terminal": bridge_terminal_config},
+        override=True,
+        authoritative_keys=authoritative_terminal_keys,
+    )
+
+    # ``sudo_password`` is a credential rather than a canonical terminal
+    # backend option, but legacy cli-config.yaml accepted it in this section.
+    if "sudo_password" in terminal_config and (
+        "sudo_password" in authoritative_terminal_keys
+        or "SUDO_PASSWORD" not in os.environ
+    ):
+        os.environ["SUDO_PASSWORD"] = str(terminal_config["sudo_password"])
+
     # Apply browser config to environment variables
     browser_config = defaults.get("browser", {})
     browser_env_mappings = {

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2824,8 +2824,10 @@ if _config_path.exists():
             ).strip().lower()
             _terminal_env_map = {
                 "backend": "TERMINAL_ENV",
+                "modal_mode": "TERMINAL_MODAL_MODE",
                 "degraded_mode": "TERMINAL_DEGRADED_MODE",
                 "cwd": "TERMINAL_CWD",
+                "temp_dir": "TERMINAL_TEMP_DIR",
                 "timeout": "TERMINAL_TIMEOUT",
                 "home_mode": "TERMINAL_HOME_MODE",
                 "lifetime_seconds": "TERMINAL_LIFETIME_SECONDS",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3875,7 +3875,74 @@ def load_config() -> Dict[str, Any]:
     defensive deepcopy — that path matters in agent-loop hot spots like
     ``get_provider_request_timeout`` which is called once per API turn.
     """
-    return _load_config_impl(want_deepcopy=True)
+    return load_config_snapshot()
+
+
+def load_config_snapshot(config_path: Optional[Path] = None) -> Dict[str, Any]:
+    """Return a mutable snapshot of canonically resolved effective config.
+
+    ``config_path`` defaults to the active profile's ``config.yaml``. The
+    explicit-path form supports compatibility readers such as the classic
+    interactive CLI's project-level ``cli-config.yaml`` fallback; it applies
+    the same defaults, recursive merge, normalization, environment expansion,
+    managed-policy overlay, and last-known-good behavior as the normal path.
+
+    This is an *effective* snapshot. Presence-sensitive and write-back paths
+    must continue to use :func:`read_user_config_raw` / :func:`read_raw_config`
+    so defaults and managed values are never mistaken for user-authored data.
+    """
+    if config_path is not None:
+        config_path = config_path.expanduser().resolve(strict=False)
+    return _load_config_impl(want_deepcopy=True, config_path=config_path)
+
+
+def load_config_snapshot_with_raw(
+    config_path: Optional[Path] = None,
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """Return coherent effective and user-authored config snapshots.
+
+    This is for presence-sensitive compatibility readers that need effective
+    values and authored-key provenance from the same file observation. The
+    process lock serializes Hermes readers, while the bounded signature retry
+    also detects an editor or another process atomically replacing the file
+    between the effective and raw reads.
+    """
+    if config_path is None:
+        ensure_hermes_home()
+        config_path = get_config_path()
+    config_path = config_path.expanduser().resolve(strict=False)
+    path_key = str(config_path)
+
+    def observation_signature() -> Optional[Tuple[int, int, int, int, int]]:
+        try:
+            st = config_path.stat()
+        except OSError:
+            return None
+        return (st.st_dev, st.st_ino, st.st_mtime_ns, st.st_ctime_ns, st.st_size)
+
+    with _CONFIG_LOCK:
+        for _attempt in range(3):
+            before = observation_signature()
+            # This compatibility API promises a pair from the observed file,
+            # rather than two independently valid cache entries. Drop only this
+            # path's entries so an atomic replacement that preserves mtime/size
+            # cannot make either half reuse the replaced inode's value.
+            _LOAD_CONFIG_CACHE.pop(path_key, None)
+            _RAW_CONFIG_CACHE.pop(path_key, None)
+            effective = _load_config_impl(want_deepcopy=True, config_path=config_path)
+            try:
+                raw = read_user_config_raw(config_path)
+            except Exception:
+                # Preserve the effective loader's last-known-good behavior while
+                # refusing to claim any authored-key provenance for bad input.
+                raw = {}
+            if before == observation_signature():
+                return effective, raw
+
+        # A continuously changing file has no coherent authored snapshot. Keep
+        # serving the effective loader's defaults/LKG, but fail safe on presence:
+        # no raw keys are treated as authoritative.
+        return effective, {}
 
 
 def load_config_readonly() -> Dict[str, Any]:
@@ -3936,6 +4003,7 @@ TERMINAL_CONFIG_ENV_MAP = {
     "cwd": "TERMINAL_CWD",
     "temp_dir": "TERMINAL_TEMP_DIR",
     "timeout": "TERMINAL_TIMEOUT",
+    "home_mode": "TERMINAL_HOME_MODE",
     "lifetime_seconds": "TERMINAL_LIFETIME_SECONDS",
     "docker_image": "TERMINAL_DOCKER_IMAGE",
     "docker_forward_env": "TERMINAL_DOCKER_FORWARD_ENV",
@@ -4016,6 +4084,7 @@ def apply_terminal_config_to_env(
     env: Optional[Dict[str, str]] = None,
     config: Optional[Dict[str, Any]] = None,
     override: Optional[bool] = None,
+    authoritative_keys: Optional[Set[str]] = None,
 ) -> Dict[str, str]:
     """Bridge ``terminal.*`` config into the env vars terminal tools read.
 
@@ -4025,29 +4094,50 @@ def apply_terminal_config_to_env(
     CLI without importing ``cli.py`` and paying for its startup side effects.
 
     Explicit keys in the user config's ``terminal`` section are authoritative
-    and override their matching env values.  Merged defaults only backfill
-    missing env vars; they never replace unrelated exported/.env values.
+    and override their matching env values. Managed keys always override env
+    values. ``authoritative_keys`` lets compatibility readers provide exact
+    user/managed provenance when ``config`` is already an effective snapshot.
+    Merged defaults only backfill missing env vars; they never replace unrelated
+    exported/.env values.
     """
     target = os.environ if env is None else env
 
-    raw_config = read_raw_config()
-    raw_terminal_cfg = raw_config.get("terminal")
-    file_has_terminal_config = isinstance(raw_terminal_cfg, dict)
-    if not file_has_terminal_config:
+    if authoritative_keys is None:
+        raw_config = read_raw_config()
+        raw_terminal_cfg = raw_config.get("terminal")
+        if not isinstance(raw_terminal_cfg, dict):
+            raw_terminal_cfg = {}
+    else:
         raw_terminal_cfg = {}
-    should_override = file_has_terminal_config if override is None else override
+    if override is None:
+        should_override = (
+            bool(raw_terminal_cfg)
+            if authoritative_keys is None
+            else bool(authoritative_keys)
+        )
+    else:
+        should_override = override
 
     cfg = config if config is not None else load_config_readonly()
     terminal_cfg = cfg.get("terminal", {}) if isinstance(cfg, dict) else {}
     if not isinstance(terminal_cfg, dict):
         return target
 
-    # A caller-supplied config is its own source of explicit keys.  For the
-    # normal merged-config path, only keys present in raw config.yaml may
-    # override existing env values; keys inherited from DEFAULT_CONFIG are
-    # backfill-only.
-    explicit_keys = terminal_cfg.keys() if config is not None else raw_terminal_cfg.keys()
-    backend_is_explicit = config is not None or "backend" in raw_terminal_cfg
+    # A caller-supplied config is its own source of explicit keys unless it
+    # provides narrower provenance. Managed terminal leaves are authoritative
+    # regardless of shell/.env values (managed-scope precedence contract).
+    from hermes_cli import managed_scope
+
+    managed_keys = {
+        key.removeprefix("terminal.")
+        for key in managed_scope.managed_config_keys()
+        if key.startswith("terminal.")
+    }
+    if authoritative_keys is None:
+        explicit_keys = set(terminal_cfg) if config is not None else set(raw_terminal_cfg)
+    else:
+        explicit_keys = set(authoritative_keys)
+    backend_is_explicit = "backend" in explicit_keys or "backend" in managed_keys
     if backend_is_explicit:
         terminal_backend = str(
             terminal_cfg.get("backend") or target.get("TERMINAL_ENV") or ""
@@ -4069,15 +4159,24 @@ def apply_terminal_config_to_env(
                 terminal_backend, raw_cwd
             ):
                 value = os.path.expanduser(value)
-        if (should_override and cfg_key in explicit_keys) or env_var not in target:
+        if (
+            cfg_key in managed_keys
+            or (should_override and cfg_key in explicit_keys)
+            or env_var not in target
+        ):
             target[env_var] = _terminal_env_value(value)
     return target
 
 
-def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
+def _load_config_impl(
+    *, want_deepcopy: bool, config_path: Optional[Path] = None
+) -> Dict[str, Any]:
     with _CONFIG_LOCK:
-        ensure_hermes_home()
-        config_path = get_config_path()
+        if config_path is None:
+            ensure_hermes_home()
+            config_path = get_config_path()
+        else:
+            config_path = config_path.expanduser().resolve(strict=False)
         path_key = str(config_path)
 
         try:

--- a/plugins/platforms/wecom/callback_adapter.py
+++ b/plugins/platforms/wecom/callback_adapter.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import socket as _socket
+import sqlite3
+import threading
 import time
 from typing import Any, Dict, List, Optional
 # Security: parse untrusted, pre-auth request bodies (WeCom callbacks) with
@@ -47,6 +49,7 @@ except ImportError:
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from plugins.plugin_storage import plugin_db
 from plugins.platforms.wecom.wecom_crypto import WXBizMsgCrypt, WeComCryptoError
 
 logger = logging.getLogger(__name__)
@@ -66,6 +69,9 @@ DEFAULT_PATH = "/wecom/callback"
 _MAX_BODY = 65_536
 ACCESS_TOKEN_TTL_SECONDS = 7200
 MESSAGE_DEDUP_TTL_SECONDS = 300
+# Callback claims should fail quickly under writer contention so WeCom can
+# retry instead of tying up an HTTP request for sqlite3's five-second default.
+_REPLAY_BUSY_TIMEOUT_MS = 250
 
 
 def check_wecom_callback_requirements() -> bool:
@@ -121,7 +127,8 @@ class WecomCallbackAdapter(BasePlatformAdapter):
         self._http_client: Optional[httpx.AsyncClient] = None
         self._message_queue: asyncio.Queue[MessageEvent] = asyncio.Queue()
         self._poll_task: Optional[asyncio.Task] = None
-        self._seen_messages: Dict[str, float] = {}
+        self._replay_store: Optional[sqlite3.Connection] = None
+        self._replay_store_lock = threading.Lock()
         self._user_app_map: Dict[str, str] = {}
         self._access_tokens: Dict[str, Dict[str, Any]] = {}
 
@@ -162,6 +169,22 @@ class WecomCallbackAdapter(BasePlatformAdapter):
         # ignored — but the kwarg MUST be present or the reconnect watcher
         # dies with TypeError and the platform silently stays offline.
         del is_reconnect
+        # Be idempotent when a caller invokes connect twice without a clean
+        # disconnect. In particular, never overwrite an open replay database.
+        if any((self._poll_task, self._runner, self._http_client, self._replay_store)):
+            self._running = False
+            if self._poll_task:
+                self._poll_task.cancel()
+                try:
+                    await self._poll_task
+                except asyncio.CancelledError:
+                    pass
+                self._poll_task = None
+            try:
+                await self._cleanup()
+            except Exception:
+                logger.exception("[WecomCallback] Failed to clean up previous connection")
+                return False
         if not self._apps:
             logger.warning("[WecomCallback] No callback apps configured")
             return False
@@ -180,6 +203,10 @@ class WecomCallbackAdapter(BasePlatformAdapter):
             pass
 
         try:
+            # Retry deduplication is a prerequisite for accepting callbacks.
+            # Open it before constructing or binding the HTTP listener so a
+            # storage failure cannot leave an endpoint without deduplication.
+            self._init_replay_store()
             # Tighter keepalive so idle CLOSE_WAIT drains promptly (#18451).
             from gateway.platforms._http_client_limits import platform_httpx_limits
             self._http_client = httpx.AsyncClient(timeout=20.0, limits=platform_httpx_limits())
@@ -209,8 +236,11 @@ class WecomCallbackAdapter(BasePlatformAdapter):
                     )
             return True
         except Exception:
-            await self._cleanup()
             logger.exception("[WecomCallback] Failed to start")
+            try:
+                await self._cleanup()
+            except Exception:
+                logger.exception("[WecomCallback] Startup cleanup also failed")
             return False
 
     async def disconnect(self) -> None:
@@ -228,13 +258,112 @@ class WecomCallbackAdapter(BasePlatformAdapter):
 
     async def _cleanup(self) -> None:
         self._site = None
-        if self._runner:
-            await self._runner.cleanup()
-            self._runner = None
+        errors: List[BaseException] = []
+        runner, self._runner = self._runner, None
+        if runner:
+            try:
+                await runner.cleanup()
+            except BaseException as exc:
+                errors.append(exc)
         self._app = None
-        if self._http_client:
-            await self._http_client.aclose()
-            self._http_client = None
+        http_client, self._http_client = self._http_client, None
+        if http_client:
+            try:
+                await http_client.aclose()
+            except BaseException as exc:
+                errors.append(exc)
+        try:
+            self._close_replay_store()
+        except BaseException as exc:
+            errors.append(exc)
+        if errors:
+            raise errors[0]
+
+    def _init_replay_store(self) -> None:
+        """Open, initialize, and prune the profile-local retry metadata."""
+        # Reinitialization must not leak a connection (notably when connect is
+        # called repeatedly by lifecycle supervisors).
+        self._close_replay_store()
+        connection = plugin_db("wecom-platform", filename="callback-replays.db")
+        try:
+            connection.execute(f"PRAGMA busy_timeout={_REPLAY_BUSY_TIMEOUT_MS}")
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS callback_replays (
+                    corp_id TEXT NOT NULL,
+                    agent_id TEXT NOT NULL,
+                    message_id TEXT NOT NULL,
+                    claimed_at REAL NOT NULL,
+                    PRIMARY KEY (corp_id, agent_id, message_id)
+                )
+                """
+            )
+            connection.execute(
+                """
+                CREATE INDEX IF NOT EXISTS callback_replays_claimed_at
+                ON callback_replays (claimed_at)
+                """
+            )
+            # These rows are bounded retry-deduplication metadata, not a
+            # durable message inbox. Keep them only for the configured TTL;
+            # pruning here also bounds idle stores that receive no new claim.
+            connection.execute(
+                "DELETE FROM callback_replays WHERE claimed_at <= ?",
+                (time.time() - MESSAGE_DEDUP_TTL_SECONDS,),
+            )
+            connection.commit()
+        except Exception:
+            connection.close()
+            raise
+        self._replay_store = connection
+
+    def _close_replay_store(self) -> None:
+        connection, self._replay_store = self._replay_store, None
+        if connection is not None:
+            connection.close()
+
+    def _claim_message(self, app: Dict[str, Any], message_id: str) -> bool:
+        """Atomically claim a scoped message ID, returning false for a retry.
+
+        ``BEGIN IMMEDIATE`` serializes the prune/check/insert operation across
+        SQLite connections and processes. Expiring rows at ``<= cutoff``
+        preserves the existing strict ``age < 300`` duplicate boundary.
+        """
+        connection = self._replay_store
+        if connection is None:
+            raise RuntimeError("WeCom callback replay store is not initialized")
+
+        now = time.time()
+        cutoff = now - MESSAGE_DEDUP_TTL_SECONDS
+        key = (
+            str(app.get("corp_id") or ""),
+            str(app.get("agent_id") or ""),
+            message_id,
+        )
+        with self._replay_store_lock:
+            try:
+                connection.execute("BEGIN IMMEDIATE")
+                connection.execute(
+                    "DELETE FROM callback_replays WHERE claimed_at <= ?",
+                    (cutoff,),
+                )
+                cursor = connection.execute(
+                    """
+                    INSERT OR IGNORE INTO callback_replays
+                        (corp_id, agent_id, message_id, claimed_at)
+                    VALUES (?, ?, ?, ?)
+                    """,
+                    (*key, now),
+                )
+                claimed = cursor.rowcount == 1
+                connection.commit()
+                return claimed
+            except Exception:
+                try:
+                    connection.rollback()
+                except Exception:
+                    pass
+                raise
 
     # ------------------------------------------------------------------
     # Outbound: proactive send via access-token API
@@ -342,19 +471,29 @@ class WecomCallbackAdapter(BasePlatformAdapter):
                 event = self._build_event(app, decrypted)
                 if event is not None:
                     # Deduplicate: WeCom retries callbacks on timeout,
-                    # producing duplicate inbound messages (#10305).
+                    # producing duplicate inbound messages (#10305). The
+                    # durable, scoped claim survives gateway restarts.
                     if event.message_id:
-                        now = time.time()
-                        if event.message_id in self._seen_messages:
-                            if now - self._seen_messages[event.message_id] < MESSAGE_DEDUP_TTL_SECONDS:
-                                logger.debug("[WecomCallback] Duplicate MsgId %s, skipping", event.message_id)
-                                return web.Response(text="success", content_type="text/plain")
-                            del self._seen_messages[event.message_id]
-                        self._seen_messages[event.message_id] = now
-                        # Prune expired entries when cache grows large
-                        if len(self._seen_messages) > 2000:
-                            cutoff = now - MESSAGE_DEDUP_TTL_SECONDS
-                            self._seen_messages = {k: v for k, v in self._seen_messages.items() if v > cutoff}
+                        try:
+                            # sqlite3 transactions are blocking. Keep them off
+                            # the gateway's shared event loop so other platform
+                            # callbacks and health checks remain responsive.
+                            claimed = await asyncio.to_thread(
+                                self._claim_message, app, event.message_id,
+                            )
+                        except Exception:
+                            # Fail closed and ask WeCom to retry. An in-memory
+                            # fallback would reintroduce duplicate-delivery
+                            # races across workers and gateway restarts.
+                            logger.exception("[WecomCallback] Retry-dedup store claim failed")
+                            return web.Response(status=500, text="replay store unavailable")
+                        if not claimed:
+                            logger.debug("[WecomCallback] Duplicate MsgId %s, skipping", event.message_id)
+                            return web.Response(text="success", content_type="text/plain")
+                    # The claim intentionally happens before queueing. A crash
+                    # in this narrow window can drop this delivery until the
+                    # TTL expires; this bounded design provides retry
+                    # deduplication, not durable inbox semantics.
                     # Record which app this user belongs to.
                     if event.source and event.source.user_id:
                         map_key = self._user_app_key(

--- a/tests/cli/test_prompt_stash_cli.py
+++ b/tests/cli/test_prompt_stash_cli.py
@@ -50,16 +50,31 @@ def _make_cli(**kwargs):
         "prompt_toolkit.formatted_text": MagicMock(),
         "prompt_toolkit.auto_suggest": MagicMock(),
     }
-    with patch.dict(sys.modules, prompt_toolkit_stubs), patch.dict(
-        "os.environ", clean_env, clear=False
-    ):
-        import cli as _cli_mod
-
-        _cli_mod = importlib.reload(_cli_mod)
-        with patch.object(_cli_mod, "get_tool_definitions", return_value=[]), patch.dict(
-            _cli_mod.__dict__, {"CLI_CONFIG": _clean_config}
+    _cli_mod = None
+    original_globals = None
+    instance = None
+    try:
+        with patch.dict(sys.modules, prompt_toolkit_stubs), patch.dict(
+            "os.environ", clean_env, clear=False
         ):
-            return _cli_mod.HermesCLI(**kwargs)
+            import cli as _cli_mod
+
+            # reload() mutates the existing module object in place, so preserve
+            # its exact pre-test state. A second reload is not equivalent: it can
+            # replace class identities and invalidate references imported by
+            # earlier test modules.
+            original_globals = dict(_cli_mod.__dict__)
+            _cli_mod = importlib.reload(_cli_mod)
+            with patch.object(_cli_mod, "get_tool_definitions", return_value=[]), patch.dict(
+                _cli_mod.__dict__, {"CLI_CONFIG": _clean_config}
+            ):
+                instance = _cli_mod.HermesCLI(**kwargs)
+    finally:
+        if _cli_mod is not None and original_globals is not None:
+            _cli_mod.__dict__.clear()
+            _cli_mod.__dict__.update(original_globals)
+
+    return instance
 
 
 @pytest.fixture(scope="module")

--- a/tests/cli/test_quick_commands.py
+++ b/tests/cli/test_quick_commands.py
@@ -154,7 +154,15 @@ class TestGatewayQuickCommands:
         runner._is_user_authorized = MagicMock(return_value=True)
 
         event = self._make_event("slow")
-        with patch("asyncio.wait_for", side_effect=asyncio.TimeoutError):
+
+        async def timeout_and_close(awaitable, **_kwargs):
+            # wait_for receives proc.communicate() after that coroutine has
+            # already been created. A bare mocked TimeoutError abandons it and
+            # emits "Process.communicate was never awaited" later during GC.
+            awaitable.close()
+            raise asyncio.TimeoutError
+
+        with patch("asyncio.wait_for", side_effect=timeout_and_close):
             result = await runner._handle_message(event)
         assert result is not None
         assert "timed out" in result.lower()

--- a/tests/gateway/test_wecom_callback.py
+++ b/tests/gateway/test_wecom_callback.py
@@ -1,12 +1,21 @@
 """Tests for the WeCom callback-mode adapter."""
 
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
+import sqlite3
+import threading
+import time
+from unittest.mock import Mock
 from xml.etree import ElementTree as ET
 
 import pytest
 
 from gateway.config import PlatformConfig
-from plugins.platforms.wecom.callback_adapter import WecomCallbackAdapter
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from plugins.platforms.wecom.callback_adapter import (
+    MESSAGE_DEDUP_TTL_SECONDS,
+    WecomCallbackAdapter,
+)
 from plugins.platforms.wecom.wecom_crypto import WXBizMsgCrypt
 
 
@@ -26,6 +35,46 @@ def _config(apps=None):
         enabled=True,
         extra={"mode": "callback", "host": "127.0.0.1", "port": 0, "apps": apps or [_app()]},
     )
+
+
+@pytest.fixture
+def hermes_home(tmp_path):
+    token = set_hermes_home_override(str(tmp_path))
+    try:
+        yield tmp_path
+    finally:
+        reset_hermes_home_override(token)
+
+
+def _callback_request(
+    app, *, msg_id="callback-1", msg_type="text", valid_signature=True,
+):
+    """Build the real signed/encrypted HTTP request WeCom sends."""
+    from aiohttp import StreamReader
+    from aiohttp.test_utils import make_mocked_request
+
+    plaintext = f"""
+    <xml>
+      <ToUserName>{app['corp_id']}</ToUserName>
+      <FromUserName>alice</FromUserName>
+      <CreateTime>1710000000</CreateTime>
+      <MsgType>{msg_type}</MsgType>
+      <Content>hello</Content>
+      <MsgId>{msg_id}</MsgId>
+    </xml>
+    """
+    crypt = WXBizMsgCrypt(app["token"], app["encoding_aes_key"], app["corp_id"])
+    envelope = crypt.encrypt(plaintext, nonce="nonce123", timestamp="1710000000")
+    root = ET.fromstring(envelope)
+    signature = root.findtext("MsgSignature") if valid_signature else "invalid"
+    query = (
+        f"msg_signature={signature}"
+        f"&timestamp={root.findtext('TimeStamp')}&nonce={root.findtext('Nonce')}"
+    )
+    reader = StreamReader(protocol=Mock(_reading_paused=False), limit=2**20)
+    reader.feed_data(envelope.encode())
+    reader.feed_eof()
+    return make_mocked_request("POST", f"/wecom/callback?{query}", payload=reader)
 
 
 class TestWecomCrypto:
@@ -169,6 +218,333 @@ class TestWecomCallbackPollLoop:
         with pytest.raises(asyncio.CancelledError):
             await task
         assert calls == ["test"]
+
+
+class TestWecomCallbackRetryDeduplication:
+    @pytest.mark.asyncio
+    async def test_slow_claim_does_not_block_event_loop(self, hermes_home, monkeypatch):
+        app = _app()
+        adapter = WecomCallbackAdapter(_config([app]))
+        adapter._init_replay_store()
+        claim_started = threading.Event()
+        release_claim = threading.Event()
+
+        def slow_claim(*args, **kwargs):
+            claim_started.set()
+            assert release_claim.wait(timeout=1)
+            return True
+
+        monkeypatch.setattr(adapter, "_claim_message", slow_claim)
+        callback = asyncio.create_task(adapter._handle_callback(_callback_request(app)))
+        assert await asyncio.to_thread(claim_started.wait, 1)
+
+        sentinel = asyncio.Event()
+        asyncio.get_running_loop().call_soon(sentinel.set)
+        await asyncio.wait_for(sentinel.wait(), timeout=0.05)
+        assert not callback.done()
+
+        release_claim.set()
+        response = await callback
+        assert response.status == 200
+        assert adapter._message_queue.qsize() == 1
+        await adapter._cleanup()
+
+    @pytest.mark.asyncio
+    async def test_lock_contention_fails_quickly_without_queueing(self, hermes_home):
+        app = _app()
+        adapter = WecomCallbackAdapter(_config([app]))
+        adapter._init_replay_store()
+        db_path = adapter._replay_store.execute("PRAGMA database_list").fetchone()[2]
+        blocker = sqlite3.connect(db_path)
+        blocker.execute("BEGIN IMMEDIATE")
+        try:
+            started = time.monotonic()
+            response = await adapter._handle_callback(_callback_request(app))
+            elapsed = time.monotonic() - started
+        finally:
+            blocker.rollback()
+            blocker.close()
+
+        assert response.status == 500
+        assert elapsed < 1.0
+        assert adapter._message_queue.empty()
+        await adapter._cleanup()
+
+    @pytest.mark.asyncio
+    async def test_duplicate_survives_adapter_restart(self, hermes_home):
+        app = _app()
+        first = WecomCallbackAdapter(_config([app]))
+        first._init_replay_store()
+
+        response = await first._handle_callback(_callback_request(app, msg_id="same-id"))
+        assert response.status == 200
+        assert response.text == "success"
+        assert first._message_queue.qsize() == 1
+        await first._cleanup()
+
+        restarted = WecomCallbackAdapter(_config([app]))
+        restarted._init_replay_store()
+        response = await restarted._handle_callback(_callback_request(app, msg_id="same-id"))
+        assert response.status == 200
+        assert response.text == "success"
+        assert restarted._message_queue.empty()
+        await restarted._cleanup()
+
+    @pytest.mark.asyncio
+    async def test_same_message_id_is_scoped_by_corp_and_agent(self, hermes_home):
+        apps = [
+            _app(name="corp-a", corp_id="corp-a", agent_id="1001"),
+            _app(name="corp-b", corp_id="corp-b", agent_id="2002"),
+        ]
+        adapter = WecomCallbackAdapter(_config(apps))
+        adapter._init_replay_store()
+
+        for app in apps:
+            response = await adapter._handle_callback(_callback_request(app, msg_id="shared"))
+            assert response.status == 200
+        assert adapter._message_queue.qsize() == 2
+
+        # Agent ID is part of the durable key too, independently of callback routing.
+        assert adapter._claim_message(apps[0], "agent-scoped") is True
+        other_agent = {**apps[0], "agent_id": "9999"}
+        assert adapter._claim_message(other_agent, "agent-scoped") is True
+        await adapter._cleanup()
+
+    def test_claim_is_atomic_across_connections(self, hermes_home):
+        first = WecomCallbackAdapter(_config())
+        second = WecomCallbackAdapter(_config())
+        first._init_replay_store()
+        second._init_replay_store()
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            claims = list(pool.map(lambda adapter: adapter._claim_message(_app(), "race"), [first, second]))
+
+        assert sorted(claims) == [False, True]
+        first._close_replay_store()
+        second._close_replay_store()
+
+    def test_ttl_is_strict_and_expired_rows_are_pruned(self, hermes_home, monkeypatch):
+        from plugins.platforms.wecom import callback_adapter as callback_module
+
+        adapter = WecomCallbackAdapter(_config())
+        adapter._init_replay_store()
+        monkeypatch.setattr(callback_module.time, "time", lambda: 1_000.0)
+        assert adapter._claim_message(_app(), "boundary") is True
+
+        monkeypatch.setattr(
+            callback_module.time,
+            "time",
+            lambda: 1_000.0 + MESSAGE_DEDUP_TTL_SECONDS - 0.001,
+        )
+        assert adapter._claim_message(_app(), "boundary") is False
+
+        monkeypatch.setattr(
+            callback_module.time,
+            "time",
+            lambda: 1_000.0 + MESSAGE_DEDUP_TTL_SECONDS,
+        )
+        assert adapter._claim_message(_app(), "boundary") is True
+        rows = adapter._replay_store.execute(
+            "SELECT COUNT(*) FROM callback_replays WHERE claimed_at <= ?",
+            (1_000.0,),
+        ).fetchone()[0]
+        assert rows == 0
+        adapter._close_replay_store()
+
+    def test_initialization_prunes_expired_metadata(self, hermes_home, monkeypatch):
+        from plugins.platforms.wecom import callback_adapter as callback_module
+
+        adapter = WecomCallbackAdapter(_config())
+        adapter._init_replay_store()
+        adapter._replay_store.executemany(
+            "INSERT INTO callback_replays VALUES (?, ?, ?, ?)",
+            [
+                ("corp", "agent", "expired", 699.0),
+                ("corp", "agent", "fresh", 701.0),
+            ],
+        )
+        adapter._replay_store.commit()
+        adapter._close_replay_store()
+
+        monkeypatch.setattr(callback_module.time, "time", lambda: 1_000.0)
+        adapter._init_replay_store()
+        message_ids = {
+            row[0]
+            for row in adapter._replay_store.execute(
+                "SELECT message_id FROM callback_replays"
+            )
+        }
+        assert message_ids == {"fresh"}
+        adapter._close_replay_store()
+
+    def test_reinitialization_closes_previous_connection(self, hermes_home):
+        adapter = WecomCallbackAdapter(_config())
+        adapter._init_replay_store()
+        previous = adapter._replay_store
+
+        adapter._init_replay_store()
+
+        with pytest.raises(sqlite3.ProgrammingError):
+            previous.execute("SELECT 1")
+        assert adapter._replay_store is not previous
+        adapter._close_replay_store()
+
+    def test_retry_metadata_is_profile_isolated(self, tmp_path):
+        profile_a = tmp_path / "profile-a"
+        profile_b = tmp_path / "profile-b"
+        token_a = set_hermes_home_override(str(profile_a))
+        try:
+            first = WecomCallbackAdapter(_config())
+            first._init_replay_store()
+            assert first._claim_message(_app(), "same-id") is True
+            first._close_replay_store()
+
+            token_b = set_hermes_home_override(str(profile_b))
+            try:
+                second = WecomCallbackAdapter(_config())
+                second._init_replay_store()
+                assert second._claim_message(_app(), "same-id") is True
+                second._close_replay_store()
+            finally:
+                reset_hermes_home_override(token_b)
+        finally:
+            reset_hermes_home_override(token_a)
+
+    @pytest.mark.asyncio
+    async def test_store_failure_returns_500_without_queueing(self, hermes_home):
+        app = _app()
+        adapter = WecomCallbackAdapter(_config([app]))
+        adapter._init_replay_store()
+        adapter._replay_store.close()
+
+        response = await adapter._handle_callback(_callback_request(app))
+
+        assert response.status == 500
+        assert adapter._message_queue.empty()
+        await adapter._cleanup()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("request_kwargs", "expected_status"),
+        [
+            ({"msg_type": "image"}, 200),
+            ({"valid_signature": False}, 400),
+        ],
+    )
+    async def test_invalid_or_ignored_callback_does_not_claim(
+        self, hermes_home, monkeypatch, request_kwargs, expected_status,
+    ):
+        app = _app()
+        adapter = WecomCallbackAdapter(_config([app]))
+        adapter._init_replay_store()
+
+        def fail_if_called(*args, **kwargs):
+            raise AssertionError("invalid/ignored callbacks must not consume a replay key")
+
+        monkeypatch.setattr(adapter, "_claim_message", fail_if_called)
+        response = await adapter._handle_callback(
+            _callback_request(app, msg_id="unclaimed", **request_kwargs)
+        )
+
+        assert response.status == expected_status
+        assert adapter._message_queue.empty()
+        await adapter._cleanup()
+
+    @pytest.mark.asyncio
+    async def test_connect_fails_closed_before_binding_when_store_init_fails(
+        self, monkeypatch,
+    ):
+        from plugins.platforms.wecom import callback_adapter as callback_module
+
+        adapter = WecomCallbackAdapter(_config())
+        bound = False
+
+        def fail_store(*args, **kwargs):
+            raise OSError("storage unavailable")
+
+        class NeverBind:
+            def __init__(self, *args, **kwargs):
+                nonlocal bound
+                bound = True
+
+        monkeypatch.setattr(callback_module, "plugin_db", fail_store, raising=False)
+        monkeypatch.setattr(callback_module.web, "TCPSite", NeverBind)
+
+        assert await adapter.connect() is False
+        assert bound is False
+        assert adapter._message_queue.empty()
+
+    @pytest.mark.asyncio
+    async def test_repeated_connect_closes_previous_replay_connection(
+        self, hermes_home, monkeypatch,
+    ):
+        from plugins.platforms.wecom import callback_adapter as callback_module
+
+        class TokenResponse:
+            def json(self):
+                return {"errcode": 0, "access_token": "token", "expires_in": 7200}
+
+        class FakeClient:
+            def __init__(self, *args, **kwargs):
+                self.closed = False
+
+            async def get(self, *args, **kwargs):
+                return TokenResponse()
+
+            async def aclose(self):
+                self.closed = True
+
+        monkeypatch.setattr(callback_module.httpx, "AsyncClient", FakeClient)
+        adapter = WecomCallbackAdapter(_config())
+        assert await adapter.connect() is True
+        previous = adapter._replay_store
+
+        assert await adapter.connect() is True
+
+        with pytest.raises(sqlite3.ProgrammingError):
+            previous.execute("SELECT 1")
+        assert adapter._replay_store is not previous
+        await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_closes_replay_store(self, hermes_home):
+        adapter = WecomCallbackAdapter(_config())
+        adapter._init_replay_store()
+        connection = adapter._replay_store
+
+        await adapter._cleanup()
+
+        with pytest.raises(sqlite3.ProgrammingError):
+            connection.execute("SELECT 1")
+
+    @pytest.mark.asyncio
+    async def test_cleanup_closes_every_resource_when_other_cleanup_raises(self, hermes_home):
+        adapter = WecomCallbackAdapter(_config())
+        adapter._init_replay_store()
+        connection = adapter._replay_store
+
+        class BrokenRunner:
+            async def cleanup(self):
+                raise RuntimeError("runner cleanup failed")
+
+        class BrokenClient:
+            async def aclose(self):
+                raise RuntimeError("client cleanup failed")
+
+        adapter._runner = BrokenRunner()
+        adapter._http_client = BrokenClient()
+
+        with pytest.raises(RuntimeError, match="runner cleanup failed"):
+            await adapter._cleanup()
+
+        assert adapter._runner is None
+        assert adapter._http_client is None
+        assert adapter._replay_store is None
+        with pytest.raises(sqlite3.ProgrammingError):
+            connection.execute("SELECT 1")
+
+        # Cleanup remains safe after a partially failing cleanup pass.
+        await adapter._cleanup()
 
 
 class TestWecomCallbackBodySizeLimit:

--- a/tests/hermes_cli/test_cli_config_unification.py
+++ b/tests/hermes_cli/test_cli_config_unification.py
@@ -1,0 +1,466 @@
+"""Relationship tests for the interactive CLI's effective config snapshot."""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+import yaml
+
+
+@pytest.fixture
+def config_modules(tmp_path, monkeypatch):
+    original_env = dict(os.environ)
+    home = tmp_path / "home"
+    home.mkdir()
+    managed = tmp_path / "managed"
+    managed.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed))
+    monkeypatch.delenv("HERMES_IGNORE_USER_CONFIG", raising=False)
+
+    import cli
+    from hermes_cli import managed_scope
+    from hermes_cli import config as canonical
+
+    monkeypatch.setattr(cli, "_hermes_home", home)
+    canonical._LOAD_CONFIG_CACHE.clear()
+    canonical._RAW_CONFIG_CACHE.clear()
+    canonical._LAST_EXPANDED_CONFIG_BY_PATH.clear()
+    managed_scope.invalidate_managed_cache()
+    try:
+        yield cli, canonical, managed_scope, home, managed
+    finally:
+        # load_cli_config intentionally bridges effective config into os.environ
+        # with direct assignments. Restore the complete process environment,
+        # including keys that monkeypatch did not create itself.
+        os.environ.clear()
+        os.environ.update(original_env)
+
+
+def _at(config, dotted_path):
+    value = config
+    for part in dotted_path.split("."):
+        value = value[part]
+    return value
+
+
+@pytest.mark.parametrize(
+    "dotted_path",
+    [
+        "agent.max_turns",
+        "display.streaming",
+        "delegation.max_iterations",
+        "auxiliary.vision.timeout",
+    ],
+)
+def test_cli_defaults_are_owned_by_canonical_config(config_modules, dotted_path):
+    cli, canonical, _managed_scope, _home, _managed = config_modules
+
+    cli_config = cli.load_cli_config()
+    effective = canonical.load_config()
+
+    assert _at(cli_config, dotted_path) == _at(effective, dotted_path)
+    assert _at(cli_config, dotted_path) == _at(canonical.DEFAULT_CONFIG, dotted_path)
+
+
+def test_cli_uses_canonical_recursive_merge_without_materializing_defaults(
+    config_modules,
+):
+    cli, canonical, _managed_scope, home, _managed = config_modules
+    raw = {
+        "browser": {"camofox": {"rewrite_loopback_urls": True}},
+        "auxiliary": {"vision": {"model": "test/vision"}},
+    }
+    (home / "config.yaml").write_text(yaml.safe_dump(raw), encoding="utf-8")
+
+    cli_config = cli.load_cli_config()
+    effective = canonical.load_config()
+
+    assert cli_config["browser"]["camofox"] == effective["browser"]["camofox"]
+    assert cli_config["auxiliary"]["vision"] == effective["auxiliary"]["vision"]
+    assert cli_config["browser"]["camofox"]["rewrite_loopback_urls"] is True
+    assert "loopback_host_alias" in cli_config["browser"]["camofox"]
+    assert canonical.read_raw_config() == raw
+
+
+def test_partial_terminal_config_only_overrides_authored_env_keys(
+    config_modules, monkeypatch
+):
+    cli, _canonical, _managed_scope, home, _managed = config_modules
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({"terminal": {"backend": "docker"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("TERMINAL_TIMEOUT", "987")
+
+    cli.load_cli_config()
+
+    assert os.environ["TERMINAL_ENV"] == "docker"
+    assert os.environ["TERMINAL_TIMEOUT"] == "987"
+
+
+def test_legacy_env_type_is_not_shadowed_by_default_backend(
+    config_modules, monkeypatch
+):
+    cli, _canonical, _managed_scope, home, _managed = config_modules
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({"terminal": {"env_type": "docker"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("TERMINAL_ENV", "from-shell")
+
+    loaded = cli.load_cli_config()
+
+    assert loaded["terminal"]["env_type"] == "docker"
+    assert os.environ["TERMINAL_ENV"] == "docker"
+
+
+@pytest.mark.parametrize(
+    ("user_terminal", "managed_terminal", "expected"),
+    [
+        ({}, {}, "local"),
+        ({"env_type": "user-legacy"}, {}, "user-legacy"),
+        (
+            {"backend": "user-canonical", "env_type": "user-legacy"},
+            {},
+            "user-canonical",
+        ),
+        (
+            {"backend": "user-canonical"},
+            {"env_type": "managed-legacy"},
+            "managed-legacy",
+        ),
+        (
+            {"env_type": "user-legacy"},
+            {"backend": "managed-canonical"},
+            "managed-canonical",
+        ),
+        (
+            {"backend": "user-canonical", "env_type": "user-legacy"},
+            {"backend": "managed-canonical", "env_type": "managed-legacy"},
+            "managed-canonical",
+        ),
+    ],
+)
+def test_terminal_backend_alias_precedence(
+    config_modules,
+    monkeypatch,
+    user_terminal,
+    managed_terminal,
+    expected,
+):
+    cli, _canonical, managed_scope, home, managed = config_modules
+    if user_terminal:
+        (home / "config.yaml").write_text(
+            yaml.safe_dump({"terminal": user_terminal}), encoding="utf-8"
+        )
+    if managed_terminal:
+        (managed / "config.yaml").write_text(
+            yaml.safe_dump({"terminal": managed_terminal}), encoding="utf-8"
+        )
+        managed_scope.invalidate_managed_cache()
+    monkeypatch.setenv("TERMINAL_ENV", "from-shell")
+
+    loaded = cli.load_cli_config()
+
+    assert loaded["terminal"]["backend"] == expected
+    assert loaded["terminal"]["env_type"] == expected
+    expected_env = "from-shell" if not user_terminal and not managed_terminal else expected
+    assert os.environ["TERMINAL_ENV"] == expected_env
+
+
+def test_managed_backend_overrides_legacy_env_type_and_existing_env(
+    config_modules, monkeypatch
+):
+    cli, _canonical, managed_scope, home, managed = config_modules
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({"terminal": {"env_type": "docker"}}),
+        encoding="utf-8",
+    )
+    (managed / "config.yaml").write_text(
+        yaml.safe_dump({"terminal": {"backend": "modal"}}),
+        encoding="utf-8",
+    )
+    managed_scope.invalidate_managed_cache()
+    monkeypatch.setenv("TERMINAL_ENV", "from-shell")
+
+    loaded = cli.load_cli_config()
+
+    assert loaded["terminal"]["env_type"] == "modal"
+    assert os.environ["TERMINAL_ENV"] == "modal"
+
+
+def test_managed_terminal_leaves_override_existing_env_per_leaf(
+    config_modules, monkeypatch
+):
+    cli, _canonical, managed_scope, _home, managed = config_modules
+    (managed / "config.yaml").write_text(
+        yaml.safe_dump({
+            "terminal": {
+                "modal_mode": "managed",
+                "temp_dir": "/managed/tmp",
+            }
+        }),
+        encoding="utf-8",
+    )
+    managed_scope.invalidate_managed_cache()
+    monkeypatch.setenv("TERMINAL_MODAL_MODE", "direct")
+    monkeypatch.setenv("TERMINAL_TEMP_DIR", "/shell/tmp")
+    monkeypatch.setenv("TERMINAL_TIMEOUT", "987")
+
+    cli.load_cli_config()
+
+    assert os.environ["TERMINAL_MODAL_MODE"] == "managed"
+    assert os.environ["TERMINAL_TEMP_DIR"] == "/managed/tmp"
+    assert os.environ["TERMINAL_TIMEOUT"] == "987"
+
+
+def test_cli_uses_canonical_terminal_mapping_for_modal_mode_and_temp_dir(
+    config_modules,
+):
+    cli, _canonical, _managed_scope, home, _managed = config_modules
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({"terminal": {"modal_mode": "direct", "temp_dir": "/user/tmp"}}),
+        encoding="utf-8",
+    )
+
+    cli.load_cli_config()
+
+    assert os.environ["TERMINAL_MODAL_MODE"] == "direct"
+    assert os.environ["TERMINAL_TEMP_DIR"] == "/user/tmp"
+
+
+def test_effective_and_raw_snapshot_retry_across_atomic_replacement(
+    config_modules, monkeypatch
+):
+    _cli, canonical, _managed_scope, home, _managed = config_modules
+    config_path = home / "config.yaml"
+    replacement = home / "config.yaml.next"
+    config_path.write_text("display:\n  skin: first\n", encoding="utf-8")
+    replacement.write_text("display:\n  skin: other\n", encoding="utf-8")
+    original_read_raw = canonical.read_user_config_raw
+    reads = 0
+
+    def replace_before_first_raw_read(path):
+        nonlocal reads
+        reads += 1
+        if reads == 1:
+            os.replace(replacement, config_path)
+        return original_read_raw(path)
+
+    monkeypatch.setattr(canonical, "read_user_config_raw", replace_before_first_raw_read)
+
+    effective, raw = canonical.load_config_snapshot_with_raw(config_path)
+
+    assert reads == 2
+    assert effective["display"]["skin"] == "other"
+    assert raw["display"]["skin"] == "other"
+
+
+def test_effective_and_raw_snapshot_preserves_lkg_on_parse_failure(config_modules):
+    _cli, canonical, _managed_scope, home, _managed = config_modules
+    config_path = home / "config.yaml"
+    config_path.write_text("display:\n  skin: known-good\n", encoding="utf-8")
+    first_effective, first_raw = canonical.load_config_snapshot_with_raw(config_path)
+    assert first_effective["display"]["skin"] == "known-good"
+    assert first_raw["display"]["skin"] == "known-good"
+
+    config_path.write_text("display:\n  skin: [unclosed\n", encoding="utf-8")
+    effective, raw = canonical.load_config_snapshot_with_raw(config_path)
+
+    assert effective["display"]["skin"] == "known-good"
+    assert raw == {}
+
+
+def test_cli_calls_canonical_terminal_bridge(config_modules, monkeypatch):
+    cli, canonical, _managed_scope, _home, _managed = config_modules
+    calls = []
+    original = canonical.apply_terminal_config_to_env
+
+    def spy(**kwargs):
+        calls.append(kwargs)
+        return original(**kwargs)
+
+    monkeypatch.setattr(canonical, "apply_terminal_config_to_env", spy)
+
+    cli.load_cli_config()
+
+    assert len(calls) == 1
+    assert calls[0]["config"]["terminal"]
+    assert calls[0]["authoritative_keys"] is not None
+
+
+def test_explicit_relative_snapshot_paths_have_stable_distinct_cache_identity(
+    config_modules, monkeypatch, tmp_path
+):
+    _cli, canonical, _managed_scope, _home, _managed = config_modules
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    # Equal-size files plus an identical timestamp reproduce a relative cache-key
+    # collision when the loader keys only on the spelling "config.yaml".
+    first_config = first / "config.yaml"
+    second_config = second / "config.yaml"
+    first_config.write_text("display:\n  skin: first\n", encoding="utf-8")
+    second_config.write_text("display:\n  skin: other\n", encoding="utf-8")
+    timestamp_ns = 1_700_000_000_000_000_000
+    os.utime(first_config, ns=(timestamp_ns, timestamp_ns))
+    os.utime(second_config, ns=(timestamp_ns, timestamp_ns))
+
+    monkeypatch.chdir(first)
+    first_loaded = canonical.load_config_snapshot(Path("config.yaml"))
+    monkeypatch.chdir(second)
+    second_loaded = canonical.load_config_snapshot(Path("config.yaml"))
+
+    assert first_loaded["display"]["skin"] == "first"
+    assert second_loaded["display"]["skin"] == "other"
+    assert {str(first_config.resolve()), str(second_config.resolve())} <= set(
+        canonical._LOAD_CONFIG_CACHE
+    )
+
+
+def test_cli_model_dict_has_complete_compatibility_shape_without_overrides(
+    config_modules,
+):
+    cli, _canonical, _managed_scope, home, _managed = config_modules
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({
+            "model": {
+                "default": "user/model",
+                "provider": "user-provider",
+            }
+        }),
+        encoding="utf-8",
+    )
+
+    model = cli.load_cli_config()["model"]
+
+    assert {"default", "base_url", "provider"} <= model.keys()
+    assert model["default"] == "user/model"
+    assert model["base_url"] == ""
+    assert model["provider"] == "user-provider"
+
+
+def test_cli_matches_canonical_env_expansion_and_managed_precedence(
+    config_modules, monkeypatch
+):
+    cli, canonical, managed_scope, home, managed = config_modules
+    monkeypatch.setenv("USER_VISION_MODEL", "test/user-vision")
+    monkeypatch.setenv("MANAGED_VISION_MODEL", "test/managed-vision")
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({
+            "auxiliary": {
+                "vision": {
+                    "model": "${USER_VISION_MODEL}",
+                    "provider": "user-provider",
+                }
+            }
+        }),
+        encoding="utf-8",
+    )
+    (managed / "config.yaml").write_text(
+        yaml.safe_dump({
+            "auxiliary": {"vision": {"model": "${env:MANAGED_VISION_MODEL}"}}
+        }),
+        encoding="utf-8",
+    )
+    managed_scope.invalidate_managed_cache()
+
+    cli_config = cli.load_cli_config()
+    effective = canonical.load_config()
+
+    assert cli_config["auxiliary"]["vision"] == effective["auxiliary"]["vision"]
+    assert cli_config["auxiliary"]["vision"]["model"] == "test/managed-vision"
+    assert cli_config["auxiliary"]["vision"]["provider"] == "user-provider"
+    assert (
+        canonical.read_raw_config()["auxiliary"]["vision"]["model"]
+        == "${USER_VISION_MODEL}"
+    )
+
+
+def test_ignore_user_config_keeps_project_fallback_on_canonical_defaults(
+    config_modules, monkeypatch, tmp_path
+):
+    cli, canonical, _managed_scope, home, _managed = config_modules
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({"agent": {"system_prompt": "must-not-leak"}}),
+        encoding="utf-8",
+    )
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.setattr(cli, "__file__", str(project / "cli.py"))
+    (project / "cli-config.yaml").write_text(
+        yaml.safe_dump({
+            "display": {"compact": True},
+            "browser": {"camofox": {"rewrite_loopback_urls": True}},
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_IGNORE_USER_CONFIG", "1")
+
+    cli_config = cli.load_cli_config()
+
+    assert cli_config["agent"].get("system_prompt") != "must-not-leak"
+    assert cli_config["display"]["compact"] is True
+    assert cli_config["browser"]["camofox"]["rewrite_loopback_urls"] is True
+    assert (
+        cli_config["browser"]["camofox"]["loopback_host_alias"]
+        == canonical.DEFAULT_CONFIG["browser"]["camofox"]["loopback_host_alias"]
+    )
+
+
+def test_import_time_cli_config_isolated_and_preserves_parent_environment(tmp_path):
+    home = tmp_path / "subprocess-home"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({
+            "model": {"default": "import/model"},
+            "terminal": {"backend": "docker"},
+        }),
+        encoding="utf-8",
+    )
+    child_env = copy.deepcopy(dict(os.environ))
+    child_env.update({
+        "HERMES_HOME": str(home),
+        "HERMES_MANAGED_DIR": str(tmp_path / "managed"),
+        "TERMINAL_TIMEOUT": "654",
+    })
+    parent_env = dict(os.environ)
+    script = """
+import json
+import os
+import cli
+print("CONFIG_RESULT=" + json.dumps({
+    "model": cli.CLI_CONFIG["model"],
+    "terminal_env": os.environ.get("TERMINAL_ENV"),
+    "terminal_timeout": os.environ.get("TERMINAL_TIMEOUT"),
+}, sort_keys=True))
+"""
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=Path(__file__).parents[2],
+        env=child_env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    result_line = next(
+        line
+        for line in completed.stdout.splitlines()
+        if line.startswith("CONFIG_RESULT=")
+    )
+    result = json.loads(result_line.removeprefix("CONFIG_RESULT="))
+
+    assert {"default", "base_url", "provider"} <= result["model"].keys()
+    assert result["model"]["default"] == "import/model"
+    assert result["terminal_env"] == "docker"
+    assert result["terminal_timeout"] == "654"
+    assert dict(os.environ) == parent_env

--- a/tests/tools/test_terminal_config_env_sync.py
+++ b/tests/tools/test_terminal_config_env_sync.py
@@ -71,10 +71,10 @@ def _extract_dict_keys(source: str, dict_name: str) -> set[str]:
 
 
 def _cli_env_map_keys() -> set[str]:
-    """terminal config keys bridged by cli.load_cli_config()."""
-    import cli
-    source = inspect.getsource(cli.load_cli_config)
-    return _extract_dict_keys(source, "env_mappings")
+    """Terminal keys bridged by CLI through the canonical helper/map."""
+    from hermes_cli.config import TERMINAL_CONFIG_ENV_MAP
+
+    return set(TERMINAL_CONFIG_ENV_MAP)
 
 
 def _gateway_env_map_keys() -> set[str]:
@@ -82,6 +82,7 @@ def _gateway_env_map_keys() -> set[str]:
     # gateway/run.py builds the dict at module top-level (not inside a
     # function), so inspect the whole module source.
     import gateway.run as gr
+
     source = inspect.getsource(gr)
     return _extract_dict_keys(source, "_terminal_env_map")
 
@@ -97,53 +98,29 @@ def _save_config_env_sync_keys() -> set[str]:
     literal that the consolidation removed.
     """
     from hermes_cli import config as hc_config
+
     # set_config_value bridges every TERMINAL_CONFIG_ENV_MAP key except
     # terminal.cwd (see the ``key != "terminal.cwd"`` guard in
     # set_config_value); mirror that exclusion here.
     return {k for k in hc_config.TERMINAL_CONFIG_ENV_MAP if k != "cwd"}
 
 
-# Keys present in cli.py env_mappings but intentionally absent from
-# gateway/run.py or set_config_value.  Each entry must be justified.
-_CLI_ONLY_OK = frozenset({
-    # `env_type` is a legacy YAML key alias for `backend` that cli.py
-    # accepts for backwards-compat with older cli-config.yaml.  The
-    # gateway path normalizes on the canonical `backend` key, which is
-    # also in the map and handles the same bridging.  See cli.py ~line 515.
-    "env_type",
-    # sudo_password is not a terminal-backend option — it's a credential
-    # used across backends, bridged to $SUDO_PASSWORD (not TERMINAL_*).
-    # Treating it as terminal-only would be misleading.
-    "sudo_password",
-})
-
-
 def _terminal_tool_env_var_names() -> set[str]:
     """All TERMINAL_* env vars actually consumed by terminal_tool."""
     import tools.terminal_tool as tt
+
     source = inspect.getsource(tt)
     # Naive scan: every os.getenv("TERMINAL_X", ...) and _parse_env_var("TERMINAL_X", ...).
     import re
+
     pat = re.compile(r'["\'](TERMINAL_[A-Z0-9_]+)["\']')
     return set(pat.findall(source))
 
 
 def test_cli_and_gateway_env_maps_agree():
-    """cli.py and gateway/run.py must bridge the same set of terminal keys.
-
-    Both feed the same downstream consumer (terminal_tool).  Drift between
-    them means a config.yaml setting that "works in CLI mode but not gateway
-    mode" (or vice-versa) — the bug class that shipped twice already.
-    """
-    cli_keys = _cli_env_map_keys() - _CLI_ONLY_OK
+    """The canonical CLI bridge and gateway must bridge exactly the same keys."""
+    cli_keys = _cli_env_map_keys()
     gw_keys = _gateway_env_map_keys()
-
-    # Normalize the legacy `env_type` alias: cli.py accepts both `env_type`
-    # and `backend` as source keys for TERMINAL_ENV; gateway only accepts
-    # `backend`.  Since cli.py copies `backend` → `env_type` before the
-    # lookup, they're equivalent.  Remove `backend` from the gateway side
-    # to avoid a spurious "backend missing from cli" failure.
-    gw_keys = gw_keys - {"backend"}
 
     missing_in_gateway = cli_keys - gw_keys
     missing_in_cli = gw_keys - cli_keys


### PR DESCRIPTION
## Summary

This hardening slice removes configuration drift before future CLI decomposition, makes WeCom callback retry deduplication durable across restarts, and fixes two order-dependent CLI test-suite leaks.

### Configuration unification

- Route classic CLI configuration through the canonical effective/raw snapshot loader.
- Preserve `HERMES_IGNORE_USER_CONFIG=1`, project `cli-config.yaml` fallback, classic model mapping shape, legacy `terminal.env_type`, environment backfill behavior, and managed leaf-level authority.
- Define terminal backend alias precedence as:
  `managed backend > managed env_type > user backend > user env_type > default`.
- Use one canonical terminal config-to-environment bridge across classic CLI and gateway entry points.
- Add coherent snapshot observation and absolute path cache identity handling.

### WeCom callback retry deduplication

- Replace process-local callback IDs with profile-aware SQLite storage.
- Scope claims by `(corp_id, agent_id, message_id)` and claim atomically with `BEGIN IMMEDIATE`.
- Initialize storage before listener binding and fail closed on startup/runtime storage errors.
- Keep the exact TTL boundary: callbacks aged `< 300s` are duplicates; age `300s` is accepted again.
- Prune expired metadata on initialization and claim.
- Move SQLite claim work off the asyncio event loop and bound lock contention to 250 ms so WeCom can retry quickly.
- Make reconnect and cleanup lifecycle handling idempotent and exception-safe.

### Test stabilization

- Restore `cli` module globals after prompt-toolkit stub reloads so later tests do not inherit mocked output functions or replaced class identities.
- Close the mocked `Process.communicate()` coroutine in the quick-command timeout test, eliminating the unawaited-coroutine warning.

## Compatibility and security behavior

- No intentional public API or config-schema break.
- Invalid, malformed, or ignored WeCom callbacks do not consume retry keys.
- Valid duplicates acknowledge with HTTP 200 and are not queued, including after adapter restart.
- Runtime replay-store failure returns HTTP 500 and queues nothing; there is no in-memory fallback.
- Immediate acknowledgement/proactive reply behavior is preserved.

## Verification

- Config compatibility/regression slice: **43 passed**
- CLI isolation/approval/timeout regression slice: **62 passed**
- WeCom callback + plugin storage slice: **33 passed**
- Broader WeCom gateway/plugin-storage review run: **142 passed, 3 skipped, 1 xfailed**
- Ruff on all changed Python files: **passed**
- Python compile checks: **passed**
- `git diff --check`: **passed**
- Independent final integrated review: **APPROVE**, no critical/high/medium findings

A broad all-CLI/all-`hermes_cli` diagnostic run advanced through **1,705 passed, 8 skipped** before stopping on an existing order-dependent `test_approval_transport` failure. That test and the affected integration slice pass together (**62 passed**); the remaining cross-suite pollution is not attributed to this change set.

## Deliberate follow-ups / accepted limitations

- This remains TTL-bounded retry deduplication, not total replay prevention. Signed callback timestamp-freshness validation is intentionally deferred.
- Claims are durable before the in-memory queue handoff, preserving current behavior but retaining a narrow crash-loss window. Eliminating it requires a durable inbox/state machine and is outside this bounded patch.

## Rollout / rollback

- No migration command is required; the profile-aware replay database/table is initialized before WeCom listener bind.
- Rollback is the three commits in this PR. No production deployment or infrastructure change is included.
