### PR TITLE
fix(kanban): treat request_review / request_changes as terminal in the worker stop-guard

### DIFF
--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -1,6 +1,7 @@
 """Turn-end guard for kanban workers.
 
-Kanban workers must end with ``kanban_complete`` or ``kanban_block``. Models
+Kanban workers must end with a terminal board tool (``kanban_complete``,
+``kanban_block``, ``kanban_request_review``, ``kanban_request_changes``). Models
 (especially GLM / Qwen families) sometimes narrate the next step
 ("Let me write the report now") and stop with ``finish_reason=stop`` and no
 tool calls. Hermes treats that as a clean exit → ``rc=0`` → dispatcher
@@ -17,7 +18,16 @@ import os
 from typing import Any, Iterable, Optional
 
 
-_TERMINAL_KANBAN_TOOLS = frozenset({"kanban_complete", "kanban_block"})
+# Every tool that closes the worker's run. ``kanban_request_review`` and
+# ``kanban_request_changes`` hand the task to another run — nudging after
+# them makes the worker keep calling complete/block on a task it no longer
+# owns (it loops for hours; the 2026-09-02 coloring-books runaway).
+_TERMINAL_KANBAN_TOOLS = frozenset({
+    "kanban_complete",
+    "kanban_block",
+    "kanban_request_review",
+    "kanban_request_changes",
+})
 
 _DEFAULT_MAX_ATTEMPTS = 2
 

--- a/tests/agent/test_kanban_stop.py
+++ b/tests/agent/test_kanban_stop.py
@@ -74,6 +74,30 @@ def test_no_nudge_after_kanban_complete(clear_kanban_env):
     assert build_kanban_stop_nudge(messages=messages) is None
 
 
+@pytest.mark.parametrize("tool", ["kanban_request_review", "kanban_request_changes"])
+def test_no_nudge_after_review_handoff(clear_kanban_env, tool):
+    """Handing off to review (or back to the implementer) closes the worker's
+    run — the process must be allowed to exit instead of being nudged to
+    call complete/block on a task it no longer owns (2026-09-02 runaway)."""
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "1",
+                    "type": "function",
+                    "function": {"name": tool, "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "name": tool, "tool_call_id": "1", "content": "ok"},
+    ]
+    assert session_called_kanban_terminal(messages) is True
+    assert build_kanban_stop_nudge(messages=messages) is None
+
+
 
 
 


### PR DESCRIPTION
## Problem

`agent/kanban_stop.py` only counts `kanban_complete` and `kanban_block` as terminal. A worker that hands off with `kanban_request_review` (or `kanban_request_changes`) is told it violated protocol and nudged to call complete/block on a task it no longer owns. With a local model that never answers with a plain stop, the worker loops through tool calls for hours while the dispatcher spawns the reviewer run beside it.

Observed 2026-09-01/02 on a three-card coloring-book board: three orphaned workers plus the chat agent on one local model, single calls up to 83 minutes. The two runs that hit `max_runtime` were killed correctly; every orphan was a run closed by `review_requested`.

## Fix

Add `kanban_request_review` and `kanban_request_changes` to `_TERMINAL_KANBAN_TOOLS`. Test added in `tests/agent/test_kanban_stop.py` (5 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1U9NfE1xYyLdcuzC7Juxo