### PR TITLE
docs(cron): fix stale skip_memory=True claim in cron memory docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1214,8 +1214,8 @@ Hardening invariants:
 - Grace window: 120s for one-shot jobs whose fire time was missed.
 - File lock at `~/.hermes/cron/.tick.lock` prevents duplicate ticks
   across processes.
-- Cron sessions pass `skip_memory=True` by default; memory providers
-  intentionally do not run during cron.
+- Cron sessions pass `skip_memory=False` by default — memory loads
+  like any other agent run.
 
 Cron deliveries are **not** mirrored into the target gateway session —
 they land in their own cron session with a header/footer frame so the

--- a/skills/autonomous-ai-agents/hermes-agent/references/background-systems.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/background-systems.md
@@ -38,9 +38,10 @@ the `cronjob` tool, the `hermes cron` CLI (`list`, `add`, `edit`,
   multi-platform delivery.
 - **Invariants:** 3-minute hard interrupt per run, `.tick.lock` file
   prevents duplicate ticks across processes, cron sessions pass
-  `skip_memory=True` by default, and cron deliveries are framed with a
-  header/footer instead of being mirrored into the target gateway
-  session (keeps role alternation intact).
+  `skip_memory=False` by default (memory loads like any other agent
+  run), and cron deliveries are framed with a header/footer instead of
+  being mirrored into the target gateway session (keeps role
+  alternation intact).
 
 User docs: https://hermes-agent.nousresearch.com/docs/user-guide/features/cron
 

--- a/tests/cron/test_cron_memory_doc_conformance.py
+++ b/tests/cron/test_cron_memory_doc_conformance.py
@@ -1,0 +1,46 @@
+"""Doc ⟷ code conformance: cron memory behavior.
+
+``cron/scheduler.py`` runs cron jobs with ``skip_memory=False`` (see
+``TestRunJobMemory`` in ``test_scheduler.py``) — memory loads for cron
+sessions like any other agent run. Several docs used to claim the opposite
+(``skip_memory=True``, "memory providers intentionally do not run during
+cron"), which would lead a reader (human or agent) to reason from a false
+premise about whether a cron job touched persistent memory. These tests pin
+the docs to the code so the two can't silently diverge again.
+"""
+
+from pathlib import Path
+
+# tests/cron/test_cron_memory_doc_conformance.py -> repo root is parents[2]
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_DOC_PATHS = [
+    _REPO_ROOT / "AGENTS.md",
+    _REPO_ROOT
+    / "skills"
+    / "autonomous-ai-agents"
+    / "hermes-agent"
+    / "references"
+    / "background-systems.md",
+    _REPO_ROOT / "website" / "docs" / "user-guide" / "features" / "spotify.md",
+]
+
+
+def test_cron_memory_docs_do_not_claim_skip_memory_true():
+    for path in _DOC_PATHS:
+        text = path.read_text(encoding="utf-8")
+        assert "skip_memory=True" not in text, (
+            f"{path} claims cron passes skip_memory=True, but cron/scheduler.py "
+            f"passes skip_memory=False — memory loads for cron like any other "
+            f"agent run. See test_run_job_memory_enabled_in_cron in "
+            f"tests/cron/test_scheduler.py."
+        )
+
+
+def test_cron_memory_docs_state_skip_memory_false():
+    for path in _DOC_PATHS:
+        text = path.read_text(encoding="utf-8")
+        assert "skip_memory=False" in text, (
+            f"{path} should document that cron passes skip_memory=False, "
+            f"matching cron/scheduler.py."
+        )

--- a/website/docs/user-guide/features/spotify.md
+++ b/website/docs/user-guide/features/spotify.md
@@ -215,7 +215,7 @@ hermes cron add \
 - **An active device must exist when the cron fires.** If no Spotify client is running (phone/desktop/Connect speaker), playback actions return `403 no active device`. For morning playlists, the trick is to target a device that's always on (Sonos, Echo, a smart speaker) rather than your phone.
 - **Premium required for anything that mutates playback** — play, pause, skip, volume, transfer. Read-only cron jobs (scheduled "email me my recently played tracks") work fine on Free.
 - **The cron agent inherits your active toolsets.** Spotify must be enabled in `hermes tools` for the cron session to see the Spotify tools.
-- **Cron jobs run with `skip_memory=True`** so they don't write to your memory store.
+- **Cron jobs load memory like any other run** (`skip_memory=False`), so they can read and write your memory store.
 
 Full cron reference: [Cron Jobs](./cron).
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/spotify.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/spotify.md
@@ -215,7 +215,7 @@ hermes cron add \
 - **cron 触发时必须存在活跃设备。** 若没有 Spotify 客户端在运行（手机/桌面端/Connect 音箱），播放操作将返回 `403 no active device`。对于早晨播放列表，建议指定一个始终开机的设备（Sonos、Echo、智能音箱），而非手机。
 - **任何修改播放状态的操作都需要 Premium**——播放、暂停、跳曲、音量、切换设备。只读 cron 任务（例如定时"发送我最近播放的曲目"）在免费版上可正常使用。
 - **cron agent 继承你的活跃工具集。** Spotify 必须在 `hermes tools` 中启用，cron 会话才能看到 Spotify 工具。
-- **Cron 任务以 `skip_memory=True` 运行**，不会写入你的记忆存储。
+- **Cron 任务与其他运行一样加载记忆**（`skip_memory=False`），可以读写你的记忆存储。
 
 完整 cron 参考：[Cron Jobs](./cron)。
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
@@ -647,7 +647,7 @@ terminal(command="tmux new-session -d -s resumed 'hermes --resume 20260225_14305
 
 - **调度格式：** 持续时间（`"30m"`、`"2h"`）、"every" 短语（`"every monday 9am"`）、5 字段 cron（`"0 9 * * *"`）或 ISO 时间戳。
 - **每任务选项：** `skills`、`model`/`provider` 覆盖、`script`（预运行数据收集；`no_agent=True` 使脚本成为整个任务）、`context_from`（将任务 A 的输出链接到任务 B）、`workdir`（在特定目录中运行，加载其 `AGENTS.md` / `CLAUDE.md`）、多平台投递。
-- **不变量：** 每次运行 3 分钟硬中断，`.tick.lock` 文件防止跨进程重复 tick，cron 会话默认传递 `skip_memory=True`，cron 投递使用页眉/页脚框架而非镜像到目标 gateway 会话（保持角色交替完整）。
+- **不变量：** 每次运行 3 分钟硬中断，`.tick.lock` 文件防止跨进程重复 tick，cron 会话默认传递 `skip_memory=False`（记忆像其他任何一次代理运行一样加载），cron 投递使用页眉/页脚框架而非镜像到目标 gateway 会话（保持角色交替完整）。
 
 用户文档：https://hermes-agent.nousresearch.com/docs/user-guide/features/cron
 


### PR DESCRIPTION
## What

Fixes #101754 — three documentation surfaces claimed cron sessions run with
`skip_memory=True` (no memory read/write). `cron/scheduler.py` (~line 6737)
does the opposite: cron agents load memory like any other agent run
(`skip_memory=False`), and this is the intended, tested behavior (see
`test_run_job_memory_enabled_in_cron` in `tests/cron/test_scheduler.py`, and
the code comment at the call site explaining why memory is enabled for cron).
The docs were the stale side, so this flips them to match the code:

- `AGENTS.md` (~line 1217)
- `skills/autonomous-ai-agents/hermes-agent/references/background-systems.md` (~line 41)
- `website/docs/user-guide/features/spotify.md` (~line 218)
- `website/i18n/zh-Hans/.../features/spotify.md` and
  `.../autonomous-ai-agents-hermes-agent.md` (same claim, in translation)

## Why

Agents and users reason about cron behavior from these docs. A future agent
that trusts them would believe cron jobs are memory-isolated when they are
not, and could act on that false premise (e.g. assuming a cron job never
wrote to persistent memory when it did).

## Test

Added `tests/cron/test_cron_memory_doc_conformance.py`, which pins the three
canonical English docs (`AGENTS.md`, `background-systems.md`, `spotify.md`)
against re-drift: it fails if any of them claim `skip_memory=True` for cron,
and fails if any of them stop stating `skip_memory=False`.

Verified the test fails without the fix by reverting the three doc files
(`git stash push -- <files>`) and re-running:

```
FAILED tests/cron/test_cron_memory_doc_conformance.py::test_cron_memory_docs_do_not_claim_skip_memory_true
FAILED tests/cron/test_cron_memory_doc_conformance.py::test_cron_memory_docs_state_skip_memory_false
2 failed in 0.24s
```

With the fix restored:

```
tests/cron/test_cron_memory_doc_conformance.py::test_cron_memory_docs_do_not_claim_skip_memory_true PASSED
tests/cron/test_cron_memory_doc_conformance.py::test_cron_memory_docs_state_skip_memory_false PASSED
2 passed in 0.20s
```

Full relevant suite via the canonical runner:

```
$ scripts/run_tests.sh tests/cron/test_cron_memory_doc_conformance.py tests/cron/test_scheduler.py -q
=== Summary: 2 files, 105 tests passed, 0 failed (100% complete) in 6.0s (8 workers) ===
```

`ruff check tests/cron/test_cron_memory_doc_conformance.py` — all checks passed.

## Platforms tested

Docs-only change plus a pure Python text-conformance test; not platform-specific.

## AI assistance disclosure

This PR was prepared by an autonomous AI coding agent (Claude), including the
diagnosis, doc fixes, and the new regression test. A human reviews before
merge.
