### PR TITLE
fix(desktop): open clicked links in a new Browser tab

### DIFF
--- a/apps/desktop/src/store/preview.test.ts
+++ b/apps/desktop/src/store/preview.test.ts
@@ -85,6 +85,19 @@ describe('preview store', () => {
     expect($rightRailActiveTabId.get()).toBe(urlTabs[0].id)
   })
 
+  it('opens an explicit link in a new Browser without replacing the current page', () => {
+    openPreview(urlTarget('https://news.ycombinator.com'), 'tool-result')
+    const existingId = $previewTabs.get()[0].id
+
+    openPreview(urlTarget('https://www.reddit.com'), 'explicit-link')
+
+    const urlTabs = $previewTabs.get().filter(tab => tab.target.kind === 'url')
+
+    expect(urlTabs).toHaveLength(2)
+    expect(urlTabs.find(tab => tab.id === existingId)?.target.url).toBe('https://news.ycombinator.com')
+    expect($previewTarget.get()?.url).toBe('https://www.reddit.com')
+  })
+
   it('commits the live page onto a Browser tab without changing its id', () => {
     openPreview(urlTarget('https://news.ycombinator.com'), 'tool-result')
     const id = $previewTabs.get()[0].id

--- a/apps/desktop/src/store/preview.ts
+++ b/apps/desktop/src/store/preview.ts
@@ -351,10 +351,9 @@ function mintBrowserTabId(): RightRailTabId {
   return `url:browser-${unique}`
 }
 
-/** The Browser a URL should open in: the one you're looking at, else the one
- *  you used last. A link from chat navigates the browser you already have
- *  rather than stacking another identical tab — new tabs are something you
- *  ask for (the strip's "+"), the way they are in a real browser. */
+/** The Browser a tool should open in: the one you're looking at, else the one
+ *  you used last. Tool-driven opens reuse a Browser to avoid tab spam; explicit
+ *  user-clicked links skip this resolver and mint a new tab. */
 function browserTabId(tabs: PreviewTab[]): RightRailTabId {
   const active = tabs.find(tab => tab.id === $rightRailActiveTabId.get())
 
@@ -385,7 +384,14 @@ function previewTargetForSource(target: PreviewTarget, source: PreviewRecordSour
 export function openPreview(target: PreviewTarget, source: PreviewRecordSource = 'manual') {
   const resolved = previewTargetForSource(target, source)
   const current = $previewTabs.get()
-  const id = resolved.kind === 'url' ? browserTabId(current) : previewTabId(resolved)
+
+  const id =
+    resolved.kind === 'url'
+      ? source === 'explicit-link'
+        ? mintBrowserTabId()
+        : browserTabId(current)
+      : previewTabId(resolved)
+
   const index = current.findIndex(tab => tab.id === id)
   const tab: PreviewTab = { id, target: resolved }
 


### PR DESCRIPTION
## Problem

The multi-tab Browser intentionally reuses the active/latest Browser for URL opens so agents do not create one tab per tool call. User-clicked links currently take the same path, so clicking a PR or other link can replace a page an agent is using.

## Fix

Treat the existing `explicit-link` source as human intent:

- explicit user-clicked URLs mint a new Browser tab
- tool-driven URL opens keep reusing the active/latest Browser
- file and artifact routing is unchanged

This keeps the anti-tab-spam design from #94152 without allowing a click to destroy another task's visible page.

## Success criteria

- [x] A user-clicked URL creates a second Browser tab.
- [x] The existing Browser tab keeps its id and URL.
- [x] The clicked URL becomes the active preview.
- [x] Tool-driven URL opens still reuse one Browser tab.
- [x] No new dependency, setting, abstraction or persisted state.

## Validation

- [x] Regression proof: the new test failed on current `main` with one URL tab instead of two.
- [x] `npm run test:ui -- src/store/preview.test.ts src/lib/external-link.test.tsx src/app/chat/preview-tile.test.ts` (56 passed)
- [x] `npm run check:lint`
- [x] `npm run test:ui` (full UI suite)
- [x] `npm run test:desktop:all`
- [ ] `npm run test:desktop:platforms` (2,081 passed, 6 skipped; one unrelated `managed-ssh-update.test.ts` assertion fails identically on untouched `593aa74c61`)

## Scope

This PR only separates explicit human link clicks from tool-driven Browser reuse. Session/profile ownership, owner-aware labels and background agent routing remain separate follow-ups so each security and lifecycle contract can be reviewed independently.

Related to #90435.
Follow-up ownership/concurrency issue: #101856.
