### PR TITLE
fix(desktop): salvage #44556 serve dashboard bundle from desktop backend

### DIFF
--- a/apps/desktop/electron/dashboard-web-dist.test.ts
+++ b/apps/desktop/electron/dashboard-web-dist.test.ts
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { test } from 'vitest'
+
+import { resolveDashboardWebDist } from './dashboard-web-dist'
+
+function touchIndex(dir) {
+  fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(path.join(dir, 'index.html'), '<!doctype html>')
+}
+
+function withTempRoot(fn) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-dashboard-web-dist-'))
+  try {
+    return fn(root)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+}
+
+test('desktop-spawned dashboard resolves hermes_cli/web_dist, not Desktop renderer dist', () => {
+  withTempRoot(root => {
+    const activeHermesRoot = path.join(root, 'hermes-agent')
+    const desktopDist = path.join(
+      activeHermesRoot,
+      'apps',
+      'desktop',
+      'release',
+      'win-unpacked',
+      'resources',
+      'app.asar.unpacked',
+      'dist'
+    )
+    const dashboardDist = path.join(activeHermesRoot, 'hermes_cli', 'web_dist')
+    touchIndex(desktopDist)
+    touchIndex(dashboardDist)
+    assert.equal(
+      resolveDashboardWebDist({
+        activeHermesRoot,
+        appRoot: path.join(activeHermesRoot, 'apps', 'desktop'),
+        env: {}
+      }),
+      dashboardDist
+    )
+  })
+})
+
+test('explicit dashboard dist override wins when it exists', () => {
+  withTempRoot(root => {
+    const override = path.join(root, 'custom-dashboard-dist')
+    touchIndex(override)
+    assert.equal(
+      resolveDashboardWebDist({
+        activeHermesRoot: path.join(root, 'hermes-agent'),
+        env: { HERMES_DESKTOP_DASHBOARD_WEB_DIST: override }
+      }),
+      override
+    )
+  })
+})
+
+test('missing dashboard bundle falls back to canonical path for a clear child error', () => {
+  withTempRoot(root => {
+    const activeHermesRoot = path.join(root, 'hermes-agent')
+    assert.equal(
+      resolveDashboardWebDist({ activeHermesRoot, env: {} }),
+      path.join(activeHermesRoot, 'hermes_cli', 'web_dist')
+    )
+  })
+})
+
+test('appRoot candidate is used when it has a dashboard bundle and activeHermesRoot does not', () => {
+  withTempRoot(root => {
+    const activeHermesRoot = path.join(root, 'active-install')
+    const sourceRoot = path.join(root, 'source-checkout')
+    const appRoot = path.join(sourceRoot, 'apps', 'desktop')
+    const appRootDashboard = path.resolve(appRoot, '..', '..', 'hermes_cli', 'web_dist')
+    fs.mkdirSync(activeHermesRoot, { recursive: true })
+    touchIndex(appRootDashboard)
+    assert.equal(
+      resolveDashboardWebDist({
+        activeHermesRoot,
+        appRoot,
+        env: {}
+      }),
+      appRootDashboard
+    )
+  })
+})

--- a/apps/desktop/electron/dashboard-web-dist.ts
+++ b/apps/desktop/electron/dashboard-web-dist.ts
@@ -1,0 +1,66 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+function directoryExists(dir) {
+  try {
+    return fs.statSync(dir).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+function hasDashboardBundle(dir) {
+  try {
+    return fs.statSync(path.join(dir, 'index.html')).isFile()
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Resolve the web bundle served by `hermes dashboard` / `hermes serve` when it
+ * is spawned by Desktop as the local backend.
+ *
+ * This must be the dashboard bundle (`hermes_cli/web_dist`), not the Electron
+ * renderer bundle (`apps/desktop/dist` or the packaged `app.asar.unpacked/dist`).
+ * The Electron renderer is loaded by BrowserWindow from file://; the dashboard
+ * backend is also reachable in a normal browser, where serving the Desktop
+ * renderer produces a broken page (`Desktop IPC bridge is unavailable`).
+ */
+function resolveDashboardWebDist(options: any = {}) {
+  const env = options.env || process.env
+  const override = env.HERMES_DESKTOP_DASHBOARD_WEB_DIST
+  if (override && directoryExists(path.resolve(override))) {
+    return path.resolve(override)
+  }
+
+  const candidates = []
+
+  if (options.activeHermesRoot) {
+    candidates.push(path.join(options.activeHermesRoot, 'hermes_cli', 'web_dist'))
+  }
+
+  if (options.appRoot) {
+    // Dev/source layout: <repo>/apps/desktop/electron/main.ts has APP_ROOT at
+    // <repo>/apps/desktop. Packaged layout can put APP_ROOT under resources/app.asar;
+    // this candidate is harmless there and useful in tests/source checkouts.
+    candidates.push(path.resolve(options.appRoot, '..', '..', 'hermes_cli', 'web_dist'))
+  }
+
+  for (const candidate of candidates) {
+    if (hasDashboardBundle(candidate)) {
+      return candidate
+    }
+  }
+
+  // Fall back to the canonical active install path even if it does not exist so
+  // the child `hermes dashboard --skip-build` fails with its explicit missing
+  // dist error instead of silently serving the wrong Desktop bundle.
+  if (options.activeHermesRoot) {
+    return path.join(options.activeHermesRoot, 'hermes_cli', 'web_dist')
+  }
+
+  return path.resolve('hermes_cli', 'web_dist')
+}
+
+export { resolveDashboardWebDist }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -155,6 +155,7 @@ import {
 import type { RosterProfileMetadata } from './connection-registry'
 import { describeCrashReason, installCrashForensics } from './crash-forensics'
 import { adoptServedDashboardToken } from './dashboard-token'
+import { resolveDashboardWebDist } from './dashboard-web-dist'
 import { loadOrCreateInstallationId, sshOwnershipId } from './desktop-installation'
 import { formatDesktopLogLine } from './desktop-log-line'
 import { resolveDesktopRemoteRoute } from './desktop-remote-route'
@@ -12247,7 +12248,11 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
   // Route old runtimes (no `serve`) through the legacy `dashboard --no-open`.
   backend.args = getBackendArgsForRuntime(backend)
   const hermesCwd = resolveHermesCwd()
-  const webDist = resolveWebDist()
+  const webDist = resolveDashboardWebDist({
+    activeHermesRoot: ACTIVE_HERMES_ROOT,
+    appRoot: APP_ROOT,
+    env: process.env
+  })
   const readyFile = backend.readyFile ? makeDashboardReadyFile() : null
 
   // Guard BEFORE the "Starting" line: a profile that only exists on a remote
@@ -12659,7 +12664,11 @@ async function startHermes() {
     // Route old runtimes (no `serve`) through the legacy `dashboard --no-open`.
     backend.args = getBackendArgsForRuntime(backend)
     const hermesCwd = resolveHermesCwd()
-    const webDist = resolveWebDist()
+    const webDist = resolveDashboardWebDist({
+      activeHermesRoot: ACTIVE_HERMES_ROOT,
+      appRoot: APP_ROOT,
+      env: process.env
+    })
     const readyFile = backend.readyFile ? makeDashboardReadyFile() : null
 
     await advanceBootProgress('backend.spawn', `Starting Hermes backend via ${backend.label}`, 84)


### PR DESCRIPTION
## Summary
- Port of [#44556](https://github.com/NousResearch/hermes-agent/pull/44556) (@dontcallmejames, `9f3445d`) onto current TypeScript Electron after the CJS→TS migration (`39d09453f`).
- Desktop-spawned backends (`HERMES_DESKTOP=1`) were inheriting `HERMES_WEB_DIST` from `resolveWebDist()`, which points at the Electron renderer (`apps/desktop/dist` / `app.asar.unpacked/dist`). Opening loopback in a normal browser served the Desktop app and failed with "Desktop IPC bridge is unavailable".
- Fixes [#101748](https://github.com/NousResearch/hermes-agent/issues/101748). This is **not** a duplicate of #78388 (which clears env when opening the dashboard from the Desktop shell). The remaining gap is: a `HERMES_DESKTOP=1` child still serving the Electron bundle to browsers.

## What changed
- Add `apps/desktop/electron/dashboard-web-dist.ts` exporting `resolveDashboardWebDist` (override: `HERMES_DESKTOP_DASHBOARD_WEB_DIST`).
- In `spawnPoolBackend` and `startHermes`, set spawn env `HERMES_WEB_DIST` from `resolveDashboardWebDist({ activeHermesRoot: ACTIVE_HERMES_ROOT, appRoot: APP_ROOT, env: process.env })`.
- Both the supported `serve` path and the legacy `dashboard --no-open` rewrite (`getBackendArgsForRuntime`) share that spawn env, so primary + pooled backends get `hermes_cli/web_dist`.
- `resolveWebDist()` is unchanged; BrowserWindow / `resolveRendererIndex()` still load the Electron renderer.

## Test plan
- [x] `vitest run --project electron electron/dashboard-web-dist.test.ts`
  - prefers `hermes_cli/web_dist` over Desktop renderer dist
  - `HERMES_DESKTOP_DASHBOARD_WEB_DIST` override wins when it exists
  - missing bundle falls back to canonical path
  - appRoot candidate is used when it has a bundle and `activeHermesRoot` does not
- [ ] Smoke: launch Desktop, open `http://127.0.0.1:<port>/` in a normal browser — dashboard SPA, not "Desktop IPC bridge is unavailable"
- [ ] Smoke: Electron window still loads the Desktop renderer (IPC bridge present)