### PR TITLE
fix(cli): guarantee pt_key_to_sequence is bound in voice keybinding fallback

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5188,6 +5188,49 @@ def _should_seed_interactive(query, image, quiet: bool, oneshot: bool) -> bool:
         return False
 
 
+def _resolve_voice_keybinding() -> tuple[object, tuple[str, ...]]:
+    """Resolve the CLI's voice push-to-talk key: the raw config value (for
+    the status cache) and the prompt_toolkit key sequence for ``kb.add``.
+
+    Never raises. ``pt_key_to_sequence`` starts out as a local fallback
+    (behaviorally identical to ``hermes_cli.voice.pt_key_to_sequence`` for
+    the ctrl-only default this falls back to) and is only replaced once the
+    config-dependent imports below have actually succeeded. Previously the
+    real function was imported inside the same ``try`` as ``load_config()``,
+    so any exception raised before that import line — e.g. a broken
+    config.yaml — left it unbound and crashed ``@kb.add(*pt_key_to_sequence(...))``
+    below with ``UnboundLocalError`` instead of falling back to Ctrl+B (#101757).
+    """
+    def pt_key_to_sequence(pt_key: str) -> tuple[str, ...]:
+        return (pt_key,)
+
+    raw_key: object = "ctrl+b"
+    voice_key = "c-b"
+    try:
+        from hermes_cli.config import load_config
+        from hermes_cli.voice import (
+            normalize_voice_record_key_for_prompt_toolkit,
+            pt_key_to_sequence,
+            voice_record_key_from_config,
+        )
+        raw_key = voice_record_key_from_config(load_config())
+        voice_key = normalize_voice_record_key_for_prompt_toolkit(raw_key)
+        if (
+            isinstance(raw_key, str)
+            and raw_key.strip().lower().split("+", 1)[0].strip() in {"super", "win", "windows"}
+            and voice_key == "c-b"
+        ):
+            logger.warning(
+                "voice.record_key %r uses a TUI-only modifier (super/win); "
+                "CLI fell back to Ctrl+B. Use ctrl+<key> or alt+<key> for "
+                "cross-runtime parity.",
+                raw_key,
+            )
+    except Exception:
+        voice_key = "c-b"
+    return raw_key, pt_key_to_sequence(voice_key)
+
+
 class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
     """
     Interactive CLI for the Hermes Agent.
@@ -19630,29 +19673,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # configs silently fall back to the default here since prompt_toolkit
         # has no super modifier — log a warning so users notice the
         # TUI/CLI split instead of a silent mismatch (round-11).
-        _raw_key: object = "ctrl+b"
-        try:
-            from hermes_cli.config import load_config
-            from hermes_cli.voice import (
-                normalize_voice_record_key_for_prompt_toolkit,
-                pt_key_to_sequence,
-                voice_record_key_from_config,
-            )
-            _raw_key = voice_record_key_from_config(load_config())
-            _voice_key = normalize_voice_record_key_for_prompt_toolkit(_raw_key)
-            if (
-                isinstance(_raw_key, str)
-                and _raw_key.strip().lower().split("+", 1)[0].strip() in {"super", "win", "windows"}
-                and _voice_key == "c-b"
-            ):
-                logger.warning(
-                    "voice.record_key %r uses a TUI-only modifier (super/win); "
-                    "CLI fell back to Ctrl+B. Use ctrl+<key> or alt+<key> for "
-                    "cross-runtime parity.",
-                    _raw_key,
-                )
-        except Exception:
-            _voice_key = "c-b"
+        _raw_key, _voice_key_sequence = _resolve_voice_keybinding()
 
         # Cache the UI label here — same ``_raw_key`` that drives the
         # prompt_toolkit binding below. Every status / placeholder /
@@ -19661,7 +19682,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # voice.record_key mid-session (Copilot round-13 on #19835).
         self.set_voice_record_key_cache(_raw_key)
 
-        @kb.add(*pt_key_to_sequence(_voice_key))
+        @kb.add(*_voice_key_sequence)
         def handle_voice_record(event):
             """Toggle voice recording when voice mode is active.
 

--- a/tests/hermes_cli/test_cli_voice_keybinding.py
+++ b/tests/hermes_cli/test_cli_voice_keybinding.py
@@ -1,0 +1,41 @@
+"""Regression test for #101757.
+
+``HermesCLI.run()`` registers the voice push-to-talk keybinding via
+``_resolve_voice_keybinding()``. That helper must never raise: any failure
+while loading ``voice.record_key`` from config (a broken/unreadable
+config.yaml, reported from a Docker deployment) has to fall back to the
+documented Ctrl+B default instead of crashing the whole CLI at startup with
+``UnboundLocalError: cannot access local variable 'pt_key_to_sequence'``.
+"""
+
+import sys
+import types
+
+import cli
+
+
+def test_falls_back_to_ctrl_b_when_config_import_fails(monkeypatch):
+    """Simulates the reported crash: importing ``hermes_cli.config`` (or
+    anything else in the try block before the real ``pt_key_to_sequence``
+    is imported) fails. The old inline code left ``pt_key_to_sequence``
+    unbound in that case and crashed on the very next line; the extracted
+    helper must instead return the Ctrl+B default without raising."""
+    fake_config_module = types.ModuleType("hermes_cli.config")  # no load_config attribute
+    monkeypatch.setitem(sys.modules, "hermes_cli.config", fake_config_module)
+
+    raw_key, sequence = cli._resolve_voice_keybinding()
+
+    assert raw_key == "ctrl+b"
+    assert sequence == ("c-b",)
+
+
+def test_resolves_configured_key_on_the_happy_path(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"voice": {"record_key": "alt+v"}},
+    )
+
+    raw_key, sequence = cli._resolve_voice_keybinding()
+
+    assert raw_key == "alt+v"
+    assert sequence == ("escape", "v")


### PR DESCRIPTION
Fixes #101757

## Bug

Reported from a Docker deployment: the classic CLI crashed on startup with

```
File "/opt/hermes/cli.py", line 19664, in run
    @kb.add(*pt_key_to_sequence(_voice_key))
             ^^^^^^^^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'pt_key_to_sequence' where it is not associated with a value
```

`HermesCLI.run()` registered the voice push-to-talk keybinding like this:

```python
try:
    from hermes_cli.config import load_config
    from hermes_cli.voice import (
        normalize_voice_record_key_for_prompt_toolkit,
        pt_key_to_sequence,
        voice_record_key_from_config,
    )
    _raw_key = voice_record_key_from_config(load_config())
    _voice_key = normalize_voice_record_key_for_prompt_toolkit(_raw_key)
    ...
except Exception:
    _voice_key = "c-b"

@kb.add(*pt_key_to_sequence(_voice_key))
```

The `except` branch assumes `pt_key_to_sequence` was already imported by the
time anything can go wrong. But if the exception is raised *before* that
import line finishes — e.g. `from hermes_cli.config import load_config`
itself fails, which is exactly what a broken/unreadable `config.yaml` in a
container does — `pt_key_to_sequence` is never bound. The `except` clause
sets `_voice_key = "c-b"` and swallows the real error, but the very next
line still calls the never-imported `pt_key_to_sequence`, crashing the
entire CLI with an unrelated-looking `UnboundLocalError` instead of falling
back to the documented Ctrl+B default.

Confirmed the mechanism reproduces the exact traceback:

```python
import sys, types
fake_config_mod = types.ModuleType("hermes_cli.config")  # no load_config attribute
sys.modules["hermes_cli.config"] = fake_config_mod

def run():
    _raw_key = "ctrl+b"
    try:
        from hermes_cli.config import load_config
        from hermes_cli.voice import (
            normalize_voice_record_key_for_prompt_toolkit,
            pt_key_to_sequence,
            voice_record_key_from_config,
        )
        ...
    except Exception as e:
        print("caught:", type(e).__name__, e)
        _voice_key = "c-b"
    print(pt_key_to_sequence(_voice_key))

run()
# caught: ImportError cannot import name 'load_config' from 'hermes_cli.config'
# UnboundLocalError: cannot access local variable 'pt_key_to_sequence' ...
```

## Fix

Extracted the resolution logic into a module-level `_resolve_voice_keybinding()`
(`cli.py`). It defines a trivial local fallback for `pt_key_to_sequence`
first (behaviorally identical to the real function for the non-Alt keys the
Ctrl+B default uses) and only swaps in the real one once the config-dependent
imports have actually succeeded. No matter which line inside the `try` raises,
the name used afterward is always bound, so the existing Ctrl+B fallback
behavior actually works instead of crashing.

`run()` now just calls `_raw_key, _voice_key_sequence = _resolve_voice_keybinding()`
and uses the returned sequence directly — no behavior change on the happy path.

## Test plan

Added `tests/hermes_cli/test_cli_voice_keybinding.py`:
- `test_falls_back_to_ctrl_b_when_config_import_fails` — replaces
  `sys.modules["hermes_cli.config"]` with a module missing `load_config`
  (simulating the failure above) and asserts `_resolve_voice_keybinding()`
  returns the Ctrl+B default instead of raising.
- `test_resolves_configured_key_on_the_happy_path` — asserts a configured
  `voice.record_key` still resolves correctly.

Verified the new test fails without the fix (checked out `cli.py` from
before this change, function doesn't exist / old inline code raises
`UnboundLocalError` as shown above), and passes with it:

```
$ scripts/run_tests.sh tests/hermes_cli/test_cli_voice_keybinding.py tests/hermes_cli/test_voice_wrapper.py
Discovered 2 test files (~23 tests) ...
✓ tests/hermes_cli/test_cli_voice_keybinding.py (2✓, 1.0s)
✓ tests/hermes_cli/test_voice_wrapper.py (23✓, 2.2s)
=== Summary: 2 files, 25 tests passed, 0 failed (100% complete) in 2.2s (8 workers) ===
```

Also ran the full `tests/hermes_cli/` directory (287 files) — same 3
pre-existing failures on unmodified `main` (missing `acp` module,
one unrelated `test_local_quickstart.py`/`test_kanban_review_surfaces.py`
fixture issue), confirmed unaffected by this change by reproducing them
with `cli.py` reverted to `main`.

`ruff check cli.py tests/hermes_cli/test_cli_voice_keybinding.py` — clean.

---
This fix was developed with AI assistance (Claude), including writing the
regression test and verifying the failure mode against the pre-fix code.
