### PR TITLE
fix(config): refuse migration on malformed YAML

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2272,7 +2272,7 @@ def _raw_config_has_explicit_version() -> bool:
     return isinstance(raw, dict) and "_config_version" in raw
 
 
-def check_config_version() -> Tuple[int, int]:
+def check_config_version(*, raise_on_parse_error: bool = False) -> Tuple[int, int]:
     """
     Check the raw on-disk config schema version.
 
@@ -2282,7 +2282,10 @@ def check_config_version() -> Tuple[int, int]:
     raw ``_config_version`` must remain visible as legacy instead of inheriting
     the latest default version in memory.
 
-    Returns (current_version, latest_version).
+    Returns (current_version, latest_version). Tolerant runtime status callers
+    retain the historical latest/latest fallback for malformed YAML. Mutation
+    and explicit validation paths can set ``raise_on_parse_error`` so a parse
+    failure cannot be mistaken for an up-to-date config.
     """
     latest = _coerce_config_version(DEFAULT_CONFIG.get("_config_version", 1)) or 1
     config_path = get_config_path()
@@ -2296,6 +2299,10 @@ def check_config_version() -> Tuple[int, int]:
         # Invalid YAML needs a parse warning, not an automatic schema rewrite
         # that could replace the user's broken file with defaults.
         _warn_config_parse_failure(config_path, e)
+        if raise_on_parse_error:
+            raise InvalidUserConfigError(
+                f"Cannot inspect {config_path}: config.yaml is not valid YAML ({e})"
+            ) from e
         return latest, latest
 
     if not isinstance(config, dict):
@@ -2659,6 +2666,11 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
     """
     results = {"env_added": [], "config_added": [], "warnings": []}
 
+    # Validate config.yaml before any migration side effect. In particular,
+    # sanitize_env_file() can rewrite .env, which must not happen when the
+    # migration will be refused for malformed YAML.
+    current_ver, latest_ver = check_config_version(raise_on_parse_error=True)
+
     # ── Always: normalize safe .env line formatting ──
     try:
         fixes = sanitize_env_file()
@@ -2666,9 +2678,6 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
             print(f"  ✓ Normalized .env line formatting ({fixes} line(s) changed)")
     except Exception:
         pass  # best-effort; don't block migration on sanitize failure
-
-    # Check config version
-    current_ver, latest_ver = check_config_version()
 
     # ── Auto-migration support floor (policy: v12, July 2026) ──
     # A config with an EXPLICIT on-disk ``_config_version`` below the floor is
@@ -6366,7 +6375,7 @@ def config_command(args):
         # Check what's missing
         missing_env = get_missing_env_vars(required_only=False)
         missing_config = get_missing_config_fields()
-        current_ver, latest_ver = check_config_version()
+        current_ver, latest_ver = check_config_version(raise_on_parse_error=True)
         
         if not missing_env and not missing_config and current_ver >= latest_ver:
             print(color("✓ Configuration is up to date!", Colors.GREEN))
@@ -6420,7 +6429,7 @@ def config_command(args):
         print(color("📋 Configuration Status", Colors.CYAN, Colors.BOLD))
         print()
         
-        current_ver, latest_ver = check_config_version()
+        current_ver, latest_ver = check_config_version(raise_on_parse_error=True)
         if current_ver >= latest_ver:
             print(f"  Config version: {current_ver} ✓")
         else:

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -227,7 +227,7 @@ def _run_config_check_fresh() -> tuple:
     _reload_config_modules()
     from hermes_cli.config import check_config_version
 
-    return check_config_version()
+    return check_config_version(raise_on_parse_error=True)
 
 
 def _run_migrate_config_fresh(*, interactive: bool = False, quiet: bool = False) -> dict:

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -10,6 +10,7 @@ import yaml
 
 from hermes_cli.config import (
     DEFAULT_CONFIG,
+    InvalidUserConfigError,
     check_config_version,
     get_hermes_home,
     ensure_hermes_home,
@@ -738,7 +739,9 @@ class TestConfigMigrationSecretPrompts:
         saved = {}
 
         monkeypatch.setattr(cfg_mod, "sanitize_env_file", lambda: 0)
-        monkeypatch.setattr(cfg_mod, "check_config_version", lambda: (999, 999))
+        monkeypatch.setattr(
+            cfg_mod, "check_config_version", lambda **_kwargs: (999, 999)
+        )
         monkeypatch.setattr(cfg_mod, "get_missing_config_fields", lambda: [])
         monkeypatch.setattr(cfg_mod, "get_missing_skill_config_vars", lambda: [])
         monkeypatch.setattr(
@@ -782,6 +785,29 @@ class TestConfigVersionDetection:
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
             assert load_config()["_config_version"] == DEFAULT_CONFIG["_config_version"]
             assert check_config_version() == (0, DEFAULT_CONFIG["_config_version"])
+
+    def test_strict_check_rejects_malformed_yaml(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("model: [unterminated\n", encoding="utf-8")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            with pytest.raises(InvalidUserConfigError, match="not valid YAML"):
+                check_config_version(raise_on_parse_error=True)
+
+    def test_migration_rejects_malformed_yaml_before_sanitizing_env(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_bytes = b"model: [unterminated\n"
+        config_path.write_bytes(config_bytes)
+        env_path = tmp_path / ".env"
+        env_bytes = b"OPENAI_API_KEY=test-without-final-newline"
+        env_path.write_bytes(env_bytes)
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            with pytest.raises(InvalidUserConfigError, match="not valid YAML"):
+                migrate_config(interactive=False, quiet=True)
+
+        assert config_path.read_bytes() == config_bytes
+        assert env_path.read_bytes() == env_bytes
 
 
 class TestConfigSupportFloor:


### PR DESCRIPTION
## What does this PR do?

Prevents malformed `config.yaml` from being treated as current during explicit checks and migrations. Previously, `check_config_version()` returned the latest version after a YAML parse failure, so migration could continue and mutate `.env` before the invalid config was surfaced.

Strict callers now request a parse error, and `migrate_config()` validates the config before any migration side effect. Tolerant runtime status callers retain the existing fallback behavior.

## Related Issue

No linked issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add strict parse-error handling to `check_config_version()` in `hermes_cli/config.py`.
- Validate malformed YAML before `.env` sanitization or other migration side effects.
- Use strict checks in explicit config commands and the update flow.
- Add regression coverage in `tests/hermes_cli/test_config.py` for error reporting and file preservation.

## How to Test

1. Write malformed YAML to `$HERMES_HOME/config.yaml` and a non-normalized `$HERMES_HOME/.env`.
2. Run the non-interactive config migration.
3. Verify `InvalidUserConfigError` is raised and both files remain byte-for-byte unchanged.

Automated verification run:

`HERMES_PYTHON=/Users/emanuele/Documents/Hermes/.venv-hermes-dev/bin/python scripts/run_tests.sh tests/hermes_cli/test_config.py -k 'strict_check_rejects_malformed_yaml or migration_rejects_malformed_yaml_before_sanitizing_env'`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (focused regression tests passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 25.3)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior is documented in the affected function
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

- Focused regression tests passed.
- `ruff check` passed for all changed files.
- The Windows-footgun scan reported only pre-existing matches elsewhere in the already-modified test file; the new test uses explicit encodings or byte I/O.

Made with [Cursor](https://cursor.com)