### PR TITLE
test(tui_gateway): pin the warm-switch display read includes compacted turns

### DIFF
--- a/tests/tui_gateway/test_live_visible_history.py
+++ b/tests/tui_gateway/test_live_visible_history.py
@@ -1,0 +1,79 @@
+"""Regression coverage for the warm/live session display projection.
+
+``_live_visible_history`` reads the persisted display lineage — and, since
+#92080, it must pass ``include_compacted=True`` so a compacted session's
+archived turns survive a warm session switch (without it the chat repainted
+as just summary + tail while REST showed everything). These tests pin the
+``include_compacted`` flag and the reconcile/fallback contract.
+"""
+
+from tui_gateway.server import _live_visible_history
+
+
+class _FakeDB:
+    def __init__(self, rows=None, error=None):
+        self.calls = []
+        self._rows = rows if rows is not None else []
+        self._error = error
+
+    def get_messages_as_conversation(self, key, **kwargs):
+        self.calls.append((key, kwargs))
+        if self._error is not None:
+            raise self._error
+        return self._rows
+
+
+def _msg(role, text):
+    return {"role": role, "content": text}
+
+
+class TestIncludeCompactedFlag:
+    def test_compacted_flag_is_passed_to_the_db_read(self):
+        """#92080: the display read must include compacted (archived) turns."""
+        db = _FakeDB(rows=[_msg("user", "hi")])
+        _live_visible_history({"session_key": "s1"}, db, [])
+        assert len(db.calls) == 1
+        key, kwargs = db.calls[0]
+        assert key == "s1"
+        assert kwargs.get("include_compacted") is True
+        assert kwargs.get("include_ancestors") is True
+        assert kwargs.get("include_row_ids") is True
+
+
+class TestReconcileContract:
+    def test_db_display_used_when_memory_empty(self):
+        rows = [_msg("user", "hi"), _msg("assistant", "hello")]
+        db = _FakeDB(rows=rows)
+        result = _live_visible_history({"session_key": "s1"}, db, [])
+        assert result == rows
+
+    def test_unflushed_memory_tail_appended_after_db_anchor(self):
+        db_rows = [_msg("user", "hi"), _msg("assistant", "hello")]
+        db = _FakeDB(rows=db_rows)
+        memory = [
+            _msg("user", "hi"),
+            _msg("assistant", "hello"),
+            _msg("user", "not flushed yet"),
+        ]
+        result = _live_visible_history({"session_key": "s1"}, db, memory)
+        assert result == db_rows + [_msg("user", "not flushed yet")]
+
+
+class TestFallbacks:
+    def test_db_read_failure_falls_back_to_memory(self):
+        db = _FakeDB(error=RuntimeError("db gone"))
+        memory = [_msg("user", "in memory only")]
+        result = _live_visible_history({"session_key": "s1"}, db, memory)
+        assert result == memory
+
+    def test_no_db_falls_back_to_memory(self):
+        memory = [_msg("user", "in memory only")]
+        result = _live_visible_history({"session_key": "s1"}, None, memory)
+        assert result == memory
+
+    def test_no_session_key_falls_back_to_memory(self):
+        memory = [_msg("user", "in memory only")]
+        db = _FakeDB(rows=[_msg("user", "ignored")])
+        result = _live_visible_history({}, db, memory)
+        assert result == memory
+        assert db.calls == []


### PR DESCRIPTION
## What does this PR do?

Adds the regression coverage missing from 86b204081d (`fix(gateway): read the compacted transcript for a warm session switch`). That fix resolved #92080 — a warm session switch repainted the chat as just the compression summary + tail because `_live_visible_history` read the DB display lineage without `include_compacted=True`, dropping the session's archived turns from what the user saw while the REST/eager-resume paths showed everything — but shipped without tests.

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tests/tui_gateway/test_live_visible_history.py` (new): 6 tests covering
  - the DB read flags: `include_compacted=True` (the #92080 core), plus `include_ancestors` / `include_row_ids`;
  - the reconcile contract: DB display is the base, and an unflushed in-memory tail is appended after the DB anchor rather than dropped;
  - the three fallback paths: DB read failure, `db=None`, and missing `session_key` all fall back to the in-memory history without touching the DB.

## How to Test

`scripts/run_tests.sh tests/tui_gateway/test_live_visible_history.py -q` — 6 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- N/A — pure test addition. -->
