### PR TITLE
fix(context): attribute skills from volatile prompt tier

### DIFF
--- a/agent/context_breakdown.py
+++ b/agent/context_breakdown.py
@@ -99,14 +99,14 @@ def compute_session_context_breakdown(
     context = parts.get("context", "") or ""
     volatile = parts.get("volatile", "") or ""
 
-    skills_match = _SKILLS_BLOCK_RE.search(stable)
+    skills_match = _SKILLS_BLOCK_RE.search(volatile) or _SKILLS_BLOCK_RE.search(stable)
     skills_index = skills_match.group(0) if skills_match else ""
 
     memory_block, user_block = _memory_blocks(agent)
     memory_text = "\n\n".join(part for part in (memory_block, user_block) if part).strip()
 
     system_core = _strip_blocks(stable, skills_index)
-    system_tail = _strip_blocks(volatile, memory_block, user_block)
+    system_tail = _strip_blocks(volatile, skills_index, memory_block, user_block)
     system_prompt_text = "\n\n".join(part for part in (system_core, system_tail) if part).strip()
 
     tools = list(getattr(agent, "tools", None) or [])
@@ -227,7 +227,8 @@ def compute_context_details(agent: Any) -> Dict[str, Any]:
 
     parts = build_system_prompt_parts(agent)
     stable = parts.get("stable", "") or ""
-    skills_match = _SKILLS_BLOCK_RE.search(stable)
+    volatile = parts.get("volatile", "") or ""
+    skills_match = _SKILLS_BLOCK_RE.search(volatile) or _SKILLS_BLOCK_RE.search(stable)
     skills_block = skills_match.group(0) if skills_match else ""
 
     skills: List[Dict[str, Any]] = []

--- a/tests/agent/test_context_breakdown.py
+++ b/tests/agent/test_context_breakdown.py
@@ -50,6 +50,34 @@ def test_breakdown_includes_major_categories():
     assert data["estimated_total"] > 0
 
 
+def test_breakdown_reads_skills_from_volatile_tier_without_double_counting():
+    skills_block = "<available_skills>\n    - demo: hi\n</available_skills>"
+    agent, parts = _make_agent(
+        stable="base guidance",
+        volatile=f"Current time: now\n{skills_block}",
+    )
+
+    with patch("agent.system_prompt.build_system_prompt_parts", return_value=parts):
+        data = compute_session_context_breakdown(agent)
+
+    tokens_by_id = {item["id"]: item["tokens"] for item in data["categories"]}
+    assert tokens_by_id["skills"] > 0
+    assert tokens_by_id["system_prompt"] == 8
+
+
+def test_context_details_reads_skills_from_volatile_tier():
+    skills_block = "<available_skills>\n    - demo: hi\n</available_skills>"
+    agent, parts = _make_agent(
+        stable="base guidance",
+        volatile=f"Current time: now\n{skills_block}",
+    )
+
+    with patch("agent.system_prompt.build_system_prompt_parts", return_value=parts):
+        details = compute_context_details(agent)
+
+    assert [entry["name"] for entry in details["skills"]] == ["demo"]
+
+
 
 # ── /context renderers (pure functions over the payload) ────────────────────
 


### PR DESCRIPTION
> **Historical status:** Closed unmerged as a duplicate of #78186. The original pre-submission search missed that earlier implementation.

## What does this PR do?

Fixes incorrect `/context` and `/context all` skill accounting after the rendered `<available_skills>` block moved from the stable system-prompt tier to the volatile tier.

The live context breakdown still searched only the stable tier. As a result, the skill index disappeared from its dedicated category and was counted inside the generic system-prompt total. This change mirrors the existing volatile-first behavior in `hermes_cli/prompt_size.py`, while retaining the stable-tier fallback for older callers/tests.

## Related Issue

Duplicate of #78186, which already implemented the same volatile-first skills lookup, stable fallback, and de-duplication. This PR was closed in favor of that earlier work.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/context_breakdown.py`
  - read the skills block from `volatile` first, with the stable-tier layout as a legacy fallback;
  - exclude the block from generic system-prompt accounting to prevent double-counting;
  - restore `/context all` skill enumeration for the current prompt layout.
- `tests/agent/test_context_breakdown.py`
  - add focused regression coverage for volatile-tier attribution and de-duplication.

## How to Test

1. Run `venv/bin/python -m pytest -q tests/agent/test_context_breakdown.py tests/hermes_cli/test_prompt_size.py tests/agent/test_system_prompt.py`.
2. Run `venv/bin/ruff check agent/context_breakdown.py tests/agent/test_context_breakdown.py`.
3. Build a real inspection agent and verify `compute_session_context_breakdown()` reports available skills separately from `system_prompt`.

Verified locally on the historical head:

- 58 related tests passed.
- Ruff passed.
- `git diff --check` passed.
- A real prompt smoke test enumerated 175 skills in the dedicated category.
- Independent read-only review found no code blocker.

The repository-wide `scripts/run_tests.sh` was also executed but completed with unrelated environment/platform failures across 49 files, including missing optional `fal-client`, Linux-specific socket behavior, and ACP/update test-environment failures. Neither changed file failed, and only the focused suites above are claimed green.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I found no duplicate — #78186 was missed initially and this PR was closed when triage identified the overlap
- [x] My PR contains **only** changes related to this fix and its tests
- [ ] I've run `pytest tests/ -q` and all tests pass — the full run had unrelated environment/platform failures documented above
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.6.2 (Apple Silicon / arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A, behavior-only diagnostic fix
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — pure prompt-string parsing with no platform-specific APIs
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

N/A — this was a diagnostic accounting fix with no UI layout change. The real prompt smoke result is recorded above.
