### PR TITLE
fix(compaction): count api_content in tail budget

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1127,7 +1127,9 @@ def _estimate_msg_budget_tokens(msg: dict, charge_stale_thinking: bool = True) -
     and always-replayed provider fields. Always-replayed fields are charged because the preflight estimator sees
     the full shape; a mismatched size class protects blob-heavy rows as "small" and compaction re-fires.
     ``charge_stale_thinking=False`` skips newest-turn-only thinking keys. Accounting only; never mutates."""
-    content = msg.get("content") or ""
+    # Charge the wire substitute, not both it and the clean display content.
+    sidecar = msg.get("api_content")
+    content = sidecar if isinstance(sidecar, str) and sidecar and msg.get("role") in ("user", "assistant") else msg.get("content") or ""
     text_tokens = estimate_tokens_rough(content) if isinstance(content, str) else _content_length_for_budget(content) // _CHARS_PER_TOKEN
     tokens = text_tokens + 10  # +10 for role/key overhead
     tokens += sum(estimate_tokens_rough(str(tc)) for tc in msg.get("tool_calls") or [] if isinstance(tc, dict))

--- a/tests/agent/test_replay_budget_accounting.py
+++ b/tests/agent/test_replay_budget_accounting.py
@@ -12,6 +12,8 @@ ARE wire-replayed on every retained turn and stay charged unconditionally
 (#55572) — including native compaction checkpoints (#81747).
 """
 
+import pytest
+
 from agent.context_compressor import (
     _ALWAYS_REPLAYED_BUDGET_KEYS,
     _NEWEST_TURN_ONLY_BUDGET_KEYS,
@@ -19,10 +21,44 @@ from agent.context_compressor import (
     _estimate_msg_budget_tokens,
     _last_assistant_index,
 )
+from agent.model_metadata import estimate_tokens_rough
+from agent.turn_context import substitute_api_content
 
 
 BIG_THINKING = "deliberation " * 400  # ~1.3K tokens of stale thinking text
 BIG_BLOB = [{"type": "reasoning", "encrypted_content": "x" * 4000}]
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        {"role": "user", "content": "clean", "api_content": "wire user"},
+        {"role": "assistant", "content": "clean", "api_content": "wire assistant"},
+        {"role": "system", "content": "clean", "api_content": "ignored"},
+        {"role": "tool", "content": "clean", "api_content": "ignored"},
+        {"role": "user", "content": "clean", "api_content": ""},
+        {"role": "user", "content": "clean", "api_content": ["ignored"]},
+    ],
+    ids=[
+        "user-sidecar",
+        "assistant-sidecar",
+        "system-role",
+        "tool-role",
+        "empty-sidecar",
+        "non-string-sidecar",
+    ],
+)
+def test_api_content_matches_wire_substitution_without_mutation(message):
+    """Tail budgeting must mirror ``substitute_api_content`` exactly."""
+    original = dict(message)
+    wire_message = dict(message)
+    substitute_api_content(wire_message)
+
+    tokens = _estimate_msg_budget_tokens(message)
+
+    expected_content = wire_message.get("content") or ""
+    assert tokens == estimate_tokens_rough(expected_content) + 10
+    assert message == original
 
 
 def _assistant(thinking=False, codex=False):


### PR DESCRIPTION
## What does this PR do?

Makes protected-tail token budgeting mirror the `api_content` substitution that Hermes performs when reconstructing the actual provider request.

Session rows can retain clean display `content` together with an `api_content` sidecar containing the byte-exact text sent to the model. The general request estimator already accounts for that wire representation, but the context compressor's per-message estimator charged only `content`. A larger sidecar could therefore make the protected tail look smaller than the payload actually sent and retain more context than the configured tail budget allows.

The fix uses a valid, non-empty `api_content` value instead of `content` for `user` and `assistant` messages only. It preserves existing behavior for all other roles and for invalid or empty sidecars, and does not mutate the stored message.

## Related Issue

N/A — no issue or PR found in the overlap search implements this protected-tail accounting fix. #102194 and #102245 cover persistence and a broader typed-sidecar contract; they are related to `api_content` but do not replace this compressor correction.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/context_compressor.py`
  - make `_estimate_msg_budget_tokens()` follow the same substitution conditions as `turn_context.substitute_api_content()`;
  - charge a valid non-empty sidecar instead of, rather than in addition to, stored `content`;
  - restrict substitution to `user` and `assistant` roles and leave the input message unchanged.
- `tests/agent/test_replay_budget_accounting.py`
  - add regression coverage against the production substitution helper for valid, empty, invalid, and role-ineligible sidecars.

## How to Test

Run:

```bash
scripts/run_tests.sh tests/agent/test_context_compressor.py tests/agent/test_replay_budget_accounting.py tests/agent/test_model_metadata.py tests/agent/test_turn_context.py tests/agent/test_turn_context_overflow_warning.py
```

Verified after rebasing onto `main` `5a0b1ba766956a1a16bc2f17dc3b83eb63633402`:

- 317 affected tests passed on head `9a611a10c7cf8c637e2a4317a256553a98c6164a`.
- The user/assistant sidecar regression fails against the current base (two failing cases), then passes with this fix; fallback and input non-mutation cases pass.
- Ruff and `git diff --check` passed.
- The current compact estimator and all other replay accounting are preserved.

The repository-wide suite was not run for this revision. Local results are not a claim that GitHub Actions passed.

## Current GitHub status

After the update GitHub reports `MERGEABLE` against `main` `5a0b1ba766956a1a16bc2f17dc3b83eb63633402`. [Exact-head CI run](https://github.com/NousResearch/hermes-agent/actions/runs/33911670702) is `action_required`; the external-fork workflows require maintainer approval. The PR remains `BLOCKED` pending repository gates, so conflict-free and locally tested does not yet mean CI-green or merge-ready.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched open and closed issues and PRs for overlapping `api_content`, replay-budget, and compaction work
- [x] My PR contains **only** changes related to this fix and its regression tests
- [ ] I've run `pytest tests/ -q` and all tests pass — the full repository suite is not claimed; current affected-suite evidence is listed above
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.6.2 (Apple Silicon / arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A, this aligns an internal estimator with the existing documented wire substitution
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — pure Python message/token accounting with no platform-specific APIs
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no model tool changed

## Screenshots / Logs

N/A — this is an internal token-budgeting fix with no UI change. Test results are included above.

