### PR TITLE
fix(skills): report ambiguous short-name install as a real failure

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13404,7 +13404,7 @@ def cmd_skills(args):
     else:
         from hermes_cli.skills_hub import skills_command
 
-        skills_command(args)
+        return skills_command(args)
 
 
 def _cmd_skills_trust(args):

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -544,8 +544,18 @@ def do_install(identifier: str, category: str = "", force: bool = False,
                console: Optional[Console] = None, skip_confirm: bool = False,
                invalidate_cache: bool = True,
                name_override: str = "",
-               source_id: Optional[str] = None) -> None:
+               source_id: Optional[str] = None) -> Optional[int]:
     """Fetch, quarantine, scan, confirm, and install a skill.
+
+    Returns ``1`` when short-name resolution can't produce a single
+    identifier (no match, or multiple candidates) so callers that propagate
+    this as a process exit code -- notably the Desktop hub picker, which
+    posts a bare catalog name and treats any non-zero exit as a failed
+    install -- see it as one instead of an apparent success with nothing
+    installed. Other early-exit paths (already installed, scan-blocked,
+    user-declined) keep returning ``None`` (exit 0): they already print a
+    clear reason and aren't the ambiguous-identifier failure mode this
+    guards.
 
     ``name_override`` lets non-interactive callers (slash commands, gateway,
     scripts) supply a skill name when the upstream SKILL.md lacks a valid
@@ -591,7 +601,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     if "/" not in identifier:
         identifier = _resolve_short_name(identifier, sources, c)
         if not identifier:
-            return
+            return 1
 
     c.print(f"\n[bold]Fetching:[/] {identifier}")
 
@@ -1817,7 +1827,7 @@ def do_snapshot_import(input_path: str, force: bool = False,
 # CLI argparse entry point
 # ---------------------------------------------------------------------------
 
-def skills_command(args) -> None:
+def skills_command(args) -> Optional[int]:
     """Router for `hermes skills <subcommand>` — called from hermes_cli/main.py."""
     action = getattr(args, "skills_action", None)
 
@@ -1827,7 +1837,7 @@ def skills_command(args) -> None:
         do_search(args.query, source=args.source, limit=args.limit,
                   as_json=getattr(args, "json", False))
     elif action == "install":
-        do_install(args.identifier, category=args.category, force=args.force,
+        return do_install(args.identifier, category=args.category, force=args.force,
                    skip_confirm=getattr(args, "yes", False),
                    name_override=getattr(args, "name", "") or "")
     elif action == "inspect":

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -489,3 +489,44 @@ def test_do_update_unmodified_skill_updates_normally(monkeypatch, tmp_path):
 
     assert installs == ["someone/hub-skill"]
     assert "Updated 1 skill(s)" in sink.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Regression (#101670): an ambiguous short name must fail the install, not
+# report success with nothing installed.
+# ---------------------------------------------------------------------------
+
+
+def _ambiguous_candidate(name, source, identifier):
+    return type("Candidate", (), {
+        "name": name,
+        "source": source,
+        "identifier": identifier,
+        "trust_level": "community",
+        "extra": {},
+    })()
+
+
+def test_do_install_fails_on_ambiguous_short_name(monkeypatch):
+    """`hermes skills install humanizer --yes` (the Desktop hub picker's exact
+    call, per #101670) must return a non-zero status when the name matches
+    several catalog entries, so the CLI process exits non-zero and the
+    Desktop action pipeline surfaces the failure instead of reading the
+    unchanged skills list as a successful install."""
+    import tools.skills_hub as hub
+
+    monkeypatch.setattr(hub, "ensure_hub_dirs", lambda: None)
+    monkeypatch.setattr(hub, "GitHubAuth", lambda: object())
+    monkeypatch.setattr(hub, "create_source_router", lambda auth: [])
+    monkeypatch.setattr(hub, "unified_search", lambda *a, **k: [
+        _ambiguous_candidate("humanizer", "skills.sh", "skills.sh/humanizer"),
+        _ambiguous_candidate("humanizer", "clawhub", "clawhub/humanizer"),
+    ])
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None, width=80)
+
+    rc = do_install("humanizer", skip_confirm=True, console=console)
+
+    assert rc == 1
+    assert "Multiple skills named" in sink.getvalue()


### PR DESCRIPTION
## What does this PR do?

Fixes the `do_install()` → `skills_command()` → `cmd_skills()` return-value
chain so that a short skill name that can't be resolved to a single
identifier makes `hermes skills install <name> --yes` exit non-zero,
instead of silently exiting 0 with nothing installed.

`do_install()`'s `_resolve_short_name()` call already detects "no match"
and "multiple exact matches" and prints a candidate table, but it then does
a bare `return` — which is `None`, and `main.py`'s dispatcher only
propagates an **`int`** return as a non-zero exit code ("Handlers that
return `None` are treated as success (exit 0)", `hermes_cli/main.py`).
So every layer between the failed resolution and the process exit code
reported success.

This matters because Hermes Desktop's embedded Skills Hub picker
(`apps/desktop/src/app/skills/embedded-hub-picker.tsx`) posts a card's
`skill.identifier || skill.name` straight into
`installHubSkill()` → `POST /api/skills/hub/install` →
`hermes skills install <name> --yes` (`hermes_cli/web_routers/skills.py`).
For a catalog entry with no globally-unique identifier (e.g. a community
skill named `humanizer` that exists under several sources), that's a bare,
ambiguous name. The Desktop action pipeline (`hub-actions.ts`)
*already* treats a non-zero subprocess exit as a real failure and toasts
it — it just never received one, so the user saw "install started" and
then... nothing, with no error.

## Related Issue

Fixes #101670

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/skills_hub.py`: `do_install()` returns `1` when
  `_resolve_short_name()` can't produce a single identifier (no match, or
  multiple ambiguous matches); doc comment explains the contract. Other
  early-return paths (already installed, scan-blocked, user-declined) are
  unchanged — they already print a clear reason and aren't the silent
  ambiguous-identifier failure this issue reports.
- `hermes_cli/skills_hub.py`: `skills_command()`'s `install` branch now
  `return`s `do_install()`'s result instead of discarding it.
- `hermes_cli/main.py`: `cmd_skills()`'s default branch now `return`s
  `skills_command()`'s result instead of discarding it, so it reaches
  `main()`'s existing `rc = args.func(args); ... sys.exit(rc)` propagation.

This is scoped to the exit-code plumbing bug identified in the issue's
root-cause section ("the ambiguous CLI result is not a typed failure").
The broader UI-side asks in the issue (canonical source-qualified
identifiers from the picker, a chooser UI, a typed `ambiguous_identifier`
JSON contract) are separate, larger design changes left for a follow-up.

## How to Test

1. `hermes skills install humanizer --yes` (or any short name matching
   several catalog entries across sources) now exits non-zero instead of 0.
2. Automated regression:
   `tests/hermes_cli/test_skills_hub.py::test_do_install_fails_on_ambiguous_short_name`
   mocks `unified_search` to return two same-named candidates from
   different sources, calls `do_install("humanizer", skip_confirm=True)`,
   and asserts the return value is `1`.

Verified the test fails without the fix (reverted just the two source
files with `git stash`, keeping the test):

```
$ python3 -m pytest tests/hermes_cli/test_skills_hub.py -k ambiguous -q
F
...
E       assert None == 1
1 failed, 8 deselected in 0.46s
```

And passes with the fix restored:

```
$ python3 -m pytest tests/hermes_cli/test_skills_hub.py -q
.........
9 passed in 0.48s
```

Also ran the neighboring install-path suites, all green:

```
$ python3 -m pytest tests/hermes_cli/test_skills_install_flags.py \
    tests/hermes_cli/test_subcommands_followup.py \
    tests/hermes_cli/test_skills_uninstall_flags.py \
    tests/hermes_cli/test_skills_skip_confirm.py \
    tests/tools/test_skill_bundle_provenance.py -q
...........................................
40 passed in ~4s
```

`ruff check` on the three changed files: clean. `ty check` on
`hermes_cli/skills_hub.py` and `hermes_cli/main.py`: same diagnostic
counts before and after this change (1 and 59 respectively, both
pre-existing and unrelated to `do_install`/`cmd_skills`).

Note: this sandbox checkout has no `.venv`, so I couldn't run the
canonical `scripts/run_tests.sh` (it requires a pre-built venv or the Nix
devShell); I ran `pytest` directly against the affected suites instead.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the affected test suites and they pass (see above; full
      `pytest tests/ -q` not run — see note above)
- [x] I've added a test for this change
- [ ] I've tested on my platform — sandboxed CI-like Linux container, no
      GUI, so the Desktop picker itself wasn't exercised end-to-end; only
      the CLI/exit-code path this PR changes was.

### Documentation & Housekeeping

- [x] N/A — no docs, config keys, or tool schemas changed.

## Screenshots / Logs

See the pytest output above.

---

Disclosure: this change was written with AI assistance (Claude Code),
with the diff, tests, and PR description reviewed by me before submission.
