### PR TITLE
fix(agent): stop display-tz conversion from shifting session-start's calendar day

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -309,9 +309,28 @@ def _session_start_like(agent: Any, now: Any) -> Any:
     3. ``now`` (initial/legacy build without either).
 
     Session-id and ``session_start`` stamps are recorded in the box's local
-    wall-clock; attach that zone first, then convert to the configured /
-    rendered zone (``now``'s tzinfo) so the displayed date is consistent with
-    the per-turn clock even when the box's TZ differs from the configured one.
+    wall-clock. We attach that zone for type-consistency (some callers may
+    later want %Z/offset info) but we deliberately do NOT convert the value
+    into the configured / rendered zone (``now``'s tzinfo).
+
+    Converting a wall-clock reading into a *different* UTC offset can shift
+    which calendar day it falls on whenever the instant sits within one
+    offset-delta of local midnight in either zone (e.g. a session minted at
+    23:30 box-local, with a display zone several hours ahead, lands on the
+    display zone's NEXT calendar day). That shift silently detaches the
+    printed weekday from the printed day-of-month — ``strftime`` never lies
+    about which weekday a given date falls on, but the *date itself* becomes
+    wrong for the day the session actually started on, which is what
+    "Conversation started" promises to report. Verified with real stdlib
+    zoneinfo: an instant recorded as 23:30 US/Pacific on Sept 4 reads as
+    Sept 5 once converted to Asia/Kolkata or Europe/London — a full
+    calendar-day (and weekday) shift caused purely by the display-zone
+    conversion, not by any real ambiguity about when the session started.
+
+    The box-local wall-clock calendar date is ground truth for "what day did
+    this session start" — it must never move because of a display-timezone
+    choice. Only the offset/zone *annotation* appended elsewhere (via
+    ``now``, see ``_zone_suffix`` below) may vary with the configured zone.
     """
     from datetime import datetime
 
@@ -321,15 +340,15 @@ def _session_start_like(agent: Any, now: Any) -> Any:
         machine_local_tz = None
 
     def _to_display_tz(dt: Any) -> Any:
+        # Attach the box-local zone for callers that inspect ``.tzinfo``,
+        # but never ``astimezone()`` into a different zone here — see the
+        # docstring above for why that conversion is exactly the bug this
+        # function exists to avoid. The calendar date/time-of-day fields of
+        # ``dt`` are never altered.
         if machine_local_tz is not None and dt.tzinfo is None:
             try:
                 dt = dt.replace(tzinfo=machine_local_tz)
             except ValueError:
-                pass
-        if getattr(now, "tzinfo", None) is not None and dt.tzinfo is not None:
-            try:
-                dt = dt.astimezone(now.tzinfo)
-            except (ValueError, OSError):
                 pass
         return dt
 

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -691,6 +691,38 @@ class TestSessionStartLike:
         start = _session_start_like(agent, now)
         assert start.strftime("%Y-%m-%d") == "2026-01-01"
 
+    def test_display_tz_conversion_never_shifts_the_calendar_day(self, monkeypatch):
+        """Regression (t_70c45711): the session-id embedded stamp is a
+        box-local wall-clock reading. Converting it into a display timezone
+        that is far enough away from box-local can cross midnight and land
+        on a different calendar day/weekday than the session actually
+        started on — even though the box-local clock never left Sept 4.
+
+        This reproduces the exact scenario from the root-cause analysis:
+        box-local (machine) timezone is US/Pacific, session mints at 23:30
+        Sept 4, and the CONFIGURED display timezone (``now.tzinfo``) is
+        Asia/Kolkata — 13.5 hours ahead, well past the day boundary.
+        """
+        from agent.system_prompt import _session_start_like
+
+        class _FixedNow(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                base = datetime(2026, 9, 4, 12, 0, tzinfo=ZoneInfo("America/Los_Angeles"))
+                return base if tz is None else base.astimezone(tz)
+
+        with patch("datetime.datetime", _FixedNow):
+            # Session minted 23:30 Sept 4 box-local (naive — matches how the
+            # session_id embedded timestamp and session_start are recorded).
+            now = datetime(2026, 9, 5, 3, 0, tzinfo=ZoneInfo("Asia/Kolkata"))
+            agent = SimpleNamespace(
+                session_id="20260904_233000_abc123",
+                session_start=datetime(2026, 9, 4, 23, 30),
+            )
+            start = _session_start_like(agent, now)
+        assert start.strftime("%Y-%m-%d") == "2026-09-04"
+        assert start.strftime("%A") == "Friday"
+
 
 def test_conversation_start_uses_session_start_not_build_time(monkeypatch):
     """Regression: a session that started on Jan 1 must still read


### PR DESCRIPTION
fix(agent): stop display-tz conversion from shifting session-start's calendar day

_session_start_like()'s _to_display_tz() helper converted the box-local
wall-clock session-start stamp into the configured display timezone via
astimezone(). That conversion can cross midnight in one zone but not the
other, silently shifting the "Conversation started" date (and therefore
its printed weekday) by one day in either direction whenever the box's
OS timezone and the user's configured Hermes timezone are far enough
apart (e.g. a UTC cloud VM with timezone: America/New_York configured,
or any pair of zones straddling a midnight boundary at session-mint
time).

Verified with real stdlib zoneinfo: a session minted 23:30 US/Pacific on
Sept 4 read as Sept 5 (Saturday) once converted into Asia/Kolkata or
Europe/London, when box-local (the true wall-clock the session started
on) was still Sept 4 (Friday).

Fix: _session_start_like() now attaches the box-local tzinfo to the
recorded stamp for type-consistency but never astimezone()s it into a
different offset. The box-local wall-clock calendar date is ground
truth for "when did this session start" and must not move because of a
display-timezone choice -- only the separate zone/offset annotation
(driven by hermes_time.now()) may vary with the configured timezone.
This makes the fix generic across every profile: it lives in the one
shared code path (agent/system_prompt.py) all profiles funnel through,
not a per-profile patch.

Added TestSessionStartLike::test_display_tz_conversion_never_shifts_the_calendar_day,
which reproduces the exact box-local/display-tz mismatch from the root
cause analysis (t_4b148b82) and fails on the pre-fix code (asserts Sept 5
Saturday, gets Sept 4 Friday) to prove this is a real regression guard.

Task: t_70c45711 (parent: t_36d744db)
