### PR TITLE
fix(photon): mirror all runtime sidecar modules to writable dir

### DIFF
--- a/plugins/platforms/photon/sidecar_paths.py
+++ b/plugins/platforms/photon/sidecar_paths.py
@@ -22,7 +22,10 @@ logger = logging.getLogger(__name__)
 SOURCE_SIDECAR_DIR = Path(__file__).parent / "sidecar"
 # Files that define the sidecar; node_modules is deliberately absent (baked on managed
 # images or installed by npm in the mirror).
-_MIRROR_FILES = ("index.mjs", "package.json", "package-lock.json", "patch-spectrum-mixed-attachments.mjs")
+# Every runtime .mjs module must be listed: index.mjs statically imports
+# send-format.mjs and stream-staleness.mjs, so a mirror without them fails
+# at import (#85046).
+_MIRROR_FILES = ("index.mjs", "package.json", "package-lock.json", "patch-spectrum-mixed-attachments.mjs", "send-format.mjs", "stream-staleness.mjs")
 # Tests monkeypatch these module globals directly; the accessors honor a non-None value.
 _SIDECAR_DIR: Optional[Path] = None
 # Written by `hermes photon install-sidecar` on npm failure so check_requirements() can

--- a/tests/plugins/platforms/photon/test_sidecar_paths.py
+++ b/tests/plugins/platforms/photon/test_sidecar_paths.py
@@ -138,3 +138,41 @@ def test_adapter_import_does_not_resolve_sidecar_dir(monkeypatch) -> None:
         monkeypatch.undo()
         importlib.reload(photon_adapter)
         importlib.reload(photon_cli)
+
+
+def test_mirror_lists_every_sidecar_module() -> None:
+    """The read-only mirror must ship every runtime .mjs module (#85046).
+
+    index.mjs statically imports send-format.mjs and stream-staleness.mjs;
+    a mirror without them starts a sidecar that dies at import. Guards
+    against adding a sidecar module without extending _MIRROR_FILES.
+    """
+    modules = {
+        p.name for p in sidecar_paths.SOURCE_SIDECAR_DIR.glob("*.mjs")
+    }
+    assert modules, "expected sidecar .mjs modules beside sidecar_paths.py"
+    assert modules <= set(sidecar_paths._MIRROR_FILES), (
+        f"mirror misses sidecar modules: {sorted(modules - set(sidecar_paths._MIRROR_FILES))}"
+    )
+
+
+def test_mirror_copies_static_imports(tmp_path, monkeypatch) -> None:
+    """End-to-end: the mirror contains index.mjs's static .mjs imports."""
+    import re
+
+    monkeypatch.delenv("PHOTON_SIDECAR_DIR", raising=False)
+    home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    source = tmp_path / "src"
+    _seed_source(source)
+    monkeypatch.setattr(sidecar_paths, "_dir_writable", lambda _p: False)
+
+    mirror = sidecar_paths.resolve_sidecar_dir(source)
+
+    index_src = (sidecar_paths.SOURCE_SIDECAR_DIR / "index.mjs").read_text(
+        encoding="utf-8"
+    )
+    imported = set(re.findall(r'from\s+"./([^"]+\.mjs)"', index_src))
+    assert imported, "expected static .mjs imports in index.mjs"
+    for name in imported:
+        assert (mirror / name).exists(), f"mirror misses {name}"


### PR DESCRIPTION
## What does this PR do?

Managed-image / Kubernetes setups run the Photon sidecar from a mirrored
directory (`$HERMES_HOME/photon/sidecar`) because the install tree under
`/opt/hermes` is read-only. The mirror allowlist (`_MIRROR_FILES` in
`plugins/platforms/photon/sidecar_paths.py`) listed only four files, but
`index.mjs` statically imports `send-format.mjs` and `stream-staleness.mjs`.
After `hermes photon setup` + gateway restart the mirrored sidecar missed
both modules and died at import, so Photon never connected. Copying the two
files by hand fixed it — this PR makes the mirror ship them.

The explicit list is kept (it is the existing contract the Dockerfile layer
cache and tests seed from); a new regression test asserts every `.mjs`
beside `sidecar_paths.py` is listed, so the next sidecar module turns an
omission into a test failure instead of a runtime breakage.

## Related Issue

Fixes #85046

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/photon/sidecar_paths.py`: extend `_MIRROR_FILES` with
  `send-format.mjs` and `stream-staleness.mjs` (+ comment explaining the
  static-import coupling, refs #85046).
- `tests/plugins/platforms/photon/test_sidecar_paths.py`:
  - `test_mirror_lists_every_sidecar_module`: every runtime `.mjs` in the
    source sidecar dir must be in `_MIRROR_FILES`.
  - `test_mirror_copies_static_imports`: end-to-end mirror resolve contains
    every static `./*.mjs` import of `index.mjs`.

## How to Test

1. `pytest tests/plugins/platforms/photon/test_sidecar_paths.py -q` — 8/8 pass
   (6 existing + 2 new).
2. Regression proof: with the fix stashed,
   `test_mirror_lists_every_sidecar_module` fails with
   `mirror misses sidecar modules: ['send-format.mjs', 'stream-staleness.mjs']`;
   with the fix applied it passes.
3. `scripts/check.sh --project hermes-agent --worktree worktrees/hermes-agent/85046`
   — all blocking gates passed (ruff, ty diff vs base, changed-area tests,
   uv lock check).
4. Manual shape: read-only source tree + `resolve_sidecar_dir()` now produces
   a mirror containing `index.mjs`, `send-format.mjs`, `stream-staleness.mjs`,
   `patch-spectrum-mixed-attachments.mjs`, `package.json`, `package-lock.json`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (changed-area: 8/8 via `scripts/check.sh`; full ~17k suite runs in CI per profile Resources & cleanup)
- [x] I've added tests for my changes (2 new regression tests, both fail on base)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (code comment covers the coupling; no user docs change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config change)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure path-copy logic, no platform branch; existing `dir_writable` probe unchanged)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
8 passed in 0.29s — tests/plugins/platforms/photon/test_sidecar_paths.py
✓ All blocking gates passed. (scripts/check.sh)
```