### PR TITLE
fix(desktop): prevent mismatched provider and model selections

### DIFF
--- a/apps/desktop/e2e/fleet-profile-rail.spec.ts
+++ b/apps/desktop/e2e/fleet-profile-rail.spec.ts
@@ -44,7 +44,12 @@ interface RemoteGateway {
 }
 
 function findHermesBinary(): string {
-  const venv = path.join(REPO_ROOT, '.venv', 'bin', 'hermes')
+  const venv = path.join(
+    REPO_ROOT,
+    '.venv',
+    process.platform === 'win32' ? 'Scripts' : 'bin',
+    process.platform === 'win32' ? 'hermes.exe' : 'hermes'
+  )
 
   if (fs.existsSync(venv)) {
     return venv

--- a/apps/desktop/e2e/mock-server.ts
+++ b/apps/desktop/e2e/mock-server.ts
@@ -43,6 +43,7 @@ backgroundReleasePath?: string
 export interface MockServer {
   port: number
   url: string
+  receivedModels: string[]
   receivedPrompts: string[]
   waitForHeldStream: () => Promise<void>
   waitForHeldCompletion: () => Promise<void>
@@ -396,6 +397,7 @@ function includesBlockingClarifyTrigger(value: unknown): boolean {
  */
 export function startMockServer(options: MockServerOptions = {}): Promise<MockServer> {
   return new Promise((resolve, reject) => {
+    const receivedModels: string[] = []
     const receivedPrompts: string[] = []
     let resolveHeldStreamStarted: (() => void) | null = null
     let releaseHeldStream: (() => void) | null = null
@@ -465,6 +467,7 @@ export function startMockServer(options: MockServerOptions = {}): Promise<MockSe
 
           const stream = parsed.stream === true
           const model = parsed.model || 'mock-model'
+          receivedModels.push(String(model))
           const holdThisCompletion = Boolean(
             options.holdFirstCompletionContaining &&
             heldCompletionCount === 0 &&
@@ -665,6 +668,7 @@ export function startMockServer(options: MockServerOptions = {}): Promise<MockSe
       resolve({
         port,
         url,
+        receivedModels,
         receivedPrompts,
         waitForHeldStream: () => heldStreamStarted,
         waitForHeldCompletion: () => heldStreamStarted,

--- a/apps/desktop/e2e/provider-model-profile-isolation.spec.ts
+++ b/apps/desktop/e2e/provider-model-profile-isolation.spec.ts
@@ -1,0 +1,177 @@
+/**
+ * A manual model choice belongs to the profile where it was made. Switching
+ * profiles must restore the target pair before a new session is created, or
+ * the target backend receives a model owned by a different provider.
+ */
+
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+import {
+  buildAppEnv,
+  createSandbox,
+  launchDesktop,
+  type MockBackendFixture,
+  waitForAppReady
+} from './fixtures'
+import { startMockServer } from './mock-server'
+import { expect, test } from './test'
+
+const PROMPT = 'Keep this request on the Xiaomi profile.'
+const TARGET_PROFILE = 'xiaomi'
+
+function writeProviderProfile(
+  home: string,
+  provider: 'deepseek' | 'xiaomi',
+  model: string,
+  mockUrl: string
+): void {
+  fs.mkdirSync(home, { recursive: true })
+  fs.writeFileSync(
+    path.join(home, 'config.yaml'),
+    `model:
+  default: ${model}
+  provider: ${provider}
+  base_url: ${mockUrl}/v1
+  api_mode: chat_completions
+auxiliary:
+  title_generation:
+    enabled: false
+approvals:
+  mode: "off"
+`,
+    'utf8'
+  )
+  fs.writeFileSync(
+    path.join(home, '.env'),
+    `${provider === 'deepseek' ? 'DEEPSEEK_API_KEY' : 'XIAOMI_API_KEY'}=e2e-mock-key\n`,
+    'utf8'
+  )
+}
+
+test('creates a target-profile session with that profile model and provider', async ({}, testInfo) => {
+  test.setTimeout(420_000)
+
+  const deepseek = await startMockServer()
+  const xiaomi = await startMockServer()
+  const sandbox = createSandbox('provider-model-profile')
+
+  writeProviderProfile(sandbox.hermesHome, 'deepseek', 'deepseek-v4-pro', deepseek.url)
+  writeProviderProfile(
+    path.join(sandbox.hermesHome, 'profiles', TARGET_PROFILE),
+    'xiaomi',
+    'mimo-v2.5-pro',
+    xiaomi.url
+  )
+
+  const { app, page } = await launchDesktop(buildAppEnv(sandbox))
+  const consoleErrors: string[] = []
+  const pageErrors: string[] = []
+  const failedRequests: string[] = []
+  const sessionCreates: Array<Record<string, unknown>> = []
+
+  page.on('console', message => {
+    if (message.type() === 'error') {
+      consoleErrors.push(message.text())
+    }
+  })
+  page.on('pageerror', error => pageErrors.push(error.message))
+  page.on('websocket', socket => {
+    socket.on('framesent', event => {
+      try {
+        const message = JSON.parse(String(event.payload)) as {
+          method?: string
+          params?: Record<string, unknown>
+        }
+
+        if (message.method === 'session.create' && message.params) {
+          sessionCreates.push(message.params)
+        }
+      } catch {
+        // Binary and non-JSON WebSocket frames are unrelated to gateway RPC.
+      }
+    })
+  })
+
+  try {
+    await page.waitForLoadState('domcontentloaded')
+    await page.evaluate(
+      selections => {
+        for (const [profile, selection] of Object.entries(selections)) {
+          const value = JSON.stringify(selection)
+          const encodedProfile = encodeURIComponent(profile)
+
+          window.localStorage.setItem(`hermes.desktop.composer.selection.v1.profile.${encodedProfile}`, value)
+          window.localStorage.setItem(`hermes.desktop.composer.selection.v1.registry.local.${encodedProfile}`, value)
+        }
+      },
+      {
+        default: { model: 'deepseek-v4-pro', provider: 'deepseek', source: 'manual' },
+        [TARGET_PROFILE]: { model: 'mimo-v2.5-pro', provider: 'xiaomi', source: 'manual' }
+      }
+    )
+    await page.reload()
+    await waitForAppReady({ app, page } as MockBackendFixture, 120_000)
+    consoleErrors.length = 0
+    pageErrors.length = 0
+    page.on('requestfailed', request => {
+      failedRequests.push(`${request.method()} ${request.url()}: ${request.failure()?.errorText ?? 'unknown error'}`)
+    })
+
+    const rail = page.locator('[data-slot="profile-rail"]')
+    const sourceModel = page.getByRole('button', {
+      name: /Model · deepseek: deepseek-v4-pro/
+    })
+
+    await expect(sourceModel).toBeVisible()
+    expect(
+      await page.evaluate(() =>
+        window.localStorage.getItem('hermes.desktop.composer.selection.v1.profile.default')
+      )
+    ).toContain('"source":"manual"')
+
+    const target = rail.getByRole('button', { name: TARGET_PROFILE, exact: true })
+    await target.click()
+    await expect(target).toHaveAttribute('aria-pressed', 'true', { timeout: 120_000 })
+    await expect(page.getByRole('button', { name: /Model · xiaomi: mimo-v2.5-pro/ })).toBeVisible({
+      timeout: 120_000
+    })
+
+    const composer = page.locator('[data-slot="composer-root"] [contenteditable="true"]').filter({ visible: true }).first()
+    await composer.click()
+    await composer.fill(PROMPT)
+    await page.keyboard.press('Enter')
+
+    await expect.poll(() => sessionCreates.length, { timeout: 60_000 }).toBe(1)
+    expect(sessionCreates[0]).toMatchObject({
+      model: 'mimo-v2.5-pro',
+      profile: TARGET_PROFILE,
+      provider: 'xiaomi',
+      source: 'desktop'
+    })
+    expect(JSON.stringify(sessionCreates[0])).not.toContain('deepseek-v4-pro')
+    expect(JSON.stringify(sessionCreates[0])).not.toContain('"provider":"deepseek"')
+
+    await expect.poll(() => xiaomi.receivedPrompts.includes(PROMPT), { timeout: 180_000 }).toBe(true)
+    await expect.poll(() => xiaomi.receivedModels.includes('mimo-v2.5-pro'), { timeout: 180_000 }).toBe(true)
+    expect(deepseek.receivedPrompts).not.toContain(PROMPT)
+    expect(deepseek.receivedModels).not.toContain('mimo-v2.5-pro')
+
+    await expect(page.locator('[data-slot="aui_thread-viewport"]')).toContainText(
+      'Hello from the mock inference server!',
+      { timeout: 60_000 }
+    )
+    await expect(page.locator('[role="alert"]')).toHaveCount(0)
+    expect(consoleErrors).toEqual([])
+    expect(pageErrors).toEqual([])
+    expect(failedRequests).toEqual([])
+
+    await page.screenshot({
+      path: testInfo.outputPath('xiaomi-profile-model-provider-isolated.png')
+    })
+  } finally {
+    await app.close().catch(() => undefined)
+    await Promise.all([deepseek.close(), xiaomi.close()])
+    sandbox.cleanup()
+  }
+})

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -16,9 +16,8 @@ import {
   getComposerSelectionGeneration,
   getCurrentModelSource,
   markComposerSelectionManual,
-  setCurrentModel,
-  setCurrentModelSource,
-  setCurrentProvider
+  setComposerSelection,
+  setCurrentModelSource
 } from '@/store/session'
 import { $sessionStates, sessionTileDelegate } from '@/store/session-states'
 import type { ModelOptionsResponse } from '@/types/hermes'
@@ -91,11 +90,10 @@ export function useModelControls({
     (provider: string, model: string) => {
       const liveSessionId = $activeSessionId.get()
 
-      setCurrentModelSource('default')
-
       if (!liveSessionId) {
-        setCurrentProvider(provider)
-        setCurrentModel(model)
+        setComposerSelection({ model, provider, source: 'default' })
+      } else {
+        setCurrentModelSource('default')
       }
 
       // A null session id is the profile-global model-options key. Never patch
@@ -162,16 +160,12 @@ export function useModelControls({
           return
         }
 
-        if (typeof result.model === 'string') {
-          setCurrentModel(result.model)
-        }
-
-        if (typeof result.provider === 'string') {
-          setCurrentProvider(result.provider)
-        }
-
         if (typeof result.model === 'string' || typeof result.provider === 'string') {
-          setCurrentModelSource('default')
+          setComposerSelection(current => ({
+            model: typeof result.model === 'string' ? result.model : current.model,
+            provider: typeof result.provider === 'string' ? result.provider : current.provider,
+            source: 'default'
+          }))
         }
       } catch {
         // The delayed session.info event still updates this once the agent is ready.
@@ -214,8 +208,7 @@ export function useModelControls({
 
       const paintSelection = () => {
         if (touchesPrimary) {
-          setCurrentModel(selection.model)
-          setCurrentProvider(selection.provider)
+          setComposerSelection({ model: selection.model, provider: selection.provider, source: 'manual' })
           markComposerSelectionManual()
         } else if (liveSessionId) {
           // Optimistic tile paint — session.info will confirm; rollback on error.
@@ -233,9 +226,7 @@ export function useModelControls({
 
       const rollbackSelection = () => {
         if (touchesPrimary) {
-          setCurrentModel(prevModel)
-          setCurrentProvider(prevProvider)
-          setCurrentModelSource(prevSource)
+          setComposerSelection({ model: prevModel, provider: prevProvider, source: prevSource })
         } else if (liveSessionId) {
           sessionTileDelegate()?.updateSession(liveSessionId, state => ({
             ...state,

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -32,8 +32,6 @@ import {
   $cronSessions,
   $currentCwd,
   $currentFastMode,
-  $currentModel,
-  $currentProvider,
   $currentReasoningEffort,
   $messages,
   $messagingSessions,
@@ -49,6 +47,7 @@ import {
   setActiveSessionStoredIdRotation,
   setAwaitingResponse,
   setBusy,
+  setComposerSelection,
   setConnection,
   setCronSessions,
   setCurrentCwd,
@@ -723,6 +722,12 @@ describe('startFreshSessionDraft', () => {
 })
 
 describe('createBackendSessionForSend profile routing', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    setConnection({ baseUrl: '', connectionId: 'local', mode: 'local', profile: 'default' } as never)
+    setComposerSelection({ model: '', provider: '', source: '' })
+  })
+
   afterEach(() => {
     cleanup()
     $newChatProfile.set(null)
@@ -732,11 +737,11 @@ describe('createBackendSessionForSend profile routing', () => {
     $projectTree.set([])
     $currentCwd.set('')
     $currentFastMode.set(false)
-    $currentModel.set('')
-    $currentProvider.set('')
-    setCurrentModelSource('')
+    setConnection({ baseUrl: '', connectionId: 'local', mode: 'local', profile: 'default' } as never)
+    setComposerSelection({ model: '', provider: '', source: '' })
     $currentReasoningEffort.set('')
     setNewChatWorkspaceTarget(undefined)
+    window.localStorage.clear()
     vi.restoreAllMocks()
   })
 
@@ -810,6 +815,33 @@ describe('createBackendSessionForSend profile routing', () => {
       model: 'anthropic/claude-opus-5',
       provider: 'anthropic'
     })
+  })
+
+  it("does not send another profile's manual selection to the target profile", async () => {
+    let params: Record<string, unknown> | undefined
+
+    vi.mocked(requestGatewayForAgent).mockImplementationOnce(async (_connectionId, _profile, method, requestParams) => {
+      if (method === 'session.create') {
+        params = requestParams
+      }
+
+      return { session_id: RUNTIME_SESSION_ID, stored_session_id: null } as never
+    })
+
+    await createWith(() => {
+      setConnection({
+        baseUrl: 'https://gateway.example',
+        connectionId: 'source-a',
+        mode: 'remote',
+        profile: 'default'
+      } as never)
+      setComposerSelection({ model: 'deepseek-v4-pro', provider: 'deepseek', source: 'manual' })
+      $newChatRoute.set({ connectionId: 'source-a', mode: 'remote', profile: 'analyst' })
+    })
+
+    expect(params).toMatchObject({ profile: 'analyst' })
+    expect(params).not.toHaveProperty('model')
+    expect(params).not.toHaveProperty('provider')
   })
 
   // An unset source is the first-run/cleared state — nothing the user picked,

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -57,14 +57,12 @@ import {
   $connection,
   $currentCwd,
   $currentFastMode,
-  $currentModel,
-  $currentProvider,
   $currentReasoningEffort,
   $messages,
   $newChatWorkspaceTarget,
   $sessions,
   $yoloActive,
-  getCurrentModelSource,
+  getComposerSelectionForOwner,
   getSessionOwnerHint,
   type NewChatWorkspaceTarget,
   resolveComposerSessionKey,
@@ -298,16 +296,16 @@ async function desktopSessionCreateParams(
   // the live agent (applySavedMainModel) and only flips the source to 'default'.
   // Shipping that stale value as an override pins every new chat to the old
   // model. Omit model/provider unless the source is 'manual'.
-  const isManualSelection = getCurrentModelSource() === 'manual'
+  const profile = capturedRoute?.profile || $newChatProfile.get() || normalizeProfileKey($activeGatewayProfile.get())
+  const composerSelection = getComposerSelectionForOwner(capturedRoute, profile)
+  const isManualSelection = composerSelection.source === 'manual'
 
   const selection = {
     effort: $currentReasoningEffort.get().trim(),
     fast: $currentFastMode.get(),
-    model: isManualSelection ? $currentModel.get().trim() : '',
-    provider: isManualSelection ? $currentProvider.get().trim() : ''
+    model: isManualSelection ? composerSelection.model.trim() : '',
+    provider: isManualSelection ? composerSelection.provider.trim() : ''
   }
-
-  const profile = capturedRoute?.profile || $newChatProfile.get() || normalizeProfileKey($activeGatewayProfile.get())
 
   if (capturedRoute) {
     await ensureGatewayAgent(capturedRoute.connectionId, profile)

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -17,13 +17,12 @@ import {
   commitWorkspaceCwdForSelectedSession,
   releaseWorkspaceCwdOwner,
   sessionMatchesStoredId,
+  setComposerSelection,
   setCronSessions,
   setCurrentBranch,
   setCurrentCwdTransient,
   setCurrentFastMode,
-  setCurrentModel,
   setCurrentPersonality,
-  setCurrentProvider,
   setCurrentReasoningEffort,
   setCurrentServiceTier,
   setCurrentUsage,
@@ -1600,12 +1599,12 @@ interface ApplyRuntimeInfoOptions {
 /** Mirror a session's runtime state into the composer atoms the MAIN pane
  *  renders from. Foreground sessions only — see ApplyRuntimeInfoOptions. */
 function publishRuntimeToComposer(state: SessionRuntimeStatePatch): void {
-  if (state.model !== undefined) {
-    setCurrentModel(state.model)
-  }
-
-  if (state.provider !== undefined) {
-    setCurrentProvider(state.provider)
+  if (state.model !== undefined || state.provider !== undefined) {
+    setComposerSelection(current => ({
+      ...current,
+      model: state.model ?? current.model,
+      provider: state.provider ?? current.provider
+    }))
   }
 
   if (state.cwd !== undefined) {
@@ -1724,8 +1723,7 @@ export function applyStoredSessionPreviewRuntimeInfo(
   stored: { cwd?: null | string; model?: null | string } | undefined,
   storedSessionId: null | string
 ) {
-  setCurrentModel(stored?.model || '')
-  setCurrentProvider('')
+  setComposerSelection(current => ({ ...current, model: stored?.model || '', provider: '' }))
   setCurrentReasoningEffort('')
   setCurrentServiceTier('')
   setCurrentFastMode(false)

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -11,10 +11,9 @@ import {
   $activeSessionId,
   $messages,
   setActiveSessionStoredIdRotation,
+  setComposerSelection,
   setCurrentFastMode,
-  setCurrentModel,
   setCurrentPersonality,
-  setCurrentProvider,
   setCurrentReasoningEffort,
   setCurrentServiceTier,
   setTurnStartedAt,
@@ -41,8 +40,11 @@ interface SessionStateCacheOptions {
 }
 
 function syncRuntimeMetadataToView(state: ClientSessionState) {
-  setCurrentModel(state.model ?? '')
-  setCurrentProvider(state.provider ?? '')
+  setComposerSelection(current => ({
+    ...current,
+    model: state.model ?? '',
+    provider: state.provider ?? ''
+  }))
   setCurrentReasoningEffort(state.reasoningEffort ?? '')
   setCurrentServiceTier(state.serviceTier ?? '')
   setCurrentFastMode(state.fast ?? false)

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -53,6 +53,7 @@ import {
   sessionMatchesStoredId,
   sessionOwnerRouteFromRow,
   sessionPinId,
+  setComposerSelection,
   setComposerSelectionOwner,
   setConnection,
   setCurrentCwd,
@@ -115,18 +116,40 @@ describe('composer model persistence scope', () => {
     expect($currentProvider.get()).toBe('xai-oauth')
   })
 
-  it('keeps inferred local-primary connections on the historical bare keys', () => {
+  it('keeps ordinary local profiles isolated', () => {
+    setConnection({ baseUrl: '', connectionId: 'local', mode: 'local', profile: 'default' } as never)
+    setComposerSelection({ model: 'mimo-v2.5-pro', provider: 'xiaomi', source: 'manual' })
+
+    setConnection({ baseUrl: '', connectionId: 'local', mode: 'local', profile: 'dev' } as never)
+    expect($currentModel.get()).toBe('')
+    expect($currentProvider.get()).toBe('')
+
+    setComposerSelection({ model: 'deepseek-v4-pro', provider: 'deepseek', source: 'manual' })
+    setConnection({ baseUrl: '', connectionId: 'local', mode: 'local', profile: 'default' } as never)
+
+    expect($currentModel.get()).toBe('mimo-v2.5-pro')
+    expect($currentProvider.get()).toBe('xiaomi')
+  })
+
+  it('does not adopt unowned bare legacy keys into a local profile', () => {
     setComposerSelectionOwner('remote', 'default')
     window.localStorage.setItem('hermes.desktop.composer.model', 'legacy-model')
     window.localStorage.setItem('hermes.desktop.composer.provider', 'legacy-provider')
+    window.localStorage.setItem('hermes.desktop.composer.model-source', 'manual')
 
     setConnection({ baseUrl: '', connectionId: 'local', mode: 'local', profile: 'default' } as never)
 
-    expect($currentModel.get()).toBe('legacy-model')
-    expect($currentProvider.get()).toBe('legacy-provider')
-    setCurrentModel('next-model')
-    expect(window.localStorage.getItem('hermes.desktop.composer.model')).toBe('next-model')
-    expect(window.localStorage.getItem('hermes.desktop.composer.model.registry.local.default')).toBeNull()
+    expect($currentModel.get()).toBe('')
+    expect($currentProvider.get()).toBe('')
+  })
+
+  it('persists model, provider, and source as one record', () => {
+    setConnection({ baseUrl: '', connectionId: 'local', mode: 'local', profile: 'dev' } as never)
+    setComposerSelection({ model: 'mimo-v2.5-pro', provider: 'xiaomi', source: 'manual' })
+
+    expect(window.localStorage.getItem('hermes.desktop.composer.selection.v1.profile.dev')).toBe(
+      JSON.stringify({ model: 'mimo-v2.5-pro', provider: 'xiaomi', source: 'manual' })
+    )
   })
 
   it('uses the live registry owner when the connection descriptor is stale', () => {

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -1,5 +1,5 @@
 import type { ConnectionState } from '@hermes/shared'
-import { atom, computed } from 'nanostores'
+import { atom, batch, computed } from 'nanostores'
 
 import { lastVisibleMessageIsUser } from '@/app/chat/thread-loading'
 import type { ContextSuggestion } from '@/app/types'
@@ -20,15 +20,21 @@ import { clearUnreadOnOpen } from './session-unread-remote'
 
 type Updater<T> = T | ((current: T) => T)
 export type ComposerModelSource = '' | 'default' | 'manual'
+export interface ComposerSelection {
+  model: string
+  provider: string
+  source: ComposerModelSource
+}
 
 const WORKSPACE_CWD_KEY = 'hermes.desktop.workspace-cwd'
 
 // The composer's model/effort/fast is sticky UI state, NOT the profile default
 // (that lives in Settings → Model). Persisting it in localStorage makes a pick
 // follow across Cmd+N and app restarts instead of snapping back to the default.
-// Model/provider/source are scoped to the remote (connection, profile) owner so
-// a provider authenticated on one profile cannot contaminate another profile's
-// session.create. Local/single-backend users retain the historical bare keys.
+// Model/provider/source are persisted as one record scoped to the exact
+// (connection, profile) owner so a provider authenticated on one profile cannot
+// contaminate another profile's session.create.
+const COMPOSER_SELECTION_KEY = 'hermes.desktop.composer.selection.v1'
 const COMPOSER_MODEL_KEY = 'hermes.desktop.composer.model'
 const COMPOSER_PROVIDER_KEY = 'hermes.desktop.composer.provider'
 const COMPOSER_MODEL_SOURCE_KEY = 'hermes.desktop.composer.model-source'
@@ -39,7 +45,7 @@ const COMPOSER_FAST_KEY = 'hermes.desktop.composer.fast'
 // gateway activation coordinate before profile-change effects can reseed the
 // composer. null means the exact owner is temporarily unknown: values may still
 // paint, but must not be written through the previous backend's storage key.
-let composerSelectionScope: string | null = ''
+let composerSelectionScope: string | null = '.profile.default'
 
 function composerScopeForConnection(connection: HermesConnection | null): string | null {
   if (!connection) {
@@ -47,10 +53,10 @@ function composerScopeForConnection(connection: HermesConnection | null): string
   }
 
   // Electron may infer the sole `local` registry id onto the ordinary primary
-  // descriptor. That remains the legacy single-backend path: only an explicit
-  // registry-scoped route earns a new namespace.
+  // descriptor. Only an explicit registry-scoped route earns the registry
+  // namespace, but ordinary local profiles still need distinct storage.
   if (connection.mode !== 'remote' && !connection.registryScoped) {
-    return ''
+    return `.profile.${encodeURIComponent(connection.profile || 'default')}`
   }
 
   if (connection.connectionId) {
@@ -60,14 +66,94 @@ function composerScopeForConnection(connection: HermesConnection | null): string
   return connectionScopeSuffix(connection)
 }
 
-function composerSelectionKey(base: string): string | null {
-  return composerSelectionScope === null ? null : `${base}${composerSelectionScope}`
+function composerSelectionKey(base: string, scope = composerSelectionScope): string | null {
+  return scope === null ? null : `${base}${scope}`
 }
 
-function storedComposerString(base: string): string | null {
-  const key = composerSelectionKey(base)
+const EMPTY_COMPOSER_SELECTION: ComposerSelection = { model: '', provider: '', source: '' }
 
-  return key === null ? null : storedString(key)
+function validComposerSelection(value: unknown): value is ComposerSelection {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false
+  }
+
+  const selection = value as Partial<ComposerSelection>
+
+  return (
+    typeof selection.model === 'string' &&
+    typeof selection.provider === 'string' &&
+    (selection.source === '' || selection.source === 'default' || selection.source === 'manual')
+  )
+}
+
+function readComposerSelection(scope = composerSelectionScope): ComposerSelection {
+  const key = composerSelectionKey(COMPOSER_SELECTION_KEY, scope)
+
+  if (key === null) {
+    return { ...EMPTY_COMPOSER_SELECTION }
+  }
+
+  const stored = readJson<ComposerSelection>(key)
+
+  if (validComposerSelection(stored)) {
+    return stored
+  }
+
+  // Old remote/registry records already name their owner and are safe to
+  // migrate. Bare legacy keys do not identify a local profile, so they are
+  // deliberately ignored rather than guessed into whichever profile opens
+  // first.
+  if (scope && !scope.startsWith('.profile.')) {
+    const model = storedString(`${COMPOSER_MODEL_KEY}${scope}`) ?? ''
+    const provider = storedString(`${COMPOSER_PROVIDER_KEY}${scope}`) ?? ''
+    const rawSource = storedString(`${COMPOSER_MODEL_SOURCE_KEY}${scope}`)
+
+    const source: ComposerModelSource =
+      rawSource === 'default' || rawSource === 'manual' ? rawSource : ''
+
+    if (model || provider || source) {
+      const migrated = { model, provider, source }
+      writeJson(key, migrated)
+
+      return migrated
+    }
+  }
+
+  return { ...EMPTY_COMPOSER_SELECTION }
+}
+
+function composerSelectionScopeForOwner(route: SessionOwnerRoute | null, profile: string): string | null {
+  if (route) {
+    const connection = $connection.get()
+
+    // The ordinary on-device primary exposes `connectionId: local` for its
+    // default route, but it is still profile-scoped storage rather than a
+    // registry-owned connection. Keep that route on the same key the visible
+    // composer wrote before Enter.
+    if (
+      connection?.connectionId === route.connectionId &&
+      connection.mode !== 'remote' &&
+      !connection.registryScoped
+    ) {
+      return `.profile.${encodeURIComponent(route.profile || 'default')}`
+    }
+
+    return `.registry.${encodeURIComponent(route.connectionId)}.${encodeURIComponent(route.profile || 'default')}`
+  }
+
+  const connection = $connection.get()
+
+  if (!connection) {
+    return `.profile.${encodeURIComponent(profile.trim() || 'default')}`
+  }
+
+  return composerScopeForConnection({ ...connection, profile: profile.trim() || 'default' })
+}
+
+/** Snapshot the complete composer selection owned by a target route without
+ * changing the selection painted by the current foreground profile. */
+export function getComposerSelectionForOwner(route: SessionOwnerRoute | null, profile: string): ComposerSelection {
+  return readComposerSelection(composerSelectionScopeForOwner(route, profile))
 }
 
 // The last chat the user had open, so a relaunch lands back on it instead of an
@@ -1086,8 +1172,9 @@ export function getSessionOwnerHint(
 // clears it and resets the retry counter. Null whenever the active route has a
 // healthy, in-flight, or still-auto-retrying resume.
 export const $resumeExhaustedSessionId = atom<string | null>(null)
-export const $currentModel = atom(storedComposerString(COMPOSER_MODEL_KEY) ?? '')
-export const $currentProvider = atom(storedComposerString(COMPOSER_PROVIDER_KEY) ?? '')
+const initialComposerSelection = readComposerSelection()
+export const $currentModel = atom(initialComposerSelection.model)
+export const $currentProvider = atom(initialComposerSelection.provider)
 export const $currentReasoningEffort = atom(storedString(COMPOSER_EFFORT_KEY) ?? '')
 export const $currentServiceTier = atom('')
 export const $currentFastMode = atom(storedBoolean(COMPOSER_FAST_KEY, false))
@@ -1149,9 +1236,13 @@ function rescopeComposerSelection(nextScope: string | null): void {
   }
 
   composerSelectionScope = nextScope
-  $currentModel.set(storedComposerString(COMPOSER_MODEL_KEY) ?? '')
-  $currentProvider.set(storedComposerString(COMPOSER_PROVIDER_KEY) ?? '')
-  $currentModelSource.set(getCurrentModelSource())
+  const selection = readComposerSelection()
+
+  batch(() => {
+    $currentModel.set(selection.model)
+    $currentProvider.set(selection.provider)
+    $currentModelSource.set(selection.source)
+  })
 }
 
 /** Publish an exact registry route before active-profile effects can persist a
@@ -1309,44 +1400,49 @@ export const setResumeExhaustedSessionId = (next: Updater<string | null>) => upd
 export const setBusy = (next: Updater<boolean>) => updateAtom($busy, next)
 export const setAwaitingResponse = (next: Updater<boolean>) => updateAtom($awaitingResponse, next)
 
-export const setCurrentModel = (next: Updater<string>) => {
-  updateAtom($currentModel, next)
-  const key = composerSelectionKey(COMPOSER_MODEL_KEY)
-
-  if (key !== null) {
-    persistString(key, $currentModel.get() || null)
-  }
-}
-
-export const setCurrentProvider = (next: Updater<string>) => {
-  updateAtom($currentProvider, next)
-  const key = composerSelectionKey(COMPOSER_PROVIDER_KEY)
-
-  if (key !== null) {
-    persistString(key, $currentProvider.get() || null)
-  }
-}
-
-export const getCurrentModelSource = (): ComposerModelSource => {
-  const source = storedComposerString(COMPOSER_MODEL_SOURCE_KEY)
-
-  return source === 'default' || source === 'manual' ? source : ''
-}
+export const getCurrentModelSource = (): ComposerModelSource => readComposerSelection().source
 
 // Reactive mirror of the persisted source so UI (the composer pill's
 // override badge) can subscribe. The getter above stays storage-backed —
 // it's read cross-window, where this atom wouldn't see writes.
-export const $currentModelSource = atom<ComposerModelSource>(getCurrentModelSource())
+export const $currentModelSource = atom<ComposerModelSource>(initialComposerSelection.source)
 
-export const setCurrentModelSource = (source: ComposerModelSource) => {
-  const key = composerSelectionKey(COMPOSER_MODEL_SOURCE_KEY)
-
-  if (key !== null) {
-    persistString(key, source || null)
+export const setComposerSelection = (next: Updater<ComposerSelection>) => {
+  const current = {
+    model: $currentModel.get(),
+    provider: $currentProvider.get(),
+    source: $currentModelSource.get()
   }
 
-  $currentModelSource.set(source)
+  const selection = typeof next === 'function' ? next(current) : next
+
+  batch(() => {
+    $currentModel.set(selection.model)
+    $currentProvider.set(selection.provider)
+    $currentModelSource.set(selection.source)
+  })
+
+  const key = composerSelectionKey(COMPOSER_SELECTION_KEY)
+
+  if (key !== null) {
+    writeJson(key, selection)
+  }
 }
+
+export const setCurrentModel = (next: Updater<string>) =>
+  setComposerSelection(current => ({
+    ...current,
+    model: typeof next === 'function' ? next(current.model) : next
+  }))
+
+export const setCurrentProvider = (next: Updater<string>) =>
+  setComposerSelection(current => ({
+    ...current,
+    provider: typeof next === 'function' ? next(current.provider) : next
+  }))
+
+export const setCurrentModelSource = (source: ComposerModelSource) =>
+  setComposerSelection(current => ({ ...current, source }))
 
 // Monotonic intent token for async default refreshes. A profile/config request
 // may start before the user opens the picker and finish after their click; the
@@ -1358,7 +1454,10 @@ export const getComposerSelectionGeneration = (): number => composerSelectionGen
 
 export const markComposerSelectionManual = (): void => {
   composerSelectionGeneration += 1
-  setCurrentModelSource('manual')
+
+  if ($currentModelSource.get() !== 'manual') {
+    setCurrentModelSource('manual')
+  }
 }
 
 export const setCurrentReasoningEffort = (next: Updater<string>) => {

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1344,9 +1344,24 @@ def _validate_switch(st: _Switch) -> Optional[ModelSwitchResult]:
     """COMMON PATH part 2: normalize the model name for the target provider, validate it, and
     accept config-declared models the remote catalog lacks."""
     from hermes_cli.models_local import _get_ollama_request_headers
+    from hermes_cli.models import model_provider_compatibility_error
     from hermes_cli.models_validate import validate_requested_model
     st.new_model = _resolve_named_custom_model_id(st.new_model, st.target_provider, st.custom_providers)
     st.new_model = normalize_model_for_provider(st.new_model, st.target_provider)
+
+    compatibility_error = model_provider_compatibility_error(
+        st.new_model,
+        st.target_provider,
+        user_providers=st.user_providers,
+        custom_providers=st.custom_providers,
+    )
+    if compatibility_error:
+        return st.fail(
+            compatibility_error,
+            new_model=st.new_model,
+            target_provider=st.target_provider,
+            provider_label=st.provider_label,
+        )
 
     if st.target_provider.strip().lower() == "ollama":
         headers = {} if st.suppress_ollama_headers else (st.validation_headers or _get_ollama_request_headers())

--- a/hermes_cli/model_switch_providers.py
+++ b/hermes_cli/model_switch_providers.py
@@ -1081,10 +1081,10 @@ def list_authenticated_providers(
     _lap_bare_custom_row(b, custom_providers)
     if custom_providers and isinstance(custom_providers, list):
         _lap_custom_provider_rows(b, custom_providers)
-    return _finalize_picker_rows(b.results, user_providers, current_model)
+    return _finalize_picker_rows(b.results, user_providers, custom_providers, current_model)
 
 
-def _finalize_picker_rows(results: list, user_providers, current_model: str) -> list:
+def _finalize_picker_rows(results: list, user_providers, custom_providers, current_model: str) -> list:
     """Post-passes: drop ``providers.<name>.enabled: false`` rows, inject the current model, sort."""
     # The enabled post-filter covers built-in rows (sections 1-2) that bypass the per-section
     # gate; matched by slug and ``provider_id``.
@@ -1106,9 +1106,18 @@ def _finalize_picker_rows(results: list, user_providers, current_model: str) -> 
     # picker (main and MoA slot pickers read these rows); inject it at the front of the current
     # provider's row.
     if current_model:
+        from hermes_cli.models import model_provider_compatibility_error
+
         for row in results:
             if not row.get("is_current") or row.get("native_catalog_empty"):
                 continue
+            if model_provider_compatibility_error(
+                current_model,
+                str(row.get("slug") or row.get("provider_id") or ""),
+                user_providers=user_providers,
+                custom_providers=custom_providers,
+            ):
+                break
             models = row.get("models") or []
             if current_model not in models:
                 row["models"] = [current_model, *models]

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -839,6 +839,150 @@ def detect_static_provider_for_model(
     return None
 
 
+def _declared_config_model_ids(value: Any) -> set[str]:
+    """Return model ids explicitly declared by a provider config block."""
+    if isinstance(value, str):
+        return {value.strip()} if value.strip() else set()
+    if isinstance(value, dict):
+        return {str(item).strip() for item in value if str(item).strip()}
+    if not isinstance(value, (list, tuple)):
+        return set()
+
+    declared: set[str] = set()
+    for item in value:
+        if isinstance(item, dict):
+            candidate = item.get("id") or item.get("name") or item.get("model")
+        else:
+            candidate = item
+        candidate = str(candidate or "").strip()
+        if candidate:
+            declared.add(candidate)
+    return declared
+
+
+def _config_allows_model_provider_pair(
+    model: str,
+    provider: str,
+    user_providers: Optional[dict],
+    custom_providers: Optional[list],
+) -> bool:
+    requested_keys = _provider_keys(provider)
+    model_lower = model.lower()
+
+    configured = user_providers if isinstance(user_providers, dict) else {}
+    for slug, entry in configured.items():
+        if not isinstance(entry, dict) or not (_provider_keys(str(slug)) & requested_keys):
+            continue
+        declared = _declared_config_model_ids(entry.get("models"))
+        for key in ("model", "default"):
+            value = str(entry.get(key) or "").strip()
+            if value:
+                declared.add(value)
+        if model_lower in {item.lower() for item in declared}:
+            return True
+        # A configured endpoint is user-owned rather than a native catalog
+        # contract. It may legitimately expose any model id.
+        if str(entry.get("base_url") or "").strip():
+            return True
+
+    if not isinstance(custom_providers, list):
+        return False
+
+    from hermes_cli.providers import custom_provider_aliases
+
+    for entry in custom_providers:
+        if not isinstance(entry, dict):
+            continue
+        aliases = custom_provider_aliases(
+            str(entry.get("name") or ""),
+            str(entry.get("provider_key") or ""),
+        )
+        if not (aliases & requested_keys):
+            continue
+        declared = _declared_config_model_ids(entry.get("models"))
+        configured_model = str(entry.get("model") or "").strip()
+        if configured_model:
+            declared.add(configured_model)
+        if model_lower in {item.lower() for item in declared}:
+            return True
+        if str(entry.get("base_url") or "").strip():
+            return True
+
+    return False
+
+
+def _static_catalog_contains(provider: str, model: str) -> bool:
+    model_lower = model.lower()
+    candidates = {model_lower}
+    prefix, separator, suffix = model_lower.partition("/")
+    if separator and normalize_provider(prefix) in _provider_keys(provider):
+        candidates.add(suffix)
+    catalog = {item.lower() for item in _provider_catalog_names(provider)}
+    return bool(candidates & catalog)
+
+
+def find_model_provider_conflict(
+    model: str,
+    provider: str,
+    *,
+    user_providers: Optional[dict] = None,
+    custom_providers: Optional[list] = None,
+) -> Optional[str]:
+    """Return the native owner when a model/provider pair clearly conflicts.
+
+    The check is intentionally offline and fail-open. Aggregators, configured
+    endpoints, explicitly declared models, and unknown future model ids are
+    accepted; only a model claimed by another native provider is rejected.
+    """
+    model = str(model or "").strip()
+    provider = str(provider or "").strip()
+    if not model or not provider:
+        return None
+
+    normalized = normalize_provider(provider)
+    if (
+        normalized in _AGGREGATOR_PROVIDERS
+        or normalized == "moa"
+        or normalized == "custom"
+        or normalized.startswith("custom:")
+        or _config_allows_model_provider_pair(model, provider, user_providers, custom_providers)
+    ):
+        return None
+
+    requested_keys = _provider_keys(provider)
+    if any(_static_catalog_contains(key, model) for key in requested_keys):
+        return None
+
+    detected = detect_static_provider_for_model(model, normalized)
+    if detected is None:
+        return None
+    owner, _resolved_model = detected
+    return None if normalize_provider(owner) in requested_keys else normalize_provider(owner)
+
+
+def model_provider_compatibility_error(
+    model: str,
+    provider: str,
+    *,
+    user_providers: Optional[dict] = None,
+    custom_providers: Optional[list] = None,
+) -> Optional[str]:
+    """Return an actionable error for a clear native-provider mismatch."""
+    owner = find_model_provider_conflict(
+        model,
+        provider,
+        user_providers=user_providers,
+        custom_providers=custom_providers,
+    )
+    if owner is None:
+        return None
+    return (
+        f"Model '{str(model).strip()}' belongs to provider '{owner}', "
+        f"but provider '{str(provider).strip()}' was requested. "
+        "Select the matching provider or choose a model offered by the requested provider."
+    )
+
+
 def _configured_provider_ids() -> set[str]:
     """Provider ids (incl. ``custom:*``) from the user's ``providers:`` config block; empty when config
     is unreadable (callers fall through to built-in catalogs)."""

--- a/tests/hermes_cli/test_model_provider_compatibility.py
+++ b/tests/hermes_cli/test_model_provider_compatibility.py
@@ -1,0 +1,110 @@
+"""Regression coverage for native model/provider pair validation (#101091)."""
+
+from unittest.mock import patch
+
+from hermes_cli.model_switch import list_authenticated_providers, switch_model
+from hermes_cli.models import model_provider_compatibility_error
+
+
+def test_rejects_model_claimed_by_another_native_provider():
+    error = model_provider_compatibility_error("deepseek-v4-pro", "xiaomi")
+
+    assert error is not None
+    assert "deepseek" in error
+    assert "xiaomi" in error
+
+
+def test_accepts_model_from_requested_native_provider():
+    assert model_provider_compatibility_error("mimo-v2.5-pro", "xiaomi") is None
+
+
+def test_accepts_unknown_future_native_model():
+    assert model_provider_compatibility_error("mimo-v3-future", "xiaomi") is None
+
+
+def test_accepts_aggregator_model():
+    assert model_provider_compatibility_error("deepseek-v4-pro", "openrouter") is None
+
+
+def test_accepts_user_defined_endpoint():
+    assert (
+        model_provider_compatibility_error(
+            "deepseek-v4-pro",
+            "lab",
+            user_providers={"lab": {"base_url": "http://127.0.0.1:8000/v1"}},
+        )
+        is None
+    )
+
+
+def test_accepts_explicitly_declared_model_for_builtin_provider():
+    assert (
+        model_provider_compatibility_error(
+            "deepseek-v4-pro",
+            "xiaomi",
+            user_providers={"xiaomi": {"models": ["deepseek-v4-pro"]}},
+        )
+        is None
+    )
+
+
+def test_inventory_does_not_inject_foreign_current_model_into_native_provider(monkeypatch):
+    monkeypatch.setenv("XIAOMI_API_KEY", "sk-test-xiaomi")
+
+    with (
+        patch(
+            "agent.models_dev.fetch_models_dev",
+            return_value={"xiaomi": {"env": ["XIAOMI_API_KEY"], "name": "Xiaomi"}},
+        ),
+        patch("agent.models_dev.PROVIDER_TO_MODELS_DEV", {"xiaomi": "xiaomi"}),
+        patch(
+            "hermes_cli.models.cached_provider_model_ids",
+            return_value=["mimo-v2.5-pro"],
+        ),
+    ):
+        rows = list_authenticated_providers(
+            current_provider="xiaomi",
+            current_model="deepseek-v4-pro",
+            max_models=10,
+        )
+
+    xiaomi = next(row for row in rows if row["slug"] == "xiaomi")
+    assert "mimo-v2.5-pro" in xiaomi["models"]
+    assert "deepseek-v4-pro" not in xiaomi["models"]
+
+
+def test_inventory_keeps_current_model_for_custom_provider():
+    with patch("agent.models_dev.fetch_models_dev", return_value={}):
+        rows = list_authenticated_providers(
+            current_provider="custom:lab",
+            current_base_url="https://lab.example/v1",
+            current_model="private-current-model",
+            custom_providers=[
+                {
+                    "name": "Lab",
+                    "base_url": "https://lab.example/v1",
+                    "models": ["catalog-model"],
+                }
+            ],
+            max_models=10,
+            probe_custom_providers=False,
+        )
+
+    lab = next(row for row in rows if row["is_current"])
+    assert lab["slug"] == "custom:lab"
+    assert lab["models"][0] == "private-current-model"
+    assert "catalog-model" in lab["models"]
+
+
+def test_model_switch_rejects_clear_native_conflict_before_remote_validation(monkeypatch):
+    monkeypatch.setenv("XIAOMI_API_KEY", "sk-test-xiaomi")
+
+    result = switch_model(
+        raw_input="deepseek-v4-pro",
+        current_provider="xiaomi",
+        current_model="mimo-v2.5-pro",
+        explicit_provider="xiaomi",
+    )
+
+    assert result.success is False
+    assert "belongs to provider 'deepseek'" in result.error_message

--- a/tests/tui_gateway/test_make_agent_provider.py
+++ b/tests/tui_gateway/test_make_agent_provider.py
@@ -8,6 +8,8 @@ provider/base_url/api_key empty in AIAgent, causing HTTP 404.
 import os
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 
 def test_make_agent_passes_resolved_provider():
     """_make_agent forwards provider/base_url/api_key/api_mode from
@@ -58,6 +60,25 @@ def test_make_agent_passes_resolved_provider():
         assert call_kwargs.kwargs["base_url"] == "https://api.anthropic.com"
         assert call_kwargs.kwargs["api_key"] == "sk-test-key"
         assert call_kwargs.kwargs["api_mode"] == "anthropic_messages"
+
+
+def test_make_agent_rejects_legacy_cross_provider_override_before_resolution():
+    with (
+        patch("tui_gateway.server._load_cfg", return_value={}),
+        patch("tui_gateway.server._parse_tui_skills_env", return_value=[]),
+        patch("tui_gateway.server._resolve_runtime_with_fallback") as resolve_runtime,
+        patch("run_agent.AIAgent"),
+    ):
+        from tui_gateway.server import _make_agent
+
+        with pytest.raises(ValueError, match="belongs to provider 'deepseek'"):
+            _make_agent(
+                "sid-corrupt",
+                "key-corrupt",
+                model_override={"model": "deepseek-v4-pro", "provider": "xiaomi"},
+            )
+
+    resolve_runtime.assert_not_called()
 
 
 def test_probe_config_health_flags_null_sections():

--- a/tests/tui_gateway/test_session_create_model_provider_guard.py
+++ b/tests/tui_gateway/test_session_create_model_provider_guard.py
@@ -1,0 +1,30 @@
+"""Session creation must reject corrupt model/provider pairs before side effects."""
+
+from unittest.mock import patch
+
+from tui_gateway import server as srv
+
+
+def test_invalid_pair_creates_no_session_and_schedules_no_build():
+    before = set(srv._sessions)
+
+    with (
+        patch("tui_gateway.server._profile_home", return_value=None),
+        patch("tui_gateway.server._load_cfg", return_value={}),
+        patch("tui_gateway.server._schedule_agent_build") as schedule_build,
+        patch("tui_gateway.server._schedule_session_cap_enforcement") as schedule_cap,
+    ):
+        response = srv._methods["session.create"](
+            "rid-1",
+            {
+                "model": "deepseek-v4-pro",
+                "provider": "xiaomi",
+                "source": "desktop",
+            },
+        )
+
+    assert response["error"]["code"] == 4002
+    assert "belongs to provider 'deepseek'" in response["error"]["message"]
+    assert set(srv._sessions) == before
+    schedule_build.assert_not_called()
+    schedule_cap.assert_not_called()

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -293,8 +293,37 @@ def _create_overrides(params: dict) -> tuple:
     return model_override, reasoning_override, service_tier_override
 
 
+def _session_create_model_provider_error(params: dict, profile_home) -> str | None:
+    """Reject only clear native-provider mismatches before session side effects."""
+    model = _str_param(params, "model")
+    provider = _str_param(params, "provider")
+    if not model or not provider:
+        return None
+
+    from hermes_cli.config import get_compatible_custom_providers
+    from hermes_cli.models import model_provider_compatibility_error
+
+    with _profile_build_scope(profile_home):
+        cfg = _load_cfg()
+    return model_provider_compatibility_error(
+        model,
+        provider,
+        user_providers=cfg.get("providers") if isinstance(cfg, dict) else None,
+        custom_providers=(
+            get_compatible_custom_providers(cfg)
+            if isinstance(cfg, dict)
+            else None
+        ),
+    )
+
+
 @method("session.create")
 def _(rid, params: dict) -> dict:
+    profile = (params.get("profile") or "").strip() or None
+    profile_home = _profile_home(profile)
+    if compatibility_error := _session_create_model_provider_error(params, profile_home):
+        return _err(rid, 4002, compatibility_error)
+
     (sid, source), key = _new_runtime_ids(params), _new_session_key()
     history = _coerce_seed_history(params.get("messages"))
     # Branch: links back so list_sessions_rich keeps it visible and the sidebar nests it.
@@ -306,7 +335,6 @@ def _(rid, params: dict) -> dict:
         explicit_cwd = bool(raw_cwd) and os.path.isdir(os.path.abspath(os.path.expanduser(raw_cwd)))
     _enable_gateway_prompts()
     # ``profile`` (app-global remote mode): stored so the build and every turn re-bind HERMES_HOME.
-    profile_home = _profile_home(profile := (params.get("profile") or "").strip() or None)
     session_model_override, create_reasoning_override, create_service_tier_override = _create_overrides(params)
     now = time.time()
     with _sessions_lock:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2199,11 +2199,32 @@ def _resolve_runtime_with_fallback(resolve_kwargs: dict | None = None) -> _Runti
         raise
 
 
-def _resolve_agent_model_runtime(model_override, provider_override) -> tuple[str, dict]:
+def _validate_model_provider_pair(model: str, provider: str | None, cfg: dict) -> None:
+    if not model or not provider:
+        return
+    from hermes_cli.config import get_compatible_custom_providers
+    from hermes_cli.models import model_provider_compatibility_error
+
+    error = model_provider_compatibility_error(
+        model,
+        provider,
+        user_providers=cfg.get("providers") if isinstance(cfg, dict) else None,
+        custom_providers=(
+            get_compatible_custom_providers(cfg)
+            if isinstance(cfg, dict)
+            else None
+        ),
+    )
+    if error:
+        raise ValueError(error)
+
+
+def _resolve_agent_model_runtime(model_override, provider_override, cfg: dict | None = None) -> tuple[str, dict]:
     """(model, runtime) for a new agent; a per-session override (/model switch or a resumed row's persisted
     runtime) wins over global config/env. Older rows stored the resolved provider "custom" (no named entry
     matches) — recover the identity from the persisted base_url or the rebuild fails "No LLM provider
     configured". Persisted base_url/api_key/api_mode are honored only for the original runtime, never a fallback."""
+    cfg = cfg if isinstance(cfg, dict) else _load_cfg()
     if isinstance(model_override, dict) and model_override.get("model"):
         model = str(model_override.get("model") or "")
         requested_provider = model_override.get("provider") or provider_override or None
@@ -2216,6 +2237,8 @@ def _resolve_agent_model_runtime(model_override, provider_override) -> tuple[str
             if override_base_url:
                 # Failing identity recovery, still hand base_url to the direct-alias branch so pool/env credentials resolve.
                 resolve_kwargs["explicit_base_url"] = override_base_url
+        if not override_base_url:
+            _validate_model_provider_pair(model, requested_provider, cfg)
         resolve_kwargs.update(requested=requested_provider, target_model=model or None)
         overrides = {k: model_override.get(k) for k in ("base_url", "api_key", "api_mode")}
     else:
@@ -2224,6 +2247,7 @@ def _resolve_agent_model_runtime(model_override, provider_override) -> tuple[str
             model = model_override
         if provider_override:
             requested_provider = provider_override
+        _validate_model_provider_pair(model, requested_provider, cfg)
         resolve_kwargs = {"requested": requested_provider, "target_model": model or None}
         overrides = {}
     resolution = _resolve_runtime_with_fallback(resolve_kwargs)
@@ -2274,7 +2298,7 @@ def _make_agent(
             importlib.import_module(_mod).wait_for_mcp_discovery()
     cfg = _load_cfg()
     system_prompt = _startup_system_prompt(cfg, session_id or key)
-    model, runtime = _resolve_agent_model_runtime(model_override, provider_override)
+    model, runtime = _resolve_agent_model_runtime(model_override, provider_override, cfg)
     _pr = _load_provider_routing()
     platform = _resolve_agent_platform(platform_override)
     ignore_rules = is_truthy_value(os.environ.get("HERMES_IGNORE_RULES"))


### PR DESCRIPTION
## Summary

Hermes Desktop could carry a manual model selection from one profile into a session created for another profile. In the reported case, `deepseek-v4-pro` was paired with the Xiaomi provider and sent to Xiaomi's endpoint, which rejected it as unsupported.

This change scopes model selection to the profile that owns it and rejects clear native-provider mismatches before session or network side effects begin.

Fixes #101091.

## Changes

- Store the composer model, provider, and selection source together in profile-scoped state.
- Resolve session creation parameters from the target profile instead of stale composer state.
- Validate native model/provider pairs in `/model`, `session.create`, and agent construction.
- Keep incompatible current models out of a native provider's model list.
- Preserve aggregator, custom-endpoint, explicitly configured, and unknown future model behavior.

Legacy unscoped Desktop selections are ignored because their original profile cannot be identified. Existing scoped selections are migrated to the combined record.

## Verification

Rebased onto current `main` at `79445a496c86a19332ad786494b8384d2167e2d0` and tested on Windows 11 with Python 3.11 and Node.js 24.

- Focused Python regression tests: 14/14 passed.
- Focused Desktop tests: 453/453 passed across 7 files.
- Desktop typecheck: passed.
- ESLint: zero errors; 124 existing warnings.
- Desktop production build: passed.
- Provider/profile Electron E2E: 1/1 passed with one Playwright worker. The Xiaomi session request used `xiaomi / mimo-v2.5-pro`; stale DeepSeek values reached neither `session.create` nor the mock inference endpoint.
- Fleet profile rail E2E: 5/5 passed.
- Focused Ruff checks, the explicit-path Windows footgun scan, and `git diff --check`: passed.

## Related work

#101544 by @FalconOrtiz independently addresses the Desktop profile-isolation path and remains open. This PR also covers gateway validation and model-inventory behavior, so both approaches remain available for maintainers to compare or combine.