### PR TITLE
feat(plugins): expose route metadata to tool hooks

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2168,6 +2168,18 @@ def switch_model(
     _persist_switch_billing_route(agent)
 
 
+def tool_hook_route_metadata(agent: Any) -> Dict[str, str]:
+    """Return stable, non-message routing identity for plugin tool hooks."""
+    fields = {
+        "platform": getattr(agent, "platform", None),
+        "chat_id": getattr(agent, "_chat_id", None),
+        "thread_id": getattr(agent, "_thread_id", None),
+        "user_id": getattr(agent, "_user_id", None),
+        "session_key": getattr(agent, "_gateway_session_key", None),
+    }
+    return {key: str(value) for key, value in fields.items() if value not in (None, "")}
+
+
 def _pre_tool_block_message(agent, function_name, function_args, effective_task_id, tool_call_id, middleware_trace):
     """Plugin pre-tool-call hook verdict: ``(block_message, function_args)``; failures never block."""
     try:
@@ -2178,6 +2190,7 @@ def _pre_tool_block_message(agent, function_name, function_args, effective_task_
             turn_id=getattr(agent, "_current_turn_id", "") or "",
             api_request_id=getattr(agent, "_current_api_request_id", "") or "",
             middleware_trace=list(middleware_trace),
+            route_metadata=tool_hook_route_metadata(agent),
         )
         return block_message, (modified_args if modified_args is not None else function_args)
     except Exception:

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -45,6 +45,7 @@ from agent.tool_dispatch_helpers import (
     _plan_tool_batch_segments,
     make_tool_result_message,
 )
+from agent.agent_runtime_helpers import tool_hook_route_metadata
 from tools.terminal_tool_lifecycle import get_active_env
 from tools.thread_context import propagate_context_to_thread
 from tools.tool_result_storage import (
@@ -624,6 +625,7 @@ def _pre_tool_block(agent, ref: _ToolCallRef):
             ref.args,
             **tool_hook_ids(agent, ref.task_id, ref.call_id),
             middleware_trace=list(ref.trace),
+            route_metadata=tool_hook_route_metadata(agent),
         )
         return block_msg, (ref.args if modified_args is None else modified_args)
     except Exception:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1772,6 +1772,7 @@ def _get_pre_tool_call_directive_details(
     tool_name: str, args: Optional[Dict[str, Any]], task_id: str = "", session_id: str = "",
     tool_call_id: str = "", turn_id: str = "", api_request_id: str = "",
     middleware_trace: Optional[List[Dict[str, Any]]] = None,
+    route_metadata: Optional[Dict[str, Any]] = None,
 ) -> _PreToolCallDirective:
     """Check ``pre_tool_call`` hooks for ``{"action": "block", "message"}`` (veto; message becomes
     the tool result) or ``{"action": "approve", "message", "rule_key"?}`` (escalate ANY tool to the
@@ -1786,6 +1787,7 @@ def _get_pre_tool_call_directive_details(
         "pre_tool_call", tool_name=tool_name, args=args if isinstance(args, dict) else {},
         task_id=task_id, session_id=session_id, tool_call_id=tool_call_id, turn_id=turn_id,
         api_request_id=api_request_id, middleware_trace=list(middleware_trace or []),
+        route_metadata=dict(route_metadata or {}),
     )
     modified_args: Optional[Dict[str, Any]] = None
     for result in hook_results:

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1358,6 +1358,7 @@ class TestPreToolCallDirective:
                     "turn_id": "",
                     "api_request_id": "",
                     "middleware_trace": [],
+                    "route_metadata": {},
                 },
             )
         ]

--- a/tests/run_agent/test_tool_hook_route_metadata.py
+++ b/tests/run_agent/test_tool_hook_route_metadata.py
@@ -1,0 +1,448 @@
+"""E2E contracts for route-aware tool admission plugins."""
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+import hermes_cli.plugins as plugins_mod
+from agent.agent_runtime_helpers import tool_hook_route_metadata
+from hermes_cli.plugins import PluginManager
+from run_agent import AIAgent
+
+
+def _install_admission_plugin(
+    hermes_home: Path, active_work: list[dict] | None = None
+) -> None:
+    plugin_dir = hermes_home / "plugins" / "route-admission"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.yaml").write_text(
+        yaml.safe_dump({"name": "route-admission", "version": "0.1.0"}),
+        encoding="utf-8",
+    )
+    (plugin_dir / "__init__.py").write_text(
+        "import json\n"
+        "from pathlib import Path\n\n"
+        "def register(ctx):\n"
+        "    def admit(**kwargs):\n"
+        "        route = kwargs.get('route_metadata', {})\n"
+        "        if kwargs['tool_name'] != 'delegate_task':\n"
+        "            return None\n"
+        "        work = json.loads((Path(__file__).parent / 'active-work.json').read_text())\n"
+        "        admitted = any(\n"
+        "            item.get('active') and item.get('subscribed') and\n"
+        "            item.get('session_id') == kwargs.get('session_id') and\n"
+        "            item.get('route') == route\n"
+        "            for item in work\n"
+        "        )\n"
+        "        if not admitted:\n"
+        "            return {'action': 'block', 'message': 'mission admission denied'}\n"
+        "    ctx.register_hook('pre_tool_call', admit)\n",
+        encoding="utf-8",
+    )
+    (plugin_dir / "active-work.json").write_text(
+        json.dumps(active_work or []), encoding="utf-8"
+    )
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"plugins": {"enabled": ["route-admission"]}}),
+        encoding="utf-8",
+    )
+
+
+def _tool_defs() -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": "delegate_task",
+                "description": "delegate",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+
+def _admitted_work() -> list[dict]:
+    return [
+        {
+            "active": True,
+            "subscribed": True,
+            "session_id": "session-123",
+            "route": {
+                "platform": "telegram",
+                "chat_id": "chat-42",
+                "thread_id": "topic-7",
+                "session_key": "agent:main:telegram:group:chat-42:topic-7",
+            },
+        }
+    ]
+
+
+def test_route_aware_plugin_vetoes_delegate_task_before_dispatch(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    _install_admission_plugin(hermes_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    manager = PluginManager()
+    monkeypatch.setattr(plugins_mod, "_plugin_manager", manager)
+    monkeypatch.setattr(plugins_mod, "get_plugin_manager", lambda: manager)
+    manager.discover_and_load()
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_tool_defs()),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            session_id="session-123",
+            platform="telegram",
+            chat_id="chat-42",
+            thread_id="topic-7",
+            gateway_session_key="agent:main:telegram:group:chat-42:topic-7",
+        )
+    agent.client = MagicMock()
+    dispatched = []
+    agent._dispatch_delegate_task = lambda function_args: (
+        dispatched.append(function_args) or "dispatched"
+    )
+
+    cached_prompt = object()
+    setattr(agent, "_cached_system_prompt", cached_prompt)
+    with patch.object(agent, "_invalidate_system_prompt") as invalidate_prompt:
+        result = json.loads(
+            agent._invoke_tool(
+                "delegate_task",
+                {"goal": "start downstream work"},
+                "task-parent",
+                tool_call_id="call-1",
+            )
+        )
+
+    assert result == {"error": "mission admission denied"}
+    assert dispatched == []
+    assert getattr(agent, "_cached_system_prompt") is cached_prompt
+    invalidate_prompt.assert_not_called()
+
+
+def test_plugin_correlates_active_subscribed_work_and_permits_dispatch(
+    tmp_path, monkeypatch
+):
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    _install_admission_plugin(hermes_home, _admitted_work())
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    manager = PluginManager()
+    monkeypatch.setattr(plugins_mod, "_plugin_manager", manager)
+    monkeypatch.setattr(plugins_mod, "get_plugin_manager", lambda: manager)
+    manager.discover_and_load()
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_tool_defs()),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            session_id="session-123",
+            platform="telegram",
+            chat_id="chat-42",
+            thread_id="topic-7",
+            gateway_session_key="agent:main:telegram:group:chat-42:topic-7",
+        )
+    agent.client = MagicMock()
+    dispatched = []
+    agent._dispatch_delegate_task = lambda function_args: (
+        dispatched.append(function_args) or "dispatched"
+    )
+
+    result = agent._invoke_tool(
+        "delegate_task", {"goal": "admitted work"}, "task-parent"
+    )
+
+    assert result == "dispatched"
+    assert dispatched == [{"goal": "admitted work"}]
+
+
+def test_delegate_dispatch_is_unchanged_when_admission_plugin_is_absent(
+    tmp_path, monkeypatch
+):
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    manager = PluginManager()
+    monkeypatch.setattr(plugins_mod, "_plugin_manager", manager)
+    monkeypatch.setattr(plugins_mod, "get_plugin_manager", lambda: manager)
+    manager.discover_and_load()
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_tool_defs()),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            session_id="session-123",
+            platform="telegram",
+        )
+    agent.client = MagicMock()
+    dispatched = []
+    agent._dispatch_delegate_task = lambda function_args: (
+        dispatched.append(function_args) or "dispatched"
+    )
+
+    result = agent._invoke_tool(
+        "delegate_task", {"goal": "ordinary work"}, "task-parent"
+    )
+
+    assert result == "dispatched"
+    assert dispatched == [{"goal": "ordinary work"}]
+
+
+def test_sequential_agent_loop_uses_route_metadata_before_delegate_dispatch(
+    tmp_path, monkeypatch
+):
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    _install_admission_plugin(hermes_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    manager = PluginManager()
+    monkeypatch.setattr(plugins_mod, "_plugin_manager", manager)
+    monkeypatch.setattr(plugins_mod, "get_plugin_manager", lambda: manager)
+    manager.discover_and_load()
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_tool_defs()),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            session_id="session-123",
+            platform="telegram",
+            chat_id="chat-42",
+            thread_id="topic-7",
+            gateway_session_key="agent:main:telegram:group:chat-42:topic-7",
+        )
+    dispatched = []
+    agent._dispatch_delegate_task = lambda function_args: (
+        dispatched.append(function_args) or "dispatched"
+    )
+    tool_call = SimpleNamespace(
+        id="call-1",
+        function=SimpleNamespace(
+            name="delegate_task",
+            arguments=json.dumps({"goal": "start downstream work"}),
+        ),
+    )
+    assistant_message = SimpleNamespace(tool_calls=[tool_call])
+    messages = []
+
+    agent._execute_tool_calls_sequential(assistant_message, messages, "task-parent")
+
+    transcript = [
+        {"role": "user", "content": "start downstream work"},
+        {"role": "assistant", "tool_calls": [tool_call]},
+        *messages,
+    ]
+    assert [message["role"] for message in transcript] == [
+        "user",
+        "assistant",
+        "tool",
+    ]
+    assert json.loads(messages[0]["content"]) == {"error": "mission admission denied"}
+    assert "route_metadata" not in messages[0]["content"]
+    assert dispatched == []
+
+
+def test_concurrent_agent_loop_uses_route_metadata_before_delegate_dispatch(
+    tmp_path, monkeypatch
+):
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    _install_admission_plugin(hermes_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    manager = PluginManager()
+    monkeypatch.setattr(plugins_mod, "_plugin_manager", manager)
+    monkeypatch.setattr(plugins_mod, "get_plugin_manager", lambda: manager)
+    manager.discover_and_load()
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_tool_defs()),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            session_id="session-123",
+            platform="telegram",
+            chat_id="chat-42",
+            thread_id="topic-7",
+            gateway_session_key="agent:main:telegram:group:chat-42:topic-7",
+        )
+    dispatched = []
+    agent._dispatch_delegate_task = lambda function_args: (
+        dispatched.append(function_args) or "dispatched"
+    )
+    tool_call = SimpleNamespace(
+        id="call-1",
+        function=SimpleNamespace(
+            name="delegate_task",
+            arguments=json.dumps({"goal": "start downstream work"}),
+        ),
+    )
+    assistant_message = SimpleNamespace(tool_calls=[tool_call])
+    messages = []
+
+    agent._execute_tool_calls_concurrent(assistant_message, messages, "task-parent")
+
+    assert json.loads(messages[0]["content"]) == {"error": "mission admission denied"}
+    assert dispatched == []
+
+
+def test_route_identity_is_stable_and_copied_across_tool_calls(monkeypatch):
+    manager = PluginManager()
+    monkeypatch.setattr(plugins_mod, "_plugin_manager", manager)
+    monkeypatch.setattr(plugins_mod, "get_plugin_manager", lambda: manager)
+    observed = []
+
+    def capture(**kwargs):
+        observed.append((kwargs["session_id"], kwargs["route_metadata"]))
+
+    manager._hooks["pre_tool_call"] = [capture]
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_tool_defs()),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            session_id="session-stable",
+            platform="telegram",
+            user_id="user-9",
+            chat_id="chat-42",
+            thread_id="topic-7",
+            gateway_session_key="agent:main:telegram:group:chat-42:topic-7",
+        )
+    agent.client = MagicMock()
+    agent._dispatch_delegate_task = lambda function_args: "dispatched"
+
+    agent._invoke_tool("delegate_task", {"goal": "first"}, "task-parent")
+    observed[0][1]["chat_id"] = "plugin-mutated-copy"
+    agent._invoke_tool("delegate_task", {"goal": "second"}, "task-parent")
+
+    expected_route = {
+        "platform": "telegram",
+        "user_id": "user-9",
+        "chat_id": "chat-42",
+        "thread_id": "topic-7",
+        "session_key": "agent:main:telegram:group:chat-42:topic-7",
+    }
+    assert observed[0][0] == observed[1][0] == "session-stable"
+    assert observed[1][1] == expected_route
+    assert tool_hook_route_metadata(agent) == expected_route
+
+
+def test_route_identity_is_isolated_between_sessions(monkeypatch):
+    manager = PluginManager()
+    monkeypatch.setattr(plugins_mod, "_plugin_manager", manager)
+    monkeypatch.setattr(plugins_mod, "get_plugin_manager", lambda: manager)
+    observed = []
+    manager._hooks["pre_tool_call"] = [
+        lambda **kwargs: observed.append(
+            (
+                kwargs["session_id"],
+                kwargs["route_metadata"],
+            )
+        )
+    ]
+
+    agents = []
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_tool_defs()),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        for suffix in ("one", "two"):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                session_id=f"session-{suffix}",
+                platform="discord",
+                chat_id=f"chat-{suffix}",
+                gateway_session_key=f"agent:main:discord:channel:chat-{suffix}",
+            )
+            agent.client = MagicMock()
+            agent._dispatch_delegate_task = lambda function_args: "dispatched"
+            agents.append(agent)
+
+    for agent in agents:
+        agent._invoke_tool("delegate_task", {"goal": "work"}, "task-parent")
+
+    assert observed == [
+        (
+            "session-one",
+            {
+                "platform": "discord",
+                "chat_id": "chat-one",
+                "session_key": "agent:main:discord:channel:chat-one",
+            },
+        ),
+        (
+            "session-two",
+            {
+                "platform": "discord",
+                "chat_id": "chat-two",
+                "session_key": "agent:main:discord:channel:chat-two",
+            },
+        ),
+    ]
+
+
+def test_route_identity_defaults_to_empty_for_non_gateway_agents(monkeypatch):
+    manager = PluginManager()
+    monkeypatch.setattr(plugins_mod, "_plugin_manager", manager)
+    monkeypatch.setattr(plugins_mod, "get_plugin_manager", lambda: manager)
+    observed = []
+    manager._hooks["pre_tool_call"] = [
+        lambda **kwargs: observed.append(kwargs["route_metadata"])
+    ]
+
+    assert tool_hook_route_metadata(SimpleNamespace()) == {}
+    assert plugins_mod.resolve_pre_tool_block("read_file", {}) is None
+    assert observed == [{}]

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -940,7 +940,7 @@ Each hook is documented in full on the **[Event Hooks reference](/user-guide/fea
 
 | Hook | Fires when | Callback signature | Returns |
 |------|-----------|-------------------|---------|
-| [`pre_tool_call`](/user-guide/features/hooks#pre_tool_call) | Before any tool executes | `tool_name: str, args: dict, task_id: str` | optional directive: `{"action": "block", "message": ...}` vetoes the call; `{"action": "approve", "message": ...}` escalates to the human-approval gate |
+| [`pre_tool_call`](/user-guide/features/hooks#pre_tool_call) | Before any tool executes, including agent-loop tools | `tool_name: str, args: dict, task_id: str, session_id: str, route_metadata: dict, **kwargs` | `None` allows; optional directive: `{"action": "block", "message": ...}` vetoes before dispatch; `{"action": "approve", "message": ...}` escalates to the human-approval gate |
 | [`post_tool_call`](/user-guide/features/hooks#post_tool_call) | After any tool returns | `tool_name: str, args: dict, result: str, task_id: str, duration_ms: int` | ignored |
 | [`pre_llm_call`](/user-guide/features/hooks#pre_llm_call) | Once per turn, before the tool-calling loop | `session_id: str, user_message: str, conversation_history: list, is_first_turn: bool, model: str, platform: str` | [context injection](#pre_llm_call-context-injection) |
 | [`post_llm_call`](/user-guide/features/hooks#post_llm_call) | Once per turn, after the tool-calling loop (successful turns only) | `session_id: str, user_message: str, assistant_response: str, conversation_history: list, model: str, platform: str` | ignored |

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -533,16 +533,18 @@ Fires **immediately before** every tool execution — built-in tools and plugin 
 **Callback signature:**
 
 ```python
-def my_callback(tool_name: str, args: dict, task_id: str, **kwargs):
+def my_callback(tool_name: str, args: dict, task_id: str, session_id: str, **kwargs):
 ```
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `tool_name` | `str` | Name of the tool about to execute (e.g. `"terminal"`, `"web_search"`, `"read_file"`) |
 | `args` | `dict` | The arguments the model passed to the tool |
-| `task_id` | `str` | Session/task identifier. Empty string if not set. |
+| `task_id` | `str` | Active task identifier. Empty string if not set. |
+| `session_id` | `str` | Stable Hermes session identifier for the current agent session. Empty string if not set. |
+| `route_metadata` | `dict` | Stable gateway route identity when available: `platform`, `chat_id`, `thread_id`, `user_id`, and `session_key`. CLI sessions normally receive an empty dict. |
 
-**Fires:** In `model_tools.py`, inside `handle_function_call()`, before the tool's handler runs. Fires once per tool call — if the model calls 3 tools in parallel, this fires 3 times.
+**Fires:** Immediately before dispatch, including agent-loop tools such as `delegate_task`, `todo`, and `memory`. Fires once per tool call — if the model calls 3 tools in parallel, this fires 3 times. A block is resolved before the handler or agent-loop dispatcher runs, so the blocked call has no tool side effect. Concurrent calls still receive separate hook invocations.
 
 **Return value — block or require approval:**
 
@@ -552,7 +554,7 @@ return {"action": "block", "message": "Reason the tool call was blocked"}
 return {"action": "approve", "message": "Why approval is required", "rule_key": "optional:scope"}
 ```
 
-The first valid directive wins (Python plugins registered first, then shell hooks). `block` requires a non-empty `message` and short-circuits the tool with that text as the error returned to the model. `approve` escalates the call to the existing human-approval gate; `message` and `rule_key` are optional, and denial, timeout, or gate error fails closed. Other return values are ignored, so existing observer-only callbacks keep working unchanged.
+The first valid directive wins (Python plugins registered first, then shell hooks). `block` requires a non-empty `message` and short-circuits the tool with that text as the error returned to the model. `approve` escalates the call to the existing human-approval gate; `message` and `rule_key` are optional, and denial, timeout, or gate error fails closed. Return `None` to allow normal execution. Other return values are ignored, so existing observer-only callbacks keep working unchanged. Hook exceptions are logged and skipped, so a plugin that requires fail-closed policy must catch its own lookup errors and return a block directive.
 
 **Return value — rewrite the tool's arguments:**
 
@@ -573,6 +575,42 @@ Both formats are normalized internally to `{"action": "modify", "args": {...}}`.
 If a `pre_tool_call` callback exceeds `plugins.hook_callback_timeout` (or is still running from a previous timed-out fire), Hermes **fails closed**: the tool is blocked with a timeout message rather than proceeding without a policy decision.
 
 **Use cases:** Logging, audit trails, tool call counters, blocking dangerous operations, rate limiting, per-user policy enforcement, argument sanitization, path rewriting, injecting default parameters.
+
+**Concrete admission-control use case:** A mission-admission plugin can match
+`session_id` and `route_metadata` against its own active, subscribed-work index before
+allowing a `delegate_task` call. If the current chat/thread has no active admitted
+work, the hook returns a block directive. Register it like any other plugin hook:
+
+```python
+def admit_mission(tool_name, session_id, route_metadata, **kwargs):
+    if tool_name != "delegate_task":
+        return None
+    if subscribed_work_index.contains_active(session_id, route_metadata):
+        return None
+    return {"action": "block", "message": "No active admitted mission for this route"}
+
+def register(ctx):
+    ctx.register_hook("pre_tool_call", admit_mission)
+```
+
+`subscribed_work_index` is deliberately plugin-owned. Hermes supplies generic tool,
+session, and origin context but does not query a board or decide which work is admitted.
+This keeps organisation-specific policy outside core. Route metadata is hook context
+only and does not alter the system prompt, conversation messages, or tool schemas.
+
+**Lifecycle and stability:** `session_id` is stable for the current Hermes session;
+`route_metadata` is a fresh, shallow copy on every invocation, so callback mutation does
+not change agent state. Missing or non-gateway values are omitted, and a non-gateway
+session normally receives `{}`. A reset or new session may produce a new session or
+route identity. Treat route values, especially `session_key`, as opaque correlation
+identifiers rather than credentials or proof of authorisation. The key set is additive
+hook context, not a frozen public wire schema; accept `**kwargs`, use `.get()`, and fail
+according to your plugin's own policy when required identity is absent.
+
+**Compatibility note:** Existing hooks that already accept `**kwargs` need no changes;
+observer callbacks may continue returning `None`. Authors updating older fixed-signature
+callbacks should add `**kwargs` before relying on new context. Existing no-plugin and
+no-directive behaviour remains allow-by-default.
 
 **Example — tool call audit log:**
 


### PR DESCRIPTION
Adds copied gateway route metadata to pre_tool_call hooks and proves veto coverage for agent-loop tools, including direct, sequential, and concurrent delegate_task dispatch.\n\nTests: scripts/run_tests.sh tests/hermes_cli/test_plugins.py tests/run_agent/test_tool_hook_route_metadata.py (83 passed)\n\nThis is a generic extension seam; organisation-specific admission policy remains plugin-owned.