### PR TITLE
fix(gateway): stop Discord typing from persisting after idle

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5710,7 +5710,8 @@ class DiscordAdapter(BasePlatformAdapter):
             except asyncio.CancelledError:
                 pass
             finally:
-                self._typing_tasks.pop(chat_id, None)
+                if self._typing_tasks.get(chat_id) is asyncio.current_task():
+                    self._typing_tasks.pop(chat_id, None)
 
         self._typing_tasks[chat_id] = asyncio.create_task(_typing_loop())
 

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -269,6 +269,30 @@ async def test_typing_restartable_after_error():
         "Should restart typing after previous failure"
 
 
+@pytest.mark.asyncio
+async def test_stale_typing_task_does_not_forget_replacement():
+    """A cancelled loop must not unregister a newer loop for the same chat."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._client = MagicMock()
+    adapter._client.http = MagicMock(request=AsyncMock())
+
+    await adapter.send_typing("12345")
+    await asyncio.sleep(0)
+    stale_task = adapter._typing_tasks.pop("12345")
+    stale_task.cancel()
+
+    # Reproduce the base refresh race: stop_typing has removed the stale task,
+    # but its cancellation cleanup has not run before the next refresh arrives.
+    await adapter.send_typing("12345")
+    replacement_task = adapter._typing_tasks["12345"]
+    try:
+        await asyncio.sleep(0)
+        assert adapter._typing_tasks.get("12345") is replacement_task
+    finally:
+        replacement_task.cancel()
+        await asyncio.gather(stale_task, replacement_task, return_exceptions=True)
+
+
 # ---------------------------------------------------------------------------
 # #66797 — outbound MEDIA video must reach channel.send as a real attachment
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Stops Discord's typing indicator from continuing to refresh after a turn is idle. A stale per-channel typing task can no longer unregister a replacement task, so the normal turn cleanup can still find and cancel the active refresh loop.

### Symptom

After a Discord DM turn completes, the bot can remain shown as typing for minutes instead of letting Discord's normal typing TTL expire.

### Impact

Discord users can be misled into thinking the bot is still processing work even though the gateway is idle. The affected blast radius beyond the reported DM session is unknown.

### Bug Cause

**Trigger:** `plugins/platforms/discord/adapter.py:5712` / `_typing_loop` cancellation cleanup racing with the next `send_typing` refresh.

**Causal chain:**
1. `stop_typing()` removes task A from `_typing_tasks` before task A finishes cancellation.
2. A concurrent base refresh sees the empty slot and registers task B for the same chat.
3. Task A's unconditional `finally` pop removes task B's registry entry, so later cleanup cannot find task B while it continues refreshing Discord typing state.

**Why it is wrong:** The stale task deletes state owned by a newer task instead of checking ownership.

**Working sibling / contrast:** Base session cleanup already guard-matches session task ownership before deleting replacement state. Applying the same ownership rule to Discord typing tasks preserves the active task until its own cleanup runs.

**Ruled out:** Discord's server-side typing TTL cannot explain a five-minute indicator by itself; the indicator requires repeated refreshes, and the deterministic task race reproduces the lost registry entry on current main.

### Fix

Only remove a Discord typing registry entry when it still points to the task performing cleanup. Add a deterministic regression test that cancels an old task, registers its replacement before cancellation cleanup runs, and asserts that the replacement remains registered.

## Related Issue

Closes #101783

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/discord/adapter.py` - guard typing-task cleanup by task ownership.
- `tests/gateway/test_discord_send.py` - reproduce and cover the stale-task replacement race.

## How to Test

1. Run the focused Discord typing lifecycle regression test.
2. Run the Discord send, base typing timeout, stream final contract, and Discord double-dispatch suites.
3. Confirm all related tests pass and `git diff --check` is clean.

```bash
scripts/run_tests.sh tests/gateway/test_discord_send.py -q
scripts/run_tests.sh tests/gateway/test_keep_typing_timeout.py -q
scripts/run_tests.sh tests/gateway/test_stream_final_contract.py -q
scripts/run_tests.sh tests/gateway/test_discord_double_dispatch.py -q
git diff --check
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A - no user-facing configuration or workflow changed
- [x] `cli-config.yaml.example` update: N/A - no configuration keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered: the change uses platform-independent asyncio task identity
- [x] Tool descriptions/schemas update: N/A - no tool behavior changed

## Screenshots / Logs

N/A - the async race is covered by a deterministic regression test.
