### PR TITLE
fix(env): skip unsafe UTF-32 dotenv loads

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -237,21 +237,22 @@ def _load_dotenv_with_fallback(path: Path, *, override: bool) -> None:
     _sanitize_loaded_credentials()  # httpx encodes headers as ASCII
 
 
-def _sanitize_env_file_if_needed(path: Path) -> None:
+def _sanitize_env_file_if_needed(path: Path) -> bool:
     """Pre-sanitize a .env file before python-dotenv reads it. Sniffs a leading BOM *before* any text
     decode: UTF-16 (Notepad "Unicode") is rewritten as clean UTF-8; UTF-32 is refused (left untouched) so
-    we never fall through to the errors=replace corruption path."""
+    we never fall through to the errors=replace corruption path. Returns ``False`` only when the file is
+    known to be unsafe for python-dotenv; other best-effort failures retain historical load behavior."""
     if not path.exists():
-        return
+        return True
     try:
         from hermes_cli.config import _sanitize_env_lines
     except ImportError:
-        return  # early bootstrap — config module not available yet
+        return True  # early bootstrap — config module not available yet
 
     try:
         raw = path.read_bytes()
     except Exception:
-        return
+        return True
 
     # ORDER MATTERS: BOM_UTF32_LE (FF FE 00 00) startswith BOM_UTF16_LE (FF FE); UTF-16 first would mangle it.
     force_utf8_rewrite = False
@@ -261,9 +262,9 @@ def _sanitize_env_file_if_needed(path: Path) -> None:
         path_key = str(path.resolve())
         if path_key not in _WARNED_UTF32_PATHS:
             _WARNED_UTF32_PATHS.add(path_key)
-            logger.warning("Skipping .env sanitize for %s: UTF-32 BOM detected; "
+            logger.warning("Skipping .env load for %s: UTF-32 BOM detected; "
                            "leaving file untouched to avoid corruption", path)
-        return
+        return False
     if raw.startswith(codecs.BOM_UTF16_LE) or raw.startswith(codecs.BOM_UTF16_BE):
         # "utf-16" uses the BOM for endianness and strips it; newline=None matches open()'s universal
         # newlines (not splitlines()'s extra boundaries like U+2028) so sanitize sees the same lines.
@@ -271,7 +272,7 @@ def _sanitize_env_file_if_needed(path: Path) -> None:
             with io.TextIOWrapper(io.BytesIO(raw), encoding="utf-16", newline=None) as f:
                 original = f.readlines()
         except UnicodeDecodeError:
-            return
+            return True
         force_utf8_rewrite = True  # always rewrite UTF-16 as UTF-8 so the dotenv load sees a canonical file
     else:
         # utf-8-sig strips a UTF-8 BOM; errors=replace so embedded NULs can be stripped below.
@@ -279,11 +280,11 @@ def _sanitize_env_file_if_needed(path: Path) -> None:
             with open(path, encoding="utf-8-sig", errors="replace") as f:
                 original = f.readlines()
         except Exception:
-            return
+            return True
         # errors=replace turns undecodable leading bytes into U+FFFD; persisting would glue them onto
         # the first key name permanently — leave the file untouched instead.
         if original and original[0].startswith("\ufffd"):
-            return
+            return True
 
     try:
         # Strip NULs (os.environ raises ValueError on them); also repairs BOM-less UTF-16 (NUL-padded ASCII).
@@ -306,6 +307,7 @@ def _sanitize_env_file_if_needed(path: Path) -> None:
                 raise
     except Exception:
         pass  # best-effort — don't block gateway startup
+    return True
 
 
 def load_hermes_dotenv(
@@ -341,12 +343,17 @@ def load_hermes_dotenv(
     user_env = home_path / ".env"
     project_env_path = Path(project_env) if project_env else None
 
-    if user_env.exists():  # normalize formatting / strip NULs before parsing
-        _sanitize_env_file_if_needed(user_env)
-    if project_env_path and project_env_path.exists():
-        _sanitize_env_file_if_needed(project_env_path)
+    # Normalize safe formatting and remove invalid NUL bytes before parsing.
+    user_env_loadable = (
+        user_env.exists() and _sanitize_env_file_if_needed(user_env)
+    )
+    project_env_loadable = bool(
+        project_env_path
+        and project_env_path.exists()
+        and _sanitize_env_file_if_needed(project_env_path)
+    )
 
-    if user_env.exists():
+    if user_env_loadable:
         _load_dotenv_with_fallback(user_env, override=True)
         loaded.append(user_env)
         _clear_known_keys_missing_from_dotenv(user_env)  # mirrors reload_env(): inherited keys must not leak
@@ -358,7 +365,7 @@ def load_hermes_dotenv(
     if op_env.exists() and not os.environ.get("OP_SERVICE_ACCOUNT_TOKEN"):
         _load_dotenv_with_fallback(op_env, override=False)
 
-    if project_env_path and project_env_path.exists():
+    if project_env_loadable and project_env_path is not None:
         _load_dotenv_with_fallback(project_env_path, override=not loaded)
         loaded.append(project_env_path)
 
@@ -421,8 +428,8 @@ def _apply_managed_env() -> None:
     managed_env = managed_dir / ".env"
     if not managed_env.exists():
         return
-    _sanitize_env_file_if_needed(managed_env)
-    _load_dotenv_with_fallback(managed_env, override=True)
+    if _sanitize_env_file_if_needed(managed_env):
+        _load_dotenv_with_fallback(managed_env, override=True)
 
 
 def _apply_external_secret_sources(home_path: Path) -> None:

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -271,6 +271,22 @@ def test_utf32_le_bom_is_skipped_without_crashing(tmp_path, caplog, monkeypatch)
     assert any("UTF-32" in r.message for r in caplog.records)
 
 
+def test_utf32_user_env_leaves_project_env_as_active_source(tmp_path, monkeypatch):
+    """A skipped user env must not weaken project-env precedence."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    user_env = home / ".env"
+    raw = codecs.BOM_UTF32_LE + "PRECEDENCE_PROBE=user\n".encode("utf-32-le")
+    user_env.write_bytes(raw)
+    project_env = tmp_path / "project.env"
+    project_env.write_text("PRECEDENCE_PROBE=project\n", encoding="utf-8")
+    monkeypatch.setenv("PRECEDENCE_PROBE", "stale-shell")
+
+    loaded = load_hermes_dotenv(hermes_home=home, project_env=project_env)
+
+    assert loaded == [project_env]
+    assert os.environ["PRECEDENCE_PROBE"] == "project"
+    assert user_env.read_bytes() == raw
 
 
 def test_utf32_warning_fires_once_per_path(tmp_path, caplog, monkeypatch):

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -1,5 +1,6 @@
 import codecs
 import importlib
+import logging
 import os
 import sys
 
@@ -245,27 +246,27 @@ def test_utf16_le_bom_preserves_non_ascii_values(tmp_path, monkeypatch):
     assert b"\xef\xbf\xbd" not in after
 
 
-def test_utf32_le_bom_leaves_file_untouched(tmp_path, caplog):
-    """UTF-32-LE BOM: refuse-to-mangle (leave bytes untouched + warning).
+def test_utf32_le_bom_is_skipped_without_crashing(tmp_path, caplog, monkeypatch):
+    """UTF-32-LE BOM: skip loading and leave the bytes untouched.
 
     UTF-32-LE's BOM starts with UTF-16-LE's FF FE; sniff order must check
     UTF-32 first so we never misdetect and corrupt.
-
-    Exercises ``_sanitize_env_file_if_needed`` only: the dotenv load path
-    is out of scope here (#65124's surface) and still cannot ingest UTF-32.
     """
-    import logging
-
-    from hermes_cli.env_loader import _sanitize_env_file_if_needed
-
-    env_file = tmp_path / ".env"
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
     content = "HERMES_TEST_KEY=hello_utf32\nSECOND_KEY=world\n"
     raw = codecs.BOM_UTF32_LE + content.encode("utf-32-le")
     env_file.write_bytes(raw)
+    monkeypatch.delenv("HERMES_TEST_KEY", raising=False)
+    monkeypatch.delenv("SECOND_KEY", raising=False)
 
     with caplog.at_level(logging.WARNING, logger="hermes_cli.env_loader"):
-        _sanitize_env_file_if_needed(env_file)
+        loaded = load_hermes_dotenv(hermes_home=home)
 
+    assert loaded == []
+    assert os.getenv("HERMES_TEST_KEY") is None
+    assert os.getenv("SECOND_KEY") is None
     assert env_file.read_bytes() == raw  # untouched
     assert any("UTF-32" in r.message for r in caplog.records)
 
@@ -278,8 +279,6 @@ def test_utf32_warning_fires_once_per_path(tmp_path, caplog, monkeypatch):
     Matches house style for warn-once (module-level seen-set, same class as
     ``_WARNED_KEYS``): hot-reload / multi-entry load must not spam logs.
     """
-    import logging
-
     import hermes_cli.env_loader as env_loader
     from hermes_cli.env_loader import _sanitize_env_file_if_needed
 
@@ -292,10 +291,13 @@ def test_utf32_warning_fires_once_per_path(tmp_path, caplog, monkeypatch):
     env_file.write_bytes(raw)
 
     with caplog.at_level(logging.WARNING, logger="hermes_cli.env_loader"):
-        _sanitize_env_file_if_needed(env_file)
-        _sanitize_env_file_if_needed(env_file)
-        _sanitize_env_file_if_needed(env_file)
+        results = [
+            _sanitize_env_file_if_needed(env_file),
+            _sanitize_env_file_if_needed(env_file),
+            _sanitize_env_file_if_needed(env_file),
+        ]
 
+    assert results == [False, False, False]
     utf32_warnings = [r for r in caplog.records if "UTF-32" in r.message]
     assert len(utf32_warnings) == 1
     assert env_file.read_bytes() == raw


### PR DESCRIPTION
## What does this PR do?

Prevents Hermes startup from passing UTF-32 `.env` files to `python-dotenv`. UTF-32 input contains embedded NUL bytes and is not supported by the existing sanitizer/load path, so the loader now leaves the file untouched, emits a warning once, and skips it instead of risking a startup crash.

The sanitizer returns a load-safety result that is honored by user, project, and managed environment loading. Other best-effort sanitizer failures preserve the existing behavior.

## Related Issue

No linked issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `hermes_cli/env_loader.py` to identify UTF-32 files as unsafe to load while leaving their bytes untouched.
- Apply the safety result to user, project, and managed `.env` loading paths.
- Add end-to-end regression coverage in `tests/hermes_cli/test_env_loader.py`, including warn-once behavior.

## How to Test

1. Create a `.env` encoded as UTF-32 with a BOM.
2. Call `load_hermes_dotenv()` for that Hermes home.
3. Verify startup does not raise, no variables from the file are loaded, the file is unchanged, and a UTF-32 warning is logged.

Automated verification run:

`HERMES_PYTHON=/Users/emanuele/Documents/Hermes/.venv-hermes-dev/bin/python scripts/run_tests.sh tests/hermes_cli/test_env_loader.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (focused regression file passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 25.3)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior is documented in the affected function
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

- Focused regression tests passed.
- `ruff check` passed for both changed files.
- `scripts/check-windows-footguns.py --diff main` passed.

Made with [Cursor](https://cursor.com)