### PR TITLE
fix(tui): hot-apply checkpoint_required to open sessions

### DIFF
--- a/tests/tui_gateway/test_compression_config_hot_reload.py
+++ b/tests/tui_gateway/test_compression_config_hot_reload.py
@@ -26,6 +26,7 @@ def _session_with_compressor(**compression_ctor):
         provider="openai-codex",
         context_compressor=compressor,
         compression_enabled=True,
+        compression_checkpoint_required=False,
         compression_idle_compact_after_seconds=0,
         codex_responses_native_compaction=False,
         codex_responses_compact_threshold=200_000,
@@ -81,6 +82,49 @@ def test_live_codex_native_compaction_applies_on_next_turn(monkeypatch):
     server._sync_agent_compression_with_config("sid-95151", session)
 
     assert session["agent"].codex_responses_native_compaction is True
+
+
+def test_live_checkpoint_gate_disable_applies_on_next_turn(monkeypatch):
+    session, _ = _session_with_compressor()
+    session["agent"].compression_checkpoint_required = True
+
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"compression": {"checkpoint_required": False}},
+    )
+
+    server._sync_agent_compression_with_config("sid-95151", session)
+
+    assert session["agent"].compression_checkpoint_required is False
+
+
+def test_live_checkpoint_gate_reads_changed_config_from_active_home(
+    monkeypatch, tmp_path
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    config_path = home / "config.yaml"
+    config_path.write_text(
+        "compression:\n  checkpoint_required: true\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(server, "_hermes_home", home)
+    monkeypatch.setattr(server, "_cfg_cache", None)
+    monkeypatch.setattr(server, "_cfg_mtime", None)
+    monkeypatch.setattr(server, "_cfg_path", None)
+
+    session, _ = _session_with_compressor()
+    session["agent"].compression_checkpoint_required = True
+    session["config_compression_seen"] = server._tui_compression_config_signature(
+        server._load_cfg()
+    )
+
+    config_path.write_text(
+        "compression:\n  checkpoint_required: false\n# changed\n", encoding="utf-8"
+    )
+    server._sync_agent_compression_with_config("sid-95151", session)
+
+    assert session["agent"].compression_checkpoint_required is False
 
 
 def test_live_codex_native_threshold_applies_on_next_turn(monkeypatch):
@@ -164,6 +208,7 @@ def _neutral_session(**compression_ctor):
         provider="",
         context_compressor=compressor,
         compression_enabled=True,
+        compression_checkpoint_required=False,
         compression_idle_compact_after_seconds=0,
         codex_responses_native_compaction=False,
         codex_responses_compact_threshold=200_000,
@@ -267,6 +312,13 @@ def test_removing_enabled_restores_true(monkeypatch):
     session["agent"].compression_enabled = False
     _sync_with_cfg(monkeypatch, session, {"compression": {}})
     assert session["agent"].compression_enabled is True
+
+
+def test_removing_checkpoint_required_restores_false(monkeypatch):
+    session, _ = _neutral_session()
+    session["agent"].compression_checkpoint_required = True
+    _sync_with_cfg(monkeypatch, session, {"compression": {}})
+    assert session["agent"].compression_checkpoint_required is False
 
 
 def test_removing_codex_native_compaction_restores_false(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7027,6 +7027,15 @@ def _apply_live_compression_config(agent: Any, cfg: dict | None) -> None:
     else:
         agent.compression_enabled = str(enabled_raw).lower() in {"true", "1", "yes"}
 
+    # This gate is baked onto the agent at construction time, just like the
+    # other compression authorities below.  The turn-start signature already
+    # watches checkpoint_required, so adopt the changed value here too; without
+    # this assignment an open Desktop/TUI session stays fail-closed forever
+    # after the user disables a gate its memory provider cannot satisfy.
+    agent.compression_checkpoint_required = is_truthy_value(
+        compression.get("checkpoint_required", False)
+    )
+
     agent.codex_responses_native_compaction = is_truthy_value(
         compression.get("codex_responses_native", False)
     )


### PR DESCRIPTION
## What does this PR do?

Desktop/TUI already detects changes to `compression.checkpoint_required` at
turn start, but its live compression updater did not assign the changed value
to the open agent. An existing conversation could therefore remain
fail-closed with a stale `true` value after the operator changed the setting to
`false`, continuing to raise `CompressionCheckpointUnavailable` until Hermes
Desktop was fully restarted.

This completes the live-config path introduced by #98547: the existing agent
now adopts `compression.checkpoint_required` on the next turn, and removing the
key restores the normalized default `false`.

## Related Issue

Follow-up to #98547. Related checkpoint-contract work: #94983.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `tui_gateway/server.py` so `_apply_live_compression_config()` assigns
  `agent.compression_checkpoint_required` from the current compression config.
- Add a regression proving `true → false` reaches an already-open agent on the
  next turn without rebuilding the session.
- Add an integration-style regression that changes `config.yaml` under the
  active Hermes home and proves the existing agent adopts the new value.
- Add a regression proving an absent key restores the default `false` rather
  than retaining stale `true`.

## How to Test

1. Start with an open Desktop/TUI session whose live agent has
   `compression_checkpoint_required=true`.
2. Change `compression.checkpoint_required` to `false` and submit the next
   turn. Confirm the same agent instance adopts `false`.
3. Run:

   ```text
   scripts/run_tests.sh \
     tests/tui_gateway/test_compression_config_hot_reload.py \
     tests/agent/test_pre_compress_checkpoint_contract.py -q
   ```

   Result: `43 passed`.

4. Run the complete TUI gateway suite:

   ```text
   scripts/run_tests.sh tests/tui_gateway/ -q
   ```

   Result: `979 passed` across 105 files.

5. Run Ruff against both changed files. Result: clean.

6. Run `git diff --check`. Result: clean.

7. A full local suite sweep completed 3,673 files with 44,388 tests passed,
   126 failed, and 439 skipped. The failures are outside this change and are
   dominated by unavailable optional dependencies/runtime fixtures (`acp`,
   Anthropic, FAL, Modal, wake-word/voice), cross-platform assumptions, and a
   pre-existing recursive local skill symlink. The changed test file passed
   again inside that sweep. CI remains the authoritative clean-environment
   full-suite result.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched existing open and merged PRs and issues for duplicates.
- [x] My proposed PR diff contains only the two files related to this fix.
- [ ] I've run `pytest tests/ -q` and all tests pass. (The repository wrapper
  completed the full local suite, but 126 unrelated environment/platform
  failures remain; focused and complete TUI gateway suites pass.)
- [x] I've added tests for the bug.
- [x] I've tested on macOS.

### Documentation & Housekeeping

- [x] Documentation update: N/A; this restores the already-documented live
  configuration semantics and does not introduce a key.
- [x] `cli-config.yaml.example`: N/A; no configuration key was added or changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no architecture or workflow change.
- [x] Cross-platform impact considered: the updater is platform-independent;
  the production reproduction and recovery were on macOS.
- [x] Tool descriptions/schemas: N/A.

## Screenshots / Logs

Before: an already-open Desktop session continued to fail after config changed
to `checkpoint_required=false`:

```text
BLOCKED_MISSING_PREREQUISITE: required pre-compress checkpoint unavailable:
active provider does not implement checkpoint API v2
```

![Desktop showing CompressionCheckpointUnavailable after checkpoint_required changed to false](https://raw.githubusercontent.com/mooserini/hermes-agent/pr-evidence-101805/pr-evidence/101805/checkpoint-error.png)

SHA-256:
`eaf87d4f43946539de4ec21e9ba944f38870dda59f23a664ef1518ff7c6b83da`

After a full Desktop restart rebuilt the agent from the corrected config, the
exact failed prompt completed successfully. This is production proof of the
restart workaround and stale-agent diagnosis; the regression tests directly
prove the no-restart fix.

![The exact failed prompt completing after a full Desktop restart](https://raw.githubusercontent.com/mooserini/hermes-agent/pr-evidence-101805/pr-evidence/101805/retry-success.png)

SHA-256:
`b26753b094acac31ade6ff0ea84ab5c324fe89fd56e468f089ce4d1da20fdba4`

The local forensic packet preserves Guardian snapshots, process boundaries,
timestamps, screenshot hashes, database inspection, and the distinction
between field-workaround and code-fix proof. Its relevant, reviewer-verifiable
claims are summarized above; it is not required to trust the patch.
