### PR TITLE
fix(buzz): notify users on Hermes replies

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -151,6 +151,13 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) 
         scope_id = getattr(source, "scope_id", None)
         if scope_id:
             metadata["slack_team_id"] = str(scope_id)
+    # Carry the triggering sender as platform-neutral delivery context. Most
+    # adapters do not need it; recipient-addressed protocols such as Nostr can
+    # translate it into their native notification tag without changing the
+    # assistant's visible reply text.
+    reply_recipient_id = str(getattr(source, "user_id", None) or "").strip()
+    if reply_recipient_id:
+        metadata["reply_recipient_id"] = reply_recipient_id
     if not metadata:
         return None
     if _platform_name(getattr(source, "platform", None)) == "telegram" and getattr(source, "chat_type", None) == "dm":

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1283,6 +1283,28 @@ class BuzzAdapter(BasePlatformAdapter):
                 text = pattern.sub("\x00", text)
         return found
 
+    def _outbound_recipient_pubkeys(
+        self,
+        metadata: Optional[Dict[str, Any]],
+        mention_pubkeys: Optional[List[str]] = None,
+    ) -> List[str]:
+        """Merge visible mentions with the triggering Buzz user's p-tag.
+
+        The gateway stamps ``reply_recipient_id`` from the inbound
+        ``SessionSource.user_id``. Keeping this transport-only avoids changing
+        the generated reply text while making the response discoverable by
+        Buzz's #p-based Inbox/Activity and notification paths.
+        """
+        recipients = list(mention_pubkeys or [])
+        candidate = str((metadata or {}).get("reply_recipient_id") or "").strip().lower()
+        if (
+            re.fullmatch(r"[0-9a-f]{64}", candidate)
+            and candidate != getattr(self, "_self_pubkey", None)
+            and candidate not in recipients
+        ):
+            recipients.append(candidate)
+        return recipients
+
     async def _run_message_send(
         self,
         args: List[str],
@@ -1358,7 +1380,10 @@ class BuzzAdapter(BasePlatformAdapter):
         )
         if reply_target and self._reply_to_mode != "off":
             args += ["--reply-to", str(reply_target)]
-        mention_pubkeys = await self._mention_pubkeys_for(chat_id, content)
+        mention_pubkeys = self._outbound_recipient_pubkeys(
+            meta,
+            await self._mention_pubkeys_for(chat_id, content),
+        )
         code, out, err = await self._run_message_send(args, content, mention_pubkeys)
         if code != 0:
             return SendResult(
@@ -1508,7 +1533,10 @@ class BuzzAdapter(BasePlatformAdapter):
         )
         if reply_target and self._reply_to_mode != "off":
             args += ["--reply-to", str(reply_target)]
-        code, out, err = await self._run_message_send(args, caption or "")
+        mention_pubkeys = self._outbound_recipient_pubkeys(metadata)
+        code, out, err = await self._run_message_send(
+            args, caption or "", mention_pubkeys
+        )
         if code != 0:
             return SendResult(
                 success=False,
@@ -1576,7 +1604,10 @@ class BuzzAdapter(BasePlatformAdapter):
         )
         if reply_target and self._reply_to_mode != "off":
             args += ["--reply-to", str(reply_target)]
-        code, out, err = await self._run_message_send(args, caption or "")
+        mention_pubkeys = self._outbound_recipient_pubkeys(metadata)
+        code, out, err = await self._run_message_send(
+            args, caption or "", mention_pubkeys
+        )
         if code != 0:
             return SendResult(
                 success=False,

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -2208,6 +2208,60 @@ class TestBuzzAdapterSend:
         assert args[args.index("--reply-to") + 1] == "root-event-abc"
 
     @pytest.mark.asyncio
+    async def test_send_p_tags_triggering_user_for_buzz_inbox(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-notify"})
+        adapter._run_cli = cli
+
+        result = await adapter.send(
+            CHANNEL,
+            "reply without a visible mention",
+            metadata={"reply_recipient_id": OTHER_PUBKEY},
+        )
+
+        assert result.success is True
+        args, _stdin = cli.calls[0]
+        assert args[args.index("--mention") + 1] == OTHER_PUBKEY
+
+    @pytest.mark.asyncio
+    async def test_send_deduplicates_triggering_user_and_visible_mention(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("channels", "members", [OTHER_PUBKEY])
+        cli.script("users", "get", [{"pubkey": OTHER_PUBKEY, "display_name": "John"}])
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-dedupe"})
+        adapter._run_cli = cli
+
+        await adapter.send(
+            CHANNEL,
+            "Thanks @John",
+            metadata={"reply_recipient_id": OTHER_PUBKEY},
+        )
+
+        args, _stdin = [
+            call for call in cli.calls if call[0][:2] == ["messages", "send"]
+        ][0]
+        assert args.count("--mention") == 1
+        assert args[args.index("--mention") + 1] == OTHER_PUBKEY
+
+    @pytest.mark.asyncio
+    async def test_send_ignores_invalid_buzz_recipient_metadata(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-invalid"})
+        adapter._run_cli = cli
+
+        await adapter.send(
+            CHANNEL,
+            "reply",
+            metadata={"reply_recipient_id": "not-a-pubkey"},
+        )
+
+        args, _stdin = cli.calls[0]
+        assert "--mention" not in args
+
+    @pytest.mark.asyncio
     async def test_send_prefers_stable_thread_root_over_latest_reply(self):
         adapter = _make_adapter()
         cli = _ScriptedCli()

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -2,6 +2,7 @@
 
 import os
 import time
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -21,6 +22,35 @@ from gateway.platforms.base import (
     _prefix_within_utf16_limit,
     cache_audio_from_bytes,
 )
+
+
+def test_thread_metadata_carries_triggering_user_id():
+    import gateway.platforms.base as base
+
+    source = SimpleNamespace(
+        platform="buzz",
+        thread_id="thread-root",
+        user_id="A" * 64,
+        profile=None,
+    )
+
+    assert base._thread_metadata_for_source(source) == {
+        "thread_id": "thread-root",
+        "reply_recipient_id": "A" * 64,
+    }
+
+
+def test_thread_metadata_omits_empty_triggering_user_id():
+    import gateway.platforms.base as base
+
+    source = SimpleNamespace(
+        platform="buzz",
+        thread_id=None,
+        user_id=None,
+        profile=None,
+    )
+
+    assert base._thread_metadata_for_source(source) is None
 
 
 def test_media_delivery_denies_encrypted_bitwarden_cache(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- carry the triggering sender ID as generic reply delivery metadata
- translate valid Buzz pubkeys into CLI `--mention` arguments, producing signed Nostr `p` tags without visible @mention text
- cover text and native attachment replies; deduplicate visible mentions and reject malformed recipient IDs

Buzz Inbox/Activity and notification subscriptions are `#p`-based, so Hermes replies without a `p` tag do not appear there.

## Verification
- `python -m pytest tests/gateway/test_buzz_adapter.py tests/gateway/test_platform_base.py -o addopts= -q`
- 295 passed

Related upstream Buzz issue: block/buzz#3032