### PR TITLE
fix(security): block Kanban attachment DNS rebinding

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -10,9 +10,13 @@ from __future__ import annotations
 
 import json
 import os
+import socket
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 
 import pytest
+
+from tools.url_safety import SSRFConnectionBlocked
 
 
 # ---------------------------------------------------------------------------
@@ -1124,12 +1128,52 @@ class _FakeStreamResponse:
         return False
 
 
+class _FakeSafeClient:
+    def __init__(self, response):
+        self._response = response
+
+    def stream(self, method, url):
+        assert method == "GET"
+        assert url == "http://files.example.com/docs/spec.pdf"
+        return self._response
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def test_attach_url_blocks_connect_time_dns_rebind(
+    worker_env, default_url_guard, monkeypatch
+):
+    """A public preflight answer cannot rebind to metadata IP at connect."""
+    from tools import kanban_tools as kt
+
+    for proxy_var in (
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "ALL_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "all_proxy",
+    ):
+        monkeypatch.delenv(proxy_var, raising=False)
+
+    answers = iter(("93.184.216.34", "169.254.169.254"))
+
+    def fake_getaddrinfo(_host, port, *_args, **_kwargs):
+        ip = next(answers)
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, port or 0))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+    with pytest.raises(SSRFConnectionBlocked):
+        kt._download_url_with_cap("http://rebind.example/file.bin", 1024)
+
+
 def test_attach_url_happy_path_public_host(worker_env, default_url_guard, monkeypatch):
     """A public URL passes the guard and the bytes are stored (mocked fetch)."""
-    from pathlib import Path
-
-    import httpx
-
     from hermes_cli import kanban_db as kb
     from hermes_cli import kanban_db_connect as kbc
     from tools import kanban_tools as kt
@@ -1138,15 +1182,18 @@ def test_attach_url_happy_path_public_host(worker_env, default_url_guard, monkey
 
     payload = b"public fetch body"
 
-    def fake_stream(method, url, **kwargs):
-        assert url == "http://files.example.com/docs/spec.pdf"
-        return _FakeStreamResponse(
-            status_code=200,
-            headers={"content-type": "application/pdf; charset=binary"},
-            body=payload,
+    def fake_safe_client(**kwargs):
+        assert kwargs["follow_redirects"] is False
+        assert kwargs["headers"]["User-Agent"] == "hermes-kanban/attach"
+        return _FakeSafeClient(
+            _FakeStreamResponse(
+                status_code=200,
+                headers={"content-type": "application/pdf; charset=binary"},
+                body=payload,
+            )
         )
 
-    monkeypatch.setattr(httpx, "stream", fake_stream)
+    monkeypatch.setattr(kt, "create_ssrf_safe_client", fake_safe_client)
 
     out = kt._handle_attach_url({"url": "http://files.example.com/docs/spec.pdf"})
     d = json.loads(out)

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -14,11 +14,13 @@ import os
 import time
 from contextlib import contextmanager
 from typing import Any, Callable, Optional
+from urllib.parse import urljoin, urlparse
 
 from agent.redact import redact_sensitive_text
+from hermes_cli.config import cfg_get, load_config
 from hermes_cli.goals import judge_goal
 from tools.registry import registry, tool_error
-from hermes_cli.config import cfg_get, load_config
+from tools.url_safety import create_ssrf_safe_client, is_safe_url
 from tools.kanban_tools_schemas import (
     KANBAN_ATTACH_SCHEMA,
     KANBAN_ATTACH_URL_SCHEMA, KANBAN_ATTACHMENTS_SCHEMA, KANBAN_BLOCK_SCHEMA, KANBAN_COMMENT_SCHEMA,
@@ -729,40 +731,61 @@ _MAX_ATTACH_URL_REDIRECTS = 5
 
 
 def _download_url_with_cap(url: str, max_bytes: int) -> tuple[bytes, Optional[str]]:
-    """Fetch ``url`` over http(s) capped at ``max_bytes`` -> ``(data, content_type)``.
-    Every hop is SSRF-checked (redirects followed manually) so a model-controlled URL, or a
-    public host 302ing, cannot reach loopback/private/cloud-metadata ranges. ``ValueError``
-    for bad scheme, blocked target, too many redirects, or a body over the cap (checked
-    while streaming, so nothing oversize is buffered)."""
-    from urllib.parse import urljoin, urlparse
-    import httpx
-    from tools.url_safety import is_safe_url
+    """Fetch ``url`` over http(s) with SSRF guarding, capped at ``max_bytes``.
+
+    Every hop — the initial URL and each redirect target — is validated with
+    ``tools.url_safety.is_safe_url`` before it is fetched. The shared
+    SSRF-safe client also validates and pins DNS at TCP connect time, closing
+    the gap where a hostname could resolve publicly during preflight and then
+    rebind to an internal address. Redirects are followed manually
+    (``follow_redirects=False``) so each Location is re-checked.
+
+    Returns ``(data, content_type)``. Raises ``ValueError`` for a non-http(s)
+    scheme, an SSRF-blocked target, too many redirects, or a body that
+    overruns the cap (the caller maps it to a clean tool error). Reads in
+    chunks so an oversize response is rejected without buffering the whole
+    thing.
+    """
     current_url = url
-    for _ in range(_MAX_ATTACH_URL_REDIRECTS + 1):
-        scheme = (urlparse(current_url).scheme or "").lower()
-        if scheme not in ("http", "https"):
-            raise ValueError(f"unsupported URL scheme {scheme!r}; only http/https are allowed")
-        if not is_safe_url(current_url):
-            raise ValueError(
-                f"URL blocked by SSRF protection (private/internal address): {current_url}")
-        chunks: list[bytes] = []
-        total = 0
-        with httpx.stream("GET", current_url, headers={"User-Agent": "hermes-kanban/attach"},
-                          timeout=30, follow_redirects=False) as resp:
-            if resp.is_redirect:
-                location = resp.headers.get("location")
-                if not location:
-                    raise ValueError(f"redirect without Location header from {current_url}")
-                current_url = urljoin(current_url, location)
-                continue
-            resp.raise_for_status()
-            content_type = (resp.headers.get("content-type") or "").split(";")[0].strip() or None
-            for chunk in resp.iter_bytes(1024 * 1024):
-                total += len(chunk)
-                if total > max_bytes:
-                    raise ValueError(f"attachment exceeds {max_bytes // (1024 * 1024)} MB limit")
-                chunks.append(chunk)
-        return b"".join(chunks), content_type
+    with create_ssrf_safe_client(
+        headers={"User-Agent": "hermes-kanban/attach"},
+        timeout=30,
+        follow_redirects=False,
+    ) as client:
+        for _ in range(_MAX_ATTACH_URL_REDIRECTS + 1):
+            scheme = (urlparse(current_url).scheme or "").lower()
+            if scheme not in ("http", "https"):
+                raise ValueError(
+                    f"unsupported URL scheme {scheme!r}; only http/https are allowed"
+                )
+            if not is_safe_url(current_url):
+                raise ValueError(
+                    f"URL blocked by SSRF protection (private/internal address): {current_url}"
+                )
+            chunks: list[bytes] = []
+            total = 0
+            with client.stream("GET", current_url) as resp:
+                if resp.is_redirect:
+                    location = resp.headers.get("location")
+                    if not location:
+                        raise ValueError(
+                            f"redirect without Location header from {current_url}"
+                        )
+                    current_url = urljoin(current_url, location)
+                    continue
+                resp.raise_for_status()
+                content_type = (
+                    (resp.headers.get("content-type") or "").split(";")[0].strip()
+                    or None
+                )
+                for chunk in resp.iter_bytes(1024 * 1024):
+                    total += len(chunk)
+                    if total > max_bytes:
+                        raise ValueError(
+                            f"attachment exceeds {max_bytes // (1024 * 1024)} MB limit"
+                        )
+                    chunks.append(chunk)
+            return b"".join(chunks), content_type
     raise ValueError(f"too many redirects fetching {url}")
 
 


### PR DESCRIPTION
## What does this PR do?

Closes a DNS-rebinding gap in Kanban URL attachments. The existing preflight URL checks could resolve a hostname as public and then allow the HTTP client to resolve it again to a private or metadata address at connection time.

Kanban downloads now use the shared SSRF-safe HTTP client, which validates and pins DNS during connection establishment. The existing per-hop checks and manual redirect validation remain in place.

## Related Issue

No linked issue.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `tools/kanban_tools.py` to fetch attachments through `create_ssrf_safe_client`.
- Preserve scheme validation, SSRF preflight checks, per-redirect validation, and response-size limits.
- Add a connect-time DNS-rebinding regression test in `tests/tools/test_kanban_tools.py`.
- Adapt the public-host happy-path test to the shared safe-client abstraction.

## How to Test

1. Make preflight DNS resolution return a public address for an attachment hostname.
2. Make connect-time resolution return `169.254.169.254`.
3. Verify `_download_url_with_cap()` raises `SSRFConnectionBlocked` before making the request.

Automated verification run:

`HERMES_PYTHON=/Users/emanuele/Documents/Hermes/.venv-hermes-dev/bin/python scripts/run_tests.sh tests/tools/test_kanban_tools.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (focused regression file passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 25.3)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior is documented in the affected function
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; the schema is unchanged

## Screenshots / Logs

- Focused Kanban tests passed.
- `ruff check` passed for both changed files.
- `scripts/check-windows-footguns.py --diff main` passed.

Made with [Cursor](https://cursor.com)