### PR TITLE
fix(doctor): warn instead of false-green on npm audit network failure

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2701,7 +2701,16 @@ def run_doctor(args):
                 )
                 import json as _json
                 audit_data = _json.loads(audit_result.stdout) if audit_result.stdout.strip() else {}
-                vuln_count = audit_data.get("metadata", {}).get("vulnerabilities", {})
+                # A network/registry failure (e.g. DNS lookup to registry.npmjs.org
+                # fails) still exits 0 with a JSON body shaped like a result, but
+                # it carries a top-level "error" instead of "metadata.vulnerabilities".
+                # Treating the missing/invalid shape as zero vulnerabilities turns
+                # an audit failure into a false "no known vulnerabilities". See #101760.
+                vuln_count = audit_data.get("metadata", {}).get("vulnerabilities") \
+                    if isinstance(audit_data, dict) else None
+                if not isinstance(audit_data, dict) or audit_data.get("error") or not isinstance(vuln_count, dict):
+                    check_warn(f"{label} deps", "(npm audit unavailable: registry/network error)")
+                    continue
                 critical = vuln_count.get("critical", 0)
                 high = vuln_count.get("high", 0)
                 moderate = vuln_count.get("moderate", 0)
@@ -2758,7 +2767,7 @@ def run_doctor(args):
                         f"{'vulnerability' if moderate == 1 else 'vulnerabilities'})",
                     )
             except Exception:
-                pass
+                check_warn(f"{label} deps", "(npm audit unavailable: registry/network error)")
 
     if _is_termux():
         check_info("Termux compatibility fallbacks:")

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -408,6 +408,43 @@ def test_run_doctor_termux_treats_docker_and_browser_warnings_as_expected(monkey
     assert "docker not found (optional)" not in out
 
 
+def test_run_doctor_npm_audit_network_failure_warns_instead_of_ok(monkeypatch, tmp_path):
+    """#101760: a registry/network failure must not be reported as clean."""
+    helper = TestDoctorMemoryProviderSection()
+
+    real_which = doctor_mod.shutil.which
+
+    def fake_which(cmd):
+        if cmd == "npm":
+            return "/usr/bin/npm"
+        return real_which(cmd)
+
+    monkeypatch.setattr(doctor_mod.shutil, "which", fake_which)
+
+    project_root = tmp_path / "project"
+    (project_root / "node_modules").mkdir(parents=True, exist_ok=True)
+
+    network_failure_stdout = (
+        '{"message": "request to https://registry.npmjs.org/-/npm/v1/security/'
+        'audits/quick failed, reason: getaddrinfo ENOTFOUND registry.npmjs.org", '
+        '"error": {"summary": "", "detail": ""}}'
+    )
+
+    real_run = doctor_mod.subprocess.run
+
+    def fake_run(cmd, **kwargs):
+        if isinstance(cmd, list) and "audit" in cmd:
+            return SimpleNamespace(stdout=network_failure_stdout, stderr="", returncode=1)
+        return real_run(cmd, **kwargs)
+
+    monkeypatch.setattr(doctor_mod.subprocess, "run", fake_run)
+
+    out = helper._run_doctor_and_capture(monkeypatch, tmp_path, provider="")
+
+    assert "no known vulnerabilities" not in out
+    assert "npm audit unavailable: registry/network error" in out
+
+
 def test_run_doctor_accepts_named_provider_from_providers_section(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

Fixes #101760.

`hermes doctor` reports `✓ ... deps (no known vulnerabilities)` even when
`npm audit --json` failed before returning vulnerability metadata (e.g. a
DNS/network failure reaching `registry.npmjs.org`). npm exits 0 in that case
with a JSON body shaped like:

```json
{
  "message": "request to https://registry.npmjs.org/-/npm/v1/security/audits/quick failed, reason: getaddrinfo ENOTFOUND registry.npmjs.org",
  "error": {"summary": "", "detail": ""}
}
```

`hermes_cli/doctor.py` defaulted the missing `metadata.vulnerabilities` to
`{}` and each severity to `0`, so this audit-failure payload was
indistinguishable from a genuinely clean audit, and the broad
`except Exception: pass` also silently swallowed timeouts/parse failures.

## Fix

In the npm-audit block of `run_doctor()` (`hermes_cli/doctor.py`):
- Before counting vulnerabilities, require `audit_data` to be a dict, reject
  a top-level `error` key, and require `metadata.vulnerabilities` to actually
  be a mapping. If any of those fail, emit
  `⚠ <label> deps (npm audit unavailable: registry/network error)` and move
  on to the next audit target instead of printing a false "clean" result.
- The `except Exception: pass` around the whole audit/parse path now emits
  the same warning instead of silently doing nothing, so a subprocess
  timeout or JSON parse failure is visible too.

Only the audit-result-shape validation changed — the existing severity
counting, fix-command hints, and non-network-failure code paths are
untouched.

## Test plan

Added `test_run_doctor_npm_audit_network_failure_warns_instead_of_ok` in
`tests/hermes_cli/test_doctor.py`, which stubs `npm` as available, creates a
`node_modules` dir so the audit runs, and stubs `subprocess.run` to return
the exact network-failure JSON payload from the issue for any `npm audit`
invocation (other subprocess calls pass through untouched). It asserts the
output never contains `"no known vulnerabilities"` and does contain the new
`"npm audit unavailable: registry/network error"` warning.

Confirmed the test fails without the fix (reverted just `hermes_cli/doctor.py`
to `HEAD~1` while keeping the new test) with:

```
AssertionError: assert 'no known vulnerabilities' not in '...'
'no known vulnerabilities' is contained here:
  ✓ Browser tools (agent-browser) deps (no known vulnerabilities)
  ✓ web workspace deps (no known vulnerabilities)
  ✓ ui-tui workspace deps (no known vulnerabilities)
```

With the fix applied:

```
$ source .venv/bin/activate && python -m pytest tests/hermes_cli/test_doctor.py -q
.......................................................................  [100%]
71 passed in 16.17s
```

```
$ ruff check hermes_cli/doctor.py tests/hermes_cli/test_doctor.py
All checks passed!
```

## AI assistance disclosure

This change was written by an AI coding agent (Claude), including the
diagnosis, the fix, and the regression test. All commands above were run
and their real output is pasted verbatim, not fabricated.
