### PR TITLE
fix(gateway): point api_server fatal errors at a working recovery

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -7900,8 +7900,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 "API_SERVER_KEY was rejected by the startup guard (missing, "
                 "placeholder/too short, or strength unverifiable — see the "
                 "error logged above). Generate a strong secret (e.g. "
-                "`openssl rand -hex 32`), set API_SERVER_KEY, then "
-                "`/platform resume api_server`.",
+                "`openssl rand -hex 32`), set API_SERVER_KEY, then restart "
+                "the gateway (`hermes gateway restart`).",
                 retryable=False,
             )
             return False
@@ -8010,13 +8010,15 @@ class APIServerAdapter(BasePlatformAdapter):
                     # defaulting to the same port, #52132), filling
                     # errors.log and leaking the adapter's ResponseStore
                     # fds each retry. Non-retryable drops it from the
-                    # reconnect queue; the operator recovers with
-                    # ``/platform resume api_server`` after changing the port.
+                    # reconnect queue, so ``/platform resume`` cannot bring
+                    # it back — the operator must restart the gateway after
+                    # changing the port.
                     self._set_fatal_error(
                         "api_server_port_in_use",
                         f"Port {self._port} already in use. Set "
                         f"platforms.api_server.port in config.yaml to a "
-                        f"different value, then `/platform resume api_server`.",
+                        f"different value, then restart the gateway "
+                        f"(`hermes gateway restart`).",
                         retryable=False,
                     )
                 logger.error(

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2833,7 +2833,14 @@ class TestKeyRejectionSetsNonRetryableFatalError:
             assert adapter.has_fatal_error is True
             assert adapter.fatal_error_retryable is False
             assert adapter.fatal_error_code == "api_server_key_invalid"
-            assert "API_SERVER_KEY" in (adapter.fatal_error_message or "")
+            message = adapter.fatal_error_message or ""
+            assert "API_SERVER_KEY" in message
+            # Non-retryable fatals are never queued in _failed_platforms
+            # (gateway/run.py), so `/platform resume` always replies "not
+            # in the retry queue" for this error class (#101745). Only a
+            # gateway restart actually recovers it.
+            assert "/platform resume" not in message
+            assert "gateway restart" in message
         finally:
             await adapter.disconnect()
 

--- a/tests/gateway/test_api_server_bind_guard.py
+++ b/tests/gateway/test_api_server_bind_guard.py
@@ -170,3 +170,26 @@ class TestBindMechanics:
         finally:
             await first.disconnect()
             await second.disconnect()
+
+
+    @pytest.mark.asyncio
+    async def test_port_conflict_message_names_a_working_recovery(self):
+        """The port-conflict message must not send the operator to
+        ``/platform resume``: a non-retryable fatal is never queued in
+        ``_failed_platforms`` (gateway/run.py), so slash_commands.py's
+        resume handler always replies "not in the retry queue — nothing
+        to resume" for this exact error. The only real recovery is a
+        gateway restart, and the message must say so (#101745).
+        """
+        port = self._free_port()
+        first = self._make_adapter(port)
+        assert await first.connect() is True
+        second = self._make_adapter(port)
+        try:
+            assert await second.connect() is False
+            message = second.fatal_error_message or ""
+            assert "/platform resume" not in message
+            assert "gateway restart" in message
+        finally:
+            await first.disconnect()
+            await second.disconnect()


### PR DESCRIPTION
## What does this PR do?

When `api_server` hits a non-retryable fatal error (port already in use,
or an invalid/missing `API_SERVER_KEY`), the error message told the
operator to run `/platform resume api_server` after fixing the
underlying cause. That instruction can never succeed for these two
error classes:

- `gateway/platforms/api_server.py` calls `_set_fatal_error(..., retryable=False)`
  for both cases.
- `gateway/run.py`'s `_queue_retryable_fatal_platform()` returns early
  (`if not adapter.fatal_error_retryable: return False`) for non-retryable
  fatals, so the platform is never added to `_failed_platforms`.
- `gateway/slash_commands.py`'s `/platform resume` handler checks
  `if platform not in failed: return "... not in the retry queue —
  nothing to resume."` — which is exactly what happens here, every time.

The only real recovery is a full gateway restart (`hermes gateway
restart`), which the message never mentioned. This fixes both messages
to point at the working recovery path instead of the dead end.

## Related Issue

Fixes #101745

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `gateway/platforms/api_server.py` — both `api_server_port_in_use` and
  `api_server_key_invalid` fatal-error messages now say "restart the
  gateway (`hermes gateway restart`)" instead of "`/platform resume
  api_server`". (The key-invalid case was already flagged in a code
  comment as "same treatment as the port-conflict guard" — same defect,
  same fix.)
- `tests/gateway/test_api_server_bind_guard.py` — new
  `test_port_conflict_message_names_a_working_recovery`, asserting the
  port-conflict message excludes `/platform resume` and includes
  `gateway restart`.
- `tests/gateway/test_api_server.py` — extended
  `TestKeyRejectionSetsNonRetryableFatalError._assert_key_rejection_is_fatal`
  with the same assertions for the key-invalid message.

## How to Test

1. Run two `api_server` adapters bound to the same port (or supply an
   invalid `API_SERVER_KEY`) and observe the fatal error message.
2. Confirm the message names `hermes gateway restart`, not
   `/platform resume`.
3. Confirm `/platform resume api_server` in this state replies "not in
   the retry queue — nothing to resume" (pre-existing, unchanged
   behavior — this PR fixes what the error *tells* the operator to do,
   not the resume gate itself).

Regression proof — reverted the source change only
(`git checkout HEAD~1 -- gateway/platforms/api_server.py`) and reran the
new assertions:

```
FAILED tests/gateway/test_api_server_bind_guard.py::TestBindMechanics::test_port_conflict_message_names_a_working_recovery
  AssertionError: assert '/platform resume' not in 'Port 52803 ...api_server`.'

FAILED tests/gateway/test_api_server.py::TestKeyRejectionSetsNonRetryableFatalError::test_missing_key_sets_non_retryable_fatal_error
  AssertionError: assert '/platform resume' not in 'API_SERVER_...api_server`.'
```

With the fix restored:

```
$ python -m pytest tests/gateway/test_api_server_bind_guard.py -q
10 passed, 3 warnings in 0.78s

$ python -m pytest tests/gateway/test_api_server.py -q
110 passed, 54 warnings in 11.26s

$ ruff check gateway/platforms/api_server.py tests/gateway/test_api_server_bind_guard.py tests/gateway/test_api_server.py
All checks passed!
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the affected suites and `ruff check`; full-suite run not
      performed in this sandbox (no CI access here)
- [x] I've added tests for my changes
- [ ] Tested on my platform — validated via the automated test suite in a
      Linux sandbox only; the issue was filed from Windows 11 but the
      change is a plain string edit with no platform-specific behavior

### Documentation & Housekeeping

- [x] Documentation updates — N/A, no docs reference the old message text
- [x] `cli-config.yaml.example` — N/A, no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture or workflow changed
- [x] Cross-platform impact — N/A, plain string change
- [x] Tool descriptions/schemas — N/A

## AI assistance disclosure

This PR was prepared with AI assistance (Claude, Anthropic), including
locating the referenced code paths, drafting the fix, and writing/running
the regression tests. All test output above was executed and verified,
not fabricated.
