### PR TITLE
fix(dashboard): detect browser language for first-visit locale

### DIFF
--- a/web/src/i18n/context.test.ts
+++ b/web/src/i18n/context.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { getInitialLocale } from "./context";
+
+const originalNavigator = globalThis.navigator;
+const originalLocalStorage = globalThis.localStorage;
+
+function setGlobal<K extends keyof typeof globalThis>(
+  key: K,
+  value: (typeof globalThis)[K] | undefined,
+) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    value,
+  });
+}
+
+function setLanguages(languages: string[]) {
+  setGlobal("navigator", { languages, language: languages[0] } as unknown as Navigator);
+}
+
+afterEach(() => {
+  setGlobal("navigator", originalNavigator);
+  setGlobal("localStorage", originalLocalStorage);
+});
+
+describe("getInitialLocale", () => {
+  it("returns the stored locale when one was explicitly chosen", () => {
+    setGlobal("localStorage", {
+      getItem: () => "ja",
+    } as unknown as Storage);
+    setLanguages(["de"]);
+
+    expect(getInitialLocale()).toBe("ja");
+  });
+
+  it("matches an exact supported browser language over English", () => {
+    setGlobal("localStorage", { getItem: () => null } as unknown as Storage);
+    setLanguages(["de-DE", "en-US"]);
+
+    expect(getInitialLocale()).toBe("de");
+  });
+
+  it("falls back to the base subtag when the region tag isn't supported", () => {
+    setGlobal("localStorage", { getItem: () => null } as unknown as Storage);
+    setLanguages(["pt-BR"]);
+
+    expect(getInitialLocale()).toBe("pt");
+  });
+
+  it("maps Traditional Chinese region tags to zh-hant instead of the zh base", () => {
+    setGlobal("localStorage", { getItem: () => null } as unknown as Storage);
+    setLanguages(["zh-TW"]);
+
+    expect(getInitialLocale()).toBe("zh-hant");
+  });
+
+  it("defaults to English when nothing matches", () => {
+    setGlobal("localStorage", { getItem: () => null } as unknown as Storage);
+    setLanguages(["vi-VN"]);
+
+    expect(getInitialLocale()).toBe("en");
+  });
+});

--- a/web/src/i18n/context.tsx
+++ b/web/src/i18n/context.tsx
@@ -78,13 +78,30 @@ function isLocale(value: string): value is Locale {
   return (SUPPORTED_LOCALES as string[]).includes(value);
 }
 
-function getInitialLocale(): Locale {
+// zh-TW/zh-HK/zh-MO must map to Traditional Chinese explicitly — their base
+// subtag "zh" would otherwise resolve to Simplified.
+const ZH_HANT_TAGS = new Set(["zh-tw", "zh-hk", "zh-mo"]);
+
+export function getInitialLocale(): Locale {
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored && isLocale(stored)) return stored;
   } catch {
     // SSR or privacy mode
   }
+
+  const preferred =
+    typeof navigator === "undefined"
+      ? []
+      : navigator.languages ?? (navigator.language ? [navigator.language] : []);
+  for (const tag of preferred) {
+    const lower = tag.toLowerCase();
+    if (isLocale(lower)) return lower;
+    if (ZH_HANT_TAGS.has(lower)) return "zh-hant";
+    const base = lower.split("-")[0];
+    if (isLocale(base)) return base;
+  }
+
   return "en";
 }
 


### PR DESCRIPTION
## What does this PR do?

`getInitialLocale()` in `web/src/i18n/context.tsx` unconditionally returned
`"en"` for a first-time visitor, even though the dashboard ships 17 locales
(`LOCALE_META`). `navigator.languages`/`navigator.language` was never
consulted, so the localized UI was effectively unreachable unless a user
already knew to open the language switcher.

Now, when there is no stored `localStorage` preference, it walks
`navigator.languages` (falling back to `navigator.language`) and returns the
first supported match: an exact tag, then `zh-hant` for `zh-TW`/`zh-HK`/`zh-MO`
(whose base subtag `zh` would otherwise resolve to Simplified), then the base
subtag (e.g. `pt-BR` → `pt`). An explicit choice already saved to
`localStorage` still always wins, unchanged.

## Related Issue

Fixes #101746

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `web/src/i18n/context.tsx`: `getInitialLocale()` now matches
  `navigator.languages`/`navigator.language` against the supported locale
  list before defaulting to `"en"`, with an explicit `zh-hant` mapping for
  Traditional Chinese region tags. Exported so it's independently testable.
- `web/src/i18n/context.test.ts` (new): covers stored-preference precedence,
  exact match, base-subtag fallback, the `zh-hant` region mapping, and the
  no-match default to English.

## How to Test

1. `npm run install:web` (from repo root) if `web/node_modules` isn't present.
2. `cd web && npx vitest run src/i18n/context.test.ts`
3. Manually: clear the dashboard's `localStorage`, set the browser/OS language
   to e.g. German or Traditional Chinese, and reload — the UI now opens in
   that language instead of English.

### Test output

Before the fix (`git checkout HEAD~1 -- web/src/i18n/context.tsx` to restore
the old `getInitialLocale`, run, then restore the fix):

```
 FAIL  src/i18n/context.test.ts > getInitialLocale > returns the stored locale when one was explicitly chosen
TypeError: getInitialLocale is not a function
 FAIL  src/i18n/context.test.ts > getInitialLocale > matches an exact supported browser language over English
TypeError: getInitialLocale is not a function
 FAIL  src/i18n/context.test.ts > getInitialLocale > falls back to the base subtag when the region tag isn't supported
TypeError: getInitialLocale is not a function
 FAIL  src/i18n/context.test.ts > getInitialLocale > maps Traditional Chinese region tags to zh-hant instead of the zh base
TypeError: getInitialLocale is not a function
 FAIL  src/i18n/context.test.ts > getInitialLocale > defaults to English when nothing matches
TypeError: getInitialLocale is not a function

 Test Files  1 failed (1)
      Tests  5 failed (5)
```

After the fix:

```
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

Full suite and typecheck after the fix:

```
$ npx tsc -p . --noEmit
(no output — passes)

$ npx vitest run
 Test Files  40 passed (40)
      Tests  296 passed (296)
```

`npx eslint .` on the touched files reports 0 errors (the pre-existing
`react-refresh/only-export-components` warning count on `context.tsx` goes
from 2 to 3, matching the file's existing pattern of exporting a few plain
functions/constants alongside the provider component — not a new class of
warning).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate — open
      PR #63328 touches the same function as part of a much larger Brazilian
      Portuguese locale addition; a maintainer noted in the issue that
      #101746 "remains the focused bug/spec thread," so this PR is a minimal,
      standalone fix scoped to just the reported bug.
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've added tests for my changes
- [ ] I've tested on my platform — tested in a Linux CI checkout only (no
      access to a browser to click through the dashboard manually); verified
      via the unit tests above plus reading `navigator.languages` semantics.

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or tool schemas changed.

---

Note: this PR was prepared with AI assistance (Claude Code); the diff was
reviewed, tested, and pushed by a human-supervised automated workflow before
being opened.
