### PR TITLE
fix(config): resolve ${env:VAR} refs from .env before os.environ is populated

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3001,9 +3001,11 @@ def _env_ref_lookup(name: str) -> Optional[str]:
     try:
         from agent.secret_scope import current_secret_scope, get_secret as _get_secret
     except Exception:
-        return os.environ.get(name)
+        val = os.environ.get(name)
+        return val if val is not None else load_env().get(name)
     if current_secret_scope() is None:
-        return os.environ.get(name)
+        val = os.environ.get(name)
+        return val if val is not None else load_env().get(name)
     return _get_secret(name)
 
 

--- a/tests/hermes_cli/test_config_env_expansion.py
+++ b/tests/hermes_cli/test_config_env_expansion.py
@@ -54,6 +54,19 @@ class TestLoadConfigCacheEnvStaleness:
     environment (#58514): a load before load_hermes_dotenv() runs, or an env
     var rotated in-process, must not keep serving the old expansion."""
 
+    def test_ref_resolves_from_dotenv_before_os_environ_populated(self, tmp_path, monkeypatch):
+        """A ${env:VAR} ref must resolve from ~/.hermes/.env even when the
+        process env isn't populated yet (import-time plugin discovery runs
+        load_config() before load_hermes_dotenv()). Regression: the ref was
+        left as a literal placeholder and a spurious 'not set' warning fired
+        even though the key existed in .env."""
+        from hermes_cli.config import _env_ref_lookup
+        env_file = tmp_path / ".env"
+        env_file.write_text("LATE_DOTENV_KEY_58514=from-dotenv\n")
+        monkeypatch.setattr("hermes_cli.config.get_env_path", lambda: env_file)
+        monkeypatch.delenv("LATE_DOTENV_KEY_58514", raising=False)
+        assert _env_ref_lookup("LATE_DOTENV_KEY_58514") == "from-dotenv"
+
     def test_env_var_appearing_after_first_load_invalidates_cache(self, tmp_path, monkeypatch):
         config_yaml = "auxiliary:\n  vision:\n    api_key: ${LATE_DOTENV_KEY_58514}\n"
         config_file = tmp_path / "config.yaml"


### PR DESCRIPTION
## Problem

`hermes doctor` (and any CLI entrypoint) prints spurious warnings at startup:

```
Config ref '${env:OPENROUTER_API_KEY}': OPENROUTER_API_KEY is not set (check ~/.hermes/.env); keeping the literal placeholder
```

even when the key **is** present and non-empty in `~/.hermes/.env`. The config still resolves correctly later (API connectivity checks pass), so this is a false alarm — but it's noisy and misleading.

## Root cause

At **import time** of `hermes_cli.config`, module-level `_inject_profile_env_vars()` runs:

```
import hermes_cli.config
  → _inject_profile_env_vars()
    → providers.list_providers() → _discover_entry_point_providers() → _get_enabled_plugins()
      → load_config() → _expand_env_vars() → _env_ref_lookup() → os.environ.get() → None
```

`load_hermes_dotenv()` (which populates `os.environ` from `.env`) runs **later** — in `doctor.py:32`, after the import. So the first `load_config()` expands every `${env:VAR}` against an empty process env, logs "not set", and keeps the literal placeholder. A later `load_config()` re-expands correctly (the cache-staleness guard in #58514 handles that), but the damage — the misleading warning — is already printed.

## Fix

`_env_ref_lookup()` falls back to `load_env()` (the memoized `.env` reader) on the **unscoped** path, exactly mirroring what `get_env_value()` already does. Scoped (multiplex) reads are unchanged: a miss is still a miss, never another profile's value (#84079).

## Verification

- `import hermes_cli.config` with a `.env` containing the key and an empty `os.environ` → no warning, ref resolves.
- `hermes doctor` → the 5 `Config ref ... not set` lines are gone.
- Config still resolves all `api_key` values correctly.
- Added regression test `test_ref_resolves_from_dotenv_before_os_environ_populated`.
- `tests/hermes_cli/test_config_env_expansion.py`, `test_config_env_ref_parity.py`, `tests/cron/test_scheduler.py`, `tests/cli/test_cli_mcp_config_watch.py`: **120 passed**.