### PR TITLE
fix(auxiliary): keep absent fallbacks out of health cache

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3354,7 +3354,12 @@ def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Op
 
     or_key = explicit_api_key or _scoped_key_env("OPENROUTER_API_KEY")
     if not or_key:
-        _mark_provider_unhealthy("openrouter", ttl=60)
+        # An unconfigured fallback is absent, not unhealthy.  In particular,
+        # availability probes run this path while deciding whether to expose
+        # vision tools; poisoning the health cache here both mislabels the
+        # condition as a payment failure and makes unrelated auxiliary calls
+        # skip OpenRouter after credentials are supplied in the same process.
+        logger.debug("Auxiliary OpenRouter client unavailable: no API key found")
         return None, None
     logger.debug("Auxiliary client: OpenRouter")
     return _create_openai_client(api_key=or_key, base_url=OPENROUTER_BASE_URL,
@@ -3401,11 +3406,14 @@ def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
     nous = _read_nous_auth()
     runtime = _resolve_nous_runtime_api(force_refresh=False)
     if runtime is None and not nous:
-        logger.warning(
+        # Missing optional credentials are expected during tool-availability
+        # probes and fallback discovery.  The explicit-provider resolver emits
+        # a warning for a real request; this low-level candidate must stay
+        # side-effect free when it is merely absent.
+        logger.debug(
             "Auxiliary Nous client unavailable: no Nous authentication found "
             "(run: hermes auth)."
         )
-        _mark_provider_unhealthy("nous", ttl=60)
         return None, None
     if runtime is None and nous:
         logger.debug(

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1092,6 +1092,22 @@ class TestOpenRouterPaidLaneGuard:
         assert model is None
         mark_unhealthy.assert_not_called()
 
+    def test_missing_key_does_not_mark_openrouter_unhealthy(self, monkeypatch, caplog):
+        """An absent optional fallback is not a provider health failure."""
+        import logging
+
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("hermes_cli.config.load_config_readonly", return_value={}), \
+             patch("agent.auxiliary_client._mark_provider_unhealthy") as mark_unhealthy, \
+             caplog.at_level(logging.WARNING, logger="agent.auxiliary_client"):
+            client, model = _try_openrouter()
+
+        assert client is None
+        assert model is None
+        mark_unhealthy.assert_not_called()
+        assert not caplog.records
+
     def test_free_only_gate_reports_policy_not_credentials(self, monkeypatch, caplog):
         import logging
 
@@ -1208,6 +1224,23 @@ class TestGetTextAuxiliaryClient:
 
 class TestVisionClientFallback:
     """Vision client auto mode resolves known-good multimodal backends."""
+
+    def test_missing_nous_auth_is_quiet_and_not_marked_unhealthy(self, caplog):
+        """Discovery may inspect an unconfigured optional Nous fallback."""
+        import logging
+        from agent.auxiliary_client import _try_nous
+
+        with patch("agent.nous_rate_guard.nous_rate_limit_remaining", return_value=None), \
+             patch("agent.auxiliary_client._read_nous_auth", return_value=None), \
+             patch("agent.auxiliary_client._resolve_nous_runtime_api", return_value=None), \
+             patch("agent.auxiliary_client._mark_provider_unhealthy") as mark_unhealthy, \
+             caplog.at_level(logging.WARNING, logger="agent.auxiliary_client"):
+            client, model = _try_nous()
+
+        assert client is None
+        assert model is None
+        mark_unhealthy.assert_not_called()
+        assert not caplog.records
 
     def test_vision_auto_includes_active_provider_when_configured(self, monkeypatch):
         """Active provider appears in available backends when credentials exist."""


### PR DESCRIPTION
## Summary

- treat missing optional OpenRouter credentials as an absent fallback, not a payment failure
- keep missing Nous authentication at debug level during fallback discovery
- avoid poisoning the auxiliary provider health cache during vision/tool availability probes

## Why

`_try_openrouter()` and `_try_nous()` currently call `_mark_provider_unhealthy()` when credentials are simply absent. The health helper describes every entry as a payment/credit failure, so routine `aux_probe_mode()` vision checks emit misleading warnings and temporarily quarantine providers that never failed.

Explicit provider resolution still reports a warning to a real caller; confirmed auth/payment/rate-limit failures still use the health cache.

## Verification

- `pytest -q tests/agent/test_auxiliary_client.py tests/tools/test_startup_latency_regressions.py`
- 210 passed
