### PR TITLE
fix(skills): scope project skill discovery to session cwd for slash and /api/skills (#101786)

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -756,10 +756,25 @@ def find_project_root(start: Optional[Path] = None) -> Optional[Path]:
     """
     try:
         if start is None:
-            from agent.runtime_cwd import scope_terminal_cwd
+            # Project skills are session-scoped (#101786): when the gateway
+            # or dashboard has pinned a per-session cwd (runtime_cwd's
+            # _SESSION_CWD), that wins over the process-global
+            # TERMINAL_CWD so a project session discovers its own skills
+            # even when the launch cwd is the Hermes repo itself.
+            try:
+                from agent.runtime_cwd import _session_cwd_override, scope_terminal_cwd
 
-            env_cwd = scope_terminal_cwd()
-            start = Path(env_cwd) if env_cwd else Path.cwd()
+                session_cwd = _session_cwd_override()
+                if session_cwd:
+                    start = Path(session_cwd)
+                else:
+                    env_cwd = scope_terminal_cwd()
+                    start = Path(env_cwd) if env_cwd else Path.cwd()
+            except Exception:
+                from agent.runtime_cwd import scope_terminal_cwd
+
+                env_cwd = scope_terminal_cwd()
+                start = Path(env_cwd) if env_cwd else Path.cwd()
         cur = Path(start).resolve()
     except OSError:
         return None

--- a/apps/desktop/src/api/skills.ts
+++ b/apps/desktop/src/api/skills.ts
@@ -11,10 +11,19 @@ import type { ActionResponse } from '@/types/hermes'
 
 import { capabilityScoped, hermesApi, type ProfileScope, profileScoped } from './client'
 
-export function getSkills(profile?: ProfileScope): Promise<SkillInfo[]> {
+export function getSkills(profile?: ProfileScope, cwd?: string): Promise<SkillInfo[]> {
+  const normalizedCwd = cwd?.trim()
+  const basePath = '/api/skills'
+  // Profile routing is handled by the Electron preload's path rewriting
+  // (registry-primary-profile-scope), but cwd is a plain query param that
+  // must be forwarded so the backend can scope project skill discovery to
+  // the active session's project (fix for #101786).
+  const path = normalizedCwd
+    ? `${basePath}?cwd=${encodeURIComponent(normalizedCwd)}`
+    : basePath
   return window.hermesDesktop.api<SkillInfo[]>({
     ...capabilityScoped(profile),
-    path: '/api/skills'
+    path
   })
 }
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts
@@ -17,7 +17,7 @@ import {
 } from '@/lib/desktop-slash-commands'
 import { $slashCompletionsEpoch, cachedSlashCompletion, hasCachedSlashCompletion } from '@/lib/slash-completion-cache'
 import { normalize } from '@/lib/text'
-import { $sessions } from '@/store/session'
+import { $activeSessionId, $sessions } from '@/store/session'
 
 import type { CompletionEntry, CompletionPayload } from './use-live-completion-adapter'
 import { useLiveCompletionAdapter } from './use-live-completion-adapter'
@@ -69,13 +69,31 @@ export function useSlashCompletions(options: {
   const enabled = Boolean(gateway)
   const epoch = useStore($slashCompletionsEpoch)
 
+  // Helper to build session-aware params so project skills are discovered
+  // from the active session's project (fix for #101786). The gateway's
+  // commands.catalog / complete.slash now scopes find_project_root to the
+  // session cwd via _SESSION_CWD.
+  const sessionParams = useCallback(() => {
+    const sid = $activeSessionId.get()
+    if (!sid) return {} as Record<string, string>
+    const sess = $sessions.get().find(s => s.id === sid) as unknown as { cwd?: string } | undefined
+    const out: Record<string, string> = { session_id: sid }
+    const cwd = sess?.cwd
+    if (cwd && typeof cwd === 'string' && cwd.trim()) {
+      out.cwd = cwd.trim()
+    }
+    return out
+  }, [epoch])
+
   // Warm argument_mode before the first `/` so Space treats /review as text.
   useEffect(() => {
     if (!gateway) {
       return
     }
 
-    void cachedSlashCompletion('catalog', () => gateway.request<CommandsCatalogLike>('commands.catalog'))
+    const params = sessionParams()
+    const cacheKey = params.cwd ? `catalog:${params.cwd}` : 'catalog'
+    void cachedSlashCompletion(cacheKey, () => gateway.request<CommandsCatalogLike>('commands.catalog', params))
       .then(catalog => {
         filterDesktopCommandsCatalog(catalog)
       })
@@ -153,8 +171,10 @@ export function useSlashCompletions(options: {
 
       try {
         if (!query) {
+          const params = sessionParams()
+          const cacheKey = params.cwd ? `catalog:${params.cwd}` : 'catalog'
           const catalog = filterDesktopCommandsCatalog(
-            await cachedSlashCompletion('catalog', () => gateway.request<CommandsCatalogLike>('commands.catalog'))
+            await cachedSlashCompletion(cacheKey, () => gateway.request<CommandsCatalogLike>('commands.catalog', params))
           )
 
           // Prefer the categorized layout so the popover renders section headers
@@ -194,8 +214,10 @@ export function useSlashCompletions(options: {
           return { items, query }
         }
 
-        const result = await cachedSlashCompletion(`slash:${text.toLowerCase()}`, () =>
-          gateway.request<{ items?: CompletionEntry[]; replace_from?: number }>('complete.slash', { text })
+        const params = sessionParams()
+        const slashCacheKey = params.cwd ? `slash:${text.toLowerCase()}:${params.cwd}` : `slash:${text.toLowerCase()}`
+        const result = await cachedSlashCompletion(slashCacheKey, () =>
+          gateway.request<{ items?: CompletionEntry[]; replace_from?: number }>('complete.slash', { text, ...params })
         )
 
         // Arg-completion items (replace_from > 1) carry just the arg stub —
@@ -251,7 +273,7 @@ export function useSlashCompletions(options: {
         return { items: [], query }
       }
     },
-    [gateway, skinThemes, activeSkin]
+    [gateway, skinThemes, activeSkin, sessionParams]
   )
 
   const toItem = useCallback((entry: CompletionEntry, index: number): Unstable_TriggerItem => {
@@ -293,9 +315,12 @@ export function useSlashCompletions(options: {
         return true
       }
 
-      return hasCachedSlashCompletion(query ? `slash:${text.toLowerCase()}` : 'catalog')
+      const params = sessionParams()
+      const catalogKey = params.cwd ? `catalog:${params.cwd}` : 'catalog'
+      const slashKey = params.cwd ? `slash:${text.toLowerCase()}:${params.cwd}` : `slash:${text.toLowerCase()}`
+      return hasCachedSlashCompletion(query ? slashKey : catalogKey)
     },
-    [skinThemes]
+    [skinThemes, sessionParams]
   )
 
   return useLiveCompletionAdapter({ enabled, epoch, fetcher, isCached, toItem })

--- a/hermes_cli/web_routers/skills.py
+++ b/hermes_cli/web_routers/skills.py
@@ -463,7 +463,7 @@ async def scan_skill_hub(identifier: str = "", profile: Optional[str] = None):
 
 
 @router.get("/api/skills")
-async def get_skills(profile: Optional[str] = None):
+async def get_skills(profile: Optional[str] = None, cwd: Optional[str] = None):
     from tools.skills_tool import _find_all_skills
     from hermes_cli.skills_config import get_disabled_skills
     from tools.skill_usage import (
@@ -473,17 +473,38 @@ async def get_skills(profile: Optional[str] = None):
         load_usage,
     )
     def _run():
-        with _profile_scope(profile):
-            config = load_config()
-            disabled = get_disabled_skills(config)
-            skills = _find_all_skills(skip_disabled=True)
-            usage = load_usage()
-            # Set-based provenance (same classification as skill_usage.provenance,
-            # without a per-skill manifest read): hub > bundled > agent, where
-            # "agent" covers agent-authored AND local hand-made skills — the ones
-            # the user may edit/delete from the UI.
-            bundled_names = _read_bundled_manifest_names()
-            hub_names = _read_hub_installed_names()
+        # Project skills are discovered from the session cwd (#101786).
+        # When the desktop fetches /api/skills it now passes ?cwd=<session cwd>
+        # so the backend scopes find_project_root() to that project even when
+        # the dashboard backend was launched from the Hermes repo itself.
+        token = None
+        try:
+            if cwd and cwd.strip():
+                try:
+                    from agent.runtime_cwd import set_session_cwd
+
+                    token = set_session_cwd(cwd.strip())
+                except Exception:
+                    pass
+            with _profile_scope(profile):
+                config = load_config()
+                disabled = get_disabled_skills(config)
+                skills = _find_all_skills(skip_disabled=True)
+                usage = load_usage()
+                # Set-based provenance (same classification as skill_usage.provenance,
+                # without a per-skill manifest read): hub > bundled > agent, where
+                # "agent" covers agent-authored AND local hand-made skills — the ones
+                # the user may edit/delete from the UI.
+                bundled_names = _read_bundled_manifest_names()
+                hub_names = _read_hub_installed_names()
+        finally:
+            if token is not None:
+                try:
+                    from agent.runtime_cwd import _SESSION_CWD
+
+                    _SESSION_CWD.reset(token)
+                except Exception:
+                    pass
         for s in skills:
             s["enabled"] = s["name"] not in disabled
             s["usage"] = activity_count(usage.get(s["name"], {}))

--- a/tui_gateway/methods_complete.py
+++ b/tui_gateway/methods_complete.py
@@ -333,7 +333,27 @@ def _(rid, params: dict) -> dict:
     if not text.startswith("/"):
         return _ok(rid, {"items": []})
 
+    _slash_cwd_token = None
     try:
+        try:
+            from agent.runtime_cwd import set_session_cwd
+
+            _cwd_val = None
+            if params.get("cwd"):
+                _cwd_val = str(params.get("cwd")).strip()
+            elif params.get("session_id"):
+                _s = _sessions.get(str(params.get("session_id")))
+                if _s and _s.get("cwd"):
+                    _cwd_val = str(_s.get("cwd"))
+            if not _cwd_val:
+                try:
+                    _cwd_val = _completion_cwd(params)
+                except Exception:
+                    _cwd_val = None
+            if _cwd_val and _cwd_val.strip():
+                _slash_cwd_token = set_session_cwd(_cwd_val.strip())
+        except Exception:
+            pass
         from hermes_cli.commands import SlashCommandCompleter
         from prompt_toolkit.document import Document
         from prompt_toolkit.formatted_text import to_plain_text
@@ -450,19 +470,42 @@ def _(rid, params: dict) -> dict:
 
         details_items = _details_completions(text)
         if details_items is not None:
-            return _ok(
+            _res = _ok(
                 rid,
                 {
                     "items": details_items,
                     "replace_from": text.rfind(" ") + 1 if " " in text else len(text),
                 },
             )
+            if _slash_cwd_token is not None:
+                try:
+                    from agent.runtime_cwd import _SESSION_CWD
 
-        return _ok(
+                    _SESSION_CWD.reset(_slash_cwd_token)
+                except Exception:
+                    pass
+            return _res
+
+        _res2 = _ok(
             rid,
             {"items": items, "replace_from": text.rfind(" ") + 1 if " " in text else 1},
         )
+        if _slash_cwd_token is not None:
+            try:
+                from agent.runtime_cwd import _SESSION_CWD
+
+                _SESSION_CWD.reset(_slash_cwd_token)
+            except Exception:
+                pass
+        return _res2
     except Exception as e:
+        if _slash_cwd_token is not None:
+            try:
+                from agent.runtime_cwd import _SESSION_CWD
+
+                _SESSION_CWD.reset(_slash_cwd_token)
+            except Exception:
+                pass
         return _err(rid, 5020, str(e))
 
 

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -256,7 +256,31 @@ def _(rid, params: dict) -> dict:
 @method("commands.catalog")
 def _(rid, params: dict) -> dict:
     """Registry-backed slash metadata for the TUI — categorized, no aliases."""
+    _catalog_cwd_token = None
     try:
+        try:
+            from agent.runtime_cwd import set_session_cwd
+
+            _cwd_val = None
+            if params.get("cwd"):
+                _cwd_val = str(params.get("cwd")).strip()
+            elif params.get("session_id"):
+                _s = _sessions.get(str(params.get("session_id")))
+                if _s and _s.get("cwd"):
+                    _cwd_val = str(_s.get("cwd"))
+            if not _cwd_val:
+                try:
+                    _cwd_val = _completion_cwd(params)
+                except Exception:
+                    _cwd_val = None
+            if _cwd_val and _cwd_val.strip():
+                # Scope project skill discovery to this session's project
+                # (#101786): find_project_root now checks _SESSION_CWD first
+                # so a session inside a project discovers its project skills
+                # even when the dashboard was launched elsewhere.
+                _catalog_cwd_token = set_session_cwd(_cwd_val.strip())
+        except Exception:
+            pass
         from hermes_cli.commands import (
             COMMAND_REGISTRY,
             SUBCOMMANDS,
@@ -389,7 +413,7 @@ def _(rid, params: dict) -> dict:
             categories.append({"name": cat, "pairs": cat_map[cat]})
 
         sub = {k: v[:] for k, v in SUBCOMMANDS.items()}
-        return _ok(
+        result = _ok(
             rid,
             {
                 "pairs": all_pairs,
@@ -402,7 +426,22 @@ def _(rid, params: dict) -> dict:
                 "warning": warning,
             },
         )
+        if _catalog_cwd_token is not None:
+            try:
+                from agent.runtime_cwd import _SESSION_CWD
+
+                _SESSION_CWD.reset(_catalog_cwd_token)
+            except Exception:
+                pass
+        return result
     except Exception as e:
+        if _catalog_cwd_token is not None:
+            try:
+                from agent.runtime_cwd import _SESSION_CWD
+
+                _SESSION_CWD.reset(_catalog_cwd_token)
+            except Exception:
+                pass
         return _err(rid, 5020, str(e))
 
 


### PR DESCRIPTION
Fixes #101786

Project-level skills (e.g. `.hermes/skills` inside a git checkout) were invisible when typing `/` in a project session. The gateway/TUI launch dir is the Hermes repo itself, so `find_project_root()` resolved the Hermes repo instead of the session's project.

The first half-fix made `runtime_cwd` session-aware, but:
- Desktop fetched `GET /api/skills` without `?cwd=`, so the backend still scanned the launch dir
- Gateway handlers `commands.catalog` / `complete.slash` called `scan_skill_commands()` without scoping to the session

This patch:

1. `agent/skill_utils.py` — `find_project_root()` now checks `_SESSION_CWD` first, so any request-scoped `set_session_cwd(cwd)` wins over `TERMINAL_CWD` / `os.getcwd()`
2. `hermes_cli/web_routers/skills.py` — `GET /api/skills` accepts optional `?cwd=` and scopes discovery via `set_session_cwd()`
3. `tui_gateway/methods_tools.py` + `methods_complete.py` — `commands.catalog` and `complete.slash` now scope discovery to `params.cwd` / `params.session_id` / `_completion_cwd()` via `set_session_cwd()`
4. `apps/desktop` — `getSkills()` now forwards `?cwd=`; `useSlashCompletions` now sends `{session_id, cwd}` with both `commands.catalog` and `complete.slash` and uses cwd-aware cache keys so project and non-project sessions do not share stale completions

Test: `find_project_root` now correctly resolves the session project even when `TERMINAL_CWD` points at the Hermes repo.

Closes #101786