### PR TITLE
fix(mcp): close the OAuth inner auth flow in-task to avoid a poisoned context.lock (#101756)

### DIFF
--- a/tests/tools/test_mcp_oauth_bridge_teardown.py
+++ b/tests/tools/test_mcp_oauth_bridge_teardown.py
@@ -1,0 +1,119 @@
+"""Regression test for #101756: the ``async_auth_flow`` bridge must close the
+SDK's inner generator in the same task that drove it.
+
+``httpx`` closes the **outer** bridge generator deterministically when the
+auth flow ends. Before the fix, the wrapped SDK generator (``inner``) was
+simply abandoned: asyncio's asyncgen finalization hook later ran
+``athrow(GeneratorExit)`` through it **in a new task**, and the SDK's
+``async with self.context.lock`` teardown release is task-affine —
+``anyio.Lock.release()`` raises *before* clearing the owner task, so the lock
+stayed owned by a dead task forever. Every later OAuth flow for that server
+then deadlocked inside ``async with self.context.lock`` before issuing any
+HTTP, and the provider was cached for the process lifetime.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+pytest.importorskip("mcp.client.auth.oauth2", reason="MCP SDK 1.26.0+ required")
+
+
+@pytest.mark.asyncio
+async def test_outer_close_releases_context_lock(tmp_path, monkeypatch):
+    """Closing the outer bridge must close ``inner`` in the same task.
+
+    Deterministic assertion (no GC/hook timing): after the outer generator is
+    closed at its yield point, the bridge's lock-balancing finally re-acquires
+    ``context.lock`` on behalf of the suspended SDK ``async with``; only a
+    same-task ``inner.aclose()`` lets the SDK's teardown release run legally
+    and leave the lock FREE. Without the fix the lock reads as still held.
+    """
+    from tools.mcp_tool import sdk_httpx
+
+    httpx = sdk_httpx()
+    from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
+    from pydantic import AnyUrl
+
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import _HERMES_PROVIDER_CLS, reset_manager_for_tests
+
+    assert _HERMES_PROVIDER_CLS is not None, "SDK OAuth types must be available"
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    reset_manager_for_tests()
+
+    storage = HermesTokenStorage("srv")
+    await storage.set_tokens(
+        OAuthToken(
+            access_token="old_access",
+            token_type="Bearer",
+            expires_in=3600,
+            refresh_token="old_refresh",
+        )
+    )
+    await storage.set_client_info(
+        OAuthClientInformationFull(
+            client_id="test-client",
+            redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            token_endpoint_auth_method="none",
+        )
+    )
+
+    metadata = OAuthClientMetadata(
+        redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+        client_name="Hermes Agent",
+    )
+    provider = _HERMES_PROVIDER_CLS(
+        server_name="srv",
+        server_url="https://example.com/mcp",
+        client_metadata=metadata,
+        storage=storage,
+        redirect_handler=_noop_redirect,
+        callback_handler=_noop_callback,
+    )
+
+    req = httpx.Request("POST", "https://example.com/mcp")
+    flow = provider.async_auth_flow(req)
+
+    # Drive to the suspension point: the SDK yielded the outbound request and
+    # the bridge released context.lock around the resource call.
+    outbound = await flow.__anext__()
+    assert outbound is not None
+
+    # httpx tears the auth flow down exactly like this when the transport
+    # dies mid-flow (e.g. a 405 on the GET stream) — httpx2/_client.py:1845.
+    await flow.aclose()
+
+    # Without the same-task inner.aclose() the SDK's lock teardown release
+    # either never runs (abandoned generator) or runs cross-task and raises
+    # before clearing the owner — either way the lock reads as held and the
+    # provider is poisoned for the process lifetime.
+    import anyio
+
+    lock_free = True
+    try:
+        provider.context.lock.acquire_nowait()
+    except anyio.WouldBlock:
+        lock_free = False
+    else:
+        provider.context.lock.release()
+    assert lock_free, (
+        "context.lock must be free after the auth flow is torn down; a held "
+        "lock deadlocks every later OAuth flow for this server (#101756)"
+    )
+
+
+async def _noop_redirect(_url: str) -> None:
+    """Redirect handler that does nothing (won't be invoked in these tests)."""
+    return None
+
+
+async def _noop_callback() -> tuple[str, str | None]:
+    """Callback handler that won't be invoked in these tests."""
+    raise AssertionError(
+        "callback handler should not be invoked in teardown tests"
+    )

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -597,6 +597,25 @@ def _make_hermes_provider_class() -> Optional[type]:
 
                     with anyio.CancelScope(shield=True):
                         await self.context.lock.acquire()
+                # Close the SDK generator in THIS task. httpx closes the
+                # outer bridge deterministically; an abandoned ``inner`` is
+                # instead finalized later by asyncio's asyncgen hook in a
+                # NEW task, where the SDK's ``async with context.lock``
+                # release is task-affine and anyio raises before clearing
+                # the owner — leaving the lock poisoned for the process
+                # lifetime and every later OAuth flow for that server
+                # deadlocked before issuing any HTTP (#101756). After the
+                # re-acquire above the lock is held by this task again, so
+                # the SDK's teardown release inside aclose() is legal.
+                try:
+                    await inner.aclose()
+                except Exception:
+                    logger.debug(
+                        "MCP OAuth '%s': inner auth flow teardown error "
+                        "(suppressed)",
+                        self._hermes_server_name,
+                        exc_info=True,
+                    )
 
             if retry_after_concurrent_auth:
                 yield request


### PR DESCRIPTION
## What does this PR do?

Fixes #101756: `HermesMCPOAuthProvider.async_auth_flow` bridges httpx's bidirectional generator protocol but never closed the SDK generator it wraps. That generator suspends at its `yield request` **while holding `context.lock`**; abandoned, asyncio's asyncgen finalization hook later ran `athrow(GeneratorExit)` through it **in a new task**, where the SDK's `async with self.context.lock` teardown release is task-affine — `anyio.Lock.release()` raises before clearing the owner task, so the lock stayed owned by a dead task forever.

Because `MCPOAuthManager` caches one provider per server, every subsequent OAuth flow for that server then deadlocked inside `async with self.context.lock` **before issuing any HTTP**, and the provider parked permanently — the missing root cause behind #81051 and #84132.

## Related Issue

Fixes #101756

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_oauth_manager.py::async_auth_flow`: the bridge generator now closes `inner` in a `finally` after its existing lock-balancing re-acquire. httpx closes the outer bridge deterministically (`httpx2/_client.py:1845`), so this runs the SDK teardown **in the driving task** — after the re-acquire, the SDK's release inside `aclose()` is legal and the lock ends free. The aclose is best-effort (suppressed + debug-logged): the bridge's own release/acquire dance around the resource-request yield means the SDK half may not hold the lock at teardown on every path. Idempotent with the existing concurrent-auth branch that already closed `inner` before breaking.
- `tests/tools/test_mcp_oauth_bridge_teardown.py` (new): drives a real provider to the suspension point, closes the outer generator exactly as httpx does, and asserts `context.lock` is free. Fails on `main` before the fix (lock still held), passes after.

## How to Test

`scripts/run_tests.sh tests/tools/test_mcp_oauth_bridge_teardown.py -q` — 1 passed. RED/GREEN verified: the test fails with the fix reverted and passes with it.

End-to-end: point an `auth: oauth` MCP server at a server that 405s the GET stream (frequent teardowns, the issue's reproducer); before, it parked within minutes and never recovered; after, reconnects keep the OAuth provider usable.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- N/A — async teardown fix with a deterministic regression test. -->
