### PR TITLE
fix(acp): stream nested Copilot responses incrementally

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3596,16 +3596,14 @@ def run_conversation(
                 # session instead of re-failing every retry.
                 if getattr(agent, "_disable_streaming", False):
                     _use_streaming = False
-                # An ACP client communicates via subprocess stdio and returns a
-                # plain SimpleNamespace — not an iterable stream.  Keyed on the
-                # `acp://` scheme rather than one vendor, so any ACP client is
-                # excluded.  Mirror the ACP exclusion used for Responses API
-                # upgrade (lines ~1083-1085).
+                # ACP clients opt into streaming explicitly. Older/general ACP
+                # shims still return one-shot completion objects, while the
+                # Copilot ACP client exposes a queue-backed iterable stream.
                 elif (
                     agent.provider in {"copilot-acp"}
                     or str(agent.base_url or "").lower().startswith("acp://")
                     or str(agent.base_url or "").lower().startswith("acp+tcp://")
-                ):
+                ) and getattr(agent.client, "supports_streaming", False) is not True:
                     _use_streaming = False
                 # MoA streams only when a display/TTS consumer is present to
                 # receive the deltas. MoAChatCompletions.create() honors

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -20,10 +20,9 @@ import time
 from collections import deque
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, Callable, Iterator
 
 from agent.acp_openai_bridge import (
-    completion_to_stream_chunks as _completion_to_stream_chunks,
     extract_tool_calls_from_text as _extract_tool_calls_from_text,
     render_tool_bridge_sections as _render_tool_bridge_sections,
 )
@@ -355,6 +354,218 @@ class _ACPChatNamespace:
         self.completions = _ACPChatCompletions(client)
 
 
+class _ToolCallStreamFilter:
+    """Suppress tool bridge payloads while preserving surrounding text."""
+
+    _START = "<tool_call>"
+    _END = "</tool_call>"
+
+    def __init__(self) -> None:
+        self._buffer = ""
+        self._inside_tool_call = False
+
+    @staticmethod
+    def _partial_marker_length(text: str, marker: str) -> int:
+        limit = min(len(text), len(marker) - 1)
+        for length in range(limit, 0, -1):
+            if text.endswith(marker[:length]):
+                return length
+        return 0
+
+    def feed(self, text: str) -> str:
+        if not text:
+            return ""
+
+        self._buffer += text
+        visible: list[str] = []
+        while self._buffer:
+            marker = self._END if self._inside_tool_call else self._START
+            marker_index = self._buffer.find(marker)
+            if marker_index >= 0:
+                if not self._inside_tool_call and marker_index:
+                    visible.append(self._buffer[:marker_index])
+                self._buffer = self._buffer[marker_index + len(marker):]
+                self._inside_tool_call = not self._inside_tool_call
+                continue
+
+            keep = self._partial_marker_length(self._buffer, marker)
+            if self._inside_tool_call:
+                self._buffer = self._buffer[-keep:] if keep else ""
+            else:
+                emit_length = len(self._buffer) - keep
+                if emit_length:
+                    visible.append(self._buffer[:emit_length])
+                self._buffer = self._buffer[emit_length:]
+            break
+        return "".join(visible)
+
+    def finish(self) -> str:
+        if self._inside_tool_call:
+            self._buffer = ""
+            return ""
+        tail = self._buffer
+        self._buffer = ""
+        return tail
+
+
+def _empty_usage() -> SimpleNamespace:
+    return SimpleNamespace(
+        prompt_tokens=0,
+        completion_tokens=0,
+        total_tokens=0,
+        prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+    )
+
+
+def _stream_chunk(
+    *,
+    model: str,
+    content: str | None = None,
+    reasoning: str | None = None,
+    tool_calls: list[Any] | None = None,
+    finish_reason: str | None = None,
+) -> SimpleNamespace:
+    delta = SimpleNamespace(
+        role="assistant",
+        content=content,
+        tool_calls=tool_calls,
+        reasoning_content=reasoning,
+        reasoning=reasoning,
+    )
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                index=0,
+                delta=delta,
+                finish_reason=finish_reason,
+            )
+        ],
+        model=model,
+        usage=None,
+    )
+
+
+def _tool_call_stream_deltas(tool_calls: list[Any]) -> list[SimpleNamespace]:
+    return [
+        SimpleNamespace(
+            index=index,
+            id=getattr(tool_call, "id", None),
+            type=getattr(tool_call, "type", "function"),
+            function=SimpleNamespace(
+                name=getattr(tool_call.function, "name", None),
+                arguments=getattr(tool_call.function, "arguments", None),
+            ),
+        )
+        for index, tool_call in enumerate(tool_calls)
+    ]
+
+
+class _ACPStreamingResponse:
+    """Queue-backed OpenAI-style stream over one ACP prompt."""
+
+    response = None
+
+    def __init__(
+        self,
+        client: "CopilotACPClient",
+        *,
+        prompt_text: str,
+        model: str,
+        timeout_seconds: float,
+    ) -> None:
+        self._client = client
+        self._prompt_text = prompt_text
+        self._model = model
+        self._timeout_seconds = timeout_seconds
+        self._events: queue.Queue[tuple[str, Any]] = queue.Queue()
+        self._closed = threading.Event()
+        self._worker = threading.Thread(target=self._produce, daemon=True)
+        self._worker.start()
+
+    def _put_delta(self, kind: str, text: str) -> None:
+        if text and not self._closed.is_set():
+            self._events.put((kind, text))
+
+    def _produce(self) -> None:
+        try:
+            response_text, reasoning_text = self._client._run_prompt(
+                self._prompt_text,
+                timeout_seconds=self._timeout_seconds,
+                model=self._model,
+                text_delta_callback=lambda text: self._put_delta("text", text),
+                reasoning_delta_callback=lambda text: self._put_delta("reasoning", text),
+            )
+            self._events.put(("complete", (response_text, reasoning_text)))
+        except Exception as exc:
+            self._events.put(("error", exc))
+
+    def __iter__(self) -> Iterator[SimpleNamespace]:
+        tool_filter = _ToolCallStreamFilter()
+        streamed_text_parts: list[str] = []
+        streamed_reasoning_parts: list[str] = []
+
+        while True:
+            kind, payload = self._events.get()
+            if kind == "text":
+                text = str(payload)
+                streamed_text_parts.append(text)
+                visible = tool_filter.feed(text)
+                if visible:
+                    yield _stream_chunk(model=self._model, content=visible)
+                continue
+            if kind == "reasoning":
+                reasoning = str(payload)
+                streamed_reasoning_parts.append(reasoning)
+                yield _stream_chunk(model=self._model, reasoning=reasoning)
+                continue
+            if kind == "error":
+                self._closed.set()
+                raise payload
+
+            response_text, reasoning_text = payload
+            streamed_text = "".join(streamed_text_parts)
+            if not streamed_text:
+                visible = tool_filter.feed(response_text)
+            elif response_text.startswith(streamed_text):
+                visible = tool_filter.feed(response_text[len(streamed_text):])
+            else:
+                visible = ""
+            visible += tool_filter.finish()
+            if visible:
+                yield _stream_chunk(model=self._model, content=visible)
+
+            streamed_reasoning = "".join(streamed_reasoning_parts)
+            if not streamed_reasoning:
+                remaining_reasoning = reasoning_text
+            elif reasoning_text.startswith(streamed_reasoning):
+                remaining_reasoning = reasoning_text[len(streamed_reasoning):]
+            else:
+                remaining_reasoning = ""
+            if remaining_reasoning:
+                yield _stream_chunk(model=self._model, reasoning=remaining_reasoning)
+
+            tool_calls, _ = _extract_tool_calls_from_text(response_text)
+            finish_reason = "tool_calls" if tool_calls else "stop"
+            yield _stream_chunk(
+                model=self._model,
+                tool_calls=_tool_call_stream_deltas(tool_calls) or None,
+                finish_reason=finish_reason,
+            )
+            yield SimpleNamespace(
+                choices=[],
+                model=self._model,
+                usage=_empty_usage(),
+            )
+            self._closed.set()
+            return
+
+    def close(self) -> None:
+        if self._closed.is_set():
+            return
+        self._closed.set()
+        self._client.close()
+
+
 class CopilotACPClient:
     """Minimal OpenAI-client-compatible facade for Copilot ACP."""
 
@@ -363,6 +574,7 @@ class CopilotACPClient:
     # through a wire adapter) and is safe to use from async code as-is.
     HERMES_SKIP_TRANSPORT_WRAP = True
     HERMES_SKIP_ASYNC_WRAP = True
+    supports_streaming = True
 
     def __init__(
         self,
@@ -438,20 +650,22 @@ class CopilotACPClient:
             _numeric = [float(v) for v in _candidates if isinstance(v, (int, float))]
             _effective_timeout = max(_numeric) if _numeric else _DEFAULT_TIMEOUT_SECONDS
 
+        if stream:
+            return _ACPStreamingResponse(
+                self,
+                prompt_text=prompt_text,
+                model=model or "copilot-acp",
+                timeout_seconds=_effective_timeout,
+            )
+
         response_text, reasoning_text = self._run_prompt(
             prompt_text,
             timeout_seconds=_effective_timeout,
             model=model,
         )
-
         tool_calls, cleaned_text = _extract_tool_calls_from_text(response_text)
 
-        usage = SimpleNamespace(
-            prompt_tokens=0,
-            completion_tokens=0,
-            total_tokens=0,
-            prompt_tokens_details=SimpleNamespace(cached_tokens=0),
-        )
+        usage = _empty_usage()
         assistant_message = SimpleNamespace(
             content=cleaned_text,
             tool_calls=tool_calls,
@@ -466,8 +680,6 @@ class CopilotACPClient:
             usage=usage,
             model=model or "copilot-acp",
         )
-        if stream:
-            return _completion_to_stream_chunks(completion)
         return completion
 
     def _run_prompt(
@@ -476,6 +688,8 @@ class CopilotACPClient:
         *,
         timeout_seconds: float,
         model: str | None = None,
+        text_delta_callback: Callable[[str], None] | None = None,
+        reasoning_delta_callback: Callable[[str], None] | None = None,
     ) -> tuple[str, str]:
         # Fast-fail when the CLI doesn't support the ACP args we'd pass.
         # Without this guard, a CLI like Claude Code v2.x exits with
@@ -589,6 +803,8 @@ class CopilotACPClient:
                     cwd=self._acp_cwd,
                     text_parts=text_parts,
                     reasoning_parts=reasoning_parts,
+                    text_delta_callback=text_delta_callback,
+                    reasoning_delta_callback=reasoning_delta_callback,
                 ):
                     continue
 
@@ -703,6 +919,8 @@ class CopilotACPClient:
         cwd: str,
         text_parts: list[str] | None,
         reasoning_parts: list[str] | None,
+        text_delta_callback: Callable[[str], None] | None = None,
+        reasoning_delta_callback: Callable[[str], None] | None = None,
     ) -> bool:
         method = msg.get("method")
         if not isinstance(method, str):
@@ -716,10 +934,16 @@ class CopilotACPClient:
             chunk_text = ""
             if isinstance(content, dict):
                 chunk_text = str(content.get("text") or "")
-            if kind == "agent_message_chunk" and chunk_text and text_parts is not None:
-                text_parts.append(chunk_text)
-            elif kind == "agent_thought_chunk" and chunk_text and reasoning_parts is not None:
-                reasoning_parts.append(chunk_text)
+            if kind == "agent_message_chunk" and chunk_text:
+                if text_parts is not None:
+                    text_parts.append(chunk_text)
+                if text_delta_callback is not None:
+                    text_delta_callback(chunk_text)
+            elif kind == "agent_thought_chunk" and chunk_text:
+                if reasoning_parts is not None:
+                    reasoning_parts.append(chunk_text)
+                if reasoning_delta_callback is not None:
+                    reasoning_delta_callback(chunk_text)
             return True
 
         if process.stdin is None:

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -178,7 +178,10 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             secret_file = root / "config.env"
-            secret_file.write_text("OPENAI_API_KEY=sk-proj-abc123def456ghi789jkl012")
+            secret_file.write_text(
+                "OPENAI_API_KEY=sk-proj-abc123def456ghi789jkl012",
+                encoding="utf-8",
+            )
 
             # agent.redact snapshots HERMES_REDACT_SECRETS at import time into
             # _REDACT_ENABLED, so patching os.environ is a no-op. Flip the

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -6,6 +6,7 @@ import io
 import json
 import os
 import tempfile
+import threading
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -53,6 +54,108 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
             {"path": "README.md"},
         )
         self.assertEqual(chunks[1].choices, [])
+
+    def test_stream_emits_text_before_prompt_completes(self) -> None:
+        release_prompt = threading.Event()
+
+        def _run_prompt(
+            _prompt,
+            *,
+            timeout_seconds,
+            model,
+            text_delta_callback,
+            reasoning_delta_callback,
+        ):
+            self.assertEqual(model, "copilot-acp")
+            text_delta_callback("Hello ")
+            release_prompt.wait(timeout=2)
+            text_delta_callback("world")
+            return "Hello world", ""
+
+        with patch.object(self.client, "_run_prompt", side_effect=_run_prompt):
+            stream = self.client._create_chat_completion(
+                model="copilot-acp",
+                messages=[{"role": "user", "content": "say hello"}],
+                stream=True,
+            )
+            iterator = iter(stream)
+            first = next(iterator)
+            self.assertEqual(first.choices[0].delta.content, "Hello ")
+            self.assertTrue(stream._worker.is_alive())
+            release_prompt.set()
+            chunks = list(iterator)
+
+        text = "".join(
+            chunk.choices[0].delta.content or ""
+            for chunk in [first, *chunks]
+            if chunk.choices
+        )
+        self.assertEqual(text, "Hello world")
+        self.assertEqual(chunks[-2].choices[0].finish_reason, "stop")
+        self.assertEqual(chunks[-1].choices, [])
+
+    def test_stream_separates_reasoning_and_suppresses_split_tool_payload(self) -> None:
+        tool_json = (
+            '{"id":"call_read","type":"function",'
+            '"function":{"name":"read_file","arguments":"{\\"path\\":\\"README.md\\"}"}}'
+        )
+        response_parts = [
+            "Checking. ",
+            "<tool_",
+            "call>",
+            tool_json[:35],
+            tool_json[35:],
+            "</tool_",
+            "call>",
+        ]
+
+        def _run_prompt(
+            _prompt,
+            *,
+            timeout_seconds,
+            model,
+            text_delta_callback,
+            reasoning_delta_callback,
+        ):
+            self.assertEqual(model, "copilot-acp")
+            reasoning_delta_callback("Need the file first.")
+            for part in response_parts:
+                text_delta_callback(part)
+            return "".join(response_parts), "Need the file first."
+
+        with patch.object(self.client, "_run_prompt", side_effect=_run_prompt):
+            chunks = list(
+                self.client._create_chat_completion(
+                    model="copilot-acp",
+                    messages=[{"role": "user", "content": "read README.md"}],
+                    stream=True,
+                )
+            )
+
+        visible_text = "".join(
+            chunk.choices[0].delta.content or ""
+            for chunk in chunks
+            if chunk.choices
+        )
+        reasoning = "".join(
+            chunk.choices[0].delta.reasoning_content or ""
+            for chunk in chunks
+            if chunk.choices
+        )
+        self.assertEqual(visible_text, "Checking. ")
+        self.assertEqual(reasoning, "Need the file first.")
+        self.assertNotIn("tool_call", visible_text)
+        self.assertNotIn("read_file", visible_text)
+
+        final = chunks[-2]
+        self.assertEqual(final.choices[0].finish_reason, "tool_calls")
+        tool_delta = final.choices[0].delta.tool_calls[0]
+        self.assertEqual(tool_delta.id, "call_read")
+        self.assertEqual(tool_delta.function.name, "read_file")
+        self.assertEqual(
+            json.loads(tool_delta.function.arguments),
+            {"path": "README.md"},
+        )
 
 
     def _dispatch(self, message: dict, *, cwd: str) -> dict:

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -1424,61 +1424,47 @@ def _make_acp_agent(provider="copilot-acp", base_url="acp://copilot"):
 
 
 class TestCopilotACPStreamingDecision:
-    """Verify that copilot-acp routes to the non-streaming path.
-
-    CopilotACPClient communicates via subprocess stdio and returns a plain
-    SimpleNamespace — not an iterable stream.  The streaming decision logic
-    must detect ACP runtimes and route to _interruptible_api_call instead.
-    """
+    """Verify that ACP streaming is gated by the client capability."""
 
     @patch("run_agent.get_tool_definitions", return_value=[])
     @patch("run_agent.check_toolset_requirements", return_value={})
     @patch("agent.copilot_acp_client.CopilotACPClient")
-    def test_provider_name_triggers_non_streaming(
+    def test_copilot_acp_capability_allows_streaming(
         self, mock_acp_cls, _mock_check, _mock_tools
     ):
-        """provider='copilot-acp' → non-streaming path."""
-        mock_acp_cls.return_value = MagicMock()
+        mock_acp_cls.return_value = MagicMock(supports_streaming=True)
         agent = _make_acp_agent(provider="copilot-acp", base_url="acp://copilot")
+        agent.client.supports_streaming = True
 
-        with (
-            patch.object(agent, "_interruptible_api_call",
-                         return_value=_valid_acp_response()) as mock_non_stream,
-            patch.object(agent, "_interruptible_streaming_api_call") as mock_stream,
-        ):
-            # Verify the decision logic correctly disables streaming
-            _use_streaming = True
-            if getattr(agent, "_disable_streaming", False):
-                _use_streaming = False
-            elif (
-                agent.provider == "copilot-acp"
-                or str(agent.base_url or "").lower().startswith("acp://copilot")
-                or str(agent.base_url or "").lower().startswith("acp+tcp://")
-            ):
-                _use_streaming = False
+        _use_streaming = True
+        if getattr(agent, "_disable_streaming", False):
+            _use_streaming = False
+        elif (
+            agent.provider == "copilot-acp"
+            or str(agent.base_url or "").lower().startswith("acp://")
+            or str(agent.base_url or "").lower().startswith("acp+tcp://")
+        ) and getattr(agent.client, "supports_streaming", False) is not True:
+            _use_streaming = False
 
-            assert _use_streaming is False
-            # Call the non-streaming path as the loop would
-            response = mock_non_stream({})
-            mock_stream.assert_not_called()
+        assert _use_streaming is True
 
     @patch("run_agent.get_tool_definitions", return_value=[])
     @patch("run_agent.check_toolset_requirements", return_value={})
     @patch("agent.copilot_acp_client.CopilotACPClient")
-    def test_acp_base_url_triggers_non_streaming(
+    def test_acp_client_without_capability_stays_non_streaming(
         self, mock_acp_cls, _mock_check, _mock_tools
     ):
-        """base_url='acp://copilot' → non-streaming even without provider name."""
-        mock_acp_cls.return_value = MagicMock()
+        mock_acp_cls.return_value = MagicMock(supports_streaming=False)
         agent = _make_acp_agent(provider="custom", base_url="acp://copilot")
         agent.provider = "custom"
+        agent.client.supports_streaming = False
 
         _use_streaming = True
         if (
             agent.provider == "copilot-acp"
-            or str(agent.base_url or "").lower().startswith("acp://copilot")
+            or str(agent.base_url or "").lower().startswith("acp://")
             or str(agent.base_url or "").lower().startswith("acp+tcp://")
-        ):
+        ) and getattr(agent.client, "supports_streaming", False) is not True:
             _use_streaming = False
 
         assert _use_streaming is False
@@ -1504,9 +1490,9 @@ class TestCopilotACPStreamingDecision:
             _use_streaming = False
         elif (
             agent.provider == "copilot-acp"
-            or str(agent.base_url or "").lower().startswith("acp://copilot")
+            or str(agent.base_url or "").lower().startswith("acp://")
             or str(agent.base_url or "").lower().startswith("acp+tcp://")
-        ):
+        ) and getattr(agent.client, "supports_streaming", False) is not True:
             _use_streaming = False
 
         assert _use_streaming is True


### PR DESCRIPTION
## What does this PR do?

Fixes nested ACP streaming when Hermes uses `copilot-acp` as its model provider
and is itself serving an outer ACP client:

```text
ACP client -> hermes acp -> copilot-acp provider
```

The Copilot ACP shim previously collected every `agent_message_chunk` and
`agent_thought_chunk` in memory and returned only after `session/prompt`
completed. The conversation loop also disabled streaming for every ACP-backed
client. Together, those behaviors made the outer client appear stalled for the
entire model turn.

This change forwards text and reasoning deltas as the inner ACP process emits
them, while retaining the complete response for final parsing. A queue-backed
OpenAI-compatible iterator preserves chunk order and usage-finalization
semantics. Tool bridge payloads remain hidden even when `<tool_call>` tags and
JSON are split across chunks, then surface once as structured tool calls.

This is distinct from #54652: that PR made a completed, already-buffered ACP
response iterable; this PR yields updates while the inner `session/prompt`
request is still active.

## Related Issue

Fixes #101507

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `agent/copilot_acp_client.py`
  - forwards message and reasoning updates through callbacks
  - exposes a queue-backed streaming response
  - suppresses partial tool bridge payloads and emits complete structured calls
  - preserves model selection, transport guards, final parsing, and usage data
- `agent/conversation_loop.py`
  - replaces the blanket ACP streaming exclusion with an explicit client
    capability check
- `tests/agent/test_copilot_acp_client.py`
  - verifies first-delta delivery before prompt completion, reasoning
    separation, split tool payload filtering, model forwarding, and tool calls
- `tests/run_agent/test_streaming.py`
  - verifies capable ACP clients stream while older/general ACP shims retain
    non-streaming behavior

## How to Test

1. Run:
   `scripts/run_tests.sh tests/agent/test_copilot_acp_client.py tests/run_agent/test_streaming.py -q`
2. Configure Hermes with the `copilot-acp` provider and start `hermes acp`.
3. Connect an ACP client and send a prompt that emits several reasoning and
   message chunks. Confirm the first outer `session/update` arrives before the
   inner prompt completes, reasoning remains separate, and tool calls execute
   without visible bridge markup or duplicate final text.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] The focused ACP and streaming suites pass: 59 tests
- [x] I've added tests for my changes
- [x] I've tested on Ubuntu 26.04 under WSL

### Documentation & Housekeeping

- [x] Documentation update: N/A; this restores expected ACP streaming behavior
- [x] `cli-config.yaml.example`: N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no workflow or architecture policy changed
- [x] Cross-platform impact considered; the change uses existing Python queue and threading primitives
- [x] Tool descriptions/schemas: N/A; no model tool behavior changed

## Screenshots / Logs

```text
Discovered 2 test files (~56 tests)
tests/agent/test_copilot_acp_client.py: 20 passed
tests/run_agent/test_streaming.py: 39 passed
Summary: 59 tests passed, 0 failed
```
