### PR TITLE
fix(desktop): stop composer/model-picker focus churn during resume retries

### DIFF
--- a/apps/desktop/src/app/chat/index.test.tsx
+++ b/apps/desktop/src/app/chat/index.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { useState } from 'react'
 import { MemoryRouter } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -48,7 +48,16 @@ vi.mock('@/lib/model-options', () => ({
 }))
 vi.mock('./chat-drop-overlay', () => ({ ChatDropOverlay: () => null }))
 vi.mock('./chat-swap-overlay', () => ({ ChatSwapOverlay: () => null, ChatSyncBadge: () => null }))
-vi.mock('./composer', () => ({ ChatBar: () => null, ChatBarFallback: () => null }))
+const chatBarFocusKeys = vi.hoisted(() => ({ current: [] as Array<string | null | undefined> }))
+
+vi.mock('./composer', () => ({
+  ChatBar: ({ focusKey }: { focusKey?: string | null }) => {
+    chatBarFocusKeys.current.push(focusKey)
+
+    return null
+  },
+  ChatBarFallback: () => null
+}))
 vi.mock('./hooks/use-file-drop-zone', () => ({
   useFileDropZone: () => ({ dragKind: null, dropHandlers: {} })
 }))
@@ -74,6 +83,7 @@ function assistantMessage(id: string, text: string): ChatMessage {
 describe('ChatView render isolation', () => {
   beforeEach(() => {
     threadRenderCount.current = 0
+    chatBarFocusKeys.current = []
     $activeSessionId.set('runtime-1')
     $awaitingResponse.set(false)
     $busy.set(false)
@@ -160,5 +170,65 @@ describe('ChatView render isolation', () => {
     // memo(ChatView) with stable props must absorb the parent's idle tick —
     // the transcript (Thread) must not re-render. This is PR #38470's contract.
     expect(threadRenderCount.current).toBe(1)
+  })
+
+  it('keeps the composer focusKey stable while the runtime id churns on a same-session resume retry (#101712)', () => {
+    const props = {
+      gateway: null,
+      maxVoiceRecordingSeconds: 120,
+      onAddContextRef: vi.fn(),
+      onAddUrl: vi.fn(),
+      onAttachDroppedItems: vi.fn(),
+      onAttachImageBlob: vi.fn(),
+      onBranchInNewChat: vi.fn(),
+      onCancel: vi.fn(),
+      onDeleteSelectedSession: vi.fn(),
+      onEdit: vi.fn(),
+      onPasteClipboardImage: vi.fn(),
+      onPickFiles: vi.fn(),
+      onPickFolders: vi.fn(),
+      onPickImages: vi.fn(),
+      onReload: vi.fn(),
+      onRemoveAttachment: vi.fn(),
+      onRetryResume: vi.fn(),
+      onSteer: vi.fn(),
+      onSubmit: vi.fn(),
+      onThreadMessagesChange: vi.fn(),
+      onToggleSelectedPin: vi.fn(),
+      onTranscribeAudio: vi.fn()
+    }
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } }
+    })
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/stored-1']}>
+          <ChatView {...props} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
+
+    expect(chatBarFocusKeys.current.at(-1)).toBe('stored-1')
+
+    // A failed resume attempt against the SAME routed session (a 404-looping
+    // reconciliation, e.g. auto-continue after a backend restart mid-turn)
+    // unbinds the runtime id before retrying — $selectedStoredSessionId never
+    // moves off the routed session, only $activeSessionId churns.
+    act(() => {
+      $activeSessionId.set(null)
+    })
+
+    expect(chatBarFocusKeys.current.at(-1)).toBe('stored-1')
+
+    act(() => {
+      $activeSessionId.set('runtime-2')
+    })
+
+    // Every focusKey observed across the churn must be the stable stored id —
+    // never null and never the transient runtime id — so the composer's
+    // focus-on-key-change effect never re-fires (and steals focus) mid-retry.
+    expect(chatBarFocusKeys.current.every(key => key === 'stored-1')).toBe(true)
   })
 })

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -733,7 +733,14 @@ const ChatViewContent = memo(function ChatViewContent({
               busy={busy}
               cwd={currentCwd}
               disabled={!gatewayOpen}
-              focusKey={activeSessionId}
+              // threadKey, not activeSessionId: the runtime binding churns (unbinds
+              // to null, then rebinds) on every resume-retry attempt of the SAME
+              // routed session — e.g. the reconciliation loop after a backend
+              // restart mid-turn (#101712). threadKey stays constant across that
+              // churn (it prefers the durable stored id), so the composer's
+              // focus-on-key-change effect no longer yanks focus out of wherever
+              // the user is (composer, model picker, …) on every failed retry.
+              focusKey={threadKey}
               gateway={gateway}
               maxRecordingSeconds={maxVoiceRecordingSeconds}
               onAddContextRef={onAddContextRef}


### PR DESCRIPTION
## Summary

Fixes #101712 — during the interrupted-turn 404-loop described there (a
backend restart mid-turn, followed by ~minutes of auto-continue
reconciliation), the desktop composer and model picker keep losing
focus/state on every retry cycle, even though the user is looking at
the same routed session the whole time.

## Root cause

`ChatBar`'s `focusKey` prop (`apps/desktop/src/app/chat/index.tsx`) was
wired to `activeSessionId` — the *runtime* binding. `resumeSession()`
unconditionally clears this to `null` at the start of every resume
attempt (`setActiveSessionId(null)`) before re-binding it on success,
and the bounded auto-retry in `use-route-resume.ts` re-invokes
`resumeSession()` on the SAME routed session for every failed attempt
during a 404 loop like the one in the issue. Each of those transitions
(`id -> null -> id -> null -> ...`) changed `focusKey`, which re-fires
the composer's `useEffect` in `use-composer-draft.ts` that calls
`focusInput()` — pulling focus out of wherever it was (including the
model picker's search input, which doesn't match the guard that
protects the composer's own input) on every retry.

`activeSessionId` is the wrong identity for "did the user switch
sessions" — it's also used as an internal "runtime not yet bound"
sentinel. `threadKey` (a few lines above, already used for `Thread`'s
`sessionKey`) is the value built for exactly this: it prefers the
durable `selectedSessionId` (the stored id, set once at resume entry
and unchanged across retries of the same session) and only falls back
to `activeSessionId` when there's no stored id yet (a brand-new
draft). Swapping `focusKey` to use it stops the focus churn without
changing behavior on a real session switch.

## Changes

- `apps/desktop/src/app/chat/index.tsx`: `focusKey={activeSessionId}` → `focusKey={threadKey}`, with a comment explaining why.
- `apps/desktop/src/app/chat/index.test.tsx`: new test that renders `ChatView`, flips `$activeSessionId` to `null` and to a different runtime id (simulating a same-session resume retry) while `$selectedStoredSessionId` stays fixed, and asserts every `focusKey` observed by `ChatBar` stays the stable stored id.

## Test plan

Confirmed the new test fails without the fix (`git checkout HEAD~1 -- apps/desktop/src/app/chat/index.tsx`, i.e. `focusKey={activeSessionId}`):

```
 × ChatView render isolation > keeps the composer focusKey stable while the runtime id churns on a same-session resume retry (#101712)
   AssertionError: expected 'runtime-1' to be 'stored-1'
```

With the fix restored:

```
 ✓ ChatView render isolation > does not re-render chat history when an unrelated parent idle tick updates
 ✓ ChatView render isolation > keeps the composer focusKey stable while the runtime id churns on a same-session resume retry (#101712)

 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Full `chat`/`session` slice (153 files, 1671 tests) still passes:

```
 Test Files  153 passed (153)
      Tests  1671 passed (1671)
```

`tsc -p . --noEmit`: clean, no errors.

`eslint src/app/chat/index.tsx src/app/chat/index.test.tsx`: 0 errors, 1 pre-existing warning at an unrelated line (`tailProfile` exhaustive-deps, untouched by this diff).

## Disclosure

Investigated and written with AI assistance (Claude), including tracing the resume-retry/focus-effect interaction and writing/verifying the regression test above.
