### PR TITLE
fix(qqbot): treat dm like c2c in approval-button session authorization

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1132,7 +1132,11 @@ class QQAdapter(BasePlatformAdapter):
 
         chat_type = parsed.get("chat_type", "")
         chat_id = parsed.get("chat_id", "")
-        if chat_type == "c2c":
+        if chat_type in {"c2c", "dm"}:
+            # build_session_key() uses "dm" for every platform's private
+            # chat (gateway/session.py); QQ C2C DMs surface both variants
+            # depending on the code path, and in both the chat_id is the
+            # operator's own identifier.
             return bool(chat_id) and operator == chat_id
 
         if chat_type in {"group", "guild"}:


### PR DESCRIPTION
## Summary

On the QQ messaging platform, clicking the **approve/deny buttons** on a dangerous-command approval prompt in a **DM (C2C) chat** is always rejected with `Rejected unauthorized approval click`, and the pending approval then times out (300 s, fail-closed). Group-chat approval buttons are unaffected.

This is the same root cause reported in #32528 and #98100 — this PR fixes the whole mismatch at the reported site.

## Root cause

- `build_session_key()` (`gateway/session.py`) uses `chat_type="dm"` for every platform's private chat, so QQ C2C conversations produce session keys like `agent:main:qqbot:dm:<user_openid>`.
- `_is_authorized_interaction_for_session()` in `gateway/platforms/qqbot/adapter.py` only handled `chat_type == "c2c"` and `chat_type in {"group", "guild"}`; `"dm"` fell through to `return False`.

So every button click on a DM approval prompt was dropped as unauthorized. Observed on a live deployment (2026-09-03):

```
[QQBot:1905161317] Interaction: scene=c2c button_data='approve:agent:main:qqbot:dm:34754FC...:allow-once' operator=34754FC...
[QQBot:1905161317] Rejected unauthorized approval click for session agent:main:qqbot:dm:34754FC... (operator=34754FC...)
```

## Fix

Accept `"dm"` alongside `"c2c"`:

```python
if chat_type in {"c2c", "dm"}:
    return bool(chat_id) and operator == chat_id
```

In both chat types the session `chat_id` is the operator's own identifier, so the existing `operator == chat_id` check still rejects clicks from other users. The `"group"`/`"guild"` branch is unchanged.

## Verification

- `ast.parse` on the modified adapter: clean.
- Replayed the authorization logic for all session-key shapes: `dm` + operator==chat_id → True, `dm` + foreign operator → False, `c2c` + operator==chat_id → True, `group` + operator==session_user → True.
- Module imports cleanly (`import gateway.platforms.qqbot.adapter`).
- Deployed this exact patch on a live gateway; after restart the QQ DM approval flow works (button click resolves the approval instead of being rejected).

Closes #32528
Closes #98100