### PR TITLE
fix(tui_gateway): flag rollback.diff truncation instead of cutting silently

### DIFF
--- a/tests/tui_gateway/test_rollback_diff_truncation.py
+++ b/tests/tui_gateway/test_rollback_diff_truncation.py
@@ -1,0 +1,84 @@
+"""Regression tests for the rollback.diff truncation flags (#101744).
+
+``rollback.diff`` caps the returned diff at 4000 chars. Before the fix the
+payload was indistinguishable from a complete diff; it now carries
+``truncated`` and ``total_length`` so clients can surface that the preview
+was cut short mid-line.
+"""
+
+from __future__ import annotations
+
+import importlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def server():
+    # Mocks are scoped to the initial import only (see
+    # tests/tui_gateway/test_protocol.py for the rationale).
+    with patch.dict(
+        "sys.modules",
+        {
+            "hermes_cli.env_loader": MagicMock(),
+            "hermes_cli.banner": MagicMock(),
+        },
+    ):
+        mod = importlib.import_module("tui_gateway.server")
+    yield mod
+
+
+class _FakeMgr:
+    """Stands in for CheckpointManager — only ``diff`` is reachable."""
+
+    def __init__(self, diff: str, stat: str = "1 file changed"):
+        self._diff = diff
+        self._stat = stat
+
+    def diff(self, cwd: str, commit_hash: str) -> dict:
+        return {"success": True, "stat": self._stat, "diff": self._diff}
+
+
+def _call(server, monkeypatch, diff_text: str) -> dict:
+    monkeypatch.setattr(server, "_sess", lambda params, rid: ({"cols": 80}, None))
+    monkeypatch.setattr(
+        server,
+        "_with_checkpoints",
+        lambda session, fn: fn(_FakeMgr(diff_text), "/tmp/proj"),
+    )
+    monkeypatch.setattr(server, "_resolve_checkpoint_hash", lambda mgr, cwd, ref: ref)
+    monkeypatch.setattr(server, "render_diff", lambda raw, cols: "")
+    resp = server._methods["rollback.diff"]("r1", {"session_id": "sid", "hash": "abc123"})
+    assert "error" not in resp
+    return resp["result"]
+
+
+def test_long_diff_is_flagged_truncated(server, monkeypatch):
+    full = "x" * 4500
+    result = _call(server, monkeypatch, full)
+    assert result["diff"] == full[:4000]
+    assert result["truncated"] is True
+    assert result["total_length"] == 4500
+
+
+def test_short_diff_is_not_flagged(server, monkeypatch):
+    result = _call(server, monkeypatch, "short diff")
+    assert result["diff"] == "short diff"
+    assert result["truncated"] is False
+    assert result["total_length"] == len("short diff")
+
+
+def test_exactly_4000_chars_is_not_truncated(server, monkeypatch):
+    full = "y" * 4000
+    result = _call(server, monkeypatch, full)
+    assert result["diff"] == full
+    assert result["truncated"] is False
+    assert result["total_length"] == 4000
+
+
+def test_empty_diff_keeps_flags(server, monkeypatch):
+    result = _call(server, monkeypatch, "")
+    assert result["diff"] == ""
+    assert result["truncated"] is False
+    assert result["total_length"] == 0

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1463,8 +1463,14 @@ def _(rid, params: dict) -> dict:
             session,
             lambda mgr, cwd: mgr.diff(cwd, _resolve_checkpoint_hash(mgr, cwd, target)),
         )
-        raw = r.get("diff", "")[:4000]
-        payload = {"stat": r.get("stat", ""), "diff": raw}
+        full = r.get("diff", "")
+        raw = full[:4000]
+        payload = {
+            "stat": r.get("stat", ""),
+            "diff": raw,
+            "truncated": len(full) > len(raw),
+            "total_length": len(full),
+        }
         rendered = render_diff(raw, session.get("cols", 80))
         if rendered:
             payload["rendered"] = rendered

--- a/ui-tui/src/app/slash/commands/ops.ts
+++ b/ui-tui/src/app/slash/commands/ops.ts
@@ -254,7 +254,13 @@ export const opsCommands: SlashCommand[] = [
                 return ctx.transcript.sys('no changes since this checkpoint')
               }
 
-              const text = [r.stat || '', body].filter(Boolean).join('\n\n')
+              const parts = [r.stat || '', body]
+              if (r.truncated) {
+                parts.push(
+                  `… diff truncated — showing 4000 of ${r.total_length ?? body.length} chars`
+                )
+              }
+              const text = parts.filter(Boolean).join('\n\n')
               ctx.transcript.page(text, 'Rollback diff')
             })
           )

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -528,6 +528,8 @@ export interface RollbackDiffResponse {
   diff?: string
   rendered?: string
   stat?: string
+  total_length?: number
+  truncated?: boolean
 }
 
 export interface RollbackRestoreResponse {


### PR DESCRIPTION
## What does this PR do?

The `rollback.diff` RPC caps the diff payload at 4000 chars but returned it as if it were complete: the payload carried neither a `truncated` flag nor a total size, so a client paging the preview could not tell "this is the whole diff" from "this is the first 4000 characters" — and neither could the user deciding whether to restore the checkpoint.

The payload now carries `truncated` (`len(full) > len(raw)`) and `total_length` alongside the capped `diff`. The TUI `/rollback diff` page appends a `… diff truncated — showing 4000 of N chars` line when the flag is set, matching the CLI slash path (`cli_commands_mixin.py`) which already discloses its 80-line cap with a `... (N more lines)` notice.

Field naming follows the existing snake_case gateway payload convention (`history_removed`, `restored_to`) rather than the camelCase sketched in the issue.

## Related Issue

Fixes #101744

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/methods_tools.py` — `rollback.diff` handler: compute `full`/`raw` explicitly, add `truncated` and `total_length` to the payload (`rendered` still renders the capped text).
- `ui-tui/src/gatewayTypes.ts` — `RollbackDiffResponse` gains optional `truncated?: boolean` / `total_length?: number`.
- `ui-tui/src/app/slash/commands/ops.ts` — append a truncation notice line to the `/rollback diff` page when `truncated` is set.
- `tests/tui_gateway/test_rollback_diff_truncation.py` — new: long diff flagged truncated with correct `total_length`; short, exactly-4000 and empty diffs flagged not truncated (all 4 fail on `main` with `KeyError: 'truncated'`, pass with the fix).

## How to Test

1. `python -m pytest tests/tui_gateway/test_rollback_diff_truncation.py -v` — 4 passed (observed result: `4 failed` on unpatched `main`, `4 passed` with this change).
2. `cd ui-tui && npm run typecheck` — passes.
3. Manual: record a checkpoint, make >4000 chars of changes, run `/rollback diff <n>` in the TUI — the page now ends with `… diff truncated — showing 4000 of N chars`; a small diff shows no notice.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run the relevant test suite (`pytest tests/tui_gateway/ -q` for the touched module) and all tests pass
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: macOS 15 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] N/A — payload fields are additive; no config keys, docs or tool schemas change
- [x] N/A — `cli-config.yaml.example` unchanged (no config keys touched)
- [x] N/A — no architecture/workflow change
- [x] N/A — pure Python string handling + additive TS fields, no platform-specific behavior
- [x] N/A — no tool behavior change

## For New Skills

N/A — no skill added.

## Screenshots / Logs

```
$ python -m pytest tests/tui_gateway/test_rollback_diff_truncation.py -q
4 passed, 6 warnings in 0.67s
```