### PR TITLE
fix(computer-use): pass native Wayland opt-in to gateway drivers

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3899,6 +3899,7 @@ DEFAULT_CONFIG = {
         # every invocation (MCP backend, status, doctor, install). Set true
         # to let cua-driver use its own default (telemetry on).
         "cua_telemetry": False,
+        "native_wayland": False,
         # Cap driver screenshot longest edge (pixels) via set_config on
         # session start. Shrinks SOM multimodal payloads; 0 disables.
         "max_image_dimension": 1456,

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -790,12 +790,11 @@ def _resolved_cua_driver_cmd() -> Optional[str]:
 
 
 def _cua_driver_env() -> dict:
-    """cua-driver child env with the Hermes telemetry policy applied.
+    """Return the shared cua-driver child environment.
 
-    Delegates to ``cua_backend.cua_driver_child_env`` (telemetry disabled by
-    default; user opt-in via ``computer_use.cua_telemetry``). Falls back to the
-    current environment if the helper can't be imported, so install/status
-    never break on a telemetry-helper error.
+    Delegates to ``cua_backend.cua_driver_child_env`` so install and status use
+    the same policy as runtime and doctor. Falls back to the current environment
+    if the helper cannot be imported.
     """
     try:
         from tools.computer_use.cua_backend import cua_driver_child_env

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1522,9 +1522,7 @@ _CATEGORY_MERGE: Dict[str, str] = {
     # the MCP tab) — fold it into the agent tab rather than spawning a
     # one-field orphan category.
     "mcp": "agent",
-    # `computer_use.cua_telemetry` is the only schema-surfaced computer_use
-    # field — fold it into the agent tab rather than spawning a one-field
-    # orphan category.
+    # Keep the small computer_use settings group in the agent tab.
     "computer_use": "agent",
     # `telemetry.shared_metrics.enabled` is the only schema-surfaced telemetry
     # field — fold it into security alongside the other privacy-posture toggles.

--- a/tests/computer_use/test_cua_wayland_env.py
+++ b/tests/computer_use/test_cua_wayland_env.py
@@ -1,0 +1,31 @@
+from unittest.mock import patch
+
+from tools.computer_use import cua_backend
+
+
+_VAR = "CUA_DRIVER_RS_ENABLE_WAYLAND"
+
+
+def test_configured_native_wayland_reaches_linux_wayland_child():
+    config = {"computer_use": {"native_wayland": True}}
+    with patch("hermes_cli.config.load_config", return_value=config), \
+         patch.object(cua_backend.sys, "platform", "linux"):
+        env = cua_backend.cua_driver_child_env({"WAYLAND_DISPLAY": "wayland-1"})
+    assert env[_VAR] == "1"
+
+
+def test_configured_native_wayland_does_not_enable_x11_child():
+    config = {"computer_use": {"native_wayland": True}}
+    with patch("hermes_cli.config.load_config", return_value=config), \
+         patch.object(cua_backend.sys, "platform", "linux"):
+        env = cua_backend.cua_driver_child_env({"DISPLAY": ":0"})
+    assert _VAR not in env
+
+
+def test_default_preserves_manual_environment_opt_in():
+    config = {"computer_use": {"native_wayland": False}}
+    base_env = {"WAYLAND_DISPLAY": "wayland-1", _VAR: "1"}
+    with patch("hermes_cli.config.load_config", return_value=config), \
+         patch.object(cua_backend.sys, "platform", "linux"):
+        env = cua_backend.cua_driver_child_env(base_env)
+    assert env[_VAR] == "1"

--- a/tests/computer_use/test_doctor.py
+++ b/tests/computer_use/test_doctor.py
@@ -267,6 +267,49 @@ class TestJsonOutput:
         assert "hermes_identity" in parsed
         assert parsed["hermes_identity"]["resolved_binary"]
 
+    def test_linux_wayland_output_identifies_cli_environment_scope(self, monkeypatch):
+        from tools.computer_use import doctor
+
+        monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-1")
+        monkeypatch.setenv("DISPLAY", ":0")
+        report = _ok_report()
+        report["platform"] = "linux"
+        proc = _fake_proc_with_responses(
+            {"jsonrpc": "2.0", "id": 1, "result": {}},
+            {"jsonrpc": "2.0", "id": 2, "result": {"structuredContent": report}},
+        )
+
+        with patch("shutil.which", return_value="/fake/cua-driver"), \
+             patch("subprocess.Popen", return_value=proc), \
+             patch("sys.stdout", new_callable=StringIO) as out:
+            doctor.run_doctor(json_output=True)
+
+        context = json.loads(out.getvalue())["hermes_environment"]
+        assert context == {
+            "gateway_environment_checked": False,
+            "scope": "cli_process",
+        }
+
+    def test_linux_wayland_text_warns_gateway_environment_may_differ(self, monkeypatch):
+        from tools.computer_use import doctor
+
+        monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-1")
+        report = _ok_report()
+        report["platform"] = "linux"
+        proc = _fake_proc_with_responses(
+            {"jsonrpc": "2.0", "id": 1, "result": {}},
+            {"jsonrpc": "2.0", "id": 2, "result": {"structuredContent": report}},
+        )
+
+        with patch("shutil.which", return_value="/fake/cua-driver"), \
+             patch("subprocess.Popen", return_value=proc), \
+             patch("sys.stdout", new_callable=StringIO) as out:
+            doctor.run_doctor()
+
+        text = out.getvalue().lower()
+        assert "current cli process" in text
+        assert "gateway environment was not checked" in text
+
 
 # ── HERMES_CUA_DRIVER_CMD resolution ───────────────────────────────────────
 

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -218,6 +218,7 @@ _NON_APP_WINDOW_TITLE_PREFIXES = (
 # Setting it to "0" disables telemetry; absence => the binary's own default
 # (telemetry ON upstream).
 _CUA_TELEMETRY_ENV_VAR = "CUA_DRIVER_RS_TELEMETRY_ENABLED"
+_CUA_NATIVE_WAYLAND_ENV_VAR = "CUA_DRIVER_RS_ENABLE_WAYLAND"
 
 
 def _computer_use_cfg() -> Dict[str, Any]:
@@ -356,15 +357,20 @@ def _computer_use_max_image_dimension() -> Optional[int]:
 def cua_driver_child_env(base_env: Optional[Dict[str, str]] = None) -> Dict[str, str]:
     """Return the environment dict for spawning cua-driver.
 
-    Starts from ``base_env`` (defaults to ``os.environ``) and, when telemetry
-    is disabled (the default), injects ``CUA_DRIVER_RS_TELEMETRY_ENABLED=0``.
-    When the user has opted in, the var is left untouched so cua-driver uses
-    its own default. Used by every cua-driver spawn site (MCP backend, status,
-    doctor, install) so the policy is applied consistently.
+    Starts from ``base_env`` (defaults to ``os.environ``), applies the Hermes
+    telemetry policy, and bridges an explicit native-Wayland config opt-in only
+    when the child has a Wayland display. Used by every cua-driver spawn site
+    so CLI and gateway runtimes share one policy.
     """
     env = dict(base_env if base_env is not None else os.environ)
     if _cua_telemetry_disabled():
         env[_CUA_TELEMETRY_ENV_VAR] = "0"
+    if (
+        sys.platform == "linux"
+        and env.get("WAYLAND_DISPLAY")
+        and bool(_computer_use_cfg().get("native_wayland", False))
+    ):
+        env[_CUA_NATIVE_WAYLAND_ENV_VAR] = "1"
     return env
 
 

--- a/tools/computer_use/doctor.py
+++ b/tools/computer_use/doctor.py
@@ -742,11 +742,18 @@ def _apply_display_count_guard(report: Dict[str, Any]) -> Dict[str, Any]:
     return report
 
 
+def _wayland_environment_context(report: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    if report.get("platform") != "linux" or not os.environ.get("WAYLAND_DISPLAY"):
+        return None
+    return {"scope": "cli_process", "gateway_environment_checked": False}
+
+
 def _print_text_report(
     report: Dict[str, Any],
     color: bool,
     *,
     identity: Optional[Dict[str, Any]] = None,
+    environment: Optional[Dict[str, Any]] = None,
 ) -> None:
     """Render the report in the same style as `cua-driver call health_report`
     would (one line per check + a summary footer).
@@ -797,6 +804,12 @@ def _print_text_report(
     elif cli_v and not mismatch:
         # Still show the resolved path; version already matches header.
         pass
+    if environment:
+        print(f"  {col_dim}environment: current CLI process{col_reset}")
+        print(
+            f"  {col_dim}gateway environment was not checked; active gateway "
+            f"computer_use sessions use that process environment{col_reset}"
+        )
     if mismatch:
         warn = col_yellow if color else ""
         print(
@@ -881,6 +894,7 @@ def run_doctor(
         return 2
 
     identity = _build_identity(binary, report)
+    environment = _wayland_environment_context(report)
 
     if json_output:
         # Additive envelope: preserve the upstream health_report keys and
@@ -888,12 +902,19 @@ def run_doctor(
         # that only read overall/checks keep working.
         payload = dict(report)
         payload["hermes_identity"] = identity
+        if environment:
+            payload["hermes_environment"] = environment
         json.dump(payload, sys.stdout, indent=2, sort_keys=True)
         sys.stdout.write("\n")
     else:
         if color is None:
             color = sys.stdout.isatty()
-        _print_text_report(report, color=bool(color), identity=identity)
+        _print_text_report(
+            report,
+            color=bool(color),
+            identity=identity,
+            environment=environment,
+        )
 
     overall = report.get("overall")
     if overall in ("degraded", "failed"):

--- a/website/docs/user-guide/features/computer-use.md
+++ b/website/docs/user-guide/features/computer-use.md
@@ -430,6 +430,17 @@ computer_use:
   capability_manifest: ""          # capability manifest path, required for bounded
 ```
 
+On Linux, native Wayland support remains an explicit opt-in. Hermes passes the
+opt-in to every cua-driver process, including gateway sessions, only when that
+process also has `WAYLAND_DISPLAY`:
+
+```yaml
+computer_use:
+  native_wayland: true
+```
+
+Restart a running gateway after changing this setting.
+
 Override the driver binary path (tests / CI / local builds):
 
 ```


### PR DESCRIPTION
## summary

- add `computer_use.native_wayland` as a persistent, explicit opt-in
- bridge that setting through the shared cua-driver child environment used by gateway, cli, doctor, status, and install
- inject `CUA_DRIVER_RS_ENABLE_WAYLAND=1` only for linux children that also have `WAYLAND_DISPLAY`
- distinguish the cli doctor environment from an active gateway environment in text and json output

## root cause

hermes previously had no persistent configuration path for cua-driver native wayland. users could export `CUA_DRIVER_RS_ENABLE_WAYLAND=1`, but a systemd-managed gateway would not receive an interactive shell export. doctor then launched from the shell environment and presented that result without identifying its process scope.

this change fixes both sides at the existing `cua_driver_child_env` boundary. a single config value now reaches every cua-driver launch path, while cua-driver remains disabled by default and the bridge remains conditional on a wayland display. manually managed environment opt-ins continue to work.

## scope

this does not add automatic compositor probing, capability-manifest parsing, routing preferences, or desktop ui. it remains separate from the broader work in #73826.

## usage

```yaml
computer_use:
  native_wayland: true
```

restart a running gateway after changing the setting.

## validation

- focused child-environment, doctor, and telemetry tests: 24 passed
- ruff on all changed python files: passed
- `git diff --check`: passed

fixes #86740