### PR TITLE
fix(mcp): isolate a tool the SDK rejects instead of parking the whole server

### DIFF
--- a/contributors/emails/kyr76789@gmail.com
+++ b/contributors/emails/kyr76789@gmail.com
@@ -1,0 +1,2 @@
+hyeonsang010716
+# #101804 contributor attribution

--- a/tests/tools/test_mcp_listing_guard.py
+++ b/tests/tools/test_mcp_listing_guard.py
@@ -1,0 +1,627 @@
+"""Tests for the MCP tool-listing guard (#101669).
+
+The mcp 2.x SDK validates a ``tools/list`` page as a whole, so one tool the
+negotiated wire schema rejects fails the entire response and Hermes parks
+the server: the reporter lost 311 good tools to one. The guard wraps the
+session's stream pair between the transport and ``ClientSession``: the
+write proxy remembers each outbound request's method by id, and the read
+proxy validates every tool of the response to ``tools/list`` — and only
+that response — against the SDK's per-version ``Tool`` model, so only
+genuinely invalid tools are dropped, by name, and the rest of the catalog
+loads.
+
+Accepting the reporter's *boolean property subschema* is the SDK model's
+job and is owned by a separate change (upstream python-sdk#3354; #102900 for
+the pinned release) — this guard neither accepts nor rewrites schemas. These
+tests therefore use a tool every era rejects (``inputSchema.type !=
+"object"``) as the invalid case, and treat the boolean tool as "kept once
+the model in use accepts it, isolated by name until then".
+
+The end-to-end tests drive a *real* ``ClientSession`` over in-memory streams
+against a fake server; no subprocess, no network.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import logging
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from tools.mcp_listing_guard import (
+    GuardedWriteStream,
+    ToolListingGuard,
+    drop_invalid_tools,
+    guard_session_streams,
+)
+
+# The protocol era most servers still negotiate.
+LEGACY_VERSION = "2025-11-25"
+GUARD_LOGGER = "tools.mcp_listing_guard"
+
+GOOD = {"name": "good", "inputSchema": {"type": "object", "properties": {"q": {"type": "string"}}}}
+# Genuinely invalid for every era's tools/list wire schema: root must be an object.
+BROKEN = {"name": "broken", "inputSchema": {"type": "array"}}
+# The reporter's case: a boolean property subschema (legal JSON Schema).
+BOOL_PROP = {"name": "posthogmcp_endpoint_run", "inputSchema": {"type": "object", "properties": {"refresh": True}}}
+
+
+def _sdk_accepts_boolean_property_schemas() -> bool:
+    """Whether the installed SDK model (with any Hermes widening) takes the
+    reporter's shape — the guard's verdict must track the model, not
+    hard-code either answer."""
+    from mcp_types.methods import validate_server_result
+    from pydantic import ValidationError
+
+    try:
+        validate_server_result("tools/list", LEGACY_VERSION, {"tools": [copy.deepcopy(BOOL_PROP)]})
+    except ValidationError:
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# drop_invalid_tools — needs the SDK generation with per-version validation
+# ---------------------------------------------------------------------------
+
+class TestDropInvalidTools:
+    @pytest.fixture(autouse=True)
+    def _needs_versioned_sdk(self):
+        pytest.importorskip("mcp_types.methods")
+
+    def test_valid_page_is_left_alone(self):
+        result = {"tools": [copy.deepcopy(GOOD), {"name": "b", "inputSchema": {"type": "object"}}]}
+        before = copy.deepcopy(result)
+
+        assert drop_invalid_tools(result, LEGACY_VERSION) == []
+        assert result == before
+
+    def test_only_the_offending_tool_is_dropped_and_named(self):
+        result = {"tools": [
+            copy.deepcopy(GOOD), copy.deepcopy(BROKEN),
+            {"name": "also_good", "inputSchema": {"type": "object", "properties": {}}},
+        ]}
+        dropped = drop_invalid_tools(result, LEGACY_VERSION)
+
+        assert [name for name, _ in dropped] == ["broken"]
+        assert "inputSchema" in dropped[0][1]
+        assert [t["name"] for t in result["tools"]] == ["good", "also_good"]
+
+    def test_verdict_tracks_the_sdk_model_for_boolean_property_schemas(self):
+        """Once the model accepts booleans (upstream #3354 / the Hermes
+        widening) the tool stays; until then it is isolated, not the server."""
+        result = {"tools": [copy.deepcopy(GOOD), copy.deepcopy(BOOL_PROP)]}
+        dropped = drop_invalid_tools(result, LEGACY_VERSION)
+        names = [t["name"] for t in result["tools"]]
+
+        if _sdk_accepts_boolean_property_schemas():
+            assert dropped == [] and names == ["good", "posthogmcp_endpoint_run"]
+        else:
+            assert [n for n, _ in dropped] == ["posthogmcp_endpoint_run"]
+            assert "properties.refresh" in dropped[0][1]
+            assert names == ["good"]
+
+    def test_page_level_errors_neither_hide_nor_condemn_tools(self):
+        """A broken page-level field (the SDK clamps a negative ttl itself,
+        and rejects a non-string cursor on its own) must not stop an invalid
+        tool from being dropped, nor take a valid tool with it."""
+        result = {
+            "tools": [{"name": "fine", "inputSchema": {"type": "object"}}, copy.deepcopy(BROKEN)],
+            "nextCursor": 12345,
+            "ttlMs": -5,
+        }
+        dropped = drop_invalid_tools(result, LEGACY_VERSION)
+
+        assert [name for name, _ in dropped] == ["broken"]
+        assert [t["name"] for t in result["tools"]] == ["fine"]
+        assert result["nextCursor"] == 12345
+        assert result["ttlMs"] == -5
+
+    def test_unknown_version_defers_to_the_sdk(self):
+        result = {"tools": [copy.deepcopy(BROKEN)]}
+        assert drop_invalid_tools(result, "9999-01-01") == []
+        assert len(result["tools"]) == 1
+
+    def test_non_listing_input_is_untouched(self):
+        assert drop_invalid_tools({"tools": "nope"}, LEGACY_VERSION) == []
+        assert drop_invalid_tools({"resources": []}, LEGACY_VERSION) == []
+
+
+# ---------------------------------------------------------------------------
+# The guarded stream pair
+# ---------------------------------------------------------------------------
+
+class _ScriptedStream:
+    """Minimal ReadStream stand-in yielding a fixed sequence of items."""
+
+    last_context = "sender-context"
+
+    def __init__(self, items):
+        self._items = list(items)
+        self.entered = 0
+        self.closed = False
+
+    async def receive(self):
+        if not self._items:
+            raise StopAsyncIteration
+        return self._items.pop(0)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        return await self.receive()
+
+    async def __aenter__(self):
+        self.entered += 1
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def aclose(self):
+        self.closed = True
+
+
+class _RecordingWrite:
+    """Minimal WriteStream stand-in that records what was sent."""
+
+    def __init__(self):
+        self.sent = []
+        self.entered = 0
+        self.closed = False
+
+    async def send(self, item):
+        self.sent.append(item)
+
+    async def __aenter__(self):
+        self.entered += 1
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def aclose(self):
+        self.closed = True
+
+
+def _request(request_id, method):
+    return SimpleNamespace(message=SimpleNamespace(id=request_id, method=method, params=None), metadata=None)
+
+
+def _notification(method):
+    return SimpleNamespace(message=SimpleNamespace(method=method, params=None), metadata=None)
+
+
+def _response(request_id, result):
+    return SimpleNamespace(message=SimpleNamespace(id=request_id, result=result), metadata=None)
+
+
+def _error(request_id):
+    return SimpleNamespace(message=SimpleNamespace(id=request_id, error={"code": -1}), metadata=None)
+
+
+def _listing(request_id, *tools):
+    return _response(request_id, {"tools": [copy.deepcopy(t) for t in tools]})
+
+
+def _guarded(inbound, *, outbound=(), version=LEGACY_VERSION, on_drop=None):
+    """A guarded pair whose write side has already seen ``outbound`` requests."""
+    inner_write = _RecordingWrite()
+    read, write = guard_session_streams(
+        _ScriptedStream(inbound), inner_write, server_name="srv",
+        version_getter=lambda: version, on_drop=on_drop,
+    )
+
+    async def prime():
+        for item in outbound:
+            await write.send(item)
+
+    asyncio.run(prime())
+    return read, write, inner_write
+
+
+async def _drain(guard):
+    # The SDK's dispatcher consumes the stream with ``async with`` +
+    # ``async for``, so exercise that path rather than ``receive()``.
+    async with guard:
+        return [item async for item in guard]
+
+
+def _names(item):
+    return [t["name"] for t in item.message.result["tools"]]
+
+
+class TestGuardedStreamPair:
+    def test_only_the_response_to_tools_list_is_isolated(self):
+        pytest.importorskip("mcp_types.methods")
+        listing = _listing(1, GOOD, BROKEN)
+        custom = _response(2, {"tools": [copy.deepcopy(BROKEN)], "note": "extension payload"})
+        read, _, _ = _guarded([listing, custom], outbound=[_request(1, "tools/list"), _request(2, "x/custom")])
+
+        items = asyncio.run(_drain(read))
+
+        assert items == [listing, custom]
+        assert _names(listing) == ["good"]
+        assert custom.message.result == {"tools": [BROKEN], "note": "extension payload"}
+
+    def test_a_tools_shaped_result_without_a_known_request_is_untouched(self):
+        pytest.importorskip("mcp_types.methods")
+        orphan = _listing(99, GOOD, BROKEN)
+        read, _, _ = _guarded([orphan], outbound=[_request(1, "tools/list")])
+
+        asyncio.run(_drain(read))
+        assert _names(orphan) == ["good", "broken"]
+
+    def test_request_ids_are_retired_by_their_answer(self):
+        """An id answered by an error (or a response) must not linger and
+        later claim an unrelated result that reuses the id."""
+        pytest.importorskip("mcp_types.methods")
+        errored = _error(1)
+        reused = _listing(1, GOOD, BROKEN)  # same id, but no tools/list request behind it now
+        read, _, _ = _guarded([errored, reused], outbound=[_request(1, "tools/list")])
+
+        items = asyncio.run(_drain(read))
+        assert items[0] is errored
+        assert _names(reused) == ["good", "broken"]
+
+    def test_server_originated_requests_and_notifications_pass_through(self):
+        inbound = [
+            _request(7, "sampling/createMessage"),  # server → client request
+            _notification("notifications/tools/list_changed"),
+            ConnectionResetError("boom"),
+        ]
+        read, _, _ = _guarded(inbound, outbound=[_request(7, "tools/list")])
+
+        items = asyncio.run(_drain(read))
+        assert items == inbound
+
+    def test_write_proxy_forwards_every_send(self):
+        read, write, inner_write = _guarded([], outbound=[])
+        outbound = [_request(1, "ping"), _notification("notifications/initialized")]
+
+        async def send_all():
+            for item in outbound:
+                await write.send(item)
+
+        asyncio.run(send_all())
+        assert inner_write.sent == outbound
+        assert isinstance(write, GuardedWriteStream)
+
+    def test_mcp_1x_root_wrapped_messages_are_handled_too(self):
+        pytest.importorskip("mcp_types.methods")
+        request = SimpleNamespace(message=SimpleNamespace(root=SimpleNamespace(id=1, method="tools/list")), metadata=None)
+        inner = SimpleNamespace(id=1, result={"tools": [copy.deepcopy(GOOD), copy.deepcopy(BROKEN)]})
+        listing = SimpleNamespace(message=SimpleNamespace(root=inner), metadata=None)
+        read, _, _ = _guarded([listing], outbound=[request])
+
+        asyncio.run(read.receive())
+        assert [t["name"] for t in inner.result["tools"]] == ["good"]
+
+    def test_delegates_protocol_extras_to_the_wrapped_streams(self):
+        inner_read = _ScriptedStream([])
+        inner_write = _RecordingWrite()
+        read, write = guard_session_streams(inner_read, inner_write, server_name="srv")
+
+        async def lifecycle():
+            async with read, write:
+                pass
+            await read.aclose()
+            await write.aclose()
+
+        asyncio.run(lifecycle())
+        assert isinstance(read, ToolListingGuard)
+        assert read.last_context == "sender-context"
+        assert (inner_read.entered, inner_read.closed) == (1, True)
+        assert (inner_write.entered, inner_write.closed) == (1, True)
+        with pytest.raises(AttributeError):
+            read._not_an_attribute  # private names are never forwarded
+
+    def test_guard_failure_never_breaks_the_stream(self):
+        """A shape the isolation code chokes on must be forwarded, not raised."""
+        class _Explosive(dict):
+            def get(self, *_a, **_k):
+                raise RuntimeError("malformed")
+
+        item = _response(1, _Explosive(tools=[]))
+        read, _, _ = _guarded([item], outbound=[_request(1, "tools/list")])
+
+        assert asyncio.run(read.receive()) is item
+
+    def test_drops_invalid_tools_using_the_negotiated_version(self, caplog):
+        pytest.importorskip("mcp_types.methods")
+        listing = _listing(1, GOOD, BROKEN)
+        seen = []
+        read, _, _ = _guarded([listing], outbound=[_request(1, "tools/list")], on_drop=seen.append)
+
+        with caplog.at_level(logging.WARNING, logger=GUARD_LOGGER):
+            asyncio.run(_drain(read))
+
+        assert _names(listing) == ["good"]
+        assert [name for name, _ in seen[0]] == ["broken"]
+        assert any("'broken'" in rec.getMessage() and "srv" in rec.getMessage()
+                   for rec in caplog.records)
+
+    def test_falls_back_to_the_version_the_handshake_returned(self):
+        """Before the session exposes a negotiated version, the handshake
+        response that passed through this same stream is the next best
+        source — the SDK adopts exactly that value."""
+        pytest.importorskip("mcp_types.methods")
+        handshake = _response(1, {"protocolVersion": LEGACY_VERSION, "capabilities": {"tools": {}}})
+        listing = _listing(2, GOOD, BROKEN)
+        read, _, _ = _guarded([handshake, listing], version=None,
+                              outbound=[_request(1, "initialize"), _request(2, "tools/list")])
+
+        asyncio.run(_drain(read))
+        assert _names(listing) == ["good"]
+
+    def test_a_protocol_version_in_a_non_handshake_result_is_not_adopted(self):
+        pytest.importorskip("mcp_types.methods")
+        decoy = _response(1, {"protocolVersion": LEGACY_VERSION})
+        listing = _listing(2, GOOD, BROKEN)
+        read, _, _ = _guarded([decoy, listing], version=None,
+                              outbound=[_request(1, "x/custom"), _request(2, "tools/list")])
+
+        asyncio.run(_drain(read))
+        assert _names(listing) == ["good", "broken"]
+
+    def test_repeated_verdicts_are_reported_once(self, caplog):
+        """A keepalive that re-lists tools every few seconds must not repeat
+        the same WARNING into agent.log on every tick."""
+        pytest.importorskip("mcp_types.methods")
+        pages = [_listing(i, GOOD, BROKEN) for i in range(3)]
+        read, _, _ = _guarded(pages, outbound=[_request(i, "tools/list") for i in range(3)])
+
+        with caplog.at_level(logging.DEBUG, logger=GUARD_LOGGER):
+            asyncio.run(_drain(read))
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1 and "'broken'" in warnings[0].getMessage()
+        for page in pages:  # every page was still isolated, not just the first
+            assert _names(page) == ["good"]
+
+
+# ---------------------------------------------------------------------------
+# MCPServerTask wiring
+# ---------------------------------------------------------------------------
+
+class TestServerTaskWiring:
+    def test_guard_reads_the_live_session_version_and_records_drops(self):
+        pytest.importorskip("mcp_types.methods")
+        from tools.mcp_tool import MCPServerTask
+
+        server = MCPServerTask("wired")
+        listing = _listing(1, GOOD, BROKEN)
+        read, write = server._guard_session_streams(_ScriptedStream([listing]), _RecordingWrite())
+        assert isinstance(read, ToolListingGuard) and isinstance(write, GuardedWriteStream)
+
+        # The session is negotiated after the streams are wrapped; the guard
+        # must pick the version up from whatever session is live at read time.
+        server.session = SimpleNamespace(protocol_version=LEGACY_VERSION)
+
+        async def drive():
+            await write.send(_request(1, "tools/list"))
+            return await _drain(read)
+
+        asyncio.run(drive())
+        assert _names(listing) == ["good"]
+        assert list(server._dropped_tools) == ["broken"]
+        assert "inputSchema" in server._dropped_tools["broken"]
+
+    def test_status_lists_dropped_tools_for_a_connected_server(self, monkeypatch):
+        import tools.mcp_tool as mcp_tool
+        from tools import mcp_tool_config as _mcp_config
+        from tools import mcp_tool_discovery as _mcp_discovery
+
+        server = mcp_tool.MCPServerTask("dropper")
+        server.session = SimpleNamespace(protocol_version=LEGACY_VERSION)
+        server._record_dropped_tools([("broken", "inputSchema.type: Input should be 'object'")])
+        clean = mcp_tool.MCPServerTask("clean")
+        clean.session = SimpleNamespace(protocol_version=LEGACY_VERSION)
+
+        monkeypatch.setattr(
+            _mcp_config, "_load_mcp_config",
+            lambda: {"dropper": {"command": "x"}, "clean": {"command": "y"}},
+        )
+        with mcp_tool._lock:
+            saved = dict(mcp_tool._servers)
+            mcp_tool._servers.clear()
+            mcp_tool._servers.update({"dropper": server, "clean": clean})
+        try:
+            statuses = {e["name"]: e for e in _mcp_discovery.get_mcp_status()}
+        finally:
+            with mcp_tool._lock:
+                mcp_tool._servers.clear()
+                mcp_tool._servers.update(saved)
+
+        assert statuses["dropper"]["status"] == "connected"
+        assert statuses["dropper"]["dropped_tools"] == ["broken"]
+        assert "dropped_tools" not in statuses["clean"]
+
+    def test_rediscovery_forgets_stale_drops(self):
+        """A tool the server fixed must not haunt status after a refresh."""
+        from unittest.mock import MagicMock
+
+        from tools.mcp_tool import MCPServerTask
+
+        server = MCPServerTask("refreshing")
+        server._record_dropped_tools([("broken", "stale reason")])
+
+        async def fake_list(cursor=None):
+            return SimpleNamespace(tools=[])
+
+        server.session = MagicMock()
+        server.session.list_tools = fake_list
+        asyncio.run(server._discover_tools())
+
+        assert server._dropped_tools == {}
+
+    @staticmethod
+    def _server_without_tools_capability(name):
+        """A task whose captured handshake omits ``tools`` — ``tools/list`` is never called."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from tools.mcp_tool import MCPServerTask
+
+        server = MCPServerTask(name)
+        server._record_dropped_tools([("broken", "verdict from the previous catalog")])
+        server.initialize_result = SimpleNamespace(capabilities=SimpleNamespace(tools=None))
+        server.session = MagicMock()
+        server.session.list_tools = AsyncMock(side_effect=AssertionError("tools/list must not be called"))
+        return server
+
+    def test_rediscovery_without_tools_capability_forgets_stale_drops(self):
+        """A server that reconnects as prompt-/resource-only fetches no catalog;
+        the previous catalog's verdicts must not survive into status."""
+        server = self._server_without_tools_capability("prompts-only")
+
+        asyncio.run(server._discover_tools())
+
+        assert server._dropped_tools == {}
+        server.session.list_tools.assert_not_called()
+
+    def test_refresh_without_tools_capability_forgets_stale_drops(self):
+        """Same for a ``tools/list_changed`` refresh that early-returns on the capability gate."""
+        server = self._server_without_tools_capability("prompts-only")
+
+        asyncio.run(server._refresh_tools())
+
+        assert server._dropped_tools == {}
+        server.session.list_tools.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# End to end: a real ClientSession over memory streams
+# ---------------------------------------------------------------------------
+
+CATALOG = [GOOD, BOOL_PROP, BROKEN]
+# A custom/extension method whose result merely *looks like* a tool catalog. The pinned SDK
+# forwards custom results without surface validation, so the guard must leave it alone.
+CUSTOM_METHOD = "x/tools_like"
+CUSTOM_RESULT = {"tools": [copy.deepcopy(BROKEN)], "note": "extension payload"}
+
+
+def _unwrap(message):
+    # mcp 1.x wraps JSON-RPC messages in a root model; 2.x does not.
+    return getattr(message, "root", message)
+
+
+def _wrap(types_mod, response):
+    cls = getattr(types_mod, "JSONRPCMessage", None)
+    if isinstance(cls, type) and "root" in getattr(cls, "model_fields", {}):
+        return cls(root=response)
+    return response
+
+
+async def _fake_server(recv, send, catalog):
+    """Answer ``initialize``, ``tools/list`` and the custom method; ignore notifications."""
+    import mcp.types as types
+    from mcp.shared.message import SessionMessage
+
+    async with recv, send:
+        async for item in recv:
+            msg = _unwrap(item.message)
+            request_id = getattr(msg, "id", None)
+            if request_id is None:
+                continue
+            method = getattr(msg, "method", None)
+            if method == "initialize":
+                result = {
+                    "protocolVersion": LEGACY_VERSION,
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "fake", "version": "0"},
+                }
+            elif method == "tools/list":
+                result = {"tools": copy.deepcopy(catalog)}
+            elif method == CUSTOM_METHOD:
+                result = copy.deepcopy(CUSTOM_RESULT)
+            else:
+                result = {}
+            response = types.JSONRPCResponse(jsonrpc="2.0", id=request_id, result=result)
+            await send.send(SessionMessage(message=_wrap(types, response)))
+
+
+async def _session_through(catalog, *, guarded, use):
+    """Run ``use(session)`` on a real ClientSession, optionally behind the guard."""
+    import anyio
+    from mcp.client.session import ClientSession
+
+    client_send, server_recv = anyio.create_memory_object_stream(64)
+    server_send, client_recv = anyio.create_memory_object_stream(64)
+    server = asyncio.create_task(_fake_server(server_recv, server_send, catalog))
+    live = {}
+    read, write = client_recv, client_send
+    if guarded:
+        read, write = guard_session_streams(
+            client_recv, client_send, server_name="fake",
+            version_getter=lambda: getattr(live.get("session"), "protocol_version", None),
+        )
+    try:
+        async with ClientSession(read, write) as session:
+            live["session"] = session
+            await asyncio.wait_for(session.initialize(), timeout=5)
+            return await asyncio.wait_for(use(session), timeout=5)
+    finally:
+        server.cancel()
+
+
+async def _list_tool_names(session):
+    return [tool.name for tool in (await session.list_tools()).tools]
+
+
+async def _call_custom_method(session):
+    import mcp.types as types
+    from pydantic import TypeAdapter
+
+    return await session.send_request(
+        types.Request(method=CUSTOM_METHOD, params=None), TypeAdapter(dict[str, Any]),
+    )
+
+
+def _leaf_exceptions(exc):
+    nested = getattr(exc, "exceptions", None)
+    if nested is None:
+        return [exc]
+    return [leaf for sub in nested for leaf in _leaf_exceptions(sub)]
+
+
+class TestEndToEndWithRealClientSession:
+    @pytest.fixture(autouse=True)
+    def _needs_sdk(self):
+        pytest.importorskip("mcp")
+        pytest.importorskip("mcp_types.methods")
+
+    def test_premise_sdk_rejects_the_whole_page_without_the_guard(self):
+        """Pins the failure mode from #101669: one rejected tool, whole page gone."""
+        from pydantic import ValidationError
+
+        with pytest.raises(BaseException) as excinfo:
+            asyncio.run(_session_through([GOOD, BROKEN], guarded=False, use=_list_tool_names))
+
+        leaves = _leaf_exceptions(excinfo.value)
+        assert any(isinstance(leaf, ValidationError) for leaf in leaves), leaves
+        assert any("inputSchema" in str(leaf) for leaf in leaves)
+
+    def test_guarded_session_loads_the_catalog_minus_the_invalid_tool(self, caplog):
+        with caplog.at_level(logging.WARNING, logger=GUARD_LOGGER):
+            names = asyncio.run(_session_through(CATALOG, guarded=True, use=_list_tool_names))
+
+        expected = ["good"]
+        if _sdk_accepts_boolean_property_schemas():
+            expected.append("posthogmcp_endpoint_run")
+        assert names == expected
+        messages = [rec.getMessage() for rec in caplog.records]
+        assert any("'broken'" in m for m in messages)
+        assert not any("'good'" in m for m in messages)
+
+    def test_custom_method_result_carrying_a_tools_list_is_untouched(self, caplog):
+        """The pinned SDK forwards custom-method results as-is; so must the guard."""
+        with caplog.at_level(logging.DEBUG, logger=GUARD_LOGGER):
+            unguarded = asyncio.run(_session_through(CATALOG, guarded=False, use=_call_custom_method))
+            guarded = asyncio.run(_session_through(CATALOG, guarded=True, use=_call_custom_method))
+
+        assert guarded == unguarded == CUSTOM_RESULT
+        assert not caplog.records

--- a/tests/tools/test_mcp_streamable_http_arity.py
+++ b/tests/tools/test_mcp_streamable_http_arity.py
@@ -122,7 +122,12 @@ def test_the_session_streams_are_the_first_two_yielded():
 
     asyncio.run(_drive())
 
-    assert passed["args"][:2] == (read, write)
+    # Both streams are handed over wrapped by the tool-listing guard, which
+    # forwards everything it doesn't intercept to the transport's streams.
+    guarded_read, guarded_write = passed["args"][:2]
+    assert guarded_read is not read and guarded_write is not write
+    assert guarded_read.last_context is read.last_context
+    assert guarded_write.last_context is write.last_context
 
 
 def test_the_seeded_protocol_header_matches_the_handshake_the_client_sends():

--- a/tools/mcp_listing_guard.py
+++ b/tools/mcp_listing_guard.py
@@ -1,0 +1,321 @@
+"""Keep one malformed tool from taking down a whole MCP server's catalog.
+
+The ``mcp`` 2.x SDK validates every ``tools/list`` page against the wire
+schema of the *negotiated protocol version* before the client ever sees it,
+and it validates the page as a whole: one tool whose definition the schema
+rejects fails the entire response. Hermes then parks the server, so a
+single bad tool takes every other tool on that server with it — and the
+error names the offender only by index (``tools.291.inputSchema...``).
+
+Issue #101669 hit this with a boolean property subschema
+(``"properties": {"refresh": true}``), which the pinned SDK's 2025-11-25
+wire model rejects although it is legal JSON Schema. *Accepting* that shape
+is the SDK model's job and is owned elsewhere: upstream widened the model in
+modelcontextprotocol/python-sdk#3354, and the Hermes-side widening for the
+pinned ``mcp==2.0.0`` is a separate change (#102900). This module does not
+accept or rewrite any schema. It is the complementary layer the reporter
+asked for independently of that fix: whatever the SDK model in use still
+rejects — a boolean property until the widening is present, a tool without
+``type: "object"`` regardless — costs that one tool, not the server.
+
+It wraps both session streams between the transport and ``ClientSession``.
+The write proxy remembers the method of every outbound request by id; the
+read proxy uses that ledger to recognise the response to ``tools/list`` —
+and only that one: a custom or extension method whose result happens to
+carry a ``tools`` list passes through untouched, exactly as the SDK
+forwards it. For a ``tools/list`` page it validates every tool on its own
+against the SDK's own per-version ``Tool`` model; tools that fail are
+dropped *individually*, logged by name with the failing path, and recorded
+on the owning server so status can show what went missing; the rest of the
+catalog loads.
+
+Everything here is best-effort: any unexpected shape or SDK difference makes
+the guard pass the message through untouched, so behaviour can never be worse
+than the SDK's own.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import OrderedDict
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, get_args
+
+logger = logging.getLogger(__name__)
+
+DroppedTools = List[Tuple[str, str]]
+
+# Requests whose responses the guard acts on. Everything else is forwarded as-is.
+_LISTING_METHOD = "tools/list"
+_HANDSHAKE_METHODS = frozenset({"initialize", "server/discover"})
+
+# Upper bound on remembered in-flight request ids: a response (or error) retires its id, so
+# the ledger only grows when a peer never answers; beyond this the oldest entries are forgotten.
+_MAX_PENDING_REQUESTS = 4096
+
+
+def _tool_label(tool: Any, index: int) -> str:
+    name = tool.get("name") if isinstance(tool, dict) else None
+    return name if isinstance(name, str) and name else f"<tools[{index}]>"
+
+
+def _versioned_tool_model(version: str) -> Optional[Any]:
+    """Return the SDK's ``Tool`` wire model for ``version``.
+
+    Derived from the same ``tools/list`` result model the SDK validates
+    against, so a tool that passes here passes the SDK — including any
+    widening Hermes applies to that model at import time. ``None`` when
+    this SDK generation has no per-version surface (mcp 1.x, which
+    validates ``inputSchema`` as a free-form dict) or the version is one it
+    doesn't know.
+    """
+    try:
+        from mcp_types.methods import SERVER_RESULTS
+    except ImportError:
+        return None
+    try:
+        page_model = SERVER_RESULTS[(_LISTING_METHOD, version)]
+        (tool_model,) = get_args(page_model.model_fields["tools"].annotation)
+    except Exception:
+        return None
+    return tool_model if callable(getattr(tool_model, "model_validate", None)) else None
+
+
+def _error_summary(exc: BaseException) -> str:
+    """Render the first pydantic error as ``<path within the tool>: <message>``."""
+    errors = getattr(exc, "errors", None)
+    if callable(errors):
+        try:
+            first = errors()[0]
+            path = ".".join(str(part) for part in first.get("loc", ()))
+            message = str(first.get("msg", "")).strip()
+            return f"{path}: {message}" if path else message
+        except Exception:  # pragma: no cover - defensive against SDK drift
+            pass
+    return str(exc).splitlines()[0][:200]
+
+
+def drop_invalid_tools(result: Dict[str, Any], version: str) -> DroppedTools:
+    """Remove the tools the SDK would reject, in place; keep the rest.
+
+    Each tool is validated on its own against the versioned ``Tool`` model,
+    so a broken page-level field (a bad ``nextCursor``, a negative
+    ``ttlMs`` the SDK clamps itself) neither hides an invalid tool nor
+    condemns a valid one. Returns ``[(tool_name, reason), ...]`` for the
+    tools removed.
+    """
+    tools = result.get("tools")
+    if not isinstance(tools, list) or not tools:
+        return []
+    tool_model = _versioned_tool_model(version)
+    if tool_model is None:
+        return []
+    try:
+        from pydantic import ValidationError
+    except ImportError:  # pragma: no cover - pydantic is an SDK dependency
+        return []
+    kept: List[Any] = []
+    dropped: DroppedTools = []
+    for index, tool in enumerate(tools):
+        try:
+            tool_model.model_validate(tool, by_name=False)
+        except ValidationError as exc:
+            dropped.append((_tool_label(tool, index), _error_summary(exc)))
+            continue
+        except Exception:
+            # Not a validation verdict: keep the tool and let the SDK decide.
+            logger.debug("per-tool MCP schema validation failed unexpectedly", exc_info=True)
+        kept.append(tool)
+    if dropped:
+        result["tools"] = kept
+    return dropped
+
+
+def _unwrap_message(item: Any) -> Any:
+    """Return the JSON-RPC message carried by a stream item, or ``None``.
+
+    Handles both SDK generations: mcp 1.x wraps the message in a
+    ``JSONRPCMessage`` root model (``item.message.root``), mcp 2.x carries the
+    request/response object directly (``item.message``).
+    """
+    message = getattr(item, "message", None)
+    if message is None:
+        return None
+    return getattr(message, "root", message)
+
+
+class _RequestLedger:
+    """Outbound request id → method, so a response can be tied to its method."""
+
+    def __init__(self) -> None:
+        self._pending: "OrderedDict[Any, str]" = OrderedDict()
+
+    def note_request(self, item: Any) -> None:
+        message = _unwrap_message(item)
+        method = getattr(message, "method", None)
+        request_id = getattr(message, "id", None)
+        if request_id is None or not isinstance(method, str):
+            return  # notification, response, or not a JSON-RPC message at all
+        try:
+            self._pending[request_id] = method
+        except TypeError:
+            return  # unhashable id: not a JSON-RPC id
+        while len(self._pending) > _MAX_PENDING_REQUESTS:
+            self._pending.popitem(last=False)
+
+    def retire(self, item: Any) -> Optional[str]:
+        """Forget the request a response/error answers; return its method."""
+        message = _unwrap_message(item)
+        request_id = getattr(message, "id", None)
+        if request_id is None or getattr(message, "method", None) is not None:
+            return None  # a request or notification coming *from* the server
+        try:
+            return self._pending.pop(request_id, None)
+        except TypeError:
+            return None
+
+
+class _StreamProxy:
+    """Delegate the SDK stream protocol (context management, ``aclose``, extras) to a wrapped stream."""
+
+    def __init__(self, inner: Any) -> None:
+        self._inner = inner
+
+    async def __aenter__(self):
+        await self._inner.__aenter__()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return await self._inner.__aexit__(exc_type, exc_val, exc_tb)
+
+    async def aclose(self) -> None:
+        await self._inner.aclose()
+
+    def __getattr__(self, name: str):
+        # Anything outside the protocol (``last_context``, ``clone``, ...) belongs to the
+        # wrapped stream. Private names are never forwarded: a lookup of ``_inner`` itself
+        # before ``__init__`` ran (copy / unpickling paths) would otherwise recurse forever.
+        if name.startswith("_"):
+            raise AttributeError(name)
+        return getattr(self._inner, name)
+
+
+class GuardedWriteStream(_StreamProxy):
+    """Write-stream proxy that records the method of every outbound request."""
+
+    def __init__(self, inner: Any, ledger: _RequestLedger) -> None:
+        super().__init__(inner)
+        self._ledger = ledger
+
+    async def send(self, item: Any) -> None:
+        try:
+            self._ledger.note_request(item)
+        except Exception:  # pragma: no cover - never let bookkeeping break a send
+            logger.debug("tool-listing guard could not record an outbound request", exc_info=True)
+        await self._inner.send(item)
+
+
+class ToolListingGuard(_StreamProxy):
+    """Read-stream proxy that isolates invalid tools before the SDK rejects a ``tools/list`` page.
+
+    Only the response to a request the paired :class:`GuardedWriteStream` saw
+    go out as ``tools/list`` is touched; every other item — including a
+    custom-method result that happens to carry a ``tools`` list — is
+    forwarded unchanged.
+
+    The protocol version used for per-tool validation comes from
+    ``version_getter`` (the live session's negotiated version) and, before
+    that is available, from the ``protocolVersion`` the server returned for
+    the handshake request — the exact value the SDK adopts.
+    """
+
+    def __init__(
+        self,
+        inner: Any,
+        ledger: _RequestLedger,
+        *,
+        server_name: str,
+        version_getter: Optional[Callable[[], Optional[str]]] = None,
+        on_drop: Optional[Callable[[DroppedTools], None]] = None,
+    ) -> None:
+        super().__init__(inner)
+        self._ledger = ledger
+        self._server_name = server_name
+        self._version_getter = version_getter
+        self._on_drop = on_drop
+        self._announced_version: Optional[str] = None
+        # Latch so a keepalive that re-lists tools every few seconds does not repeat the
+        # same verdict into agent.log on every tick.
+        self._reported_drops: Set[Tuple[str, str]] = set()
+
+    # -- ReadStream protocol -------------------------------------------------
+
+    async def receive(self):
+        return self._process(await self._inner.receive())
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        return self._process(await self._inner.__anext__())
+
+    # -- isolation -----------------------------------------------------------
+
+    def _process(self, item: Any) -> Any:
+        try:
+            method = self._ledger.retire(item)
+            if method is None:
+                return item
+            result = getattr(_unwrap_message(item), "result", None)
+            if not isinstance(result, dict):
+                return item  # an error response, or a shape the SDK will judge itself
+            if method in _HANDSHAKE_METHODS:
+                announced = result.get("protocolVersion")
+                if isinstance(announced, str) and announced:
+                    self._announced_version = announced
+            elif method == _LISTING_METHOD and isinstance(result.get("tools"), list):
+                self._isolate_invalid_tools(result)
+        except Exception:
+            # Never let the guard itself break a live session.
+            logger.debug("MCP server '%s': tool-listing guard skipped a message",
+                         self._server_name, exc_info=True)
+        return item
+
+    def _version(self) -> Optional[str]:
+        version = self._version_getter() if self._version_getter else None
+        if isinstance(version, str) and version:
+            return version
+        return self._announced_version
+
+    def _isolate_invalid_tools(self, result: Dict[str, Any]) -> None:
+        version = self._version()
+        if not version:
+            return
+        dropped = drop_invalid_tools(result, version)
+        for name, reason in dropped:
+            first_time = (name, reason) not in self._reported_drops
+            self._reported_drops.add((name, reason))
+            logger.log(
+                logging.WARNING if first_time else logging.DEBUG,
+                "MCP server '%s': dropping tool '%s' whose definition fails MCP %s schema "
+                "validation (%s); the server's other tools remain available",
+                self._server_name, name, version, reason,
+            )
+        if dropped and self._on_drop is not None:
+            self._on_drop(dropped)
+
+
+def guard_session_streams(
+    read_stream: Any,
+    write_stream: Any,
+    *,
+    server_name: str,
+    version_getter: Optional[Callable[[], Optional[str]]] = None,
+    on_drop: Optional[Callable[[DroppedTools], None]] = None,
+) -> Tuple[ToolListingGuard, GuardedWriteStream]:
+    """Wrap a transport's stream pair for ``ClientSession``; the two proxies share one ledger."""
+    ledger = _RequestLedger()
+    return (
+        ToolListingGuard(read_stream, ledger, server_name=server_name,
+                         version_getter=version_getter, on_drop=on_drop),
+        GuardedWriteStream(write_stream, ledger),
+    )

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -301,7 +301,7 @@ class MCPServerTask(MCPServerRunMixin, MCPServerTransportMixin, MCPServerHealthM
         "_recycled_reason", "initialize_result", "_ping_unsupported", "_list_cache_meta",
         "_reconnect_retries", "_session_proven", "_was_parked", "_inflight_tasks", "_reconnecting",
         "_suspect_reason", "_teardown_race", "_permanent_grace_used", "_stdio_child_pids",
-        "_ever_connected")
+        "_ever_connected", "_dropped_tools")
 
     def __init__(self, name: str):
         self.name = name
@@ -314,6 +314,9 @@ class MCPServerTask(MCPServerRunMixin, MCPServerTransportMixin, MCPServerHealthM
         self._reconnect_event = asyncio.Event()
         self._tools: list = []
         self._registered_tool_names: list[str] = []
+        # Tools the server offered but the tool-listing guard discarded because their definition
+        # fails the SDK's wire schema: ``{tool_name: reason}``. Reset on every (re)discovery.
+        self._dropped_tools: Dict[str, str] = {}
         self._config: dict = {}
         self._error: Optional[Exception] = None
         self._sampling: Optional[SamplingHandler] = None

--- a/tools/mcp_tool_discovery.py
+++ b/tools/mcp_tool_discovery.py
@@ -479,6 +479,10 @@ def get_mcp_status() -> List[dict]:
                               else len(server._tools))
             if server._sampling:
                 entry["sampling"] = dict(server._sampling.metrics)
+            if server._dropped_tools:
+                # Offered by the server but discarded because their definition fails the SDK's wire
+                # schema (see tools/mcp_listing_guard.py); agent.log has the reasons.
+                entry["dropped_tools"] = sorted(server._dropped_tools)
         elif status == "failed":
             entry["error"] = connect_errors[name]
         result.append(entry)

--- a/tools/mcp_tool_health.py
+++ b/tools/mcp_tool_health.py
@@ -134,6 +134,9 @@ class MCPServerHealthMixin:
     async def _refresh_tools(self):
         """Re-fetch tools on ``tools/list_changed`` and update the registry. The lock serializes rapid-fire
         notifications; after the list_tools ``await`` all mutations are synchronous — atomic on the event loop."""
+        # Previous guard verdicts describe the previous catalog; forget them even when the server no
+        # longer advertises ``tools`` and no new catalog is fetched, so status can't report stale drops.
+        self._dropped_tools = {}
         if not self._advertises_tools():
             return  # tools/list would raise MCPError(-32601)
         async with self._refresh_lock:

--- a/tools/mcp_tool_transport.py
+++ b/tools/mcp_tool_transport.py
@@ -138,12 +138,39 @@ class MCPServerTransportMixin:
             logger.info("MCP server '%s': reconnect requested — tearing down %s session", self.name, label)
         return reason
 
+    def _guard_session_streams(self, read_stream, write_stream):
+        """Wrap a transport's stream pair so one bad tool can't park the server.
+
+        The mcp 2.x SDK validates each ``tools/list`` page as a whole against the negotiated protocol
+        version's wire schema *before* the client sees it, so one tool the schema rejects fails the
+        entire response and the server parks with zero tools (#101669). The guard validates each tool
+        on its own with the same versioned model and drops just the offending ones, by name, recording
+        them in ``_dropped_tools`` for status. The write proxy remembers each outbound request's method,
+        so only the response to ``tools/list`` is touched — a custom method whose result carries a
+        ``tools`` list passes through untouched. Wrapping the streams covers every ``list_tools`` caller
+        at once: discovery, ``tools/list_changed`` refreshes and the keepalive fallback.
+        """
+        from tools.mcp_listing_guard import guard_session_streams
+
+        return guard_session_streams(
+            read_stream, write_stream,
+            server_name=self.name,
+            version_getter=lambda: getattr(self.session, "protocol_version", None),
+            on_drop=self._record_dropped_tools,
+        )
+
+    def _record_dropped_tools(self, dropped) -> None:
+        """Remember guard-dropped tools so status can show what went missing."""
+        for name, reason in dropped:
+            self._dropped_tools[name] = reason
+
     async def _serve_transport(self, transport_cm, label: str, connect_timeout: float) -> str:
         """Open *transport_cm*, wrap its streams in a ClientSession and serve it. Streams are indexed,
         not unpacked (mcp 1.x yields a 3-tuple, 2.x a pair); a TaskGroup drop maps to ``"reconnect"``."""
         try:
             async with transport_cm as _streams:
-                async with _core.ClientSession(_streams[0], _streams[1], **self._session_kwargs()) as session:
+                read_stream, write_stream = self._guard_session_streams(_streams[0], _streams[1])
+                async with _core.ClientSession(read_stream, write_stream, **self._session_kwargs()) as session:
                     return await self._serve_session(session, connect_timeout, label)
         except BaseExceptionGroup as _eg:
             return self._reconnect_or_reraise_group(_eg)
@@ -243,6 +270,7 @@ class MCPServerTransportMixin:
                 if new_pids:
                     self._track_spawned_children(new_pids)
                 self._stdio_child_pids = set(new_pids)  # so in-flight calls fail fast when the child dies
+                read_stream, write_stream = self._guard_session_streams(read_stream, write_stream)
                 async with _core.ClientSession(read_stream, write_stream, **self._session_kwargs()) as session:
                     # Bound the handshake here (``connect_timeout`` only bounds the caller's ``.result()``):
                     # a server that never answers ``initialize`` would leak child + pipes per retry until EMFILE.
@@ -428,6 +456,9 @@ class MCPServerTransportMixin:
         anomalyco/opencode#31271.)
         """
         self._ping_unsupported = False  # fresh transport: re-probe ``ping`` across the reconnect
+        # Forget guard verdicts from the previous catalog before deciding whether a new one is even
+        # fetched: a server that stops advertising ``tools`` must not keep reporting stale drops.
+        self._dropped_tools = {}
         if self.session is None:
             return
         if not self._advertises_tools():


### PR DESCRIPTION
## What does this PR do?

The mcp 2.x SDK validates a `tools/list` page **as a whole** against the negotiated protocol version's wire schema before the client sees it. One tool the schema rejects therefore fails the entire response, and Hermes parks the whole server — every other tool on it disappears, and the log names the offender only by index (`tools.291.inputSchema...`). #101669 hit this with a boolean property subschema and lost 311 working tools to one.

This PR is the **per-tool isolation layer** the reporter asked for independently of accepting that particular shape (their points (2) and (3)):

- **Degrade per tool, not per server — and only for `tools/list`.** A small guard, `tools/mcp_listing_guard.py`, wraps the session's stream pair between the transport and `ClientSession`. The write proxy remembers each outbound request's method by id; the read proxy uses that ledger so that only the response to `tools/list` is touched — a custom/extension method whose result happens to carry a `tools` list passes through unchanged, exactly as the pinned SDK forwards custom results. For a `tools/list` page it validates each tool on its own against the SDK's versioned `Tool` model (derived from the same `SERVER_RESULTS[("tools/list", version)]` entry the SDK validates with, so it tracks any widening applied to that model). Only tools that fail are dropped; a broken page-level field (bad `nextCursor`, a negative `ttlMs` the SDK clamps itself) neither hides an invalid tool nor condemns a valid one.
- **Name the tool.** Drops are logged at WARNING with the tool name, protocol version and the failing path (`inputSchema.type: Input should be 'object'`), latched per connection so a server whose keepalive falls back to `list_tools` does not repeat the same line every tick. Dropped tools are recorded on the task and surfaced as `dropped_tools` in `get_mcp_status()` for a connected server, so status no longer looks perfectly healthy while a tool silently went missing.
- **Never worse than the SDK.** Any unexpected shape passes through untouched. On mcp 1.x, which has no per-version surface, the guard is inert.

**Ownership of the boolean-schema edge itself.** Accepting `"properties": {"refresh": true}` is the SDK model's job and is owned separately: upstream widened the 2025-11-25 `InputSchema`/`OutputSchema.properties` values to `object | boolean` in modelcontextprotocol/python-sdk#3354 (mcp 2.1.0), and #102900 (@littlestar030) carries that widening for the pinned `mcp==2.0.0`. This PR contains **no** boolean acceptance or rewrite of any schema — on this head the pinned SDK still rejects the boolean shape, and the guard isolates that one tool by name instead of letting it park the server (which is what happens on `main` today). Once #102900 lands the same tool simply stays (verified by applying its widening in-process and running the end-to-end test). The two are complementary; neither replaces the other.

The protocol version for per-tool validation comes from the live session's `protocol_version`; before that is available the guard falls back to the `protocolVersion` the server returned for the handshake request (the exact value the SDK adopts).

Wrapping the streams (rather than catching the error at one call site) covers every `list_tools` caller at once — initial discovery, `tools/list_changed` refreshes, the keepalive `list_tools` fallback and `hermes mcp test` — on every transport: `_serve_transport` (SSE and both streamable-HTTP paths) and `_run_stdio`.

Out of scope, on purpose: `tools/computer_use/cua_backend.py` opens its own `ClientSession` against the Hermes-owned CUA driver (its schema is under our control, and a failure there is already soft-failed), and consolidating the four transport bodies into one session-opening helper is a separate refactor.

**Recomposed onto the decomposed MCP owners.** #102117 landed and split `tools/mcp_tool.py` into bounded `tools/mcp_tool_*.py` modules; this PR is rematerialized on current `main` against those owners rather than the old monolith: the guard methods and both `ClientSession(...)` sites live in `tools/mcp_tool_transport.py`, the refresh reset in `tools/mcp_tool_health.py`, the status key in `tools/mcp_tool_discovery.py`, and only the `__slots__`/`__init__` entry for `_dropped_tools` remains on the `MCPServerTask` facade. The #98762 / #78642 interlock declared earlier still applies to whatever `tools/mcp_tool*.py` hunks #98762 carries after its own recompose.

## Related Issue

Fixes #101669. Complementary to #101810 (boolean-schema acceptance on the pinned SDK).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_listing_guard.py` (new): `drop_invalid_tools`, `guard_session_streams()` and the `ToolListingGuard` / `GuardedWriteStream` pair (implement the SDK's read/write stream protocols; forward `last_context` etc. to the wrapped streams; share a request-id → method ledger so only `tools/list` responses are acted on; handle both the mcp 1.x root-wrapped and 2.x direct message shapes; latch repeated verdicts; report drops through an `on_drop` callback).
- `tools/mcp_tool_transport.py`: `MCPServerTransportMixin._guard_session_streams()` / `_record_dropped_tools()`; both `ClientSession(...)` sites (`_serve_transport`, `_run_stdio`) wrap the stream pair; `_discover_tools` resets `_dropped_tools` before the capability gate.
- `tools/mcp_tool_health.py`: `_refresh_tools` resets `_dropped_tools` before the capability gate / re-listing.
- `tools/mcp_tool_discovery.py`: `get_mcp_status()` exposes `dropped_tools` for a connected server that has any.
- `tools/mcp_tool.py`: `_dropped_tools` added to `MCPServerTask.__slots__` and initialised.
- `contributors/emails/kyr76789@gmail.com`: contributor mapping required by the attribution check (folded into the single commit).
- `tests/tools/test_mcp_listing_guard.py` (new, 26 tests): unit tests for per-tool isolation (including page-level-error and unknown-version behaviour, and a verdict test that tracks whether the installed model accepts boolean property schemas), the guarded stream pair (only the `tools/list` response is isolated; a custom-method result carrying `tools` is untouched; ids retired by their answer; server-originated requests/notifications pass through by identity; delegation, never-raises, handshake-only version fallback, latching), `MCPServerTask` wiring (version pickup, drop recording, status surfacing, reset on rediscovery — including both no-tools-capability paths), and **end-to-end tests that drive a real `ClientSession` over in-memory streams against a fake server** — including a premise test pinning that the SDK rejects the whole page without the guard, and a custom-method regression proving a result that carries a `tools` list round-trips unchanged with and without the guard.
- `tests/tools/test_mcp_streamable_http_arity.py`: the arity test now asserts both streams are handed over wrapped (delegating to the transport's streams) rather than by identity.

## How to Test

1. Serve an MCP catalog with one genuinely invalid tool, e.g. `{"name": "broken", "inputSchema": {"type": "array"}}`, next to valid ones, and run `hermes mcp test <server>`.
2. Before: `✗ Connection failed` with `ValidationError: 1 validation error for ListToolsResult tools.N.inputSchema.type ...` and the server parks with zero tools. After: the server connects with every other tool, agent.log has `dropping tool 'broken' whose definition fails MCP 2025-11-25 schema validation (inputSchema.type: Input should be 'object')`, and `get_mcp_status()` lists it under `dropped_tools`.
3. With the reporter's `"properties": {"refresh": true}` tool: on a pinned SDK without #101810 it is isolated by name the same way (server stays up); with #101810 applied it loads.
4. `scripts/run_tests.sh tests/tools/test_mcp_listing_guard.py` — the premise test fails on `main` (the SDK rejects the page) and passes with this change; the MCP test set (`tests/tools/test_mcp*.py` plus the status consumers) is green locally: 65 files, 766 tests.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — #101810 owns the boolean acceptance; this is the complementary isolation layer
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (via `scripts/run_tests.sh`, CI-parity)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5), Python 3.11, mcp 2.0.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — module and method docstrings; no user-facing config changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python, no I/O; N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Guarded run against a fake server offering `good`, the reporter's boolean-schema tool and one genuinely invalid tool, on the pinned SDK with #101810's widening applied in-process:

```
WARNING MCP server 'fake': dropping tool 'broken' whose definition fails MCP 2025-11-25 schema validation (inputSchema.type: Input should be 'object'); the server's other tools remain available
guard=False -> ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)   # ValidationError, whole page rejected
guard=True  -> ['good', 'posthogmcp_endpoint_run']
```



